### PR TITLE
Add monorepo documentation — READMEs and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md — Sesori Apps Monorepo
+
+## Monorepo Layout
+
+- `bridge/` — pure Dart CLI workspace (relay server + plugin system)
+- `mobile/` — Flutter workspace (mobile client)
+- `shared/sesori_shared/` — pure Dart, shared crypto and protocol types
+
+Two independent Dart workspaces. `shared/sesori_shared` is consumed via path dependency by both.
+
+## Workspace Commands
+
+Run `dart pub get` from the workspace root, not from individual module dirs:
+
+```sh
+cd bridge && dart pub get
+cd mobile && dart pub get
+```
+
+Bridge workspace also exposes:
+
+```sh
+cd bridge
+make codegen   # runs build_runner across all bridge modules
+make test      # runs dart test across all bridge modules
+make analyze   # runs dart analyze across all bridge modules
+```
+
+## Generated Files
+
+Never edit `*.freezed.dart`, `*.g.dart`, or `*.config.dart` by hand.
+
+After modifying a `@freezed` class, regenerate from the module dir:
+
+```sh
+dart run build_runner build --delete-conflicting-outputs
+```
+
+## Git
+
+Conventional commits: `fix:`, `feat:`, `ci:`, `docs:`, `chore:`.
+
+Branch naming: `type/short-description` (e.g. `feat/relay-reconnect`).
+
+## Testing
+
+| Location | Command |
+|---|---|
+| bridge modules | `dart test` |
+| mobile/app | `flutter test` |
+| mobile pure Dart modules | `dart test` |
+
+## Analysis
+
+Strict analysis is enabled across all packages. Don't add `// ignore:` comments without a written justification in the same line.
+
+## Forbidden
+
+- Don't modify `shared/sesori_shared` without considering impact on both bridge and mobile consumers.
+- Don't create a root-level `pubspec.yaml`. There is no root workspace.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# Sesori Apps Monorepo
+
+Sesori bridges AI coding assistants (like OpenCode) to mobile devices over an encrypted relay. This monorepo contains the bridge CLI, mobile Flutter client, and shared crypto/protocol library.
+
+## Repository Structure
+
+```
+bridge/                     # Dart workspace — Bridge CLI + plugin system
+  app/                      # CLI relay server
+  sesori_plugin_interface/  # Abstract plugin contract
+  sesori_plugin_opencode/   # OpenCode backend plugin
+mobile/                     # Dart workspace — Flutter mobile client
+  app/                      # Flutter UI shell
+  module_core/              # Pure Dart business logic
+  module_auth/              # Auth & token lifecycle
+shared/
+  sesori_shared/            # Shared crypto & protocol types
+```
+
+`bridge/` and `mobile/` are independent Dart workspaces with separate dependency resolution. `shared/sesori_shared` is referenced via path by both workspaces.
+
+## Dependency Graph
+
+```mermaid
+graph TD
+  bridge_app[bridge/app] --> sesori_plugin_interface[bridge/sesori_plugin_interface]
+  bridge_app --> sesori_plugin_opencode[bridge/sesori_plugin_opencode]
+  bridge_app --> sesori_shared[shared/sesori_shared]
+  sesori_plugin_opencode --> sesori_plugin_interface
+  sesori_plugin_opencode --> sesori_shared
+  mobile_app[mobile/app] --> module_core[mobile/module_core]
+  mobile_app --> module_auth[mobile/module_auth]
+  mobile_app --> sesori_shared
+  module_core --> module_auth
+  module_core --> sesori_shared
+  module_auth --> sesori_shared
+```
+
+## Prerequisites
+
+- **Dart 3.11.2** — bridge workspace
+- **Flutter 3.41.4-stable** — mobile workspace
+- **asdf** — recommended for version management
+
+## Getting Started
+
+```sh
+git clone <repo-url>
+cd sesori_apps_monorepo
+
+# Install bridge dependencies
+cd bridge && dart pub get
+
+# Install mobile dependencies
+cd ../mobile && dart pub get
+```
+
+## Workspace Docs
+
+- [bridge/README.md](bridge/README.md) — bridge CLI, plugin system, codegen, and testing
+- [mobile/README.md](mobile/README.md) — Flutter client, module structure, and testing

--- a/bridge/AGENTS.md
+++ b/bridge/AGENTS.md
@@ -1,0 +1,48 @@
+# Bridge Workspace — Agent Rules
+
+## Commands
+
+From `bridge/`:
+- `dart pub get` — install dependencies for the workspace
+- `make codegen` — regenerate Freezed/JSON files across all modules
+- `make test` — run tests in all modules that have a `test/` directory
+- `make analyze` — static analysis across all modules
+
+From `bridge/app/`:
+- `make build` — build all targets (host-native + Linux cross-compiled)
+- `make build-host` — native binary only
+- `make build-linux` — Linux cross-compiled binaries only
+
+## Module Order
+
+Dependencies flow in one direction:
+
+1. `sesori_plugin_interface` — no internal deps; defines the contract
+2. `sesori_plugin_opencode` — depends on interface + `sesori_shared`
+3. `app` — depends on both plugin packages + `sesori_shared`
+
+When changing shared types, update in this order.
+
+## Forbidden
+
+- Don't edit `*.freezed.dart` or `*.g.dart` — these are generated; run `make codegen` instead.
+- Don't modify `sesori_plugin_interface` without checking all implementors (`sesori_plugin_opencode` and any others).
+- Don't add Flutter dependencies — this is a pure Dart workspace.
+- Don't modify `sesori_shared` from here; it lives in the monorepo root and is shared with the mobile app.
+
+## Testing
+
+- `dart test` from `app/` and `sesori_plugin_opencode/`
+- `sesori_plugin_interface` has no tests (it's a contract package)
+
+## Conventions
+
+- Freezed models use `build.yaml` options: `format: false`, `map: false`, `when: false`
+- Plugin implementations must implement all 8 `BridgePlugin` methods — no partial implementations
+- SSE events use sealed classes (see `bridge_sse_event.dart`)
+
+## Definition of Done
+
+- `dart pub get` exits 0
+- `make analyze` exits 0
+- `make test` all pass

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -1,0 +1,75 @@
+# Sesori Bridge
+
+Dart workspace containing the Sesori Bridge CLI and its plugin system. The bridge connects a local OpenCode server to mobile devices over an encrypted WebSocket relay.
+
+## Architecture
+
+Plugin-based design with three modules:
+
+- **`sesori_plugin_interface`** defines the abstract `BridgePlugin` contract. All plugins implement its 8 methods: `getProjects`, `getSessions`, `getSessionMessages`, `healthCheck`, `getProviders`, `getActiveSessionsSummary`, `proxyRequest`, `dispose`.
+- **`sesori_plugin_opencode`** implements that contract for the OpenCode backend.
+- **`app`** orchestrates everything: auth (OAuth PKCE), relay connection, encryption, and request routing. It depends only on the plugin interface, not on any specific implementation.
+
+```
+Phone <--(E2E encrypted)--> Relay Server <--(E2E encrypted)--> Bridge CLI -> [Plugin] -> opencode serve
+```
+
+## Modules
+
+| Module | Description |
+|--------|-------------|
+| `sesori_plugin_interface` | Abstract `BridgePlugin` contract and shared model types |
+| `sesori_plugin_opencode` | OpenCode backend implementation of `BridgePlugin` |
+| `app` | CLI entry point: auth, relay, encryption, request routing |
+
+## Quick Start
+
+```bash
+# Install dependencies for the whole workspace
+dart pub get
+
+# Build a native binary (from bridge/app/)
+make build
+```
+
+## Development Commands
+
+Run these from `bridge/`:
+
+| Command | Description |
+|---------|-------------|
+| `make pub-get` | Run `dart pub get` across all modules |
+| `make codegen` | Run `build_runner` in all modules (generates Freezed/JSON code) |
+| `make test` | Run `dart test` in every module that has a `test/` directory |
+| `make analyze` | Run `dart analyze` across all modules |
+
+## Build Commands
+
+Run these from `bridge/app/`:
+
+| Command | Description |
+|---------|-------------|
+| `make build` | Build all targets: host-native binary + Linux cross-compiled binaries |
+| `make build-host` | Build the native binary for the current OS and architecture |
+| `make build-linux` | Cross-compile Linux binaries for arm, arm64, riscv64, x64 |
+
+Artifacts land in `app/dist/` named `bridge-<os>-<arch>`.
+
+## Security
+
+All traffic between phones and the bridge is end-to-end encrypted. The relay server only sees ciphertext.
+
+| Layer | Algorithm |
+|-------|-----------|
+| Key exchange | X25519 (Diffie-Hellman) |
+| Key derivation | HKDF-SHA256 with info `"sesori-relay-v1"` |
+| Symmetric encryption | XChaCha20-Poly1305 (24-byte nonce) |
+
+See `app/README.md` for the full security and protocol details.
+
+## Adding a New Plugin
+
+1. Create a new Dart package in `bridge/`.
+2. Add `sesori_plugin_interface` as a dependency.
+3. Implement the `BridgePlugin` abstract class — all 8 methods are required.
+4. Register the plugin in the `app` orchestrator (`bin/bridge.dart`).

--- a/bridge/app/README.md
+++ b/bridge/app/README.md
@@ -1,70 +1,70 @@
-# Sesori Bridge (for OpenCode)
+# Sesori Bridge CLI
 
-CLI tool written in Dart, compiled to a native binary, that runs on your laptop to bridge a local [OpenCode](https://github.com/anomalyco/opencode) server to your phone over the internet via an encrypted relay.
+Native CLI tool written in Dart, compiled to a platform binary, that bridges a local OpenCode server to mobile devices over the internet via an encrypted WebSocket relay.
 
-It authenticates with OAuth PKCE, connects to the relay, and routes encrypted traffic between phones and the local server. Uses a plugin-based architecture to support multiple backends.
+It authenticates with OAuth PKCE, spawns `opencode serve`, connects to the relay, performs an X25519 key exchange with each connecting phone, and routes encrypted requests and responses between them. All traffic is end-to-end encrypted; the relay server only ever sees ciphertext.
 
-## Quick start
+## Quick Start
 
 ```bash
-# Build
+# Build a native binary
 make build
 
-# Run the host binary (example for Apple Silicon macOS)
+# Run (example for Apple Silicon macOS)
 ./dist/bridge-macos-arm64
 ```
 
-Press `Ctrl+C` to stop — this shuts down both the bridge and the opencode server it started.
+Press `Ctrl+C` to stop. This shuts down both the bridge and the OpenCode server it started.
 
-Alternatively, use the npm distribution (no Dart SDK required):
+No Dart SDK? Use the npm distribution instead:
 
 ```bash
 npx @sesori/bridge
 ```
 
-## How it works
+## How It Works
 
 ```
 Phone <--(E2E encrypted)--> Relay Server <--(E2E encrypted)--> Bridge CLI -> [OpenCode Plugin] -> opencode serve
 ```
 
-1. Bridge starts `opencode serve` on `127.0.0.1:4096` with a generated password
-2. Bridge authenticates with the auth backend (OAuth PKCE)
-3. Bridge connects to the relay WebSocket, sends auth with role `"bridge"`
-4. Phone connects to the same relay, grouped by userId
-5. Key exchange: phone sends X25519 public key, bridge derives shared secret, sends encrypted ready message containing room key
-6. All subsequent traffic is end-to-end encrypted — the relay cannot read any data
-7. Multiple phones can connect simultaneously (up to 5)
-8. Phone's HTTP requests are decrypted by the bridge and forwarded to the local opencode server
-9. Responses flow back encrypted through the relay to the phone
+1. Bridge starts `opencode serve` on `127.0.0.1:4096` with a generated password.
+2. Bridge authenticates with the auth backend (OAuth PKCE).
+3. Bridge connects to the relay WebSocket with role `"bridge"`.
+4. Phone connects to the same relay, grouped by user ID.
+5. Key exchange: phone sends its X25519 public key; bridge derives a shared secret via HKDF-SHA256 and sends an encrypted ready message containing the room key.
+6. All subsequent traffic is end-to-end encrypted. The relay cannot read any data.
+7. Up to 5 phones can connect simultaneously.
+8. Phone HTTP requests are decrypted by the bridge and forwarded to the local OpenCode server.
+9. Responses flow back encrypted through the relay to the phone.
 
-## CLI flags
+## CLI Flags
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--relay` | `wss://relay.sesori.com` | Relay server URL |
-| `--port` | `4096` | Port for the localhost server (auto-start and `--no-auto-start`) |
+| `--port` | `4096` | Port for the OpenCode server (applies to both auto-start and `--no-auto-start`) |
 | `--password` | *(auto-generated)* | Override the server password |
-| `--opencode-bin` | `opencode` | Path to the opencode binary |
-| `--no-auto-start` | `false` | Don't start opencode server (connect to existing on localhost) |
-| `--auth-backend` | `https://api.sesori.com` | Auth backend URL |
+| `--opencode-bin` | `opencode` | Path to the OpenCode binary |
+| `--no-auto-start` | `false` | Skip spawning OpenCode; connect to an existing server on localhost instead |
+| `--auth-backend` | `https://api.sesori.com` | Auth backend URL (also reads `AUTH_BACKEND_URL` env var) |
 | `--login` | `false` | Force re-login and clear stored tokens |
-| `--debug-port` | *(disabled)* | Start a debug HTTP server on this port (for Postman/curl testing) |
+| `--debug-port` | *(disabled)* | Start a debug HTTP server on this port for Postman/curl testing |
+| `--log-level` | `info` | Minimum log level: `verbose`, `debug`, `info`, `warning`, `error` |
 
 ## Examples
 
 ```bash
-# Replace with your host artifact name as needed, e.g. `bridge-linux-x64`.
 # Use a custom relay server
 ./dist/bridge-macos-arm64 --relay wss://my-relay.example.com
 
-# Connect to an already-running opencode server on port 4096
+# Connect to an already-running OpenCode server on port 4096
 ./dist/bridge-macos-arm64 --no-auto-start --port 4096
 
-# Connect to an already-running opencode server on a custom port
+# Connect to an already-running OpenCode server on a custom port
 ./dist/bridge-macos-arm64 --no-auto-start --port 8080
 
-# Use a custom opencode binary path
+# Use a custom OpenCode binary path
 ./dist/bridge-macos-arm64 --opencode-bin /usr/local/bin/opencode
 
 # Force re-login (clears stored tokens)
@@ -84,77 +84,66 @@ All traffic between phones and the bridge is end-to-end encrypted. The relay ser
 | Key derivation | HKDF-SHA256 with info `"sesori-relay-v1"` |
 | Symmetric encryption | XChaCha20-Poly1305 (24-byte nonce) |
 
-The bridge generates a 32-byte room key on startup. This key is delivered to each phone via DH key exchange and used for all subsequent message encryption.
+The bridge generates a 32-byte room key on startup. Each phone receives this key via the DH key exchange, and all subsequent messages use it for symmetric encryption. Because the bridge generates a fresh ephemeral key pair per session, forward secrecy holds: compromising a long-term key does not expose past session traffic.
 
 ### Password authentication
 
-The bridge generates a 64-character hex password (32 random bytes) and passes it to `opencode serve` via the `OPENCODE_SERVER_PASSWORD` environment variable. The bridge injects `Authorization: Basic` headers into all proxied requests. The password never leaves the local machine.
+The bridge generates a 64-character hex password (32 random bytes) and passes it to `opencode serve` via the `OPENCODE_SERVER_PASSWORD` environment variable. All proxied requests include an `Authorization: Basic` header injected by the bridge. The password never leaves the local machine.
 
-## Process management
+## Process Management
 
-The bridge manages the opencode server process lifecycle:
+The bridge manages the OpenCode server process lifecycle:
 
-- On startup, it spawns `opencode serve` and waits for the health endpoint to respond
-- On `Ctrl+C` (SIGINT) or SIGTERM, it sends SIGTERM to the child process and waits for clean exit
-- On Windows, SIGTERM is not available — the bridge sends SIGKILL directly
-- If the child process exits unexpectedly, the bridge shuts down as well
+- On startup, it spawns `opencode serve` and polls the health endpoint until it responds.
+- On `Ctrl+C` (SIGINT) or SIGTERM, it sends SIGTERM to the child process and waits for a clean exit.
+- On Windows, SIGTERM is unavailable; the bridge sends SIGKILL directly.
+- If the child process exits unexpectedly, the bridge shuts down as well.
+- A 10-second safety timer forces process exit if graceful shutdown stalls.
 
-## Project structure
+## Build
 
-```
-bin/bridge.dart              CLI entry point — flag parsing, auth, plugin loading
-lib/src/bridge/              Core bridge (plugin-agnostic): routing, SSE delivery, relay, orchestrator
-lib/src/auth/                OAuth PKCE login, token persistence, validation
-lib/src/server/              Process management (start/stop/health)
-modules/
-├── sesori_plugin_interface/ Plugin contract (BridgePlugin interface)
-└── opencode_plugin/         OpenCode backend implementation + models + tests
-```
+Requires Dart 3.11+. Run from `bridge/app/`.
 
-The crypto and protocol types live in the `sesori_shared` package, shared with the Flutter mobile app.
+| Command | Description |
+|---------|-------------|
+| `make build` | Build all targets: host-native binary plus Linux cross-compiled binaries |
+| `make build-host` | Build the native binary for the current OS and architecture only |
+| `make build-linux` | Cross-compile Linux binaries for arm, arm64, riscv64, and x64 |
 
-## Architecture
-
-The bridge uses a plugin-based architecture. All backend-specific code lives in plugin packages under `modules/`:
-
-- **`sesori_plugin_interface`** — defines the `BridgePlugin` contract that all plugins implement
-- **`opencode_plugin`** — implements `BridgePlugin` for the OpenCode backend
-
-The bridge core (`lib/src/bridge/`) is backend-agnostic — it only depends on the plugin interface. This enables future support for alternative backends (Codex, Claude Code, etc.) and eventual user-defined dynamic plugins.
-
-## Building from source
-
-Requires Dart 3.11+.
-
-```bash
-make build
-```
-
-This produces:
-
-- one host-native binary named `dist/bridge-<os>-<arch>`
-- Linux cross-compiled binaries in `dist/bridge-linux-<arch>` for the architectures supported by Dart
-
-## Build outputs
-
-`make build` creates the host-native binary plus the supported Linux cross-compiled binaries.
-
-Examples on an Apple Silicon Mac:
+Artifacts land in `dist/` named `bridge-<os>-<arch>`. Example outputs on Apple Silicon macOS:
 
 | Artifact | How it's produced |
-|--------|---------|
-| `dist/bridge-macos-arm64` | native host build |
+|----------|-------------------|
+| `dist/bridge-macos-arm64` | `make build-host` |
 | `dist/bridge-linux-arm` | `make build` |
 | `dist/bridge-linux-arm64` | `make build` |
 | `dist/bridge-linux-riscv64` | `make build` |
 | `dist/bridge-linux-x64` | `make build` |
 
-`dart compile exe` outputs are architecture-specific. This project's `Makefile` names artifacts with both OS and arch to avoid ambiguity.
+## Run
 
-## Related
+```bash
+# From source (requires Dart SDK)
+dart run bin/bridge.dart
 
-- [Sesori Mobile App](https://github.com/sesori-ai/sesori_mobile) — Flutter mobile client
-- [Sesori Relay](https://github.com/sesori-ai/sesori_relay_server) — WebSocket relay server
-- [Sesori Auth Server](https://github.com/sesori-ai/sesori_relay_server) — the remote auth server
-- [sesori_shared](../sesori_shared) — Shared crypto and protocol package
-- [OpenCode (not affiliated with Sesori)](https://github.com/anomalyco/opencode) — the AI coding assistant server
+# Compiled binary
+./dist/bridge-macos-arm64
+./dist/bridge-linux-x64
+```
+
+## Project Structure
+
+```
+bin/bridge.dart       CLI entry point: flag parsing, auth, plugin loading, signal handling
+lib/src/auth/         OAuth PKCE login, token persistence, validation
+lib/src/bridge/       Core bridge (plugin-agnostic): relay client, orchestrator, SSE delivery, debug server
+lib/src/server/       OpenCode process management: start, stop, health polling
+```
+
+The crypto and protocol types live in `sesori_shared`, shared with the Flutter mobile app.
+
+## Testing
+
+```bash
+dart test
+```

--- a/bridge/sesori_plugin_interface/README.md
+++ b/bridge/sesori_plugin_interface/README.md
@@ -1,0 +1,223 @@
+# Sesori Plugin Interface
+
+Defines the abstract `BridgePlugin` contract and the data models that all backend plugins must implement. The bridge core depends only on this package, keeping it decoupled from any specific backend.
+
+## BridgePlugin Interface
+
+Every plugin must implement `BridgePlugin` from `lib/src/bridge_plugin.dart`. The interface has 8 members:
+
+```dart
+abstract class BridgePlugin {
+  /// Unique plugin identifier, e.g. "opencode" or "codex".
+  String get id;
+
+  /// Stream of bridge SSE events. Buffered until the first listener subscribes.
+  Stream<BridgeSseEvent> get events;
+
+  /// Returns the list of projects from the backend.
+  Future<List<PluginProject>> getProjects();
+
+  /// Returns sessions for a worktree directory, with optional pagination.
+  Future<List<PluginSession>> getSessions(String worktree, {int? start, int? limit});
+
+  /// Returns messages for a session (last exchange only).
+  Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId);
+
+  /// Returns the backend's health status as a raw JSON string.
+  Future<String> healthCheck();
+
+  /// Returns providers and their models.
+  /// Pass connectedOnly: true to filter to providers with valid credentials.
+  Future<PluginProvidersResult> getProviders({required bool connectedOnly});
+
+  /// Returns a per-project count of currently active (busy) sessions.
+  List<PluginProjectActivitySummary> getActiveSessionsSummary();
+
+  /// Proxies a raw HTTP request to the backend. Temporary escape hatch.
+  @Deprecated("Temporary proxy — replace with typed plugin methods")
+  Future<({int status, Map<String, String> headers, String? body})> proxyRequest({
+    required String method,
+    required String path,
+    required Map<String, String> headers,
+    String? body,
+  });
+
+  /// Stops the plugin and releases resources (SSE connections, HTTP clients, etc.).
+  Future<void> dispose();
+}
+```
+
+## Data Models
+
+All models are generated with [Freezed](https://pub.dev/packages/freezed) and support JSON serialization.
+
+### Sessions
+
+| Class | Fields |
+|-------|--------|
+| `PluginSession` | `id`, `projectID`, `directory`, `parentID?`, `title?`, `time?`, `summary?` |
+| `PluginSessionTime` | `created`, `updated`, `archived?` |
+| `PluginSessionSummary` | `additions`, `deletions`, `files` |
+
+### Messages
+
+| Class | Fields |
+|-------|--------|
+| `PluginMessage` | `role`, `id`, `sessionID`, `parentID?`, `agent?`, `modelID?`, `providerID?`, `cost?`, `time?`, `finish?` |
+| `PluginMessageWithParts` | `info` (PluginMessage), `parts` (List\<PluginMessagePart\>) |
+| `PluginMessagePart` | `id`, `sessionID`, `messageID`, `type`, `text?`, `tool?`, `callID?`, `state?`, `mime?`, `url?`, `filename?`, `cost?`, `reason?`, `prompt?`, `description?`, `agent?`, `snapshot?`, `time?` |
+| `PluginToolState` | `status`, `title?`, `output?`, `error?` |
+| `PluginMessageTime` | `created`, `completed?` |
+| `PluginPartTime` | `start?`, `end?` |
+
+### Projects
+
+| Class | Fields |
+|-------|--------|
+| `PluginProject` | `id`, `worktree`, `name?`, `time?` |
+| `PluginProjectTime` | `created`, `updated`, `initialized?` |
+| `PluginProjectActivitySummary` | `worktree`, `activeSessions` |
+
+### Providers
+
+`PluginProvider` is a sealed union with named variants for known providers plus a `custom` catch-all. Each variant carries `id`, `name`, `authType`, `models`, and `defaultModelID?`.
+
+| Variant | Factory |
+|---------|---------|
+| Anthropic | `PluginProvider.anthropic(...)` |
+| OpenAI | `PluginProvider.openAI(...)` |
+| Google | `PluginProvider.google(...)` |
+| Mistral | `PluginProvider.mistral(...)` |
+| Groq | `PluginProvider.groq(...)` |
+| xAI | `PluginProvider.xAI(...)` |
+| DeepSeek | `PluginProvider.deepseek(...)` |
+| Amazon Bedrock | `PluginProvider.amazonBedrock(...)` |
+| Azure | `PluginProvider.azure(...)` |
+| Custom | `PluginProvider.custom(...)` |
+
+`PluginProviderAuthType` is an enum: `apiKey`, `oauth`, `unknown`.
+
+`PluginModel` carries `id`, `name`, and `family?`.
+
+`PluginProvidersResult` wraps a `List<PluginProvider>` and is the return type of `getProviders`.
+
+## SSE Events
+
+`BridgeSseEvent` is a sealed class. Plugins emit events on their `events` stream; the bridge core delivers them to connected phones. Events are grouped by category:
+
+### Server
+
+| Class | Notable fields |
+|-------|----------------|
+| `BridgeSseServerConnected` | none |
+| `BridgeSseServerHeartbeat` | none |
+| `BridgeSseServerInstanceDisposed` | `directory?` |
+| `BridgeSseGlobalDisposed` | none |
+
+### Session
+
+| Class | Notable fields |
+|-------|----------------|
+| `BridgeSseSessionCreated` | `info` (raw JSON map) |
+| `BridgeSseSessionUpdated` | `info` |
+| `BridgeSseSessionDeleted` | `info` |
+| `BridgeSseSessionDiff` | `sessionID`, `diff` (list of JSON maps) |
+| `BridgeSseSessionError` | `sessionID` |
+| `BridgeSseSessionCompacted` | `sessionID` |
+| `BridgeSseSessionStatus` | `sessionID`, `status` (raw JSON map) |
+| `BridgeSseSessionIdle` | `sessionID` |
+
+### Message
+
+| Class | Notable fields |
+|-------|----------------|
+| `BridgeSseMessageUpdated` | `info` (raw JSON map) |
+| `BridgeSseMessageRemoved` | `sessionID`, `messageID` |
+| `BridgeSseMessagePartUpdated` | `part` (raw JSON map) |
+| `BridgeSseMessagePartDelta` | `sessionID`, `messageID`, `partID`, `field`, `delta` |
+| `BridgeSseMessagePartRemoved` | `sessionID`, `messageID`, `partID` |
+
+### PTY
+
+| Class | Notable fields |
+|-------|----------------|
+| `BridgeSsePtyCreated` | none |
+| `BridgeSsePtyUpdated` | none |
+| `BridgeSsePtyExited` | `id?`, `exitCode?` |
+| `BridgeSsePtyDeleted` | `id?` |
+
+### Permission and Question
+
+| Class | Notable fields |
+|-------|----------------|
+| `BridgeSsePermissionAsked` | `requestID`, `sessionID`, `tool`, `description` |
+| `BridgeSsePermissionReplied` | `requestID`, `reply` |
+| `BridgeSsePermissionUpdated` | none |
+| `BridgeSseQuestionAsked` | `id`, `sessionID`, `questions` (list of JSON maps) |
+| `BridgeSseQuestionReplied` | `requestID`, `sessionID` |
+| `BridgeSseQuestionRejected` | `requestID`, `sessionID` |
+
+### File, LSP, and MCP
+
+| Class | Notable fields |
+|-------|----------------|
+| `BridgeSseFileEdited` | `file?` |
+| `BridgeSseFileWatcherUpdated` | `file?`, `event?` |
+| `BridgeSseLspUpdated` | none |
+| `BridgeSseLspClientDiagnostics` | `serverID?`, `path?` |
+| `BridgeSseMcpToolsChanged` | none |
+| `BridgeSseMcpBrowserOpenFailed` | none |
+
+### Workspace and Worktree
+
+| Class | Notable fields |
+|-------|----------------|
+| `BridgeSseWorkspaceReady` | `name?` |
+| `BridgeSseWorkspaceFailed` | `message?` |
+| `BridgeSseWorktreeReady` | none |
+| `BridgeSseWorktreeFailed` | none |
+
+### Project and VCS
+
+| Class | Notable fields |
+|-------|----------------|
+| `BridgeSseProjectUpdated` | none |
+| `BridgeSseVcsBranchUpdated` | none |
+| `BridgeSseTodoUpdated` | `sessionID` |
+
+### Installation and UI
+
+| Class | Notable fields |
+|-------|----------------|
+| `BridgeSseInstallationUpdated` | `version?` |
+| `BridgeSseInstallationUpdateAvailable` | `version?` |
+| `BridgeSseTuiToastShow` | `title?`, `message?`, `variant?` |
+
+## Implementing a New Plugin
+
+1. Create a new Dart package in `bridge/`.
+2. Add `sesori_plugin_interface` as a dependency.
+3. Implement `BridgePlugin`. All 8 members are required.
+4. Expose a `Stream<BridgeSseEvent>` on `events`. Use `BufferedUntilFirstListener` from this package to buffer events emitted before the bridge subscribes.
+5. Emit events by adding to the stream as your backend produces them.
+6. Register the plugin in `bridge/app/bin/bridge.dart`.
+
+```dart
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
+
+class MyPlugin implements BridgePlugin {
+  @override
+  String get id => 'my-backend';
+
+  @override
+  Stream<BridgeSseEvent> get events => _buffer.stream;
+
+  // ... implement all 8 methods
+}
+```
+
+## Testing
+
+```bash
+dart test
+```

--- a/bridge/sesori_plugin_opencode/README.md
+++ b/bridge/sesori_plugin_opencode/README.md
@@ -1,0 +1,98 @@
+# Sesori OpenCode Plugin
+
+Implements the `BridgePlugin` interface for the [OpenCode](https://github.com/anomalyco/opencode) backend. Handles HTTP API communication, SSE event parsing, session tracking, and translation of OpenCode-specific types into the shared plugin interface models.
+
+## Architecture
+
+The plugin is layered. Each layer has a single responsibility:
+
+```
+OpenCodePlugin          BridgePlugin implementation — coordinates all layers, maps types
+    |
+OpenCodeService         Coordination — pagination, last-exchange extraction, SSE dispatch
+    |
+OpenCodeRepository      Data access — merges standard and global sessions, builds virtual projects
+    |
+OpenCodeApi             HTTP client — raw requests to the OpenCode REST API
+```
+
+`SseConnection` runs alongside this stack, maintaining a persistent SSE connection to `GET /global/event` and feeding raw event strings to `OpenCodePlugin`. `SseEventParser` translates those strings into typed `SseEventData` objects. `ActiveSessionTracker` watches session status events to maintain a live count of busy sessions per project.
+
+## Key Components
+
+### `OpenCodePlugin`
+
+The main entry point. Implements all 8 `BridgePlugin` methods and wires together the other components.
+
+```dart
+OpenCodePlugin({
+  required String serverUrl,
+  String? password,
+})
+```
+
+On construction it creates the full service stack, starts an `SseConnection`, and performs a cold start to populate the `ActiveSessionTracker`. Its `events` stream is backed by a `BufferedUntilFirstListener` so events emitted before the bridge subscribes are not lost.
+
+Plugin ID: `"opencode"`.
+
+### `SseConnection`
+
+Manages a persistent SSE connection to `GET /global/event` on the OpenCode server. Reconnects automatically with exponential backoff (1s initial, 30s cap). On reconnect, it calls an optional `onReconnect` callback so the plugin can reset and re-sync state.
+
+```dart
+SseConnection({
+  required String targetUrl,
+  required String? password,
+  required void Function(String rawData) onEvent,
+  Future<void> Function()? onReconnect,
+})
+```
+
+Call `start()` to begin streaming and `stop()` to disconnect.
+
+### `SseEventParser`
+
+Translates raw OpenCode SSE data strings into typed `SseEventData` objects. Never throws; on any parse failure it returns a result with a null event so the raw data can still be forwarded.
+
+```dart
+SseParseResult parse(String rawData)
+```
+
+The parser follows OpenCode's event envelope format: it JSON-decodes the string, extracts `payload.type` and `payload.properties`, merges them into `{"type": type, ...properties}`, then deserializes via `SseEventData.fromJson`. The top-level `directory` field, when present, is preserved in the result for use by `ActiveSessionTracker`.
+
+### `ActiveSessionTracker`
+
+Tracks which sessions are currently active (busy or retrying) and maps them back to their project worktrees. Used to power `getActiveSessionsSummary`.
+
+On cold start it fetches all projects and current session statuses from the API. It then updates incrementally as `SseSessionStatus`, `SseSessionCreated`, `SseSessionUpdated`, `SseSessionDeleted`, and `SseSessionIdle` events arrive. `handleEvent` returns `true` when the active session counts change, signaling the plugin to emit a `BridgeSseProjectUpdated` event.
+
+### `OpenCodeApi`
+
+Raw HTTP client for the OpenCode REST API. All methods add `Authorization: Basic` headers when a password is configured.
+
+| Method | Endpoint |
+|--------|----------|
+| `listProjects()` | `GET /project` |
+| `listSessions({directory?})` | `GET /session` |
+| `listRootSessions()` | `GET /session?roots=true` |
+| `listGlobalSessions({directory?, roots?})` | `GET /experimental/session` |
+| `getMessages(sessionId)` | `GET /session/:id/message` |
+| `listProviders()` | `GET /provider` |
+| `getSessionStatuses()` | `GET /session/status` |
+
+### `OpenCodeRepository`
+
+Data access layer that merges OpenCode's standard and global session APIs into a unified view. Key behaviors:
+
+- `getProjects()` fetches both `/project` and `/experimental/session` (roots), merges timestamps, and synthesizes virtual projects for directories that have global sessions but no real project entry.
+- `getSessions(worktree:)` merges standard and global sessions, deduplicates by ID, filters to root sessions under the given worktree, and sorts by `updated` descending.
+
+### `OpenCodeService`
+
+Thin coordination layer sitting between `OpenCodePlugin` and `OpenCodeRepository`. Applies `start` and `limit` pagination to session lists, extracts the last exchange from a message list (from the last user message to the end), and delegates SSE event handling and summary building to `ActiveSessionTracker`.
+
+## Testing
+
+```bash
+dart test
+```

--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -1,64 +1,52 @@
-# Sesori Mobile — Monorepo
+# Mobile Workspace — Agent Rules
 
-Multi-package Dart/Flutter repository for the Sesori mobile ecosystem.
+## Commands
 
-## Repository Structure
-
-```
-sesori_auth/        Pure Dart package — authentication, token lifecycle, OAuth flow
-sesori_dart_core/   Pure Dart package — business logic, services, cubits, models
-sesori_flutter/     Flutter app — UI screens, widgets, routing, platform adapters
-```
-
-Authentication is fully encapsulated in `sesori_auth` behind narrow interfaces (`AuthTokenProvider`, `OAuthFlowProvider`, `AuthSession`). All non-UI business logic lives in `sesori_dart_core`. The Flutter app is a thin shell that provides platform implementations and UI.
-
-## Shared Conventions
-
-- Dart SDK `^3.11.1`
-- Double quotes for all strings consistently
-- `http` package for networking (NOT dio)
-- `rxdart` for reactive streams (`BehaviorSubject`)
-- `get_it` + `injectable` for dependency injection
-  - Services: `@lazySingleton` — single shared instance
-  - Cubits: NOT registered in DI — constructed manually in `BlocProvider(create:)`
-  - Use positional constructor parameters for injectable auto-wiring
-- `freezed` for immutable models — always `sealed class`, `build.yaml` options: `format: false`, `map: false`, `when: false`
-- Errors always logged (`loge`/`logw` from `sesori_dart_core`), never silently swallowed
-
-## Architecture Layering
-
-```
-http.Client <- AuthenticatedHttpApiClient/HttpApiClient <- XyzApi <- 0+ Repository <- 1+ Service <- Cubit <- Widget
+```bash
+dart pub get                                              # from mobile/ — installs all modules
+dart analyze                                              # run per module (app/, module_core/, module_auth/)
+cd app && flutter test                                    # Flutter tests
+cd module_core && dart test                               # pure Dart tests
+cd module_auth && dart test                               # pure Dart tests
+dart run build_runner build --delete-conflicting-outputs  # per module, after modifying annotated classes
 ```
 
-- **DO NOT** inject/use `http.Client` into services/repositories/widgets — only API clients get direct access
-- **ALL** API calls go through an `XyzApi` class
-- **Authenticated API calls** use `AuthenticatedHttpApiClient` (from `sesori_auth`) which auto-injects Bearer tokens and handles 401 retry
-- **Repository** layer only when mixing multiple data sources
-- **Service** layer provides simple APIs for cubits
-- **Cubit** contains UI display logic (lives in `sesori_dart_core`)
-- **Widget** consumes cubits via `BlocProvider` (lives in `sesori_flutter`)
+## Module Dependency Direction
 
-## Authentication Architecture
+```
+app -> module_core -> module_auth -> sesori_shared
+```
 
-Auth is a separate package (`sesori_auth`) with package-boundary enforcement. Internal types are not exported.
+NEVER reverse this. NEVER skip layers. `app` does not import `module_auth` directly.
 
-- **`AuthManager`** (internal) — single owner of token lifecycle, OAuth flow, and auth state. Implements all 3 interfaces.
-- **`AuthTokenProvider`** — read-only fresh token access. Injected by `ConnectionService` for relay WebSocket auth.
-- **`OAuthFlowProvider`** — drives OAuth login (PKCE + code exchange). Injected by `LoginCubit`.
-- **`AuthSession`** — auth state stream + logout + getCurrentUser. Injected by `AuthRedirectService`, `ConnectionOverlayCubit`.
-- **`AuthenticatedHttpApiClient`** — HTTP decorator that adds Bearer token + 401 retry. Injected by `VoiceApi`.
+## Forbidden
 
-DI initialization order: **Flutter platform** (SecureStorage, etc.) → **`configureAuthDependencies`** → **`configureCoreDependencies`**
+- `module_core` MUST NOT import `package:flutter`. It is pure Dart.
+- `module_auth` MUST NOT import `module_core`.
+- Do NOT edit `*.freezed.dart`, `*.g.dart`, or `*.config.dart` — these are generated.
 
-## Testing
+## DI
 
-- Unit test all non-widget code. Use `mocktail`.
-- Never use `getIt<...>()` outside widget code — inject via constructor for testability
-- Core package tests use `package:test`; Flutter app tests use `package:flutter_test`
+3-phase init in `app/lib/core/di/injection.dart`:
 
-## Per-Package Details
+1. `getIt.init()` — Flutter platform deps
+2. `configureAuthDependencies(getIt)` — auth module
+3. `configureCoreDependencies(getIt)` — core module
 
-- [`sesori_auth/AGENTS.md`](sesori_auth/AGENTS.md) — auth package conventions, public API surface
-- [`sesori_dart_core/AGENTS.md`](sesori_dart_core/AGENTS.md) — pure Dart conventions, package structure
-- [`sesori_flutter/AGENTS.md`](sesori_flutter/AGENTS.md) — Flutter-specific conventions, UI patterns
+New services register in their module's `configure*Dependencies()` function, not in `app/`.
+
+## State Management
+
+BLoC/Cubit only. New features: add a Cubit in `module_core/`, add a UI widget in `app/`. Cubits are NOT registered in DI — construct them in `BlocProvider(create:)`.
+
+## Definition of Done
+
+- `dart pub get` exits 0 from `mobile/`
+- `dart analyze` exits 0 in all three modules
+- All tests pass (`flutter test` for `app/`, `dart test` for `module_core/` and `module_auth/`)
+
+## Per-Module Details
+
+- [`app/AGENTS.md`](app/AGENTS.md) — Flutter shell conventions, routing, widget patterns
+- [`module_core/AGENTS.md`](module_core/AGENTS.md) — pure Dart conventions, cubit/service patterns
+- [`module_auth/AGENTS.md`](module_auth/AGENTS.md) — auth package public API, token lifecycle

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,103 +1,94 @@
 # Sesori Mobile
 
-Monorepo for the Sesori mobile ecosystem. Connect to a running [OpenCode](https://github.com/anomalyco/opencode) server on your laptop via the encrypted relay and manage your coding sessions from your phone.
+Flutter workspace containing the Sesori mobile client — an app that connects to the Bridge to interact with AI coding sessions on the go.
 
-## Packages
+## Modules
 
-| Package | Description |
-|---------|-------------|
-| [`sesori_auth`](sesori_auth/) | Authentication — token lifecycle, OAuth flow, authenticated HTTP client. Pure Dart. |
-| [`sesori_dart_core`](sesori_dart_core/) | Pure Dart business logic — cubits, services, models, API clients. No Flutter dependency. |
-| [`sesori_flutter`](sesori_flutter/) | Flutter UI shell — screens, widgets, routing, platform adapters. |
+| Module | Purpose |
+|--------|---------|
+| `app/` | Flutter UI shell. Screens, routing, DI setup, platform adapters. All business logic delegates to `module_core`. |
+| `module_core/` | Pure Dart business logic. Zero Flutter dependency. Cubits, services, relay client, platform interfaces. |
+| `module_auth/` | Authentication. OAuth PKCE flow, token refresh, authenticated HTTP client. |
 
 ## Architecture
 
+**Dependency direction**: `app` -> `module_core` -> `module_auth` -> `sesori_shared`. Never reverse, never skip layers.
+
 ```
-sesori_auth/          Authentication — standalone pure Dart package
-  lib/src/
-  ├── client/         AuthenticatedHttpApiClient (Bearer token decorator)
-  ├── interfaces/     AuthTokenProvider, OAuthFlowProvider, AuthSession
-  ├── models/         AuthState (freezed)
-  ├── platform/       SecureStorage abstract interface
-  ├── storage/        TokenStorageService, OAuthStorageService (internal)
-  └── di/             Auth DI configuration
-
-sesori_dart_core/     Pure Dart — shared by Flutter app and future CLI/TUI
-  lib/src/
-  ├── api/            HTTP clients (base, relay-routed), models, converters, parsing
-  ├── capabilities/   Relay, server connection, project, session, voice API
-  ├── concurrency/    Isolate pool, message queue, concurrent cache
-  ├── cubits/         All state management (login, project_list, session_list, etc.)
-  ├── di/             Core DI configuration (@InjectableInit)
-  ├── extensions/     Dart utility extensions
-  ├── logging/        logd/logw/loge helpers with configurable LogLevel
-  ├── platform/       Abstract interfaces (UrlLauncher, DeepLinkSource, LifecycleSource)
-  ├── reporting/      Error reporting
-  └── routing/        AppRoute enum, AuthRedirectService
-
-sesori_flutter/       Flutter UI shell
+app/
   lib/
-  ├── capabilities/   Voice recording subsystem (Flutter-specific)
   ├── core/
-  │   ├── di/         Flutter DI (registers platform adapters, calls auth + core init)
-  │   ├── extensions/ BuildContext extensions (localization)
-  │   ├── platform/   Platform adapters (FlutterSecureStorageAdapter, etc.)
+  │   ├── di/         DI setup — 3-phase init (platform → auth → core)
   │   ├── routing/    GoRouter routes, deep link handling
-  │   └── widgets/    Shared widgets (connection overlay, modal sheets)
-  ├── features/       Screens (login, project_list, session_list, session_detail)
-  └── l10n/           Localization (English)
+  │   └── widgets/    Shared widgets (ConnectionOverlay, modal sheets)
+  └── features/       Screens: Login, ProjectList, SessionList, SessionDetail
+
+module_core/
+  lib/src/
+  ├── cubits/         LoginCubit, ProjectListCubit, SessionListCubit, SessionDetailCubit, ConnectionOverlayCubit
+  ├── services/       ProjectService, SessionService, ConnectionService
+  ├── relay/          RelayClient (WebSocket relay connection)
+  └── platform/       Abstract interfaces (UrlLauncher, DeepLinkSource, LifecycleSource)
+
+module_auth/
+  lib/src/
+  ├── auth_manager/   AuthManager — owns token lifecycle, OAuth flow, auth state
+  ├── client/         AuthenticatedHttpApiClient (Bearer token + 401 retry)
+  ├── interfaces/     AuthTokenProvider, OAuthFlowProvider, AuthSession
+  └── storage/        TokenStorageService
 ```
 
-## Relay connection
+### DI initialization (3 phases)
 
-Sign in with your GitHub or Google account. The [Sesori Bridge CLI](https://github.com/sesori-ai/sesori_bridge) running on your laptop authenticates with the same account — the relay automatically groups both ends by account, so no QR code is needed. All traffic is end-to-end encrypted through the relay; the relay cannot read any data.
+Defined in `app/lib/core/di/injection.dart`, called once from `main()`:
 
-```
-Phone ←──(E2E encrypted)──→ Relay Server ←──(E2E encrypted)──→ Bridge CLI → OpenCode server (localhost)
-```
+1. `getIt.init()` — Flutter platform deps (SecureStorage, http.Client, platform adapters)
+2. `configureAuthDependencies(getIt)` — auth module deps
+3. `configureCoreDependencies(getIt)` — core module deps
+
+### State management
+
+BLoC/Cubit throughout. Cubits live in `module_core` (pure Dart, testable without Flutter). Widgets in `app/` consume them via `BlocProvider`.
+
+### Authentication
+
+`AuthManager` in `module_auth` is the single owner of token state. It implements three narrow interfaces consumed by the rest of the app:
+
+- `AuthTokenProvider` — fresh token access for WebSocket auth
+- `OAuthFlowProvider` — drives OAuth PKCE login
+- `AuthSession` — auth state stream, logout, current user
+
+## Prerequisites
+
+- Flutter 3.41.4-stable via [asdf](https://asdf-vm.com/) (`.tool-versions` at workspace root)
 
 ## Getting started
 
-### Prerequisites
-
-- Flutter SDK (Dart `^3.11.1`)
-- iOS or Android device/emulator
-- A running OpenCode server (local or via Sesori Bridge CLI)
-
-### Run
-
 ```bash
-cd sesori_flutter
-flutter pub get
-dart run build_runner build
-flutter run
+# Install dependencies for all modules
+dart pub get   # run from mobile/
+
+# Run the app
+cd app && flutter run
 ```
 
-### Test
+## Testing
 
 ```bash
-# Auth package
-cd sesori_auth && dart test
-
-# Core package
-cd sesori_dart_core && dart test
-
-# Flutter app
-cd sesori_flutter && flutter test
+cd app && flutter test
+cd module_core && dart test
+cd module_auth && dart test
 ```
 
-### Code generation
+## Code generation
 
-All three packages use `freezed` for immutable models and `injectable` for DI. After modifying annotated classes:
+After modifying `freezed` models or `injectable`-annotated classes, run from each affected module:
 
 ```bash
-cd sesori_auth && dart run build_runner build
-cd sesori_dart_core && dart run build_runner build
-cd sesori_flutter && dart run build_runner build
+dart run build_runner build --delete-conflicting-outputs
 ```
 
 ## Related
 
-- [Sesori Bridge CLI](https://github.com/sesori-ai/sesori_bridge) — laptop-side bridge
+- [Sesori Bridge](https://github.com/sesori-ai/sesori_bridge) — laptop-side CLI that connects to OpenCode
 - [Sesori Relay Server](https://github.com/sesori-ai/sesori_relay_server) — WebSocket relay
-- [OpenCode (not affiliated with Sesori)](https://github.com/anomalyco/opencode) — the AI coding assistant

--- a/mobile/app/README.md
+++ b/mobile/app/README.md
@@ -1,10 +1,49 @@
-# sesori_flutter
+# Sesori Mobile App
 
-Flutter UI shell for the Sesori mobile client. Provides screens, widgets, routing, and platform adapter implementations. All business logic lives in [`sesori_dart_core`](../sesori_dart_core/).
+Flutter UI shell providing screens, navigation, and platform adapters for the Sesori mobile client. All business logic lives in [`module_core`](../module_core/).
 
 See the [root README](../README.md) for the full monorepo overview.
 
-## Run
+## Screens
+
+| Screen | Description |
+|--------|-------------|
+| `LoginScreen` | OAuth sign-in entry point, handles deep link callback |
+| `ProjectListScreen` | Lists available projects for the authenticated user |
+| `SessionListScreen` | Lists sessions for a selected project |
+| `SessionDetailScreen` | Full session view with message thread, voice input, and live updates |
+
+## Key Components
+
+**Routing**
+
+`AppRouter` (`app_router.dart`) — `go_router`-based router built from `AppRoute` enum values defined in `module_core`. Handles session restore on startup and suppresses deep link URIs that `app_links` processes separately.
+
+**Dependency Injection**
+
+Three-phase init in `configureDependencies()`:
+1. Flutter platform adapters (`getIt.init()`)
+2. `configureAuthDependencies(getIt)` — auth module
+3. `configureCoreDependencies(getIt)` — core module
+
+**Platform Adapters**
+
+| Adapter | Interface |
+|---------|-----------|
+| `FlutterSecureStorageAdapter` | `SecureStorage` |
+| `FlutterUrlLauncher` | `UrlLauncher` |
+| `AppLifecycleObserver` | `LifecycleSource` |
+| `DeepLinkSource` (app_links) | `DeepLinkSource` |
+
+**Widgets**
+
+`ConnectionOverlay` — wraps the app and shows connection status banners driven by `ConnectionOverlayCubit`.
+
+**Voice Features**
+
+`VoiceTranscriptionService` — records audio via the `record` package and submits to the voice API. `WakeLockService` — keeps the screen on during active sessions using `wakelock_plus`.
+
+## Running
 
 ```bash
 flutter pub get
@@ -12,17 +51,30 @@ dart run build_runner build
 flutter run
 ```
 
-## Tech stack
+## Testing
+
+```bash
+flutter test
+```
+
+## Adding a New Screen
+
+1. Create a `Cubit` (and state) in `module_core/lib/src/cubits/`
+2. Create the screen widget in `app/lib/features/<feature>/`
+3. Add a new value to `AppRoute` in `module_core` and handle it in `AppRouter.toGoRoute()`
+4. Register any new DI bindings in the appropriate module's `injection.dart`
+
+## Tech Stack
 
 | Concern | Library |
 |---------|---------|
-| State management (widgets) | `flutter_bloc` (`BlocProvider`, `context.watch`) |
+| State management | `flutter_bloc` |
 | Dependency injection | `get_it` + `injectable` |
 | Navigation | `go_router` |
-| Relay encryption (accelerated) | `cryptography_flutter` |
 | Secure storage | `flutter_secure_storage` |
 | Deep links | `app_links` |
 | URL launching | `url_launcher` |
 | Audio recording | `record` |
 | Wake lock | `wakelock_plus` |
+| Relay encryption (accelerated) | `cryptography_flutter` |
 | Markdown rendering | `flutter_markdown_plus` |

--- a/mobile/module_auth/README.md
+++ b/mobile/module_auth/README.md
@@ -1,0 +1,79 @@
+# Sesori Auth (sesori_auth)
+
+Authentication package handling OAuth flow, token lifecycle, and authenticated HTTP client. Pure Dart — no Flutter dependency.
+
+See the [root README](../README.md) for the full monorepo overview.
+
+## Key Components
+
+**`AuthManager`**
+
+Central auth coordinator. Implements `AuthTokenProvider`, `OAuthFlowProvider`, and `AuthSession`.
+
+- `authStateStream` — `Stream<AuthState>` broadcasting current auth state
+- `currentState` — synchronous snapshot of the current `AuthState`
+- `getFreshAccessToken({Duration minTtl, bool forceRefresh})` — returns a valid access token, refreshing proactively when TTL drops below 90 seconds and blocking when below `minTtl` (default 30s). Deduplicates concurrent refresh calls.
+- `getAuthorizationUrl(OAuthProvider provider, String redirectUri)` — generates PKCE verifier/challenge, persists them, and returns the provider's authorization URL
+- `exchangeCode({String code, String state, String redirectUri})` — completes the PKCE flow, persists tokens, emits `AuthState.authenticated`
+- `getCurrentUser()` — fetches `/auth/me` with a fresh token
+- `invalidateAllSessions()` — calls `/auth/logout`, clears all stored tokens, emits `AuthState.unauthenticated`
+- `logoutCurrentDevice()` — clears local tokens only, emits `AuthState.unauthenticated`
+
+**`AuthenticatedHttpApiClient`**
+
+Decorates `HttpApiClient` with bearer token injection and automatic one-time retry on 401. Implements `SafeApiClient` (GET, POST, PATCH, DELETE, multipart POST).
+
+**`TokenStorageService` / `OAuthStorageService`**
+
+Internal services for persisting access/refresh tokens and PKCE state via the `SecureStorage` platform interface.
+
+**`AuthState`**
+
+Freezed sealed class with four variants:
+
+```dart
+AuthState.unauthenticated()
+AuthState.authenticating()
+AuthState.authenticated(user: AuthUser)
+AuthState.failed(error: String)
+```
+
+**`ApiResponse<T>`**
+
+Freezed sealed class wrapping all HTTP results:
+
+```dart
+ApiResponse.success(T data)   // SuccessResponse<T>
+ApiResponse.error(ApiError)   // ErrorResponse<T>
+```
+
+**`ApiError`**
+
+Freezed sealed class for typed error handling:
+
+| Variant | When |
+|---------|------|
+| `JsonParsingError` | Response body failed to parse |
+| `DartHttpClientError` | Network-level failure |
+| `NonSuccessCodeError` | HTTP status outside 2xx |
+| `NotAuthenticatedError` | No valid token available |
+| `GenericError` | Unclassified failure |
+
+## DI Registration
+
+```dart
+import "package:sesori_auth/sesori_auth.dart";
+
+// Phase 2 of 3-phase init — after platform adapters, before core:
+configureAuthDependencies(getIt);
+```
+
+Platform adapters (`SecureStorage`, `http.Client`) must be registered before calling this. `configureCoreDependencies` must be called after.
+
+## Testing
+
+```bash
+dart test
+```
+
+Pure Dart — no Flutter toolchain needed.

--- a/mobile/module_core/README.md
+++ b/mobile/module_core/README.md
@@ -1,41 +1,73 @@
-# sesori_dart_core
+# Sesori Core (sesori_dart_core)
 
-Pure Dart package containing all business logic, state management, services, and models for the Sesori ecosystem. Zero Flutter SDK dependency — shared by the Flutter app and future CLI/TUI tools.
+Pure Dart package containing all business logic, state management, services, and platform interfaces for the Sesori mobile client. Zero Flutter dependency — can be used from the Flutter app, a CLI, or any Dart environment.
 
 See the [root README](../README.md) for the full monorepo overview.
 
-## Usage
+## Key Exports
 
-Add as a path dependency:
+**Cubits**
 
-```yaml
-dependencies:
-  sesori_dart_core:
-    path: ../sesori_dart_core
-```
+| Cubit | Purpose |
+|-------|---------|
+| `LoginCubit` | OAuth sign-in flow, session restore |
+| `ProjectListCubit` | Fetches and holds the project list |
+| `SessionListCubit` | Fetches sessions for a project |
+| `SessionDetailCubit` | Manages live session state, messages, and SSE updates |
+| `ConnectionOverlayCubit` | Tracks relay connection status for the overlay widget |
 
-Initialize from your platform entry point:
+**Services**
+
+| Service | Purpose |
+|---------|---------|
+| `ProjectService` | CRUD operations for projects |
+| `SessionService` | Session creation, listing, and message fetching |
+| `ConnectionService` | Manages the relay WebSocket lifecycle |
+| `RelayClient` | Low-level relay WebSocket client with E2E encryption |
+| `SseEventRepository` | Buffers and dispatches SSE events from the relay |
+
+**Concurrency** (re-exported from `sesori_shared`)
+
+`SingleTaskIsolate`, `MultiTaskIsolate` — typed isolate wrappers with persistent and transient pool variants. `ConcurrentCache` — async-safe cache with per-key locking.
+
+**Platform Interfaces**
+
+These abstract interfaces are defined here and implemented by Flutter adapters in `app/lib/core/platform/`:
+
+| Interface | Flutter Adapter |
+|-----------|----------------|
+| `SecureStorage` | `FlutterSecureStorageAdapter` |
+| `UrlLauncher` | `FlutterUrlLauncher` |
+| `DeepLinkSource` | `DeepLinkSource` (app_links) |
+| `LifecycleSource` | `AppLifecycleObserver` |
+
+**Routing**
+
+`AppRoute` — enum of all named routes with path builders. `AuthRedirectService` — checks token state on startup to decide whether to skip the login screen.
+
+**Logging**
+
+`logd` / `logw` / `loge` — structured log helpers with a configurable `LogLevel`.
+
+## DI Registration
 
 ```dart
 import "package:sesori_dart_core/sesori_dart_core.dart";
 
-// Register platform implementations first (SecureStorage, UrlLauncher, etc.)
-// Then initialize core DI:
+// Must be called after platform adapters and auth module are registered:
 configureCoreDependencies(getIt);
 ```
 
-## What's inside
+The auth module (`configureAuthDependencies`) must be initialized first. The full three-phase order is in `app/lib/core/di/injection.dart`.
 
-- **Cubits** — login, project list, session list, session detail, connection overlay
-- **Services** — auth, project, session, voice API, connection management, relay client
-- **API layer** — HTTP clients (direct + relay-routed), models, converters, JSON parsing
-- **Models** — auth state, connection status, SSE events, server config
-- **Concurrency** — isolate pool, message queue, concurrent cache
-- **Platform interfaces** — `SecureStorage`, `UrlLauncher`, `DeepLinkSource`
-- **Logging** — `logd`/`logw`/`loge` with configurable `LogLevel`
-
-## Test
+## Testing
 
 ```bash
 dart test
 ```
+
+Pure Dart — no Flutter toolchain needed.
+
+## Important
+
+This module must not import `package:flutter`. Any Flutter-specific code belongs in `app/`. If you need a new platform capability, define an abstract interface here and implement it as a Flutter adapter in `app/lib/core/platform/`.

--- a/shared/sesori_shared/README.md
+++ b/shared/sesori_shared/README.md
@@ -1,24 +1,64 @@
 # Sesori Shared
 
-Shared Dart package containing the crypto primitives and protocol types for the Sesori relay system. Used by both `sesori_bridge_dart` and `sesori_mobile` to avoid duplicating core logic.
+Shared Dart package containing crypto primitives, relay protocol types, data models, and concurrency utilities. Used by both the bridge (`sesori_bridge_dart`) and the mobile client (`sesori_apps_monorepo`). Changes here affect both consumers.
 
-## What it exports
+## Crypto
 
-**Crypto**
+**`RelayCryptoService`**
 
-- `RelayCryptoService` — X25519 key generation, HKDF-SHA256 key derivation, XChaCha20-Poly1305 encryption/decryption
-- `SessionEncryptor` — stateful encryptor tied to a derived session key
+- X25519 key pair generation
+- HKDF-SHA256 session key derivation
+- XChaCha20-Poly1305 encrypt/decrypt
 
-**Protocol**
+**`SessionEncryptor`**
 
-- `RelayMessage` — Freezed sealed class with 11 message variants (`request`, `response`, `sseEvent`, `sseSubscribe`, `sseUnsubscribe`, `keyExchange`, `ready`, `resume`, `resumeAck`, `rekeyRequired`, `auth`)
-- `frame` / `unframe` — binary framing with version byte prefix for WebSocket transport
-- Protocol constants (message type strings, role identifiers)
-- Close codes
+Stateful encryptor bound to a derived session key. Wraps `RelayCryptoService` for use within an established relay session.
 
-## Adding as a dependency
+## Protocol
 
-In your `pubspec.yaml`:
+**`RelayMessage`**
+
+Freezed sealed class with 11 variants:
+
+| Variant | Direction |
+|---------|-----------|
+| `request` | Mobile to bridge |
+| `response` | Bridge to mobile |
+| `sseEvent` | Bridge to mobile |
+| `sseSubscribe` | Mobile to bridge |
+| `sseUnsubscribe` | Mobile to bridge |
+| `keyExchange` | Both |
+| `ready` | Relay to client |
+| `resume` | Client to relay |
+| `resumeAck` | Relay to client |
+| `rekeyRequired` | Relay to client |
+| `auth` | Client to relay |
+
+**`frame` / `unframe`**
+
+Binary WebSocket framing with a version byte prefix. Used by both ends of the relay connection.
+
+Protocol constants (message type strings, role identifiers) and close codes are also exported.
+
+## Data Models
+
+**Auth**
+
+`AuthUser`, `AuthResponse`, `AuthUrlResponse`, `AuthMeResponse`, `LogoutResponse`
+
+**Sesori**
+
+`Project`, `Session`, `Message`, `MessagePart`, `MessageWithParts`, `Question`, `AgentInfo`, `AgentMode`, `ProviderInfo`, `SessionStatus`, `HealthResponse`, `FileDiff`, `ProjectActivitySummary`, `SesoriSseEvent`
+
+## Concurrency
+
+`ConcurrentCache` — async-safe cache with per-key locking to prevent duplicate concurrent fetches.
+
+`EventQueue` — ordered async event dispatcher.
+
+`SingleTaskIsolate` / `MultiTaskIsolate` — typed isolate wrappers with persistent and transient pool variants. Constructed via factory constructors that select the right implementation based on `minPoolSize`/`maxPoolSize`.
+
+## Adding as a Dependency
 
 ```yaml
 dependencies:
@@ -32,4 +72,4 @@ Then run `dart pub get`.
 
 Pure Dart — no Flutter dependency. Works in any Dart environment including native binaries and Flutter apps.
 
-The package requires Dart 3.8+ for sealed class support and the `freezed` code generation output.
+Requires Dart 3.8.0 or later (sealed class support, `freezed` generated output).


### PR DESCRIPTION
## Summary

Adds comprehensive documentation across the monorepo: root-level overview, workspace-level docs for bridge and mobile, and module-level READMEs for all 7 modules.

## Files (13 total)

### New
- `README.md` — Monorepo overview with structure, dependency graph, and getting started
- `AGENTS.md` — Cross-cutting AI agent rules (60 lines)
- `bridge/README.md` — Bridge workspace overview, architecture, commands
- `bridge/AGENTS.md` — Bridge-specific agent rules (48 lines)
- `mobile/README.md` — Mobile workspace overview, architecture, DI flow
- `bridge/sesori_plugin_interface/README.md` — Plugin contract with 8 method signatures, SSE events, data models
- `bridge/sesori_plugin_opencode/README.md` — OpenCode plugin architecture and components
- `mobile/module_auth/README.md` — Auth module: AuthManager, OAuth, HTTP client

### Rewritten
- `mobile/AGENTS.md` — Restructured for hierarchy consistency (52 lines)
- `bridge/app/README.md` — CLI docs with flags, security model, build commands
- `mobile/app/README.md` — Flutter app screens, components, adding new screens
- `mobile/module_core/README.md` — Core module exports, platform interfaces, DI
- `shared/sesori_shared/README.md` — Crypto, protocol, data models

## AGENTS.md Hierarchy

- **Root** (≤80 lines): cross-cutting conventions — workspaces, git, generated files, analysis
- **Workspace** (≤60 lines): workspace-specific commands, module ordering, forbidden zones
- **Module** (existing, untouched): package-specific conventions

No content duplication between levels.