### PR TITLE
feat: fix real-time project activity tracking and add session activity indicators

### DIFF
--- a/.sisyphus/boulder.json
+++ b/.sisyphus/boulder.json
@@ -1,0 +1,6 @@
+{
+  "active_plan": "/Users/alexandrudochioiu/sesori-ai/sesori_apps_monorepo/.sisyphus/plans/fix-activity-tracking.md",
+  "started_at": "2026-03-20T12:00:00Z",
+  "session_ids": ["current"],
+  "plan_name": "fix-activity-tracking"
+}

--- a/.sisyphus/plans/fix-activity-tracking.md
+++ b/.sisyphus/plans/fix-activity-tracking.md
@@ -1,0 +1,812 @@
+# Fix Real-Time Activity Tracking + Session Activity Indicators
+
+## TL;DR
+
+> **Quick Summary**: Fix the bug where project activity indicators don't refresh in real-time (orchestrator sends empty signal instead of data payload), and add session-level activity indicators in the session list screen by enriching the existing `ProjectActivitySummary` with active session IDs.
+>
+> **Deliverables**:
+> - Real-time project activity updates work without pull-to-refresh
+> - Session list shows which sessions are currently running (green dot + "Running" label)
+> - Same SSE event (`projects.summary`) carries both project and session activity data
+>
+> **Estimated Effort**: Medium
+> **Parallel Execution**: YES — 4 waves
+> **Critical Path**: T1 → T2/T3/T4 → T5 → T7
+
+---
+
+## Context
+
+### Original Request
+Active project indicators don't refresh in real-time — UI shows stale "active" state until pull-to-refresh. Additionally, the session list screen should show which sessions are currently running, similar to how the project list shows active project indicators.
+
+### Interview Summary
+**Key Discussions**:
+- User confirmed the same SSE response should carry both project and session activity data
+- Tests after implementation strategy agreed
+
+**Research Findings**:
+- **Root cause identified**: When session status changes, bridge emits `BridgeSseProjectUpdated()` (empty signal) → orchestrator maps to `SesoriSseEvent.projectUpdated()` (still empty) → mobile `SseEventRepository` only handles `SesoriProjectsSummary` (with data) → update silently dropped
+- **Initial load works** because orchestrator explicitly builds full `projectsSummary` on SSE subscribe (orchestrator.dart:447-458)
+- **`ActiveSessionTracker`** already tracks session IDs internally via `_sessionStatuses` map — just needs to expose them in `buildSummary()`
+- **`PluginProjectActivitySummary`** (bridge interface) must stay in sync with shared `ProjectActivitySummary`
+- **Dual emission source**: `BridgeSseProjectUpdated` is emitted both from activity changes AND `SseProjectUpdated` mapping — converting both to `projectsSummary` is correct since mobile ignores `projectUpdated` anyway
+
+### Metis Review
+**Identified Gaps** (addressed):
+- **Build order**: Codegen must run in dependency order: `shared/sesori_shared` → `bridge/` → `mobile/`
+- **Change detection gap**: `_mapsEqual` compares counts only — if session A→idle and session B→busy simultaneously, count unchanged, no event. Accepted for V1
+- **No orchestrator tests**: Mapping layer is currently untested — should add tests as part of this work
+- **Dual `BridgeSseProjectUpdated` semantic**: Converting all to `projectsSummary` loses the "project metadata changed" semantic. Documented in code comment — no mobile consumer needs it
+
+---
+
+## Work Objectives
+
+### Core Objective
+Fix the real-time project activity bug and add session-level activity indicators to the session list, using the same `projects.summary` SSE event.
+
+### Concrete Deliverables
+- `ProjectActivitySummary` model enriched with `activeSessionIds: List<String>`
+- Orchestrator sends full `projectsSummary` event on activity changes (instead of empty `projectUpdated`)
+- Session list UI shows green dot + "Running" label for active sessions
+- Updated tests for `ActiveSessionTracker.buildSummary()` and new `SseEventRepository` session activity
+
+### Definition of Done
+- [ ] `dart analyze` passes in all workspaces: `shared/sesori_shared`, `bridge/` (all modules), `mobile/` (all modules)
+- [ ] `make test` from `bridge/` passes
+- [ ] `dart test` from `mobile/module_core` passes
+- [ ] Active project indicators refresh in real-time when sessions start/stop (no pull-to-refresh needed)
+- [ ] Session list shows running indicator for busy sessions
+
+### Must Have
+- Follow the exact mapping pattern from orchestrator initial-subscribe handler (lines 447-456)
+- Codegen run in dependency order: shared → bridge → mobile
+
+### Must NOT Have (Guardrails)
+- Do NOT change `ActiveSessionTracker.handleEvent()` return logic or `_mapsEqual` comparison — count-based change detection is correct for V1
+- Do NOT add new `BridgeSseEvent` variants — enrich existing mapping, not event protocol
+- Do NOT change `_emitProjectsSummary()` in `opencode_plugin_impl.dart` — it correctly emits `BridgeSseProjectUpdated()` as trigger
+- Do NOT add `distinct()` or equality operators to the `BehaviorSubject` in `SseEventRepository`
+- Do NOT include session status types (busy/retry) in the payload — only IDs
+- Do NOT add animations or complex UI for the indicator — simple green dot + text, matching project list pattern
+- Do NOT modify `ActiveSessionTracker._handleEvent` switch cases or `_resolveWorktree` logic
+
+---
+
+## Verification Strategy
+
+> **ZERO HUMAN INTERVENTION** — ALL verification is agent-executed. No exceptions.
+
+### Test Decision
+- **Infrastructure exists**: YES (dart test, flutter test, existing test files)
+- **Automated tests**: Tests-after
+- **Framework**: dart test (bridge + mobile/module_core), flutter test (mobile/app)
+
+### QA Policy
+Every task MUST include agent-executed QA scenarios.
+Evidence saved to `.sisyphus/evidence/task-{N}-{scenario-slug}.{ext}`.
+
+- **Model/Shared**: Use Bash (dart test) — Run tests, verify JSON roundtrip
+- **Bridge**: Use Bash (dart test + dart analyze) — Run tests, verify mapping
+- **Mobile cubit**: Use Bash (dart test) — Run cubit tests
+- **Mobile UI**: Use Bash (dart analyze + flutter test) — Verify compilation and analysis
+
+---
+
+## Execution Strategy
+
+### Parallel Execution Waves
+
+```
+Wave 1 (Foundation — models + codegen):
+└── Task 1: Shared + bridge interface models [quick]
+
+Wave 2 (Core implementation — MAX PARALLEL after Wave 1):
+├── Task 2: Bridge tracker + plugin (expose session IDs) [quick]
+├── Task 3: Bridge orchestrator fix (projectsSummary mapping) [quick]
+└── Task 4: Mobile SseEventRepository (session activity stream) [quick]
+
+Wave 3 (Consumers + bridge tests — parallel after Wave 2):
+├── Task 5: Mobile SessionListCubit + state (subscribe to activity) [quick]
+└── Task 6: Bridge tests (tracker + orchestrator) [unspecified-high]
+
+Wave 4 (UI + mobile tests — parallel after Wave 3):
+├── Task 7: Session list UI (activity indicator) [visual-engineering]
+└── Task 8: Mobile tests (repository + cubit) [quick]
+
+Wave FINAL (After ALL tasks — parallel reviews, then user okay):
+├── Task F1: Plan compliance audit (oracle)
+├── Task F2: Code quality review (unspecified-high)
+├── Task F3: Real manual QA (unspecified-high)
+└── Task F4: Scope fidelity check (deep)
+-> Present results -> Get explicit user okay
+
+Critical Path: T1 → T3 → T5 → T7 → F1-F4 → user okay
+Parallel Speedup: ~50% faster than sequential
+Max Concurrent: 3 (Wave 2)
+```
+
+### Dependency Matrix
+
+| Task | Depends On | Blocks |
+|------|-----------|--------|
+| T1 | — | T2, T3, T4 |
+| T2 | T1 | T6 |
+| T3 | T1 | T6 |
+| T4 | T1 | T5 |
+| T5 | T4 | T7, T8 |
+| T6 | T2, T3 | — |
+| T7 | T5 | — |
+| T8 | T5 | — |
+
+### Agent Dispatch Summary
+
+- **Wave 1**: **1** — T1 → `quick`
+- **Wave 2**: **3** — T2 → `quick`, T3 → `quick`, T4 → `quick`
+- **Wave 3**: **2** — T5 → `quick`, T6 → `unspecified-high`
+- **Wave 4**: **2** — T7 → `visual-engineering`, T8 → `quick`
+- **FINAL**: **4** — F1 → `oracle`, F2 → `unspecified-high`, F3 → `unspecified-high`, F4 → `deep`
+
+---
+
+## TODOs
+
+- [ ] 1. Add `activeSessionIds` to shared and bridge interface models + codegen
+
+  **What to do**:
+  - In `shared/sesori_shared/lib/src/models/sesori/project_activity_summary.dart`:
+    - Add field `@Default([]) List<String> activeSessionIds` to `ProjectActivitySummary`
+  - In `bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.dart`:
+    - Add field `@Default([]) List<String> activeSessionIds` to `PluginProjectActivitySummary`
+  - Run codegen in dependency order:
+    1. `cd shared/sesori_shared && dart run build_runner build --delete-conflicting-outputs`
+    2. `cd bridge && make codegen`
+    3. `cd mobile && dart run build_runner build --delete-conflicting-outputs` (from each module that imports sesori_shared)
+  - Verify `dart analyze` passes in `shared/sesori_shared` and `bridge/sesori_plugin_interface`
+
+  **Must NOT do**:
+  - Do NOT change `@Freezed(fromJson: true, toJson: true)` annotation on `ProjectActivitySummary`
+  - Do NOT change `PluginProjectActivitySummary`'s existing `@freezed` annotation (note: lowercase, no JSON)
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Two small model file edits + codegen commands. Mechanical changes.
+  - **Skills**: []
+    - No special skills needed — standard Dart/Freezed model editing.
+
+  **Parallelization**:
+  - **Can Run In Parallel**: NO (foundation task)
+  - **Parallel Group**: Wave 1 (solo)
+  - **Blocks**: T2, T3, T4
+  - **Blocked By**: None (can start immediately)
+
+  **References**:
+
+  **Pattern References**:
+  - `shared/sesori_shared/lib/src/models/sesori/project_activity_summary.dart` — Current model. Has `@Default(0) int activeSessions`. Add `activeSessionIds` with same `@Default` pattern.
+  - `bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.dart` — Plugin-side mirror. Currently has `required String worktree, required int activeSessions`. Add `activeSessionIds` here too.
+
+  **External References**:
+  - Freezed docs: `@Default([])` syntax for default values on collection fields.
+
+  **WHY Each Reference Matters**:
+  - The shared model is a Freezed class with `fromJson`/`toJson`. Adding the field here makes it available in the SSE event payload.
+  - The plugin interface model is also Freezed but WITHOUT JSON serialization — used only in-process between plugin and orchestrator.
+
+  **Acceptance Criteria**:
+
+  **QA Scenarios (MANDATORY):**
+
+  ```
+  Scenario: JSON roundtrip preserves activeSessionIds
+    Tool: Bash (dart test)
+    Preconditions: Codegen completed in shared/sesori_shared
+    Steps:
+      1. Run: cd shared/sesori_shared && dart analyze
+      2. Verify output: "No issues found"
+    Expected Result: dart analyze exits with code 0, no issues
+    Failure Indicators: Any analysis error mentioning project_activity_summary
+    Evidence: .sisyphus/evidence/task-1-analyze-shared.txt
+
+  Scenario: Bridge interface analysis passes
+    Tool: Bash (dart analyze)
+    Preconditions: Codegen completed in bridge workspace
+    Steps:
+      1. Run: cd bridge && make analyze
+      2. Verify output includes no errors
+    Expected Result: Analysis passes for all bridge modules
+    Failure Indicators: Error in plugin_project_activity_summary
+    Evidence: .sisyphus/evidence/task-1-analyze-bridge.txt
+  ```
+
+  **Commit**: YES (group 1)
+  - Message: `feat(shared): add activeSessionIds to ProjectActivitySummary`
+  - Files: `shared/sesori_shared/lib/src/models/sesori/project_activity_summary.dart`, `shared/sesori_shared/lib/src/models/sesori/project_activity_summary.freezed.dart`, `shared/sesori_shared/lib/src/models/sesori/project_activity_summary.g.dart`, `bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.dart`, `bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.freezed.dart`
+  - Pre-commit: `cd shared/sesori_shared && dart analyze && cd ../../bridge && make analyze`
+
+- [ ] 2. Expose active session IDs from `ActiveSessionTracker.buildSummary()` and plugin mapping
+
+  **What to do**:
+  - In `bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart`:
+    - Modify `buildSummary()` to include `activeSessionIds` per worktree. The data is already available: iterate `_sessionStatuses` entries, group session IDs by their worktree (via `_sessionWorktrees`), and include in `ProjectActivitySummary`.
+    - The existing `activeSessions` map already computes per-worktree counts from `_sessionStatuses` — the session IDs can be collected alongside the counts.
+  - In `bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart`:
+    - Update `getActiveSessionsSummary()` (line 476-486) to map `activeSessionIds` from `ProjectActivitySummary` to `PluginProjectActivitySummary`.
+  - Run `make codegen` from `bridge/` if any Freezed changes needed (likely not — just logic changes).
+
+  **Must NOT do**:
+  - Do NOT modify `handleEvent()` or `_mapsEqual()` — change detection stays count-based
+  - Do NOT modify `_emitProjectsSummary()` in `opencode_plugin_impl.dart`
+  - Do NOT change `activeSessions` getter logic — only modify `buildSummary()`
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Two files, small logic changes. The data structures are already in place.
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 2 (with T3, T4)
+  - **Blocks**: T6
+  - **Blocked By**: T1
+
+  **References**:
+
+  **Pattern References**:
+  - `bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart:88-94` — Current `buildSummary()`. Maps `activeSessions` entries to `ProjectActivitySummary`. Extend to include session IDs per worktree.
+  - `bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart:96-104` — `activeSessions` getter. Shows how `_sessionStatuses` entries are grouped by worktree via `_sessionWorktrees`. Same grouping logic applies for collecting session IDs.
+  - `bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart:10-13` — Internal maps: `_sessionWorktrees` (sessionID → worktree), `_sessionStatuses` (sessionID → status). These contain all needed data.
+  - `bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart:475-486` — Current `getActiveSessionsSummary()`. Maps `ProjectActivitySummary` → `PluginProjectActivitySummary`. Add `activeSessionIds` to the mapping.
+
+  **Test References**:
+  - `bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart:16-26` — Existing test pattern: cold start tracker, send events, assert `activeSessions` map. New tests should assert `buildSummary()` includes correct session IDs.
+  - `bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart:288-308` — Test helpers: `_fakeRepository()`, `_coldStartedTracker()`. Use these for new test cases.
+
+  **WHY Each Reference Matters**:
+  - `buildSummary()` is the single point where activity data is packaged for external consumption. The session IDs must be added HERE.
+  - The `activeSessions` getter shows the grouping pattern (iterate `_sessionStatuses`, resolve worktree via `_sessionWorktrees`). The same iteration should collect IDs.
+  - `getActiveSessionsSummary()` is the plugin-to-orchestrator bridge. The new field must flow through this mapping.
+
+  **Acceptance Criteria**:
+
+  **QA Scenarios (MANDATORY):**
+
+  ```
+  Scenario: buildSummary includes session IDs for active sessions
+    Tool: Bash (dart test)
+    Preconditions: T1 completed (models updated)
+    Steps:
+      1. Run: cd bridge/sesori_plugin_opencode && dart test test/active_session_tracker_test.dart
+      2. Verify all existing tests still pass
+      3. Verify new test: cold-start tracker with 2 busy sessions in same project → buildSummary() returns entry with activeSessionIds containing both session IDs
+    Expected Result: All tests pass, buildSummary includes correct IDs
+    Failure Indicators: buildSummary returns empty activeSessionIds
+    Evidence: .sisyphus/evidence/task-2-tracker-test.txt
+
+  Scenario: Plugin mapping preserves activeSessionIds
+    Tool: Bash (dart analyze)
+    Preconditions: T1 completed
+    Steps:
+      1. Run: cd bridge && make analyze
+      2. Verify no analysis errors
+    Expected Result: dart analyze passes for all bridge modules
+    Failure Indicators: Type error in getActiveSessionsSummary mapping
+    Evidence: .sisyphus/evidence/task-2-analyze-bridge.txt
+  ```
+
+  **Commit**: YES (group 2, with T3)
+  - Message: `fix(bridge): send projectsSummary on activity change and expose session IDs`
+  - Files: `bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart`, `bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart`
+  - Pre-commit: `cd bridge && make analyze`
+
+- [ ] 3. Fix orchestrator to send `projectsSummary` instead of empty `projectUpdated`
+
+  **What to do**:
+  - In `bridge/app/lib/src/bridge/orchestrator.dart`:
+    - Modify `_mapBridgeToSesoriEvent()` (line 587-588): Instead of returning `const SesoriSseEvent.projectUpdated()` for `BridgeSseProjectUpdated`, build and return a full `SesoriSseEvent.projectsSummary(...)` using `_plugin.getActiveSessionsSummary()`.
+    - Follow the EXACT same mapping pattern used in the initial-subscribe handler (lines 447-456): call `_plugin.getActiveSessionsSummary()`, map each `PluginProjectActivitySummary` to `ProjectActivitySummary`, return as `projectsSummary` event.
+    - Add a code comment at the mapping site explaining that `BridgeSseProjectUpdated` is emitted both from activity changes AND project metadata changes, and converting both to `projectsSummary` is intentional since mobile doesn't handle `projectUpdated`.
+  - This is the **critical bug fix** — after this change, the mobile `SseEventRepository` will receive `projectsSummary` events on every activity change, updating the UI in real-time.
+
+  **Must NOT do**:
+  - Do NOT add new `BridgeSseEvent` variants
+  - Do NOT change the `RelaySseSubscribe` handler (lines 443-462) — it already works correctly
+  - Do NOT modify any other case in `_mapBridgeToSesoriEvent` — only the `BridgeSseProjectUpdated` case
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Single file, single method, ~10 lines of change. The pattern to follow already exists in the same file.
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 2 (with T2, T4)
+  - **Blocks**: T6
+  - **Blocked By**: T1
+
+  **References**:
+
+  **Pattern References**:
+  - `bridge/app/lib/src/bridge/orchestrator.dart:443-458` — Initial-subscribe handler. This is the EXACT pattern to replicate: calls `_plugin.getActiveSessionsSummary()`, maps each `PluginProjectActivitySummary` → `ProjectActivitySummary`, wraps in `SesoriSseEvent.projectsSummary(...)`. Copy this logic.
+  - `bridge/app/lib/src/bridge/orchestrator.dart:587-588` — The broken mapping: `case BridgeSseProjectUpdated(): return const SesoriSseEvent.projectUpdated();`. Replace this entire case.
+  - `bridge/app/lib/src/bridge/orchestrator.dart:91-99` — Event stream subscription. Shows how `_mapBridgeToSesoriEvent` is called and its return value is enqueued. The mapping function must return a non-null `SesoriSseEvent`.
+
+  **API/Type References**:
+  - `bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart` — `getActiveSessionsSummary()` returns `List<PluginProjectActivitySummary>`. Called on `_plugin`.
+  - `shared/sesori_shared/lib/src/models/sesori/project_activity_summary.dart` — `ProjectActivitySummary(worktree:, activeSessions:, activeSessionIds:)`. Target model.
+  - `shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart:229-232` — `SesoriSseEvent.projectsSummary(projects: List<ProjectActivitySummary>)`. The event to return.
+
+  **WHY Each Reference Matters**:
+  - Lines 447-456 are the gold standard — the initial subscribe handler already does exactly what we need. The fix is literally copying this pattern into the `_mapBridgeToSesoriEvent` case for `BridgeSseProjectUpdated`.
+  - Lines 587-588 are the bug — the empty `projectUpdated()` that mobile silently drops.
+
+  **Acceptance Criteria**:
+
+  **QA Scenarios (MANDATORY):**
+
+  ```
+  Scenario: Orchestrator maps BridgeSseProjectUpdated to projectsSummary
+    Tool: Bash (dart analyze)
+    Preconditions: T1 completed (models updated)
+    Steps:
+      1. Run: cd bridge/app && dart analyze
+      2. Verify no analysis errors in orchestrator.dart
+    Expected Result: dart analyze passes
+    Failure Indicators: Type error in _mapBridgeToSesoriEvent
+    Evidence: .sisyphus/evidence/task-3-analyze-orchestrator.txt
+
+  Scenario: Full bridge analysis and test suite passes
+    Tool: Bash (make analyze && make test)
+    Preconditions: T1 and T2 completed
+    Steps:
+      1. Run: cd bridge && make analyze && make test
+      2. Verify all pass
+    Expected Result: Zero analysis errors, all tests pass
+    Failure Indicators: Any failure in orchestrator or SSE-related tests
+    Evidence: .sisyphus/evidence/task-3-bridge-full.txt
+  ```
+
+  **Commit**: YES (group 2, with T2)
+  - Message: `fix(bridge): send projectsSummary on activity change and expose session IDs`
+  - Files: `bridge/app/lib/src/bridge/orchestrator.dart`
+  - Pre-commit: `cd bridge && make analyze`
+
+- [ ] 4. Expose session-level activity from `SseEventRepository`
+
+  **What to do**:
+  - In `mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart`:
+    - Add a new `BehaviorSubject<Map<String, Set<String>>>` for session activity: maps worktree → set of active session IDs.
+    - In `_handleEvent`, when receiving `SesoriProjectsSummary`, also extract `activeSessionIds` from each `ProjectActivitySummary` and update the new subject.
+    - Expose the new stream as `ValueStream<Map<String, Set<String>>> get sessionActivity`.
+    - Expose synchronous accessor `Map<String, Set<String>> get currentSessionActivity`.
+    - Close the new subject in `onDispose()`.
+  - The existing `_projectActivity` (`Map<String, int>`) stays unchanged — it continues to serve `ProjectListCubit`.
+
+  **Must NOT do**:
+  - Do NOT modify the existing `_projectActivity` BehaviorSubject type or behavior
+  - Do NOT add `distinct()` or equality operators
+  - Do NOT change how `SesoriProjectsSummary` is parsed for the project-level data
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Single file, extending existing pattern. Add a parallel BehaviorSubject alongside the existing one.
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 2 (with T2, T3)
+  - **Blocks**: T5
+  - **Blocked By**: T1
+
+  **References**:
+
+  **Pattern References**:
+  - `mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart:16` — Existing `_projectActivity` BehaviorSubject. Follow the same pattern for session activity.
+  - `mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart:26-29` — Existing stream + synchronous accessor pattern. Replicate for session activity.
+  - `mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart:31-41` — `_handleEvent` method. Extend the `SesoriProjectsSummary` case to also extract `activeSessionIds`.
+
+  **API/Type References**:
+  - `shared/sesori_shared/lib/src/models/sesori/project_activity_summary.dart` — `ProjectActivitySummary.activeSessionIds` (after T1) — the field to extract.
+
+  **WHY Each Reference Matters**:
+  - The existing `_projectActivity` is the exact template. The new `_sessionActivity` follows the same BehaviorSubject pattern with a different data shape (`Set<String>` per worktree instead of `int`).
+  - `_handleEvent` already destructures `SesoriProjectsSummary` — extending the existing case is trivial.
+
+  **Acceptance Criteria**:
+
+  **QA Scenarios (MANDATORY):**
+
+  ```
+  Scenario: SseEventRepository exposes session activity stream
+    Tool: Bash (dart analyze)
+    Preconditions: T1 completed
+    Steps:
+      1. Run: cd mobile/module_core && dart analyze
+      2. Verify no analysis errors in sse_event_repository.dart
+    Expected Result: dart analyze passes
+    Failure Indicators: Type errors related to new BehaviorSubject or missing imports
+    Evidence: .sisyphus/evidence/task-4-analyze-mobile.txt
+
+  Scenario: Session activity correctly defaults to empty
+    Tool: Bash (dart analyze)
+    Preconditions: T1 completed
+    Steps:
+      1. Verify currentSessionActivity returns empty map when no events received
+      2. Run: cd mobile/module_core && dart analyze
+    Expected Result: Compiles and analyzes cleanly
+    Failure Indicators: Null reference or uninitialized BehaviorSubject
+    Evidence: .sisyphus/evidence/task-4-default-value.txt
+  ```
+
+  **Commit**: YES (group 3, with T5)
+  - Message: `feat(mobile): add session-level activity tracking to cubit and repository`
+  - Files: `mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart`
+  - Pre-commit: `cd mobile/module_core && dart analyze`
+
+- [ ] 5. Add active session tracking to `SessionListCubit` and state
+
+  **What to do**:
+  - In `mobile/module_core/lib/src/cubits/session_list/session_list_state.dart`:
+    - Add field `@Default({}) Set<String> activeSessionIds` to `SessionListLoaded` variant. This holds the set of session IDs that are currently active (busy/retry) for this project.
+  - In `mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart`:
+    - Accept `SseEventRepository` as a new constructor parameter (same as `ProjectListCubit` does).
+    - Subscribe to `sseEventRepository.sessionActivity` stream in the constructor.
+    - In the listener callback, extract the active session IDs for `_worktree` from the `Map<String, Set<String>>` and emit updated state with the new `activeSessionIds`.
+    - In `_emitFiltered()`, include `currentSessionActivity` from the repository as the initial value.
+    - Run codegen in `mobile/module_core` after changing the Freezed state.
+  - Update the `SessionListScreen` widget in `mobile/app/lib/features/session_list/session_list_screen.dart`:
+    - Pass `getIt<SseEventRepository>()` to the `SessionListCubit` constructor.
+
+  **Must NOT do**:
+  - Do NOT subscribe to `ConnectionService.events` for status events — use the `SseEventRepository` stream instead (single source of truth)
+  - Do NOT add session status types (busy/retry) to the state — only the set of active session IDs
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Three files — state model (add field), cubit (add subscription + listener), screen (pass DI dependency). Follows existing patterns.
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 3 (with T6)
+  - **Blocks**: T7, T8
+  - **Blocked By**: T4
+
+  **References**:
+
+  **Pattern References**:
+  - `mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart:20-31` — `ProjectListCubit` constructor. Shows how to accept `SseEventRepository` and subscribe to its stream. **Copy this pattern exactly** for `SessionListCubit`.
+  - `mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart:38-47` — `_onActivityUpdated()` handler. Shows how to merge activity data into existing state. Replicate for session activity.
+  - `mobile/module_core/lib/src/cubits/project_list/project_list_state.dart:11-14` — `ProjectListLoaded` with `activityByWorktree`. Model for extending `SessionListLoaded`.
+  - `mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart:27-39` — Current constructor. Add `SseEventRepository` parameter after `ConnectionService`.
+  - `mobile/module_core/lib/src/cubits/session_list/session_list_state.dart:11-14` — Current `SessionListLoaded`. Add `activeSessionIds` field.
+  - `mobile/app/lib/features/session_list/session_list_screen.dart:27-35` — `BlocProvider.create`. Add `getIt<SseEventRepository>()` to cubit constructor.
+
+  **WHY Each Reference Matters**:
+  - `ProjectListCubit` is the exact template — it already subscribes to `SseEventRepository.projectActivity`. The session-level version is structurally identical but uses `sessionActivity` and filters by worktree.
+  - The screen's `BlocProvider.create` is where DI dependencies are injected. Adding `SseEventRepository` follows the same `getIt<>()` pattern.
+
+  **Acceptance Criteria**:
+
+  **QA Scenarios (MANDATORY):**
+
+  ```
+  Scenario: SessionListCubit accepts SseEventRepository
+    Tool: Bash (dart analyze)
+    Preconditions: T4 completed, codegen run in mobile/module_core
+    Steps:
+      1. Run: cd mobile/module_core && dart run build_runner build --delete-conflicting-outputs
+      2. Run: cd mobile/module_core && dart analyze
+      3. Run: cd mobile/app && dart analyze
+    Expected Result: All analysis passes — no type errors in cubit, state, or screen
+    Failure Indicators: Missing parameter error in SessionListScreen or type mismatch
+    Evidence: .sisyphus/evidence/task-5-analyze-cubit.txt
+
+  Scenario: SessionListState.loaded includes activeSessionIds
+    Tool: Bash (dart analyze)
+    Preconditions: Codegen completed
+    Steps:
+      1. Verify SessionListLoaded has activeSessionIds field with @Default({})
+      2. Run: cd mobile/module_core && dart analyze
+    Expected Result: State model compiles with default empty set
+    Failure Indicators: Missing field or wrong default value
+    Evidence: .sisyphus/evidence/task-5-state-model.txt
+  ```
+
+  **Commit**: YES (group 3, with T4)
+  - Message: `feat(mobile): add session-level activity tracking to cubit and repository`
+  - Files: `mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart`, `mobile/module_core/lib/src/cubits/session_list/session_list_state.dart`, `mobile/module_core/lib/src/cubits/session_list/session_list_state.freezed.dart`, `mobile/app/lib/features/session_list/session_list_screen.dart`
+  - Pre-commit: `cd mobile/module_core && dart analyze && cd ../../mobile/app && dart analyze`
+
+- [ ] 6. Add bridge tests for `buildSummary` session IDs and orchestrator mapping
+
+  **What to do**:
+  - In `bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart`:
+    - Add test: "buildSummary includes activeSessionIds for busy sessions" — cold-start tracker with 2 busy sessions in same project → assert `buildSummary()` returns entry with `activeSessionIds` containing both session IDs.
+    - Add test: "buildSummary excludes idle sessions from activeSessionIds" — start with 2 busy sessions, then idle one → assert only remaining session ID is in list.
+    - Add test: "buildSummary groups session IDs by worktree correctly" — 2 projects, 1 busy session each → assert each summary entry has correct session ID.
+  - Optionally add orchestrator mapping test if test infrastructure exists for it (check for existing orchestrator test files). If no orchestrator test file exists, document the gap in a code comment.
+
+  **Must NOT do**:
+  - Do NOT modify existing test helpers or test cases
+  - Do NOT add tests for unrelated orchestrator mappings — only `BridgeSseProjectUpdated`
+
+  **Recommended Agent Profile**:
+  - **Category**: `unspecified-high`
+    - Reason: Writing tests requires careful setup of test fixtures and understanding of existing test patterns.
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 3 (with T5)
+  - **Blocks**: —
+  - **Blocked By**: T2, T3
+
+  **References**:
+
+  **Pattern References**:
+  - `bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart:16-26` — Existing test pattern: `_coldStartedTracker(projects: [...])`, send events via `handleEvent()`, assert results. Follow this pattern exactly.
+  - `bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart:280-286` — `_sessionBusy()` helper. Creates `SseSessionStatus` with `SessionStatus.busy()`.
+  - `bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart:288-308` — `_fakeRepository()` and `_coldStartedTracker()` helpers. Use these for new tests.
+  - `bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart:310-350` — `_FakeApi` class. Shows how to mock the API layer.
+
+  **WHY Each Reference Matters**:
+  - All existing test infrastructure is already in place — `_coldStartedTracker`, `_sessionBusy`, `_sessionCreated`, `_fakeRepository`. New tests just use these helpers.
+  - The test pattern is: create tracker → send SSE events → assert `buildSummary()` / `activeSessions`. New tests add assertions on `activeSessionIds` field.
+
+  **Acceptance Criteria**:
+
+  **QA Scenarios (MANDATORY):**
+
+  ```
+  Scenario: All bridge tests pass including new buildSummary tests
+    Tool: Bash (make test)
+    Preconditions: T2 and T3 completed
+    Steps:
+      1. Run: cd bridge && make test
+      2. Verify all tests pass, including new activeSessionIds tests
+    Expected Result: All tests pass (0 failures)
+    Failure Indicators: Any test failure in active_session_tracker_test.dart
+    Evidence: .sisyphus/evidence/task-6-bridge-tests.txt
+
+  Scenario: New tests actually verify session IDs, not just counts
+    Tool: Bash (dart test)
+    Preconditions: T2 completed
+    Steps:
+      1. Run: cd bridge/sesori_plugin_opencode && dart test test/active_session_tracker_test.dart -r expanded
+      2. Verify test names include "activeSessionIds" or "session IDs"
+    Expected Result: At least 3 new tests visible in output
+    Failure Indicators: No new tests appear
+    Evidence: .sisyphus/evidence/task-6-new-tests.txt
+  ```
+
+  **Commit**: YES (group 4)
+  - Message: `test(bridge): add tests for buildSummary session IDs`
+  - Files: `bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart`
+  - Pre-commit: `cd bridge && make test`
+
+- [ ] 7. Add active session indicator to session list UI
+
+  **What to do**:
+  - In `mobile/app/lib/features/session_list/session_list_screen.dart`:
+    - In `_SessionListBody.build()`, extract `activeSessionIds` from the cubit state (available after T5).
+    - Pass `isActive: activeSessionIds.contains(session.id)` to each `_SessionTile`.
+    - In `_SessionTile`, add `isActive` parameter. When `true`, display a green dot + "Running" label in the subtitle, following the exact same visual pattern as `_ProjectTile` in `project_list_screen.dart` (lines 119-132):
+      ```dart
+      if (isActive)
+        Row(
+          children: [
+            Icon(Icons.circle, size: 8, color: theme.colorScheme.primary),
+            const SizedBox(width: 4),
+            Text(
+              loc.sessionListRunning,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.primary,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+      ```
+    - Update `isThreeLine` to account for the new row.
+  - In `mobile/app/lib/l10n/app_en.arb`:
+    - Add localization string: `"sessionListRunning": "Running"`
+
+  **Must NOT do**:
+  - Do NOT add animations or pulsing effects — simple static indicator matching project list
+  - Do NOT change the CircleAvatar leading icon — add the indicator in subtitle like projects do
+  - Do NOT add any filtering/toggle for active sessions — just visual indicator
+
+  **Recommended Agent Profile**:
+  - **Category**: `visual-engineering`
+    - Reason: UI widget modification with visual indicator. Needs to match existing project list pattern precisely.
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 4 (with T8)
+  - **Blocks**: —
+  - **Blocked By**: T5
+
+  **References**:
+
+  **Pattern References**:
+  - `mobile/app/lib/features/project_list/project_list_screen.dart:92-132` — **THE visual pattern to match**. Shows `isActive` check, green dot `Icon(Icons.circle, size: 8, color: theme.colorScheme.primary)`, `SizedBox(width: 4)`, text with `colorScheme.primary` and `FontWeight.w500`. Copy this styling exactly.
+  - `mobile/app/lib/features/session_list/session_list_screen.dart:273-353` — Current `_SessionTile` widget. The subtitle `Column` (lines 324-339) is where the indicator goes, after `updatedAt` and `filesChanged`.
+  - `mobile/app/lib/features/session_list/session_list_screen.dart:221-259` — `SessionListLoaded` branch with `ListView.builder`. This is where `activeSessionIds` is extracted from state and passed to each tile.
+  - `mobile/app/lib/features/session_list/session_list_screen.dart:246-258` — `itemBuilder`. Add `isActive: state.activeSessionIds.contains(session.id)` to `_SessionTile` constructor.
+
+  **External References**:
+  - `mobile/app/lib/l10n/app_en.arb:49-50` — Existing `projectListActiveSessions` localization pattern. The session version is simpler: just "Running" (no count needed since it's per-session).
+
+  **WHY Each Reference Matters**:
+  - `project_list_screen.dart:119-132` is the gold standard for the visual indicator. The user explicitly said "same kind of indicator". This must be pixel-identical in style.
+  - `session_list_screen.dart` widget structure shows exactly where the new Row should be inserted in the subtitle Column.
+
+  **Acceptance Criteria**:
+
+  **QA Scenarios (MANDATORY):**
+
+  ```
+  Scenario: Session list UI compiles with active indicator
+    Tool: Bash (dart analyze)
+    Preconditions: T5 completed
+    Steps:
+      1. Run: cd mobile/app && dart analyze
+      2. Verify no analysis errors in session_list_screen.dart
+    Expected Result: dart analyze passes
+    Failure Indicators: Type error for isActive parameter or missing localization
+    Evidence: .sisyphus/evidence/task-7-analyze-ui.txt
+
+  Scenario: Localization string exists
+    Tool: Bash (grep)
+    Preconditions: Localization file updated
+    Steps:
+      1. Verify "sessionListRunning" key exists in mobile/app/lib/l10n/app_en.arb
+      2. Run: cd mobile/app && dart analyze
+    Expected Result: Localization compiles correctly
+    Failure Indicators: Missing localization key causes compile error
+    Evidence: .sisyphus/evidence/task-7-localization.txt
+
+  Scenario: _SessionTile accepts isActive parameter
+    Tool: Bash (dart analyze)
+    Preconditions: Widget updated
+    Steps:
+      1. Verify _SessionTile constructor includes isActive: bool
+      2. Verify all call sites pass the parameter
+      3. Run: cd mobile/app && dart analyze
+    Expected Result: No missing argument errors
+    Failure Indicators: Required parameter not passed at call site
+    Evidence: .sisyphus/evidence/task-7-widget-param.txt
+  ```
+
+  **Commit**: YES (group 5)
+  - Message: `feat(mobile): add active session indicator to session list UI`
+  - Files: `mobile/app/lib/features/session_list/session_list_screen.dart`, `mobile/app/lib/l10n/app_en.arb`
+  - Pre-commit: `cd mobile/app && dart analyze`
+
+- [ ] 8. Add mobile tests for session activity tracking
+
+  **What to do**:
+  - Create or extend test file for `SseEventRepository`:
+    - Test: "sessionActivity emits active session IDs from projectsSummary event" — feed a `SesoriProjectsSummary` event with `activeSessionIds: ["s1", "s2"]` → verify `sessionActivity` stream emits `{"/path": {"s1", "s2"}}`.
+    - Test: "sessionActivity defaults to empty map" — verify initial value is `{}`.
+    - Test: "sessionActivity excludes worktrees with no active sessions" — feed event with `activeSessions: 0, activeSessionIds: []` → verify worktree not in map.
+  - Create or extend test file for `SessionListCubit`:
+    - Test: "state includes activeSessionIds from SseEventRepository" — mock `SseEventRepository.sessionActivity` stream, emit activity data → verify `SessionListLoaded.activeSessionIds` contains correct IDs.
+    - Test: "activeSessionIds updates when activity changes" — emit initial data, then updated data → verify state reflects change.
+
+  **Must NOT do**:
+  - Do NOT test UI rendering — only cubit/repository logic
+  - Do NOT test the full SSE pipeline end-to-end — test each unit in isolation
+
+  **Recommended Agent Profile**:
+  - **Category**: `quick`
+    - Reason: Standard bloc_test / unit test patterns. Follow existing test conventions.
+  - **Skills**: []
+
+  **Parallelization**:
+  - **Can Run In Parallel**: YES
+  - **Parallel Group**: Wave 4 (with T7)
+  - **Blocks**: —
+  - **Blocked By**: T5
+
+  **References**:
+
+  **Pattern References**:
+  - Check for existing test files in `mobile/module_core/test/` — look for cubit tests or repository tests to follow conventions.
+  - `bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart` — General test pattern in this codebase: plain `test()` functions, helpers for test fixtures, assertions on computed values.
+
+  **API/Type References**:
+  - `mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart` — Public API: `sessionActivity`, `currentSessionActivity`. These are what tests assert against.
+  - `mobile/module_core/lib/src/cubits/session_list/session_list_state.dart` — `SessionListLoaded.activeSessionIds`. Verify this field in cubit tests.
+
+  **WHY Each Reference Matters**:
+  - Existing test patterns in this codebase show the testing style (plain dart test, mocktail for mocks). Following these ensures consistency.
+  - The public API of `SseEventRepository` and `SessionListCubit` defines the test contract.
+
+  **Acceptance Criteria**:
+
+  **QA Scenarios (MANDATORY):**
+
+  ```
+  Scenario: All mobile tests pass
+    Tool: Bash (dart test)
+    Preconditions: T4 and T5 completed
+    Steps:
+      1. Run: cd mobile/module_core && dart test
+      2. Verify all tests pass including new session activity tests
+    Expected Result: All tests pass (0 failures)
+    Failure Indicators: Any test failure in new test files
+    Evidence: .sisyphus/evidence/task-8-mobile-tests.txt
+
+  Scenario: New tests cover both repository and cubit
+    Tool: Bash (dart test)
+    Preconditions: Tests written
+    Steps:
+      1. Run: cd mobile/module_core && dart test -r expanded
+      2. Verify test output includes tests for both SseEventRepository and SessionListCubit
+    Expected Result: At least 5 new tests visible (3 repository + 2 cubit)
+    Failure Indicators: Missing test groups
+    Evidence: .sisyphus/evidence/task-8-test-count.txt
+  ```
+
+  **Commit**: YES (group 6)
+  - Message: `test(mobile): add tests for session activity tracking`
+  - Files: `mobile/module_core/test/...` (new or extended test files)
+  - Pre-commit: `cd mobile/module_core && dart test`
+
+---
+
+## Final Verification Wave
+
+> 4 review agents run in PARALLEL. ALL must APPROVE. Present consolidated results to user and get explicit "okay" before completing.
+
+- [ ] F1. **Plan Compliance Audit** — `oracle`
+  Read `.sisyphus/plans/fix-activity-tracking.md` end-to-end. For each "Must Have": verify implementation exists. For each "Must NOT Have": search codebase for forbidden patterns — reject with file:line if found. Check evidence files exist in `.sisyphus/evidence/`. Compare deliverables against plan.
+  Output: `Must Have [N/N] | Must NOT Have [N/N] | Tasks [N/N] | VERDICT: APPROVE/REJECT`
+
+- [ ] F2. **Code Quality Review** — `unspecified-high`
+  Run `dart analyze` in `shared/sesori_shared`, `bridge/` (all modules via `make analyze`), `mobile/` (all modules). Run `make test` from `bridge/`, `dart test` from `mobile/module_core`. Review all changed files for: `as any`/`@ts-ignore` equivalents, empty catches, unused imports. Check AI slop: excessive comments, over-abstraction.
+  Output: `Analyze [PASS/FAIL] | Tests [N pass/N fail] | Files [N clean/N issues] | VERDICT`
+
+- [ ] F3. **Real Manual QA** — `unspecified-high`
+  Verify JSON roundtrip for `ProjectActivitySummary` with `activeSessionIds`. Run `ActiveSessionTracker` test suite. Run mobile cubit tests. Save evidence to `.sisyphus/evidence/final-qa/`.
+  Output: `Scenarios [N/N pass] | Integration [N/N] | VERDICT`
+
+- [ ] F4. **Scope Fidelity Check** — `deep`
+  For each task: read "What to do", read actual diff (`git log`/`git diff`). Verify 1:1 — everything in spec was built, nothing beyond spec was built. Check "Must NOT do" compliance. Detect cross-task contamination. Flag unaccounted changes.
+  Output: `Tasks [N/N compliant] | Contamination [CLEAN/N issues] | VERDICT`
+
+---
+
+## Commit Strategy
+
+| # | Scope | Message | Files | Pre-commit |
+|---|-------|---------|-------|------------|
+| 1 | T1 | `feat(shared): add activeSessionIds to ProjectActivitySummary` | `shared/sesori_shared/...`, `bridge/sesori_plugin_interface/...` | `dart analyze` in both |
+| 2 | T2+T3 | `fix(bridge): send projectsSummary on activity change and expose session IDs` | `bridge/sesori_plugin_opencode/...`, `bridge/app/...` | `make analyze` from `bridge/` |
+| 3 | T4+T5 | `feat(mobile): add session-level activity tracking to cubit and repository` | `mobile/module_core/...` | `dart analyze` in `mobile/module_core` |
+| 4 | T6 | `test(bridge): add tests for buildSummary session IDs and orchestrator mapping` | `bridge/sesori_plugin_opencode/test/...` | `make test` from `bridge/` |
+| 5 | T7 | `feat(mobile): add active session indicator to session list UI` | `mobile/app/...` | `dart analyze` in `mobile/app` |
+| 6 | T8 | `test(mobile): add tests for session activity tracking` | `mobile/module_core/test/...` | `dart test` in `mobile/module_core` |
+
+---
+
+## Success Criteria
+
+### Verification Commands
+```bash
+cd shared/sesori_shared && dart analyze    # Expected: No issues found
+cd bridge && make analyze                  # Expected: No issues found (all modules)
+cd bridge && make test                     # Expected: All tests pass
+cd mobile/module_core && dart analyze      # Expected: No issues found
+cd mobile/module_core && dart test         # Expected: All tests pass
+cd mobile/app && dart analyze              # Expected: No issues found
+```
+
+### Final Checklist
+- [ ] All "Must Have" present (mapping pattern match, codegen order)
+- [ ] All "Must NOT Have" absent (no `_mapsEqual` changes, no new BridgeSseEvent variants, no animations)
+- [ ] All tests pass across bridge and mobile workspaces

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -451,6 +451,7 @@ class OrchestratorSession {
                   (e) => ProjectActivitySummary(
                     worktree: e.worktree,
                     activeSessions: e.activeSessions,
+                    activeSessionIds: e.activeSessionIds,
                   ),
                 )
                 .toList(),
@@ -584,8 +585,22 @@ class OrchestratorSession {
         );
       case BridgeSseTodoUpdated(:final sessionID):
         return SesoriSseEvent.todoUpdated(sessionID: sessionID);
+      // BridgeSseProjectUpdated is emitted on both activity changes and project
+      // metadata changes. We always send the full projectsSummary so the mobile
+      // client receives updated activity data in real time.
       case BridgeSseProjectUpdated():
-        return const SesoriSseEvent.projectUpdated();
+        final summary = _plugin.getActiveSessionsSummary();
+        return SesoriSseEvent.projectsSummary(
+          projects: summary
+              .map(
+                (e) => ProjectActivitySummary(
+                  worktree: e.worktree,
+                  activeSessions: e.activeSessions,
+                  activeSessionIds: e.activeSessionIds,
+                ),
+              )
+              .toList(),
+        );
       case BridgeSseVcsBranchUpdated():
         return const SesoriSseEvent.vcsBranchUpdated();
       case BridgeSseFileEdited(:final file):

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -648,7 +648,7 @@ class OrchestratorSession {
       projects: summary
           .map(
             (e) => ProjectActivitySummary(
-              worktree: e.worktree,
+              id: e.id,
               activeSessions: e.activeSessions,
               activeSessionIds: e.activeSessionIds,
             ),

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -649,7 +649,6 @@ class OrchestratorSession {
           .map(
             (e) => ProjectActivitySummary(
               id: e.id,
-              activeSessions: e.activeSessions,
               activeSessionIds: e.activeSessionIds,
             ),
           )

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -444,19 +444,7 @@ class OrchestratorSession {
         Log.v("[dbg] SseSubscribe: path=${subscribe.path}");
         try {
           _sseManager.subscribePath(connID, subscribe.path, _client);
-          final summary = _plugin.getActiveSessionsSummary();
-          final initialEvent = SesoriSseEvent.projectsSummary(
-            projects: summary
-                .map(
-                  (e) => ProjectActivitySummary(
-                    worktree: e.worktree,
-                    activeSessions: e.activeSessions,
-                    activeSessionIds: e.activeSessionIds,
-                  ),
-                )
-                .toList(),
-          );
-          _sseManager.enqueueEvent(initialEvent);
+          _sseManager.enqueueEvent(_buildProjectsSummaryEvent());
           Log.v("[dbg] initial projectsSummary enqueued");
         } catch (e) {
           Log.e("sse subscribe failed for connId $connID: $e");
@@ -589,18 +577,7 @@ class OrchestratorSession {
       // metadata changes. We always send the full projectsSummary so the mobile
       // client receives updated activity data in real time.
       case BridgeSseProjectUpdated():
-        final summary = _plugin.getActiveSessionsSummary();
-        return SesoriSseEvent.projectsSummary(
-          projects: summary
-              .map(
-                (e) => ProjectActivitySummary(
-                  worktree: e.worktree,
-                  activeSessions: e.activeSessions,
-                  activeSessionIds: e.activeSessionIds,
-                ),
-              )
-              .toList(),
-        );
+        return _buildProjectsSummaryEvent();
       case BridgeSseVcsBranchUpdated():
         return const SesoriSseEvent.vcsBranchUpdated();
       case BridgeSseFileEdited(:final file):
@@ -663,5 +640,20 @@ class OrchestratorSession {
     final encryptor = cryptoService.createSessionEncryptor(encryptionKey);
     final framed = await frame(utf8.encode(respJson), encryptor);
     _client.send(connID, framed);
+  }
+
+  SesoriSseEvent _buildProjectsSummaryEvent() {
+    final summary = _plugin.getActiveSessionsSummary();
+    return SesoriSseEvent.projectsSummary(
+      projects: summary
+          .map(
+            (e) => ProjectActivitySummary(
+              worktree: e.worktree,
+              activeSessions: e.activeSessions,
+              activeSessionIds: e.activeSessionIds,
+            ),
+          )
+          .toList(),
+    );
   }
 }

--- a/bridge/app/test/bridge/event_queue_test.dart
+++ b/bridge/app/test/bridge/event_queue_test.dart
@@ -247,7 +247,9 @@ void main() {
 
 SesoriSseEvent _event(String worktree) {
   return SesoriSseEvent.projectsSummary(
-    projects: [ProjectActivitySummary(id: worktree, activeSessions: 1)],
+    projects: [
+      ProjectActivitySummary(id: worktree, activeSessionIds: const ["s1"]),
+    ],
   );
 }
 

--- a/bridge/app/test/bridge/event_queue_test.dart
+++ b/bridge/app/test/bridge/event_queue_test.dart
@@ -247,7 +247,7 @@ void main() {
 
 SesoriSseEvent _event(String worktree) {
   return SesoriSseEvent.projectsSummary(
-    projects: [ProjectActivitySummary(worktree: worktree, activeSessions: 1)],
+    projects: [ProjectActivitySummary(id: worktree, activeSessions: 1)],
   );
 }
 

--- a/bridge/app/test/bridge/sse_manager_test.dart
+++ b/bridge/app/test/bridge/sse_manager_test.dart
@@ -169,7 +169,9 @@ void main() {
 
 SesoriSseEvent _event(String worktree) {
   return SesoriSseEvent.projectsSummary(
-    projects: [ProjectActivitySummary(id: worktree, activeSessions: 1)],
+    projects: [
+      ProjectActivitySummary(id: worktree, activeSessionIds: const ["s1"]),
+    ],
   );
 }
 

--- a/bridge/app/test/bridge/sse_manager_test.dart
+++ b/bridge/app/test/bridge/sse_manager_test.dart
@@ -169,7 +169,7 @@ void main() {
 
 SesoriSseEvent _event(String worktree) {
   return SesoriSseEvent.projectsSummary(
-    projects: [ProjectActivitySummary(worktree: worktree, activeSessions: 1)],
+    projects: [ProjectActivitySummary(id: worktree, activeSessions: 1)],
   );
 }
 

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.dart
@@ -8,5 +8,6 @@ sealed class PluginProjectActivitySummary with _$PluginProjectActivitySummary {
   const factory PluginProjectActivitySummary({
     required String worktree,
     required int activeSessions,
+    @Default([]) List<String> activeSessionIds,
   }) = _PluginProjectActivitySummary;
 }

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.dart
@@ -6,7 +6,7 @@ part "plugin_project_activity_summary.g.dart";
 @freezed
 sealed class PluginProjectActivitySummary with _$PluginProjectActivitySummary {
   const factory PluginProjectActivitySummary({
-    required String worktree,
+    required String id,
     required int activeSessions,
     @Default([]) List<String> activeSessionIds,
   }) = _PluginProjectActivitySummary;

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.dart
@@ -7,7 +7,6 @@ part "plugin_project_activity_summary.g.dart";
 sealed class PluginProjectActivitySummary with _$PluginProjectActivitySummary {
   const factory PluginProjectActivitySummary({
     required String id,
-    required int activeSessions,
-    @Default([]) List<String> activeSessionIds,
+    required List<String> activeSessionIds,
   }) = _PluginProjectActivitySummary;
 }

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.freezed.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$PluginProjectActivitySummary {
 
- String get worktree; int get activeSessions;
+ String get worktree; int get activeSessions; List<String> get activeSessionIds;
 /// Create a copy of PluginProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -27,16 +27,16 @@ $PluginProjectActivitySummaryCopyWith<PluginProjectActivitySummary> get copyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginProjectActivitySummary&&(identical(other.worktree, worktree) || other.worktree == worktree)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginProjectActivitySummary&&(identical(other.worktree, worktree) || other.worktree == worktree)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions)&&const DeepCollectionEquality().equals(other.activeSessionIds, activeSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,worktree,activeSessions);
+int get hashCode => Object.hash(runtimeType,worktree,activeSessions,const DeepCollectionEquality().hash(activeSessionIds));
 
 @override
 String toString() {
-  return 'PluginProjectActivitySummary(worktree: $worktree, activeSessions: $activeSessions)';
+  return 'PluginProjectActivitySummary(worktree: $worktree, activeSessions: $activeSessions, activeSessionIds: $activeSessionIds)';
 }
 
 
@@ -47,7 +47,7 @@ abstract mixin class $PluginProjectActivitySummaryCopyWith<$Res>  {
   factory $PluginProjectActivitySummaryCopyWith(PluginProjectActivitySummary value, $Res Function(PluginProjectActivitySummary) _then) = _$PluginProjectActivitySummaryCopyWithImpl;
 @useResult
 $Res call({
- String worktree, int activeSessions
+ String worktree, int activeSessions, List<String> activeSessionIds
 });
 
 
@@ -64,11 +64,12 @@ class _$PluginProjectActivitySummaryCopyWithImpl<$Res>
 
 /// Create a copy of PluginProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? worktree = null,Object? activeSessions = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? worktree = null,Object? activeSessions = null,Object? activeSessionIds = null,}) {
   return _then(_self.copyWith(
 worktree: null == worktree ? _self.worktree : worktree // ignore: cast_nullable_to_non_nullable
 as String,activeSessions: null == activeSessions ? _self.activeSessions : activeSessions // ignore: cast_nullable_to_non_nullable
-as int,
+as int,activeSessionIds: null == activeSessionIds ? _self.activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
+as List<String>,
   ));
 }
 
@@ -80,11 +81,18 @@ as int,
 @JsonSerializable(createFactory: false)
 
 class _PluginProjectActivitySummary implements PluginProjectActivitySummary {
-  const _PluginProjectActivitySummary({required this.worktree, required this.activeSessions});
+  const _PluginProjectActivitySummary({required this.worktree, required this.activeSessions, final  List<String> activeSessionIds = const []}): _activeSessionIds = activeSessionIds;
   
 
 @override final  String worktree;
 @override final  int activeSessions;
+ final  List<String> _activeSessionIds;
+@override@JsonKey() List<String> get activeSessionIds {
+  if (_activeSessionIds is EqualUnmodifiableListView) return _activeSessionIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_activeSessionIds);
+}
+
 
 /// Create a copy of PluginProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
@@ -99,16 +107,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginProjectActivitySummary&&(identical(other.worktree, worktree) || other.worktree == worktree)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginProjectActivitySummary&&(identical(other.worktree, worktree) || other.worktree == worktree)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions)&&const DeepCollectionEquality().equals(other._activeSessionIds, _activeSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,worktree,activeSessions);
+int get hashCode => Object.hash(runtimeType,worktree,activeSessions,const DeepCollectionEquality().hash(_activeSessionIds));
 
 @override
 String toString() {
-  return 'PluginProjectActivitySummary(worktree: $worktree, activeSessions: $activeSessions)';
+  return 'PluginProjectActivitySummary(worktree: $worktree, activeSessions: $activeSessions, activeSessionIds: $activeSessionIds)';
 }
 
 
@@ -119,7 +127,7 @@ abstract mixin class _$PluginProjectActivitySummaryCopyWith<$Res> implements $Pl
   factory _$PluginProjectActivitySummaryCopyWith(_PluginProjectActivitySummary value, $Res Function(_PluginProjectActivitySummary) _then) = __$PluginProjectActivitySummaryCopyWithImpl;
 @override @useResult
 $Res call({
- String worktree, int activeSessions
+ String worktree, int activeSessions, List<String> activeSessionIds
 });
 
 
@@ -136,11 +144,12 @@ class __$PluginProjectActivitySummaryCopyWithImpl<$Res>
 
 /// Create a copy of PluginProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? worktree = null,Object? activeSessions = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? worktree = null,Object? activeSessions = null,Object? activeSessionIds = null,}) {
   return _then(_PluginProjectActivitySummary(
 worktree: null == worktree ? _self.worktree : worktree // ignore: cast_nullable_to_non_nullable
 as String,activeSessions: null == activeSessions ? _self.activeSessions : activeSessions // ignore: cast_nullable_to_non_nullable
-as int,
+as int,activeSessionIds: null == activeSessionIds ? _self._activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
+as List<String>,
   ));
 }
 

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.freezed.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$PluginProjectActivitySummary {
 
- String get id; int get activeSessions; List<String> get activeSessionIds;
+ String get id; List<String> get activeSessionIds;
 /// Create a copy of PluginProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -27,16 +27,16 @@ $PluginProjectActivitySummaryCopyWith<PluginProjectActivitySummary> get copyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginProjectActivitySummary&&(identical(other.id, id) || other.id == id)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions)&&const DeepCollectionEquality().equals(other.activeSessionIds, activeSessionIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginProjectActivitySummary&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.activeSessionIds, activeSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,activeSessions,const DeepCollectionEquality().hash(activeSessionIds));
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(activeSessionIds));
 
 @override
 String toString() {
-  return 'PluginProjectActivitySummary(id: $id, activeSessions: $activeSessions, activeSessionIds: $activeSessionIds)';
+  return 'PluginProjectActivitySummary(id: $id, activeSessionIds: $activeSessionIds)';
 }
 
 
@@ -47,7 +47,7 @@ abstract mixin class $PluginProjectActivitySummaryCopyWith<$Res>  {
   factory $PluginProjectActivitySummaryCopyWith(PluginProjectActivitySummary value, $Res Function(PluginProjectActivitySummary) _then) = _$PluginProjectActivitySummaryCopyWithImpl;
 @useResult
 $Res call({
- String id, int activeSessions, List<String> activeSessionIds
+ String id, List<String> activeSessionIds
 });
 
 
@@ -64,11 +64,10 @@ class _$PluginProjectActivitySummaryCopyWithImpl<$Res>
 
 /// Create a copy of PluginProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? activeSessions = null,Object? activeSessionIds = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? activeSessionIds = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as String,activeSessions: null == activeSessions ? _self.activeSessions : activeSessions // ignore: cast_nullable_to_non_nullable
-as int,activeSessionIds: null == activeSessionIds ? _self.activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
+as String,activeSessionIds: null == activeSessionIds ? _self.activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
 as List<String>,
   ));
 }
@@ -81,13 +80,12 @@ as List<String>,
 @JsonSerializable(createFactory: false)
 
 class _PluginProjectActivitySummary implements PluginProjectActivitySummary {
-  const _PluginProjectActivitySummary({required this.id, required this.activeSessions, final  List<String> activeSessionIds = const []}): _activeSessionIds = activeSessionIds;
+  const _PluginProjectActivitySummary({required this.id, required final  List<String> activeSessionIds}): _activeSessionIds = activeSessionIds;
   
 
 @override final  String id;
-@override final  int activeSessions;
  final  List<String> _activeSessionIds;
-@override@JsonKey() List<String> get activeSessionIds {
+@override List<String> get activeSessionIds {
   if (_activeSessionIds is EqualUnmodifiableListView) return _activeSessionIds;
   // ignore: implicit_dynamic_type
   return EqualUnmodifiableListView(_activeSessionIds);
@@ -107,16 +105,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginProjectActivitySummary&&(identical(other.id, id) || other.id == id)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions)&&const DeepCollectionEquality().equals(other._activeSessionIds, _activeSessionIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginProjectActivitySummary&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other._activeSessionIds, _activeSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,activeSessions,const DeepCollectionEquality().hash(_activeSessionIds));
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(_activeSessionIds));
 
 @override
 String toString() {
-  return 'PluginProjectActivitySummary(id: $id, activeSessions: $activeSessions, activeSessionIds: $activeSessionIds)';
+  return 'PluginProjectActivitySummary(id: $id, activeSessionIds: $activeSessionIds)';
 }
 
 
@@ -127,7 +125,7 @@ abstract mixin class _$PluginProjectActivitySummaryCopyWith<$Res> implements $Pl
   factory _$PluginProjectActivitySummaryCopyWith(_PluginProjectActivitySummary value, $Res Function(_PluginProjectActivitySummary) _then) = __$PluginProjectActivitySummaryCopyWithImpl;
 @override @useResult
 $Res call({
- String id, int activeSessions, List<String> activeSessionIds
+ String id, List<String> activeSessionIds
 });
 
 
@@ -144,11 +142,10 @@ class __$PluginProjectActivitySummaryCopyWithImpl<$Res>
 
 /// Create a copy of PluginProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? activeSessions = null,Object? activeSessionIds = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? activeSessionIds = null,}) {
   return _then(_PluginProjectActivitySummary(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as String,activeSessions: null == activeSessions ? _self.activeSessions : activeSessions // ignore: cast_nullable_to_non_nullable
-as int,activeSessionIds: null == activeSessionIds ? _self._activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
+as String,activeSessionIds: null == activeSessionIds ? _self._activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
 as List<String>,
   ));
 }

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.freezed.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$PluginProjectActivitySummary {
 
- String get worktree; int get activeSessions; List<String> get activeSessionIds;
+ String get id; int get activeSessions; List<String> get activeSessionIds;
 /// Create a copy of PluginProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -27,16 +27,16 @@ $PluginProjectActivitySummaryCopyWith<PluginProjectActivitySummary> get copyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginProjectActivitySummary&&(identical(other.worktree, worktree) || other.worktree == worktree)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions)&&const DeepCollectionEquality().equals(other.activeSessionIds, activeSessionIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginProjectActivitySummary&&(identical(other.id, id) || other.id == id)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions)&&const DeepCollectionEquality().equals(other.activeSessionIds, activeSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,worktree,activeSessions,const DeepCollectionEquality().hash(activeSessionIds));
+int get hashCode => Object.hash(runtimeType,id,activeSessions,const DeepCollectionEquality().hash(activeSessionIds));
 
 @override
 String toString() {
-  return 'PluginProjectActivitySummary(worktree: $worktree, activeSessions: $activeSessions, activeSessionIds: $activeSessionIds)';
+  return 'PluginProjectActivitySummary(id: $id, activeSessions: $activeSessions, activeSessionIds: $activeSessionIds)';
 }
 
 
@@ -47,7 +47,7 @@ abstract mixin class $PluginProjectActivitySummaryCopyWith<$Res>  {
   factory $PluginProjectActivitySummaryCopyWith(PluginProjectActivitySummary value, $Res Function(PluginProjectActivitySummary) _then) = _$PluginProjectActivitySummaryCopyWithImpl;
 @useResult
 $Res call({
- String worktree, int activeSessions, List<String> activeSessionIds
+ String id, int activeSessions, List<String> activeSessionIds
 });
 
 
@@ -64,9 +64,9 @@ class _$PluginProjectActivitySummaryCopyWithImpl<$Res>
 
 /// Create a copy of PluginProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? worktree = null,Object? activeSessions = null,Object? activeSessionIds = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? activeSessions = null,Object? activeSessionIds = null,}) {
   return _then(_self.copyWith(
-worktree: null == worktree ? _self.worktree : worktree // ignore: cast_nullable_to_non_nullable
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,activeSessions: null == activeSessions ? _self.activeSessions : activeSessions // ignore: cast_nullable_to_non_nullable
 as int,activeSessionIds: null == activeSessionIds ? _self.activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
 as List<String>,
@@ -81,10 +81,10 @@ as List<String>,
 @JsonSerializable(createFactory: false)
 
 class _PluginProjectActivitySummary implements PluginProjectActivitySummary {
-  const _PluginProjectActivitySummary({required this.worktree, required this.activeSessions, final  List<String> activeSessionIds = const []}): _activeSessionIds = activeSessionIds;
+  const _PluginProjectActivitySummary({required this.id, required this.activeSessions, final  List<String> activeSessionIds = const []}): _activeSessionIds = activeSessionIds;
   
 
-@override final  String worktree;
+@override final  String id;
 @override final  int activeSessions;
  final  List<String> _activeSessionIds;
 @override@JsonKey() List<String> get activeSessionIds {
@@ -107,16 +107,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginProjectActivitySummary&&(identical(other.worktree, worktree) || other.worktree == worktree)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions)&&const DeepCollectionEquality().equals(other._activeSessionIds, _activeSessionIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginProjectActivitySummary&&(identical(other.id, id) || other.id == id)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions)&&const DeepCollectionEquality().equals(other._activeSessionIds, _activeSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,worktree,activeSessions,const DeepCollectionEquality().hash(_activeSessionIds));
+int get hashCode => Object.hash(runtimeType,id,activeSessions,const DeepCollectionEquality().hash(_activeSessionIds));
 
 @override
 String toString() {
-  return 'PluginProjectActivitySummary(worktree: $worktree, activeSessions: $activeSessions, activeSessionIds: $activeSessionIds)';
+  return 'PluginProjectActivitySummary(id: $id, activeSessions: $activeSessions, activeSessionIds: $activeSessionIds)';
 }
 
 
@@ -127,7 +127,7 @@ abstract mixin class _$PluginProjectActivitySummaryCopyWith<$Res> implements $Pl
   factory _$PluginProjectActivitySummaryCopyWith(_PluginProjectActivitySummary value, $Res Function(_PluginProjectActivitySummary) _then) = __$PluginProjectActivitySummaryCopyWithImpl;
 @override @useResult
 $Res call({
- String worktree, int activeSessions, List<String> activeSessionIds
+ String id, int activeSessions, List<String> activeSessionIds
 });
 
 
@@ -144,9 +144,9 @@ class __$PluginProjectActivitySummaryCopyWithImpl<$Res>
 
 /// Create a copy of PluginProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? worktree = null,Object? activeSessions = null,Object? activeSessionIds = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? activeSessions = null,Object? activeSessionIds = null,}) {
   return _then(_PluginProjectActivitySummary(
-worktree: null == worktree ? _self.worktree : worktree // ignore: cast_nullable_to_non_nullable
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,activeSessions: null == activeSessions ? _self.activeSessions : activeSessions // ignore: cast_nullable_to_non_nullable
 as int,activeSessionIds: null == activeSessionIds ? _self._activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
 as List<String>,

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.g.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.g.dart
@@ -9,7 +9,7 @@ part of 'plugin_project_activity_summary.dart';
 Map<String, dynamic> _$PluginProjectActivitySummaryToJson(
   _PluginProjectActivitySummary instance,
 ) => <String, dynamic>{
-  'worktree': instance.worktree,
+  'id': instance.id,
   'activeSessions': instance.activeSessions,
   'activeSessionIds': instance.activeSessionIds,
 };

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.g.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.g.dart
@@ -10,6 +10,5 @@ Map<String, dynamic> _$PluginProjectActivitySummaryToJson(
   _PluginProjectActivitySummary instance,
 ) => <String, dynamic>{
   'id': instance.id,
-  'activeSessions': instance.activeSessions,
   'activeSessionIds': instance.activeSessionIds,
 };

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.g.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_project_activity_summary.g.dart
@@ -11,4 +11,5 @@ Map<String, dynamic> _$PluginProjectActivitySummaryToJson(
 ) => <String, dynamic>{
   'worktree': instance.worktree,
   'activeSessions': instance.activeSessions,
+  'activeSessionIds': instance.activeSessionIds,
 };

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -102,7 +102,6 @@ class ActiveSessionTracker {
         .map(
           (e) => ProjectActivitySummary(
             id: e.key,
-            activeSessions: e.value,
             activeSessionIds: sessionIdsByWorktree[e.key] ?? [],
           ),
         )

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -1,3 +1,4 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart" show ProjectActivitySummary, wait2;
 
 import "models/session_status.dart";
@@ -90,7 +91,10 @@ class ActiveSessionTracker {
     final sessionIdsByWorktree = <String, List<String>>{};
     for (final entry in _sessionStatuses.entries) {
       final worktree = _sessionWorktrees[entry.key];
-      if (worktree == null) continue;
+      if (worktree == null) {
+        Log.w("buildSummary: no worktree for session ${entry.key}");
+        continue;
+      }
       sessionIdsByWorktree.putIfAbsent(worktree, () => []).add(entry.key);
     }
 

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -86,9 +86,21 @@ class ActiveSessionTracker {
   }
 
   List<ProjectActivitySummary> buildSummary() {
+    // Collect session IDs per worktree
+    final sessionIdsByWorktree = <String, List<String>>{};
+    for (final entry in _sessionStatuses.entries) {
+      final worktree = _sessionWorktrees[entry.key];
+      if (worktree == null) continue;
+      sessionIdsByWorktree.putIfAbsent(worktree, () => []).add(entry.key);
+    }
+
     return activeSessions.entries
         .map(
-          (e) => ProjectActivitySummary(worktree: e.key, activeSessions: e.value),
+          (e) => ProjectActivitySummary(
+            worktree: e.key,
+            activeSessions: e.value,
+            activeSessionIds: sessionIdsByWorktree[e.key] ?? [],
+          ),
         )
         .toList();
   }

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -101,7 +101,7 @@ class ActiveSessionTracker {
     return activeSessions.entries
         .map(
           (e) => ProjectActivitySummary(
-            worktree: e.key,
+            id: e.key,
             activeSessions: e.value,
             activeSessionIds: sessionIdsByWorktree[e.key] ?? [],
           ),

--- a/bridge/sesori_plugin_opencode/lib/src/models/agent_info.g.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/agent_info.g.dart
@@ -9,7 +9,9 @@ part of 'agent_info.dart';
 _AgentInfo _$AgentInfoFromJson(Map json) => _AgentInfo(
   name: json['name'] as String,
   description: json['description'] as String?,
-  model: json['model'] == null ? null : AgentModel.fromJson(Map<String, dynamic>.from(json['model'] as Map)),
+  model: json['model'] == null
+      ? null
+      : AgentModel.fromJson(Map<String, dynamic>.from(json['model'] as Map)),
   variant: json['variant'] as String?,
   mode: $enumDecode(
     _$AgentModeEnumMap,
@@ -19,14 +21,15 @@ _AgentInfo _$AgentInfoFromJson(Map json) => _AgentInfo(
   hidden: json['hidden'] as bool? ?? false,
 );
 
-Map<String, dynamic> _$AgentInfoToJson(_AgentInfo instance) => <String, dynamic>{
-  'name': instance.name,
-  'description': instance.description,
-  'model': instance.model?.toJson(),
-  'variant': instance.variant,
-  'mode': _$AgentModeEnumMap[instance.mode]!,
-  'hidden': instance.hidden,
-};
+Map<String, dynamic> _$AgentInfoToJson(_AgentInfo instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'description': instance.description,
+      'model': instance.model?.toJson(),
+      'variant': instance.variant,
+      'mode': _$AgentModeEnumMap[instance.mode]!,
+      'hidden': instance.hidden,
+    };
 
 const _$AgentModeEnumMap = {
   AgentMode.all: 'all',
@@ -40,7 +43,8 @@ _AgentModel _$AgentModelFromJson(Map json) => _AgentModel(
   providerID: json['providerID'] as String,
 );
 
-Map<String, dynamic> _$AgentModelToJson(_AgentModel instance) => <String, dynamic>{
-  'modelID': instance.modelID,
-  'providerID': instance.providerID,
-};
+Map<String, dynamic> _$AgentModelToJson(_AgentModel instance) =>
+    <String, dynamic>{
+      'modelID': instance.modelID,
+      'providerID': instance.providerID,
+    };

--- a/bridge/sesori_plugin_opencode/lib/src/models/health_response.g.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/health_response.g.dart
@@ -11,7 +11,5 @@ _HealthResponse _$HealthResponseFromJson(Map json) => _HealthResponse(
   version: json['version'] as String,
 );
 
-Map<String, dynamic> _$HealthResponseToJson(_HealthResponse instance) => <String, dynamic>{
-  'healthy': instance.healthy,
-  'version': instance.version,
-};
+Map<String, dynamic> _$HealthResponseToJson(_HealthResponse instance) =>
+    <String, dynamic>{'healthy': instance.healthy, 'version': instance.version};

--- a/bridge/sesori_plugin_opencode/lib/src/models/message.g.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/message.g.dart
@@ -20,7 +20,9 @@ _Message _$MessageFromJson(Map json) => _Message(
       : MessageTokens.fromJson(
           Map<String, dynamic>.from(json['tokens'] as Map),
         ),
-  time: json['time'] == null ? null : MessageTime.fromJson(Map<String, dynamic>.from(json['time'] as Map)),
+  time: json['time'] == null
+      ? null
+      : MessageTime.fromJson(Map<String, dynamic>.from(json['time'] as Map)),
   finish: json['finish'] as String?,
 );
 
@@ -43,31 +45,33 @@ _MessageTime _$MessageTimeFromJson(Map json) => _MessageTime(
   completed: (json['completed'] as num?)?.toInt(),
 );
 
-Map<String, dynamic> _$MessageTimeToJson(_MessageTime instance) => <String, dynamic>{
-  'created': instance.created,
-  'completed': instance.completed,
-};
+Map<String, dynamic> _$MessageTimeToJson(_MessageTime instance) =>
+    <String, dynamic>{
+      'created': instance.created,
+      'completed': instance.completed,
+    };
 
 _MessageTokens _$MessageTokensFromJson(Map json) => _MessageTokens(
   input: (json['input'] as num?)?.toInt() ?? 0,
   output: (json['output'] as num?)?.toInt() ?? 0,
   reasoning: (json['reasoning'] as num?)?.toInt() ?? 0,
-  cache: json['cache'] == null ? null : TokenCache.fromJson(Map<String, dynamic>.from(json['cache'] as Map)),
+  cache: json['cache'] == null
+      ? null
+      : TokenCache.fromJson(Map<String, dynamic>.from(json['cache'] as Map)),
 );
 
-Map<String, dynamic> _$MessageTokensToJson(_MessageTokens instance) => <String, dynamic>{
-  'input': instance.input,
-  'output': instance.output,
-  'reasoning': instance.reasoning,
-  'cache': instance.cache?.toJson(),
-};
+Map<String, dynamic> _$MessageTokensToJson(_MessageTokens instance) =>
+    <String, dynamic>{
+      'input': instance.input,
+      'output': instance.output,
+      'reasoning': instance.reasoning,
+      'cache': instance.cache?.toJson(),
+    };
 
 _TokenCache _$TokenCacheFromJson(Map json) => _TokenCache(
   read: (json['read'] as num?)?.toInt() ?? 0,
   write: (json['write'] as num?)?.toInt() ?? 0,
 );
 
-Map<String, dynamic> _$TokenCacheToJson(_TokenCache instance) => <String, dynamic>{
-  'read': instance.read,
-  'write': instance.write,
-};
+Map<String, dynamic> _$TokenCacheToJson(_TokenCache instance) =>
+    <String, dynamic>{'read': instance.read, 'write': instance.write};

--- a/bridge/sesori_plugin_opencode/lib/src/models/message_part.g.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/message_part.g.dart
@@ -14,7 +14,9 @@ _MessagePart _$MessagePartFromJson(Map json) => _MessagePart(
   text: json['text'] as String?,
   tool: json['tool'] as String?,
   callID: json['callID'] as String?,
-  state: json['state'] == null ? null : ToolState.fromJson(Map<String, dynamic>.from(json['state'] as Map)),
+  state: json['state'] == null
+      ? null
+      : ToolState.fromJson(Map<String, dynamic>.from(json['state'] as Map)),
   mime: json['mime'] as String?,
   url: json['url'] as String?,
   filename: json['filename'] as String?,
@@ -24,29 +26,32 @@ _MessagePart _$MessagePartFromJson(Map json) => _MessagePart(
   description: json['description'] as String?,
   agent: json['agent'] as String?,
   snapshot: json['snapshot'] as String?,
-  time: json['time'] == null ? null : PartTime.fromJson(Map<String, dynamic>.from(json['time'] as Map)),
+  time: json['time'] == null
+      ? null
+      : PartTime.fromJson(Map<String, dynamic>.from(json['time'] as Map)),
 );
 
-Map<String, dynamic> _$MessagePartToJson(_MessagePart instance) => <String, dynamic>{
-  'id': instance.id,
-  'sessionID': instance.sessionID,
-  'messageID': instance.messageID,
-  'type': instance.type,
-  'text': instance.text,
-  'tool': instance.tool,
-  'callID': instance.callID,
-  'state': instance.state?.toJson(),
-  'mime': instance.mime,
-  'url': instance.url,
-  'filename': instance.filename,
-  'cost': instance.cost,
-  'reason': instance.reason,
-  'prompt': instance.prompt,
-  'description': instance.description,
-  'agent': instance.agent,
-  'snapshot': instance.snapshot,
-  'time': instance.time?.toJson(),
-};
+Map<String, dynamic> _$MessagePartToJson(_MessagePart instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'sessionID': instance.sessionID,
+      'messageID': instance.messageID,
+      'type': instance.type,
+      'text': instance.text,
+      'tool': instance.tool,
+      'callID': instance.callID,
+      'state': instance.state?.toJson(),
+      'mime': instance.mime,
+      'url': instance.url,
+      'filename': instance.filename,
+      'cost': instance.cost,
+      'reason': instance.reason,
+      'prompt': instance.prompt,
+      'description': instance.description,
+      'agent': instance.agent,
+      'snapshot': instance.snapshot,
+      'time': instance.time?.toJson(),
+    };
 
 _ToolState _$ToolStateFromJson(Map json) => _ToolState(
   status: json['status'] as String,
@@ -55,12 +60,13 @@ _ToolState _$ToolStateFromJson(Map json) => _ToolState(
   error: json['error'] as String?,
 );
 
-Map<String, dynamic> _$ToolStateToJson(_ToolState instance) => <String, dynamic>{
-  'status': instance.status,
-  'title': instance.title,
-  'output': instance.output,
-  'error': instance.error,
-};
+Map<String, dynamic> _$ToolStateToJson(_ToolState instance) =>
+    <String, dynamic>{
+      'status': instance.status,
+      'title': instance.title,
+      'output': instance.output,
+      'error': instance.error,
+    };
 
 _PartTime _$PartTimeFromJson(Map json) => _PartTime(
   start: (json['start'] as num?)?.toInt(),

--- a/bridge/sesori_plugin_opencode/lib/src/models/message_with_parts.g.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/message_with_parts.g.dart
@@ -13,7 +13,8 @@ _MessageWithParts _$MessageWithPartsFromJson(Map json) => _MessageWithParts(
       .toList(),
 );
 
-Map<String, dynamic> _$MessageWithPartsToJson(_MessageWithParts instance) => <String, dynamic>{
-  'info': instance.info.toJson(),
-  'parts': instance.parts.map((e) => e.toJson()).toList(),
-};
+Map<String, dynamic> _$MessageWithPartsToJson(_MessageWithParts instance) =>
+    <String, dynamic>{
+      'info': instance.info.toJson(),
+      'parts': instance.parts.map((e) => e.toJson()).toList(),
+    };

--- a/bridge/sesori_plugin_opencode/lib/src/models/project.g.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/project.g.dart
@@ -10,7 +10,9 @@ _Project _$ProjectFromJson(Map json) => _Project(
   id: json['id'] as String,
   worktree: json['worktree'] as String,
   name: json['name'] as String?,
-  time: json['time'] == null ? null : ProjectTime.fromJson(Map<String, dynamic>.from(json['time'] as Map)),
+  time: json['time'] == null
+      ? null
+      : ProjectTime.fromJson(Map<String, dynamic>.from(json['time'] as Map)),
 );
 
 Map<String, dynamic> _$ProjectToJson(_Project instance) => <String, dynamic>{
@@ -26,8 +28,9 @@ _ProjectTime _$ProjectTimeFromJson(Map json) => _ProjectTime(
   initialized: (json['initialized'] as num?)?.toInt(),
 );
 
-Map<String, dynamic> _$ProjectTimeToJson(_ProjectTime instance) => <String, dynamic>{
-  'created': instance.created,
-  'updated': instance.updated,
-  'initialized': instance.initialized,
-};
+Map<String, dynamic> _$ProjectTimeToJson(_ProjectTime instance) =>
+    <String, dynamic>{
+      'created': instance.created,
+      'updated': instance.updated,
+      'initialized': instance.initialized,
+    };

--- a/bridge/sesori_plugin_opencode/lib/src/models/provider_info.g.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/provider_info.g.dart
@@ -17,11 +17,12 @@ _ProviderInfo _$ProviderInfoFromJson(Map json) => _ProviderInfo(
   ),
 );
 
-Map<String, dynamic> _$ProviderInfoToJson(_ProviderInfo instance) => <String, dynamic>{
-  'id': instance.id,
-  'name': instance.name,
-  'models': instance.models.map((k, e) => MapEntry(k, e.toJson())),
-};
+Map<String, dynamic> _$ProviderInfoToJson(_ProviderInfo instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'models': instance.models.map((k, e) => MapEntry(k, e.toJson())),
+    };
 
 _ProviderModel _$ProviderModelFromJson(Map json) => _ProviderModel(
   id: json['id'] as String,
@@ -32,24 +33,28 @@ _ProviderModel _$ProviderModelFromJson(Map json) => _ProviderModel(
   releaseDate: json['release_date'] as String?,
 );
 
-Map<String, dynamic> _$ProviderModelToJson(_ProviderModel instance) => <String, dynamic>{
-  'id': instance.id,
-  'providerID': instance.providerID,
-  'name': instance.name,
-  'family': instance.family,
-  'status': instance.status,
-  'release_date': instance.releaseDate,
-};
+Map<String, dynamic> _$ProviderModelToJson(_ProviderModel instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'providerID': instance.providerID,
+      'name': instance.name,
+      'family': instance.family,
+      'status': instance.status,
+      'release_date': instance.releaseDate,
+    };
 
-_ProviderListResponse _$ProviderListResponseFromJson(Map json) => _ProviderListResponse(
-  all: (json['all'] as List<dynamic>)
-      .map(
-        (e) => ProviderInfo.fromJson(Map<String, dynamic>.from(e as Map)),
-      )
-      .toList(),
-  defaults: Map<String, String>.from(json['default'] as Map),
-  connected: (json['connected'] as List<dynamic>).map((e) => e as String).toList(),
-);
+_ProviderListResponse _$ProviderListResponseFromJson(Map json) =>
+    _ProviderListResponse(
+      all: (json['all'] as List<dynamic>)
+          .map(
+            (e) => ProviderInfo.fromJson(Map<String, dynamic>.from(e as Map)),
+          )
+          .toList(),
+      defaults: Map<String, String>.from(json['default'] as Map),
+      connected: (json['connected'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
+    );
 
 Map<String, dynamic> _$ProviderListResponseToJson(
   _ProviderListResponse instance,

--- a/bridge/sesori_plugin_opencode/lib/src/models/question.g.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/question.g.dart
@@ -20,20 +20,22 @@ _QuestionInfo _$QuestionInfoFromJson(Map json) => _QuestionInfo(
   custom: json['custom'] as bool? ?? true,
 );
 
-Map<String, dynamic> _$QuestionInfoToJson(_QuestionInfo instance) => <String, dynamic>{
-  'question': instance.question,
-  'header': instance.header,
-  'options': instance.options.map((e) => e.toJson()).toList(),
-  'multiple': instance.multiple,
-  'custom': instance.custom,
-};
+Map<String, dynamic> _$QuestionInfoToJson(_QuestionInfo instance) =>
+    <String, dynamic>{
+      'question': instance.question,
+      'header': instance.header,
+      'options': instance.options.map((e) => e.toJson()).toList(),
+      'multiple': instance.multiple,
+      'custom': instance.custom,
+    };
 
 _QuestionOption _$QuestionOptionFromJson(Map json) => _QuestionOption(
   label: json['label'] as String,
   description: json['description'] as String,
 );
 
-Map<String, dynamic> _$QuestionOptionToJson(_QuestionOption instance) => <String, dynamic>{
-  'label': instance.label,
-  'description': instance.description,
-};
+Map<String, dynamic> _$QuestionOptionToJson(_QuestionOption instance) =>
+    <String, dynamic>{
+      'label': instance.label,
+      'description': instance.description,
+    };

--- a/bridge/sesori_plugin_opencode/lib/src/models/session.g.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/session.g.dart
@@ -12,7 +12,9 @@ _Session _$SessionFromJson(Map json) => _Session(
   directory: json['directory'] as String,
   parentID: json['parentID'] as String?,
   title: json['title'] as String?,
-  time: json['time'] == null ? null : SessionTime.fromJson(Map<String, dynamic>.from(json['time'] as Map)),
+  time: json['time'] == null
+      ? null
+      : SessionTime.fromJson(Map<String, dynamic>.from(json['time'] as Map)),
   summary: json['summary'] == null
       ? null
       : SessionSummary.fromJson(
@@ -36,11 +38,12 @@ _SessionTime _$SessionTimeFromJson(Map json) => _SessionTime(
   archived: (json['archived'] as num?)?.toInt(),
 );
 
-Map<String, dynamic> _$SessionTimeToJson(_SessionTime instance) => <String, dynamic>{
-  'created': instance.created,
-  'updated': instance.updated,
-  'archived': instance.archived,
-};
+Map<String, dynamic> _$SessionTimeToJson(_SessionTime instance) =>
+    <String, dynamic>{
+      'created': instance.created,
+      'updated': instance.updated,
+      'archived': instance.archived,
+    };
 
 _SessionSummary _$SessionSummaryFromJson(Map json) => _SessionSummary(
   additions: (json['additions'] as num?)?.toInt() ?? 0,
@@ -48,11 +51,12 @@ _SessionSummary _$SessionSummaryFromJson(Map json) => _SessionSummary(
   files: (json['files'] as num?)?.toInt() ?? 0,
 );
 
-Map<String, dynamic> _$SessionSummaryToJson(_SessionSummary instance) => <String, dynamic>{
-  'additions': instance.additions,
-  'deletions': instance.deletions,
-  'files': instance.files,
-};
+Map<String, dynamic> _$SessionSummaryToJson(_SessionSummary instance) =>
+    <String, dynamic>{
+      'additions': instance.additions,
+      'deletions': instance.deletions,
+      'files': instance.files,
+    };
 
 _GlobalSession _$GlobalSessionFromJson(Map json) => _GlobalSession(
   id: json['id'] as String,
@@ -60,7 +64,9 @@ _GlobalSession _$GlobalSessionFromJson(Map json) => _GlobalSession(
   directory: json['directory'] as String,
   parentID: json['parentID'] as String?,
   title: json['title'] as String?,
-  time: json['time'] == null ? null : SessionTime.fromJson(Map<String, dynamic>.from(json['time'] as Map)),
+  time: json['time'] == null
+      ? null
+      : SessionTime.fromJson(Map<String, dynamic>.from(json['time'] as Map)),
   summary: json['summary'] == null
       ? null
       : SessionSummary.fromJson(
@@ -73,16 +79,17 @@ _GlobalSession _$GlobalSessionFromJson(Map json) => _GlobalSession(
         ),
 );
 
-Map<String, dynamic> _$GlobalSessionToJson(_GlobalSession instance) => <String, dynamic>{
-  'id': instance.id,
-  'projectID': instance.projectID,
-  'directory': instance.directory,
-  'parentID': instance.parentID,
-  'title': instance.title,
-  'time': instance.time?.toJson(),
-  'summary': instance.summary?.toJson(),
-  'project': instance.project?.toJson(),
-};
+Map<String, dynamic> _$GlobalSessionToJson(_GlobalSession instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'projectID': instance.projectID,
+      'directory': instance.directory,
+      'parentID': instance.parentID,
+      'title': instance.title,
+      'time': instance.time?.toJson(),
+      'summary': instance.summary?.toJson(),
+      'project': instance.project?.toJson(),
+    };
 
 _SessionProject _$SessionProjectFromJson(Map json) => _SessionProject(
   id: json['id'] as String,
@@ -90,8 +97,9 @@ _SessionProject _$SessionProjectFromJson(Map json) => _SessionProject(
   worktree: json['worktree'] as String,
 );
 
-Map<String, dynamic> _$SessionProjectToJson(_SessionProject instance) => <String, dynamic>{
-  'id': instance.id,
-  'name': instance.name,
-  'worktree': instance.worktree,
-};
+Map<String, dynamic> _$SessionProjectToJson(_SessionProject instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'worktree': instance.worktree,
+    };

--- a/bridge/sesori_plugin_opencode/lib/src/models/session_status.g.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/session_status.g.dart
@@ -6,13 +6,17 @@ part of 'session_status.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-SessionStatusIdle _$SessionStatusIdleFromJson(Map json) => SessionStatusIdle($type: json['type'] as String?);
+SessionStatusIdle _$SessionStatusIdleFromJson(Map json) =>
+    SessionStatusIdle($type: json['type'] as String?);
 
-Map<String, dynamic> _$SessionStatusIdleToJson(SessionStatusIdle instance) => <String, dynamic>{'type': instance.$type};
+Map<String, dynamic> _$SessionStatusIdleToJson(SessionStatusIdle instance) =>
+    <String, dynamic>{'type': instance.$type};
 
-SessionStatusBusy _$SessionStatusBusyFromJson(Map json) => SessionStatusBusy($type: json['type'] as String?);
+SessionStatusBusy _$SessionStatusBusyFromJson(Map json) =>
+    SessionStatusBusy($type: json['type'] as String?);
 
-Map<String, dynamic> _$SessionStatusBusyToJson(SessionStatusBusy instance) => <String, dynamic>{'type': instance.$type};
+Map<String, dynamic> _$SessionStatusBusyToJson(SessionStatusBusy instance) =>
+    <String, dynamic>{'type': instance.$type};
 
 SessionStatusRetry _$SessionStatusRetryFromJson(Map json) => SessionStatusRetry(
   attempt: (json['attempt'] as num).toInt(),
@@ -21,9 +25,10 @@ SessionStatusRetry _$SessionStatusRetryFromJson(Map json) => SessionStatusRetry(
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SessionStatusRetryToJson(SessionStatusRetry instance) => <String, dynamic>{
-  'attempt': instance.attempt,
-  'message': instance.message,
-  'next': instance.next,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SessionStatusRetryToJson(SessionStatusRetry instance) =>
+    <String, dynamic>{
+      'attempt': instance.attempt,
+      'message': instance.message,
+      'next': instance.next,
+      'type': instance.$type,
+    };

--- a/bridge/sesori_plugin_opencode/lib/src/models/sse_event_data.g.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/sse_event_data.g.dart
@@ -6,87 +6,86 @@ part of 'sse_event_data.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-SseServerConnected _$SseServerConnectedFromJson(Map json) => SseServerConnected($type: json['type'] as String?);
+SseServerConnected _$SseServerConnectedFromJson(Map json) =>
+    SseServerConnected($type: json['type'] as String?);
 
-Map<String, dynamic> _$SseServerConnectedToJson(SseServerConnected instance) => <String, dynamic>{
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseServerConnectedToJson(SseServerConnected instance) =>
+    <String, dynamic>{'type': instance.$type};
 
-SseServerHeartbeat _$SseServerHeartbeatFromJson(Map json) => SseServerHeartbeat($type: json['type'] as String?);
+SseServerHeartbeat _$SseServerHeartbeatFromJson(Map json) =>
+    SseServerHeartbeat($type: json['type'] as String?);
 
-Map<String, dynamic> _$SseServerHeartbeatToJson(SseServerHeartbeat instance) => <String, dynamic>{
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseServerHeartbeatToJson(SseServerHeartbeat instance) =>
+    <String, dynamic>{'type': instance.$type};
 
-SseServerInstanceDisposed _$SseServerInstanceDisposedFromJson(Map json) => SseServerInstanceDisposed(
-  directory: json['directory'] as String?,
-  $type: json['type'] as String?,
-);
+SseServerInstanceDisposed _$SseServerInstanceDisposedFromJson(Map json) =>
+    SseServerInstanceDisposed(
+      directory: json['directory'] as String?,
+      $type: json['type'] as String?,
+    );
 
 Map<String, dynamic> _$SseServerInstanceDisposedToJson(
   SseServerInstanceDisposed instance,
 ) => <String, dynamic>{'directory': instance.directory, 'type': instance.$type};
 
-SseGlobalDisposed _$SseGlobalDisposedFromJson(Map json) => SseGlobalDisposed($type: json['type'] as String?);
+SseGlobalDisposed _$SseGlobalDisposedFromJson(Map json) =>
+    SseGlobalDisposed($type: json['type'] as String?);
 
-Map<String, dynamic> _$SseGlobalDisposedToJson(SseGlobalDisposed instance) => <String, dynamic>{'type': instance.$type};
+Map<String, dynamic> _$SseGlobalDisposedToJson(SseGlobalDisposed instance) =>
+    <String, dynamic>{'type': instance.$type};
 
 SseSessionCreated _$SseSessionCreatedFromJson(Map json) => SseSessionCreated(
   info: Session.fromJson(Map<String, dynamic>.from(json['info'] as Map)),
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SseSessionCreatedToJson(SseSessionCreated instance) => <String, dynamic>{
-  'info': instance.info.toJson(),
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseSessionCreatedToJson(SseSessionCreated instance) =>
+    <String, dynamic>{'info': instance.info.toJson(), 'type': instance.$type};
 
 SseSessionUpdated _$SseSessionUpdatedFromJson(Map json) => SseSessionUpdated(
   info: Session.fromJson(Map<String, dynamic>.from(json['info'] as Map)),
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SseSessionUpdatedToJson(SseSessionUpdated instance) => <String, dynamic>{
-  'info': instance.info.toJson(),
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseSessionUpdatedToJson(SseSessionUpdated instance) =>
+    <String, dynamic>{'info': instance.info.toJson(), 'type': instance.$type};
 
 SseSessionDeleted _$SseSessionDeletedFromJson(Map json) => SseSessionDeleted(
   info: Session.fromJson(Map<String, dynamic>.from(json['info'] as Map)),
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SseSessionDeletedToJson(SseSessionDeleted instance) => <String, dynamic>{
-  'info': instance.info.toJson(),
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseSessionDeletedToJson(SseSessionDeleted instance) =>
+    <String, dynamic>{'info': instance.info.toJson(), 'type': instance.$type};
 
 SseSessionDiff _$SseSessionDiffFromJson(Map json) => SseSessionDiff(
   sessionID: json['sessionID'] as String,
-  diff: (json['diff'] as List<dynamic>).map((e) => FileDiff.fromJson(Map<String, dynamic>.from(e as Map))).toList(),
+  diff: (json['diff'] as List<dynamic>)
+      .map((e) => FileDiff.fromJson(Map<String, dynamic>.from(e as Map)))
+      .toList(),
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SseSessionDiffToJson(SseSessionDiff instance) => <String, dynamic>{
-  'sessionID': instance.sessionID,
-  'diff': instance.diff.map((e) => e.toJson()).toList(),
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseSessionDiffToJson(SseSessionDiff instance) =>
+    <String, dynamic>{
+      'sessionID': instance.sessionID,
+      'diff': instance.diff.map((e) => e.toJson()).toList(),
+      'type': instance.$type,
+    };
 
 SseSessionError _$SseSessionErrorFromJson(Map json) => SseSessionError(
   sessionID: json['sessionID'] as String,
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SseSessionErrorToJson(SseSessionError instance) => <String, dynamic>{
-  'sessionID': instance.sessionID,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseSessionErrorToJson(SseSessionError instance) =>
+    <String, dynamic>{'sessionID': instance.sessionID, 'type': instance.$type};
 
-SseSessionCompacted _$SseSessionCompactedFromJson(Map json) => SseSessionCompacted(
-  sessionID: json['sessionID'] as String,
-  $type: json['type'] as String?,
-);
+SseSessionCompacted _$SseSessionCompactedFromJson(Map json) =>
+    SseSessionCompacted(
+      sessionID: json['sessionID'] as String,
+      $type: json['type'] as String?,
+    );
 
 Map<String, dynamic> _$SseSessionCompactedToJson(
   SseSessionCompacted instance,
@@ -100,31 +99,28 @@ SseSessionStatus _$SseSessionStatusFromJson(Map json) => SseSessionStatus(
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SseSessionStatusToJson(SseSessionStatus instance) => <String, dynamic>{
-  'sessionID': instance.sessionID,
-  'status': instance.status.toJson(),
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseSessionStatusToJson(SseSessionStatus instance) =>
+    <String, dynamic>{
+      'sessionID': instance.sessionID,
+      'status': instance.status.toJson(),
+      'type': instance.$type,
+    };
 
 SseSessionIdle _$SseSessionIdleFromJson(Map json) => SseSessionIdle(
   sessionID: json['sessionID'] as String,
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SseSessionIdleToJson(SseSessionIdle instance) => <String, dynamic>{
-  'sessionID': instance.sessionID,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseSessionIdleToJson(SseSessionIdle instance) =>
+    <String, dynamic>{'sessionID': instance.sessionID, 'type': instance.$type};
 
 SseMessageUpdated _$SseMessageUpdatedFromJson(Map json) => SseMessageUpdated(
   info: Message.fromJson(Map<String, dynamic>.from(json['info'] as Map)),
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SseMessageUpdatedToJson(SseMessageUpdated instance) => <String, dynamic>{
-  'info': instance.info.toJson(),
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseMessageUpdatedToJson(SseMessageUpdated instance) =>
+    <String, dynamic>{'info': instance.info.toJson(), 'type': instance.$type};
 
 SseMessageRemoved _$SseMessageRemovedFromJson(Map json) => SseMessageRemoved(
   sessionID: json['sessionID'] as String,
@@ -132,31 +128,34 @@ SseMessageRemoved _$SseMessageRemovedFromJson(Map json) => SseMessageRemoved(
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SseMessageRemovedToJson(SseMessageRemoved instance) => <String, dynamic>{
-  'sessionID': instance.sessionID,
-  'messageID': instance.messageID,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseMessageRemovedToJson(SseMessageRemoved instance) =>
+    <String, dynamic>{
+      'sessionID': instance.sessionID,
+      'messageID': instance.messageID,
+      'type': instance.$type,
+    };
 
-SseMessagePartUpdated _$SseMessagePartUpdatedFromJson(Map json) => SseMessagePartUpdated(
-  part: MessagePart.fromJson(
-    Map<String, dynamic>.from(json['part'] as Map),
-  ),
-  $type: json['type'] as String?,
-);
+SseMessagePartUpdated _$SseMessagePartUpdatedFromJson(Map json) =>
+    SseMessagePartUpdated(
+      part: MessagePart.fromJson(
+        Map<String, dynamic>.from(json['part'] as Map),
+      ),
+      $type: json['type'] as String?,
+    );
 
 Map<String, dynamic> _$SseMessagePartUpdatedToJson(
   SseMessagePartUpdated instance,
 ) => <String, dynamic>{'part': instance.part.toJson(), 'type': instance.$type};
 
-SseMessagePartDelta _$SseMessagePartDeltaFromJson(Map json) => SseMessagePartDelta(
-  sessionID: json['sessionID'] as String,
-  messageID: json['messageID'] as String,
-  partID: json['partID'] as String,
-  field: json['field'] as String,
-  delta: json['delta'] as String,
-  $type: json['type'] as String?,
-);
+SseMessagePartDelta _$SseMessagePartDeltaFromJson(Map json) =>
+    SseMessagePartDelta(
+      sessionID: json['sessionID'] as String,
+      messageID: json['messageID'] as String,
+      partID: json['partID'] as String,
+      field: json['field'] as String,
+      delta: json['delta'] as String,
+      $type: json['type'] as String?,
+    );
 
 Map<String, dynamic> _$SseMessagePartDeltaToJson(
   SseMessagePartDelta instance,
@@ -169,12 +168,13 @@ Map<String, dynamic> _$SseMessagePartDeltaToJson(
   'type': instance.$type,
 };
 
-SseMessagePartRemoved _$SseMessagePartRemovedFromJson(Map json) => SseMessagePartRemoved(
-  sessionID: json['sessionID'] as String,
-  messageID: json['messageID'] as String,
-  partID: json['partID'] as String,
-  $type: json['type'] as String?,
-);
+SseMessagePartRemoved _$SseMessagePartRemovedFromJson(Map json) =>
+    SseMessagePartRemoved(
+      sessionID: json['sessionID'] as String,
+      messageID: json['messageID'] as String,
+      partID: json['partID'] as String,
+      $type: json['type'] as String?,
+    );
 
 Map<String, dynamic> _$SseMessagePartRemovedToJson(
   SseMessagePartRemoved instance,
@@ -185,13 +185,17 @@ Map<String, dynamic> _$SseMessagePartRemovedToJson(
   'type': instance.$type,
 };
 
-SsePtyCreated _$SsePtyCreatedFromJson(Map json) => SsePtyCreated($type: json['type'] as String?);
+SsePtyCreated _$SsePtyCreatedFromJson(Map json) =>
+    SsePtyCreated($type: json['type'] as String?);
 
-Map<String, dynamic> _$SsePtyCreatedToJson(SsePtyCreated instance) => <String, dynamic>{'type': instance.$type};
+Map<String, dynamic> _$SsePtyCreatedToJson(SsePtyCreated instance) =>
+    <String, dynamic>{'type': instance.$type};
 
-SsePtyUpdated _$SsePtyUpdatedFromJson(Map json) => SsePtyUpdated($type: json['type'] as String?);
+SsePtyUpdated _$SsePtyUpdatedFromJson(Map json) =>
+    SsePtyUpdated($type: json['type'] as String?);
 
-Map<String, dynamic> _$SsePtyUpdatedToJson(SsePtyUpdated instance) => <String, dynamic>{'type': instance.$type};
+Map<String, dynamic> _$SsePtyUpdatedToJson(SsePtyUpdated instance) =>
+    <String, dynamic>{'type': instance.$type};
 
 SsePtyExited _$SsePtyExitedFromJson(Map json) => SsePtyExited(
   id: json['id'] as String?,
@@ -199,19 +203,18 @@ SsePtyExited _$SsePtyExitedFromJson(Map json) => SsePtyExited(
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SsePtyExitedToJson(SsePtyExited instance) => <String, dynamic>{
-  'id': instance.id,
-  'exitCode': instance.exitCode,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SsePtyExitedToJson(SsePtyExited instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'exitCode': instance.exitCode,
+      'type': instance.$type,
+    };
 
 SsePtyDeleted _$SsePtyDeletedFromJson(Map json) =>
     SsePtyDeleted(id: json['id'] as String?, $type: json['type'] as String?);
 
-Map<String, dynamic> _$SsePtyDeletedToJson(SsePtyDeleted instance) => <String, dynamic>{
-  'id': instance.id,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SsePtyDeletedToJson(SsePtyDeleted instance) =>
+    <String, dynamic>{'id': instance.id, 'type': instance.$type};
 
 SsePermissionAsked _$SsePermissionAskedFromJson(Map json) => SsePermissionAsked(
   requestID: json['requestID'] as String,
@@ -221,19 +224,21 @@ SsePermissionAsked _$SsePermissionAskedFromJson(Map json) => SsePermissionAsked(
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SsePermissionAskedToJson(SsePermissionAsked instance) => <String, dynamic>{
-  'requestID': instance.requestID,
-  'sessionID': instance.sessionID,
-  'tool': instance.tool,
-  'description': instance.description,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SsePermissionAskedToJson(SsePermissionAsked instance) =>
+    <String, dynamic>{
+      'requestID': instance.requestID,
+      'sessionID': instance.sessionID,
+      'tool': instance.tool,
+      'description': instance.description,
+      'type': instance.$type,
+    };
 
-SsePermissionReplied _$SsePermissionRepliedFromJson(Map json) => SsePermissionReplied(
-  requestID: json['requestID'] as String,
-  reply: json['reply'] as String,
-  $type: json['type'] as String?,
-);
+SsePermissionReplied _$SsePermissionRepliedFromJson(Map json) =>
+    SsePermissionReplied(
+      requestID: json['requestID'] as String,
+      reply: json['reply'] as String,
+      $type: json['type'] as String?,
+    );
 
 Map<String, dynamic> _$SsePermissionRepliedToJson(
   SsePermissionReplied instance,
@@ -243,7 +248,8 @@ Map<String, dynamic> _$SsePermissionRepliedToJson(
   'type': instance.$type,
 };
 
-SsePermissionUpdated _$SsePermissionUpdatedFromJson(Map json) => SsePermissionUpdated($type: json['type'] as String?);
+SsePermissionUpdated _$SsePermissionUpdatedFromJson(Map json) =>
+    SsePermissionUpdated($type: json['type'] as String?);
 
 Map<String, dynamic> _$SsePermissionUpdatedToJson(
   SsePermissionUpdated instance,
@@ -258,12 +264,13 @@ SseQuestionAsked _$SseQuestionAskedFromJson(Map json) => SseQuestionAsked(
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SseQuestionAskedToJson(SseQuestionAsked instance) => <String, dynamic>{
-  'id': instance.id,
-  'sessionID': instance.sessionID,
-  'questions': instance.questions.map((e) => e.toJson()).toList(),
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseQuestionAskedToJson(SseQuestionAsked instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'sessionID': instance.sessionID,
+      'questions': instance.questions.map((e) => e.toJson()).toList(),
+      'type': instance.$type,
+    };
 
 SseQuestionReplied _$SseQuestionRepliedFromJson(Map json) => SseQuestionReplied(
   requestID: json['requestID'] as String,
@@ -271,17 +278,19 @@ SseQuestionReplied _$SseQuestionRepliedFromJson(Map json) => SseQuestionReplied(
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SseQuestionRepliedToJson(SseQuestionReplied instance) => <String, dynamic>{
-  'requestID': instance.requestID,
-  'sessionID': instance.sessionID,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseQuestionRepliedToJson(SseQuestionReplied instance) =>
+    <String, dynamic>{
+      'requestID': instance.requestID,
+      'sessionID': instance.sessionID,
+      'type': instance.$type,
+    };
 
-SseQuestionRejected _$SseQuestionRejectedFromJson(Map json) => SseQuestionRejected(
-  requestID: json['requestID'] as String,
-  sessionID: json['sessionID'] as String,
-  $type: json['type'] as String?,
-);
+SseQuestionRejected _$SseQuestionRejectedFromJson(Map json) =>
+    SseQuestionRejected(
+      requestID: json['requestID'] as String,
+      sessionID: json['sessionID'] as String,
+      $type: json['type'] as String?,
+    );
 
 Map<String, dynamic> _$SseQuestionRejectedToJson(
   SseQuestionRejected instance,
@@ -296,16 +305,17 @@ SseTodoUpdated _$SseTodoUpdatedFromJson(Map json) => SseTodoUpdated(
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SseTodoUpdatedToJson(SseTodoUpdated instance) => <String, dynamic>{
-  'sessionID': instance.sessionID,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseTodoUpdatedToJson(SseTodoUpdated instance) =>
+    <String, dynamic>{'sessionID': instance.sessionID, 'type': instance.$type};
 
-SseProjectUpdated _$SseProjectUpdatedFromJson(Map json) => SseProjectUpdated($type: json['type'] as String?);
+SseProjectUpdated _$SseProjectUpdatedFromJson(Map json) =>
+    SseProjectUpdated($type: json['type'] as String?);
 
-Map<String, dynamic> _$SseProjectUpdatedToJson(SseProjectUpdated instance) => <String, dynamic>{'type': instance.$type};
+Map<String, dynamic> _$SseProjectUpdatedToJson(SseProjectUpdated instance) =>
+    <String, dynamic>{'type': instance.$type};
 
-SseVcsBranchUpdated _$SseVcsBranchUpdatedFromJson(Map json) => SseVcsBranchUpdated($type: json['type'] as String?);
+SseVcsBranchUpdated _$SseVcsBranchUpdatedFromJson(Map json) =>
+    SseVcsBranchUpdated($type: json['type'] as String?);
 
 Map<String, dynamic> _$SseVcsBranchUpdatedToJson(
   SseVcsBranchUpdated instance,
@@ -316,16 +326,15 @@ SseFileEdited _$SseFileEditedFromJson(Map json) => SseFileEdited(
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SseFileEditedToJson(SseFileEdited instance) => <String, dynamic>{
-  'file': instance.file,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseFileEditedToJson(SseFileEdited instance) =>
+    <String, dynamic>{'file': instance.file, 'type': instance.$type};
 
-SseFileWatcherUpdated _$SseFileWatcherUpdatedFromJson(Map json) => SseFileWatcherUpdated(
-  file: json['file'] as String?,
-  event: json['event'] as String?,
-  $type: json['type'] as String?,
-);
+SseFileWatcherUpdated _$SseFileWatcherUpdatedFromJson(Map json) =>
+    SseFileWatcherUpdated(
+      file: json['file'] as String?,
+      event: json['event'] as String?,
+      $type: json['type'] as String?,
+    );
 
 Map<String, dynamic> _$SseFileWatcherUpdatedToJson(
   SseFileWatcherUpdated instance,
@@ -335,15 +344,18 @@ Map<String, dynamic> _$SseFileWatcherUpdatedToJson(
   'type': instance.$type,
 };
 
-SseLspUpdated _$SseLspUpdatedFromJson(Map json) => SseLspUpdated($type: json['type'] as String?);
+SseLspUpdated _$SseLspUpdatedFromJson(Map json) =>
+    SseLspUpdated($type: json['type'] as String?);
 
-Map<String, dynamic> _$SseLspUpdatedToJson(SseLspUpdated instance) => <String, dynamic>{'type': instance.$type};
+Map<String, dynamic> _$SseLspUpdatedToJson(SseLspUpdated instance) =>
+    <String, dynamic>{'type': instance.$type};
 
-SseLspClientDiagnostics _$SseLspClientDiagnosticsFromJson(Map json) => SseLspClientDiagnostics(
-  serverID: json['serverID'] as String?,
-  path: json['path'] as String?,
-  $type: json['type'] as String?,
-);
+SseLspClientDiagnostics _$SseLspClientDiagnosticsFromJson(Map json) =>
+    SseLspClientDiagnostics(
+      serverID: json['serverID'] as String?,
+      path: json['path'] as String?,
+      $type: json['type'] as String?,
+    );
 
 Map<String, dynamic> _$SseLspClientDiagnosticsToJson(
   SseLspClientDiagnostics instance,
@@ -353,11 +365,11 @@ Map<String, dynamic> _$SseLspClientDiagnosticsToJson(
   'type': instance.$type,
 };
 
-SseMcpToolsChanged _$SseMcpToolsChangedFromJson(Map json) => SseMcpToolsChanged($type: json['type'] as String?);
+SseMcpToolsChanged _$SseMcpToolsChangedFromJson(Map json) =>
+    SseMcpToolsChanged($type: json['type'] as String?);
 
-Map<String, dynamic> _$SseMcpToolsChangedToJson(SseMcpToolsChanged instance) => <String, dynamic>{
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseMcpToolsChangedToJson(SseMcpToolsChanged instance) =>
+    <String, dynamic>{'type': instance.$type};
 
 SseMcpBrowserOpenFailed _$SseMcpBrowserOpenFailedFromJson(Map json) =>
     SseMcpBrowserOpenFailed($type: json['type'] as String?);
@@ -366,10 +378,11 @@ Map<String, dynamic> _$SseMcpBrowserOpenFailedToJson(
   SseMcpBrowserOpenFailed instance,
 ) => <String, dynamic>{'type': instance.$type};
 
-SseInstallationUpdated _$SseInstallationUpdatedFromJson(Map json) => SseInstallationUpdated(
-  version: json['version'] as String?,
-  $type: json['type'] as String?,
-);
+SseInstallationUpdated _$SseInstallationUpdatedFromJson(Map json) =>
+    SseInstallationUpdated(
+      version: json['version'] as String?,
+      $type: json['type'] as String?,
+    );
 
 Map<String, dynamic> _$SseInstallationUpdatedToJson(
   SseInstallationUpdated instance,
@@ -391,20 +404,16 @@ SseWorkspaceReady _$SseWorkspaceReadyFromJson(Map json) => SseWorkspaceReady(
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SseWorkspaceReadyToJson(SseWorkspaceReady instance) => <String, dynamic>{
-  'name': instance.name,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseWorkspaceReadyToJson(SseWorkspaceReady instance) =>
+    <String, dynamic>{'name': instance.name, 'type': instance.$type};
 
 SseWorkspaceFailed _$SseWorkspaceFailedFromJson(Map json) => SseWorkspaceFailed(
   message: json['message'] as String?,
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SseWorkspaceFailedToJson(SseWorkspaceFailed instance) => <String, dynamic>{
-  'message': instance.message,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseWorkspaceFailedToJson(SseWorkspaceFailed instance) =>
+    <String, dynamic>{'message': instance.message, 'type': instance.$type};
 
 SseTuiToastShow _$SseTuiToastShowFromJson(Map json) => SseTuiToastShow(
   title: json['title'] as String?,
@@ -413,17 +422,22 @@ SseTuiToastShow _$SseTuiToastShowFromJson(Map json) => SseTuiToastShow(
   $type: json['type'] as String?,
 );
 
-Map<String, dynamic> _$SseTuiToastShowToJson(SseTuiToastShow instance) => <String, dynamic>{
-  'title': instance.title,
-  'message': instance.message,
-  'variant': instance.variant,
-  'type': instance.$type,
-};
+Map<String, dynamic> _$SseTuiToastShowToJson(SseTuiToastShow instance) =>
+    <String, dynamic>{
+      'title': instance.title,
+      'message': instance.message,
+      'variant': instance.variant,
+      'type': instance.$type,
+    };
 
-SseWorktreeReady _$SseWorktreeReadyFromJson(Map json) => SseWorktreeReady($type: json['type'] as String?);
+SseWorktreeReady _$SseWorktreeReadyFromJson(Map json) =>
+    SseWorktreeReady($type: json['type'] as String?);
 
-Map<String, dynamic> _$SseWorktreeReadyToJson(SseWorktreeReady instance) => <String, dynamic>{'type': instance.$type};
+Map<String, dynamic> _$SseWorktreeReadyToJson(SseWorktreeReady instance) =>
+    <String, dynamic>{'type': instance.$type};
 
-SseWorktreeFailed _$SseWorktreeFailedFromJson(Map json) => SseWorktreeFailed($type: json['type'] as String?);
+SseWorktreeFailed _$SseWorktreeFailedFromJson(Map json) =>
+    SseWorktreeFailed($type: json['type'] as String?);
 
-Map<String, dynamic> _$SseWorktreeFailedToJson(SseWorktreeFailed instance) => <String, dynamic>{'type': instance.$type};
+Map<String, dynamic> _$SseWorktreeFailedToJson(SseWorktreeFailed instance) =>
+    <String, dynamic>{'type': instance.$type};

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -479,7 +479,6 @@ class OpenCodePlugin implements BridgePlugin {
         .map(
           (s) => PluginProjectActivitySummary(
             id: s.id,
-            activeSessions: s.activeSessions,
             activeSessionIds: s.activeSessionIds,
           ),
         )

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -480,6 +480,7 @@ class OpenCodePlugin implements BridgePlugin {
           (s) => PluginProjectActivitySummary(
             worktree: s.worktree,
             activeSessions: s.activeSessions,
+            activeSessionIds: s.activeSessionIds,
           ),
         )
         .toList();

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -478,7 +478,7 @@ class OpenCodePlugin implements BridgePlugin {
         .buildSummary()
         .map(
           (s) => PluginProjectActivitySummary(
-            worktree: s.worktree,
+            id: s.id,
             activeSessions: s.activeSessions,
             activeSessionIds: s.activeSessionIds,
           ),

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -256,6 +256,64 @@ void main() {
 
       expect(tracker.activeSessions, isEmpty);
     });
+
+    test("buildSummary includes activeSessionIds for busy sessions", () async {
+      final tracker = await _coldStartedTracker(
+        projects: [const Project(id: "p1", worktree: "/projects/foo")],
+      );
+
+      tracker.handleEvent(_sessionCreated("s1", "/projects/foo"), null);
+      tracker.handleEvent(_sessionBusy("s1"), null);
+      tracker.handleEvent(_sessionCreated("s2", "/projects/foo"), null);
+      tracker.handleEvent(_sessionBusy("s2"), null);
+
+      final summary = tracker.buildSummary();
+
+      expect(summary, hasLength(1));
+      expect(summary.first.activeSessionIds, unorderedEquals(["s1", "s2"]));
+      expect(summary.first.activeSessions, equals(2));
+    });
+
+    test("buildSummary excludes idle sessions from activeSessionIds", () async {
+      final tracker = await _coldStartedTracker(
+        projects: [const Project(id: "p1", worktree: "/projects/foo")],
+      );
+
+      tracker.handleEvent(_sessionCreated("s1", "/projects/foo"), null);
+      tracker.handleEvent(_sessionBusy("s1"), null);
+      tracker.handleEvent(_sessionCreated("s2", "/projects/foo"), null);
+      tracker.handleEvent(_sessionBusy("s2"), null);
+      tracker.handleEvent(_sessionIdle("s1"), null);
+
+      final summary = tracker.buildSummary();
+
+      expect(summary.first.activeSessionIds, equals(["s2"]));
+      expect(summary.first.activeSessions, equals(1));
+    });
+
+    test("buildSummary groups session IDs by worktree correctly", () async {
+      final tracker = await _coldStartedTracker(
+        projects: [
+          const Project(id: "p1", worktree: "/projects/foo"),
+          const Project(id: "p2", worktree: "/projects/bar"),
+        ],
+      );
+
+      tracker.handleEvent(_sessionCreated("s1", "/projects/foo"), null);
+      tracker.handleEvent(_sessionBusy("s1"), null);
+      tracker.handleEvent(_sessionCreated("s2", "/projects/bar"), null);
+      tracker.handleEvent(_sessionBusy("s2"), null);
+
+      final summary = tracker.buildSummary();
+
+      expect(summary, hasLength(2));
+
+      final fooEntry = summary.firstWhere((e) => e.worktree == "/projects/foo");
+      final barEntry = summary.firstWhere((e) => e.worktree == "/projects/bar");
+
+      expect(fooEntry.activeSessionIds, equals(["s1"]));
+      expect(barEntry.activeSessionIds, equals(["s2"]));
+    });
   });
 }
 

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -213,7 +213,7 @@ void main() {
       tracker.handleEvent(_sessionBusy("s1"), null);
 
       final summary = tracker.buildSummary();
-      final pairs = summary.map((item) => (item.worktree, item.activeSessions)).toSet();
+      final pairs = summary.map((item) => (item.id, item.activeSessions)).toSet();
 
       expect(pairs, equals({("/repo-a", 1)}));
     });
@@ -308,8 +308,8 @@ void main() {
 
       expect(summary, hasLength(2));
 
-      final fooEntry = summary.firstWhere((e) => e.worktree == "/projects/foo");
-      final barEntry = summary.firstWhere((e) => e.worktree == "/projects/bar");
+      final fooEntry = summary.firstWhere((e) => e.id == "/projects/foo");
+      final barEntry = summary.firstWhere((e) => e.id == "/projects/bar");
 
       expect(fooEntry.activeSessionIds, equals(["s1"]));
       expect(barEntry.activeSessionIds, equals(["s2"]));

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -213,7 +213,7 @@ void main() {
       tracker.handleEvent(_sessionBusy("s1"), null);
 
       final summary = tracker.buildSummary();
-      final pairs = summary.map((item) => (item.id, item.activeSessions)).toSet();
+      final pairs = summary.map((item) => (item.id, item.activeSessionIds.length)).toSet();
 
       expect(pairs, equals({("/repo-a", 1)}));
     });
@@ -271,7 +271,7 @@ void main() {
 
       expect(summary, hasLength(1));
       expect(summary.first.activeSessionIds, unorderedEquals(["s1", "s2"]));
-      expect(summary.first.activeSessions, equals(2));
+      expect(summary.first.activeSessionIds.length, equals(2));
     });
 
     test("buildSummary excludes idle sessions from activeSessionIds", () async {
@@ -288,7 +288,7 @@ void main() {
       final summary = tracker.buildSummary();
 
       expect(summary.first.activeSessionIds, equals(["s2"]));
-      expect(summary.first.activeSessions, equals(1));
+      expect(summary.first.activeSessionIds.length, equals(1));
     });
 
     test("buildSummary groups session IDs by worktree correctly", () async {

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -319,7 +319,7 @@ void main() {
     test("buildSummary delegates to tracker", () {
       final tracker = FakeActiveSessionTracker(
         summary: [
-          const ProjectActivitySummary(id: "/repo", activeSessions: 3),
+          const ProjectActivitySummary(id: "/repo", activeSessionIds: ["s1", "s2", "s3"]),
         ],
       );
       final service = OpenCodeService(FakeOpenCodeRepository(), tracker);

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -319,7 +319,7 @@ void main() {
     test("buildSummary delegates to tracker", () {
       final tracker = FakeActiveSessionTracker(
         summary: [
-          const ProjectActivitySummary(worktree: "/repo", activeSessions: 3),
+          const ProjectActivitySummary(id: "/repo", activeSessions: 3),
         ],
       );
       final service = OpenCodeService(FakeOpenCodeRepository(), tracker);

--- a/mobile/app/lib/features/project_list/project_list_screen.dart
+++ b/mobile/app/lib/features/project_list/project_list_screen.dart
@@ -37,7 +37,7 @@ class _ProjectListBody extends StatelessWidget {
         ProjectListLoading() => const Center(
           child: CircularProgressIndicator(),
         ),
-        ProjectListLoaded(:final projects, :final activityByWorktree) => RefreshIndicator(
+        ProjectListLoaded(:final projects, :final activityById) => RefreshIndicator(
           onRefresh: () async {
             final success = await context.read<ProjectListCubit>().refreshProjects();
             if (!context.mounted) return;
@@ -62,7 +62,7 @@ class _ProjectListBody extends StatelessWidget {
                     final project = projects[index];
                     return _ProjectTile(
                       project: project,
-                      activeSessions: activityByWorktree[project.worktree] ?? 0,
+                      activeSessions: activityById[project.worktree] ?? 0,
                     );
                   },
                 ),

--- a/mobile/app/lib/features/session_list/session_list_screen.dart
+++ b/mobile/app/lib/features/session_list/session_list_screen.dart
@@ -29,6 +29,7 @@ class SessionListScreen extends StatelessWidget {
         getIt<SessionService>(),
         getIt<ProjectService>(),
         getIt<ConnectionService>(),
+        getIt<SseEventRepository>(),
         projectId: projectId,
         worktree: worktree,
       ),
@@ -250,6 +251,7 @@ class _SessionListBody extends StatelessWidget {
                     return _SessionTile(
                       session: session,
                       isArchived: isArchived,
+                      isActive: state.activeSessionIds.contains(session.id),
                       onLongPress: () => _showSessionActions(context, session),
                       onSwipe: () => isArchived
                           ? _unarchiveSession(context, cubit, session.id)
@@ -273,12 +275,14 @@ class _SessionListBody extends StatelessWidget {
 class _SessionTile extends StatelessWidget {
   final Session session;
   final bool isArchived;
+  final bool isActive;
   final VoidCallback onLongPress;
   final VoidCallback onSwipe;
 
   const _SessionTile({
     required this.session,
     required this.isArchived,
+    required this.isActive,
     required this.onLongPress,
     required this.onSwipe,
   });
@@ -336,9 +340,23 @@ class _SessionTile extends StatelessWidget {
                 loc.sessionListFilesChanged(filesChanged),
                 style: theme.textTheme.bodySmall,
               ),
+            if (isActive)
+              Row(
+                children: [
+                  Icon(Icons.circle, size: 8, color: theme.colorScheme.primary),
+                  const SizedBox(width: 4),
+                  Text(
+                    loc.sessionListRunning,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.primary,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ],
+              ),
           ],
         ),
-        isThreeLine: updatedAt != null && filesChanged > 0,
+        isThreeLine: updatedAt != null && (filesChanged > 0 || isActive),
         trailing: const Icon(Icons.chevron_right),
         onTap: () {
           context.pushRoute(

--- a/mobile/app/lib/l10n/app_en.arb
+++ b/mobile/app/lib/l10n/app_en.arb
@@ -189,6 +189,10 @@
    "loginCallbackMissingParams": "Invalid authorization callback. Please try again.",
    "loginStateMismatch": "Authorization state mismatch. Please try again.",
    "loginPkceStateMissing": "Login session expired. Please start again.",
+   "sessionListRunning": "Running",
+   "@sessionListRunning": {
+     "description": "Label shown next to the green dot for sessions that are currently active"
+   },
    "sessionListStaleProjectTitle": "Project directory not found",
    "sessionListStaleProjectMessage": "The directory for this project no longer exists or has been renamed. Sessions cannot be loaded because the server can no longer resolve this project.",
    "sessionListStaleProjectBack": "Go back",

--- a/mobile/app/lib/l10n/app_localizations.dart
+++ b/mobile/app/lib/l10n/app_localizations.dart
@@ -685,6 +685,12 @@ abstract class AppLocalizations {
   /// **'Login session expired. Please start again.'**
   String get loginPkceStateMissing;
 
+  /// Label shown next to the green dot for sessions that are currently active
+  ///
+  /// In en, this message translates to:
+  /// **'Running'**
+  String get sessionListRunning;
+
   /// No description provided for @sessionListStaleProjectTitle.
   ///
   /// In en, this message translates to:

--- a/mobile/app/lib/l10n/app_localizations_en.dart
+++ b/mobile/app/lib/l10n/app_localizations_en.dart
@@ -349,6 +349,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get loginPkceStateMissing => 'Login session expired. Please start again.';
 
   @override
+  String get sessionListRunning => 'Running';
+
+  @override
   String get sessionListStaleProjectTitle => 'Project directory not found';
 
   @override

--- a/mobile/app/test/features/project_list/project_list_cubit_test.dart
+++ b/mobile/app/test/features/project_list/project_list_cubit_test.dart
@@ -230,7 +230,7 @@ void main() {
     // -------------------------------------------------------------------------
 
     blocTest<ProjectListCubit, ProjectListState>(
-      "projectActivity update: emits loaded state with updated activityByWorktree",
+      "projectActivity update: emits loaded state with updated activityById",
       build: () {
         when(() => mockProjectService.listProjects()).thenAnswer((_) async => ApiResponse.success([testProject()]));
         return buildCubit();
@@ -242,7 +242,7 @@ void main() {
       },
       skip: 1, // skip initial loaded emission (no activity yet)
       expect: () => [
-        isA<ProjectListLoaded>().having((s) => s.activityByWorktree, "activityByWorktree", {_worktree: 3}),
+        isA<ProjectListLoaded>().having((s) => s.activityById, "activityById", {_worktree: 3}),
       ],
     );
 
@@ -271,14 +271,14 @@ void main() {
     // -------------------------------------------------------------------------
 
     blocTest<ProjectListCubit, ProjectListState>(
-      "_fetchProjects: seeds activityByWorktree from repository at load time",
+      "_fetchProjects: seeds activityById from repository at load time",
       build: () {
         mockSseEventRepository.emitProjectActivity({_worktree: 2});
         when(() => mockProjectService.listProjects()).thenAnswer((_) async => ApiResponse.success([testProject()]));
         return buildCubit();
       },
       expect: () => [
-        isA<ProjectListLoaded>().having((s) => s.activityByWorktree, "activityByWorktree", {_worktree: 2}),
+        isA<ProjectListLoaded>().having((s) => s.activityById, "activityById", {_worktree: 2}),
       ],
     );
 
@@ -300,9 +300,9 @@ void main() {
         mockSseEventRepository.emitProjectActivity(const {});
         await Future<void>.delayed(Duration.zero);
       },
-      skip: 1, // skip initial loaded emission (activityByWorktree: {_worktree: 1})
+      skip: 1, // skip initial loaded emission (activityById: {_worktree: 1})
       expect: () => [
-        isA<ProjectListLoaded>().having((s) => s.activityByWorktree, "activityByWorktree", isEmpty),
+        isA<ProjectListLoaded>().having((s) => s.activityById, "activityById", isEmpty),
       ],
     );
   });

--- a/mobile/app/test/features/project_list/project_list_cubit_test.dart
+++ b/mobile/app/test/features/project_list/project_list_cubit_test.dart
@@ -237,7 +237,7 @@ void main() {
       },
       act: (cubit) async {
         await Future<void>.delayed(Duration.zero); // let initial load settle
-        mockSseEventRepository.emitActivity({_worktree: 3});
+        mockSseEventRepository.emitProjectActivity({_worktree: 3});
         await Future<void>.delayed(Duration.zero);
       },
       skip: 1, // skip initial loaded emission (no activity yet)
@@ -259,7 +259,7 @@ void main() {
         return buildCubit();
       },
       act: (cubit) async {
-        mockSseEventRepository.emitActivity({_worktree: 2});
+        mockSseEventRepository.emitProjectActivity({_worktree: 2});
         await Future<void>.delayed(Duration.zero);
       },
       // Still in loading state — no emission expected.
@@ -273,7 +273,7 @@ void main() {
     blocTest<ProjectListCubit, ProjectListState>(
       "_fetchProjects: seeds activityByWorktree from repository at load time",
       build: () {
-        mockSseEventRepository.emitActivity({_worktree: 2});
+        mockSseEventRepository.emitProjectActivity({_worktree: 2});
         when(() => mockProjectService.listProjects()).thenAnswer((_) async => ApiResponse.success([testProject()]));
         return buildCubit();
       },
@@ -290,14 +290,14 @@ void main() {
       "projectActivity update: activity clears when repository emits empty map",
       build: () {
         // Seed with activity so state starts non-empty.
-        mockSseEventRepository.emitActivity({_worktree: 1});
+        mockSseEventRepository.emitProjectActivity({_worktree: 1});
         when(() => mockProjectService.listProjects()).thenAnswer((_) async => ApiResponse.success([testProject()]));
         return buildCubit();
       },
       act: (cubit) async {
         await Future<void>.delayed(Duration.zero); // let load settle with activity
         // Now clear activity — repository filters out zeros and emits empty.
-        mockSseEventRepository.emitActivity(const {});
+        mockSseEventRepository.emitProjectActivity(const {});
         await Future<void>.delayed(Duration.zero);
       },
       skip: 1, // skip initial loaded emission (activityByWorktree: {_worktree: 1})

--- a/mobile/app/test/features/session_list/session_list_cubit_test.dart
+++ b/mobile/app/test/features/session_list/session_list_cubit_test.dart
@@ -18,6 +18,7 @@ void main() {
     late MockSessionService mockSessionService;
     late MockProjectService mockProjectService;
     late MockConnectionService mockConnectionService;
+    late MockSseEventRepository mockSseEventRepository;
     late StreamController<SseEvent> eventController;
 
     const projectId = "project-1";
@@ -27,6 +28,7 @@ void main() {
       mockSessionService = MockSessionService();
       mockProjectService = MockProjectService();
       mockConnectionService = MockConnectionService();
+      mockSseEventRepository = MockSseEventRepository();
       eventController = StreamController<SseEvent>.broadcast();
 
       // Must be stubbed before any cubit is built — constructor subscribes immediately.
@@ -43,6 +45,7 @@ void main() {
       mockSessionService,
       mockProjectService,
       mockConnectionService,
+      mockSseEventRepository,
       projectId: projectId,
       worktree: worktree,
     );
@@ -702,6 +705,7 @@ void main() {
           mockSessionService,
           mockProjectService,
           mockConnectionService,
+          mockSseEventRepository,
           projectId: "global",
           worktree: "/",
         );
@@ -712,6 +716,133 @@ void main() {
           "all sessions under root",
           2,
         ),
+      ],
+    );
+
+    // -------------------------------------------------------------------------
+    // 20. activeSessionIds from SseEventRepository
+    // -------------------------------------------------------------------------
+
+    blocTest<SessionListCubit, SessionListState>(
+      "state includes activeSessionIds from SseEventRepository",
+      build: () {
+        when(() => mockSessionService.listSessions()).thenAnswer(
+          (_) async => ApiResponse.success([
+            testSession(id: "s1", title: "Session 1"),
+            testSession(id: "s2", title: "Session 2"),
+          ]),
+        );
+        // Mock the repository to emit activity for this worktree
+        mockSseEventRepository.emitSessionActivity({
+          worktree: {"s1", "s2"},
+        });
+        return buildCubit();
+      },
+      expect: () => [
+        isA<SessionListLoaded>().having((s) => s.sessions.length, "sessions count", 2).having(
+          (s) => s.activeSessionIds,
+          "activeSessionIds",
+          {"s1", "s2"},
+        ),
+      ],
+    );
+
+    // -------------------------------------------------------------------------
+    // 21. activeSessionIds updates when activity changes
+    // -------------------------------------------------------------------------
+
+    blocTest<SessionListCubit, SessionListState>(
+      "activeSessionIds updates when activity changes",
+      build: () {
+        when(() => mockSessionService.listSessions()).thenAnswer(
+          (_) async => ApiResponse.success([
+            testSession(id: "s1", title: "Session 1"),
+            testSession(id: "s2", title: "Session 2"),
+          ]),
+        );
+        return buildCubit();
+      },
+      act: (cubit) async {
+        // Wait for initial load
+        await Future<void>.delayed(Duration.zero);
+        // Emit initial activity
+        mockSseEventRepository.emitSessionActivity({
+          worktree: {"s1"},
+        });
+        // Wait for the activity update to be processed
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+        // Emit updated activity
+        mockSseEventRepository.emitSessionActivity({
+          worktree: {"s1", "s2"},
+        });
+      },
+      skip: 1, // skip initial load
+      expect: () => [
+        // First activity update: only s1 is active
+        isA<SessionListLoaded>().having((s) => s.sessions.length, "sessions count", 2).having(
+          (s) => s.activeSessionIds,
+          "activeSessionIds after first update",
+          {"s1"},
+        ),
+        // Second activity update: both s1 and s2 are active
+        isA<SessionListLoaded>().having((s) => s.sessions.length, "sessions count", 2).having(
+          (s) => s.activeSessionIds,
+          "activeSessionIds after second update",
+          {"s1", "s2"},
+        ),
+      ],
+    );
+
+    // -------------------------------------------------------------------------
+    // 22. activeSessionIds excludes sessions from other worktrees
+    // -------------------------------------------------------------------------
+
+    blocTest<SessionListCubit, SessionListState>(
+      "activeSessionIds excludes sessions from other worktrees",
+      build: () {
+        when(() => mockSessionService.listSessions()).thenAnswer(
+          (_) async => ApiResponse.success([
+            testSession(id: "s1", title: "Session 1"),
+          ]),
+        );
+        // Emit activity for this worktree and another
+        mockSseEventRepository.emitSessionActivity({
+          worktree: {"s1"},
+          "/other/worktree": {"s2", "s3"},
+        });
+        return buildCubit();
+      },
+      expect: () => [
+        isA<SessionListLoaded>().having((s) => s.sessions.length, "sessions count", 1).having(
+          (s) => s.activeSessionIds,
+          "activeSessionIds for this worktree only",
+          {"s1"},
+        ),
+      ],
+    );
+
+    // -------------------------------------------------------------------------
+    // 23. activeSessionIds is empty when no activity for this worktree
+    // -------------------------------------------------------------------------
+
+    blocTest<SessionListCubit, SessionListState>(
+      "activeSessionIds is empty when no activity for this worktree",
+      build: () {
+        when(() => mockSessionService.listSessions()).thenAnswer(
+          (_) async => ApiResponse.success([
+            testSession(id: "s1", title: "Session 1"),
+          ]),
+        );
+        // Emit activity for a different worktree
+        mockSseEventRepository.emitSessionActivity({
+          "/other/worktree": {"s2"},
+        });
+        return buildCubit();
+      },
+      expect: () => [
+        isA<SessionListLoaded>()
+            .having((s) => s.sessions.length, "sessions count", 1)
+            .having((s) => s.activeSessionIds, "activeSessionIds empty", isEmpty),
       ],
     );
   });

--- a/mobile/app/test/helpers/test_helpers.dart
+++ b/mobile/app/test/helpers/test_helpers.dart
@@ -77,15 +77,24 @@ class MockLifecycleSource extends Mock implements LifecycleSource {
 }
 
 class MockSseEventRepository extends Mock implements SseEventRepository {
-  final BehaviorSubject<Map<String, int>> _activity = BehaviorSubject.seeded(const {});
+  final BehaviorSubject<Map<String, int>> _projectActivity = BehaviorSubject.seeded(const {});
+  final BehaviorSubject<Map<String, Set<String>>> _sessionActivity = BehaviorSubject.seeded(const {});
 
   @override
-  ValueStream<Map<String, int>> get projectActivity => _activity.stream;
+  ValueStream<Map<String, int>> get projectActivity => _projectActivity.stream;
 
   @override
-  Map<String, int> get currentProjectActivity => _activity.value;
+  Map<String, int> get currentProjectActivity => _projectActivity.value;
 
-  void emitActivity(Map<String, int> activity) => _activity.add(activity);
+  @override
+  ValueStream<Map<String, Set<String>>> get sessionActivity => _sessionActivity.stream;
+
+  @override
+  Map<String, Set<String>> get currentSessionActivity => _sessionActivity.value;
+
+  void emitProjectActivity(Map<String, int> activity) => _projectActivity.add(activity);
+
+  void emitSessionActivity(Map<String, Set<String>> activity) => _sessionActivity.add(activity);
 }
 
 // ---------------------------------------------------------------------------

--- a/mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart
+++ b/mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart
@@ -14,6 +14,7 @@ class SseEventRepository with Disposable {
   late final StreamSubscription<SseEvent> _subscription;
 
   final BehaviorSubject<Map<String, int>> _projectActivity = BehaviorSubject.seeded(const {});
+  final BehaviorSubject<Map<String, Set<String>>> _sessionActivity = BehaviorSubject.seeded(const {});
 
   SseEventRepository(ConnectionService connectionService) : _connectionService = connectionService {
     _subscription = _connectionService.events.listen(_handleEvent);
@@ -28,15 +29,29 @@ class SseEventRepository with Disposable {
   /// The latest project activity map, synchronously available.
   Map<String, int> get currentProjectActivity => _projectActivity.value;
 
+  /// Map of worktree path -> set of active session IDs.
+  ///
+  /// Only includes worktrees with active sessions.
+  /// Late subscribers immediately receive the latest cached value.
+  ValueStream<Map<String, Set<String>>> get sessionActivity => _sessionActivity.stream;
+
+  /// The latest session activity map, synchronously available.
+  Map<String, Set<String>> get currentSessionActivity => _sessionActivity.value;
+
   void _handleEvent(SseEvent event) {
     if (event.data case SesoriProjectsSummary(:final projects)) {
-      final map = <String, int>{};
+      final projectMap = <String, int>{};
+      final sessionMap = <String, Set<String>>{};
       for (final summary in projects) {
         if (summary.activeSessions > 0) {
-          map[summary.worktree] = summary.activeSessions;
+          projectMap[summary.worktree] = summary.activeSessions;
+        }
+        if (summary.activeSessionIds.isNotEmpty) {
+          sessionMap[summary.worktree] = summary.activeSessionIds.toSet();
         }
       }
-      _projectActivity.add(map);
+      _projectActivity.add(projectMap);
+      _sessionActivity.add(sessionMap);
     }
   }
 
@@ -44,5 +59,6 @@ class SseEventRepository with Disposable {
   FutureOr<void> onDispose() {
     _subscription.cancel();
     _projectActivity.close();
+    _sessionActivity.close();
   }
 }

--- a/mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart
+++ b/mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart
@@ -22,7 +22,7 @@ class SseEventRepository with Disposable {
 
   /// Map of worktree path -> active session count.
   ///
-  /// Only includes projects with `activeSessions > 0`.
+  /// Only includes projects with active sessions.
   /// Late subscribers immediately receive the latest cached value.
   ValueStream<Map<String, int>> get projectActivity => _projectActivity.stream;
 
@@ -43,8 +43,8 @@ class SseEventRepository with Disposable {
       final projectMap = <String, int>{};
       final sessionMap = <String, Set<String>>{};
       for (final summary in projects) {
-        if (summary.activeSessions > 0) {
-          projectMap[summary.id] = summary.activeSessions;
+        if (summary.activeSessionIds.isNotEmpty) {
+          projectMap[summary.id] = summary.activeSessionIds.length;
         }
         if (summary.activeSessionIds.isNotEmpty) {
           sessionMap[summary.id] = summary.activeSessionIds.toSet();

--- a/mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart
+++ b/mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart
@@ -44,10 +44,10 @@ class SseEventRepository with Disposable {
       final sessionMap = <String, Set<String>>{};
       for (final summary in projects) {
         if (summary.activeSessions > 0) {
-          projectMap[summary.worktree] = summary.activeSessions;
+          projectMap[summary.id] = summary.activeSessions;
         }
         if (summary.activeSessionIds.isNotEmpty) {
-          sessionMap[summary.worktree] = summary.activeSessionIds.toSet();
+          sessionMap[summary.id] = summary.activeSessionIds.toSet();
         }
       }
       _projectActivity.add(projectMap);

--- a/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -35,13 +35,13 @@ class ProjectListCubit extends Cubit<ProjectListState> {
     _connectionService.setActiveDirectory(project.worktree);
   }
 
-  void _onActivityUpdated(Map<String, int> activityByWorktree) {
+  void _onActivityUpdated(Map<String, int> activityById) {
     if (state is! ProjectListLoaded) return;
     if (isClosed) return;
     emit(
       ProjectListState.loaded(
         projects: (state as ProjectListLoaded).projects,
-        activityByWorktree: activityByWorktree,
+        activityById: activityById,
       ),
     );
   }
@@ -70,7 +70,7 @@ class ProjectListCubit extends Cubit<ProjectListState> {
         emit(
           ProjectListState.loaded(
             projects: projects,
-            activityByWorktree: _sseEventRepository.currentProjectActivity,
+            activityById: _sseEventRepository.currentProjectActivity,
           ),
         );
         return true;

--- a/mobile/module_core/lib/src/cubits/project_list/project_list_state.dart
+++ b/mobile/module_core/lib/src/cubits/project_list/project_list_state.dart
@@ -10,7 +10,7 @@ sealed class ProjectListState with _$ProjectListState {
 
   const factory ProjectListState.loaded({
     required List<Project> projects,
-    required Map<String, int> activityByWorktree,
+    required Map<String, int> activityById,
   }) = ProjectListLoaded;
 
   const factory ProjectListState.failed({required ApiError error}) = ProjectListFailed;

--- a/mobile/module_core/lib/src/cubits/project_list/project_list_state.freezed.dart
+++ b/mobile/module_core/lib/src/cubits/project_list/project_list_state.freezed.dart
@@ -78,7 +78,7 @@ String toString() {
 
 
 class ProjectListLoaded implements ProjectListState {
-  const ProjectListLoaded({required final  List<Project> projects, required final  Map<String, int> activityByWorktree}): _projects = projects,_activityByWorktree = activityByWorktree;
+  const ProjectListLoaded({required final  List<Project> projects, required final  Map<String, int> activityById}): _projects = projects,_activityById = activityById;
   
 
  final  List<Project> _projects;
@@ -88,11 +88,11 @@ class ProjectListLoaded implements ProjectListState {
   return EqualUnmodifiableListView(_projects);
 }
 
- final  Map<String, int> _activityByWorktree;
- Map<String, int> get activityByWorktree {
-  if (_activityByWorktree is EqualUnmodifiableMapView) return _activityByWorktree;
+ final  Map<String, int> _activityById;
+ Map<String, int> get activityById {
+  if (_activityById is EqualUnmodifiableMapView) return _activityById;
   // ignore: implicit_dynamic_type
-  return EqualUnmodifiableMapView(_activityByWorktree);
+  return EqualUnmodifiableMapView(_activityById);
 }
 
 
@@ -106,16 +106,16 @@ $ProjectListLoadedCopyWith<ProjectListLoaded> get copyWith => _$ProjectListLoade
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectListLoaded&&const DeepCollectionEquality().equals(other._projects, _projects)&&const DeepCollectionEquality().equals(other._activityByWorktree, _activityByWorktree));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectListLoaded&&const DeepCollectionEquality().equals(other._projects, _projects)&&const DeepCollectionEquality().equals(other._activityById, _activityById));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_projects),const DeepCollectionEquality().hash(_activityByWorktree));
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_projects),const DeepCollectionEquality().hash(_activityById));
 
 @override
 String toString() {
-  return 'ProjectListState.loaded(projects: $projects, activityByWorktree: $activityByWorktree)';
+  return 'ProjectListState.loaded(projects: $projects, activityById: $activityById)';
 }
 
 
@@ -126,7 +126,7 @@ abstract mixin class $ProjectListLoadedCopyWith<$Res> implements $ProjectListSta
   factory $ProjectListLoadedCopyWith(ProjectListLoaded value, $Res Function(ProjectListLoaded) _then) = _$ProjectListLoadedCopyWithImpl;
 @useResult
 $Res call({
- List<Project> projects, Map<String, int> activityByWorktree
+ List<Project> projects, Map<String, int> activityById
 });
 
 
@@ -143,10 +143,10 @@ class _$ProjectListLoadedCopyWithImpl<$Res>
 
 /// Create a copy of ProjectListState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? projects = null,Object? activityByWorktree = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? projects = null,Object? activityById = null,}) {
   return _then(ProjectListLoaded(
 projects: null == projects ? _self._projects : projects // ignore: cast_nullable_to_non_nullable
-as List<Project>,activityByWorktree: null == activityByWorktree ? _self._activityByWorktree : activityByWorktree // ignore: cast_nullable_to_non_nullable
+as List<Project>,activityById: null == activityById ? _self._activityById : activityById // ignore: cast_nullable_to_non_nullable
 as Map<String, int>,
   ));
 }

--- a/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -9,6 +9,7 @@ import "../../capabilities/project/project_service.dart";
 import "../../capabilities/server_connection/connection_service.dart";
 import "../../capabilities/server_connection/models/sse_event.dart";
 import "../../capabilities/session/session_service.dart";
+import "../../capabilities/sse/sse_event_repository.dart";
 import "../../logging/logging.dart";
 import "session_list_state.dart";
 
@@ -17,6 +18,7 @@ class SessionListCubit extends Cubit<SessionListState> {
 
   final SessionService _service;
   final ProjectService _projectService;
+  final SseEventRepository _sseEventRepository;
   final String _projectId;
   final String _worktree;
 
@@ -27,16 +29,21 @@ class SessionListCubit extends Cubit<SessionListState> {
   SessionListCubit(
     SessionService service,
     ProjectService projectService,
-    ConnectionService connectionService, {
+    ConnectionService connectionService,
+    SseEventRepository sseEventRepository, {
     required String projectId,
     required String worktree,
   }) : _service = service,
        _projectService = projectService,
+       _sseEventRepository = sseEventRepository,
        _projectId = projectId,
        _worktree = worktree,
        super(const SessionListState.loading()) {
     loadSessions();
     _subscriptions.add(connectionService.events.listen(_handleEvent));
+    _subscriptions.add(
+      _sseEventRepository.sessionActivity.listen(_onSessionActivityUpdated),
+    );
   }
 
   /// Returns `true` when [session] belongs to this project's worktree.
@@ -60,6 +67,19 @@ class SessionListCubit extends Cubit<SessionListState> {
       default:
         break;
     }
+  }
+
+  void _onSessionActivityUpdated(Map<String, Set<String>> activityByWorktree) {
+    if (isClosed) return;
+    if (state is! SessionListLoaded) return;
+    final activeIds = activityByWorktree[_worktree] ?? {};
+    emit(
+      SessionListState.loaded(
+        sessions: (state as SessionListLoaded).sessions,
+        showArchived: (state as SessionListLoaded).showArchived,
+        activeSessionIds: activeIds,
+      ),
+    );
   }
 
   void _onSessionCreated(Session session) {
@@ -282,7 +302,13 @@ class SessionListCubit extends Cubit<SessionListState> {
     final sorted = visible.toList()..sort((a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0));
 
     if (isClosed) return;
-    emit(SessionListState.loaded(sessions: sorted, showArchived: _showArchived));
+    emit(
+      SessionListState.loaded(
+        sessions: sorted,
+        showArchived: _showArchived,
+        activeSessionIds: _sseEventRepository.currentSessionActivity[_worktree] ?? {},
+      ),
+    );
   }
 
   Future<void> loadSessions() async {

--- a/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -69,10 +69,10 @@ class SessionListCubit extends Cubit<SessionListState> {
     }
   }
 
-  void _onSessionActivityUpdated(Map<String, Set<String>> activityByWorktree) {
+  void _onSessionActivityUpdated(Map<String, Set<String>> activityById) {
     if (isClosed) return;
     if (state is! SessionListLoaded) return;
-    final activeIds = activityByWorktree[_worktree] ?? {};
+    final activeIds = activityById[_worktree] ?? {};
     emit(
       SessionListState.loaded(
         sessions: (state as SessionListLoaded).sessions,

--- a/mobile/module_core/lib/src/cubits/session_list/session_list_state.dart
+++ b/mobile/module_core/lib/src/cubits/session_list/session_list_state.dart
@@ -11,6 +11,7 @@ sealed class SessionListState with _$SessionListState {
   const factory SessionListState.loaded({
     required List<Session> sessions,
     @Default(false) bool showArchived,
+    @Default({}) Set<String> activeSessionIds,
   }) = SessionListLoaded;
 
   /// The stored worktree no longer resolves to the expected project on the

--- a/mobile/module_core/lib/src/cubits/session_list/session_list_state.freezed.dart
+++ b/mobile/module_core/lib/src/cubits/session_list/session_list_state.freezed.dart
@@ -78,7 +78,7 @@ String toString() {
 
 
 class SessionListLoaded implements SessionListState {
-  const SessionListLoaded({required final  List<Session> sessions, this.showArchived = false}): _sessions = sessions;
+  const SessionListLoaded({required final  List<Session> sessions, this.showArchived = false, final  Set<String> activeSessionIds = const {}}): _sessions = sessions,_activeSessionIds = activeSessionIds;
   
 
  final  List<Session> _sessions;
@@ -89,6 +89,13 @@ class SessionListLoaded implements SessionListState {
 }
 
 @JsonKey() final  bool showArchived;
+ final  Set<String> _activeSessionIds;
+@JsonKey() Set<String> get activeSessionIds {
+  if (_activeSessionIds is EqualUnmodifiableSetView) return _activeSessionIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableSetView(_activeSessionIds);
+}
+
 
 /// Create a copy of SessionListState
 /// with the given fields replaced by the non-null parameter values.
@@ -100,16 +107,16 @@ $SessionListLoadedCopyWith<SessionListLoaded> get copyWith => _$SessionListLoade
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionListLoaded&&const DeepCollectionEquality().equals(other._sessions, _sessions)&&(identical(other.showArchived, showArchived) || other.showArchived == showArchived));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionListLoaded&&const DeepCollectionEquality().equals(other._sessions, _sessions)&&(identical(other.showArchived, showArchived) || other.showArchived == showArchived)&&const DeepCollectionEquality().equals(other._activeSessionIds, _activeSessionIds));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_sessions),showArchived);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_sessions),showArchived,const DeepCollectionEquality().hash(_activeSessionIds));
 
 @override
 String toString() {
-  return 'SessionListState.loaded(sessions: $sessions, showArchived: $showArchived)';
+  return 'SessionListState.loaded(sessions: $sessions, showArchived: $showArchived, activeSessionIds: $activeSessionIds)';
 }
 
 
@@ -120,7 +127,7 @@ abstract mixin class $SessionListLoadedCopyWith<$Res> implements $SessionListSta
   factory $SessionListLoadedCopyWith(SessionListLoaded value, $Res Function(SessionListLoaded) _then) = _$SessionListLoadedCopyWithImpl;
 @useResult
 $Res call({
- List<Session> sessions, bool showArchived
+ List<Session> sessions, bool showArchived, Set<String> activeSessionIds
 });
 
 
@@ -137,11 +144,12 @@ class _$SessionListLoadedCopyWithImpl<$Res>
 
 /// Create a copy of SessionListState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? sessions = null,Object? showArchived = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? sessions = null,Object? showArchived = null,Object? activeSessionIds = null,}) {
   return _then(SessionListLoaded(
 sessions: null == sessions ? _self._sessions : sessions // ignore: cast_nullable_to_non_nullable
 as List<Session>,showArchived: null == showArchived ? _self.showArchived : showArchived // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,activeSessionIds: null == activeSessionIds ? _self._activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
+as Set<String>,
   ));
 }
 

--- a/mobile/module_core/test/capabilities/sse/sse_event_repository_test.dart
+++ b/mobile/module_core/test/capabilities/sse/sse_event_repository_test.dart
@@ -54,7 +54,6 @@ void main() {
           projects: [
             ProjectActivitySummary(
               id: "/foo",
-              activeSessions: 2,
               activeSessionIds: ["s1", "s2"],
             ),
           ],
@@ -87,6 +86,7 @@ void main() {
           projects: [
             ProjectActivitySummary(
               id: "/bar",
+              activeSessionIds: [],
             ),
           ],
         ),
@@ -120,12 +120,10 @@ void main() {
           projects: [
             ProjectActivitySummary(
               id: "/foo",
-              activeSessions: 1,
               activeSessionIds: ["s1"],
             ),
             ProjectActivitySummary(
               id: "/bar",
-              activeSessions: 2,
               activeSessionIds: ["s2", "s3"],
             ),
           ],
@@ -164,7 +162,6 @@ void main() {
             projects: [
               ProjectActivitySummary(
                 id: "/foo",
-                activeSessions: 1,
                 activeSessionIds: ["s1"],
               ),
             ],
@@ -182,7 +179,6 @@ void main() {
             projects: [
               ProjectActivitySummary(
                 id: "/foo",
-                activeSessions: 2,
                 activeSessionIds: ["s1", "s2"],
               ),
             ],
@@ -235,7 +231,6 @@ void main() {
           projects: [
             ProjectActivitySummary(
               id: "/foo",
-              activeSessions: 3,
               activeSessionIds: ["s1", "s2", "s3"],
             ),
           ],
@@ -266,6 +261,7 @@ void main() {
           projects: [
             ProjectActivitySummary(
               id: "/bar",
+              activeSessionIds: [],
             ),
           ],
         ),

--- a/mobile/module_core/test/capabilities/sse/sse_event_repository_test.dart
+++ b/mobile/module_core/test/capabilities/sse/sse_event_repository_test.dart
@@ -53,7 +53,7 @@ void main() {
         data: const SesoriProjectsSummary(
           projects: [
             ProjectActivitySummary(
-              worktree: "/foo",
+              id: "/foo",
               activeSessions: 2,
               activeSessionIds: ["s1", "s2"],
             ),
@@ -86,7 +86,7 @@ void main() {
         data: const SesoriProjectsSummary(
           projects: [
             ProjectActivitySummary(
-              worktree: "/bar",
+              id: "/bar",
             ),
           ],
         ),
@@ -119,12 +119,12 @@ void main() {
         data: const SesoriProjectsSummary(
           projects: [
             ProjectActivitySummary(
-              worktree: "/foo",
+              id: "/foo",
               activeSessions: 1,
               activeSessionIds: ["s1"],
             ),
             ProjectActivitySummary(
-              worktree: "/bar",
+              id: "/bar",
               activeSessions: 2,
               activeSessionIds: ["s2", "s3"],
             ),
@@ -163,7 +163,7 @@ void main() {
           data: const SesoriProjectsSummary(
             projects: [
               ProjectActivitySummary(
-                worktree: "/foo",
+                id: "/foo",
                 activeSessions: 1,
                 activeSessionIds: ["s1"],
               ),
@@ -181,7 +181,7 @@ void main() {
           data: const SesoriProjectsSummary(
             projects: [
               ProjectActivitySummary(
-                worktree: "/foo",
+                id: "/foo",
                 activeSessions: 2,
                 activeSessionIds: ["s1", "s2"],
               ),
@@ -234,7 +234,7 @@ void main() {
         data: const SesoriProjectsSummary(
           projects: [
             ProjectActivitySummary(
-              worktree: "/foo",
+              id: "/foo",
               activeSessions: 3,
               activeSessionIds: ["s1", "s2", "s3"],
             ),
@@ -265,7 +265,7 @@ void main() {
         data: const SesoriProjectsSummary(
           projects: [
             ProjectActivitySummary(
-              worktree: "/bar",
+              id: "/bar",
             ),
           ],
         ),

--- a/mobile/module_core/test/capabilities/sse/sse_event_repository_test.dart
+++ b/mobile/module_core/test/capabilities/sse/sse_event_repository_test.dart
@@ -1,0 +1,319 @@
+import "dart:async";
+
+import "package:mocktail/mocktail.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/connection_service.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/models/sse_event.dart";
+import "package:sesori_dart_core/src/capabilities/sse/sse_event_repository.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+class MockConnectionService extends Mock implements ConnectionService {}
+
+void main() {
+  group("SseEventRepository", () {
+    late MockConnectionService mockConnectionService;
+    late StreamController<SseEvent> eventController;
+
+    setUp(() {
+      mockConnectionService = MockConnectionService();
+      eventController = StreamController<SseEvent>.broadcast();
+      when(() => mockConnectionService.events).thenAnswer((_) => eventController.stream);
+    });
+
+    tearDown(() async {
+      await eventController.close();
+    });
+
+    // -------------------------------------------------------------------------
+    // 1. sessionActivity defaults to empty map
+    // -------------------------------------------------------------------------
+
+    test("sessionActivity defaults to empty map", () {
+      final repo = SseEventRepository(mockConnectionService);
+      expect(repo.currentSessionActivity, isEmpty);
+      repo.onDispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // 2. sessionActivity emits active session IDs from projectsSummary event
+    // -------------------------------------------------------------------------
+
+    test("sessionActivity emits active session IDs from projectsSummary event", () async {
+      final repo = SseEventRepository(mockConnectionService);
+
+      final completer = Completer<Map<String, Set<String>>>();
+      final subscription = repo.sessionActivity.listen((activity) {
+        if (activity.isNotEmpty) {
+          completer.complete(activity);
+        }
+      });
+
+      // Emit a projectsSummary event with active sessions for "/foo"
+      final event = SseEvent(
+        data: const SesoriProjectsSummary(
+          projects: [
+            ProjectActivitySummary(
+              worktree: "/foo",
+              activeSessions: 2,
+              activeSessionIds: ["s1", "s2"],
+            ),
+          ],
+        ),
+      );
+      eventController.add(event);
+
+      final activity = await completer.future;
+      expect(activity, {
+        "/foo": {"s1", "s2"},
+      });
+
+      await subscription.cancel();
+      repo.onDispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // 3. sessionActivity excludes worktrees with no active sessions
+    // -------------------------------------------------------------------------
+
+    test("sessionActivity excludes worktrees with no active sessions", () async {
+      final repo = SseEventRepository(mockConnectionService);
+
+      final completer = Completer<Map<String, Set<String>>>();
+      final subscription = repo.sessionActivity.listen(completer.complete);
+
+      // Emit a projectsSummary event with no active sessions for "/bar"
+      final event = SseEvent(
+        data: const SesoriProjectsSummary(
+          projects: [
+            ProjectActivitySummary(
+              worktree: "/bar",
+            ),
+          ],
+        ),
+      );
+      eventController.add(event);
+
+      final activity = await completer.future;
+      expect(activity, isEmpty);
+
+      await subscription.cancel();
+      repo.onDispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // 4. sessionActivity handles multiple worktrees
+    // -------------------------------------------------------------------------
+
+    test("sessionActivity handles multiple worktrees", () async {
+      final repo = SseEventRepository(mockConnectionService);
+
+      final completer = Completer<Map<String, Set<String>>>();
+      final subscription = repo.sessionActivity.listen((activity) {
+        if (activity.length == 2) {
+          completer.complete(activity);
+        }
+      });
+
+      // Emit a projectsSummary event with active sessions for multiple worktrees
+      final event = SseEvent(
+        data: const SesoriProjectsSummary(
+          projects: [
+            ProjectActivitySummary(
+              worktree: "/foo",
+              activeSessions: 1,
+              activeSessionIds: ["s1"],
+            ),
+            ProjectActivitySummary(
+              worktree: "/bar",
+              activeSessions: 2,
+              activeSessionIds: ["s2", "s3"],
+            ),
+          ],
+        ),
+      );
+      eventController.add(event);
+
+      final activity = await completer.future;
+      expect(activity, {
+        "/foo": {"s1"},
+        "/bar": {"s2", "s3"},
+      });
+
+      await subscription.cancel();
+      repo.onDispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // 5. sessionActivity updates when new event arrives
+    // -------------------------------------------------------------------------
+
+    test("sessionActivity updates when new event arrives", () async {
+      final repo = SseEventRepository(mockConnectionService);
+
+      final activities = <Map<String, Set<String>>>[];
+      final subscription = repo.sessionActivity.listen((activity) {
+        if (activity.isNotEmpty) {
+          activities.add(activity);
+        }
+      });
+
+      // First event
+      eventController.add(
+        SseEvent(
+          data: const SesoriProjectsSummary(
+            projects: [
+              ProjectActivitySummary(
+                worktree: "/foo",
+                activeSessions: 1,
+                activeSessionIds: ["s1"],
+              ),
+            ],
+          ),
+        ),
+      );
+
+      // Wait for first emission
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      // Second event with updated data
+      eventController.add(
+        SseEvent(
+          data: const SesoriProjectsSummary(
+            projects: [
+              ProjectActivitySummary(
+                worktree: "/foo",
+                activeSessions: 2,
+                activeSessionIds: ["s1", "s2"],
+              ),
+            ],
+          ),
+        ),
+      );
+
+      // Wait for second emission
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      expect(activities.length, 2);
+      expect(activities[0], {
+        "/foo": {"s1"},
+      });
+      expect(activities[1], {
+        "/foo": {"s1", "s2"},
+      });
+
+      await subscription.cancel();
+      repo.onDispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // 6. projectActivity defaults to empty map
+    // -------------------------------------------------------------------------
+
+    test("projectActivity defaults to empty map", () {
+      final repo = SseEventRepository(mockConnectionService);
+      expect(repo.currentProjectActivity, isEmpty);
+      repo.onDispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // 7. projectActivity emits active session counts from projectsSummary event
+    // -------------------------------------------------------------------------
+
+    test("projectActivity emits active session counts from projectsSummary event", () async {
+      final repo = SseEventRepository(mockConnectionService);
+
+      final completer = Completer<Map<String, int>>();
+      final subscription = repo.projectActivity.listen((activity) {
+        if (activity.isNotEmpty) {
+          completer.complete(activity);
+        }
+      });
+
+      // Emit a projectsSummary event with active sessions for "/foo"
+      final event = SseEvent(
+        data: const SesoriProjectsSummary(
+          projects: [
+            ProjectActivitySummary(
+              worktree: "/foo",
+              activeSessions: 3,
+              activeSessionIds: ["s1", "s2", "s3"],
+            ),
+          ],
+        ),
+      );
+      eventController.add(event);
+
+      final activity = await completer.future;
+      expect(activity, {"/foo": 3});
+
+      await subscription.cancel();
+      repo.onDispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // 8. projectActivity excludes worktrees with no active sessions
+    // -------------------------------------------------------------------------
+
+    test("projectActivity excludes worktrees with no active sessions", () async {
+      final repo = SseEventRepository(mockConnectionService);
+
+      final completer = Completer<Map<String, int>>();
+      final subscription = repo.projectActivity.listen(completer.complete);
+
+      // Emit a projectsSummary event with no active sessions for "/bar"
+      final event = SseEvent(
+        data: const SesoriProjectsSummary(
+          projects: [
+            ProjectActivitySummary(
+              worktree: "/bar",
+            ),
+          ],
+        ),
+      );
+      eventController.add(event);
+
+      final activity = await completer.future;
+      expect(activity, isEmpty);
+
+      await subscription.cancel();
+      repo.onDispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // 9. Non-projectsSummary events are ignored
+    // -------------------------------------------------------------------------
+
+    test("non-projectsSummary events are ignored", () async {
+      final repo = SseEventRepository(mockConnectionService);
+
+      var emissionCount = 0;
+      final subscription = repo.sessionActivity.listen((_) => emissionCount++);
+
+      // Wait for initial seeded value
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      final initialCount = emissionCount;
+
+      // Emit a non-projectsSummary event (should be ignored)
+      final event = SseEvent(
+        data: const SesoriSessionCreated(
+          info: Session(
+            id: "s1",
+            projectID: "p1",
+            directory: "/foo",
+            time: SessionTime(created: 1, updated: 2),
+          ),
+        ),
+      );
+      eventController.add(event);
+
+      // Wait a bit to ensure no additional emission
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      // Should not have increased from initial count
+      expect(emissionCount, initialCount);
+
+      await subscription.cancel();
+      repo.onDispose();
+    });
+  });
+}

--- a/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.dart
@@ -7,8 +7,7 @@ part "project_activity_summary.g.dart";
 sealed class ProjectActivitySummary with _$ProjectActivitySummary {
   const factory ProjectActivitySummary({
     required String id,
-    @Default(0) int activeSessions,
-    @Default([]) List<String> activeSessionIds,
+    required List<String> activeSessionIds,
   }) = _ProjectActivitySummary;
 
   factory ProjectActivitySummary.fromJson(Map<String, dynamic> json) => _$ProjectActivitySummaryFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.dart
@@ -8,6 +8,7 @@ sealed class ProjectActivitySummary with _$ProjectActivitySummary {
   const factory ProjectActivitySummary({
     required String worktree,
     @Default(0) int activeSessions,
+    @Default([]) List<String> activeSessionIds,
   }) = _ProjectActivitySummary;
 
   factory ProjectActivitySummary.fromJson(Map<String, dynamic> json) => _$ProjectActivitySummaryFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.dart
@@ -6,7 +6,7 @@ part "project_activity_summary.g.dart";
 @Freezed(fromJson: true, toJson: true)
 sealed class ProjectActivitySummary with _$ProjectActivitySummary {
   const factory ProjectActivitySummary({
-    required String worktree,
+    required String id,
     @Default(0) int activeSessions,
     @Default([]) List<String> activeSessionIds,
   }) = _ProjectActivitySummary;

--- a/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ProjectActivitySummary {
 
- String get id; int get activeSessions; List<String> get activeSessionIds;
+ String get id; List<String> get activeSessionIds;
 /// Create a copy of ProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $ProjectActivitySummaryCopyWith<ProjectActivitySummary> get copyWith => _$Projec
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectActivitySummary&&(identical(other.id, id) || other.id == id)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions)&&const DeepCollectionEquality().equals(other.activeSessionIds, activeSessionIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectActivitySummary&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.activeSessionIds, activeSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,activeSessions,const DeepCollectionEquality().hash(activeSessionIds));
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(activeSessionIds));
 
 @override
 String toString() {
-  return 'ProjectActivitySummary(id: $id, activeSessions: $activeSessions, activeSessionIds: $activeSessionIds)';
+  return 'ProjectActivitySummary(id: $id, activeSessionIds: $activeSessionIds)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $ProjectActivitySummaryCopyWith<$Res>  {
   factory $ProjectActivitySummaryCopyWith(ProjectActivitySummary value, $Res Function(ProjectActivitySummary) _then) = _$ProjectActivitySummaryCopyWithImpl;
 @useResult
 $Res call({
- String id, int activeSessions, List<String> activeSessionIds
+ String id, List<String> activeSessionIds
 });
 
 
@@ -65,11 +65,10 @@ class _$ProjectActivitySummaryCopyWithImpl<$Res>
 
 /// Create a copy of ProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? activeSessions = null,Object? activeSessionIds = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? activeSessionIds = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as String,activeSessions: null == activeSessions ? _self.activeSessions : activeSessions // ignore: cast_nullable_to_non_nullable
-as int,activeSessionIds: null == activeSessionIds ? _self.activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
+as String,activeSessionIds: null == activeSessionIds ? _self.activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
 as List<String>,
   ));
 }
@@ -82,13 +81,12 @@ as List<String>,
 @JsonSerializable()
 
 class _ProjectActivitySummary implements ProjectActivitySummary {
-  const _ProjectActivitySummary({required this.id, this.activeSessions = 0, final  List<String> activeSessionIds = const []}): _activeSessionIds = activeSessionIds;
+  const _ProjectActivitySummary({required this.id, required final  List<String> activeSessionIds}): _activeSessionIds = activeSessionIds;
   factory _ProjectActivitySummary.fromJson(Map<String, dynamic> json) => _$ProjectActivitySummaryFromJson(json);
 
 @override final  String id;
-@override@JsonKey() final  int activeSessions;
  final  List<String> _activeSessionIds;
-@override@JsonKey() List<String> get activeSessionIds {
+@override List<String> get activeSessionIds {
   if (_activeSessionIds is EqualUnmodifiableListView) return _activeSessionIds;
   // ignore: implicit_dynamic_type
   return EqualUnmodifiableListView(_activeSessionIds);
@@ -108,16 +106,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ProjectActivitySummary&&(identical(other.id, id) || other.id == id)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions)&&const DeepCollectionEquality().equals(other._activeSessionIds, _activeSessionIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ProjectActivitySummary&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other._activeSessionIds, _activeSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,activeSessions,const DeepCollectionEquality().hash(_activeSessionIds));
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(_activeSessionIds));
 
 @override
 String toString() {
-  return 'ProjectActivitySummary(id: $id, activeSessions: $activeSessions, activeSessionIds: $activeSessionIds)';
+  return 'ProjectActivitySummary(id: $id, activeSessionIds: $activeSessionIds)';
 }
 
 
@@ -128,7 +126,7 @@ abstract mixin class _$ProjectActivitySummaryCopyWith<$Res> implements $ProjectA
   factory _$ProjectActivitySummaryCopyWith(_ProjectActivitySummary value, $Res Function(_ProjectActivitySummary) _then) = __$ProjectActivitySummaryCopyWithImpl;
 @override @useResult
 $Res call({
- String id, int activeSessions, List<String> activeSessionIds
+ String id, List<String> activeSessionIds
 });
 
 
@@ -145,11 +143,10 @@ class __$ProjectActivitySummaryCopyWithImpl<$Res>
 
 /// Create a copy of ProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? activeSessions = null,Object? activeSessionIds = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? activeSessionIds = null,}) {
   return _then(_ProjectActivitySummary(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as String,activeSessions: null == activeSessions ? _self.activeSessions : activeSessions // ignore: cast_nullable_to_non_nullable
-as int,activeSessionIds: null == activeSessionIds ? _self._activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
+as String,activeSessionIds: null == activeSessionIds ? _self._activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
 as List<String>,
   ));
 }

--- a/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ProjectActivitySummary {
 
- String get worktree; int get activeSessions; List<String> get activeSessionIds;
+ String get id; int get activeSessions; List<String> get activeSessionIds;
 /// Create a copy of ProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $ProjectActivitySummaryCopyWith<ProjectActivitySummary> get copyWith => _$Projec
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectActivitySummary&&(identical(other.worktree, worktree) || other.worktree == worktree)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions)&&const DeepCollectionEquality().equals(other.activeSessionIds, activeSessionIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectActivitySummary&&(identical(other.id, id) || other.id == id)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions)&&const DeepCollectionEquality().equals(other.activeSessionIds, activeSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,worktree,activeSessions,const DeepCollectionEquality().hash(activeSessionIds));
+int get hashCode => Object.hash(runtimeType,id,activeSessions,const DeepCollectionEquality().hash(activeSessionIds));
 
 @override
 String toString() {
-  return 'ProjectActivitySummary(worktree: $worktree, activeSessions: $activeSessions, activeSessionIds: $activeSessionIds)';
+  return 'ProjectActivitySummary(id: $id, activeSessions: $activeSessions, activeSessionIds: $activeSessionIds)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $ProjectActivitySummaryCopyWith<$Res>  {
   factory $ProjectActivitySummaryCopyWith(ProjectActivitySummary value, $Res Function(ProjectActivitySummary) _then) = _$ProjectActivitySummaryCopyWithImpl;
 @useResult
 $Res call({
- String worktree, int activeSessions, List<String> activeSessionIds
+ String id, int activeSessions, List<String> activeSessionIds
 });
 
 
@@ -65,9 +65,9 @@ class _$ProjectActivitySummaryCopyWithImpl<$Res>
 
 /// Create a copy of ProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? worktree = null,Object? activeSessions = null,Object? activeSessionIds = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? activeSessions = null,Object? activeSessionIds = null,}) {
   return _then(_self.copyWith(
-worktree: null == worktree ? _self.worktree : worktree // ignore: cast_nullable_to_non_nullable
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,activeSessions: null == activeSessions ? _self.activeSessions : activeSessions // ignore: cast_nullable_to_non_nullable
 as int,activeSessionIds: null == activeSessionIds ? _self.activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
 as List<String>,
@@ -82,10 +82,10 @@ as List<String>,
 @JsonSerializable()
 
 class _ProjectActivitySummary implements ProjectActivitySummary {
-  const _ProjectActivitySummary({required this.worktree, this.activeSessions = 0, final  List<String> activeSessionIds = const []}): _activeSessionIds = activeSessionIds;
+  const _ProjectActivitySummary({required this.id, this.activeSessions = 0, final  List<String> activeSessionIds = const []}): _activeSessionIds = activeSessionIds;
   factory _ProjectActivitySummary.fromJson(Map<String, dynamic> json) => _$ProjectActivitySummaryFromJson(json);
 
-@override final  String worktree;
+@override final  String id;
 @override@JsonKey() final  int activeSessions;
  final  List<String> _activeSessionIds;
 @override@JsonKey() List<String> get activeSessionIds {
@@ -108,16 +108,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ProjectActivitySummary&&(identical(other.worktree, worktree) || other.worktree == worktree)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions)&&const DeepCollectionEquality().equals(other._activeSessionIds, _activeSessionIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ProjectActivitySummary&&(identical(other.id, id) || other.id == id)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions)&&const DeepCollectionEquality().equals(other._activeSessionIds, _activeSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,worktree,activeSessions,const DeepCollectionEquality().hash(_activeSessionIds));
+int get hashCode => Object.hash(runtimeType,id,activeSessions,const DeepCollectionEquality().hash(_activeSessionIds));
 
 @override
 String toString() {
-  return 'ProjectActivitySummary(worktree: $worktree, activeSessions: $activeSessions, activeSessionIds: $activeSessionIds)';
+  return 'ProjectActivitySummary(id: $id, activeSessions: $activeSessions, activeSessionIds: $activeSessionIds)';
 }
 
 
@@ -128,7 +128,7 @@ abstract mixin class _$ProjectActivitySummaryCopyWith<$Res> implements $ProjectA
   factory _$ProjectActivitySummaryCopyWith(_ProjectActivitySummary value, $Res Function(_ProjectActivitySummary) _then) = __$ProjectActivitySummaryCopyWithImpl;
 @override @useResult
 $Res call({
- String worktree, int activeSessions, List<String> activeSessionIds
+ String id, int activeSessions, List<String> activeSessionIds
 });
 
 
@@ -145,9 +145,9 @@ class __$ProjectActivitySummaryCopyWithImpl<$Res>
 
 /// Create a copy of ProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? worktree = null,Object? activeSessions = null,Object? activeSessionIds = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? activeSessions = null,Object? activeSessionIds = null,}) {
   return _then(_ProjectActivitySummary(
-worktree: null == worktree ? _self.worktree : worktree // ignore: cast_nullable_to_non_nullable
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,activeSessions: null == activeSessions ? _self.activeSessions : activeSessions // ignore: cast_nullable_to_non_nullable
 as int,activeSessionIds: null == activeSessionIds ? _self._activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
 as List<String>,

--- a/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ProjectActivitySummary {
 
- String get worktree; int get activeSessions;
+ String get worktree; int get activeSessions; List<String> get activeSessionIds;
 /// Create a copy of ProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $ProjectActivitySummaryCopyWith<ProjectActivitySummary> get copyWith => _$Projec
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectActivitySummary&&(identical(other.worktree, worktree) || other.worktree == worktree)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectActivitySummary&&(identical(other.worktree, worktree) || other.worktree == worktree)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions)&&const DeepCollectionEquality().equals(other.activeSessionIds, activeSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,worktree,activeSessions);
+int get hashCode => Object.hash(runtimeType,worktree,activeSessions,const DeepCollectionEquality().hash(activeSessionIds));
 
 @override
 String toString() {
-  return 'ProjectActivitySummary(worktree: $worktree, activeSessions: $activeSessions)';
+  return 'ProjectActivitySummary(worktree: $worktree, activeSessions: $activeSessions, activeSessionIds: $activeSessionIds)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $ProjectActivitySummaryCopyWith<$Res>  {
   factory $ProjectActivitySummaryCopyWith(ProjectActivitySummary value, $Res Function(ProjectActivitySummary) _then) = _$ProjectActivitySummaryCopyWithImpl;
 @useResult
 $Res call({
- String worktree, int activeSessions
+ String worktree, int activeSessions, List<String> activeSessionIds
 });
 
 
@@ -65,11 +65,12 @@ class _$ProjectActivitySummaryCopyWithImpl<$Res>
 
 /// Create a copy of ProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? worktree = null,Object? activeSessions = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? worktree = null,Object? activeSessions = null,Object? activeSessionIds = null,}) {
   return _then(_self.copyWith(
 worktree: null == worktree ? _self.worktree : worktree // ignore: cast_nullable_to_non_nullable
 as String,activeSessions: null == activeSessions ? _self.activeSessions : activeSessions // ignore: cast_nullable_to_non_nullable
-as int,
+as int,activeSessionIds: null == activeSessionIds ? _self.activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
+as List<String>,
   ));
 }
 
@@ -81,11 +82,18 @@ as int,
 @JsonSerializable()
 
 class _ProjectActivitySummary implements ProjectActivitySummary {
-  const _ProjectActivitySummary({required this.worktree, this.activeSessions = 0});
+  const _ProjectActivitySummary({required this.worktree, this.activeSessions = 0, final  List<String> activeSessionIds = const []}): _activeSessionIds = activeSessionIds;
   factory _ProjectActivitySummary.fromJson(Map<String, dynamic> json) => _$ProjectActivitySummaryFromJson(json);
 
 @override final  String worktree;
 @override@JsonKey() final  int activeSessions;
+ final  List<String> _activeSessionIds;
+@override@JsonKey() List<String> get activeSessionIds {
+  if (_activeSessionIds is EqualUnmodifiableListView) return _activeSessionIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_activeSessionIds);
+}
+
 
 /// Create a copy of ProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
@@ -100,16 +108,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ProjectActivitySummary&&(identical(other.worktree, worktree) || other.worktree == worktree)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ProjectActivitySummary&&(identical(other.worktree, worktree) || other.worktree == worktree)&&(identical(other.activeSessions, activeSessions) || other.activeSessions == activeSessions)&&const DeepCollectionEquality().equals(other._activeSessionIds, _activeSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,worktree,activeSessions);
+int get hashCode => Object.hash(runtimeType,worktree,activeSessions,const DeepCollectionEquality().hash(_activeSessionIds));
 
 @override
 String toString() {
-  return 'ProjectActivitySummary(worktree: $worktree, activeSessions: $activeSessions)';
+  return 'ProjectActivitySummary(worktree: $worktree, activeSessions: $activeSessions, activeSessionIds: $activeSessionIds)';
 }
 
 
@@ -120,7 +128,7 @@ abstract mixin class _$ProjectActivitySummaryCopyWith<$Res> implements $ProjectA
   factory _$ProjectActivitySummaryCopyWith(_ProjectActivitySummary value, $Res Function(_ProjectActivitySummary) _then) = __$ProjectActivitySummaryCopyWithImpl;
 @override @useResult
 $Res call({
- String worktree, int activeSessions
+ String worktree, int activeSessions, List<String> activeSessionIds
 });
 
 
@@ -137,11 +145,12 @@ class __$ProjectActivitySummaryCopyWithImpl<$Res>
 
 /// Create a copy of ProjectActivitySummary
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? worktree = null,Object? activeSessions = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? worktree = null,Object? activeSessions = null,Object? activeSessionIds = null,}) {
   return _then(_ProjectActivitySummary(
 worktree: null == worktree ? _self.worktree : worktree // ignore: cast_nullable_to_non_nullable
 as String,activeSessions: null == activeSessions ? _self.activeSessions : activeSessions // ignore: cast_nullable_to_non_nullable
-as int,
+as int,activeSessionIds: null == activeSessionIds ? _self._activeSessionIds : activeSessionIds // ignore: cast_nullable_to_non_nullable
+as List<String>,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.g.dart
@@ -10,6 +10,11 @@ _ProjectActivitySummary _$ProjectActivitySummaryFromJson(Map json) =>
     _ProjectActivitySummary(
       worktree: json['worktree'] as String,
       activeSessions: (json['activeSessions'] as num?)?.toInt() ?? 0,
+      activeSessionIds:
+          (json['activeSessionIds'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
     );
 
 Map<String, dynamic> _$ProjectActivitySummaryToJson(
@@ -17,4 +22,5 @@ Map<String, dynamic> _$ProjectActivitySummaryToJson(
 ) => <String, dynamic>{
   'worktree': instance.worktree,
   'activeSessions': instance.activeSessions,
+  'activeSessionIds': instance.activeSessionIds,
 };

--- a/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.g.dart
@@ -9,18 +9,14 @@ part of 'project_activity_summary.dart';
 _ProjectActivitySummary _$ProjectActivitySummaryFromJson(Map json) =>
     _ProjectActivitySummary(
       id: json['id'] as String,
-      activeSessions: (json['activeSessions'] as num?)?.toInt() ?? 0,
-      activeSessionIds:
-          (json['activeSessionIds'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          const [],
+      activeSessionIds: (json['activeSessionIds'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
     );
 
 Map<String, dynamic> _$ProjectActivitySummaryToJson(
   _ProjectActivitySummary instance,
 ) => <String, dynamic>{
   'id': instance.id,
-  'activeSessions': instance.activeSessions,
   'activeSessionIds': instance.activeSessionIds,
 };

--- a/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project_activity_summary.g.dart
@@ -8,7 +8,7 @@ part of 'project_activity_summary.dart';
 
 _ProjectActivitySummary _$ProjectActivitySummaryFromJson(Map json) =>
     _ProjectActivitySummary(
-      worktree: json['worktree'] as String,
+      id: json['id'] as String,
       activeSessions: (json['activeSessions'] as num?)?.toInt() ?? 0,
       activeSessionIds:
           (json['activeSessionIds'] as List<dynamic>?)
@@ -20,7 +20,7 @@ _ProjectActivitySummary _$ProjectActivitySummaryFromJson(Map json) =>
 Map<String, dynamic> _$ProjectActivitySummaryToJson(
   _ProjectActivitySummary instance,
 ) => <String, dynamic>{
-  'worktree': instance.worktree,
+  'id': instance.id,
   'activeSessions': instance.activeSessions,
   'activeSessionIds': instance.activeSessionIds,
 };

--- a/shared/sesori_shared/test/models/sesori_sse_event_test.dart
+++ b/shared/sesori_shared/test/models/sesori_sse_event_test.dart
@@ -197,8 +197,8 @@ void main() {
     test('serializes correctly', () {
       const event = SesoriSseEvent.projectsSummary(
         projects: [
-          ProjectActivitySummary(worktree: '/foo', activeSessions: 2),
-          ProjectActivitySummary(worktree: '/bar', activeSessions: 0),
+          ProjectActivitySummary(id: '/foo', activeSessionIds: ['s1', 's2']),
+          ProjectActivitySummary(id: '/bar', activeSessionIds: []),
         ],
       );
       final json = event.toJson();
@@ -206,18 +206,21 @@ void main() {
       expect(json['type'], 'projects.summary');
       expect(json['projects'], hasLength(2));
       final first = (json['projects'] as List)[0] as Map<String, dynamic>;
-      expect(first['worktree'], '/foo');
-      expect(first['activeSessions'], 2);
+      expect(first['id'], '/foo');
+      expect(first['activeSessionIds'], ['s1', 's2']);
       final second = (json['projects'] as List)[1] as Map<String, dynamic>;
-      expect(second['worktree'], '/bar');
-      expect(second['activeSessions'], 0);
+      expect(second['id'], '/bar');
+      expect(second['activeSessionIds'], <String>[]);
     });
 
     test('deserializes correctly', () {
       final json = {
         'type': 'projects.summary',
         'projects': [
-          {'worktree': '/foo', 'activeSessions': 3},
+          {
+            'id': '/foo',
+            'activeSessionIds': ['s1', 's2', 's3'],
+          },
         ],
       };
       final event = SesoriSseEvent.fromJson(json);
@@ -225,16 +228,16 @@ void main() {
       expect(event, isA<SesoriProjectsSummary>());
       final cast = event as SesoriProjectsSummary;
       expect(cast.projects, hasLength(1));
-      expect(cast.projects.first.worktree, '/foo');
-      expect(cast.projects.first.activeSessions, 3);
+      expect(cast.projects.first.id, '/foo');
+      expect(cast.projects.first.activeSessionIds, ['s1', 's2', 's3']);
     });
 
     test('round-trips correctly', () {
       const original = SesoriSseEvent.projectsSummary(
         projects: [
-          ProjectActivitySummary(worktree: '/alpha', activeSessions: 5),
-          ProjectActivitySummary(worktree: '/beta', activeSessions: 1),
-          ProjectActivitySummary(worktree: '/gamma', activeSessions: 0),
+          ProjectActivitySummary(id: '/alpha', activeSessionIds: ['s1', 's2', 's3', 's4', 's5']),
+          ProjectActivitySummary(id: '/beta', activeSessionIds: ['s1']),
+          ProjectActivitySummary(id: '/gamma', activeSessionIds: []),
         ],
       );
       final json = original.toJson();
@@ -243,12 +246,12 @@ void main() {
       expect(parsed, isA<SesoriProjectsSummary>());
       final cast = parsed as SesoriProjectsSummary;
       expect(cast.projects, hasLength(3));
-      expect(cast.projects[0].worktree, '/alpha');
-      expect(cast.projects[0].activeSessions, 5);
-      expect(cast.projects[1].worktree, '/beta');
-      expect(cast.projects[1].activeSessions, 1);
-      expect(cast.projects[2].worktree, '/gamma');
-      expect(cast.projects[2].activeSessions, 0);
+      expect(cast.projects[0].id, '/alpha');
+      expect(cast.projects[0].activeSessionIds.length, 5);
+      expect(cast.projects[1].id, '/beta');
+      expect(cast.projects[1].activeSessionIds.length, 1);
+      expect(cast.projects[2].id, '/gamma');
+      expect(cast.projects[2].activeSessionIds.length, 0);
     });
 
     test('empty projects list round-trips correctly', () {
@@ -327,36 +330,41 @@ void main() {
   // ---------------------------------------------------------------------------
 
   group('ProjectActivitySummary', () {
-    test('defaults activeSessions to 0', () {
-      const summary = ProjectActivitySummary(worktree: '/test');
-      expect(summary.activeSessions, 0);
+    test('requires id and activeSessionIds', () {
+      const summary = ProjectActivitySummary(id: '/test', activeSessionIds: []);
+      expect(summary.id, '/test');
+      expect(summary.activeSessionIds, <String>[]);
     });
 
-    test('accepts explicit activeSessions value', () {
-      const summary = ProjectActivitySummary(worktree: '/test', activeSessions: 7);
-      expect(summary.worktree, '/test');
-      expect(summary.activeSessions, 7);
+    test('accepts explicit activeSessionIds list', () {
+      const summary = ProjectActivitySummary(id: '/test', activeSessionIds: ['s1', 's2', 's3', 's4', 's5', 's6', 's7']);
+      expect(summary.id, '/test');
+      expect(summary.activeSessionIds.length, 7);
     });
 
-    test('serializes worktree and activeSessions to JSON', () {
-      const summary = ProjectActivitySummary(worktree: '/my/path', activeSessions: 4);
+    test('serializes id and activeSessionIds to JSON', () {
+      const summary = ProjectActivitySummary(id: '/my/path', activeSessionIds: ['s1', 's2', 's3', 's4']);
       final json = summary.toJson();
-      expect(json['worktree'], '/my/path');
-      expect(json['activeSessions'], 4);
+      expect(json['id'], '/my/path');
+      expect(json['activeSessionIds'], ['s1', 's2', 's3', 's4']);
     });
 
     test('deserializes from JSON correctly', () {
-      final json = {'worktree': '/from/json', 'activeSessions': 9};
+      final json = {
+        'id': '/from/json',
+        'activeSessionIds': ['s1', 's2', 's3', 's4', 's5', 's6', 's7', 's8', 's9'],
+      };
       final summary = ProjectActivitySummary.fromJson(json);
-      expect(summary.worktree, '/from/json');
-      expect(summary.activeSessions, 9);
+      expect(summary.id, '/from/json');
+      expect(summary.activeSessionIds.length, 9);
     });
 
-    test('fromJson uses 0 as default when activeSessions absent', () {
-      final json = {'worktree': '/no/count'};
-      final summary = ProjectActivitySummary.fromJson(json);
-      expect(summary.worktree, '/no/count');
-      expect(summary.activeSessions, 0);
+    test('fromJson requires activeSessionIds', () {
+      final json = {'id': '/no/sessions'};
+      expect(
+        () => ProjectActivitySummary.fromJson(json),
+        throwsA(isA<TypeError>()),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- **Fix**: Project activity indicators now refresh in real-time when sessions start/stop (no more stale state requiring pull-to-refresh)
- **Feature**: Session list screen shows a "Running" indicator for active sessions, matching the project list visual pattern
- **Same SSE event**: Both project and session activity data flow through the existing `projects.summary` event

## Root Cause (Bug Fix)

When session status changed, the bridge emitted `BridgeSseProjectUpdated()` — an empty signal with no data. The orchestrator mapped this to `SesoriSseEvent.projectUpdated()` (still empty), but the mobile `SseEventRepository` only handled `SesoriProjectsSummary` (which carries data). The update was silently dropped.

**Fix**: Orchestrator now builds and sends a full `projectsSummary` event with current activity data from `getActiveSessionsSummary()`, using the same pattern as the initial SSE subscribe handler.

## Changes

### Shared (`sesori_shared`)
- Add `activeSessionIds: List<String>` field to `ProjectActivitySummary`

### Bridge
- `PluginProjectActivitySummary`: Add `activeSessionIds` field
- `ActiveSessionTracker.buildSummary()`: Expose active session IDs per worktree (data was already tracked internally)
- `OpenCodePlugin.getActiveSessionsSummary()`: Map new field through
- `Orchestrator._mapBridgeToSesoriEvent()`: Send `projectsSummary` instead of empty `projectUpdated` for `BridgeSseProjectUpdated`

### Mobile
- `SseEventRepository`: Add `sessionActivity` stream (worktree → set of active session IDs)
- `SessionListCubit`: Subscribe to session activity, expose `activeSessionIds` in state
- `SessionListScreen`: Show green dot + "Running" label on active session tiles
- Localization: Add `sessionListRunning` string

## Tests
- Bridge: 3 new `ActiveSessionTracker` tests for `buildSummary()` session IDs (65 total pass)
- Mobile core: 9 new `SseEventRepository` tests (30 total pass)
- Mobile app: 4 new `SessionListCubit` activity tests (367 total pass)