### PR TITLE
fix(bridge): resolve session worktrees correctly during cold start

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -1,5 +1,5 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
-import "package:sesori_shared/sesori_shared.dart" show ActiveSession, ProjectActivitySummary, wait2;
+import "package:sesori_shared/sesori_shared.dart" show ActiveSession, ProjectActivitySummary, wait3;
 
 import "models/session_status.dart";
 import "models/sse_event_data.dart";
@@ -21,9 +21,10 @@ class ActiveSessionTracker {
   ActiveSessionTracker(this._repository);
 
   Future<void> coldStart() async {
-    final (projects, statuses) = await wait2(
+    final (projects, statuses, sessions) = await wait3(
       _repository.getProjects(),
       _repository.api.getSessionStatuses(),
+      _repository.api.listRootSessions(),
     );
 
     _projectWorktrees
@@ -32,6 +33,13 @@ class ActiveSessionTracker {
 
     _sessionWorktrees.clear();
     _sessionParentIds.clear();
+
+    // Build directory lookup and parent ID mapping from fetched sessions.
+    final sessionDirectories = <String, String>{};
+    for (final session in sessions) {
+      sessionDirectories[session.id] = session.directory;
+      _sessionParentIds[session.id] = session.parentID;
+    }
 
     _sessionStatuses
       ..clear()
@@ -43,10 +51,12 @@ class ActiveSessionTracker {
         ),
       );
 
-    for (final entry in _sessionStatuses.keys.toList()) {
-      final worktree = _resolveWorktree(entry);
+    for (final sessionId in _sessionStatuses.keys.toList()) {
+      final directory = sessionDirectories[sessionId];
+      if (directory == null) continue;
+      final worktree = _resolveWorktree(directory);
       if (worktree != null) {
-        _sessionWorktrees[entry] = worktree;
+        _sessionWorktrees[sessionId] = worktree;
       }
     }
 

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -242,19 +242,54 @@ void main() {
     });
 
     test("coldStart populates state from API", () async {
-      final tracker = ActiveSessionTracker(
-        _fakeRepository(
-          projects: [
-            const Project(id: "p1", worktree: "/foo"),
-            const Project(id: "p2", worktree: "/bar"),
-          ],
-          statuses: {"s1": const SessionStatus.busy(), "s2": const SessionStatus.idle()},
-        ),
+      final tracker = await _coldStartedTracker(
+        projects: [
+          const Project(id: "p1", worktree: "/foo"),
+          const Project(id: "p2", worktree: "/bar"),
+        ],
+        sessions: [
+          const Session(id: "s1", projectID: "p1", directory: "/foo"),
+          const Session(id: "s2", projectID: "p2", directory: "/bar"),
+        ],
+        statuses: {"s1": const SessionStatus.busy(), "s2": const SessionStatus.idle()},
       );
 
-      await tracker.coldStart();
+      expect(tracker.activeSessions, equals({"/foo": 1}));
+    });
 
-      expect(tracker.activeSessions, isEmpty);
+    test("coldStart buildSummary reflects busy sessions", () async {
+      final tracker = await _coldStartedTracker(
+        projects: [const Project(id: "p1", worktree: "/repo")],
+        sessions: [
+          const Session(id: "s1", projectID: "p1", directory: "/repo"),
+        ],
+        statuses: {"s1": const SessionStatus.busy()},
+      );
+
+      final summary = tracker.buildSummary();
+
+      expect(summary, hasLength(1));
+      expect(summary.first.id, equals("/repo"));
+      expect(summary.first.activeSessions.first.id, equals("s1"));
+      expect(summary.first.activeSessions.first.mainAgentRunning, isTrue);
+    });
+
+    test("coldStart groups child sessions under parents", () async {
+      final tracker = await _coldStartedTracker(
+        projects: [const Project(id: "p1", worktree: "/repo")],
+        sessions: [
+          const Session(id: "s1", projectID: "p1", directory: "/repo"),
+          const Session(id: "c1", projectID: "p1", directory: "/repo", parentID: "s1"),
+        ],
+        statuses: {"c1": const SessionStatus.busy()},
+      );
+
+      final summary = tracker.buildSummary();
+
+      expect(summary, hasLength(1));
+      expect(summary.first.activeSessions.first.id, equals("s1"));
+      expect(summary.first.activeSessions.first.mainAgentRunning, isFalse);
+      expect(summary.first.activeSessions.first.childSessionIds, equals(["c1"]));
     });
 
     test("buildSummary includes activeSessions for busy sessions", () async {


### PR DESCRIPTION
## Summary

- **Fix**: `ActiveSessionTracker.coldStart()` was passing session IDs (e.g. `ses_abc123`) to `_resolveWorktree()` which expects directory paths — so worktrees were never resolved after bridge startup or SSE reconnect, making active sessions invisible in the summary until new SSE events arrived.
- **Fix**: Now fetches sessions via `listRootSessions()` alongside projects and statuses, uses actual directory paths for worktree resolution, and populates `_sessionParentIds` for correct parent-child grouping in `buildSummary()`.
- **Tests**: Updated existing cold start test to assert correct behavior, added 2 new tests covering `buildSummary()` output and parent-child grouping after cold start.