### PR TITLE
fix(bridge): resolve child session worktrees during cold start

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -24,7 +24,7 @@ class ActiveSessionTracker {
     final (projects, statuses, sessions) = await wait3(
       _repository.getProjects(),
       _repository.api.getSessionStatuses(),
-      _repository.api.listRootSessions(),
+      _repository.api.listSessions(),
     );
 
     _projectWorktrees

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -415,6 +415,28 @@ void main() {
       expect(summary, isEmpty);
     });
 
+    test("coldStart resolves busy child sessions not in root list", () async {
+      // Regression: coldStart used to call listRootSessions() which omitted
+      // child sessions.  A busy child would have no directory / parentId and
+      // be treated as an orphan root, logging "no worktree for session".
+      // After switching to listSessions(), child metadata is available.
+      final tracker = await _coldStartedTracker(
+        projects: [const Project(id: "p1", worktree: "/repo")],
+        sessions: [
+          const Session(id: "s1", projectID: "p1", directory: "/repo"),
+          const Session(id: "c1", projectID: "p1", directory: "/repo", parentID: "s1"),
+        ],
+        statuses: {"c1": const SessionStatus.busy()},
+      );
+
+      final summary = tracker.buildSummary();
+
+      expect(summary, hasLength(1));
+      expect(summary.first.activeSessions.first.id, equals("s1"));
+      expect(summary.first.activeSessions.first.mainAgentRunning, isFalse);
+      expect(summary.first.activeSessions.first.childSessionIds, equals(["c1"]));
+    });
+
     test("deeply nested children are ignored", () async {
       final tracker = await _coldStartedTracker(
         projects: [const Project(id: "p1", worktree: "/repo")],


### PR DESCRIPTION
## Summary

- **Bug**: `coldStart()` called `listRootSessions()` which only returns sessions without a parent, but `getSessionStatuses()` returns all busy sessions including children. Child sessions that were busy at startup had no directory or parentId metadata, causing them to be misclassified as orphan roots and logged as `"buildSummary: no worktree for session"`.
- **Fix**: Switch `coldStart()` from `listRootSessions()` to `listSessions()` so child session metadata (directory, parentId) is available at startup. This is a single localhost HTTP call on startup — no meaningful traffic difference.
- **Test**: Added regression test verifying busy child sessions are properly grouped under their parent during cold start.