### PR TITLE
fix(bridge): include x-opencode-directory header in session-scoped API calls

### DIFF
--- a/bridge/app/lib/src/bridge/debug_server.dart
+++ b/bridge/app/lib/src/bridge/debug_server.dart
@@ -103,13 +103,12 @@ class DebugServer {
     if (request.method == "GET" && path == "/project") {
       final projects = await _plugin.getProjects();
       final body = jsonEncode(projects.map((p) => p.toJson()).toList());
-      return RelayMessage.response(
-            id: request.id,
-            status: 200,
-            headers: {"content-type": "application/json"},
-            body: body,
-          )
-          as RelayResponse;
+      return RelayResponse(
+        id: request.id,
+        status: 200,
+        headers: {"content-type": "application/json"},
+        body: body,
+      );
     }
 
     if (request.method == "GET" && path == "/session") {
@@ -121,26 +120,24 @@ class DebugServer {
         }
       }
       if (worktree == null || worktree.isEmpty) {
-        return RelayMessage.response(
-              id: request.id,
-              status: 400,
-              headers: {},
-              body: "missing x-opencode-directory header",
-            )
-            as RelayResponse;
+        return RelayResponse(
+          id: request.id,
+          status: 400,
+          headers: {},
+          body: "missing x-opencode-directory header",
+        );
       }
       final uri = Uri.parse(request.path);
       final start = uri.queryParameters["start"] != null ? int.tryParse(uri.queryParameters["start"]!) : null;
       final limit = uri.queryParameters["limit"] != null ? int.tryParse(uri.queryParameters["limit"]!) : null;
       final sessions = await _plugin.getSessions(worktree, start: start, limit: limit);
       final body = jsonEncode(sessions.map((s) => s.toJson()).toList());
-      return RelayMessage.response(
-            id: request.id,
-            status: 200,
-            headers: {"content-type": "application/json"},
-            body: body,
-          )
-          as RelayResponse;
+      return RelayResponse(
+        id: request.id,
+        status: 200,
+        headers: {"content-type": "application/json"},
+        body: body,
+      );
     }
 
     final sessionMsgPattern = RegExp(r"^/session/[^/]+/message$");
@@ -150,23 +147,21 @@ class DebugServer {
       final sessionId = segments[2];
       final messages = await _plugin.getSessionMessages(sessionId);
       final body = jsonEncode(messages.map((m) => m.toJson()).toList());
-      return RelayMessage.response(
-            id: request.id,
-            status: 200,
-            headers: {"content-type": "application/json"},
-            body: body,
-          )
-          as RelayResponse;
+      return RelayResponse(
+        id: request.id,
+        status: 200,
+        headers: {"content-type": "application/json"},
+        body: body,
+      );
     }
 
     // Fallback: explicit handlers not implemented for this route yet.
-    return RelayMessage.response(
-          id: request.id,
-          status: 404,
-          headers: {},
-          body: "route not handled",
-        )
-        as RelayResponse;
+    return RelayResponse(
+      id: request.id,
+      status: 404,
+      headers: {},
+      body: "route not handled",
+    );
   }
 
   Future<void> _handleSSE(HttpRequest request) async {

--- a/bridge/app/lib/src/bridge/routing/abort_session_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/abort_session_handler.dart
@@ -24,12 +24,11 @@ class AbortSessionHandler extends RequestHandler {
     }
 
     await _plugin.abortSession(sessionId);
-    return RelayMessage.response(
-          id: request.id,
-          status: 200,
-          headers: {},
-          body: null,
-        )
-        as RelayResponse;
+    return RelayResponse(
+      id: request.id,
+      status: 200,
+      headers: {},
+      body: null,
+    );
   }
 }

--- a/bridge/app/lib/src/bridge/routing/delete_session_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/delete_session_handler.dart
@@ -31,12 +31,11 @@ class DeleteSessionHandler extends RequestHandler {
       }
     }
 
-    return RelayMessage.response(
-          id: request.id,
-          status: 200,
-          headers: {},
-          body: null,
-        )
-        as RelayResponse;
+    return RelayResponse(
+      id: request.id,
+      status: 200,
+      headers: {},
+      body: null,
+    );
   }
 }

--- a/bridge/app/lib/src/bridge/routing/reject_question_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/reject_question_handler.dart
@@ -26,12 +26,11 @@ class RejectQuestionHandler extends RequestHandler {
     }
 
     await _plugin.rejectQuestion(questionId);
-    return RelayMessage.response(
-          id: request.id,
-          status: 200,
-          headers: {},
-          body: null,
-        )
-        as RelayResponse;
+    return RelayResponse(
+      id: request.id,
+      status: 200,
+      headers: {},
+      body: null,
+    );
   }
 }

--- a/bridge/app/lib/src/bridge/routing/reply_to_question_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/reply_to_question_handler.dart
@@ -51,12 +51,11 @@ class ReplyToQuestionHandler extends RequestHandler {
       questionId,
       answers: replyRequest.answers.map((answer) => answer.values).toList(),
     );
-    return RelayMessage.response(
-          id: request.id,
-          status: 200,
-          headers: {},
-          body: null,
-        )
-        as RelayResponse;
+    return RelayResponse(
+      id: request.id,
+      status: 200,
+      headers: {},
+      body: null,
+    );
   }
 }

--- a/bridge/app/lib/src/bridge/routing/request_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/request_handler.dart
@@ -101,28 +101,24 @@ abstract class RequestHandler {
   }
 
   /// Builds a 200 JSON response.
-  RelayResponse buildOkJsonResponse(RelayRequest request, String body) =>
-      RelayMessage.response(
-            id: request.id,
-            status: 200,
-            headers: {"content-type": "application/json"},
-            body: body,
-          )
-          as RelayResponse;
+  RelayResponse buildOkJsonResponse(RelayRequest request, String body) => RelayResponse(
+    id: request.id,
+    status: 200,
+    headers: {"content-type": "application/json"},
+    body: body,
+  );
 
   /// Builds an error response with the given [status] and plain-text [message].
   RelayResponse buildErrorResponse(
     RelayRequest request,
     int status,
     String message,
-  ) =>
-      RelayMessage.response(
-            id: request.id,
-            status: status,
-            headers: {},
-            body: message,
-          )
-          as RelayResponse;
+  ) => RelayResponse(
+    id: request.id,
+    status: status,
+    headers: {},
+    body: message,
+  );
 
   // ── Path matching internals ─────────────────────────────────────────────────
 

--- a/bridge/app/lib/src/bridge/routing/request_router.dart
+++ b/bridge/app/lib/src/bridge/routing/request_router.dart
@@ -65,30 +65,27 @@ class RequestRouter {
           );
         }
       }
-      return RelayMessage.response(
-            id: request.id,
-            status: 404,
-            headers: {},
-            body: "no handler found for ${request.method} ${request.path}",
-          )
-          as RelayResponse;
+      return RelayResponse(
+        id: request.id,
+        status: 404,
+        headers: {},
+        body: "no handler found for ${request.method} ${request.path}",
+      );
     } on PluginApiException catch (e) {
       Log.w("upstream error: $e");
-      return RelayMessage.response(
-            id: request.id,
-            status: e.statusCode,
-            headers: {},
-            body: e.toString(),
-          )
-          as RelayResponse;
+      return RelayResponse(
+        id: request.id,
+        status: e.statusCode,
+        headers: {},
+        body: e.toString(),
+      );
     } catch (e) {
-      return RelayMessage.response(
-            id: request.id,
-            status: 502,
-            headers: {},
-            body: "request failed: $e",
-          )
-          as RelayResponse;
+      return RelayResponse(
+        id: request.id,
+        status: 502,
+        headers: {},
+        body: "request failed: $e",
+      );
     }
   }
 }

--- a/bridge/app/lib/src/bridge/routing/send_prompt_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/send_prompt_handler.dart
@@ -44,22 +44,23 @@ class SendPromptHandler extends RequestHandler {
         )
         .toList();
 
-    final model = promptRequest.model;
+    final model = switch (promptRequest.model) {
+      PromptModel(:final providerID, :final modelID) => (providerID: providerID, modelID: modelID),
+      null => null,
+    };
 
     await _plugin.sendPrompt(
       sessionId: sessionId,
       parts: parts,
       agent: promptRequest.agent,
-      providerID: model?.providerID,
-      modelID: model?.modelID,
+      model: model,
     );
 
-    return RelayMessage.response(
-          id: request.id,
-          status: 200,
-          headers: {},
-          body: null,
-        )
-        as RelayResponse;
+    return RelayResponse(
+      id: request.id,
+      status: 200,
+      headers: {},
+      body: null,
+    );
   }
 }

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -282,9 +282,8 @@ class _FakeBridgePlugin implements BridgePlugin {
   Future<void> sendPrompt({
     required String sessionId,
     required List<PluginPromptPart> parts,
-    String? agent,
-    String? providerID,
-    String? modelID,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
   }) async {}
 
   @override
@@ -404,9 +403,8 @@ class _TrackingBridgePlugin implements BridgePlugin {
   Future<void> sendPrompt({
     required String sessionId,
     required List<PluginPromptPart> parts,
-    String? agent,
-    String? providerID,
-    String? modelID,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
   }) async {}
 
   @override

--- a/bridge/app/test/bridge/routing/request_handler_test.dart
+++ b/bridge/app/test/bridge/routing/request_handler_test.dart
@@ -14,14 +14,12 @@ class _StubHandler extends RequestHandler {
     required Map<String, String> pathParams,
     required Map<String, String> queryParams,
     String? fragment,
-  }) async =>
-      RelayMessage.response(
-            id: request.id,
-            status: 200,
-            headers: {},
-            body: null,
-          )
-          as RelayResponse;
+  }) async => RelayResponse(
+    id: request.id,
+    status: 200,
+    headers: {},
+    body: null,
+  );
 }
 
 void main() {

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -55,8 +55,7 @@ class FakeBridgePlugin implements BridgePlugin {
   String? lastSendPromptSessionId;
   List<PluginPromptPart>? lastSendPromptParts;
   String? lastSendPromptAgent;
-  String? lastSendPromptProviderID;
-  String? lastSendPromptModelID;
+  ({String providerID, String modelID})? lastSendPromptModel;
   String? lastAbortSessionId;
   String? lastReplyQuestionId;
   List<List<String>>? lastReplyAnswers;
@@ -171,15 +170,13 @@ class FakeBridgePlugin implements BridgePlugin {
   Future<void> sendPrompt({
     required String sessionId,
     required List<PluginPromptPart> parts,
-    String? agent,
-    String? providerID,
-    String? modelID,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
   }) async {
     lastSendPromptSessionId = sessionId;
     lastSendPromptParts = parts;
     lastSendPromptAgent = agent;
-    lastSendPromptProviderID = providerID;
-    lastSendPromptModelID = modelID;
+    lastSendPromptModel = model;
   }
 
   @override

--- a/bridge/app/test/bridge/routing/send_prompt_handler_test.dart
+++ b/bridge/app/test/bridge/routing/send_prompt_handler_test.dart
@@ -93,8 +93,8 @@ void main() {
       );
 
       expect(plugin.lastSendPromptAgent, equals("planner"));
-      expect(plugin.lastSendPromptProviderID, equals("openai"));
-      expect(plugin.lastSendPromptModelID, equals("gpt-4o"));
+      expect(plugin.lastSendPromptModel?.providerID, equals("openai"));
+      expect(plugin.lastSendPromptModel?.modelID, equals("gpt-4o"));
     });
 
     test("records correct args", () async {
@@ -121,8 +121,8 @@ void main() {
       expect(plugin.lastSendPromptParts, hasLength(1));
       expect(plugin.lastSendPromptParts![0], equals(const PluginPromptPart.text(text: "Ship it")));
       expect(plugin.lastSendPromptAgent, equals("coder"));
-      expect(plugin.lastSendPromptProviderID, equals("anthropic"));
-      expect(plugin.lastSendPromptModelID, equals("claude-3-5-sonnet"));
+      expect(plugin.lastSendPromptModel?.providerID, equals("anthropic"));
+      expect(plugin.lastSendPromptModel?.modelID, equals("claude-3-5-sonnet"));
     });
 
     test("returns 200", () async {

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -42,9 +42,8 @@ abstract class BridgePlugin {
   Future<void> sendPrompt({
     required String sessionId,
     required List<PluginPromptPart> parts,
-    String? agent,
-    String? providerID,
-    String? modelID,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
   });
 
   Future<void> abortSession(String sessionId);

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -10,6 +10,7 @@ class ActiveSessionTracker {
 
   final Set<String> _projectWorktrees = {};
   final Map<String, String> _sessionWorktrees = {};
+  final Map<String, String> _sessionDirectories = {};
   final Map<String, SessionStatus> _sessionStatuses = {};
 
   /// Tracks parent IDs for all known sessions.
@@ -32,6 +33,7 @@ class ActiveSessionTracker {
       ..addAll(projects.map((p) => p.worktree));
 
     _sessionWorktrees.clear();
+    _sessionDirectories.clear();
     _sessionParentIds.clear();
 
     // Build directory lookup and parent ID mapping from fetched sessions.
@@ -40,6 +42,10 @@ class ActiveSessionTracker {
       sessionDirectories[session.id] = session.directory;
       _sessionParentIds[session.id] = session.parentID;
     }
+
+    _sessionDirectories
+      ..clear()
+      ..addAll(sessionDirectories);
 
     _sessionStatuses
       ..clear()
@@ -68,6 +74,7 @@ class ActiveSessionTracker {
 
     switch (event) {
       case SseSessionCreated():
+        _sessionDirectories[event.info.id] = event.info.directory;
         _updateSessionWorktree(event.info.id, event.info.directory);
         final prevParentId = _sessionParentIds[event.info.id];
         _sessionParentIds[event.info.id] = event.info.parentID;
@@ -77,6 +84,7 @@ class ActiveSessionTracker {
           forceReemit = true;
         }
       case SseSessionUpdated():
+        _sessionDirectories[event.info.id] = event.info.directory;
         _updateSessionWorktree(event.info.id, event.info.directory);
         final prevParentId = _sessionParentIds[event.info.id];
         _sessionParentIds[event.info.id] = event.info.parentID;
@@ -84,6 +92,7 @@ class ActiveSessionTracker {
           forceReemit = true;
         }
       case SseSessionDeleted():
+        _sessionDirectories.remove(event.info.id);
         _sessionWorktrees.remove(event.info.id);
         _sessionStatuses.remove(event.info.id);
         _sessionParentIds.remove(event.info.id);
@@ -113,6 +122,7 @@ class ActiveSessionTracker {
   void reset() {
     _projectWorktrees.clear();
     _sessionWorktrees.clear();
+    _sessionDirectories.clear();
     _sessionStatuses.clear();
     _sessionParentIds.clear();
     _lastEmittedActiveSessions = {};
@@ -120,12 +130,12 @@ class ActiveSessionTracker {
 
   /// Register a known session -> directory mapping (e.g., after session creation).
   void registerSession(String sessionId, String directory) {
-    _sessionWorktrees[sessionId] = directory;
+    _sessionDirectories[sessionId] = directory;
   }
 
   /// Look up the directory for a session. Returns null if unknown.
   String? getSessionDirectory(String sessionId) {
-    return _sessionWorktrees[sessionId];
+    return _sessionDirectories[sessionId];
   }
 
   List<ProjectActivitySummary> buildSummary() {

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -10,7 +10,7 @@ class ActiveSessionTracker {
 
   final Set<String> _projectWorktrees = {};
   final Map<String, String> _sessionWorktrees = {};
-  final Map<String, String> _sessionDirectories = {};
+  final Map<String, String> _sessionDirectories = {}; // directory where the session is located
   final Map<String, SessionStatus> _sessionStatuses = {};
 
   /// Tracks parent IDs for all known sessions.
@@ -129,12 +129,12 @@ class ActiveSessionTracker {
   }
 
   /// Register a known session -> directory mapping (e.g., after session creation).
-  void registerSession(String sessionId, String directory) {
+  void registerSession({required String sessionId, required String directory}) {
     _sessionDirectories[sessionId] = directory;
   }
 
   /// Look up the directory for a session. Returns null if unknown.
-  String? getSessionDirectory(String sessionId) {
+  String? getSessionDirectory({required String sessionId}) {
     return _sessionDirectories[sessionId];
   }
 

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -118,6 +118,16 @@ class ActiveSessionTracker {
     _lastEmittedActiveSessions = {};
   }
 
+  /// Register a known session -> directory mapping (e.g., after session creation).
+  void registerSession(String sessionId, String directory) {
+    _sessionWorktrees[sessionId] = directory;
+  }
+
+  /// Look up the directory for a session. Returns null if unknown.
+  String? getSessionDirectory(String sessionId) {
+    return _sessionWorktrees[sessionId];
+  }
+
   List<ProjectActivitySummary> buildSummary() {
     // Partition active (busy/retry) sessions into root vs child.
     final activeRoots = <String>{};

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -14,7 +14,10 @@ class OpenCodeApi {
   final String serverURL;
   final String? _password;
 
-  OpenCodeApi({required this.serverURL, String? password}) : _password = password;
+  OpenCodeApi({
+    required this.serverURL,
+    required String? password,
+  }) : _password = password;
 
   Map<String, String> get _authHeaders {
     if (_password == null) return const {};
@@ -59,7 +62,7 @@ class OpenCodeApi {
   }
 
   Future<Session> createSession({
-    required String workspacePath,
+    required String directory,
     String? parentSessionId,
   }) async {
     final client = http.Client();
@@ -80,7 +83,7 @@ class OpenCodeApi {
         headers: {
           ..._authHeaders,
           "content-type": "application/json",
-          "x-opencode-directory": workspacePath,
+          "x-opencode-directory": directory,
         },
         body: jsonEncode(body),
       );
@@ -91,7 +94,11 @@ class OpenCodeApi {
     }
   }
 
-  Future<Session> updateSession(String sessionId, Map<String, dynamic> body, {String? directory}) async {
+  Future<Session> updateSession({
+    required String sessionId,
+    required Map<String, dynamic> body,
+    required String? directory,
+  }) async {
     final client = http.Client();
     try {
       final response = await client.patch(
@@ -99,7 +106,7 @@ class OpenCodeApi {
         headers: {
           ..._authHeaders,
           "content-type": "application/json",
-          if (directory != null) "x-opencode-directory": directory,
+          "x-opencode-directory": ?directory,
         },
         body: jsonEncode(body),
       );
@@ -110,12 +117,15 @@ class OpenCodeApi {
     }
   }
 
-  Future<void> deleteSession(String sessionId, {String? directory}) async {
+  Future<void> deleteSession({
+    required String sessionId,
+    required String? directory,
+  }) async {
     final client = http.Client();
     try {
       final headers = <String, String>{
         ..._authHeaders,
-        if (directory != null) "x-opencode-directory": directory,
+        "x-opencode-directory": ?directory,
       };
       final response = await client.delete(
         Uri.parse("$serverURL/session/$sessionId"),
@@ -127,10 +137,13 @@ class OpenCodeApi {
     }
   }
 
-  Future<List<Session>> getChildren(String sessionId, {String? directory}) async {
+  Future<List<Session>> getChildren({
+    required String sessionId,
+    required String? directory,
+  }) async {
     final headers = <String, String>{
       ..._authHeaders,
-      if (directory != null) "x-opencode-directory": directory,
+      "x-opencode-directory": ?directory, // probably irrelevant for this endpoint
     };
     final response = await http.get(
       Uri.parse("$serverURL/session/$sessionId/children"),
@@ -142,10 +155,13 @@ class OpenCodeApi {
     return decoded.cast<Map<String, dynamic>>().map(Session.fromJson).toList();
   }
 
-  Future<List<MessageWithParts>> getMessages(String sessionId, {String? directory}) async {
+  Future<List<MessageWithParts>> getMessages({
+    required String sessionId,
+    required String? directory,
+  }) async {
     final headers = <String, String>{
       ..._authHeaders,
-      if (directory != null) "x-opencode-directory": directory,
+      "x-opencode-directory": ?directory, // probably irrelevant for this endpoint
     };
     final response = await http.get(
       Uri.parse("$serverURL/session/$sessionId/message"),
@@ -157,7 +173,13 @@ class OpenCodeApi {
     return decoded.cast<Map<String, dynamic>>().map(MessageWithParts.fromJson).toList();
   }
 
-  Future<void> sendPrompt(String sessionId, {required Map<String, dynamic> body, String? directory}) async {
+  Future<void> sendPrompt({
+    required String sessionId,
+    required Map<String, dynamic> body,
+     // 100% required for this endpoint
+     // because otherwise it picks the CWD of where bridge is running
+    required String? directory,
+  }) async {
     final client = http.Client();
     try {
       final response = await client.post(
@@ -165,7 +187,7 @@ class OpenCodeApi {
         headers: {
           ..._authHeaders,
           "content-type": "application/json",
-          if (directory != null) "x-opencode-directory": directory,
+          "x-opencode-directory": ?directory,
         },
         body: jsonEncode(body),
       );
@@ -175,12 +197,15 @@ class OpenCodeApi {
     }
   }
 
-  Future<void> abortSession(String sessionId, {String? directory}) async {
+  Future<void> abortSession({
+    required String sessionId,
+    required String? directory,
+  }) async {
     final client = http.Client();
     try {
       final headers = <String, String>{
         ..._authHeaders,
-        if (directory != null) "x-opencode-directory": directory,
+        "x-opencode-directory": ?directory,
       };
       final response = await client.post(
         Uri.parse("$serverURL/session/$sessionId/abort"),
@@ -209,7 +234,10 @@ class OpenCodeApi {
     return decoded.cast<Map<String, dynamic>>().map(PendingQuestion.fromJson).toList();
   }
 
-  Future<void> replyToQuestion(String questionId, {required Map<String, dynamic> body}) async {
+  Future<void> replyToQuestion({
+    required String questionId,
+    required Map<String, dynamic> body,
+  }) async {
     final client = http.Client();
     try {
       final response = await client.post(
@@ -226,7 +254,9 @@ class OpenCodeApi {
     }
   }
 
-  Future<void> rejectQuestion(String questionId) async {
+  Future<void> rejectQuestion({
+    required String questionId,
+  }) async {
     final client = http.Client();
     try {
       final response = await client.post(
@@ -240,7 +270,9 @@ class OpenCodeApi {
     }
   }
 
-  Future<Project> getProject(String directory) async {
+  Future<Project> getProject({
+    required String directory,
+  }) async {
     final response = await http.get(
       Uri.parse("$serverURL/project/current"),
       headers: {
@@ -253,16 +285,17 @@ class OpenCodeApi {
   }
 
   Future<List<GlobalSession>> listGlobalSessions({
-    String? directory,
-    bool roots = false,
+    required String? directory,
+    required bool roots,
   }) async {
-    final query = <String, String>{};
-    if (directory != null) query["directory"] = directory;
-    if (roots) query["roots"] = "true";
+    final queryParams = <String, String>{
+      "directory": ?directory,
+      if (roots) "roots": "true",
+    };
 
     final uri = Uri.parse(
       "$serverURL/experimental/session",
-    ).replace(queryParameters: query.isEmpty ? null : query);
+    ).replace(queryParameters: queryParams.isEmpty ? null : queryParams);
     final response = await http.get(uri, headers: _authHeaders);
     _ensureSuccess(response, "GET /experimental/session");
 

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -91,7 +91,7 @@ class OpenCodeApi {
     }
   }
 
-  Future<Session> updateSession(String sessionId, Map<String, dynamic> body) async {
+  Future<Session> updateSession(String sessionId, Map<String, dynamic> body, {String? directory}) async {
     final client = http.Client();
     try {
       final response = await client.patch(
@@ -99,6 +99,7 @@ class OpenCodeApi {
         headers: {
           ..._authHeaders,
           "content-type": "application/json",
+          if (directory != null) "x-opencode-directory": directory,
         },
         body: jsonEncode(body),
       );
@@ -109,12 +110,16 @@ class OpenCodeApi {
     }
   }
 
-  Future<void> deleteSession(String sessionId) async {
+  Future<void> deleteSession(String sessionId, {String? directory}) async {
     final client = http.Client();
     try {
+      final headers = <String, String>{
+        ..._authHeaders,
+        if (directory != null) "x-opencode-directory": directory,
+      };
       final response = await client.delete(
         Uri.parse("$serverURL/session/$sessionId"),
-        headers: _authHeaders,
+        headers: headers,
       );
       _ensureSuccess(response, "DELETE /session/$sessionId");
     } finally {
@@ -122,10 +127,14 @@ class OpenCodeApi {
     }
   }
 
-  Future<List<Session>> getChildren(String sessionId) async {
+  Future<List<Session>> getChildren(String sessionId, {String? directory}) async {
+    final headers = <String, String>{
+      ..._authHeaders,
+      if (directory != null) "x-opencode-directory": directory,
+    };
     final response = await http.get(
       Uri.parse("$serverURL/session/$sessionId/children"),
-      headers: _authHeaders,
+      headers: headers,
     );
     _ensureSuccess(response, "GET /session/$sessionId/children");
 
@@ -133,10 +142,14 @@ class OpenCodeApi {
     return decoded.cast<Map<String, dynamic>>().map(Session.fromJson).toList();
   }
 
-  Future<List<MessageWithParts>> getMessages(String sessionId) async {
+  Future<List<MessageWithParts>> getMessages(String sessionId, {String? directory}) async {
+    final headers = <String, String>{
+      ..._authHeaders,
+      if (directory != null) "x-opencode-directory": directory,
+    };
     final response = await http.get(
       Uri.parse("$serverURL/session/$sessionId/message"),
-      headers: _authHeaders,
+      headers: headers,
     );
     _ensureSuccess(response, "GET /session/$sessionId/message");
 
@@ -144,7 +157,7 @@ class OpenCodeApi {
     return decoded.cast<Map<String, dynamic>>().map(MessageWithParts.fromJson).toList();
   }
 
-  Future<void> sendPrompt(String sessionId, {required Map<String, dynamic> body}) async {
+  Future<void> sendPrompt(String sessionId, {required Map<String, dynamic> body, String? directory}) async {
     final client = http.Client();
     try {
       final response = await client.post(
@@ -152,6 +165,7 @@ class OpenCodeApi {
         headers: {
           ..._authHeaders,
           "content-type": "application/json",
+          if (directory != null) "x-opencode-directory": directory,
         },
         body: jsonEncode(body),
       );
@@ -161,12 +175,16 @@ class OpenCodeApi {
     }
   }
 
-  Future<void> abortSession(String sessionId) async {
+  Future<void> abortSession(String sessionId, {String? directory}) async {
     final client = http.Client();
     try {
+      final headers = <String, String>{
+        ..._authHeaders,
+        if (directory != null) "x-opencode-directory": directory,
+      };
       final response = await client.post(
         Uri.parse("$serverURL/session/$sessionId/abort"),
-        headers: _authHeaders,
+        headers: headers,
         body: "",
       );
       _ensureSuccess(response, "POST /session/$sessionId/abort");

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -210,6 +210,9 @@ class OpenCodePlugin implements BridgePlugin {
         limit: limit,
       ),
     );
+    for (final session in sessions) {
+      _service.tracker.registerSession(session.id, session.directory);
+    }
     return sessions.map((session) => session.toPlugin()).toList();
   }
 

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -211,7 +211,10 @@ class OpenCodePlugin implements BridgePlugin {
       ),
     );
     for (final session in sessions) {
-      _service.tracker.registerSession(session.id, session.directory);
+      _service.tracker.registerSession(
+        sessionId: session.id,
+        directory: session.directory,
+      );
     }
     return sessions.map((session) => session.toPlugin()).toList();
   }
@@ -220,39 +223,56 @@ class OpenCodePlugin implements BridgePlugin {
   Future<PluginSession> createSession({required String projectId, String? parentSessionId}) async {
     final session = await _call(
       () => _service.repository.api.createSession(
-        // this sesori plugin uses workspace path as project id
+        // this sesori plugin uses workspace path (directory) as project id
         // because it's the most reliable UID with opencode
-        workspacePath: projectId,
+        directory: projectId,
         parentSessionId: parentSessionId,
       ),
     );
-    _service.tracker.registerSession(session.id, session.directory);
+    _service.tracker.registerSession(
+      sessionId: session.id,
+      directory: session.directory,
+    );
     return session.toPlugin();
   }
 
   @override
   Future<PluginSession> updateSessionArchiveStatus(String sessionId, {required bool archived}) async {
-    final directory = _service.tracker.getSessionDirectory(sessionId);
+    final directory = _service.tracker.getSessionDirectory(sessionId: sessionId);
     final session = await _call(
-      () => _service.repository.api.updateSession(sessionId, {
-        "time": {
-          "archived": archived ? DateTime.now().millisecondsSinceEpoch : null,
+      () => _service.repository.api.updateSession(
+        sessionId: sessionId,
+        directory: directory,
+        body: {
+          "time": {
+            "archived": archived ? DateTime.now().millisecondsSinceEpoch : null,
+          },
         },
-      }, directory: directory),
+      ),
     );
     return session.toPlugin();
   }
 
   @override
   Future<void> deleteSession(String sessionId) {
-    final directory = _service.tracker.getSessionDirectory(sessionId);
-    return _call(() => _service.repository.api.deleteSession(sessionId, directory: directory));
+    final directory = _service.tracker.getSessionDirectory(sessionId: sessionId);
+    return _call(
+      () => _service.repository.api.deleteSession(
+        sessionId: sessionId,
+        directory: directory,
+      ),
+    );
   }
 
   @override
   Future<List<PluginSession>> getChildSessions(String sessionId) async {
-    final directory = _service.tracker.getSessionDirectory(sessionId);
-    final sessions = await _call(() => _service.repository.api.getChildren(sessionId, directory: directory));
+    final directory = _service.tracker.getSessionDirectory(sessionId: sessionId);
+    final sessions = await _call(
+      () => _service.repository.api.getChildren(
+        sessionId: sessionId,
+        directory: directory,
+      ),
+    );
     return sessions.map((session) => session.toPlugin()).toList();
   }
 
@@ -264,8 +284,13 @@ class OpenCodePlugin implements BridgePlugin {
 
   @override
   Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId) async {
-    final directory = _service.tracker.getSessionDirectory(sessionId);
-    final messages = await _call(() => _service.getLastExchange(sessionId, directory: directory));
+    final directory = _service.tracker.getSessionDirectory(sessionId: sessionId);
+    final messages = await _call(
+      () => _service.getLastExchange(
+        sessionId: sessionId,
+        directory: directory,
+      ),
+    );
     return messages.map(_mapMessage).toList();
   }
 
@@ -273,11 +298,15 @@ class OpenCodePlugin implements BridgePlugin {
   Future<void> sendPrompt({
     required String sessionId,
     required List<PluginPromptPart> parts,
-    String? agent,
-    String? providerID,
-    String? modelID,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
   }) {
-    final directory = _service.tracker.getSessionDirectory(sessionId);
+    final directory = _service.tracker.getSessionDirectory(sessionId: sessionId);
+
+    if (directory == null) {
+      Log.w("directory missing for session $sessionId. Defaulting to bridge CWD as directory.");
+    }
+
     final body = <String, dynamic>{
       "parts": parts.map((part) {
         return switch (part) {
@@ -287,34 +316,32 @@ class OpenCodePlugin implements BridgePlugin {
           },
         };
       }).toList(),
+      "agent": ?agent,
+      if (model != null)
+        "model": {
+          "providerID": model.providerID,
+          "modelID": model.modelID,
+        },
     };
-
-    if (agent case final agentName?) {
-      body["agent"] = agentName;
-    }
-
-    if (providerID case final provider?) {
-      if (modelID case final model?) {
-        body["model"] = {
-          "providerID": provider,
-          "modelID": model,
-        };
-      }
-    }
 
     return _call(
       () => _service.repository.api.sendPrompt(
-        sessionId,
-        body: body,
+        sessionId: sessionId,
         directory: directory,
+        body: body,
       ),
     );
   }
 
   @override
   Future<void> abortSession(String sessionId) {
-    final directory = _service.tracker.getSessionDirectory(sessionId);
-    return _call(() => _service.repository.api.abortSession(sessionId, directory: directory));
+    final directory = _service.tracker.getSessionDirectory(sessionId: sessionId);
+    return _call(
+      () => _service.repository.api.abortSession(
+        sessionId: sessionId,
+        directory: directory,
+      ),
+    );
   }
 
   @override
@@ -333,7 +360,7 @@ class OpenCodePlugin implements BridgePlugin {
   Future<void> replyToQuestion(String questionId, {required List<List<String>> answers}) {
     return _call(
       () => _service.repository.api.replyToQuestion(
-        questionId,
+        questionId: questionId,
         body: {
           "answers": answers,
         },
@@ -343,12 +370,20 @@ class OpenCodePlugin implements BridgePlugin {
 
   @override
   Future<void> rejectQuestion(String questionId) {
-    return _call(() => _service.repository.api.rejectQuestion(questionId));
+    return _call(
+      () => _service.repository.api.rejectQuestion(
+        questionId: questionId,
+      ),
+    );
   }
 
   @override
   Future<PluginProject> getProject(String projectId) async {
-    final project = await _call(() => _service.repository.api.getProject(projectId));
+    final project = await _call(
+      () => _service.repository.api.getProject(
+        directory: projectId,
+      ),
+    );
     return project.toPlugin();
   }
 

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -223,29 +223,33 @@ class OpenCodePlugin implements BridgePlugin {
         parentSessionId: parentSessionId,
       ),
     );
+    _service.tracker.registerSession(session.id, session.directory);
     return session.toPlugin();
   }
 
   @override
   Future<PluginSession> updateSessionArchiveStatus(String sessionId, {required bool archived}) async {
+    final directory = _service.tracker.getSessionDirectory(sessionId);
     final session = await _call(
       () => _service.repository.api.updateSession(sessionId, {
         "time": {
           "archived": archived ? DateTime.now().millisecondsSinceEpoch : null,
         },
-      }),
+      }, directory: directory),
     );
     return session.toPlugin();
   }
 
   @override
   Future<void> deleteSession(String sessionId) {
-    return _call(() => _service.repository.api.deleteSession(sessionId));
+    final directory = _service.tracker.getSessionDirectory(sessionId);
+    return _call(() => _service.repository.api.deleteSession(sessionId, directory: directory));
   }
 
   @override
   Future<List<PluginSession>> getChildSessions(String sessionId) async {
-    final sessions = await _call(() => _service.repository.api.getChildren(sessionId));
+    final directory = _service.tracker.getSessionDirectory(sessionId);
+    final sessions = await _call(() => _service.repository.api.getChildren(sessionId, directory: directory));
     return sessions.map((session) => session.toPlugin()).toList();
   }
 
@@ -257,7 +261,8 @@ class OpenCodePlugin implements BridgePlugin {
 
   @override
   Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId) async {
-    final messages = await _call(() => _service.getLastExchange(sessionId));
+    final directory = _service.tracker.getSessionDirectory(sessionId);
+    final messages = await _call(() => _service.getLastExchange(sessionId, directory: directory));
     return messages.map(_mapMessage).toList();
   }
 
@@ -269,6 +274,7 @@ class OpenCodePlugin implements BridgePlugin {
     String? providerID,
     String? modelID,
   }) {
+    final directory = _service.tracker.getSessionDirectory(sessionId);
     final body = <String, dynamic>{
       "parts": parts.map((part) {
         return switch (part) {
@@ -297,13 +303,15 @@ class OpenCodePlugin implements BridgePlugin {
       () => _service.repository.api.sendPrompt(
         sessionId,
         body: body,
+        directory: directory,
       ),
     );
   }
 
   @override
   Future<void> abortSession(String sessionId) {
-    return _call(() => _service.repository.api.abortSession(sessionId));
+    final directory = _service.tracker.getSessionDirectory(sessionId);
+    return _call(() => _service.repository.api.abortSession(sessionId, directory: directory));
   }
 
   @override

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
@@ -16,7 +16,7 @@ class OpenCodeRepository {
   Future<List<Project>> getProjects() async {
     final (rawProjects, globalSessions) = await wait2(
       _api.listProjects(),
-      _api.listGlobalSessions(roots: true),
+      _api.listGlobalSessions(directory: null, roots: true),
     );
 
     final realProjects = <Project>[];

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -28,9 +28,9 @@ class OpenCodeService {
     return _applyLimit(afterStart, limit);
   }
 
-  Future<List<MessageWithParts>> getLastExchange(String sessionId) async {
+  Future<List<MessageWithParts>> getLastExchange(String sessionId, {String? directory}) async {
     try {
-      final messages = await repository.api.getMessages(sessionId);
+      final messages = await repository.api.getMessages(sessionId, directory: directory);
       Log.d("[dbg] got ${messages.length} messages for session $sessionId");
       if (messages.isNotEmpty) {
         Log.v("[dbg] first message: ${messages[0].toJson()}");

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -28,9 +28,12 @@ class OpenCodeService {
     return _applyLimit(afterStart, limit);
   }
 
-  Future<List<MessageWithParts>> getLastExchange(String sessionId, {String? directory}) async {
+  Future<List<MessageWithParts>> getLastExchange({
+    required String sessionId,
+    required String? directory,
+  }) async {
     try {
-      final messages = await repository.api.getMessages(sessionId, directory: directory);
+      final messages = await repository.api.getMessages(sessionId: sessionId, directory: directory);
       Log.d("[dbg] got ${messages.length} messages for session $sessionId");
       if (messages.isNotEmpty) {
         Log.v("[dbg] first message: ${messages[0].toJson()}");

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -17,24 +17,24 @@ void main() {
       test("registerSession stores directory for lookup", () {
         final tracker = ActiveSessionTracker(_fakeRepository());
 
-        tracker.registerSession("s1", "/projects/foo");
+        tracker.registerSession(sessionId: "s1", directory: "/projects/foo");
 
-        expect(tracker.getSessionDirectory("s1"), equals("/projects/foo"));
+        expect(tracker.getSessionDirectory(sessionId: "s1"), equals("/projects/foo"));
       });
 
       test("getSessionDirectory returns null for unknown session", () {
         final tracker = ActiveSessionTracker(_fakeRepository());
 
-        expect(tracker.getSessionDirectory("missing"), isNull);
+        expect(tracker.getSessionDirectory(sessionId: "missing"), isNull);
       });
 
       test("registerSession preserves raw directory without worktree normalization", () {
         final tracker = ActiveSessionTracker(_fakeRepository());
 
-        tracker.registerSession("s1", "/projects/foo/packages/bar");
+        tracker.registerSession(sessionId: "s1", directory: "/projects/foo/packages/bar");
 
         expect(
-          tracker.getSessionDirectory("s1"),
+          tracker.getSessionDirectory(sessionId: "s1"),
           equals("/projects/foo/packages/bar"),
         );
       });
@@ -50,7 +50,7 @@ void main() {
         );
 
         expect(
-          tracker.getSessionDirectory("s1"),
+          tracker.getSessionDirectory(sessionId: "s1"),
           equals("/projects/foo/packages/bar"),
         );
       });
@@ -70,7 +70,7 @@ void main() {
         );
 
         expect(
-          tracker.getSessionDirectory("s1"),
+          tracker.getSessionDirectory(sessionId: "s1"),
           equals("/projects/foo/packages/bar"),
         );
       });
@@ -81,11 +81,11 @@ void main() {
         );
 
         tracker.handleEvent(_sessionCreated("s1", "/projects/foo"), null);
-        expect(tracker.getSessionDirectory("s1"), equals("/projects/foo"));
+        expect(tracker.getSessionDirectory(sessionId: "s1"), equals("/projects/foo"));
 
         tracker.handleEvent(_sessionDeleted("s1"), null);
 
-        expect(tracker.getSessionDirectory("s1"), isNull);
+        expect(tracker.getSessionDirectory(sessionId: "s1"), isNull);
       });
 
       test("coldStart populates getSessionDirectory for all fetched sessions", () async {
@@ -97,19 +97,19 @@ void main() {
           ],
         );
 
-        expect(tracker.getSessionDirectory("s1"), equals("/projects/foo"));
-        expect(tracker.getSessionDirectory("s2"), equals("/projects/foo/lib"));
+        expect(tracker.getSessionDirectory(sessionId: "s1"), equals("/projects/foo"));
+        expect(tracker.getSessionDirectory(sessionId: "s2"), equals("/projects/foo/lib"));
       });
 
       test("reset clears session directories", () {
         final tracker = ActiveSessionTracker(_fakeRepository());
 
-        tracker.registerSession("s1", "/projects/foo");
-        expect(tracker.getSessionDirectory("s1"), isNotNull);
+        tracker.registerSession(sessionId: "s1", directory: "/projects/foo");
+        expect(tracker.getSessionDirectory(sessionId: "s1"), isNotNull);
 
         tracker.reset();
 
-        expect(tracker.getSessionDirectory("s1"), isNull);
+        expect(tracker.getSessionDirectory(sessionId: "s1"), isNull);
       });
     });
 
@@ -653,33 +653,40 @@ class _FakeApi implements OpenCodeApi {
   Future<List<Session>> listSessions({String? directory}) async => _sessions;
 
   @override
-  Future<Session> createSession({required String workspacePath, String? parentSessionId}) async =>
+  Future<Session> createSession({required String directory, String? parentSessionId}) async =>
       throw UnimplementedError();
 
   @override
-  Future<Session> updateSession(String sessionId, Map<String, dynamic> body, {String? directory}) async =>
-      throw UnimplementedError();
+  Future<Session> updateSession({
+    required String sessionId,
+    required Map<String, dynamic> body,
+    required String? directory,
+  }) async => throw UnimplementedError();
 
   @override
-  Future<void> deleteSession(String sessionId, {String? directory}) async {}
+  Future<void> deleteSession({required String sessionId, required String? directory}) async {}
 
   @override
-  Future<List<Session>> getChildren(String sessionId, {String? directory}) async => [];
+  Future<List<Session>> getChildren({required String sessionId, required String? directory}) async => [];
 
   @override
   Future<List<GlobalSession>> listGlobalSessions({
-    String? directory,
-    bool roots = false,
+    required String? directory,
+    required bool roots,
   }) async => [];
 
   @override
-  Future<List<MessageWithParts>> getMessages(String sessionId, {String? directory}) async => [];
+  Future<List<MessageWithParts>> getMessages({required String sessionId, required String? directory}) async => [];
 
   @override
-  Future<void> sendPrompt(String sessionId, {required Map<String, dynamic> body, String? directory}) async {}
+  Future<void> sendPrompt({
+    required String sessionId,
+    required Map<String, dynamic> body,
+    required String? directory,
+  }) async {}
 
   @override
-  Future<void> abortSession(String sessionId, {String? directory}) async {}
+  Future<void> abortSession({required String sessionId, required String? directory}) async {}
 
   @override
   Future<List<AgentInfo>> listAgents() async => [];
@@ -688,13 +695,13 @@ class _FakeApi implements OpenCodeApi {
   Future<List<PendingQuestion>> getPendingQuestions() async => [];
 
   @override
-  Future<void> replyToQuestion(String questionId, {required Map<String, dynamic> body}) async {}
+  Future<void> replyToQuestion({required String questionId, required Map<String, dynamic> body}) async {}
 
   @override
-  Future<void> rejectQuestion(String questionId) async {}
+  Future<void> rejectQuestion({required String questionId}) async {}
 
   @override
-  Future<Project> getProject(String directory) async => throw UnimplementedError();
+  Future<Project> getProject({required String directory}) async => throw UnimplementedError();
 
   @override
   Future<Map<String, SessionStatus>> getSessionStatuses() async => _statuses;

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -27,6 +27,90 @@ void main() {
 
         expect(tracker.getSessionDirectory("missing"), isNull);
       });
+
+      test("registerSession preserves raw directory without worktree normalization", () {
+        final tracker = ActiveSessionTracker(_fakeRepository());
+
+        tracker.registerSession("s1", "/projects/foo/packages/bar");
+
+        expect(
+          tracker.getSessionDirectory("s1"),
+          equals("/projects/foo/packages/bar"),
+        );
+      });
+
+      test("SSE session.created populates getSessionDirectory", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/projects/foo")],
+        );
+
+        tracker.handleEvent(
+          _sessionCreated("s1", "/projects/foo/packages/bar"),
+          null,
+        );
+
+        expect(
+          tracker.getSessionDirectory("s1"),
+          equals("/projects/foo/packages/bar"),
+        );
+      });
+
+      test("SSE session.updated preserves raw directory", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/projects/foo")],
+        );
+
+        tracker.handleEvent(
+          _sessionCreated("s1", "/projects/foo/packages/bar"),
+          null,
+        );
+        tracker.handleEvent(
+          _sessionUpdated("s1", "/projects/foo/packages/bar"),
+          null,
+        );
+
+        expect(
+          tracker.getSessionDirectory("s1"),
+          equals("/projects/foo/packages/bar"),
+        );
+      });
+
+      test("SSE session.deleted removes from getSessionDirectory", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/projects/foo")],
+        );
+
+        tracker.handleEvent(_sessionCreated("s1", "/projects/foo"), null);
+        expect(tracker.getSessionDirectory("s1"), equals("/projects/foo"));
+
+        tracker.handleEvent(_sessionDeleted("s1"), null);
+
+        expect(tracker.getSessionDirectory("s1"), isNull);
+      });
+
+      test("coldStart populates getSessionDirectory for all fetched sessions", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/projects/foo")],
+          sessions: [
+            _session("s1", "/projects/foo"),
+            _session("s2", "/projects/foo/lib"),
+          ],
+        );
+
+        expect(tracker.getSessionDirectory("s1"), equals("/projects/foo"));
+        expect(tracker.getSessionDirectory("s2"), equals("/projects/foo/lib"));
+      });
+
+      test("reset clears session directories", () {
+        final tracker = ActiveSessionTracker(_fakeRepository());
+
+        tracker.registerSession("s1", "/projects/foo");
+        expect(tracker.getSessionDirectory("s1"), isNotNull);
+
+        tracker.reset();
+
+        expect(tracker.getSessionDirectory("s1"), isNull);
+      });
     });
 
     test("session directory exactly matches worktree", () async {
@@ -491,10 +575,20 @@ SseEventData _sessionCreated(String id, String directory) {
   );
 }
 
-SseEventData _sessionDeleted(String id, String directory) {
+SseEventData _sessionUpdated(String id, String directory) {
+  return SseEventData.sessionUpdated(
+    info: Session(id: id, projectID: "project", directory: directory),
+  );
+}
+
+SseEventData _sessionDeleted(String id, [String directory = ""]) {
   return SseEventData.sessionDeleted(
     info: Session(id: id, projectID: "project", directory: directory),
   );
+}
+
+Session _session(String id, String directory) {
+  return Session(id: id, projectID: "project", directory: directory);
 }
 
 SseEventData _sessionBusy(String id) {

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -13,6 +13,22 @@ void main() {
       expect(tracker.buildSummary(), isEmpty);
     });
 
+    group("session directory registration", () {
+      test("registerSession stores directory for lookup", () {
+        final tracker = ActiveSessionTracker(_fakeRepository());
+
+        tracker.registerSession("s1", "/projects/foo");
+
+        expect(tracker.getSessionDirectory("s1"), equals("/projects/foo"));
+      });
+
+      test("getSessionDirectory returns null for unknown session", () {
+        final tracker = ActiveSessionTracker(_fakeRepository());
+
+        expect(tracker.getSessionDirectory("missing"), isNull);
+      });
+    });
+
     test("session directory exactly matches worktree", () async {
       final tracker = await _coldStartedTracker(
         projects: [const Project(id: "p1", worktree: "/projects/foo")],
@@ -547,13 +563,14 @@ class _FakeApi implements OpenCodeApi {
       throw UnimplementedError();
 
   @override
-  Future<Session> updateSession(String sessionId, Map<String, dynamic> body) async => throw UnimplementedError();
+  Future<Session> updateSession(String sessionId, Map<String, dynamic> body, {String? directory}) async =>
+      throw UnimplementedError();
 
   @override
-  Future<void> deleteSession(String sessionId) async {}
+  Future<void> deleteSession(String sessionId, {String? directory}) async {}
 
   @override
-  Future<List<Session>> getChildren(String sessionId) async => [];
+  Future<List<Session>> getChildren(String sessionId, {String? directory}) async => [];
 
   @override
   Future<List<GlobalSession>> listGlobalSessions({
@@ -562,13 +579,13 @@ class _FakeApi implements OpenCodeApi {
   }) async => [];
 
   @override
-  Future<List<MessageWithParts>> getMessages(String sessionId) async => [];
+  Future<List<MessageWithParts>> getMessages(String sessionId, {String? directory}) async => [];
 
   @override
-  Future<void> sendPrompt(String sessionId, {required Map<String, dynamic> body}) async {}
+  Future<void> sendPrompt(String sessionId, {required Map<String, dynamic> body, String? directory}) async {}
 
   @override
-  Future<void> abortSession(String sessionId) async {}
+  Future<void> abortSession(String sessionId, {String? directory}) async {}
 
   @override
   Future<List<AgentInfo>> listAgents() async => [];

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -153,13 +153,14 @@ class _FakeApi implements OpenCodeApi {
       throw UnimplementedError();
 
   @override
-  Future<Session> updateSession(String sessionId, Map<String, dynamic> body) async => throw UnimplementedError();
+  Future<Session> updateSession(String sessionId, Map<String, dynamic> body, {String? directory}) async =>
+      throw UnimplementedError();
 
   @override
-  Future<void> deleteSession(String sessionId) async {}
+  Future<void> deleteSession(String sessionId, {String? directory}) async {}
 
   @override
-  Future<List<Session>> getChildren(String sessionId) async => [];
+  Future<List<Session>> getChildren(String sessionId, {String? directory}) async => [];
 
   @override
   Future<List<GlobalSession>> listGlobalSessions({
@@ -168,13 +169,13 @@ class _FakeApi implements OpenCodeApi {
   }) async => _globalSessions;
 
   @override
-  Future<List<MessageWithParts>> getMessages(String sessionId) async => [];
+  Future<List<MessageWithParts>> getMessages(String sessionId, {String? directory}) async => [];
 
   @override
-  Future<void> sendPrompt(String sessionId, {required Map<String, dynamic> body}) async {}
+  Future<void> sendPrompt(String sessionId, {required Map<String, dynamic> body, String? directory}) async {}
 
   @override
-  Future<void> abortSession(String sessionId) async {}
+  Future<void> abortSession(String sessionId, {String? directory}) async {}
 
   @override
   Future<List<AgentInfo>> listAgents() async => [];

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -149,33 +149,40 @@ class _FakeApi implements OpenCodeApi {
   Future<List<Session>> listSessions({String? directory}) async => _sessions;
 
   @override
-  Future<Session> createSession({required String workspacePath, String? parentSessionId}) async =>
+  Future<Session> createSession({required String directory, String? parentSessionId}) async =>
       throw UnimplementedError();
 
   @override
-  Future<Session> updateSession(String sessionId, Map<String, dynamic> body, {String? directory}) async =>
-      throw UnimplementedError();
+  Future<Session> updateSession({
+    required String sessionId,
+    required Map<String, dynamic> body,
+    required String? directory,
+  }) async => throw UnimplementedError();
 
   @override
-  Future<void> deleteSession(String sessionId, {String? directory}) async {}
+  Future<void> deleteSession({required String sessionId, required String? directory}) async {}
 
   @override
-  Future<List<Session>> getChildren(String sessionId, {String? directory}) async => [];
+  Future<List<Session>> getChildren({required String sessionId, required String? directory}) async => [];
 
   @override
   Future<List<GlobalSession>> listGlobalSessions({
-    String? directory,
-    bool roots = false,
+    required String? directory,
+    required bool roots,
   }) async => _globalSessions;
 
   @override
-  Future<List<MessageWithParts>> getMessages(String sessionId, {String? directory}) async => [];
+  Future<List<MessageWithParts>> getMessages({required String sessionId, required String? directory}) async => [];
 
   @override
-  Future<void> sendPrompt(String sessionId, {required Map<String, dynamic> body, String? directory}) async {}
+  Future<void> sendPrompt({
+    required String sessionId,
+    required Map<String, dynamic> body,
+    required String? directory,
+  }) async {}
 
   @override
-  Future<void> abortSession(String sessionId, {String? directory}) async {}
+  Future<void> abortSession({required String sessionId, required String? directory}) async {}
 
   @override
   Future<List<AgentInfo>> listAgents() async => [];
@@ -184,13 +191,13 @@ class _FakeApi implements OpenCodeApi {
   Future<List<PendingQuestion>> getPendingQuestions() async => [];
 
   @override
-  Future<void> replyToQuestion(String questionId, {required Map<String, dynamic> body}) async {}
+  Future<void> replyToQuestion({required String questionId, required Map<String, dynamic> body}) async {}
 
   @override
-  Future<void> rejectQuestion(String questionId) async {}
+  Future<void> rejectQuestion({required String questionId}) async {}
 
   @override
-  Future<Project> getProject(String directory) async => throw UnimplementedError();
+  Future<Project> getProject({required String directory}) async => throw UnimplementedError();
 
   @override
   Future<Map<String, SessionStatus>> getSessionStatuses() async => {};

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -117,7 +117,7 @@ void main() {
       );
       final service = OpenCodeService(repository, FakeActiveSessionTracker());
 
-      final result = await service.getLastExchange("ses-1");
+      final result = await service.getLastExchange(sessionId: "ses-1", directory: null);
 
       expect(result.map(_messageId).toList(), equals(["m2", "m3"]));
       expect(repository.api.lastRequestedSessionId, equals("ses-1"));
@@ -127,7 +127,7 @@ void main() {
       final repository = FakeOpenCodeRepository(messages: [_msg("user", "m1")]);
       final service = OpenCodeService(repository, FakeActiveSessionTracker());
 
-      await service.getLastExchange("ses-1", directory: "/repo");
+      await service.getLastExchange(sessionId: "ses-1", directory: "/repo");
 
       expect(repository.api.lastRequestedSessionId, equals("ses-1"));
       expect(repository.api.lastRequestedDirectory, equals("/repo"));
@@ -144,7 +144,7 @@ void main() {
       );
       final service = OpenCodeService(repository, FakeActiveSessionTracker());
 
-      final result = await service.getLastExchange("ses-1");
+      final result = await service.getLastExchange(sessionId: "ses-1", directory: null);
 
       expect(result.map(_messageId).toList(), equals(["m3", "m4"]));
     });
@@ -155,7 +155,7 @@ void main() {
       );
       final service = OpenCodeService(repository, FakeActiveSessionTracker());
 
-      final result = await service.getLastExchange("ses-1");
+      final result = await service.getLastExchange(sessionId: "ses-1", directory: null);
 
       expect(result, isEmpty);
     });
@@ -164,7 +164,7 @@ void main() {
       final repository = FakeOpenCodeRepository(messages: const []);
       final service = OpenCodeService(repository, FakeActiveSessionTracker());
 
-      final result = await service.getLastExchange("ses-1");
+      final result = await service.getLastExchange(sessionId: "ses-1", directory: null);
 
       expect(result, isEmpty);
     });
@@ -173,7 +173,7 @@ void main() {
       final repository = FakeOpenCodeRepository(messages: [_msg("user", "m1")]);
       final service = OpenCodeService(repository, FakeActiveSessionTracker());
 
-      final result = await service.getLastExchange("ses-1");
+      final result = await service.getLastExchange(sessionId: "ses-1", directory: null);
 
       expect(result.map(_messageId).toList(), equals(["m1"]));
     });
@@ -188,7 +188,7 @@ void main() {
       );
       final service = OpenCodeService(repository, FakeActiveSessionTracker());
 
-      final result = await service.getLastExchange("ses-1");
+      final result = await service.getLastExchange(sessionId: "ses-1", directory: null);
 
       expect(result, hasLength(2));
       expect(_messageId(result.first), equals("m1"));
@@ -200,7 +200,7 @@ void main() {
       );
       final service = OpenCodeService(repository, FakeActiveSessionTracker());
 
-      final result = await service.getLastExchange("ses-1");
+      final result = await service.getLastExchange(sessionId: "ses-1", directory: null);
 
       expect(result, isEmpty);
     });
@@ -372,7 +372,7 @@ class FakeOpenCodeApi implements OpenCodeApi {
   FakeOpenCodeApi({this.messages = const [], this.messagesError});
 
   @override
-  Future<List<MessageWithParts>> getMessages(String sessionId, {String? directory}) async {
+  Future<List<MessageWithParts>> getMessages({required String sessionId, required String? directory}) async {
     lastRequestedSessionId = sessionId;
     lastRequestedDirectory = directory;
     if (messagesError != null) throw messagesError!;
@@ -380,27 +380,34 @@ class FakeOpenCodeApi implements OpenCodeApi {
   }
 
   @override
-  Future<Session> createSession({required String workspacePath, String? parentSessionId}) async =>
+  Future<Session> createSession({required String directory, String? parentSessionId}) async =>
       throw UnimplementedError();
 
   @override
-  Future<Session> updateSession(String sessionId, Map<String, dynamic> body, {String? directory}) async =>
-      throw UnimplementedError();
+  Future<Session> updateSession({
+    required String sessionId,
+    required Map<String, dynamic> body,
+    required String? directory,
+  }) async => throw UnimplementedError();
 
   @override
-  Future<void> deleteSession(String sessionId, {String? directory}) async {}
+  Future<void> deleteSession({required String sessionId, required String? directory}) async {}
 
   @override
-  Future<List<Session>> getChildren(String sessionId, {String? directory}) async => [];
+  Future<List<Session>> getChildren({required String sessionId, required String? directory}) async => [];
 
   @override
   Future<Map<String, SessionStatus>> getSessionStatuses() async => <String, SessionStatus>{};
 
   @override
-  Future<void> sendPrompt(String sessionId, {required Map<String, dynamic> body, String? directory}) async {}
+  Future<void> sendPrompt({
+    required String sessionId,
+    required Map<String, dynamic> body,
+    required String? directory,
+  }) async {}
 
   @override
-  Future<void> abortSession(String sessionId, {String? directory}) async {}
+  Future<void> abortSession({required String sessionId, required String? directory}) async {}
 
   @override
   Future<List<AgentInfo>> listAgents() async => [];
@@ -409,18 +416,18 @@ class FakeOpenCodeApi implements OpenCodeApi {
   Future<List<PendingQuestion>> getPendingQuestions() async => [];
 
   @override
-  Future<void> replyToQuestion(String questionId, {required Map<String, dynamic> body}) async {}
+  Future<void> replyToQuestion({required String questionId, required Map<String, dynamic> body}) async {}
 
   @override
-  Future<void> rejectQuestion(String questionId) async {}
+  Future<void> rejectQuestion({required String questionId}) async {}
 
   @override
-  Future<Project> getProject(String directory) async => throw UnimplementedError();
+  Future<Project> getProject({required String directory}) async => throw UnimplementedError();
 
   @override
   Future<List<GlobalSession>> listGlobalSessions({
-    String? directory,
-    bool roots = false,
+    required String? directory,
+    required bool roots,
   }) async => [];
 
   @override

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -123,6 +123,16 @@ void main() {
       expect(repository.api.lastRequestedSessionId, equals("ses-1"));
     });
 
+    test("passes directory to api when provided", () async {
+      final repository = FakeOpenCodeRepository(messages: [_msg("user", "m1")]);
+      final service = OpenCodeService(repository, FakeActiveSessionTracker());
+
+      await service.getLastExchange("ses-1", directory: "/repo");
+
+      expect(repository.api.lastRequestedSessionId, equals("ses-1"));
+      expect(repository.api.lastRequestedDirectory, equals("/repo"));
+    });
+
     test("multiple user messages returns from last user", () async {
       final repository = FakeOpenCodeRepository(
         messages: [
@@ -357,12 +367,14 @@ class FakeOpenCodeApi implements OpenCodeApi {
   List<MessageWithParts> messages;
   Object? messagesError;
   String? lastRequestedSessionId;
+  String? lastRequestedDirectory;
 
   FakeOpenCodeApi({this.messages = const [], this.messagesError});
 
   @override
-  Future<List<MessageWithParts>> getMessages(String sessionId) async {
+  Future<List<MessageWithParts>> getMessages(String sessionId, {String? directory}) async {
     lastRequestedSessionId = sessionId;
+    lastRequestedDirectory = directory;
     if (messagesError != null) throw messagesError!;
     return messages;
   }
@@ -372,22 +384,23 @@ class FakeOpenCodeApi implements OpenCodeApi {
       throw UnimplementedError();
 
   @override
-  Future<Session> updateSession(String sessionId, Map<String, dynamic> body) async => throw UnimplementedError();
+  Future<Session> updateSession(String sessionId, Map<String, dynamic> body, {String? directory}) async =>
+      throw UnimplementedError();
 
   @override
-  Future<void> deleteSession(String sessionId) async {}
+  Future<void> deleteSession(String sessionId, {String? directory}) async {}
 
   @override
-  Future<List<Session>> getChildren(String sessionId) async => [];
+  Future<List<Session>> getChildren(String sessionId, {String? directory}) async => [];
 
   @override
   Future<Map<String, SessionStatus>> getSessionStatuses() async => <String, SessionStatus>{};
 
   @override
-  Future<void> sendPrompt(String sessionId, {required Map<String, dynamic> body}) async {}
+  Future<void> sendPrompt(String sessionId, {required Map<String, dynamic> body, String? directory}) async {}
 
   @override
-  Future<void> abortSession(String sessionId) async {}
+  Future<void> abortSession(String sessionId, {String? directory}) async {}
 
   @override
   Future<List<AgentInfo>> listAgents() async => [];


### PR DESCRIPTION
## Summary

- **Bug**: Session-scoped OpenCode API calls (`sendPrompt`, `getMessages`, `abortSession`, `updateSession`, `deleteSession`, `getChildren`) were missing the `x-opencode-directory` HTTP header. OpenCode's middleware falls back to `process.cwd()` when this header is absent, so agents ran in the bridge's working directory instead of the correct project directory.
- **Fix**: Track `sessionId → directory` mappings via `ActiveSessionTracker.registerSession()` (populated on session creation + SSE events), and propagate the directory as `x-opencode-directory` header through all session-scoped `OpenCodeApi` calls.
- **Scope**: All changes are within `sesori_plugin_opencode` — no interface, shared model, or mobile changes required.

## Changed files

| File | Change |
|---|---|
| `active_session_tracker.dart` | Added `registerSession()` / `getSessionDirectory()` — public accessors for the existing `_sessionWorktrees` map |
| `opencode_api.dart` | Added optional `directory` param to 6 session-scoped methods; includes `x-opencode-directory` header when provided |
| `opencode_service.dart` | Threaded `directory` param through `getLastExchange()` to `api.getMessages()` |
| `opencode_plugin_impl.dart` | Registers directory after `createSession`; all session-scoped operations look up directory from tracker |
| Tests (3 files) | Updated fake API signatures; added tracker registration + directory forwarding tests |

## Verification

- `make analyze` ✅ (info-level lint suggestions only)
- `make test` ✅ (all 286 tests pass)