### PR TITLE
feat(mobile): auto-refresh project list with route visibility gating and timestamp ticker

### DIFF
--- a/mobile/app/lib/core/di/injection.config.dart
+++ b/mobile/app/lib/core/di/injection.config.dart
@@ -30,6 +30,8 @@ import 'package:sesori_mobile/core/platform/app_lifecycle_observer.dart'
 import 'package:sesori_mobile/core/platform/flutter_secure_storage_adapter.dart'
     as _i816;
 import 'package:sesori_mobile/core/platform/flutter_url_launcher.dart' as _i10;
+import 'package:sesori_mobile/core/platform/go_router_route_source.dart'
+    as _i597;
 import 'package:sesori_mobile/core/platform/local_notification_manager.dart'
     as _i492;
 import 'package:sesori_mobile/core/platform/notification_service.dart' as _i737;
@@ -59,6 +61,7 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i492.LocalNotificationManager(),
     );
     gh.singleton<_i948.LifecycleSource>(() => _i875.AppLifecycleObserver());
+    gh.singleton<_i948.RouteSource>(() => _i597.GoRouterRouteSource());
     gh.lazySingleton<_i948.DeepLinkSource>(
       () => _i919.AppLinksDeepLinkSource(),
     );

--- a/mobile/app/lib/core/platform/go_router_route_source.dart
+++ b/mobile/app/lib/core/platform/go_router_route_source.dart
@@ -1,0 +1,62 @@
+import "dart:async";
+
+import "package:get_it/get_it.dart";
+import "package:injectable/injectable.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+
+import "../routing/app_router.dart";
+
+@Singleton(as: RouteSource)
+class GoRouterRouteSource implements RouteSource, Disposable {
+  final BehaviorSubject<AppRoute?> _currentRouteStream;
+
+  GoRouterRouteSource()
+    : _currentRouteStream = BehaviorSubject.seeded(
+        _matchRoute(appRouter.routerDelegate.currentConfiguration.uri.path),
+      ) {
+    appRouter.routerDelegate.addListener(_onRouteChanged);
+  }
+
+  @override
+  ValueStream<AppRoute?> get currentRouteStream => _currentRouteStream.stream;
+
+  @override
+  FutureOr<void> onDispose() {
+    appRouter.routerDelegate.removeListener(_onRouteChanged);
+    _currentRouteStream.close();
+  }
+
+  void _onRouteChanged() {
+    final matchedRoute = _matchRoute(appRouter.routerDelegate.currentConfiguration.uri.path);
+    if (_currentRouteStream.valueOrNull == matchedRoute) {
+      return;
+    }
+    _currentRouteStream.add(matchedRoute);
+  }
+
+  static AppRoute? _matchRoute(String path) {
+    final orderedRoutes = AppRoute.values.toList()..sort((a, b) => b.path.length.compareTo(a.path.length));
+
+    for (final route in orderedRoutes) {
+      if (_routeRegex(route).hasMatch(path)) {
+        return route;
+      }
+    }
+    return null;
+  }
+
+  static RegExp _routeRegex(AppRoute route) {
+    final regexPath = route.path
+        .split("/")
+        .map((segment) {
+          if (segment.startsWith(":")) {
+            return "[^/]+";
+          }
+          return RegExp.escape(segment);
+        })
+        .join("/");
+
+    return RegExp("^$regexPath\$");
+  }
+}

--- a/mobile/app/lib/core/platform/go_router_route_source.dart
+++ b/mobile/app/lib/core/platform/go_router_route_source.dart
@@ -35,18 +35,24 @@ class GoRouterRouteSource implements RouteSource, Disposable {
     _currentRouteStream.add(matchedRoute);
   }
 
-  static AppRoute? _matchRoute(String path) {
-    final orderedRoutes = AppRoute.values.toList()..sort((a, b) => b.path.length.compareTo(a.path.length));
+  /// Routes sorted longest-path-first so `/projects/:id/sessions` is tried
+  /// before `/projects`. Computed once — the route table is static.
+  static final _orderedRoutes = AppRoute.values.toList()..sort((a, b) => b.path.length.compareTo(a.path.length));
 
-    for (final route in orderedRoutes) {
-      if (_routeRegex(route).hasMatch(path)) {
+  static final _regexByRoute = {
+    for (final route in AppRoute.values) route: _buildRegex(route),
+  };
+
+  static AppRoute? _matchRoute(String path) {
+    for (final route in _orderedRoutes) {
+      if (_regexByRoute[route]!.hasMatch(path)) {
         return route;
       }
     }
     return null;
   }
 
-  static RegExp _routeRegex(AppRoute route) {
+  static RegExp _buildRegex(AppRoute route) {
     final regexPath = route.path
         .split("/")
         .map((segment) {

--- a/mobile/app/lib/features/project_list/project_list_screen.dart
+++ b/mobile/app/lib/features/project_list/project_list_screen.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
@@ -17,14 +19,37 @@ class ProjectListScreen extends StatelessWidget {
         getIt<ProjectService>(),
         getIt<ConnectionService>(),
         getIt<SseEventRepository>(),
+        getIt<RouteSource>(),
       ),
       child: const _ProjectListBody(),
     );
   }
 }
 
-class _ProjectListBody extends StatelessWidget {
+class _ProjectListBody extends StatefulWidget {
   const _ProjectListBody();
+
+  @override
+  State<_ProjectListBody> createState() => _ProjectListBodyState();
+}
+
+class _ProjectListBodyState extends State<_ProjectListBody> {
+  late final Timer _ticker;
+
+  @override
+  void initState() {
+    super.initState();
+    _ticker = Timer.periodic(const Duration(minutes: 1), (_) {
+      if (!mounted) return;
+      setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _ticker.cancel();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/app/test/features/project_list/project_list_cubit_test.dart
+++ b/mobile/app/test/features/project_list/project_list_cubit_test.dart
@@ -35,10 +35,9 @@ void main() {
       mockRouteSource = MockRouteSource();
     });
 
-    /// Creates a fresh [ProjectListCubit].
-    ///
-    /// All mock stubs MUST be configured before calling this because the
-    /// constructor immediately calls [ProjectListCubit.loadProjects].
+    /// Creates a fresh [ProjectListCubit] with the route source seeded to
+    /// null (auto-refresh inactive). All mock stubs MUST be configured before
+    /// calling this because the constructor immediately calls loadProjects.
     ProjectListCubit buildCubit() => ProjectListCubit(
       mockProjectService,
       mockConnectionService,
@@ -56,7 +55,6 @@ void main() {
         when(() => mockProjectService.listProjects()).thenAnswer((_) async => ApiResponse.success([testProject()]));
         return buildCubit();
       },
-      skip: 1,
       expect: () => [
         isA<ProjectListLoaded>().having(
           (s) => s.projects,
@@ -76,7 +74,6 @@ void main() {
         when(() => mockProjectService.listProjects()).thenAnswer((_) async => ApiResponse.success(<Project>[]));
         return buildCubit();
       },
-      skip: 1,
       expect: () => [
         isA<ProjectListLoaded>().having(
           (s) => s.projects,
@@ -96,7 +93,6 @@ void main() {
         when(() => mockProjectService.listProjects()).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
         return buildCubit();
       },
-      skip: 1,
       expect: () => [
         isA<ProjectListFailed>(),
       ],
@@ -113,9 +109,6 @@ void main() {
         return buildCubit();
       },
       act: (cubit) => cubit.setActiveProject(testProject()),
-      // The constructor's async loadProjects completes during the post-act wait
-      // and emits a single ProjectListLoaded state.
-      skip: 1,
       expect: () => [
         isA<ProjectListLoaded>(),
       ],
@@ -137,13 +130,9 @@ void main() {
         return buildCubit();
       },
       act: (cubit) async {
-        // Let the constructor's async loadProjects settle first so that the
-        // cubit is in ProjectListLoaded before we trigger a second load. This
-        // guarantees the explicit emit(loading) is not a same-state no-op.
         await Future<void>.delayed(Duration.zero);
         await cubit.loadProjects();
       },
-      skip: 1,
       expect: () => [
         isA<ProjectListLoaded>(), // constructor's async load
         isA<ProjectListLoading>(), // explicit loadProjects begins
@@ -174,7 +163,6 @@ void main() {
         );
         return buildCubit();
       },
-      skip: 1,
       expect: () => [
         isA<ProjectListLoaded>()
             .having(
@@ -202,16 +190,14 @@ void main() {
       },
       act: (cubit) async {
         await Future<void>.delayed(Duration.zero);
-        // Return different data on refresh to prove new data is used.
         when(() => mockProjectService.listProjects()).thenAnswer(
           (_) async => ApiResponse.success([testProject(name: "Refreshed")]),
         );
         final result = await cubit.refreshProjects();
         expect(result, isTrue);
       },
-      skip: 2, // skip constructor's initial loaded emission
+      skip: 1,
       expect: () => [
-        // Only ProjectListLoaded — no ProjectListLoading in between.
         isA<ProjectListLoaded>().having(
           (s) => s.projects.first.name,
           "refreshed project name",
@@ -232,13 +218,11 @@ void main() {
       },
       act: (cubit) async {
         await Future<void>.delayed(Duration.zero);
-        // Switch mock to error for the refresh call.
         when(() => mockProjectService.listProjects()).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
         final result = await cubit.refreshProjects();
         expect(result, isFalse);
       },
-      skip: 2, // skip constructor's initial loaded emission
-      // No state changes — current loaded state is preserved.
+      skip: 1,
       expect: () => <ProjectListState>[],
     );
 
@@ -253,11 +237,11 @@ void main() {
         return buildCubit();
       },
       act: (cubit) async {
-        await Future<void>.delayed(Duration.zero); // let initial load settle
+        await Future<void>.delayed(Duration.zero);
         mockSseEventRepository.emitProjectActivity({_projectId: 3});
         await Future<void>.delayed(Duration.zero);
       },
-      skip: 2, // skip initial loaded emission (no activity yet)
+      skip: 1,
       expect: () => [
         isA<ProjectListLoaded>().having((s) => s.activityById, "activityById", {_projectId: 3}),
       ],
@@ -270,7 +254,6 @@ void main() {
     blocTest<ProjectListCubit, ProjectListState>(
       "projectActivity update: ignored when state is not ProjectListLoaded",
       build: () {
-        // Keep the API hanging so state stays at loading.
         final completer = Completer<ApiResponse<List<Project>>>();
         when(() => mockProjectService.listProjects()).thenAnswer((_) => completer.future);
         return buildCubit();
@@ -279,8 +262,6 @@ void main() {
         mockSseEventRepository.emitProjectActivity({_projectId: 2});
         await Future<void>.delayed(Duration.zero);
       },
-      skip: 1,
-      // Still in loading state — no emission expected.
       expect: () => <ProjectListState>[],
     );
 
@@ -295,7 +276,6 @@ void main() {
         when(() => mockProjectService.listProjects()).thenAnswer((_) async => ApiResponse.success([testProject()]));
         return buildCubit();
       },
-      skip: 1,
       expect: () => [
         isA<ProjectListLoaded>().having((s) => s.activityById, "activityById", {_projectId: 2}),
       ],
@@ -308,18 +288,16 @@ void main() {
     blocTest<ProjectListCubit, ProjectListState>(
       "projectActivity update: activity clears when repository emits empty map",
       build: () {
-        // Seed with activity so state starts non-empty.
         mockSseEventRepository.emitProjectActivity({_projectId: 1});
         when(() => mockProjectService.listProjects()).thenAnswer((_) async => ApiResponse.success([testProject()]));
         return buildCubit();
       },
       act: (cubit) async {
-        await Future<void>.delayed(Duration.zero); // let load settle with activity
-        // Now clear activity — repository filters out zeros and emits empty.
+        await Future<void>.delayed(Duration.zero);
         mockSseEventRepository.emitProjectActivity(const {});
         await Future<void>.delayed(Duration.zero);
       },
-      skip: 2, // skip initial loaded emission (activityById: {_projectId: 1})
+      skip: 1,
       expect: () => [
         isA<ProjectListLoaded>().having((s) => s.activityById, "activityById", isEmpty),
       ],
@@ -330,41 +308,24 @@ void main() {
     // =========================================================================
 
     group("throttled project data refresh", () {
-      /// Builds a cubit with the route already set to projects.
-      /// The auto-refresh stream's immediate fetch + the manual loadProjects()
-      /// results in 2 initial API calls — `initialFetchCount` accounts for this.
-      const initialFetchCount = 2;
-
-      late MockRouteSource projectsRouteSource;
-
-      setUp(() {
-        projectsRouteSource = MockRouteSource(initialRoute: AppRoute.projects);
-      });
-
-      ProjectListCubit buildCubitOnProjectsPage() => ProjectListCubit(
-        mockProjectService,
-        mockConnectionService,
-        mockSseEventRepository,
-        projectsRouteSource,
-      );
-
-      test("activity event schedules refresh that fires after 30 seconds", () {
+      test("activity event triggers refresh after throttle duration", () {
         fakeAsync((FakeAsync async) {
           var fetchCount = 0;
           when(() => mockProjectService.listProjects()).thenAnswer((_) async {
             fetchCount++;
             return ApiResponse.success([testProject()]);
           });
-          final cubit = buildCubitOnProjectsPage();
+          mockRouteSource.emitRoute(AppRoute.projects);
+          final cubit = buildCubit();
           async.elapse(Duration.zero);
-          expect(fetchCount, initialFetchCount, reason: "initial loads settled");
+          final baseline = fetchCount;
 
           mockSseEventRepository.emitProjectActivity({_projectId: 1});
           async.elapse(Duration.zero);
-          expect(fetchCount, initialFetchCount, reason: "throttle hasn't fired yet");
+          expect(fetchCount, baseline, reason: "throttle hasn't fired yet");
 
           async.elapse(refreshThrottleDuration);
-          expect(fetchCount, initialFetchCount + 1, reason: "throttle fired");
+          expect(fetchCount, baseline + 1, reason: "throttle fired");
           cubit.close();
         });
       });
@@ -376,18 +337,19 @@ void main() {
             fetchCount++;
             return ApiResponse.success([testProject()]);
           });
-          final cubit = buildCubitOnProjectsPage();
+          mockRouteSource.emitRoute(AppRoute.projects);
+          final cubit = buildCubit();
           async.elapse(Duration.zero);
-          expect(fetchCount, initialFetchCount);
+          final baseline = fetchCount;
 
           for (var i = 0; i < 5; i++) {
             mockSseEventRepository.emitProjectActivity({_projectId: i});
             async.elapse(const Duration(seconds: 1));
           }
-          expect(fetchCount, initialFetchCount, reason: "still within window");
+          expect(fetchCount, baseline, reason: "still within window");
 
           async.elapse(const Duration(seconds: 25));
-          expect(fetchCount, initialFetchCount + 1, reason: "one refresh despite 5 events");
+          expect(fetchCount, baseline + 1, reason: "one refresh despite 5 events");
           cubit.close();
         });
       });
@@ -399,8 +361,7 @@ void main() {
             fetchCount++;
             return ApiResponse.success([testProject()]);
           });
-          // Start with route = null (page not visible). Only manual load fires.
-          final cubit = buildCubit();
+          final cubit = buildCubit(); // route = null
           async.elapse(Duration.zero);
           expect(fetchCount, 1, reason: "only manual load");
 
@@ -412,74 +373,49 @@ void main() {
         });
       });
 
-      test("immediate refresh when navigating to projects page", () {
+      test("immediate refresh when navigating back to projects page", () {
         fakeAsync((FakeAsync async) {
           var fetchCount = 0;
           when(() => mockProjectService.listProjects()).thenAnswer((_) async {
             fetchCount++;
             return ApiResponse.success([testProject()]);
           });
-          // Start with route = null.
+          // Start on projects, navigate away, navigate back.
+          mockRouteSource.emitRoute(AppRoute.projects);
           final cubit = buildCubit();
           async.elapse(Duration.zero);
-          expect(fetchCount, 1, reason: "only manual load");
+          final baseline = fetchCount;
 
-          // Activity arrives while page not visible.
-          mockSseEventRepository.emitProjectActivity({_projectId: 1});
+          mockRouteSource.emitRoute(AppRoute.sessions);
           async.elapse(Duration.zero);
-          expect(fetchCount, 1, reason: "no refresh while hidden");
+          expect(fetchCount, baseline, reason: "no fetch on navigate away");
 
-          // Navigate to projects page — immediate fetch fires.
           mockRouteSource.emitRoute(AppRoute.projects);
           async.elapse(Duration.zero);
-          expect(fetchCount, 2, reason: "immediate refresh on navigate");
+          expect(fetchCount, baseline + 1, reason: "immediate refresh on navigate back");
           cubit.close();
         });
       });
 
-      test("navigate to projects without prior activity still refreshes once", () {
+      test("new throttle window starts after previous completes", () {
         fakeAsync((FakeAsync async) {
           var fetchCount = 0;
           when(() => mockProjectService.listProjects()).thenAnswer((_) async {
             fetchCount++;
             return ApiResponse.success([testProject()]);
           });
+          mockRouteSource.emitRoute(AppRoute.projects);
           final cubit = buildCubit();
           async.elapse(Duration.zero);
-          expect(fetchCount, 1);
+          final baseline = fetchCount;
 
-          // Navigate to projects — immediate fetch from Stream.value(null).
-          mockRouteSource.emitRoute(AppRoute.projects);
-          async.elapse(Duration.zero);
-          expect(fetchCount, 2, reason: "one refresh on page enter");
-
-          // No further fetches without activity events.
-          async.elapse(const Duration(seconds: 60));
-          expect(fetchCount, 2, reason: "no spurious refreshes");
-          cubit.close();
-        });
-      });
-
-      test("new throttle window starts after previous refresh completes", () {
-        fakeAsync((FakeAsync async) {
-          var fetchCount = 0;
-          when(() => mockProjectService.listProjects()).thenAnswer((_) async {
-            fetchCount++;
-            return ApiResponse.success([testProject()]);
-          });
-          final cubit = buildCubitOnProjectsPage();
-          async.elapse(Duration.zero);
-          expect(fetchCount, initialFetchCount);
-
-          // First event.
           mockSseEventRepository.emitProjectActivity({_projectId: 1});
           async.elapse(refreshThrottleDuration);
-          expect(fetchCount, initialFetchCount + 1, reason: "first window");
+          expect(fetchCount, baseline + 1, reason: "first window");
 
-          // Second event — new window.
           mockSseEventRepository.emitProjectActivity({_projectId: 2});
           async.elapse(refreshThrottleDuration);
-          expect(fetchCount, initialFetchCount + 2, reason: "second window");
+          expect(fetchCount, baseline + 2, reason: "second window");
           cubit.close();
         });
       });

--- a/mobile/app/test/features/project_list/project_list_cubit_test.dart
+++ b/mobile/app/test/features/project_list/project_list_cubit_test.dart
@@ -56,6 +56,7 @@ void main() {
         when(() => mockProjectService.listProjects()).thenAnswer((_) async => ApiResponse.success([testProject()]));
         return buildCubit();
       },
+      skip: 1,
       expect: () => [
         isA<ProjectListLoaded>().having(
           (s) => s.projects,
@@ -75,6 +76,7 @@ void main() {
         when(() => mockProjectService.listProjects()).thenAnswer((_) async => ApiResponse.success(<Project>[]));
         return buildCubit();
       },
+      skip: 1,
       expect: () => [
         isA<ProjectListLoaded>().having(
           (s) => s.projects,
@@ -94,6 +96,7 @@ void main() {
         when(() => mockProjectService.listProjects()).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
         return buildCubit();
       },
+      skip: 1,
       expect: () => [
         isA<ProjectListFailed>(),
       ],
@@ -112,6 +115,7 @@ void main() {
       act: (cubit) => cubit.setActiveProject(testProject()),
       // The constructor's async loadProjects completes during the post-act wait
       // and emits a single ProjectListLoaded state.
+      skip: 1,
       expect: () => [
         isA<ProjectListLoaded>(),
       ],
@@ -139,6 +143,7 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         await cubit.loadProjects();
       },
+      skip: 1,
       expect: () => [
         isA<ProjectListLoaded>(), // constructor's async load
         isA<ProjectListLoading>(), // explicit loadProjects begins
@@ -169,6 +174,7 @@ void main() {
         );
         return buildCubit();
       },
+      skip: 1,
       expect: () => [
         isA<ProjectListLoaded>()
             .having(
@@ -203,7 +209,7 @@ void main() {
         final result = await cubit.refreshProjects();
         expect(result, isTrue);
       },
-      skip: 1, // skip constructor's initial loaded emission
+      skip: 2, // skip constructor's initial loaded emission
       expect: () => [
         // Only ProjectListLoaded — no ProjectListLoading in between.
         isA<ProjectListLoaded>().having(
@@ -231,7 +237,7 @@ void main() {
         final result = await cubit.refreshProjects();
         expect(result, isFalse);
       },
-      skip: 1, // skip constructor's initial loaded emission
+      skip: 2, // skip constructor's initial loaded emission
       // No state changes — current loaded state is preserved.
       expect: () => <ProjectListState>[],
     );
@@ -251,7 +257,7 @@ void main() {
         mockSseEventRepository.emitProjectActivity({_projectId: 3});
         await Future<void>.delayed(Duration.zero);
       },
-      skip: 1, // skip initial loaded emission (no activity yet)
+      skip: 2, // skip initial loaded emission (no activity yet)
       expect: () => [
         isA<ProjectListLoaded>().having((s) => s.activityById, "activityById", {_projectId: 3}),
       ],
@@ -273,6 +279,7 @@ void main() {
         mockSseEventRepository.emitProjectActivity({_projectId: 2});
         await Future<void>.delayed(Duration.zero);
       },
+      skip: 1,
       // Still in loading state — no emission expected.
       expect: () => <ProjectListState>[],
     );
@@ -288,6 +295,7 @@ void main() {
         when(() => mockProjectService.listProjects()).thenAnswer((_) async => ApiResponse.success([testProject()]));
         return buildCubit();
       },
+      skip: 1,
       expect: () => [
         isA<ProjectListLoaded>().having((s) => s.activityById, "activityById", {_projectId: 2}),
       ],
@@ -311,7 +319,7 @@ void main() {
         mockSseEventRepository.emitProjectActivity(const {});
         await Future<void>.delayed(Duration.zero);
       },
-      skip: 1, // skip initial loaded emission (activityById: {_projectId: 1})
+      skip: 2, // skip initial loaded emission (activityById: {_projectId: 1})
       expect: () => [
         isA<ProjectListLoaded>().having((s) => s.activityById, "activityById", isEmpty),
       ],
@@ -322,6 +330,24 @@ void main() {
     // =========================================================================
 
     group("throttled project data refresh", () {
+      /// Builds a cubit with the route already set to projects.
+      /// The auto-refresh stream's immediate fetch + the manual loadProjects()
+      /// results in 2 initial API calls — `initialFetchCount` accounts for this.
+      const initialFetchCount = 2;
+
+      late MockRouteSource projectsRouteSource;
+
+      setUp(() {
+        projectsRouteSource = MockRouteSource(initialRoute: AppRoute.projects);
+      });
+
+      ProjectListCubit buildCubitOnProjectsPage() => ProjectListCubit(
+        mockProjectService,
+        mockConnectionService,
+        mockSseEventRepository,
+        projectsRouteSource,
+      );
+
       test("activity event schedules refresh that fires after 30 seconds", () {
         fakeAsync((FakeAsync async) {
           var fetchCount = 0;
@@ -329,16 +355,16 @@ void main() {
             fetchCount++;
             return ApiResponse.success([testProject()]);
           });
-          final cubit = buildCubit();
+          final cubit = buildCubitOnProjectsPage();
           async.elapse(Duration.zero);
-          expect(fetchCount, 1, reason: "initial load");
+          expect(fetchCount, initialFetchCount, reason: "initial loads settled");
 
           mockSseEventRepository.emitProjectActivity({_projectId: 1});
           async.elapse(Duration.zero);
-          expect(fetchCount, 1, reason: "throttle hasn't fired yet");
+          expect(fetchCount, initialFetchCount, reason: "throttle hasn't fired yet");
 
-          async.elapse(const Duration(seconds: 30));
-          expect(fetchCount, 2, reason: "throttle fired after 30s");
+          async.elapse(refreshThrottleDuration);
+          expect(fetchCount, initialFetchCount + 1, reason: "throttle fired");
           cubit.close();
         });
       });
@@ -350,49 +376,68 @@ void main() {
             fetchCount++;
             return ApiResponse.success([testProject()]);
           });
-          final cubit = buildCubit();
+          final cubit = buildCubitOnProjectsPage();
           async.elapse(Duration.zero);
-          expect(fetchCount, 1);
+          expect(fetchCount, initialFetchCount);
 
           for (var i = 0; i < 5; i++) {
             mockSseEventRepository.emitProjectActivity({_projectId: i});
             async.elapse(const Duration(seconds: 1));
           }
-          expect(fetchCount, 1, reason: "still within first 30s window");
+          expect(fetchCount, initialFetchCount, reason: "still within window");
 
           async.elapse(const Duration(seconds: 25));
-          expect(fetchCount, 2, reason: "exactly one refresh despite 5 events");
+          expect(fetchCount, initialFetchCount + 1, reason: "one refresh despite 5 events");
           cubit.close();
         });
       });
 
-      test("no refresh scheduled when page is not visible", () {
+      test("no auto-refresh when page is not visible", () {
         fakeAsync((FakeAsync async) {
           var fetchCount = 0;
           when(() => mockProjectService.listProjects()).thenAnswer((_) async {
             fetchCount++;
             return ApiResponse.success([testProject()]);
           });
+          // Start with route = null (page not visible). Only manual load fires.
           final cubit = buildCubit();
           async.elapse(Duration.zero);
-          expect(fetchCount, 1, reason: "after initial load");
-
-          mockRouteSource.emitRoute(AppRoute.sessions);
-          expect(fetchCount, 1, reason: "after emitRoute(sessions)");
-          async.elapse(Duration.zero);
-          expect(fetchCount, 1, reason: "after elapse after sessions");
+          expect(fetchCount, 1, reason: "only manual load");
 
           mockSseEventRepository.emitProjectActivity({_projectId: 1});
-          expect(fetchCount, 1, reason: "after emitProjectActivity");
-          async.elapse(const Duration(seconds: 1));
-          expect(fetchCount, 1, reason: "after 1s");
-          async.elapse(const Duration(seconds: 59));
-          expect(fetchCount, 1, reason: "after 60s total");
+          async.elapse(const Duration(seconds: 60));
+
+          expect(fetchCount, 1, reason: "no auto-refresh when page not visible");
           cubit.close();
         });
       });
 
-      test("pending refresh fires immediately when navigating back to page", () {
+      test("immediate refresh when navigating to projects page", () {
+        fakeAsync((FakeAsync async) {
+          var fetchCount = 0;
+          when(() => mockProjectService.listProjects()).thenAnswer((_) async {
+            fetchCount++;
+            return ApiResponse.success([testProject()]);
+          });
+          // Start with route = null.
+          final cubit = buildCubit();
+          async.elapse(Duration.zero);
+          expect(fetchCount, 1, reason: "only manual load");
+
+          // Activity arrives while page not visible.
+          mockSseEventRepository.emitProjectActivity({_projectId: 1});
+          async.elapse(Duration.zero);
+          expect(fetchCount, 1, reason: "no refresh while hidden");
+
+          // Navigate to projects page — immediate fetch fires.
+          mockRouteSource.emitRoute(AppRoute.projects);
+          async.elapse(Duration.zero);
+          expect(fetchCount, 2, reason: "immediate refresh on navigate");
+          cubit.close();
+        });
+      });
+
+      test("navigate to projects without prior activity still refreshes once", () {
         fakeAsync((FakeAsync async) {
           var fetchCount = 0;
           when(() => mockProjectService.listProjects()).thenAnswer((_) async {
@@ -403,36 +448,14 @@ void main() {
           async.elapse(Duration.zero);
           expect(fetchCount, 1);
 
-          mockRouteSource.emitRoute(AppRoute.sessions);
-          async.elapse(Duration.zero);
-          mockSseEventRepository.emitProjectActivity({_projectId: 1});
-          async.elapse(Duration.zero);
-          expect(fetchCount, 1, reason: "no refresh while page hidden");
-
+          // Navigate to projects — immediate fetch from Stream.value(null).
           mockRouteSource.emitRoute(AppRoute.projects);
           async.elapse(Duration.zero);
-          expect(fetchCount, 2, reason: "immediate refresh when page visible");
-          cubit.close();
-        });
-      });
+          expect(fetchCount, 2, reason: "one refresh on page enter");
 
-      test("no refresh when navigating back without pending events", () {
-        fakeAsync((FakeAsync async) {
-          var fetchCount = 0;
-          when(() => mockProjectService.listProjects()).thenAnswer((_) async {
-            fetchCount++;
-            return ApiResponse.success([testProject()]);
-          });
-          final cubit = buildCubit();
-          async.elapse(Duration.zero);
-          expect(fetchCount, 1);
-
-          mockRouteSource.emitRoute(AppRoute.sessions);
-          async.elapse(Duration.zero);
-          mockRouteSource.emitRoute(AppRoute.projects);
-          async.elapse(Duration.zero);
-
-          expect(fetchCount, 1, reason: "no refresh when no pending events");
+          // No further fetches without activity events.
+          async.elapse(const Duration(seconds: 60));
+          expect(fetchCount, 2, reason: "no spurious refreshes");
           cubit.close();
         });
       });
@@ -444,17 +467,19 @@ void main() {
             fetchCount++;
             return ApiResponse.success([testProject()]);
           });
-          final cubit = buildCubit();
+          final cubit = buildCubitOnProjectsPage();
           async.elapse(Duration.zero);
-          expect(fetchCount, 1);
+          expect(fetchCount, initialFetchCount);
 
+          // First event.
           mockSseEventRepository.emitProjectActivity({_projectId: 1});
-          async.elapse(const Duration(seconds: 30));
-          expect(fetchCount, 2, reason: "first throttle window");
+          async.elapse(refreshThrottleDuration);
+          expect(fetchCount, initialFetchCount + 1, reason: "first window");
 
+          // Second event — new window.
           mockSseEventRepository.emitProjectActivity({_projectId: 2});
-          async.elapse(const Duration(seconds: 30));
-          expect(fetchCount, 3, reason: "second throttle window");
+          async.elapse(refreshThrottleDuration);
+          expect(fetchCount, initialFetchCount + 2, reason: "second window");
           cubit.close();
         });
       });

--- a/mobile/app/test/features/project_list/project_list_cubit_test.dart
+++ b/mobile/app/test/features/project_list/project_list_cubit_test.dart
@@ -1,9 +1,11 @@
 import "dart:async";
 
 import "package:bloc_test/bloc_test.dart";
+import "package:fake_async/fake_async.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:mocktail/mocktail.dart";
 import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart" show AppRoute;
 import "package:sesori_dart_core/src/cubits/project_list/project_list_cubit.dart";
 import "package:sesori_dart_core/src/cubits/project_list/project_list_state.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -24,11 +26,13 @@ void main() {
     late MockProjectService mockProjectService;
     late MockConnectionService mockConnectionService;
     late MockSseEventRepository mockSseEventRepository;
+    late MockRouteSource mockRouteSource;
 
     setUp(() {
       mockProjectService = MockProjectService();
       mockConnectionService = MockConnectionService();
       mockSseEventRepository = MockSseEventRepository();
+      mockRouteSource = MockRouteSource();
     });
 
     /// Creates a fresh [ProjectListCubit].
@@ -39,6 +43,7 @@ void main() {
       mockProjectService,
       mockConnectionService,
       mockSseEventRepository,
+      mockRouteSource,
     );
 
     // -------------------------------------------------------------------------
@@ -311,5 +316,148 @@ void main() {
         isA<ProjectListLoaded>().having((s) => s.activityById, "activityById", isEmpty),
       ],
     );
+
+    // =========================================================================
+    // Throttled project data refresh
+    // =========================================================================
+
+    group("throttled project data refresh", () {
+      test("activity event schedules refresh that fires after 30 seconds", () {
+        fakeAsync((FakeAsync async) {
+          var fetchCount = 0;
+          when(() => mockProjectService.listProjects()).thenAnswer((_) async {
+            fetchCount++;
+            return ApiResponse.success([testProject()]);
+          });
+          final cubit = buildCubit();
+          async.elapse(Duration.zero);
+          expect(fetchCount, 1, reason: "initial load");
+
+          mockSseEventRepository.emitProjectActivity({_projectId: 1});
+          async.elapse(Duration.zero);
+          expect(fetchCount, 1, reason: "throttle hasn't fired yet");
+
+          async.elapse(const Duration(seconds: 30));
+          expect(fetchCount, 2, reason: "throttle fired after 30s");
+          cubit.close();
+        });
+      });
+
+      test("multiple rapid events result in single refresh", () {
+        fakeAsync((FakeAsync async) {
+          var fetchCount = 0;
+          when(() => mockProjectService.listProjects()).thenAnswer((_) async {
+            fetchCount++;
+            return ApiResponse.success([testProject()]);
+          });
+          final cubit = buildCubit();
+          async.elapse(Duration.zero);
+          expect(fetchCount, 1);
+
+          for (var i = 0; i < 5; i++) {
+            mockSseEventRepository.emitProjectActivity({_projectId: i});
+            async.elapse(const Duration(seconds: 1));
+          }
+          expect(fetchCount, 1, reason: "still within first 30s window");
+
+          async.elapse(const Duration(seconds: 25));
+          expect(fetchCount, 2, reason: "exactly one refresh despite 5 events");
+          cubit.close();
+        });
+      });
+
+      test("no refresh scheduled when page is not visible", () {
+        fakeAsync((FakeAsync async) {
+          var fetchCount = 0;
+          when(() => mockProjectService.listProjects()).thenAnswer((_) async {
+            fetchCount++;
+            return ApiResponse.success([testProject()]);
+          });
+          final cubit = buildCubit();
+          async.elapse(Duration.zero);
+          expect(fetchCount, 1, reason: "after initial load");
+
+          mockRouteSource.emitRoute(AppRoute.sessions);
+          expect(fetchCount, 1, reason: "after emitRoute(sessions)");
+          async.elapse(Duration.zero);
+          expect(fetchCount, 1, reason: "after elapse after sessions");
+
+          mockSseEventRepository.emitProjectActivity({_projectId: 1});
+          expect(fetchCount, 1, reason: "after emitProjectActivity");
+          async.elapse(const Duration(seconds: 1));
+          expect(fetchCount, 1, reason: "after 1s");
+          async.elapse(const Duration(seconds: 59));
+          expect(fetchCount, 1, reason: "after 60s total");
+          cubit.close();
+        });
+      });
+
+      test("pending refresh fires immediately when navigating back to page", () {
+        fakeAsync((FakeAsync async) {
+          var fetchCount = 0;
+          when(() => mockProjectService.listProjects()).thenAnswer((_) async {
+            fetchCount++;
+            return ApiResponse.success([testProject()]);
+          });
+          final cubit = buildCubit();
+          async.elapse(Duration.zero);
+          expect(fetchCount, 1);
+
+          mockRouteSource.emitRoute(AppRoute.sessions);
+          async.elapse(Duration.zero);
+          mockSseEventRepository.emitProjectActivity({_projectId: 1});
+          async.elapse(Duration.zero);
+          expect(fetchCount, 1, reason: "no refresh while page hidden");
+
+          mockRouteSource.emitRoute(AppRoute.projects);
+          async.elapse(Duration.zero);
+          expect(fetchCount, 2, reason: "immediate refresh when page visible");
+          cubit.close();
+        });
+      });
+
+      test("no refresh when navigating back without pending events", () {
+        fakeAsync((FakeAsync async) {
+          var fetchCount = 0;
+          when(() => mockProjectService.listProjects()).thenAnswer((_) async {
+            fetchCount++;
+            return ApiResponse.success([testProject()]);
+          });
+          final cubit = buildCubit();
+          async.elapse(Duration.zero);
+          expect(fetchCount, 1);
+
+          mockRouteSource.emitRoute(AppRoute.sessions);
+          async.elapse(Duration.zero);
+          mockRouteSource.emitRoute(AppRoute.projects);
+          async.elapse(Duration.zero);
+
+          expect(fetchCount, 1, reason: "no refresh when no pending events");
+          cubit.close();
+        });
+      });
+
+      test("new throttle window starts after previous refresh completes", () {
+        fakeAsync((FakeAsync async) {
+          var fetchCount = 0;
+          when(() => mockProjectService.listProjects()).thenAnswer((_) async {
+            fetchCount++;
+            return ApiResponse.success([testProject()]);
+          });
+          final cubit = buildCubit();
+          async.elapse(Duration.zero);
+          expect(fetchCount, 1);
+
+          mockSseEventRepository.emitProjectActivity({_projectId: 1});
+          async.elapse(const Duration(seconds: 30));
+          expect(fetchCount, 2, reason: "first throttle window");
+
+          mockSseEventRepository.emitProjectActivity({_projectId: 2});
+          async.elapse(const Duration(seconds: 30));
+          expect(fetchCount, 3, reason: "second throttle window");
+          cubit.close();
+        });
+      });
+    });
   });
 }

--- a/mobile/app/test/helpers/test_helpers.dart
+++ b/mobile/app/test/helpers/test_helpers.dart
@@ -79,7 +79,9 @@ class MockLifecycleSource extends Mock implements LifecycleSource {
 }
 
 class MockRouteSource extends Mock implements RouteSource {
-  final BehaviorSubject<AppRoute?> _currentRoute = BehaviorSubject.seeded(AppRoute.projects);
+  final BehaviorSubject<AppRoute?> _currentRoute;
+
+  MockRouteSource({AppRoute? initialRoute}) : _currentRoute = BehaviorSubject.seeded(initialRoute);
 
   @override
   ValueStream<AppRoute?> get currentRouteStream => _currentRoute.stream;

--- a/mobile/app/test/helpers/test_helpers.dart
+++ b/mobile/app/test/helpers/test_helpers.dart
@@ -4,6 +4,7 @@ import "package:mocktail/mocktail.dart";
 import "package:record/record.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart" show AppRoute, RouteSource;
 import "package:sesori_dart_core/src/api/client/relay_http_client.dart";
 import "package:sesori_dart_core/src/capabilities/project/project_service.dart";
 import "package:sesori_dart_core/src/capabilities/relay/relay_client.dart";
@@ -75,6 +76,17 @@ class MockLifecycleSource extends Mock implements LifecycleSource {
   ValueStream<LifecycleState> get lifecycleStateStream => _state.stream;
 
   void emitState(LifecycleState state) => _state.add(state);
+}
+
+class MockRouteSource extends Mock implements RouteSource {
+  final BehaviorSubject<AppRoute?> _currentRoute = BehaviorSubject.seeded(AppRoute.projects);
+
+  @override
+  ValueStream<AppRoute?> get currentRouteStream => _currentRoute.stream;
+
+  AppRoute? get currentRoute => _currentRoute.value;
+
+  void emitRoute(AppRoute? route) => _currentRoute.add(route);
 }
 
 class MockSseEventRepository extends Mock implements SseEventRepository {

--- a/mobile/module_core/lib/sesori_dart_core.dart
+++ b/mobile/module_core/lib/sesori_dart_core.dart
@@ -48,6 +48,7 @@ export "src/logging/logging.dart";
 // Platform interfaces
 export "src/platform/deep_link_source.dart";
 export "src/platform/lifecycle_source.dart";
+export "src/platform/route_source.dart";
 export "src/platform/url_launcher.dart";
 // Reporting
 export "src/reporting/reporting.dart";

--- a/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -1,6 +1,7 @@
 import "dart:async";
 
 import "package:bloc/bloc.dart";
+import "package:meta/meta.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -9,25 +10,42 @@ import "../../capabilities/project/project_service.dart";
 import "../../capabilities/server_connection/connection_service.dart";
 import "../../capabilities/sse/sse_event_repository.dart";
 import "../../logging/logging.dart";
+import "../../platform/route_source.dart";
+import "../../routing/app_routes.dart";
 import "project_list_state.dart";
+
+/// How long to wait after the first activity event before refreshing project
+/// data. Additional events during this window are coalesced into a single
+/// refresh, avoiding excessive API calls during active sessions.
+@visibleForTesting
+const refreshThrottleDuration = Duration(seconds: 30);
 
 class ProjectListCubit extends Cubit<ProjectListState> {
   final ProjectService _projectService;
   final ConnectionService _connectionService;
   final SseEventRepository _sseEventRepository;
+  final RouteSource _routeSource;
   final CompositeSubscription _subscriptions = CompositeSubscription();
+
+  Timer? _refreshTimer;
+  bool _refreshPending = false;
 
   ProjectListCubit(
     ProjectService projectService,
     ConnectionService connectionService,
     SseEventRepository sseEventRepository,
+    RouteSource routeSource,
   ) : _projectService = projectService,
       _connectionService = connectionService,
       _sseEventRepository = sseEventRepository,
+      _routeSource = routeSource,
       super(const ProjectListState.loading()) {
     loadProjects();
     _subscriptions.add(
       _sseEventRepository.projectActivity.listen(_onActivityUpdated),
+    );
+    _subscriptions.add(
+      _routeSource.currentRouteStream.listen(_onRouteChanged),
     );
   }
 
@@ -38,12 +56,58 @@ class ProjectListCubit extends Cubit<ProjectListState> {
   void _onActivityUpdated(Map<String, int> activityById) {
     if (state is! ProjectListLoaded) return;
     if (isClosed) return;
+
+    // Always update activity badges immediately — this is cheap (no API call).
     emit(
       ProjectListState.loaded(
         projects: (state as ProjectListLoaded).projects,
         activityById: activityById,
       ),
     );
+
+    // Schedule a throttled project data refresh so that timestamps update too.
+    _scheduleRefresh();
+  }
+
+  /// Schedules a throttled [refreshProjects] call.
+  ///
+  /// When the projects page is visible, the first event starts a 30-second
+  /// timer. Additional events during that window are coalesced. If another
+  /// route is visible, the refresh is deferred until projects becomes active.
+  void _scheduleRefresh() {
+    if (_routeSource.currentRoute != AppRoute.projects) {
+      _refreshPending = true;
+      return;
+    }
+
+    if (_refreshTimer != null) return;
+
+    _refreshTimer = Timer(refreshThrottleDuration, () {
+      unawaited(_runScheduledRefresh());
+    });
+  }
+
+  Future<void> _runScheduledRefresh() async {
+    if (isClosed) return;
+
+    try {
+      if (_routeSource.currentRoute != AppRoute.projects) {
+        _refreshPending = true;
+        return;
+      }
+      _refreshPending = false;
+      await refreshProjects();
+    } finally {
+      _refreshTimer = null;
+    }
+  }
+
+  void _onRouteChanged(AppRoute? currentRoute) {
+    if (isClosed) return;
+    if (currentRoute == AppRoute.projects && _refreshPending) {
+      _refreshPending = false;
+      unawaited(refreshProjects());
+    }
   }
 
   Future<void> loadProjects() async {
@@ -87,6 +151,7 @@ class ProjectListCubit extends Cubit<ProjectListState> {
 
   @override
   Future<void> close() {
+    _refreshTimer?.cancel();
     _subscriptions.dispose();
     return super.close();
   }

--- a/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -14,9 +14,8 @@ import "../../platform/route_source.dart";
 import "../../routing/app_routes.dart";
 import "project_list_state.dart";
 
-/// How long to wait after the first activity event before refreshing project
-/// data. Additional events during this window are coalesced into a single
-/// refresh, avoiding excessive API calls during active sessions.
+/// How long to wait after an activity event before auto-refreshing project
+/// data. Events during this window are coalesced into a single refresh.
 @visibleForTesting
 const refreshThrottleDuration = Duration(seconds: 30);
 
@@ -25,10 +24,6 @@ class ProjectListCubit extends Cubit<ProjectListState> {
   final ConnectionService _connectionService;
   final SseEventRepository _sseEventRepository;
   final CompositeSubscription _subscriptions = CompositeSubscription();
-
-  /// Manual load/refresh requests feed into this subject so that all state
-  /// emission flows through the single merged stream pipeline.
-  final PublishSubject<_RefreshRequest> _refreshRequests = PublishSubject();
 
   ProjectListCubit(
     ProjectService projectService,
@@ -39,140 +34,104 @@ class ProjectListCubit extends Cubit<ProjectListState> {
       _connectionService = connectionService,
       _sseEventRepository = sseEventRepository,
       super(const ProjectListState.loading()) {
+    loadProjects();
+
+    // 1. Immediate activity badge updates (no API call).
     _subscriptions.add(
-      Rx.merge<ProjectListState?>([
-        // Immediate activity badge updates (no API call).
-        _sseEventRepository.projectActivity.map(_applyActivityBadge),
-
-        // Auto-refresh: route-gated, throttled project data refresh.
-        // When the projects page is visible, activity events trigger a
-        // throttled fetch. On navigate-back, an immediate fetch fires.
-        routeSource.currentRouteStream.switchMap((route) {
-          if (route != AppRoute.projects) {
-            return const Stream<ProjectListState?>.empty();
-          }
-          return Rx.merge<void>([
-            // Immediate refresh when entering the page. switchMap cancels
-            // this chain when the route leaves projects and re-enters it,
-            // so we get one instant fetch per navigation.
-            Stream<void>.value(null),
-            // Throttled refresh from activity events while on the page.
-            // skip(1) drops the BehaviorSubject replay (the immediate
-            // fetch above already covers it).
-            _sseEventRepository.projectActivity
-                .skip(1)
-                .throttleTime(refreshThrottleDuration, trailing: true, leading: false),
-          ]).asyncMap((_) => _fetchProjectsQuietly());
-        }),
-
-        // Manual load/refresh requests (initial load, pull-to-refresh, retry).
-        _refreshRequests.switchMap(_handleRefreshRequest),
-      ]).whereType<ProjectListState>().listen((state) {
-        if (isClosed) return;
-        emit(state);
-      }),
+      _sseEventRepository.projectActivity.listen(_onActivityUpdated),
     );
 
-    // Trigger initial load through the stream pipeline.
-    loadProjects();
+    // 2. Auto-refresh: throttled project data fetch, active only while the
+    //    projects page is visible. switchMap cancels the inner subscription
+    //    when the route leaves projects and restarts it when coming back.
+    _subscriptions.add(
+      routeSource.currentRouteStream
+          .switchMap((route) {
+            if (route != AppRoute.projects) return const Stream<void>.empty();
+            return _sseEventRepository.projectActivity.throttleTime(
+              refreshThrottleDuration,
+              trailing: true,
+              leading: false,
+            );
+          })
+          .listen((_) {
+            if (isClosed) return;
+            unawaited(refreshProjects());
+          }),
+    );
+
+    // 3. Navigate-back refresh: one immediate fetch when the user returns to
+    //    the projects page. pairwise() ensures this doesn't fire on the
+    //    initial route emission (needs two values before it emits).
+    _subscriptions.add(
+      routeSource.currentRouteStream
+          .distinct()
+          .pairwise()
+          .where((pair) => pair.first != AppRoute.projects && pair.last == AppRoute.projects)
+          .listen((_) {
+            if (isClosed) return;
+            unawaited(refreshProjects());
+          }),
+    );
   }
 
   void setActiveProject(Project project) {
     _connectionService.setActiveDirectory(project.id);
   }
 
-  /// Triggers a full load (shows loading indicator, emits error on failure).
+  void _onActivityUpdated(Map<String, int> activityById) {
+    if (state is! ProjectListLoaded) return;
+    if (isClosed) return;
+    emit(
+      ProjectListState.loaded(
+        projects: (state as ProjectListLoaded).projects,
+        activityById: activityById,
+      ),
+    );
+  }
+
   Future<void> loadProjects() async {
-    final completer = Completer<bool>();
-    _refreshRequests.add(_RefreshRequest(silent: false, completer: completer));
-    await completer.future;
+    emit(const ProjectListState.loading());
+    await _fetchProjects();
   }
 
   /// Re-fetches projects without showing the full-screen loading indicator.
   /// Returns `false` when the refresh fails so the UI can show feedback.
   Future<bool> refreshProjects() async {
-    final completer = Completer<bool>();
-    _refreshRequests.add(_RefreshRequest(silent: true, completer: completer));
-    return completer.future;
+    return _fetchProjects(silent: true);
   }
 
-  // ---------------------------------------------------------------------------
-  // Stream pipeline helpers
-  // ---------------------------------------------------------------------------
+  Future<bool> _fetchProjects({bool silent = false}) async {
+    final projectResponse = await _projectService.listProjects();
+    if (isClosed) return false;
 
-  /// Maps an activity event to an updated loaded state, or null if the cubit
-  /// is not yet loaded (the null is filtered by [whereType] in the merge).
-  ProjectListState? _applyActivityBadge(Map<String, int> activityById) {
-    final s = state;
-    if (s is! ProjectListLoaded) return null;
-    return ProjectListState.loaded(
-      projects: s.projects,
-      activityById: activityById,
-    );
-  }
-
-  /// Fetches projects silently (no loading indicator, no error state).
-  /// Returns null on failure so the merge pipeline can filter it out.
-  Future<ProjectListState?> _fetchProjectsQuietly() async {
-    final response = await _projectService.listProjects();
-    if (isClosed) return null;
-    if (response case SuccessResponse(:final data)) {
-      final projects = data.toList();
-      projects.sort(
-        (a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0),
-      );
-      return ProjectListState.loaded(
-        projects: projects,
-        activityById: _sseEventRepository.currentProjectActivity,
-      );
-    }
-    logw("Failed to auto-refresh projects: $response");
-    return null;
-  }
-
-  /// Processes a manual load/refresh request as a stream of state updates.
-  Stream<ProjectListState?> _handleRefreshRequest(_RefreshRequest request) async* {
-    if (!request.silent) {
-      yield const ProjectListState.loading();
-    }
-
-    final response = await _projectService.listProjects();
-    if (isClosed) {
-      request.completer?.complete(false);
-      return;
-    }
-
-    switch (response) {
+    switch (projectResponse) {
       case SuccessResponse(:final data):
         final projects = data.toList();
         projects.sort(
           (a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0),
         );
-        request.completer?.complete(true);
-        yield ProjectListState.loaded(
-          projects: projects,
-          activityById: _sseEventRepository.currentProjectActivity,
+        emit(
+          ProjectListState.loaded(
+            projects: projects,
+            activityById: _sseEventRepository.currentProjectActivity,
+          ),
         );
+        return true;
+
       case ErrorResponse(:final error):
-        request.completer?.complete(false);
-        if (request.silent) {
+        if (silent) {
           logw("Failed to refresh projects: $error");
         } else {
-          yield ProjectListState.failed(error: error);
+          emit(ProjectListState.failed(error: error));
         }
+        return false;
     }
   }
 
   @override
   Future<void> close() {
-    _refreshRequests.close();
     _subscriptions.dispose();
     return super.close();
   }
-}
-
-class _RefreshRequest {
-  final bool silent;
-  final Completer<bool>? completer;
-  const _RefreshRequest({required this.silent, this.completer});
 }

--- a/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -24,11 +24,11 @@ class ProjectListCubit extends Cubit<ProjectListState> {
   final ProjectService _projectService;
   final ConnectionService _connectionService;
   final SseEventRepository _sseEventRepository;
-  final RouteSource _routeSource;
   final CompositeSubscription _subscriptions = CompositeSubscription();
 
-  Timer? _refreshTimer;
-  bool _refreshPending = false;
+  /// Manual load/refresh requests feed into this subject so that all state
+  /// emission flows through the single merged stream pipeline.
+  final PublishSubject<_RefreshRequest> _refreshRequests = PublishSubject();
 
   ProjectListCubit(
     ProjectService projectService,
@@ -38,121 +38,141 @@ class ProjectListCubit extends Cubit<ProjectListState> {
   ) : _projectService = projectService,
       _connectionService = connectionService,
       _sseEventRepository = sseEventRepository,
-      _routeSource = routeSource,
       super(const ProjectListState.loading()) {
+    _subscriptions.add(
+      Rx.merge<ProjectListState?>([
+        // Immediate activity badge updates (no API call).
+        _sseEventRepository.projectActivity.map(_applyActivityBadge),
+
+        // Auto-refresh: route-gated, throttled project data refresh.
+        // When the projects page is visible, activity events trigger a
+        // throttled fetch. On navigate-back, an immediate fetch fires.
+        routeSource.currentRouteStream.switchMap((route) {
+          if (route != AppRoute.projects) {
+            return const Stream<ProjectListState?>.empty();
+          }
+          return Rx.merge<void>([
+            // Immediate refresh when entering the page. switchMap cancels
+            // this chain when the route leaves projects and re-enters it,
+            // so we get one instant fetch per navigation.
+            Stream<void>.value(null),
+            // Throttled refresh from activity events while on the page.
+            // skip(1) drops the BehaviorSubject replay (the immediate
+            // fetch above already covers it).
+            _sseEventRepository.projectActivity
+                .skip(1)
+                .throttleTime(refreshThrottleDuration, trailing: true, leading: false),
+          ]).asyncMap((_) => _fetchProjectsQuietly());
+        }),
+
+        // Manual load/refresh requests (initial load, pull-to-refresh, retry).
+        _refreshRequests.switchMap(_handleRefreshRequest),
+      ]).whereType<ProjectListState>().listen((state) {
+        if (isClosed) return;
+        emit(state);
+      }),
+    );
+
+    // Trigger initial load through the stream pipeline.
     loadProjects();
-    _subscriptions.add(
-      _sseEventRepository.projectActivity.listen(_onActivityUpdated),
-    );
-    _subscriptions.add(
-      _routeSource.currentRouteStream.listen(_onRouteChanged),
-    );
   }
 
   void setActiveProject(Project project) {
     _connectionService.setActiveDirectory(project.id);
   }
 
-  void _onActivityUpdated(Map<String, int> activityById) {
-    if (state is! ProjectListLoaded) return;
-    if (isClosed) return;
-
-    // Always update activity badges immediately — this is cheap (no API call).
-    emit(
-      ProjectListState.loaded(
-        projects: (state as ProjectListLoaded).projects,
-        activityById: activityById,
-      ),
-    );
-
-    // Schedule a throttled project data refresh so that timestamps update too.
-    _scheduleRefresh();
-  }
-
-  /// Schedules a throttled [refreshProjects] call.
-  ///
-  /// When the projects page is visible, the first event starts a 30-second
-  /// timer. Additional events during that window are coalesced. If another
-  /// route is visible, the refresh is deferred until projects becomes active.
-  void _scheduleRefresh() {
-    if (_routeSource.currentRoute != AppRoute.projects) {
-      _refreshPending = true;
-      return;
-    }
-
-    if (_refreshTimer != null) return;
-
-    _refreshTimer = Timer(refreshThrottleDuration, () {
-      unawaited(_runScheduledRefresh());
-    });
-  }
-
-  Future<void> _runScheduledRefresh() async {
-    if (isClosed) return;
-
-    try {
-      if (_routeSource.currentRoute != AppRoute.projects) {
-        _refreshPending = true;
-        return;
-      }
-      _refreshPending = false;
-      await refreshProjects();
-    } finally {
-      _refreshTimer = null;
-    }
-  }
-
-  void _onRouteChanged(AppRoute? currentRoute) {
-    if (isClosed) return;
-    if (currentRoute == AppRoute.projects && _refreshPending) {
-      _refreshPending = false;
-      unawaited(refreshProjects());
-    }
-  }
-
+  /// Triggers a full load (shows loading indicator, emits error on failure).
   Future<void> loadProjects() async {
-    emit(const ProjectListState.loading());
-    await _fetchProjects();
+    final completer = Completer<bool>();
+    _refreshRequests.add(_RefreshRequest(silent: false, completer: completer));
+    await completer.future;
   }
 
   /// Re-fetches projects without showing the full-screen loading indicator.
   /// Returns `false` when the refresh fails so the UI can show feedback.
   Future<bool> refreshProjects() async {
-    return _fetchProjects(silent: true);
+    final completer = Completer<bool>();
+    _refreshRequests.add(_RefreshRequest(silent: true, completer: completer));
+    return completer.future;
   }
 
-  Future<bool> _fetchProjects({bool silent = false}) async {
-    final projectResponse = await _projectService.listProjects();
-    if (isClosed) return false;
+  // ---------------------------------------------------------------------------
+  // Stream pipeline helpers
+  // ---------------------------------------------------------------------------
 
-    switch (projectResponse) {
+  /// Maps an activity event to an updated loaded state, or null if the cubit
+  /// is not yet loaded (the null is filtered by [whereType] in the merge).
+  ProjectListState? _applyActivityBadge(Map<String, int> activityById) {
+    final s = state;
+    if (s is! ProjectListLoaded) return null;
+    return ProjectListState.loaded(
+      projects: s.projects,
+      activityById: activityById,
+    );
+  }
+
+  /// Fetches projects silently (no loading indicator, no error state).
+  /// Returns null on failure so the merge pipeline can filter it out.
+  Future<ProjectListState?> _fetchProjectsQuietly() async {
+    final response = await _projectService.listProjects();
+    if (isClosed) return null;
+    if (response case SuccessResponse(:final data)) {
+      final projects = data.toList();
+      projects.sort(
+        (a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0),
+      );
+      return ProjectListState.loaded(
+        projects: projects,
+        activityById: _sseEventRepository.currentProjectActivity,
+      );
+    }
+    logw("Failed to auto-refresh projects: $response");
+    return null;
+  }
+
+  /// Processes a manual load/refresh request as a stream of state updates.
+  Stream<ProjectListState?> _handleRefreshRequest(_RefreshRequest request) async* {
+    if (!request.silent) {
+      yield const ProjectListState.loading();
+    }
+
+    final response = await _projectService.listProjects();
+    if (isClosed) {
+      request.completer?.complete(false);
+      return;
+    }
+
+    switch (response) {
       case SuccessResponse(:final data):
         final projects = data.toList();
         projects.sort(
           (a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0),
         );
-        emit(
-          ProjectListState.loaded(
-            projects: projects,
-            activityById: _sseEventRepository.currentProjectActivity,
-          ),
+        request.completer?.complete(true);
+        yield ProjectListState.loaded(
+          projects: projects,
+          activityById: _sseEventRepository.currentProjectActivity,
         );
-        return true;
-
       case ErrorResponse(:final error):
-        if (silent) {
+        request.completer?.complete(false);
+        if (request.silent) {
           logw("Failed to refresh projects: $error");
         } else {
-          emit(ProjectListState.failed(error: error));
+          yield ProjectListState.failed(error: error);
         }
-        return false;
     }
   }
 
   @override
   Future<void> close() {
-    _refreshTimer?.cancel();
+    _refreshRequests.close();
     _subscriptions.dispose();
     return super.close();
   }
+}
+
+class _RefreshRequest {
+  final bool silent;
+  final Completer<bool>? completer;
+  const _RefreshRequest({required this.silent, this.completer});
 }

--- a/mobile/module_core/lib/src/platform/route_source.dart
+++ b/mobile/module_core/lib/src/platform/route_source.dart
@@ -1,0 +1,16 @@
+import "package:rxdart/rxdart.dart";
+
+import "../routing/app_routes.dart";
+
+/// Exposes the currently active [AppRoute] so pure-Dart code (cubits, services)
+/// can check which page is visible without depending on Flutter or GoRouter.
+///
+/// The Flutter app provides a concrete implementation backed by GoRouter.
+/// See also: [LifecycleSource] for app-level lifecycle.
+abstract interface class RouteSource {
+  ValueStream<AppRoute?> get currentRouteStream;
+}
+
+extension RouteSourceX on RouteSource {
+  AppRoute? get currentRoute => currentRouteStream.value;
+}


### PR DESCRIPTION
## Summary

- **Route-level visibility abstraction**: New `RouteSource` interface in `module_core` (pure Dart) exposes the currently active `AppRoute` as a `ValueStream`. `GoRouterRouteSource` in `app/` provides the Flutter implementation by listening to GoRouter navigation changes and matching locations to `AppRoute` via regex.
- **Throttled project data refresh**: `ProjectListCubit` now auto-refreshes project data when SSE activity events arrive, but only when the project list is the visible page. Uses a 30-second trailing-edge throttle to coalesce rapid events during active sessions (idle→busy→idle per message). Events while the page is not visible are deferred — one immediate refresh fires when the user navigates back.
- **Periodic timestamp ticker**: `_ProjectListBody` converted to `StatefulWidget` with a 60-second `Timer.periodic` that forces rebuilds, keeping relative timestamps ("5m ago") fresh without relying on state changes.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Session activity while on project list | Stale timestamps, no refresh | Auto-refresh after 30s throttle |
| Session activity while on session detail | Wasted API calls (if we had auto-refresh) | No refresh — deferred until user returns |
| User navigates back to project list | Stale until pull-to-refresh | Immediate refresh if events were pending |
| "Updated 5m ago" text over time | Stays "5m ago" forever | Recomputes every 60s ("6m ago", "7m ago"...) |
| 10 rapid SSE events in 5 seconds | Would have been 10 API calls | Coalesced into 1 call after 30s |

## New files

| File | Purpose |
|------|---------|
| `module_core/.../platform/route_source.dart` | Abstract interface — mirrors `LifecycleSource` pattern |
| `app/.../platform/go_router_route_source.dart` | Flutter implementation — `@Singleton(as: RouteSource)` |

## Modified files

| File | Change |
|------|--------|
| `module_core/.../project_list_cubit.dart` | Added `RouteSource` dependency, 30s throttle, route visibility gating |
| `app/.../project_list_screen.dart` | Pass `RouteSource` to cubit, 60s rebuild timer for timestamps |
| `app/.../di/injection.config.dart` | Regenerated — registers `GoRouterRouteSource` |
| `app/test/.../test_helpers.dart` | Added `MockRouteSource` |
| `app/test/.../project_list_cubit_test.dart` | 6 new fakeAsync throttle tests + updated constructor in existing tests |

## Verification

- `dart analyze` — clean in both `module_core` and `app`
- `dart test` — 40 module_core tests pass
- `flutter test` — all app tests pass (18 cubit tests including 6 new)