### PR TITLE
refactor(bridge): unify debug server routing with relay path

### DIFF
--- a/bridge/app/lib/src/bridge/debug_server.dart
+++ b/bridge/app/lib/src/bridge/debug_server.dart
@@ -5,8 +5,11 @@ import "dart:io";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
+import "routing/request_router.dart";
+
 class DebugServer {
   final BridgePlugin _plugin;
+  final RequestRouter _router;
   final int port;
   HttpServer? _server;
   final List<HttpResponse> _sseClients = [];
@@ -14,7 +17,7 @@ class DebugServer {
 
   int _nextRequestId = 1;
 
-  DebugServer(BridgePlugin plugin, {required this.port}) : _plugin = plugin;
+  DebugServer(BridgePlugin plugin, {required this.port}) : _plugin = plugin, _router = RequestRouter(plugin);
 
   int? get boundPort => _server?.port;
 
@@ -74,7 +77,7 @@ class DebugServer {
               )
               as RelayRequest;
 
-      final message = await _routeRequest(relayRequest);
+      final message = await _router.route(relayRequest);
       request.response.statusCode = message.status;
       // Skip hop-by-hop and length headers — dart:io sets them
       // automatically based on the actual response body written.
@@ -95,73 +98,6 @@ class DebugServer {
     } finally {
       await request.response.close();
     }
-  }
-
-  Future<RelayResponse> _routeRequest(RelayRequest request) async {
-    final path = request.path.split("?").first;
-
-    if (request.method == "GET" && path == "/project") {
-      final projects = await _plugin.getProjects();
-      final body = jsonEncode(projects.map((p) => p.toJson()).toList());
-      return RelayResponse(
-        id: request.id,
-        status: 200,
-        headers: {"content-type": "application/json"},
-        body: body,
-      );
-    }
-
-    if (request.method == "GET" && path == "/session") {
-      String? worktree;
-      for (final entry in request.headers.entries) {
-        if (entry.key.toLowerCase() == "x-opencode-directory") {
-          worktree = entry.value;
-          break;
-        }
-      }
-      if (worktree == null || worktree.isEmpty) {
-        return RelayResponse(
-          id: request.id,
-          status: 400,
-          headers: {},
-          body: "missing x-opencode-directory header",
-        );
-      }
-      final uri = Uri.parse(request.path);
-      final start = uri.queryParameters["start"] != null ? int.tryParse(uri.queryParameters["start"]!) : null;
-      final limit = uri.queryParameters["limit"] != null ? int.tryParse(uri.queryParameters["limit"]!) : null;
-      final sessions = await _plugin.getSessions(worktree, start: start, limit: limit);
-      final body = jsonEncode(sessions.map((s) => s.toJson()).toList());
-      return RelayResponse(
-        id: request.id,
-        status: 200,
-        headers: {"content-type": "application/json"},
-        body: body,
-      );
-    }
-
-    final sessionMsgPattern = RegExp(r"^/session/[^/]+/message$");
-    if (request.method == "GET" && sessionMsgPattern.hasMatch(path)) {
-      Log.v("[dbg] getting messages for session $path");
-      final segments = path.split("/");
-      final sessionId = segments[2];
-      final messages = await _plugin.getSessionMessages(sessionId);
-      final body = jsonEncode(messages.map((m) => m.toJson()).toList());
-      return RelayResponse(
-        id: request.id,
-        status: 200,
-        headers: {"content-type": "application/json"},
-        body: body,
-      );
-    }
-
-    // Fallback: explicit handlers not implemented for this route yet.
-    return RelayResponse(
-      id: request.id,
-      status: 404,
-      headers: {},
-      body: "route not handled",
-    );
   }
 
   Future<void> _handleSSE(HttpRequest request) async {

--- a/bridge/app/lib/src/bridge/debug_server.dart
+++ b/bridge/app/lib/src/bridge/debug_server.dart
@@ -6,10 +6,12 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "routing/request_router.dart";
+import "sse/bridge_event_mapper.dart";
 
 class DebugServer {
   final BridgePlugin _plugin;
   final RequestRouter _router;
+  final BridgeEventMapper _mapper;
   final int port;
   HttpServer? _server;
   final List<HttpResponse> _sseClients = [];
@@ -17,7 +19,10 @@ class DebugServer {
 
   int _nextRequestId = 1;
 
-  DebugServer(BridgePlugin plugin, {required this.port}) : _plugin = plugin, _router = RequestRouter(plugin);
+  DebugServer(BridgePlugin plugin, {required this.port})
+    : _plugin = plugin,
+      _router = RequestRouter(plugin),
+      _mapper = BridgeEventMapper(plugin);
 
   int? get boundPort => _server?.port;
 
@@ -115,7 +120,10 @@ class DebugServer {
       _sseClients.add(response);
 
       _pluginEventsSub ??= _plugin.events.listen((event) {
-        unawaited(_fanOutEvent(jsonEncode({"type": event.runtimeType.toString()})));
+        final mapped = _mapper.map(event);
+        if (mapped != null) {
+          unawaited(_fanOutEvent(jsonEncode(mapped.toJson())));
+        }
       });
 
       final disconnected = Completer<void>();

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -15,6 +15,7 @@ import "key_exchange.dart";
 import "models/bridge_config.dart";
 import "relay_client.dart";
 import "routing/request_router.dart";
+import "sse/bridge_event_mapper.dart";
 import "sse/sse_manager.dart";
 
 /// Factory that creates [OrchestratorSession] instances with all runtime
@@ -77,6 +78,7 @@ class OrchestratorSession {
   final List<int> _roomKey;
   final SSEManager _sseManager;
   final RequestRouter _router;
+  final BridgeEventMapper _mapper;
   final PushNotificationService _pushNotificationService;
   final AccessTokenUpdater _accessTokenUpdater;
   StreamSubscription<BridgeSseEvent>? _eventSubscription;
@@ -97,7 +99,8 @@ class OrchestratorSession {
        _accessTokenUpdater = accessTokenUpdater,
        _roomKey = roomKey,
        _sseManager = sseManager,
-       _router = RequestRouter(plugin);
+       _router = RequestRouter(plugin),
+       _mapper = BridgeEventMapper(plugin);
 
   Future<void> run() async {
     final kxManager = KeyExchangeManager(_roomKey);
@@ -107,7 +110,7 @@ class OrchestratorSession {
     _eventSubscription = _plugin.events.listen(
       (BridgeSseEvent event) {
         Log.v("[sse] plugin event arrived: ${event.runtimeType}");
-        final sesoriEvent = _mapBridgeToSesoriEvent(event);
+        final sesoriEvent = _mapper.map(event);
         if (sesoriEvent != null) {
           Log.v(
             "[sse] mapped to: ${sesoriEvent.runtimeType} — enqueuing (subscribers: ${_sseManager.subscriberCount})",
@@ -461,7 +464,7 @@ class OrchestratorSession {
         Log.v("[dbg] SseSubscribe: path=${subscribe.path}");
         try {
           _sseManager.subscribePath(connID, subscribe.path, _client);
-          _sseManager.enqueueEvent(_buildProjectsSummaryEvent());
+          _sseManager.enqueueEvent(_mapper.buildProjectsSummaryEvent());
           Log.v("[dbg] initial projectsSummary enqueued");
         } catch (e) {
           Log.e("sse subscribe failed for connId $connID: $e");
@@ -471,170 +474,6 @@ class OrchestratorSession {
         _sseManager.unsubscribe(connID);
       default:
         Log.v("[dbg] unhandled msg type: ${msg.runtimeType}");
-    }
-  }
-
-  SesoriSseEvent? _mapBridgeToSesoriEvent(BridgeSseEvent event) {
-    switch (event) {
-      case BridgeSseServerConnected():
-        return const SesoriSseEvent.serverConnected();
-      case BridgeSseServerHeartbeat():
-        return const SesoriSseEvent.serverHeartbeat();
-      case BridgeSseServerInstanceDisposed(:final directory):
-        return SesoriSseEvent.serverInstanceDisposed(directory: directory);
-      case BridgeSseGlobalDisposed():
-        return const SesoriSseEvent.globalDisposed();
-      case BridgeSseSessionCreated(:final info):
-        return _tryParseSseEvent({"type": "session.created", "info": info});
-      case BridgeSseSessionUpdated(:final info):
-        return _tryParseSseEvent({"type": "session.updated", "info": info});
-      case BridgeSseSessionDeleted(:final info):
-        return _tryParseSseEvent({"type": "session.deleted", "info": info});
-      case BridgeSseSessionDiff(:final sessionID, :final diff):
-        return _tryParseSseEvent({
-          "type": "session.diff",
-          "sessionID": sessionID,
-          "diff": diff,
-        });
-      case BridgeSseSessionError(:final sessionID):
-        return SesoriSseEvent.sessionError(sessionID: sessionID);
-      case BridgeSseSessionCompacted(:final sessionID):
-        return SesoriSseEvent.sessionCompacted(sessionID: sessionID);
-      case BridgeSseSessionStatus(:final sessionID, :final status):
-        return _tryParseSseEvent({
-          "type": "session.status",
-          "sessionID": sessionID,
-          "status": status,
-        });
-      case BridgeSseSessionIdle(:final sessionID):
-        return SesoriSseEvent.sessionStatus(
-          sessionID: sessionID,
-          status: const SessionStatus.idle(),
-        );
-      case BridgeSseMessageUpdated(:final info):
-        return _tryParseSseEvent({"type": "message.updated", "info": info});
-      case BridgeSseMessageRemoved(:final sessionID, :final messageID):
-        return SesoriSseEvent.messageRemoved(
-          sessionID: sessionID,
-          messageID: messageID,
-        );
-      case BridgeSseMessagePartUpdated(:final part):
-        return _tryParseSseEvent({"type": "message.part.updated", "part": part});
-      case BridgeSseMessagePartDelta(
-        :final sessionID,
-        :final messageID,
-        :final partID,
-        :final field,
-        :final delta,
-      ):
-        return SesoriSseEvent.messagePartDelta(
-          sessionID: sessionID,
-          messageID: messageID,
-          partID: partID,
-          field: field,
-          delta: delta,
-        );
-      case BridgeSseMessagePartRemoved(
-        :final sessionID,
-        :final messageID,
-        :final partID,
-      ):
-        return SesoriSseEvent.messagePartRemoved(
-          sessionID: sessionID,
-          messageID: messageID,
-          partID: partID,
-        );
-      case BridgeSsePtyCreated():
-        return const SesoriSseEvent.ptyCreated();
-      case BridgeSsePtyUpdated():
-        return const SesoriSseEvent.ptyUpdated();
-      case BridgeSsePtyExited(:final id, :final exitCode):
-        return SesoriSseEvent.ptyExited(id: id, exitCode: exitCode);
-      case BridgeSsePtyDeleted(:final id):
-        return SesoriSseEvent.ptyDeleted(id: id);
-      case BridgeSsePermissionAsked(
-        :final requestID,
-        :final sessionID,
-        :final tool,
-        :final description,
-      ):
-        return SesoriSseEvent.permissionAsked(
-          requestID: requestID,
-          sessionID: sessionID,
-          tool: tool,
-          description: description,
-        );
-      case BridgeSsePermissionReplied(:final requestID, :final reply):
-        return SesoriSseEvent.permissionReplied(
-          requestID: requestID,
-          reply: reply,
-        );
-      case BridgeSsePermissionUpdated():
-        return const SesoriSseEvent.permissionUpdated();
-      case BridgeSseQuestionAsked(:final id, :final sessionID, :final questions):
-        return _tryParseSseEvent({
-          "type": "question.asked",
-          "id": id,
-          "sessionID": sessionID,
-          "questions": questions,
-        });
-      case BridgeSseQuestionReplied(:final requestID, :final sessionID):
-        return SesoriSseEvent.questionReplied(
-          requestID: requestID,
-          sessionID: sessionID,
-        );
-      case BridgeSseQuestionRejected(:final requestID, :final sessionID):
-        return SesoriSseEvent.questionRejected(
-          requestID: requestID,
-          sessionID: sessionID,
-        );
-      case BridgeSseTodoUpdated(:final sessionID):
-        return SesoriSseEvent.todoUpdated(sessionID: sessionID);
-      // BridgeSseProjectUpdated is emitted on both activity changes and project
-      // metadata changes. We always send the full projectsSummary so the mobile
-      // client receives updated activity data in real time.
-      case BridgeSseProjectUpdated():
-        return _buildProjectsSummaryEvent();
-      case BridgeSseVcsBranchUpdated():
-        return const SesoriSseEvent.vcsBranchUpdated();
-      case BridgeSseFileEdited(:final file):
-        return SesoriSseEvent.fileEdited(file: file);
-      case BridgeSseFileWatcherUpdated(:final file, :final event):
-        return SesoriSseEvent.fileWatcherUpdated(file: file, event: event);
-      case BridgeSseLspUpdated():
-        return const SesoriSseEvent.lspUpdated();
-      case BridgeSseLspClientDiagnostics(:final serverID, :final path):
-        return SesoriSseEvent.lspClientDiagnostics(serverID: serverID, path: path);
-      case BridgeSseMcpToolsChanged():
-        return const SesoriSseEvent.mcpToolsChanged();
-      case BridgeSseMcpBrowserOpenFailed():
-        return const SesoriSseEvent.mcpBrowserOpenFailed();
-      case BridgeSseInstallationUpdated(:final version):
-        return SesoriSseEvent.installationUpdated(version: version);
-      case BridgeSseInstallationUpdateAvailable(:final version):
-        return SesoriSseEvent.installationUpdateAvailable(version: version);
-      case BridgeSseWorkspaceReady(:final name):
-        return SesoriSseEvent.workspaceReady(name: name);
-      case BridgeSseWorkspaceFailed(:final message):
-        return SesoriSseEvent.workspaceFailed(message: message);
-      case BridgeSseTuiToastShow(:final title, :final message, :final variant):
-        return SesoriSseEvent.tuiToastShow(
-          title: title,
-          message: message,
-          variant: variant,
-        );
-      case BridgeSseWorktreeReady():
-        return const SesoriSseEvent.worktreeReady();
-      case BridgeSseWorktreeFailed():
-        return const SesoriSseEvent.worktreeFailed();
-    }
-  }
-
-  SesoriSseEvent? _tryParseSseEvent(Map<String, dynamic> payload) {
-    try {
-      return SesoriSseEvent.fromJson(payload);
-    } catch (_) {
-      return null;
     }
   }
 
@@ -657,27 +496,5 @@ class OrchestratorSession {
     final encryptor = cryptoService.createSessionEncryptor(encryptionKey);
     final framed = await frame(utf8.encode(respJson), encryptor);
     _client.send(connID, framed);
-  }
-
-  SesoriSseEvent _buildProjectsSummaryEvent() {
-    final summary = _plugin.getActiveSessionsSummary();
-    return SesoriSseEvent.projectsSummary(
-      projects: summary
-          .map(
-            (e) => ProjectActivitySummary(
-              id: e.id,
-              activeSessions: e.activeSessions
-                  .map(
-                    (a) => ActiveSession(
-                      id: a.id,
-                      mainAgentRunning: a.mainAgentRunning,
-                      childSessionIds: a.childSessionIds,
-                    ),
-                  )
-                  .toList(),
-            ),
-          )
-          .toList(),
-    );
   }
 }

--- a/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
@@ -193,7 +193,8 @@ class BridgeEventMapper {
   SesoriSseEvent? _tryParseSseEvent(Map<String, dynamic> payload) {
     try {
       return SesoriSseEvent.fromJson(payload);
-    } catch (_) {
+    } catch (e) {
+      Log.w("failed to parse SSE event from payload: $payload, error: $e");
       return null;
     }
   }

--- a/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
@@ -1,0 +1,200 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+/// Maps [BridgeSseEvent]s from the plugin to [SesoriSseEvent]s for relay delivery.
+///
+/// Handles all event type conversions and builds the projects summary event.
+class BridgeEventMapper {
+  final BridgePlugin _plugin;
+
+  BridgeEventMapper(this._plugin);
+
+  /// Maps a [BridgeSseEvent] to a [SesoriSseEvent], or null if unmappable.
+  SesoriSseEvent? map(BridgeSseEvent event) {
+    switch (event) {
+      case BridgeSseServerConnected():
+        return const SesoriSseEvent.serverConnected();
+      case BridgeSseServerHeartbeat():
+        return const SesoriSseEvent.serverHeartbeat();
+      case BridgeSseServerInstanceDisposed(:final directory):
+        return SesoriSseEvent.serverInstanceDisposed(directory: directory);
+      case BridgeSseGlobalDisposed():
+        return const SesoriSseEvent.globalDisposed();
+      case BridgeSseSessionCreated(:final info):
+        return _tryParseSseEvent({"type": "session.created", "info": info});
+      case BridgeSseSessionUpdated(:final info):
+        return _tryParseSseEvent({"type": "session.updated", "info": info});
+      case BridgeSseSessionDeleted(:final info):
+        return _tryParseSseEvent({"type": "session.deleted", "info": info});
+      case BridgeSseSessionDiff(:final sessionID, :final diff):
+        return _tryParseSseEvent({
+          "type": "session.diff",
+          "sessionID": sessionID,
+          "diff": diff,
+        });
+      case BridgeSseSessionError(:final sessionID):
+        return SesoriSseEvent.sessionError(sessionID: sessionID);
+      case BridgeSseSessionCompacted(:final sessionID):
+        return SesoriSseEvent.sessionCompacted(sessionID: sessionID);
+      case BridgeSseSessionStatus(:final sessionID, :final status):
+        return _tryParseSseEvent({
+          "type": "session.status",
+          "sessionID": sessionID,
+          "status": status,
+        });
+      case BridgeSseSessionIdle(:final sessionID):
+        return SesoriSseEvent.sessionStatus(
+          sessionID: sessionID,
+          status: const SessionStatus.idle(),
+        );
+      case BridgeSseMessageUpdated(:final info):
+        return _tryParseSseEvent({"type": "message.updated", "info": info});
+      case BridgeSseMessageRemoved(:final sessionID, :final messageID):
+        return SesoriSseEvent.messageRemoved(
+          sessionID: sessionID,
+          messageID: messageID,
+        );
+      case BridgeSseMessagePartUpdated(:final part):
+        return _tryParseSseEvent({"type": "message.part.updated", "part": part});
+      case BridgeSseMessagePartDelta(
+        :final sessionID,
+        :final messageID,
+        :final partID,
+        :final field,
+        :final delta,
+      ):
+        return SesoriSseEvent.messagePartDelta(
+          sessionID: sessionID,
+          messageID: messageID,
+          partID: partID,
+          field: field,
+          delta: delta,
+        );
+      case BridgeSseMessagePartRemoved(
+        :final sessionID,
+        :final messageID,
+        :final partID,
+      ):
+        return SesoriSseEvent.messagePartRemoved(
+          sessionID: sessionID,
+          messageID: messageID,
+          partID: partID,
+        );
+      case BridgeSsePtyCreated():
+        return const SesoriSseEvent.ptyCreated();
+      case BridgeSsePtyUpdated():
+        return const SesoriSseEvent.ptyUpdated();
+      case BridgeSsePtyExited(:final id, :final exitCode):
+        return SesoriSseEvent.ptyExited(id: id, exitCode: exitCode);
+      case BridgeSsePtyDeleted(:final id):
+        return SesoriSseEvent.ptyDeleted(id: id);
+      case BridgeSsePermissionAsked(
+        :final requestID,
+        :final sessionID,
+        :final tool,
+        :final description,
+      ):
+        return SesoriSseEvent.permissionAsked(
+          requestID: requestID,
+          sessionID: sessionID,
+          tool: tool,
+          description: description,
+        );
+      case BridgeSsePermissionReplied(:final requestID, :final reply):
+        return SesoriSseEvent.permissionReplied(
+          requestID: requestID,
+          reply: reply,
+        );
+      case BridgeSsePermissionUpdated():
+        return const SesoriSseEvent.permissionUpdated();
+      case BridgeSseQuestionAsked(:final id, :final sessionID, :final questions):
+        return _tryParseSseEvent({
+          "type": "question.asked",
+          "id": id,
+          "sessionID": sessionID,
+          "questions": questions,
+        });
+      case BridgeSseQuestionReplied(:final requestID, :final sessionID):
+        return SesoriSseEvent.questionReplied(
+          requestID: requestID,
+          sessionID: sessionID,
+        );
+      case BridgeSseQuestionRejected(:final requestID, :final sessionID):
+        return SesoriSseEvent.questionRejected(
+          requestID: requestID,
+          sessionID: sessionID,
+        );
+      case BridgeSseTodoUpdated(:final sessionID):
+        return SesoriSseEvent.todoUpdated(sessionID: sessionID);
+      // BridgeSseProjectUpdated is emitted on both activity changes and project
+      // metadata changes. We always send the full projectsSummary so the mobile
+      // client receives updated activity data in real time.
+      case BridgeSseProjectUpdated():
+        return buildProjectsSummaryEvent();
+      case BridgeSseVcsBranchUpdated():
+        return const SesoriSseEvent.vcsBranchUpdated();
+      case BridgeSseFileEdited(:final file):
+        return SesoriSseEvent.fileEdited(file: file);
+      case BridgeSseFileWatcherUpdated(:final file, :final event):
+        return SesoriSseEvent.fileWatcherUpdated(file: file, event: event);
+      case BridgeSseLspUpdated():
+        return const SesoriSseEvent.lspUpdated();
+      case BridgeSseLspClientDiagnostics(:final serverID, :final path):
+        return SesoriSseEvent.lspClientDiagnostics(serverID: serverID, path: path);
+      case BridgeSseMcpToolsChanged():
+        return const SesoriSseEvent.mcpToolsChanged();
+      case BridgeSseMcpBrowserOpenFailed():
+        return const SesoriSseEvent.mcpBrowserOpenFailed();
+      case BridgeSseInstallationUpdated(:final version):
+        return SesoriSseEvent.installationUpdated(version: version);
+      case BridgeSseInstallationUpdateAvailable(:final version):
+        return SesoriSseEvent.installationUpdateAvailable(version: version);
+      case BridgeSseWorkspaceReady(:final name):
+        return SesoriSseEvent.workspaceReady(name: name);
+      case BridgeSseWorkspaceFailed(:final message):
+        return SesoriSseEvent.workspaceFailed(message: message);
+      case BridgeSseTuiToastShow(:final title, :final message, :final variant):
+        return SesoriSseEvent.tuiToastShow(
+          title: title,
+          message: message,
+          variant: variant,
+        );
+      case BridgeSseWorktreeReady():
+        return const SesoriSseEvent.worktreeReady();
+      case BridgeSseWorktreeFailed():
+        return const SesoriSseEvent.worktreeFailed();
+    }
+  }
+
+  /// Builds a projects summary event from the current active sessions.
+  SesoriSseEvent buildProjectsSummaryEvent() {
+    final summary = _plugin.getActiveSessionsSummary();
+    return SesoriSseEvent.projectsSummary(
+      projects: summary
+          .map(
+            (e) => ProjectActivitySummary(
+              id: e.id,
+              activeSessions: e.activeSessions
+                  .map(
+                    (a) => ActiveSession(
+                      id: a.id,
+                      mainAgentRunning: a.mainAgentRunning,
+                      childSessionIds: a.childSessionIds,
+                    ),
+                  )
+                  .toList(),
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  /// Attempts to parse an SSE event from a JSON payload.
+  SesoriSseEvent? _tryParseSseEvent(Map<String, dynamic> payload) {
+    try {
+      return SesoriSseEvent.fromJson(payload);
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -143,7 +143,7 @@ void main() {
       final request = await client.getUrl(
         Uri.parse("http://127.0.0.1:${debugServer.boundPort!}/session"),
       );
-      request.headers.set("x-opencode-directory", "/tmp/test");
+      request.headers.set("x-project-id", "/tmp/test");
       final response = await request.close();
       final body = await utf8.decoder.bind(response).join();
 
@@ -202,7 +202,7 @@ void main() {
       final body = await utf8.decoder.bind(response).join();
 
       expect(response.statusCode, equals(HttpStatus.badGateway));
-      expect(body, contains("Debug server proxy error"));
+      expect(body, contains("request failed"));
     });
   });
 }

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -34,8 +34,8 @@ void main() {
       final firstEvent = await first.nextEvent();
       final secondEvent = await second.nextEvent();
 
-      expect(firstEvent, contains("BridgeSseServerConnected"));
-      expect(secondEvent, contains("BridgeSseServerConnected"));
+      expect(firstEvent, contains("server.connected"));
+      expect(secondEvent, contains("server.connected"));
     });
 
     test(
@@ -50,7 +50,7 @@ void main() {
 
         plugin.add(const BridgeSseServerConnected());
         final firstEvent = await first.nextEvent();
-        expect(firstEvent, contains("BridgeSseServerConnected"));
+        expect(firstEvent, contains("server.connected"));
       },
     );
 


### PR DESCRIPTION
## Summary

- Extract `BridgeEventMapper` from `OrchestratorSession` into a shared class so both the orchestrator and debug server use the same SSE event mapping pipeline
- Replace the debug server's inline `_routeRequest()` (3 hardcoded routes) with `RequestRouter` — the same 17-handler chain used by the relay/orchestrator path
- Replace the debug server's minimal SSE event formatting (`runtimeType.toString()`) with `BridgeEventMapper`, producing properly structured `SesoriSseEvent` JSON identical to the relay path

## Motivation

The debug server had its own divergent request handling that only covered 3 routes, returned raw plugin model JSON (instead of properly transformed sesori_shared models), and sent minimal SSE events. This made it unreliable for testing — behavior didn't match what mobile clients actually see through the relay.

Now both paths share the exact same routing and event mapping. The only difference is the transport layer: the relay path encrypts/decrypts, the debug server doesn't.

## Changes

| File | Change |
|------|--------|
| `bridge_event_mapper.dart` | **NEW** — Extracted from `OrchestratorSession`. Maps `BridgeSseEvent` → `SesoriSseEvent`. |
| `orchestrator.dart` | Delegates to `BridgeEventMapper` instead of private methods (pure extraction, zero behavioral change) |
| `debug_server.dart` | Uses `RequestRouter` for HTTP + `BridgeEventMapper` for SSE. Deleted inline `_routeRequest()`. |
| `debug_server_test.dart` | Updated assertions: header (`x-project-id`), error format (`request failed`), SSE events (`server.connected`) |

## What's NOT changed

- `SSEManager`, `RelayClient`, `KeyExchange` — completely untouched
- All 17 routing handlers — untouched
- Relay encryption/decryption path — untouched
- Debug server's lazy SSE lifecycle, hop-by-hop header filtering, outer try-catch — all preserved

## Testing

- All 211 existing tests pass
- Zero analysis issues across all 3 bridge modules
- Rebased on latest `main`