### PR TITLE
fix(mobile): filter SSE session events by project ID in SessionListCubit

### DIFF
--- a/bridge/app/yaak/opencode/yaak.rq_rsCAN6A9zh.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_rsCAN6A9zh.yaml
@@ -1,0 +1,35 @@
+type: http_request
+model: http_request
+id: rq_rsCAN6A9zh
+createdAt: 2026-03-24T12:42:42.183998
+updatedAt: 2026-03-24T12:49:00.651053
+workspaceId: wk_CKpMKQdH7W
+folderId: fl_AHgrxwb38h
+authentication: {}
+authenticationType: null
+body:
+  text: ''
+bodyType: application/json
+description: ''
+headers:
+- enabled: true
+  name: Content-Type
+  value: application/json
+  id: ZKKNTARaxK
+- enabled: true
+  name: x-opencode-directory
+  value: /Users/alexandrudochioiu/sesori-ai/sesori_apps_monorepo
+  id: wMmVRg8M8R
+- enabled: true
+  name: ''
+  value: ''
+  id: fkUfgIT6Jz
+method: GET
+name: Questions List
+sortPriority: 0.001
+url: ${[ base_url ]}/question
+urlParameters:
+- enabled: true
+  name: ''
+  value: ''
+  id: eEeAZ7YYcQ

--- a/bridge/app/yaak/sesori-bridge/yaak.fl_KKPLMJLWXX.yaml
+++ b/bridge/app/yaak/sesori-bridge/yaak.fl_KKPLMJLWXX.yaml
@@ -1,0 +1,13 @@
+type: folder
+model: folder
+id: fl_KKPLMJLWXX
+createdAt: 2026-03-24T16:57:55.381695
+updatedAt: 2026-03-24T16:57:57.480362
+workspaceId: wk_rSi2KDTVqo
+folderId: null
+authentication: {}
+authenticationType: null
+description: ''
+headers: []
+name: session
+sortPriority: 1000.0

--- a/bridge/app/yaak/sesori-bridge/yaak.fl_aDHUTwiwwj.yaml
+++ b/bridge/app/yaak/sesori-bridge/yaak.fl_aDHUTwiwwj.yaml
@@ -1,0 +1,13 @@
+type: folder
+model: folder
+id: fl_aDHUTwiwwj
+createdAt: 2026-03-24T16:58:12.338574
+updatedAt: 2026-03-24T16:58:12.338575
+workspaceId: wk_rSi2KDTVqo
+folderId: null
+authentication: {}
+authenticationType: null
+description: ''
+headers: []
+name: project
+sortPriority: -1774371492337.0

--- a/bridge/app/yaak/sesori-bridge/yaak.rq_NpmUa49kkF.yaml
+++ b/bridge/app/yaak/sesori-bridge/yaak.rq_NpmUa49kkF.yaml
@@ -1,0 +1,26 @@
+type: http_request
+model: http_request
+id: rq_NpmUa49kkF
+createdAt: 2026-03-24T12:37:52.588724
+updatedAt: 2026-03-24T12:40:29.893862
+workspaceId: wk_rSi2KDTVqo
+folderId: null
+authentication: {}
+authenticationType: null
+body: {}
+bodyType: null
+description: ''
+headers:
+- enabled: true
+  name: x-project-id
+  value: /Users/alexandrudochioiu/sesori-ai/sesori_apps_monorepo
+  id: jD0MEpp09G
+- enabled: true
+  name: ''
+  value: ''
+  id: FAWr8SZpk7
+method: GET
+name: Session Messages
+sortPriority: 1000.0
+url: ${[ url ]}/session/ses_2e064c306ffeuie3U7eaFMPCr7/message
+urlParameters: []

--- a/bridge/app/yaak/sesori-bridge/yaak.rq_NpmUa49kkF.yaml
+++ b/bridge/app/yaak/sesori-bridge/yaak.rq_NpmUa49kkF.yaml
@@ -2,9 +2,9 @@ type: http_request
 model: http_request
 id: rq_NpmUa49kkF
 createdAt: 2026-03-24T12:37:52.588724
-updatedAt: 2026-03-24T12:40:29.893862
+updatedAt: 2026-03-24T16:58:56.632747
 workspaceId: wk_rSi2KDTVqo
-folderId: null
+folderId: fl_KKPLMJLWXX
 authentication: {}
 authenticationType: null
 body: {}
@@ -13,14 +13,22 @@ description: ''
 headers:
 - enabled: true
   name: x-project-id
-  value: /Users/alexandrudochioiu/sesori-ai/sesori_apps_monorepo
+  value: ${[ project_id ]}
   id: jD0MEpp09G
 - enabled: true
   name: ''
   value: ''
-  id: FAWr8SZpk7
+  id: 5ekI0ZiiD4
 method: GET
 name: Session Messages
-sortPriority: 1000.0
-url: ${[ url ]}/session/ses_2e064c306ffeuie3U7eaFMPCr7/message
-urlParameters: []
+sortPriority: 2000.0
+url: ${[ url ]}/session/:sessionId/message
+urlParameters:
+- enabled: true
+  name: :sessionId
+  value: ses_2e064c306ffeuie3U7eaFMPCr7
+  id: 8uABx5Vc5b
+- enabled: true
+  name: ''
+  value: ''
+  id: 6VfTJNMXSz

--- a/bridge/app/yaak/sesori-bridge/yaak.rq_RcZLMX9F99.yaml
+++ b/bridge/app/yaak/sesori-bridge/yaak.rq_RcZLMX9F99.yaml
@@ -1,0 +1,26 @@
+type: http_request
+model: http_request
+id: rq_RcZLMX9F99
+createdAt: 2026-03-24T12:36:02.499026
+updatedAt: 2026-03-24T12:37:53.866253
+workspaceId: wk_rSi2KDTVqo
+folderId: null
+authentication: {}
+authenticationType: null
+body: {}
+bodyType: null
+description: ''
+headers:
+- enabled: true
+  name: x-project-id
+  value: /Users/alexandrudochioiu/sesori-ai/sesori_apps_monorepo
+  id: jD0MEpp09G
+- enabled: true
+  name: ''
+  value: ''
+  id: FAWr8SZpk7
+method: GET
+name: Sessions List
+sortPriority: 0.0
+url: ${[ url ]}/session
+urlParameters: []

--- a/bridge/app/yaak/sesori-bridge/yaak.rq_RcZLMX9F99.yaml
+++ b/bridge/app/yaak/sesori-bridge/yaak.rq_RcZLMX9F99.yaml
@@ -2,9 +2,9 @@ type: http_request
 model: http_request
 id: rq_RcZLMX9F99
 createdAt: 2026-03-24T12:36:02.499026
-updatedAt: 2026-03-24T12:37:53.866253
+updatedAt: 2026-03-24T16:58:56.628266
 workspaceId: wk_rSi2KDTVqo
-folderId: null
+folderId: fl_KKPLMJLWXX
 authentication: {}
 authenticationType: null
 body: {}
@@ -13,12 +13,12 @@ description: ''
 headers:
 - enabled: true
   name: x-project-id
-  value: /Users/alexandrudochioiu/sesori-ai/sesori_apps_monorepo
+  value: ${[ project_id ]}
   id: jD0MEpp09G
 - enabled: true
   name: ''
   value: ''
-  id: FAWr8SZpk7
+  id: uVuKUCuYeh
 method: GET
 name: Sessions List
 sortPriority: 0.0

--- a/bridge/app/yaak/sesori-bridge/yaak.rq_WweEAarGjT.yaml
+++ b/bridge/app/yaak/sesori-bridge/yaak.rq_WweEAarGjT.yaml
@@ -1,0 +1,34 @@
+type: http_request
+model: http_request
+id: rq_WweEAarGjT
+createdAt: 2026-03-24T12:41:13.132692
+updatedAt: 2026-03-24T12:57:55.289623
+workspaceId: wk_rSi2KDTVqo
+folderId: null
+authentication: {}
+authenticationType: null
+body: {}
+bodyType: null
+description: ''
+headers:
+- enabled: false
+  name: x-project-id
+  value: ''
+  id: jD0MEpp09G
+- enabled: true
+  name: ''
+  value: ''
+  id: Gw82u95vVu
+method: GET
+name: Questions List
+sortPriority: 0.001
+url: ${[ url ]}/session/:sessionId/questions
+urlParameters:
+- enabled: true
+  name: :sessionId
+  value: ses_2e064c306ffeuie3U7eaFMPCr7
+  id: c9PRk27rgZ
+- enabled: true
+  name: ''
+  value: ''
+  id: x0HXKDunQU

--- a/bridge/app/yaak/sesori-bridge/yaak.rq_WweEAarGjT.yaml
+++ b/bridge/app/yaak/sesori-bridge/yaak.rq_WweEAarGjT.yaml
@@ -2,9 +2,9 @@ type: http_request
 model: http_request
 id: rq_WweEAarGjT
 createdAt: 2026-03-24T12:41:13.132692
-updatedAt: 2026-03-24T12:57:55.289623
+updatedAt: 2026-03-24T16:58:56.631357
 workspaceId: wk_rSi2KDTVqo
-folderId: null
+folderId: fl_KKPLMJLWXX
 authentication: {}
 authenticationType: null
 body: {}
@@ -20,15 +20,15 @@ headers:
   value: ''
   id: Gw82u95vVu
 method: GET
-name: Questions List
-sortPriority: 0.001
+name: Session Questions
+sortPriority: 1000.0
 url: ${[ url ]}/session/:sessionId/questions
 urlParameters:
 - enabled: true
   name: :sessionId
-  value: ses_2e064c306ffeuie3U7eaFMPCr7
+  value: ${[ session_id ]}
   id: c9PRk27rgZ
 - enabled: true
   name: ''
   value: ''
-  id: x0HXKDunQU
+  id: 7nTj5dmytN

--- a/bridge/app/yaak/sesori-bridge/yaak.rq_h5rVJzSnNW.yaml
+++ b/bridge/app/yaak/sesori-bridge/yaak.rq_h5rVJzSnNW.yaml
@@ -1,0 +1,26 @@
+type: http_request
+model: http_request
+id: rq_h5rVJzSnNW
+createdAt: 2026-03-24T12:37:11.755433
+updatedAt: 2026-03-24T12:37:53.868176
+workspaceId: wk_rSi2KDTVqo
+folderId: null
+authentication: {}
+authenticationType: null
+body: {}
+bodyType: null
+description: ''
+headers:
+- enabled: false
+  name: x-project-id
+  value: ''
+  id: jD0MEpp09G
+- enabled: true
+  name: ''
+  value: ''
+  id: QT9Yw3QUcw
+method: GET
+name: Projects List
+sortPriority: 2000.0
+url: ${[ url ]}/project
+urlParameters: []

--- a/bridge/app/yaak/sesori-bridge/yaak.rq_h5rVJzSnNW.yaml
+++ b/bridge/app/yaak/sesori-bridge/yaak.rq_h5rVJzSnNW.yaml
@@ -2,25 +2,21 @@ type: http_request
 model: http_request
 id: rq_h5rVJzSnNW
 createdAt: 2026-03-24T12:37:11.755433
-updatedAt: 2026-03-24T12:37:53.868176
+updatedAt: 2026-03-24T16:58:14.516598
 workspaceId: wk_rSi2KDTVqo
-folderId: null
+folderId: fl_aDHUTwiwwj
 authentication: {}
 authenticationType: null
 body: {}
 bodyType: null
 description: ''
 headers:
-- enabled: false
-  name: x-project-id
-  value: ''
-  id: jD0MEpp09G
 - enabled: true
   name: ''
   value: ''
-  id: QT9Yw3QUcw
+  id: Vvzj8kX6z9
 method: GET
 name: Projects List
-sortPriority: 2000.0
+sortPriority: 0.0
 url: ${[ url ]}/project
 urlParameters: []

--- a/bridge/app/yaak/sesori-bridge/yaak.rq_vqVFwSgfCP.yaml
+++ b/bridge/app/yaak/sesori-bridge/yaak.rq_vqVFwSgfCP.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_vqVFwSgfCP
 createdAt: 2026-03-24T12:39:53.285069
-updatedAt: 2026-03-24T12:40:14.117085
+updatedAt: 2026-03-24T16:59:15.837214
 workspaceId: wk_rSi2KDTVqo
 folderId: null
 authentication: {}
@@ -11,16 +11,16 @@ body: {}
 bodyType: null
 description: ''
 headers:
-- enabled: false
+- enabled: true
   name: x-project-id
-  value: /Users/alexandrudochioiu/sesori-ai/sesori_apps_monorepo
-  id: jD0MEpp09G
+  value: ${[ project_id ]}
+  id: EIqfjEaXNX
 - enabled: true
   name: ''
   value: ''
-  id: QpwkcqaHaG
+  id: ve7GWShwjG
 method: GET
-name: Sessions Status
-sortPriority: 0.001
+name: All Sessions Status
+sortPriority: 3000.0
 url: ${[ url ]}/session/status
 urlParameters: []

--- a/bridge/app/yaak/sesori-bridge/yaak.rq_vqVFwSgfCP.yaml
+++ b/bridge/app/yaak/sesori-bridge/yaak.rq_vqVFwSgfCP.yaml
@@ -1,0 +1,26 @@
+type: http_request
+model: http_request
+id: rq_vqVFwSgfCP
+createdAt: 2026-03-24T12:39:53.285069
+updatedAt: 2026-03-24T12:40:14.117085
+workspaceId: wk_rSi2KDTVqo
+folderId: null
+authentication: {}
+authenticationType: null
+body: {}
+bodyType: null
+description: ''
+headers:
+- enabled: false
+  name: x-project-id
+  value: /Users/alexandrudochioiu/sesori-ai/sesori_apps_monorepo
+  id: jD0MEpp09G
+- enabled: true
+  name: ''
+  value: ''
+  id: QpwkcqaHaG
+method: GET
+name: Sessions Status
+sortPriority: 0.001
+url: ${[ url ]}/session/status
+urlParameters: []

--- a/bridge/app/yaak/sesori-bridge/yaak.wk_rSi2KDTVqo.yaml
+++ b/bridge/app/yaak/sesori-bridge/yaak.wk_rSi2KDTVqo.yaml
@@ -1,0 +1,15 @@
+type: workspace
+model: workspace
+id: wk_rSi2KDTVqo
+createdAt: 2026-03-24T12:35:58.650243
+updatedAt: 2026-03-24T12:35:58.650243
+authentication: {}
+authenticationType: null
+description: ''
+headers: []
+name: Sesori Bridge
+encryptionKeyChallenge: null
+settingValidateCertificates: true
+settingFollowRedirects: true
+settingRequestTimeout: 0
+settingDnsOverrides: []

--- a/mobile/app/test/features/session_list/session_list_cubit_test.dart
+++ b/mobile/app/test/features/session_list/session_list_cubit_test.dart
@@ -645,6 +645,101 @@ void main() {
     );
 
     // -------------------------------------------------------------------------
+    // SSE events from other projects are ignored
+    // -------------------------------------------------------------------------
+
+    blocTest<SessionListCubit, SessionListState>(
+      "SSE session.created for a different project is ignored",
+      build: () {
+        when(
+          () => mockSessionService.listSessions(projectId: projectId),
+        ).thenAnswer((_) async => ApiResponse.success([testSession(id: "s1")]));
+        return buildCubit();
+      },
+      act: (cubit) async {
+        await Future<void>.delayed(Duration.zero);
+        // Emit a session.created event for a different project.
+        eventController.add(
+          SseEvent(
+            data: SesoriSseEvent.sessionCreated(
+              info: const Session(
+                id: "foreign-session",
+                projectID: "project-other",
+                directory: "/other/project",
+                title: "Foreign Session",
+                time: SessionTime(created: 1, updated: 2),
+              ),
+            ),
+          ),
+        );
+        // Give the event time to be processed.
+        await Future<void>.delayed(Duration.zero);
+      },
+      skip: 1, // skip constructor's initial loaded emission
+      // No state changes — the foreign session must be ignored.
+      expect: () => <SessionListState>[],
+    );
+
+    blocTest<SessionListCubit, SessionListState>(
+      "SSE session.updated for a different project is ignored",
+      build: () {
+        when(
+          () => mockSessionService.listSessions(projectId: projectId),
+        ).thenAnswer((_) async => ApiResponse.success([testSession(id: "s1")]));
+        return buildCubit();
+      },
+      act: (cubit) async {
+        await Future<void>.delayed(Duration.zero);
+        // Emit a session.updated event for a different project.
+        eventController.add(
+          SseEvent(
+            data: SesoriSseEvent.sessionUpdated(
+              info: const Session(
+                id: "foreign-session",
+                projectID: "project-other",
+                directory: "/other/project",
+                title: "Foreign Session Updated",
+                time: SessionTime(created: 1, updated: 3),
+              ),
+            ),
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+      },
+      skip: 1,
+      expect: () => <SessionListState>[],
+    );
+
+    blocTest<SessionListCubit, SessionListState>(
+      "SSE session.deleted for a different project is ignored",
+      build: () {
+        when(
+          () => mockSessionService.listSessions(projectId: projectId),
+        ).thenAnswer((_) async => ApiResponse.success([testSession(id: "s1")]));
+        return buildCubit();
+      },
+      act: (cubit) async {
+        await Future<void>.delayed(Duration.zero);
+        // Emit a session.deleted event for a different project.
+        eventController.add(
+          SseEvent(
+            data: SesoriSseEvent.sessionDeleted(
+              info: const Session(
+                id: "foreign-session",
+                projectID: "project-other",
+                directory: "/other/project",
+                time: SessionTime(created: 1, updated: 2),
+              ),
+            ),
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+      },
+      skip: 1,
+      expect: () => <SessionListState>[],
+    );
+
+    // -------------------------------------------------------------------------
     // Root "global" project — sessions in subdirectories still belong here
     // -------------------------------------------------------------------------
 

--- a/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -68,8 +68,9 @@ class SessionListCubit extends Cubit<SessionListState> {
   }
 
   void _onSessionCreated(Session session) {
-    // Only add root sessions (server already filters by project via x-project-id header).
+    // Only add root sessions that belong to this project.
     if (session.parentID != null) return;
+    if (session.projectID != _projectId) return;
 
     if (state is! SessionListLoaded) return;
 
@@ -81,6 +82,7 @@ class SessionListCubit extends Cubit<SessionListState> {
   }
 
   void _onSessionUpdated(Session session) {
+    if (session.projectID != _projectId) return;
     if (state is! SessionListLoaded) return;
 
     final index = _allSessions.indexWhere((s) => s.id == session.id);
@@ -97,6 +99,7 @@ class SessionListCubit extends Cubit<SessionListState> {
   }
 
   void _onSessionDeleted(Session session) {
+    if (session.projectID != _projectId) return;
     if (state is! SessionListLoaded) return;
 
     final before = _allSessions.length;


### PR DESCRIPTION
## Summary

- **Bug**: SSE `session.created`/`updated`/`deleted` events from the global event stream were not filtered by project ID in `SessionListCubit`, causing sessions from other projects to appear in the session list when the AI was active on a different project.
- **Fix**: Added `session.projectID != _projectId` early-return guards to `_onSessionCreated`, `_onSessionUpdated`, and `_onSessionDeleted`. The `Session` model already carries `projectID`, so no model changes were needed.
- **Tests**: Added 3 blocTests verifying that session created/updated/deleted events for a different project are ignored (no state changes emitted).