### PR TITLE
feat(bridge): replace per-message push notifications with state-based session completion

### DIFF
--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -15,6 +15,7 @@ import 'package:sesori_bridge/src/bridge/relay_client.dart';
 import 'package:sesori_bridge/src/push/push_notification_client.dart';
 import 'package:sesori_bridge/src/push/push_notification_service.dart';
 import 'package:sesori_bridge/src/push/push_rate_limiter.dart';
+import 'package:sesori_bridge/src/push/push_session_state_tracker.dart';
 import 'package:sesori_bridge/src/server/process.dart';
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Log, LogLevel;
 
@@ -165,6 +166,7 @@ Future<void> main(List<String> args) async {
   final pushNotificationService = PushNotificationService(
     client: pushClient,
     rateLimiter: pushRateLimiter,
+    tracker: PushSessionStateTracker(),
   );
 
   final relayClient = RelayClient(relayURL: relayURL, accessTokenProvider: tokenManager);

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -12,6 +12,7 @@ import 'package:sesori_bridge/src/bridge/debug_server.dart';
 import 'package:sesori_bridge/src/bridge/models/bridge_config.dart';
 import 'package:sesori_bridge/src/bridge/orchestrator.dart';
 import 'package:sesori_bridge/src/bridge/relay_client.dart';
+import 'package:sesori_bridge/src/push/completion_notifier.dart';
 import 'package:sesori_bridge/src/push/push_notification_client.dart';
 import 'package:sesori_bridge/src/push/push_notification_service.dart';
 import 'package:sesori_bridge/src/push/push_rate_limiter.dart';
@@ -163,10 +164,16 @@ Future<void> main(List<String> args) async {
     tokenRefreshManager: tokenManager,
   );
   final pushRateLimiter = PushRateLimiter();
+  final pushSessionStateTracker = PushSessionStateTracker();
+  final completionNotifier = CompletionNotifier(
+    tracker: pushSessionStateTracker,
+    debounceDuration: const Duration(milliseconds: 500),
+  );
   final pushNotificationService = PushNotificationService(
     client: pushClient,
     rateLimiter: pushRateLimiter,
-    tracker: PushSessionStateTracker(),
+    tracker: pushSessionStateTracker,
+    completionNotifier: completionNotifier,
   );
 
   final relayClient = RelayClient(relayURL: relayURL, accessTokenProvider: tokenManager);

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -155,6 +155,7 @@ class OrchestratorSession {
 
         Log.w("Connection lost. Reconnecting...");
         _sseManager.stop();
+        _pushNotificationService.reset();
 
         var backoff = const Duration(seconds: 1);
         while (!_cancelled) {
@@ -189,6 +190,9 @@ class OrchestratorSession {
       Log.d("[dbg] stopping sse manager...");
       _sseManager.stop();
       Log.d("[dbg] sse manager stopped");
+      Log.d("[dbg] disposing push notification service...");
+      _pushNotificationService.dispose();
+      Log.d("[dbg] push notification service disposed");
       try {
         Log.d("[dbg] closing relay client...");
         await _client.close();

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -113,7 +113,7 @@ class OrchestratorSession {
           Log.v(
             "[sse] mapped to: ${sesoriEvent.runtimeType} — enqueuing (subscribers: ${_sseManager.subscriberCount})",
           );
-          _pushNotificationService.maybeSendForEvent(sesoriEvent);
+          _pushNotificationService.handleSseEvent(sesoriEvent);
           _sseManager.enqueueEvent(sesoriEvent);
         } else {
           Log.v("[sse] mapping returned null — event dropped");
@@ -191,7 +191,7 @@ class OrchestratorSession {
       _sseManager.stop();
       Log.d("[dbg] sse manager stopped");
       Log.d("[dbg] disposing push notification service...");
-      _pushNotificationService.dispose();
+      await _pushNotificationService.dispose();
       Log.d("[dbg] push notification service disposed");
       try {
         Log.d("[dbg] closing relay client...");

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -155,7 +155,6 @@ class OrchestratorSession {
 
         Log.w("Connection lost. Reconnecting...");
         _sseManager.stop();
-        _pushNotificationService.reset();
 
         var backoff = const Duration(seconds: 1);
         while (!_cancelled) {

--- a/bridge/app/lib/src/push/completion_notifier.dart
+++ b/bridge/app/lib/src/push/completion_notifier.dart
@@ -7,33 +7,36 @@ import "push_session_state_tracker.dart";
 /// Manages debounced "session completed" notifications.
 ///
 /// Tracks when session groups transition from busy to idle and fires
-/// a callback after a debounce period, provided no pending interactions
+/// a stream event after a debounce period, provided no pending interactions
 /// (questions/permissions) block it.
 class CompletionNotifier {
   final PushSessionStateTracker _tracker;
-  final void Function(String rootSessionId) _onCompletion;
   final Duration _debounceDuration;
+  final StreamController<String> _completionController = StreamController<String>.broadcast();
   final Map<String, Timer> _debounceTimers = {};
   final Set<String> _completionSentForRoots = {};
   final Map<String, String> _permissionRequestToSession = {};
 
+  Stream<String> get completions => _completionController.stream;
+
   CompletionNotifier({
     required PushSessionStateTracker tracker,
-    required void Function(String rootSessionId) onCompletion,
     Duration debounceDuration = const Duration(milliseconds: 500),
   }) : _tracker = tracker,
-       _onCompletion = onCompletion,
        _debounceDuration = debounceDuration;
 
   /// Process an SSE event for completion tracking.
   /// Call AFTER tracker.handleEvent() has already updated state.
   void handleEvent(SesoriSseEvent event) {
     switch (event) {
+      // A new question blocks completion for this session group.
       case SesoriQuestionAsked(:final sessionID):
         _cancelDebounceForSessionGroup(sessionID);
+      // A new permission request blocks completion for this session group.
       case SesoriPermissionAsked(:final requestID, :final sessionID):
         _permissionRequestToSession[requestID] = sessionID;
         _cancelDebounceForSessionGroup(sessionID);
+      // Session status transitions determine when completion can fire.
       case SesoriSessionStatus(:final sessionID, :final status):
         final rootSessionId = _tracker.resolveRootSessionId(sessionID);
         switch (status) {
@@ -44,39 +47,53 @@ class CompletionNotifier {
           case SessionStatusIdle():
             _maybeScheduleCompletion(sessionID);
         }
+      // Deletion clears any pending completion work for this session group.
       case SesoriSessionDeleted(:final info):
         _cancelDebounceForSessionGroup(info.id);
         _completionSentForRoots.remove(info.id);
         _permissionRequestToSession.removeWhere((_, sessionId) => sessionId == info.id);
+      // User already handled the question, so cancel any pending completion ping.
       case SesoriQuestionReplied(:final sessionID):
-        _maybeScheduleCompletion(sessionID);
+        _cancelDebounceForSessionGroup(sessionID);
+      // Rejected questions are also already seen by the user.
       case SesoriQuestionRejected(:final sessionID):
-        _maybeScheduleCompletion(sessionID);
+        _cancelDebounceForSessionGroup(sessionID);
+      // Permission replies are user actions, so cancel completion debounce.
       case SesoriPermissionReplied(:final requestID):
         final sessionId = _permissionRequestToSession.remove(requestID);
         if (sessionId != null) {
-          _maybeScheduleCompletion(sessionId);
+          _cancelDebounceForSessionGroup(sessionId);
         }
+      // Ignore unsupported events.
       default:
         break;
     }
   }
 
-  /// Cancel all timers.
+  /// Cancels all timers and closes the completion stream.
   void dispose() {
+    _cancelAllDebounceTimers();
+    if (!_completionController.isClosed) {
+      _completionController.close();
+    }
+  }
+
+  /// Clears debounce state but keeps the completion stream open.
+  void reset() {
+    _cancelAllDebounceTimers();
+    _completionSentForRoots.clear();
+    _permissionRequestToSession.clear();
+  }
+
+  /// Cancels every active debounce timer.
+  void _cancelAllDebounceTimers() {
     for (final timer in _debounceTimers.values) {
       timer.cancel();
     }
     _debounceTimers.clear();
   }
 
-  /// Cancel all timers and clear internal state.
-  void reset() {
-    dispose();
-    _completionSentForRoots.clear();
-    _permissionRequestToSession.clear();
-  }
-
+  /// Schedules (or reschedules) completion emission for [sessionId]'s root.
   void _maybeScheduleCompletion(String sessionId) {
     final rootSessionId = _tracker.resolveRootSessionId(sessionId);
     if (!_shouldTriggerCompletion(rootSessionId)) {
@@ -90,11 +107,15 @@ class CompletionNotifier {
       if (!_shouldTriggerCompletion(rootSessionId)) {
         return;
       }
-      _onCompletion(rootSessionId);
+      if (_completionController.isClosed) {
+        return;
+      }
+      _completionController.add(rootSessionId);
       _completionSentForRoots.add(rootSessionId);
     });
   }
 
+  /// Returns true when completion notification criteria are satisfied.
   bool _shouldTriggerCompletion(String rootSessionId) {
     return _tracker.wasPreviouslyBusy(rootSessionId) &&
         _tracker.isSessionGroupFullyIdle(rootSessionId) &&
@@ -102,14 +123,18 @@ class CompletionNotifier {
         !_completionSentForRoots.contains(rootSessionId);
   }
 
+  /// Cancels debounce timers for a session and its current root session.
   void _cancelDebounceForSessionGroup(String sessionId) {
     final rootSessionId = _tracker.resolveRootSessionId(sessionId);
     _cancelDebounceForRoot(rootSessionId);
     if (rootSessionId != sessionId) {
+      // Also cancel any timer for sessionId itself, in case it was
+      // previously a root and has since been reparented.
       _cancelDebounceForRoot(sessionId);
     }
   }
 
+  /// Cancels and removes a single root debounce timer.
   void _cancelDebounceForRoot(String rootSessionId) {
     final timer = _debounceTimers.remove(rootSessionId);
     timer?.cancel();

--- a/bridge/app/lib/src/push/completion_notifier.dart
+++ b/bridge/app/lib/src/push/completion_notifier.dart
@@ -1,0 +1,117 @@
+import "dart:async";
+
+import "package:sesori_shared/sesori_shared.dart";
+
+import "push_session_state_tracker.dart";
+
+/// Manages debounced "session completed" notifications.
+///
+/// Tracks when session groups transition from busy to idle and fires
+/// a callback after a debounce period, provided no pending interactions
+/// (questions/permissions) block it.
+class CompletionNotifier {
+  final PushSessionStateTracker _tracker;
+  final void Function(String rootSessionId) _onCompletion;
+  final Duration _debounceDuration;
+  final Map<String, Timer> _debounceTimers = {};
+  final Set<String> _completionSentForRoots = {};
+  final Map<String, String> _permissionRequestToSession = {};
+
+  CompletionNotifier({
+    required PushSessionStateTracker tracker,
+    required void Function(String rootSessionId) onCompletion,
+    Duration debounceDuration = const Duration(milliseconds: 500),
+  }) : _tracker = tracker,
+       _onCompletion = onCompletion,
+       _debounceDuration = debounceDuration;
+
+  /// Process an SSE event for completion tracking.
+  /// Call AFTER tracker.handleEvent() has already updated state.
+  void handleEvent(SesoriSseEvent event) {
+    switch (event) {
+      case SesoriQuestionAsked(:final sessionID):
+        _cancelDebounceForSessionGroup(sessionID);
+      case SesoriPermissionAsked(:final requestID, :final sessionID):
+        _permissionRequestToSession[requestID] = sessionID;
+        _cancelDebounceForSessionGroup(sessionID);
+      case SesoriSessionStatus(:final sessionID, :final status):
+        final rootSessionId = _tracker.resolveRootSessionId(sessionID);
+        switch (status) {
+          case SessionStatusBusy():
+          case SessionStatusRetry():
+            _completionSentForRoots.remove(rootSessionId);
+            _cancelDebounceForRoot(rootSessionId);
+          case SessionStatusIdle():
+            _maybeScheduleCompletion(sessionID);
+        }
+      case SesoriSessionDeleted(:final info):
+        _cancelDebounceForSessionGroup(info.id);
+        _completionSentForRoots.remove(info.id);
+        _permissionRequestToSession.removeWhere((_, sessionId) => sessionId == info.id);
+      case SesoriQuestionReplied(:final sessionID):
+        _maybeScheduleCompletion(sessionID);
+      case SesoriQuestionRejected(:final sessionID):
+        _maybeScheduleCompletion(sessionID);
+      case SesoriPermissionReplied(:final requestID):
+        final sessionId = _permissionRequestToSession.remove(requestID);
+        if (sessionId != null) {
+          _maybeScheduleCompletion(sessionId);
+        }
+      default:
+        break;
+    }
+  }
+
+  /// Cancel all timers.
+  void dispose() {
+    for (final timer in _debounceTimers.values) {
+      timer.cancel();
+    }
+    _debounceTimers.clear();
+  }
+
+  /// Cancel all timers and clear internal state.
+  void reset() {
+    dispose();
+    _completionSentForRoots.clear();
+    _permissionRequestToSession.clear();
+  }
+
+  void _maybeScheduleCompletion(String sessionId) {
+    final rootSessionId = _tracker.resolveRootSessionId(sessionId);
+    if (!_shouldTriggerCompletion(rootSessionId)) {
+      _cancelDebounceForRoot(rootSessionId);
+      return;
+    }
+
+    _debounceTimers[rootSessionId]?.cancel();
+    _debounceTimers[rootSessionId] = Timer(_debounceDuration, () {
+      _debounceTimers.remove(rootSessionId);
+      if (!_shouldTriggerCompletion(rootSessionId)) {
+        return;
+      }
+      _onCompletion(rootSessionId);
+      _completionSentForRoots.add(rootSessionId);
+    });
+  }
+
+  bool _shouldTriggerCompletion(String rootSessionId) {
+    return _tracker.wasPreviouslyBusy(rootSessionId) &&
+        _tracker.isSessionGroupFullyIdle(rootSessionId) &&
+        !_tracker.hasPendingInteraction(rootSessionId) &&
+        !_completionSentForRoots.contains(rootSessionId);
+  }
+
+  void _cancelDebounceForSessionGroup(String sessionId) {
+    final rootSessionId = _tracker.resolveRootSessionId(sessionId);
+    _cancelDebounceForRoot(rootSessionId);
+    if (rootSessionId != sessionId) {
+      _cancelDebounceForRoot(sessionId);
+    }
+  }
+
+  void _cancelDebounceForRoot(String rootSessionId) {
+    final timer = _debounceTimers.remove(rootSessionId);
+    timer?.cancel();
+  }
+}

--- a/bridge/app/lib/src/push/push_notification_service.dart
+++ b/bridge/app/lib/src/push/push_notification_service.dart
@@ -15,33 +15,29 @@ class PushNotificationService {
   final PushNotificationClient _client;
   final PushRateLimiter _rateLimiter;
   final PushSessionStateTracker _tracker;
-  late final CompletionNotifier _completionNotifier;
+  final CompletionNotifier _completionNotifier;
+  late final StreamSubscription<String> _completionSubscription;
 
   PushNotificationService({
     required PushNotificationClient client,
     required PushRateLimiter rateLimiter,
     required PushSessionStateTracker tracker,
-    Duration debounceDuration = const Duration(milliseconds: 500),
-    CompletionNotifier? completionNotifier,
+    required CompletionNotifier completionNotifier,
   }) : _client = client,
        _rateLimiter = rateLimiter,
-       _tracker = tracker {
-    _completionNotifier =
-        completionNotifier ??
-        CompletionNotifier(
-          tracker: _tracker,
-          debounceDuration: debounceDuration,
-          onCompletion: _sendCompletionNotification,
-        );
+       _tracker = tracker,
+       _completionNotifier = completionNotifier {
+    _completionSubscription = _completionNotifier.completions.listen(_sendCompletionNotification);
   }
 
-  void maybeSendForEvent(SesoriSseEvent event) {
+  void handleSseEvent(SesoriSseEvent event) {
     _tracker.handleEvent(event);
     _completionNotifier.handleEvent(event);
     _sendImmediateNotificationIfApplicable(event);
   }
 
-  void dispose() {
+  Future<void> dispose() async {
+    await _completionSubscription.cancel();
     _completionNotifier.dispose();
   }
 
@@ -78,7 +74,7 @@ class PushNotificationService {
 
     _sendNotification(
       category: NotificationCategory.sessionMessage,
-      eventType: NotificationEventType.sessionCompleted,
+      eventType: NotificationEventType.agentTurnCompleted,
       title: title,
       body: body,
       sessionId: rootSessionId,

--- a/bridge/app/lib/src/push/push_notification_service.dart
+++ b/bridge/app/lib/src/push/push_notification_service.dart
@@ -5,30 +5,96 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../auth/token_refresh_exception.dart";
+import "completion_notifier.dart";
 import "push_notification_client.dart";
 import "push_rate_limiter.dart";
 import "push_send_exception.dart";
+import "push_session_state_tracker.dart";
 
 class PushNotificationService {
   final PushNotificationClient _client;
   final PushRateLimiter _rateLimiter;
+  final PushSessionStateTracker _tracker;
+  late final CompletionNotifier _completionNotifier;
 
   PushNotificationService({
     required PushNotificationClient client,
     required PushRateLimiter rateLimiter,
+    required PushSessionStateTracker tracker,
+    Duration debounceDuration = const Duration(milliseconds: 500),
+    CompletionNotifier? completionNotifier,
   }) : _client = client,
-       _rateLimiter = rateLimiter;
+       _rateLimiter = rateLimiter,
+       _tracker = tracker {
+    _completionNotifier =
+        completionNotifier ??
+        CompletionNotifier(
+          tracker: _tracker,
+          debounceDuration: debounceDuration,
+          onCompletion: _sendCompletionNotification,
+        );
+  }
 
   void maybeSendForEvent(SesoriSseEvent event) {
+    _tracker.handleEvent(event);
+    _completionNotifier.handleEvent(event);
+    _sendImmediateNotificationIfApplicable(event);
+  }
+
+  void dispose() {
+    _completionNotifier.dispose();
+  }
+
+  void reset() {
+    _completionNotifier.reset();
+    _tracker.reset();
+  }
+
+  void _sendImmediateNotificationIfApplicable(SesoriSseEvent event) {
     final notificationData = extractNotificationData(event);
     if (notificationData == null) {
       return;
     }
 
-    final sessionId = extractSessionId(event);
-    final collapseKey = "${notificationData.category.id}-${sessionId ?? "global"}";
-    if (!_rateLimiter.shouldSend(
+    _sendNotification(
       category: notificationData.category,
+      eventType: notificationData.eventType,
+      title: notificationData.title,
+      body: notificationData.body,
+      sessionId: extractSessionId(event),
+    );
+  }
+
+  void _sendCompletionNotification(String rootSessionId) {
+    final sessionTitle = _tracker.getSessionTitle(rootSessionId);
+    final latestAssistantText = _tracker.getLatestAssistantText(rootSessionId);
+
+    final title = truncateTitle(
+      (sessionTitle == null || sessionTitle.trim().isEmpty) ? "Session completed" : sessionTitle,
+    );
+    final body = truncateToWords(
+      (latestAssistantText == null || latestAssistantText.trim().isEmpty) ? "Task completed" : latestAssistantText,
+    );
+
+    _sendNotification(
+      category: NotificationCategory.sessionMessage,
+      eventType: NotificationEventType.sessionCompleted,
+      title: title,
+      body: body,
+      sessionId: rootSessionId,
+    );
+  }
+
+  void _sendNotification({
+    required NotificationCategory category,
+    required NotificationEventType eventType,
+    required String title,
+    required String body,
+    required String? sessionId,
+  }) {
+    final collapseKey = "${category.id}-${sessionId ?? "global"}";
+    if (!_rateLimiter.shouldSend(
+      category: category,
       collapseKey: collapseKey,
       sessionId: sessionId,
     )) {
@@ -36,10 +102,10 @@ class PushNotificationService {
     }
 
     final payload = buildNotificationPayload(
-      category: notificationData.category,
-      eventType: notificationData.eventType,
-      title: notificationData.title,
-      body: notificationData.body,
+      category: category,
+      eventType: eventType,
+      title: title,
+      body: body,
       sessionId: sessionId,
       collapseKey: collapseKey,
     );
@@ -54,6 +120,28 @@ class PushNotificationService {
       }),
     );
   }
+}
+
+@visibleForTesting
+String truncateTitle(String title, {int maxChars = 50}) {
+  final normalized = title.trim();
+  if (normalized.length <= maxChars) {
+    return normalized;
+  }
+
+  final cutoffIndex = normalized.lastIndexOf(" ", maxChars);
+  final safeCutoff = cutoffIndex > 0 ? cutoffIndex : maxChars;
+  return "${normalized.substring(0, safeCutoff).trimRight()}...";
+}
+
+@visibleForTesting
+String truncateToWords(String text, {int maxWords = 10}) {
+  final words = text.trim().split(RegExp(r"\s+")).where((word) => word.isNotEmpty).toList();
+  if (words.length <= maxWords) {
+    return words.join(" ");
+  }
+
+  return "${words.take(maxWords).join(" ")}...";
 }
 
 @visibleForTesting
@@ -76,12 +164,6 @@ extractNotificationData(SesoriSseEvent event) {
       eventType: NotificationEventType.permissionAsked,
       title: "Permission requested",
       body: description.isNotEmpty ? description : "The assistant requested permission to run $tool.",
-    ),
-    SesoriMessageUpdated(:final info) => (
-      category: NotificationCategory.sessionMessage,
-      eventType: NotificationEventType.messageUpdated,
-      title: "New session message",
-      body: "${info.role} updated message ${info.id}",
     ),
     SesoriInstallationUpdateAvailable(:final version) => (
       category: NotificationCategory.systemUpdate,

--- a/bridge/app/lib/src/push/push_session_state_tracker.dart
+++ b/bridge/app/lib/src/push/push_session_state_tracker.dart
@@ -1,16 +1,11 @@
+import "dart:collection";
+
 import "package:sesori_shared/sesori_shared.dart";
 
 class PushSessionStateTracker {
-  final Map<String, SessionStatus> _sessionStatuses = {};
-  final Map<String, String?> _sessionParentIds = {};
-  final Map<String, Set<String>> _sessionChildren = {};
-  final Map<String, String> _sessionTitles = {};
+  final Map<String, _SessionState> _sessions = {};
   final Map<String, String> _messageRoles = {};
-  final Map<String, String> _latestAssistantText = {};
-  final Set<String> _pendingQuestions = {};
-  final Set<String> _pendingPermissions = {};
   final Map<String, String> _permissionRequestToSession = {};
-  final Set<String> _previouslyBusy = {};
 
   PushSessionStateTracker();
 
@@ -25,11 +20,15 @@ class PushSessionStateTracker {
       case SesoriSessionStatus(:final sessionID, :final status):
         switch (status) {
           case SessionStatusIdle():
-            _sessionStatuses.remove(sessionID);
+            final sessionState = _sessions[sessionID];
+            if (sessionState != null) {
+              sessionState.status = null;
+            }
           case SessionStatusBusy():
           case SessionStatusRetry():
-            _sessionStatuses[sessionID] = status;
-            _previouslyBusy.add(sessionID);
+            final sessionState = _stateForWrite(sessionID);
+            sessionState.status = status;
+            sessionState.previouslyBusy = true;
         }
       case SesoriMessageUpdated(:final info):
         _messageRoles[info.id] = info.role;
@@ -38,18 +37,27 @@ class PushSessionStateTracker {
       case SesoriMessagePartUpdated(:final part):
         _handleMessagePartUpdated(part);
       case SesoriQuestionAsked(:final sessionID):
-        _pendingQuestions.add(sessionID);
+        _stateForWrite(sessionID).hasPendingQuestion = true;
       case SesoriQuestionReplied(:final sessionID):
-        _pendingQuestions.remove(sessionID);
+        final sessionState = _sessions[sessionID];
+        if (sessionState != null) {
+          sessionState.hasPendingQuestion = false;
+        }
       case SesoriQuestionRejected(:final sessionID):
-        _pendingQuestions.remove(sessionID);
+        final sessionState = _sessions[sessionID];
+        if (sessionState != null) {
+          sessionState.hasPendingQuestion = false;
+        }
       case SesoriPermissionAsked(:final requestID, :final sessionID):
         _permissionRequestToSession[requestID] = sessionID;
-        _pendingPermissions.add(sessionID);
+        _stateForWrite(sessionID).hasPendingPermission = true;
       case SesoriPermissionReplied(:final requestID):
         final sessionID = _permissionRequestToSession.remove(requestID);
         if (sessionID != null) {
-          _pendingPermissions.remove(sessionID);
+          final sessionState = _sessions[sessionID];
+          if (sessionState != null) {
+            sessionState.hasPendingPermission = false;
+          }
         }
       default:
         break;
@@ -57,48 +65,67 @@ class PushSessionStateTracker {
   }
 
   bool isSessionGroupFullyIdle(String sessionId) {
-    if (_sessionStatuses.containsKey(sessionId)) {
-      return false;
-    }
-    final children = _sessionChildren[sessionId];
-    if (children == null || children.isEmpty) {
-      return true;
-    }
-    for (final childId in children) {
-      if (_sessionStatuses.containsKey(childId)) {
+    final queue = Queue<String>()..add(sessionId);
+    final visited = <String>{};
+
+    while (queue.isNotEmpty) {
+      final currentId = queue.removeFirst();
+      if (!visited.add(currentId)) {
+        continue;
+      }
+
+      final sessionState = _sessions[currentId];
+      if (sessionState == null) {
+        continue;
+      }
+
+      if (sessionState.status != null) {
         return false;
       }
+
+      queue.addAll(sessionState.childIds);
     }
+
     return true;
   }
 
-  /// True if [sessionId] or any of its direct children has a pending
+  /// True if [sessionId] or any of its descendants has a pending
   /// question or permission.
   bool hasPendingInteraction(String sessionId) {
-    if (_pendingQuestions.contains(sessionId) || _pendingPermissions.contains(sessionId)) {
-      return true;
-    }
-    final children = _sessionChildren[sessionId];
-    if (children != null) {
-      for (final childId in children) {
-        if (_pendingQuestions.contains(childId) || _pendingPermissions.contains(childId)) {
-          return true;
-        }
+    final queue = Queue<String>()..add(sessionId);
+    final visited = <String>{};
+
+    while (queue.isNotEmpty) {
+      final currentId = queue.removeFirst();
+      if (!visited.add(currentId)) {
+        continue;
       }
+
+      final sessionState = _sessions[currentId];
+      if (sessionState == null) {
+        continue;
+      }
+
+      if (sessionState.hasPendingQuestion || sessionState.hasPendingPermission) {
+        return true;
+      }
+
+      queue.addAll(sessionState.childIds);
     }
+
     return false;
   }
 
   bool wasPreviouslyBusy(String sessionId) {
-    return _previouslyBusy.contains(sessionId);
+    return _sessions[sessionId]?.previouslyBusy ?? false;
   }
 
   String? getSessionTitle(String sessionId) {
-    return _sessionTitles[sessionId];
+    return _sessions[sessionId]?.title;
   }
 
   String? getLatestAssistantText(String sessionId) {
-    return _latestAssistantText[sessionId];
+    return _sessions[sessionId]?.latestAssistantText;
   }
 
   String resolveRootSessionId(String sessionId) {
@@ -110,12 +137,12 @@ class PushSessionStateTracker {
         return current;
       }
 
-      final parentId = _sessionParentIds[current];
+      final parentId = _sessions[current]?.parentId;
       if (parentId == null) {
         return current;
       }
 
-      if (!_sessionParentIds.containsKey(parentId)) {
+      if (!_sessions.containsKey(parentId)) {
         return current;
       }
 
@@ -124,68 +151,45 @@ class PushSessionStateTracker {
   }
 
   void reset() {
-    _sessionStatuses.clear();
-    _sessionParentIds.clear();
-    _sessionChildren.clear();
-    _sessionTitles.clear();
+    _sessions.clear();
     _messageRoles.clear();
-    _latestAssistantText.clear();
-    _pendingQuestions.clear();
-    _pendingPermissions.clear();
     _permissionRequestToSession.clear();
-    _previouslyBusy.clear();
   }
 
   void _upsertSession(Session session) {
     final sessionId = session.id;
-    final prevParentId = _sessionParentIds[sessionId];
+    final sessionState = _stateForWrite(sessionId);
+    final prevParentId = sessionState.parentId;
     final nextParentId = session.parentID;
 
     if (prevParentId != null && prevParentId != nextParentId) {
-      final siblings = _sessionChildren[prevParentId];
-      siblings?.remove(sessionId);
-      if (siblings != null && siblings.isEmpty) {
-        _sessionChildren.remove(prevParentId);
+      _sessions[prevParentId]?.childIds.remove(sessionId);
+    }
+
+    sessionState.parentId = nextParentId;
+
+    if (nextParentId != null) {
+      final parentState = _sessions[nextParentId];
+      if (parentState != null) {
+        parentState.childIds.add(sessionId);
       }
     }
 
-    _sessionParentIds[sessionId] = nextParentId;
+    sessionState.title = session.title;
 
-    if (nextParentId != null) {
-      _sessionChildren.putIfAbsent(nextParentId, () => <String>{}).add(sessionId);
-    }
-
-    final title = session.title;
-    if (title == null) {
-      _sessionTitles.remove(sessionId);
-    } else {
-      _sessionTitles[sessionId] = title;
-    }
+    _rebuildChildLinksForParent(sessionId);
   }
 
   void _deleteSession(String sessionId) {
-    final parentId = _sessionParentIds.remove(sessionId);
-    if (parentId != null) {
-      final siblings = _sessionChildren[parentId];
-      siblings?.remove(sessionId);
-      if (siblings != null && siblings.isEmpty) {
-        _sessionChildren.remove(parentId);
+    _sessions.remove(sessionId);
+
+    for (final sessionState in _sessions.values) {
+      sessionState.childIds.remove(sessionId);
+      if (sessionState.parentId == sessionId) {
+        sessionState.parentId = null;
       }
     }
 
-    final children = _sessionChildren.remove(sessionId);
-    if (children != null) {
-      for (final childId in children) {
-        _sessionParentIds[childId] = null;
-      }
-    }
-
-    _sessionStatuses.remove(sessionId);
-    _sessionTitles.remove(sessionId);
-    _latestAssistantText.remove(sessionId);
-    _pendingQuestions.remove(sessionId);
-    _pendingPermissions.remove(sessionId);
-    _previouslyBusy.remove(sessionId);
     _permissionRequestToSession.removeWhere((_, value) => value == sessionId);
   }
 
@@ -198,6 +202,35 @@ class PushSessionStateTracker {
       return;
     }
 
-    _latestAssistantText[part.sessionID] = part.text ?? "";
+    _stateForWrite(part.sessionID).latestAssistantText = part.text ?? "";
   }
+
+  _SessionState _stateForWrite(String sessionId) {
+    return _sessions.putIfAbsent(sessionId, _SessionState.new);
+  }
+
+  void _rebuildChildLinksForParent(String parentId) {
+    final parentState = _sessions[parentId];
+    if (parentState == null) {
+      return;
+    }
+
+    parentState.childIds.removeWhere((childId) => _sessions[childId]?.parentId != parentId);
+    for (final entry in _sessions.entries) {
+      if (entry.value.parentId == parentId) {
+        parentState.childIds.add(entry.key);
+      }
+    }
+  }
+}
+
+class _SessionState {
+  String? parentId;
+  String? title;
+  SessionStatus? status;
+  bool previouslyBusy = false;
+  final Set<String> childIds = <String>{};
+  String? latestAssistantText;
+  bool hasPendingQuestion = false;
+  bool hasPendingPermission = false;
 }

--- a/bridge/app/lib/src/push/push_session_state_tracker.dart
+++ b/bridge/app/lib/src/push/push_session_state_tracker.dart
@@ -1,0 +1,203 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+class PushSessionStateTracker {
+  final Map<String, SessionStatus> _sessionStatuses = {};
+  final Map<String, String?> _sessionParentIds = {};
+  final Map<String, Set<String>> _sessionChildren = {};
+  final Map<String, String> _sessionTitles = {};
+  final Map<String, String> _messageRoles = {};
+  final Map<String, String> _latestAssistantText = {};
+  final Set<String> _pendingQuestions = {};
+  final Set<String> _pendingPermissions = {};
+  final Map<String, String> _permissionRequestToSession = {};
+  final Set<String> _previouslyBusy = {};
+
+  PushSessionStateTracker();
+
+  void handleEvent(SesoriSseEvent event) {
+    switch (event) {
+      case SesoriSessionCreated(:final info):
+        _upsertSession(info);
+      case SesoriSessionUpdated(:final info):
+        _upsertSession(info);
+      case SesoriSessionDeleted(:final info):
+        _deleteSession(info.id);
+      case SesoriSessionStatus(:final sessionID, :final status):
+        switch (status) {
+          case SessionStatusIdle():
+            _sessionStatuses.remove(sessionID);
+          case SessionStatusBusy():
+          case SessionStatusRetry():
+            _sessionStatuses[sessionID] = status;
+            _previouslyBusy.add(sessionID);
+        }
+      case SesoriMessageUpdated(:final info):
+        _messageRoles[info.id] = info.role;
+      case SesoriMessageRemoved(:final messageID):
+        _messageRoles.remove(messageID);
+      case SesoriMessagePartUpdated(:final part):
+        _handleMessagePartUpdated(part);
+      case SesoriQuestionAsked(:final sessionID):
+        _pendingQuestions.add(sessionID);
+      case SesoriQuestionReplied(:final sessionID):
+        _pendingQuestions.remove(sessionID);
+      case SesoriQuestionRejected(:final sessionID):
+        _pendingQuestions.remove(sessionID);
+      case SesoriPermissionAsked(:final requestID, :final sessionID):
+        _permissionRequestToSession[requestID] = sessionID;
+        _pendingPermissions.add(sessionID);
+      case SesoriPermissionReplied(:final requestID):
+        final sessionID = _permissionRequestToSession.remove(requestID);
+        if (sessionID != null) {
+          _pendingPermissions.remove(sessionID);
+        }
+      default:
+        break;
+    }
+  }
+
+  bool isSessionGroupFullyIdle(String sessionId) {
+    if (_sessionStatuses.containsKey(sessionId)) {
+      return false;
+    }
+    final children = _sessionChildren[sessionId];
+    if (children == null || children.isEmpty) {
+      return true;
+    }
+    for (final childId in children) {
+      if (_sessionStatuses.containsKey(childId)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// True if [sessionId] or any of its direct children has a pending
+  /// question or permission.
+  bool hasPendingInteraction(String sessionId) {
+    if (_pendingQuestions.contains(sessionId) || _pendingPermissions.contains(sessionId)) {
+      return true;
+    }
+    final children = _sessionChildren[sessionId];
+    if (children != null) {
+      for (final childId in children) {
+        if (_pendingQuestions.contains(childId) || _pendingPermissions.contains(childId)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  bool wasPreviouslyBusy(String sessionId) {
+    return _previouslyBusy.contains(sessionId);
+  }
+
+  String? getSessionTitle(String sessionId) {
+    return _sessionTitles[sessionId];
+  }
+
+  String? getLatestAssistantText(String sessionId) {
+    return _latestAssistantText[sessionId];
+  }
+
+  String resolveRootSessionId(String sessionId) {
+    var current = sessionId;
+    final visited = <String>{};
+
+    while (true) {
+      if (!visited.add(current)) {
+        return current;
+      }
+
+      final parentId = _sessionParentIds[current];
+      if (parentId == null) {
+        return current;
+      }
+
+      if (!_sessionParentIds.containsKey(parentId)) {
+        return current;
+      }
+
+      current = parentId;
+    }
+  }
+
+  void reset() {
+    _sessionStatuses.clear();
+    _sessionParentIds.clear();
+    _sessionChildren.clear();
+    _sessionTitles.clear();
+    _messageRoles.clear();
+    _latestAssistantText.clear();
+    _pendingQuestions.clear();
+    _pendingPermissions.clear();
+    _permissionRequestToSession.clear();
+    _previouslyBusy.clear();
+  }
+
+  void _upsertSession(Session session) {
+    final sessionId = session.id;
+    final prevParentId = _sessionParentIds[sessionId];
+    final nextParentId = session.parentID;
+
+    if (prevParentId != null && prevParentId != nextParentId) {
+      final siblings = _sessionChildren[prevParentId];
+      siblings?.remove(sessionId);
+      if (siblings != null && siblings.isEmpty) {
+        _sessionChildren.remove(prevParentId);
+      }
+    }
+
+    _sessionParentIds[sessionId] = nextParentId;
+
+    if (nextParentId != null) {
+      _sessionChildren.putIfAbsent(nextParentId, () => <String>{}).add(sessionId);
+    }
+
+    final title = session.title;
+    if (title == null) {
+      _sessionTitles.remove(sessionId);
+    } else {
+      _sessionTitles[sessionId] = title;
+    }
+  }
+
+  void _deleteSession(String sessionId) {
+    final parentId = _sessionParentIds.remove(sessionId);
+    if (parentId != null) {
+      final siblings = _sessionChildren[parentId];
+      siblings?.remove(sessionId);
+      if (siblings != null && siblings.isEmpty) {
+        _sessionChildren.remove(parentId);
+      }
+    }
+
+    final children = _sessionChildren.remove(sessionId);
+    if (children != null) {
+      for (final childId in children) {
+        _sessionParentIds[childId] = null;
+      }
+    }
+
+    _sessionStatuses.remove(sessionId);
+    _sessionTitles.remove(sessionId);
+    _latestAssistantText.remove(sessionId);
+    _pendingQuestions.remove(sessionId);
+    _pendingPermissions.remove(sessionId);
+    _previouslyBusy.remove(sessionId);
+    _permissionRequestToSession.removeWhere((_, value) => value == sessionId);
+  }
+
+  void _handleMessagePartUpdated(MessagePart part) {
+    if (part.type != "text") {
+      return;
+    }
+
+    if (_messageRoles[part.messageID] != "assistant") {
+      return;
+    }
+
+    _latestAssistantText[part.sessionID] = part.text ?? "";
+  }
+}

--- a/bridge/app/lib/src/push/push_session_state_tracker.dart
+++ b/bridge/app/lib/src/push/push_session_state_tracker.dart
@@ -116,8 +116,30 @@ class PushSessionStateTracker {
     return false;
   }
 
+  /// True if [sessionId] or any of its descendants was previously busy.
   bool wasPreviouslyBusy(String sessionId) {
-    return _sessions[sessionId]?.previouslyBusy ?? false;
+    final queue = Queue<String>()..add(sessionId);
+    final visited = <String>{};
+
+    while (queue.isNotEmpty) {
+      final currentId = queue.removeFirst();
+      if (!visited.add(currentId)) {
+        continue;
+      }
+
+      final sessionState = _sessions[currentId];
+      if (sessionState == null) {
+        continue;
+      }
+
+      if (sessionState.previouslyBusy) {
+        return true;
+      }
+
+      queue.addAll(sessionState.childIds);
+    }
+
+    return false;
   }
 
   String? getSessionTitle(String sessionId) {

--- a/bridge/app/test/push/completion_notifier_test.dart
+++ b/bridge/app/test/push/completion_notifier_test.dart
@@ -6,7 +6,7 @@ import "package:test/test.dart";
 
 void main() {
   group("CompletionNotifier", () {
-    test("idle after busy fires callback after debounce", () {
+    test("idle after busy emits completion after debounce", () {
       fakeAsync((async) {
         final harness = _newHarness();
 
@@ -18,9 +18,11 @@ void main() {
         );
 
         async.elapse(const Duration(milliseconds: 499));
+        async.flushMicrotasks();
         expect(harness.completedRoots, isEmpty);
 
         async.elapse(const Duration(milliseconds: 1));
+        async.flushMicrotasks();
         expect(harness.completedRoots, equals(["session-a"]));
       });
     });
@@ -36,6 +38,7 @@ void main() {
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 200));
+        async.flushMicrotasks();
 
         harness.dispatch(
           const SesoriSseEvent.questionAsked(
@@ -46,6 +49,7 @@ void main() {
         );
 
         async.elapse(const Duration(milliseconds: 800));
+        async.flushMicrotasks();
         expect(harness.completedRoots, isEmpty);
       });
     });
@@ -61,6 +65,7 @@ void main() {
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 200));
+        async.flushMicrotasks();
 
         harness.dispatch(
           const SesoriSseEvent.permissionAsked(
@@ -72,6 +77,7 @@ void main() {
         );
 
         async.elapse(const Duration(milliseconds: 800));
+        async.flushMicrotasks();
         expect(harness.completedRoots, isEmpty);
       });
     });
@@ -87,12 +93,14 @@ void main() {
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 200));
+        async.flushMicrotasks();
 
         harness.dispatch(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
         );
 
         async.elapse(const Duration(milliseconds: 800));
+        async.flushMicrotasks();
         expect(harness.completedRoots, isEmpty);
       });
     });
@@ -110,15 +118,17 @@ void main() {
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 200));
+        async.flushMicrotasks();
 
         harness.dispatch(SesoriSseEvent.sessionDeleted(info: session));
 
         async.elapse(const Duration(milliseconds: 800));
+        async.flushMicrotasks();
         expect(harness.completedRoots, isEmpty);
       });
     });
 
-    test("question replied re-evaluates and schedules completion", () {
+    test("question replied cancels any pending completion", () {
       fakeAsync((async) {
         final harness = _newHarness();
 
@@ -129,6 +139,7 @@ void main() {
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 200));
+        async.flushMicrotasks();
         harness.dispatch(
           const SesoriSseEvent.questionAsked(
             id: "q-1",
@@ -141,11 +152,12 @@ void main() {
         );
 
         async.elapse(const Duration(milliseconds: 500));
-        expect(harness.completedRoots, equals(["session-a"]));
+        async.flushMicrotasks();
+        expect(harness.completedRoots, isEmpty);
       });
     });
 
-    test("permission replied re-evaluates through requestID lookup", () {
+    test("question rejected cancels any pending completion", () {
       fakeAsync((async) {
         final harness = _newHarness();
 
@@ -156,6 +168,36 @@ void main() {
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 200));
+        async.flushMicrotasks();
+        harness.dispatch(
+          const SesoriSseEvent.questionAsked(
+            id: "q-1",
+            sessionID: "session-a",
+            questions: [QuestionInfo(header: "Prompt", question: "Proceed?")],
+          ),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.questionRejected(requestID: "q-1", sessionID: "session-a"),
+        );
+
+        async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
+        expect(harness.completedRoots, isEmpty);
+      });
+    });
+
+    test("permission replied cancels any pending completion", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 200));
+        async.flushMicrotasks();
         harness.dispatch(
           const SesoriSseEvent.permissionAsked(
             requestID: "perm-1",
@@ -169,7 +211,8 @@ void main() {
         );
 
         async.elapse(const Duration(milliseconds: 500));
-        expect(harness.completedRoots, equals(["session-a"]));
+        async.flushMicrotasks();
+        expect(harness.completedRoots, isEmpty);
       });
     });
 
@@ -194,12 +237,14 @@ void main() {
           const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
         expect(harness.completedRoots, isEmpty);
 
         harness.dispatch(
           const SesoriSseEvent.sessionStatus(sessionID: "parent", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
         expect(harness.completedRoots, equals(["parent"]));
       });
     });
@@ -215,6 +260,7 @@ void main() {
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 200));
+        async.flushMicrotasks();
         harness.dispatch(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
         );
@@ -223,6 +269,7 @@ void main() {
         );
 
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
         expect(harness.completedRoots, equals(["session-a"]));
       });
     });
@@ -238,12 +285,14 @@ void main() {
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
         expect(harness.completedRoots, equals(["session-a"]));
 
         harness.dispatch(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
 
         expect(harness.completedRoots, equals(["session-a"]));
       });
@@ -262,6 +311,7 @@ void main() {
         harness.notifier.reset();
 
         async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
         expect(harness.completedRoots, isEmpty);
       });
     });
@@ -279,11 +329,12 @@ void main() {
         harness.notifier.dispose();
 
         async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
         expect(harness.completedRoots, isEmpty);
       });
     });
 
-    test("callback receives root session ID for child events", () {
+    test("completion stream emits root session ID for child events", () {
       fakeAsync((async) {
         final harness = _newHarness();
 
@@ -307,6 +358,7 @@ void main() {
         );
 
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
         expect(harness.completedRoots, equals(["parent"]));
       });
     });
@@ -336,8 +388,8 @@ _Harness _newHarness() {
   final notifier = CompletionNotifier(
     tracker: tracker,
     debounceDuration: const Duration(milliseconds: 500),
-    onCompletion: completedRoots.add,
   );
+  notifier.completions.listen(completedRoots.add);
   return _Harness(tracker: tracker, notifier: notifier, completedRoots: completedRoots);
 }
 

--- a/bridge/app/test/push/completion_notifier_test.dart
+++ b/bridge/app/test/push/completion_notifier_test.dart
@@ -1,0 +1,358 @@
+import "package:fake_async/fake_async.dart";
+import "package:sesori_bridge/src/push/completion_notifier.dart";
+import "package:sesori_bridge/src/push/push_session_state_tracker.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("CompletionNotifier", () {
+    test("idle after busy fires callback after debounce", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+
+        async.elapse(const Duration(milliseconds: 499));
+        expect(harness.completedRoots, isEmpty);
+
+        async.elapse(const Duration(milliseconds: 1));
+        expect(harness.completedRoots, equals(["session-a"]));
+      });
+    });
+
+    test("question asked during debounce cancels callback", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 200));
+
+        harness.dispatch(
+          const SesoriSseEvent.questionAsked(
+            id: "q-1",
+            sessionID: "session-a",
+            questions: [QuestionInfo(header: "Prompt", question: "Continue?")],
+          ),
+        );
+
+        async.elapse(const Duration(milliseconds: 800));
+        expect(harness.completedRoots, isEmpty);
+      });
+    });
+
+    test("permission asked during debounce cancels callback", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 200));
+
+        harness.dispatch(
+          const SesoriSseEvent.permissionAsked(
+            requestID: "perm-1",
+            sessionID: "session-a",
+            tool: "bash",
+            description: "Run command",
+          ),
+        );
+
+        async.elapse(const Duration(milliseconds: 800));
+        expect(harness.completedRoots, isEmpty);
+      });
+    });
+
+    test("busy during debounce cancels pending callback", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 200));
+
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+
+        async.elapse(const Duration(milliseconds: 800));
+        expect(harness.completedRoots, isEmpty);
+      });
+    });
+
+    test("session deleted during debounce cancels pending callback", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+        final session = _session(id: "session-a");
+
+        harness.dispatch(SesoriSseEvent.sessionCreated(info: session));
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 200));
+
+        harness.dispatch(SesoriSseEvent.sessionDeleted(info: session));
+
+        async.elapse(const Duration(milliseconds: 800));
+        expect(harness.completedRoots, isEmpty);
+      });
+    });
+
+    test("question replied re-evaluates and schedules completion", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 200));
+        harness.dispatch(
+          const SesoriSseEvent.questionAsked(
+            id: "q-1",
+            sessionID: "session-a",
+            questions: [QuestionInfo(header: "Prompt", question: "Proceed?")],
+          ),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.questionReplied(requestID: "q-1", sessionID: "session-a"),
+        );
+
+        async.elapse(const Duration(milliseconds: 500));
+        expect(harness.completedRoots, equals(["session-a"]));
+      });
+    });
+
+    test("permission replied re-evaluates through requestID lookup", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 200));
+        harness.dispatch(
+          const SesoriSseEvent.permissionAsked(
+            requestID: "perm-1",
+            sessionID: "session-a",
+            tool: "bash",
+            description: "Run command",
+          ),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.permissionReplied(requestID: "perm-1", reply: "allow"),
+        );
+
+        async.elapse(const Duration(milliseconds: 500));
+        expect(harness.completedRoots, equals(["session-a"]));
+      });
+    });
+
+    test("parent+child completion fires only when whole group is idle", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.dispatch(SesoriSseEvent.sessionCreated(info: _session(id: "parent")));
+        harness.dispatch(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "child", parentID: "parent"),
+          ),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "parent", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.busy()),
+        );
+
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 500));
+        expect(harness.completedRoots, isEmpty);
+
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "parent", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 500));
+        expect(harness.completedRoots, equals(["parent"]));
+      });
+    });
+
+    test("rapid busy-idle-busy-idle emits one callback", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 200));
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+
+        async.elapse(const Duration(milliseconds: 500));
+        expect(harness.completedRoots, equals(["session-a"]));
+      });
+    });
+
+    test("duplicate idle without new busy does not emit duplicate callback", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 500));
+        expect(harness.completedRoots, equals(["session-a"]));
+
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 500));
+
+        expect(harness.completedRoots, equals(["session-a"]));
+      });
+    });
+
+    test("reset clears timers and internal state", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+        harness.notifier.reset();
+
+        async.elapse(const Duration(seconds: 1));
+        expect(harness.completedRoots, isEmpty);
+      });
+    });
+
+    test("dispose cancels timers", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+        harness.notifier.dispose();
+
+        async.elapse(const Duration(seconds: 1));
+        expect(harness.completedRoots, isEmpty);
+      });
+    });
+
+    test("callback receives root session ID for child events", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.dispatch(SesoriSseEvent.sessionCreated(info: _session(id: "parent")));
+        harness.dispatch(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "child", parentID: "parent"),
+          ),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "parent", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "parent", status: SessionStatus.idle()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.idle()),
+        );
+
+        async.elapse(const Duration(milliseconds: 500));
+        expect(harness.completedRoots, equals(["parent"]));
+      });
+    });
+  });
+}
+
+class _Harness {
+  final PushSessionStateTracker tracker;
+  final CompletionNotifier notifier;
+  final List<String> completedRoots;
+
+  _Harness({
+    required this.tracker,
+    required this.notifier,
+    required this.completedRoots,
+  });
+
+  void dispatch(SesoriSseEvent event) {
+    tracker.handleEvent(event);
+    notifier.handleEvent(event);
+  }
+}
+
+_Harness _newHarness() {
+  final tracker = PushSessionStateTracker();
+  final completedRoots = <String>[];
+  final notifier = CompletionNotifier(
+    tracker: tracker,
+    debounceDuration: const Duration(milliseconds: 500),
+    onCompletion: completedRoots.add,
+  );
+  return _Harness(tracker: tracker, notifier: notifier, completedRoots: completedRoots);
+}
+
+Session _session({
+  required String id,
+  String projectID = "project-a",
+  String directory = "/tmp/project",
+  String? parentID,
+  String? title,
+}) {
+  return Session(
+    id: id,
+    projectID: projectID,
+    directory: directory,
+    parentID: parentID,
+    title: title,
+  );
+}

--- a/bridge/app/test/push/notification_category_test.dart
+++ b/bridge/app/test/push/notification_category_test.dart
@@ -21,12 +21,12 @@ void main() {
       expect(extractNotificationData(permissionEvent)?.category, NotificationCategory.aiInteraction);
     });
 
-    test("maps message.updated to session_message", () {
+    test("returns null for message.updated", () {
       const event = SesoriSseEvent.messageUpdated(
         info: Message(role: "assistant", id: "m-1", sessionID: "session-a"),
       );
 
-      expect(extractNotificationData(event)?.category, NotificationCategory.sessionMessage);
+      expect(extractNotificationData(event), isNull);
     });
 
     test("maps installation.update-available to system_update", () {

--- a/bridge/app/test/push/notification_category_test.dart
+++ b/bridge/app/test/push/notification_category_test.dart
@@ -21,14 +21,6 @@ void main() {
       expect(extractNotificationData(permissionEvent)?.category, NotificationCategory.aiInteraction);
     });
 
-    test("returns null for message.updated", () {
-      const event = SesoriSseEvent.messageUpdated(
-        info: Message(role: "assistant", id: "m-1", sessionID: "session-a"),
-      );
-
-      expect(extractNotificationData(event), isNull);
-    });
-
     test("maps installation.update-available to system_update", () {
       const event = SesoriSseEvent.installationUpdateAvailable(version: "1.2.3");
 

--- a/bridge/app/test/push/push_notification_service_test.dart
+++ b/bridge/app/test/push/push_notification_service_test.dart
@@ -1,0 +1,645 @@
+import "package:fake_async/fake_async.dart";
+import "package:sesori_bridge/src/auth/token_refresher.dart";
+import "package:sesori_bridge/src/push/push_notification_client.dart";
+import "package:sesori_bridge/src/push/push_notification_service.dart";
+import "package:sesori_bridge/src/push/push_rate_limiter.dart";
+import "package:sesori_bridge/src/push/push_session_state_tracker.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("PushNotificationService", () {
+    test("AC1a: SesoriMessageUpdated with user role sends no notification", () {
+      final harness = _newHarness();
+
+      harness.service.maybeSendForEvent(
+        const SesoriSseEvent.messageUpdated(
+          info: Message(id: "msg-1", role: "user", sessionID: "session-a"),
+        ),
+      );
+
+      expect(harness.client.sentPayloads, isEmpty);
+    });
+
+    test("AC1b: SesoriMessageUpdated with assistant role sends no notification", () {
+      final harness = _newHarness();
+
+      harness.service.maybeSendForEvent(
+        const SesoriSseEvent.messageUpdated(
+          info: Message(id: "msg-1", role: "assistant", sessionID: "session-a"),
+        ),
+      );
+
+      expect(harness.client.sentPayloads, isEmpty);
+    });
+
+    test("AC2: parent+child idle completion sends one sessionCompleted notification", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.service.maybeSendForEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "parent", title: "Parent title"),
+          ),
+        );
+        harness.service.maybeSendForEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "child", parentID: "parent"),
+          ),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "parent", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.busy()),
+        );
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 500));
+        expect(harness.client.sentPayloads, isEmpty);
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "parent", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 500));
+
+        expect(harness.client.sentPayloads.length, equals(1));
+        final payload = harness.client.sentPayloads.single;
+        expect(payload.category, equals(NotificationCategory.sessionMessage));
+        expect(payload.data?.eventType, equals(NotificationEventType.sessionCompleted));
+      });
+    });
+
+    test("AC3a: question asked during debounce cancels completion", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+
+        async.elapse(const Duration(milliseconds: 200));
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.questionAsked(
+            id: "q-1",
+            sessionID: "session-a",
+            questions: [QuestionInfo(header: "Prompt", question: "Continue?")],
+          ),
+        );
+
+        async.elapse(const Duration(milliseconds: 600));
+        final completionCount = harness.client.sentPayloads
+            .where((payload) => payload.data?.eventType == NotificationEventType.sessionCompleted)
+            .length;
+        expect(completionCount, equals(0));
+      });
+    });
+
+    test("AC3b: permission asked during debounce cancels completion", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+
+        async.elapse(const Duration(milliseconds: 200));
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.permissionAsked(
+            requestID: "perm-1",
+            sessionID: "session-a",
+            tool: "bash",
+            description: "Run command",
+          ),
+        );
+
+        async.elapse(const Duration(milliseconds: 600));
+        final completionCount = harness.client.sentPayloads
+            .where((payload) => payload.data?.eventType == NotificationEventType.sessionCompleted)
+            .length;
+        expect(completionCount, equals(0));
+      });
+    });
+
+    test("AC4: completion uses session title and assistant text preview", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+        const title = "Implement user authentication for the dashboard";
+
+        harness.service.maybeSendForEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "session-a", title: title),
+          ),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.messageUpdated(
+            info: Message(id: "msg-1", role: "assistant", sessionID: "session-a"),
+          ),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.messagePartUpdated(
+            part: MessagePart(
+              id: "part-1",
+              sessionID: "session-a",
+              messageID: "msg-1",
+              type: "text",
+              text: "I implemented user auth using JWT, refresh tokens, secure cookies, and role checks.",
+            ),
+          ),
+        );
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+
+        async.elapse(const Duration(milliseconds: 500));
+
+        final completion = harness.client.sentPayloads.singleWhere(
+          (payload) => payload.data?.eventType == NotificationEventType.sessionCompleted,
+        );
+        expect(completion.title, equals(title));
+        expect(completion.body, equals("I implemented user auth using JWT, refresh tokens, secure cookies,..."));
+      });
+    });
+
+    test("AC5: debounce fires only after full 500ms", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+
+        async.elapse(const Duration(milliseconds: 400));
+        expect(harness.client.sentPayloads, isEmpty);
+
+        async.elapse(const Duration(milliseconds: 100));
+        expect(harness.client.sentPayloads.length, equals(1));
+      });
+    });
+
+    test("AC6: parent idle with busy child waits for child idle", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.service.maybeSendForEvent(SesoriSseEvent.sessionCreated(info: _session(id: "parent")));
+        harness.service.maybeSendForEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "child", parentID: "parent"),
+          ),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "parent", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.busy()),
+        );
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "parent", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 500));
+        expect(harness.client.sentPayloads, isEmpty);
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 500));
+
+        expect(harness.client.sentPayloads.length, equals(1));
+        expect(
+          harness.client.sentPayloads.single.data?.eventType,
+          equals(NotificationEventType.sessionCompleted),
+        );
+      });
+    });
+
+    test("AC7: reset clears state and cancels pending debounce timers", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.service.maybeSendForEvent(SesoriSseEvent.sessionCreated(info: _session(id: "session-a")));
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+        harness.service.reset();
+
+        async.elapse(const Duration(seconds: 2));
+
+        expect(harness.client.sentPayloads, isEmpty);
+      });
+    });
+
+    test("AC8: question replied unblocks completion when still idle", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 200));
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.questionAsked(
+            id: "q-1",
+            sessionID: "session-a",
+            questions: [QuestionInfo(header: "Prompt", question: "Proceed?")],
+          ),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.questionReplied(requestID: "q-1", sessionID: "session-a"),
+        );
+
+        async.elapse(const Duration(milliseconds: 500));
+
+        final completionCount = harness.client.sentPayloads
+            .where((payload) => payload.data?.eventType == NotificationEventType.sessionCompleted)
+            .length;
+        expect(completionCount, equals(1));
+      });
+    });
+
+    test("AC9a: question asked still sends immediate aiInteraction notification", () {
+      final harness = _newHarness();
+
+      harness.service.maybeSendForEvent(
+        const SesoriSseEvent.questionAsked(
+          id: "q-1",
+          sessionID: "session-a",
+          questions: [QuestionInfo(header: "Prompt", question: "Continue?")],
+        ),
+      );
+
+      expect(harness.client.sentPayloads.length, equals(1));
+      final payload = harness.client.sentPayloads.single;
+      expect(payload.category, equals(NotificationCategory.aiInteraction));
+      expect(payload.data?.eventType, equals(NotificationEventType.questionAsked));
+    });
+
+    test("AC9b: installation update still sends immediate systemUpdate notification", () {
+      final harness = _newHarness();
+
+      harness.service.maybeSendForEvent(
+        const SesoriSseEvent.installationUpdateAvailable(version: "1.2.3"),
+      );
+
+      expect(harness.client.sentPayloads.length, equals(1));
+      final payload = harness.client.sentPayloads.single;
+      expect(payload.category, equals(NotificationCategory.systemUpdate));
+      expect(
+        payload.data?.eventType,
+        equals(NotificationEventType.installationUpdateAvailable),
+      );
+    });
+
+    test("AC10a: tool message part does not affect completion body", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.messageUpdated(
+            info: Message(id: "msg-1", role: "assistant", sessionID: "session-a"),
+          ),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.messagePartUpdated(
+            part: MessagePart(
+              id: "part-1",
+              sessionID: "session-a",
+              messageID: "msg-1",
+              type: "tool",
+              text: "ignored",
+            ),
+          ),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+
+        async.elapse(const Duration(milliseconds: 500));
+
+        final completion = harness.client.sentPayloads.singleWhere(
+          (payload) => payload.data?.eventType == NotificationEventType.sessionCompleted,
+        );
+        expect(completion.body, equals("Task completed"));
+      });
+    });
+
+    test("AC10b: text message part updates completion body", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.messageUpdated(
+            info: Message(id: "msg-1", role: "assistant", sessionID: "session-a"),
+          ),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.messagePartUpdated(
+            part: MessagePart(
+              id: "part-1",
+              sessionID: "session-a",
+              messageID: "msg-1",
+              type: "text",
+              text: "Done with migration, tests, docs, and verification checks.",
+            ),
+          ),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+
+        async.elapse(const Duration(milliseconds: 500));
+
+        final completion = harness.client.sentPayloads.singleWhere(
+          (payload) => payload.data?.eventType == NotificationEventType.sessionCompleted,
+        );
+        expect(completion.body, equals("Done with migration, tests, docs, and verification checks."));
+      });
+    });
+
+    test("E1: session deleted during debounce cancels completion timer", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        final session = _session(id: "session-a");
+        harness.service.maybeSendForEvent(SesoriSseEvent.sessionCreated(info: session));
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+
+        async.elapse(const Duration(milliseconds: 200));
+        harness.service.maybeSendForEvent(SesoriSseEvent.sessionDeleted(info: session));
+
+        async.elapse(const Duration(seconds: 1));
+        expect(harness.client.sentPayloads, isEmpty);
+      });
+    });
+
+    test("E2: busy-idle-busy-idle only yields one completion notification", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+
+        async.elapse(const Duration(milliseconds: 200));
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+
+        async.elapse(const Duration(milliseconds: 500));
+
+        final completionCount = harness.client.sentPayloads
+            .where((payload) => payload.data?.eventType == NotificationEventType.sessionCompleted)
+            .length;
+        expect(completionCount, equals(1));
+      });
+    });
+
+    test("E3: multiple children finishing in sequence produces a single completion", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.service.maybeSendForEvent(SesoriSseEvent.sessionCreated(info: _session(id: "root")));
+        harness.service.maybeSendForEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "child-1", parentID: "root"),
+          ),
+        );
+        harness.service.maybeSendForEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "child-2", parentID: "root"),
+          ),
+        );
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "child-1", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "child-2", status: SessionStatus.busy()),
+        );
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "child-1", status: SessionStatus.idle()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 500));
+        expect(harness.client.sentPayloads, isEmpty);
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "child-2", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 500));
+
+        final completionCount = harness.client.sentPayloads
+            .where((payload) => payload.data?.eventType == NotificationEventType.sessionCompleted)
+            .length;
+        expect(completionCount, equals(1));
+      });
+    });
+
+    test("E4: completion body falls back when no assistant text exists", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+
+        async.elapse(const Duration(milliseconds: 500));
+
+        final completion = harness.client.sentPayloads.singleWhere(
+          (payload) => payload.data?.eventType == NotificationEventType.sessionCompleted,
+        );
+        expect(completion.body, equals("Task completed"));
+      });
+    });
+
+    test("E5: completion title falls back when session title is null", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.service.maybeSendForEvent(
+          SesoriSseEvent.sessionCreated(info: _session(id: "session-a", title: null)),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+
+        async.elapse(const Duration(milliseconds: 500));
+
+        final completion = harness.client.sentPayloads.singleWhere(
+          (payload) => payload.data?.eventType == NotificationEventType.sessionCompleted,
+        );
+        expect(completion.title, equals("Session completed"));
+      });
+    });
+
+    test("E8: duplicate idle without new busy does not send duplicate completion", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 500));
+        expect(harness.client.sentPayloads.length, equals(1));
+
+        harness.service.maybeSendForEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+        async.elapse(const Duration(milliseconds: 500));
+
+        final completionCount = harness.client.sentPayloads
+            .where((payload) => payload.data?.eventType == NotificationEventType.sessionCompleted)
+            .length;
+        expect(completionCount, equals(1));
+      });
+    });
+
+    test("E9: question asked for untracked session still sends aiInteraction", () {
+      final harness = _newHarness();
+
+      harness.service.maybeSendForEvent(
+        const SesoriSseEvent.questionAsked(
+          id: "q-1",
+          sessionID: "missing-session",
+          questions: [QuestionInfo(header: "Prompt", question: "Need decision")],
+        ),
+      );
+
+      expect(harness.client.sentPayloads.length, equals(1));
+      expect(harness.client.sentPayloads.single.category, equals(NotificationCategory.aiInteraction));
+    });
+  });
+
+  group("truncate helpers", () {
+    test("truncateTitle truncates at word boundary with ellipsis", () {
+      const title = "One two three four five six seven eight nine ten eleven twelve";
+      expect(truncateTitle(title, maxChars: 25), equals("One two three four five..."));
+    });
+
+    test("truncateToWords truncates to max word count with ellipsis", () {
+      const text = "one two three four five six seven eight nine ten eleven";
+      expect(truncateToWords(text, maxWords: 10), equals("one two three four five six seven eight nine ten..."));
+    });
+  });
+}
+
+({
+  PushNotificationService service,
+  FakePushNotificationClient client,
+})
+_newHarness() {
+  final client = FakePushNotificationClient();
+  final service = PushNotificationService(
+    client: client,
+    rateLimiter: FakePushRateLimiter(),
+    tracker: PushSessionStateTracker(),
+    debounceDuration: const Duration(milliseconds: 500),
+  );
+
+  return (service: service, client: client);
+}
+
+class FakePushNotificationClient extends PushNotificationClient {
+  final List<SendNotificationPayload> sentPayloads = [];
+
+  FakePushNotificationClient()
+    : super(
+        authBackendURL: "https://example.com",
+        tokenRefreshManager: _FakeTokenRefresher(),
+      );
+
+  @override
+  Future<void> sendNotification(SendNotificationPayload payload) async {
+    sentPayloads.add(payload);
+  }
+}
+
+class FakePushRateLimiter extends PushRateLimiter {
+  FakePushRateLimiter();
+
+  @override
+  bool shouldSend({
+    required NotificationCategory category,
+    required String? sessionId,
+    required String collapseKey,
+  }) {
+    return true;
+  }
+}
+
+class _FakeTokenRefresher implements TokenRefresher {
+  @override
+  Future<String> getAccessToken({bool forceRefresh = false}) async {
+    return "token";
+  }
+}
+
+Session _session({
+  required String id,
+  String projectID = "project-a",
+  String directory = "/tmp/project",
+  String? parentID,
+  String? title,
+}) {
+  return Session(
+    id: id,
+    projectID: projectID,
+    directory: directory,
+    parentID: parentID,
+    title: title,
+  );
+}

--- a/bridge/app/test/push/push_notification_service_test.dart
+++ b/bridge/app/test/push/push_notification_service_test.dart
@@ -1,5 +1,6 @@
 import "package:fake_async/fake_async.dart";
 import "package:sesori_bridge/src/auth/token_refresher.dart";
+import "package:sesori_bridge/src/push/completion_notifier.dart";
 import "package:sesori_bridge/src/push/push_notification_client.dart";
 import "package:sesori_bridge/src/push/push_notification_service.dart";
 import "package:sesori_bridge/src/push/push_rate_limiter.dart";
@@ -12,7 +13,7 @@ void main() {
     test("AC1a: SesoriMessageUpdated with user role sends no notification", () {
       final harness = _newHarness();
 
-      harness.service.maybeSendForEvent(
+      harness.service.handleSseEvent(
         const SesoriSseEvent.messageUpdated(
           info: Message(id: "msg-1", role: "user", sessionID: "session-a"),
         ),
@@ -24,7 +25,7 @@ void main() {
     test("AC1b: SesoriMessageUpdated with assistant role sends no notification", () {
       final harness = _newHarness();
 
-      harness.service.maybeSendForEvent(
+      harness.service.handleSseEvent(
         const SesoriSseEvent.messageUpdated(
           info: Message(id: "msg-1", role: "assistant", sessionID: "session-a"),
         ),
@@ -33,42 +34,44 @@ void main() {
       expect(harness.client.sentPayloads, isEmpty);
     });
 
-    test("AC2: parent+child idle completion sends one sessionCompleted notification", () {
+    test("AC2: parent+child idle completion sends one agentTurnCompleted notification", () {
       fakeAsync((async) {
         final harness = _newHarness();
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           SesoriSseEvent.sessionCreated(
             info: _session(id: "parent", title: "Parent title"),
           ),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           SesoriSseEvent.sessionCreated(
             info: _session(id: "child", parentID: "parent"),
           ),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "parent", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.busy()),
         );
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
         expect(harness.client.sentPayloads, isEmpty);
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "parent", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
 
         expect(harness.client.sentPayloads.length, equals(1));
         final payload = harness.client.sentPayloads.single;
         expect(payload.category, equals(NotificationCategory.sessionMessage));
-        expect(payload.data?.eventType, equals(NotificationEventType.sessionCompleted));
+        expect(payload.data?.eventType, equals(NotificationEventType.agentTurnCompleted));
       });
     });
 
@@ -76,15 +79,16 @@ void main() {
       fakeAsync((async) {
         final harness = _newHarness();
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
 
         async.elapse(const Duration(milliseconds: 200));
-        harness.service.maybeSendForEvent(
+        async.flushMicrotasks();
+        harness.service.handleSseEvent(
           const SesoriSseEvent.questionAsked(
             id: "q-1",
             sessionID: "session-a",
@@ -93,8 +97,9 @@ void main() {
         );
 
         async.elapse(const Duration(milliseconds: 600));
+        async.flushMicrotasks();
         final completionCount = harness.client.sentPayloads
-            .where((payload) => payload.data?.eventType == NotificationEventType.sessionCompleted)
+            .where((payload) => payload.data?.eventType == NotificationEventType.agentTurnCompleted)
             .length;
         expect(completionCount, equals(0));
       });
@@ -104,15 +109,16 @@ void main() {
       fakeAsync((async) {
         final harness = _newHarness();
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
 
         async.elapse(const Duration(milliseconds: 200));
-        harness.service.maybeSendForEvent(
+        async.flushMicrotasks();
+        harness.service.handleSseEvent(
           const SesoriSseEvent.permissionAsked(
             requestID: "perm-1",
             sessionID: "session-a",
@@ -122,8 +128,9 @@ void main() {
         );
 
         async.elapse(const Duration(milliseconds: 600));
+        async.flushMicrotasks();
         final completionCount = harness.client.sentPayloads
-            .where((payload) => payload.data?.eventType == NotificationEventType.sessionCompleted)
+            .where((payload) => payload.data?.eventType == NotificationEventType.agentTurnCompleted)
             .length;
         expect(completionCount, equals(0));
       });
@@ -134,17 +141,17 @@ void main() {
         final harness = _newHarness();
         const title = "Implement user authentication for the dashboard";
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           SesoriSseEvent.sessionCreated(
             info: _session(id: "session-a", title: title),
           ),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.messageUpdated(
             info: Message(id: "msg-1", role: "assistant", sessionID: "session-a"),
           ),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.messagePartUpdated(
             part: MessagePart(
               id: "part-1",
@@ -156,17 +163,18 @@ void main() {
           ),
         );
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
 
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
 
         final completion = harness.client.sentPayloads.singleWhere(
-          (payload) => payload.data?.eventType == NotificationEventType.sessionCompleted,
+          (payload) => payload.data?.eventType == NotificationEventType.agentTurnCompleted,
         );
         expect(completion.title, equals(title));
         expect(completion.body, equals("I implemented user auth using JWT, refresh tokens, secure cookies,..."));
@@ -177,17 +185,19 @@ void main() {
       fakeAsync((async) {
         final harness = _newHarness();
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
 
         async.elapse(const Duration(milliseconds: 400));
+        async.flushMicrotasks();
         expect(harness.client.sentPayloads, isEmpty);
 
         async.elapse(const Duration(milliseconds: 100));
+        async.flushMicrotasks();
         expect(harness.client.sentPayloads.length, equals(1));
       });
     });
@@ -196,34 +206,36 @@ void main() {
       fakeAsync((async) {
         final harness = _newHarness();
 
-        harness.service.maybeSendForEvent(SesoriSseEvent.sessionCreated(info: _session(id: "parent")));
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(SesoriSseEvent.sessionCreated(info: _session(id: "parent")));
+        harness.service.handleSseEvent(
           SesoriSseEvent.sessionCreated(
             info: _session(id: "child", parentID: "parent"),
           ),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "parent", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.busy()),
         );
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "parent", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
         expect(harness.client.sentPayloads, isEmpty);
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
 
         expect(harness.client.sentPayloads.length, equals(1));
         expect(
           harness.client.sentPayloads.single.data?.eventType,
-          equals(NotificationEventType.sessionCompleted),
+          equals(NotificationEventType.agentTurnCompleted),
         );
       });
     });
@@ -232,57 +244,60 @@ void main() {
       fakeAsync((async) {
         final harness = _newHarness();
 
-        harness.service.maybeSendForEvent(SesoriSseEvent.sessionCreated(info: _session(id: "session-a")));
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(SesoriSseEvent.sessionCreated(info: _session(id: "session-a")));
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
         harness.service.reset();
 
         async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
 
         expect(harness.client.sentPayloads, isEmpty);
       });
     });
 
-    test("AC8: question replied unblocks completion when still idle", () {
+    test("AC8: question replied cancels pending completion", () {
       fakeAsync((async) {
         final harness = _newHarness();
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 200));
+        async.flushMicrotasks();
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.questionAsked(
             id: "q-1",
             sessionID: "session-a",
             questions: [QuestionInfo(header: "Prompt", question: "Proceed?")],
           ),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.questionReplied(requestID: "q-1", sessionID: "session-a"),
         );
 
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
 
         final completionCount = harness.client.sentPayloads
-            .where((payload) => payload.data?.eventType == NotificationEventType.sessionCompleted)
+            .where((payload) => payload.data?.eventType == NotificationEventType.agentTurnCompleted)
             .length;
-        expect(completionCount, equals(1));
+        expect(completionCount, equals(0));
       });
     });
 
     test("AC9a: question asked still sends immediate aiInteraction notification", () {
       final harness = _newHarness();
 
-      harness.service.maybeSendForEvent(
+      harness.service.handleSseEvent(
         const SesoriSseEvent.questionAsked(
           id: "q-1",
           sessionID: "session-a",
@@ -299,7 +314,7 @@ void main() {
     test("AC9b: installation update still sends immediate systemUpdate notification", () {
       final harness = _newHarness();
 
-      harness.service.maybeSendForEvent(
+      harness.service.handleSseEvent(
         const SesoriSseEvent.installationUpdateAvailable(version: "1.2.3"),
       );
 
@@ -316,12 +331,12 @@ void main() {
       fakeAsync((async) {
         final harness = _newHarness();
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.messageUpdated(
             info: Message(id: "msg-1", role: "assistant", sessionID: "session-a"),
           ),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.messagePartUpdated(
             part: MessagePart(
               id: "part-1",
@@ -332,17 +347,18 @@ void main() {
             ),
           ),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
 
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
 
         final completion = harness.client.sentPayloads.singleWhere(
-          (payload) => payload.data?.eventType == NotificationEventType.sessionCompleted,
+          (payload) => payload.data?.eventType == NotificationEventType.agentTurnCompleted,
         );
         expect(completion.body, equals("Task completed"));
       });
@@ -352,12 +368,12 @@ void main() {
       fakeAsync((async) {
         final harness = _newHarness();
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.messageUpdated(
             info: Message(id: "msg-1", role: "assistant", sessionID: "session-a"),
           ),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.messagePartUpdated(
             part: MessagePart(
               id: "part-1",
@@ -368,17 +384,18 @@ void main() {
             ),
           ),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
 
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
 
         final completion = harness.client.sentPayloads.singleWhere(
-          (payload) => payload.data?.eventType == NotificationEventType.sessionCompleted,
+          (payload) => payload.data?.eventType == NotificationEventType.agentTurnCompleted,
         );
         expect(completion.body, equals("Done with migration, tests, docs, and verification checks."));
       });
@@ -389,18 +406,20 @@ void main() {
         final harness = _newHarness();
 
         final session = _session(id: "session-a");
-        harness.service.maybeSendForEvent(SesoriSseEvent.sessionCreated(info: session));
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(SesoriSseEvent.sessionCreated(info: session));
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
 
         async.elapse(const Duration(milliseconds: 200));
-        harness.service.maybeSendForEvent(SesoriSseEvent.sessionDeleted(info: session));
+        async.flushMicrotasks();
+        harness.service.handleSseEvent(SesoriSseEvent.sessionDeleted(info: session));
 
         async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
         expect(harness.client.sentPayloads, isEmpty);
       });
     });
@@ -409,25 +428,27 @@ void main() {
       fakeAsync((async) {
         final harness = _newHarness();
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
 
         async.elapse(const Duration(milliseconds: 200));
-        harness.service.maybeSendForEvent(
+        async.flushMicrotasks();
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
 
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
 
         final completionCount = harness.client.sentPayloads
-            .where((payload) => payload.data?.eventType == NotificationEventType.sessionCompleted)
+            .where((payload) => payload.data?.eventType == NotificationEventType.agentTurnCompleted)
             .length;
         expect(completionCount, equals(1));
       });
@@ -437,44 +458,46 @@ void main() {
       fakeAsync((async) {
         final harness = _newHarness();
 
-        harness.service.maybeSendForEvent(SesoriSseEvent.sessionCreated(info: _session(id: "root")));
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(SesoriSseEvent.sessionCreated(info: _session(id: "root")));
+        harness.service.handleSseEvent(
           SesoriSseEvent.sessionCreated(
             info: _session(id: "child-1", parentID: "root"),
           ),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           SesoriSseEvent.sessionCreated(
             info: _session(id: "child-2", parentID: "root"),
           ),
         );
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "child-1", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "child-2", status: SessionStatus.busy()),
         );
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "child-1", status: SessionStatus.idle()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
         expect(harness.client.sentPayloads, isEmpty);
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "child-2", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
 
         final completionCount = harness.client.sentPayloads
-            .where((payload) => payload.data?.eventType == NotificationEventType.sessionCompleted)
+            .where((payload) => payload.data?.eventType == NotificationEventType.agentTurnCompleted)
             .length;
         expect(completionCount, equals(1));
       });
@@ -484,17 +507,18 @@ void main() {
       fakeAsync((async) {
         final harness = _newHarness();
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
 
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
 
         final completion = harness.client.sentPayloads.singleWhere(
-          (payload) => payload.data?.eventType == NotificationEventType.sessionCompleted,
+          (payload) => payload.data?.eventType == NotificationEventType.agentTurnCompleted,
         );
         expect(completion.body, equals("Task completed"));
       });
@@ -504,20 +528,21 @@ void main() {
       fakeAsync((async) {
         final harness = _newHarness();
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           SesoriSseEvent.sessionCreated(info: _session(id: "session-a", title: null)),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
 
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
 
         final completion = harness.client.sentPayloads.singleWhere(
-          (payload) => payload.data?.eventType == NotificationEventType.sessionCompleted,
+          (payload) => payload.data?.eventType == NotificationEventType.agentTurnCompleted,
         );
         expect(completion.title, equals("Session completed"));
       });
@@ -527,22 +552,24 @@ void main() {
       fakeAsync((async) {
         final harness = _newHarness();
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
         );
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
         expect(harness.client.sentPayloads.length, equals(1));
 
-        harness.service.maybeSendForEvent(
+        harness.service.handleSseEvent(
           const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
         );
         async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
 
         final completionCount = harness.client.sentPayloads
-            .where((payload) => payload.data?.eventType == NotificationEventType.sessionCompleted)
+            .where((payload) => payload.data?.eventType == NotificationEventType.agentTurnCompleted)
             .length;
         expect(completionCount, equals(1));
       });
@@ -551,7 +578,7 @@ void main() {
     test("E9: question asked for untracked session still sends aiInteraction", () {
       final harness = _newHarness();
 
-      harness.service.maybeSendForEvent(
+      harness.service.handleSseEvent(
         const SesoriSseEvent.questionAsked(
           id: "q-1",
           sessionID: "missing-session",
@@ -583,11 +610,16 @@ void main() {
 })
 _newHarness() {
   final client = FakePushNotificationClient();
+  final tracker = PushSessionStateTracker();
+  final notifier = CompletionNotifier(
+    tracker: tracker,
+    debounceDuration: const Duration(milliseconds: 500),
+  );
   final service = PushNotificationService(
     client: client,
     rateLimiter: FakePushRateLimiter(),
-    tracker: PushSessionStateTracker(),
-    debounceDuration: const Duration(milliseconds: 500),
+    tracker: tracker,
+    completionNotifier: notifier,
   );
 
   return (service: service, client: client);

--- a/bridge/app/test/push/push_session_state_tracker_test.dart
+++ b/bridge/app/test/push/push_session_state_tracker_test.dart
@@ -626,6 +626,30 @@ void main() {
       expect(tracker.wasPreviouslyBusy("session-a"), isFalse);
       expect(tracker.isSessionGroupFullyIdle("session-a"), isTrue);
     });
+
+    test("wasPreviouslyBusy returns true if only a descendant was busy", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(info: _session(id: "root")),
+      );
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "child", parentID: "root"),
+        ),
+      );
+
+      // Only child goes busy, root never does.
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.busy()),
+      );
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.idle()),
+      );
+
+      // Root was never busy itself, but its descendant was.
+      expect(tracker.wasPreviouslyBusy("root"), isTrue);
+    });
   });
 }
 

--- a/bridge/app/test/push/push_session_state_tracker_test.dart
+++ b/bridge/app/test/push/push_session_state_tracker_test.dart
@@ -1,0 +1,577 @@
+import "package:sesori_bridge/src/push/push_session_state_tracker.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("PushSessionStateTracker", () {
+    test("tracks session statuses from SesoriSessionStatus events", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(
+          sessionID: "session-a",
+          status: SessionStatus.busy(),
+        ),
+      );
+
+      expect(tracker.isSessionGroupFullyIdle("session-a"), isFalse);
+      expect(tracker.wasPreviouslyBusy("session-a"), isTrue);
+
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(
+          sessionID: "session-a",
+          status: SessionStatus.retry(attempt: 2, message: "retry", next: 1000),
+        ),
+      );
+
+      expect(tracker.isSessionGroupFullyIdle("session-a"), isFalse);
+      expect(tracker.wasPreviouslyBusy("session-a"), isTrue);
+
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(
+          sessionID: "session-a",
+          status: SessionStatus.idle(),
+        ),
+      );
+
+      expect(tracker.isSessionGroupFullyIdle("session-a"), isTrue);
+      expect(tracker.wasPreviouslyBusy("session-a"), isTrue);
+    });
+
+    test("tracks parent-child relationships from session created and updated", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "parent"),
+        ),
+      );
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "child", parentID: "parent"),
+        ),
+      );
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(
+          sessionID: "child",
+          status: SessionStatus.busy(),
+        ),
+      );
+
+      expect(tracker.isSessionGroupFullyIdle("parent"), isFalse);
+      expect(tracker.resolveRootSessionId("child"), equals("parent"));
+
+      tracker.handleEvent(
+        SesoriSseEvent.sessionUpdated(
+          info: _session(id: "child", parentID: null),
+        ),
+      );
+
+      expect(tracker.isSessionGroupFullyIdle("parent"), isTrue);
+      expect(tracker.resolveRootSessionId("child"), equals("child"));
+    });
+
+    test("tracks session titles from session created and updated", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "session-a", title: "Initial title"),
+        ),
+      );
+      expect(tracker.getSessionTitle("session-a"), equals("Initial title"));
+
+      tracker.handleEvent(
+        SesoriSseEvent.sessionUpdated(
+          info: _session(id: "session-a", title: "Updated title"),
+        ),
+      );
+      expect(tracker.getSessionTitle("session-a"), equals("Updated title"));
+    });
+
+    test("tracks messageID to role from message updated events", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(
+        const SesoriSseEvent.messageUpdated(
+          info: Message(id: "m-1", role: "assistant", sessionID: "session-a"),
+        ),
+      );
+
+      tracker.handleEvent(
+        const SesoriSseEvent.messagePartUpdated(
+          part: MessagePart(
+            id: "part-1",
+            sessionID: "session-a",
+            messageID: "m-1",
+            type: "text",
+            text: "assistant text",
+          ),
+        ),
+      );
+
+      expect(tracker.getLatestAssistantText("session-a"), equals("assistant text"));
+    });
+
+    test("tracks latest assistant text only for assistant text parts", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(
+        const SesoriSseEvent.messageUpdated(
+          info: Message(id: "assistant-msg", role: "assistant", sessionID: "session-a"),
+        ),
+      );
+      tracker.handleEvent(
+        const SesoriSseEvent.messagePartUpdated(
+          part: MessagePart(
+            id: "part-1",
+            sessionID: "session-a",
+            messageID: "assistant-msg",
+            type: "text",
+            text: "first",
+          ),
+        ),
+      );
+      tracker.handleEvent(
+        const SesoriSseEvent.messagePartUpdated(
+          part: MessagePart(
+            id: "part-2",
+            sessionID: "session-a",
+            messageID: "assistant-msg",
+            type: "text",
+            text: "latest",
+          ),
+        ),
+      );
+
+      expect(tracker.getLatestAssistantText("session-a"), equals("latest"));
+    });
+
+    test("tracks pending questions and clears on replied or rejected", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(
+        const SesoriSseEvent.questionAsked(
+          id: "q-1",
+          sessionID: "session-a",
+          questions: [QuestionInfo(header: "h", question: "q")],
+        ),
+      );
+      expect(tracker.hasPendingInteraction("session-a"), isTrue);
+
+      tracker.handleEvent(
+        const SesoriSseEvent.questionReplied(
+          requestID: "q-1",
+          sessionID: "session-a",
+        ),
+      );
+      expect(tracker.hasPendingInteraction("session-a"), isFalse);
+
+      tracker.handleEvent(
+        const SesoriSseEvent.questionAsked(
+          id: "q-2",
+          sessionID: "session-a",
+          questions: [QuestionInfo(header: "h", question: "q")],
+        ),
+      );
+      expect(tracker.hasPendingInteraction("session-a"), isTrue);
+
+      tracker.handleEvent(
+        const SesoriSseEvent.questionRejected(
+          requestID: "q-2",
+          sessionID: "session-a",
+        ),
+      );
+      expect(tracker.hasPendingInteraction("session-a"), isFalse);
+    });
+
+    test("tracks pending permissions using requestID to sessionID mapping", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(
+        const SesoriSseEvent.permissionAsked(
+          requestID: "req-1",
+          sessionID: "session-a",
+          tool: "bash",
+          description: "run",
+        ),
+      );
+
+      expect(tracker.hasPendingInteraction("session-a"), isTrue);
+
+      tracker.handleEvent(
+        const SesoriSseEvent.permissionReplied(
+          requestID: "req-1",
+          reply: "allow",
+        ),
+      );
+
+      expect(tracker.hasPendingInteraction("session-a"), isFalse);
+    });
+
+    test("isSessionGroupFullyIdle is true only when session and direct children are idle", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(SesoriSseEvent.sessionCreated(info: _session(id: "root")));
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "child-1", parentID: "root"),
+        ),
+      );
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "child-2", parentID: "root"),
+        ),
+      );
+
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(
+          sessionID: "child-1",
+          status: SessionStatus.busy(),
+        ),
+      );
+
+      expect(tracker.isSessionGroupFullyIdle("root"), isFalse);
+
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(
+          sessionID: "child-1",
+          status: SessionStatus.idle(),
+        ),
+      );
+
+      expect(tracker.isSessionGroupFullyIdle("root"), isTrue);
+    });
+
+    test("hasPendingInteraction returns true for pending question or permission", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(
+        const SesoriSseEvent.questionAsked(
+          id: "q-1",
+          sessionID: "session-a",
+          questions: [QuestionInfo(header: "h", question: "q")],
+        ),
+      );
+      expect(tracker.hasPendingInteraction("session-a"), isTrue);
+
+      tracker.handleEvent(
+        const SesoriSseEvent.questionReplied(requestID: "q-1", sessionID: "session-a"),
+      );
+      expect(tracker.hasPendingInteraction("session-a"), isFalse);
+
+      tracker.handleEvent(
+        const SesoriSseEvent.permissionAsked(
+          requestID: "req-1",
+          sessionID: "session-a",
+          tool: "bash",
+          description: "run",
+        ),
+      );
+      expect(tracker.hasPendingInteraction("session-a"), isTrue);
+    });
+
+    test("hasPendingInteraction includes direct child sessions", () {
+      final tracker = PushSessionStateTracker();
+
+      // Register parent and child.
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "parent"),
+        ),
+      );
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "child", parentID: "parent"),
+        ),
+      );
+
+      // No pending on either.
+      expect(tracker.hasPendingInteraction("parent"), isFalse);
+
+      // Question on child → parent group has pending interaction.
+      tracker.handleEvent(
+        const SesoriSseEvent.questionAsked(
+          id: "q-child",
+          sessionID: "child",
+          questions: [QuestionInfo(header: "h", question: "q")],
+        ),
+      );
+      expect(tracker.hasPendingInteraction("parent"), isTrue);
+      expect(tracker.hasPendingInteraction("child"), isTrue);
+
+      // Reply clears it.
+      tracker.handleEvent(
+        const SesoriSseEvent.questionReplied(requestID: "q-child", sessionID: "child"),
+      );
+      expect(tracker.hasPendingInteraction("parent"), isFalse);
+    });
+
+    test("getSessionTitle returns cached title or null", () {
+      final tracker = PushSessionStateTracker();
+
+      expect(tracker.getSessionTitle("missing"), isNull);
+
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "session-a", title: "A title"),
+        ),
+      );
+
+      expect(tracker.getSessionTitle("session-a"), equals("A title"));
+    });
+
+    test("getLatestAssistantText returns cached text or null", () {
+      final tracker = PushSessionStateTracker();
+
+      expect(tracker.getLatestAssistantText("session-a"), isNull);
+
+      tracker.handleEvent(
+        const SesoriSseEvent.messageUpdated(
+          info: Message(id: "m-1", role: "assistant", sessionID: "session-a"),
+        ),
+      );
+      tracker.handleEvent(
+        const SesoriSseEvent.messagePartUpdated(
+          part: MessagePart(
+            id: "p-1",
+            sessionID: "session-a",
+            messageID: "m-1",
+            type: "text",
+            text: "hello",
+          ),
+        ),
+      );
+
+      expect(tracker.getLatestAssistantText("session-a"), equals("hello"));
+    });
+
+    test("wasPreviouslyBusy true only when session was seen busy before idle", () {
+      final tracker = PushSessionStateTracker();
+
+      expect(tracker.wasPreviouslyBusy("session-a"), isFalse);
+
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(
+          sessionID: "session-a",
+          status: SessionStatus.busy(),
+        ),
+      );
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(
+          sessionID: "session-a",
+          status: SessionStatus.idle(),
+        ),
+      );
+
+      expect(tracker.wasPreviouslyBusy("session-a"), isTrue);
+    });
+
+    test("reset clears all maps and state", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker
+        ..handleEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "root", title: "Root"),
+          ),
+        )
+        ..handleEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "child", parentID: "root"),
+          ),
+        )
+        ..handleEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.busy()),
+        )
+        ..handleEvent(
+          const SesoriSseEvent.questionAsked(
+            id: "q-1",
+            sessionID: "root",
+            questions: [QuestionInfo(header: "h", question: "q")],
+          ),
+        )
+        ..handleEvent(
+          const SesoriSseEvent.permissionAsked(
+            requestID: "req-1",
+            sessionID: "root",
+            tool: "bash",
+            description: "run",
+          ),
+        )
+        ..handleEvent(
+          const SesoriSseEvent.messageUpdated(
+            info: Message(id: "m-1", role: "assistant", sessionID: "root"),
+          ),
+        )
+        ..handleEvent(
+          const SesoriSseEvent.messagePartUpdated(
+            part: MessagePart(
+              id: "p-1",
+              sessionID: "root",
+              messageID: "m-1",
+              type: "text",
+              text: "latest",
+            ),
+          ),
+        );
+
+      tracker.reset();
+
+      expect(tracker.isSessionGroupFullyIdle("root"), isTrue);
+      expect(tracker.hasPendingInteraction("root"), isFalse);
+      expect(tracker.getSessionTitle("root"), isNull);
+      expect(tracker.getLatestAssistantText("root"), isNull);
+      expect(tracker.wasPreviouslyBusy("root"), isFalse);
+      expect(tracker.resolveRootSessionId("child"), equals("child"));
+    });
+
+    test("handleEvent processes events and updates state", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "root", title: "Root title"),
+        ),
+      );
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.busy()),
+      );
+      tracker.handleEvent(
+        const SesoriSseEvent.questionAsked(
+          id: "q-1",
+          sessionID: "root",
+          questions: [QuestionInfo(header: "h", question: "q")],
+        ),
+      );
+
+      expect(tracker.isSessionGroupFullyIdle("root"), isFalse);
+      expect(tracker.hasPendingInteraction("root"), isTrue);
+      expect(tracker.getSessionTitle("root"), equals("Root title"));
+    });
+
+    test("cleans up session state on session deleted", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker
+        ..handleEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "root", title: "Root"),
+          ),
+        )
+        ..handleEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "child", parentID: "root"),
+          ),
+        )
+        ..handleEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.busy()),
+        )
+        ..handleEvent(
+          const SesoriSseEvent.questionAsked(
+            id: "q-1",
+            sessionID: "root",
+            questions: [QuestionInfo(header: "h", question: "q")],
+          ),
+        )
+        ..handleEvent(
+          const SesoriSseEvent.permissionAsked(
+            requestID: "req-1",
+            sessionID: "root",
+            tool: "bash",
+            description: "run",
+          ),
+        );
+
+      tracker.handleEvent(
+        SesoriSseEvent.sessionDeleted(
+          info: _session(id: "root", title: "Root"),
+        ),
+      );
+
+      expect(tracker.isSessionGroupFullyIdle("root"), isTrue);
+      expect(tracker.hasPendingInteraction("root"), isFalse);
+      expect(tracker.getSessionTitle("root"), isNull);
+      expect(tracker.wasPreviouslyBusy("root"), isFalse);
+      expect(tracker.resolveRootSessionId("child"), equals("child"));
+    });
+
+    test("ignores message part updates with non-text type", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker
+        ..handleEvent(
+          const SesoriSseEvent.messageUpdated(
+            info: Message(id: "m-1", role: "assistant", sessionID: "session-a"),
+          ),
+        )
+        ..handleEvent(
+          const SesoriSseEvent.messagePartUpdated(
+            part: MessagePart(
+              id: "p-1",
+              sessionID: "session-a",
+              messageID: "m-1",
+              type: "tool",
+              text: "should be ignored",
+            ),
+          ),
+        );
+
+      expect(tracker.getLatestAssistantText("session-a"), isNull);
+    });
+
+    test("ignores message part updates for non-assistant messages", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker
+        ..handleEvent(
+          const SesoriSseEvent.messageUpdated(
+            info: Message(id: "m-1", role: "user", sessionID: "session-a"),
+          ),
+        )
+        ..handleEvent(
+          const SesoriSseEvent.messagePartUpdated(
+            part: MessagePart(
+              id: "p-1",
+              sessionID: "session-a",
+              messageID: "m-1",
+              type: "text",
+              text: "should be ignored",
+            ),
+          ),
+        );
+
+      expect(tracker.getLatestAssistantText("session-a"), isNull);
+    });
+
+    test("idle without prior busy does not mark session as previously busy", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(
+          sessionID: "session-a",
+          status: SessionStatus.idle(),
+        ),
+      );
+
+      expect(tracker.wasPreviouslyBusy("session-a"), isFalse);
+      expect(tracker.isSessionGroupFullyIdle("session-a"), isTrue);
+    });
+  });
+}
+
+Session _session({
+  required String id,
+  String projectID = "project-a",
+  String directory = "/tmp/project",
+  String? parentID,
+  String? title,
+}) {
+  return Session(
+    id: id,
+    projectID: projectID,
+    directory: directory,
+    parentID: parentID,
+    title: title,
+  );
+}

--- a/bridge/app/test/push/push_session_state_tracker_test.dart
+++ b/bridge/app/test/push/push_session_state_tracker_test.dart
@@ -243,6 +243,40 @@ void main() {
       expect(tracker.isSessionGroupFullyIdle("root"), isTrue);
     });
 
+    test("isSessionGroupFullyIdle returns false when a grandchild is busy", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(SesoriSseEvent.sessionCreated(info: _session(id: "root")));
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "child", parentID: "root"),
+        ),
+      );
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "grandchild", parentID: "child"),
+        ),
+      );
+
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(
+          sessionID: "grandchild",
+          status: SessionStatus.busy(),
+        ),
+      );
+
+      expect(tracker.isSessionGroupFullyIdle("root"), isFalse);
+
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(
+          sessionID: "grandchild",
+          status: SessionStatus.idle(),
+        ),
+      );
+
+      expect(tracker.isSessionGroupFullyIdle("root"), isTrue);
+    });
+
     test("hasPendingInteraction returns true for pending question or permission", () {
       final tracker = PushSessionStateTracker();
 
@@ -305,6 +339,41 @@ void main() {
         const SesoriSseEvent.questionReplied(requestID: "q-child", sessionID: "child"),
       );
       expect(tracker.hasPendingInteraction("parent"), isFalse);
+    });
+
+    test("hasPendingInteraction includes grandchild sessions", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(SesoriSseEvent.sessionCreated(info: _session(id: "root")));
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "child", parentID: "root"),
+        ),
+      );
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "grandchild", parentID: "child"),
+        ),
+      );
+
+      tracker.handleEvent(
+        const SesoriSseEvent.questionAsked(
+          id: "q-grandchild",
+          sessionID: "grandchild",
+          questions: [QuestionInfo(header: "h", question: "q")],
+        ),
+      );
+
+      expect(tracker.hasPendingInteraction("root"), isTrue);
+
+      tracker.handleEvent(
+        const SesoriSseEvent.questionReplied(
+          requestID: "q-grandchild",
+          sessionID: "grandchild",
+        ),
+      );
+
+      expect(tracker.hasPendingInteraction("root"), isFalse);
     });
 
     test("getSessionTitle returns cached title or null", () {

--- a/shared/sesori_shared/lib/src/models/sesori/notification_data.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/notification_data.dart
@@ -72,12 +72,10 @@ enum NotificationEventType {
   questionAsked,
   @JsonValue("permission_asked")
   permissionAsked,
-  @JsonValue("message_updated")
-  messageUpdated,
   @JsonValue("installation_update_available")
   installationUpdateAvailable,
-  @JsonValue("session_completed")
-  sessionCompleted,
+  @JsonValue("agent_turn_completed")
+  agentTurnCompleted,
   // fallback for unknown event types (for backwards compatibility)
   @JsonValue("unknown")
   unknown,

--- a/shared/sesori_shared/lib/src/models/sesori/notification_data.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/notification_data.dart
@@ -76,6 +76,8 @@ enum NotificationEventType {
   messageUpdated,
   @JsonValue("installation_update_available")
   installationUpdateAvailable,
+  @JsonValue("session_completed")
+  sessionCompleted,
   // fallback for unknown event types (for backwards compatibility)
   @JsonValue("unknown")
   unknown,

--- a/shared/sesori_shared/lib/src/models/sesori/notification_data.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/notification_data.g.dart
@@ -38,9 +38,8 @@ const _$NotificationCategoryEnumMap = {
 const _$NotificationEventTypeEnumMap = {
   NotificationEventType.questionAsked: 'question_asked',
   NotificationEventType.permissionAsked: 'permission_asked',
-  NotificationEventType.messageUpdated: 'message_updated',
   NotificationEventType.installationUpdateAvailable:
       'installation_update_available',
-  NotificationEventType.sessionCompleted: 'session_completed',
+  NotificationEventType.agentTurnCompleted: 'agent_turn_completed',
   NotificationEventType.unknown: 'unknown',
 };

--- a/shared/sesori_shared/lib/src/models/sesori/notification_data.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/notification_data.g.dart
@@ -41,5 +41,6 @@ const _$NotificationEventTypeEnumMap = {
   NotificationEventType.messageUpdated: 'message_updated',
   NotificationEventType.installationUpdateAvailable:
       'installation_update_available',
+  NotificationEventType.sessionCompleted: 'session_completed',
   NotificationEventType.unknown: 'unknown',
 };


### PR DESCRIPTION
## Summary

- Replace noisy per-message push notifications with a single "session completed" notification that fires when the AI finishes all work (main agent + all subtasks idle)
- Add `PushSessionStateTracker` to track session statuses, parent-child relationships, pending questions/permissions, session titles, and latest assistant text
- Refactor `PushNotificationService` from stateless to stateful with 500ms debounce, group-idle detection, and question/permission suppression
- Notification content now shows truncated session title + ~10 words from AI reply instead of generic "New session message"

## Changes

### Shared (`sesori_shared`)
- Add `NotificationEventType.sessionCompleted` enum value

### Bridge
- **New**: `PushSessionStateTracker` — pure state machine tracking session lifecycle events for notification decisions
- **Refactored**: `PushNotificationService` — now stateful with:
  - 500ms debounce after busy→idle transition before sending completion notification
  - Parent-child group awareness (only fires when root + all children idle)
  - Pending question/permission suppression (defers to existing `aiInteraction` notification)
  - `dispose()` / `reset()` lifecycle methods for timer management
  - Content formatting: truncated session title (50 chars) + message snippet (10 words) with fallbacks
- **Orchestrator**: `reset()` on reconnect, `dispose()` on shutdown
- **Removed**: `SesoriMessageUpdated` notification mapping (no more per-message notifications)

### Tests
- 58 tests covering all acceptance criteria and edge cases
- `fakeAsync` for deterministic timer testing
- Hand-written fakes (no mockito)

## What This Solves
1. **User's own messages no longer trigger notifications** — `SesoriMessageUpdated` mapping removed entirely
2. **AI responses don't spam** — one notification when done, not per-message
3. **Subtasks respected** — waits for main agent + all child sessions to finish
4. **No duplicate with question/permission** — if AI is asking a question, only the question notification fires
5. **Friendly content** — session title + message preview instead of "New session message" / "assistant updated message m-123"