### PR TITLE
fix(bridge): merge tracker SSE statuses into getSessionStatuses response

### DIFF
--- a/bridge/app/yaak/opencode/yaak.rq_35oLQknZX8.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_35oLQknZX8.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_35oLQknZX8
 createdAt: 2026-03-23T14:35:57.877892
-updatedAt: 2026-03-23T14:37:49.955261
+updatedAt: 2026-03-25T12:13:39.624089
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_AHgrxwb38h
 authentication: {}
@@ -20,13 +20,9 @@ headers:
   value: application/json
   id: ZKKNTARaxK
 - enabled: true
-  name: x-opencode-directory
-  value: /Users/alexandrudochioiu/sesori-ai/sesori_apps_monorepo
-  id: wMmVRg8M8R
-- enabled: true
   name: ''
   value: ''
-  id: i8StkUdi4J
+  id: Wg6ivZpixf
 method: POST
 name: Reply to Question
 sortPriority: 0.0

--- a/bridge/app/yaak/opencode/yaak.rq_4ugDZFeSMc.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_4ugDZFeSMc.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_4ugDZFeSMc
 createdAt: 2026-03-13T12:50:55.869145
-updatedAt: 2026-03-13T12:56:35.316524
+updatedAt: 2026-03-25T12:14:12.733008
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_yk5jRTWYoF
 authentication: {}
@@ -27,9 +27,9 @@ url: ${[ base_url ]}/session/:sessionID/share
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ''
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: ''
   value: ''
-  id: WYqwwFSh9E
+  id: yPMNaBc3N4

--- a/bridge/app/yaak/opencode/yaak.rq_6DUWeLhvkX.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_6DUWeLhvkX.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_6DUWeLhvkX
 createdAt: 2026-03-13T12:45:07.130166
-updatedAt: 2026-03-13T12:48:54.467329
+updatedAt: 2026-03-25T12:13:44.373674
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_McTnzzzzcF
 authentication: {}
@@ -23,7 +23,11 @@ description: |-
     "permission": {} // optional — permission ruleset
   }
   ```
-headers: []
+headers:
+- enabled: true
+  name: ''
+  value: ''
+  id: EqnmISnM9K
 method: POST
 name: Create New Session
 sortPriority: 3000.0

--- a/bridge/app/yaak/opencode/yaak.rq_6U2nLMDY7K.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_6U2nLMDY7K.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_6U2nLMDY7K
 createdAt: 2026-03-13T12:47:56.012412
-updatedAt: 2026-03-13T12:56:35.313282
+updatedAt: 2026-03-25T12:15:06.296948
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_yk5jRTWYoF
 authentication: {}
@@ -27,9 +27,9 @@ url: ${[ base_url ]}/session/:sessionID
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ''
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: ''
   value: ''
-  id: WYqwwFSh9E
+  id: RuQc37Kndq

--- a/bridge/app/yaak/opencode/yaak.rq_85uGEoShnV.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_85uGEoShnV.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_85uGEoShnV
 createdAt: 2026-03-13T12:53:20.497170
-updatedAt: 2026-03-13T12:56:35.318199
+updatedAt: 2026-03-25T12:14:04.495982
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_yk5jRTWYoF
 authentication: {}
@@ -39,9 +39,9 @@ url: ${[ base_url ]}/session/:sessionID/revert
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ''
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: ''
   value: ''
-  id: WYqwwFSh9E
+  id: GBpiQMvJfc

--- a/bridge/app/yaak/opencode/yaak.rq_8WAJx3BNjJ.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_8WAJx3BNjJ.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_8WAJx3BNjJ
 createdAt: 2026-03-13T12:35:12.359372
-updatedAt: 2026-03-13T12:35:42.223600
+updatedAt: 2026-03-25T12:18:58.674701
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_CEW8q5zwRE
 authentication: {}
@@ -19,9 +19,9 @@ url: ${[ base_url ]}/global/:providerID
 urlParameters:
 - enabled: true
   name: :providerID
-  value: anthropic
+  value: anthropic (test)
   id: 8y4ICupfsC
 - enabled: true
   name: ''
   value: ''
-  id: GhvfyHH8K4
+  id: xEVPhyVnxp

--- a/bridge/app/yaak/opencode/yaak.rq_8qQzdWKdFL.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_8qQzdWKdFL.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_8qQzdWKdFL
 createdAt: 2026-03-13T13:01:04.771763
-updatedAt: 2026-03-13T13:03:04.957235
+updatedAt: 2026-03-25T12:12:02.965624
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_Y6vgggGpzk
 authentication: {}
@@ -41,9 +41,9 @@ url: ${[ base_url ]}/session/:sessionID/prompt_async
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ses_318d2c9e3ffeZ6s6SJu83vXQv3
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: ''
   value: ''
-  id: DHI5EH0usq
+  id: vjj9eRDv2N

--- a/bridge/app/yaak/opencode/yaak.rq_AzuoAzjtUK.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_AzuoAzjtUK.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_AzuoAzjtUK
 createdAt: 2026-03-13T12:44:03.283053
-updatedAt: 2026-03-21T08:13:35.068152
+updatedAt: 2026-03-25T12:10:12.445586
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_yk5jRTWYoF
 authentication: {}
@@ -35,9 +35,9 @@ url: ${[ base_url ]}/session/:sessionID
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ses_2f08dbf52ffezTT6Rtn4R9FbzX
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: ''
   value: ''
-  id: wBnV5Uw9FE
+  id: rCAAcsfUuc

--- a/bridge/app/yaak/opencode/yaak.rq_DyXk9gYNMk.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_DyXk9gYNMk.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_DyXk9gYNMk
 createdAt: 2026-03-13T12:59:52.823596
-updatedAt: 2026-03-13T13:03:04.956535
+updatedAt: 2026-03-25T12:11:28.344130
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_Y6vgggGpzk
 authentication: {}
@@ -63,9 +63,9 @@ url: ${[ base_url ]}/session/:sessionID/message
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ses_318d2c9e3ffeZ6s6SJu83vXQv3
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: ''
   value: ''
-  id: DHI5EH0usq
+  id: SJ77k2BTSJ

--- a/bridge/app/yaak/opencode/yaak.rq_EiqVfGFhMB.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_EiqVfGFhMB.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_EiqVfGFhMB
 createdAt: 2026-03-13T12:54:45.028620
-updatedAt: 2026-03-13T12:56:35.309848
+updatedAt: 2026-03-25T12:10:18.980343
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_yk5jRTWYoF
 authentication: {}
@@ -23,9 +23,9 @@ url: ${[ base_url ]}/session/:sessionID/children
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ses_318d2c9e3ffeZ6s6SJu83vXQv3
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: ''
   value: ''
-  id: E7Q3MKJyIZ
+  id: ayZJ39gKE3

--- a/bridge/app/yaak/opencode/yaak.rq_J8opUFNVgn.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_J8opUFNVgn.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_J8opUFNVgn
 createdAt: 2026-03-13T12:54:12.550293
-updatedAt: 2026-03-13T12:56:35.318945
+updatedAt: 2026-03-25T12:14:00.847031
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_yk5jRTWYoF
 authentication: {}
@@ -33,9 +33,9 @@ url: ${[ base_url ]}/session/:sessionID/unrevert
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ''
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: ''
   value: ''
-  id: WYqwwFSh9E
+  id: hYdjaXfx2r

--- a/bridge/app/yaak/opencode/yaak.rq_MBpgmJUDuF.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_MBpgmJUDuF.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_MBpgmJUDuF
 createdAt: 2026-03-13T12:49:08.853917
-updatedAt: 2026-03-13T12:56:35.314070
+updatedAt: 2026-03-25T12:15:02.925768
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_yk5jRTWYoF
 authentication: {}
@@ -39,9 +39,9 @@ url: ${[ base_url ]}/session/:sessionID/fork
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ''
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: ''
   value: ''
-  id: WYqwwFSh9E
+  id: VwjqGJztrv

--- a/bridge/app/yaak/opencode/yaak.rq_Mo7uqACELb.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_Mo7uqACELb.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_Mo7uqACELb
 createdAt: 2026-03-13T12:55:32.014739
-updatedAt: 2026-03-13T12:56:35.311487
+updatedAt: 2026-03-25T12:10:41.494647
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_yk5jRTWYoF
 authentication: {}
@@ -25,11 +25,11 @@ url: ${[ base_url ]}/session/:sessionID/diff
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ses_318d2c9e3ffeZ6s6SJu83vXQv3
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: messageID
-  value: required
+  value: ${[ message_id ]}
   id: XQWMQAhEWv
 - enabled: false
   name: partID
@@ -38,4 +38,4 @@ urlParameters:
 - enabled: true
   name: ''
   value: ''
-  id: n6rrDDemJg
+  id: Sd3KNvfxXZ

--- a/bridge/app/yaak/opencode/yaak.rq_N7mJB3jFam.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_N7mJB3jFam.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_N7mJB3jFam
 createdAt: 2026-03-13T13:02:59.943083
-updatedAt: 2026-03-13T13:03:20.892223
+updatedAt: 2026-03-25T12:12:20.707302
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_Y6vgggGpzk
 authentication: {}
@@ -23,13 +23,13 @@ url: ${[ base_url ]}/session/:sessionID/shell
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ses_318d2c9e3ffeZ6s6SJu83vXQv3
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: :messageID
-  value: msg_ce72d37a5001yyBvHZnV1wfmkR
+  value: ${[ message_id ]}
   id: thUXzDnqTk
 - enabled: true
   name: ''
   value: ''
-  id: msHkU69j74
+  id: xD206XVzvg

--- a/bridge/app/yaak/opencode/yaak.rq_N8oLQXLeLP.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_N8oLQXLeLP.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_N8oLQXLeLP
 createdAt: 2026-03-13T13:03:53.315465
-updatedAt: 2026-03-13T13:04:19.321274
+updatedAt: 2026-03-25T12:11:09.295875
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_Y6vgggGpzk
 authentication: {}
@@ -23,13 +23,13 @@ url: ${[ base_url ]}/session/:sessionID/message/:messageID
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ses_318d2c9e3ffeZ6s6SJu83vXQv3
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: :messageID
-  value: msg_ce72d37a5001yyBvHZnV1wfmkR
+  value: ${[ message_id ]}
   id: thUXzDnqTk
 - enabled: true
   name: ''
   value: ''
-  id: msHkU69j74
+  id: Fvdbdvnpek

--- a/bridge/app/yaak/opencode/yaak.rq_Nt8SnNRUJs.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_Nt8SnNRUJs.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_Nt8SnNRUJs
 createdAt: 2026-03-13T12:50:03.612944
-updatedAt: 2026-03-13T12:56:35.314965
+updatedAt: 2026-03-25T12:14:55.321756
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_yk5jRTWYoF
 authentication: {}
@@ -27,9 +27,9 @@ url: ${[ base_url ]}/session/:sessionID/abort
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ''
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: ''
   value: ''
-  id: WYqwwFSh9E
+  id: FhdaudWpHb

--- a/bridge/app/yaak/opencode/yaak.rq_QMTnZRrYKQ.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_QMTnZRrYKQ.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_QMTnZRrYKQ
 createdAt: 2026-03-13T12:17:59.419424
-updatedAt: 2026-03-15T10:57:52.695545
+updatedAt: 2026-03-25T12:18:21.977765
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_8zJSeVv6ST
 authentication: {}
@@ -12,15 +12,11 @@ bodyType: null
 description: ''
 headers: []
 method: GET
-name: Session
+name: Session (all projects)
 sortPriority: -1773404101891.0
 url: ${[ base_url ]}/experimental/session
 urlParameters:
 - enabled: true
-  name: worktree
-  value: /Users/alexandrudochioiu/sesori-ai/sesori_mobile
-  id: VWw5F4cXz7
-- enabled: true
   name: ''
   value: ''
-  id: 2XaCBKCQaH
+  id: DB4HVcfKWq

--- a/bridge/app/yaak/opencode/yaak.rq_TqJPQ2PVhp.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_TqJPQ2PVhp.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_TqJPQ2PVhp
 createdAt: 2026-03-13T13:05:32.481288
-updatedAt: 2026-03-13T13:05:48.252786
+updatedAt: 2026-03-25T12:15:49.240651
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_HfZ2GNqEB8
 authentication: {}
@@ -24,13 +24,17 @@ url: ${[ base_url ]}/session/:sessionID/message/:messageID/part/:partID
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ses_318d2c9e3ffeZ6s6SJu83vXQv3
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: :messageID
-  value: msg_ce72d37a5001yyBvHZnV1wfmkR
+  value: ${[ message_id ]}
   id: thUXzDnqTk
+- enabled: true
+  name: :partID
+  value: ${[ part_id ]}
+  id: wAhK658siS
 - enabled: true
   name: ''
   value: ''
-  id: msHkU69j74
+  id: 7DbsKAifh7

--- a/bridge/app/yaak/opencode/yaak.rq_VX9QrZeDUP.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_VX9QrZeDUP.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_VX9QrZeDUP
 createdAt: 2026-03-13T12:55:12.667466
-updatedAt: 2026-03-13T12:56:35.310673
+updatedAt: 2026-03-25T12:10:22.042313
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_yk5jRTWYoF
 authentication: {}
@@ -23,9 +23,9 @@ url: ${[ base_url ]}/session/:sessionID/todo
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ses_318d2c9e3ffeZ6s6SJu83vXQv3
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: ''
   value: ''
-  id: E7Q3MKJyIZ
+  id: eTpyy8rdgv

--- a/bridge/app/yaak/opencode/yaak.rq_YJFJuFifCr.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_YJFJuFifCr.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_YJFJuFifCr
 createdAt: 2026-03-13T12:56:30.781590
-updatedAt: 2026-03-13T12:57:08.376804
+updatedAt: 2026-03-25T12:13:17.727750
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_McTnzzzzcF
 authentication: {}
@@ -22,17 +22,17 @@ description: |-
     "session_xyz": "busy"
   }
   ```
-headers: []
+headers:
+- enabled: true
+  name: ''
+  value: ''
+  id: AiPMZcJ3fq
 method: GET
 name: Session Status
 sortPriority: 2333.3333333333335
 url: ${[ base_url ]}/session/status
 urlParameters:
 - enabled: true
-  name: :sessionID
-  value: ses_318d2c9e3ffeZ6s6SJu83vXQv3
-  id: kz6efcSPKb
-- enabled: true
   name: ''
   value: ''
-  id: E7Q3MKJyIZ
+  id: scwHIAhW2X

--- a/bridge/app/yaak/opencode/yaak.rq_kCdbCv3Pfy.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_kCdbCv3Pfy.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_kCdbCv3Pfy
 createdAt: 2026-03-13T12:46:05.029460
-updatedAt: 2026-03-13T12:56:35.312415
+updatedAt: 2026-03-25T12:15:09.195374
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_yk5jRTWYoF
 authentication: {}
@@ -41,9 +41,9 @@ url: ${[ base_url ]}/session/:sessionID
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ''
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: ''
   value: ''
-  id: WYqwwFSh9E
+  id: zZ0UAdBT3s

--- a/bridge/app/yaak/opencode/yaak.rq_mjbV7yeSh4.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_mjbV7yeSh4.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_mjbV7yeSh4
 createdAt: 2026-03-13T12:50:27.946792
-updatedAt: 2026-03-13T12:56:35.315737
+updatedAt: 2026-03-25T12:14:15.904005
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_yk5jRTWYoF
 authentication: {}
@@ -27,9 +27,9 @@ url: ${[ base_url ]}/session/:sessionID/share
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ''
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: ''
   value: ''
-  id: WYqwwFSh9E
+  id: n6Mj6MiB0N

--- a/bridge/app/yaak/opencode/yaak.rq_rckUaYrLFM.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_rckUaYrLFM.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_rckUaYrLFM
 createdAt: 2026-03-13T12:51:28.302938
-updatedAt: 2026-03-13T12:56:35.317437
+updatedAt: 2026-03-25T12:14:09.604519
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_yk5jRTWYoF
 authentication: {}
@@ -27,9 +27,9 @@ url: ${[ base_url ]}/session/:sessionID/summarize
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ''
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: ''
   value: ''
-  id: WYqwwFSh9E
+  id: rPnrBRkqhI

--- a/bridge/app/yaak/opencode/yaak.rq_rsCAN6A9zh.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_rsCAN6A9zh.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_rsCAN6A9zh
 createdAt: 2026-03-24T12:42:42.183998
-updatedAt: 2026-03-24T12:49:00.651053
+updatedAt: 2026-03-25T12:13:32.991376
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_AHgrxwb38h
 authentication: {}
@@ -17,13 +17,9 @@ headers:
   value: application/json
   id: ZKKNTARaxK
 - enabled: true
-  name: x-opencode-directory
-  value: /Users/alexandrudochioiu/sesori-ai/sesori_apps_monorepo
-  id: wMmVRg8M8R
-- enabled: true
   name: ''
   value: ''
-  id: fkUfgIT6Jz
+  id: qPsbGfRJJg
 method: GET
 name: Questions List
 sortPriority: 0.001

--- a/bridge/app/yaak/opencode/yaak.rq_sVCFwvKjhS.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_sVCFwvKjhS.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_sVCFwvKjhS
 createdAt: 2026-03-13T13:01:49.577890
-updatedAt: 2026-03-13T13:03:04.958092
+updatedAt: 2026-03-25T12:12:14.032142
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_Y6vgggGpzk
 authentication: {}
@@ -39,9 +39,9 @@ url: ${[ base_url ]}/session/:sessionID/command
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ses_318d2c9e3ffeZ6s6SJu83vXQv3
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: ''
   value: ''
-  id: DHI5EH0usq
+  id: wZUU0GSjPC

--- a/bridge/app/yaak/opencode/yaak.rq_uHvP6X9GLW.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_uHvP6X9GLW.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_uHvP6X9GLW
 createdAt: 2026-03-13T13:04:45.765670
-updatedAt: 2026-03-13T13:05:22.530085
+updatedAt: 2026-03-25T12:15:56.428700
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_HfZ2GNqEB8
 authentication: {}
@@ -23,13 +23,17 @@ url: ${[ base_url ]}/session/:sessionID/message/:messageID/part/:partID
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ses_318d2c9e3ffeZ6s6SJu83vXQv3
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: :messageID
-  value: msg_ce72d37a5001yyBvHZnV1wfmkR
+  value: ${[ message_id ]}
   id: thUXzDnqTk
+- enabled: true
+  name: :partID
+  value: ${[ part_id ]}
+  id: GVJkHYa72A
 - enabled: true
   name: ''
   value: ''
-  id: msHkU69j74
+  id: 53yqSndEhZ

--- a/bridge/app/yaak/opencode/yaak.rq_uWEWKdJTp2.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_uWEWKdJTp2.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_uWEWKdJTp2
 createdAt: 2026-03-13T12:38:17.775650
-updatedAt: 2026-03-13T12:39:48.450863
+updatedAt: 2026-03-25T12:16:24.555605
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_MnoHDmtDYi
 authentication: {}
@@ -82,9 +82,9 @@ url: ${[ base_url ]}/project/:projectID
 urlParameters:
 - enabled: true
   name: :projectID
-  value: ''
+  value: ${[ project_id ]}
   id: 0SgjNqT9Zt
 - enabled: true
   name: ''
   value: ''
-  id: 05Jezz6XXH
+  id: edE8gDvQeQ

--- a/bridge/app/yaak/opencode/yaak.rq_vjYY9Smsj6.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_vjYY9Smsj6.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_vjYY9Smsj6
 createdAt: 2026-03-13T12:37:01.107807
-updatedAt: 2026-03-21T12:41:31.596738
+updatedAt: 2026-03-25T12:17:01.818646
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_MnoHDmtDYi
 authentication: {}
@@ -12,13 +12,9 @@ bodyType: null
 description: "`x-opencode-directory` header \n* used to give a path to look. \n* When missing, it uses the path where the server was started.\n* Seems to find the best match (it will keep on going one dir level up until it finds an existing opencode project)"
 headers:
 - enabled: true
-  name: x-opencode-directory
-  value: /Users/alexandrudochioiu/sesori-ai/sesori_auth_server/test/
-  id: ZncWse2XIT
-- enabled: true
   name: ''
   value: ''
-  id: IXVQt4MquG
+  id: sWXf56neYY
 method: GET
 name: Current (or at directory)
 sortPriority: 2000.0

--- a/bridge/app/yaak/opencode/yaak.rq_wF9ZECFv3B.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_wF9ZECFv3B.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_wF9ZECFv3B
 createdAt: 2026-03-13T12:58:42.885992
-updatedAt: 2026-03-13T13:03:04.955762
+updatedAt: 2026-03-25T12:10:58.390174
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_Y6vgggGpzk
 authentication: {}
@@ -23,13 +23,13 @@ url: ${[ base_url ]}/session/:sessionID/message/:messageID
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ses_318d2c9e3ffeZ6s6SJu83vXQv3
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: :messageID
-  value: msg_ce72d37a5001yyBvHZnV1wfmkR
+  value: ${[ message_id ]}
   id: thUXzDnqTk
 - enabled: true
   name: ''
   value: ''
-  id: msHkU69j74
+  id: s83ttx9IxS

--- a/bridge/app/yaak/opencode/yaak.rq_zhrLKDR8xV.yaml
+++ b/bridge/app/yaak/opencode/yaak.rq_zhrLKDR8xV.yaml
@@ -2,7 +2,7 @@ type: http_request
 model: http_request
 id: rq_zhrLKDR8xV
 createdAt: 2026-03-13T12:57:40.667170
-updatedAt: 2026-03-21T08:13:41.937342
+updatedAt: 2026-03-25T12:11:16.588995
 workspaceId: wk_CKpMKQdH7W
 folderId: fl_Y6vgggGpzk
 authentication: {}
@@ -41,9 +41,9 @@ url: ${[ base_url ]}/session/:sessionID/message
 urlParameters:
 - enabled: true
   name: :sessionID
-  value: ses_2f08dbf52ffezTT6Rtn4R9FbzX
+  value: ${[ session_id ]}
   id: kz6efcSPKb
 - enabled: true
   name: ''
   value: ''
-  id: Qvudidxg53
+  id: F8wVBtH0tj

--- a/bridge/app/yaak/opencode/yaak.wk_CKpMKQdH7W.yaml
+++ b/bridge/app/yaak/opencode/yaak.wk_CKpMKQdH7W.yaml
@@ -2,11 +2,19 @@ type: workspace
 model: workspace
 id: wk_CKpMKQdH7W
 createdAt: 2026-03-13T12:14:59.017417
-updatedAt: 2026-03-13T12:14:59.017417
+updatedAt: 2026-03-25T12:13:13.404324
 authentication: {}
 authenticationType: null
 description: ''
-headers: []
+headers:
+- enabled: true
+  name: x-opencode-directory
+  value: ${[ directory ]}
+  id: NhBk7IeTZi
+- enabled: true
+  name: ''
+  value: ''
+  id: MyUN0pfMkP
 name: OpenCode
 encryptionKeyChallenge: null
 settingValidateCertificates: true

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -138,6 +138,16 @@ class ActiveSessionTracker {
     return _sessionDirectories[sessionId];
   }
 
+  /// Returns the current status of every session the tracker considers
+  /// active (busy or retry).
+  ///
+  /// This map is maintained in real time by SSE events and is the most
+  /// accurate source of session status. Sessions that are idle are absent
+  /// from the map.
+  Map<String, SessionStatus> getActiveStatuses() {
+    return Map.unmodifiable(_sessionStatuses);
+  }
+
   List<ProjectActivitySummary> buildSummary() {
     // Partition active (busy/retry) sessions into root vs child.
     final activeRoots = <String>{};

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -278,8 +278,21 @@ class OpenCodePlugin implements BridgePlugin {
 
   @override
   Future<Map<String, PluginSessionStatus>> getSessionStatuses() async {
-    final statuses = await _call(_service.repository.api.getSessionStatuses);
-    return statuses.map((key, value) => MapEntry(key, value.toPlugin()));
+    final apiStatuses = await _call(_service.repository.api.getSessionStatuses);
+
+    // Start with the API response as a baseline.
+    final merged = apiStatuses.map((key, value) => MapEntry(key, value.toPlugin()));
+
+    // Overlay the tracker's real-time active statuses. The tracker is
+    // maintained by SSE events and accurately reflects which sessions are
+    // busy/retry. The API response may be scoped by OpenCode's directory
+    // context and miss sessions from other projects.
+    final activeStatuses = _service.tracker.getActiveStatuses();
+    for (final entry in activeStatuses.entries) {
+      merged[entry.key] = entry.value.toPlugin();
+    }
+
+    return merged;
   }
 
   @override

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -113,6 +113,85 @@ void main() {
       });
     });
 
+    group("getActiveStatuses", () {
+      test("empty tracker returns empty map", () {
+        final tracker = ActiveSessionTracker(_fakeRepository());
+
+        expect(tracker.getActiveStatuses(), isEmpty);
+      });
+
+      test("coldStart populates active statuses from busy/retry sessions", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/projects/foo")],
+          sessions: [
+            _session("s1", "/projects/foo"),
+            _session("s2", "/projects/foo"),
+            _session("s3", "/projects/foo"),
+          ],
+          statuses: {
+            "s1": const SessionStatus.busy(),
+            "s2": const SessionStatus.idle(),
+            "s3": const SessionStatus.retry(attempt: 1, message: "fail", next: 123),
+          },
+        );
+
+        final active = tracker.getActiveStatuses();
+
+        expect(active, hasLength(2));
+        expect(active["s1"], isA<SessionStatusBusy>());
+        expect(active["s3"], isA<SessionStatusRetry>());
+        expect(active.containsKey("s2"), isFalse);
+      });
+
+      test("SSE busy event adds to active statuses", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/projects/foo")],
+        );
+
+        tracker.handleEvent(_sessionCreated("s1", "/projects/foo"), null);
+        tracker.handleEvent(_sessionBusy("s1"), null);
+
+        final active = tracker.getActiveStatuses();
+
+        expect(active, hasLength(1));
+        expect(active["s1"], isA<SessionStatusBusy>());
+      });
+
+      test("SSE idle event removes from active statuses", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/projects/foo")],
+          sessions: [_session("s1", "/projects/foo")],
+          statuses: {"s1": const SessionStatus.busy()},
+        );
+        expect(tracker.getActiveStatuses(), hasLength(1));
+
+        tracker.handleEvent(_sessionIdle("s1"), null);
+
+        expect(tracker.getActiveStatuses(), isEmpty);
+      });
+
+      test("returns unmodifiable map", () {
+        final tracker = ActiveSessionTracker(_fakeRepository());
+
+        final active = tracker.getActiveStatuses();
+
+        expect(() => active["x"] = const SessionStatus.busy(), throwsA(anything));
+      });
+
+      test("reset clears active statuses", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/projects/foo")],
+          sessions: [_session("s1", "/projects/foo")],
+          statuses: {"s1": const SessionStatus.busy()},
+        );
+        expect(tracker.getActiveStatuses(), hasLength(1));
+
+        tracker.reset();
+
+        expect(tracker.getActiveStatuses(), isEmpty);
+      });
+    });
+
     test("session directory exactly matches worktree", () async {
       final tracker = await _coldStartedTracker(
         projects: [const Project(id: "p1", worktree: "/projects/foo")],

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -137,7 +137,146 @@ void main() {
 
       expect(collected.whereType<BridgeSseProjectUpdated>(), isNotEmpty);
     });
+
+    test("getSessionStatuses merges tracker data with API response", () async {
+      // Use a configurable server: cold start sees the full status map
+      // (including a busy child), but subsequent API calls return only
+      // the root session — simulating OpenCode's directory-scoped response.
+      final dynamicServer = _DynamicStatusServer();
+      await dynamicServer.start();
+      addTearDown(dynamicServer.close);
+
+      // During cold start, the tracker ingests the busy child status.
+      dynamicServer.sessionStatuses = {
+        "s-root": {"type": "idle"},
+        "child-1": {"type": "busy"},
+      };
+
+      final plugin = OpenCodePlugin(serverUrl: dynamicServer.baseUrl);
+      await dynamicServer.waitForSseConnection();
+
+      // Now change the API response to omit the child — as if OpenCode
+      // scoped /session/status by directory on subsequent calls.
+      dynamicServer.sessionStatuses = {
+        "s-root": {"type": "idle"},
+      };
+
+      final statuses = await plugin.getSessionStatuses();
+
+      // API-returned status is preserved.
+      expect(statuses["s-root"], isA<PluginSessionStatusIdle>());
+      // The tracker's SSE-maintained busy status fills in the gap the
+      // scoped API response left — this is the fix for the cold-load bug.
+      expect(statuses["child-1"], isA<PluginSessionStatusBusy>());
+    });
+
+    test("getSessionStatuses tracker overrides stale API idle", () async {
+      final dynamicServer = _DynamicStatusServer();
+      await dynamicServer.start();
+      addTearDown(dynamicServer.close);
+
+      // Cold start: root is busy in the tracker.
+      dynamicServer.sessionStatuses = {
+        "s-root": {"type": "busy"},
+      };
+
+      final plugin = OpenCodePlugin(serverUrl: dynamicServer.baseUrl);
+      await dynamicServer.waitForSseConnection();
+
+      // API now returns idle — stale relative to the tracker.
+      dynamicServer.sessionStatuses = {
+        "s-root": {"type": "idle"},
+      };
+
+      final statuses = await plugin.getSessionStatuses();
+
+      // Tracker's busy overrides the API's stale idle.
+      expect(statuses["s-root"], isA<PluginSessionStatusBusy>());
+    });
   });
+}
+
+/// A lightweight fake OpenCode server whose `/session/status` response can be
+/// changed between calls — used to test the merge of API data with tracker data.
+class _DynamicStatusServer {
+  HttpServer? _server;
+  final Completer<void> _firstSseClient = Completer<void>();
+
+  /// The JSON map returned by `GET /session/status`. Mutable so tests can
+  /// change it between the cold-start call and the explicit plugin call.
+  Map<String, Map<String, dynamic>> sessionStatuses = {};
+
+  String get baseUrl => "http://${_server!.address.address}:${_server!.port}";
+
+  Future<void> start() async {
+    _server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    _server!.listen((request) async {
+      final path = request.uri.path;
+
+      if (request.method == "GET" && path == "/project") {
+        await _json(request.response, [
+          {"id": "p1", "worktree": "/repo", "name": "Repo"},
+        ]);
+        return;
+      }
+
+      if (request.method == "GET" && path == "/session/status") {
+        await _json(request.response, sessionStatuses);
+        return;
+      }
+
+      if (request.method == "GET" && path == "/session") {
+        await _json(request.response, [
+          {
+            "id": "s-root",
+            "projectID": "p1",
+            "directory": "/repo",
+            "time": {"created": 1, "updated": 2},
+          },
+          {
+            "id": "child-1",
+            "projectID": "p1",
+            "directory": "/repo",
+            "parentID": "s-root",
+            "time": {"created": 3, "updated": 4},
+          },
+        ]);
+        return;
+      }
+
+      if (request.method == "GET" && path == "/experimental/session") {
+        await _json(request.response, <Map<String, dynamic>>[]);
+        return;
+      }
+
+      if (request.method == "GET" && path == "/global/event") {
+        request.response.statusCode = HttpStatus.ok;
+        request.response.headers.contentType = ContentType("text", "event-stream");
+        request.response.headers.set("cache-control", "no-cache");
+        request.response.write(": connected\n\n");
+        await request.response.flush();
+        if (!_firstSseClient.isCompleted) _firstSseClient.complete();
+        // Keep the response open (SSE stream).
+        return;
+      }
+
+      request.response.statusCode = HttpStatus.notFound;
+      await request.response.close();
+    });
+  }
+
+  Future<void> waitForSseConnection() => _firstSseClient.future;
+
+  Future<void> close() async {
+    await _server?.close(force: true);
+  }
+
+  Future<void> _json(HttpResponse response, Object body) async {
+    response.statusCode = HttpStatus.ok;
+    response.headers.contentType = ContentType.json;
+    response.write(jsonEncode(body));
+    await response.close();
+  }
 }
 
 class _FakeOpenCodeServer {


### PR DESCRIPTION
## Summary

- Running child tasks (background tasks) appeared as completed when cold-loading a session detail screen, only becoming visible as "running" after an SSE event arrived
- Root cause: `OpenCodePlugin.getSessionStatuses()` returned only the OpenCode API response, which may be scoped by directory and miss busy/retry statuses for child sessions from other projects
- Fix: overlay the `ActiveSessionTracker`'s SSE-maintained active statuses on top of the API response — the tracker is continuously updated by real-time SSE events and is the most accurate source of session status

## Problem

Two separate data paths exist for session activity:

| Screen | Data source | Result |
|--------|-------------|--------|
| **Session list** | SSE pipeline (`ActiveSessionTracker` → `ProjectActivitySummary`) | ✅ Correctly shows running child tasks |
| **Session detail** | API calls (`getChildren()` + `getSessionStatuses()`) | ❌ Running children shown as completed |

The session list was unaffected because it uses the SSE pipeline which is always accurate. The session detail relied on `getSessionStatuses()` which calls OpenCode's `GET /session/status` without the `x-opencode-directory` header — the response may be scoped and omit child session statuses.

## Changes

### `active_session_tracker.dart`
- Added `getActiveStatuses()` — exposes the tracker's real-time busy/retry session map (unmodifiable)

### `opencode_plugin_impl.dart`
- Modified `getSessionStatuses()` to merge the API response with the tracker's active statuses, with tracker data taking precedence

### Tests
- **6 new tracker tests**: `getActiveStatuses()` coverage — empty state, cold start population, SSE event updates, idle removal, immutability, reset
- **2 new plugin integration tests**: verifies merge behavior using a dynamic fake server that changes its status response between cold start and explicit API calls

## Verification

- `dart analyze bridge/sesori_plugin_opencode` — no issues
- `dart analyze bridge/app` — no issues
- All 97 plugin tests pass (8 new)
- All 303 bridge app tests pass