### PR TITLE
feat: add push notification deep linking with session navigation

### DIFF
--- a/bridge/app/lib/src/push/push_notification_service.dart
+++ b/bridge/app/lib/src/push/push_notification_service.dart
@@ -104,6 +104,7 @@ class PushNotificationService {
       body: body,
       sessionId: sessionId,
       collapseKey: collapseKey,
+      projectId: sessionId != null ? _tracker.getSessionProjectId(sessionId: sessionId) : null,
     );
 
     unawaited(
@@ -181,11 +182,13 @@ SendNotificationPayload buildNotificationPayload({
   required String body,
   required String collapseKey,
   required String? sessionId,
+  required String? projectId,
 }) {
   final data = NotificationData(
     category: category,
     sessionId: sessionId,
     eventType: eventType,
+    projectId: projectId,
   );
 
   return SendNotificationPayload(

--- a/bridge/app/lib/src/push/push_session_state_tracker.dart
+++ b/bridge/app/lib/src/push/push_session_state_tracker.dart
@@ -146,6 +146,10 @@ class PushSessionStateTracker {
     return _sessions[sessionId]?.title;
   }
 
+  String? getSessionProjectId({required String sessionId}) {
+    return _sessions[sessionId]?.projectId;
+  }
+
   String? getLatestAssistantText(String sessionId) {
     return _sessions[sessionId]?.latestAssistantText;
   }
@@ -198,6 +202,7 @@ class PushSessionStateTracker {
     }
 
     sessionState.title = session.title;
+    sessionState.projectId = session.projectID;
 
     _rebuildChildLinksForParent(sessionId);
   }
@@ -248,6 +253,7 @@ class PushSessionStateTracker {
 
 class _SessionState {
   String? parentId;
+  String? projectId;
   String? title;
   SessionStatus? status;
   bool previouslyBusy = false;

--- a/bridge/app/test/push/notification_category_test.dart
+++ b/bridge/app/test/push/notification_category_test.dart
@@ -49,6 +49,7 @@ void main() {
         body: data.body,
         collapseKey: "${data.category.id}-${sessionId ?? "global"}",
         sessionId: sessionId,
+        projectId: null,
       );
 
       expect(payload.title, equals("Question requires input"));
@@ -71,6 +72,7 @@ void main() {
         body: data.body,
         collapseKey: "${data.category.id}-${sessionId ?? "global"}",
         sessionId: sessionId,
+        projectId: null,
       );
 
       expect(payload.collapseKey, equals("system_update-global"));

--- a/bridge/app/test/push/push_notification_client_test.dart
+++ b/bridge/app/test/push/push_notification_client_test.dart
@@ -64,6 +64,7 @@ void main() {
             category: NotificationCategory.aiInteraction,
             eventType: NotificationEventType.questionAsked,
             sessionId: "session-a",
+            projectId: null,
           ),
         ),
       );
@@ -80,6 +81,7 @@ void main() {
           "category": "ai_interaction",
           "eventType": "question_asked",
           "sessionId": "session-a",
+          "projectId": null,
         },
       });
     });
@@ -101,6 +103,7 @@ void main() {
               category: NotificationCategory.aiInteraction,
               eventType: NotificationEventType.questionAsked,
               sessionId: null,
+              projectId: null,
             ),
           ),
         ),
@@ -138,6 +141,7 @@ void main() {
             category: NotificationCategory.aiInteraction,
             eventType: NotificationEventType.questionAsked,
             sessionId: null,
+            projectId: null,
           ),
         ),
       );
@@ -184,6 +188,7 @@ void main() {
             category: NotificationCategory.aiInteraction,
             eventType: NotificationEventType.questionAsked,
             sessionId: null,
+            projectId: null,
           ),
         ),
       );
@@ -228,6 +233,7 @@ void main() {
               category: NotificationCategory.aiInteraction,
               eventType: NotificationEventType.questionAsked,
               sessionId: null,
+              projectId: null,
             ),
           ),
         ),
@@ -267,6 +273,7 @@ void main() {
               category: NotificationCategory.aiInteraction,
               eventType: NotificationEventType.questionAsked,
               sessionId: null,
+              projectId: null,
             ),
           ),
         ),
@@ -307,6 +314,7 @@ void main() {
               category: NotificationCategory.aiInteraction,
               eventType: NotificationEventType.questionAsked,
               sessionId: null,
+              projectId: null,
             ),
           ),
         ),

--- a/bridge/app/test/push/push_notification_service_test.dart
+++ b/bridge/app/test/push/push_notification_service_test.dart
@@ -575,6 +575,52 @@ void main() {
       });
     });
 
+    test("AC11: completion notification includes projectId from tracker", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        harness.service.handleSseEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "session-a", projectID: "project-x"),
+          ),
+        );
+        harness.service.handleSseEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.service.handleSseEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+
+        async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
+
+        final completion = harness.client.sentPayloads.singleWhere(
+          (payload) => payload.data?.eventType == NotificationEventType.agentTurnCompleted,
+        );
+        expect(completion.data?.projectId, equals("project-x"));
+      });
+    });
+
+    test("AC12: question notification includes projectId from tracker", () {
+      final harness = _newHarness();
+
+      harness.service.handleSseEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "session-a", projectID: "project-y"),
+        ),
+      );
+      harness.service.handleSseEvent(
+        const SesoriSseEvent.questionAsked(
+          id: "q-1",
+          sessionID: "session-a",
+          questions: [QuestionInfo(header: "h", question: "q")],
+        ),
+      );
+
+      expect(harness.client.sentPayloads.length, equals(1));
+      expect(harness.client.sentPayloads.single.data?.projectId, equals("project-y"));
+    });
+
     test("E9: question asked for untracked session still sends aiInteraction", () {
       final harness = _newHarness();
 

--- a/bridge/app/test/push/push_session_state_tracker_test.dart
+++ b/bridge/app/test/push/push_session_state_tracker_test.dart
@@ -627,6 +627,24 @@ void main() {
       expect(tracker.isSessionGroupFullyIdle("session-a"), isTrue);
     });
 
+    test("getSessionProjectId returns stored projectId after session upsert", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "x", projectID: "p1"),
+        ),
+      );
+
+      expect(tracker.getSessionProjectId(sessionId: "x"), equals("p1"));
+    });
+
+    test("getSessionProjectId returns null for unknown sessionId", () {
+      final tracker = PushSessionStateTracker();
+
+      expect(tracker.getSessionProjectId(sessionId: "unknown"), isNull);
+    });
+
     test("wasPreviouslyBusy returns true if only a descendant was busy", () {
       final tracker = PushSessionStateTracker();
 

--- a/mobile/app/lib/core/platform/local_notification_manager.dart
+++ b/mobile/app/lib/core/platform/local_notification_manager.dart
@@ -1,11 +1,21 @@
+import "dart:async";
+import "dart:convert";
 import "dart:io";
 
+import "package:flutter/foundation.dart";
 import "package:flutter_local_notifications/flutter_local_notifications.dart";
 import "package:injectable/injectable.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "notification_id_utils.dart";
+
+class NotificationTapEvent {
+  final String? sessionId;
+  final String? projectId;
+
+  const NotificationTapEvent({this.sessionId, this.projectId});
+}
 
 extension on NotificationImportance {
   Importance toLocalNotificationImportance() {
@@ -24,8 +34,11 @@ extension on NotificationImportance {
 @lazySingleton
 class LocalNotificationManager implements NotificationCanceller {
   final FlutterLocalNotificationsPlugin _plugin;
+  final StreamController<NotificationTapEvent> _tapController = StreamController.broadcast();
 
   LocalNotificationManager({required FlutterLocalNotificationsPlugin plugin}) : _plugin = plugin;
+
+  Stream<NotificationTapEvent> get onNotificationTapped => _tapController.stream;
 
   Future<void> initialize() async {
     if (Platform.isAndroid) {
@@ -47,7 +60,31 @@ class LocalNotificationManager implements NotificationCanceller {
         android: AndroidInitializationSettings("@drawable/ic_notification"),
         iOS: DarwinInitializationSettings(),
       ),
+      onDidReceiveNotificationResponse: _onNotificationTapped,
     );
+  }
+
+  @visibleForTesting
+  void handleNotificationResponseForTesting(NotificationResponse response) => _onNotificationTapped(response);
+
+  void _onNotificationTapped(NotificationResponse response) {
+    final payload = response.payload;
+    if (payload == null || payload.isEmpty) {
+      _tapController.add(const NotificationTapEvent(sessionId: null, projectId: null));
+      return;
+    }
+
+    try {
+      final data = jsonDecode(payload) as Map<String, dynamic>;
+      _tapController.add(
+        NotificationTapEvent(
+          sessionId: data['sessionId'] as String?,
+          projectId: data['projectId'] as String?,
+        ),
+      );
+    } catch (_) {
+      _tapController.add(const NotificationTapEvent(sessionId: null, projectId: null));
+    }
   }
 
   Future<void> show({
@@ -55,6 +92,7 @@ class LocalNotificationManager implements NotificationCanceller {
     required String body,
     required NotificationCategory category,
     required String? sessionId,
+    required String? projectId,
   }) async {
     final channelId = category.id;
 
@@ -64,6 +102,8 @@ class LocalNotificationManager implements NotificationCanceller {
     } else {
       id = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     }
+
+    final payload = jsonEncode({'sessionId': sessionId, 'projectId': projectId});
 
     await _plugin.show(
       id: id,
@@ -77,6 +117,7 @@ class LocalNotificationManager implements NotificationCanceller {
         ),
         iOS: const DarwinNotificationDetails(),
       ),
+      payload: payload,
     );
   }
 

--- a/mobile/app/lib/core/platform/local_notification_manager.dart
+++ b/mobile/app/lib/core/platform/local_notification_manager.dart
@@ -9,13 +9,8 @@ import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "notification_id_utils.dart";
-
-class NotificationTapEvent {
-  final String? sessionId;
-  final String? projectId;
-
-  const NotificationTapEvent({this.sessionId, this.projectId});
-}
+import "notification_tap_event.dart";
+export "notification_tap_event.dart";
 
 extension on NotificationImportance {
   Importance toLocalNotificationImportance() {
@@ -76,12 +71,7 @@ class LocalNotificationManager implements NotificationCanceller {
 
     try {
       final data = jsonDecode(payload) as Map<String, dynamic>;
-      _tapController.add(
-        NotificationTapEvent(
-          sessionId: data['sessionId'] as String?,
-          projectId: data['projectId'] as String?,
-        ),
-      );
+      _tapController.add(NotificationTapEvent.fromJson(data));
     } catch (_) {
       _tapController.add(const NotificationTapEvent(sessionId: null, projectId: null));
     }
@@ -103,7 +93,9 @@ class LocalNotificationManager implements NotificationCanceller {
       id = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     }
 
-    final payload = jsonEncode({'sessionId': sessionId, 'projectId': projectId});
+    final payload = jsonEncode(
+      NotificationTapEvent(sessionId: sessionId, projectId: projectId).toJson(),
+    );
 
     await _plugin.show(
       id: id,

--- a/mobile/app/lib/core/platform/notification_service.dart
+++ b/mobile/app/lib/core/platform/notification_service.dart
@@ -255,11 +255,14 @@ class NotificationService {
   }
 
   String? _extractProjectId({required shared.NotificationData notificationData, required Map<String, dynamic> data}) {
-    final dynamic maybeProjectId = (notificationData as dynamic).projectId;
-    if (maybeProjectId is String) {
-      return maybeProjectId;
+    // Prefer the typed field from the deserialized model.
+    // fromJson handles missing keys for nullable fields by assigning null.
+    if (notificationData.projectId != null) {
+      return notificationData.projectId;
     }
 
+    // Defensive fallback: read from raw data map in case the model
+    // was deserialized by an older version of sesori_shared.
     final dynamic rawProjectId = data["projectId"];
     if (rawProjectId is String) {
       return rawProjectId;

--- a/mobile/app/lib/core/platform/notification_service.dart
+++ b/mobile/app/lib/core/platform/notification_service.dart
@@ -98,7 +98,7 @@ class NotificationService {
     }
 
     final sessionId = notificationData.sessionId;
-    final projectId = _extractProjectId(notificationData: notificationData, data: message.data);
+    final projectId = notificationData.projectId;
     if (sessionId == null) return;
 
     _navigateToSession(sessionId: sessionId, projectId: projectId);
@@ -250,25 +250,8 @@ class NotificationService {
       body: body,
       category: category,
       sessionId: notificationData.sessionId,
-      projectId: _extractProjectId(notificationData: notificationData, data: message.data),
+      projectId: notificationData.projectId,
     );
-  }
-
-  String? _extractProjectId({required shared.NotificationData notificationData, required Map<String, dynamic> data}) {
-    // Prefer the typed field from the deserialized model.
-    // fromJson handles missing keys for nullable fields by assigning null.
-    if (notificationData.projectId != null) {
-      return notificationData.projectId;
-    }
-
-    // Defensive fallback: read from raw data map in case the model
-    // was deserialized by an older version of sesori_shared.
-    final dynamic rawProjectId = data["projectId"];
-    if (rawProjectId is String) {
-      return rawProjectId;
-    }
-
-    return null;
   }
 
   @disposeMethod

--- a/mobile/app/lib/core/platform/notification_service.dart
+++ b/mobile/app/lib/core/platform/notification_service.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:io";
 
 import "package:firebase_messaging/firebase_messaging.dart";
@@ -6,8 +7,9 @@ import "package:injectable/injectable.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
-import "package:sesori_shared/sesori_shared.dart";
+import "package:sesori_shared/sesori_shared.dart" as shared;
 
+import "../routing/app_router.dart";
 import "local_notification_manager.dart";
 
 @lazySingleton
@@ -18,6 +20,21 @@ class NotificationService {
   final AuthSession _authSession;
   final CompositeSubscription _subscriptions = CompositeSubscription();
   String? _currentToken;
+  String? _pendingSessionId;
+  String? _pendingProjectId;
+
+  @visibleForTesting
+  void Function(String route) goForTesting = appRouter.go;
+
+  @visibleForTesting
+  Future<void> Function(String route) pushForTesting = (route) async {
+    await appRouter.push<void>(route);
+  };
+
+  @visibleForTesting
+  String Function() currentPathProviderForTesting = () {
+    return appRouter.routeInformationProvider.value.uri.path;
+  };
 
   @visibleForTesting
   String? get currentTokenForTesting => _currentToken;
@@ -56,6 +73,7 @@ class NotificationService {
 
     _subscriptions.add(FirebaseMessaging.instance.onTokenRefresh.listen(_onTokenRefresh));
     _subscriptions.add(FirebaseMessaging.onMessage.listen(onForegroundMessage));
+    _subscriptions.add(_localNotificationManager.onNotificationTapped.listen(_onLocalNotificationTapped));
 
     // value stream that emits the current auth state too
     _subscriptions.add(_authSession.authStateStream.listen(onAuthStateChanged));
@@ -71,8 +89,62 @@ class NotificationService {
   }
 
   void _onNotificationTapped(RemoteMessage message) {
-    // TODO: handle event — navigate to the relevant screen based on message.data
-    // e.g. if message.data['sessionId'] is present, navigate to session detail
+    shared.NotificationData notificationData;
+    try {
+      notificationData = shared.NotificationData.fromJson(message.data);
+    } catch (error, stackTrace) {
+      logw("Failed to parse notification tap data", error, stackTrace);
+      return;
+    }
+
+    final sessionId = notificationData.sessionId;
+    final projectId = _extractProjectId(notificationData: notificationData, data: message.data);
+    if (sessionId == null) return;
+
+    _navigateToSession(sessionId: sessionId, projectId: projectId);
+  }
+
+  @visibleForTesting
+  void onNotificationTappedForTesting(RemoteMessage message) => _onNotificationTapped(message);
+
+  void _onLocalNotificationTapped(NotificationTapEvent event) {
+    final sessionId = event.sessionId;
+    if (sessionId == null) return;
+
+    _navigateToSession(sessionId: sessionId, projectId: event.projectId);
+  }
+
+  @visibleForTesting
+  void onLocalNotificationTappedForTesting(NotificationTapEvent event) => _onLocalNotificationTapped(event);
+
+  void _navigateToSession({required String sessionId, required String? projectId}) {
+    if (_authSession.currentState is! AuthAuthenticated) {
+      _pendingSessionId = sessionId;
+      _pendingProjectId = projectId;
+      return;
+    }
+
+    _pushSessionRoute(sessionId: sessionId, projectId: projectId);
+  }
+
+  void _pushSessionRoute({required String sessionId, required String? projectId}) {
+    if (projectId == null) {
+      goForTesting(AppRoute.projects.path);
+      return;
+    }
+
+    final sessionDetailPath = AppRoute.sessionDetail.buildPath(
+      pathParams: {"projectId": projectId, "sessionId": sessionId},
+    );
+
+    if (currentPathProviderForTesting() == sessionDetailPath) {
+      return;
+    }
+
+    final sessionPath = AppRoute.sessions.buildPath(pathParams: {"projectId": projectId});
+    goForTesting(AppRoute.projects.path);
+    unawaited(pushForTesting(sessionPath));
+    unawaited(pushForTesting(sessionDetailPath));
   }
 
   Future<void> registerCurrentToken() async {
@@ -89,7 +161,7 @@ class NotificationService {
 
     final request = RegisterTokenRequest(
       token: token,
-      platform: Platform.isIOS ? DevicePlatform.ios : DevicePlatform.android,
+      platform: Platform.isIOS ? shared.DevicePlatform.ios : shared.DevicePlatform.android,
     );
     logd("[FCM] Registering push token: ...${token.takeLast(6)}");
     await _apiClient.registerToken(request);
@@ -113,6 +185,13 @@ class NotificationService {
           await registerCurrentToken();
         } catch (error, stackTrace) {
           logw("Failed to register push token after auth", error, stackTrace);
+        }
+        final pendingSessionId = _pendingSessionId;
+        if (pendingSessionId != null) {
+          _pendingSessionId = null;
+          final pendingProjectId = _pendingProjectId;
+          _pendingProjectId = null;
+          _pushSessionRoute(sessionId: pendingSessionId, projectId: pendingProjectId);
         }
       case AuthUnauthenticated() || AuthFailed():
         try {
@@ -140,7 +219,7 @@ class NotificationService {
 
     final request = RegisterTokenRequest(
       token: newToken,
-      platform: Platform.isIOS ? DevicePlatform.ios : DevicePlatform.android,
+      platform: Platform.isIOS ? shared.DevicePlatform.ios : shared.DevicePlatform.android,
     );
     await _apiClient.registerToken(request);
     _currentToken = newToken;
@@ -148,9 +227,9 @@ class NotificationService {
 
   @visibleForTesting
   Future<void> onForegroundMessage(RemoteMessage message) async {
-    NotificationData notificationData;
+    shared.NotificationData notificationData;
     try {
-      notificationData = NotificationData.fromJson(message.data);
+      notificationData = shared.NotificationData.fromJson(message.data);
     } catch (error, stackTrace) {
       logw("Failed to parse notification data", error, stackTrace);
       return;
@@ -171,7 +250,22 @@ class NotificationService {
       body: body,
       category: category,
       sessionId: notificationData.sessionId,
+      projectId: _extractProjectId(notificationData: notificationData, data: message.data),
     );
+  }
+
+  String? _extractProjectId({required shared.NotificationData notificationData, required Map<String, dynamic> data}) {
+    final dynamic maybeProjectId = (notificationData as dynamic).projectId;
+    if (maybeProjectId is String) {
+      return maybeProjectId;
+    }
+
+    final dynamic rawProjectId = data["projectId"];
+    if (rawProjectId is String) {
+      return rawProjectId;
+    }
+
+    return null;
   }
 
   @disposeMethod

--- a/mobile/app/lib/core/platform/notification_tap_event.dart
+++ b/mobile/app/lib/core/platform/notification_tap_event.dart
@@ -1,0 +1,15 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "notification_tap_event.freezed.dart";
+
+part "notification_tap_event.g.dart";
+
+@Freezed(fromJson: true, toJson: true)
+sealed class NotificationTapEvent with _$NotificationTapEvent {
+  const factory NotificationTapEvent({
+    required String? sessionId,
+    required String? projectId,
+  }) = _NotificationTapEvent;
+
+  factory NotificationTapEvent.fromJson(Map<String, dynamic> json) => _$NotificationTapEventFromJson(json);
+}

--- a/mobile/app/lib/core/platform/notification_tap_event.freezed.dart
+++ b/mobile/app/lib/core/platform/notification_tap_event.freezed.dart
@@ -1,0 +1,151 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'notification_tap_event.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$NotificationTapEvent {
+
+ String? get sessionId; String? get projectId;
+/// Create a copy of NotificationTapEvent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$NotificationTapEventCopyWith<NotificationTapEvent> get copyWith => _$NotificationTapEventCopyWithImpl<NotificationTapEvent>(this as NotificationTapEvent, _$identity);
+
+  /// Serializes this NotificationTapEvent to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationTapEvent&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.projectId, projectId) || other.projectId == projectId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,sessionId,projectId);
+
+@override
+String toString() {
+  return 'NotificationTapEvent(sessionId: $sessionId, projectId: $projectId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $NotificationTapEventCopyWith<$Res>  {
+  factory $NotificationTapEventCopyWith(NotificationTapEvent value, $Res Function(NotificationTapEvent) _then) = _$NotificationTapEventCopyWithImpl;
+@useResult
+$Res call({
+ String? sessionId, String? projectId
+});
+
+
+
+
+}
+/// @nodoc
+class _$NotificationTapEventCopyWithImpl<$Res>
+    implements $NotificationTapEventCopyWith<$Res> {
+  _$NotificationTapEventCopyWithImpl(this._self, this._then);
+
+  final NotificationTapEvent _self;
+  final $Res Function(NotificationTapEvent) _then;
+
+/// Create a copy of NotificationTapEvent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? sessionId = freezed,Object? projectId = freezed,}) {
+  return _then(_self.copyWith(
+sessionId: freezed == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String?,projectId: freezed == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _NotificationTapEvent implements NotificationTapEvent {
+  const _NotificationTapEvent({required this.sessionId, required this.projectId});
+  factory _NotificationTapEvent.fromJson(Map<String, dynamic> json) => _$NotificationTapEventFromJson(json);
+
+@override final  String? sessionId;
+@override final  String? projectId;
+
+/// Create a copy of NotificationTapEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$NotificationTapEventCopyWith<_NotificationTapEvent> get copyWith => __$NotificationTapEventCopyWithImpl<_NotificationTapEvent>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$NotificationTapEventToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationTapEvent&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.projectId, projectId) || other.projectId == projectId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,sessionId,projectId);
+
+@override
+String toString() {
+  return 'NotificationTapEvent(sessionId: $sessionId, projectId: $projectId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$NotificationTapEventCopyWith<$Res> implements $NotificationTapEventCopyWith<$Res> {
+  factory _$NotificationTapEventCopyWith(_NotificationTapEvent value, $Res Function(_NotificationTapEvent) _then) = __$NotificationTapEventCopyWithImpl;
+@override @useResult
+$Res call({
+ String? sessionId, String? projectId
+});
+
+
+
+
+}
+/// @nodoc
+class __$NotificationTapEventCopyWithImpl<$Res>
+    implements _$NotificationTapEventCopyWith<$Res> {
+  __$NotificationTapEventCopyWithImpl(this._self, this._then);
+
+  final _NotificationTapEvent _self;
+  final $Res Function(_NotificationTapEvent) _then;
+
+/// Create a copy of NotificationTapEvent
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? sessionId = freezed,Object? projectId = freezed,}) {
+  return _then(_NotificationTapEvent(
+sessionId: freezed == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String?,projectId: freezed == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/mobile/app/lib/core/platform/notification_tap_event.g.dart
+++ b/mobile/app/lib/core/platform/notification_tap_event.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'notification_tap_event.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_NotificationTapEvent _$NotificationTapEventFromJson(Map json) =>
+    _NotificationTapEvent(
+      sessionId: json['sessionId'] as String?,
+      projectId: json['projectId'] as String?,
+    );
+
+Map<String, dynamic> _$NotificationTapEventToJson(
+  _NotificationTapEvent instance,
+) => <String, dynamic>{
+  'sessionId': instance.sessionId,
+  'projectId': instance.projectId,
+};

--- a/mobile/app/lib/core/routing/app_router.dart
+++ b/mobile/app/lib/core/routing/app_router.dart
@@ -26,6 +26,7 @@ extension AppRouteToGoRoute on AppRoute {
           projectName: state.uri.queryParameters["name"],
         ),
         AppRoute.sessionDetail => SessionDetailScreen(
+          projectId: state.pathParameters["projectId"],
           sessionId: state.pathParameters["sessionId"] ?? "",
           sessionTitle: state.uri.queryParameters["title"],
           readOnly: state.uri.queryParameters["readOnly"] == "true",

--- a/mobile/app/lib/features/session_detail/session_detail_screen.dart
+++ b/mobile/app/lib/features/session_detail/session_detail_screen.dart
@@ -18,12 +18,14 @@ import "widgets/queued_message_bubble.dart";
 import "widgets/user_message_card.dart";
 
 class SessionDetailScreen extends StatelessWidget {
+  final String? projectId;
   final String sessionId;
   final String? sessionTitle;
   final bool readOnly;
 
   const SessionDetailScreen({
     super.key,
+    this.projectId,
     required this.sessionId,
     this.sessionTitle,
     this.readOnly = false,

--- a/mobile/app/lib/features/session_detail/widgets/background_tasks_bar.dart
+++ b/mobile/app/lib/features/session_detail/widgets/background_tasks_bar.dart
@@ -274,7 +274,10 @@ class _TaskRow extends StatelessWidget {
         }
         context.pushRoute(
           AppRoute.sessionDetail,
-          pathParams: {"sessionId": session.id},
+          pathParams: {
+            "projectId": session.projectID,
+            "sessionId": session.id,
+          },
           queryParams: queryParams,
         );
       },

--- a/mobile/app/lib/features/session_detail/widgets/subtask_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/subtask_part_widget.dart
@@ -40,7 +40,10 @@ class SubtaskPartWidget extends StatelessWidget {
               ? () {
                   context.pushRoute(
                     AppRoute.sessionDetail,
-                    pathParams: {"sessionId": childSession.id},
+                    pathParams: {
+                      "projectId": childSession.projectID,
+                      "sessionId": childSession.id,
+                    },
                     queryParams: childSession.title != null ? {"title": childSession.title!} : null,
                   );
                 }

--- a/mobile/app/lib/features/session_list/session_list_screen.dart
+++ b/mobile/app/lib/features/session_list/session_list_screen.dart
@@ -44,7 +44,7 @@ class _SessionListBody extends StatelessWidget {
     if (session == null || !context.mounted) return;
     await context.pushRoute(
       AppRoute.sessionDetail,
-      pathParams: {"sessionId": session.id},
+      pathParams: {"projectId": session.projectID, "sessionId": session.id},
       queryParams: {"title": session.title ?? ""},
     );
   }
@@ -376,7 +376,7 @@ class _SessionTile extends StatelessWidget {
         onTap: () {
           context.pushRoute(
             AppRoute.sessionDetail,
-            pathParams: {"sessionId": session.id},
+            pathParams: {"projectId": session.projectID, "sessionId": session.id},
             queryParams: {"title": session.title ?? ""},
           );
         },

--- a/mobile/app/test/core/platform/local_notification_manager_test.dart
+++ b/mobile/app/test/core/platform/local_notification_manager_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:sesori_mobile/core/platform/local_notification_manager.dart';
+import 'package:sesori_mobile/core/platform/notification_tap_event.dart';
 import 'package:sesori_mobile/core/platform/notification_id_utils.dart';
 import 'package:sesori_shared/sesori_shared.dart';
 
@@ -198,6 +199,32 @@ void main() {
       final decoded = jsonDecode(payloadJson!) as Map<String, dynamic>;
       expect(decoded['sessionId'], isNull);
       expect(decoded['projectId'], isNull);
+    });
+  });
+
+  group('NotificationTapEvent serialization', () {
+    test('toJson produces correct map', () {
+      const event = NotificationTapEvent(sessionId: 'ses_1', projectId: 'proj_1');
+      final json = event.toJson();
+      expect(json, equals({'sessionId': 'ses_1', 'projectId': 'proj_1'}));
+    });
+
+    test('fromJson parses correctly', () {
+      final event = NotificationTapEvent.fromJson({'sessionId': 'ses_1', 'projectId': 'proj_1'});
+      expect(event.sessionId, equals('ses_1'));
+      expect(event.projectId, equals('proj_1'));
+    });
+
+    test('fromJson handles missing keys as null', () {
+      final event = NotificationTapEvent.fromJson({});
+      expect(event.sessionId, isNull);
+      expect(event.projectId, isNull);
+    });
+
+    test('roundtrip toJson/fromJson preserves values', () {
+      const original = NotificationTapEvent(sessionId: 'ses_rt', projectId: 'proj_rt');
+      final restored = NotificationTapEvent.fromJson(original.toJson());
+      expect(restored, equals(original));
     });
   });
 

--- a/mobile/app/test/core/platform/local_notification_manager_test.dart
+++ b/mobile/app/test/core/platform/local_notification_manager_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -43,15 +45,20 @@ void main() {
   });
 
   group('show', () {
-    test('with sessionId and aiInteraction category uses deterministic ID', () async {
+    void stubPluginShow() {
       when(
         () => mockPlugin.show(
           id: any(named: 'id'),
           title: any(named: 'title'),
           body: any(named: 'body'),
           notificationDetails: any(named: 'notificationDetails'),
+          payload: any(named: 'payload'),
         ),
       ).thenAnswer((_) async {});
+    }
+
+    test('with sessionId and aiInteraction category uses deterministic ID', () async {
+      stubPluginShow();
 
       const sessionId = 'ses_abc';
       const category = NotificationCategory.aiInteraction;
@@ -62,6 +69,7 @@ void main() {
         body: 'Test Body',
         category: category,
         sessionId: sessionId,
+        projectId: null,
       );
 
       verify(
@@ -70,19 +78,13 @@ void main() {
           title: any(named: 'title'),
           body: any(named: 'body'),
           notificationDetails: any(named: 'notificationDetails'),
+          payload: any(named: 'payload'),
         ),
       ).called(1);
     });
 
     test('with sessionId but non-aiInteraction category uses timestamp-based ID', () async {
-      when(
-        () => mockPlugin.show(
-          id: any(named: 'id'),
-          title: any(named: 'title'),
-          body: any(named: 'body'),
-          notificationDetails: any(named: 'notificationDetails'),
-        ),
-      ).thenAnswer((_) async {});
+      stubPluginShow();
 
       const sessionId = 'ses_abc';
       const category = NotificationCategory.sessionMessage;
@@ -93,6 +95,7 @@ void main() {
         body: 'Test Body',
         category: category,
         sessionId: sessionId,
+        projectId: null,
       );
 
       // Capture the actual ID used
@@ -102,6 +105,7 @@ void main() {
           title: any(named: 'title'),
           body: any(named: 'body'),
           notificationDetails: any(named: 'notificationDetails'),
+          payload: any(named: 'payload'),
         ),
       ).captured;
 
@@ -111,14 +115,7 @@ void main() {
     });
 
     test('without sessionId uses timestamp-based ID even for aiInteraction', () async {
-      when(
-        () => mockPlugin.show(
-          id: any(named: 'id'),
-          title: any(named: 'title'),
-          body: any(named: 'body'),
-          notificationDetails: any(named: 'notificationDetails'),
-        ),
-      ).thenAnswer((_) async {});
+      stubPluginShow();
 
       const category = NotificationCategory.aiInteraction;
 
@@ -127,6 +124,7 @@ void main() {
         body: 'Test Body',
         category: category,
         sessionId: null,
+        projectId: null,
       );
 
       // Capture the actual ID used
@@ -136,6 +134,7 @@ void main() {
           title: any(named: 'title'),
           body: any(named: 'body'),
           notificationDetails: any(named: 'notificationDetails'),
+          payload: any(named: 'payload'),
         ),
       ).captured;
 
@@ -143,6 +142,116 @@ void main() {
       // Verify it's a reasonable timestamp-based ID (should be in seconds range)
       expect(actualId, greaterThan(0));
       expect(actualId, lessThan(DateTime.now().millisecondsSinceEpoch ~/ 1000 + 1000));
+    });
+
+    test('passes JSON payload with sessionId and projectId to plugin.show()', () async {
+      stubPluginShow();
+
+      await manager.show(
+        title: 'Title',
+        body: 'Body',
+        category: NotificationCategory.aiInteraction,
+        sessionId: 's1',
+        projectId: 'p1',
+      );
+
+      final captured = verify(
+        () => mockPlugin.show(
+          id: any(named: 'id'),
+          title: any(named: 'title'),
+          body: any(named: 'body'),
+          notificationDetails: any(named: 'notificationDetails'),
+          payload: captureAny(named: 'payload'),
+        ),
+      ).captured;
+
+      final payloadJson = captured[0] as String?;
+      expect(payloadJson, isNotNull);
+      final decoded = jsonDecode(payloadJson!) as Map<String, dynamic>;
+      expect(decoded['sessionId'], equals('s1'));
+      expect(decoded['projectId'], equals('p1'));
+    });
+
+    test('payload contains null values when sessionId and projectId are null', () async {
+      stubPluginShow();
+
+      await manager.show(
+        title: 'Title',
+        body: 'Body',
+        category: NotificationCategory.sessionMessage,
+        sessionId: null,
+        projectId: null,
+      );
+
+      final captured = verify(
+        () => mockPlugin.show(
+          id: any(named: 'id'),
+          title: any(named: 'title'),
+          body: any(named: 'body'),
+          notificationDetails: any(named: 'notificationDetails'),
+          payload: captureAny(named: 'payload'),
+        ),
+      ).captured;
+
+      final payloadJson = captured[0] as String?;
+      expect(payloadJson, isNotNull);
+      final decoded = jsonDecode(payloadJson!) as Map<String, dynamic>;
+      expect(decoded['sessionId'], isNull);
+      expect(decoded['projectId'], isNull);
+    });
+  });
+
+  group('onNotificationTapped stream', () {
+    NotificationResponse makeResponse(String? payload) {
+      return NotificationResponse(
+        notificationResponseType: NotificationResponseType.selectedNotification,
+        payload: payload,
+      );
+    }
+
+    test('emits NotificationTapEvent with correct sessionId and projectId for valid JSON', () async {
+      final payload = jsonEncode({'sessionId': 'ses_123', 'projectId': 'proj_456'});
+      final response = makeResponse(payload);
+
+      final eventFuture = manager.onNotificationTapped.first;
+      manager.handleNotificationResponseForTesting(response);
+
+      final event = await eventFuture;
+      expect(event.sessionId, equals('ses_123'));
+      expect(event.projectId, equals('proj_456'));
+    });
+
+    test('emits event with null fields when payload is null', () async {
+      final response = makeResponse(null);
+
+      final eventFuture = manager.onNotificationTapped.first;
+      manager.handleNotificationResponseForTesting(response);
+
+      final event = await eventFuture;
+      expect(event.sessionId, isNull);
+      expect(event.projectId, isNull);
+    });
+
+    test('emits event with null fields when payload is empty string', () async {
+      final response = makeResponse('');
+
+      final eventFuture = manager.onNotificationTapped.first;
+      manager.handleNotificationResponseForTesting(response);
+
+      final event = await eventFuture;
+      expect(event.sessionId, isNull);
+      expect(event.projectId, isNull);
+    });
+
+    test('emits event with null fields and does not crash on malformed JSON', () async {
+      final response = makeResponse('not-valid-json{{{');
+
+      final eventFuture = manager.onNotificationTapped.first;
+      expect(() => manager.handleNotificationResponseForTesting(response), returnsNormally);
+
+      final event = await eventFuture;
+      expect(event.sessionId, isNull);
+      expect(event.projectId, isNull);
     });
   });
 }

--- a/mobile/app/test/core/platform/notification_service_test.dart
+++ b/mobile/app/test/core/platform/notification_service_test.dart
@@ -37,6 +37,176 @@ void main() {
       localNotificationManager,
       authSession,
     );
+
+    when(() => authSession.currentState).thenReturn(
+      const AuthState.authenticated(
+        user: AuthUser(
+          id: "user-1",
+          provider: "github",
+          providerUserId: "provider-user-1",
+          providerUsername: "test-user",
+        ),
+      ),
+    );
+  });
+
+  group("notification tap navigation", () {
+    RemoteMessage buildTapMessage({required String? sessionId, required String? projectId}) {
+      return RemoteMessage(
+        data: {
+          "category": "ai_interaction",
+          "eventType": "question_asked",
+          "sessionId": sessionId,
+          "projectId": projectId,
+        },
+      );
+    }
+
+    test("firebase tap with sessionId and projectId builds full navigation stack", () {
+      final goCalls = <String>[];
+      final pushCalls = <String>[];
+
+      service.goForTesting = goCalls.add;
+      service.pushForTesting = (route) async {
+        pushCalls.add(route);
+      };
+      service.currentPathProviderForTesting = () => "/projects";
+
+      service.onNotificationTappedForTesting(
+        buildTapMessage(sessionId: "ses_1", projectId: "proj_1"),
+      );
+
+      expect(goCalls, equals([AppRoute.projects.path]));
+      expect(
+        pushCalls,
+        equals([
+          AppRoute.sessions.buildPath(pathParams: {"projectId": "proj_1"}),
+          AppRoute.sessionDetail.buildPath(pathParams: {"projectId": "proj_1", "sessionId": "ses_1"}),
+        ]),
+      );
+    });
+
+    test("firebase tap with sessionId and no projectId navigates to project list only", () {
+      final goCalls = <String>[];
+      final pushCalls = <String>[];
+
+      service.goForTesting = goCalls.add;
+      service.pushForTesting = (route) async {
+        pushCalls.add(route);
+      };
+      service.currentPathProviderForTesting = () => "/projects";
+
+      service.onNotificationTappedForTesting(
+        buildTapMessage(sessionId: "ses_1", projectId: null),
+      );
+
+      expect(goCalls, equals([AppRoute.projects.path]));
+      expect(pushCalls, isEmpty);
+    });
+
+    test("firebase tap with no sessionId does not navigate", () {
+      final goCalls = <String>[];
+      final pushCalls = <String>[];
+
+      service.goForTesting = goCalls.add;
+      service.pushForTesting = (route) async {
+        pushCalls.add(route);
+      };
+      service.currentPathProviderForTesting = () => "/projects";
+
+      service.onNotificationTappedForTesting(
+        buildTapMessage(sessionId: null, projectId: "proj_1"),
+      );
+
+      expect(goCalls, isEmpty);
+      expect(pushCalls, isEmpty);
+    });
+
+    test("local notification tap uses same navigation path as firebase tap", () {
+      final goCalls = <String>[];
+      final pushCalls = <String>[];
+
+      service.goForTesting = goCalls.add;
+      service.pushForTesting = (route) async {
+        pushCalls.add(route);
+      };
+      service.currentPathProviderForTesting = () => "/projects";
+
+      service.onLocalNotificationTappedForTesting(
+        const NotificationTapEvent(sessionId: "ses_local", projectId: "proj_local"),
+      );
+
+      expect(goCalls, equals([AppRoute.projects.path]));
+      expect(
+        pushCalls,
+        equals([
+          AppRoute.sessions.buildPath(pathParams: {"projectId": "proj_local"}),
+          AppRoute.sessionDetail.buildPath(pathParams: {"projectId": "proj_local", "sessionId": "ses_local"}),
+        ]),
+      );
+    });
+
+    test("tap while unauthenticated is deferred and replayed after authentication", () async {
+      final goCalls = <String>[];
+      final pushCalls = <String>[];
+
+      when(() => authSession.currentState).thenReturn(const AuthState.unauthenticated());
+
+      service.goForTesting = goCalls.add;
+      service.pushForTesting = (route) async {
+        pushCalls.add(route);
+      };
+      service.currentPathProviderForTesting = () => "/projects";
+
+      service.onNotificationTappedForTesting(
+        buildTapMessage(sessionId: "ses_pending", projectId: "proj_pending"),
+      );
+
+      expect(goCalls, isEmpty);
+      expect(pushCalls, isEmpty);
+
+      await service.onAuthStateChanged(
+        const AuthState.authenticated(
+          user: AuthUser(
+            id: "user-1",
+            provider: "github",
+            providerUserId: "provider-user-1",
+            providerUsername: "test-user",
+          ),
+        ),
+      );
+
+      expect(goCalls, equals([AppRoute.projects.path]));
+      expect(
+        pushCalls,
+        equals([
+          AppRoute.sessions.buildPath(pathParams: {"projectId": "proj_pending"}),
+          AppRoute.sessionDetail.buildPath(pathParams: {"projectId": "proj_pending", "sessionId": "ses_pending"}),
+        ]),
+      );
+    });
+
+    test("tap while already on target session does not navigate again", () {
+      final goCalls = <String>[];
+      final pushCalls = <String>[];
+
+      final targetPath = AppRoute.sessionDetail.buildPath(
+        pathParams: {"projectId": "proj_1", "sessionId": "ses_1"},
+      );
+
+      service.goForTesting = goCalls.add;
+      service.pushForTesting = (route) async {
+        pushCalls.add(route);
+      };
+      service.currentPathProviderForTesting = () => targetPath;
+
+      service.onNotificationTappedForTesting(
+        buildTapMessage(sessionId: "ses_1", projectId: "proj_1"),
+      );
+
+      expect(goCalls, isEmpty);
+      expect(pushCalls, isEmpty);
+    });
   });
 
   group("onAuthStateChanged", () {
@@ -115,7 +285,7 @@ void main() {
   });
 
   group("onForegroundMessage", () {
-    test("passes sessionId to show() when message contains sessionId", () async {
+    test("passes sessionId and projectId to show() when message contains them", () async {
       when(() => preferencesService.isEnabled(any())).thenAnswer((_) async => true);
       when(
         () => localNotificationManager.show(
@@ -123,15 +293,18 @@ void main() {
           body: any(named: "body"),
           category: any(named: "category"),
           sessionId: any(named: "sessionId"),
+          projectId: any(named: "projectId"),
         ),
       ).thenAnswer((_) async {});
 
       const sessionId = "ses_abc";
+      const projectId = "proj_xyz";
       const message = RemoteMessage(
         data: {
           "category": "ai_interaction",
           "eventType": "question_asked",
           "sessionId": sessionId,
+          "projectId": projectId,
         },
         notification: RemoteNotification(
           title: "Test Title",
@@ -147,11 +320,12 @@ void main() {
           body: "Test Body",
           category: NotificationCategory.aiInteraction,
           sessionId: sessionId,
+          projectId: projectId,
         ),
       ).called(1);
     });
 
-    test("calls show() without sessionId when message has no sessionId", () async {
+    test("calls show() without sessionId or projectId when message has neither", () async {
       when(() => preferencesService.isEnabled(any())).thenAnswer((_) async => true);
       when(
         () => localNotificationManager.show(
@@ -159,6 +333,7 @@ void main() {
           body: any(named: "body"),
           category: any(named: "category"),
           sessionId: any(named: "sessionId"),
+          projectId: any(named: "projectId"),
         ),
       ).thenAnswer((_) async {});
 
@@ -181,6 +356,7 @@ void main() {
           body: "Test Body",
           category: NotificationCategory.sessionMessage,
           sessionId: null,
+          projectId: null,
         ),
       ).called(1);
     });

--- a/mobile/app/test/core/platform/notification_service_test.dart
+++ b/mobile/app/test/core/platform/notification_service_test.dart
@@ -285,6 +285,46 @@ void main() {
   });
 
   group("onForegroundMessage", () {
+    test("extracts projectId from typed NotificationData model without dynamic cast", () async {
+      when(() => preferencesService.isEnabled(any())).thenAnswer((_) async => true);
+      when(
+        () => localNotificationManager.show(
+          title: any(named: "title"),
+          body: any(named: "body"),
+          category: any(named: "category"),
+          sessionId: any(named: "sessionId"),
+          projectId: any(named: "projectId"),
+        ),
+      ).thenAnswer((_) async {});
+
+      // projectId is in the data map and will be parsed by NotificationData.fromJson
+      // The service should use notificationData.projectId (typed access) — not (as dynamic).projectId
+      const message = RemoteMessage(
+        data: {
+          "category": "ai_interaction",
+          "eventType": "question_asked",
+          "sessionId": "ses_typed",
+          "projectId": "proj_typed",
+        },
+        notification: RemoteNotification(
+          title: "Title",
+          body: "Body",
+        ),
+      );
+
+      await service.onForegroundMessage(message);
+
+      verify(
+        () => localNotificationManager.show(
+          title: "Title",
+          body: "Body",
+          category: NotificationCategory.aiInteraction,
+          sessionId: "ses_typed",
+          projectId: "proj_typed",
+        ),
+      ).called(1);
+    });
+
     test("passes sessionId and projectId to show() when message contains them", () async {
       when(() => preferencesService.isEnabled(any())).thenAnswer((_) async => true);
       when(

--- a/mobile/app/test/core/routing/app_route_test.dart
+++ b/mobile/app/test/core/routing/app_route_test.dart
@@ -34,9 +34,16 @@ void main() {
 
     test("substitutes path params for sessionDetail", () {
       final result = AppRoute.sessionDetail.buildPath(
-        pathParams: {"sessionId": "ses-456"},
+        pathParams: {"projectId": "proj-123", "sessionId": "ses-456"},
       );
-      expect(result, "/sessions/ses-456");
+      expect(result, "/projects/proj-123/sessions/ses-456");
+    });
+
+    test("builds /projects/p1/sessions/s1 for sessionDetail", () {
+      final result = AppRoute.sessionDetail.buildPath(
+        pathParams: {"projectId": "p1", "sessionId": "s1"},
+      );
+      expect(result, "/projects/p1/sessions/s1");
     });
 
     test("appends query params", () {
@@ -57,20 +64,26 @@ void main() {
 
     test("encodes query param values automatically", () {
       final result = AppRoute.sessionDetail.buildPath(
-        pathParams: {"sessionId": "ses-1"},
+        pathParams: {"projectId": "proj-1", "sessionId": "ses-1"},
         queryParams: {"title": "hello world & more"},
       );
-      expect(result, contains("/sessions/ses-1?"));
+      expect(result, contains("/projects/proj-1/sessions/ses-1?"));
       // Verify the value is encoded (space becomes + or %20, & becomes %26)
       expect(result, isNot(contains("& more")));
     });
 
-    test("encodes path param values with special characters", () {
+    test("encodes sessionDetail path params with special characters", () {
       final result = AppRoute.sessionDetail.buildPath(
-        pathParams: {"sessionId": "id/with?special&chars"},
+        pathParams: {
+          "projectId": "project/with?special&chars",
+          "sessionId": "id/with?special&chars",
+        },
       );
       // Special characters in the param value must be percent-encoded
-      expect(result, "/sessions/id%2Fwith%3Fspecial%26chars");
+      expect(
+        result,
+        "/projects/project%2Fwith%3Fspecial%26chars/sessions/id%2Fwith%3Fspecial%26chars",
+      );
     });
 
     test("ignores empty query params map", () {
@@ -144,12 +157,13 @@ void main() {
       final widget = goRoute.builder!(
         _FakeBuildContext(),
         _FakeGoRouterState(
-          pathParameters: {"sessionId": "ses-99"},
+          pathParameters: {"projectId": "proj-42", "sessionId": "ses-99"},
           queryParameters: {"title": "Debug session", "readOnly": "true"},
         ),
       );
       expect(widget, isA<SessionDetailScreen>());
       final screen = widget as SessionDetailScreen;
+      expect(screen.projectId, "proj-42");
       expect(screen.sessionId, "ses-99");
       expect(screen.sessionTitle, "Debug session");
       expect(screen.readOnly, isTrue);
@@ -160,10 +174,11 @@ void main() {
       final widget = goRoute.builder!(
         _FakeBuildContext(),
         _FakeGoRouterState(
-          pathParameters: {"sessionId": "ses-1"},
+          pathParameters: {"projectId": "proj-1", "sessionId": "ses-1"},
         ),
       );
       final screen = widget as SessionDetailScreen;
+      expect(screen.projectId, "proj-1");
       expect(screen.sessionId, "ses-1");
       expect(screen.sessionTitle, isNull);
       expect(screen.readOnly, isFalse);

--- a/mobile/module_core/lib/src/routing/app_routes.dart
+++ b/mobile/module_core/lib/src/routing/app_routes.dart
@@ -6,7 +6,7 @@ enum AppRoute {
   projects("/projects"),
   notificationSettings("/settings/notifications"),
   sessions("/projects/:projectId/sessions"),
-  sessionDetail("/sessions/:sessionId")
+  sessionDetail("/projects/:projectId/sessions/:sessionId")
   ;
 
   const AppRoute(this.path);

--- a/shared/sesori_shared/lib/src/models/sesori/notification_data.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/notification_data.dart
@@ -10,6 +10,7 @@ sealed class NotificationData with _$NotificationData {
     @JsonKey(unknownEnumValue: NotificationCategory.unknown) required NotificationCategory category,
     @JsonKey(unknownEnumValue: NotificationEventType.unknown) required NotificationEventType? eventType,
     required String? sessionId,
+    required String? projectId,
   }) = _NotificationData;
 
   factory NotificationData.fromJson(Map<String, dynamic> json) => _$NotificationDataFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/notification_data.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/notification_data.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$NotificationData {
 
-@JsonKey(unknownEnumValue: NotificationCategory.unknown) NotificationCategory get category;@JsonKey(unknownEnumValue: NotificationEventType.unknown) NotificationEventType? get eventType; String? get sessionId;
+@JsonKey(unknownEnumValue: NotificationCategory.unknown) NotificationCategory get category;@JsonKey(unknownEnumValue: NotificationEventType.unknown) NotificationEventType? get eventType; String? get sessionId; String? get projectId;
 /// Create a copy of NotificationData
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $NotificationDataCopyWith<NotificationData> get copyWith => _$NotificationDataCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationData&&(identical(other.category, category) || other.category == category)&&(identical(other.eventType, eventType) || other.eventType == eventType)&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationData&&(identical(other.category, category) || other.category == category)&&(identical(other.eventType, eventType) || other.eventType == eventType)&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.projectId, projectId) || other.projectId == projectId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,category,eventType,sessionId);
+int get hashCode => Object.hash(runtimeType,category,eventType,sessionId,projectId);
 
 @override
 String toString() {
-  return 'NotificationData(category: $category, eventType: $eventType, sessionId: $sessionId)';
+  return 'NotificationData(category: $category, eventType: $eventType, sessionId: $sessionId, projectId: $projectId)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $NotificationDataCopyWith<$Res>  {
   factory $NotificationDataCopyWith(NotificationData value, $Res Function(NotificationData) _then) = _$NotificationDataCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(unknownEnumValue: NotificationCategory.unknown) NotificationCategory category,@JsonKey(unknownEnumValue: NotificationEventType.unknown) NotificationEventType? eventType, String? sessionId
+@JsonKey(unknownEnumValue: NotificationCategory.unknown) NotificationCategory category,@JsonKey(unknownEnumValue: NotificationEventType.unknown) NotificationEventType? eventType, String? sessionId, String? projectId
 });
 
 
@@ -65,11 +65,12 @@ class _$NotificationDataCopyWithImpl<$Res>
 
 /// Create a copy of NotificationData
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? category = null,Object? eventType = freezed,Object? sessionId = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? category = null,Object? eventType = freezed,Object? sessionId = freezed,Object? projectId = freezed,}) {
   return _then(_self.copyWith(
 category: null == category ? _self.category : category // ignore: cast_nullable_to_non_nullable
 as NotificationCategory,eventType: freezed == eventType ? _self.eventType : eventType // ignore: cast_nullable_to_non_nullable
 as NotificationEventType?,sessionId: freezed == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String?,projectId: freezed == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }
@@ -82,12 +83,13 @@ as String?,
 @JsonSerializable()
 
 class _NotificationData implements NotificationData {
-  const _NotificationData({@JsonKey(unknownEnumValue: NotificationCategory.unknown) required this.category, @JsonKey(unknownEnumValue: NotificationEventType.unknown) required this.eventType, required this.sessionId});
+  const _NotificationData({@JsonKey(unknownEnumValue: NotificationCategory.unknown) required this.category, @JsonKey(unknownEnumValue: NotificationEventType.unknown) required this.eventType, required this.sessionId, required this.projectId});
   factory _NotificationData.fromJson(Map<String, dynamic> json) => _$NotificationDataFromJson(json);
 
 @override@JsonKey(unknownEnumValue: NotificationCategory.unknown) final  NotificationCategory category;
 @override@JsonKey(unknownEnumValue: NotificationEventType.unknown) final  NotificationEventType? eventType;
 @override final  String? sessionId;
+@override final  String? projectId;
 
 /// Create a copy of NotificationData
 /// with the given fields replaced by the non-null parameter values.
@@ -102,16 +104,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationData&&(identical(other.category, category) || other.category == category)&&(identical(other.eventType, eventType) || other.eventType == eventType)&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationData&&(identical(other.category, category) || other.category == category)&&(identical(other.eventType, eventType) || other.eventType == eventType)&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.projectId, projectId) || other.projectId == projectId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,category,eventType,sessionId);
+int get hashCode => Object.hash(runtimeType,category,eventType,sessionId,projectId);
 
 @override
 String toString() {
-  return 'NotificationData(category: $category, eventType: $eventType, sessionId: $sessionId)';
+  return 'NotificationData(category: $category, eventType: $eventType, sessionId: $sessionId, projectId: $projectId)';
 }
 
 
@@ -122,7 +124,7 @@ abstract mixin class _$NotificationDataCopyWith<$Res> implements $NotificationDa
   factory _$NotificationDataCopyWith(_NotificationData value, $Res Function(_NotificationData) _then) = __$NotificationDataCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(unknownEnumValue: NotificationCategory.unknown) NotificationCategory category,@JsonKey(unknownEnumValue: NotificationEventType.unknown) NotificationEventType? eventType, String? sessionId
+@JsonKey(unknownEnumValue: NotificationCategory.unknown) NotificationCategory category,@JsonKey(unknownEnumValue: NotificationEventType.unknown) NotificationEventType? eventType, String? sessionId, String? projectId
 });
 
 
@@ -139,11 +141,12 @@ class __$NotificationDataCopyWithImpl<$Res>
 
 /// Create a copy of NotificationData
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? category = null,Object? eventType = freezed,Object? sessionId = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? category = null,Object? eventType = freezed,Object? sessionId = freezed,Object? projectId = freezed,}) {
   return _then(_NotificationData(
 category: null == category ? _self.category : category // ignore: cast_nullable_to_non_nullable
 as NotificationCategory,eventType: freezed == eventType ? _self.eventType : eventType // ignore: cast_nullable_to_non_nullable
 as NotificationEventType?,sessionId: freezed == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String?,projectId: freezed == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }

--- a/shared/sesori_shared/lib/src/models/sesori/notification_data.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/notification_data.g.dart
@@ -18,6 +18,7 @@ _NotificationData _$NotificationDataFromJson(Map json) => _NotificationData(
     unknownValue: NotificationEventType.unknown,
   ),
   sessionId: json['sessionId'] as String?,
+  projectId: json['projectId'] as String?,
 );
 
 Map<String, dynamic> _$NotificationDataToJson(_NotificationData instance) =>
@@ -25,6 +26,7 @@ Map<String, dynamic> _$NotificationDataToJson(_NotificationData instance) =>
       'category': _$NotificationCategoryEnumMap[instance.category]!,
       'eventType': _$NotificationEventTypeEnumMap[instance.eventType],
       'sessionId': instance.sessionId,
+      'projectId': instance.projectId,
     };
 
 const _$NotificationCategoryEnumMap = {


### PR DESCRIPTION
## Summary

- Push notification taps now navigate to the correct session instead of just opening the app
- Session detail route restructured from `/sessions/:sessionId` to `/projects/:projectId/sessions/:sessionId` for proper back-navigation stack
- All three notification tap paths handled: cold start (getInitialMessage), backgrounded app (onMessageOpenedApp), and foreground local notification (onDidReceiveNotificationResponse)

## Changes

### Shared (`sesori_shared`)
- Added nullable `projectId` field to `NotificationData` model (backwards-compatible — older bridges send null)

### Bridge
- `PushSessionStateTracker` stores `projectId` per session from `Session.projectID`
- `PushNotificationService` includes `projectId` in notification payloads via the tracker

### Mobile
- **Route restructuring**: `AppRoute.sessionDetail` changed to `/projects/:projectId/sessions/:sessionId`
- **Navigation call sites**: All 4 session detail navigation points updated with `projectId` in path params (session list × 2, subtask widget, background tasks bar)
- **Notification payload wiring**: `LocalNotificationManager.show()` serializes `sessionId` + `projectId` as JSON payload; `initialize()` registers `onDidReceiveNotificationResponse` callback; tap events exposed via stream
- **Tap handler**: `NotificationService._onNotificationTapped()` parses payload, builds full nav stack (`go(/projects)` → `push(sessions)` → `push(sessionDetail)`), with auth gating (defers navigation until authenticated), null-projectId fallback (opens project list), and duplicate navigation prevention
- **Tests**: 6 new test scenarios covering all tap paths, auth deferral, null handling, and dedup

## Verification

| Check | Result |
|-------|--------|
| `shared/sesori_shared` dart analyze | ✅ No issues |
| `bridge/app` dart test | ✅ 307/307 passed |
| `mobile/app` flutter test | ✅ 364/364 passed |
| `mobile/app` dart analyze | ✅ 0 errors |