### PR TITLE
fix(bridge): preserve SSE orphan queues on phone disconnect and relay reconnect

### DIFF
--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -14,6 +14,7 @@ import 'package:sesori_bridge/src/bridge/orchestrator.dart';
 import 'package:sesori_bridge/src/bridge/persistence/bridge_diagnostics.dart';
 import 'package:sesori_bridge/src/bridge/persistence/hidden_projects_store.dart';
 import 'package:sesori_bridge/src/bridge/relay_client.dart';
+import 'package:sesori_bridge/src/bridge/sse/sse_manager.dart';
 import 'package:sesori_bridge/src/push/completion_notifier.dart';
 import 'package:sesori_bridge/src/push/push_notification_client.dart';
 import 'package:sesori_bridge/src/push/push_notification_service.dart';
@@ -25,7 +26,6 @@ import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Log, 
 const String _defaultRelayURL = 'wss://relay.sesori.com';
 const String _defaultAuthURL = 'https://api.sesori.com';
 const String _defaultTargetHost = 'http://127.0.0.1';
-const Duration _defaultSseReplayWindow = Duration(minutes: 5);
 
 Future<void> main(List<String> args) async {
   final parser = ArgParser()
@@ -149,7 +149,7 @@ Future<void> main(List<String> args) async {
     serverURL: serverURL,
     serverPassword: serverPasswordPtr,
     authBackendURL: authBackendURL,
-    sseReplayWindow: _defaultSseReplayWindow,
+    sseReplayWindow: SSEManager.defaultReplayWindow,
   );
   final plugin = OpenCodePlugin(
     serverUrl: serverURL,

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -160,7 +160,8 @@ class OrchestratorSession {
         }
 
         Log.w("Connection lost. Reconnecting...");
-        _sseManager.stop();
+        _sseManager.orphanAll();
+        activePhones.clear();
 
         var backoff = const Duration(seconds: 1);
         while (!_cancelled) {

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -159,7 +159,7 @@ class OrchestratorSession {
           break;
         }
 
-        Log.w("Connection lost. Reconnecting...");
+        Log.w("Relay connection lost. Reconnecting...");
         _sseManager.orphanAll();
         activePhones.clear();
 

--- a/bridge/app/lib/src/bridge/sse/sse_manager.dart
+++ b/bridge/app/lib/src/bridge/sse/sse_manager.dart
@@ -9,6 +9,10 @@ import "package:sesori_shared/sesori_shared.dart";
 import "../relay_client.dart";
 
 class SSEManager {
+  /// Default duration for which orphan queues remain valid after a phone
+  /// disconnects. Referenced by the CLI entry point and tests.
+  static const Duration defaultReplayWindow = Duration(minutes: 5);
+
   /// How long a disconnected subscriber's orphan queue stays valid.
   final Duration replayWindow;
 
@@ -50,18 +54,12 @@ class SSEManager {
 
   /// Removes [connID] from active subscribers.
   ///
-  /// If other subscribers remain, the queue is paused and retained as an
-  /// orphan queue for replay during [replayWindow]. If this was the last
-  /// subscriber, orphan state is cleared.
+  /// The queue is paused and retained as an orphan queue for replay during
+  /// [replayWindow]. If the phone reconnects within that window, the orphan
+  /// is resumed via [subscribePath] and all buffered events are delivered.
   void unsubscribe(int connID) {
     final queue = _subscribers.remove(connID);
     if (queue == null) return;
-
-    if (_subscribers.isEmpty) {
-      queue.dispose();
-      _disposeOrphans();
-      return;
-    }
 
     queue.pause();
     _orphanQueues.addLast((
@@ -72,6 +70,22 @@ class SSEManager {
 
   /// Alias for [unsubscribe].
   void removeSubscriber(int connID) => unsubscribe(connID);
+
+  /// Pauses all active subscriber queues and moves them to orphan state.
+  ///
+  /// Use this when the relay connection drops but may recover. Orphan queues
+  /// continue to buffer incoming events and will be replayed when phones
+  /// reconnect within [replayWindow].
+  void orphanAll() {
+    for (final queue in _subscribers.values) {
+      queue.pause();
+      _orphanQueues.addLast((
+        queue: queue,
+        expiry: clock.now().add(replayWindow),
+      ));
+    }
+    _subscribers.clear();
+  }
 
   /// Clears all subscribers and orphan state.
   void stop() {

--- a/bridge/app/test/bridge/sse_manager_test.dart
+++ b/bridge/app/test/bridge/sse_manager_test.dart
@@ -13,7 +13,7 @@ import "../helpers/test_helpers.dart";
 void main() {
   group("SSEManager", () {
     test("subscribe registers subscribers", () {
-      final manager = SSEManager(replayWindow: const Duration(seconds: 30));
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
@@ -27,7 +27,7 @@ void main() {
     });
 
     test("enqueueEvent with no subscribers does nothing", () async {
-      final manager = SSEManager(replayWindow: const Duration(seconds: 30));
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
       final client = _RecordingRelayClient();
       manager.setRoomKey(makeRoomKey());
 
@@ -40,7 +40,7 @@ void main() {
     test("enqueueEvent delivers typed payload envelope to all subscribers", () async {
       final roomKey = makeRoomKey();
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: const Duration(seconds: 30));
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
@@ -78,7 +78,7 @@ void main() {
 
     test("without room key events are not sent", () async {
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: const Duration(seconds: 30));
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
       addTearDown(manager.stop);
 
       manager.subscribePath(7, "/global/event", client);
@@ -89,7 +89,7 @@ void main() {
     });
 
     test("non-last unsubscribe creates orphan queue", () {
-      final manager = SSEManager(replayWindow: const Duration(seconds: 30));
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
@@ -104,10 +104,56 @@ void main() {
       expect(manager.pendingReplayCount, equals(1));
     });
 
+    test("last unsubscribe creates orphan queue", () {
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
+      final relayClient = RelayClient(
+        relayURL: "ws://127.0.0.1:1",
+        accessTokenProvider: FakeAccessTokenProvider(""),
+      );
+      addTearDown(manager.stop);
+
+      manager.subscribePath(1, "/global/event", relayClient);
+      manager.unsubscribe(1);
+
+      expect(manager.subscriberCount, equals(0));
+      expect(manager.pendingReplayCount, equals(1));
+    });
+
+    test("single subscriber reconnect replays buffered events", () async {
+      final roomKey = makeRoomKey();
+      final client = _RecordingRelayClient();
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
+      manager.setRoomKey(roomKey);
+      addTearDown(manager.stop);
+
+      // Phone connects and receives one event.
+      manager.subscribePath(1, "/global/event", client);
+      manager.enqueueEvent(_event("event-a"));
+      await _waitForSendCount(client, 1);
+      expect(client.sentConnIDs, [1]);
+
+      // Phone disconnects — only subscriber, queue should become orphan.
+      manager.unsubscribe(1);
+      expect(manager.pendingReplayCount, equals(1));
+
+      // Events arriving while phone is away are buffered in the orphan queue.
+      manager.enqueueEvent(_event("event-b"));
+      manager.enqueueEvent(_event("event-c"));
+
+      // Phone reconnects with a new connID (relay assigns fresh IDs).
+      manager.subscribePath(5, "/global/event", client);
+      await _waitForSendCount(client, 3);
+
+      // The two buffered events were replayed to the new connID.
+      expect(client.sentConnIDs[1], equals(5));
+      expect(client.sentConnIDs[2], equals(5));
+      expect(manager.pendingReplayCount, equals(0));
+    });
+
     test("orphan queue replays to next subscriber within replay window", () async {
       final roomKey = makeRoomKey();
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: const Duration(seconds: 30));
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
@@ -135,7 +181,7 @@ void main() {
       await withClock(fakeClock, () async {
         final roomKey = makeRoomKey();
         final client = _RecordingRelayClient();
-        final manager = SSEManager(replayWindow: const Duration(seconds: 30));
+        final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
         manager.setRoomKey(roomKey);
         addTearDown(manager.stop);
 
@@ -146,7 +192,7 @@ void main() {
         manager.enqueueEvent(_event("queued-for-orphan"));
         await _waitForSendCount(client, 1);
 
-        now = now.add(const Duration(seconds: 31));
+        now = now.add(SSEManager.defaultReplayWindow + const Duration(seconds: 1));
         final sendsBefore = client.sentConnIDs.length;
 
         manager.subscribePath(3, "/global/event", client);
@@ -157,8 +203,42 @@ void main() {
       });
     });
 
+    test("orphanAll moves all subscribers to orphan state", () async {
+      final roomKey = makeRoomKey();
+      final client = _RecordingRelayClient();
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
+      manager.setRoomKey(roomKey);
+      addTearDown(manager.stop);
+
+      manager.subscribePath(1, "/global/event", client);
+      manager.subscribePath(2, "/global/event", client);
+
+      manager.enqueueEvent(_event("before-orphan"));
+      await _waitForSendCount(client, 2);
+
+      // Simulate relay disconnect — all subscribers become orphans.
+      manager.orphanAll();
+      expect(manager.subscriberCount, equals(0));
+      expect(manager.pendingReplayCount, equals(2));
+
+      // Events arriving during relay reconnect are buffered.
+      manager.enqueueEvent(_event("during-reconnect"));
+
+      // First phone reconnects — picks up orphan with buffered event.
+      manager.subscribePath(3, "/global/event", client);
+      await _waitForSendCount(client, 3);
+      expect(client.sentConnIDs[2], equals(3));
+      expect(manager.pendingReplayCount, equals(1));
+
+      // Second phone reconnects.
+      manager.subscribePath(4, "/global/event", client);
+      await _waitForSendCount(client, 4);
+      expect(client.sentConnIDs[3], equals(4));
+      expect(manager.pendingReplayCount, equals(0));
+    });
+
     test("stop clears subscribers and orphan queues", () {
-      final manager = SSEManager(replayWindow: const Duration(seconds: 30));
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),


### PR DESCRIPTION
## Summary

Fixes SSE event buffering so that events are actually replayed when a phone reconnects within the 5-minute replay window. Two bugs were preventing this from working:

**Bug 1 — Single-phone disconnect destroyed the buffer:**
`SSEManager.unsubscribe()` checked `_subscribers.isEmpty` after removing the phone and, when it was the last (only) subscriber, called `queue.dispose()` instead of orphaning it. Since the typical use case is a single phone, the orphan queue mechanism was effectively dead code.

**Bug 2 — Relay reconnect destroyed all orphan state:**
`orchestrator.dart` called `_sseManager.stop()` whenever the bridge's relay WebSocket dropped, which disposed every subscriber queue and every orphan queue. Even if Bug 1 were fixed, a brief relay hiccup would still wipe all buffered events.

## Changes

- **`sse_manager.dart`**: `unsubscribe()` now always pauses the queue and adds it to the orphan list, regardless of remaining subscriber count
- **`sse_manager.dart`**: Added `orphanAll()` method that moves all active subscribers to orphan state (for relay reconnect)
- **`sse_manager.dart`**: Added `static const defaultReplayWindow = Duration(minutes: 5)` as single source of truth
- **`orchestrator.dart`**: Replaced `_sseManager.stop()` with `_sseManager.orphanAll()` on relay disconnect, and clear stale `activePhones`
- **`bridge.dart`**: Reference `SSEManager.defaultReplayWindow` instead of private constant
- **`sse_manager_test.dart`**: Added tests for single-subscriber orphaning, `orphanAll()`, and single-phone reconnect replay; updated all tests to reference `SSEManager.defaultReplayWindow`