### PR TITLE
feat: implement session unarchive via fork+delete+rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### Sesori AI tooling
 .sisyphus/
+.worktrees/
 
 ### Dart
 .dart_tool/

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -99,6 +99,43 @@ class OpenCodeApi {
     }
   }
 
+  Future<Session> getSession({
+    required String sessionId,
+    required String? directory,
+  }) async {
+    final headers = <String, String>{
+      ..._authHeaders,
+      _directoryOpenCodeHeader: ?directory,
+    };
+    final response = await http.get(
+      Uri.parse("$serverURL/session/$sessionId"),
+      headers: headers,
+    );
+    _ensureSuccess(response, "GET /session/$sessionId");
+    return Session.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+  }
+
+  Future<Session> forkSession({
+    required String sessionId,
+    required String? directory,
+  }) async {
+    final client = http.Client();
+    try {
+      final response = await client.post(
+        Uri.parse("$serverURL/session/$sessionId/fork"),
+        headers: {
+          ..._authHeaders,
+          _directoryOpenCodeHeader: ?directory,
+        },
+        body: "",
+      );
+      _ensureSuccess(response, "POST /session/$sessionId/fork");
+      return Session.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+    } finally {
+      client.close();
+    }
+  }
+
   Future<Session> updateSession({
     required String sessionId,
     required Map<String, dynamic> body,

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -239,18 +239,65 @@ class OpenCodePlugin implements BridgePlugin {
   @override
   Future<PluginSession> updateSessionArchiveStatus(String sessionId, {required bool archived}) async {
     final directory = _service.tracker.getSessionDirectory(sessionId: sessionId);
-    final session = await _call(
-      () => _service.repository.api.updateSession(
+
+    if (archived) {
+      final session = await _call(
+        () => _service.repository.api.updateSession(
+          sessionId: sessionId,
+          directory: directory,
+          body: {
+            "time": {
+              "archived": DateTime.now().millisecondsSinceEpoch,
+            },
+          },
+        ),
+      );
+      return session.toPlugin();
+    }
+
+    final original = await _call(
+      () => _service.repository.api.getSession(
         sessionId: sessionId,
         directory: directory,
-        body: {
-          "time": {
-            "archived": archived ? DateTime.now().millisecondsSinceEpoch : null,
-          },
-        },
       ),
     );
-    return session.toPlugin();
+
+    final forked = await _call(
+      () => _service.repository.api.forkSession(
+        sessionId: sessionId,
+        directory: directory,
+      ),
+    );
+
+    _service.tracker.registerSession(
+      sessionId: forked.id,
+      directory: forked.directory,
+    );
+
+    try {
+      await _call(
+        () => _service.repository.api.deleteSession(
+          sessionId: sessionId,
+          directory: directory,
+        ),
+      );
+    } on Object catch (e) {
+      Log.w("Unarchive: failed to delete original session $sessionId: $e");
+    }
+
+    try {
+      final renamed = await _call(
+        () => _service.repository.api.updateSession(
+          sessionId: forked.id,
+          directory: directory,
+          body: {"title": original.title},
+        ),
+      );
+      return renamed.toPlugin();
+    } on Object catch (e) {
+      Log.w("Unarchive: failed to rename forked session ${forked.id}: $e");
+      return forked.toPlugin();
+    }
   }
 
   @override

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -736,6 +736,14 @@ class _FakeApi implements OpenCodeApi {
       throw UnimplementedError();
 
   @override
+  Future<Session> getSession({required String sessionId, required String? directory}) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<Session> forkSession({required String sessionId, required String? directory}) async =>
+      throw UnimplementedError();
+
+  @override
   Future<Session> updateSession({
     required String sessionId,
     required Map<String, dynamic> body,

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -193,6 +193,103 @@ void main() {
       // Tracker's busy overrides the API's stale idle.
       expect(statuses["s-root"], isA<PluginSessionStatusBusy>());
     });
+
+    group("updateSessionArchiveStatus", () {
+      test("archive sends PATCH with timestamp (no regression)", () async {
+        final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
+        await server.waitForSseConnection();
+        server.requestLog.clear();
+
+        final session = await plugin.updateSessionArchiveStatus("s-root", archived: true);
+
+        expect(session.id, equals("s-root"));
+        expect(session.time?.archived, isNotNull);
+        expect(server.requestLog, equals(["PATCH /session/s-root"]));
+      });
+
+      test("unarchive forks, deletes original, renames fork, returns renamed session", () async {
+        final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
+        await server.waitForSseConnection();
+        server.requestLog.clear();
+
+        final session = await plugin.updateSessionArchiveStatus("s-root", archived: false);
+
+        expect(session.id, isNot(equals("s-root")));
+        expect(session.id, equals("s-root-fork"));
+        expect(session.title, equals("Root Session"));
+        expect(session.time?.archived, isNull);
+        expect(
+          server.requestLog,
+          equals([
+            "GET /session/s-root",
+            "POST /session/s-root/fork",
+            "DELETE /session/s-root",
+            "PATCH /session/s-root-fork",
+          ]),
+        );
+      });
+
+      test("unarchive continues and returns renamed session when delete fails", () async {
+        server.failDelete = true;
+        final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
+        await server.waitForSseConnection();
+        server.requestLog.clear();
+
+        final session = await plugin.updateSessionArchiveStatus("s-root", archived: false);
+
+        expect(session.id, equals("s-root-fork"));
+        expect(session.title, equals("Root Session"));
+        expect(
+          server.requestLog,
+          equals([
+            "GET /session/s-root",
+            "POST /session/s-root/fork",
+            "DELETE /session/s-root",
+            "PATCH /session/s-root-fork",
+          ]),
+        );
+      });
+
+      test("unarchive returns forked session when rename fails", () async {
+        server.failRename = true;
+        final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
+        await server.waitForSseConnection();
+        server.requestLog.clear();
+
+        final session = await plugin.updateSessionArchiveStatus("s-root", archived: false);
+
+        expect(session.id, equals("s-root-fork"));
+        expect(session.title, equals("Root Session (fork #1)"));
+        expect(
+          server.requestLog,
+          equals([
+            "GET /session/s-root",
+            "POST /session/s-root/fork",
+            "DELETE /session/s-root",
+            "PATCH /session/s-root-fork",
+          ]),
+        );
+      });
+
+      test("unarchive throws when fork fails", () async {
+        server.failFork = true;
+        final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
+        await server.waitForSseConnection();
+        server.requestLog.clear();
+
+        await expectLater(
+          () => plugin.updateSessionArchiveStatus("s-root", archived: false),
+          throwsA(isA<PluginApiException>()),
+        );
+        expect(
+          server.requestLog,
+          equals([
+            "GET /session/s-root",
+            "POST /session/s-root/fork",
+          ]),
+        );
+      });
+    });
   });
 }
 
@@ -283,6 +380,21 @@ class _FakeOpenCodeServer {
   HttpServer? _server;
   final List<HttpResponse> _sseClients = [];
   final Completer<void> _firstSseClient = Completer<void>();
+  final List<String> requestLog = [];
+
+  bool failFork = false;
+  bool failDelete = false;
+  bool failRename = false;
+
+  final Map<String, Map<String, dynamic>> _sessions = {
+    "s-root": {
+      "id": "s-root",
+      "projectID": "p1",
+      "directory": "/repo",
+      "title": "Root Session",
+      "time": <String, dynamic>{"created": 100, "updated": 200, "archived": 999},
+    },
+  };
 
   String get baseUrl => "http://${_server!.address.address}:${_server!.port}";
 
@@ -290,6 +402,7 @@ class _FakeOpenCodeServer {
     _server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     _server!.listen((request) async {
       final path = request.uri.path;
+      requestLog.add("${request.method} $path");
 
       if (request.method == "GET" && path == "/project") {
         await _sendJson(request.response, [
@@ -311,9 +424,99 @@ class _FakeOpenCodeServer {
             "id": "s-root",
             "projectID": "p1",
             "directory": "/repo",
+            "title": "Root Session",
             "time": {"created": 100, "updated": 200},
           },
         ]);
+        return;
+      }
+
+      final forkMatch = RegExp(r"^/session/([^/]+)/fork$").firstMatch(path);
+      if (request.method == "POST" && forkMatch != null) {
+        if (failFork) {
+          request.response.statusCode = HttpStatus.internalServerError;
+          await request.response.close();
+          return;
+        }
+        final sessionId = forkMatch.group(1)!;
+        final original = _sessions[sessionId];
+        if (original == null) {
+          request.response.statusCode = HttpStatus.notFound;
+          await request.response.close();
+          return;
+        }
+
+        final forked = {
+          ...original,
+          "id": "$sessionId-fork",
+          "title": "${original["title"]} (fork #1)",
+          "time": {
+            "created": original["time"]["created"],
+            "updated": original["time"]["updated"],
+          },
+        };
+        _sessions[forked["id"]! as String] = Map<String, dynamic>.from(forked);
+        await _sendJson(request.response, forked);
+        return;
+      }
+
+      final sessionMatch = RegExp(r"^/session/([^/]+)$").firstMatch(path);
+      if (sessionMatch != null && request.method == "GET") {
+        final sessionId = sessionMatch.group(1)!;
+        final session = _sessions[sessionId];
+        if (session == null) {
+          request.response.statusCode = HttpStatus.notFound;
+          await request.response.close();
+          return;
+        }
+        await _sendJson(request.response, session);
+        return;
+      }
+
+      if (sessionMatch != null && request.method == "DELETE") {
+        if (failDelete) {
+          request.response.statusCode = HttpStatus.internalServerError;
+          await request.response.close();
+          return;
+        }
+        final sessionId = sessionMatch.group(1)!;
+        _sessions.remove(sessionId);
+        await _sendJson(request.response, true);
+        return;
+      }
+
+      if (sessionMatch != null && request.method == "PATCH") {
+        final sessionId = sessionMatch.group(1)!;
+        final session = _sessions[sessionId];
+        if (session == null) {
+          request.response.statusCode = HttpStatus.notFound;
+          await request.response.close();
+          return;
+        }
+
+        final rawBody = await utf8.decoder.bind(request).join();
+        final body = (jsonDecode(rawBody) as Map).cast<String, dynamic>();
+        final title = body["title"];
+        if (title is String) {
+          if (failRename) {
+            request.response.statusCode = HttpStatus.internalServerError;
+            await request.response.close();
+            return;
+          }
+          session["title"] = title;
+        }
+
+        final timeBody = body["time"];
+        if (timeBody is Map<String, dynamic>) {
+          final archived = timeBody["archived"];
+          final currentTime = (session["time"] as Map?) != null
+              ? Map<String, dynamic>.from((session["time"] as Map).cast<String, dynamic>())
+              : <String, dynamic>{"created": 100, "updated": 200};
+          currentTime["archived"] = archived;
+          session["time"] = currentTime;
+        }
+
+        await _sendJson(request.response, session);
         return;
       }
 

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -387,6 +387,14 @@ class _FakeApi implements OpenCodeApi {
       throw UnimplementedError();
 
   @override
+  Future<Session> getSession({required String sessionId, required String? directory}) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<Session> forkSession({required String sessionId, required String? directory}) async =>
+      throw UnimplementedError();
+
+  @override
   Future<Session> updateSession({
     required String sessionId,
     required Map<String, dynamic> body,

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -384,6 +384,14 @@ class FakeOpenCodeApi implements OpenCodeApi {
       throw UnimplementedError();
 
   @override
+  Future<Session> getSession({required String sessionId, required String? directory}) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<Session> forkSession({required String sessionId, required String? directory}) async =>
+      throw UnimplementedError();
+
+  @override
   Future<Session> updateSession({
     required String sessionId,
     required Map<String, dynamic> body,

--- a/mobile/app/lib/features/session_list/session_list_screen.dart
+++ b/mobile/app/lib/features/session_list/session_list_screen.dart
@@ -110,7 +110,11 @@ class _SessionListBody extends StatelessWidget {
     final success = await cubit.unarchiveSession(sessionId);
     if (!success || !context.mounted) return;
 
-    _showUndoSnackBar(context, cubit, loc.sessionListUnarchived);
+    // Show confirmation without undo — unarchive creates a new session
+    // (via fork + delete), so the original cannot be restored.
+    ScaffoldMessenger.of(context)
+      ..clearSnackBars()
+      ..showSnackBar(SnackBar(content: Text(loc.sessionListUnarchived)));
   }
 
   void _showUndoSnackBar(BuildContext context, SessionListCubit cubit, String message) {

--- a/mobile/app/test/features/session_list/session_list_cubit_test.dart
+++ b/mobile/app/test/features/session_list/session_list_cubit_test.dart
@@ -391,7 +391,7 @@ void main() {
     // -------------------------------------------------------------------------
 
     blocTest<SessionListCubit, SessionListState>(
-      "unarchiveSession: optimistically unarchives session and returns true on API success",
+      "unarchiveSession: optimistically removes session and inserts new session on API success",
       build: () {
         final archivedSession = testSession(
           id: "s1",
@@ -400,8 +400,9 @@ void main() {
         when(() => mockSessionService.listSessions(projectId: projectId)).thenAnswer(
           (_) async => ApiResponse.success([archivedSession]),
         );
+        // API returns a session with a DIFFERENT ID (fork + delete creates new session).
         when(() => mockSessionService.unarchiveSession("s1")).thenAnswer(
-          (_) async => ApiResponse.success(testSession(id: "s1")),
+          (_) async => ApiResponse.success(testSession(id: "s1-new")),
         );
         return buildCubit();
       },
@@ -419,10 +420,12 @@ void main() {
         isA<SessionListLoaded>()
             .having((s) => s.showArchived, "showArchived", isTrue)
             .having((s) => s.sessions.length, "sessions after toggle", 1),
-        // Optimistic unarchive: session now has archived=null.
-        // Server response is identical, so bloc deduplicates — only one emission.
+        // Optimistic remove: old session (s1) removed from list.
+        isA<SessionListLoaded>().having((s) => s.sessions, "sessions after optimistic remove", isEmpty),
+        // API success: new session (s1-new, different ID) inserted.
         isA<SessionListLoaded>()
-            .having((s) => s.sessions.length, "sessions after unarchive", 1)
+            .having((s) => s.sessions.length, "sessions after API success", 1)
+            .having((s) => s.sessions.first.id, "new session id", "s1-new")
             .having((s) => s.sessions.first.time?.archived, "archived cleared", isNull),
       ],
     );
@@ -458,9 +461,9 @@ void main() {
         isA<SessionListLoaded>()
             .having((s) => s.showArchived, "showArchived", isTrue)
             .having((s) => s.sessions.length, "sessions after toggle", 1),
-        // Optimistic unarchive: session still visible.
-        isA<SessionListLoaded>().having((s) => s.sessions.length, "sessions after optimistic unarchive", 1),
-        // Rollback: archived session restored.
+        // Optimistic remove: old session removed from list.
+        isA<SessionListLoaded>().having((s) => s.sessions, "sessions after optimistic remove", isEmpty),
+        // Rollback: original archived session re-inserted (with archived timestamp).
         isA<SessionListLoaded>()
             .having((s) => s.sessions.length, "sessions after rollback", 1)
             .having((s) => s.sessions.first.time?.archived, "archived timestamp restored", isNotNull),
@@ -503,11 +506,55 @@ void main() {
     );
 
     // -------------------------------------------------------------------------
-    // 16. undoLastArchiveAction — reverses unarchive (undo = re-archive)
+    // 16. undoLastArchiveAction — returns false after unarchive (undo disabled)
     // -------------------------------------------------------------------------
 
     blocTest<SessionListCubit, SessionListState>(
-      "undoLastArchiveAction: re-archives after unarchive",
+      "undoLastArchiveAction: returns false after unarchive (undo disabled for unarchive)",
+      build: () {
+        final archivedSession = testSession(
+          id: "s1",
+          archivedAt: DateTime.fromMillisecondsSinceEpoch(1700000001000),
+        );
+        when(() => mockSessionService.listSessions(projectId: projectId)).thenAnswer(
+          (_) async => ApiResponse.success([archivedSession]),
+        );
+        // Returns new ID to reflect fork+delete behaviour.
+        when(() => mockSessionService.unarchiveSession("s1")).thenAnswer(
+          (_) async => ApiResponse.success(testSession(id: "s1-new")),
+        );
+        return buildCubit();
+      },
+      act: (cubit) async {
+        await Future<void>.delayed(Duration.zero);
+        cubit.toggleArchived();
+        await cubit.unarchiveSession("s1");
+        final undoResult = await cubit.undoLastArchiveAction();
+        // Undo snapshot is NOT set during unarchive → undo always returns false.
+        expect(undoResult, isFalse);
+      },
+      skip: 1,
+      expect: () => [
+        // toggleArchived: shows the archived session.
+        isA<SessionListLoaded>()
+            .having((s) => s.showArchived, "showArchived", isTrue)
+            .having((s) => s.sessions.length, "sessions after toggle", 1),
+        // Optimistic remove: session removed.
+        isA<SessionListLoaded>().having((s) => s.sessions, "sessions after optimistic remove", isEmpty),
+        // API success: new session (s1-new) inserted.
+        isA<SessionListLoaded>()
+            .having((s) => s.sessions.length, "sessions after unarchive", 1)
+            .having((s) => s.sessions.first.id, "new session id", "s1-new"),
+        // No undo emission — undoLastArchiveAction returned false (undo disabled for unarchive).
+      ],
+    );
+
+    // -------------------------------------------------------------------------
+    // 16b. unarchiveSession does not set undo snapshot
+    // -------------------------------------------------------------------------
+
+    blocTest<SessionListCubit, SessionListState>(
+      "unarchiveSession: does not set undo snapshot — undoLastArchiveAction returns false",
       build: () {
         final archivedSession = testSession(
           id: "s1",
@@ -517,10 +564,7 @@ void main() {
           (_) async => ApiResponse.success([archivedSession]),
         );
         when(() => mockSessionService.unarchiveSession("s1")).thenAnswer(
-          (_) async => ApiResponse.success(testSession(id: "s1")),
-        );
-        when(() => mockSessionService.archiveSession("s1")).thenAnswer(
-          (_) async => ApiResponse.success(archivedSession),
+          (_) async => ApiResponse.success(testSession(id: "s1-new")),
         );
         return buildCubit();
       },
@@ -529,23 +573,18 @@ void main() {
         cubit.toggleArchived();
         await cubit.unarchiveSession("s1");
         final undoResult = await cubit.undoLastArchiveAction();
-        expect(undoResult, isTrue);
+        // No undo snapshot was stored → must return false.
+        expect(undoResult, isFalse);
       },
       skip: 1,
+      // State emissions match the success path; the undo call emits nothing.
       expect: () => [
-        // toggleArchived: shows the archived session.
+        isA<SessionListLoaded>().having((s) => s.sessions.length, "sessions after toggle", 1),
+        isA<SessionListLoaded>().having((s) => s.sessions, "sessions after optimistic remove", isEmpty),
         isA<SessionListLoaded>()
-            .having((s) => s.showArchived, "showArchived", isTrue)
-            .having((s) => s.sessions.length, "sessions after toggle", 1),
-        // Optimistic unarchive: session now has archived=null.
-        // Server response is identical, so bloc deduplicates — only one emission.
-        isA<SessionListLoaded>()
-            .having((s) => s.sessions.length, "sessions after unarchive", 1)
-            .having((s) => s.sessions.first.time?.archived, "archived cleared", isNull),
-        // Undo (re-archive): session still visible (showArchived is true), archived restored.
-        isA<SessionListLoaded>()
-            .having((s) => s.sessions.length, "sessions after undo", 1)
-            .having((s) => s.sessions.first.time?.archived, "re-archived timestamp", isNotNull),
+            .having((s) => s.sessions.length, "sessions after reinsert", 1)
+            .having((s) => s.sessions.first.id, "new session id", "s1-new"),
+        // No 4th emission — undo snapshot was null.
       ],
     );
 

--- a/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -147,21 +147,23 @@ class SessionListCubit extends Cubit<SessionListState> {
   }
 
   /// Unarchives a session. Returns `true` on success so the screen can show
-  /// an undo toast.
+  /// a confirmation message.
+  ///
+  /// Unlike [archiveSession], this does NOT set [_undoSnapshot] because the
+  /// operation internally creates a new session (via fork + delete) with a
+  /// different ID, so the original cannot be restored.
   Future<bool> unarchiveSession(String sessionId) async {
     if (state is! SessionListLoaded) return false;
 
     final index = _allSessions.indexWhere((s) => s.id == sessionId);
     if (index < 0) return false;
 
-    // Store for undo before modifying.
-    _undoSnapshot = _allSessions[index];
+    // Store for rollback (NOT for undo — undo is disabled for unarchive).
+    final original = _allSessions[index];
 
-    // Optimistically mark as unarchived.
-    _allSessions = List<Session>.from(_allSessions);
-    _allSessions[index] = _allSessions[index].copyWith(
-      time: _allSessions[index].time?.copyWith(archived: null),
-    );
+    // Optimistically REMOVE the session (it's archived, so removing it
+    // from the list is the expected visual outcome).
+    _allSessions = List<Session>.from(_allSessions)..removeAt(index);
     _emitFiltered();
 
     final response = await _service.unarchiveSession(sessionId);
@@ -169,14 +171,14 @@ class SessionListCubit extends Cubit<SessionListState> {
 
     return switch (response) {
       SuccessResponse(:final data) => () {
-        // Replace with fresh server data.
+        // Insert the NEW session (which may have a different ID).
         _reinsertSession(data);
         return true;
       }(),
       ErrorResponse(:final error) => () {
         loge("Failed to unarchive session: $error");
-        // Rollback — restore the archived session.
-        _rollbackLastAction();
+        // Rollback — re-insert the ORIGINAL session.
+        _reinsertSession(original);
         return false;
       }(),
     };


### PR DESCRIPTION
## Summary

- **Problem**: OpenCode's API doesn't support unarchiving sessions — the Zod schema (`z.number().optional()`) rejects `null`, JSON can't represent `undefined`, and there's no unarchive code path in their codebase
- **Solution**: Implement unarchive as fork → delete original → rename fork to original title, entirely within the OpenCode plugin
- **Mobile**: Handle the session ID change (the unarchived session has a new ID); disable undo for unarchive since the original is deleted

## Changes

### Bridge (`sesori_plugin_opencode`)
- **`OpenCodeApi`**: Add `getSession()` and `forkSession()` methods
- **`OpenCodePlugin.updateSessionArchiveStatus`**: When `archived: false`, perform getSession → fork → register tracker → delete (roll-forward) → rename (roll-forward) instead of sending an unsupported PATCH
- Archive path (`archived: true`) unchanged — still sends PATCH with timestamp
- Roll-forward error handling: fork failure propagates, delete/rename failures are logged but non-fatal
- 5 new plugin tests (happy path, delete/rename/fork failures, archive regression)

### Mobile (`module_core` + `app`)
- **`SessionListCubit.unarchiveSession()`**: Optimistically removes old session from list instead of modifying it; inserts new session (different ID) on success; rolls back on failure
- **Undo disabled for unarchive**: `_undoSnapshot` not set (original session is deleted, can't be restored); archive undo unchanged
- **`SessionListScreen`**: Shows simple confirmation snackbar without undo button for unarchive
- Updated and added cubit tests for the new behavior

## Test Results

| Module | Tests | Analysis |
|--------|-------|----------|
| Bridge plugin | 102 pass | Clean |
| Bridge app | 361 pass | — |
| Mobile app | 382 pass | Clean |
| Mobile module_core | — | Clean |