### PR TITLE
refactor: remove idle-state gating from message send queue

### DIFF
--- a/mobile/app/lib/features/session_detail/session_detail_screen.dart
+++ b/mobile/app/lib/features/session_detail/session_detail_screen.dart
@@ -236,7 +236,6 @@ class _SessionDetailBodyState extends State<_SessionDetailBody> {
                 if (queuedMessages.isNotEmpty)
                   _QueuedMessagesSection(
                     messages: queuedMessages,
-                    onSendNow: (index) => context.read<SessionDetailCubit>().sendNow(index),
                     onCancel: (index) => context.read<SessionDetailCubit>().cancelQueuedMessage(index),
                   ),
                 PromptInput(
@@ -495,12 +494,10 @@ class _AgentModelButtons extends StatelessWidget {
 
 class _QueuedMessagesSection extends StatelessWidget {
   final List<String> messages;
-  final ValueChanged<int> onSendNow;
   final ValueChanged<int> onCancel;
 
   const _QueuedMessagesSection({
     required this.messages,
-    required this.onSendNow,
     required this.onCancel,
   });
 
@@ -512,7 +509,6 @@ class _QueuedMessagesSection extends StatelessWidget {
         for (var i = 0; i < messages.length; i++)
           QueuedMessageBubble(
             text: messages[i],
-            onSendNow: () => onSendNow(i),
             onCancel: () => onCancel(i),
           ),
       ],

--- a/mobile/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/mobile/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -214,25 +214,18 @@ class _PromptInputState extends State<PromptInput> {
                   onTap: _handleMicTap,
                 ),
                 if (_voiceState == _VoiceState.idle) ...[
-                  if (widget.isBusy) ...[
-                    IconButton(
-                      onPressed: _handleSend,
-                      icon: const Icon(Icons.send),
-                      color: theme.colorScheme.tertiary,
-                      tooltip: loc.sessionDetailQueue,
-                    ),
+                  IconButton(
+                    onPressed: _handleSend,
+                    icon: const Icon(Icons.send),
+                    color: theme.colorScheme.primary,
+                    tooltip: loc.sessionDetailSend,
+                  ),
+                  if (widget.isBusy)
                     IconButton(
                       onPressed: widget.onAbort,
                       icon: const Icon(Icons.stop_circle),
                       color: theme.colorScheme.error,
                       tooltip: loc.sessionDetailAbort,
-                    ),
-                  ] else
-                    IconButton(
-                      onPressed: _handleSend,
-                      icon: const Icon(Icons.send),
-                      color: theme.colorScheme.primary,
-                      tooltip: loc.sessionDetailSend,
                     ),
                 ],
               ],

--- a/mobile/app/lib/features/session_detail/widgets/queued_message_bubble.dart
+++ b/mobile/app/lib/features/session_detail/widgets/queued_message_bubble.dart
@@ -4,13 +4,11 @@ import "../../../core/extensions/build_context_x.dart";
 
 class QueuedMessageBubble extends StatelessWidget {
   final String text;
-  final VoidCallback onSendNow;
   final VoidCallback onCancel;
 
   const QueuedMessageBubble({
     super.key,
     required this.text,
-    required this.onSendNow,
     required this.onCancel,
   });
 
@@ -77,19 +75,6 @@ class QueuedMessageBubble extends StatelessWidget {
                     child: Row(
                       mainAxisSize: .min,
                       children: [
-                        TextButton.icon(
-                          onPressed: onSendNow,
-                          icon: const Icon(Icons.flash_on, size: 16),
-                          label: Text(loc.sessionDetailSendNow),
-                          style: TextButton.styleFrom(
-                            foregroundColor: theme.colorScheme.tertiary,
-                            padding: const EdgeInsets.symmetric(horizontal: 8),
-                            minimumSize: .zero,
-                            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                            textStyle: theme.textTheme.labelSmall,
-                          ),
-                        ),
-                        const SizedBox(width: 4),
                         TextButton.icon(
                           onPressed: onCancel,
                           icon: const Icon(Icons.close, size: 14),

--- a/mobile/app/lib/l10n/app_en.arb
+++ b/mobile/app/lib/l10n/app_en.arb
@@ -143,9 +143,7 @@
     }
   },
   "sessionDetailSubtaskUnnamed": "Background task",
-  "sessionDetailQueue": "Queue message",
   "sessionDetailQueuedMessage": "Queued",
-  "sessionDetailSendNow": "Send now",
   "sessionDetailCancelQueued": "Cancel",
   "sessionDetailPickerAgent": "Agent",
   "sessionDetailPickerModel": "Model",

--- a/mobile/app/lib/l10n/app_localizations.dart
+++ b/mobile/app/lib/l10n/app_localizations.dart
@@ -493,23 +493,11 @@ abstract class AppLocalizations {
   /// **'Background task'**
   String get sessionDetailSubtaskUnnamed;
 
-  /// No description provided for @sessionDetailQueue.
-  ///
-  /// In en, this message translates to:
-  /// **'Queue message'**
-  String get sessionDetailQueue;
-
   /// No description provided for @sessionDetailQueuedMessage.
   ///
   /// In en, this message translates to:
   /// **'Queued'**
   String get sessionDetailQueuedMessage;
-
-  /// No description provided for @sessionDetailSendNow.
-  ///
-  /// In en, this message translates to:
-  /// **'Send now'**
-  String get sessionDetailSendNow;
 
   /// No description provided for @sessionDetailCancelQueued.
   ///

--- a/mobile/app/lib/l10n/app_localizations_en.dart
+++ b/mobile/app/lib/l10n/app_localizations_en.dart
@@ -237,13 +237,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionDetailSubtaskUnnamed => 'Background task';
 
   @override
-  String get sessionDetailQueue => 'Queue message';
-
-  @override
   String get sessionDetailQueuedMessage => 'Queued';
-
-  @override
-  String get sessionDetailSendNow => 'Send now';
 
   @override
   String get sessionDetailCancelQueued => 'Cancel';

--- a/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -882,6 +882,17 @@ void main() {
           ["will fail"],
         ),
       ],
+      verify: (_) {
+        verify(
+          () => mockSessionService.sendMessage(
+            sessionId,
+            "will fail",
+            agent: any(named: "agent"),
+            providerID: any(named: "providerID"),
+            modelID: any(named: "modelID"),
+          ),
+        ).called(1);
+      },
     );
   });
 }

--- a/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -123,7 +123,7 @@ void main() {
     );
 
     blocTest<SessionDetailCubit, SessionDetailState>(
-      "sendMessage when idle delegates to service with trimmed text",
+      "sendMessage when connected delegates to service with trimmed text",
       build: () => SessionDetailCubit(
         mockSessionService,
         mockConnectionService,
@@ -142,6 +142,49 @@ void main() {
           () => mockSessionService.sendMessage(
             sessionId,
             "hi",
+            agent: "coder",
+            providerID: "anthropic",
+            modelID: "claude-3-5-sonnet",
+          ),
+        ).called(1);
+      },
+    );
+
+    blocTest<SessionDetailCubit, SessionDetailState>(
+      "sendMessage sends immediately when session is busy but connected",
+      build: () => SessionDetailCubit(
+        mockSessionService,
+        mockConnectionService,
+        sessionId: sessionId,
+        notificationCanceller: mockNotificationCanceller,
+      ),
+      act: (cubit) async {
+        await _awaitLoaded(cubit);
+
+        // Session becomes busy.
+        sessionEvents.add(
+          const SesoriSessionStatus(sessionID: sessionId, status: SessionStatus.busy()),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        // Send message while busy — should send immediately (not queue).
+        await cubit.sendMessage("hello");
+      },
+      expect: () => [
+        isA<SessionDetailLoaded>(),
+        // Session busy.
+        isA<SessionDetailLoaded>().having(
+          (state) => state.sessionStatus,
+          "sessionStatus",
+          const SessionStatus.busy(),
+        ),
+        // No queuedMessages emission — message was sent directly.
+      ],
+      verify: (_) {
+        verify(
+          () => mockSessionService.sendMessage(
+            sessionId,
+            "hello",
             agent: "coder",
             providerID: "anthropic",
             modelID: "claude-3-5-sonnet",
@@ -579,23 +622,24 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "session becoming idle does not drain queue when disconnected",
-      build: () => SessionDetailCubit(
-        mockSessionService,
-        mockConnectionService,
-        sessionId: sessionId,
-        notificationCanceller: mockNotificationCanceller,
-      ),
+      build: () {
+        // Start with a busy session so the idle SSE event produces a real state
+        // transition (idle vs busy), allowing the test to verify the queue is
+        // NOT drained even when the session becomes idle while disconnected.
+        when(
+          () => mockSessionService.getSessionStatuses(),
+        ).thenAnswer(
+          (_) async => ApiResponse.success({sessionId: const SessionStatus.busy()}),
+        );
+        return SessionDetailCubit(
+          mockSessionService,
+          mockConnectionService,
+          sessionId: sessionId,
+          notificationCanceller: mockNotificationCanceller,
+        );
+      },
       act: (cubit) async {
         await _awaitLoaded(cubit);
-
-        // Session becomes busy.
-        sessionEvents.add(
-          const SesoriSessionStatus(sessionID: sessionId, status: SessionStatus.busy()),
-        );
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-
-        // Send message while busy — queued.
-        await cubit.sendMessage("queued msg");
 
         // Connection drops.
         when(() => mockConnectionService.currentStatus).thenReturn(
@@ -603,6 +647,9 @@ void main() {
             config: ServerConnectionConfig(relayHost: "fake.example.com"),
           ),
         );
+
+        // Send message while disconnected — queued.
+        await cubit.sendMessage("queued msg");
 
         // Session becomes idle — but connection is lost, so queue stays.
         sessionEvents.add(
@@ -613,12 +660,6 @@ void main() {
       expect: () => [
         // Initial load.
         isA<SessionDetailLoaded>(),
-        // Session busy.
-        isA<SessionDetailLoaded>().having(
-          (state) => state.sessionStatus,
-          "sessionStatus",
-          const SessionStatus.busy(),
-        ),
         // Message queued.
         isA<SessionDetailLoaded>().having(
           (state) => state.queuedMessages,
@@ -709,117 +750,6 @@ void main() {
     );
 
     blocTest<SessionDetailCubit, SessionDetailState>(
-      "sendNow re-queues on send failure",
-      build: () => SessionDetailCubit(
-        mockSessionService,
-        mockConnectionService,
-        sessionId: sessionId,
-        notificationCanceller: mockNotificationCanceller,
-      ),
-      act: (cubit) async {
-        await _awaitLoaded(cubit);
-
-        // Session becomes busy.
-        sessionEvents.add(
-          const SesoriSessionStatus(sessionID: sessionId, status: SessionStatus.busy()),
-        );
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-
-        // Queue a message.
-        await cubit.sendMessage("important msg");
-
-        // Make next send fail.
-        when(
-          () => mockSessionService.sendMessage(
-            any(),
-            any(),
-            agent: any(named: "agent"),
-            providerID: any(named: "providerID"),
-            modelID: any(named: "modelID"),
-          ),
-        ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
-
-        // Try to send now (abort + send) — send fails.
-        await cubit.sendNow(0);
-      },
-      expect: () => [
-        // Initial load.
-        isA<SessionDetailLoaded>(),
-        // Session busy.
-        isA<SessionDetailLoaded>().having(
-          (state) => state.sessionStatus,
-          "sessionStatus",
-          const SessionStatus.busy(),
-        ),
-        // Message queued.
-        isA<SessionDetailLoaded>().having(
-          (state) => state.queuedMessages,
-          "queuedMessages",
-          ["important msg"],
-        ),
-        // Dequeued (optimistic).
-        isA<SessionDetailLoaded>().having(
-          (state) => state.queuedMessages,
-          "queuedMessages",
-          isEmpty,
-        ),
-        // Re-queued after failure.
-        isA<SessionDetailLoaded>().having(
-          (state) => state.queuedMessages,
-          "queuedMessages",
-          ["important msg"],
-        ),
-      ],
-    );
-
-    blocTest<SessionDetailCubit, SessionDetailState>(
-      "sendNow does nothing when disconnected",
-      build: () {
-        when(() => mockConnectionService.currentStatus).thenReturn(
-          const ConnectionStatus.connectionLost(
-            config: ServerConnectionConfig(relayHost: "fake.example.com"),
-          ),
-        );
-        return SessionDetailCubit(
-          mockSessionService,
-          mockConnectionService,
-          sessionId: sessionId,
-          notificationCanceller: mockNotificationCanceller,
-        );
-      },
-      act: (cubit) async {
-        await _awaitLoaded(cubit);
-
-        // Queue a message while disconnected.
-        await cubit.sendMessage("queued");
-
-        // sendNow should be a no-op when disconnected.
-        await cubit.sendNow(0);
-      },
-      expect: () => [
-        isA<SessionDetailLoaded>(),
-        isA<SessionDetailLoaded>().having(
-          (state) => state.queuedMessages,
-          "queuedMessages",
-          ["queued"],
-        ),
-        // No further state change — message stays queued.
-      ],
-      verify: (_) {
-        verifyNever(() => mockSessionService.abortSession(any()));
-        verifyNever(
-          () => mockSessionService.sendMessage(
-            any(),
-            any(),
-            agent: any(named: "agent"),
-            providerID: any(named: "providerID"),
-            modelID: any(named: "modelID"),
-          ),
-        );
-      },
-    );
-
-    blocTest<SessionDetailCubit, SessionDetailState>(
       "multiple queued messages drain sequentially on reconnection",
       build: () => SessionDetailCubit(
         mockSessionService,
@@ -855,12 +785,8 @@ void main() {
           ),
         );
 
-        // Wait for first message to drain; then session goes idle to drain second.
-        await Future<void>.delayed(const Duration(milliseconds: 10));
-        sessionEvents.add(
-          const SesoriSessionStatus(sessionID: sessionId, status: SessionStatus.idle()),
-        );
-        await Future<void>.delayed(const Duration(milliseconds: 50));
+        // Wait for both messages to drain via self-chaining.
+        await Future<void>.delayed(const Duration(milliseconds: 100));
       },
       verify: (_) {
         verify(
@@ -909,40 +835,40 @@ void main() {
       act: (cubit) async {
         await _awaitLoaded(cubit);
 
-        // Session becomes busy.
-        sessionEvents.add(
-          const SesoriSessionStatus(sessionID: sessionId, status: SessionStatus.busy()),
+        // Simulate disconnection.
+        when(() => mockConnectionService.currentStatus).thenReturn(
+          const ConnectionStatus.connectionLost(
+            config: ServerConnectionConfig(relayHost: "fake.example.com"),
+          ),
         );
-        await Future<void>.delayed(const Duration(milliseconds: 10));
 
         // Queue a message.
         await cubit.sendMessage("will fail");
 
-        // Session goes idle — triggers drain, but send will fail.
-        sessionEvents.add(
-          const SesoriSessionStatus(sessionID: sessionId, status: SessionStatus.idle()),
+        // Simulate reconnection — triggers drain, but send will fail.
+        when(() => mockConnectionService.currentStatus).thenReturn(
+          ConnectionStatus.connected(
+            config: const ServerConnectionConfig(relayHost: "fake.example.com"),
+            health: testHealthResponse(),
+          ),
+        );
+        connectionStatus.add(
+          ConnectionStatus.connected(
+            config: const ServerConnectionConfig(relayHost: "fake.example.com"),
+            health: testHealthResponse(),
+          ),
         );
         await Future<void>.delayed(const Duration(milliseconds: 50));
       },
       expect: () => [
         // Initial load.
         isA<SessionDetailLoaded>(),
-        // Session busy.
-        isA<SessionDetailLoaded>().having(
-          (state) => state.sessionStatus,
-          "sessionStatus",
-          const SessionStatus.busy(),
-        ),
         // Message queued.
         isA<SessionDetailLoaded>().having(
           (state) => state.queuedMessages,
           "queuedMessages",
           ["will fail"],
         ),
-        // Session idle.
-        isA<SessionDetailLoaded>()
-            .having((state) => state.sessionStatus, "sessionStatus", const SessionStatus.idle())
-            .having((state) => state.queuedMessages, "queuedMessages", ["will fail"]),
         // Dequeued (optimistic).
         isA<SessionDetailLoaded>().having(
           (state) => state.queuedMessages,

--- a/mobile/module_core/lib/src/cubits/session_detail/prompt_send_queue.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/prompt_send_queue.dart
@@ -4,7 +4,7 @@ import "dart:collection";
 ///
 /// This is a thin data structure — it owns the list of pending messages and
 /// provides methods to enqueue, dequeue, requeue, and cancel items. The send
-/// logic and condition checks (connection alive, session idle) remain in the
+/// logic and condition checks (connection alive) remain in the
 /// cubit that owns this queue.
 class PromptSendQueue {
   final Queue<String> _items = Queue<String>();

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -319,12 +319,6 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
 
     if (isClosed) return;
     emit(current.copyWith(sessionStatus: sessionStatus));
-
-    // Auto-send the first queued message when the session becomes idle
-    // and the connection is active.
-    if (sessionStatus is SessionStatusIdle) {
-      _tryDrainQueue();
-    }
   }
 
   // ---------------------------------------------------------------------------
@@ -411,14 +405,13 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     }
   }
 
-  /// Attempts to send the next queued message when both conditions are met:
-  /// connection is alive AND session is idle.
+  /// Attempts to send the next queued message when the condition is met:
+  /// connection is alive.
   void _tryDrainQueue() {
     if (isClosed) return;
     if (_promptQueue.isEmpty) return;
     final current = state;
     if (current is! SessionDetailLoaded) return;
-    if (current.sessionStatus is! SessionStatusIdle) return;
     if (!_isConnected) return;
     _sendNextQueued();
   }
@@ -429,8 +422,8 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
 
     final current = state;
     if (current is SessionDetailLoaded) {
-      // Queue if session is busy or connection is not active.
-      if (current.sessionStatus is! SessionStatusIdle || !_isConnected) {
+      // Queue if connection is not active.
+      if (!_isConnected) {
         _promptQueue.enqueue(trimmed);
         _emitQueueUpdate(current);
         return;
@@ -456,34 +449,6 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     // State not yet loaded — queue the message so it isn't lost.
     // It will drain via _tryDrainQueue once the session finishes loading.
     _promptQueue.enqueue(trimmed);
-  }
-
-  /// Abort the current operation and immediately send a queued message.
-  Future<void> sendNow(int index) async {
-    if (!_isConnected) return;
-    final current = state;
-    if (current is! SessionDetailLoaded) return;
-
-    final message = _promptQueue.cancel(index);
-    if (message == null) return;
-    _emitQueueUpdate(current);
-
-    // Abort current operation, then send.
-    await _service.abortSession(_sessionId);
-    if (isClosed) return;
-    final result = await _service.sendMessage(
-      _sessionId,
-      message,
-      agent: current.selectedAgent,
-      providerID: current.selectedProviderID,
-      modelID: current.selectedModelID,
-    );
-
-    // If send failed, re-queue the message at the front.
-    if (result case ErrorResponse()) {
-      _promptQueue.requeue(message);
-      _emitQueueUpdate();
-    }
   }
 
   void cancelQueuedMessage(int index) {
@@ -523,6 +488,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     } finally {
       _isSending = false;
     }
+    _tryDrainQueue();
   }
 
   /// Syncs [_promptQueue] items into the cubit state.

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -470,6 +470,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     _isSending = true;
     _emitQueueUpdate();
 
+    var sendSucceeded = false;
     try {
       final current = state;
       final result = await _service.sendMessage(
@@ -484,11 +485,18 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       if (result case ErrorResponse()) {
         _promptQueue.requeue(message);
         _emitQueueUpdate();
+      } else {
+        sendSucceeded = true;
       }
     } finally {
       _isSending = false;
     }
-    _tryDrainQueue();
+
+    // Continue draining only if the send succeeded. On failure the message
+    // stays re-queued and will be retried on the next reconnect event.
+    if (sendSucceeded) {
+      _tryDrainQueue();
+    }
   }
 
   /// Syncs [_promptQueue] items into the cubit state.

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_state.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_state.dart
@@ -22,7 +22,7 @@ sealed class SessionDetailState with _$SessionDetailState {
     // Background tasks (child sessions).
     @Default([]) List<Session> children,
     @Default({}) Map<String, SessionStatus> childStatuses,
-    // Queued messages (waiting to be sent when session becomes idle).
+    // Queued messages (waiting to be sent when connection is restored).
     @Default([]) List<String> queuedMessages,
     // Available agents and providers for selection.
     @Default([]) List<AgentInfo> availableAgents,


### PR DESCRIPTION
## Summary

- **Removes redundant idle-state gating** from mobile message sending — OpenCode handles its own queuing, so messages now send immediately when connected regardless of session busy/idle state
- **Keeps the queue for disconnected state** — messages still buffer when WebSocket is down and drain automatically on reconnection
- **Simplifies UI** — send button always shows "Send" (no more "Queue" variant), QueuedMessageBubble removes "Send Now" action (keeps Cancel), abort button remains visible when session is busy

## What Changed

**State management (`session_detail_cubit.dart`)**:
- `sendMessage()` — only gates on `_isConnected` (removed `sessionStatus is! SessionStatusIdle` check)
- `_tryDrainQueue()` — only gates on `_isConnected` (removed idle check)
- `_sendNextQueued()` — added self-chaining drain (`_tryDrainQueue()` after each send) to replace idle-event-driven drain cycle
- `_onSessionStatus()` — removed idle drain trigger
- Deleted `sendNow()` method entirely (abort + force-send, no longer needed)

**UI**:
- `prompt_input.dart` — always primary Send button + conditional Abort when busy (was: tertiary "Queue" + Abort when busy, primary "Send" when idle)
- `queued_message_bubble.dart` — removed `onSendNow` prop and Send Now button
- `session_detail_screen.dart` — removed `sendNow` wiring from `_QueuedMessagesSection`

**Tests** (`session_detail_cubit_test.dart`):
- Deleted 2 `sendNow` test cases
- Added 1 new test: "sendMessage sends immediately when session is busy but connected"
- Modified 3 tests to use disconnect-based queuing instead of busy-based queuing
- Net: -74 lines (simplified)

**L10n**: Removed dead strings `sessionDetailQueue` and `sessionDetailSendNow`

## Verification

- All 155 app tests pass (`flutter test`)
- All 52 module_core tests pass (`dart test`)
- `dart analyze` clean
- Zero `sendNow` references in production code
- Zero dead l10n string references