### PR TITLE
feat(bridge): return full session history and add bandwidth tracking

### DIFF
--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -197,11 +197,7 @@ Future<void> main(List<String> args) async {
   final session = orchestrator.create();
 
   // Wire up bandwidth tracking when debug server is active
-  BandwidthTracker? bandwidthTracker;
-  if (debugPort != null) {
-    bandwidthTracker = BandwidthTracker();
-    session.bytesSent.listen((bytes) => bandwidthTracker!.record(bytes: bytes));
-  }
+  final bandwidthTracker = debugPort != null ? BandwidthTracker(bytesSent: session.bytesSent) : null;
 
   // Create and start debug server if requested
   DebugServer? debugServer;
@@ -229,18 +225,15 @@ Future<void> main(List<String> args) async {
   }
 
   // Run bridge; stop the server process on exit regardless of outcome
-  bandwidthTracker?.start();
   try {
     await session.run();
   } catch (e) {
     Log.e('$e');
-    bandwidthTracker?.stop();
-    await _shutdown(cmd, sigintSub, sigtermSub, debugServer, db);
+    await _shutdown(cmd, sigintSub, sigtermSub, debugServer, db, bandwidthTracker);
     exit(1);
   }
 
-  bandwidthTracker?.stop();
-  await _shutdown(cmd, sigintSub, sigtermSub, debugServer, db);
+  await _shutdown(cmd, sigintSub, sigtermSub, debugServer, db, bandwidthTracker);
 }
 
 /// Performs graceful shutdown: stops the server and cancels signal listeners.
@@ -253,11 +246,14 @@ Future<void> _shutdown(
   StreamSubscription<ProcessSignal>? sigtermSub,
   DebugServer? debugServer,
   AppDatabase db,
+  BandwidthTracker? bandwidthTracker,
 ) async {
   final safetyTimer = Timer(const Duration(seconds: 10), () {
     Log.e('Failed to finish gracefully');
     exit(0);
   });
+
+  bandwidthTracker?.dispose();
 
   await Future.wait([
     stopServer(serverProcess),

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -8,6 +8,7 @@ import 'package:sesori_bridge/src/auth/profile.dart';
 import 'package:sesori_bridge/src/auth/token.dart';
 import 'package:sesori_bridge/src/auth/token_manager.dart';
 import 'package:sesori_bridge/src/auth/validate.dart';
+import 'package:sesori_bridge/src/bridge/bandwidth_tracker.dart';
 import 'package:sesori_bridge/src/bridge/debug_server.dart';
 import 'package:sesori_bridge/src/bridge/models/bridge_config.dart';
 import 'package:sesori_bridge/src/bridge/orchestrator.dart';
@@ -195,6 +196,13 @@ Future<void> main(List<String> args) async {
   );
   final session = orchestrator.create();
 
+  // Wire up bandwidth tracking when debug server is active
+  BandwidthTracker? bandwidthTracker;
+  if (debugPort != null) {
+    bandwidthTracker = BandwidthTracker();
+    session.bytesSent.listen((bytes) => bandwidthTracker!.record(bytes: bytes));
+  }
+
   // Create and start debug server if requested
   DebugServer? debugServer;
   if (debugPort != null) {
@@ -221,14 +229,17 @@ Future<void> main(List<String> args) async {
   }
 
   // Run bridge; stop the server process on exit regardless of outcome
+  bandwidthTracker?.start();
   try {
     await session.run();
   } catch (e) {
     Log.e('$e');
+    bandwidthTracker?.stop();
     await _shutdown(cmd, sigintSub, sigtermSub, debugServer, db);
     exit(1);
   }
 
+  bandwidthTracker?.stop();
   await _shutdown(cmd, sigintSub, sigtermSub, debugServer, db);
 }
 

--- a/bridge/app/lib/src/bridge/bandwidth_tracker.dart
+++ b/bridge/app/lib/src/bridge/bandwidth_tracker.dart
@@ -1,0 +1,72 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
+/// Tracks bytes sent to mobile and logs periodic bandwidth summaries.
+///
+/// Call [record] every time data is sent. Call [start] to begin the periodic
+/// log timer (every 60 s) and [stop] to cancel it. The timer logs totals for
+/// the last 1 minute, 10 minutes, and 1 hour.
+class BandwidthTracker {
+  final List<_Record> _records = [];
+  Timer? _timer;
+
+  /// Record [bytes] sent at the current time.
+  void record({required int bytes}) {
+    _records.add(_Record(DateTime.now(), bytes));
+    _prune();
+  }
+
+  /// Start the periodic stats timer (logs every 60 seconds).
+  void start() {
+    _timer = Timer.periodic(const Duration(minutes: 1), (_) => _logStats());
+  }
+
+  /// Stop the periodic stats timer.
+  void stop() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  void _logStats() {
+    final now = DateTime.now();
+    final last1m = _sumSince(now.subtract(const Duration(minutes: 1)));
+    final last10m = _sumSince(now.subtract(const Duration(minutes: 10)));
+    final last1h = _sumSince(now.subtract(const Duration(hours: 1)));
+
+    Log.i(
+      "[bandwidth] last 1m: ${formatBytes(last1m)} "
+      "| last 10m: ${formatBytes(last10m)} "
+      "| last 1h: ${formatBytes(last1h)}",
+    );
+  }
+
+  int _sumSince(DateTime since) {
+    int sum = 0;
+    for (final r in _records) {
+      if (r.time.isAfter(since)) sum += r.bytes;
+    }
+    return sum;
+  }
+
+  /// Remove entries older than 1 hour to bound memory.
+  void _prune() {
+    final cutoff = DateTime.now().subtract(const Duration(hours: 1));
+    _records.removeWhere((r) => r.time.isBefore(cutoff));
+  }
+
+  /// Format a byte count as a human-readable string (B / KB / MB).
+  static String formatBytes(int bytes) {
+    if (bytes < 1024) return "$bytes B";
+    if (bytes < 1024 * 1024) {
+      return "${(bytes / 1024).toStringAsFixed(2)} KB";
+    }
+    return "${(bytes / (1024 * 1024)).toStringAsFixed(2)} MB";
+  }
+}
+
+class _Record {
+  final DateTime time;
+  final int bytes;
+  const _Record(this.time, this.bytes);
+}

--- a/bridge/app/lib/src/bridge/bandwidth_tracker.dart
+++ b/bridge/app/lib/src/bridge/bandwidth_tracker.dart
@@ -4,37 +4,37 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 /// Tracks bytes sent to mobile and logs periodic bandwidth summaries.
 ///
-/// Call [record] every time data is sent. Call [start] to begin the periodic
-/// log timer (every 60 s) and [stop] to cancel it. The timer logs totals for
-/// the last 1 minute, 10 minutes, and 1 hour.
+/// Subscribes to [bytesSent] on construction and starts a periodic timer that
+/// logs rolling totals (last 1 m / 10 m / 1 h) every 60 seconds. Call
+/// [dispose] to cancel the timer and the stream subscription.
 class BandwidthTracker {
   final List<_Record> _records = [];
-  Timer? _timer;
+  late final Timer _timer;
+  late final StreamSubscription<int> _subscription;
 
-  /// Record [bytes] sent at the current time.
-  void record({required int bytes}) {
-    _records.add(_Record(DateTime.now(), bytes));
-    _prune();
-  }
-
-  /// Start the periodic stats timer (logs every 60 seconds).
-  void start() {
+  BandwidthTracker({required Stream<int> bytesSent}) {
+    _subscription = bytesSent.listen((bytes) {
+      _records.add(_Record(DateTime.now(), bytes));
+    });
     _timer = Timer.periodic(const Duration(minutes: 1), (_) => _logStats());
   }
 
-  /// Stop the periodic stats timer.
-  void stop() {
-    _timer?.cancel();
-    _timer = null;
+  /// Stop the periodic timer and cancel the stream subscription.
+  void dispose() {
+    _timer.cancel();
+    _subscription.cancel();
   }
 
   void _logStats() {
     final now = DateTime.now();
+    final cutoff = now.subtract(const Duration(hours: 1));
+    _records.removeWhere((r) => r.time.isBefore(cutoff));
+
     final last1m = _sumSince(now.subtract(const Duration(minutes: 1)));
     final last10m = _sumSince(now.subtract(const Duration(minutes: 10)));
     final last1h = _sumSince(now.subtract(const Duration(hours: 1)));
 
-    Log.i(
+    Log.d(
       "[bandwidth] last 1m: ${formatBytes(last1m)} "
       "| last 10m: ${formatBytes(last10m)} "
       "| last 1h: ${formatBytes(last1h)}",
@@ -43,16 +43,14 @@ class BandwidthTracker {
 
   int _sumSince(DateTime since) {
     int sum = 0;
-    for (final r in _records) {
-      if (r.time.isAfter(since)) sum += r.bytes;
+    for (final r in _records.reversed) {
+      if (r.time.isAfter(since)) {
+        sum += r.bytes;
+      } else {
+        break;
+      }
     }
     return sum;
-  }
-
-  /// Remove entries older than 1 hour to bound memory.
-  void _prune() {
-    final cutoff = DateTime.now().subtract(const Duration(hours: 1));
-    _records.removeWhere((r) => r.time.isBefore(cutoff));
   }
 
   /// Format a byte count as a human-readable string (B / KB / MB).

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -43,7 +43,11 @@ class Orchestrator {
   /// Creates a new session with a fresh room key and SSE manager.
   OrchestratorSession create() {
     final roomKey = _generateRoomKey();
-    final sseManager = _buildSseManager();
+    final bytesSentController = StreamController<int>.broadcast();
+    final sseManager = SSEManager(
+      replayWindow: config.sseReplayWindow,
+      onBytesSent: bytesSentController.add,
+    );
     sseManager.setRoomKey(roomKey);
 
     return OrchestratorSession._(
@@ -55,11 +59,8 @@ class Orchestrator {
       projectsDao: _projectsDao,
       roomKey: roomKey,
       sseManager: sseManager,
+      bytesSentController: bytesSentController,
     );
-  }
-
-  SSEManager _buildSseManager() {
-    return SSEManager(replayWindow: config.sseReplayWindow);
   }
 
   static List<int> _generateRoomKey() {
@@ -84,6 +85,7 @@ class OrchestratorSession {
   final BridgeEventMapper _mapper;
   final PushNotificationService _pushNotificationService;
   final TokenRefresher _tokenRefresher;
+  final StreamController<int> _bytesSentController;
   StreamSubscription<BridgeSseEvent>? _eventSubscription;
 
   bool _cancelled = false;
@@ -97,14 +99,22 @@ class OrchestratorSession {
     required ProjectsDao projectsDao,
     required List<int> roomKey,
     required SSEManager sseManager,
+    required StreamController<int> bytesSentController,
   }) : _client = client,
        _plugin = plugin,
        _pushNotificationService = pushNotificationService,
        _tokenRefresher = tokenRefresher,
        _roomKey = roomKey,
        _sseManager = sseManager,
+       _bytesSentController = bytesSentController,
        _router = RequestRouter(plugin: plugin, projectsDao: projectsDao),
        _mapper = BridgeEventMapper(plugin);
+
+  /// Broadcast stream of byte counts emitted each time data is sent to a phone.
+  ///
+  /// Includes both API responses and SSE events. Subscribe to this stream to
+  /// track bandwidth (e.g. with [BandwidthTracker]).
+  Stream<int> get bytesSent => _bytesSentController.stream;
 
   Future<void> run() async {
     final kxManager = KeyExchangeManager(_roomKey);
@@ -199,6 +209,7 @@ class OrchestratorSession {
       Log.d("[dbg] disposing push notification service...");
       await _pushNotificationService.dispose();
       Log.d("[dbg] push notification service disposed");
+      await _bytesSentController.close();
       try {
         Log.d("[dbg] closing relay client...");
         await _client.close();
@@ -462,10 +473,13 @@ class OrchestratorSession {
     required RelayMessage message,
   }) async {
     final respJson = jsonEncode(message.toJson());
+    final jsonBytes = utf8.encode(respJson);
+    Log.d("[response] sending ${jsonBytes.length} bytes to connID=$connID");
+    _bytesSentController.add(jsonBytes.length);
     final cryptoService = RelayCryptoService();
     final encryptionKey = SecretKey(List<int>.from(_roomKey));
     final encryptor = cryptoService.createSessionEncryptor(encryptionKey);
-    final framed = await frame(utf8.encode(respJson), encryptor);
+    final framed = await frame(jsonBytes, encryptor);
     _client.send(connID, framed);
   }
 }

--- a/bridge/app/lib/src/bridge/sse/sse_manager.dart
+++ b/bridge/app/lib/src/bridge/sse/sse_manager.dart
@@ -16,6 +16,8 @@ class SSEManager {
   /// How long a disconnected subscriber's orphan queue stays valid.
   final Duration replayWindow;
 
+  final void Function(int bytes)? _onBytesSent;
+
   /// Maximum number of events retained per subscriber queue.
   static const int maxQueueSize = 50000;
 
@@ -25,7 +27,7 @@ class SSEManager {
 
   List<int>? _roomKey;
 
-  SSEManager({required this.replayWindow});
+  SSEManager({required this.replayWindow, required void Function(int bytes)? onBytesSent}) : _onBytesSent = onBytesSent;
 
   /// Stores a copy of the room key used to encrypt outgoing SSE events.
   void setRoomKey(List<int> roomKey) {
@@ -157,6 +159,7 @@ class SSEManager {
       final relayMessage = RelayMessage.sseEvent(data: eventData);
       final payloadBytes = utf8.encode(jsonEncode(relayMessage.toJson()));
       Log.v("[sse] sending ${payloadBytes.length} bytes to connID=$connID");
+      _onBytesSent?.call(payloadBytes.length);
       final framed = await frame(payloadBytes, encryptor!);
       client.send(connID, framed);
     };

--- a/bridge/app/lib/src/bridge/sse/sse_manager.dart
+++ b/bridge/app/lib/src/bridge/sse/sse_manager.dart
@@ -16,7 +16,7 @@ class SSEManager {
   /// How long a disconnected subscriber's orphan queue stays valid.
   final Duration replayWindow;
 
-  final void Function(int bytes)? _onBytesSent;
+  final void Function(int bytes) _onBytesSent;
 
   /// Maximum number of events retained per subscriber queue.
   static const int maxQueueSize = 50000;
@@ -27,7 +27,7 @@ class SSEManager {
 
   List<int>? _roomKey;
 
-  SSEManager({required this.replayWindow, required void Function(int bytes)? onBytesSent}) : _onBytesSent = onBytesSent;
+  SSEManager({required this.replayWindow, required void Function(int bytes) onBytesSent}) : _onBytesSent = onBytesSent;
 
   /// Stores a copy of the room key used to encrypt outgoing SSE events.
   void setRoomKey(List<int> roomKey) {
@@ -159,7 +159,7 @@ class SSEManager {
       final relayMessage = RelayMessage.sseEvent(data: eventData);
       final payloadBytes = utf8.encode(jsonEncode(relayMessage.toJson()));
       Log.v("[sse] sending ${payloadBytes.length} bytes to connID=$connID");
-      _onBytesSent?.call(payloadBytes.length);
+      _onBytesSent(payloadBytes.length);
       final framed = await frame(payloadBytes, encryptor!);
       client.send(connID, framed);
     };

--- a/bridge/app/test/bridge/sse_manager_test.dart
+++ b/bridge/app/test/bridge/sse_manager_test.dart
@@ -13,7 +13,7 @@ import "../helpers/test_helpers.dart";
 void main() {
   group("SSEManager", () {
     test("subscribe registers subscribers", () {
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
@@ -27,7 +27,7 @@ void main() {
     });
 
     test("enqueueEvent with no subscribers does nothing", () async {
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
       final client = _RecordingRelayClient();
       manager.setRoomKey(makeRoomKey());
 
@@ -40,7 +40,7 @@ void main() {
     test("enqueueEvent delivers typed payload envelope to all subscribers", () async {
       final roomKey = makeRoomKey();
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
@@ -78,7 +78,7 @@ void main() {
 
     test("without room key events are not sent", () async {
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
       addTearDown(manager.stop);
 
       manager.subscribePath(7, "/global/event", client);
@@ -89,7 +89,7 @@ void main() {
     });
 
     test("non-last unsubscribe creates orphan queue", () {
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
@@ -105,7 +105,7 @@ void main() {
     });
 
     test("last unsubscribe creates orphan queue", () {
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
@@ -122,7 +122,7 @@ void main() {
     test("single subscriber reconnect replays buffered events", () async {
       final roomKey = makeRoomKey();
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
@@ -153,7 +153,7 @@ void main() {
     test("orphan queue replays to next subscriber within replay window", () async {
       final roomKey = makeRoomKey();
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
@@ -181,7 +181,7 @@ void main() {
       await withClock(fakeClock, () async {
         final roomKey = makeRoomKey();
         final client = _RecordingRelayClient();
-        final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
+        final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
         manager.setRoomKey(roomKey);
         addTearDown(manager.stop);
 
@@ -206,7 +206,7 @@ void main() {
     test("orphanAll moves all subscribers to orphan state", () async {
       final roomKey = makeRoomKey();
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
@@ -238,7 +238,7 @@ void main() {
     });
 
     test("stop clears subscribers and orphan queues", () {
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),

--- a/bridge/app/test/bridge/sse_manager_test.dart
+++ b/bridge/app/test/bridge/sse_manager_test.dart
@@ -13,7 +13,7 @@ import "../helpers/test_helpers.dart";
 void main() {
   group("SSEManager", () {
     test("subscribe registers subscribers", () {
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
@@ -27,7 +27,7 @@ void main() {
     });
 
     test("enqueueEvent with no subscribers does nothing", () async {
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
       final client = _RecordingRelayClient();
       manager.setRoomKey(makeRoomKey());
 
@@ -40,7 +40,7 @@ void main() {
     test("enqueueEvent delivers typed payload envelope to all subscribers", () async {
       final roomKey = makeRoomKey();
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
@@ -78,7 +78,7 @@ void main() {
 
     test("without room key events are not sent", () async {
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
       addTearDown(manager.stop);
 
       manager.subscribePath(7, "/global/event", client);
@@ -89,7 +89,7 @@ void main() {
     });
 
     test("non-last unsubscribe creates orphan queue", () {
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
@@ -105,7 +105,7 @@ void main() {
     });
 
     test("last unsubscribe creates orphan queue", () {
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
@@ -122,7 +122,7 @@ void main() {
     test("single subscriber reconnect replays buffered events", () async {
       final roomKey = makeRoomKey();
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
@@ -153,7 +153,7 @@ void main() {
     test("orphan queue replays to next subscriber within replay window", () async {
       final roomKey = makeRoomKey();
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
@@ -181,7 +181,7 @@ void main() {
       await withClock(fakeClock, () async {
         final roomKey = makeRoomKey();
         final client = _RecordingRelayClient();
-        final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
+        final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
         manager.setRoomKey(roomKey);
         addTearDown(manager.stop);
 
@@ -206,7 +206,7 @@ void main() {
     test("orphanAll moves all subscribers to orphan state", () async {
       final roomKey = makeRoomKey();
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
@@ -238,7 +238,7 @@ void main() {
     });
 
     test("stop clears subscribers and orphan queues", () {
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: null);
+      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -36,7 +36,7 @@ abstract class BridgePlugin {
 
   Future<Map<String, PluginSessionStatus>> getSessionStatuses();
 
-  /// Get messages for a session (last exchange).
+  /// Get all messages for a session.
   Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId);
 
   Future<void> sendPrompt({

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -346,7 +346,7 @@ class OpenCodePlugin implements BridgePlugin {
   Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId) async {
     final directory = _service.tracker.getSessionDirectory(sessionId: sessionId);
     final messages = await _call(
-      () => _service.getLastExchange(
+      () => _service.getMessages(
         sessionId: sessionId,
         directory: directory,
       ),

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -1,3 +1,4 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart" show ProjectActivitySummary;
 
 import "../opencode_plugin.dart";
@@ -31,7 +32,12 @@ class OpenCodeService {
     required String sessionId,
     required String? directory,
   }) async {
-    return repository.api.getMessages(sessionId: sessionId, directory: directory);
+    try {
+      return await repository.api.getMessages(sessionId: sessionId, directory: directory);
+    } catch (e) {
+      Log.w("Failed to get messages for session $sessionId: $e");
+      return [];
+    }
   }
 
   bool handleSseEvent(SseEventData event, String? directory) {

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -1,4 +1,3 @@
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart" show ProjectActivitySummary;
 
 import "../opencode_plugin.dart";
@@ -28,31 +27,11 @@ class OpenCodeService {
     return _applyLimit(afterStart, limit);
   }
 
-  Future<List<MessageWithParts>> getLastExchange({
+  Future<List<MessageWithParts>> getMessages({
     required String sessionId,
     required String? directory,
   }) async {
-    try {
-      final messages = await repository.api.getMessages(sessionId: sessionId, directory: directory);
-      Log.d("[dbg] got ${messages.length} messages for session $sessionId");
-      if (messages.isNotEmpty) {
-        Log.v("[dbg] first message: ${messages[0].toJson()}");
-      }
-      if (messages.isEmpty) return [];
-
-      int lastUserIndex = -1;
-      for (int i = messages.length - 1; i >= 0; i--) {
-        if (messages[i].info.role == "user") {
-          lastUserIndex = i;
-          break;
-        }
-      }
-
-      if (lastUserIndex == -1) return [];
-      return messages.sublist(lastUserIndex);
-    } catch (_) {
-      return [];
-    }
+    return repository.api.getMessages(sessionId: sessionId, directory: directory);
   }
 
   bool handleSseEvent(SseEventData event, String? directory) {

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -106,8 +106,8 @@ void main() {
     });
   });
 
-  group("OpenCodeService.getLastExchange", () {
-    test("returns from last user message onwards", () async {
+  group("OpenCodeService.getMessages", () {
+    test("returns all messages from api", () async {
       final repository = FakeOpenCodeRepository(
         messages: [
           _msg("assistant", "m1"),
@@ -117,9 +117,9 @@ void main() {
       );
       final service = OpenCodeService(repository, FakeActiveSessionTracker());
 
-      final result = await service.getLastExchange(sessionId: "ses-1", directory: null);
+      final result = await service.getMessages(sessionId: "ses-1", directory: null);
 
-      expect(result.map(_messageId).toList(), equals(["m2", "m3"]));
+      expect(result.map(_messageId).toList(), equals(["m1", "m2", "m3"]));
       expect(repository.api.lastRequestedSessionId, equals("ses-1"));
     });
 
@@ -127,80 +127,17 @@ void main() {
       final repository = FakeOpenCodeRepository(messages: [_msg("user", "m1")]);
       final service = OpenCodeService(repository, FakeActiveSessionTracker());
 
-      await service.getLastExchange(sessionId: "ses-1", directory: "/repo");
+      await service.getMessages(sessionId: "ses-1", directory: "/repo");
 
       expect(repository.api.lastRequestedSessionId, equals("ses-1"));
       expect(repository.api.lastRequestedDirectory, equals("/repo"));
-    });
-
-    test("multiple user messages returns from last user", () async {
-      final repository = FakeOpenCodeRepository(
-        messages: [
-          _msg("user", "m1"),
-          _msg("assistant", "m2"),
-          _msg("user", "m3"),
-          _msg("assistant", "m4"),
-        ],
-      );
-      final service = OpenCodeService(repository, FakeActiveSessionTracker());
-
-      final result = await service.getLastExchange(sessionId: "ses-1", directory: null);
-
-      expect(result.map(_messageId).toList(), equals(["m3", "m4"]));
-    });
-
-    test("no user message returns empty", () async {
-      final repository = FakeOpenCodeRepository(
-        messages: [_msg("assistant", "m1"), _msg("assistant", "m2")],
-      );
-      final service = OpenCodeService(repository, FakeActiveSessionTracker());
-
-      final result = await service.getLastExchange(sessionId: "ses-1", directory: null);
-
-      expect(result, isEmpty);
     });
 
     test("empty list returns empty", () async {
       final repository = FakeOpenCodeRepository(messages: const []);
       final service = OpenCodeService(repository, FakeActiveSessionTracker());
 
-      final result = await service.getLastExchange(sessionId: "ses-1", directory: null);
-
-      expect(result, isEmpty);
-    });
-
-    test("single user message returns one element", () async {
-      final repository = FakeOpenCodeRepository(messages: [_msg("user", "m1")]);
-      final service = OpenCodeService(repository, FakeActiveSessionTracker());
-
-      final result = await service.getLastExchange(sessionId: "ses-1", directory: null);
-
-      expect(result.map(_messageId).toList(), equals(["m1"]));
-    });
-
-    test("non-user roles before last user are excluded from result", () async {
-      final repository = FakeOpenCodeRepository(
-        messages: [
-          _msg("system", "m0"),
-          _msg("user", "m1"),
-          _msg("assistant", "m2"),
-        ],
-      );
-      final service = OpenCodeService(repository, FakeActiveSessionTracker());
-
-      final result = await service.getLastExchange(sessionId: "ses-1", directory: null);
-
-      expect(result, hasLength(2));
-      expect(_messageId(result.first), equals("m1"));
-    });
-
-    test("api throw returns empty", () async {
-      final repository = FakeOpenCodeRepository(
-        messagesError: Exception("boom"),
-      );
-      final service = OpenCodeService(repository, FakeActiveSessionTracker());
-
-      final result = await service.getLastExchange(sessionId: "ses-1", directory: null);
+      final result = await service.getMessages(sessionId: "ses-1", directory: null);
 
       expect(result, isEmpty);
     });


### PR DESCRIPTION
## Summary

- **Remove last-exchange filtering** from `getSessionMessages` — the endpoint now returns the complete message history instead of only the final user/assistant exchange. `OpenCodeService.getLastExchange()` is replaced with a simple `getMessages()` passthrough.
- **Add `bytesSent` broadcast stream** to `OrchestratorSession` — emits byte counts for every API response and SSE event sent to mobile. The orchestrator announces data, it doesn't track it.
- **Add `BandwidthTracker`** — a standalone subscriber that, when the debug server is active (`--debug-port`), listens to the bytes stream and logs rolling bandwidth totals every 60 seconds (last 1m / 10m / 1h).

## Changes

| File | What changed |
|------|-------------|
| `opencode_service.dart` | Replaced `getLastExchange()` with `getMessages()` — no more filtering to last user message |
| `opencode_plugin_impl.dart` | Updated call site |
| `bridge_plugin.dart` | Updated interface doc comment |
| `opencode_service_test.dart` | Rewrote tests to verify full history returned |
| `orchestrator.dart` | Added `StreamController<int>.broadcast()`, exposed `bytesSent` stream, wired SSE manager via `onBytesSent` callback |
| `sse_manager.dart` | Replaced `BandwidthTracker?` injection with `void Function(int)?` callback |
| `bandwidth_tracker.dart` | New — records bytes, prunes >1h entries, logs `[bandwidth] last 1m / 10m / 1h` every 60s |
| `bridge.dart` | Creates `BandwidthTracker` only when `debugPort != null`, subscribes to `session.bytesSent` |

## Testing

- `dart analyze` clean across all three bridge packages
- `dart test` passes (369 app tests + 100 plugin tests)