### PR TITLE
fix(mobile): auto-retry project list load on relay reconnect

### DIFF
--- a/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -102,10 +102,13 @@ class ProjectListCubit extends Cubit<ProjectListState> {
     logd("[ProjectList] connection status: ${status.runtimeType}");
     if (isClosed) return;
     if (status is ConnectionConnected) {
-      if (state is ProjectListLoaded) {
-        unawaited(refreshProjects());
-      } else if (state is ProjectListFailed) {
-        unawaited(loadProjects());
+      switch (state) {
+        case ProjectListLoaded():
+          unawaited(refreshProjects());
+        case ProjectListFailed():
+          unawaited(loadProjects());
+        case ProjectListLoading():
+          break; // Load already in progress.
       }
     }
   }

--- a/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -101,8 +101,12 @@ class ProjectListCubit extends Cubit<ProjectListState> {
   void _onConnectionStatusChanged(ConnectionStatus status) {
     logd("[ProjectList] connection status: ${status.runtimeType}");
     if (isClosed) return;
-    if (status is ConnectionConnected && state is ProjectListLoaded) {
-      unawaited(refreshProjects());
+    if (status is ConnectionConnected) {
+      if (state is ProjectListLoaded) {
+        unawaited(refreshProjects());
+      } else if (state is ProjectListFailed) {
+        unawaited(loadProjects());
+      }
     }
   }
 

--- a/mobile/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/mobile/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -615,6 +615,41 @@ void main() {
     );
 
     blocTest<ProjectListCubit, ProjectListState>(
+      "connection reconnect triggers loadProjects when state is ProjectListFailed",
+      build: () {
+        when(() => mockProjectService.listProjects()).thenAnswer(
+          (_) async => ApiResponse.error(ApiError.generic()),
+        );
+        return buildCubit();
+      },
+      act: (cubit) async {
+        await Future<void>.delayed(Duration.zero);
+        // Switch mock to succeed so the reconnect-triggered load works.
+        when(() => mockProjectService.listProjects()).thenAnswer(
+          (_) async => ApiResponse.success([testProject()]),
+        );
+        const config = ServerConnectionConfig(
+          relayHost: "relay.example.com",
+          authToken: "test-token",
+        );
+        const health = HealthResponse(healthy: true, version: "0.1.200");
+        statusController.add(
+          const ConnectionStatus.connected(config: config, health: health),
+        );
+        await Future<void>.delayed(Duration.zero);
+      },
+      skip: 1, // Skip the initial ProjectListFailed from constructor.
+      expect: () => [
+        isA<ProjectListLoading>(),
+        isA<ProjectListLoaded>().having(
+          (s) => s.projects.length,
+          "projects count after reconnect retry",
+          1,
+        ),
+      ],
+    );
+
+    blocTest<ProjectListCubit, ProjectListState>(
       "rapid ConnectionConnected events coalesce into single refresh",
       build: () {
         when(() => mockProjectService.listProjects()).thenAnswer(


### PR DESCRIPTION
## Summary

- **Fix**: `ProjectListCubit` now calls `loadProjects()` when the relay reconnects while in `ProjectListFailed` state, automatically recovering from the error screen.

## Problem

The retry button on the project list error screen appeared non-functional. Two issues combined:

1. **Invisible retry**: When the relay is disconnected, `RelayHttpApiClient` returns an error response immediately (no network round-trip). This caused `loading` and `failed` states to emit within the same frame — Flutter only renders the final state, so the loading spinner was never painted. The error view looked identical before and after tapping retry.

2. **No auto-recovery on reconnect**: `_onConnectionStatusChanged` only triggered `refreshProjects()` when `state is ProjectListLoaded`. If the initial load failed (state was `ProjectListFailed`) and the relay later reconnected, nothing happened — the user was stuck on the error screen with no signal to retry.

## Fix

Extend `_onConnectionStatusChanged` to also handle `ProjectListFailed` by calling `loadProjects()` on reconnect. This gives the request a real network round-trip (relay is now connected), making the loading spinner visible and the load likely to succeed.

## Test

Added: `"connection reconnect triggers loadProjects when state is ProjectListFailed"` — verifies the state transitions from `failed` → `loading` → `loaded` on reconnect.