### PR TITLE
fix(mobile): make URLs in markdown text clickable

### DIFF
--- a/mobile/app/lib/core/widgets/markdown_styles.dart
+++ b/mobile/app/lib/core/widgets/markdown_styles.dart
@@ -1,5 +1,17 @@
 import "package:flutter/material.dart";
 import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+
+import "../di/injection.dart";
+
+/// Shared [MarkdownBody.onTapLink] handler that opens URLs in the system
+/// browser via the DI-registered [UrlLauncher].
+void handleMarkdownLinkTap(String text, String? href, String title) {
+  if (href == null) return;
+  final uri = Uri.tryParse(href);
+  if (uri == null) return;
+  getIt<UrlLauncher>().launch(uri);
+}
 
 MarkdownStyleSheet buildSessionMarkdownStyleSheet(
   ThemeData theme, {

--- a/mobile/app/lib/features/session_detail/widgets/question_modal.dart
+++ b/mobile/app/lib/features/session_detail/widgets/question_modal.dart
@@ -274,6 +274,7 @@ class _QuestionModalState extends State<QuestionModal> {
                 MarkdownBody(
                   data: info.question,
                   selectable: true,
+                  onTapLink: handleMarkdownLinkTap,
                   styleSheet: buildSessionMarkdownStyleSheet(
                     theme,
                     paragraphStyle: theme.textTheme.bodyLarge,

--- a/mobile/app/lib/features/session_detail/widgets/reasoning_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/reasoning_part_widget.dart
@@ -148,6 +148,7 @@ class _ReasoningPartWidgetState extends State<ReasoningPartWidget> {
                               MarkdownBody(
                                 data: text,
                                 selectable: true,
+                                onTapLink: handleMarkdownLinkTap,
                                 styleSheet: buildSessionMarkdownStyleSheet(
                                   theme,
                                   paragraphStyle: theme.textTheme.bodySmall?.copyWith(

--- a/mobile/app/lib/features/session_detail/widgets/text_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/text_part_widget.dart
@@ -24,6 +24,7 @@ class TextPartWidget extends StatelessWidget {
       child: MarkdownBody(
         data: text,
         selectable: true,
+        onTapLink: handleMarkdownLinkTap,
         styleSheet: buildSessionMarkdownStyleSheet(theme),
       ),
     );


### PR DESCRIPTION
## Summary

- Add shared `handleMarkdownLinkTap` callback in `markdown_styles.dart` that opens URLs via the existing `UrlLauncher` DI singleton
- Wire `onTapLink` into all three `MarkdownBody` widgets: `TextPartWidget` (AI responses), `QuestionModal` (question text), and `ReasoningPartWidget` (thinking content)

## Changes

| File | Change |
|------|--------|
| `markdown_styles.dart` | New `handleMarkdownLinkTap()` function — parses href, launches via `getIt<UrlLauncher>()` |
| `text_part_widget.dart` | Add `onTapLink: handleMarkdownLinkTap` |
| `question_modal.dart` | Add `onTapLink: handleMarkdownLinkTap` |
| `reasoning_part_widget.dart` | Add `onTapLink: handleMarkdownLinkTap` |

No new dependencies — uses existing `url_launcher` and `UrlLauncher` infrastructure.