### PR TITLE
fix: sort completed background tasks most-recent-first

### DIFF
--- a/mobile/app/lib/features/session_detail/widgets/background_tasks_bar.dart
+++ b/mobile/app/lib/features/session_detail/widgets/background_tasks_bar.dart
@@ -38,7 +38,9 @@ class _BackgroundTasksBarState extends State<BackgroundTasksBar> {
 
   List<Session> get _runningTasks => widget.children.where(_isRunning).toList();
 
-  List<Session> get _completedTasks => widget.children.where((c) => !_isRunning(c)).toList();
+  List<Session> get _completedTasks =>
+      widget.children.where((c) => !_isRunning(c)).toList()
+        ..sort((a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0));
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/app/lib/features/session_detail/widgets/background_tasks_bar.dart
+++ b/mobile/app/lib/features/session_detail/widgets/background_tasks_bar.dart
@@ -38,9 +38,7 @@ class _BackgroundTasksBarState extends State<BackgroundTasksBar> {
 
   List<Session> get _runningTasks => widget.children.where(_isRunning).toList();
 
-  List<Session> get _completedTasks =>
-      widget.children.where((c) => !_isRunning(c)).toList()
-        ..sort((a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0));
+  List<Session> get _completedTasks => widget.children.where((c) => !_isRunning(c)).toList();
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -472,6 +472,74 @@ void main() {
     );
 
     blocTest<SessionDetailCubit, SessionDetailState>(
+      "children are sorted most-recent-first on initial load",
+      build: () {
+        final oldChild = testSession(id: "child-old", parentID: sessionId, updatedAt: 1000);
+        final midChild = testSession(id: "child-mid", parentID: sessionId, updatedAt: 2000);
+        final newChild = testSession(id: "child-new", parentID: sessionId, updatedAt: 3000);
+
+        // Service returns children in ASC order (oldest first).
+        when(
+          () => mockSessionService.getChildren(sessionId),
+        ).thenAnswer((_) async => ApiResponse.success([oldChild, midChild, newChild]));
+
+        return SessionDetailCubit(
+          mockSessionService,
+          mockConnectionService,
+          sessionId: sessionId,
+          notificationCanceller: mockNotificationCanceller,
+        );
+      },
+      expect: () => [
+        isA<SessionDetailLoaded>().having(
+          (state) => state.children.map((c) => c.id).toList(),
+          "children ids (DESC)",
+          ["child-new", "child-mid", "child-old"],
+        ),
+      ],
+    );
+
+    blocTest<SessionDetailCubit, SessionDetailState>(
+      "new child session via SSE is inserted in sorted order",
+      build: () {
+        final existingChild = testSession(id: "child-1", parentID: sessionId, updatedAt: 1000);
+
+        when(
+          () => mockSessionService.getChildren(sessionId),
+        ).thenAnswer((_) async => ApiResponse.success([existingChild]));
+
+        return SessionDetailCubit(
+          mockSessionService,
+          mockConnectionService,
+          sessionId: sessionId,
+          notificationCanceller: mockNotificationCanceller,
+        );
+      },
+      act: (cubit) async {
+        await _awaitLoaded(cubit);
+
+        // A newer child session arrives via global SSE event.
+        final newerChild = testSession(id: "child-2", parentID: sessionId, updatedAt: 5000);
+        globalEvents.add(SseEvent(data: SesoriSessionCreated(info: newerChild)));
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      },
+      expect: () => [
+        // Initial load with one child.
+        isA<SessionDetailLoaded>().having(
+          (state) => state.children.map((c) => c.id).toList(),
+          "children ids",
+          ["child-1"],
+        ),
+        // After SSE event, newer child sorted first.
+        isA<SessionDetailLoaded>().having(
+          (state) => state.children.map((c) => c.id).toList(),
+          "children ids (DESC)",
+          ["child-2", "child-1"],
+        ),
+      ],
+    );
+
+    blocTest<SessionDetailCubit, SessionDetailState>(
       "close disposes event subscriptions",
       build: () => SessionDetailCubit(
         mockSessionService,

--- a/mobile/app/test/helpers/test_helpers.dart
+++ b/mobile/app/test/helpers/test_helpers.dart
@@ -164,16 +164,20 @@ Project testProject({String? path, String? name}) {
 Session testSession({
   String? id,
   String? title,
+  String? parentID,
+  int? createdAt,
+  int? updatedAt,
   DateTime? archivedAt,
 }) {
   return Session(
     id: id ?? "session-1",
     projectID: "project-1",
     directory: "/home/user/my-project",
+    parentID: parentID,
     title: title,
     time: SessionTime(
-      created: 1700000000000,
-      updated: 1700000000000,
+      created: createdAt ?? 1700000000000,
+      updated: updatedAt ?? 1700000000000,
       archived: archivedAt?.millisecondsSinceEpoch,
     ),
   );

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -92,7 +92,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
         final childSessions = switch (childrenResponse) {
           SuccessResponse(:final data) => data,
           ErrorResponse() => <Session>[],
-        };
+        }..sort((a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0));
         // Filter statuses to only include child session IDs.
         final childIds = childSessions.map((c) => c.id).toSet();
         final childStatuses = Map<String, SessionStatus>.fromEntries(
@@ -256,7 +256,9 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     if (current.children.any((c) => c.id == child.id)) return;
 
     if (isClosed) return;
-    emit(current.copyWith(children: [...current.children, child]));
+    final updated = [...current.children, child]
+      ..sort((a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0));
+    emit(current.copyWith(children: updated));
   }
 
   void _onChildSessionStatus(String sessionId, SessionStatus status) {


### PR DESCRIPTION
## Summary

- Completed background tasks in the `BackgroundTasksBar` were displayed oldest-first (ASC) because no sort was applied to the filtered list. Added a DESC sort by `session.time.updated` using the same proven pattern from `session_list_cubit.dart`, so the most recently completed tasks now appear first.

## Changes

- `mobile/app/lib/features/session_detail/widgets/background_tasks_bar.dart` — Added `..sort()` cascade to `_completedTasks` getter to sort by `time.updated` descending (most recent first). Sessions with null time sort to the bottom.

## Verification

- `dart analyze` — no issues found
- `flutter test` — all 337 tests pass