### PR TITLE
fix(mobile): make inline subtask widget clickable in chat

### DIFF
--- a/mobile/app/lib/features/session_detail/widgets/subtask_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/subtask_part_widget.dart
@@ -38,13 +38,17 @@ class SubtaskPartWidget extends StatelessWidget {
           borderRadius: BorderRadius.circular(8),
           onTap: childSession != null
               ? () {
+                  final queryParams = <String, String>{"readOnly": "true"};
+                  if (childSession.title != null) {
+                    queryParams["title"] = childSession.title!;
+                  }
                   context.pushRoute(
                     AppRoute.sessionDetail,
                     pathParams: {
                       "projectId": childSession.projectID,
                       "sessionId": childSession.id,
                     },
-                    queryParams: childSession.title != null ? {"title": childSession.title!} : null,
+                    queryParams: queryParams,
                   );
                 }
               : null,
@@ -122,8 +126,8 @@ class SubtaskPartWidget extends StatelessWidget {
 
   /// Try to find the child session that matches this subtask part.
   ///
-  /// We match by looking for child sessions whose title or description
-  /// matches the subtask description. If no direct match, we return null.
+  /// Uses multi-strategy matching: exact → case-insensitive → contains.
+  /// If no match found, returns null.
   Session? _findChildSession() {
     if (children.isEmpty) return null;
     // If there's only one child, it's likely the one.
@@ -132,12 +136,25 @@ class SubtaskPartWidget extends StatelessWidget {
     final desc = part.description ?? part.prompt;
     if (desc == null) return null;
 
-    // Try exact title match.
+    // 1. Exact match.
     for (final child in children) {
       if (child.title == desc) return child;
     }
 
-    // No exact match — return null, the subtask just renders without navigation.
+    // 2. Case-insensitive match.
+    final descLower = desc.toLowerCase();
+    for (final child in children) {
+      if (child.title?.toLowerCase() == descLower) return child;
+    }
+
+    // 3. Contains match (either direction).
+    for (final child in children) {
+      final titleLower = child.title?.toLowerCase();
+      if (titleLower != null && (titleLower.contains(descLower) || descLower.contains(titleLower))) {
+        return child;
+      }
+    }
+
     return null;
   }
 }

--- a/mobile/app/lib/features/session_detail/widgets/subtask_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/subtask_part_widget.dart
@@ -38,17 +38,16 @@ class SubtaskPartWidget extends StatelessWidget {
           borderRadius: BorderRadius.circular(8),
           onTap: childSession != null
               ? () {
-                  final queryParams = <String, String>{"readOnly": "true"};
-                  if (childSession.title != null) {
-                    queryParams["title"] = childSession.title!;
-                  }
                   context.pushRoute(
                     AppRoute.sessionDetail,
                     pathParams: {
                       "projectId": childSession.projectID,
                       "sessionId": childSession.id,
                     },
-                    queryParams: queryParams,
+                    queryParams: {
+                      "readOnly": "true",
+                      if (childSession.title != null) "title": childSession.title!,
+                    },
                   );
                 }
               : null,

--- a/mobile/app/lib/features/session_detail/widgets/subtask_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/subtask_part_widget.dart
@@ -46,7 +46,7 @@ class SubtaskPartWidget extends StatelessWidget {
                     },
                     queryParams: {
                       "readOnly": "true",
-                      if (childSession.title != null) "title": childSession.title!,
+                      "title": ?childSession.title,
                     },
                   );
                 }

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -235,6 +235,8 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
         _onChildSessionCreated(info);
       case SesoriSessionStatus(:final sessionID, :final status):
         _onChildSessionStatus(sessionID, status);
+      case SesoriSessionUpdated(:final info):
+        _onChildSessionUpdated(info);
       default:
         break;
     }
@@ -274,6 +276,20 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
         childStatuses: {...current.childStatuses, sessionId: status},
       ),
     );
+  }
+
+  void _onChildSessionUpdated(Session updatedChild) {
+    final current = state;
+    if (current is! SessionDetailLoaded) return;
+
+    // Only update if this is one of our child sessions.
+    final index = current.children.indexWhere((c) => c.id == updatedChild.id);
+    if (index < 0) return;
+
+    if (isClosed) return;
+    final updatedChildren = List<Session>.of(current.children);
+    updatedChildren[index] = updatedChild;
+    emit(current.copyWith(children: updatedChildren));
   }
 
   void _onMessageUpdated(Message message) {


### PR DESCRIPTION
## Summary

- **Propagate child session title updates via SSE** — `SessionDetailCubit._handleGlobalEvent()` now handles `SesoriSessionUpdated` for child sessions, keeping the `children` list up-to-date (previously titles stayed `null` forever after SSE creation)
- **Improve subtask-to-child session matching** — `SubtaskPartWidget._findChildSession()` now uses multi-strategy matching: exact → case-insensitive → contains (previously only exact match, which failed for null/mismatched titles)
- **Add `readOnly: "true"` to navigation** — Clicking an inline subtask now navigates to the child session detail in read-only mode, matching the existing bottom bar/sheet behavior

## Problem

The inline subtask widget in chat messages was not clickable. Root cause was two-layered:
1. **Stale data**: Child session titles were never updated after initial SSE creation (the cubit dropped `SesoriSessionUpdated` events for children)
2. **Brittle matching**: The widget used exact string comparison only (`child.title == desc`), failing when titles were `null` or had different casing

## Changes

| File | Change |
|------|--------|
| `mobile/module_core/.../session_detail_cubit.dart` | Add `SesoriSessionUpdated` handler in `_handleGlobalEvent` + new `_onChildSessionUpdated()` method |
| `mobile/app/.../subtask_part_widget.dart` | Multi-strategy matching in `_findChildSession()` + `readOnly: "true"` in navigation queryParams |

## Verification

- `dart analyze` exits 0 in all three mobile modules
- `dart test` passes in `module_core/` (107 tests)
- `flutter test` passes in `app/` (339 tests)