### PR TITLE
fix(mobile): handle question reject/reply failures with error logging and snackbar

### DIFF
--- a/mobile/app/lib/features/session_detail/session_detail_screen.dart
+++ b/mobile/app/lib/features/session_detail/session_detail_screen.dart
@@ -110,15 +110,23 @@ class _SessionDetailBodyState extends State<_SessionDetailBody> {
     QuestionModal.show(
       context,
       question: question,
-      onReply: (requestId, answers) {
-        context.read<SessionDetailCubit>().replyToQuestion(
+      onReply: (requestId, answers) async {
+        final success = await context.read<SessionDetailCubit>().replyToQuestion(
           requestId: requestId,
           sessionId: question.sessionID,
           answers: answers,
         );
 
-        // Auto-open the next pending question, if any.
         if (!mounted) return;
+
+        if (!success) {
+          ScaffoldMessenger.of(context)
+            ..clearSnackBars()
+            ..showSnackBar(SnackBar(content: Text(context.loc.questionReplyFailed)));
+          return;
+        }
+
+        // Auto-open the next pending question, if any.
         final current = context.read<SessionDetailCubit>().state;
         if (current case SessionDetailLoaded(:final pendingQuestions) when pendingQuestions.isNotEmpty) {
           // Schedule after the current modal finishes closing.
@@ -128,10 +136,18 @@ class _SessionDetailBodyState extends State<_SessionDetailBody> {
           });
         }
       },
-      onReject: (requestId) {
-        context.read<SessionDetailCubit>().rejectQuestion(requestId);
+      onReject: (requestId) async {
+        final success = await context.read<SessionDetailCubit>().rejectQuestion(requestId);
 
         if (!mounted) return;
+
+        if (!success) {
+          ScaffoldMessenger.of(context)
+            ..clearSnackBars()
+            ..showSnackBar(SnackBar(content: Text(context.loc.questionRejectFailed)));
+          return;
+        }
+
         final current = context.read<SessionDetailCubit>().state;
         if (current case SessionDetailLoaded(:final pendingQuestions) when pendingQuestions.isNotEmpty) {
           Future.delayed(const Duration(milliseconds: 200), () {

--- a/mobile/app/lib/l10n/app_en.arb
+++ b/mobile/app/lib/l10n/app_en.arb
@@ -243,5 +243,7 @@
      "projectCreated": "Project created",
      "projectDiscovered": "Project discovered",
      "projectCreateFailed": "Failed to create project",
-     "projectDiscoverFailed": "Failed to discover project"
+      "projectDiscoverFailed": "Failed to discover project",
+      "questionReplyFailed": "Failed to send answer. Please try again.",
+      "questionRejectFailed": "Failed to reject question. Please try again."
 }

--- a/mobile/app/lib/l10n/app_localizations.dart
+++ b/mobile/app/lib/l10n/app_localizations.dart
@@ -930,6 +930,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Failed to discover project'**
   String get projectDiscoverFailed;
+
+  /// No description provided for @questionReplyFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to send answer. Please try again.'**
+  String get questionReplyFailed;
+
+  /// No description provided for @questionRejectFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to reject question. Please try again.'**
+  String get questionRejectFailed;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/mobile/app/lib/l10n/app_localizations_en.dart
+++ b/mobile/app/lib/l10n/app_localizations_en.dart
@@ -480,4 +480,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get projectDiscoverFailed => 'Failed to discover project';
+
+  @override
+  String get questionReplyFailed => 'Failed to send answer. Please try again.';
+
+  @override
+  String get questionRejectFailed => 'Failed to reject question. Please try again.';
 }

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -554,7 +554,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     emit(current.copyWith(pendingQuestions: pending));
   }
 
-  Future<void> replyToQuestion({
+  Future<bool> replyToQuestion({
     required String requestId,
     required String sessionId,
     required List<ReplyAnswer> answers,
@@ -567,16 +567,30 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       sessionId: sessionId,
       category: NotificationCategory.aiInteraction,
     );
-    await _service.replyToQuestion(requestId: requestId, sessionId: sessionId, answers: answers);
+    try {
+      await _service.replyToQuestion(requestId: requestId, sessionId: sessionId, answers: answers);
+      return true;
+    } on Object catch (e, st) {
+      loge("Failed to reply to question $requestId", e, st);
+      await _loadMessages();
+      return false;
+    }
   }
 
-  Future<void> rejectQuestion(String requestId) async {
+  Future<bool> rejectQuestion(String requestId) async {
     _onQuestionResolved(requestId);
     _notificationCanceller.cancelForSession(
       sessionId: _sessionId,
       category: NotificationCategory.aiInteraction,
     );
-    await _service.rejectQuestion(requestId);
+    try {
+      await _service.rejectQuestion(requestId);
+      return true;
+    } on Object catch (e, st) {
+      loge("Failed to reject question $requestId", e, st);
+      await _loadMessages();
+      return false;
+    }
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Problem**: When `rejectQuestion` or `replyToQuestion` network calls fail, the error is silently swallowed. The question is optimistically removed from the UI, so the user thinks the action succeeded — but OpenCode still holds the question pending. On screen re-entry or app restart, the question reappears with no explanation.

- **Fix**: Wrap both cubit methods in try-catch. On failure: log with `loge`, reload all session data via `_loadMessages()` so the question reappears, and return `false` so the screen can show a snackbar telling the user something went wrong.

- **Changed files**:
  - `session_detail_cubit.dart` — `rejectQuestion` and `replyToQuestion` now return `Future<bool>`, catch errors, log them, and trigger a full data reload on failure
  - `session_detail_screen.dart` — callbacks await the cubit methods and show a `SnackBar` when they return `false`
  - `app_en.arb` + generated l10n files — added `questionReplyFailed` and `questionRejectFailed` localization strings