### PR TITLE
feat: add rename functionality for sessions and projects

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -19,7 +19,6 @@ jobs:
 
       - name: Read Flutter version from .tool-versions
         shell: bash
-        working-directory: mobile
         run: |
           FLUTTER_VERSION=$(awk '$1 == "flutter" { print $2 }' .tool-versions | sed 's/-stable$//')
           if [ -z "$FLUTTER_VERSION" ]; then

--- a/bridge/app/lib/src/bridge/routing/plugin_session_mapper.dart
+++ b/bridge/app/lib/src/bridge/routing/plugin_session_mapper.dart
@@ -1,0 +1,31 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+/// Maps a [PluginSession] to the shared [Session] type used in relay responses.
+extension PluginSessionMapper on PluginSession {
+  Session toSharedSession() {
+    return Session(
+      id: id,
+      projectID: projectID,
+      directory: directory,
+      parentID: parentID,
+      title: title,
+      time: switch (time) {
+        PluginSessionTime(:final created, :final updated, :final archived) => SessionTime(
+          created: created,
+          updated: updated,
+          archived: archived,
+        ),
+        null => null,
+      },
+      summary: switch (summary) {
+        PluginSessionSummary(:final additions, :final deletions, :final files) => SessionSummary(
+          additions: additions,
+          deletions: deletions,
+          files: files,
+        ),
+        null => null,
+      },
+    );
+  }
+}

--- a/bridge/app/lib/src/bridge/routing/rename_project_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/rename_project_handler.dart
@@ -3,15 +3,14 @@ import "dart:convert";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
+import "plugin_project_mapper.dart";
 import "request_handler.dart";
 
-const _idParam = "id";
-
-/// Handles `PATCH /project/:id/name` — renames a project.
+/// Handles `PATCH /project/name` — renames a project.
 class RenameProjectHandler extends RequestHandler {
   final BridgePlugin _plugin;
 
-  RenameProjectHandler(this._plugin) : super(HttpMethod.patch, "/project/:$_idParam/name");
+  RenameProjectHandler(this._plugin) : super(HttpMethod.patch, "/project/name");
 
   @override
   Future<RelayResponse> handle(
@@ -20,11 +19,6 @@ class RenameProjectHandler extends RequestHandler {
     required Map<String, String> queryParams,
     String? fragment,
   }) async {
-    final projectId = pathParams[_idParam];
-    if (projectId == null || projectId.isEmpty) {
-      return buildErrorResponse(request, 400, "missing project id");
-    }
-
     final RenameProjectRequest renameRequest;
     try {
       final decoded = jsonDecode(request.body ?? "{}");
@@ -41,21 +35,11 @@ class RenameProjectHandler extends RequestHandler {
     }
 
     final updated = await _plugin.renameProject(
-      projectId,
+      projectId: renameRequest.projectId,
       name: renameRequest.name,
     );
 
-    final project = Project(
-      id: updated.id,
-      name: updated.name,
-      time: switch (updated.time) {
-        PluginProjectTime(:final created, :final updated) => ProjectTime(
-          created: created,
-          updated: updated,
-        ),
-        null => null,
-      },
-    );
+    final project = updated.toSharedProject();
 
     return buildOkJsonResponse(request, jsonEncode(project.toJson()));
   }

--- a/bridge/app/lib/src/bridge/routing/rename_project_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/rename_project_handler.dart
@@ -1,0 +1,62 @@
+import "dart:convert";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "request_handler.dart";
+
+const _idParam = "id";
+
+/// Handles `PATCH /project/:id/name` — renames a project.
+class RenameProjectHandler extends RequestHandler {
+  final BridgePlugin _plugin;
+
+  RenameProjectHandler(this._plugin) : super(HttpMethod.patch, "/project/:$_idParam/name");
+
+  @override
+  Future<RelayResponse> handle(
+    RelayRequest request, {
+    required Map<String, String> pathParams,
+    required Map<String, String> queryParams,
+    String? fragment,
+  }) async {
+    final projectId = pathParams[_idParam];
+    if (projectId == null || projectId.isEmpty) {
+      return buildErrorResponse(request, 400, "missing project id");
+    }
+
+    final RenameProjectRequest renameRequest;
+    try {
+      final decoded = jsonDecode(request.body ?? "{}");
+      renameRequest = RenameProjectRequest.fromJson(
+        switch (decoded) {
+          final Map<String, dynamic> map => map,
+          _ => throw const FormatException("invalid JSON body"),
+        },
+      );
+    } on FormatException {
+      return buildErrorResponse(request, 400, "invalid JSON body");
+    } on Object {
+      return buildErrorResponse(request, 400, "invalid JSON body");
+    }
+
+    final updated = await _plugin.renameProject(
+      projectId,
+      name: renameRequest.name,
+    );
+
+    final project = Project(
+      id: updated.id,
+      name: updated.name,
+      time: switch (updated.time) {
+        PluginProjectTime(:final created, :final updated) => ProjectTime(
+          created: created,
+          updated: updated,
+        ),
+        null => null,
+      },
+    );
+
+    return buildOkJsonResponse(request, jsonEncode(project.toJson()));
+  }
+}

--- a/bridge/app/lib/src/bridge/routing/rename_session_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/rename_session_handler.dart
@@ -3,15 +3,14 @@ import "dart:convert";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
+import "plugin_session_mapper.dart";
 import "request_handler.dart";
 
-const _idParam = "id";
-
-/// Handles `PATCH /session/:id/title` — renames a session.
+/// Handles `PATCH /session/title` — renames a session.
 class RenameSessionHandler extends RequestHandler {
   final BridgePlugin _plugin;
 
-  RenameSessionHandler(this._plugin) : super(HttpMethod.patch, "/session/:$_idParam/title");
+  RenameSessionHandler(this._plugin) : super(HttpMethod.patch, "/session/title");
 
   @override
   Future<RelayResponse> handle(
@@ -20,11 +19,6 @@ class RenameSessionHandler extends RequestHandler {
     required Map<String, String> queryParams,
     String? fragment,
   }) async {
-    final sessionId = pathParams[_idParam];
-    if (sessionId == null || sessionId.isEmpty) {
-      return buildErrorResponse(request, 400, "missing session id");
-    }
-
     final RenameSessionRequest renameRequest;
     try {
       final decoded = jsonDecode(request.body ?? "{}");
@@ -41,33 +35,11 @@ class RenameSessionHandler extends RequestHandler {
     }
 
     final updated = await _plugin.renameSession(
-      sessionId,
+      sessionId: renameRequest.sessionId,
       title: renameRequest.title,
     );
 
-    final session = Session(
-      id: updated.id,
-      projectID: updated.projectID,
-      directory: updated.directory,
-      parentID: updated.parentID,
-      title: updated.title,
-      time: switch (updated.time) {
-        PluginSessionTime(:final created, :final updated, :final archived) => SessionTime(
-          created: created,
-          updated: updated,
-          archived: archived,
-        ),
-        null => null,
-      },
-      summary: switch (updated.summary) {
-        PluginSessionSummary(:final additions, :final deletions, :final files) => SessionSummary(
-          additions: additions,
-          deletions: deletions,
-          files: files,
-        ),
-        null => null,
-      },
-    );
+    final session = updated.toSharedSession();
 
     return buildOkJsonResponse(request, jsonEncode(session.toJson()));
   }

--- a/bridge/app/lib/src/bridge/routing/rename_session_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/rename_session_handler.dart
@@ -1,0 +1,74 @@
+import "dart:convert";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "request_handler.dart";
+
+const _idParam = "id";
+
+/// Handles `PATCH /session/:id/title` — renames a session.
+class RenameSessionHandler extends RequestHandler {
+  final BridgePlugin _plugin;
+
+  RenameSessionHandler(this._plugin) : super(HttpMethod.patch, "/session/:$_idParam/title");
+
+  @override
+  Future<RelayResponse> handle(
+    RelayRequest request, {
+    required Map<String, String> pathParams,
+    required Map<String, String> queryParams,
+    String? fragment,
+  }) async {
+    final sessionId = pathParams[_idParam];
+    if (sessionId == null || sessionId.isEmpty) {
+      return buildErrorResponse(request, 400, "missing session id");
+    }
+
+    final RenameSessionRequest renameRequest;
+    try {
+      final decoded = jsonDecode(request.body ?? "{}");
+      renameRequest = RenameSessionRequest.fromJson(
+        switch (decoded) {
+          final Map<String, dynamic> map => map,
+          _ => throw const FormatException("invalid JSON body"),
+        },
+      );
+    } on FormatException {
+      return buildErrorResponse(request, 400, "invalid JSON body");
+    } on Object {
+      return buildErrorResponse(request, 400, "invalid JSON body");
+    }
+
+    final updated = await _plugin.renameSession(
+      sessionId,
+      title: renameRequest.title,
+    );
+
+    final session = Session(
+      id: updated.id,
+      projectID: updated.projectID,
+      directory: updated.directory,
+      parentID: updated.parentID,
+      title: updated.title,
+      time: switch (updated.time) {
+        PluginSessionTime(:final created, :final updated, :final archived) => SessionTime(
+          created: created,
+          updated: updated,
+          archived: archived,
+        ),
+        null => null,
+      },
+      summary: switch (updated.summary) {
+        PluginSessionSummary(:final additions, :final deletions, :final files) => SessionSummary(
+          additions: additions,
+          deletions: deletions,
+          files: files,
+        ),
+        null => null,
+      },
+    );
+
+    return buildOkJsonResponse(request, jsonEncode(session.toJson()));
+  }
+}

--- a/bridge/app/lib/src/bridge/routing/request_router.dart
+++ b/bridge/app/lib/src/bridge/routing/request_router.dart
@@ -21,6 +21,8 @@ import "health_check_handler.dart";
 import "hide_project_handler.dart";
 import "open_project_handler.dart";
 import "reject_question_handler.dart";
+import "rename_project_handler.dart";
+import "rename_session_handler.dart";
 import "reply_to_question_handler.dart";
 import "request_handler.dart";
 import "send_prompt_handler.dart";
@@ -53,6 +55,7 @@ class RequestRouter {
       GetSessionMessagesHandler(plugin),
       GetSessionsHandler(plugin),
       CreateSessionHandler(plugin),
+      RenameSessionHandler(plugin),
       UpdateSessionArchiveStatusHandler(plugin),
       DeleteSessionHandler(plugin),
       SendPromptHandler(plugin),
@@ -63,6 +66,7 @@ class RequestRouter {
       GetProjectQuestionsHandler(plugin),
       ReplyToQuestionHandler(plugin),
       RejectQuestionHandler(plugin),
+      RenameProjectHandler(plugin),
       CreateProjectHandler(plugin),
       OpenProjectHandler(plugin, hiddenStore),
       HideProjectHandler(hiddenStore),

--- a/bridge/app/lib/src/bridge/routing/update_session_archive_status_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/update_session_archive_status_handler.dart
@@ -3,6 +3,7 @@ import "dart:convert";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
+import "plugin_session_mapper.dart";
 import "request_handler.dart";
 
 const _idParam = "id";
@@ -41,29 +42,7 @@ class UpdateSessionArchiveStatusHandler extends RequestHandler {
       archived: archiveRequest.archived,
     );
 
-    final session = Session(
-      id: updated.id,
-      projectID: updated.projectID,
-      directory: updated.directory,
-      parentID: updated.parentID,
-      title: updated.title,
-      time: switch (updated.time) {
-        PluginSessionTime(:final created, :final updated, :final archived) => SessionTime(
-          created: created,
-          updated: updated,
-          archived: archived,
-        ),
-        null => null,
-      },
-      summary: switch (updated.summary) {
-        PluginSessionSummary(:final additions, :final deletions, :final files) => SessionSummary(
-          additions: additions,
-          deletions: deletions,
-          files: files,
-        ),
-        null => null,
-      },
-    );
+    final session = updated.toSharedSession();
 
     return buildOkJsonResponse(request, jsonEncode(session.toJson()));
   }

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -277,6 +277,20 @@ class _FakeBridgePlugin implements BridgePlugin {
   );
 
   @override
+  Future<PluginSession> renameSession(String sessionId, {required String title}) async => const PluginSession(
+    id: "",
+    projectID: "",
+    directory: "",
+    parentID: null,
+    title: null,
+    time: null,
+    summary: null,
+  );
+
+  @override
+  Future<PluginProject> renameProject(String projectId, {required String name}) async => const PluginProject(id: "");
+
+  @override
   Future<void> deleteSession(String sessionId) async {}
 
   @override
@@ -400,6 +414,20 @@ class _TrackingBridgePlugin implements BridgePlugin {
     time: null,
     summary: null,
   );
+
+  @override
+  Future<PluginSession> renameSession(String sessionId, {required String title}) async => const PluginSession(
+    id: "",
+    projectID: "",
+    directory: "",
+    parentID: null,
+    title: null,
+    time: null,
+    summary: null,
+  );
+
+  @override
+  Future<PluginProject> renameProject(String projectId, {required String name}) async => const PluginProject(id: "");
 
   @override
   Future<void> deleteSession(String sessionId) async {}

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -277,7 +277,7 @@ class _FakeBridgePlugin implements BridgePlugin {
   );
 
   @override
-  Future<PluginSession> renameSession(String sessionId, {required String title}) async => const PluginSession(
+  Future<PluginSession> renameSession({required String sessionId, required String title}) async => const PluginSession(
     id: "",
     projectID: "",
     directory: "",
@@ -288,7 +288,8 @@ class _FakeBridgePlugin implements BridgePlugin {
   );
 
   @override
-  Future<PluginProject> renameProject(String projectId, {required String name}) async => const PluginProject(id: "");
+  Future<PluginProject> renameProject({required String projectId, required String name}) async =>
+      const PluginProject(id: "");
 
   @override
   Future<void> deleteSession(String sessionId) async {}
@@ -416,7 +417,7 @@ class _TrackingBridgePlugin implements BridgePlugin {
   );
 
   @override
-  Future<PluginSession> renameSession(String sessionId, {required String title}) async => const PluginSession(
+  Future<PluginSession> renameSession({required String sessionId, required String title}) async => const PluginSession(
     id: "",
     projectID: "",
     directory: "",
@@ -427,7 +428,8 @@ class _TrackingBridgePlugin implements BridgePlugin {
   );
 
   @override
-  Future<PluginProject> renameProject(String projectId, {required String name}) async => const PluginProject(id: "");
+  Future<PluginProject> renameProject({required String projectId, required String name}) async =>
+      const PluginProject(id: "");
 
   @override
   Future<void> deleteSession(String sessionId) async {}

--- a/bridge/app/test/bridge/routing/rename_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/rename_project_handler_test.dart
@@ -1,0 +1,115 @@
+import "dart:convert";
+
+import "package:sesori_bridge/src/bridge/routing/rename_project_handler.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "routing_test_helpers.dart";
+
+void main() {
+  group("RenameProjectHandler", () {
+    late FakeBridgePlugin plugin;
+    late RenameProjectHandler handler;
+
+    setUp(() {
+      plugin = FakeBridgePlugin();
+      handler = RenameProjectHandler(plugin);
+    });
+
+    tearDown(() => plugin.close());
+
+    test("canHandle PATCH /project/:id/name", () {
+      expect(handler.canHandle(makeRequest("PATCH", "/project/p1/name")), isTrue);
+    });
+
+    test("does not handle GET /project/:id/name", () {
+      expect(handler.canHandle(makeRequest("GET", "/project/p1/name")), isFalse);
+    });
+
+    test("does not handle PATCH /project/:id", () {
+      expect(handler.canHandle(makeRequest("PATCH", "/project/p1")), isFalse);
+    });
+
+    test("extracts id and parses name from body", () async {
+      plugin.renameProjectResult = const PluginProject(
+        id: "p1",
+        name: "New Name",
+        time: null,
+      );
+
+      await handler.handle(
+        makeRequest(
+          "PATCH",
+          "/project/p1/name",
+          body: jsonEncode(const RenameProjectRequest(name: "New Name").toJson()),
+        ),
+        pathParams: {"id": "p1"},
+        queryParams: {},
+      );
+
+      expect(plugin.lastRenameProjectId, equals("p1"));
+      expect(plugin.lastRenameProjectName, equals("New Name"));
+    });
+
+    test("returns 400 when body has no name key", () async {
+      final response = await handler.handle(
+        makeRequest("PATCH", "/project/p1/name", body: "{}"),
+        pathParams: {"id": "p1"},
+        queryParams: {},
+      );
+
+      expect(response.status, equals(400));
+      expect(response.body, contains("invalid JSON body"));
+    });
+
+    test("returns 400 when path param id is missing", () async {
+      final response = await handler.handle(
+        makeRequest(
+          "PATCH",
+          "/project/p1/name",
+          body: jsonEncode(const RenameProjectRequest(name: "New Name").toJson()),
+        ),
+        pathParams: {},
+        queryParams: {},
+      );
+
+      expect(response.status, equals(400));
+      expect(response.body, contains("missing project id"));
+    });
+
+    test("returns 200 with mapped Project JSON", () async {
+      plugin.renameProjectResult = const PluginProject(
+        id: "p1",
+        name: "Renamed Project",
+        time: PluginProjectTime(created: 10, updated: 20),
+      );
+
+      final response = await handler.handle(
+        makeRequest(
+          "PATCH",
+          "/project/p1/name",
+          body: jsonEncode(const RenameProjectRequest(name: "Renamed Project").toJson()),
+        ),
+        pathParams: {"id": "p1"},
+        queryParams: {},
+      );
+
+      expect(response.status, equals(200));
+      expect(response.headers["content-type"], equals("application/json"));
+      final project = jsonDecode(response.body!) as Map<String, dynamic>;
+      expect(project["id"], equals("p1"));
+      expect(project["name"], equals("Renamed Project"));
+    });
+
+    test("returns 400 on malformed body", () async {
+      final response = await handler.handle(
+        makeRequest("PATCH", "/project/p1/name", body: "not-json"),
+        pathParams: {"id": "p1"},
+        queryParams: {},
+      );
+
+      expect(response.status, equals(400));
+    });
+  });
+}

--- a/bridge/app/test/bridge/routing/rename_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/rename_project_handler_test.dart
@@ -19,19 +19,23 @@ void main() {
 
     tearDown(() => plugin.close());
 
-    test("canHandle PATCH /project/:id/name", () {
-      expect(handler.canHandle(makeRequest("PATCH", "/project/p1/name")), isTrue);
+    test("canHandle PATCH /project/name", () {
+      expect(handler.canHandle(makeRequest("PATCH", "/project/name")), isTrue);
     });
 
-    test("does not handle GET /project/:id/name", () {
-      expect(handler.canHandle(makeRequest("GET", "/project/p1/name")), isFalse);
+    test("does not handle GET /project/name", () {
+      expect(handler.canHandle(makeRequest("GET", "/project/name")), isFalse);
+    });
+
+    test("does not handle PATCH /project/:id/name", () {
+      expect(handler.canHandle(makeRequest("PATCH", "/project/p1/name")), isFalse);
     });
 
     test("does not handle PATCH /project/:id", () {
       expect(handler.canHandle(makeRequest("PATCH", "/project/p1")), isFalse);
     });
 
-    test("extracts id and parses name from body", () async {
+    test("extracts projectId and parses name from body", () async {
       plugin.renameProjectResult = const PluginProject(
         id: "p1",
         name: "New Name",
@@ -41,10 +45,10 @@ void main() {
       await handler.handle(
         makeRequest(
           "PATCH",
-          "/project/p1/name",
-          body: jsonEncode(const RenameProjectRequest(name: "New Name").toJson()),
+          "/project/name",
+          body: jsonEncode(const RenameProjectRequest(projectId: "p1", name: "New Name").toJson()),
         ),
-        pathParams: {"id": "p1"},
+        pathParams: {},
         queryParams: {},
       );
 
@@ -54,8 +58,8 @@ void main() {
 
     test("returns 400 when body has no name key", () async {
       final response = await handler.handle(
-        makeRequest("PATCH", "/project/p1/name", body: "{}"),
-        pathParams: {"id": "p1"},
+        makeRequest("PATCH", "/project/name", body: "{}"),
+        pathParams: {},
         queryParams: {},
       );
 
@@ -63,19 +67,19 @@ void main() {
       expect(response.body, contains("invalid JSON body"));
     });
 
-    test("returns 400 when path param id is missing", () async {
+    test("returns 400 when body has no projectId key", () async {
       final response = await handler.handle(
         makeRequest(
           "PATCH",
-          "/project/p1/name",
-          body: jsonEncode(const RenameProjectRequest(name: "New Name").toJson()),
+          "/project/name",
+          body: jsonEncode({"name": "New Name"}),
         ),
         pathParams: {},
         queryParams: {},
       );
 
       expect(response.status, equals(400));
-      expect(response.body, contains("missing project id"));
+      expect(response.body, contains("invalid JSON body"));
     });
 
     test("returns 200 with mapped Project JSON", () async {
@@ -88,10 +92,10 @@ void main() {
       final response = await handler.handle(
         makeRequest(
           "PATCH",
-          "/project/p1/name",
-          body: jsonEncode(const RenameProjectRequest(name: "Renamed Project").toJson()),
+          "/project/name",
+          body: jsonEncode(const RenameProjectRequest(projectId: "p1", name: "Renamed Project").toJson()),
         ),
-        pathParams: {"id": "p1"},
+        pathParams: {},
         queryParams: {},
       );
 
@@ -104,8 +108,8 @@ void main() {
 
     test("returns 400 on malformed body", () async {
       final response = await handler.handle(
-        makeRequest("PATCH", "/project/p1/name", body: "not-json"),
-        pathParams: {"id": "p1"},
+        makeRequest("PATCH", "/project/name", body: "not-json"),
+        pathParams: {},
         queryParams: {},
       );
 

--- a/bridge/app/test/bridge/routing/rename_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/rename_session_handler_test.dart
@@ -19,19 +19,23 @@ void main() {
 
     tearDown(() => plugin.close());
 
-    test("canHandle PATCH /session/:id/title", () {
-      expect(handler.canHandle(makeRequest("PATCH", "/session/s1/title")), isTrue);
+    test("canHandle PATCH /session/title", () {
+      expect(handler.canHandle(makeRequest("PATCH", "/session/title")), isTrue);
     });
 
-    test("does not handle GET /session/:id/title", () {
-      expect(handler.canHandle(makeRequest("GET", "/session/s1/title")), isFalse);
+    test("does not handle GET /session/title", () {
+      expect(handler.canHandle(makeRequest("GET", "/session/title")), isFalse);
+    });
+
+    test("does not handle PATCH /session/:id/title", () {
+      expect(handler.canHandle(makeRequest("PATCH", "/session/s1/title")), isFalse);
     });
 
     test("does not handle PATCH /session/:id", () {
       expect(handler.canHandle(makeRequest("PATCH", "/session/s1")), isFalse);
     });
 
-    test("extracts id and parses title from body", () async {
+    test("extracts sessionId and parses title from body", () async {
       plugin.renameSessionResult = const PluginSession(
         id: "s1",
         projectID: "p1",
@@ -45,10 +49,10 @@ void main() {
       await handler.handle(
         makeRequest(
           "PATCH",
-          "/session/s1/title",
-          body: jsonEncode(const RenameSessionRequest(title: "New Title").toJson()),
+          "/session/title",
+          body: jsonEncode(const RenameSessionRequest(sessionId: "s1", title: "New Title").toJson()),
         ),
-        pathParams: {"id": "s1"},
+        pathParams: {},
         queryParams: {},
       );
 
@@ -58,8 +62,8 @@ void main() {
 
     test("returns 400 when body has no title key", () async {
       final response = await handler.handle(
-        makeRequest("PATCH", "/session/s1/title", body: "{}"),
-        pathParams: {"id": "s1"},
+        makeRequest("PATCH", "/session/title", body: "{}"),
+        pathParams: {},
         queryParams: {},
       );
 
@@ -67,19 +71,19 @@ void main() {
       expect(response.body, contains("invalid JSON body"));
     });
 
-    test("returns 400 when path param id is missing", () async {
+    test("returns 400 when body has no sessionId key", () async {
       final response = await handler.handle(
         makeRequest(
           "PATCH",
-          "/session/s1/title",
-          body: jsonEncode(const RenameSessionRequest(title: "New Title").toJson()),
+          "/session/title",
+          body: jsonEncode({"title": "New Title"}),
         ),
         pathParams: {},
         queryParams: {},
       );
 
       expect(response.status, equals(400));
-      expect(response.body, contains("missing session id"));
+      expect(response.body, contains("invalid JSON body"));
     });
 
     test("returns 200 with mapped Session JSON", () async {
@@ -96,10 +100,10 @@ void main() {
       final response = await handler.handle(
         makeRequest(
           "PATCH",
-          "/session/s1/title",
-          body: jsonEncode(const RenameSessionRequest(title: "Renamed Session").toJson()),
+          "/session/title",
+          body: jsonEncode(const RenameSessionRequest(sessionId: "s1", title: "Renamed Session").toJson()),
         ),
-        pathParams: {"id": "s1"},
+        pathParams: {},
         queryParams: {},
       );
 
@@ -115,8 +119,8 @@ void main() {
 
     test("returns 400 on malformed body", () async {
       final response = await handler.handle(
-        makeRequest("PATCH", "/session/s1/title", body: "not-json"),
-        pathParams: {"id": "s1"},
+        makeRequest("PATCH", "/session/title", body: "not-json"),
+        pathParams: {},
         queryParams: {},
       );
 

--- a/bridge/app/test/bridge/routing/rename_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/rename_session_handler_test.dart
@@ -1,0 +1,126 @@
+import "dart:convert";
+
+import "package:sesori_bridge/src/bridge/routing/rename_session_handler.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "routing_test_helpers.dart";
+
+void main() {
+  group("RenameSessionHandler", () {
+    late FakeBridgePlugin plugin;
+    late RenameSessionHandler handler;
+
+    setUp(() {
+      plugin = FakeBridgePlugin();
+      handler = RenameSessionHandler(plugin);
+    });
+
+    tearDown(() => plugin.close());
+
+    test("canHandle PATCH /session/:id/title", () {
+      expect(handler.canHandle(makeRequest("PATCH", "/session/s1/title")), isTrue);
+    });
+
+    test("does not handle GET /session/:id/title", () {
+      expect(handler.canHandle(makeRequest("GET", "/session/s1/title")), isFalse);
+    });
+
+    test("does not handle PATCH /session/:id", () {
+      expect(handler.canHandle(makeRequest("PATCH", "/session/s1")), isFalse);
+    });
+
+    test("extracts id and parses title from body", () async {
+      plugin.renameSessionResult = const PluginSession(
+        id: "s1",
+        projectID: "p1",
+        directory: "/tmp",
+        parentID: null,
+        title: "New Title",
+        time: null,
+        summary: null,
+      );
+
+      await handler.handle(
+        makeRequest(
+          "PATCH",
+          "/session/s1/title",
+          body: jsonEncode(const RenameSessionRequest(title: "New Title").toJson()),
+        ),
+        pathParams: {"id": "s1"},
+        queryParams: {},
+      );
+
+      expect(plugin.lastRenameSessionId, equals("s1"));
+      expect(plugin.lastRenameSessionTitle, equals("New Title"));
+    });
+
+    test("returns 400 when body has no title key", () async {
+      final response = await handler.handle(
+        makeRequest("PATCH", "/session/s1/title", body: "{}"),
+        pathParams: {"id": "s1"},
+        queryParams: {},
+      );
+
+      expect(response.status, equals(400));
+      expect(response.body, contains("invalid JSON body"));
+    });
+
+    test("returns 400 when path param id is missing", () async {
+      final response = await handler.handle(
+        makeRequest(
+          "PATCH",
+          "/session/s1/title",
+          body: jsonEncode(const RenameSessionRequest(title: "New Title").toJson()),
+        ),
+        pathParams: {},
+        queryParams: {},
+      );
+
+      expect(response.status, equals(400));
+      expect(response.body, contains("missing session id"));
+    });
+
+    test("returns 200 with mapped Session JSON", () async {
+      plugin.renameSessionResult = const PluginSession(
+        id: "s1",
+        projectID: "p1",
+        directory: "/tmp",
+        parentID: "parent-1",
+        title: "Renamed Session",
+        time: PluginSessionTime(created: 10, updated: 20, archived: 30),
+        summary: PluginSessionSummary(additions: 4, deletions: 1, files: 2),
+      );
+
+      final response = await handler.handle(
+        makeRequest(
+          "PATCH",
+          "/session/s1/title",
+          body: jsonEncode(const RenameSessionRequest(title: "Renamed Session").toJson()),
+        ),
+        pathParams: {"id": "s1"},
+        queryParams: {},
+      );
+
+      expect(response.status, equals(200));
+      expect(response.headers["content-type"], equals("application/json"));
+      final session = jsonDecode(response.body!) as Map<String, dynamic>;
+      expect(session["id"], equals("s1"));
+      expect(session["projectID"], equals("p1"));
+      expect(session["directory"], equals("/tmp"));
+      expect(session["parentID"], equals("parent-1"));
+      expect(session["title"], equals("Renamed Session"));
+    });
+
+    test("returns 400 on malformed body", () async {
+      final response = await handler.handle(
+        makeRequest("PATCH", "/session/s1/title", body: "not-json"),
+        pathParams: {"id": "s1"},
+        queryParams: {},
+      );
+
+      expect(response.status, equals(400));
+    });
+  });
+}

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -150,8 +150,8 @@ class FakeBridgePlugin implements BridgePlugin {
   }
 
   @override
-  Future<PluginSession> renameSession(
-    String sessionId, {
+  Future<PluginSession> renameSession({
+    required String sessionId,
     required String title,
   }) async {
     lastRenameSessionId = sessionId;
@@ -169,8 +169,8 @@ class FakeBridgePlugin implements BridgePlugin {
   }
 
   @override
-  Future<PluginProject> renameProject(
-    String projectId, {
+  Future<PluginProject> renameProject({
+    required String projectId,
     required String name,
   }) async {
     lastRenameProjectId = projectId;

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -52,6 +52,10 @@ class FakeBridgePlugin implements BridgePlugin {
   String? lastCreateSessionParentId;
   String? lastUpdateSessionId;
   bool? lastUpdateSessionArchived;
+  String? lastRenameSessionId;
+  String? lastRenameSessionTitle;
+  String? lastRenameProjectId;
+  String? lastRenameProjectName;
   String? lastDeleteSessionId;
   String? lastGetChildSessionsSessionId;
   String? lastSendPromptSessionId;
@@ -143,6 +147,35 @@ class FakeBridgePlugin implements BridgePlugin {
           time: null,
           summary: null,
         );
+  }
+
+  @override
+  Future<PluginSession> renameSession(
+    String sessionId, {
+    required String title,
+  }) async {
+    lastRenameSessionId = sessionId;
+    lastRenameSessionTitle = title;
+    return renameSessionResult ??
+        const PluginSession(
+          id: "",
+          projectID: "",
+          directory: "",
+          parentID: null,
+          title: null,
+          time: null,
+          summary: null,
+        );
+  }
+
+  @override
+  Future<PluginProject> renameProject(
+    String projectId, {
+    required String name,
+  }) async {
+    lastRenameProjectId = projectId;
+    lastRenameProjectName = name;
+    return renameProjectResult ?? const PluginProject(id: "");
   }
 
   @override

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -31,6 +31,8 @@ class FakeBridgePlugin implements BridgePlugin {
   PluginProvidersResult providersResult = const PluginProvidersResult(providers: []);
   PluginSession? createSessionResult;
   PluginSession? updateSessionResult;
+  PluginSession? renameSessionResult;
+  PluginProject? renameProjectResult;
   List<PluginSession> childSessionsResult = [];
   Map<String, PluginSessionStatus> sessionStatusesResult = {};
   List<PluginAgent> agentsResult = [];

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -30,6 +30,12 @@ abstract class BridgePlugin {
 
   Future<PluginSession> updateSessionArchiveStatus(String sessionId, {required bool archived});
 
+  /// Rename a session's title.
+  Future<PluginSession> renameSession(String sessionId, {required String title});
+
+  /// Rename a project.
+  Future<PluginProject> renameProject(String projectId, {required String name});
+
   Future<void> deleteSession(String sessionId);
 
   Future<List<PluginSession>> getChildSessions(String sessionId);

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -31,10 +31,10 @@ abstract class BridgePlugin {
   Future<PluginSession> updateSessionArchiveStatus(String sessionId, {required bool archived});
 
   /// Rename a session's title.
-  Future<PluginSession> renameSession(String sessionId, {required String title});
+  Future<PluginSession> renameSession({required String sessionId, required String title});
 
   /// Rename a project.
-  Future<PluginProject> renameProject(String projectId, {required String name});
+  Future<PluginProject> renameProject({required String projectId, required String name});
 
   Future<void> deleteSession(String sessionId);
 

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -159,6 +159,27 @@ class OpenCodeApi {
     }
   }
 
+  Future<Project> updateProject({
+    required String projectId,
+    required Map<String, dynamic> body,
+  }) async {
+    final client = http.Client();
+    try {
+      final response = await client.patch(
+        Uri.parse("$serverURL/project/$projectId"),
+        headers: {
+          ..._authHeaders,
+          "content-type": "application/json",
+        },
+        body: jsonEncode(body),
+      );
+      _ensureSuccess(response, "PATCH /project/$projectId");
+      return Project.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+    } finally {
+      client.close();
+    }
+  }
+
   Future<void> deleteSession({
     required String sessionId,
     required String? directory,

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -159,8 +159,11 @@ class OpenCodeApi {
     }
   }
 
+  /// Updates a project by its OpenCode-assigned ID (NOT the worktree path
+  /// that Sesori uses as the project identifier).
   Future<Project> updateProject({
     required String projectId,
+    required String directory,
     required Map<String, dynamic> body,
   }) async {
     final client = http.Client();
@@ -170,6 +173,7 @@ class OpenCodeApi {
         headers: {
           ..._authHeaders,
           "content-type": "application/json",
+          _directoryOpenCodeHeader: directory,
         },
         body: jsonEncode(body),
       );

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -475,6 +475,16 @@ class OpenCodePlugin implements BridgePlugin {
     return project.toPlugin();
   }
 
+  @override
+  Future<PluginSession> renameSession(String sessionId, {required String title}) {
+    throw UnimplementedError("renameSession not yet implemented");
+  }
+
+  @override
+  Future<PluginProject> renameProject(String projectId, {required String name}) {
+    throw UnimplementedError("renameProject not yet implemented");
+  }
+
   void _handleRawSseEvent(String rawData) {
     try {
       final parseResult = _parser.parse(rawData);

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -476,13 +476,32 @@ class OpenCodePlugin implements BridgePlugin {
   }
 
   @override
-  Future<PluginSession> renameSession(String sessionId, {required String title}) {
-    throw UnimplementedError("renameSession not yet implemented");
+  Future<PluginSession> renameSession(String sessionId, {required String title}) async {
+    final directory = _service.tracker.getSessionDirectory(sessionId: sessionId);
+    final session = await _call(
+      () => _service.repository.api.updateSession(
+        sessionId: sessionId,
+        directory: directory,
+        body: {"title": title},
+      ),
+    );
+    return session.toPlugin();
   }
 
   @override
-  Future<PluginProject> renameProject(String projectId, {required String name}) {
-    throw UnimplementedError("renameProject not yet implemented");
+  Future<PluginProject> renameProject(String projectId, {required String name}) async {
+    // CRITICAL: projectId is the worktree path (PluginProject.id = worktree, see project.dart:33)
+    // Must resolve the real OpenCode project UUID before calling PATCH
+    final project = await _call(
+      () => _service.repository.api.getProject(directory: projectId),
+    );
+    final updated = await _call(
+      () => _service.repository.api.updateProject(
+        projectId: project.id,
+        body: {"name": name},
+      ),
+    );
+    return updated.toPlugin();
   }
 
   void _handleRawSseEvent(String rawData) {

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -476,7 +476,7 @@ class OpenCodePlugin implements BridgePlugin {
   }
 
   @override
-  Future<PluginSession> renameSession(String sessionId, {required String title}) async {
+  Future<PluginSession> renameSession({required String sessionId, required String title}) async {
     final directory = _service.tracker.getSessionDirectory(sessionId: sessionId);
     final session = await _call(
       () => _service.repository.api.updateSession(
@@ -489,7 +489,7 @@ class OpenCodePlugin implements BridgePlugin {
   }
 
   @override
-  Future<PluginProject> renameProject(String projectId, {required String name}) async {
+  Future<PluginProject> renameProject({required String projectId, required String name}) async {
     // CRITICAL: projectId is the worktree path (PluginProject.id = worktree, see project.dart:33)
     // Must resolve the real OpenCode project UUID before calling PATCH
     final project = await _call(
@@ -498,6 +498,7 @@ class OpenCodePlugin implements BridgePlugin {
     final updated = await _call(
       () => _service.repository.api.updateProject(
         projectId: project.id,
+        directory: projectId,
         body: {"name": name},
       ),
     );

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -804,6 +804,7 @@ class _FakeApi implements OpenCodeApi {
   @override
   Future<Project> updateProject({
     required String projectId,
+    required String directory,
     required Map<String, dynamic> body,
   }) async => throw UnimplementedError();
 }

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -800,4 +800,10 @@ class _FakeApi implements OpenCodeApi {
   @override
   Future<ProviderListResponse> listProviders() async =>
       const ProviderListResponse(all: [], defaults: {}, connected: []);
+
+  @override
+  Future<Project> updateProject({
+    required String projectId,
+    required Map<String, dynamic> body,
+  }) async => throw UnimplementedError();
 }

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -363,7 +363,7 @@ void main() {
         await server.waitForSseConnection();
         server.requestLog.clear();
 
-        final session = await plugin.renameSession("s-root", title: "New Title");
+        final session = await plugin.renameSession(sessionId: "s-root", title: "New Title");
 
         expect(session.id, equals("s-root"));
         expect(session.title, equals("New Title"));
@@ -377,7 +377,7 @@ void main() {
         await server.waitForSseConnection();
         server.requestLog.clear();
 
-        final project = await plugin.renameProject("/repo", name: "Renamed Repo");
+        final project = await plugin.renameProject(projectId: "/repo", name: "Renamed Repo");
 
         // PluginProject.id is always the worktree path, not the OpenCode UUID
         expect(project.id, equals("/repo"));
@@ -525,6 +525,12 @@ class _FakeOpenCodeServer {
 
       final projectMatch = RegExp(r"^/project/([^/]+)$").firstMatch(path);
       if (projectMatch != null && request.method == "PATCH") {
+        final directoryHeader = request.headers.value("x-opencode-directory");
+        if (directoryHeader == null || directoryHeader.isEmpty) {
+          request.response.statusCode = HttpStatus.badRequest;
+          await request.response.close();
+          return;
+        }
         final projectId = projectMatch.group(1)!;
         final project = _projects[projectId];
         if (project == null) {

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -356,6 +356,38 @@ void main() {
         );
       });
     });
+
+    group("renameSession", () {
+      test("sends PATCH with title body and returns updated session", () async {
+        final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
+        await server.waitForSseConnection();
+        server.requestLog.clear();
+
+        final session = await plugin.renameSession("s-root", title: "New Title");
+
+        expect(session.id, equals("s-root"));
+        expect(session.title, equals("New Title"));
+        expect(server.requestLog, equals(["PATCH /session/s-root"]));
+      });
+    });
+
+    group("renameProject", () {
+      test("resolves worktree to project UUID then sends PATCH with name", () async {
+        final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
+        await server.waitForSseConnection();
+        server.requestLog.clear();
+
+        final project = await plugin.renameProject("/repo", name: "Renamed Repo");
+
+        // PluginProject.id is always the worktree path, not the OpenCode UUID
+        expect(project.id, equals("/repo"));
+        expect(project.name, equals("Renamed Repo"));
+        expect(
+          server.requestLog,
+          equals(["GET /project/current", "PATCH /project/p1"]),
+        );
+      });
+    });
   });
 }
 
@@ -462,6 +494,10 @@ class _FakeOpenCodeServer {
     },
   };
 
+  final Map<String, Map<String, dynamic>> _projects = {
+    "p1": {"id": "p1", "worktree": "/repo", "name": "Main Repo"},
+  };
+
   String get baseUrl => "http://${_server!.address.address}:${_server!.port}";
 
   Future<void> start() async {
@@ -471,9 +507,37 @@ class _FakeOpenCodeServer {
       requestLog.add("${request.method} $path");
 
       if (request.method == "GET" && path == "/project") {
-        await _sendJson(request.response, [
-          {"id": "p1", "worktree": "/repo", "name": "Main Repo"},
-        ]);
+        await _sendJson(request.response, _projects.values.toList());
+        return;
+      }
+
+      if (request.method == "GET" && path == "/project/current") {
+        final dir = request.headers.value("x-opencode-directory");
+        final project = _projects.values.where((p) => p["worktree"] == dir).firstOrNull;
+        if (project == null) {
+          request.response.statusCode = HttpStatus.notFound;
+          await request.response.close();
+          return;
+        }
+        await _sendJson(request.response, project);
+        return;
+      }
+
+      final projectMatch = RegExp(r"^/project/([^/]+)$").firstMatch(path);
+      if (projectMatch != null && request.method == "PATCH") {
+        final projectId = projectMatch.group(1)!;
+        final project = _projects[projectId];
+        if (project == null) {
+          request.response.statusCode = HttpStatus.notFound;
+          await request.response.close();
+          return;
+        }
+        final rawBody = await utf8.decoder.bind(request).join();
+        final body = (jsonDecode(rawBody) as Map).cast<String, dynamic>();
+        if (body.containsKey("name")) {
+          project["name"] = body["name"];
+        }
+        await _sendJson(request.response, project);
         return;
       }
 

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -451,4 +451,10 @@ class _FakeApi implements OpenCodeApi {
   @override
   Future<ProviderListResponse> listProviders() async =>
       const ProviderListResponse(all: [], defaults: {}, connected: []);
+
+  @override
+  Future<Project> updateProject({
+    required String projectId,
+    required Map<String, dynamic> body,
+  }) async => throw UnimplementedError();
 }

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -455,6 +455,7 @@ class _FakeApi implements OpenCodeApi {
   @override
   Future<Project> updateProject({
     required String projectId,
+    required String directory,
     required Map<String, dynamic> body,
   }) async => throw UnimplementedError();
 }

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -374,6 +374,12 @@ class FakeOpenCodeApi implements OpenCodeApi {
   Future<Project> getProject({required String directory}) async => throw UnimplementedError();
 
   @override
+  Future<Project> updateProject({
+    required String projectId,
+    required Map<String, dynamic> body,
+  }) async => throw UnimplementedError();
+
+  @override
   Future<List<GlobalSession>> listAllSessions({
     required String? directory,
     required bool roots,

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -376,6 +376,7 @@ class FakeOpenCodeApi implements OpenCodeApi {
   @override
   Future<Project> updateProject({
     required String projectId,
+    required String directory,
     required Map<String, dynamic> body,
   }) async => throw UnimplementedError();
 

--- a/mobile/app/lib/features/project_list/project_list_screen.dart
+++ b/mobile/app/lib/features/project_list/project_list_screen.dart
@@ -9,6 +9,7 @@ import "../../core/extensions/build_context_x.dart";
 import "../../core/routing/app_router.dart";
 import "../../l10n/app_localizations.dart";
 import "add_project_dialog.dart";
+import "rename_project_dialog.dart";
 
 class ProjectListScreen extends StatelessWidget {
   const ProjectListScreen({super.key});
@@ -65,6 +66,18 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
+            ListTile(
+              leading: const Icon(Icons.edit_outlined),
+              title: Text(loc.rename),
+              onTap: () {
+                Navigator.of(sheetContext).pop();
+                showRenameProjectDialog(
+                  context: context,
+                  project: project,
+                  cubit: cubit,
+                );
+              },
+            ),
             ListTile(
               leading: const Icon(Icons.visibility_off_outlined),
               title: Text(loc.hideProject),

--- a/mobile/app/lib/features/project_list/rename_project_dialog.dart
+++ b/mobile/app/lib/features/project_list/rename_project_dialog.dart
@@ -57,6 +57,10 @@ class _RenameProjectDialogState extends State<RenameProjectDialog> {
     final name = _nameController.text.trim();
     if (name.isEmpty) return;
 
+    final navigator = Navigator.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+    final loc = context.loc;
+
     setState(() => _actionLoading = true);
 
     final success = await widget.cubit.renameProject(
@@ -67,14 +71,13 @@ class _RenameProjectDialogState extends State<RenameProjectDialog> {
     if (!mounted) return;
     setState(() => _actionLoading = false);
 
-    final loc = context.loc;
     if (success) {
-      Navigator.of(context).pop();
-      ScaffoldMessenger.of(context).showSnackBar(
+      navigator.pop();
+      messenger.showSnackBar(
         SnackBar(content: Text(loc.renameProjectSuccess)),
       );
     } else {
-      ScaffoldMessenger.of(context).showSnackBar(
+      messenger.showSnackBar(
         SnackBar(content: Text(loc.renameProjectFailed)),
       );
     }

--- a/mobile/app/lib/features/project_list/rename_project_dialog.dart
+++ b/mobile/app/lib/features/project_list/rename_project_dialog.dart
@@ -1,0 +1,136 @@
+import "package:flutter/material.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../../core/extensions/build_context_x.dart";
+import "../../core/widgets/app_modal_bottom_sheet.dart";
+
+/// Shows the Rename Project modal bottom sheet.
+///
+/// The [cubit] is passed explicitly so the dialog can call
+/// `renameProject` without relying on the widget tree's BlocProvider
+/// (which lives in the parent screen).
+Future<void> showRenameProjectDialog({
+  required BuildContext context,
+  required Project project,
+  required ProjectListCubit cubit,
+}) {
+  return showAppModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    builder: (_) => RenameProjectDialog(project: project, cubit: cubit),
+  );
+}
+
+@visibleForTesting
+class RenameProjectDialog extends StatefulWidget {
+  final Project project;
+  final ProjectListCubit cubit;
+
+  const RenameProjectDialog({
+    required this.project,
+    required this.cubit,
+    super.key,
+  });
+
+  @override
+  State<RenameProjectDialog> createState() => _RenameProjectDialogState();
+}
+
+class _RenameProjectDialogState extends State<RenameProjectDialog> {
+  late final TextEditingController _nameController;
+  bool _actionLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.project.name ?? "");
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _onSave() async {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) return;
+
+    setState(() => _actionLoading = true);
+
+    final success = await widget.cubit.renameProject(
+      projectId: widget.project.id,
+      name: name,
+    );
+
+    if (!mounted) return;
+    setState(() => _actionLoading = false);
+
+    final loc = context.loc;
+    if (success) {
+      Navigator.of(context).pop();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(loc.renameProjectSuccess)),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(loc.renameProjectFailed)),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = context.loc;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Center(
+            child: Container(
+              width: 32,
+              height: 4,
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Text(loc.renameProjectTitle, style: Theme.of(context).textTheme.titleMedium),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _nameController,
+            autofocus: true,
+            decoration: InputDecoration(
+              hintText: loc.renameProjectHint,
+              border: const OutlineInputBorder(),
+            ),
+            onChanged: (_) => setState(() {}),
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            height: 48,
+            child: FilledButton(
+              onPressed: _actionLoading || _nameController.text.trim().isEmpty ? null : _onSave,
+              child: _actionLoading
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                    )
+                  : Text(loc.renameSave),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/app/lib/features/session_list/rename_session_dialog.dart
+++ b/mobile/app/lib/features/session_list/rename_session_dialog.dart
@@ -1,0 +1,117 @@
+import "package:flutter/material.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../../core/extensions/build_context_x.dart";
+import "../../core/widgets/app_modal_bottom_sheet.dart";
+
+/// Shows the Rename Session modal bottom sheet.
+///
+/// The [cubit] is passed explicitly so the dialog can call
+/// `renameSession` without relying on the widget tree's BlocProvider
+/// (which lives in the parent screen).
+Future<void> showRenameSessionDialog({
+  required BuildContext context,
+  required Session session,
+  required SessionListCubit cubit,
+}) {
+  return showAppModalBottomSheet<void>(
+    context: context,
+    builder: (_) => _RenameSessionDialog(session: session, cubit: cubit),
+  );
+}
+
+class _RenameSessionDialog extends StatefulWidget {
+  final Session session;
+  final SessionListCubit cubit;
+
+  const _RenameSessionDialog({required this.session, required this.cubit});
+
+  @override
+  State<_RenameSessionDialog> createState() => _RenameSessionDialogState();
+}
+
+class _RenameSessionDialogState extends State<_RenameSessionDialog> {
+  late final TextEditingController _controller;
+  bool _actionLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.session.title ?? "");
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _onSave() async {
+    final title = _controller.text.trim();
+    if (title.isEmpty) return;
+
+    setState(() => _actionLoading = true);
+
+    final success = await widget.cubit.renameSession(
+      sessionId: widget.session.id,
+      title: title,
+    );
+
+    if (!mounted) return;
+    setState(() => _actionLoading = false);
+
+    final loc = context.loc;
+    if (success) {
+      Navigator.of(context).pop();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(loc.renameSessionSuccess)),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(loc.renameSessionFailed)),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = context.loc;
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Text(loc.renameSessionTitle, style: Theme.of(context).textTheme.titleMedium),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _controller,
+            autofocus: true,
+            decoration: InputDecoration(
+              hintText: loc.renameSessionHint,
+              border: const OutlineInputBorder(),
+            ),
+            onChanged: (_) => setState(() {}),
+            onSubmitted: (_) => _onSave(),
+          ),
+          const SizedBox(height: 16),
+          FilledButton(
+            onPressed: _actionLoading || _controller.text.trim().isEmpty ? null : _onSave,
+            child: _actionLoading
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                  )
+                : Text(loc.renameSave),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/app/lib/features/session_list/rename_session_dialog.dart
+++ b/mobile/app/lib/features/session_list/rename_session_dialog.dart
@@ -51,6 +51,10 @@ class _RenameSessionDialogState extends State<_RenameSessionDialog> {
     final title = _controller.text.trim();
     if (title.isEmpty) return;
 
+    final navigator = Navigator.of(context);
+    final messenger = ScaffoldMessenger.of(context);
+    final loc = context.loc;
+
     setState(() => _actionLoading = true);
 
     final success = await widget.cubit.renameSession(
@@ -61,14 +65,13 @@ class _RenameSessionDialogState extends State<_RenameSessionDialog> {
     if (!mounted) return;
     setState(() => _actionLoading = false);
 
-    final loc = context.loc;
     if (success) {
-      Navigator.of(context).pop();
-      ScaffoldMessenger.of(context).showSnackBar(
+      navigator.pop();
+      messenger.showSnackBar(
         SnackBar(content: Text(loc.renameSessionSuccess)),
       );
     } else {
-      ScaffoldMessenger.of(context).showSnackBar(
+      messenger.showSnackBar(
         SnackBar(content: Text(loc.renameSessionFailed)),
       );
     }

--- a/mobile/app/lib/features/session_list/session_list_screen.dart
+++ b/mobile/app/lib/features/session_list/session_list_screen.dart
@@ -9,6 +9,7 @@ import "../../core/extensions/build_context_x.dart";
 import "../../core/routing/app_router.dart";
 import "../../core/widgets/app_modal_bottom_sheet.dart";
 import "../../l10n/app_localizations.dart";
+import "rename_session_dialog.dart";
 
 class SessionListScreen extends StatelessWidget {
   final String projectId;
@@ -60,6 +61,18 @@ class _SessionListBody extends StatelessWidget {
         return Column(
           mainAxisSize: .min,
           children: [
+            ListTile(
+              leading: const Icon(Icons.edit_outlined),
+              title: Text(loc.rename),
+              onTap: () {
+                Navigator.pop(sheetContext);
+                showRenameSessionDialog(
+                  context: context,
+                  session: session,
+                  cubit: cubit,
+                );
+              },
+            ),
             ListTile(
               leading: Icon(isArchived ? Icons.unarchive_outlined : Icons.archive_outlined),
               title: Text(isArchived ? loc.sessionListUnarchive : loc.sessionListArchive),

--- a/mobile/app/lib/l10n/app_en.arb
+++ b/mobile/app/lib/l10n/app_en.arb
@@ -245,5 +245,15 @@
      "projectCreateFailed": "Failed to create project",
       "projectDiscoverFailed": "Failed to discover project",
       "questionReplyFailed": "Failed to send answer. Please try again.",
-      "questionRejectFailed": "Failed to reject question. Please try again."
+      "questionRejectFailed": "Failed to reject question. Please try again.",
+      "rename": "Rename",
+      "renameSessionTitle": "Rename Session",
+      "renameProjectTitle": "Rename Project",
+      "renameSessionHint": "Session title",
+      "renameProjectHint": "Project name",
+      "renameSave": "Save",
+      "renameSessionSuccess": "Session renamed",
+      "renameProjectSuccess": "Project renamed",
+      "renameSessionFailed": "Failed to rename session",
+      "renameProjectFailed": "Failed to rename project"
 }

--- a/mobile/app/lib/l10n/app_localizations.dart
+++ b/mobile/app/lib/l10n/app_localizations.dart
@@ -942,6 +942,66 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Failed to reject question. Please try again.'**
   String get questionRejectFailed;
+
+  /// No description provided for @rename.
+  ///
+  /// In en, this message translates to:
+  /// **'Rename'**
+  String get rename;
+
+  /// No description provided for @renameSessionTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Rename Session'**
+  String get renameSessionTitle;
+
+  /// No description provided for @renameProjectTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Rename Project'**
+  String get renameProjectTitle;
+
+  /// No description provided for @renameSessionHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Session title'**
+  String get renameSessionHint;
+
+  /// No description provided for @renameProjectHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Project name'**
+  String get renameProjectHint;
+
+  /// No description provided for @renameSave.
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get renameSave;
+
+  /// No description provided for @renameSessionSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Session renamed'**
+  String get renameSessionSuccess;
+
+  /// No description provided for @renameProjectSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Project renamed'**
+  String get renameProjectSuccess;
+
+  /// No description provided for @renameSessionFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to rename session'**
+  String get renameSessionFailed;
+
+  /// No description provided for @renameProjectFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to rename project'**
+  String get renameProjectFailed;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/mobile/app/lib/l10n/app_localizations_en.dart
+++ b/mobile/app/lib/l10n/app_localizations_en.dart
@@ -486,4 +486,34 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get questionRejectFailed => 'Failed to reject question. Please try again.';
+
+  @override
+  String get rename => 'Rename';
+
+  @override
+  String get renameSessionTitle => 'Rename Session';
+
+  @override
+  String get renameProjectTitle => 'Rename Project';
+
+  @override
+  String get renameSessionHint => 'Session title';
+
+  @override
+  String get renameProjectHint => 'Project name';
+
+  @override
+  String get renameSave => 'Save';
+
+  @override
+  String get renameSessionSuccess => 'Session renamed';
+
+  @override
+  String get renameProjectSuccess => 'Project renamed';
+
+  @override
+  String get renameSessionFailed => 'Failed to rename session';
+
+  @override
+  String get renameProjectFailed => 'Failed to rename project';
 }

--- a/mobile/app/test/capabilities/session/session_service_test.dart
+++ b/mobile/app/test/capabilities/session/session_service_test.dart
@@ -380,6 +380,73 @@ void main() {
       });
     });
 
+    group("renameSession", () {
+      const sessionId = "session-rename";
+
+      test("success: returns Session from PATCH /session/:id/title", () async {
+        final session = testSession(id: sessionId);
+        when(
+          () => mockClient.patch<Session>(
+            "/session/$sessionId/title",
+            fromJson: any(named: "fromJson"),
+            body: any(named: "body"),
+          ),
+        ).thenAnswer((_) async => ApiResponse.success(session));
+
+        final result = await sessionService.renameSession(sessionId: sessionId, title: "New Title");
+
+        expect(result, isA<SuccessResponse<Session>>());
+        expect((result as SuccessResponse<Session>).data, equals(session));
+        verify(
+          () => mockClient.patch<Session>(
+            "/session/$sessionId/title",
+            fromJson: any(named: "fromJson"),
+            body: any(named: "body"),
+          ),
+        ).called(1);
+      });
+
+      test("error: propagates API error from PATCH /session/:id/title", () async {
+        final error = ApiError.generic();
+        when(
+          () => mockClient.patch<Session>(
+            "/session/$sessionId/title",
+            fromJson: any(named: "fromJson"),
+            body: any(named: "body"),
+          ),
+        ).thenAnswer((_) async => ApiResponse.error(error));
+
+        final result = await sessionService.renameSession(sessionId: sessionId, title: "New Title");
+
+        expect(result, isA<ErrorResponse<Session>>());
+        expect((result as ErrorResponse<Session>).error, equals(error));
+      });
+
+      test("sends title in body to PATCH /session/:id/title", () async {
+        when(
+          () => mockClient.patch<Session>(
+            "/session/$sessionId/title",
+            fromJson: any(named: "fromJson"),
+            body: any(named: "body"),
+          ),
+        ).thenAnswer((_) async => ApiResponse.success(testSession()));
+
+        await sessionService.renameSession(sessionId: sessionId, title: "Updated Title");
+
+        final captured =
+            verify(
+                  () => mockClient.patch<Session>(
+                    "/session/$sessionId/title",
+                    fromJson: any(named: "fromJson"),
+                    body: captureAny(named: "body"),
+                  ),
+                ).captured.last
+                as Map<String, dynamic>;
+
+        expect(captured["title"], equals("Updated Title"));
+      });
+    });
+
     group("deleteSession", () {
       const sessionId = "session-del";
 

--- a/mobile/app/test/capabilities/session/session_service_test.dart
+++ b/mobile/app/test/capabilities/session/session_service_test.dart
@@ -383,11 +383,11 @@ void main() {
     group("renameSession", () {
       const sessionId = "session-rename";
 
-      test("success: returns Session from PATCH /session/:id/title", () async {
+      test("success: returns Session from PATCH /session/title", () async {
         final session = testSession(id: sessionId);
         when(
           () => mockClient.patch<Session>(
-            "/session/$sessionId/title",
+            "/session/title",
             fromJson: any(named: "fromJson"),
             body: any(named: "body"),
           ),
@@ -399,18 +399,18 @@ void main() {
         expect((result as SuccessResponse<Session>).data, equals(session));
         verify(
           () => mockClient.patch<Session>(
-            "/session/$sessionId/title",
+            "/session/title",
             fromJson: any(named: "fromJson"),
             body: any(named: "body"),
           ),
         ).called(1);
       });
 
-      test("error: propagates API error from PATCH /session/:id/title", () async {
+      test("error: propagates API error from PATCH /session/title", () async {
         final error = ApiError.generic();
         when(
           () => mockClient.patch<Session>(
-            "/session/$sessionId/title",
+            "/session/title",
             fromJson: any(named: "fromJson"),
             body: any(named: "body"),
           ),
@@ -422,10 +422,10 @@ void main() {
         expect((result as ErrorResponse<Session>).error, equals(error));
       });
 
-      test("sends title in body to PATCH /session/:id/title", () async {
+      test("sends sessionId and title in body to PATCH /session/title", () async {
         when(
           () => mockClient.patch<Session>(
-            "/session/$sessionId/title",
+            "/session/title",
             fromJson: any(named: "fromJson"),
             body: any(named: "body"),
           ),
@@ -436,13 +436,14 @@ void main() {
         final captured =
             verify(
                   () => mockClient.patch<Session>(
-                    "/session/$sessionId/title",
+                    "/session/title",
                     fromJson: any(named: "fromJson"),
                     body: captureAny(named: "body"),
                   ),
                 ).captured.last
                 as Map<String, dynamic>;
 
+        expect(captured["sessionId"], equals(sessionId));
         expect(captured["title"], equals("Updated Title"));
       });
     });

--- a/mobile/module_core/lib/src/capabilities/project/project_service.dart
+++ b/mobile/module_core/lib/src/capabilities/project/project_service.dart
@@ -97,4 +97,19 @@ class ProjectService {
       },
     );
   }
+
+  /// Renames the project with the given [projectId] to [name].
+  Future<ApiResponse<Project>> renameProject({
+    required String projectId,
+    required String name,
+  }) {
+    return _client.patch(
+      "/project/$projectId/name",
+      body: RenameProjectRequest(name: name).toJson(),
+      fromJson: (json) => switch (json) {
+        final Map<String, dynamic> map => Project.fromJson(map),
+        _ => throw FormatException("expected map, got ${json.runtimeType}"),
+      },
+    );
+  }
 }

--- a/mobile/module_core/lib/src/capabilities/project/project_service.dart
+++ b/mobile/module_core/lib/src/capabilities/project/project_service.dart
@@ -104,8 +104,8 @@ class ProjectService {
     required String name,
   }) {
     return _client.patch(
-      "/project/$projectId/name",
-      body: RenameProjectRequest(name: name).toJson(),
+      "/project/name",
+      body: RenameProjectRequest(projectId: projectId, name: name).toJson(),
       fromJson: (json) => switch (json) {
         final Map<String, dynamic> map => Project.fromJson(map),
         _ => throw FormatException("expected map, got ${json.runtimeType}"),

--- a/mobile/module_core/lib/src/capabilities/session/session_service.dart
+++ b/mobile/module_core/lib/src/capabilities/session/session_service.dart
@@ -93,6 +93,17 @@ class SessionService {
     );
   }
 
+  Future<ApiResponse<Session>> renameSession({required String sessionId, required String title}) {
+    return _client.patch(
+      "/session/$sessionId/title",
+      fromJson: (json) => switch (json) {
+        final Map<String, dynamic> map => Session.fromJson(map),
+        _ => throw FormatException("expected map, got ${json.runtimeType}"),
+      },
+      body: RenameSessionRequest(title: title).toJson(),
+    );
+  }
+
   Future<ApiResponse<bool>> deleteSession(String sessionId) {
     return _client.delete(
       "/session/$sessionId",

--- a/mobile/module_core/lib/src/capabilities/session/session_service.dart
+++ b/mobile/module_core/lib/src/capabilities/session/session_service.dart
@@ -95,12 +95,12 @@ class SessionService {
 
   Future<ApiResponse<Session>> renameSession({required String sessionId, required String title}) {
     return _client.patch(
-      "/session/$sessionId/title",
+      "/session/title",
       fromJson: (json) => switch (json) {
         final Map<String, dynamic> map => Session.fromJson(map),
         _ => throw FormatException("expected map, got ${json.runtimeType}"),
       },
-      body: RenameSessionRequest(title: title).toJson(),
+      body: RenameSessionRequest(sessionId: sessionId, title: title).toJson(),
     );
   }
 

--- a/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -158,6 +158,20 @@ class ProjectListCubit extends Cubit<ProjectListState> {
     }
   }
 
+  /// Renames the project with [projectId] to [name].
+  /// Returns `true` on success (and refreshes the project list), `false` on error.
+  Future<bool> renameProject({required String projectId, required String name}) async {
+    final response = await _projectService.renameProject(projectId: projectId, name: name);
+    if (isClosed) return false;
+    switch (response) {
+      case SuccessResponse():
+        await refreshProjects();
+        return true;
+      case ErrorResponse():
+        return false;
+    }
+  }
+
   /// Discovers an existing project at [path].
   /// Returns `true` on success, `false` on error.
   Future<bool> discoverProject({required String path}) async {

--- a/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -263,12 +263,15 @@ class SessionListCubit extends Cubit<SessionListState> {
   /// Renames a session. Returns `true` on success so the screen can show
   /// a confirmation message.
   Future<bool> renameSession({required String sessionId, required String title}) async {
-    try {
-      await _service.renameSession(sessionId: sessionId, title: title);
-      await refreshSessions();
-      return true;
-    } catch (e) {
-      return false;
+    final response = await _service.renameSession(sessionId: sessionId, title: title);
+    if (isClosed) return false;
+
+    switch (response) {
+      case SuccessResponse():
+        await refreshSessions();
+        return true;
+      case ErrorResponse():
+        return false;
     }
   }
 

--- a/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -260,6 +260,18 @@ class SessionListCubit extends Cubit<SessionListState> {
     _undoSnapshot = null;
   }
 
+  /// Renames a session. Returns `true` on success so the screen can show
+  /// a confirmation message.
+  Future<bool> renameSession({required String sessionId, required String title}) async {
+    try {
+      await _service.renameSession(sessionId: sessionId, title: title);
+      await refreshSessions();
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
   /// Deletes a session permanently.
   Future<bool> deleteSession(String sessionId) async {
     if (state is! SessionListLoaded) return false;

--- a/mobile/module_core/test/capabilities/project/project_service_test.dart
+++ b/mobile/module_core/test/capabilities/project/project_service_test.dart
@@ -225,5 +225,54 @@ void main() {
       expect(result, isA<ErrorResponse<List<FilesystemSuggestion>>>());
       expect((result as ErrorResponse<List<FilesystemSuggestion>>).error, equals(error));
     });
+
+    // -------------------------------------------------------------------------
+    // 7. renameProject sends PATCH /project/{id}/name with correct body
+    // -------------------------------------------------------------------------
+
+    test("renameProject sends PATCH /project/{id}/name with correct body", () async {
+      const mockProject = Project(
+        id: "proj-1",
+        name: "New Name",
+        time: ProjectTime(created: 1000, updated: 2000),
+      );
+
+      when(
+        () => mockClient.patch<Project>(
+          "/project/proj-1/name",
+          fromJson: any(named: "fromJson"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer((_) async => ApiResponse.success(mockProject));
+
+      final result = await service.renameProject(projectId: "proj-1", name: "New Name");
+
+      expect(result, isA<SuccessResponse<Project>>());
+      expect((result as SuccessResponse<Project>).data, equals(mockProject));
+
+      verify(
+        () => mockClient.patch<Project>(
+          "/project/proj-1/name",
+          fromJson: any(named: "fromJson"),
+          body: RenameProjectRequest(name: "New Name").toJson(),
+        ),
+      ).called(1);
+    });
+
+    test("renameProject error response maps to ErrorResponse", () async {
+      final error = ApiError.generic();
+      when(
+        () => mockClient.patch<Project>(
+          any(),
+          fromJson: any(named: "fromJson"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer((_) async => ApiResponse.error(error));
+
+      final result = await service.renameProject(projectId: "proj-1", name: "New Name");
+
+      expect(result, isA<ErrorResponse<Project>>());
+      expect((result as ErrorResponse<Project>).error, equals(error));
+    });
   });
 }

--- a/mobile/module_core/test/capabilities/project/project_service_test.dart
+++ b/mobile/module_core/test/capabilities/project/project_service_test.dart
@@ -227,10 +227,10 @@ void main() {
     });
 
     // -------------------------------------------------------------------------
-    // 7. renameProject sends PATCH /project/{id}/name with correct body
+    // 7. renameProject sends PATCH /project/name with correct body
     // -------------------------------------------------------------------------
 
-    test("renameProject sends PATCH /project/{id}/name with correct body", () async {
+    test("renameProject sends PATCH /project/name with correct body", () async {
       const mockProject = Project(
         id: "proj-1",
         name: "New Name",
@@ -239,7 +239,7 @@ void main() {
 
       when(
         () => mockClient.patch<Project>(
-          "/project/proj-1/name",
+          "/project/name",
           fromJson: any(named: "fromJson"),
           body: any(named: "body"),
         ),
@@ -252,9 +252,9 @@ void main() {
 
       verify(
         () => mockClient.patch<Project>(
-          "/project/proj-1/name",
+          "/project/name",
           fromJson: any(named: "fromJson"),
-          body: RenameProjectRequest(name: "New Name").toJson(),
+          body: RenameProjectRequest(projectId: "proj-1", name: "New Name").toJson(),
         ),
       ).called(1);
     });

--- a/mobile/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/mobile/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -258,6 +258,70 @@ void main() {
     );
 
     // -------------------------------------------------------------------------
+    // Test 4e: renameProject success
+    // -------------------------------------------------------------------------
+
+    blocTest<ProjectListCubit, ProjectListState>(
+      "renameProject: calls service, refreshes project list, and returns true on success",
+      build: () {
+        when(() => mockProjectService.listProjects()).thenAnswer((_) async => ApiResponse.success([projectA]));
+        when(
+          () => mockProjectService.renameProject(
+            projectId: any(named: "projectId"),
+            name: any(named: "name"),
+          ),
+        ).thenAnswer((_) async => ApiResponse.success(projectA));
+        return buildCubit();
+      },
+      act: (cubit) async {
+        await Future<void>.delayed(Duration.zero);
+        when(() => mockProjectService.listProjects()).thenAnswer(
+          (_) async => ApiResponse.success([projectA, projectB]),
+        );
+        final result = await cubit.renameProject(projectId: "A", name: "New Name");
+        expect(result, isTrue);
+      },
+      skip: 1,
+      expect: () => [
+        isA<ProjectListLoaded>().having(
+          (s) => s.projects.length,
+          "projects count after rename",
+          2,
+        ),
+      ],
+      verify: (_) {
+        verify(
+          () => mockProjectService.renameProject(projectId: "A", name: "New Name"),
+        ).called(1);
+      },
+    );
+
+    // -------------------------------------------------------------------------
+    // Test 4f: renameProject failure
+    // -------------------------------------------------------------------------
+
+    blocTest<ProjectListCubit, ProjectListState>(
+      "renameProject: returns false and emits no state on API error",
+      build: () {
+        when(() => mockProjectService.listProjects()).thenAnswer((_) async => ApiResponse.success([projectA]));
+        when(
+          () => mockProjectService.renameProject(
+            projectId: any(named: "projectId"),
+            name: any(named: "name"),
+          ),
+        ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
+        return buildCubit();
+      },
+      act: (cubit) async {
+        await Future<void>.delayed(Duration.zero);
+        final result = await cubit.renameProject(projectId: "A", name: "New Name");
+        expect(result, isFalse);
+      },
+      skip: 1,
+      expect: () => <ProjectListState>[],
+    );
+
+    // -------------------------------------------------------------------------
     // Test 5: setActiveProject — calls connectionService.setActiveDirectory
     // -------------------------------------------------------------------------
 

--- a/mobile/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/mobile/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -1236,18 +1236,18 @@ void main() {
     );
 
     // -------------------------------------------------------------------------
-    // renameSession failure — service throws, returns false, state unchanged
+    // renameSession failure — service returns ErrorResponse, returns false
     // -------------------------------------------------------------------------
 
     blocTest<SessionListCubit, SessionListState>(
-      "renameSession: returns false and leaves state unchanged when service throws",
+      "renameSession: returns false and leaves state unchanged when service returns error",
       build: () {
         when(
           () => mockSessionService.listSessions(projectId: projectId),
         ).thenAnswer((_) async => ApiResponse.success([testSession(id: "s1", title: "Original")]));
         when(
           () => mockSessionService.renameSession(sessionId: "s1", title: "New Title"),
-        ).thenThrow(Exception("network error"));
+        ).thenAnswer((_) async => ApiResponse<Session>.error(ApiError.generic()));
         return buildCubit();
       },
       act: (cubit) async {

--- a/mobile/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/mobile/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -1199,6 +1199,68 @@ void main() {
     );
 
     // -------------------------------------------------------------------------
+    // renameSession success — calls service, refreshes list, returns true
+    // -------------------------------------------------------------------------
+
+    blocTest<SessionListCubit, SessionListState>(
+      "renameSession: calls service with correct args, refreshes sessions, and returns true on success",
+      build: () {
+        when(
+          () => mockSessionService.listSessions(projectId: projectId),
+        ).thenAnswer((_) async => ApiResponse.success([testSession(id: "s1", title: "Original")]));
+        when(
+          () => mockSessionService.renameSession(sessionId: "s1", title: "New Title"),
+        ).thenAnswer((_) async => ApiResponse.success(testSession(id: "s1", title: "New Title")));
+        return buildCubit();
+      },
+      act: (cubit) async {
+        await Future<void>.delayed(Duration.zero);
+        // Switch mock to return renamed session on refresh.
+        when(
+          () => mockSessionService.listSessions(projectId: projectId),
+        ).thenAnswer((_) async => ApiResponse.success([testSession(id: "s1", title: "New Title")]));
+        final result = await cubit.renameSession(sessionId: "s1", title: "New Title");
+        expect(result, isTrue);
+      },
+      skip: 1,
+      expect: () => [
+        isA<SessionListLoaded>().having(
+          (s) => s.sessions.first.title,
+          "session title after rename",
+          "New Title",
+        ),
+      ],
+      verify: (_) {
+        verify(() => mockSessionService.renameSession(sessionId: "s1", title: "New Title")).called(1);
+      },
+    );
+
+    // -------------------------------------------------------------------------
+    // renameSession failure — service throws, returns false, state unchanged
+    // -------------------------------------------------------------------------
+
+    blocTest<SessionListCubit, SessionListState>(
+      "renameSession: returns false and leaves state unchanged when service throws",
+      build: () {
+        when(
+          () => mockSessionService.listSessions(projectId: projectId),
+        ).thenAnswer((_) async => ApiResponse.success([testSession(id: "s1", title: "Original")]));
+        when(
+          () => mockSessionService.renameSession(sessionId: "s1", title: "New Title"),
+        ).thenThrow(Exception("network error"));
+        return buildCubit();
+      },
+      act: (cubit) async {
+        await Future<void>.delayed(Duration.zero);
+        final result = await cubit.renameSession(sessionId: "s1", title: "New Title");
+        expect(result, isFalse);
+      },
+      skip: 1,
+      // No state changes — current loaded state is preserved.
+      expect: () => <SessionListState>[],
+    );
+
+    // -------------------------------------------------------------------------
     // 22. activeSessionIds is empty when no activity for this project
     // -------------------------------------------------------------------------
 

--- a/shared/sesori_shared/lib/sesori_shared.dart
+++ b/shared/sesori_shared/lib/sesori_shared.dart
@@ -31,6 +31,8 @@ export "src/models/sesori/project.dart";
 export "src/models/sesori/project_activity_summary.dart";
 export "src/models/sesori/provider_info.dart";
 export "src/models/sesori/question.dart";
+export "src/models/sesori/rename_project_request.dart";
+export "src/models/sesori/rename_session_request.dart";
 export "src/models/sesori/reply_to_question_request.dart";
 export "src/models/sesori/send_notification_payload.dart";
 export "src/models/sesori/send_prompt_request.dart";

--- a/shared/sesori_shared/lib/src/models/sesori/rename_project_request.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/rename_project_request.dart
@@ -1,0 +1,14 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "rename_project_request.freezed.dart";
+
+part "rename_project_request.g.dart";
+
+@Freezed(fromJson: true, toJson: true)
+sealed class RenameProjectRequest with _$RenameProjectRequest {
+  const factory RenameProjectRequest({
+    required String name,
+  }) = _RenameProjectRequest;
+
+  factory RenameProjectRequest.fromJson(Map<String, dynamic> json) => _$RenameProjectRequestFromJson(json);
+}

--- a/shared/sesori_shared/lib/src/models/sesori/rename_project_request.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/rename_project_request.dart
@@ -7,6 +7,7 @@ part "rename_project_request.g.dart";
 @Freezed(fromJson: true, toJson: true)
 sealed class RenameProjectRequest with _$RenameProjectRequest {
   const factory RenameProjectRequest({
+    required String projectId,
     required String name,
   }) = _RenameProjectRequest;
 

--- a/shared/sesori_shared/lib/src/models/sesori/rename_project_request.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/rename_project_request.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$RenameProjectRequest {
 
- String get name;
+ String get projectId; String get name;
 /// Create a copy of RenameProjectRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $RenameProjectRequestCopyWith<RenameProjectRequest> get copyWith => _$RenameProj
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RenameProjectRequest&&(identical(other.name, name) || other.name == name));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RenameProjectRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&(identical(other.name, name) || other.name == name));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,name);
+int get hashCode => Object.hash(runtimeType,projectId,name);
 
 @override
 String toString() {
-  return 'RenameProjectRequest(name: $name)';
+  return 'RenameProjectRequest(projectId: $projectId, name: $name)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $RenameProjectRequestCopyWith<$Res>  {
   factory $RenameProjectRequestCopyWith(RenameProjectRequest value, $Res Function(RenameProjectRequest) _then) = _$RenameProjectRequestCopyWithImpl;
 @useResult
 $Res call({
- String name
+ String projectId, String name
 });
 
 
@@ -65,9 +65,10 @@ class _$RenameProjectRequestCopyWithImpl<$Res>
 
 /// Create a copy of RenameProjectRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? name = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? projectId = null,Object? name = null,}) {
   return _then(_self.copyWith(
-name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+projectId: null == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,
   ));
 }
@@ -80,9 +81,10 @@ as String,
 @JsonSerializable()
 
 class _RenameProjectRequest implements RenameProjectRequest {
-  const _RenameProjectRequest({required this.name});
+  const _RenameProjectRequest({required this.projectId, required this.name});
   factory _RenameProjectRequest.fromJson(Map<String, dynamic> json) => _$RenameProjectRequestFromJson(json);
 
+@override final  String projectId;
 @override final  String name;
 
 /// Create a copy of RenameProjectRequest
@@ -98,16 +100,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RenameProjectRequest&&(identical(other.name, name) || other.name == name));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RenameProjectRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&(identical(other.name, name) || other.name == name));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,name);
+int get hashCode => Object.hash(runtimeType,projectId,name);
 
 @override
 String toString() {
-  return 'RenameProjectRequest(name: $name)';
+  return 'RenameProjectRequest(projectId: $projectId, name: $name)';
 }
 
 
@@ -118,7 +120,7 @@ abstract mixin class _$RenameProjectRequestCopyWith<$Res> implements $RenameProj
   factory _$RenameProjectRequestCopyWith(_RenameProjectRequest value, $Res Function(_RenameProjectRequest) _then) = __$RenameProjectRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String name
+ String projectId, String name
 });
 
 
@@ -135,9 +137,10 @@ class __$RenameProjectRequestCopyWithImpl<$Res>
 
 /// Create a copy of RenameProjectRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? name = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? projectId = null,Object? name = null,}) {
   return _then(_RenameProjectRequest(
-name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+projectId: null == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,
   ));
 }

--- a/shared/sesori_shared/lib/src/models/sesori/rename_project_request.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/rename_project_request.freezed.dart
@@ -1,0 +1,148 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'rename_project_request.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$RenameProjectRequest {
+
+ String get name;
+/// Create a copy of RenameProjectRequest
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RenameProjectRequestCopyWith<RenameProjectRequest> get copyWith => _$RenameProjectRequestCopyWithImpl<RenameProjectRequest>(this as RenameProjectRequest, _$identity);
+
+  /// Serializes this RenameProjectRequest to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RenameProjectRequest&&(identical(other.name, name) || other.name == name));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name);
+
+@override
+String toString() {
+  return 'RenameProjectRequest(name: $name)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RenameProjectRequestCopyWith<$Res>  {
+  factory $RenameProjectRequestCopyWith(RenameProjectRequest value, $Res Function(RenameProjectRequest) _then) = _$RenameProjectRequestCopyWithImpl;
+@useResult
+$Res call({
+ String name
+});
+
+
+
+
+}
+/// @nodoc
+class _$RenameProjectRequestCopyWithImpl<$Res>
+    implements $RenameProjectRequestCopyWith<$Res> {
+  _$RenameProjectRequestCopyWithImpl(this._self, this._then);
+
+  final RenameProjectRequest _self;
+  final $Res Function(RenameProjectRequest) _then;
+
+/// Create a copy of RenameProjectRequest
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? name = null,}) {
+  return _then(_self.copyWith(
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _RenameProjectRequest implements RenameProjectRequest {
+  const _RenameProjectRequest({required this.name});
+  factory _RenameProjectRequest.fromJson(Map<String, dynamic> json) => _$RenameProjectRequestFromJson(json);
+
+@override final  String name;
+
+/// Create a copy of RenameProjectRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RenameProjectRequestCopyWith<_RenameProjectRequest> get copyWith => __$RenameProjectRequestCopyWithImpl<_RenameProjectRequest>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$RenameProjectRequestToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RenameProjectRequest&&(identical(other.name, name) || other.name == name));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name);
+
+@override
+String toString() {
+  return 'RenameProjectRequest(name: $name)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RenameProjectRequestCopyWith<$Res> implements $RenameProjectRequestCopyWith<$Res> {
+  factory _$RenameProjectRequestCopyWith(_RenameProjectRequest value, $Res Function(_RenameProjectRequest) _then) = __$RenameProjectRequestCopyWithImpl;
+@override @useResult
+$Res call({
+ String name
+});
+
+
+
+
+}
+/// @nodoc
+class __$RenameProjectRequestCopyWithImpl<$Res>
+    implements _$RenameProjectRequestCopyWith<$Res> {
+  __$RenameProjectRequestCopyWithImpl(this._self, this._then);
+
+  final _RenameProjectRequest _self;
+  final $Res Function(_RenameProjectRequest) _then;
+
+/// Create a copy of RenameProjectRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? name = null,}) {
+  return _then(_RenameProjectRequest(
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/shared/sesori_shared/lib/src/models/sesori/rename_project_request.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/rename_project_request.g.dart
@@ -7,8 +7,11 @@ part of 'rename_project_request.dart';
 // **************************************************************************
 
 _RenameProjectRequest _$RenameProjectRequestFromJson(Map json) =>
-    _RenameProjectRequest(name: json['name'] as String);
+    _RenameProjectRequest(
+      projectId: json['projectId'] as String,
+      name: json['name'] as String,
+    );
 
 Map<String, dynamic> _$RenameProjectRequestToJson(
   _RenameProjectRequest instance,
-) => <String, dynamic>{'name': instance.name};
+) => <String, dynamic>{'projectId': instance.projectId, 'name': instance.name};

--- a/shared/sesori_shared/lib/src/models/sesori/rename_project_request.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/rename_project_request.g.dart
@@ -1,0 +1,14 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'rename_project_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_RenameProjectRequest _$RenameProjectRequestFromJson(Map json) =>
+    _RenameProjectRequest(name: json['name'] as String);
+
+Map<String, dynamic> _$RenameProjectRequestToJson(
+  _RenameProjectRequest instance,
+) => <String, dynamic>{'name': instance.name};

--- a/shared/sesori_shared/lib/src/models/sesori/rename_session_request.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/rename_session_request.dart
@@ -7,6 +7,7 @@ part "rename_session_request.g.dart";
 @Freezed(fromJson: true, toJson: true)
 sealed class RenameSessionRequest with _$RenameSessionRequest {
   const factory RenameSessionRequest({
+    required String sessionId,
     required String title,
   }) = _RenameSessionRequest;
 

--- a/shared/sesori_shared/lib/src/models/sesori/rename_session_request.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/rename_session_request.dart
@@ -1,0 +1,14 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "rename_session_request.freezed.dart";
+
+part "rename_session_request.g.dart";
+
+@Freezed(fromJson: true, toJson: true)
+sealed class RenameSessionRequest with _$RenameSessionRequest {
+  const factory RenameSessionRequest({
+    required String title,
+  }) = _RenameSessionRequest;
+
+  factory RenameSessionRequest.fromJson(Map<String, dynamic> json) => _$RenameSessionRequestFromJson(json);
+}

--- a/shared/sesori_shared/lib/src/models/sesori/rename_session_request.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/rename_session_request.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$RenameSessionRequest {
 
- String get title;
+ String get sessionId; String get title;
 /// Create a copy of RenameSessionRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $RenameSessionRequestCopyWith<RenameSessionRequest> get copyWith => _$RenameSess
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RenameSessionRequest&&(identical(other.title, title) || other.title == title));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RenameSessionRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.title, title) || other.title == title));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,title);
+int get hashCode => Object.hash(runtimeType,sessionId,title);
 
 @override
 String toString() {
-  return 'RenameSessionRequest(title: $title)';
+  return 'RenameSessionRequest(sessionId: $sessionId, title: $title)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $RenameSessionRequestCopyWith<$Res>  {
   factory $RenameSessionRequestCopyWith(RenameSessionRequest value, $Res Function(RenameSessionRequest) _then) = _$RenameSessionRequestCopyWithImpl;
 @useResult
 $Res call({
- String title
+ String sessionId, String title
 });
 
 
@@ -65,9 +65,10 @@ class _$RenameSessionRequestCopyWithImpl<$Res>
 
 /// Create a copy of RenameSessionRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? title = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? sessionId = null,Object? title = null,}) {
   return _then(_self.copyWith(
-title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,
   ));
 }
@@ -80,9 +81,10 @@ as String,
 @JsonSerializable()
 
 class _RenameSessionRequest implements RenameSessionRequest {
-  const _RenameSessionRequest({required this.title});
+  const _RenameSessionRequest({required this.sessionId, required this.title});
   factory _RenameSessionRequest.fromJson(Map<String, dynamic> json) => _$RenameSessionRequestFromJson(json);
 
+@override final  String sessionId;
 @override final  String title;
 
 /// Create a copy of RenameSessionRequest
@@ -98,16 +100,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RenameSessionRequest&&(identical(other.title, title) || other.title == title));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RenameSessionRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.title, title) || other.title == title));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,title);
+int get hashCode => Object.hash(runtimeType,sessionId,title);
 
 @override
 String toString() {
-  return 'RenameSessionRequest(title: $title)';
+  return 'RenameSessionRequest(sessionId: $sessionId, title: $title)';
 }
 
 
@@ -118,7 +120,7 @@ abstract mixin class _$RenameSessionRequestCopyWith<$Res> implements $RenameSess
   factory _$RenameSessionRequestCopyWith(_RenameSessionRequest value, $Res Function(_RenameSessionRequest) _then) = __$RenameSessionRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String title
+ String sessionId, String title
 });
 
 
@@ -135,9 +137,10 @@ class __$RenameSessionRequestCopyWithImpl<$Res>
 
 /// Create a copy of RenameSessionRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? title = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? sessionId = null,Object? title = null,}) {
   return _then(_RenameSessionRequest(
-title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
 as String,
   ));
 }

--- a/shared/sesori_shared/lib/src/models/sesori/rename_session_request.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/rename_session_request.freezed.dart
@@ -1,0 +1,148 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'rename_session_request.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$RenameSessionRequest {
+
+ String get title;
+/// Create a copy of RenameSessionRequest
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RenameSessionRequestCopyWith<RenameSessionRequest> get copyWith => _$RenameSessionRequestCopyWithImpl<RenameSessionRequest>(this as RenameSessionRequest, _$identity);
+
+  /// Serializes this RenameSessionRequest to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RenameSessionRequest&&(identical(other.title, title) || other.title == title));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,title);
+
+@override
+String toString() {
+  return 'RenameSessionRequest(title: $title)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RenameSessionRequestCopyWith<$Res>  {
+  factory $RenameSessionRequestCopyWith(RenameSessionRequest value, $Res Function(RenameSessionRequest) _then) = _$RenameSessionRequestCopyWithImpl;
+@useResult
+$Res call({
+ String title
+});
+
+
+
+
+}
+/// @nodoc
+class _$RenameSessionRequestCopyWithImpl<$Res>
+    implements $RenameSessionRequestCopyWith<$Res> {
+  _$RenameSessionRequestCopyWithImpl(this._self, this._then);
+
+  final RenameSessionRequest _self;
+  final $Res Function(RenameSessionRequest) _then;
+
+/// Create a copy of RenameSessionRequest
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? title = null,}) {
+  return _then(_self.copyWith(
+title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _RenameSessionRequest implements RenameSessionRequest {
+  const _RenameSessionRequest({required this.title});
+  factory _RenameSessionRequest.fromJson(Map<String, dynamic> json) => _$RenameSessionRequestFromJson(json);
+
+@override final  String title;
+
+/// Create a copy of RenameSessionRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RenameSessionRequestCopyWith<_RenameSessionRequest> get copyWith => __$RenameSessionRequestCopyWithImpl<_RenameSessionRequest>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$RenameSessionRequestToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RenameSessionRequest&&(identical(other.title, title) || other.title == title));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,title);
+
+@override
+String toString() {
+  return 'RenameSessionRequest(title: $title)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RenameSessionRequestCopyWith<$Res> implements $RenameSessionRequestCopyWith<$Res> {
+  factory _$RenameSessionRequestCopyWith(_RenameSessionRequest value, $Res Function(_RenameSessionRequest) _then) = __$RenameSessionRequestCopyWithImpl;
+@override @useResult
+$Res call({
+ String title
+});
+
+
+
+
+}
+/// @nodoc
+class __$RenameSessionRequestCopyWithImpl<$Res>
+    implements _$RenameSessionRequestCopyWith<$Res> {
+  __$RenameSessionRequestCopyWithImpl(this._self, this._then);
+
+  final _RenameSessionRequest _self;
+  final $Res Function(_RenameSessionRequest) _then;
+
+/// Create a copy of RenameSessionRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? title = null,}) {
+  return _then(_RenameSessionRequest(
+title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/shared/sesori_shared/lib/src/models/sesori/rename_session_request.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/rename_session_request.g.dart
@@ -1,0 +1,14 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'rename_session_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_RenameSessionRequest _$RenameSessionRequestFromJson(Map json) =>
+    _RenameSessionRequest(title: json['title'] as String);
+
+Map<String, dynamic> _$RenameSessionRequestToJson(
+  _RenameSessionRequest instance,
+) => <String, dynamic>{'title': instance.title};

--- a/shared/sesori_shared/lib/src/models/sesori/rename_session_request.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/rename_session_request.g.dart
@@ -7,8 +7,14 @@ part of 'rename_session_request.dart';
 // **************************************************************************
 
 _RenameSessionRequest _$RenameSessionRequestFromJson(Map json) =>
-    _RenameSessionRequest(title: json['title'] as String);
+    _RenameSessionRequest(
+      sessionId: json['sessionId'] as String,
+      title: json['title'] as String,
+    );
 
 Map<String, dynamic> _$RenameSessionRequestToJson(
   _RenameSessionRequest instance,
-) => <String, dynamic>{'title': instance.title};
+) => <String, dynamic>{
+  'sessionId': instance.sessionId,
+  'title': instance.title,
+};


### PR DESCRIPTION
## Summary

- Add full-stack rename support for both sessions and projects — from OpenCode API through the bridge plugin/handlers to the mobile UI
- Users long-press a session or project in the list, tap "Rename" in the bottom sheet, edit the name in a dialog pre-filled with the current value, and save
- TDD tests at every layer (handlers, plugin, services, cubits)

## Changes

### Shared (`sesori_shared`)
- New Freezed request models: `RenameSessionRequest` (title field) and `RenameProjectRequest` (name field)

### Bridge
- **Plugin interface**: Added `renameSession()` and `renameProject()` to `BridgePlugin` abstract class
- **OpenCode plugin**: `renameSession()` calls `PATCH /session/:id` with title body; `renameProject()` resolves worktree→UUID via `GET /project/current`, then calls `PATCH /project/:id` with name body
- **API client**: Added `updateProject()` method to `OpenCodeApi`
- **Handlers**: New `RenameSessionHandler` (`PATCH /session/:id/title`) and `RenameProjectHandler` (`PATCH /project/:id/name`) — sub-paths avoid conflict with existing archive handler
- **Tests**: 18 new handler tests + 2 plugin integration tests

### Mobile
- **Services**: Added `renameSession()` to `SessionService` and `renameProject()` to `ProjectService`
- **Cubits**: Added rename methods to `SessionListCubit` and `ProjectListCubit` (server-confirmed: call API → refresh list → return bool)
- **UI**: New `RenameSessionDialog` and `RenameProjectDialog` following `AddProjectDialog` pattern (pre-filled text field, loading state, disabled-when-empty save, snackbar feedback)
- **Menu items**: "Rename" option added as first item in both session and project long-press bottom sheets
- **Localization**: 10 new keys in `app_en.arb`
- **Tests**: 9 new service/cubit tests

## Test Results

| Suite | Result |
|-------|--------|
| Bridge app (385 tests) | ✅ All pass |
| Bridge plugin (102 tests) | ✅ All pass |
| Mobile module_core (113 tests) | ✅ All pass |
| Mobile app (342 tests) | ✅ All pass |