### PR TITLE
feat: add FailureReporter interface with Crashlytics implementation

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/models/sse_event_data.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/sse_event_data.dart
@@ -23,7 +23,7 @@ sealed class SseSessionEventData {}
 ///
 /// Uses Freezed [unionKey] on the `"type"` field to auto-deserialize from JSON.
 /// Unknown event types cause [fromJson] to throw — callers should catch and
-/// report via [recordNonFatalError].
+/// report via [FailureReporter.recordFailure].
 @Freezed(unionKey: "type", fromJson: true, toJson: true)
 sealed class SseEventData with _$SseEventData {
   // ---------------------------------------------------------------------------

--- a/mobile/app/lib/core/di/injection.config.dart
+++ b/mobile/app/lib/core/di/injection.config.dart
@@ -9,6 +9,7 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:firebase_crashlytics/firebase_crashlytics.dart' as _i141;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart'
     as _i163;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i558;
@@ -29,6 +30,8 @@ import 'package:sesori_mobile/capabilities/voice/wake_lock_service.dart'
 import 'package:sesori_mobile/core/di/register_module.dart' as _i124;
 import 'package:sesori_mobile/core/platform/app_lifecycle_observer.dart'
     as _i875;
+import 'package:sesori_mobile/core/platform/crashlytics_failure_reporter.dart'
+    as _i534;
 import 'package:sesori_mobile/core/platform/flutter_secure_storage_adapter.dart'
     as _i816;
 import 'package:sesori_mobile/core/platform/flutter_url_launcher.dart' as _i10;
@@ -62,6 +65,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i558.FlutterSecureStorage>(
       () => registerModule.secureStorage,
     );
+    gh.lazySingleton<_i141.FirebaseCrashlytics>(
+      () => registerModule.firebaseCrashlytics,
+    );
     gh.singleton<_i948.LifecycleSource>(() => _i875.AppLifecycleObserver());
     gh.singleton<_i948.RouteSource>(() => _i597.GoRouterRouteSource());
     gh.lazySingleton<_i948.DeepLinkSource>(
@@ -85,6 +91,9 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i492.LocalNotificationManager(
         plugin: gh<_i163.FlutterLocalNotificationsPlugin>(),
       ),
+    );
+    gh.lazySingleton<_i553.FailureReporter>(
+      () => _i534.CrashlyticsFailureReporter(gh<_i141.FirebaseCrashlytics>()),
     );
     gh.lazySingleton<_i1038.VoiceTranscriptionService>(
       () => _i1038.VoiceTranscriptionService(

--- a/mobile/app/lib/core/di/register_module.dart
+++ b/mobile/app/lib/core/di/register_module.dart
@@ -1,3 +1,4 @@
+import "package:firebase_crashlytics/firebase_crashlytics.dart";
 import "package:flutter_local_notifications/flutter_local_notifications.dart";
 import "package:flutter_secure_storage/flutter_secure_storage.dart";
 import "package:http/http.dart" as http;
@@ -31,4 +32,7 @@ abstract class RegisterModule {
       accountName: "Sesori",
     ),
   );
+
+  @lazySingleton
+  FirebaseCrashlytics get firebaseCrashlytics => FirebaseCrashlytics.instance;
 }

--- a/mobile/app/lib/core/platform/crashlytics_failure_reporter.dart
+++ b/mobile/app/lib/core/platform/crashlytics_failure_reporter.dart
@@ -1,0 +1,50 @@
+import "package:firebase_crashlytics/firebase_crashlytics.dart";
+import "package:injectable/injectable.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+@LazySingleton(as: FailureReporter)
+class CrashlyticsFailureReporter implements FailureReporter {
+  final FirebaseCrashlytics _crashlytics;
+  final Set<String> _reportedNonFatalIds = {};
+
+  CrashlyticsFailureReporter(FirebaseCrashlytics crashlytics) : _crashlytics = crashlytics;
+
+  @override
+  void setGlobalKey({required String key, required Object value}) => _crashlytics.setCustomKey(key, value);
+
+  @override
+  void log({required String message}) => _crashlytics.log(message);
+
+  @override
+  Future<void> recordFailure({
+    required Object error,
+    required StackTrace stackTrace,
+    required String uniqueIdentifier,
+    required bool fatal,
+    required String? reason,
+    required Iterable<Object> information,
+  }) async {
+    if (fatal) {
+      await _crashlytics.recordError(
+        error,
+        stackTrace,
+        reason: reason,
+        information: information.toList(),
+        fatal: true,
+      );
+      return;
+    }
+
+    if (_reportedNonFatalIds.contains(uniqueIdentifier)) {
+      return;
+    }
+    _reportedNonFatalIds.add(uniqueIdentifier);
+    await _crashlytics.recordError(
+      error,
+      stackTrace,
+      reason: reason,
+      information: information.toList(),
+      fatal: false,
+    );
+  }
+}

--- a/mobile/app/lib/core/platform/crashlytics_failure_reporter.dart
+++ b/mobile/app/lib/core/platform/crashlytics_failure_reporter.dart
@@ -4,8 +4,10 @@ import "package:sesori_shared/sesori_shared.dart";
 
 @LazySingleton(as: FailureReporter)
 class CrashlyticsFailureReporter implements FailureReporter {
+  static const int maxNonFatalDedupEntries = 128;
+
   final FirebaseCrashlytics _crashlytics;
-  final Set<String> _reportedNonFatalIds = {};
+  final Set<String> _reportedNonFatalIds = {}; // LinkedHashSet by default — insertion-ordered
 
   CrashlyticsFailureReporter(FirebaseCrashlytics crashlytics) : _crashlytics = crashlytics;
 
@@ -37,6 +39,9 @@ class CrashlyticsFailureReporter implements FailureReporter {
 
     if (_reportedNonFatalIds.contains(uniqueIdentifier)) {
       return;
+    }
+    if (_reportedNonFatalIds.length >= maxNonFatalDedupEntries) {
+      _reportedNonFatalIds.remove(_reportedNonFatalIds.first);
     }
     _reportedNonFatalIds.add(uniqueIdentifier);
     await _crashlytics.recordError(

--- a/mobile/app/test/capabilities/server_connection/connection_service_test.dart
+++ b/mobile/app/test/capabilities/server_connection/connection_service_test.dart
@@ -20,6 +20,7 @@ void main() {
   late MockAuthTokenProvider authTokenProvider;
   late MockAuthSession authSession;
   late MockLifecycleSource lifecycleSource;
+  late MockFailureReporter failureReporter;
   late BehaviorSubject<AuthState> authStateController;
   late ConnectionService service;
 
@@ -29,6 +30,7 @@ void main() {
     authTokenProvider = MockAuthTokenProvider();
     authSession = MockAuthSession();
     lifecycleSource = MockLifecycleSource();
+    failureReporter = MockFailureReporter();
     authStateController = BehaviorSubject<AuthState>.seeded(const AuthState.initial());
 
     when(() => authSession.authStateStream).thenAnswer((_) => authStateController.stream);
@@ -41,6 +43,7 @@ void main() {
       authTokenProvider,
       authSession,
       lifecycleSource,
+      failureReporter,
     );
   });
 

--- a/mobile/app/test/core/platform/crashlytics_failure_reporter_test.dart
+++ b/mobile/app/test/core/platform/crashlytics_failure_reporter_test.dart
@@ -1,0 +1,229 @@
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:sesori_mobile/core/platform/crashlytics_failure_reporter.dart';
+
+class MockFirebaseCrashlytics extends Mock implements FirebaseCrashlytics {}
+
+void main() {
+  late MockFirebaseCrashlytics mockCrashlytics;
+  late CrashlyticsFailureReporter reporter;
+
+  setUp(() {
+    mockCrashlytics = MockFirebaseCrashlytics();
+    reporter = CrashlyticsFailureReporter(mockCrashlytics);
+
+    // Stub the methods that will be called
+    when(
+      () => mockCrashlytics.recordError(
+        any(),
+        any(),
+        reason: any(named: 'reason'),
+        information: any(named: 'information'),
+        fatal: any(named: 'fatal'),
+      ),
+    ).thenAnswer((_) async {});
+
+    when(() => mockCrashlytics.setCustomKey(any(), any())).thenAnswer((_) async {});
+    when(() => mockCrashlytics.log(any())).thenAnswer((_) async {});
+  });
+
+  group('Delegation tests', () {
+    test('setGlobalKey delegates to setCustomKey', () {
+      reporter.setGlobalKey(key: 'endpoint', value: '/api/orders');
+
+      verify(() => mockCrashlytics.setCustomKey('endpoint', '/api/orders')).called(1);
+    });
+
+    test('log delegates to Crashlytics log', () {
+      reporter.log(message: 'test');
+
+      verify(() => mockCrashlytics.log('test')).called(1);
+    });
+
+    test('recordFailure non-fatal records to Crashlytics', () async {
+      await reporter.recordFailure(
+        error: Exception('test error'),
+        stackTrace: StackTrace.current,
+        uniqueIdentifier: 'test-1',
+        fatal: false,
+        reason: null,
+        information: const [],
+      );
+
+      verify(
+        () => mockCrashlytics.recordError(
+          any(),
+          any(),
+          reason: null,
+          information: [],
+          fatal: false,
+        ),
+      ).called(1);
+    });
+  });
+
+  group('Deduplication tests', () {
+    test('recordFailure non-fatal duplicate is skipped', () async {
+      final error = Exception('test error');
+      final stackTrace = StackTrace.current;
+
+      // First call should record
+      await reporter.recordFailure(
+        error: error,
+        stackTrace: stackTrace,
+        uniqueIdentifier: 'test-1',
+        fatal: false,
+        reason: null,
+        information: const [],
+      );
+
+      // Second call with same ID should be skipped
+      await reporter.recordFailure(
+        error: error,
+        stackTrace: stackTrace,
+        uniqueIdentifier: 'test-1',
+        fatal: false,
+        reason: null,
+        information: const [],
+      );
+
+      verify(
+        () => mockCrashlytics.recordError(
+          any(),
+          any(),
+          reason: any(named: 'reason'),
+          information: any(named: 'information'),
+          fatal: any(named: 'fatal'),
+        ),
+      ).called(1);
+    });
+
+    test('recordFailure non-fatal different IDs both recorded', () async {
+      final error = Exception('test error');
+      final stackTrace = StackTrace.current;
+
+      await reporter.recordFailure(
+        error: error,
+        stackTrace: stackTrace,
+        uniqueIdentifier: 'test-1',
+        fatal: false,
+        reason: null,
+        information: const [],
+      );
+
+      await reporter.recordFailure(
+        error: error,
+        stackTrace: stackTrace,
+        uniqueIdentifier: 'test-2',
+        fatal: false,
+        reason: null,
+        information: const [],
+      );
+
+      verify(
+        () => mockCrashlytics.recordError(
+          any(),
+          any(),
+          reason: any(named: 'reason'),
+          information: any(named: 'information'),
+          fatal: any(named: 'fatal'),
+        ),
+      ).called(2);
+    });
+  });
+
+  group('Fatal error tests', () {
+    test('recordFailure fatal always records', () async {
+      await reporter.recordFailure(
+        error: Exception('fatal error'),
+        stackTrace: StackTrace.current,
+        uniqueIdentifier: 'fatal-1',
+        fatal: true,
+        reason: null,
+        information: const [],
+      );
+
+      verify(
+        () => mockCrashlytics.recordError(
+          any(),
+          any(),
+          reason: null,
+          information: [],
+          fatal: true,
+        ),
+      ).called(1);
+    });
+
+    test('recordFailure fatal bypasses dedup', () async {
+      final error = Exception('fatal error');
+      final stackTrace = StackTrace.current;
+
+      // First fatal call
+      await reporter.recordFailure(
+        error: error,
+        stackTrace: stackTrace,
+        uniqueIdentifier: 'same-id',
+        fatal: true,
+        reason: null,
+        information: const [],
+      );
+
+      // Second fatal call with same ID should still record
+      await reporter.recordFailure(
+        error: error,
+        stackTrace: stackTrace,
+        uniqueIdentifier: 'same-id',
+        fatal: true,
+        reason: null,
+        information: const [],
+      );
+
+      verify(
+        () => mockCrashlytics.recordError(
+          any(),
+          any(),
+          reason: any(named: 'reason'),
+          information: any(named: 'information'),
+          fatal: true,
+        ),
+      ).called(2);
+    });
+
+    test('recordFailure fatal does not pollute non-fatal dedup set', () async {
+      final error = Exception('test error');
+      final stackTrace = StackTrace.current;
+
+      // First: fatal with ID 'test-id'
+      await reporter.recordFailure(
+        error: error,
+        stackTrace: stackTrace,
+        uniqueIdentifier: 'test-id',
+        fatal: true,
+        reason: null,
+        information: const [],
+      );
+
+      // Second: non-fatal with same ID 'test-id' should still record
+      // because fatal errors don't add to the non-fatal dedup set
+      await reporter.recordFailure(
+        error: error,
+        stackTrace: stackTrace,
+        uniqueIdentifier: 'test-id',
+        fatal: false,
+        reason: null,
+        information: const [],
+      );
+
+      verify(
+        () => mockCrashlytics.recordError(
+          any(),
+          any(),
+          reason: any(named: 'reason'),
+          information: any(named: 'information'),
+          fatal: any(named: 'fatal'),
+        ),
+      ).called(2);
+    });
+  });
+}

--- a/mobile/app/test/core/platform/crashlytics_failure_reporter_test.dart
+++ b/mobile/app/test/core/platform/crashlytics_failure_reporter_test.dart
@@ -226,4 +226,125 @@ void main() {
       ).called(2);
     });
   });
+
+  group('Bounded dedup set', () {
+    test('evicts oldest entry when max capacity is exceeded', () async {
+      final error = Exception('test');
+      final stackTrace = StackTrace.current;
+
+      // Fill the dedup set to max capacity
+      for (var i = 0; i < CrashlyticsFailureReporter.maxNonFatalDedupEntries; i++) {
+        await reporter.recordFailure(
+          error: error,
+          stackTrace: stackTrace,
+          uniqueIdentifier: 'id-$i',
+          fatal: false,
+          reason: null,
+          information: const [],
+        );
+      }
+
+      // Add one more to trigger eviction of id-0
+      await reporter.recordFailure(
+        error: error,
+        stackTrace: stackTrace,
+        uniqueIdentifier: 'overflow-id',
+        fatal: false,
+        reason: null,
+        information: const [],
+      );
+
+      // Reset the mock call count
+      reset(mockCrashlytics);
+      when(
+        () => mockCrashlytics.recordError(
+          any<dynamic>(),
+          any<StackTrace?>(),
+          reason: any<dynamic>(named: 'reason'),
+          information: any<List<Object>>(named: 'information'),
+          fatal: any<bool>(named: 'fatal'),
+        ),
+      ).thenAnswer((_) async {});
+
+      // The oldest entry (id-0) should have been evicted,
+      // so reporting it again should succeed
+      await reporter.recordFailure(
+        error: error,
+        stackTrace: stackTrace,
+        uniqueIdentifier: 'id-0',
+        fatal: false,
+        reason: null,
+        information: const [],
+      );
+
+      verify(
+        () => mockCrashlytics.recordError(
+          any<dynamic>(),
+          any<StackTrace?>(),
+          reason: any<dynamic>(named: 'reason'),
+          information: any<List<Object>>(named: 'information'),
+          fatal: any<bool>(named: 'fatal'),
+        ),
+      ).called(1);
+    });
+
+    test('recent entries are retained when oldest is evicted', () async {
+      final error = Exception('test');
+      final stackTrace = StackTrace.current;
+
+      // Fill to capacity
+      for (var i = 0; i < CrashlyticsFailureReporter.maxNonFatalDedupEntries; i++) {
+        await reporter.recordFailure(
+          error: error,
+          stackTrace: stackTrace,
+          uniqueIdentifier: 'id-$i',
+          fatal: false,
+          reason: null,
+          information: const [],
+        );
+      }
+
+      // Add one more to trigger eviction of id-0
+      await reporter.recordFailure(
+        error: error,
+        stackTrace: stackTrace,
+        uniqueIdentifier: 'new-id',
+        fatal: false,
+        reason: null,
+        information: const [],
+      );
+
+      // Reset mock
+      reset(mockCrashlytics);
+      when(
+        () => mockCrashlytics.recordError(
+          any<dynamic>(),
+          any<StackTrace?>(),
+          reason: any<dynamic>(named: 'reason'),
+          information: any<List<Object>>(named: 'information'),
+          fatal: any<bool>(named: 'fatal'),
+        ),
+      ).thenAnswer((_) async {});
+
+      // id-1 should still be in the set (not evicted), so this should be skipped
+      await reporter.recordFailure(
+        error: error,
+        stackTrace: stackTrace,
+        uniqueIdentifier: 'id-1',
+        fatal: false,
+        reason: null,
+        information: const [],
+      );
+
+      verifyNever(
+        () => mockCrashlytics.recordError(
+          any<dynamic>(),
+          any<StackTrace?>(),
+          reason: any<dynamic>(named: 'reason'),
+          information: any<List<Object>>(named: 'information'),
+          fatal: any<bool>(named: 'fatal'),
+        ),
+      );
+    });
+  });
 }

--- a/mobile/app/test/core/platform/crashlytics_failure_reporter_test.dart
+++ b/mobile/app/test/core/platform/crashlytics_failure_reporter_test.dart
@@ -1,9 +1,8 @@
-import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:sesori_mobile/core/platform/crashlytics_failure_reporter.dart';
 
-class MockFirebaseCrashlytics extends Mock implements FirebaseCrashlytics {}
+import '../../helpers/test_helpers.dart';
 
 void main() {
   late MockFirebaseCrashlytics mockCrashlytics;

--- a/mobile/app/test/core/platform/crashlytics_failure_reporter_test.dart
+++ b/mobile/app/test/core/platform/crashlytics_failure_reporter_test.dart
@@ -16,16 +16,16 @@ void main() {
     // Stub the methods that will be called
     when(
       () => mockCrashlytics.recordError(
-        any(),
-        any(),
-        reason: any(named: 'reason'),
-        information: any(named: 'information'),
-        fatal: any(named: 'fatal'),
+        any<dynamic>(),
+        any<StackTrace?>(),
+        reason: any<dynamic>(named: 'reason'),
+        information: any<List<Object>>(named: 'information'),
+        fatal: any<bool>(named: 'fatal'),
       ),
     ).thenAnswer((_) async {});
 
-    when(() => mockCrashlytics.setCustomKey(any(), any())).thenAnswer((_) async {});
-    when(() => mockCrashlytics.log(any())).thenAnswer((_) async {});
+    when(() => mockCrashlytics.setCustomKey(any<String>(), any<Object>())).thenAnswer((_) async {});
+    when(() => mockCrashlytics.log(any<String>())).thenAnswer((_) async {});
   });
 
   group('Delegation tests', () {
@@ -53,8 +53,8 @@ void main() {
 
       verify(
         () => mockCrashlytics.recordError(
-          any(),
-          any(),
+          any<dynamic>(),
+          any<StackTrace?>(),
           reason: null,
           information: [],
           fatal: false,
@@ -90,11 +90,11 @@ void main() {
 
       verify(
         () => mockCrashlytics.recordError(
-          any(),
-          any(),
-          reason: any(named: 'reason'),
-          information: any(named: 'information'),
-          fatal: any(named: 'fatal'),
+          any<dynamic>(),
+          any<StackTrace?>(),
+          reason: any<dynamic>(named: 'reason'),
+          information: any<List<Object>>(named: 'information'),
+          fatal: any<bool>(named: 'fatal'),
         ),
       ).called(1);
     });
@@ -123,11 +123,11 @@ void main() {
 
       verify(
         () => mockCrashlytics.recordError(
-          any(),
-          any(),
-          reason: any(named: 'reason'),
-          information: any(named: 'information'),
-          fatal: any(named: 'fatal'),
+          any<dynamic>(),
+          any<StackTrace?>(),
+          reason: any<dynamic>(named: 'reason'),
+          information: any<List<Object>>(named: 'information'),
+          fatal: any<bool>(named: 'fatal'),
         ),
       ).called(2);
     });
@@ -146,8 +146,8 @@ void main() {
 
       verify(
         () => mockCrashlytics.recordError(
-          any(),
-          any(),
+          any<dynamic>(),
+          any<StackTrace?>(),
           reason: null,
           information: [],
           fatal: true,
@@ -181,10 +181,10 @@ void main() {
 
       verify(
         () => mockCrashlytics.recordError(
-          any(),
-          any(),
-          reason: any(named: 'reason'),
-          information: any(named: 'information'),
+          any<dynamic>(),
+          any<StackTrace?>(),
+          reason: any<dynamic>(named: 'reason'),
+          information: any<List<Object>>(named: 'information'),
           fatal: true,
         ),
       ).called(2);
@@ -217,11 +217,11 @@ void main() {
 
       verify(
         () => mockCrashlytics.recordError(
-          any(),
-          any(),
-          reason: any(named: 'reason'),
-          information: any(named: 'information'),
-          fatal: any(named: 'fatal'),
+          any<dynamic>(),
+          any<StackTrace?>(),
+          reason: any<dynamic>(named: 'reason'),
+          information: any<List<Object>>(named: 'information'),
+          fatal: any<bool>(named: 'fatal'),
         ),
       ).called(2);
     });

--- a/mobile/app/test/helpers/test_helpers.dart
+++ b/mobile/app/test/helpers/test_helpers.dart
@@ -117,6 +117,8 @@ class MockSseEventRepository extends Mock implements SseEventRepository {
   void emitSessionActivity(Map<String, Map<String, SessionActivityInfo>> activity) => _sessionActivity.add(activity);
 }
 
+class MockFailureReporter extends Mock implements FailureReporter {}
+
 // ---------------------------------------------------------------------------
 // Fake classes — for registerFallbackValue
 // ---------------------------------------------------------------------------

--- a/mobile/app/test/helpers/test_helpers.dart
+++ b/mobile/app/test/helpers/test_helpers.dart
@@ -1,3 +1,4 @@
+import "package:firebase_crashlytics/firebase_crashlytics.dart";
 import "package:flutter_secure_storage/flutter_secure_storage.dart";
 import "package:http/http.dart" as http;
 import "package:mocktail/mocktail.dart";
@@ -118,6 +119,8 @@ class MockSseEventRepository extends Mock implements SseEventRepository {
 }
 
 class MockFailureReporter extends Mock implements FailureReporter {}
+
+class MockFirebaseCrashlytics extends Mock implements FirebaseCrashlytics {}
 
 // ---------------------------------------------------------------------------
 // Fake classes — for registerFallbackValue

--- a/mobile/app/test/widget_test.dart
+++ b/mobile/app/test/widget_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: unnecessary_lambdas
 
+import "package:firebase_crashlytics/firebase_crashlytics.dart";
 import "package:flutter_secure_storage/flutter_secure_storage.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:mocktail/mocktail.dart";
@@ -22,6 +23,8 @@ void main() {
     configureDependencies();
     getIt.unregister<FlutterSecureStorage>();
     getIt.registerLazySingleton<FlutterSecureStorage>(() => mockStorage);
+    getIt.unregister<FirebaseCrashlytics>();
+    getIt.registerLazySingleton<FirebaseCrashlytics>(() => MockFirebaseCrashlytics());
   });
 
   tearDown(() async {

--- a/mobile/module_core/lib/reporting.dart
+++ b/mobile/module_core/lib/reporting.dart
@@ -1,1 +1,0 @@
-export "src/reporting/reporting.dart";

--- a/mobile/module_core/lib/sesori_dart_core.dart
+++ b/mobile/module_core/lib/sesori_dart_core.dart
@@ -48,8 +48,6 @@ export "src/platform/lifecycle_source.dart";
 export "src/platform/notification_canceller.dart";
 export "src/platform/route_source.dart";
 export "src/platform/url_launcher.dart";
-// Reporting
-export "src/reporting/reporting.dart";
 // Routing
 export "src/routing/app_routes.dart";
 export "src/routing/auth_redirect_service.dart";

--- a/mobile/module_core/lib/src/api/parsing/dto_parser.dart
+++ b/mobile/module_core/lib/src/api/parsing/dto_parser.dart
@@ -6,7 +6,6 @@ import "package:sesori_auth/sesori_auth.dart";
 import "../../concurrency/impl/isolate/isolate.dart";
 import "../../concurrency/worker.dart";
 import "../../logging/logging.dart";
-import "../../reporting/reporting.dart";
 
 /// Parser runs on dedicated isolate for VM to avoid blocking main thread
 ///
@@ -53,11 +52,6 @@ class JsonDtoParser {
         return ApiResponse.success(parsed);
       } catch (e) {
         loge("Failed to parse json", e);
-        recordNonFatalError(
-          err: e,
-          context: "failed to parse json: ${T.toString()}",
-          extraData: {"jsonData": jsonData},
-        );
         return ApiResponse.error(ApiError.jsonParsing(jsonData));
       }
     } else {

--- a/mobile/module_core/lib/src/api/parsing/dto_parser.dart
+++ b/mobile/module_core/lib/src/api/parsing/dto_parser.dart
@@ -50,8 +50,8 @@ class JsonDtoParser {
       try {
         final parsed = await _parseJson<T>(jsonData, parseJsonTask);
         return ApiResponse.success(parsed);
-      } catch (e) {
-        loge("Failed to parse json", e);
+      } on Object catch (e, st) {
+        loge("Failed to parse json", e, st);
         return ApiResponse.error(ApiError.jsonParsing(jsonData));
       }
     } else {

--- a/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -10,7 +10,6 @@ import "package:sesori_shared/sesori_shared.dart";
 import "../../capabilities/relay/room_key_storage.dart";
 import "../../logging/logging.dart";
 import "../../platform/lifecycle_source.dart";
-import "../../reporting/reporting.dart";
 import "../relay/relay_client.dart";
 import "api_paths.dart";
 import "models/connection_status.dart";
@@ -24,6 +23,7 @@ class ConnectionService {
   final LifecycleSource _lifecycleSource;
   final AuthTokenProvider _authTokenProvider;
   final AuthSession _authSession;
+  final FailureReporter _failureReporter;
 
   final BehaviorSubject<ConnectionStatus> _status = BehaviorSubject.seeded(const ConnectionStatus.disconnected());
   final StreamController<SseEvent> _events = StreamController<SseEvent>.broadcast();
@@ -48,11 +48,13 @@ class ConnectionService {
     AuthTokenProvider authTokenProvider,
     AuthSession authSession,
     LifecycleSource lifecycleSource,
+    FailureReporter failureReporter,
   ) : _cryptoService = cryptoService,
       _roomKeyStorage = roomKeyStorage,
       _authTokenProvider = authTokenProvider,
       _authSession = authSession,
-      _lifecycleSource = lifecycleSource {
+      _lifecycleSource = lifecycleSource,
+      _failureReporter = failureReporter {
     _compositeSubscription.add(
       _lifecycleSource.lifecycleStateStream.listen((state) {
         switch (state) {
@@ -279,10 +281,13 @@ class ConnectionService {
         eventData = SesoriSseEvent.fromJson(merged);
       } catch (e, st) {
         loge("Failed to parse SSE event payload", e, st);
-        recordNonFatalError(
-          err: e,
-          context: "Unknown or malformed SSE event type: $type",
-          extraData: properties,
+        _failureReporter.recordFailure(
+          error: e,
+          stackTrace: st,
+          uniqueIdentifier: "sse_parse_failure:$type",
+          fatal: false,
+          reason: "Unknown or malformed SSE event type: $type",
+          information: properties.entries.map((e) => "${e.key}: ${e.value}").toList(),
         );
         return;
       }

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_state.freezed.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_state.freezed.dart
@@ -125,9 +125,9 @@ class SessionDetailLoaded implements SessionDetailState {
   return EqualUnmodifiableMapView(_childStatuses);
 }
 
-// Queued messages (waiting to be sent when session becomes idle).
+// Queued messages (waiting to be sent when connection is restored).
  final  List<String> _queuedMessages;
-// Queued messages (waiting to be sent when session becomes idle).
+// Queued messages (waiting to be sent when connection is restored).
 @JsonKey() List<String> get queuedMessages {
   if (_queuedMessages is EqualUnmodifiableListView) return _queuedMessages;
   // ignore: implicit_dynamic_type

--- a/mobile/module_core/lib/src/di/injection.config.dart
+++ b/mobile/module_core/lib/src/di/injection.config.dart
@@ -61,6 +61,7 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i442.AuthTokenProvider>(),
         gh<_i442.AuthSession>(),
         gh<_i903.LifecycleSource>(),
+        gh<_i553.FailureReporter>(),
       ),
     );
     gh.lazySingleton<_i857.RelayHttpApiClient>(

--- a/mobile/module_core/lib/src/reporting/reporting.dart
+++ b/mobile/module_core/lib/src/reporting/reporting.dart
@@ -1,9 +1,0 @@
-import '../logging/logging.dart';
-
-void recordNonFatalError({
-  required Object err,
-  required String context,
-  Map<String, dynamic>? extraData,
-}) {
-  loge("Non-fatal error: $err", err, StackTrace.current);
-}

--- a/shared/sesori_shared/lib/sesori_shared.dart
+++ b/shared/sesori_shared/lib/sesori_shared.dart
@@ -42,3 +42,4 @@ export "src/protocol/close_codes.dart";
 export "src/protocol/constants.dart";
 export "src/protocol/framing.dart";
 export "src/protocol/messages.dart";
+export "src/reporting/failure_reporter.dart";

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
@@ -23,7 +23,7 @@ sealed class SesoriSessionEvent {}
 ///
 /// Uses Freezed [unionKey] on the `"type"` field to auto-deserialize from JSON.
 /// Unknown event types cause [fromJson] to throw — callers should catch and
-/// report via [recordNonFatalError].
+/// report via [FailureReporter.recordFailure].
 @Freezed(unionKey: "type", fromJson: true, toJson: true)
 sealed class SesoriSseEvent with _$SesoriSseEvent {
   // ---------------------------------------------------------------------------

--- a/shared/sesori_shared/lib/src/reporting/failure_reporter.dart
+++ b/shared/sesori_shared/lib/src/reporting/failure_reporter.dart
@@ -1,0 +1,17 @@
+abstract interface class FailureReporter {
+  /// Sets a global key-value pair for crash report context.
+  void setGlobalKey({required String key, required Object value});
+
+  /// Logs a free-form message to the crash report.
+  void log({required String message});
+
+  /// Records a handled failure with error details and context.
+  Future<void> recordFailure({
+    required Object error,
+    required StackTrace stackTrace,
+    required String uniqueIdentifier,
+    required bool fatal,
+    required String? reason,
+    required Iterable<Object> information,
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `FailureReporter` abstract interface to `sesori_shared` for cross-workspace error reporting (bridge + mobile)
- Implements `CrashlyticsFailureReporter` on the mobile side with in-memory deduplication for non-fatal events (mitigates Crashlytics' 8-event buffer limit)
- Migrates existing `recordNonFatalError()` callers to the new interface and removes the old placeholder

## What changed

### New: `FailureReporter` interface (`sesori_shared`)
- `setGlobalKey(key, value)` — sets crash report context (maps to Crashlytics custom keys)
- `log(message)` — logs free-form message to crash report
- `recordFailure(error, stackTrace, uniqueIdentifier, fatal, reason, information)` — records handled failures

### New: `CrashlyticsFailureReporter` (`mobile/app`)
- Implements `FailureReporter` backed by Firebase Crashlytics
- Non-fatal events are deduplicated by `uniqueIdentifier` using an in-memory `Set<String>` — prevents filling the 8-event buffer with duplicates
- Fatal events bypass dedup entirely (sent immediately, no buffer concern)
- `FirebaseCrashlytics` injected via constructor for testability
- Registered in DI via `@LazySingleton(as: FailureReporter)`

### Migration
- `ConnectionService` now uses `FailureReporter` for SSE parse failure reporting
- Old `recordNonFatalError()` function and its callers removed
- Doc comments referencing old function updated across `sesori_shared` and `bridge`

### Tests
- 8 unit tests covering delegation, deduplication, and fatal bypass behavior
- All existing tests pass (1 pre-existing failure on `main` unrelated to this PR)

## Verification
- `dart analyze` passes in `sesori_shared`, `module_core`, and `mobile/app` (zero issues)
- `dart test` passes in `module_core` (107/107)
- `flutter test` passes in `mobile/app` (346/346 new+existing, 1 pre-existing failure)
- Zero references to `recordNonFatalError` remain in codebase