### PR TITLE
feat: handle patch, agent, retry, compaction message part types

### DIFF
--- a/bridge/app/lib/src/bridge/plugin_to_shared_mapping.dart
+++ b/bridge/app/lib/src/bridge/plugin_to_shared_mapping.dart
@@ -14,6 +14,10 @@ extension PluginMessagePartTypeMapping on PluginMessagePartType {
     PluginMessagePartType.stepFinish => MessagePartType.stepFinish,
     PluginMessagePartType.file => MessagePartType.file,
     PluginMessagePartType.snapshot => MessagePartType.snapshot,
+    PluginMessagePartType.patch => MessagePartType.patch,
+    PluginMessagePartType.agent => MessagePartType.agent,
+    PluginMessagePartType.retry => MessagePartType.retry,
+    PluginMessagePartType.compaction => MessagePartType.compaction,
     PluginMessagePartType.unknown => throw StateError(
       "PluginMessagePartType.unknown must be filtered out before mapping to shared model",
     ),
@@ -43,5 +47,8 @@ extension PluginMessagePartMapping on PluginMessagePart {
     prompt: prompt,
     description: description,
     agent: agent,
+    agentName: agentName,
+    attempt: attempt,
+    retryError: retryError,
   );
 }

--- a/bridge/app/test/bridge/plugin_to_shared_mapping_test.dart
+++ b/bridge/app/test/bridge/plugin_to_shared_mapping_test.dart
@@ -1,0 +1,120 @@
+import "package:sesori_bridge/src/bridge/plugin_to_shared_mapping.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("PluginMessagePartTypeMapping.toShared()", () {
+    test("maps patch to MessagePartType.patch", () {
+      expect(PluginMessagePartType.patch.toShared(), equals(MessagePartType.patch));
+    });
+
+    test("maps agent to MessagePartType.agent", () {
+      expect(PluginMessagePartType.agent.toShared(), equals(MessagePartType.agent));
+    });
+
+    test("maps retry to MessagePartType.retry", () {
+      expect(PluginMessagePartType.retry.toShared(), equals(MessagePartType.retry));
+    });
+
+    test("maps compaction to MessagePartType.compaction", () {
+      expect(PluginMessagePartType.compaction.toShared(), equals(MessagePartType.compaction));
+    });
+
+    test("throws StateError for unknown", () {
+      expect(() => PluginMessagePartType.unknown.toShared(), throwsStateError);
+    });
+  });
+
+  group("PluginMessagePartMapping.toShared()", () {
+    test("passes through agentName", () {
+      const part = PluginMessagePart(
+        id: "p1",
+        sessionID: "s1",
+        messageID: "m1",
+        type: PluginMessagePartType.agent,
+        text: null,
+        tool: null,
+        state: null,
+        prompt: null,
+        description: null,
+        agent: null,
+        agentName: "my-agent",
+        attempt: null,
+        retryError: null,
+      );
+
+      final shared = part.toShared();
+
+      expect(shared.agentName, equals("my-agent"));
+    });
+
+    test("passes through attempt", () {
+      const part = PluginMessagePart(
+        id: "p1",
+        sessionID: "s1",
+        messageID: "m1",
+        type: PluginMessagePartType.retry,
+        text: null,
+        tool: null,
+        state: null,
+        prompt: null,
+        description: null,
+        agent: null,
+        agentName: null,
+        attempt: 3,
+        retryError: null,
+      );
+
+      final shared = part.toShared();
+
+      expect(shared.attempt, equals(3));
+    });
+
+    test("passes through retryError", () {
+      const part = PluginMessagePart(
+        id: "p1",
+        sessionID: "s1",
+        messageID: "m1",
+        type: PluginMessagePartType.retry,
+        text: null,
+        tool: null,
+        state: null,
+        prompt: null,
+        description: null,
+        agent: null,
+        agentName: null,
+        attempt: 1,
+        retryError: "connection timeout",
+      );
+
+      final shared = part.toShared();
+
+      expect(shared.retryError, equals("connection timeout"));
+    });
+
+    test("passes through null values for new fields", () {
+      const part = PluginMessagePart(
+        id: "p1",
+        sessionID: "s1",
+        messageID: "m1",
+        type: PluginMessagePartType.text,
+        text: "hello",
+        tool: null,
+        state: null,
+        prompt: null,
+        description: null,
+        agent: null,
+        agentName: null,
+        attempt: null,
+        retryError: null,
+      );
+
+      final shared = part.toShared();
+
+      expect(shared.agentName, isNull);
+      expect(shared.attempt, isNull);
+      expect(shared.retryError, isNull);
+    });
+  });
+}

--- a/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
+++ b/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
@@ -40,6 +40,9 @@ void main() {
             prompt: null,
             description: null,
             agent: null,
+            agentName: null,
+            attempt: null,
+            retryError: null,
           ),
         ),
       );
@@ -61,11 +64,112 @@ void main() {
             prompt: null,
             description: null,
             agent: null,
+            agentName: null,
+            attempt: null,
+            retryError: null,
           ),
         ),
       );
 
       expect(result, isNull);
+    });
+
+    test("filters patch message part updates", () {
+      final result = mapper.map(
+        const BridgeSseMessagePartUpdated(
+          part: PluginMessagePart(
+            id: "p1",
+            sessionID: "s1",
+            messageID: "m1",
+            type: PluginMessagePartType.patch,
+            text: null,
+            tool: null,
+            state: null,
+            prompt: null,
+            description: null,
+            agent: null,
+            agentName: null,
+            attempt: null,
+            retryError: null,
+          ),
+        ),
+      );
+
+      expect(result, isNull);
+    });
+
+    test("filters compaction message part updates", () {
+      final result = mapper.map(
+        const BridgeSseMessagePartUpdated(
+          part: PluginMessagePart(
+            id: "p1",
+            sessionID: "s1",
+            messageID: "m1",
+            type: PluginMessagePartType.compaction,
+            text: null,
+            tool: null,
+            state: null,
+            prompt: null,
+            description: null,
+            agent: null,
+            agentName: null,
+            attempt: null,
+            retryError: null,
+          ),
+        ),
+      );
+
+      expect(result, isNull);
+    });
+
+    test("passes agent message part updates", () {
+      final result = mapper.map(
+        const BridgeSseMessagePartUpdated(
+          part: PluginMessagePart(
+            id: "p1",
+            sessionID: "s1",
+            messageID: "m1",
+            type: PluginMessagePartType.agent,
+            text: null,
+            tool: null,
+            state: null,
+            prompt: null,
+            description: null,
+            agent: null,
+            agentName: "test-agent",
+            attempt: null,
+            retryError: null,
+          ),
+        ),
+      );
+
+      expect(result, isNotNull);
+      expect(result, isA<SesoriMessagePartUpdated>());
+    });
+
+    test("passes retry message part updates", () {
+      final result = mapper.map(
+        const BridgeSseMessagePartUpdated(
+          part: PluginMessagePart(
+            id: "p1",
+            sessionID: "s1",
+            messageID: "m1",
+            type: PluginMessagePartType.retry,
+            text: null,
+            tool: null,
+            state: null,
+            prompt: null,
+            description: null,
+            agent: null,
+            agentName: null,
+            attempt: 2,
+            retryError: "timeout",
+          ),
+        ),
+      );
+
+      expect(result, isNotNull);
+      expect(result, isA<SesoriMessagePartUpdated>());
     });
 
     test("truncates tool output to 500 characters", () {
@@ -88,6 +192,9 @@ void main() {
             prompt: null,
             description: null,
             agent: null,
+            agentName: null,
+            attempt: null,
+            retryError: null,
           ),
         ),
       );
@@ -112,6 +219,9 @@ void main() {
             prompt: null,
             description: null,
             agent: null,
+            agentName: null,
+            attempt: null,
+            retryError: null,
           ),
         ),
       );
@@ -141,6 +251,9 @@ void main() {
             prompt: null,
             description: null,
             agent: null,
+            agentName: null,
+            attempt: null,
+            retryError: null,
           ),
         ),
       );

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_message.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_message.dart
@@ -26,12 +26,20 @@ enum PluginMessagePartType {
   file,
   @JsonValue("snapshot")
   snapshot,
+  @JsonValue("patch")
+  patch,
+  @JsonValue("agent")
+  agent,
+  @JsonValue("retry")
+  retry,
+  @JsonValue("compaction")
+  compaction,
   @JsonValue("unknown")
   unknown
   ;
 
   /// Whether this part type is visible to mobile (rendered in the UI).
-  bool get isVisible => this != file && this != snapshot && this != unknown;
+  bool get isVisible => this != file && this != snapshot && this != patch && this != compaction && this != unknown;
 }
 
 @freezed
@@ -58,6 +66,11 @@ sealed class PluginMessagePart with _$PluginMessagePart {
     required String? prompt,
     required String? description,
     required String? agent,
+    // agent
+    required String? agentName,
+    // retry
+    required int? attempt,
+    required String? retryError,
   }) = _PluginMessagePart;
 }
 

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_message.freezed.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_message.freezed.dart
@@ -177,7 +177,9 @@ mixin _$PluginMessagePart {
  String get id; String get sessionID; String get messageID; PluginMessagePartType get type;// text / reasoning
  String? get text;// tool
  String? get tool; PluginToolState? get state;// subtask
- String? get prompt; String? get description; String? get agent;
+ String? get prompt; String? get description; String? get agent;// agent
+ String? get agentName;// retry
+ int? get attempt; String? get retryError;
 /// Create a copy of PluginMessagePart
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -190,16 +192,16 @@ $PluginMessagePartCopyWith<PluginMessagePart> get copyWith => _$PluginMessagePar
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginMessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.state, state) || other.state == state)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginMessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.state, state) || other.state == state)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.agentName, agentName) || other.agentName == agentName)&&(identical(other.attempt, attempt) || other.attempt == attempt)&&(identical(other.retryError, retryError) || other.retryError == retryError));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,state,prompt,description,agent);
+int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,state,prompt,description,agent,agentName,attempt,retryError);
 
 @override
 String toString() {
-  return 'PluginMessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, state: $state, prompt: $prompt, description: $description, agent: $agent)';
+  return 'PluginMessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, state: $state, prompt: $prompt, description: $description, agent: $agent, agentName: $agentName, attempt: $attempt, retryError: $retryError)';
 }
 
 
@@ -210,7 +212,7 @@ abstract mixin class $PluginMessagePartCopyWith<$Res>  {
   factory $PluginMessagePartCopyWith(PluginMessagePart value, $Res Function(PluginMessagePart) _then) = _$PluginMessagePartCopyWithImpl;
 @useResult
 $Res call({
- String id, String sessionID, String messageID, PluginMessagePartType type, String? text, String? tool, PluginToolState? state, String? prompt, String? description, String? agent
+ String id, String sessionID, String messageID, PluginMessagePartType type, String? text, String? tool, PluginToolState? state, String? prompt, String? description, String? agent, String? agentName, int? attempt, String? retryError
 });
 
 
@@ -227,7 +229,7 @@ class _$PluginMessagePartCopyWithImpl<$Res>
 
 /// Create a copy of PluginMessagePart
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? state = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? state = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,Object? agentName = freezed,Object? attempt = freezed,Object? retryError = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
@@ -239,6 +241,9 @@ as String?,state: freezed == state ? _self.state : state // ignore: cast_nullabl
 as PluginToolState?,prompt: freezed == prompt ? _self.prompt : prompt // ignore: cast_nullable_to_non_nullable
 as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String?,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullable_to_non_nullable
+as String?,agentName: freezed == agentName ? _self.agentName : agentName // ignore: cast_nullable_to_non_nullable
+as String?,attempt: freezed == attempt ? _self.attempt : attempt // ignore: cast_nullable_to_non_nullable
+as int?,retryError: freezed == retryError ? _self.retryError : retryError // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }
@@ -263,7 +268,7 @@ $PluginToolStateCopyWith<$Res>? get state {
 @JsonSerializable(createFactory: false)
 
 class _PluginMessagePart implements PluginMessagePart {
-  const _PluginMessagePart({required this.id, required this.sessionID, required this.messageID, required this.type, required this.text, required this.tool, required this.state, required this.prompt, required this.description, required this.agent});
+  const _PluginMessagePart({required this.id, required this.sessionID, required this.messageID, required this.type, required this.text, required this.tool, required this.state, required this.prompt, required this.description, required this.agent, required this.agentName, required this.attempt, required this.retryError});
   
 
 @override final  String id;
@@ -279,6 +284,11 @@ class _PluginMessagePart implements PluginMessagePart {
 @override final  String? prompt;
 @override final  String? description;
 @override final  String? agent;
+// agent
+@override final  String? agentName;
+// retry
+@override final  int? attempt;
+@override final  String? retryError;
 
 /// Create a copy of PluginMessagePart
 /// with the given fields replaced by the non-null parameter values.
@@ -293,16 +303,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginMessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.state, state) || other.state == state)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginMessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.state, state) || other.state == state)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.agentName, agentName) || other.agentName == agentName)&&(identical(other.attempt, attempt) || other.attempt == attempt)&&(identical(other.retryError, retryError) || other.retryError == retryError));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,state,prompt,description,agent);
+int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,state,prompt,description,agent,agentName,attempt,retryError);
 
 @override
 String toString() {
-  return 'PluginMessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, state: $state, prompt: $prompt, description: $description, agent: $agent)';
+  return 'PluginMessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, state: $state, prompt: $prompt, description: $description, agent: $agent, agentName: $agentName, attempt: $attempt, retryError: $retryError)';
 }
 
 
@@ -313,7 +323,7 @@ abstract mixin class _$PluginMessagePartCopyWith<$Res> implements $PluginMessage
   factory _$PluginMessagePartCopyWith(_PluginMessagePart value, $Res Function(_PluginMessagePart) _then) = __$PluginMessagePartCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String sessionID, String messageID, PluginMessagePartType type, String? text, String? tool, PluginToolState? state, String? prompt, String? description, String? agent
+ String id, String sessionID, String messageID, PluginMessagePartType type, String? text, String? tool, PluginToolState? state, String? prompt, String? description, String? agent, String? agentName, int? attempt, String? retryError
 });
 
 
@@ -330,7 +340,7 @@ class __$PluginMessagePartCopyWithImpl<$Res>
 
 /// Create a copy of PluginMessagePart
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? state = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? state = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,Object? agentName = freezed,Object? attempt = freezed,Object? retryError = freezed,}) {
   return _then(_PluginMessagePart(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
@@ -342,6 +352,9 @@ as String?,state: freezed == state ? _self.state : state // ignore: cast_nullabl
 as PluginToolState?,prompt: freezed == prompt ? _self.prompt : prompt // ignore: cast_nullable_to_non_nullable
 as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String?,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullable_to_non_nullable
+as String?,agentName: freezed == agentName ? _self.agentName : agentName // ignore: cast_nullable_to_non_nullable
+as String?,attempt: freezed == attempt ? _self.attempt : attempt // ignore: cast_nullable_to_non_nullable
+as int?,retryError: freezed == retryError ? _self.retryError : retryError // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_message.g.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_message.g.dart
@@ -25,6 +25,9 @@ Map<String, dynamic> _$PluginMessagePartToJson(_PluginMessagePart instance) =>
       'prompt': instance.prompt,
       'description': instance.description,
       'agent': instance.agent,
+      'agentName': instance.agentName,
+      'attempt': instance.attempt,
+      'retryError': instance.retryError,
     };
 
 const _$PluginMessagePartTypeEnumMap = {
@@ -36,6 +39,10 @@ const _$PluginMessagePartTypeEnumMap = {
   PluginMessagePartType.stepFinish: 'step-finish',
   PluginMessagePartType.file: 'file',
   PluginMessagePartType.snapshot: 'snapshot',
+  PluginMessagePartType.patch: 'patch',
+  PluginMessagePartType.agent: 'agent',
+  PluginMessagePartType.retry: 'retry',
+  PluginMessagePartType.compaction: 'compaction',
   PluginMessagePartType.unknown: 'unknown',
 };
 

--- a/bridge/sesori_plugin_opencode/lib/src/models/message_part.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/message_part.dart
@@ -28,6 +28,11 @@ sealed class MessagePart with _$MessagePart {
     String? prompt,
     String? description,
     String? agent,
+    // agent
+    String? name,
+    // retry
+    int? attempt,
+    Map<String, dynamic>? error,
     // snapshot / step-start
     String? snapshot,
     // time (for text, reasoning, tool)

--- a/bridge/sesori_plugin_opencode/lib/src/models/message_part.freezed.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/message_part.freezed.dart
@@ -20,7 +20,9 @@ mixin _$MessagePart {
  String? get tool; String? get callID; ToolState? get state;// file
  String? get mime; String? get url; String? get filename;// step-finish
  double? get cost; String? get reason;// subtask
- String? get prompt; String? get description; String? get agent;// snapshot / step-start
+ String? get prompt; String? get description; String? get agent;// agent
+ String? get name;// retry
+ int? get attempt; Map<String, dynamic>? get error;// snapshot / step-start
  String? get snapshot;// time (for text, reasoning, tool)
  PartTime? get time;
 /// Create a copy of MessagePart
@@ -35,16 +37,16 @@ $MessagePartCopyWith<MessagePart> get copyWith => _$MessagePartCopyWithImpl<Mess
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.callID, callID) || other.callID == callID)&&(identical(other.state, state) || other.state == state)&&(identical(other.mime, mime) || other.mime == mime)&&(identical(other.url, url) || other.url == url)&&(identical(other.filename, filename) || other.filename == filename)&&(identical(other.cost, cost) || other.cost == cost)&&(identical(other.reason, reason) || other.reason == reason)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.snapshot, snapshot) || other.snapshot == snapshot)&&(identical(other.time, time) || other.time == time));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.callID, callID) || other.callID == callID)&&(identical(other.state, state) || other.state == state)&&(identical(other.mime, mime) || other.mime == mime)&&(identical(other.url, url) || other.url == url)&&(identical(other.filename, filename) || other.filename == filename)&&(identical(other.cost, cost) || other.cost == cost)&&(identical(other.reason, reason) || other.reason == reason)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.name, name) || other.name == name)&&(identical(other.attempt, attempt) || other.attempt == attempt)&&const DeepCollectionEquality().equals(other.error, error)&&(identical(other.snapshot, snapshot) || other.snapshot == snapshot)&&(identical(other.time, time) || other.time == time));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,callID,state,mime,url,filename,cost,reason,prompt,description,agent,snapshot,time);
+int get hashCode => Object.hashAll([runtimeType,id,sessionID,messageID,type,text,tool,callID,state,mime,url,filename,cost,reason,prompt,description,agent,name,attempt,const DeepCollectionEquality().hash(error),snapshot,time]);
 
 @override
 String toString() {
-  return 'MessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, callID: $callID, state: $state, mime: $mime, url: $url, filename: $filename, cost: $cost, reason: $reason, prompt: $prompt, description: $description, agent: $agent, snapshot: $snapshot, time: $time)';
+  return 'MessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, callID: $callID, state: $state, mime: $mime, url: $url, filename: $filename, cost: $cost, reason: $reason, prompt: $prompt, description: $description, agent: $agent, name: $name, attempt: $attempt, error: $error, snapshot: $snapshot, time: $time)';
 }
 
 
@@ -55,7 +57,7 @@ abstract mixin class $MessagePartCopyWith<$Res>  {
   factory $MessagePartCopyWith(MessagePart value, $Res Function(MessagePart) _then) = _$MessagePartCopyWithImpl;
 @useResult
 $Res call({
- String id, String sessionID, String messageID, String type, String? text, String? tool, String? callID, ToolState? state, String? mime, String? url, String? filename, double? cost, String? reason, String? prompt, String? description, String? agent, String? snapshot, PartTime? time
+ String id, String sessionID, String messageID, String type, String? text, String? tool, String? callID, ToolState? state, String? mime, String? url, String? filename, double? cost, String? reason, String? prompt, String? description, String? agent, String? name, int? attempt, Map<String, dynamic>? error, String? snapshot, PartTime? time
 });
 
 
@@ -72,7 +74,7 @@ class _$MessagePartCopyWithImpl<$Res>
 
 /// Create a copy of MessagePart
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? callID = freezed,Object? state = freezed,Object? mime = freezed,Object? url = freezed,Object? filename = freezed,Object? cost = freezed,Object? reason = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,Object? snapshot = freezed,Object? time = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? callID = freezed,Object? state = freezed,Object? mime = freezed,Object? url = freezed,Object? filename = freezed,Object? cost = freezed,Object? reason = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,Object? name = freezed,Object? attempt = freezed,Object? error = freezed,Object? snapshot = freezed,Object? time = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
@@ -90,7 +92,10 @@ as double?,reason: freezed == reason ? _self.reason : reason // ignore: cast_nul
 as String?,prompt: freezed == prompt ? _self.prompt : prompt // ignore: cast_nullable_to_non_nullable
 as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String?,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullable_to_non_nullable
-as String?,snapshot: freezed == snapshot ? _self.snapshot : snapshot // ignore: cast_nullable_to_non_nullable
+as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,attempt: freezed == attempt ? _self.attempt : attempt // ignore: cast_nullable_to_non_nullable
+as int?,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,snapshot: freezed == snapshot ? _self.snapshot : snapshot // ignore: cast_nullable_to_non_nullable
 as String?,time: freezed == time ? _self.time : time // ignore: cast_nullable_to_non_nullable
 as PartTime?,
   ));
@@ -128,7 +133,7 @@ $PartTimeCopyWith<$Res>? get time {
 @JsonSerializable()
 
 class _MessagePart implements MessagePart {
-  const _MessagePart({required this.id, required this.sessionID, required this.messageID, required this.type, this.text, this.tool, this.callID, this.state, this.mime, this.url, this.filename, this.cost, this.reason, this.prompt, this.description, this.agent, this.snapshot, this.time});
+  const _MessagePart({required this.id, required this.sessionID, required this.messageID, required this.type, this.text, this.tool, this.callID, this.state, this.mime, this.url, this.filename, this.cost, this.reason, this.prompt, this.description, this.agent, this.name, this.attempt, final  Map<String, dynamic>? error, this.snapshot, this.time}): _error = error;
   factory _MessagePart.fromJson(Map<String, dynamic> json) => _$MessagePartFromJson(json);
 
 @override final  String id;
@@ -152,6 +157,19 @@ class _MessagePart implements MessagePart {
 @override final  String? prompt;
 @override final  String? description;
 @override final  String? agent;
+// agent
+@override final  String? name;
+// retry
+@override final  int? attempt;
+ final  Map<String, dynamic>? _error;
+@override Map<String, dynamic>? get error {
+  final value = _error;
+  if (value == null) return null;
+  if (_error is EqualUnmodifiableMapView) return _error;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(value);
+}
+
 // snapshot / step-start
 @override final  String? snapshot;
 // time (for text, reasoning, tool)
@@ -170,16 +188,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.callID, callID) || other.callID == callID)&&(identical(other.state, state) || other.state == state)&&(identical(other.mime, mime) || other.mime == mime)&&(identical(other.url, url) || other.url == url)&&(identical(other.filename, filename) || other.filename == filename)&&(identical(other.cost, cost) || other.cost == cost)&&(identical(other.reason, reason) || other.reason == reason)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.snapshot, snapshot) || other.snapshot == snapshot)&&(identical(other.time, time) || other.time == time));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.callID, callID) || other.callID == callID)&&(identical(other.state, state) || other.state == state)&&(identical(other.mime, mime) || other.mime == mime)&&(identical(other.url, url) || other.url == url)&&(identical(other.filename, filename) || other.filename == filename)&&(identical(other.cost, cost) || other.cost == cost)&&(identical(other.reason, reason) || other.reason == reason)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.name, name) || other.name == name)&&(identical(other.attempt, attempt) || other.attempt == attempt)&&const DeepCollectionEquality().equals(other._error, _error)&&(identical(other.snapshot, snapshot) || other.snapshot == snapshot)&&(identical(other.time, time) || other.time == time));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,callID,state,mime,url,filename,cost,reason,prompt,description,agent,snapshot,time);
+int get hashCode => Object.hashAll([runtimeType,id,sessionID,messageID,type,text,tool,callID,state,mime,url,filename,cost,reason,prompt,description,agent,name,attempt,const DeepCollectionEquality().hash(_error),snapshot,time]);
 
 @override
 String toString() {
-  return 'MessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, callID: $callID, state: $state, mime: $mime, url: $url, filename: $filename, cost: $cost, reason: $reason, prompt: $prompt, description: $description, agent: $agent, snapshot: $snapshot, time: $time)';
+  return 'MessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, callID: $callID, state: $state, mime: $mime, url: $url, filename: $filename, cost: $cost, reason: $reason, prompt: $prompt, description: $description, agent: $agent, name: $name, attempt: $attempt, error: $error, snapshot: $snapshot, time: $time)';
 }
 
 
@@ -190,7 +208,7 @@ abstract mixin class _$MessagePartCopyWith<$Res> implements $MessagePartCopyWith
   factory _$MessagePartCopyWith(_MessagePart value, $Res Function(_MessagePart) _then) = __$MessagePartCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String sessionID, String messageID, String type, String? text, String? tool, String? callID, ToolState? state, String? mime, String? url, String? filename, double? cost, String? reason, String? prompt, String? description, String? agent, String? snapshot, PartTime? time
+ String id, String sessionID, String messageID, String type, String? text, String? tool, String? callID, ToolState? state, String? mime, String? url, String? filename, double? cost, String? reason, String? prompt, String? description, String? agent, String? name, int? attempt, Map<String, dynamic>? error, String? snapshot, PartTime? time
 });
 
 
@@ -207,7 +225,7 @@ class __$MessagePartCopyWithImpl<$Res>
 
 /// Create a copy of MessagePart
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? callID = freezed,Object? state = freezed,Object? mime = freezed,Object? url = freezed,Object? filename = freezed,Object? cost = freezed,Object? reason = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,Object? snapshot = freezed,Object? time = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? callID = freezed,Object? state = freezed,Object? mime = freezed,Object? url = freezed,Object? filename = freezed,Object? cost = freezed,Object? reason = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,Object? name = freezed,Object? attempt = freezed,Object? error = freezed,Object? snapshot = freezed,Object? time = freezed,}) {
   return _then(_MessagePart(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
@@ -225,7 +243,10 @@ as double?,reason: freezed == reason ? _self.reason : reason // ignore: cast_nul
 as String?,prompt: freezed == prompt ? _self.prompt : prompt // ignore: cast_nullable_to_non_nullable
 as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String?,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullable_to_non_nullable
-as String?,snapshot: freezed == snapshot ? _self.snapshot : snapshot // ignore: cast_nullable_to_non_nullable
+as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,attempt: freezed == attempt ? _self.attempt : attempt // ignore: cast_nullable_to_non_nullable
+as int?,error: freezed == error ? _self._error : error // ignore: cast_nullable_to_non_nullable
+as Map<String, dynamic>?,snapshot: freezed == snapshot ? _self.snapshot : snapshot // ignore: cast_nullable_to_non_nullable
 as String?,time: freezed == time ? _self.time : time // ignore: cast_nullable_to_non_nullable
 as PartTime?,
   ));

--- a/bridge/sesori_plugin_opencode/lib/src/models/message_part.g.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/message_part.g.dart
@@ -25,6 +25,9 @@ _MessagePart _$MessagePartFromJson(Map json) => _MessagePart(
   prompt: json['prompt'] as String?,
   description: json['description'] as String?,
   agent: json['agent'] as String?,
+  name: json['name'] as String?,
+  attempt: (json['attempt'] as num?)?.toInt(),
+  error: (json['error'] as Map?)?.map((k, e) => MapEntry(k as String, e)),
   snapshot: json['snapshot'] as String?,
   time: json['time'] == null
       ? null
@@ -49,6 +52,9 @@ Map<String, dynamic> _$MessagePartToJson(_MessagePart instance) =>
       'prompt': instance.prompt,
       'description': instance.description,
       'agent': instance.agent,
+      'name': instance.name,
+      'attempt': instance.attempt,
+      'error': instance.error,
       'snapshot': instance.snapshot,
       'time': instance.time?.toJson(),
     };

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -527,6 +527,10 @@ class OpenCodePlugin implements BridgePlugin {
     "step-finish" => PluginMessagePartType.stepFinish,
     "file" => PluginMessagePartType.file,
     "snapshot" => PluginMessagePartType.snapshot,
+    "patch" => PluginMessagePartType.patch,
+    "agent" => PluginMessagePartType.agent,
+    "retry" => PluginMessagePartType.retry,
+    "compaction" => PluginMessagePartType.compaction,
     _ => () {
       Log.w("Unknown message part type: '$type' — filtering out");
       return PluginMessagePartType.unknown;
@@ -555,6 +559,9 @@ class OpenCodePlugin implements BridgePlugin {
       prompt: raw.prompt,
       description: raw.description,
       agent: raw.agent,
+      agentName: raw.name,
+      attempt: raw.attempt,
+      retryError: (raw.error?['data'] as Map<String, dynamic>?)?['message']?.toString(),
     );
   }
 

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -85,6 +85,42 @@ void main() {
       );
     });
 
+    test("getSessionMessages filters patch and compaction parts", () async {
+      final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
+
+      final messages = await plugin.getSessionMessages("ses-new-parts-filter");
+
+      expect(messages, hasLength(2));
+      final parts = messages.last.parts;
+      expect(
+        parts.map((part) => part.type).toList(),
+        equals([PluginMessagePartType.text]),
+      );
+    });
+
+    test("getSessionMessages agent part carries agentName", () async {
+      final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
+
+      final messages = await plugin.getSessionMessages("ses-agent-part");
+
+      expect(messages, hasLength(2));
+      final part = messages.last.parts.single;
+      expect(part.type, equals(PluginMessagePartType.agent));
+      expect(part.agentName, equals("explore"));
+    });
+
+    test("getSessionMessages retry part carries attempt and retryError", () async {
+      final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
+
+      final messages = await plugin.getSessionMessages("ses-retry-part");
+
+      expect(messages, hasLength(2));
+      final part = messages.last.parts.single;
+      expect(part.type, equals(PluginMessagePartType.retry));
+      expect(part.attempt, equals(2));
+      expect(part.retryError, equals("Rate limited"));
+    });
+
     test("getSessionMessages truncates tool output to 500 chars", () async {
       final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
 
@@ -827,6 +863,103 @@ class _FakeOpenCodeServer {
                   "output": "short",
                   "error": null,
                 },
+              },
+            ],
+          },
+        ]);
+        return;
+      }
+
+      if (request.method == "GET" && path == "/session/ses-new-parts-filter/message") {
+        await _sendJson(request.response, [
+          {
+            "info": {"role": "user", "id": "m-npf-user", "sessionID": "ses-new-parts-filter"},
+            "parts": [
+              {
+                "id": "p-npf-user",
+                "sessionID": "ses-new-parts-filter",
+                "messageID": "m-npf-user",
+                "type": "text",
+                "text": "go",
+              },
+            ],
+          },
+          {
+            "info": {"role": "assistant", "id": "m-npf", "sessionID": "ses-new-parts-filter"},
+            "parts": [
+              {"id": "p-patch", "sessionID": "ses-new-parts-filter", "messageID": "m-npf", "type": "patch"},
+              {"id": "p-compaction", "sessionID": "ses-new-parts-filter", "messageID": "m-npf", "type": "compaction"},
+              {
+                "id": "p-text",
+                "sessionID": "ses-new-parts-filter",
+                "messageID": "m-npf",
+                "type": "text",
+                "text": "done",
+              },
+            ],
+          },
+        ]);
+        return;
+      }
+
+      if (request.method == "GET" && path == "/session/ses-agent-part/message") {
+        await _sendJson(request.response, [
+          {
+            "info": {"role": "user", "id": "m-agent-user", "sessionID": "ses-agent-part"},
+            "parts": [
+              {
+                "id": "p-agent-user",
+                "sessionID": "ses-agent-part",
+                "messageID": "m-agent-user",
+                "type": "text",
+                "text": "go",
+              },
+            ],
+          },
+          {
+            "info": {"role": "assistant", "id": "m-agent", "sessionID": "ses-agent-part"},
+            "parts": [
+              {
+                "id": "p-agent",
+                "sessionID": "ses-agent-part",
+                "messageID": "m-agent",
+                "type": "agent",
+                "name": "explore",
+              },
+            ],
+          },
+        ]);
+        return;
+      }
+
+      if (request.method == "GET" && path == "/session/ses-retry-part/message") {
+        await _sendJson(request.response, [
+          {
+            "info": {"role": "user", "id": "m-retry-user", "sessionID": "ses-retry-part"},
+            "parts": [
+              {
+                "id": "p-retry-user",
+                "sessionID": "ses-retry-part",
+                "messageID": "m-retry-user",
+                "type": "text",
+                "text": "go",
+              },
+            ],
+          },
+          {
+            "info": {"role": "assistant", "id": "m-retry", "sessionID": "ses-retry-part"},
+            "parts": [
+              {
+                "id": "p-retry",
+                "sessionID": "ses-retry-part",
+                "messageID": "m-retry",
+                "type": "retry",
+                "attempt": 2,
+                "error": {
+                  "name": "APIError",
+                  "data": {"message": "Rate limited", "isRetryable": true},
+                },
+                "time": {"created": 1234},
               },
             ],
           },

--- a/mobile/app/lib/features/session_detail/widgets/agent_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/agent_part_widget.dart
@@ -1,0 +1,33 @@
+import "package:flutter/material.dart";
+
+class AgentPartWidget extends StatelessWidget {
+  final String? agentName;
+
+  const AgentPartWidget({super.key, required this.agentName});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final label = agentName ?? "Agent";
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          Icon(
+            Icons.smart_toy_outlined,
+            size: 14,
+            color: theme.colorScheme.outline,
+          ),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: theme.colorScheme.outline,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/app/lib/features/session_detail/widgets/assistant_message_card.dart
+++ b/mobile/app/lib/features/session_detail/widgets/assistant_message_card.dart
@@ -1,6 +1,8 @@
 import "package:flutter/material.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "agent_part_widget.dart";
 import "reasoning_part_widget.dart";
+import "retry_part_widget.dart";
 import "subtask_part_widget.dart";
 import "text_part_widget.dart";
 import "tool_part_widget.dart";
@@ -42,6 +44,8 @@ class AssistantMessageCard extends StatelessWidget {
       MessagePartType.subtask,
       MessagePartType.stepStart,
       MessagePartType.stepFinish,
+      MessagePartType.agent,
+      MessagePartType.retry,
     ].contains(part.type);
   }
 
@@ -65,6 +69,15 @@ class AssistantMessageCard extends StatelessWidget {
         part: part,
         children: children,
         childStatuses: childStatuses,
+      ),
+      MessagePartType.agent => AgentPartWidget(
+        key: ValueKey(part.id),
+        agentName: part.agentName,
+      ),
+      MessagePartType.retry => RetryPartWidget(
+        key: ValueKey(part.id),
+        attempt: part.attempt,
+        retryError: part.retryError,
       ),
       _ => const SizedBox.shrink(),
     };

--- a/mobile/app/lib/features/session_detail/widgets/retry_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/retry_part_widget.dart
@@ -1,0 +1,48 @@
+import "package:flutter/material.dart";
+
+class RetryPartWidget extends StatelessWidget {
+  final int? attempt;
+  final String? retryError;
+
+  const RetryPartWidget({
+    super.key,
+    required this.attempt,
+    required this.retryError,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final label = StringBuffer("Retry");
+    if (attempt != null) {
+      label.write(" #$attempt");
+    }
+    if (retryError != null) {
+      label.write(": $retryError");
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          Icon(
+            Icons.refresh,
+            size: 14,
+            color: theme.colorScheme.tertiary,
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              label.toString(),
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.tertiary,
+              ),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/shared/sesori_shared/lib/src/models/sesori/message_part.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_part.dart
@@ -22,6 +22,14 @@ enum MessagePartType {
   file,
   @JsonValue("snapshot")
   snapshot,
+  @JsonValue("patch")
+  patch,
+  @JsonValue("agent")
+  agent,
+  @JsonValue("retry")
+  retry,
+  @JsonValue("compaction")
+  compaction,
 }
 
 @Freezed(fromJson: true, toJson: true)
@@ -37,6 +45,11 @@ sealed class MessagePart with _$MessagePart {
     String? prompt,
     String? description,
     String? agent,
+    // agent
+    String? agentName,
+    // retry
+    int? attempt,
+    String? retryError,
   }) = _MessagePart;
 
   factory MessagePart.fromJson(Map<String, dynamic> json) => _$MessagePartFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/message_part.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_part.freezed.dart
@@ -15,7 +15,9 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MessagePart {
 
- String get id; String get sessionID; String get messageID; MessagePartType get type; String? get text; String? get tool; ToolState? get state; String? get prompt; String? get description; String? get agent;
+ String get id; String get sessionID; String get messageID; MessagePartType get type; String? get text; String? get tool; ToolState? get state; String? get prompt; String? get description; String? get agent;// agent
+ String? get agentName;// retry
+ int? get attempt; String? get retryError;
 /// Create a copy of MessagePart
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +30,16 @@ $MessagePartCopyWith<MessagePart> get copyWith => _$MessagePartCopyWithImpl<Mess
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.state, state) || other.state == state)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.state, state) || other.state == state)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.agentName, agentName) || other.agentName == agentName)&&(identical(other.attempt, attempt) || other.attempt == attempt)&&(identical(other.retryError, retryError) || other.retryError == retryError));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,state,prompt,description,agent);
+int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,state,prompt,description,agent,agentName,attempt,retryError);
 
 @override
 String toString() {
-  return 'MessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, state: $state, prompt: $prompt, description: $description, agent: $agent)';
+  return 'MessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, state: $state, prompt: $prompt, description: $description, agent: $agent, agentName: $agentName, attempt: $attempt, retryError: $retryError)';
 }
 
 
@@ -48,7 +50,7 @@ abstract mixin class $MessagePartCopyWith<$Res>  {
   factory $MessagePartCopyWith(MessagePart value, $Res Function(MessagePart) _then) = _$MessagePartCopyWithImpl;
 @useResult
 $Res call({
- String id, String sessionID, String messageID, MessagePartType type, String? text, String? tool, ToolState? state, String? prompt, String? description, String? agent
+ String id, String sessionID, String messageID, MessagePartType type, String? text, String? tool, ToolState? state, String? prompt, String? description, String? agent, String? agentName, int? attempt, String? retryError
 });
 
 
@@ -65,7 +67,7 @@ class _$MessagePartCopyWithImpl<$Res>
 
 /// Create a copy of MessagePart
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? state = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? state = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,Object? agentName = freezed,Object? attempt = freezed,Object? retryError = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
@@ -77,6 +79,9 @@ as String?,state: freezed == state ? _self.state : state // ignore: cast_nullabl
 as ToolState?,prompt: freezed == prompt ? _self.prompt : prompt // ignore: cast_nullable_to_non_nullable
 as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String?,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullable_to_non_nullable
+as String?,agentName: freezed == agentName ? _self.agentName : agentName // ignore: cast_nullable_to_non_nullable
+as String?,attempt: freezed == attempt ? _self.attempt : attempt // ignore: cast_nullable_to_non_nullable
+as int?,retryError: freezed == retryError ? _self.retryError : retryError // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }
@@ -101,7 +106,7 @@ $ToolStateCopyWith<$Res>? get state {
 @JsonSerializable()
 
 class _MessagePart implements MessagePart {
-  const _MessagePart({required this.id, required this.sessionID, required this.messageID, required this.type, this.text, this.tool, this.state, this.prompt, this.description, this.agent});
+  const _MessagePart({required this.id, required this.sessionID, required this.messageID, required this.type, this.text, this.tool, this.state, this.prompt, this.description, this.agent, this.agentName, this.attempt, this.retryError});
   factory _MessagePart.fromJson(Map<String, dynamic> json) => _$MessagePartFromJson(json);
 
 @override final  String id;
@@ -114,6 +119,11 @@ class _MessagePart implements MessagePart {
 @override final  String? prompt;
 @override final  String? description;
 @override final  String? agent;
+// agent
+@override final  String? agentName;
+// retry
+@override final  int? attempt;
+@override final  String? retryError;
 
 /// Create a copy of MessagePart
 /// with the given fields replaced by the non-null parameter values.
@@ -128,16 +138,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.state, state) || other.state == state)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MessagePart&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.messageID, messageID) || other.messageID == messageID)&&(identical(other.type, type) || other.type == type)&&(identical(other.text, text) || other.text == text)&&(identical(other.tool, tool) || other.tool == tool)&&(identical(other.state, state) || other.state == state)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.agentName, agentName) || other.agentName == agentName)&&(identical(other.attempt, attempt) || other.attempt == attempt)&&(identical(other.retryError, retryError) || other.retryError == retryError));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,state,prompt,description,agent);
+int get hashCode => Object.hash(runtimeType,id,sessionID,messageID,type,text,tool,state,prompt,description,agent,agentName,attempt,retryError);
 
 @override
 String toString() {
-  return 'MessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, state: $state, prompt: $prompt, description: $description, agent: $agent)';
+  return 'MessagePart(id: $id, sessionID: $sessionID, messageID: $messageID, type: $type, text: $text, tool: $tool, state: $state, prompt: $prompt, description: $description, agent: $agent, agentName: $agentName, attempt: $attempt, retryError: $retryError)';
 }
 
 
@@ -148,7 +158,7 @@ abstract mixin class _$MessagePartCopyWith<$Res> implements $MessagePartCopyWith
   factory _$MessagePartCopyWith(_MessagePart value, $Res Function(_MessagePart) _then) = __$MessagePartCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String sessionID, String messageID, MessagePartType type, String? text, String? tool, ToolState? state, String? prompt, String? description, String? agent
+ String id, String sessionID, String messageID, MessagePartType type, String? text, String? tool, ToolState? state, String? prompt, String? description, String? agent, String? agentName, int? attempt, String? retryError
 });
 
 
@@ -165,7 +175,7 @@ class __$MessagePartCopyWithImpl<$Res>
 
 /// Create a copy of MessagePart
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? state = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? messageID = null,Object? type = null,Object? text = freezed,Object? tool = freezed,Object? state = freezed,Object? prompt = freezed,Object? description = freezed,Object? agent = freezed,Object? agentName = freezed,Object? attempt = freezed,Object? retryError = freezed,}) {
   return _then(_MessagePart(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
@@ -177,6 +187,9 @@ as String?,state: freezed == state ? _self.state : state // ignore: cast_nullabl
 as ToolState?,prompt: freezed == prompt ? _self.prompt : prompt // ignore: cast_nullable_to_non_nullable
 as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
 as String?,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullable_to_non_nullable
+as String?,agentName: freezed == agentName ? _self.agentName : agentName // ignore: cast_nullable_to_non_nullable
+as String?,attempt: freezed == attempt ? _self.attempt : attempt // ignore: cast_nullable_to_non_nullable
+as int?,retryError: freezed == retryError ? _self.retryError : retryError // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }

--- a/shared/sesori_shared/lib/src/models/sesori/message_part.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_part.g.dart
@@ -19,6 +19,9 @@ _MessagePart _$MessagePartFromJson(Map json) => _MessagePart(
   prompt: json['prompt'] as String?,
   description: json['description'] as String?,
   agent: json['agent'] as String?,
+  agentName: json['agentName'] as String?,
+  attempt: (json['attempt'] as num?)?.toInt(),
+  retryError: json['retryError'] as String?,
 );
 
 Map<String, dynamic> _$MessagePartToJson(_MessagePart instance) =>
@@ -33,6 +36,9 @@ Map<String, dynamic> _$MessagePartToJson(_MessagePart instance) =>
       'prompt': instance.prompt,
       'description': instance.description,
       'agent': instance.agent,
+      'agentName': instance.agentName,
+      'attempt': instance.attempt,
+      'retryError': instance.retryError,
     };
 
 const _$MessagePartTypeEnumMap = {
@@ -44,6 +50,10 @@ const _$MessagePartTypeEnumMap = {
   MessagePartType.stepFinish: 'step-finish',
   MessagePartType.file: 'file',
   MessagePartType.snapshot: 'snapshot',
+  MessagePartType.patch: 'patch',
+  MessagePartType.agent: 'agent',
+  MessagePartType.retry: 'retry',
+  MessagePartType.compaction: 'compaction',
 };
 
 _ToolState _$ToolStateFromJson(Map json) => _ToolState(


### PR DESCRIPTION
## Summary

- Add proper handling for 4 previously unrecognized OpenCode message part types (`patch`, `agent`, `retry`, `compaction`) across the shared, bridge, and mobile layers
- Eliminate the `Unknown message part type: 'patch' — filtering out` bridge warning
- Render `agent` and `retry` parts on mobile with minimal inline widgets; `patch` and `compaction` are invisible (internal bookkeeping)

## What changed

### Shared (`sesori_shared`)
- `MessagePartType` enum: 4 new values (`patch`, `agent`, `retry`, `compaction`)
- `MessagePart` model: 3 new fields (`agentName`, `attempt`, `retryError`)

### Bridge — Plugin Interface (`sesori_plugin_interface`)
- `PluginMessagePartType` enum: 4 new values + `isVisible` updated (patch/compaction = invisible)
- `PluginMessagePart` model: 3 new fields (`agentName`, `attempt`, `retryError`)

### Bridge — OpenCode Plugin (`sesori_plugin_opencode`)
- `MessagePart` model: 3 new fields (`name`, `attempt`, `error`) for API deserialization
- `_toPluginPartType`: 4 new switch cases — no more warning for these types
- `_mapMessagePart`: maps `agentName`, `attempt`, and extracts `retryError` from nested `APIError.data.message`
- Tests: 3 new test cases (invisible filtering, agent mapping, retry mapping)

### Bridge — App (`bridge/app`)
- `toShared()` mapping: 4 new type cases + 3 field pass-throughs
- Tests: 4 new event mapper tests (filter patch/compaction, pass agent/retry) + 9 new mapping tests

### Mobile (`mobile/app`)
- `_isVisible` whitelist: added `agent` and `retry`
- `AgentPartWidget`: minimal inline chip showing agent name (e.g. "explore")
- `RetryPartWidget`: minimal warning notice showing retry attempt and error

## Verification
- 988 tests pass (164 shared + 103 plugin + 382 bridge app + 339 mobile)
- `dart analyze` clean across all packages
- Plan compliance: Must Have [6/6] | Must NOT Have [4/4]