### PR TITLE
fix(mobile): reattach auto-follow on scroll settle, not just drag

### DIFF
--- a/mobile/app/lib/features/session_detail/session_detail_screen.dart
+++ b/mobile/app/lib/features/session_detail/session_detail_screen.dart
@@ -410,6 +410,16 @@ class _MessageListState extends State<_MessageList> {
                   _following = true;
                 });
               }
+            } else if (notification is ScrollEndNotification) {
+              // Re-check once the scroll settles (after fling/ballistic animation).
+              // Without this, flinging to the bottom never reattaches because
+              // dragDetails is null during momentum scrolling.
+              final pixels = _scrollController.position.pixels;
+              if (!_following && pixels <= _kNearBottomThreshold) {
+                setState(() {
+                  _following = true;
+                });
+              }
             }
             return false;
           },


### PR DESCRIPTION
## Summary

- Fixes auto-follow reattachment in the session detail message list when flinging to the bottom
- The `NotificationListener` only checked scroll position during active drag (`ScrollUpdateNotification` with `dragDetails != null`), so momentum/ballistic scrolling to the bottom never triggered reattachment
- Adds a `ScrollEndNotification` handler that checks the **settled** position after all scroll animation completes — if within the 20px threshold, follow mode reattaches

## What changed

`mobile/app/lib/features/session_detail/session_detail_screen.dart` — added `ScrollEndNotification` branch to the existing `NotificationListener` callback in `_MessageListState.build()`.