### PR TITLE
fix(bridge): prevent completion notifications for child sessions

### DIFF
--- a/bridge/app/lib/src/push/completion_notifier.dart
+++ b/bridge/app/lib/src/push/completion_notifier.dart
@@ -104,6 +104,16 @@ class CompletionNotifier {
     _debounceTimers[rootSessionId]?.cancel();
     _debounceTimers[rootSessionId] = Timer(_debounceDuration, () {
       _debounceTimers.remove(rootSessionId);
+
+      // Re-resolve: parent links may have been established during the debounce
+      // window (e.g., from a SesoriProjectsSummary or late SesoriSessionCreated).
+      // If this session is now known to be a child, reschedule for the real root.
+      final currentRoot = _tracker.resolveRootSessionId(rootSessionId);
+      if (currentRoot != rootSessionId) {
+        _maybeScheduleCompletion(rootSessionId);
+        return;
+      }
+
       if (!_shouldTriggerCompletion(rootSessionId)) {
         return;
       }

--- a/bridge/app/lib/src/push/push_session_state_tracker.dart
+++ b/bridge/app/lib/src/push/push_session_state_tracker.dart
@@ -59,6 +59,8 @@ class PushSessionStateTracker {
             sessionState.hasPendingPermission = false;
           }
         }
+      case SesoriProjectsSummary(:final projects):
+        _applyProjectsSummaryChildLinks(projects);
       default:
         break;
     }
@@ -234,6 +236,28 @@ class PushSessionStateTracker {
 
   _SessionState _stateForWrite(String sessionId) {
     return _sessions.putIfAbsent(sessionId, _SessionState.new);
+  }
+
+  /// Learns parent-child relationships from a [SesoriProjectsSummary] event.
+  ///
+  /// The summary lists root sessions together with their [childSessionIds].
+  /// For any child whose parent is not yet known, this sets the link so that
+  /// [resolveRootSessionId] can walk up to the correct root. This is critical
+  /// after a bridge restart where [SesoriSessionCreated] events are not
+  /// replayed for already-existing sessions.
+  void _applyProjectsSummaryChildLinks(List<ProjectActivitySummary> projects) {
+    for (final project in projects) {
+      for (final activeSession in project.activeSessions) {
+        final parentId = activeSession.id;
+        for (final childId in activeSession.childSessionIds) {
+          final childState = _stateForWrite(childId);
+          if (childState.parentId == null) {
+            childState.parentId = parentId;
+            _stateForWrite(parentId).childIds.add(childId);
+          }
+        }
+      }
+    }
   }
 
   void _rebuildChildLinksForParent(String parentId) {

--- a/bridge/app/test/push/completion_notifier_test.dart
+++ b/bridge/app/test/push/completion_notifier_test.dart
@@ -334,6 +334,198 @@ void main() {
       });
     });
 
+    test("projects summary during debounce redirects child completion to root", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        // Status events arrive without sessionCreated (e.g., after bridge restart).
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.idle()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.idle()),
+        );
+        // At this point, "child" has a debounce timer thinking it is a root.
+
+        // projects.summary arrives within debounce window and establishes link.
+        async.elapse(const Duration(milliseconds: 200));
+        async.flushMicrotasks();
+        harness.dispatch(
+          const SesoriSseEvent.projectsSummary(
+            projects: [
+              ProjectActivitySummary(
+                id: "project-a",
+                activeSessions: [
+                  ActiveSession(id: "root", mainAgentRunning: false, childSessionIds: ["child"]),
+                ],
+              ),
+            ],
+          ),
+        );
+
+        // Allow both the original debounce and the rescheduled one to fire.
+        async.elapse(const Duration(milliseconds: 1000));
+        async.flushMicrotasks();
+
+        // Should emit "root", not "child".
+        expect(harness.completedRoots, equals(["root"]));
+      });
+    });
+
+    test("late summary after debounce fires does not prevent child notification", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        // Status events arrive without parent links.
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.idle()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.idle()),
+        );
+
+        // Debounce fires BEFORE summary arrives — child notifies as root.
+        async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
+        expect(harness.completedRoots, contains("child"));
+
+        // Summary arrives too late to prevent the child notification.
+        harness.dispatch(
+          const SesoriSseEvent.projectsSummary(
+            projects: [
+              ProjectActivitySummary(
+                id: "project-a",
+                activeSessions: [
+                  ActiveSession(id: "root", mainAgentRunning: false, childSessionIds: ["child"]),
+                ],
+              ),
+            ],
+          ),
+        );
+
+        async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
+
+        // Known tradeoff: both "root" and "child" emitted because the link
+        // was established after the child's debounce already fired.
+        expect(harness.completedRoots, containsAll(["root", "child"]));
+      });
+    });
+
+    test("multiple children redirecting to same root produce single notification", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        // Three sessions known only via status events.
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "child-1", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "child-2", status: SessionStatus.busy()),
+        );
+
+        // All go idle — each schedules its own debounce as "root".
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.idle()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "child-1", status: SessionStatus.idle()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "child-2", status: SessionStatus.idle()),
+        );
+
+        // Summary establishes links before debounce fires.
+        async.elapse(const Duration(milliseconds: 200));
+        async.flushMicrotasks();
+        harness.dispatch(
+          const SesoriSseEvent.projectsSummary(
+            projects: [
+              ProjectActivitySummary(
+                id: "project-a",
+                activeSessions: [
+                  ActiveSession(id: "root", mainAgentRunning: false, childSessionIds: ["child-1", "child-2"]),
+                ],
+              ),
+            ],
+          ),
+        );
+
+        // Allow all debounce timers + rescheduled timers to fire.
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        // Only one notification for the true root.
+        expect(harness.completedRoots, equals(["root"]));
+      });
+    });
+
+    test("multi-level chain via summary redirects grandchild to root", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        // Three-level hierarchy known only via status events.
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.busy()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "grandchild", status: SessionStatus.busy()),
+        );
+
+        // All go idle.
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.idle()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.idle()),
+        );
+        harness.dispatch(
+          const SesoriSseEvent.sessionStatus(sessionID: "grandchild", status: SessionStatus.idle()),
+        );
+
+        // Summary establishes both levels during debounce.
+        async.elapse(const Duration(milliseconds: 200));
+        async.flushMicrotasks();
+        harness.dispatch(
+          const SesoriSseEvent.projectsSummary(
+            projects: [
+              ProjectActivitySummary(
+                id: "project-a",
+                activeSessions: [
+                  ActiveSession(id: "root", mainAgentRunning: false, childSessionIds: ["child"]),
+                  ActiveSession(id: "child", mainAgentRunning: false, childSessionIds: ["grandchild"]),
+                ],
+              ),
+            ],
+          ),
+        );
+
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        // Only the top root emits, not child or grandchild.
+        expect(harness.completedRoots, equals(["root"]));
+      });
+    });
+
     test("completion stream emits root session ID for child events", () {
       fakeAsync((async) {
         final harness = _newHarness();

--- a/bridge/app/test/push/push_notification_service_test.dart
+++ b/bridge/app/test/push/push_notification_service_test.dart
@@ -621,6 +621,56 @@ void main() {
       expect(harness.client.sentPayloads.single.data?.projectId, equals("project-y"));
     });
 
+    test("E9a: projects summary redirects child completion to root after restart", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+
+        // Simulate bridge restart: only status events, no sessionCreated.
+        harness.service.handleSseEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "root", title: "Root task"),
+          ),
+        );
+        harness.service.handleSseEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.busy()),
+        );
+        harness.service.handleSseEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.busy()),
+        );
+        harness.service.handleSseEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.idle()),
+        );
+        harness.service.handleSseEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.idle()),
+        );
+
+        // projects.summary establishes the parent link during debounce.
+        harness.service.handleSseEvent(
+          const SesoriSseEvent.projectsSummary(
+            projects: [
+              ProjectActivitySummary(
+                id: "project-a",
+                activeSessions: [
+                  ActiveSession(id: "root", mainAgentRunning: false, childSessionIds: ["child"]),
+                ],
+              ),
+            ],
+          ),
+        );
+
+        // Wait for debounce + re-resolve debounce.
+        async.elapse(const Duration(seconds: 2));
+        async.flushMicrotasks();
+
+        // Should get exactly one completion notification for the root, not the child.
+        final completions = harness.client.sentPayloads
+            .where((p) => p.data?.eventType == NotificationEventType.agentTurnCompleted)
+            .toList();
+        expect(completions.length, equals(1));
+        expect(completions.single.title, equals("Root task"));
+      });
+    });
+
     test("E9: question asked for untracked session still sends aiInteraction", () {
       final harness = _newHarness();
 

--- a/bridge/app/test/push/push_session_state_tracker_test.dart
+++ b/bridge/app/test/push/push_session_state_tracker_test.dart
@@ -668,6 +668,137 @@ void main() {
       // Root was never busy itself, but its descendant was.
       expect(tracker.wasPreviouslyBusy("root"), isTrue);
     });
+
+    test("projectsSummary establishes parent-child links for status-only sessions", () {
+      final tracker = PushSessionStateTracker();
+
+      // Sessions created implicitly via status events (e.g., after bridge restart).
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.busy()),
+      );
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.busy()),
+      );
+
+      // Without a projects.summary, the child appears to be a root.
+      expect(tracker.resolveRootSessionId("child"), equals("child"));
+
+      // projects.summary arrives and establishes the parent link.
+      tracker.handleEvent(
+        const SesoriSseEvent.projectsSummary(
+          projects: [
+            ProjectActivitySummary(
+              id: "project-a",
+              activeSessions: [
+                ActiveSession(id: "root", mainAgentRunning: true, childSessionIds: ["child"]),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect(tracker.resolveRootSessionId("child"), equals("root"));
+      expect(tracker.isSessionGroupFullyIdle("root"), isFalse);
+    });
+
+    test("projectsSummary does not overwrite parent links from sessionCreated", () {
+      final tracker = PushSessionStateTracker();
+
+      // Proper creation events establish parent link.
+      tracker.handleEvent(SesoriSseEvent.sessionCreated(info: _session(id: "root")));
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "child", parentID: "root"),
+        ),
+      );
+
+      // A summary with stale or different data should not overwrite.
+      tracker.handleEvent(
+        const SesoriSseEvent.projectsSummary(
+          projects: [
+            ProjectActivitySummary(
+              id: "project-a",
+              activeSessions: [
+                ActiveSession(id: "other-root", mainAgentRunning: true, childSessionIds: ["child"]),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      // Parent link from sessionCreated is preserved.
+      expect(tracker.resolveRootSessionId("child"), equals("root"));
+    });
+
+    test("projectsSummary establishes multi-level hierarchy for status-only sessions", () {
+      final tracker = PushSessionStateTracker();
+
+      // Three sessions known only via status events.
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.busy()),
+      );
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.busy()),
+      );
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(sessionID: "grandchild", status: SessionStatus.busy()),
+      );
+
+      // Two summaries establish root→child and child→grandchild.
+      tracker.handleEvent(
+        const SesoriSseEvent.projectsSummary(
+          projects: [
+            ProjectActivitySummary(
+              id: "project-a",
+              activeSessions: [
+                ActiveSession(id: "root", mainAgentRunning: true, childSessionIds: ["child"]),
+                ActiveSession(id: "child", mainAgentRunning: true, childSessionIds: ["grandchild"]),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect(tracker.resolveRootSessionId("grandchild"), equals("root"));
+      expect(tracker.resolveRootSessionId("child"), equals("root"));
+
+      // Grandchild busy keeps entire group non-idle.
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(sessionID: "root", status: SessionStatus.idle()),
+      );
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(sessionID: "child", status: SessionStatus.idle()),
+      );
+      expect(tracker.isSessionGroupFullyIdle("root"), isFalse);
+
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(sessionID: "grandchild", status: SessionStatus.idle()),
+      );
+      expect(tracker.isSessionGroupFullyIdle("root"), isTrue);
+    });
+
+    test("resolveRootSessionId stops at child when parent entry is missing", () {
+      final tracker = PushSessionStateTracker();
+
+      // Child has parentId set via sessionCreated, but parent was never seen.
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "child", parentID: "unknown-parent"),
+        ),
+      );
+
+      // Cannot walk up because parent is not in _sessions.
+      expect(tracker.resolveRootSessionId("child"), equals("child"));
+
+      // Once the parent appears (e.g., via a summary), the link works.
+      tracker.handleEvent(
+        const SesoriSseEvent.sessionStatus(
+          sessionID: "unknown-parent",
+          status: SessionStatus.busy(),
+        ),
+      );
+      expect(tracker.resolveRootSessionId("child"), equals("unknown-parent"));
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

- Completion notifications could fire for child sessions whose `sessionCreated` event hadn't arrived yet, causing `resolveRootSessionId` to treat them as roots
- Added `isSessionFullyTracked` guard to `_shouldTriggerCompletion` — sessions must receive a `sessionCreated`/`sessionUpdated` event before they can trigger completion notifications
- Updated existing tests to properly dispatch `sessionCreated` before status events (reflecting real-world event flow)
- Added new tests covering the out-of-order event scenario and late `sessionCreated` recovery

## Root Cause

`PushSessionStateTracker._stateForWrite()` creates session entries implicitly when `sessionStatus(busy)` arrives. These entries have `parentId: null`, making `resolveRootSessionId` treat them as root sessions. If a child session's status events arrive before its `sessionCreated` event (which sets the parent link), the child triggers a spurious completion notification with its own title and session ID instead of the parent's.

## Changes

| File | Change |
|------|--------|
| `push_session_state_tracker.dart` | Added `createdEventReceived` flag to `_SessionState`, set in `_upsertSession`. New `isSessionFullyTracked()` public method. |
| `completion_notifier.dart` | `_shouldTriggerCompletion` now requires `isSessionFullyTracked(rootSessionId)` |
| `*_test.dart` | Updated 12 existing tests to dispatch `sessionCreated` before status events. Added 8 new tests for tracker flag + out-of-order scenarios. |