### PR TITLE
fix(bridge): fallback to directory name when project name is empty

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/models/project.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/project.dart
@@ -31,7 +31,7 @@ sealed class ProjectTime with _$ProjectTime {
 extension ProjectToPluginExtension on Project {
   PluginProject toPlugin() => PluginProject(
     id: worktree, // worktree is the most reliable UID with opencode
-    name: name,
+    name: _effectiveName,
     time: switch (time) {
       ProjectTime(:final created, :final updated) => PluginProjectTime(
         created: created,
@@ -40,4 +40,16 @@ extension ProjectToPluginExtension on Project {
       null => null,
     },
   );
+
+  /// Returns [name] when present and non-empty, otherwise extracts the
+  /// directory name from [worktree] as a fallback. OpenCode can return an
+  /// empty name after project metadata is edited through its web UI.
+  String? get _effectiveName {
+    final n = name;
+    if (n != null && n.isNotEmpty) return n;
+    if (worktree.isEmpty) return null;
+    final normalized = worktree.replaceAll(r"\", "/");
+    final segments = normalized.split("/").where((s) => s.isNotEmpty);
+    return segments.isEmpty ? null : segments.last;
+  }
 }

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -35,8 +35,8 @@ void main() {
       expect(real.id, equals("/repo"));
       expect(real.name, equals("Main Repo"));
 
-      final virtual = projects.firstWhere((p) => p.name == null);
-      expect(virtual.id, isNotEmpty);
+      final virtual = projects.firstWhere((p) => p.id == "/virtual");
+      expect(virtual.name, equals("virtual"));
     });
 
     test("getSessions maps internal sessions to plugin sessions", () async {


### PR DESCRIPTION
## Summary

- When OpenCode returns a null or empty project name (e.g. after editing project metadata through its web UI), the bridge now falls back to extracting the directory name from the worktree path so the mobile app never shows a blank project title.
- The fix lives in the `toPlugin()` mapping extension in `project.dart` — the single conversion point from OpenCode's model to the shared plugin interface — so all code paths (`getProjects`, `getProject`, `renameProject`) are covered.
- Updated the existing virtual project test assertion to verify the new fallback behavior.