### PR TITLE
fix: add error recovery to SSE event pipeline

### DIFF
--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -10,6 +10,7 @@ import 'package:sesori_bridge/src/auth/token_manager.dart';
 import 'package:sesori_bridge/src/auth/validate.dart';
 import 'package:sesori_bridge/src/bridge/bandwidth_tracker.dart';
 import 'package:sesori_bridge/src/bridge/debug_server.dart';
+import 'package:sesori_bridge/src/bridge/log_failure_reporter.dart';
 import 'package:sesori_bridge/src/bridge/models/bridge_config.dart';
 import 'package:sesori_bridge/src/bridge/orchestrator.dart';
 import 'package:sesori_bridge/src/bridge/persistence/bridge_diagnostics.dart';
@@ -186,6 +187,8 @@ Future<void> main(List<String> args) async {
   // Run startup diagnostics (non-blocking — logs warnings only)
   await BridgeDiagnostics().runAll();
 
+  final failureReporter = LogFailureReporter();
+
   final orchestrator = Orchestrator(
     config: bridgeConfig,
     client: relayClient,
@@ -193,6 +196,7 @@ Future<void> main(List<String> args) async {
     pushNotificationService: pushNotificationService,
     tokenRefresher: tokenManager,
     projectsDao: db.projectsDao,
+    failureReporter: failureReporter,
   );
   final session = orchestrator.create();
 
@@ -202,7 +206,12 @@ Future<void> main(List<String> args) async {
   // Create and start debug server if requested
   DebugServer? debugServer;
   if (debugPort != null) {
-    debugServer = DebugServer(plugin: plugin, projectsDao: db.projectsDao, port: debugPort);
+    debugServer = DebugServer(
+      plugin: plugin,
+      projectsDao: db.projectsDao,
+      port: debugPort,
+      failureReporter: failureReporter,
+    );
     try {
       await debugServer.start();
     } catch (e) {

--- a/bridge/app/lib/src/bridge/debug_server.dart
+++ b/bridge/app/lib/src/bridge/debug_server.dart
@@ -24,9 +24,10 @@ class DebugServer {
     required BridgePlugin plugin,
     required ProjectsDao projectsDao,
     required this.port,
+    required FailureReporter failureReporter,
   }) : _plugin = plugin,
        _router = RequestRouter(plugin: plugin, projectsDao: projectsDao),
-       _mapper = BridgeEventMapper(plugin);
+       _mapper = BridgeEventMapper(plugin: plugin, failureReporter: failureReporter);
 
   int? get boundPort => _server?.port;
 

--- a/bridge/app/lib/src/bridge/log_failure_reporter.dart
+++ b/bridge/app/lib/src/bridge/log_failure_reporter.dart
@@ -27,7 +27,9 @@ class LogFailureReporter implements FailureReporter {
     required Iterable<Object> information,
   }) {
     final severity = fatal ? 'FATAL' : 'non-fatal';
-    Log.e('[reporter:$uniqueIdentifier] $severity: $reason — $error\n$stackTrace');
+    Log.e(
+      '[reporter:$uniqueIdentifier] $severity: $reason — $error\n$stackTrace${information.isNotEmpty ? '\nInformation: $information' : ''}',
+    );
     return Future<void>.value();
   }
 }

--- a/bridge/app/lib/src/bridge/log_failure_reporter.dart
+++ b/bridge/app/lib/src/bridge/log_failure_reporter.dart
@@ -1,0 +1,33 @@
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
+import 'package:sesori_shared/sesori_shared.dart';
+
+/// Log-based implementation of [FailureReporter] for the bridge.
+///
+/// This is a minimal wrapper that logs all failures to stdout/stderr via [Log].
+/// No deduplication, no persistence — just logging. The backend isn't wired yet,
+/// but interface calls will flow automatically when it is.
+class LogFailureReporter implements FailureReporter {
+  @override
+  void setGlobalKey({required String key, required Object value}) {
+    Log.i('[reporter] $key=$value');
+  }
+
+  @override
+  void log({required String message}) {
+    Log.i('[reporter] $message');
+  }
+
+  @override
+  Future<void> recordFailure({
+    required Object error,
+    required StackTrace stackTrace,
+    required String uniqueIdentifier,
+    required bool fatal,
+    required String? reason,
+    required Iterable<Object> information,
+  }) {
+    final severity = fatal ? 'FATAL' : 'non-fatal';
+    Log.e('[reporter:$uniqueIdentifier] $severity: $reason — $error\n$stackTrace');
+    return Future<void>.value();
+  }
+}

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -26,6 +26,7 @@ class Orchestrator {
   final PushNotificationService _pushNotificationService;
   final TokenRefresher _tokenRefresher;
   final ProjectsDao _projectsDao;
+  final FailureReporter _failureReporter;
 
   Orchestrator({
     required this.config,
@@ -34,11 +35,13 @@ class Orchestrator {
     required PushNotificationService pushNotificationService,
     required TokenRefresher tokenRefresher,
     required ProjectsDao projectsDao,
+    required FailureReporter failureReporter,
   }) : _client = client,
        _plugin = plugin,
        _pushNotificationService = pushNotificationService,
        _tokenRefresher = tokenRefresher,
-       _projectsDao = projectsDao;
+       _projectsDao = projectsDao,
+       _failureReporter = failureReporter;
 
   /// Creates a new session with a fresh room key and SSE manager.
   OrchestratorSession create() {
@@ -47,6 +50,7 @@ class Orchestrator {
     final sseManager = SSEManager(
       replayWindow: config.sseReplayWindow,
       onBytesSent: bytesSentController.add,
+      failureReporter: _failureReporter,
     );
     sseManager.setRoomKey(roomKey);
 
@@ -60,6 +64,7 @@ class Orchestrator {
       roomKey: roomKey,
       sseManager: sseManager,
       bytesSentController: bytesSentController,
+      failureReporter: _failureReporter,
     );
   }
 
@@ -86,6 +91,7 @@ class OrchestratorSession {
   final PushNotificationService _pushNotificationService;
   final TokenRefresher _tokenRefresher;
   final StreamController<int> _bytesSentController;
+  final FailureReporter _failureReporter;
   StreamSubscription<BridgeSseEvent>? _eventSubscription;
 
   bool _cancelled = false;
@@ -100,6 +106,7 @@ class OrchestratorSession {
     required List<int> roomKey,
     required SSEManager sseManager,
     required StreamController<int> bytesSentController,
+    required FailureReporter failureReporter,
   }) : _client = client,
        _plugin = plugin,
        _pushNotificationService = pushNotificationService,
@@ -107,8 +114,9 @@ class OrchestratorSession {
        _roomKey = roomKey,
        _sseManager = sseManager,
        _bytesSentController = bytesSentController,
+       _failureReporter = failureReporter,
        _router = RequestRouter(plugin: plugin, projectsDao: projectsDao),
-       _mapper = BridgeEventMapper(plugin);
+       _mapper = BridgeEventMapper(plugin: plugin, failureReporter: failureReporter);
 
   /// Broadcast stream of byte counts emitted each time data is sent to a phone.
   ///
@@ -123,16 +131,32 @@ class OrchestratorSession {
     Log.d("[dbg] subscribing to plugin event stream...");
     _eventSubscription = _plugin.events.listen(
       (BridgeSseEvent event) {
-        Log.v("[sse] plugin event arrived: ${event.runtimeType}");
-        final sesoriEvent = _mapper.map(event);
-        if (sesoriEvent != null) {
-          Log.v(
-            "[sse] mapped to: ${sesoriEvent.runtimeType} — enqueuing (subscribers: ${_sseManager.subscriberCount})",
+        try {
+          Log.v("[sse] plugin event arrived: ${event.runtimeType}");
+          final sesoriEvent = _mapper.map(event);
+          if (sesoriEvent != null) {
+            Log.v(
+              "[sse] mapped to: ${sesoriEvent.runtimeType} — enqueuing (subscribers: ${_sseManager.subscriberCount})",
+            );
+            _pushNotificationService.handleSseEvent(sesoriEvent);
+            _sseManager.enqueueEvent(sesoriEvent);
+          } else {
+            Log.v("[sse] mapping returned null — event dropped");
+          }
+        } catch (e, st) {
+          Log.e("[sse] error processing event ${event.runtimeType}: $e\n$st");
+          unawaited(
+            _failureReporter
+                .recordFailure(
+                  error: e,
+                  stackTrace: st,
+                  uniqueIdentifier: "sse_event_processing:${event.runtimeType}",
+                  fatal: false,
+                  reason: "Failed to process SSE event",
+                  information: [event.runtimeType.toString()],
+                )
+                .catchError((_) {}),
           );
-          _pushNotificationService.handleSseEvent(sesoriEvent);
-          _sseManager.enqueueEvent(sesoriEvent);
-        } else {
-          Log.v("[sse] mapping returned null — event dropped");
         }
       },
       onError: (Object e) {
@@ -446,7 +470,10 @@ class OrchestratorSession {
         Log.v("[dbg] SseSubscribe: path=${subscribe.path}");
         try {
           _sseManager.subscribePath(connID, subscribe.path, _client);
-          _sseManager.enqueueEvent(_mapper.buildProjectsSummaryEvent());
+          final projSummary = _mapper.buildProjectsSummaryEvent();
+          if (projSummary != null) {
+            _sseManager.enqueueEvent(projSummary);
+          }
           Log.v("[dbg] initial projectsSummary enqueued");
         } catch (e) {
           Log.e("sse subscribe failed for connId $connID: $e");

--- a/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
@@ -8,185 +10,196 @@ import "../plugin_to_shared_mapping.dart";
 /// Handles all event type conversions and builds the projects summary event.
 class BridgeEventMapper {
   final BridgePlugin _plugin;
+  final FailureReporter _failureReporter;
 
-  BridgeEventMapper(this._plugin);
+  BridgeEventMapper({
+    required BridgePlugin plugin,
+    required FailureReporter failureReporter,
+  }) : _plugin = plugin,
+       _failureReporter = failureReporter;
 
   /// Maps a [BridgeSseEvent] to a [SesoriSseEvent], or null if unmappable.
   SesoriSseEvent? map(BridgeSseEvent event) {
-    switch (event) {
-      case BridgeSseServerConnected():
-        return const SesoriSseEvent.serverConnected();
-      case BridgeSseServerHeartbeat():
-        return null;
-      case BridgeSseServerInstanceDisposed(:final directory):
-        return SesoriSseEvent.serverInstanceDisposed(directory: directory);
-      case BridgeSseGlobalDisposed():
-        return const SesoriSseEvent.globalDisposed();
-      case BridgeSseSessionCreated(:final info):
-        return _tryParseSseEvent({"type": "session.created", "info": info});
-      case BridgeSseSessionUpdated(:final info):
-        return _tryParseSseEvent({"type": "session.updated", "info": info});
-      case BridgeSseSessionDeleted(:final info):
-        return _tryParseSseEvent({"type": "session.deleted", "info": info});
-      case BridgeSseSessionDiff(:final sessionID):
-        return SesoriSseEvent.sessionDiff(sessionID: sessionID);
-      case BridgeSseSessionError(:final sessionID):
-        return SesoriSseEvent.sessionError(sessionID: sessionID);
-      case BridgeSseSessionCompacted(:final sessionID):
-        return SesoriSseEvent.sessionCompacted(sessionID: sessionID);
-      case BridgeSseSessionStatus(:final sessionID, :final status):
-        return _tryParseSseEvent({
+    try {
+      return switch (event) {
+        BridgeSseServerConnected() => const SesoriSseEvent.serverConnected(),
+        BridgeSseServerHeartbeat() => null,
+        BridgeSseServerInstanceDisposed(:final directory) => SesoriSseEvent.serverInstanceDisposed(
+          directory: directory,
+        ),
+        BridgeSseGlobalDisposed() => const SesoriSseEvent.globalDisposed(),
+        BridgeSseSessionCreated(:final info) => _tryParseSseEvent({"type": "session.created", "info": info}),
+        BridgeSseSessionUpdated(:final info) => _tryParseSseEvent({"type": "session.updated", "info": info}),
+        BridgeSseSessionDeleted(:final info) => _tryParseSseEvent({"type": "session.deleted", "info": info}),
+        BridgeSseSessionDiff(:final sessionID) => SesoriSseEvent.sessionDiff(sessionID: sessionID),
+        BridgeSseSessionError(:final sessionID) => SesoriSseEvent.sessionError(sessionID: sessionID),
+        BridgeSseSessionCompacted(:final sessionID) => SesoriSseEvent.sessionCompacted(sessionID: sessionID),
+        BridgeSseSessionStatus(:final sessionID, :final status) => _tryParseSseEvent({
           "type": "session.status",
           "sessionID": sessionID,
           "status": status,
-        });
-      case BridgeSseSessionIdle(:final sessionID):
-        return SesoriSseEvent.sessionStatus(
+        }),
+        BridgeSseSessionIdle(:final sessionID) => SesoriSseEvent.sessionStatus(
           sessionID: sessionID,
           status: const SessionStatus.idle(),
-        );
-      case BridgeSseMessageUpdated(:final info):
-        return _tryParseSseEvent({"type": "message.updated", "info": info});
-      case BridgeSseMessageRemoved(:final sessionID, :final messageID):
-        return SesoriSseEvent.messageRemoved(
+        ),
+        BridgeSseMessageUpdated(:final info) => _tryParseSseEvent({"type": "message.updated", "info": info}),
+        BridgeSseMessageRemoved(:final sessionID, :final messageID) => SesoriSseEvent.messageRemoved(
           sessionID: sessionID,
           messageID: messageID,
-        );
-      case BridgeSseMessagePartUpdated(:final part):
-        if (!part.type.isVisible) return null;
-        final truncated = _truncateToolOutput(part);
-        return SesoriSseEvent.messagePartUpdated(part: truncated.toShared());
-      case BridgeSseMessagePartDelta(
-        :final sessionID,
-        :final messageID,
-        :final partID,
-        :final field,
-        :final delta,
-      ):
-        return SesoriSseEvent.messagePartDelta(
-          sessionID: sessionID,
-          messageID: messageID,
-          partID: partID,
-          field: field,
-          delta: delta,
-        );
-      case BridgeSseMessagePartRemoved(
-        :final sessionID,
-        :final messageID,
-        :final partID,
-      ):
-        return SesoriSseEvent.messagePartRemoved(
-          sessionID: sessionID,
-          messageID: messageID,
-          partID: partID,
-        );
-      case BridgeSsePtyCreated():
-        return const SesoriSseEvent.ptyCreated();
-      case BridgeSsePtyUpdated():
-        return const SesoriSseEvent.ptyUpdated();
-      case BridgeSsePtyExited(:final id, :final exitCode):
-        return SesoriSseEvent.ptyExited(id: id, exitCode: exitCode);
-      case BridgeSsePtyDeleted(:final id):
-        return SesoriSseEvent.ptyDeleted(id: id);
-      case BridgeSsePermissionAsked(
-        :final requestID,
-        :final sessionID,
-        :final tool,
-        :final description,
-      ):
-        return SesoriSseEvent.permissionAsked(
-          requestID: requestID,
-          sessionID: sessionID,
-          tool: tool,
-          description: description,
-        );
-      case BridgeSsePermissionReplied(:final requestID, :final reply):
-        return SesoriSseEvent.permissionReplied(
+        ),
+        BridgeSseMessagePartUpdated(:final part) => () {
+          if (!part.type.isVisible) return null;
+          final truncated = _truncateToolOutput(part);
+          return SesoriSseEvent.messagePartUpdated(part: truncated.toShared());
+        }(),
+        BridgeSseMessagePartDelta(
+          :final sessionID,
+          :final messageID,
+          :final partID,
+          :final field,
+          :final delta,
+        ) =>
+          SesoriSseEvent.messagePartDelta(
+            sessionID: sessionID,
+            messageID: messageID,
+            partID: partID,
+            field: field,
+            delta: delta,
+          ),
+        BridgeSseMessagePartRemoved(
+          :final sessionID,
+          :final messageID,
+          :final partID,
+        ) =>
+          SesoriSseEvent.messagePartRemoved(
+            sessionID: sessionID,
+            messageID: messageID,
+            partID: partID,
+          ),
+        BridgeSsePtyCreated() => const SesoriSseEvent.ptyCreated(),
+        BridgeSsePtyUpdated() => const SesoriSseEvent.ptyUpdated(),
+        BridgeSsePtyExited(:final id, :final exitCode) => SesoriSseEvent.ptyExited(id: id, exitCode: exitCode),
+        BridgeSsePtyDeleted(:final id) => SesoriSseEvent.ptyDeleted(id: id),
+        BridgeSsePermissionAsked(
+          :final requestID,
+          :final sessionID,
+          :final tool,
+          :final description,
+        ) =>
+          SesoriSseEvent.permissionAsked(
+            requestID: requestID,
+            sessionID: sessionID,
+            tool: tool,
+            description: description,
+          ),
+        BridgeSsePermissionReplied(:final requestID, :final reply) => SesoriSseEvent.permissionReplied(
           requestID: requestID,
           reply: reply,
-        );
-      case BridgeSsePermissionUpdated():
-        return const SesoriSseEvent.permissionUpdated();
-      case BridgeSseQuestionAsked(:final id, :final sessionID, :final questions):
-        return _tryParseSseEvent({
+        ),
+        BridgeSsePermissionUpdated() => const SesoriSseEvent.permissionUpdated(),
+        BridgeSseQuestionAsked(:final id, :final sessionID, :final questions) => _tryParseSseEvent({
           "type": "question.asked",
           "id": id,
           "sessionID": sessionID,
           "questions": questions,
-        });
-      case BridgeSseQuestionReplied(:final requestID, :final sessionID):
-        return SesoriSseEvent.questionReplied(
+        }),
+        BridgeSseQuestionReplied(:final requestID, :final sessionID) => SesoriSseEvent.questionReplied(
           requestID: requestID,
           sessionID: sessionID,
-        );
-      case BridgeSseQuestionRejected(:final requestID, :final sessionID):
-        return SesoriSseEvent.questionRejected(
+        ),
+        BridgeSseQuestionRejected(:final requestID, :final sessionID) => SesoriSseEvent.questionRejected(
           requestID: requestID,
           sessionID: sessionID,
-        );
-      case BridgeSseTodoUpdated(:final sessionID):
-        return SesoriSseEvent.todoUpdated(sessionID: sessionID);
-      // BridgeSseProjectUpdated is emitted on both activity changes and project
-      // metadata changes. We always send the full projectsSummary so the mobile
-      // client receives updated activity data in real time.
-      case BridgeSseProjectUpdated():
-        return buildProjectsSummaryEvent();
-      case BridgeSseVcsBranchUpdated():
-        return const SesoriSseEvent.vcsBranchUpdated();
-      case BridgeSseFileEdited(:final file):
-        return SesoriSseEvent.fileEdited(file: file);
-      case BridgeSseFileWatcherUpdated(:final file, :final event):
-        return SesoriSseEvent.fileWatcherUpdated(file: file, event: event);
-      case BridgeSseLspUpdated():
-        return const SesoriSseEvent.lspUpdated();
-      case BridgeSseLspClientDiagnostics(:final serverID, :final path):
-        return SesoriSseEvent.lspClientDiagnostics(serverID: serverID, path: path);
-      case BridgeSseMcpToolsChanged():
-        return const SesoriSseEvent.mcpToolsChanged();
-      case BridgeSseMcpBrowserOpenFailed():
-        return const SesoriSseEvent.mcpBrowserOpenFailed();
-      case BridgeSseInstallationUpdated(:final version):
-        return SesoriSseEvent.installationUpdated(version: version);
-      case BridgeSseInstallationUpdateAvailable(:final version):
-        return SesoriSseEvent.installationUpdateAvailable(version: version);
-      case BridgeSseWorkspaceReady(:final name):
-        return SesoriSseEvent.workspaceReady(name: name);
-      case BridgeSseWorkspaceFailed(:final message):
-        return SesoriSseEvent.workspaceFailed(message: message);
-      case BridgeSseTuiToastShow(:final title, :final message, :final variant):
-        return SesoriSseEvent.tuiToastShow(
+        ),
+        BridgeSseTodoUpdated(:final sessionID) => SesoriSseEvent.todoUpdated(sessionID: sessionID),
+        // BridgeSseProjectUpdated is emitted on both activity changes and project
+        // metadata changes. We always send the full projectsSummary so the mobile
+        // client receives updated activity data in real time.
+        BridgeSseProjectUpdated() => buildProjectsSummaryEvent(),
+        BridgeSseVcsBranchUpdated() => const SesoriSseEvent.vcsBranchUpdated(),
+        BridgeSseFileEdited(:final file) => SesoriSseEvent.fileEdited(file: file),
+        BridgeSseFileWatcherUpdated(:final file, :final event) => SesoriSseEvent.fileWatcherUpdated(
+          file: file,
+          event: event,
+        ),
+        BridgeSseLspUpdated() => const SesoriSseEvent.lspUpdated(),
+        BridgeSseLspClientDiagnostics(:final serverID, :final path) => SesoriSseEvent.lspClientDiagnostics(
+          serverID: serverID,
+          path: path,
+        ),
+        BridgeSseMcpToolsChanged() => const SesoriSseEvent.mcpToolsChanged(),
+        BridgeSseMcpBrowserOpenFailed() => const SesoriSseEvent.mcpBrowserOpenFailed(),
+        BridgeSseInstallationUpdated(:final version) => SesoriSseEvent.installationUpdated(version: version),
+        BridgeSseInstallationUpdateAvailable(:final version) => SesoriSseEvent.installationUpdateAvailable(
+          version: version,
+        ),
+        BridgeSseWorkspaceReady(:final name) => SesoriSseEvent.workspaceReady(name: name),
+        BridgeSseWorkspaceFailed(:final message) => SesoriSseEvent.workspaceFailed(message: message),
+        BridgeSseTuiToastShow(:final title, :final message, :final variant) => SesoriSseEvent.tuiToastShow(
           title: title,
           message: message,
           variant: variant,
-        );
-      case BridgeSseWorktreeReady():
-        return const SesoriSseEvent.worktreeReady();
-      case BridgeSseWorktreeFailed():
-        return const SesoriSseEvent.worktreeFailed();
+        ),
+        BridgeSseWorktreeReady() => const SesoriSseEvent.worktreeReady(),
+        BridgeSseWorktreeFailed() => const SesoriSseEvent.worktreeFailed(),
+      };
+    } catch (e, st) {
+      Log.e("[sse-mapper] error mapping event ${event.runtimeType}: $e\n$st");
+      unawaited(
+        _failureReporter
+            .recordFailure(
+              error: e,
+              stackTrace: st,
+              uniqueIdentifier: "sse_event_mapping:${event.runtimeType}",
+              fatal: false,
+              reason: "Failed to map SSE event",
+              information: [event.runtimeType.toString()],
+            )
+            .catchError((_) {}),
+      );
+      return null;
     }
   }
 
   /// Builds a projects summary event from the current active sessions.
-  SesoriSseEvent buildProjectsSummaryEvent() {
-    final summary = _plugin.getActiveSessionsSummary();
-    return SesoriSseEvent.projectsSummary(
-      projects: summary
-          .map(
-            (e) => ProjectActivitySummary(
-              id: e.id,
-              activeSessions: e.activeSessions
-                  .map(
-                    (a) => ActiveSession(
-                      id: a.id,
-                      mainAgentRunning: a.mainAgentRunning,
-                      childSessionIds: a.childSessionIds,
-                    ),
-                  )
-                  .toList(),
-            ),
-          )
-          .toList(),
-    );
+  SesoriSseEvent? buildProjectsSummaryEvent() {
+    try {
+      final summary = _plugin.getActiveSessionsSummary();
+      return SesoriSseEvent.projectsSummary(
+        projects: summary
+            .map(
+              (e) => ProjectActivitySummary(
+                id: e.id,
+                activeSessions: e.activeSessions
+                    .map(
+                      (a) => ActiveSession(
+                        id: a.id,
+                        mainAgentRunning: a.mainAgentRunning,
+                        childSessionIds: a.childSessionIds,
+                      ),
+                    )
+                    .toList(),
+              ),
+            )
+            .toList(),
+      );
+    } catch (e, st) {
+      Log.e("[sse-mapper] error building projects summary: $e\n$st");
+      unawaited(
+        _failureReporter
+            .recordFailure(
+              error: e,
+              stackTrace: st,
+              uniqueIdentifier: "sse_projects_summary",
+              fatal: false,
+              reason: "Failed to build projects summary event",
+              information: const [],
+            )
+            .catchError((_) {}),
+      );
+      return null;
+    }
   }
 
   /// Attempts to parse an SSE event from a JSON payload.

--- a/bridge/app/lib/src/bridge/sse/sse_manager.dart
+++ b/bridge/app/lib/src/bridge/sse/sse_manager.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:collection";
 import "dart:convert";
 
@@ -17,6 +18,7 @@ class SSEManager {
   final Duration replayWindow;
 
   final void Function(int bytes) _onBytesSent;
+  final FailureReporter _failureReporter;
 
   /// Maximum number of events retained per subscriber queue.
   static const int maxQueueSize = 50000;
@@ -27,7 +29,12 @@ class SSEManager {
 
   List<int>? _roomKey;
 
-  SSEManager({required this.replayWindow, required void Function(int bytes) onBytesSent}) : _onBytesSent = onBytesSent;
+  SSEManager({
+    required this.replayWindow,
+    required void Function(int bytes) onBytesSent,
+    required FailureReporter failureReporter,
+  }) : _onBytesSent = onBytesSent,
+       _failureReporter = failureReporter;
 
   /// Stores a copy of the room key used to encrypt outgoing SSE events.
   void setRoomKey(List<int> roomKey) {
@@ -43,6 +50,21 @@ class SSEManager {
 
     if (orphan != null) {
       orphan.onDequeue = _createSendFunction(connID, client);
+      orphan.onError = (event, error) {
+        Log.w("[sse] failed to send event ${event.runtimeType} to connID=$connID: $error");
+        unawaited(
+          _failureReporter
+              .recordFailure(
+                error: error,
+                stackTrace: StackTrace.current,
+                uniqueIdentifier: "sse_send_failure:$connID",
+                fatal: false,
+                reason: "Failed to send SSE event to phone",
+                information: [event.runtimeType.toString(), "connID=$connID"],
+              )
+              .catchError((_) {}),
+        );
+      };
       orphan.resume();
       _subscribers[connID] = orphan;
       return;
@@ -51,6 +73,21 @@ class SSEManager {
     _subscribers[connID] = EventQueue<SesoriSseEvent>(
       onDequeue: _createSendFunction(connID, client),
       maxSize: maxQueueSize,
+      onError: (event, error) {
+        Log.w("[sse] failed to send event ${event.runtimeType} to connID=$connID: $error");
+        unawaited(
+          _failureReporter
+              .recordFailure(
+                error: error,
+                stackTrace: StackTrace.current,
+                uniqueIdentifier: "sse_send_failure:$connID",
+                fatal: false,
+                reason: "Failed to send SSE event to phone",
+                information: [event.runtimeType.toString(), "connID=$connID"],
+              )
+              .catchError((_) {}),
+        );
+      },
     );
   }
 

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -8,6 +8,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
 import "../helpers/test_database.dart";
+import "../helpers/test_helpers.dart";
 
 void main() {
   group("DebugServer SSE multi-client", () {
@@ -18,7 +19,12 @@ void main() {
     setUp(() async {
       plugin = _FakeBridgePlugin();
       db = createTestDatabase();
-      debugServer = DebugServer(plugin: plugin, projectsDao: db.projectsDao, port: 0);
+      debugServer = DebugServer(
+        plugin: plugin,
+        projectsDao: db.projectsDao,
+        port: 0,
+        failureReporter: FakeFailureReporter(),
+      );
       await debugServer.start();
     });
 
@@ -67,6 +73,7 @@ void main() {
         plugin: trackingPlugin,
         projectsDao: trackingDb.projectsDao,
         port: 0,
+        failureReporter: FakeFailureReporter(),
       );
       await trackingServer.start();
       addTearDown(trackingServer.stop);
@@ -97,7 +104,12 @@ void main() {
     setUp(() async {
       plugin = _FakeBridgePlugin();
       db = createTestDatabase();
-      debugServer = DebugServer(plugin: plugin, projectsDao: db.projectsDao, port: 0);
+      debugServer = DebugServer(
+        plugin: plugin,
+        projectsDao: db.projectsDao,
+        port: 0,
+        failureReporter: FakeFailureReporter(),
+      );
       await debugServer.start();
     });
 

--- a/bridge/app/test/bridge/log_failure_reporter_test.dart
+++ b/bridge/app/test/bridge/log_failure_reporter_test.dart
@@ -1,0 +1,92 @@
+import 'package:sesori_bridge/src/bridge/log_failure_reporter.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late LogFailureReporter reporter;
+
+  setUp(() {
+    reporter = LogFailureReporter();
+  });
+
+  group('LogFailureReporter', () {
+    test('recordFailure with fatal: true returns completed Future', () async {
+      final future = reporter.recordFailure(
+        error: Exception('test error'),
+        stackTrace: StackTrace.current,
+        uniqueIdentifier: 'test-fatal-1',
+        fatal: true,
+        reason: 'Test fatal error',
+        information: const [],
+      );
+
+      // Verify it's a completed Future
+      expect(future, isA<Future<void>>());
+      await expectLater(future, completes);
+    });
+
+    test('recordFailure with fatal: false returns completed Future', () async {
+      final future = reporter.recordFailure(
+        error: Exception('test error'),
+        stackTrace: StackTrace.current,
+        uniqueIdentifier: 'test-non-fatal-1',
+        fatal: false,
+        reason: 'Test non-fatal error',
+        information: const [],
+      );
+
+      // Verify it's a completed Future
+      expect(future, isA<Future<void>>());
+      await expectLater(future, completes);
+    });
+
+    test('log does not throw', () {
+      expect(
+        () => reporter.log(message: 'test message'),
+        returnsNormally,
+      );
+    });
+
+    test('setGlobalKey does not throw', () {
+      expect(
+        () => reporter.setGlobalKey(key: 'test-key', value: 'test-value'),
+        returnsNormally,
+      );
+    });
+
+    test('recordFailure with null reason does not throw', () async {
+      final future = reporter.recordFailure(
+        error: Exception('test error'),
+        stackTrace: StackTrace.current,
+        uniqueIdentifier: 'test-null-reason',
+        fatal: false,
+        reason: null,
+        information: const [],
+      );
+
+      expect(future, isA<Future<void>>());
+      await expectLater(future, completes);
+    });
+
+    test('recordFailure with information list does not throw', () async {
+      final future = reporter.recordFailure(
+        error: Exception('test error'),
+        stackTrace: StackTrace.current,
+        uniqueIdentifier: 'test-with-info',
+        fatal: false,
+        reason: 'Test with info',
+        information: ['info1', 'info2', 'info3'],
+      );
+
+      expect(future, isA<Future<void>>());
+      await expectLater(future, completes);
+    });
+
+    test('implements FailureReporter interface', () {
+      // Verify that LogFailureReporter implements FailureReporter
+      // by checking that it has all required methods
+      expect(reporter.setGlobalKey, isNotNull);
+      expect(reporter.log, isNotNull);
+      expect(reporter.recordFailure, isNotNull);
+    });
+  });
+}

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -1,0 +1,330 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/auth/token_refresher.dart";
+import "package:sesori_bridge/src/bridge/models/bridge_config.dart";
+import "package:sesori_bridge/src/bridge/orchestrator.dart";
+import "package:sesori_bridge/src/bridge/persistence/database.dart";
+import "package:sesori_bridge/src/bridge/relay_client.dart";
+import "package:sesori_bridge/src/push/completion_notifier.dart";
+import "package:sesori_bridge/src/push/push_notification_client.dart";
+import "package:sesori_bridge/src/push/push_notification_service.dart";
+import "package:sesori_bridge/src/push/push_rate_limiter.dart";
+import "package:sesori_bridge/src/push/push_session_state_tracker.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "../helpers/test_database.dart";
+import "../helpers/test_helpers.dart";
+
+void main() {
+  group("OrchestratorSession SSE error recovery", () {
+    test("stream continues after mapper throws", () async {
+      final harness = await _TestHarness.start(
+        plugin: _ThrowingSummaryPlugin(),
+      );
+      addTearDown(harness.close);
+
+      await harness.waitForSubscription();
+
+      harness.plugin.add(const BridgeSseProjectUpdated());
+      harness.plugin.add(const BridgeSseProjectUpdated());
+
+      await harness.waitForFailureCount(expected: 2);
+
+      expect(
+        harness.failureReporter.recordedIdentifiers,
+        equals([
+          "sse_projects_summary",
+          "sse_projects_summary",
+        ]),
+      );
+    });
+
+    test("records failure with event-specific unique identifier", () async {
+      final harness = await _TestHarness.start(
+        plugin: _ThrowingSummaryPlugin(),
+      );
+      addTearDown(harness.close);
+
+      await harness.waitForSubscription();
+
+      harness.plugin.add(const BridgeSseProjectUpdated());
+
+      await harness.waitForFailureCount(expected: 1);
+
+      expect(
+        harness.failureReporter.recordedIdentifiers.single,
+        equals("sse_projects_summary"),
+      );
+    });
+  });
+}
+
+class _TestHarness {
+  final _ThrowingSummaryPlugin plugin;
+  final CapturingFailureReporter failureReporter;
+  final OrchestratorSession session;
+  final Future<void> runFuture;
+  final TestRelayServer relayServer;
+  final AppDatabase database;
+
+  _TestHarness._({
+    required this.plugin,
+    required this.failureReporter,
+    required this.session,
+    required this.runFuture,
+    required this.relayServer,
+    required this.database,
+  });
+
+  static Future<_TestHarness> start({
+    required _ThrowingSummaryPlugin plugin,
+  }) async {
+    final relayServer = await TestRelayServer.start();
+    final database = createTestDatabase();
+    final failureReporter = CapturingFailureReporter();
+    final pushService = _createPushNotificationService();
+    final tokenRefresher = _FakeTokenRefresher();
+    final relayClient = RelayClient(
+      relayURL: "ws://127.0.0.1:${relayServer.port}",
+      accessTokenProvider: FakeAccessTokenProvider(""),
+    );
+
+    final orchestrator = Orchestrator(
+      config: BridgeConfig(
+        relayURL: "ws://127.0.0.1:${relayServer.port}",
+        serverURL: "http://127.0.0.1:4096",
+        serverPassword: null,
+        authBackendURL: "http://127.0.0.1:8080",
+        sseReplayWindow: const Duration(minutes: 1),
+      ),
+      client: relayClient,
+      plugin: plugin,
+      pushNotificationService: pushService,
+      tokenRefresher: tokenRefresher,
+      projectsDao: database.projectsDao,
+      failureReporter: failureReporter,
+    );
+
+    final session = orchestrator.create();
+    final runFuture = session.run();
+
+    await relayServer.nextClient();
+
+    return _TestHarness._(
+      plugin: plugin,
+      failureReporter: failureReporter,
+      session: session,
+      runFuture: runFuture,
+      relayServer: relayServer,
+      database: database,
+    );
+  }
+
+  Future<void> waitForSubscription() async {
+    final timeoutAt = DateTime.now().add(const Duration(seconds: 2));
+    while (plugin.subscribeCount == 0) {
+      if (DateTime.now().isAfter(timeoutAt)) {
+        fail("Timed out waiting for plugin event subscription");
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+  }
+
+  Future<void> waitForFailureCount({required int expected}) async {
+    final timeoutAt = DateTime.now().add(const Duration(seconds: 2));
+    while (failureReporter.recordedIdentifiers.length < expected) {
+      if (DateTime.now().isAfter(timeoutAt)) {
+        fail("Timed out waiting for failure reports");
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+  }
+
+  Future<void> close() async {
+    await session.cancel();
+    await runFuture.timeout(const Duration(seconds: 5));
+    await plugin.close();
+    await database.close();
+    await relayServer.close();
+  }
+}
+
+PushNotificationService _createPushNotificationService() {
+  final tracker = PushSessionStateTracker();
+  final completionNotifier = CompletionNotifier(tracker: tracker);
+  return PushNotificationService(
+    client: _NoopPushNotificationClient(),
+    rateLimiter: PushRateLimiter(),
+    tracker: tracker,
+    completionNotifier: completionNotifier,
+  );
+}
+
+class _ThrowingSummaryPlugin implements BridgePlugin {
+  final _controller = StreamController<BridgeSseEvent>.broadcast();
+
+  int subscribeCount = 0;
+
+  @override
+  String get id => "throwing-summary";
+
+  @override
+  Stream<BridgeSseEvent> get events {
+    return Stream<BridgeSseEvent>.multi((controller) {
+      subscribeCount++;
+      final sub = _controller.stream.listen(
+        controller.add,
+        onError: controller.addError,
+        onDone: controller.close,
+      );
+      controller.onCancel = () => sub.cancel();
+    });
+  }
+
+  void add(BridgeSseEvent event) => _controller.add(event);
+
+  Future<void> close() => _controller.close();
+
+  @override
+  Future<List<PluginProject>> getProjects() async => [];
+
+  @override
+  Future<List<PluginSession>> getSessions(
+    String worktree, {
+    int? start,
+    int? limit,
+  }) async => [];
+
+  @override
+  Future<PluginSession> createSession({
+    required String projectId,
+    String? parentSessionId,
+  }) async => const PluginSession(
+    id: "",
+    projectID: "",
+    directory: "",
+    parentID: null,
+    title: null,
+    time: null,
+    summary: null,
+  );
+
+  @override
+  Future<PluginSession> updateSessionArchiveStatus(
+    String sessionId, {
+    required bool archived,
+  }) async => const PluginSession(
+    id: "",
+    projectID: "",
+    directory: "",
+    parentID: null,
+    title: null,
+    time: null,
+    summary: null,
+  );
+
+  @override
+  Future<PluginSession> renameSession({
+    required String sessionId,
+    required String title,
+  }) async => const PluginSession(
+    id: "",
+    projectID: "",
+    directory: "",
+    parentID: null,
+    title: null,
+    time: null,
+    summary: null,
+  );
+
+  @override
+  Future<PluginProject> renameProject({
+    required String projectId,
+    required String name,
+  }) async => const PluginProject(id: "");
+
+  @override
+  Future<void> deleteSession(String sessionId) async {}
+
+  @override
+  Future<List<PluginSession>> getChildSessions(String sessionId) async => [];
+
+  @override
+  Future<Map<String, PluginSessionStatus>> getSessionStatuses() async => {};
+
+  @override
+  Future<List<PluginMessageWithParts>> getSessionMessages(
+    String sessionId,
+  ) async => [];
+
+  @override
+  Future<void> sendPrompt({
+    required String sessionId,
+    required List<PluginPromptPart> parts,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async {}
+
+  @override
+  Future<void> abortSession({required String sessionId}) async {}
+
+  @override
+  Future<List<PluginAgent>> getAgents() async => [];
+
+  @override
+  Future<List<PluginPendingQuestion>> getPendingQuestions({
+    required String sessionId,
+  }) async => [];
+
+  @override
+  Future<List<PluginPendingQuestion>> getProjectQuestions({
+    required String projectId,
+  }) async => [];
+
+  @override
+  Future<void> replyToQuestion({
+    required String questionId,
+    required String sessionId,
+    required List<List<String>> answers,
+  }) async {}
+
+  @override
+  Future<void> rejectQuestion(String questionId) async {}
+
+  @override
+  Future<PluginProject> getProject(String projectId) async => const PluginProject(id: "");
+
+  @override
+  Future<String> healthCheck() async => '{"healthy":true}';
+
+  @override
+  List<PluginProjectActivitySummary> getActiveSessionsSummary() {
+    throw StateError("summary mapping failed");
+  }
+
+  @override
+  Future<PluginProvidersResult> getProviders({
+    required bool connectedOnly,
+  }) async => const PluginProvidersResult(providers: []);
+
+  @override
+  Future<void> dispose() async {}
+}
+
+class _NoopPushNotificationClient extends PushNotificationClient {
+  _NoopPushNotificationClient()
+    : super(
+        authBackendURL: "http://127.0.0.1:8080",
+        tokenRefreshManager: _FakeTokenRefresher(),
+      );
+
+  @override
+  Future<void> sendNotification(SendNotificationPayload payload) async {}
+}
+
+class _FakeTokenRefresher implements TokenRefresher {
+  @override
+  Future<String> getAccessToken({bool forceRefresh = false}) async => "token";
+}

--- a/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
+++ b/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
@@ -3,6 +3,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/test_helpers.dart";
 import "../routing/routing_test_helpers.dart";
 
 void main() {
@@ -10,7 +11,10 @@ void main() {
     late BridgeEventMapper mapper;
 
     setUp(() {
-      mapper = BridgeEventMapper(FakeBridgePlugin());
+      mapper = BridgeEventMapper(
+        plugin: FakeBridgePlugin(),
+        failureReporter: FakeFailureReporter(),
+      );
     });
 
     test("filters heartbeat events", () {
@@ -262,5 +266,38 @@ void main() {
       final event = result! as SesoriMessagePartUpdated;
       expect(event.part.state?.output, equals("short"));
     });
+
+    test("map() returns null and reports failure when buildProjectsSummaryEvent() throws", () {
+      final capturingReporter = CapturingFailureReporter();
+      final throwingMapper = BridgeEventMapper(
+        plugin: _ThrowingActiveSessionsPlugin(),
+        failureReporter: capturingReporter,
+      );
+
+      final result = throwingMapper.map(const BridgeSseProjectUpdated());
+
+      expect(result, isNull);
+      expect(capturingReporter.recordedIdentifiers, contains("sse_projects_summary"));
+    });
+
+    test("buildProjectsSummaryEvent() returns null and reports failure when plugin throws", () {
+      final capturingReporter = CapturingFailureReporter();
+      final throwingMapper = BridgeEventMapper(
+        plugin: _ThrowingActiveSessionsPlugin(),
+        failureReporter: capturingReporter,
+      );
+
+      final result = throwingMapper.buildProjectsSummaryEvent();
+
+      expect(result, isNull);
+      expect(capturingReporter.recordedIdentifiers, contains("sse_projects_summary"));
+    });
   });
+}
+
+class _ThrowingActiveSessionsPlugin extends FakeBridgePlugin {
+  @override
+  List<PluginProjectActivitySummary> getActiveSessionsSummary() {
+    throw StateError("summary mapping failed");
+  }
 }

--- a/bridge/app/test/bridge/sse_manager_test.dart
+++ b/bridge/app/test/bridge/sse_manager_test.dart
@@ -13,7 +13,11 @@ import "../helpers/test_helpers.dart";
 void main() {
   group("SSEManager", () {
     test("subscribe registers subscribers", () {
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
+      final manager = SSEManager(
+        replayWindow: SSEManager.defaultReplayWindow,
+        onBytesSent: (_) {},
+        failureReporter: FakeFailureReporter(),
+      );
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
@@ -27,7 +31,11 @@ void main() {
     });
 
     test("enqueueEvent with no subscribers does nothing", () async {
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
+      final manager = SSEManager(
+        replayWindow: SSEManager.defaultReplayWindow,
+        onBytesSent: (_) {},
+        failureReporter: FakeFailureReporter(),
+      );
       final client = _RecordingRelayClient();
       manager.setRoomKey(makeRoomKey());
 
@@ -40,7 +48,11 @@ void main() {
     test("enqueueEvent delivers typed payload envelope to all subscribers", () async {
       final roomKey = makeRoomKey();
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
+      final manager = SSEManager(
+        replayWindow: SSEManager.defaultReplayWindow,
+        onBytesSent: (_) {},
+        failureReporter: FakeFailureReporter(),
+      );
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
@@ -78,7 +90,11 @@ void main() {
 
     test("without room key events are not sent", () async {
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
+      final manager = SSEManager(
+        replayWindow: SSEManager.defaultReplayWindow,
+        onBytesSent: (_) {},
+        failureReporter: FakeFailureReporter(),
+      );
       addTearDown(manager.stop);
 
       manager.subscribePath(7, "/global/event", client);
@@ -89,7 +105,11 @@ void main() {
     });
 
     test("non-last unsubscribe creates orphan queue", () {
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
+      final manager = SSEManager(
+        replayWindow: SSEManager.defaultReplayWindow,
+        onBytesSent: (_) {},
+        failureReporter: FakeFailureReporter(),
+      );
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
@@ -105,7 +125,11 @@ void main() {
     });
 
     test("last unsubscribe creates orphan queue", () {
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
+      final manager = SSEManager(
+        replayWindow: SSEManager.defaultReplayWindow,
+        onBytesSent: (_) {},
+        failureReporter: FakeFailureReporter(),
+      );
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
@@ -122,7 +146,11 @@ void main() {
     test("single subscriber reconnect replays buffered events", () async {
       final roomKey = makeRoomKey();
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
+      final manager = SSEManager(
+        replayWindow: SSEManager.defaultReplayWindow,
+        onBytesSent: (_) {},
+        failureReporter: FakeFailureReporter(),
+      );
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
@@ -153,7 +181,11 @@ void main() {
     test("orphan queue replays to next subscriber within replay window", () async {
       final roomKey = makeRoomKey();
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
+      final manager = SSEManager(
+        replayWindow: SSEManager.defaultReplayWindow,
+        onBytesSent: (_) {},
+        failureReporter: FakeFailureReporter(),
+      );
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
@@ -181,7 +213,11 @@ void main() {
       await withClock(fakeClock, () async {
         final roomKey = makeRoomKey();
         final client = _RecordingRelayClient();
-        final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
+        final manager = SSEManager(
+          replayWindow: SSEManager.defaultReplayWindow,
+          onBytesSent: (_) {},
+          failureReporter: FakeFailureReporter(),
+        );
         manager.setRoomKey(roomKey);
         addTearDown(manager.stop);
 
@@ -206,7 +242,11 @@ void main() {
     test("orphanAll moves all subscribers to orphan state", () async {
       final roomKey = makeRoomKey();
       final client = _RecordingRelayClient();
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
+      final manager = SSEManager(
+        replayWindow: SSEManager.defaultReplayWindow,
+        onBytesSent: (_) {},
+        failureReporter: FakeFailureReporter(),
+      );
       manager.setRoomKey(roomKey);
       addTearDown(manager.stop);
 
@@ -238,7 +278,11 @@ void main() {
     });
 
     test("stop clears subscribers and orphan queues", () {
-      final manager = SSEManager(replayWindow: SSEManager.defaultReplayWindow, onBytesSent: (_) {});
+      final manager = SSEManager(
+        replayWindow: SSEManager.defaultReplayWindow,
+        onBytesSent: (_) {},
+        failureReporter: FakeFailureReporter(),
+      );
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
@@ -252,6 +296,36 @@ void main() {
 
       expect(manager.subscriberCount, equals(0));
       expect(manager.pendingReplayCount, equals(0));
+    });
+
+    test("EventQueue onError callback reports failure when send function throws", () async {
+      final roomKey = makeRoomKey();
+      final throwingClient = _ThrowingRelayClient();
+      final capturingReporter = CapturingFailureReporter();
+      final manager = SSEManager(
+        replayWindow: SSEManager.defaultReplayWindow,
+        onBytesSent: (_) {},
+        failureReporter: capturingReporter,
+      );
+      manager.setRoomKey(roomKey);
+      addTearDown(manager.stop);
+
+      manager.subscribePath(42, "/global/event", throwingClient);
+      manager.enqueueEvent(_event("repo-err"));
+
+      // Wait for the send function to throw and the onError callback to fire.
+      final deadline = DateTime.now().add(const Duration(seconds: 5));
+      while (capturingReporter.recordedIdentifiers.isEmpty) {
+        if (DateTime.now().isAfter(deadline)) {
+          fail("Timed out waiting for failure report from onError callback");
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+      }
+
+      expect(
+        capturingReporter.recordedIdentifiers,
+        contains("sse_send_failure:42"),
+      );
     });
   });
 }
@@ -304,5 +378,18 @@ class _RecordingRelayClient extends RelayClient {
   void send(int connID, List<int> payload) {
     sentConnIDs.add(connID);
     sentPayloads.add(List<int>.from(payload));
+  }
+}
+
+class _ThrowingRelayClient extends RelayClient {
+  _ThrowingRelayClient()
+    : super(
+        relayURL: "ws://127.0.0.1:1",
+        accessTokenProvider: FakeAccessTokenProvider(""),
+      );
+
+  @override
+  void send(int connID, List<int> payload) {
+    throw Exception("send failed intentionally");
   }
 }

--- a/bridge/app/test/helpers/test_helpers.dart
+++ b/bridge/app/test/helpers/test_helpers.dart
@@ -6,6 +6,7 @@ import "dart:math";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_bridge/src/auth/access_token_provider.dart";
 import "package:sesori_bridge/src/bridge/relay_client.dart";
+import "package:sesori_shared/sesori_shared.dart";
 
 class FakeAccessTokenProvider implements AccessTokenProvider {
   final BehaviorSubject<String> _subject;
@@ -17,6 +18,49 @@ class FakeAccessTokenProvider implements AccessTokenProvider {
 
   @override
   ValueStream<String> get tokenStream => _subject.stream;
+}
+
+class FakeFailureReporter implements FailureReporter {
+  @override
+  void setGlobalKey({required String key, required Object value}) {}
+
+  @override
+  void log({required String message}) {}
+
+  @override
+  Future<void> recordFailure({
+    required Object error,
+    required StackTrace stackTrace,
+    required String uniqueIdentifier,
+    required bool fatal,
+    required String? reason,
+    required Iterable<Object> information,
+  }) => Future<void>.value();
+}
+
+/// A [FailureReporter] that captures recorded failure identifiers for assertions.
+class CapturingFailureReporter extends FakeFailureReporter {
+  final List<String> recordedIdentifiers = [];
+
+  @override
+  Future<void> recordFailure({
+    required Object error,
+    required StackTrace stackTrace,
+    required String uniqueIdentifier,
+    required bool fatal,
+    required String? reason,
+    required Iterable<Object> information,
+  }) async {
+    recordedIdentifiers.add(uniqueIdentifier);
+    await super.recordFailure(
+      error: error,
+      stackTrace: stackTrace,
+      uniqueIdentifier: uniqueIdentifier,
+      fatal: fatal,
+      reason: reason,
+      information: information,
+    );
+  }
 }
 
 List<int> makeRoomKey() {

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -520,8 +520,8 @@ class OpenCodePlugin implements BridgePlugin {
       if (bridgeEvent != null) {
         _eventBuffer.add(bridgeEvent);
       }
-    } catch (_) {
-      // processSseEvent must never throw.
+    } catch (e, st) {
+      Log.e("[opencode] SSE event processing error: $e\n$st");
     }
   }
 

--- a/bridge/sesori_plugin_opencode/lib/src/sse/sse_connection.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse/sse_connection.dart
@@ -2,6 +2,7 @@ import "dart:async";
 import "dart:convert";
 
 import "package:http/http.dart" as http;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 class SseConnection {
   final String _targetUrl;
@@ -70,7 +71,8 @@ class SseConnection {
         isFirstConnect = false;
         reconnectDelay = const Duration(seconds: 1);
         await _readStream(response, generation);
-      } catch (_) {
+      } catch (e, st) {
+        Log.e("[sse-conn] stream loop error: $e\n$st");
         if (!_active || _generation != generation) return;
       } finally {
         client.close();
@@ -105,7 +107,11 @@ class SseConnection {
 
         if (line.isEmpty) {
           if (dataLines.isNotEmpty) {
-            _onEvent(dataLines.join("\n"));
+            try {
+              _onEvent(dataLines.join("\n"));
+            } catch (e, st) {
+              Log.e("[sse-conn] onEvent callback error: $e\n$st");
+            }
             dataLines.clear();
           }
           continue;
@@ -120,7 +126,11 @@ class SseConnection {
     }
 
     if (dataLines.isNotEmpty) {
-      _onEvent(dataLines.join("\n"));
+      try {
+        _onEvent(dataLines.join("\n"));
+      } catch (e, st) {
+        Log.e("[sse-conn] onEvent callback error: $e\n$st");
+      }
       dataLines.clear();
     }
   }

--- a/mobile/app/lib/features/project_list/project_list_screen.dart
+++ b/mobile/app/lib/features/project_list/project_list_screen.dart
@@ -22,6 +22,7 @@ class ProjectListScreen extends StatelessWidget {
         getIt<ConnectionService>(),
         getIt<SseEventRepository>(),
         getIt<RouteSource>(),
+        failureReporter: getIt<FailureReporter>(),
       ),
       child: const _ProjectListBody(),
     );

--- a/mobile/app/lib/features/session_detail/session_detail_screen.dart
+++ b/mobile/app/lib/features/session_detail/session_detail_screen.dart
@@ -39,6 +39,7 @@ class SessionDetailScreen extends StatelessWidget {
         getIt<ConnectionService>(),
         sessionId: sessionId,
         notificationCanceller: getIt<NotificationCanceller>(),
+        failureReporter: getIt<FailureReporter>(),
       ),
       child: _SessionDetailBody(
         sessionTitle: sessionTitle,

--- a/mobile/app/lib/features/session_list/session_list_screen.dart
+++ b/mobile/app/lib/features/session_list/session_list_screen.dart
@@ -29,6 +29,7 @@ class SessionListScreen extends StatelessWidget {
         getIt<ConnectionService>(),
         getIt<SseEventRepository>(),
         projectId: projectId,
+        failureReporter: getIt<FailureReporter>(),
       ),
       child: _SessionListBody(projectName: projectName),
     );

--- a/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -24,6 +24,7 @@ void main() {
     late MockSessionService mockSessionService;
     late MockConnectionService mockConnectionService;
     late MockNotificationCanceller mockNotificationCanceller;
+    late MockFailureReporter mockFailureReporter;
     late BehaviorSubject<SesoriSessionEvent> sessionEvents;
     late BehaviorSubject<SseEvent> globalEvents;
     late BehaviorSubject<ConnectionStatus> connectionStatus;
@@ -32,9 +33,21 @@ void main() {
       mockSessionService = MockSessionService();
       mockConnectionService = MockConnectionService();
       mockNotificationCanceller = MockNotificationCanceller();
+      mockFailureReporter = MockFailureReporter();
       sessionEvents = BehaviorSubject<SesoriSessionEvent>();
       globalEvents = BehaviorSubject<SseEvent>();
       connectionStatus = BehaviorSubject<ConnectionStatus>();
+
+      when(
+        () => mockFailureReporter.recordFailure(
+          error: any(named: "error"),
+          stackTrace: any(named: "stackTrace"),
+          uniqueIdentifier: any(named: "uniqueIdentifier"),
+          fatal: any(named: "fatal"),
+          reason: any(named: "reason"),
+          information: any(named: "information"),
+        ),
+      ).thenAnswer((_) async {});
 
       _stubAllDefaults(
         mockSessionService,
@@ -60,6 +73,7 @@ void main() {
         mockConnectionService,
         sessionId: sessionId,
         notificationCanceller: mockNotificationCanceller,
+        failureReporter: mockFailureReporter,
       ),
       expect: () => [
         isA<SessionDetailLoaded>(),
@@ -88,6 +102,7 @@ void main() {
           mockConnectionService,
           sessionId: sessionId,
           notificationCanceller: mockNotificationCanceller,
+          failureReporter: mockFailureReporter,
         );
       },
       expect: () => [
@@ -102,6 +117,7 @@ void main() {
         mockConnectionService,
         sessionId: sessionId,
         notificationCanceller: mockNotificationCanceller,
+        failureReporter: mockFailureReporter,
       ),
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -129,6 +145,7 @@ void main() {
         mockConnectionService,
         sessionId: sessionId,
         notificationCanceller: mockNotificationCanceller,
+        failureReporter: mockFailureReporter,
       ),
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -157,6 +174,7 @@ void main() {
         mockConnectionService,
         sessionId: sessionId,
         notificationCanceller: mockNotificationCanceller,
+        failureReporter: mockFailureReporter,
       ),
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -200,6 +218,7 @@ void main() {
         mockConnectionService,
         sessionId: sessionId,
         notificationCanceller: mockNotificationCanceller,
+        failureReporter: mockFailureReporter,
       ),
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -222,6 +241,7 @@ void main() {
         mockConnectionService,
         sessionId: sessionId,
         notificationCanceller: mockNotificationCanceller,
+        failureReporter: mockFailureReporter,
       ),
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -242,6 +262,7 @@ void main() {
         mockConnectionService,
         sessionId: sessionId,
         notificationCanceller: mockNotificationCanceller,
+        failureReporter: mockFailureReporter,
       ),
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -267,6 +288,7 @@ void main() {
           mockConnectionService,
           sessionId: sessionId,
           notificationCanceller: mockNotificationCanceller,
+          failureReporter: mockFailureReporter,
         );
       },
       act: (cubit) async {
@@ -314,6 +336,7 @@ void main() {
           mockConnectionService,
           sessionId: sessionId,
           notificationCanceller: mockNotificationCanceller,
+          failureReporter: mockFailureReporter,
         );
       },
       act: (cubit) async {
@@ -347,6 +370,7 @@ void main() {
           mockConnectionService,
           sessionId: sessionId,
           notificationCanceller: mockNotificationCanceller,
+          failureReporter: mockFailureReporter,
         );
       },
       act: (cubit) async {
@@ -373,6 +397,7 @@ void main() {
         mockConnectionService,
         sessionId: sessionId,
         notificationCanceller: mockNotificationCanceller,
+        failureReporter: mockFailureReporter,
       ),
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -400,6 +425,7 @@ void main() {
         mockConnectionService,
         sessionId: sessionId,
         notificationCanceller: mockNotificationCanceller,
+        failureReporter: mockFailureReporter,
       ),
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -425,6 +451,7 @@ void main() {
           mockConnectionService,
           sessionId: sessionId,
           notificationCanceller: mockNotificationCanceller,
+          failureReporter: mockFailureReporter,
         );
       },
       act: (cubit) async {
@@ -449,6 +476,7 @@ void main() {
         mockConnectionService,
         sessionId: sessionId,
         notificationCanceller: mockNotificationCanceller,
+        failureReporter: mockFailureReporter,
       ),
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -488,6 +516,7 @@ void main() {
           mockConnectionService,
           sessionId: sessionId,
           notificationCanceller: mockNotificationCanceller,
+          failureReporter: mockFailureReporter,
         );
       },
       expect: () => [
@@ -513,6 +542,7 @@ void main() {
           mockConnectionService,
           sessionId: sessionId,
           notificationCanceller: mockNotificationCanceller,
+          failureReporter: mockFailureReporter,
         );
       },
       act: (cubit) async {
@@ -546,6 +576,7 @@ void main() {
         mockConnectionService,
         sessionId: sessionId,
         notificationCanceller: mockNotificationCanceller,
+        failureReporter: mockFailureReporter,
       ),
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -574,6 +605,7 @@ void main() {
           mockConnectionService,
           sessionId: sessionId,
           notificationCanceller: mockNotificationCanceller,
+          failureReporter: mockFailureReporter,
         );
       },
       act: (cubit) async {
@@ -614,6 +646,7 @@ void main() {
           mockConnectionService,
           sessionId: sessionId,
           notificationCanceller: mockNotificationCanceller,
+          failureReporter: mockFailureReporter,
         );
       },
       act: (cubit) async {
@@ -659,6 +692,7 @@ void main() {
           mockConnectionService,
           sessionId: sessionId,
           notificationCanceller: mockNotificationCanceller,
+          failureReporter: mockFailureReporter,
         );
       },
       act: (cubit) async {
@@ -703,6 +737,7 @@ void main() {
           mockConnectionService,
           sessionId: sessionId,
           notificationCanceller: mockNotificationCanceller,
+          failureReporter: mockFailureReporter,
         );
       },
       act: (cubit) async {
@@ -758,6 +793,7 @@ void main() {
         mockConnectionService,
         sessionId: sessionId,
         notificationCanceller: mockNotificationCanceller,
+        failureReporter: mockFailureReporter,
       ),
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -823,6 +859,7 @@ void main() {
         mockConnectionService,
         sessionId: sessionId,
         notificationCanceller: mockNotificationCanceller,
+        failureReporter: mockFailureReporter,
       ),
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -897,6 +934,7 @@ void main() {
           mockConnectionService,
           sessionId: sessionId,
           notificationCanceller: mockNotificationCanceller,
+          failureReporter: mockFailureReporter,
         );
       },
       act: (cubit) async {

--- a/mobile/app/test/helpers/test_helpers.dart
+++ b/mobile/app/test/helpers/test_helpers.dart
@@ -143,6 +143,7 @@ void registerAllFallbackValues() {
   registerFallbackValue(const RecordConfig());
   registerFallbackValue(http.MultipartFile.fromString("audio", ""));
   registerFallbackValue(OAuthProvider.github);
+  registerFallbackValue(StackTrace.empty);
 }
 
 // ---------------------------------------------------------------------------

--- a/mobile/module_core/lib/src/capabilities/notifications/register_token_request.g.dart
+++ b/mobile/module_core/lib/src/capabilities/notifications/register_token_request.g.dart
@@ -22,4 +22,5 @@ Map<String, dynamic> _$RegisterTokenRequestToJson(
 const _$DevicePlatformEnumMap = {
   DevicePlatform.ios: 'ios',
   DevicePlatform.android: 'android',
+  DevicePlatform.macos: 'macos',
 };

--- a/mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart
+++ b/mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart
@@ -79,7 +79,7 @@ class SseEventRepository with Disposable {
             .recordFailure(
               error: e,
               stackTrace: st,
-              uniqueIdentifier: "sse_event_repository",
+              uniqueIdentifier: "sse_event_repository:${event.data.runtimeType}",
               fatal: false,
               reason: "Failed to handle SSE event in repository",
               information: [event.data.runtimeType.toString()],

--- a/mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart
+++ b/mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart
@@ -5,6 +5,7 @@ import "package:injectable/injectable.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../../logging/logging.dart";
 import "../server_connection/connection_service.dart";
 import "../server_connection/models/sse_event.dart";
 import "session_activity_info.dart";
@@ -12,6 +13,7 @@ import "session_activity_info.dart";
 @lazySingleton
 class SseEventRepository with Disposable {
   final ConnectionService _connectionService;
+  final FailureReporter _failureReporter;
   late final StreamSubscription<SseEvent> _subscription;
 
   final BehaviorSubject<Map<String, int>> _projectActivity = BehaviorSubject.seeded(const {});
@@ -21,7 +23,11 @@ class SseEventRepository with Disposable {
     const {},
   );
 
-  SseEventRepository(ConnectionService connectionService) : _connectionService = connectionService {
+  SseEventRepository(
+    ConnectionService connectionService, {
+    required FailureReporter failureReporter,
+  }) : _connectionService = connectionService,
+       _failureReporter = failureReporter {
     _subscription = _connectionService.events.listen(_handleEvent);
   }
 
@@ -46,24 +52,40 @@ class SseEventRepository with Disposable {
   Map<String, Map<String, SessionActivityInfo>> get currentSessionActivity => _sessionActivity.value;
 
   void _handleEvent(SseEvent event) {
-    if (event.data case SesoriProjectsSummary(:final projects)) {
-      final projectMap = <String, int>{};
-      final sessionMap = <String, Map<String, SessionActivityInfo>>{};
-      for (final summary in projects) {
-        if (summary.activeSessions.isNotEmpty) {
-          projectMap[summary.id] = summary.activeSessions.length;
-          final infoMap = <String, SessionActivityInfo>{};
-          for (final session in summary.activeSessions) {
-            infoMap[session.id] = SessionActivityInfo(
-              mainAgentRunning: session.mainAgentRunning,
-              backgroundTaskCount: session.childSessionIds.length,
-            );
+    try {
+      if (event.data case SesoriProjectsSummary(:final projects)) {
+        final projectMap = <String, int>{};
+        final sessionMap = <String, Map<String, SessionActivityInfo>>{};
+        for (final summary in projects) {
+          if (summary.activeSessions.isNotEmpty) {
+            projectMap[summary.id] = summary.activeSessions.length;
+            final infoMap = <String, SessionActivityInfo>{};
+            for (final session in summary.activeSessions) {
+              infoMap[session.id] = SessionActivityInfo(
+                mainAgentRunning: session.mainAgentRunning,
+                backgroundTaskCount: session.childSessionIds.length,
+              );
+            }
+            sessionMap[summary.id] = infoMap;
           }
-          sessionMap[summary.id] = infoMap;
         }
+        _projectActivity.add(projectMap);
+        _sessionActivity.add(sessionMap);
       }
-      _projectActivity.add(projectMap);
-      _sessionActivity.add(sessionMap);
+    } catch (e, st) {
+      loge("SSE event handler error", e, st);
+      unawaited(
+        _failureReporter
+            .recordFailure(
+              error: e,
+              stackTrace: st,
+              uniqueIdentifier: "sse_event_repository",
+              fatal: false,
+              reason: "Failed to handle SSE event in repository",
+              information: [event.data.runtimeType.toString()],
+            )
+            .catchError((_) {}),
+      );
     }
   }
 

--- a/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -110,7 +110,7 @@ class ProjectListCubit extends Cubit<ProjectListState> {
               uniqueIdentifier: "project_list_activity",
               fatal: false,
               reason: "Failed to handle project activity update",
-              information: [],
+              information: [activityById.toString()],
             )
             .catchError((_) {}),
       );

--- a/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -24,17 +24,20 @@ class ProjectListCubit extends Cubit<ProjectListState> {
   final ProjectService _projectService;
   final ConnectionService _connectionService;
   final SseEventRepository _sseEventRepository;
+  final FailureReporter _failureReporter;
   final CompositeSubscription _subscriptions = CompositeSubscription();
 
   ProjectListCubit(
     ProjectService projectService,
     ConnectionService connectionService,
     SseEventRepository sseEventRepository,
-    RouteSource routeSource,
-  ) : _projectService = projectService,
-      _connectionService = connectionService,
-      _sseEventRepository = sseEventRepository,
-      super(const ProjectListState.loading()) {
+    RouteSource routeSource, {
+    required FailureReporter failureReporter,
+  }) : _projectService = projectService,
+       _connectionService = connectionService,
+       _sseEventRepository = sseEventRepository,
+       _failureReporter = failureReporter,
+       super(const ProjectListState.loading()) {
     loadProjects();
 
     // 1. Immediate activity badge updates (no API call).
@@ -88,14 +91,30 @@ class ProjectListCubit extends Cubit<ProjectListState> {
   }
 
   void _onActivityUpdated(Map<String, int> activityById) {
-    if (state is! ProjectListLoaded) return;
-    if (isClosed) return;
-    emit(
-      ProjectListState.loaded(
-        projects: (state as ProjectListLoaded).projects,
-        activityById: activityById,
-      ),
-    );
+    try {
+      if (state is! ProjectListLoaded) return;
+      if (isClosed) return;
+      emit(
+        ProjectListState.loaded(
+          projects: (state as ProjectListLoaded).projects,
+          activityById: activityById,
+        ),
+      );
+    } catch (e, st) {
+      loge("Activity update handler error", e, st);
+      unawaited(
+        _failureReporter
+            .recordFailure(
+              error: e,
+              stackTrace: st,
+              uniqueIdentifier: "project_list_activity",
+              fatal: false,
+              reason: "Failed to handle project activity update",
+              information: [],
+            )
+            .catchError((_) {}),
+      );
+    }
   }
 
   void _onConnectionStatusChanged(ConnectionStatus status) {

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -19,6 +19,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
   final ConnectionService _connectionService;
   final String _sessionId;
   final NotificationCanceller _notificationCanceller;
+  final FailureReporter _failureReporter;
   final PromptSendQueue _promptQueue = PromptSendQueue();
   bool _isSending = false;
 
@@ -37,10 +38,12 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     ConnectionService connectionService, {
     required String sessionId,
     required NotificationCanceller notificationCanceller,
+    required FailureReporter failureReporter,
   }) : _service = service,
        _connectionService = connectionService,
        _sessionId = sessionId,
        _notificationCanceller = notificationCanceller,
+       _failureReporter = failureReporter,
        super(const SessionDetailState.loading()) {
     _streamingBuffer = StreamingTextBuffer(onFlush: _emitStreamingSnapshot);
     _eventSubscription = _connectionService.sessionEvents(_sessionId).listen(_handleEvent);
@@ -194,51 +197,83 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
   // ---------------------------------------------------------------------------
 
   void _handleEvent(SesoriSessionEvent event) {
-    switch (event) {
-      case SesoriMessageUpdated(:final info):
-        _onMessageUpdated(info);
-      case SesoriMessageRemoved(:final messageID):
-        _onMessageRemoved(messageID);
-      case SesoriMessagePartDelta(:final partID, :final delta):
-        _onPartDelta(partID, delta);
-      case SesoriMessagePartUpdated(:final part):
-        _onPartUpdated(part);
-      case SesoriMessagePartRemoved(:final messageID, :final partID):
-        _onPartRemoved(messageID, partID);
-      case SesoriSessionStatus(:final status):
-        _onSessionStatus(status);
-      case SesoriQuestionAsked():
-        _onQuestionAsked(event);
-      case SesoriQuestionReplied(:final requestID):
-        _onQuestionResolved(requestID);
-      case SesoriQuestionRejected(:final requestID):
-        _onQuestionResolved(requestID);
-      case SesoriSessionUpdated(:final info):
-        _onSessionUpdated(info);
-      case SesoriSessionCreated() ||
-          SesoriSessionDeleted() ||
-          SesoriSessionDiff() ||
-          SesoriSessionError() ||
-          SesoriSessionCompacted() ||
-          // ignore: deprecated_member_use
-          SesoriSessionIdle() ||
-          SesoriPermissionAsked() ||
-          SesoriTodoUpdated():
-        break;
+    try {
+      switch (event) {
+        case SesoriMessageUpdated(:final info):
+          _onMessageUpdated(info);
+        case SesoriMessageRemoved(:final messageID):
+          _onMessageRemoved(messageID);
+        case SesoriMessagePartDelta(:final partID, :final delta):
+          _onPartDelta(partID, delta);
+        case SesoriMessagePartUpdated(:final part):
+          _onPartUpdated(part);
+        case SesoriMessagePartRemoved(:final messageID, :final partID):
+          _onPartRemoved(messageID, partID);
+        case SesoriSessionStatus(:final status):
+          _onSessionStatus(status);
+        case SesoriQuestionAsked():
+          _onQuestionAsked(event);
+        case SesoriQuestionReplied(:final requestID):
+          _onQuestionResolved(requestID);
+        case SesoriQuestionRejected(:final requestID):
+          _onQuestionResolved(requestID);
+        case SesoriSessionUpdated(:final info):
+          _onSessionUpdated(info);
+        case SesoriSessionCreated() ||
+            SesoriSessionDeleted() ||
+            SesoriSessionDiff() ||
+            SesoriSessionError() ||
+            SesoriSessionCompacted() ||
+            // ignore: deprecated_member_use
+            SesoriSessionIdle() ||
+            SesoriPermissionAsked() ||
+            SesoriTodoUpdated():
+          break;
+      }
+    } catch (e, st) {
+      loge("SSE event handler error", e, st);
+      unawaited(
+        _failureReporter
+            .recordFailure(
+              error: e,
+              stackTrace: st,
+              uniqueIdentifier: "session_detail_event:${event.runtimeType}",
+              fatal: false,
+              reason: "Failed to handle session event",
+              information: [event.runtimeType.toString()],
+            )
+            .catchError((_) {}),
+      );
     }
   }
 
   void _handleGlobalEvent(SseEvent event) {
     final data = event.data;
-    switch (data) {
-      case SesoriSessionCreated(:final info) when info.parentID == _sessionId:
-        _onChildSessionCreated(info);
-      case SesoriSessionStatus(:final sessionID, :final status):
-        _onChildSessionStatus(sessionID, status);
-      case SesoriSessionUpdated(:final info):
-        _onChildSessionUpdated(info);
-      default:
-        break;
+    try {
+      switch (data) {
+        case SesoriSessionCreated(:final info) when info.parentID == _sessionId:
+          _onChildSessionCreated(info);
+        case SesoriSessionStatus(:final sessionID, :final status):
+          _onChildSessionStatus(sessionID, status);
+        case SesoriSessionUpdated(:final info):
+          _onChildSessionUpdated(info);
+        default:
+          break;
+      }
+    } catch (e, st) {
+      loge("SSE global event handler error", e, st);
+      unawaited(
+        _failureReporter
+            .recordFailure(
+              error: e,
+              stackTrace: st,
+              uniqueIdentifier: "session_detail_global_event:${data.runtimeType}",
+              fatal: false,
+              reason: "Failed to handle global session event",
+              information: [data.runtimeType.toString()],
+            )
+            .catchError((_) {}),
+      );
     }
   }
 

--- a/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -21,6 +21,7 @@ class SessionListCubit extends Cubit<SessionListState> {
   final ConnectionService _connectionService;
   final SseEventRepository _sseEventRepository;
   final String _projectId;
+  final FailureReporter _failureReporter;
 
   /// Tracks the session state before the last archive/unarchive action
   /// so the screen can offer an undo toast.
@@ -31,10 +32,12 @@ class SessionListCubit extends Cubit<SessionListState> {
     ConnectionService connectionService,
     SseEventRepository sseEventRepository, {
     required String projectId,
+    required FailureReporter failureReporter,
   }) : _service = service,
        _connectionService = connectionService,
        _sseEventRepository = sseEventRepository,
        _projectId = projectId,
+       _failureReporter = failureReporter,
        super(const SessionListState.loading()) {
     loadSessions();
     _subscriptions.add(_connectionService.events.listen(_handleEvent));
@@ -47,17 +50,33 @@ class SessionListCubit extends Cubit<SessionListState> {
   }
 
   void _handleEvent(SseEvent event) {
-    if (isClosed) return;
-    logd("[SessionList] event received: ${event.data.runtimeType}");
-    switch (event.data) {
-      case SesoriSessionCreated(:final info):
-        _onSessionCreated(info);
-      case SesoriSessionUpdated(:final info):
-        _onSessionUpdated(info);
-      case SesoriSessionDeleted(:final info):
-        _onSessionDeleted(info);
-      default:
-        break;
+    try {
+      if (isClosed) return;
+      logd("[SessionList] event received: ${event.data.runtimeType}");
+      switch (event.data) {
+        case SesoriSessionCreated(:final info):
+          _onSessionCreated(info);
+        case SesoriSessionUpdated(:final info):
+          _onSessionUpdated(info);
+        case SesoriSessionDeleted(:final info):
+          _onSessionDeleted(info);
+        default:
+          break;
+      }
+    } catch (e, st) {
+      loge("SSE event handler error", e, st);
+      unawaited(
+        _failureReporter
+            .recordFailure(
+              error: e,
+              stackTrace: st,
+              uniqueIdentifier: "session_list_event:${event.data.runtimeType}",
+              fatal: false,
+              reason: "Failed to handle session list event",
+              information: [event.data.runtimeType.toString()],
+            )
+            .catchError((_) {}),
+      );
     }
   }
 

--- a/mobile/module_core/lib/src/di/injection.config.dart
+++ b/mobile/module_core/lib/src/di/injection.config.dart
@@ -67,9 +67,6 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i857.RelayHttpApiClient>(
       () => _i857.RelayHttpApiClient(gh<_i369.ConnectionService>()),
     );
-    gh.lazySingleton<_i569.SseEventRepository>(
-      () => _i569.SseEventRepository(gh<_i369.ConnectionService>()),
-    );
     gh.lazySingleton<_i436.AuthRedirectService>(
       () => _i436.AuthRedirectService(
         gh<_i442.OAuthFlowProvider>(),
@@ -83,6 +80,12 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.lazySingleton<_i12.SessionService>(
       () => _i12.SessionService(gh<_i857.RelayHttpApiClient>()),
+    );
+    gh.lazySingleton<_i569.SseEventRepository>(
+      () => _i569.SseEventRepository(
+        gh<_i369.ConnectionService>(),
+        failureReporter: gh<_i553.FailureReporter>(),
+      ),
     );
     return this;
   }

--- a/mobile/module_core/test/capabilities/project/project_service_test.dart
+++ b/mobile/module_core/test/capabilities/project/project_service_test.dart
@@ -254,7 +254,7 @@ void main() {
         () => mockClient.patch<Project>(
           "/project/name",
           fromJson: any(named: "fromJson"),
-          body: RenameProjectRequest(projectId: "proj-1", name: "New Name").toJson(),
+          body: const RenameProjectRequest(projectId: "proj-1", name: "New Name").toJson(),
         ),
       ).called(1);
     });

--- a/mobile/module_core/test/capabilities/sse/sse_event_repository_test.dart
+++ b/mobile/module_core/test/capabilities/sse/sse_event_repository_test.dart
@@ -7,15 +7,33 @@ import "package:test/test.dart";
 
 class MockConnectionService extends Mock implements ConnectionService {}
 
+class MockFailureReporter extends Mock implements FailureReporter {}
+
 void main() {
+  setUpAll(() {
+    registerFallbackValue(StackTrace.empty);
+  });
+
   group("SseEventRepository", () {
     late MockConnectionService mockConnectionService;
+    late MockFailureReporter mockFailureReporter;
     late StreamController<SseEvent> eventController;
 
     setUp(() {
       mockConnectionService = MockConnectionService();
+      mockFailureReporter = MockFailureReporter();
       eventController = StreamController<SseEvent>.broadcast();
       when(() => mockConnectionService.events).thenAnswer((_) => eventController.stream);
+      when(
+        () => mockFailureReporter.recordFailure(
+          error: any(named: "error"),
+          stackTrace: any(named: "stackTrace"),
+          uniqueIdentifier: any(named: "uniqueIdentifier"),
+          fatal: any(named: "fatal"),
+          reason: any(named: "reason"),
+          information: any(named: "information"),
+        ),
+      ).thenAnswer((_) async {});
     });
 
     tearDown(() async {
@@ -27,7 +45,7 @@ void main() {
     // -------------------------------------------------------------------------
 
     test("sessionActivity defaults to empty map", () {
-      final repo = SseEventRepository(mockConnectionService);
+      final repo = SseEventRepository(mockConnectionService, failureReporter: mockFailureReporter);
       expect(repo.currentSessionActivity, isEmpty);
       repo.onDispose();
     });
@@ -37,7 +55,7 @@ void main() {
     // -------------------------------------------------------------------------
 
     test("sessionActivity emits active session info from projectsSummary event", () async {
-      final repo = SseEventRepository(mockConnectionService);
+      final repo = SseEventRepository(mockConnectionService, failureReporter: mockFailureReporter);
 
       final completer = Completer<Map<String, Map<String, SessionActivityInfo>>>();
       final subscription = repo.sessionActivity.listen((activity) {
@@ -77,7 +95,7 @@ void main() {
     // -------------------------------------------------------------------------
 
     test("sessionActivity excludes projects with no active sessions", () async {
-      final repo = SseEventRepository(mockConnectionService);
+      final repo = SseEventRepository(mockConnectionService, failureReporter: mockFailureReporter);
 
       final completer = Completer<Map<String, Map<String, SessionActivityInfo>>>();
       final subscription = repo.sessionActivity.listen((activity) {
@@ -111,7 +129,7 @@ void main() {
     // -------------------------------------------------------------------------
 
     test("sessionActivity handles multiple projects", () async {
-      final repo = SseEventRepository(mockConnectionService);
+      final repo = SseEventRepository(mockConnectionService, failureReporter: mockFailureReporter);
 
       final completer = Completer<Map<String, Map<String, SessionActivityInfo>>>();
       final subscription = repo.sessionActivity.listen((activity) {
@@ -156,7 +174,7 @@ void main() {
     // -------------------------------------------------------------------------
 
     test("sessionActivity updates when new event arrives", () async {
-      final repo = SseEventRepository(mockConnectionService);
+      final repo = SseEventRepository(mockConnectionService, failureReporter: mockFailureReporter);
 
       final activities = <Map<String, Map<String, SessionActivityInfo>>>[];
       final subscription = repo.sessionActivity.listen((activity) {
@@ -219,7 +237,7 @@ void main() {
     // -------------------------------------------------------------------------
 
     test("projectActivity defaults to empty map", () {
-      final repo = SseEventRepository(mockConnectionService);
+      final repo = SseEventRepository(mockConnectionService, failureReporter: mockFailureReporter);
       expect(repo.currentProjectActivity, isEmpty);
       repo.onDispose();
     });
@@ -229,7 +247,7 @@ void main() {
     // -------------------------------------------------------------------------
 
     test("projectActivity emits active session counts from projectsSummary event", () async {
-      final repo = SseEventRepository(mockConnectionService);
+      final repo = SseEventRepository(mockConnectionService, failureReporter: mockFailureReporter);
 
       final completer = Completer<Map<String, int>>();
       final subscription = repo.projectActivity.listen((activity) {
@@ -267,7 +285,7 @@ void main() {
     // -------------------------------------------------------------------------
 
     test("projectActivity excludes projects with no active sessions", () async {
-      final repo = SseEventRepository(mockConnectionService);
+      final repo = SseEventRepository(mockConnectionService, failureReporter: mockFailureReporter);
 
       final completer = Completer<Map<String, int>>();
       final subscription = repo.projectActivity.listen((activity) {
@@ -301,7 +319,7 @@ void main() {
     // -------------------------------------------------------------------------
 
     test("non-projectsSummary events are ignored", () async {
-      final repo = SseEventRepository(mockConnectionService);
+      final repo = SseEventRepository(mockConnectionService, failureReporter: mockFailureReporter);
 
       var emissionCount = 0;
       final subscription = repo.sessionActivity.listen((_) => emissionCount++);

--- a/mobile/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/mobile/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -34,6 +34,7 @@ void main() {
     late MockConnectionService mockConnectionService;
     late MockSseEventRepository mockSseEventRepository;
     late MockRouteSource mockRouteSource;
+    late MockFailureReporter mockFailureReporter;
     late BehaviorSubject<ConnectionStatus> statusController;
 
     setUp(() {
@@ -41,12 +42,23 @@ void main() {
       mockConnectionService = MockConnectionService();
       mockSseEventRepository = MockSseEventRepository();
       mockRouteSource = MockRouteSource();
+      mockFailureReporter = MockFailureReporter();
       statusController = BehaviorSubject<ConnectionStatus>.seeded(
         const ConnectionStatus.disconnected(),
       );
 
       // Must be stubbed before any cubit is built — constructor subscribes immediately.
       when(() => mockConnectionService.status).thenAnswer((_) => statusController.stream);
+      when(
+        () => mockFailureReporter.recordFailure(
+          error: any(named: "error"),
+          stackTrace: any(named: "stackTrace"),
+          uniqueIdentifier: any(named: "uniqueIdentifier"),
+          fatal: any(named: "fatal"),
+          reason: any(named: "reason"),
+          information: any(named: "information"),
+        ),
+      ).thenAnswer((_) async {});
     });
 
     tearDown(() async {
@@ -61,6 +73,7 @@ void main() {
       mockConnectionService,
       mockSseEventRepository,
       mockRouteSource,
+      failureReporter: mockFailureReporter,
     );
 
     // -------------------------------------------------------------------------

--- a/mobile/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/mobile/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -22,6 +22,7 @@ void main() {
     late MockSessionService mockSessionService;
     late MockConnectionService mockConnectionService;
     late MockSseEventRepository mockSseEventRepository;
+    late MockFailureReporter mockFailureReporter;
     late StreamController<SseEvent> eventController;
     late BehaviorSubject<ConnectionStatus> statusController;
 
@@ -31,6 +32,7 @@ void main() {
       mockSessionService = MockSessionService();
       mockConnectionService = MockConnectionService();
       mockSseEventRepository = MockSseEventRepository();
+      mockFailureReporter = MockFailureReporter();
       eventController = StreamController<SseEvent>.broadcast();
       statusController = BehaviorSubject<ConnectionStatus>.seeded(
         const ConnectionStatus.disconnected(),
@@ -39,6 +41,16 @@ void main() {
       // Must be stubbed before any cubit is built — constructor subscribes immediately.
       when(() => mockConnectionService.events).thenAnswer((_) => eventController.stream);
       when(() => mockConnectionService.status).thenAnswer((_) => statusController.stream);
+      when(
+        () => mockFailureReporter.recordFailure(
+          error: any(named: "error"),
+          stackTrace: any(named: "stackTrace"),
+          uniqueIdentifier: any(named: "uniqueIdentifier"),
+          fatal: any(named: "fatal"),
+          reason: any(named: "reason"),
+          information: any(named: "information"),
+        ),
+      ).thenAnswer((_) async {});
     });
 
     tearDown(() async {
@@ -52,6 +64,7 @@ void main() {
       mockConnectionService,
       mockSseEventRepository,
       projectId: projectId,
+      failureReporter: mockFailureReporter,
     );
 
     // -------------------------------------------------------------------------
@@ -1062,6 +1075,7 @@ void main() {
           mockConnectionService,
           mockSseEventRepository,
           projectId: "global",
+          failureReporter: mockFailureReporter,
         );
       },
       expect: () => [

--- a/mobile/module_core/test/helpers/test_helpers.dart
+++ b/mobile/module_core/test/helpers/test_helpers.dart
@@ -14,6 +14,8 @@ class MockProjectService extends Mock implements ProjectService {}
 
 class MockSessionService extends Mock implements SessionService {}
 
+class MockFailureReporter extends Mock implements FailureReporter {}
+
 class MockConnectionService extends Mock implements ConnectionService {}
 
 class MockRouteSource extends Mock implements RouteSource {
@@ -57,6 +59,7 @@ class FakeUri extends Fake implements Uri {}
 void registerAllFallbackValues() {
   registerFallbackValue(const ServerConnectionConfig(relayHost: "fake.example.com"));
   registerFallbackValue(FakeUri());
+  registerFallbackValue(StackTrace.empty);
 }
 
 Project testProject({String? id, String? path, String? name}) {


### PR DESCRIPTION
## Summary

Production incident: SSE events stopped reaching mobile because a parsing failure in the bridge killed the event listener. Restarting the bridge fixed it, but the pipeline had no error recovery — a single bad event could kill the entire real-time update stream.

This PR makes the entire SSE pipeline (bridge + mobile) self-recovering on ANY error.

## Changes

### Bridge
- **LogFailureReporter**: New `FailureReporter` implementation using `Log` class (backend not wired yet, but interface calls will flow when it is)
- **Orchestrator**: `.listen()` callback wrapped in try/catch + `FailureReporter.recordFailure()` — a thrown exception no longer kills the subscription
- **SSEManager**: `EventQueue.onError` callback wired to log + report send failures
- **BridgeEventMapper**: `map()` and `buildProjectsSummaryEvent()` wrapped in try/catch — returns null on error instead of propagating
- **SseConnection**: Silent `catch (_)` blocks replaced with `catch (e, st)` + `Log.e()`. `_onEvent()` calls wrapped in try/catch to prevent stream reader death
- **OpenCodePlugin**: Silent `catch (_)` replaced with `catch (e, st)` + `Log.e()`

### Mobile
- **SessionDetailCubit**: `_handleEvent` and `_handleGlobalEvent` wrapped in try/catch + `FailureReporter`
- **SessionListCubit**: `_handleEvent` wrapped in try/catch + `FailureReporter`
- **ProjectListCubit**: Activity listener wrapped in try/catch + `FailureReporter`
- **SseEventRepository**: `_handleEvent` wrapped in try/catch + `FailureReporter`

### Tests
- New orchestrator error recovery tests (stream survives errors, FailureReporter called)
- New BridgeEventMapper error recovery tests (returns null on failure)
- New SSEManager onError callback test
- All existing tests updated with FakeFailureReporter/MockFailureReporter

## Safety Pattern

Every catch block uses:
```dart
unawaited(_failureReporter.recordFailure(...).catchError((_) {}));
```
The `.catchError((_) {})` ensures the async reporter itself can never kill the pipeline.

## Verification
- `dart analyze` — 0 errors (bridge/app, sesori_plugin_opencode, module_core, mobile/app)
- `dart test` — 421 pass (bridge/app), 105 pass (sesori_plugin_opencode), 113 pass (module_core)