### PR TITLE
feat: lazy session creation — create on first message

### DIFF
--- a/bridge/app/lib/src/bridge/routing/create_session_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/create_session_handler.dart
@@ -4,6 +4,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../worktree_service.dart";
+import "prompt_part_mapper.dart";
 import "request_handler.dart";
 
 /// Handles `POST /session` — creates a session for a given project.
@@ -48,13 +49,7 @@ class CreateSessionHandler extends RequestHandler {
       parentSessionId: parentSessionId,
     );
 
-    final parts = createRequest.parts
-        .map(
-          (p) => switch (p) {
-            PromptPartText(:final text) => PluginPromptPart.text(text: text),
-          },
-        )
-        .toList();
+    final parts = createRequest.parts.map((p) => p.toPlugin()).toList();
 
     final model = switch (createRequest.model) {
       PromptModel(:final providerID, :final modelID) => (providerID: providerID, modelID: modelID),

--- a/bridge/app/lib/src/bridge/routing/create_session_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/create_session_handler.dart
@@ -41,12 +41,25 @@ class CreateSessionHandler extends RequestHandler {
     }
 
     final projectId = createRequest.projectId;
-    final parentSessionId = createRequest.parentSessionId;
+    final String? parentSessionId = null;
 
     final worktreeResult = await _worktreeService.prepareWorktreeForSession(
       projectId: projectId,
       parentSessionId: parentSessionId,
     );
+
+    final parts = createRequest.parts
+        .map(
+          (p) => switch (p) {
+            PromptPartText(:final text) => PluginPromptPart.text(text: text),
+          },
+        )
+        .toList();
+
+    final model = switch (createRequest.model) {
+      PromptModel(:final providerID, :final modelID) => (providerID: providerID, modelID: modelID),
+      null => null,
+    };
 
     final created = await _plugin.createSession(
       directory: switch (worktreeResult) {
@@ -54,6 +67,9 @@ class CreateSessionHandler extends RequestHandler {
         WorktreeFallback(:final originalPath) => originalPath,
       },
       parentSessionId: parentSessionId,
+      parts: parts,
+      agent: createRequest.agent,
+      model: model,
     );
 
     if (worktreeResult case WorktreeSuccess(:final path, :final branchName)) {

--- a/bridge/app/lib/src/bridge/routing/prompt_part_mapper.dart
+++ b/bridge/app/lib/src/bridge/routing/prompt_part_mapper.dart
@@ -1,0 +1,23 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+extension PromptPartToPlugin on PromptPart {
+  PluginPromptPart toPlugin() => switch (this) {
+    PromptPartText(:final text) => PluginPromptPart.text(text: text),
+    PromptPartFilePath(:final mime, :final path, :final filename) => PluginPromptPart.filePath(
+      mime: mime,
+      path: path,
+      filename: filename,
+    ),
+    PromptPartFileUrl(:final mime, :final url, :final filename) => PluginPromptPart.fileUrl(
+      mime: mime,
+      url: url,
+      filename: filename,
+    ),
+    PromptPartFileData(:final mime, :final base64, :final filename) => PluginPromptPart.fileData(
+      mime: mime,
+      base64: base64,
+      filename: filename,
+    ),
+  };
+}

--- a/bridge/app/lib/src/bridge/routing/send_prompt_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/send_prompt_handler.dart
@@ -3,6 +3,7 @@ import "dart:convert";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
+import "prompt_part_mapper.dart";
 import "request_handler.dart";
 
 const _idParam = "id";
@@ -36,13 +37,7 @@ class SendPromptHandler extends RequestHandler {
       return buildErrorResponse(request, 400, "invalid JSON body");
     }
 
-    final parts = promptRequest.parts
-        .map(
-          (p) => switch (p) {
-            PromptPartText(:final text) => PluginPromptPart.text(text: text),
-          },
-        )
-        .toList();
+    final parts = promptRequest.parts.map((p) => p.toPlugin()).toList();
 
     final model = switch (promptRequest.model) {
       PromptModel(:final providerID, :final modelID) => (providerID: providerID, modelID: modelID),

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -265,7 +265,10 @@ class _FakeBridgePlugin implements BridgePlugin {
   @override
   Future<PluginSession> createSession({
     required String directory,
-    String? parentSessionId,
+    required String? parentSessionId,
+    required List<PluginPromptPart> parts,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
   }) async => const PluginSession(
     id: "",
     projectID: "",
@@ -407,7 +410,10 @@ class _TrackingBridgePlugin implements BridgePlugin {
   @override
   Future<PluginSession> createSession({
     required String directory,
-    String? parentSessionId,
+    required String? parentSessionId,
+    required List<PluginPromptPart> parts,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
   }) async => const PluginSession(
     id: "",
     projectID: "",

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -200,7 +200,10 @@ class _ThrowingSummaryPlugin implements BridgePlugin {
   @override
   Future<PluginSession> createSession({
     required String directory,
-    String? parentSessionId,
+    required String? parentSessionId,
+    required List<PluginPromptPart> parts,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
   }) async => const PluginSession(
     id: "",
     projectID: "",

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -249,6 +249,11 @@ void main() {
     });
 
     test("passes parts, agent, and model to plugin", () async {
+      worktreeService.prepareResult = WorktreeFallback(
+        originalPath: "/tmp",
+        reason: "test",
+      );
+
       await handler.handle(
         makeRequest(
           "POST",
@@ -267,6 +272,7 @@ void main() {
       );
 
       expect(plugin.lastCreateSessionProjectId, equals("/tmp"));
+      expect(plugin.lastCreateSessionDirectory, equals("/tmp"));
       expect(plugin.lastCreateSessionParts, equals([PluginPromptPart.text(text: "Hello")]));
       expect(plugin.lastCreateSessionAgent, equals("architect"));
       expect(plugin.lastCreateSessionModel, equals((providerID: "openai", modelID: "gpt-5")));

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -70,7 +70,12 @@ void main() {
           "POST",
           "/session",
           body: jsonEncode(
-            const CreateSessionRequest(projectId: "/repo", parentSessionId: null).toJson(),
+            const CreateSessionRequest(
+              projectId: "/repo",
+              parts: [PromptPart.text(text: "Start")],
+              agent: null,
+              model: null,
+            ).toJson(),
           ),
         ),
         pathParams: {},
@@ -81,6 +86,7 @@ void main() {
       expect(worktreeService.lastPrepareParentSessionId, isNull);
       expect(plugin.lastCreateSessionDirectory, equals("/repo/.worktrees/session-001"));
       expect(plugin.lastCreateSessionParentId, isNull);
+      expect(plugin.lastCreateSessionParts, equals([PluginPromptPart.text(text: "Start")]));
       expect(worktreeService.recordCalls, hasLength(1));
       expect(worktreeService.recordCalls.first.sessionId, equals("s1"));
       expect(worktreeService.recordCalls.first.projectId, equals("/repo"));
@@ -109,7 +115,12 @@ void main() {
           "POST",
           "/session",
           body: jsonEncode(
-            const CreateSessionRequest(projectId: "/repo", parentSessionId: null).toJson(),
+            const CreateSessionRequest(
+              projectId: "/repo",
+              parts: [PromptPart.text(text: "Start")],
+              agent: null,
+              model: null,
+            ).toJson(),
           ),
         ),
         pathParams: {},
@@ -122,12 +133,12 @@ void main() {
       expect(response.status, equals(200));
     });
 
-    test("parent session calls worktree service and passes result to plugin", () async {
+    test("prepare worktree is called and result is passed to plugin", () async {
       plugin.createSessionResult = const PluginSession(
         id: "s-child",
         projectID: "p1",
         directory: "/repo",
-        parentID: "parent-1",
+        parentID: null,
         title: "Child",
         time: null,
         summary: null,
@@ -138,18 +149,23 @@ void main() {
           "POST",
           "/session",
           body: jsonEncode(
-            const CreateSessionRequest(projectId: "/repo", parentSessionId: "parent-1").toJson(),
+            const CreateSessionRequest(
+              projectId: "/repo",
+              parts: [PromptPart.text(text: "Start")],
+              agent: null,
+              model: null,
+            ).toJson(),
           ),
         ),
         pathParams: {},
         queryParams: {},
       );
 
-      // Worktree service IS called for parent sessions (it handles reuse logic).
       expect(worktreeService.prepareCallCount, equals(1));
       expect(worktreeService.lastPrepareProjectId, equals("/repo"));
       expect(plugin.lastCreateSessionDirectory, equals("/repo"));
-      expect(plugin.lastCreateSessionParentId, equals("parent-1"));
+      expect(plugin.lastCreateSessionParentId, isNull);
+      expect(plugin.lastCreateSessionProjectId, equals("/repo"));
       expect(response.status, equals(200));
     });
 
@@ -170,7 +186,12 @@ void main() {
             "POST",
             "/session",
             body: jsonEncode(
-              const CreateSessionRequest(projectId: "/repo", parentSessionId: null).toJson(),
+              const CreateSessionRequest(
+                projectId: "/repo",
+                parts: [PromptPart.text(text: "Start")],
+                agent: null,
+                model: null,
+              ).toJson(),
             ),
           ),
           pathParams: {},
@@ -202,7 +223,12 @@ void main() {
           "POST",
           "/session",
           body: jsonEncode(
-            const CreateSessionRequest(projectId: "/repo", parentSessionId: "parent-1").toJson(),
+            const CreateSessionRequest(
+              projectId: "/repo",
+              parts: [PromptPart.text(text: "Start")],
+              agent: null,
+              model: null,
+            ).toJson(),
           ),
         ),
         pathParams: {},
@@ -220,6 +246,45 @@ void main() {
       expect(body["title"], equals("Created"));
       expect(body["time"], equals({"created": 11, "updated": 22, "archived": 33}));
       expect(body["summary"], equals({"additions": 1, "deletions": 2, "files": 3}));
+    });
+
+    test("passes parts, agent, and model to plugin", () async {
+      await handler.handle(
+        makeRequest(
+          "POST",
+          "/session",
+          body: jsonEncode(
+            const CreateSessionRequest(
+              projectId: "/tmp",
+              parts: [PromptPart.text(text: "Hello")],
+              agent: "architect",
+              model: PromptModel(providerID: "openai", modelID: "gpt-5"),
+            ).toJson(),
+          ),
+        ),
+        pathParams: {},
+        queryParams: {},
+      );
+
+      expect(plugin.lastCreateSessionProjectId, equals("/tmp"));
+      expect(plugin.lastCreateSessionParts, equals([PluginPromptPart.text(text: "Hello")]));
+      expect(plugin.lastCreateSessionAgent, equals("architect"));
+      expect(plugin.lastCreateSessionModel, equals((providerID: "openai", modelID: "gpt-5")));
+    });
+
+    test("returns 400 when parts are missing", () async {
+      final response = await handler.handle(
+        makeRequest(
+          "POST",
+          "/session",
+          body: jsonEncode({"projectId": "/tmp", "agent": null, "model": null}),
+        ),
+        pathParams: {},
+        queryParams: {},
+      );
+
+      expect(response.status, equals(400));
+      expect(response.body, contains("invalid JSON body"));
     });
 
     test("returns 400 on invalid JSON body", () async {
@@ -294,7 +359,10 @@ class _ThrowingCreateSessionPlugin extends FakeBridgePlugin {
   @override
   Future<PluginSession> createSession({
     required String directory,
-    String? parentSessionId,
+    required String? parentSessionId,
+    required List<PluginPromptPart> parts,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
   }) {
     throw StateError("createSession failed");
   }

--- a/bridge/app/test/bridge/routing/request_router_test.dart
+++ b/bridge/app/test/bridge/routing/request_router_test.dart
@@ -103,14 +103,23 @@ void main() {
           "POST",
           "/session",
           body: jsonEncode(
-            const CreateSessionRequest(projectId: "/tmp", parentSessionId: "parent-1").toJson(),
+            const CreateSessionRequest(
+              projectId: "/tmp",
+              parts: [PromptPart.text(text: "Start")],
+              agent: "architect",
+              model: PromptModel(providerID: "openai", modelID: "gpt-5"),
+            ).toJson(),
           ),
         ),
       );
 
       expect(response.status, equals(200));
       expect(plugin.lastCreateSessionDirectory, equals("/tmp"));
-      expect(plugin.lastCreateSessionParentId, equals("parent-1"));
+      expect(plugin.lastCreateSessionParentId, isNull);
+      expect(plugin.lastCreateSessionProjectId, equals("/tmp"));
+      expect(plugin.lastCreateSessionParts, equals([PluginPromptPart.text(text: "Start")]));
+      expect(plugin.lastCreateSessionAgent, equals("architect"));
+      expect(plugin.lastCreateSessionModel, equals((providerID: "openai", modelID: "gpt-5")));
     });
 
     test("routes DELETE /session/:id to DeleteSessionHandler", () async {

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -50,6 +50,10 @@ class FakeBridgePlugin implements BridgePlugin {
   bool? lastGetProvidersConnectedOnly;
   String? lastCreateSessionDirectory;
   String? lastCreateSessionParentId;
+  String? lastCreateSessionProjectId;
+  List<PluginPromptPart>? lastCreateSessionParts;
+  String? lastCreateSessionAgent;
+  ({String providerID, String modelID})? lastCreateSessionModel;
   String? lastUpdateSessionId;
   bool? lastUpdateSessionArchived;
   String? lastRenameSessionId;
@@ -117,10 +121,17 @@ class FakeBridgePlugin implements BridgePlugin {
   @override
   Future<PluginSession> createSession({
     required String directory,
-    String? parentSessionId,
+    required String? parentSessionId,
+    required List<PluginPromptPart> parts,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
   }) async {
     lastCreateSessionDirectory = directory;
     lastCreateSessionParentId = parentSessionId;
+    lastCreateSessionProjectId = directory;
+    lastCreateSessionParts = parts;
+    lastCreateSessionAgent = agent;
+    lastCreateSessionModel = model;
     return createSessionResult ??
         const PluginSession(
           id: "",

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -22,7 +22,7 @@ abstract class BridgePlugin {
   /// Get sessions for a project directory.
   Future<List<PluginSession>> getSessions(String projectId, {int? start, int? limit});
 
-  /// Create a new session in the given directory.
+  /// Create a new session in the given directory and send the first prompt.
   ///
   /// [directory] is the working directory for the session (may be a worktree
   /// path or the main project path).
@@ -31,7 +31,10 @@ abstract class BridgePlugin {
   /// child (sub-session) of the specified parent.
   Future<PluginSession> createSession({
     required String directory,
-    String? parentSessionId,
+    required String? parentSessionId,
+    required List<PluginPromptPart> parts,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
   });
 
   Future<PluginSession> updateSessionArchiveStatus(String sessionId, {required bool archived});

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_prompt_part.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_prompt_part.dart
@@ -7,4 +7,10 @@ part "plugin_prompt_part.g.dart";
 @freezed
 sealed class PluginPromptPart with _$PluginPromptPart {
   const factory PluginPromptPart.text({required String text}) = PluginPromptPartText;
+  const factory PluginPromptPart.filePath({required String mime, required String path, required String? filename}) =
+      PluginPromptPartFilePath;
+  const factory PluginPromptPart.fileUrl({required String mime, required String url, required String? filename}) =
+      PluginPromptPartFileUrl;
+  const factory PluginPromptPart.fileData({required String mime, required String base64, required String? filename}) =
+      PluginPromptPartFileData;
 }

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_prompt_part.freezed.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_prompt_part.freezed.dart
@@ -14,12 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$PluginPromptPart {
 
- String get text;
-/// Create a copy of PluginPromptPart
-/// with the given fields replaced by the non-null parameter values.
-@JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-$PluginPromptPartCopyWith<PluginPromptPart> get copyWith => _$PluginPromptPartCopyWithImpl<PluginPromptPart>(this as PluginPromptPart, _$identity);
+
 
   /// Serializes this PluginPromptPart to a JSON map.
   Map<String, dynamic> toJson();
@@ -27,50 +22,24 @@ $PluginPromptPartCopyWith<PluginPromptPart> get copyWith => _$PluginPromptPartCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginPromptPart&&(identical(other.text, text) || other.text == text));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginPromptPart);
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,text);
+int get hashCode => runtimeType.hashCode;
 
 @override
 String toString() {
-  return 'PluginPromptPart(text: $text)';
+  return 'PluginPromptPart()';
 }
 
 
 }
 
 /// @nodoc
-abstract mixin class $PluginPromptPartCopyWith<$Res>  {
-  factory $PluginPromptPartCopyWith(PluginPromptPart value, $Res Function(PluginPromptPart) _then) = _$PluginPromptPartCopyWithImpl;
-@useResult
-$Res call({
- String text
-});
-
-
-
-
-}
-/// @nodoc
-class _$PluginPromptPartCopyWithImpl<$Res>
-    implements $PluginPromptPartCopyWith<$Res> {
-  _$PluginPromptPartCopyWithImpl(this._self, this._then);
-
-  final PluginPromptPart _self;
-  final $Res Function(PluginPromptPart) _then;
-
-/// Create a copy of PluginPromptPart
-/// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? text = null,}) {
-  return _then(_self.copyWith(
-text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
-as String,
-  ));
-}
-
+class $PluginPromptPartCopyWith<$Res>  {
+$PluginPromptPartCopyWith(PluginPromptPart _, $Res Function(PluginPromptPart) __);
 }
 
 
@@ -79,14 +48,18 @@ as String,
 @JsonSerializable(createFactory: false)
 
 class PluginPromptPartText implements PluginPromptPart {
-  const PluginPromptPartText({required this.text});
+  const PluginPromptPartText({required this.text, final  String? $type}): $type = $type ?? 'text';
   
 
-@override final  String text;
+ final  String text;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
 
 /// Create a copy of PluginPromptPart
 /// with the given fields replaced by the non-null parameter values.
-@override @JsonKey(includeFromJson: false, includeToJson: false)
+@JsonKey(includeFromJson: false, includeToJson: false)
 @pragma('vm:prefer-inline')
 $PluginPromptPartTextCopyWith<PluginPromptPartText> get copyWith => _$PluginPromptPartTextCopyWithImpl<PluginPromptPartText>(this, _$identity);
 
@@ -115,7 +88,7 @@ String toString() {
 /// @nodoc
 abstract mixin class $PluginPromptPartTextCopyWith<$Res> implements $PluginPromptPartCopyWith<$Res> {
   factory $PluginPromptPartTextCopyWith(PluginPromptPartText value, $Res Function(PluginPromptPartText) _then) = _$PluginPromptPartTextCopyWithImpl;
-@override @useResult
+@useResult
 $Res call({
  String text
 });
@@ -134,10 +107,241 @@ class _$PluginPromptPartTextCopyWithImpl<$Res>
 
 /// Create a copy of PluginPromptPart
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
   return _then(PluginPromptPartText(
 text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
 as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createFactory: false)
+
+class PluginPromptPartFilePath implements PluginPromptPart {
+  const PluginPromptPartFilePath({required this.mime, required this.path, required this.filename, final  String? $type}): $type = $type ?? 'filePath';
+  
+
+ final  String mime;
+ final  String path;
+ final  String? filename;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+/// Create a copy of PluginPromptPart
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PluginPromptPartFilePathCopyWith<PluginPromptPartFilePath> get copyWith => _$PluginPromptPartFilePathCopyWithImpl<PluginPromptPartFilePath>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PluginPromptPartFilePathToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginPromptPartFilePath&&(identical(other.mime, mime) || other.mime == mime)&&(identical(other.path, path) || other.path == path)&&(identical(other.filename, filename) || other.filename == filename));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,mime,path,filename);
+
+@override
+String toString() {
+  return 'PluginPromptPart.filePath(mime: $mime, path: $path, filename: $filename)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PluginPromptPartFilePathCopyWith<$Res> implements $PluginPromptPartCopyWith<$Res> {
+  factory $PluginPromptPartFilePathCopyWith(PluginPromptPartFilePath value, $Res Function(PluginPromptPartFilePath) _then) = _$PluginPromptPartFilePathCopyWithImpl;
+@useResult
+$Res call({
+ String mime, String path, String? filename
+});
+
+
+
+
+}
+/// @nodoc
+class _$PluginPromptPartFilePathCopyWithImpl<$Res>
+    implements $PluginPromptPartFilePathCopyWith<$Res> {
+  _$PluginPromptPartFilePathCopyWithImpl(this._self, this._then);
+
+  final PluginPromptPartFilePath _self;
+  final $Res Function(PluginPromptPartFilePath) _then;
+
+/// Create a copy of PluginPromptPart
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? mime = null,Object? path = null,Object? filename = freezed,}) {
+  return _then(PluginPromptPartFilePath(
+mime: null == mime ? _self.mime : mime // ignore: cast_nullable_to_non_nullable
+as String,path: null == path ? _self.path : path // ignore: cast_nullable_to_non_nullable
+as String,filename: freezed == filename ? _self.filename : filename // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createFactory: false)
+
+class PluginPromptPartFileUrl implements PluginPromptPart {
+  const PluginPromptPartFileUrl({required this.mime, required this.url, required this.filename, final  String? $type}): $type = $type ?? 'fileUrl';
+  
+
+ final  String mime;
+ final  String url;
+ final  String? filename;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+/// Create a copy of PluginPromptPart
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PluginPromptPartFileUrlCopyWith<PluginPromptPartFileUrl> get copyWith => _$PluginPromptPartFileUrlCopyWithImpl<PluginPromptPartFileUrl>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PluginPromptPartFileUrlToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginPromptPartFileUrl&&(identical(other.mime, mime) || other.mime == mime)&&(identical(other.url, url) || other.url == url)&&(identical(other.filename, filename) || other.filename == filename));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,mime,url,filename);
+
+@override
+String toString() {
+  return 'PluginPromptPart.fileUrl(mime: $mime, url: $url, filename: $filename)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PluginPromptPartFileUrlCopyWith<$Res> implements $PluginPromptPartCopyWith<$Res> {
+  factory $PluginPromptPartFileUrlCopyWith(PluginPromptPartFileUrl value, $Res Function(PluginPromptPartFileUrl) _then) = _$PluginPromptPartFileUrlCopyWithImpl;
+@useResult
+$Res call({
+ String mime, String url, String? filename
+});
+
+
+
+
+}
+/// @nodoc
+class _$PluginPromptPartFileUrlCopyWithImpl<$Res>
+    implements $PluginPromptPartFileUrlCopyWith<$Res> {
+  _$PluginPromptPartFileUrlCopyWithImpl(this._self, this._then);
+
+  final PluginPromptPartFileUrl _self;
+  final $Res Function(PluginPromptPartFileUrl) _then;
+
+/// Create a copy of PluginPromptPart
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? mime = null,Object? url = null,Object? filename = freezed,}) {
+  return _then(PluginPromptPartFileUrl(
+mime: null == mime ? _self.mime : mime // ignore: cast_nullable_to_non_nullable
+as String,url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String,filename: freezed == filename ? _self.filename : filename // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createFactory: false)
+
+class PluginPromptPartFileData implements PluginPromptPart {
+  const PluginPromptPartFileData({required this.mime, required this.base64, required this.filename, final  String? $type}): $type = $type ?? 'fileData';
+  
+
+ final  String mime;
+ final  String base64;
+ final  String? filename;
+
+@JsonKey(name: 'runtimeType')
+final String $type;
+
+
+/// Create a copy of PluginPromptPart
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PluginPromptPartFileDataCopyWith<PluginPromptPartFileData> get copyWith => _$PluginPromptPartFileDataCopyWithImpl<PluginPromptPartFileData>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PluginPromptPartFileDataToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginPromptPartFileData&&(identical(other.mime, mime) || other.mime == mime)&&(identical(other.base64, base64) || other.base64 == base64)&&(identical(other.filename, filename) || other.filename == filename));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,mime,base64,filename);
+
+@override
+String toString() {
+  return 'PluginPromptPart.fileData(mime: $mime, base64: $base64, filename: $filename)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PluginPromptPartFileDataCopyWith<$Res> implements $PluginPromptPartCopyWith<$Res> {
+  factory $PluginPromptPartFileDataCopyWith(PluginPromptPartFileData value, $Res Function(PluginPromptPartFileData) _then) = _$PluginPromptPartFileDataCopyWithImpl;
+@useResult
+$Res call({
+ String mime, String base64, String? filename
+});
+
+
+
+
+}
+/// @nodoc
+class _$PluginPromptPartFileDataCopyWithImpl<$Res>
+    implements $PluginPromptPartFileDataCopyWith<$Res> {
+  _$PluginPromptPartFileDataCopyWithImpl(this._self, this._then);
+
+  final PluginPromptPartFileData _self;
+  final $Res Function(PluginPromptPartFileData) _then;
+
+/// Create a copy of PluginPromptPart
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? mime = null,Object? base64 = null,Object? filename = freezed,}) {
+  return _then(PluginPromptPartFileData(
+mime: null == mime ? _self.mime : mime // ignore: cast_nullable_to_non_nullable
+as String,base64: null == base64 ? _self.base64 : base64 // ignore: cast_nullable_to_non_nullable
+as String,filename: freezed == filename ? _self.filename : filename // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_prompt_part.g.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_prompt_part.g.dart
@@ -8,4 +8,31 @@ part of 'plugin_prompt_part.dart';
 
 Map<String, dynamic> _$PluginPromptPartTextToJson(
   PluginPromptPartText instance,
-) => <String, dynamic>{'text': instance.text};
+) => <String, dynamic>{'text': instance.text, 'runtimeType': instance.$type};
+
+Map<String, dynamic> _$PluginPromptPartFilePathToJson(
+  PluginPromptPartFilePath instance,
+) => <String, dynamic>{
+  'mime': instance.mime,
+  'path': instance.path,
+  'filename': instance.filename,
+  'runtimeType': instance.$type,
+};
+
+Map<String, dynamic> _$PluginPromptPartFileUrlToJson(
+  PluginPromptPartFileUrl instance,
+) => <String, dynamic>{
+  'mime': instance.mime,
+  'url': instance.url,
+  'filename': instance.filename,
+  'runtimeType': instance.$type,
+};
+
+Map<String, dynamic> _$PluginPromptPartFileDataToJson(
+  PluginPromptPartFileData instance,
+) => <String, dynamic>{
+  'mime': instance.mime,
+  'base64': instance.base64,
+  'filename': instance.filename,
+  'runtimeType': instance.$type,
+};

--- a/bridge/sesori_plugin_opencode/lib/opencode_plugin.dart
+++ b/bridge/sesori_plugin_opencode/lib/opencode_plugin.dart
@@ -12,6 +12,7 @@ export "src/models/pending_question.dart";
 export "src/models/project.dart";
 export "src/models/provider_info.dart";
 export "src/models/question.dart";
+export "src/models/send_prompt_body.dart";
 export "src/models/session.dart";
 export "src/models/session_status.dart";
 export "src/models/sse_event_data.dart";

--- a/bridge/sesori_plugin_opencode/lib/src/models/send_prompt_body.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/send_prompt_body.dart
@@ -11,6 +11,12 @@ class SendPromptBody {
     required this.model,
   });
 
+  /// Converts our domain types to OpenCode's wire format.
+  ///
+  /// Both [PluginPromptPartFileUrl] and [PluginPromptPartFileData] map to
+  /// OpenCode's single `file` part type — the difference is the URL scheme:
+  /// - `fileUrl` → uses the URL as-is
+  /// - `fileData` → constructs a `data:{mime};base64,{base64}` URL
   Map<String, dynamic> toJson() {
     final selectedModel = model;
     return <String, dynamic>{
@@ -19,6 +25,24 @@ class SendPromptBody {
           PluginPromptPartText(:final text) => <String, dynamic>{
             "type": "text",
             "text": text,
+          },
+          PluginPromptPartFilePath(:final mime, :final path, :final filename) => <String, dynamic>{
+            "type": "file",
+            "mime": mime,
+            "url": Uri.file(path).toString(),
+            "filename": ?filename,
+          },
+          PluginPromptPartFileUrl(:final mime, :final url, :final filename) => <String, dynamic>{
+            "type": "file",
+            "mime": mime,
+            "url": url,
+            "filename": ?filename,
+          },
+          PluginPromptPartFileData(:final mime, :final base64, :final filename) => <String, dynamic>{
+            "type": "file",
+            "mime": mime,
+            "url": "data:$mime;base64,$base64",
+            "filename": ?filename,
           },
         };
       }).toList(),

--- a/bridge/sesori_plugin_opencode/lib/src/models/send_prompt_body.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/send_prompt_body.dart
@@ -1,0 +1,33 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+class SendPromptBody {
+  final List<PluginPromptPart> parts;
+  final String? agent;
+  final ({String providerID, String modelID})? model;
+
+  const SendPromptBody({
+    required this.parts,
+    required this.agent,
+    required this.model,
+  });
+
+  Map<String, dynamic> toJson() {
+    final selectedModel = model;
+    return <String, dynamic>{
+      "parts": parts.map((part) {
+        return switch (part) {
+          PluginPromptPartText(:final text) => <String, dynamic>{
+            "type": "text",
+            "text": text,
+          },
+        };
+      }).toList(),
+      "agent": ?agent,
+      if (selectedModel != null)
+        "model": {
+          "providerID": selectedModel.providerID,
+          "modelID": selectedModel.modelID,
+        },
+    };
+  }
+}

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -8,6 +8,7 @@ import "models/message_with_parts.dart";
 import "models/pending_question.dart";
 import "models/project.dart";
 import "models/provider_info.dart";
+import "models/send_prompt_body.dart";
 import "models/session.dart";
 import "models/session_status.dart";
 
@@ -242,7 +243,7 @@ class OpenCodeApi {
 
   Future<void> sendPrompt({
     required String sessionId,
-    required Map<String, dynamic> body,
+    required SendPromptBody body,
     // 100% required for this endpoint
     // because otherwise it picks the CWD of where bridge is running
     required String? directory,
@@ -256,7 +257,7 @@ class OpenCodeApi {
           "content-type": "application/json",
           _directoryOpenCodeHeader: ?directory,
         },
-        body: jsonEncode(body),
+        body: jsonEncode(body.toJson()),
       );
       _ensureSuccess(response, "POST /session/$sessionId/prompt_async");
     } finally {

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -238,22 +238,7 @@ class OpenCodePlugin implements BridgePlugin {
       directory: session.directory,
     );
 
-    final body = <String, dynamic>{
-      "parts": parts.map((part) {
-        return switch (part) {
-          PluginPromptPartText(:final text) => <String, dynamic>{
-            "type": "text",
-            "text": text,
-          },
-        };
-      }).toList(),
-      "agent": ?agent,
-      if (model != null)
-        "model": {
-          "providerID": model.providerID,
-          "modelID": model.modelID,
-        },
-    };
+    final body = SendPromptBody(parts: parts, agent: agent, model: model);
 
     await _call(
       () => _service.repository.api.sendPrompt(
@@ -397,22 +382,7 @@ class OpenCodePlugin implements BridgePlugin {
       Log.w("directory missing for session $sessionId. Defaulting to bridge CWD as directory.");
     }
 
-    final body = <String, dynamic>{
-      "parts": parts.map((part) {
-        return switch (part) {
-          PluginPromptPartText(:final text) => <String, dynamic>{
-            "type": "text",
-            "text": text,
-          },
-        };
-      }).toList(),
-      "agent": ?agent,
-      if (model != null)
-        "model": {
-          "providerID": model.providerID,
-          "modelID": model.modelID,
-        },
-    };
+    final body = SendPromptBody(parts: parts, agent: agent, model: model);
 
     return _call(
       () => _service.repository.api.sendPrompt(

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -222,7 +222,10 @@ class OpenCodePlugin implements BridgePlugin {
   @override
   Future<PluginSession> createSession({
     required String directory,
-    String? parentSessionId,
+    required String? parentSessionId,
+    required List<PluginPromptPart> parts,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
   }) async {
     final session = await _call(
       () => _service.repository.api.createSession(
@@ -234,6 +237,32 @@ class OpenCodePlugin implements BridgePlugin {
       sessionId: session.id,
       directory: session.directory,
     );
+
+    final body = <String, dynamic>{
+      "parts": parts.map((part) {
+        return switch (part) {
+          PluginPromptPartText(:final text) => <String, dynamic>{
+            "type": "text",
+            "text": text,
+          },
+        };
+      }).toList(),
+      "agent": ?agent,
+      if (model != null)
+        "model": {
+          "providerID": model.providerID,
+          "modelID": model.modelID,
+        },
+    };
+
+    await _call(
+      () => _service.repository.api.sendPrompt(
+        sessionId: session.id,
+        directory: session.directory,
+        body: body,
+      ),
+    );
+
     return session.toPlugin();
   }
 

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -768,7 +768,7 @@ class _FakeApi implements OpenCodeApi {
   @override
   Future<void> sendPrompt({
     required String sessionId,
-    required Map<String, dynamic> body,
+    required SendPromptBody body,
     required String? directory,
   }) async {}
 

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -419,7 +419,7 @@ class _FakeApi implements OpenCodeApi {
   @override
   Future<void> sendPrompt({
     required String sessionId,
-    required Map<String, dynamic> body,
+    required SendPromptBody body,
     required String? directory,
   }) async {}
 

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -347,7 +347,7 @@ class FakeOpenCodeApi implements OpenCodeApi {
   @override
   Future<void> sendPrompt({
     required String sessionId,
-    required Map<String, dynamic> body,
+    required SendPromptBody body,
     required String? directory,
   }) async {}
 

--- a/mobile/app/lib/core/routing/app_router.dart
+++ b/mobile/app/lib/core/routing/app_router.dart
@@ -3,6 +3,7 @@ import "package:go_router/go_router.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 
 import "../../features/login/login_screen.dart";
+import "../../features/new_session/new_session_screen.dart";
 import "../../features/project_list/project_list_screen.dart";
 import "../../features/session_detail/session_detail_screen.dart";
 import "../../features/session_list/session_list_screen.dart";
@@ -24,6 +25,9 @@ extension AppRouteToGoRoute on AppRoute {
         AppRoute.sessions => SessionListScreen(
           projectId: state.pathParameters["projectId"] ?? "",
           projectName: state.uri.queryParameters["name"],
+        ),
+        AppRoute.newSession => NewSessionScreen(
+          projectId: state.pathParameters["projectId"] ?? "",
         ),
         AppRoute.sessionDetail => SessionDetailScreen(
           projectId: state.pathParameters["projectId"],

--- a/mobile/app/lib/features/new_session/new_session_screen.dart
+++ b/mobile/app/lib/features/new_session/new_session_screen.dart
@@ -1,0 +1,89 @@
+import "package:flutter/material.dart";
+import "package:flutter_bloc/flutter_bloc.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+
+import "../../core/di/injection.dart";
+import "../../core/extensions/build_context_x.dart";
+import "../../core/routing/app_router.dart";
+import "../session_detail/widgets/prompt_input.dart";
+
+class NewSessionScreen extends StatelessWidget {
+  final String projectId;
+
+  const NewSessionScreen({
+    super.key,
+    required this.projectId,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => NewSessionCubit(
+        sessionService: getIt<SessionService>(),
+        projectId: projectId,
+      ),
+      child: const _NewSessionBody(),
+    );
+  }
+}
+
+class _NewSessionBody extends StatelessWidget {
+  const _NewSessionBody();
+
+  @override
+  Widget build(BuildContext context) {
+    final state = context.watch<NewSessionCubit>().state;
+    final loc = context.loc;
+
+    return BlocListener<NewSessionCubit, NewSessionState>(
+      listenWhen: (_, current) => current is NewSessionCreated,
+      listener: (context, state) {
+        if (state case NewSessionCreated(:final session)) {
+          context.goRoute(
+            AppRoute.sessionDetail,
+            pathParams: {"projectId": session.projectID, "sessionId": session.id},
+            queryParams: {"title": session.title ?? ""},
+          );
+        }
+      },
+      child: Scaffold(
+        appBar: AppBar(title: Text(loc.sessionListNewSession)),
+        body: Column(
+          children: [
+            const Expanded(
+              child: SizedBox.expand(),
+            ),
+            PromptInput(
+              isBusy: state is NewSessionSending,
+              onSend: (text) {
+                context.read<NewSessionCubit>().createSessionWithMessage(
+                  text: text,
+                  agent: null,
+                  providerID: null,
+                  modelID: null,
+                );
+              },
+              onAbort: () {},
+              header: switch (state) {
+                NewSessionError(:final message) => Padding(
+                  padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          message,
+                          style: TextStyle(color: Theme.of(context).colorScheme.error),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                _ => null,
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/app/lib/features/new_session/new_session_screen.dart
+++ b/mobile/app/lib/features/new_session/new_session_screen.dart
@@ -39,7 +39,8 @@ class _NewSessionBody extends StatelessWidget {
       listenWhen: (_, current) => current is NewSessionCreated,
       listener: (context, state) {
         if (state case NewSessionCreated(:final session)) {
-          context.goRoute(
+          Navigator.of(context).pop();
+          context.pushRoute(
             AppRoute.sessionDetail,
             pathParams: {"projectId": session.projectID, "sessionId": session.id},
             queryParams: {"title": session.title ?? ""},
@@ -59,11 +60,10 @@ class _NewSessionBody extends StatelessWidget {
                 context.read<NewSessionCubit>().createSessionWithMessage(
                   text: text,
                   agent: null,
-                  providerID: null,
-                  modelID: null,
+                  model: null,
                 );
               },
-              onAbort: () {},
+              onAbort: () => Navigator.of(context).pop(),
               header: switch (state) {
                 NewSessionError(:final message) => Padding(
                   padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),

--- a/mobile/app/lib/features/session_list/session_list_screen.dart
+++ b/mobile/app/lib/features/session_list/session_list_screen.dart
@@ -42,13 +42,11 @@ class _SessionListBody extends StatelessWidget {
 
   const _SessionListBody({this.projectName});
 
-  Future<void> _createSessionAndNavigate(BuildContext context) async {
-    final session = await context.read<SessionListCubit>().createSession();
-    if (session == null || !context.mounted) return;
-    await context.pushRoute(
-      AppRoute.sessionDetail,
-      pathParams: {"projectId": session.projectID, "sessionId": session.id},
-      queryParams: {"title": session.title ?? ""},
+  void _goToNewSession(BuildContext context) {
+    final projectId = context.read<SessionListCubit>().projectId;
+    context.pushRoute(
+      AppRoute.newSession,
+      pathParams: {"projectId": projectId},
     );
   }
 
@@ -239,7 +237,7 @@ class _SessionListBody extends StatelessWidget {
         ],
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => _createSessionAndNavigate(context),
+        onPressed: () => _goToNewSession(context),
         tooltip: loc.sessionListNewSession,
         child: const Icon(Icons.add),
       ),

--- a/mobile/app/test/capabilities/session/session_service_test.dart
+++ b/mobile/app/test/capabilities/session/session_service_test.dart
@@ -725,7 +725,7 @@ void main() {
         expect(
           captured["parts"],
           equals([
-            {"text": "Hello, world!"},
+            {"type": "text", "text": "Hello, world!"},
           ]),
         );
         expect(captured["agent"], isNull);

--- a/mobile/app/test/capabilities/session/session_service_test.dart
+++ b/mobile/app/test/capabilities/session/session_service_test.dart
@@ -175,7 +175,7 @@ void main() {
     // session CRUD
     // -----------------------------------------------------------------------
 
-    group("createSession", () {
+    group("createSessionWithMessage", () {
       test("success: returns Session from POST /session", () async {
         final created = testSession(id: "server-session-id");
         when(
@@ -186,7 +186,13 @@ void main() {
           ),
         ).thenAnswer((_) async => ApiResponse.success(created));
 
-        final result = await sessionService.createSession(projectId: "/tmp/project");
+        final result = await sessionService.createSessionWithMessage(
+          projectId: "/tmp/project",
+          text: "hello",
+          agent: null,
+          providerID: null,
+          modelID: null,
+        );
 
         expect(result, isA<SuccessResponse<Session>>());
         expect((result as SuccessResponse<Session>).data.id, equals("server-session-id"));
@@ -209,7 +215,13 @@ void main() {
           ),
         ).thenAnswer((_) async => ApiResponse.error(error));
 
-        final result = await sessionService.createSession(projectId: "/tmp/project");
+        final result = await sessionService.createSessionWithMessage(
+          projectId: "/tmp/project",
+          text: "hello",
+          agent: null,
+          providerID: null,
+          modelID: null,
+        );
 
         expect(result, isA<ErrorResponse<Session>>());
         expect((result as ErrorResponse<Session>).error, equals(error));
@@ -222,7 +234,7 @@ void main() {
         ).called(1);
       });
 
-      test("sends projectId and null parentSessionId in create session body", () async {
+      test("sends projectId + prompt parts and optional fields in body", () async {
         when(
           () => mockClient.post<Session>(
             any(),
@@ -231,7 +243,13 @@ void main() {
           ),
         ).thenAnswer((_) async => ApiResponse.success(testSession(id: "s1")));
 
-        await sessionService.createSession(projectId: "/tmp/project");
+        await sessionService.createSessionWithMessage(
+          projectId: "/tmp/project",
+          text: "first prompt",
+          agent: null,
+          providerID: null,
+          modelID: null,
+        );
 
         final captured =
             verify(
@@ -242,7 +260,17 @@ void main() {
                   ),
                 ).captured.last
                 as Map<String, dynamic>;
-        expect(captured, equals({"projectId": "/tmp/project", "parentSessionId": null}));
+        expect(
+          captured,
+          equals({
+            "projectId": "/tmp/project",
+            "parts": [
+              {"type": "text", "text": "first prompt"},
+            ],
+            "agent": null,
+            "model": null,
+          }),
+        );
       });
     });
 

--- a/mobile/app/test/capabilities/session/session_service_test.dart
+++ b/mobile/app/test/capabilities/session/session_service_test.dart
@@ -262,7 +262,7 @@ void main() {
           equals({
             "projectId": "/tmp/project",
             "parts": [
-              {"text": "first prompt"},
+              {"text": "first prompt", "type": "text"},
             ],
             "agent": null,
             "model": null,

--- a/mobile/app/test/capabilities/session/session_service_test.dart
+++ b/mobile/app/test/capabilities/session/session_service_test.dart
@@ -190,8 +190,7 @@ void main() {
           projectId: "/tmp/project",
           text: "hello",
           agent: null,
-          providerID: null,
-          modelID: null,
+          model: null,
         );
 
         expect(result, isA<SuccessResponse<Session>>());
@@ -219,8 +218,7 @@ void main() {
           projectId: "/tmp/project",
           text: "hello",
           agent: null,
-          providerID: null,
-          modelID: null,
+          model: null,
         );
 
         expect(result, isA<ErrorResponse<Session>>());
@@ -247,8 +245,7 @@ void main() {
           projectId: "/tmp/project",
           text: "first prompt",
           agent: null,
-          providerID: null,
-          modelID: null,
+          model: null,
         );
 
         final captured =
@@ -265,7 +262,7 @@ void main() {
           equals({
             "projectId": "/tmp/project",
             "parts": [
-              {"type": "text", "text": "first prompt"},
+              {"text": "first prompt"},
             ],
             "agent": null,
             "model": null,

--- a/mobile/app/test/capabilities/session/session_service_test.dart
+++ b/mobile/app/test/capabilities/session/session_service_test.dart
@@ -262,7 +262,7 @@ void main() {
           equals({
             "projectId": "/tmp/project",
             "parts": [
-              {"text": "first prompt"},
+              {"type": "text", "text": "first prompt"},
             ],
             "agent": null,
             "model": null,

--- a/mobile/app/test/capabilities/session/session_service_test.dart
+++ b/mobile/app/test/capabilities/session/session_service_test.dart
@@ -262,7 +262,7 @@ void main() {
           equals({
             "projectId": "/tmp/project",
             "parts": [
-              {"type": "text", "text": "first prompt"},
+              {"text": "first prompt"},
             ],
             "agent": null,
             "model": null,

--- a/mobile/module_core/lib/sesori_dart_core.dart
+++ b/mobile/module_core/lib/sesori_dart_core.dart
@@ -30,6 +30,8 @@ export "src/capabilities/voice/voice_api.dart";
 export "src/cubits/connection_overlay/connection_overlay_cubit.dart";
 export "src/cubits/login/login_cubit.dart";
 export "src/cubits/login/login_state.dart";
+export "src/cubits/new_session/new_session_cubit.dart";
+export "src/cubits/new_session/new_session_state.dart";
 export "src/cubits/notification_preferences/notification_preferences_cubit.dart";
 export "src/cubits/notification_preferences/notification_preferences_state.dart";
 export "src/cubits/project_list/project_list_cubit.dart";

--- a/mobile/module_core/lib/src/capabilities/session/session_service.dart
+++ b/mobile/module_core/lib/src/capabilities/session/session_service.dart
@@ -64,8 +64,7 @@ class SessionService {
     required String projectId,
     required String text,
     required String? agent,
-    required String? providerID,
-    required String? modelID,
+    required PromptModel? model,
   }) {
     return _client.post(
       "/session",
@@ -77,7 +76,7 @@ class SessionService {
         projectId: projectId,
         parts: [PromptPart.text(text: text)],
         agent: agent,
-        model: providerID != null && modelID != null ? PromptModel(providerID: providerID, modelID: modelID) : null,
+        model: model,
       ).toJson(),
     );
   }

--- a/mobile/module_core/lib/src/capabilities/session/session_service.dart
+++ b/mobile/module_core/lib/src/capabilities/session/session_service.dart
@@ -60,14 +60,25 @@ class SessionService {
     );
   }
 
-  Future<ApiResponse<Session>> createSession({required String projectId}) {
+  Future<ApiResponse<Session>> createSessionWithMessage({
+    required String projectId,
+    required String text,
+    required String? agent,
+    required String? providerID,
+    required String? modelID,
+  }) {
     return _client.post(
       "/session",
       fromJson: (json) => switch (json) {
         final Map<String, dynamic> map => Session.fromJson(map),
         _ => throw FormatException("expected map, got ${json.runtimeType}"),
       },
-      body: CreateSessionRequest(projectId: projectId, parentSessionId: null).toJson(),
+      body: CreateSessionRequest(
+        projectId: projectId,
+        parts: [PromptPart.text(text: text)],
+        agent: agent,
+        model: providerID != null && modelID != null ? PromptModel(providerID: providerID, modelID: modelID) : null,
+      ).toJson(),
     );
   }
 

--- a/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
@@ -1,0 +1,58 @@
+import "package:bloc/bloc.dart";
+import "package:sesori_auth/sesori_auth.dart";
+
+import "../../capabilities/session/session_service.dart";
+import "new_session_state.dart";
+
+class NewSessionCubit extends Cubit<NewSessionState> {
+  final SessionService _sessionService;
+  final String _projectId;
+
+  NewSessionCubit({
+    required SessionService sessionService,
+    required String projectId,
+  }) : _sessionService = sessionService,
+       _projectId = projectId,
+       super(const NewSessionState.idle());
+
+  Future<void> createSessionWithMessage({
+    required String text,
+    required String? agent,
+    required String? providerID,
+    required String? modelID,
+  }) async {
+    if (state is NewSessionSending) return;
+
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return;
+
+    emit(const NewSessionState.sending());
+
+    final response = await _sessionService.createSessionWithMessage(
+      projectId: _projectId,
+      text: trimmed,
+      agent: agent,
+      providerID: providerID,
+      modelID: modelID,
+    );
+
+    if (isClosed) return;
+
+    switch (response) {
+      case SuccessResponse(:final data):
+        emit(NewSessionState.created(session: data));
+      case ErrorResponse(:final error):
+        emit(NewSessionState.error(message: _describeError(error: error)));
+    }
+  }
+
+  String _describeError({required ApiError error}) {
+    return switch (error) {
+      NotAuthenticatedError() => "Authentication required.",
+      NonSuccessCodeError(:final rawErrorString) => rawErrorString ?? "Failed to create session.",
+      DartHttpClientError() => "Unable to reach server.",
+      JsonParsingError() => "Unexpected server response.",
+      GenericError() => "Failed to create session.",
+    };
+  }
+}

--- a/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
@@ -1,5 +1,6 @@
 import "package:bloc/bloc.dart";
 import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_shared/sesori_shared.dart";
 
 import "../../capabilities/session/session_service.dart";
 import "new_session_state.dart";
@@ -18,8 +19,7 @@ class NewSessionCubit extends Cubit<NewSessionState> {
   Future<void> createSessionWithMessage({
     required String text,
     required String? agent,
-    required String? providerID,
-    required String? modelID,
+    required PromptModel? model,
   }) async {
     if (state is NewSessionSending) return;
 
@@ -32,8 +32,7 @@ class NewSessionCubit extends Cubit<NewSessionState> {
       projectId: _projectId,
       text: trimmed,
       agent: agent,
-      providerID: providerID,
-      modelID: modelID,
+      model: model,
     );
 
     if (isClosed) return;

--- a/mobile/module_core/lib/src/cubits/new_session/new_session_state.dart
+++ b/mobile/module_core/lib/src/cubits/new_session/new_session_state.dart
@@ -1,0 +1,15 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+part "new_session_state.freezed.dart";
+
+@Freezed()
+sealed class NewSessionState with _$NewSessionState {
+  const factory NewSessionState.idle() = NewSessionIdle;
+
+  const factory NewSessionState.sending() = NewSessionSending;
+
+  const factory NewSessionState.error({required String message}) = NewSessionError;
+
+  const factory NewSessionState.created({required Session session}) = NewSessionCreated;
+}

--- a/mobile/module_core/lib/src/cubits/new_session/new_session_state.freezed.dart
+++ b/mobile/module_core/lib/src/cubits/new_session/new_session_state.freezed.dart
@@ -1,0 +1,250 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'new_session_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$NewSessionState {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionState);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'NewSessionState()';
+}
+
+
+}
+
+/// @nodoc
+class $NewSessionStateCopyWith<$Res>  {
+$NewSessionStateCopyWith(NewSessionState _, $Res Function(NewSessionState) __);
+}
+
+
+
+/// @nodoc
+
+
+class NewSessionIdle implements NewSessionState {
+  const NewSessionIdle();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionIdle);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'NewSessionState.idle()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class NewSessionSending implements NewSessionState {
+  const NewSessionSending();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionSending);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'NewSessionState.sending()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class NewSessionError implements NewSessionState {
+  const NewSessionError({required this.message});
+  
+
+ final  String message;
+
+/// Create a copy of NewSessionState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$NewSessionErrorCopyWith<NewSessionError> get copyWith => _$NewSessionErrorCopyWithImpl<NewSessionError>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionError&&(identical(other.message, message) || other.message == message));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,message);
+
+@override
+String toString() {
+  return 'NewSessionState.error(message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $NewSessionErrorCopyWith<$Res> implements $NewSessionStateCopyWith<$Res> {
+  factory $NewSessionErrorCopyWith(NewSessionError value, $Res Function(NewSessionError) _then) = _$NewSessionErrorCopyWithImpl;
+@useResult
+$Res call({
+ String message
+});
+
+
+
+
+}
+/// @nodoc
+class _$NewSessionErrorCopyWithImpl<$Res>
+    implements $NewSessionErrorCopyWith<$Res> {
+  _$NewSessionErrorCopyWithImpl(this._self, this._then);
+
+  final NewSessionError _self;
+  final $Res Function(NewSessionError) _then;
+
+/// Create a copy of NewSessionState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? message = null,}) {
+  return _then(NewSessionError(
+message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class NewSessionCreated implements NewSessionState {
+  const NewSessionCreated({required this.session});
+  
+
+ final  Session session;
+
+/// Create a copy of NewSessionState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$NewSessionCreatedCopyWith<NewSessionCreated> get copyWith => _$NewSessionCreatedCopyWithImpl<NewSessionCreated>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionCreated&&(identical(other.session, session) || other.session == session));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,session);
+
+@override
+String toString() {
+  return 'NewSessionState.created(session: $session)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $NewSessionCreatedCopyWith<$Res> implements $NewSessionStateCopyWith<$Res> {
+  factory $NewSessionCreatedCopyWith(NewSessionCreated value, $Res Function(NewSessionCreated) _then) = _$NewSessionCreatedCopyWithImpl;
+@useResult
+$Res call({
+ Session session
+});
+
+
+$SessionCopyWith<$Res> get session;
+
+}
+/// @nodoc
+class _$NewSessionCreatedCopyWithImpl<$Res>
+    implements $NewSessionCreatedCopyWith<$Res> {
+  _$NewSessionCreatedCopyWithImpl(this._self, this._then);
+
+  final NewSessionCreated _self;
+  final $Res Function(NewSessionCreated) _then;
+
+/// Create a copy of NewSessionState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? session = null,}) {
+  return _then(NewSessionCreated(
+session: null == session ? _self.session : session // ignore: cast_nullable_to_non_nullable
+as Session,
+  ));
+}
+
+/// Create a copy of NewSessionState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$SessionCopyWith<$Res> get session {
+  
+  return $SessionCopyWith<$Res>(_self.session, (value) {
+    return _then(_self.copyWith(session: value));
+  });
+}
+}
+
+// dart format on

--- a/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -59,6 +59,8 @@ class SessionListCubit extends Cubit<SessionListState> {
     );
   }
 
+  String get projectId => _projectId;
+
   void _handleEvent(SseEvent event) {
     try {
       if (isClosed) return;
@@ -367,21 +369,6 @@ class SessionListCubit extends Cubit<SessionListState> {
   }
 
   // ---------------------------------------------------------------------------
-
-  /// Creates a new session via POST /session and returns it, or null on failure.
-  Future<Session?> createSession() async {
-    final response = await _service.createSession(projectId: _projectId);
-
-    if (isClosed) return null;
-
-    return switch (response) {
-      SuccessResponse(:final data) => () {
-        _onSessionCreated(data);
-        return data;
-      }(),
-      ErrorResponse() => null,
-    };
-  }
 
   /// Tracks the full unfiltered server response so toggling archived
   /// doesn't require a network round-trip.

--- a/mobile/module_core/lib/src/routing/app_routes.dart
+++ b/mobile/module_core/lib/src/routing/app_routes.dart
@@ -6,6 +6,7 @@ enum AppRoute {
   projects("/projects"),
   notificationSettings("/settings/notifications"),
   sessions("/projects/:projectId/sessions"),
+  newSession("/projects/:projectId/sessions/new"),
   sessionDetail("/projects/:projectId/sessions/:sessionId")
   ;
 

--- a/mobile/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/mobile/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -254,35 +254,6 @@ void main() {
     );
 
     // -------------------------------------------------------------------------
-    // 8. createSession — calls API and returns the new Session
-    // -------------------------------------------------------------------------
-
-    blocTest<SessionListCubit, SessionListState>(
-      "createSession: calls API and returns the created Session on success",
-      build: () {
-        when(
-          () => mockSessionService.listSessions(projectId: projectId),
-        ).thenAnswer((_) async => ApiResponse.success([testSession()]));
-        when(() => mockSessionService.createSession(projectId: projectId)).thenAnswer(
-          (_) async => ApiResponse.success(testSession(id: "new-session")),
-        );
-        return buildCubit();
-      },
-      act: (cubit) async {
-        await Future<void>.delayed(Duration.zero);
-        final result = await cubit.createSession();
-        expect(result?.id, "new-session");
-      },
-      // createSession now optimistically inserts the new session into state.
-      skip: 1,
-      expect: () => [
-        isA<SessionListLoaded>()
-            .having((s) => s.sessions.length, "sessions count", 2)
-            .having((s) => s.sessions.first.id, "new session first", "new-session"),
-      ],
-    );
-
-    // -------------------------------------------------------------------------
     // 9. toggleArchived — flips showArchived flag, re-emits filtered sessions
     // -------------------------------------------------------------------------
 

--- a/shared/sesori_shared/lib/src/models/sesori/create_session_request.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/create_session_request.dart
@@ -1,5 +1,7 @@
 import "package:freezed_annotation/freezed_annotation.dart";
 
+import "send_prompt_request.dart";
+
 part "create_session_request.freezed.dart";
 
 part "create_session_request.g.dart";
@@ -8,7 +10,9 @@ part "create_session_request.g.dart";
 sealed class CreateSessionRequest with _$CreateSessionRequest {
   const factory CreateSessionRequest({
     required String projectId,
-    required String? parentSessionId,
+    required List<PromptPart> parts,
+    required String? agent,
+    required PromptModel? model,
   }) = _CreateSessionRequest;
 
   factory CreateSessionRequest.fromJson(Map<String, dynamic> json) => _$CreateSessionRequestFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/create_session_request.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/create_session_request.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$CreateSessionRequest {
 
- String get projectId; String? get parentSessionId;
+ String get projectId; List<PromptPart> get parts; String? get agent; PromptModel? get model;
 /// Create a copy of CreateSessionRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $CreateSessionRequestCopyWith<CreateSessionRequest> get copyWith => _$CreateSess
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CreateSessionRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&(identical(other.parentSessionId, parentSessionId) || other.parentSessionId == parentSessionId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CreateSessionRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&const DeepCollectionEquality().equals(other.parts, parts)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.model, model) || other.model == model));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,projectId,parentSessionId);
+int get hashCode => Object.hash(runtimeType,projectId,const DeepCollectionEquality().hash(parts),agent,model);
 
 @override
 String toString() {
-  return 'CreateSessionRequest(projectId: $projectId, parentSessionId: $parentSessionId)';
+  return 'CreateSessionRequest(projectId: $projectId, parts: $parts, agent: $agent, model: $model)';
 }
 
 
@@ -48,11 +48,11 @@ abstract mixin class $CreateSessionRequestCopyWith<$Res>  {
   factory $CreateSessionRequestCopyWith(CreateSessionRequest value, $Res Function(CreateSessionRequest) _then) = _$CreateSessionRequestCopyWithImpl;
 @useResult
 $Res call({
- String projectId, String? parentSessionId
+ String projectId, List<PromptPart> parts, String? agent, PromptModel? model
 });
 
 
-
+$PromptModelCopyWith<$Res>? get model;
 
 }
 /// @nodoc
@@ -65,14 +65,28 @@ class _$CreateSessionRequestCopyWithImpl<$Res>
 
 /// Create a copy of CreateSessionRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? projectId = null,Object? parentSessionId = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? projectId = null,Object? parts = null,Object? agent = freezed,Object? model = freezed,}) {
   return _then(_self.copyWith(
 projectId: null == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
-as String,parentSessionId: freezed == parentSessionId ? _self.parentSessionId : parentSessionId // ignore: cast_nullable_to_non_nullable
-as String?,
+as String,parts: null == parts ? _self.parts : parts // ignore: cast_nullable_to_non_nullable
+as List<PromptPart>,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullable_to_non_nullable
+as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
+as PromptModel?,
   ));
 }
+/// Create a copy of CreateSessionRequest
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PromptModelCopyWith<$Res>? get model {
+    if (_self.model == null) {
+    return null;
+  }
 
+  return $PromptModelCopyWith<$Res>(_self.model!, (value) {
+    return _then(_self.copyWith(model: value));
+  });
+}
 }
 
 
@@ -81,11 +95,19 @@ as String?,
 @JsonSerializable()
 
 class _CreateSessionRequest implements CreateSessionRequest {
-  const _CreateSessionRequest({required this.projectId, required this.parentSessionId});
+  const _CreateSessionRequest({required this.projectId, required final  List<PromptPart> parts, required this.agent, required this.model}): _parts = parts;
   factory _CreateSessionRequest.fromJson(Map<String, dynamic> json) => _$CreateSessionRequestFromJson(json);
 
 @override final  String projectId;
-@override final  String? parentSessionId;
+ final  List<PromptPart> _parts;
+@override List<PromptPart> get parts {
+  if (_parts is EqualUnmodifiableListView) return _parts;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_parts);
+}
+
+@override final  String? agent;
+@override final  PromptModel? model;
 
 /// Create a copy of CreateSessionRequest
 /// with the given fields replaced by the non-null parameter values.
@@ -100,16 +122,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CreateSessionRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&(identical(other.parentSessionId, parentSessionId) || other.parentSessionId == parentSessionId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CreateSessionRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&const DeepCollectionEquality().equals(other._parts, _parts)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.model, model) || other.model == model));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,projectId,parentSessionId);
+int get hashCode => Object.hash(runtimeType,projectId,const DeepCollectionEquality().hash(_parts),agent,model);
 
 @override
 String toString() {
-  return 'CreateSessionRequest(projectId: $projectId, parentSessionId: $parentSessionId)';
+  return 'CreateSessionRequest(projectId: $projectId, parts: $parts, agent: $agent, model: $model)';
 }
 
 
@@ -120,11 +142,11 @@ abstract mixin class _$CreateSessionRequestCopyWith<$Res> implements $CreateSess
   factory _$CreateSessionRequestCopyWith(_CreateSessionRequest value, $Res Function(_CreateSessionRequest) _then) = __$CreateSessionRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String projectId, String? parentSessionId
+ String projectId, List<PromptPart> parts, String? agent, PromptModel? model
 });
 
 
-
+@override $PromptModelCopyWith<$Res>? get model;
 
 }
 /// @nodoc
@@ -137,15 +159,29 @@ class __$CreateSessionRequestCopyWithImpl<$Res>
 
 /// Create a copy of CreateSessionRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? projectId = null,Object? parentSessionId = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? projectId = null,Object? parts = null,Object? agent = freezed,Object? model = freezed,}) {
   return _then(_CreateSessionRequest(
 projectId: null == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
-as String,parentSessionId: freezed == parentSessionId ? _self.parentSessionId : parentSessionId // ignore: cast_nullable_to_non_nullable
-as String?,
+as String,parts: null == parts ? _self._parts : parts // ignore: cast_nullable_to_non_nullable
+as List<PromptPart>,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullable_to_non_nullable
+as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
+as PromptModel?,
   ));
 }
 
+/// Create a copy of CreateSessionRequest
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$PromptModelCopyWith<$Res>? get model {
+    if (_self.model == null) {
+    return null;
+  }
 
+  return $PromptModelCopyWith<$Res>(_self.model!, (value) {
+    return _then(_self.copyWith(model: value));
+  });
+}
 }
 
 // dart format on

--- a/shared/sesori_shared/lib/src/models/sesori/create_session_request.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/create_session_request.g.dart
@@ -9,12 +9,22 @@ part of 'create_session_request.dart';
 _CreateSessionRequest _$CreateSessionRequestFromJson(Map json) =>
     _CreateSessionRequest(
       projectId: json['projectId'] as String,
-      parentSessionId: json['parentSessionId'] as String?,
+      parts: (json['parts'] as List<dynamic>)
+          .map((e) => PromptPart.fromJson(Map<String, dynamic>.from(e as Map)))
+          .toList(),
+      agent: json['agent'] as String?,
+      model: json['model'] == null
+          ? null
+          : PromptModel.fromJson(
+              Map<String, dynamic>.from(json['model'] as Map),
+            ),
     );
 
 Map<String, dynamic> _$CreateSessionRequestToJson(
   _CreateSessionRequest instance,
 ) => <String, dynamic>{
   'projectId': instance.projectId,
-  'parentSessionId': instance.parentSessionId,
+  'parts': instance.parts.map((e) => e.toJson()).toList(),
+  'agent': instance.agent,
+  'model': instance.model?.toJson(),
 };

--- a/shared/sesori_shared/lib/src/models/sesori/send_prompt_request.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/send_prompt_request.dart
@@ -15,10 +15,36 @@ sealed class SendPromptRequest with _$SendPromptRequest {
   factory SendPromptRequest.fromJson(Map<String, dynamic> json) => _$SendPromptRequestFromJson(json);
 }
 
+/// Prompt part types for the mobile ↔ bridge protocol.
 @Freezed(unionKey: "type", fromJson: true, toJson: true)
 sealed class PromptPart with _$PromptPart {
+  /// Plain text content.
   @FreezedUnionValue("text")
   const factory PromptPart.text({required String text}) = PromptPartText;
+
+  /// Local file on the host filesystem, referenced by absolute path.
+  @FreezedUnionValue("file_path")
+  const factory PromptPart.filePath({
+    required String mime,
+    required String path,
+    required String? filename,
+  }) = PromptPartFilePath;
+
+  /// Remote file referenced by URL (`https://`, etc.).
+  @FreezedUnionValue("file_url")
+  const factory PromptPart.fileUrl({
+    required String mime,
+    required String url,
+    required String? filename,
+  }) = PromptPartFileUrl;
+
+  /// Inline file content as base64-encoded data.
+  @FreezedUnionValue("file_data")
+  const factory PromptPart.fileData({
+    required String mime,
+    required String base64,
+    required String? filename,
+  }) = PromptPartFileData;
 
   factory PromptPart.fromJson(Map<String, dynamic> json) => _$PromptPartFromJson(json);
 }

--- a/shared/sesori_shared/lib/src/models/sesori/send_prompt_request.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/send_prompt_request.freezed.dart
@@ -184,20 +184,39 @@ $PromptModelCopyWith<$Res>? get model {
 PromptPart _$PromptPartFromJson(
   Map<String, dynamic> json
 ) {
-    return PromptPartText.fromJson(
-      json
-    );
+        switch (json['type']) {
+                  case 'text':
+          return PromptPartText.fromJson(
+            json
+          );
+                case 'file_path':
+          return PromptPartFilePath.fromJson(
+            json
+          );
+                case 'file_url':
+          return PromptPartFileUrl.fromJson(
+            json
+          );
+                case 'file_data':
+          return PromptPartFileData.fromJson(
+            json
+          );
+        
+          default:
+            throw CheckedFromJsonException(
+  json,
+  'type',
+  'PromptPart',
+  'Invalid union type "${json['type']}"!'
+);
+        }
+      
 }
 
 /// @nodoc
 mixin _$PromptPart {
 
- String get text;
-/// Create a copy of PromptPart
-/// with the given fields replaced by the non-null parameter values.
-@JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-$PromptPartCopyWith<PromptPart> get copyWith => _$PromptPartCopyWithImpl<PromptPart>(this as PromptPart, _$identity);
+
 
   /// Serializes this PromptPart to a JSON map.
   Map<String, dynamic> toJson();
@@ -205,50 +224,24 @@ $PromptPartCopyWith<PromptPart> get copyWith => _$PromptPartCopyWithImpl<PromptP
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PromptPart&&(identical(other.text, text) || other.text == text));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PromptPart);
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,text);
+int get hashCode => runtimeType.hashCode;
 
 @override
 String toString() {
-  return 'PromptPart(text: $text)';
+  return 'PromptPart()';
 }
 
 
 }
 
 /// @nodoc
-abstract mixin class $PromptPartCopyWith<$Res>  {
-  factory $PromptPartCopyWith(PromptPart value, $Res Function(PromptPart) _then) = _$PromptPartCopyWithImpl;
-@useResult
-$Res call({
- String text
-});
-
-
-
-
-}
-/// @nodoc
-class _$PromptPartCopyWithImpl<$Res>
-    implements $PromptPartCopyWith<$Res> {
-  _$PromptPartCopyWithImpl(this._self, this._then);
-
-  final PromptPart _self;
-  final $Res Function(PromptPart) _then;
-
-/// Create a copy of PromptPart
-/// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? text = null,}) {
-  return _then(_self.copyWith(
-text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
-as String,
-  ));
-}
-
+class $PromptPartCopyWith<$Res>  {
+$PromptPartCopyWith(PromptPart _, $Res Function(PromptPart) __);
 }
 
 
@@ -257,14 +250,18 @@ as String,
 @JsonSerializable()
 
 class PromptPartText implements PromptPart {
-  const PromptPartText({required this.text});
+  const PromptPartText({required this.text, final  String? $type}): $type = $type ?? 'text';
   factory PromptPartText.fromJson(Map<String, dynamic> json) => _$PromptPartTextFromJson(json);
 
-@override final  String text;
+ final  String text;
+
+@JsonKey(name: 'type')
+final String $type;
+
 
 /// Create a copy of PromptPart
 /// with the given fields replaced by the non-null parameter values.
-@override @JsonKey(includeFromJson: false, includeToJson: false)
+@JsonKey(includeFromJson: false, includeToJson: false)
 @pragma('vm:prefer-inline')
 $PromptPartTextCopyWith<PromptPartText> get copyWith => _$PromptPartTextCopyWithImpl<PromptPartText>(this, _$identity);
 
@@ -293,7 +290,7 @@ String toString() {
 /// @nodoc
 abstract mixin class $PromptPartTextCopyWith<$Res> implements $PromptPartCopyWith<$Res> {
   factory $PromptPartTextCopyWith(PromptPartText value, $Res Function(PromptPartText) _then) = _$PromptPartTextCopyWithImpl;
-@override @useResult
+@useResult
 $Res call({
  String text
 });
@@ -312,10 +309,241 @@ class _$PromptPartTextCopyWithImpl<$Res>
 
 /// Create a copy of PromptPart
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
   return _then(PromptPartText(
 text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
 as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class PromptPartFilePath implements PromptPart {
+  const PromptPartFilePath({required this.mime, required this.path, required this.filename, final  String? $type}): $type = $type ?? 'file_path';
+  factory PromptPartFilePath.fromJson(Map<String, dynamic> json) => _$PromptPartFilePathFromJson(json);
+
+ final  String mime;
+ final  String path;
+ final  String? filename;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of PromptPart
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PromptPartFilePathCopyWith<PromptPartFilePath> get copyWith => _$PromptPartFilePathCopyWithImpl<PromptPartFilePath>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PromptPartFilePathToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PromptPartFilePath&&(identical(other.mime, mime) || other.mime == mime)&&(identical(other.path, path) || other.path == path)&&(identical(other.filename, filename) || other.filename == filename));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,mime,path,filename);
+
+@override
+String toString() {
+  return 'PromptPart.filePath(mime: $mime, path: $path, filename: $filename)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PromptPartFilePathCopyWith<$Res> implements $PromptPartCopyWith<$Res> {
+  factory $PromptPartFilePathCopyWith(PromptPartFilePath value, $Res Function(PromptPartFilePath) _then) = _$PromptPartFilePathCopyWithImpl;
+@useResult
+$Res call({
+ String mime, String path, String? filename
+});
+
+
+
+
+}
+/// @nodoc
+class _$PromptPartFilePathCopyWithImpl<$Res>
+    implements $PromptPartFilePathCopyWith<$Res> {
+  _$PromptPartFilePathCopyWithImpl(this._self, this._then);
+
+  final PromptPartFilePath _self;
+  final $Res Function(PromptPartFilePath) _then;
+
+/// Create a copy of PromptPart
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? mime = null,Object? path = null,Object? filename = freezed,}) {
+  return _then(PromptPartFilePath(
+mime: null == mime ? _self.mime : mime // ignore: cast_nullable_to_non_nullable
+as String,path: null == path ? _self.path : path // ignore: cast_nullable_to_non_nullable
+as String,filename: freezed == filename ? _self.filename : filename // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class PromptPartFileUrl implements PromptPart {
+  const PromptPartFileUrl({required this.mime, required this.url, required this.filename, final  String? $type}): $type = $type ?? 'file_url';
+  factory PromptPartFileUrl.fromJson(Map<String, dynamic> json) => _$PromptPartFileUrlFromJson(json);
+
+ final  String mime;
+ final  String url;
+ final  String? filename;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of PromptPart
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PromptPartFileUrlCopyWith<PromptPartFileUrl> get copyWith => _$PromptPartFileUrlCopyWithImpl<PromptPartFileUrl>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PromptPartFileUrlToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PromptPartFileUrl&&(identical(other.mime, mime) || other.mime == mime)&&(identical(other.url, url) || other.url == url)&&(identical(other.filename, filename) || other.filename == filename));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,mime,url,filename);
+
+@override
+String toString() {
+  return 'PromptPart.fileUrl(mime: $mime, url: $url, filename: $filename)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PromptPartFileUrlCopyWith<$Res> implements $PromptPartCopyWith<$Res> {
+  factory $PromptPartFileUrlCopyWith(PromptPartFileUrl value, $Res Function(PromptPartFileUrl) _then) = _$PromptPartFileUrlCopyWithImpl;
+@useResult
+$Res call({
+ String mime, String url, String? filename
+});
+
+
+
+
+}
+/// @nodoc
+class _$PromptPartFileUrlCopyWithImpl<$Res>
+    implements $PromptPartFileUrlCopyWith<$Res> {
+  _$PromptPartFileUrlCopyWithImpl(this._self, this._then);
+
+  final PromptPartFileUrl _self;
+  final $Res Function(PromptPartFileUrl) _then;
+
+/// Create a copy of PromptPart
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? mime = null,Object? url = null,Object? filename = freezed,}) {
+  return _then(PromptPartFileUrl(
+mime: null == mime ? _self.mime : mime // ignore: cast_nullable_to_non_nullable
+as String,url: null == url ? _self.url : url // ignore: cast_nullable_to_non_nullable
+as String,filename: freezed == filename ? _self.filename : filename // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class PromptPartFileData implements PromptPart {
+  const PromptPartFileData({required this.mime, required this.base64, required this.filename, final  String? $type}): $type = $type ?? 'file_data';
+  factory PromptPartFileData.fromJson(Map<String, dynamic> json) => _$PromptPartFileDataFromJson(json);
+
+ final  String mime;
+ final  String base64;
+ final  String? filename;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of PromptPart
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PromptPartFileDataCopyWith<PromptPartFileData> get copyWith => _$PromptPartFileDataCopyWithImpl<PromptPartFileData>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PromptPartFileDataToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PromptPartFileData&&(identical(other.mime, mime) || other.mime == mime)&&(identical(other.base64, base64) || other.base64 == base64)&&(identical(other.filename, filename) || other.filename == filename));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,mime,base64,filename);
+
+@override
+String toString() {
+  return 'PromptPart.fileData(mime: $mime, base64: $base64, filename: $filename)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PromptPartFileDataCopyWith<$Res> implements $PromptPartCopyWith<$Res> {
+  factory $PromptPartFileDataCopyWith(PromptPartFileData value, $Res Function(PromptPartFileData) _then) = _$PromptPartFileDataCopyWithImpl;
+@useResult
+$Res call({
+ String mime, String base64, String? filename
+});
+
+
+
+
+}
+/// @nodoc
+class _$PromptPartFileDataCopyWithImpl<$Res>
+    implements $PromptPartFileDataCopyWith<$Res> {
+  _$PromptPartFileDataCopyWithImpl(this._self, this._then);
+
+  final PromptPartFileData _self;
+  final $Res Function(PromptPartFileData) _then;
+
+/// Create a copy of PromptPart
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? mime = null,Object? base64 = null,Object? filename = freezed,}) {
+  return _then(PromptPartFileData(
+mime: null == mime ? _self.mime : mime // ignore: cast_nullable_to_non_nullable
+as String,base64: null == base64 ? _self.base64 : base64 // ignore: cast_nullable_to_non_nullable
+as String,filename: freezed == filename ? _self.filename : filename // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/send_prompt_request.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/send_prompt_request.g.dart
@@ -23,11 +23,58 @@ Map<String, dynamic> _$SendPromptRequestToJson(_SendPromptRequest instance) =>
       'model': instance.model?.toJson(),
     };
 
-PromptPartText _$PromptPartTextFromJson(Map json) =>
-    PromptPartText(text: json['text'] as String);
+PromptPartText _$PromptPartTextFromJson(Map json) => PromptPartText(
+  text: json['text'] as String,
+  $type: json['type'] as String?,
+);
 
 Map<String, dynamic> _$PromptPartTextToJson(PromptPartText instance) =>
-    <String, dynamic>{'text': instance.text};
+    <String, dynamic>{'text': instance.text, 'type': instance.$type};
+
+PromptPartFilePath _$PromptPartFilePathFromJson(Map json) => PromptPartFilePath(
+  mime: json['mime'] as String,
+  path: json['path'] as String,
+  filename: json['filename'] as String?,
+  $type: json['type'] as String?,
+);
+
+Map<String, dynamic> _$PromptPartFilePathToJson(PromptPartFilePath instance) =>
+    <String, dynamic>{
+      'mime': instance.mime,
+      'path': instance.path,
+      'filename': instance.filename,
+      'type': instance.$type,
+    };
+
+PromptPartFileUrl _$PromptPartFileUrlFromJson(Map json) => PromptPartFileUrl(
+  mime: json['mime'] as String,
+  url: json['url'] as String,
+  filename: json['filename'] as String?,
+  $type: json['type'] as String?,
+);
+
+Map<String, dynamic> _$PromptPartFileUrlToJson(PromptPartFileUrl instance) =>
+    <String, dynamic>{
+      'mime': instance.mime,
+      'url': instance.url,
+      'filename': instance.filename,
+      'type': instance.$type,
+    };
+
+PromptPartFileData _$PromptPartFileDataFromJson(Map json) => PromptPartFileData(
+  mime: json['mime'] as String,
+  base64: json['base64'] as String,
+  filename: json['filename'] as String?,
+  $type: json['type'] as String?,
+);
+
+Map<String, dynamic> _$PromptPartFileDataToJson(PromptPartFileData instance) =>
+    <String, dynamic>{
+      'mime': instance.mime,
+      'base64': instance.base64,
+      'filename': instance.filename,
+      'type': instance.$type,
+    };
 
 _PromptModel _$PromptModelFromJson(Map json) => _PromptModel(
   providerID: json['providerID'] as String,


### PR DESCRIPTION
## Summary

- **Navigate immediately**: Tapping "new session" FAB now opens the new session screen instantly — no waiting for backend session creation
- **Create on first message**: Session is only created when user sends their first message, via an enriched `POST /session` endpoint that combines session creation with the initial prompt
- **Route replacement**: After session creation succeeds, the new session screen is replaced with the real session detail screen (fresh `SessionDetailCubit` with the assigned session ID)

## Changes

### Shared (`sesori_shared`)
- `CreateSessionRequest` enriched with `parts`, `agent`, `model` fields; `parentSessionId` removed

### Bridge
- `BridgePlugin.createSession()` interface updated with prompt fields
- OpenCode plugin chains: create session → register tracker → send prompt
- `CreateSessionHandler` parses enriched request and passes to plugin
- All bridge test doubles and handler tests updated

### Mobile
- `SessionService.createSessionWithMessage()` replaces `createSession()`
- `SessionListCubit.createSession()` removed; `projectId` exposed via getter
- New `AppRoute.newSession` route at `/projects/:projectId/sessions/new`
- New `NewSessionCubit` + `NewSessionState` (idle → sending → created/error)
- New `NewSessionScreen` with `PromptInput` reuse and inline error display
- FAB navigates to new session route instead of blocking on session creation
- Tests updated across both `module_core` and `app`

## Verification
- `dart analyze` passes on `sesori_shared`, `module_core`, and `app`
- `dart test` passes on `sesori_shared` (164 tests), bridge `app` (422 tests), and `module_core` (139 tests)