### PR TITLE
fix(bridge): suppress expected SSE error on graceful shutdown

### DIFF
--- a/bridge/app/lib/src/bridge/routing/create_session_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/create_session_handler.dart
@@ -42,7 +42,7 @@ class CreateSessionHandler extends RequestHandler {
     }
 
     final projectId = createRequest.projectId;
-    final String? parentSessionId = null;
+    const String? parentSessionId = null;
 
     final worktreeResult = await _worktreeService.prepareWorktreeForSession(
       projectId: projectId,

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -86,7 +86,7 @@ void main() {
       expect(worktreeService.lastPrepareParentSessionId, isNull);
       expect(plugin.lastCreateSessionDirectory, equals("/repo/.worktrees/session-001"));
       expect(plugin.lastCreateSessionParentId, isNull);
-      expect(plugin.lastCreateSessionParts, equals([PluginPromptPart.text(text: "Start")]));
+      expect(plugin.lastCreateSessionParts, equals([const PluginPromptPart.text(text: "Start")]));
       expect(worktreeService.recordCalls, hasLength(1));
       expect(worktreeService.recordCalls.first.sessionId, equals("s1"));
       expect(worktreeService.recordCalls.first.projectId, equals("/repo"));
@@ -273,7 +273,7 @@ void main() {
 
       expect(plugin.lastCreateSessionProjectId, equals("/tmp"));
       expect(plugin.lastCreateSessionDirectory, equals("/tmp"));
-      expect(plugin.lastCreateSessionParts, equals([PluginPromptPart.text(text: "Hello")]));
+      expect(plugin.lastCreateSessionParts, equals([const PluginPromptPart.text(text: "Hello")]));
       expect(plugin.lastCreateSessionAgent, equals("architect"));
       expect(plugin.lastCreateSessionModel, equals((providerID: "openai", modelID: "gpt-5")));
     });

--- a/bridge/app/test/bridge/routing/request_router_test.dart
+++ b/bridge/app/test/bridge/routing/request_router_test.dart
@@ -117,7 +117,7 @@ void main() {
       expect(plugin.lastCreateSessionDirectory, equals("/tmp"));
       expect(plugin.lastCreateSessionParentId, isNull);
       expect(plugin.lastCreateSessionProjectId, equals("/tmp"));
-      expect(plugin.lastCreateSessionParts, equals([PluginPromptPart.text(text: "Start")]));
+      expect(plugin.lastCreateSessionParts, equals([const PluginPromptPart.text(text: "Start")]));
       expect(plugin.lastCreateSessionAgent, equals("architect"));
       expect(plugin.lastCreateSessionModel, equals((providerID: "openai", modelID: "gpt-5")));
     });

--- a/bridge/sesori_plugin_opencode/lib/src/sse/sse_connection.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse/sse_connection.dart
@@ -72,8 +72,8 @@ class SseConnection {
         reconnectDelay = const Duration(seconds: 1);
         await _readStream(response, generation);
       } catch (e, st) {
-        Log.e("[sse-conn] stream loop error: $e\n$st");
         if (!_active || _generation != generation) return;
+        Log.e("[sse-conn] stream loop error: $e\n$st");
       } finally {
         client.close();
         if (_currentClient == client) _currentClient = null;


### PR DESCRIPTION
## Summary

- **Fix noisy shutdown**: Move the `_active`/`_generation` guard above the `Log.e` call in `SseConnection._streamLoop` so the expected `ClientException` during `stop()` exits silently instead of printing a full stack trace.
- **Resolve analyzer hints**: Apply `const` where flagged by `prefer_const_declarations` and `prefer_const_constructors` — `dart analyze` now reports zero issues across the bridge workspace.