### PR TITLE
fix: stability improvements and tech debt reduction from audit

### DIFF
--- a/bridge/app/lib/src/auth/login.dart
+++ b/bridge/app/lib/src/auth/login.dart
@@ -167,7 +167,9 @@ Future<TokenData> login(String authBackendURL) async {
       );
       Log.i("Open this URL manually:");
       Log.i(initResp.authUrl);
-    } catch (_) {}
+    } catch (e) {
+      Log.w("Failed to request fallback auth URL: $e");
+    }
     Log.e(
       "Cannot complete browser login automatically without callback server.",
     );

--- a/bridge/app/lib/src/bridge/debug_server.dart
+++ b/bridge/app/lib/src/bridge/debug_server.dart
@@ -55,7 +55,9 @@ class DebugServer {
     for (final client in clients) {
       try {
         await client.close();
-      } catch (_) {}
+      } catch (e) {
+        Log.d("stop: client close failed (ignored): $e");
+      }
     }
     final server = _server;
     _server = null;
@@ -145,12 +147,15 @@ class DebugServer {
       );
 
       await disconnected.future;
-    } catch (_) {
+    } catch (e) {
+      Log.d("SSE handler: error during client lifecycle (ignored): $e");
     } finally {
       _removeSseClient(response);
       try {
         await response.close();
-      } catch (_) {}
+      } catch (e) {
+        Log.d("SSE cleanup: response close failed (ignored): $e");
+      }
     }
   }
 
@@ -160,11 +165,14 @@ class DebugServer {
       try {
         client.write("data: $eventData\n\n");
         await client.flush();
-      } catch (_) {
+      } catch (e) {
+        Log.d("fan-out: client write/flush failed, removing: $e");
         _removeSseClient(client);
         try {
           await client.close();
-        } catch (_) {}
+        } catch (e) {
+          Log.d("fan-out cleanup: client close failed (ignored): $e");
+        }
       }
     }
   }

--- a/bridge/app/lib/src/bridge/relay_client.dart
+++ b/bridge/app/lib/src/bridge/relay_client.dart
@@ -68,7 +68,9 @@ class RelayClient {
   Future<void> reconnect() async {
     try {
       await close();
-    } catch (_) {}
+    } catch (e) {
+      Log.d("reconnect: close failed (ignored): $e");
+    }
     await connect();
   }
 

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -6,6 +6,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "../opencode_plugin.dart";
 import "sse/sse_connection.dart";
+import "sse_event_mapper.dart";
 
 class OpenCodePlugin implements BridgePlugin {
   final OpenCodeService _service;
@@ -13,6 +14,7 @@ class OpenCodePlugin implements BridgePlugin {
   final BufferedUntilFirstListener<BridgeSseEvent> _eventBuffer;
   final String _serverUrl;
   final String? _password;
+  final SseEventMapper _mapper = SseEventMapper();
   late final SseConnection _sseConnection;
 
   OpenCodePlugin({
@@ -516,7 +518,7 @@ class OpenCodePlugin implements BridgePlugin {
         _emitProjectsSummary();
       }
 
-      final bridgeEvent = _mapSseEvent(event);
+      final bridgeEvent = _mapper.map(event);
       if (bridgeEvent != null) {
         _eventBuffer.add(bridgeEvent);
       }
@@ -541,158 +543,8 @@ class OpenCodePlugin implements BridgePlugin {
         modelID: info.modelID,
         providerID: info.providerID,
       ),
-      parts: parts.map(_mapMessagePart).where((p) => p.type.isVisible).toList(),
+      parts: parts.map(_mapper.mapPart).where((p) => p.type.isVisible).toList(),
     );
-  }
-
-  /// Maps an OpenCode part type string to [PluginMessagePartType].
-  /// Unknown types are mapped to [PluginMessagePartType.unknown] (invisible)
-  /// and logged as a warning so new types are noticed.
-  static PluginMessagePartType _toPluginPartType({required String type}) => switch (type) {
-    "text" => PluginMessagePartType.text,
-    "reasoning" => PluginMessagePartType.reasoning,
-    "tool" => PluginMessagePartType.tool,
-    "subtask" => PluginMessagePartType.subtask,
-    "step-start" => PluginMessagePartType.stepStart,
-    "step-finish" => PluginMessagePartType.stepFinish,
-    "file" => PluginMessagePartType.file,
-    "snapshot" => PluginMessagePartType.snapshot,
-    "patch" => PluginMessagePartType.patch,
-    "agent" => PluginMessagePartType.agent,
-    "retry" => PluginMessagePartType.retry,
-    "compaction" => PluginMessagePartType.compaction,
-    _ => () {
-      Log.w("Unknown message part type: '$type' — filtering out");
-      return PluginMessagePartType.unknown;
-    }(),
-  };
-
-  PluginMessagePart _mapMessagePart(MessagePart raw) {
-    return PluginMessagePart(
-      id: raw.id,
-      sessionID: raw.sessionID,
-      messageID: raw.messageID,
-      type: _toPluginPartType(type: raw.type),
-      text: raw.text,
-      tool: raw.tool,
-      state: switch (raw.state) {
-        ToolState(:final status, :final title, :final output, :final error) => PluginToolState(
-          status: status,
-          title: title,
-          output: output != null && output.length > maxToolOutputLength
-              ? String.fromCharCodes(output.runes.take(maxToolOutputLength))
-              : output,
-          error: error,
-        ),
-        null => null,
-      },
-      prompt: raw.prompt,
-      description: raw.description,
-      agent: raw.agent,
-      agentName: raw.name,
-      attempt: raw.attempt,
-      retryError: (raw.error?['data'] as Map<String, dynamic>?)?['message']?.toString(),
-    );
-  }
-
-  BridgeSseEvent? _mapSseEvent(SseEventData event) {
-    return switch (event) {
-      SseServerConnected() => const BridgeSseServerConnected(),
-      SseServerHeartbeat() => const BridgeSseServerHeartbeat(),
-      SseServerInstanceDisposed(:final directory) => BridgeSseServerInstanceDisposed(directory: directory),
-      SseGlobalDisposed() => const BridgeSseGlobalDisposed(),
-      SseSessionCreated(:final info) => BridgeSseSessionCreated(info: info.toJson()),
-      SseSessionUpdated(:final info) => BridgeSseSessionUpdated(info: info.toJson()),
-      SseSessionDeleted(:final info) => BridgeSseSessionDeleted(info: info.toJson()),
-      SseSessionDiff(:final sessionID) => BridgeSseSessionDiff(
-        sessionID: sessionID,
-      ),
-      SseSessionError(:final sessionID) => BridgeSseSessionError(sessionID: sessionID),
-      SseSessionCompacted(:final sessionID) => BridgeSseSessionCompacted(sessionID: sessionID),
-      SseSessionStatus(:final sessionID, :final status) => BridgeSseSessionStatus(
-        sessionID: sessionID,
-        status: status.toJson(),
-      ),
-      // ignore: deprecated_member_use, forwards legacy idle event for backward compatibility
-      SseSessionIdle(:final sessionID) => BridgeSseSessionIdle(sessionID: sessionID),
-      SseMessageUpdated(:final info) => BridgeSseMessageUpdated(info: info.toJson()),
-      SseMessageRemoved(:final sessionID, :final messageID) => BridgeSseMessageRemoved(
-        sessionID: sessionID,
-        messageID: messageID,
-      ),
-      SseMessagePartUpdated(:final part) => BridgeSseMessagePartUpdated(part: _mapMessagePart(part)),
-      SseMessagePartDelta(
-        :final sessionID,
-        :final messageID,
-        :final partID,
-        :final field,
-        :final delta,
-      ) =>
-        BridgeSseMessagePartDelta(
-          sessionID: sessionID,
-          messageID: messageID,
-          partID: partID,
-          field: field,
-          delta: delta,
-        ),
-      SseMessagePartRemoved(:final sessionID, :final messageID, :final partID) => BridgeSseMessagePartRemoved(
-        sessionID: sessionID,
-        messageID: messageID,
-        partID: partID,
-      ),
-      SsePtyCreated() => const BridgeSsePtyCreated(),
-      SsePtyUpdated() => const BridgeSsePtyUpdated(),
-      SsePtyExited(:final id, :final exitCode) => BridgeSsePtyExited(id: id, exitCode: exitCode),
-      SsePtyDeleted(:final id) => BridgeSsePtyDeleted(id: id),
-      SsePermissionAsked(:final requestID, :final sessionID, :final tool, :final description) =>
-        BridgeSsePermissionAsked(
-          requestID: requestID,
-          sessionID: sessionID,
-          tool: tool,
-          description: description,
-        ),
-      SsePermissionReplied(:final requestID, :final reply) => BridgeSsePermissionReplied(
-        requestID: requestID,
-        reply: reply,
-      ),
-      SsePermissionUpdated() => const BridgeSsePermissionUpdated(),
-      SseQuestionAsked(:final id, :final sessionID, :final questions) => BridgeSseQuestionAsked(
-        id: id,
-        sessionID: sessionID,
-        questions: questions.map((q) => q.toJson()).toList(),
-      ),
-      SseQuestionReplied(:final requestID, :final sessionID) => BridgeSseQuestionReplied(
-        requestID: requestID,
-        sessionID: sessionID,
-      ),
-      SseQuestionRejected(:final requestID, :final sessionID) => BridgeSseQuestionRejected(
-        requestID: requestID,
-        sessionID: sessionID,
-      ),
-      SseTodoUpdated(:final sessionID) => BridgeSseTodoUpdated(sessionID: sessionID),
-      SseProjectUpdated() => const BridgeSseProjectUpdated(),
-      SseVcsBranchUpdated() => const BridgeSseVcsBranchUpdated(),
-      SseFileEdited(:final file) => BridgeSseFileEdited(file: file),
-      SseFileWatcherUpdated(:final file, :final event) => BridgeSseFileWatcherUpdated(file: file, event: event),
-      SseLspUpdated() => const BridgeSseLspUpdated(),
-      SseLspClientDiagnostics(:final serverID, :final path) => BridgeSseLspClientDiagnostics(
-        serverID: serverID,
-        path: path,
-      ),
-      SseMcpToolsChanged() => const BridgeSseMcpToolsChanged(),
-      SseMcpBrowserOpenFailed() => const BridgeSseMcpBrowserOpenFailed(),
-      SseInstallationUpdated(:final version) => BridgeSseInstallationUpdated(version: version),
-      SseInstallationUpdateAvailable(:final version) => BridgeSseInstallationUpdateAvailable(version: version),
-      SseWorkspaceReady(:final name) => BridgeSseWorkspaceReady(name: name),
-      SseWorkspaceFailed(:final message) => BridgeSseWorkspaceFailed(message: message),
-      SseTuiToastShow(:final title, :final message, :final variant) => BridgeSseTuiToastShow(
-        title: title,
-        message: message,
-        variant: variant,
-      ),
-      SseWorktreeReady() => const BridgeSseWorktreeReady(),
-      SseWorktreeFailed() => const BridgeSseWorktreeFailed(),
-    };
   }
 
   @override

--- a/bridge/sesori_plugin_opencode/lib/src/sse_event_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse_event_mapper.dart
@@ -1,0 +1,163 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "models/message_part.dart";
+import "models/sse_event_data.dart";
+
+/// Maps OpenCode SSE events and message parts to plugin interface types.
+///
+/// Extracted from [OpenCodePlugin] to isolate the mapping concern.
+/// This class is stateless — all methods are pure transformations.
+class SseEventMapper {
+  /// Maps an [SseEventData] to a [BridgeSseEvent], or null if the event
+  /// type has no plugin representation.
+  BridgeSseEvent? map(SseEventData event) {
+    return switch (event) {
+      SseServerConnected() => const BridgeSseServerConnected(),
+      SseServerHeartbeat() => const BridgeSseServerHeartbeat(),
+      SseServerInstanceDisposed(:final directory) => BridgeSseServerInstanceDisposed(directory: directory),
+      SseGlobalDisposed() => const BridgeSseGlobalDisposed(),
+      SseSessionCreated(:final info) => BridgeSseSessionCreated(info: info.toJson()),
+      SseSessionUpdated(:final info) => BridgeSseSessionUpdated(info: info.toJson()),
+      SseSessionDeleted(:final info) => BridgeSseSessionDeleted(info: info.toJson()),
+      SseSessionDiff(:final sessionID) => BridgeSseSessionDiff(
+        sessionID: sessionID,
+      ),
+      SseSessionError(:final sessionID) => BridgeSseSessionError(sessionID: sessionID),
+      SseSessionCompacted(:final sessionID) => BridgeSseSessionCompacted(sessionID: sessionID),
+      SseSessionStatus(:final sessionID, :final status) => BridgeSseSessionStatus(
+        sessionID: sessionID,
+        status: status.toJson(),
+      ),
+      // ignore: deprecated_member_use, forwards legacy idle event for backward compatibility
+      SseSessionIdle(:final sessionID) => BridgeSseSessionIdle(sessionID: sessionID),
+      SseMessageUpdated(:final info) => BridgeSseMessageUpdated(info: info.toJson()),
+      SseMessageRemoved(:final sessionID, :final messageID) => BridgeSseMessageRemoved(
+        sessionID: sessionID,
+        messageID: messageID,
+      ),
+      SseMessagePartUpdated(:final part) => BridgeSseMessagePartUpdated(part: mapPart(part)),
+      SseMessagePartDelta(
+        :final sessionID,
+        :final messageID,
+        :final partID,
+        :final field,
+        :final delta,
+      ) =>
+        BridgeSseMessagePartDelta(
+          sessionID: sessionID,
+          messageID: messageID,
+          partID: partID,
+          field: field,
+          delta: delta,
+        ),
+      SseMessagePartRemoved(:final sessionID, :final messageID, :final partID) => BridgeSseMessagePartRemoved(
+        sessionID: sessionID,
+        messageID: messageID,
+        partID: partID,
+      ),
+      SsePtyCreated() => const BridgeSsePtyCreated(),
+      SsePtyUpdated() => const BridgeSsePtyUpdated(),
+      SsePtyExited(:final id, :final exitCode) => BridgeSsePtyExited(id: id, exitCode: exitCode),
+      SsePtyDeleted(:final id) => BridgeSsePtyDeleted(id: id),
+      SsePermissionAsked(:final requestID, :final sessionID, :final tool, :final description) =>
+        BridgeSsePermissionAsked(
+          requestID: requestID,
+          sessionID: sessionID,
+          tool: tool,
+          description: description,
+        ),
+      SsePermissionReplied(:final requestID, :final reply) => BridgeSsePermissionReplied(
+        requestID: requestID,
+        reply: reply,
+      ),
+      SsePermissionUpdated() => const BridgeSsePermissionUpdated(),
+      SseQuestionAsked(:final id, :final sessionID, :final questions) => BridgeSseQuestionAsked(
+        id: id,
+        sessionID: sessionID,
+        questions: questions.map((q) => q.toJson()).toList(),
+      ),
+      SseQuestionReplied(:final requestID, :final sessionID) => BridgeSseQuestionReplied(
+        requestID: requestID,
+        sessionID: sessionID,
+      ),
+      SseQuestionRejected(:final requestID, :final sessionID) => BridgeSseQuestionRejected(
+        requestID: requestID,
+        sessionID: sessionID,
+      ),
+      SseTodoUpdated(:final sessionID) => BridgeSseTodoUpdated(sessionID: sessionID),
+      SseProjectUpdated() => const BridgeSseProjectUpdated(),
+      SseVcsBranchUpdated() => const BridgeSseVcsBranchUpdated(),
+      SseFileEdited(:final file) => BridgeSseFileEdited(file: file),
+      SseFileWatcherUpdated(:final file, :final event) => BridgeSseFileWatcherUpdated(file: file, event: event),
+      SseLspUpdated() => const BridgeSseLspUpdated(),
+      SseLspClientDiagnostics(:final serverID, :final path) => BridgeSseLspClientDiagnostics(
+        serverID: serverID,
+        path: path,
+      ),
+      SseMcpToolsChanged() => const BridgeSseMcpToolsChanged(),
+      SseMcpBrowserOpenFailed() => const BridgeSseMcpBrowserOpenFailed(),
+      SseInstallationUpdated(:final version) => BridgeSseInstallationUpdated(version: version),
+      SseInstallationUpdateAvailable(:final version) => BridgeSseInstallationUpdateAvailable(version: version),
+      SseWorkspaceReady(:final name) => BridgeSseWorkspaceReady(name: name),
+      SseWorkspaceFailed(:final message) => BridgeSseWorkspaceFailed(message: message),
+      SseTuiToastShow(:final title, :final message, :final variant) => BridgeSseTuiToastShow(
+        title: title,
+        message: message,
+        variant: variant,
+      ),
+      SseWorktreeReady() => const BridgeSseWorktreeReady(),
+      SseWorktreeFailed() => const BridgeSseWorktreeFailed(),
+    };
+  }
+
+  /// Maps an OpenCode [MessagePart] to a [PluginMessagePart].
+  PluginMessagePart mapPart(MessagePart raw) {
+    return PluginMessagePart(
+      id: raw.id,
+      sessionID: raw.sessionID,
+      messageID: raw.messageID,
+      type: toPluginPartType(type: raw.type),
+      text: raw.text,
+      tool: raw.tool,
+      state: switch (raw.state) {
+        ToolState(:final status, :final title, :final output, :final error) => PluginToolState(
+          status: status,
+          title: title,
+          output: output != null && output.length > maxToolOutputLength
+              ? String.fromCharCodes(output.runes.take(maxToolOutputLength))
+              : output,
+          error: error,
+        ),
+        null => null,
+      },
+      prompt: raw.prompt,
+      description: raw.description,
+      agent: raw.agent,
+      agentName: raw.name,
+      attempt: raw.attempt,
+      retryError: (raw.error?['data'] as Map<String, dynamic>?)?['message']?.toString(),
+    );
+  }
+
+  /// Maps an OpenCode part type string to [PluginMessagePartType].
+  /// Unknown types are mapped to [PluginMessagePartType.unknown] (invisible)
+  /// and logged as a warning so new types are noticed.
+  static PluginMessagePartType toPluginPartType({required String type}) => switch (type) {
+    "text" => PluginMessagePartType.text,
+    "reasoning" => PluginMessagePartType.reasoning,
+    "tool" => PluginMessagePartType.tool,
+    "subtask" => PluginMessagePartType.subtask,
+    "step-start" => PluginMessagePartType.stepStart,
+    "step-finish" => PluginMessagePartType.stepFinish,
+    "file" => PluginMessagePartType.file,
+    "snapshot" => PluginMessagePartType.snapshot,
+    "patch" => PluginMessagePartType.patch,
+    "agent" => PluginMessagePartType.agent,
+    "retry" => PluginMessagePartType.retry,
+    "compaction" => PluginMessagePartType.compaction,
+    _ => () {
+      Log.w("Unknown message part type: '$type' — filtering out");
+      return PluginMessagePartType.unknown;
+    }(),
+  };
+}

--- a/bridge/sesori_plugin_opencode/lib/src/sse_event_parser.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse_event_parser.dart
@@ -1,5 +1,7 @@
 import "dart:convert";
 
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
 import "models/sse_event_data.dart";
 
 /// Result of parsing a raw OpenCode SSE event string.
@@ -49,8 +51,9 @@ class SseEventParser {
       final SseEventData event;
       try {
         event = SseEventData.fromJson(merged);
-      } catch (_) {
+      } catch (e) {
         // Unknown or malformed event type - return null event, preserve raw
+        Log.w("SseEventParser: unknown event type '$type': $e");
         return SseParseResult(directory: directory, rawData: rawData);
       }
 
@@ -59,8 +62,9 @@ class SseEventParser {
         directory: directory,
         rawData: rawData,
       );
-    } catch (_) {
+    } catch (e) {
       // JSON decode failure or other unexpected error
+      Log.w("SseEventParser: failed to parse SSE frame: $e");
       return SseParseResult(rawData: rawData);
     }
   }

--- a/mobile/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/mobile/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -340,7 +340,8 @@ class RelayClient {
       return;
     }
 
-    if (_sessionEncryptor == null) {
+    final encryptor = _sessionEncryptor;
+    if (encryptor == null) {
       if (_firstBinaryMessage != null && !_firstBinaryMessage!.isCompleted) {
         _firstBinaryMessage!.complete(bytes);
       } else {
@@ -350,7 +351,8 @@ class RelayClient {
     }
 
     try {
-      final relayMessage = await _decryptRelayMessage(bytes, _sessionEncryptor!);
+      final relayMessage = await _decryptRelayMessage(bytes, encryptor);
+      if (_disposed) return;
 
       switch (relayMessage) {
         case final RelayResponse response:

--- a/mobile/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/mobile/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -342,8 +342,8 @@ class RelayClient {
 
     final encryptor = _sessionEncryptor;
     if (encryptor == null) {
-      if (_firstBinaryMessage != null && !_firstBinaryMessage!.isCompleted) {
-        _firstBinaryMessage!.complete(bytes);
+      if (_firstBinaryMessage case final completer? when !completer.isCompleted) {
+        completer.complete(bytes);
       } else {
         logw("Received extra binary frame before relay key exchange completion");
       }

--- a/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -26,6 +26,13 @@ class ConnectionService {
   final AuthSession _authSession;
   final FailureReporter _failureReporter;
   final DateTime Function() _clock;
+  final RelayClient Function({
+    required String relayHost,
+    required RelayCryptoService cryptoService,
+    required RoomKeyStorage roomKeyStorage,
+    required String? authToken,
+  })?
+  _relayClientFactory;
 
   final BehaviorSubject<ConnectionStatus> _status = BehaviorSubject.seeded(const ConnectionStatus.disconnected());
   final StreamController<SseEvent> _events = StreamController<SseEvent>.broadcast();
@@ -60,13 +67,22 @@ class ConnectionService {
     LifecycleSource lifecycleSource,
     FailureReporter failureReporter, {
     @visibleForTesting DateTime Function() clock = DateTime.now,
+    @visibleForTesting
+    RelayClient Function({
+      required String relayHost,
+      required RelayCryptoService cryptoService,
+      required RoomKeyStorage roomKeyStorage,
+      required String? authToken,
+    })?
+    relayClientFactory,
   }) : _cryptoService = cryptoService,
        _roomKeyStorage = roomKeyStorage,
        _authTokenProvider = authTokenProvider,
        _authSession = authSession,
        _lifecycleSource = lifecycleSource,
        _failureReporter = failureReporter,
-       _clock = clock {
+       _clock = clock,
+       _relayClientFactory = relayClientFactory {
     _compositeSubscription.add(
       _lifecycleSource.lifecycleStateStream.listen((state) {
         switch (state) {
@@ -159,12 +175,19 @@ class ConnectionService {
   Future<ApiResponse<HealthResponse>> _connectViaRelay(ServerConnectionConfig config) async {
     await _disconnectRelayClient();
 
-    final relayClient = RelayClient(
-      relayHost: config.relayHost,
-      cryptoService: _cryptoService,
-      roomKeyStorage: _roomKeyStorage,
-      authToken: config.authToken,
-    );
+    final relayClient =
+        _relayClientFactory?.call(
+          relayHost: config.relayHost,
+          cryptoService: _cryptoService,
+          roomKeyStorage: _roomKeyStorage,
+          authToken: config.authToken,
+        ) ??
+        RelayClient(
+          relayHost: config.relayHost,
+          cryptoService: _cryptoService,
+          roomKeyStorage: _roomKeyStorage,
+          authToken: config.authToken,
+        );
 
     try {
       await relayClient.connect();
@@ -204,8 +227,14 @@ class ConnectionService {
       _status.add(ConnectionStatus.connected(config: config, health: health));
       _authRetryCount = 0;
       _relayReconnectBackoff = const Duration(seconds: 1);
-      _openRelaySseStream(relayClient);
-      _subscribeBridgeStatus(relayClient, config, health);
+      try {
+        _openRelaySseStream(relayClient);
+        _subscribeBridgeStatus(relayClient, config, health);
+      } catch (error, stackTrace) {
+        loge("Failed to setup SSE streams after successful relay connect", error, stackTrace);
+        await _disconnectRelayClient();
+        return ApiResponse.error(ApiError.generic());
+      }
       return ApiResponse.success(health);
     } catch (error, stackTrace) {
       loge("Failed to connect via relay", error, stackTrace);
@@ -221,6 +250,7 @@ class ConnectionService {
 
   /// Manually disconnect. Clears config, closes SSE, cancels timers.
   void disconnect() {
+    _reconnectTimer?.cancel();
     unawaited(_disconnectRelayClient());
     _status.add(const ConnectionStatus.disconnected());
   }
@@ -432,6 +462,10 @@ class ConnectionService {
     _reconnectTimer = Timer(Duration(milliseconds: delayMs), completer.complete);
     await completer.future;
     _reconnectTimer = null;
+    if (_isInBackground) {
+      _status.add(ConnectionStatus.connectionLost(config: config));
+      return;
+    }
     if (_status.value is ConnectionDisconnected) return;
 
     logd("Relay reconnect: refreshing token and reconnecting to ${config.relayHost}");
@@ -441,6 +475,10 @@ class ConnectionService {
         minTtl: const Duration(minutes: 2),
       );
 
+      if (_isInBackground) {
+        _status.add(ConnectionStatus.connectionLost(config: config));
+        return;
+      }
       if (_status.value is ConnectionDisconnected) return;
 
       if (authToken == null) {

--- a/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -44,6 +44,7 @@ class ConnectionService {
   StreamSubscription<RelaySseEvent>? _relaySseSubscription;
   StreamSubscription<BridgeStatus>? _bridgeStatusSubscription;
   Timer? _reconnectTimer;
+  Completer<void>? _reconnectDelayCompleter;
   int _requestCounter = 0;
   final Random _requestIdRandom = Random();
   int _authRetryCount = 0;
@@ -120,6 +121,9 @@ class ConnectionService {
     _backgroundedAt = _clock();
     logd("App backgrounded — pausing reconnect attempts");
     _reconnectTimer?.cancel();
+    if (_reconnectDelayCompleter != null && !_reconnectDelayCompleter!.isCompleted) {
+      _reconnectDelayCompleter!.complete();
+    }
   }
 
   /// Push-based connection status stream.
@@ -224,7 +228,6 @@ class ConnectionService {
       }
 
       _relayClient = relayClient;
-      _status.add(ConnectionStatus.connected(config: config, health: health));
       _authRetryCount = 0;
       _relayReconnectBackoff = const Duration(seconds: 1);
       try {
@@ -235,6 +238,7 @@ class ConnectionService {
         await _disconnectRelayClient();
         return ApiResponse.error(ApiError.generic());
       }
+      _status.add(ConnectionStatus.connected(config: config, health: health));
       return ApiResponse.success(health);
     } catch (error, stackTrace) {
       loge("Failed to connect via relay", error, stackTrace);
@@ -251,6 +255,9 @@ class ConnectionService {
   /// Manually disconnect. Clears config, closes SSE, cancels timers.
   void disconnect() {
     _reconnectTimer?.cancel();
+    if (_reconnectDelayCompleter != null && !_reconnectDelayCompleter!.isCompleted) {
+      _reconnectDelayCompleter!.complete();
+    }
     unawaited(_disconnectRelayClient());
     _status.add(const ConnectionStatus.disconnected());
   }
@@ -459,9 +466,15 @@ class ConnectionService {
     logd("Relay reconnect: waiting ${delayMs}ms before attempt to ${config.relayHost}");
     _reconnectTimer?.cancel();
     final completer = Completer<void>();
-    _reconnectTimer = Timer(Duration(milliseconds: delayMs), completer.complete);
+    _reconnectDelayCompleter = completer;
+    _reconnectTimer = Timer(Duration(milliseconds: delayMs), () {
+      if (!completer.isCompleted) {
+        completer.complete();
+      }
+    });
     await completer.future;
     _reconnectTimer = null;
+    _reconnectDelayCompleter = null;
     if (_isInBackground) {
       _status.add(ConnectionStatus.connectionLost(config: config));
       return;
@@ -533,6 +546,10 @@ class ConnectionService {
 
   void dispose() {
     _reconnectTimer?.cancel();
+    if (_reconnectDelayCompleter != null && !_reconnectDelayCompleter!.isCompleted) {
+      _reconnectDelayCompleter!.complete();
+    }
+    _status.add(const ConnectionStatus.disconnected());
     unawaited(_disconnectRelayClient());
     _compositeSubscription.dispose();
     _dataMayBeStale.close();

--- a/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -17,6 +17,22 @@ import "models/connection_status.dart";
 import "models/sse_event.dart";
 import "server_connection_config.dart";
 
+class RelayClientFactory {
+  const RelayClientFactory();
+
+  RelayClient call({
+    required String relayHost,
+    required RelayCryptoService cryptoService,
+    required RoomKeyStorage roomKeyStorage,
+    required String? authToken,
+  }) => RelayClient(
+    relayHost: relayHost,
+    cryptoService: cryptoService,
+    roomKeyStorage: roomKeyStorage,
+    authToken: authToken,
+  );
+}
+
 @lazySingleton
 class ConnectionService {
   final RelayCryptoService _cryptoService;
@@ -26,13 +42,7 @@ class ConnectionService {
   final AuthSession _authSession;
   final FailureReporter _failureReporter;
   final DateTime Function() _clock;
-  final RelayClient Function({
-    required String relayHost,
-    required RelayCryptoService cryptoService,
-    required RoomKeyStorage roomKeyStorage,
-    required String? authToken,
-  })?
-  _relayClientFactory;
+  final RelayClientFactory _relayClientFactory;
 
   final BehaviorSubject<ConnectionStatus> _status = BehaviorSubject.seeded(const ConnectionStatus.disconnected());
   final StreamController<SseEvent> _events = StreamController<SseEvent>.broadcast();
@@ -68,14 +78,7 @@ class ConnectionService {
     LifecycleSource lifecycleSource,
     FailureReporter failureReporter, {
     @visibleForTesting DateTime Function() clock = DateTime.now,
-    @visibleForTesting
-    RelayClient Function({
-      required String relayHost,
-      required RelayCryptoService cryptoService,
-      required RoomKeyStorage roomKeyStorage,
-      required String? authToken,
-    })?
-    relayClientFactory,
+    @visibleForTesting RelayClientFactory relayClientFactory = const RelayClientFactory(),
   }) : _cryptoService = cryptoService,
        _roomKeyStorage = roomKeyStorage,
        _authTokenProvider = authTokenProvider,
@@ -121,8 +124,8 @@ class ConnectionService {
     _backgroundedAt = _clock();
     logd("App backgrounded — pausing reconnect attempts");
     _reconnectTimer?.cancel();
-    if (_reconnectDelayCompleter != null && !_reconnectDelayCompleter!.isCompleted) {
-      _reconnectDelayCompleter!.complete();
+    if (_reconnectDelayCompleter case final completer? when !completer.isCompleted) {
+      completer.complete();
     }
   }
 
@@ -179,19 +182,12 @@ class ConnectionService {
   Future<ApiResponse<HealthResponse>> _connectViaRelay(ServerConnectionConfig config) async {
     await _disconnectRelayClient();
 
-    final relayClient =
-        _relayClientFactory?.call(
-          relayHost: config.relayHost,
-          cryptoService: _cryptoService,
-          roomKeyStorage: _roomKeyStorage,
-          authToken: config.authToken,
-        ) ??
-        RelayClient(
-          relayHost: config.relayHost,
-          cryptoService: _cryptoService,
-          roomKeyStorage: _roomKeyStorage,
-          authToken: config.authToken,
-        );
+    final relayClient = _relayClientFactory.call(
+      relayHost: config.relayHost,
+      cryptoService: _cryptoService,
+      roomKeyStorage: _roomKeyStorage,
+      authToken: config.authToken,
+    );
 
     try {
       await relayClient.connect();
@@ -255,8 +251,8 @@ class ConnectionService {
   /// Manually disconnect. Clears config, closes SSE, cancels timers.
   void disconnect() {
     _reconnectTimer?.cancel();
-    if (_reconnectDelayCompleter != null && !_reconnectDelayCompleter!.isCompleted) {
-      _reconnectDelayCompleter!.complete();
+    if (_reconnectDelayCompleter case final completer? when !completer.isCompleted) {
+      completer.complete();
     }
     unawaited(_disconnectRelayClient());
     _status.add(const ConnectionStatus.disconnected());
@@ -546,8 +542,8 @@ class ConnectionService {
 
   void dispose() {
     _reconnectTimer?.cancel();
-    if (_reconnectDelayCompleter != null && !_reconnectDelayCompleter!.isCompleted) {
-      _reconnectDelayCompleter!.complete();
+    if (_reconnectDelayCompleter case final completer? when !completer.isCompleted) {
+      completer.complete();
     }
     _status.add(const ConnectionStatus.disconnected());
     unawaited(_disconnectRelayClient());

--- a/mobile/module_core/lib/src/cubits/session_detail/prompt_send_service.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/prompt_send_service.dart
@@ -10,6 +10,7 @@ typedef PromptSendStateSnapshot = ({
   String? providerID,
   String? modelID,
   bool isConnected,
+  bool isLoaded,
 });
 
 class PromptSendService {
@@ -77,6 +78,7 @@ class PromptSendService {
     if (_promptQueue.isEmpty) return;
     final current = _stateProvider();
     if (!current.isConnected) return;
+    if (!current.isLoaded) return;
     unawaited(_sendNextQueued());
   }
 
@@ -85,6 +87,7 @@ class PromptSendService {
 
     final current = _stateProvider();
     if (!current.isConnected) return;
+    if (!current.isLoaded) return;
 
     final message = _promptQueue.dequeue();
     if (message == null) return;

--- a/mobile/module_core/lib/src/cubits/session_detail/prompt_send_service.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/prompt_send_service.dart
@@ -1,0 +1,128 @@
+import "dart:async";
+
+import "package:sesori_auth/sesori_auth.dart";
+
+import "../../capabilities/session/session_service.dart";
+import "prompt_send_queue.dart";
+
+class PromptSendService {
+  final SessionService _service;
+  final String _sessionId;
+  final void Function() _onQueueChanged;
+
+  final PromptSendQueue _promptQueue = PromptSendQueue();
+  bool _isSending = false;
+
+  PromptSendService({
+    required SessionService service,
+    required String sessionId,
+    required void Function() onQueueChanged,
+  }) : _service = service,
+       _sessionId = sessionId,
+       _onQueueChanged = onQueueChanged;
+
+  List<String> get queuedMessages => _promptQueue.items;
+
+  bool get isEmpty => _promptQueue.isEmpty;
+
+  Future<void> sendMessage({
+    required String text,
+    required String? agent,
+    required String? providerID,
+    required String? modelID,
+    required bool isConnected,
+  }) async {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return;
+
+    if (!isConnected) {
+      _promptQueue.enqueue(trimmed);
+      _onQueueChanged();
+      return;
+    }
+
+    final result = await _service.sendMessage(
+      _sessionId,
+      trimmed,
+      agent: agent,
+      providerID: providerID,
+      modelID: modelID,
+    );
+
+    if (result case ErrorResponse()) {
+      _promptQueue.requeue(trimmed);
+      _onQueueChanged();
+    }
+  }
+
+  String? cancelQueuedMessage(int index) {
+    final removed = _promptQueue.cancel(index);
+    if (removed != null) {
+      _onQueueChanged();
+    }
+    return removed;
+  }
+
+  void drain({
+    required String? agent,
+    required String? providerID,
+    required String? modelID,
+    required bool isConnected,
+  }) {
+    if (_promptQueue.isEmpty) return;
+    if (!isConnected) return;
+    unawaited(
+      _sendNextQueued(
+        agent: agent,
+        providerID: providerID,
+        modelID: modelID,
+        isConnected: isConnected,
+      ),
+    );
+  }
+
+  Future<void> _sendNextQueued({
+    required String? agent,
+    required String? providerID,
+    required String? modelID,
+    required bool isConnected,
+  }) async {
+    if (_isSending) return;
+    if (!isConnected) return;
+
+    final message = _promptQueue.dequeue();
+    if (message == null) return;
+
+    _isSending = true;
+    _onQueueChanged();
+
+    var sendSucceeded = false;
+    try {
+      final result = await _service.sendMessage(
+        _sessionId,
+        message,
+        agent: agent,
+        providerID: providerID,
+        modelID: modelID,
+      );
+
+      if (result case ErrorResponse()) {
+        _promptQueue.requeue(message);
+        _onQueueChanged();
+      } else {
+        sendSucceeded = true;
+      }
+    } finally {
+      _isSending = false;
+    }
+
+    if (sendSucceeded) {
+      drain(
+        agent: agent,
+        providerID: providerID,
+        modelID: modelID,
+        isConnected: isConnected,
+      );
+    }
+  }
+}

--- a/mobile/module_core/lib/src/cubits/session_detail/prompt_send_service.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/prompt_send_service.dart
@@ -5,10 +5,18 @@ import "package:sesori_auth/sesori_auth.dart";
 import "../../capabilities/session/session_service.dart";
 import "prompt_send_queue.dart";
 
+typedef PromptSendStateSnapshot = ({
+  String? agent,
+  String? providerID,
+  String? modelID,
+  bool isConnected,
+});
+
 class PromptSendService {
   final SessionService _service;
   final String _sessionId;
   final void Function() _onQueueChanged;
+  final PromptSendStateSnapshot Function() _stateProvider;
 
   final PromptSendQueue _promptQueue = PromptSendQueue();
   bool _isSending = false;
@@ -17,9 +25,11 @@ class PromptSendService {
     required SessionService service,
     required String sessionId,
     required void Function() onQueueChanged,
+    required PromptSendStateSnapshot Function() stateProvider,
   }) : _service = service,
        _sessionId = sessionId,
-       _onQueueChanged = onQueueChanged;
+       _onQueueChanged = onQueueChanged,
+       _stateProvider = stateProvider;
 
   List<String> get queuedMessages => _promptQueue.items;
 
@@ -63,32 +73,18 @@ class PromptSendService {
     return removed;
   }
 
-  void drain({
-    required String? agent,
-    required String? providerID,
-    required String? modelID,
-    required bool isConnected,
-  }) {
+  void drain() {
     if (_promptQueue.isEmpty) return;
-    if (!isConnected) return;
-    unawaited(
-      _sendNextQueued(
-        agent: agent,
-        providerID: providerID,
-        modelID: modelID,
-        isConnected: isConnected,
-      ),
-    );
+    final current = _stateProvider();
+    if (!current.isConnected) return;
+    unawaited(_sendNextQueued());
   }
 
-  Future<void> _sendNextQueued({
-    required String? agent,
-    required String? providerID,
-    required String? modelID,
-    required bool isConnected,
-  }) async {
+  Future<void> _sendNextQueued() async {
     if (_isSending) return;
-    if (!isConnected) return;
+
+    final current = _stateProvider();
+    if (!current.isConnected) return;
 
     final message = _promptQueue.dequeue();
     if (message == null) return;
@@ -101,9 +97,9 @@ class PromptSendService {
       final result = await _service.sendMessage(
         _sessionId,
         message,
-        agent: agent,
-        providerID: providerID,
-        modelID: modelID,
+        agent: current.agent,
+        providerID: current.providerID,
+        modelID: current.modelID,
       );
 
       if (result case ErrorResponse()) {
@@ -117,12 +113,7 @@ class PromptSendService {
     }
 
     if (sendSucceeded) {
-      drain(
-        agent: agent,
-        providerID: providerID,
-        modelID: modelID,
-        isConnected: isConnected,
-      );
+      drain();
     }
   }
 }

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -58,6 +58,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
           providerID: current is SessionDetailLoaded ? current.selectedProviderID : null,
           modelID: current is SessionDetailLoaded ? current.selectedModelID : null,
           isConnected: _isConnected,
+          isLoaded: current is SessionDetailLoaded && !isClosed,
         );
       },
     );

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -51,6 +51,15 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       service: _service,
       sessionId: _sessionId,
       onQueueChanged: _emitQueueUpdate,
+      stateProvider: () {
+        final current = state;
+        return (
+          agent: current is SessionDetailLoaded ? current.selectedAgent : null,
+          providerID: current is SessionDetailLoaded ? current.selectedProviderID : null,
+          modelID: current is SessionDetailLoaded ? current.selectedModelID : null,
+          isConnected: _isConnected,
+        );
+      },
     );
     _streamingBuffer = StreamingTextBuffer(onFlush: _emitStreamingSnapshot);
     _eventSubscription = _connectionService.sessionEvents(_sessionId).listen(_handleEvent);
@@ -579,12 +588,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     if (isClosed) return;
     final current = state;
     if (current is! SessionDetailLoaded) return;
-    _sendService.drain(
-      agent: current.selectedAgent,
-      providerID: current.selectedProviderID,
-      modelID: current.selectedModelID,
-      isConnected: _isConnected,
-    );
+    _sendService.drain();
   }
 
   Future<void> sendMessage(String text) async {

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -10,7 +10,7 @@ import "../../capabilities/server_connection/models/sse_event.dart";
 import "../../capabilities/session/session_service.dart";
 import "../../logging/logging.dart";
 import "../../platform/notification_canceller.dart";
-import "prompt_send_queue.dart";
+import "prompt_send_service.dart";
 import "session_detail_state.dart";
 import "streaming_text_buffer.dart";
 
@@ -20,8 +20,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
   final String _sessionId;
   final NotificationCanceller _notificationCanceller;
   final FailureReporter _failureReporter;
-  final PromptSendQueue _promptQueue = PromptSendQueue();
-  bool _isSending = false;
+  late final PromptSendService _sendService;
 
   late final StreamSubscription<SesoriSessionEvent> _eventSubscription;
   late final StreamSubscription<SseEvent> _globalEventSubscription;
@@ -48,6 +47,11 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
        _notificationCanceller = notificationCanceller,
        _failureReporter = failureReporter,
        super(const SessionDetailState.loading()) {
+    _sendService = PromptSendService(
+      service: _service,
+      sessionId: _sessionId,
+      onQueueChanged: _emitQueueUpdate,
+    );
     _streamingBuffer = StreamingTextBuffer(onFlush: _emitStreamingSnapshot);
     _eventSubscription = _connectionService.sessionEvents(_sessionId).listen(_handleEvent);
     _globalEventSubscription = _connectionService.events.listen(_handleGlobalEvent);
@@ -573,102 +577,40 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
   /// connection is alive.
   void _tryDrainQueue() {
     if (isClosed) return;
-    if (_promptQueue.isEmpty) return;
     final current = state;
     if (current is! SessionDetailLoaded) return;
-    if (!_isConnected) return;
-    _sendNextQueued();
+    _sendService.drain(
+      agent: current.selectedAgent,
+      providerID: current.selectedProviderID,
+      modelID: current.selectedModelID,
+      isConnected: _isConnected,
+    );
   }
 
   Future<void> sendMessage(String text) async {
-    final trimmed = text.trim();
-    if (trimmed.isEmpty) return;
-
     final current = state;
-    if (current is SessionDetailLoaded) {
-      // Queue if connection is not active.
-      if (!_isConnected) {
-        _promptQueue.enqueue(trimmed);
-        _emitQueueUpdate(current);
-        return;
-      }
-
-      final result = await _service.sendMessage(
-        _sessionId,
-        trimmed,
-        agent: current.selectedAgent,
-        providerID: current.selectedProviderID,
-        modelID: current.selectedModelID,
-      );
-
-      // If the send failed (e.g. connection dropped mid-request), queue
-      // the message so it can be retried once the connection is restored.
-      if (result case ErrorResponse()) {
-        _promptQueue.requeue(trimmed);
-        _emitQueueUpdate();
-      }
-      return;
-    }
-
-    // State not yet loaded — queue the message so it isn't lost.
-    // It will drain via _tryDrainQueue once the session finishes loading.
-    _promptQueue.enqueue(trimmed);
+    await _sendService.sendMessage(
+      text: text,
+      agent: current is SessionDetailLoaded ? current.selectedAgent : null,
+      providerID: current is SessionDetailLoaded ? current.selectedProviderID : null,
+      modelID: current is SessionDetailLoaded ? current.selectedModelID : null,
+      isConnected: current is SessionDetailLoaded && _isConnected,
+    );
   }
 
   void cancelQueuedMessage(int index) {
     final current = state;
     if (current is! SessionDetailLoaded) return;
 
-    if (_promptQueue.cancel(index) != null) {
-      _emitQueueUpdate(current);
-    }
+    _sendService.cancelQueuedMessage(index);
   }
 
-  Future<void> _sendNextQueued() async {
-    if (_isSending) return;
-    if (!_isConnected) return;
-
-    final message = _promptQueue.dequeue();
-    if (message == null) return;
-
-    _isSending = true;
-    _emitQueueUpdate();
-
-    var sendSucceeded = false;
-    try {
-      final current = state;
-      final result = await _service.sendMessage(
-        _sessionId,
-        message,
-        agent: current is SessionDetailLoaded ? current.selectedAgent : null,
-        providerID: current is SessionDetailLoaded ? current.selectedProviderID : null,
-        modelID: current is SessionDetailLoaded ? current.selectedModelID : null,
-      );
-
-      // If send failed (e.g. connection dropped mid-request), re-queue at front.
-      if (result case ErrorResponse()) {
-        _promptQueue.requeue(message);
-        _emitQueueUpdate();
-      } else {
-        sendSucceeded = true;
-      }
-    } finally {
-      _isSending = false;
-    }
-
-    // Continue draining only if the send succeeded. On failure the message
-    // stays re-queued and will be retried on the next reconnect event.
-    if (sendSucceeded) {
-      _tryDrainQueue();
-    }
-  }
-
-  /// Syncs [_promptQueue] items into the cubit state.
+  /// Syncs queued prompt items into the cubit state.
   void _emitQueueUpdate([SessionDetailLoaded? known]) {
     if (isClosed) return;
     final current = known ?? state;
     if (current is! SessionDetailLoaded) return;
-    emit(current.copyWith(queuedMessages: _promptQueue.items));
+    emit(current.copyWith(queuedMessages: _sendService.queuedMessages));
   }
 
   // ---------------------------------------------------------------------------

--- a/mobile/module_core/test/capabilities/relay/relay_client_socket_message_snapshot_test.dart
+++ b/mobile/module_core/test/capabilities/relay/relay_client_socket_message_snapshot_test.dart
@@ -1,0 +1,57 @@
+import "dart:async";
+
+import "package:test/test.dart";
+
+class _SocketMessageHarness {
+  _SocketMessageHarness({required Object encryptor}) : _sessionEncryptor = encryptor;
+
+  Object? _sessionEncryptor;
+  bool _disposed = false;
+  bool routedMessage = false;
+  Object? decryptEncryptor;
+  final Completer<void> decryptGate = Completer<void>();
+
+  Future<void> onSocketMessage() async {
+    final encryptor = _sessionEncryptor;
+    if (encryptor == null) {
+      return;
+    }
+
+    await _decryptRelayMessage(encryptor: encryptor);
+    if (_disposed) return;
+
+    routedMessage = true;
+  }
+
+  Future<void> _decryptRelayMessage({required Object encryptor}) async {
+    decryptEncryptor = encryptor;
+    await decryptGate.future;
+  }
+
+  void clearSessionEncryptor() {
+    _sessionEncryptor = null;
+  }
+
+  void dispose() {
+    _disposed = true;
+  }
+}
+
+void main() {
+  test("uses encryptor snapshot and exits when disposed after async gap", () async {
+    final initialEncryptor = Object();
+    final harness = _SocketMessageHarness(encryptor: initialEncryptor);
+
+    final onMessageFuture = harness.onSocketMessage();
+    await Future<void>.delayed(Duration.zero);
+
+    harness.clearSessionEncryptor();
+    harness.dispose();
+    harness.decryptGate.complete();
+
+    await onMessageFuture;
+
+    expect(harness.decryptEncryptor, same(initialEncryptor));
+    expect(harness.routedMessage, isFalse);
+  });
+}

--- a/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
+++ b/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
@@ -27,6 +27,36 @@ class MockFailureReporter extends Mock implements FailureReporter {}
 
 class MockRelayClient extends Mock implements RelayClient {}
 
+class _TestRelayClientFactory extends RelayClientFactory {
+  final RelayClient Function({
+    required String relayHost,
+    required RelayCryptoService cryptoService,
+    required RoomKeyStorage roomKeyStorage,
+    required String? authToken,
+  })
+  _factory;
+
+  int callCount = 0;
+
+  _TestRelayClientFactory(this._factory);
+
+  @override
+  RelayClient call({
+    required String relayHost,
+    required RelayCryptoService cryptoService,
+    required RoomKeyStorage roomKeyStorage,
+    required String? authToken,
+  }) {
+    callCount++;
+    return _factory(
+      relayHost: relayHost,
+      cryptoService: cryptoService,
+      roomKeyStorage: roomKeyStorage,
+      authToken: authToken,
+    );
+  }
+}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(const Duration(minutes: 1));
@@ -109,8 +139,15 @@ void main() {
         () => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl")),
       ).thenAnswer((_) => tokenCompleter.future);
 
-      var relayFactoryCallCount = 0;
       final relayClient = MockRelayClient();
+      final factory = _TestRelayClientFactory(
+        ({
+          required String relayHost,
+          required RelayCryptoService cryptoService,
+          required RoomKeyStorage roomKeyStorage,
+          required String? authToken,
+        }) => relayClient,
+      );
       final service = ConnectionService(
         cryptoService,
         roomKeyStorage,
@@ -118,16 +155,7 @@ void main() {
         authSession,
         lifecycleSource,
         failureReporter,
-        relayClientFactory:
-            ({
-              required String relayHost,
-              required RelayCryptoService cryptoService,
-              required RoomKeyStorage roomKeyStorage,
-              required String? authToken,
-            }) {
-              relayFactoryCallCount++;
-              return relayClient;
-            },
+        relayClientFactory: factory,
       );
       addTearDown(service.dispose);
 
@@ -144,7 +172,7 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 50));
 
       expect(service.currentStatus, const ConnectionStatus.connectionLost(config: config));
-      expect(relayFactoryCallCount, 0);
+      expect(factory.callCount, 0);
     });
 
     test("SSE setup failure disconnects relay and returns error response", () async {
@@ -163,6 +191,14 @@ void main() {
       when(relayClient.disconnect).thenAnswer((_) async {});
       when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
 
+      final factory = _TestRelayClientFactory(
+        ({
+          required String relayHost,
+          required RelayCryptoService cryptoService,
+          required RoomKeyStorage roomKeyStorage,
+          required String? authToken,
+        }) => relayClient,
+      );
       final service = ConnectionService(
         cryptoService,
         roomKeyStorage,
@@ -170,13 +206,7 @@ void main() {
         authSession,
         lifecycleSource,
         failureReporter,
-        relayClientFactory:
-            ({
-              required String relayHost,
-              required RelayCryptoService cryptoService,
-              required RoomKeyStorage roomKeyStorage,
-              required String? authToken,
-            }) => relayClient,
+        relayClientFactory: factory,
       );
       addTearDown(service.dispose);
 

--- a/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
+++ b/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
@@ -1,0 +1,190 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:mocktail/mocktail.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_dart_core/src/capabilities/relay/relay_client.dart";
+import "package:sesori_dart_core/src/capabilities/relay/room_key_storage.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/connection_service.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/models/connection_status.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/server_connection_config.dart";
+import "package:sesori_dart_core/src/platform/lifecycle_source.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+class MockRelayCryptoService extends Mock implements RelayCryptoService {}
+
+class MockRoomKeyStorage extends Mock implements RoomKeyStorage {}
+
+class MockAuthTokenProvider extends Mock implements AuthTokenProvider {}
+
+class MockAuthSession extends Mock implements AuthSession {}
+
+class MockLifecycleSource extends Mock implements LifecycleSource {}
+
+class MockFailureReporter extends Mock implements FailureReporter {}
+
+class MockRelayClient extends Mock implements RelayClient {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(const Duration(minutes: 1));
+    registerFallbackValue(
+      const RelayRequest(
+        id: "fallback-request-id",
+        method: "GET",
+        path: "/health",
+        headers: {},
+      ),
+    );
+  });
+
+  group("ConnectionService reconnect guards", () {
+    late MockRelayCryptoService cryptoService;
+    late MockRoomKeyStorage roomKeyStorage;
+    late MockAuthTokenProvider authTokenProvider;
+    late MockAuthSession authSession;
+    late MockLifecycleSource lifecycleSource;
+    late MockFailureReporter failureReporter;
+    late BehaviorSubject<LifecycleState> lifecycleController;
+    late BehaviorSubject<AuthState> authStateController;
+
+    const config = ServerConnectionConfig(
+      relayHost: "relay.example.com",
+      authToken: "token",
+    );
+
+    const health = HealthResponse(healthy: true, version: "0.1.200");
+
+    setUp(() {
+      cryptoService = MockRelayCryptoService();
+      roomKeyStorage = MockRoomKeyStorage();
+      authTokenProvider = MockAuthTokenProvider();
+      authSession = MockAuthSession();
+      lifecycleSource = MockLifecycleSource();
+      failureReporter = MockFailureReporter();
+
+      lifecycleController = BehaviorSubject<LifecycleState>.seeded(LifecycleState.resumed);
+      authStateController = BehaviorSubject<AuthState>.seeded(const AuthState.initial());
+
+      when(() => lifecycleSource.lifecycleStateStream).thenAnswer((_) => lifecycleController.stream);
+      when(() => authSession.authStateStream).thenAnswer((_) => authStateController.stream);
+      when(
+        () => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl")),
+      ).thenAnswer((_) async => "fresh-token");
+      when(roomKeyStorage.clearRoomKey).thenAnswer((_) async {});
+    });
+
+    tearDown(() async {
+      await lifecycleController.close();
+      await authStateController.close();
+    });
+
+    test("disconnect cancels reconnect timer before token refresh", () async {
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+      );
+      addTearDown(service.dispose);
+
+      service.emitStatusForTesting(const ConnectionStatus.connectionLost(config: config));
+      service.reconnect();
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      service.disconnect();
+      await Future<void>.delayed(const Duration(milliseconds: 1400));
+
+      verifyNever(() => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl")));
+      expect(service.currentStatus, isA<ConnectionDisconnected>());
+    });
+
+    test("backgrounding during reconnect delay prevents refresh and reconnect", () async {
+      final tokenCompleter = Completer<String?>();
+      when(
+        () => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl")),
+      ).thenAnswer((_) => tokenCompleter.future);
+
+      var relayFactoryCallCount = 0;
+      final relayClient = MockRelayClient();
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+        relayClientFactory:
+            ({
+              required String relayHost,
+              required RelayCryptoService cryptoService,
+              required RoomKeyStorage roomKeyStorage,
+              required String? authToken,
+            }) {
+              relayFactoryCallCount++;
+              return relayClient;
+            },
+      );
+      addTearDown(service.dispose);
+
+      service.emitStatusForTesting(const ConnectionStatus.connectionLost(config: config));
+      service.reconnect();
+
+      await Future<void>.delayed(const Duration(milliseconds: 1400));
+      verify(() => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl"))).called(1);
+
+      lifecycleController.add(LifecycleState.hidden);
+      await Future<void>.delayed(Duration.zero);
+      tokenCompleter.complete("fresh-token");
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(service.currentStatus, const ConnectionStatus.connectionLost(config: config));
+      expect(relayFactoryCallCount, 0);
+    });
+
+    test("SSE setup failure disconnects relay and returns error response", () async {
+      final relayClient = MockRelayClient();
+
+      when(relayClient.connect).thenAnswer((_) async {});
+      when(() => relayClient.sendRequest(any())).thenAnswer(
+        (_) async => RelayResponse(
+          id: "1",
+          status: 200,
+          body: jsonEncode(health.toJson()),
+          headers: const {},
+        ),
+      );
+      when(() => relayClient.subscribeSse(any())).thenThrow(StateError("SSE subscribe failed"));
+      when(relayClient.disconnect).thenAnswer((_) async {});
+      when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
+
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+        relayClientFactory:
+            ({
+              required String relayHost,
+              required RelayCryptoService cryptoService,
+              required RoomKeyStorage roomKeyStorage,
+              required String? authToken,
+            }) => relayClient,
+      );
+      addTearDown(service.dispose);
+
+      final result = await service.connect(config);
+
+      expect(result, isA<ErrorResponse<HealthResponse>>());
+      expect(service.relayClient, isNull);
+      verify(relayClient.disconnect).called(greaterThanOrEqualTo(1));
+    });
+  });
+}

--- a/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
+++ b/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
@@ -97,7 +97,7 @@ void main() {
 
       await Future<void>.delayed(const Duration(milliseconds: 50));
       service.disconnect();
-      await Future<void>.delayed(const Duration(milliseconds: 1400));
+      await Future<void>.delayed(const Duration(milliseconds: 100));
 
       verifyNever(() => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl")));
       expect(service.currentStatus, isA<ConnectionDisconnected>());
@@ -184,6 +184,7 @@ void main() {
 
       expect(result, isA<ErrorResponse<HealthResponse>>());
       expect(service.relayClient, isNull);
+      expect(service.currentStatus, isNot(isA<ConnectionConnected>()));
       verify(relayClient.disconnect).called(greaterThanOrEqualTo(1));
     });
   });

--- a/mobile/module_core/test/cubits/session_detail/prompt_send_service_test.dart
+++ b/mobile/module_core/test/cubits/session_detail/prompt_send_service_test.dart
@@ -1,0 +1,106 @@
+import "dart:async";
+
+import "package:mocktail/mocktail.dart";
+import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_dart_core/src/cubits/session_detail/prompt_send_service.dart";
+import "package:test/test.dart";
+
+import "../../helpers/test_helpers.dart";
+
+void main() {
+  group("PromptSendService", () {
+    late MockSessionService mockSessionService;
+
+    setUp(() {
+      mockSessionService = MockSessionService();
+    });
+
+    test("drain sends queued messages with fresh params each iteration", () async {
+      const sessionId = "session-1";
+      var currentAgent = "agent-old";
+      var currentProviderID = "provider-old";
+      var currentModelID = "model-old";
+      var isConnected = true;
+
+      final sentParams = <({String? agent, String? providerID, String? modelID})>[];
+      final firstSendStarted = Completer<void>();
+      final allowFirstSendToComplete = Completer<void>();
+
+      when(
+        () => mockSessionService.sendMessage(
+          sessionId,
+          any(),
+          agent: any(named: "agent"),
+          providerID: any(named: "providerID"),
+          modelID: any(named: "modelID"),
+        ),
+      ).thenAnswer((invocation) async {
+        sentParams.add(
+          (
+            agent: invocation.namedArguments[#agent] as String?,
+            providerID: invocation.namedArguments[#providerID] as String?,
+            modelID: invocation.namedArguments[#modelID] as String?,
+          ),
+        );
+
+        if ((invocation.positionalArguments[1] as String) == "first") {
+          firstSendStarted.complete();
+          await allowFirstSendToComplete.future;
+        }
+
+        return ApiResponse.success(true);
+      });
+
+      final service = PromptSendService(
+        service: mockSessionService,
+        sessionId: sessionId,
+        onQueueChanged: () {},
+        stateProvider: () => (
+          agent: currentAgent,
+          providerID: currentProviderID,
+          modelID: currentModelID,
+          isConnected: isConnected,
+        ),
+      );
+
+      await service.sendMessage(
+        text: "first",
+        agent: "agent-old",
+        providerID: "provider-old",
+        modelID: "model-old",
+        isConnected: false,
+      );
+      await service.sendMessage(
+        text: "second",
+        agent: "agent-old",
+        providerID: "provider-old",
+        modelID: "model-old",
+        isConnected: false,
+      );
+
+      service.drain();
+
+      await firstSendStarted.future;
+
+      currentAgent = "agent-new";
+      currentProviderID = "provider-new";
+      currentModelID = "model-new";
+      isConnected = true;
+
+      allowFirstSendToComplete.complete();
+
+      await _waitFor(condition: () => sentParams.length == 2);
+
+      expect(sentParams[0], (agent: "agent-old", providerID: "provider-old", modelID: "model-old"));
+      expect(sentParams[1], (agent: "agent-new", providerID: "provider-new", modelID: "model-new"));
+    });
+  });
+}
+
+Future<void> _waitFor({required bool Function() condition}) async {
+  for (var i = 0; i < 100; i++) {
+    if (condition()) return;
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+  }
+  fail("Timed out waiting for condition");
+}

--- a/mobile/module_core/test/cubits/session_detail/prompt_send_service_test.dart
+++ b/mobile/module_core/test/cubits/session_detail/prompt_send_service_test.dart
@@ -60,6 +60,7 @@ void main() {
           providerID: currentProviderID,
           modelID: currentModelID,
           isConnected: isConnected,
+          isLoaded: true,
         ),
       );
 
@@ -93,6 +94,86 @@ void main() {
 
       expect(sentParams[0], (agent: "agent-old", providerID: "provider-old", modelID: "model-old"));
       expect(sentParams[1], (agent: "agent-new", providerID: "provider-new", modelID: "model-new"));
+    });
+
+    test("drain stops when state becomes not loaded mid-drain", () async {
+      const sessionId = "session-1";
+      var isLoaded = true;
+
+      final firstSendStarted = Completer<void>();
+      final allowFirstSendToComplete = Completer<void>();
+
+      when(
+        () => mockSessionService.sendMessage(
+          sessionId,
+          any(),
+          agent: any(named: "agent"),
+          providerID: any(named: "providerID"),
+          modelID: any(named: "modelID"),
+        ),
+      ).thenAnswer((invocation) async {
+        if ((invocation.positionalArguments[1] as String) == "first") {
+          firstSendStarted.complete();
+          await allowFirstSendToComplete.future;
+        }
+
+        return ApiResponse.success(true);
+      });
+
+      final service = PromptSendService(
+        service: mockSessionService,
+        sessionId: sessionId,
+        onQueueChanged: () {},
+        stateProvider: () => (
+          agent: "agent",
+          providerID: "provider",
+          modelID: "model",
+          isConnected: true,
+          isLoaded: isLoaded,
+        ),
+      );
+
+      await service.sendMessage(
+        text: "first",
+        agent: "agent",
+        providerID: "provider",
+        modelID: "model",
+        isConnected: false,
+      );
+      await service.sendMessage(
+        text: "second",
+        agent: "agent",
+        providerID: "provider",
+        modelID: "model",
+        isConnected: false,
+      );
+
+      service.drain();
+      await firstSendStarted.future;
+
+      isLoaded = false;
+      allowFirstSendToComplete.complete();
+
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      verify(
+        () => mockSessionService.sendMessage(
+          sessionId,
+          "first",
+          agent: any(named: "agent"),
+          providerID: any(named: "providerID"),
+          modelID: any(named: "modelID"),
+        ),
+      ).called(1);
+      verifyNever(
+        () => mockSessionService.sendMessage(
+          sessionId,
+          "second",
+          agent: any(named: "agent"),
+          providerID: any(named: "providerID"),
+          modelID: any(named: "modelID"),
+        ),
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

Comprehensive stability and maintainability improvements identified through a full codebase audit. 6 atomic commits, each independently verified with all tests passing.

### Stability Fixes (4 commits)

- **RelayClient post-await safety** — Snapshot `_sessionEncryptor` into a local variable before async gap in `_onSocketMessage()`, and re-check `_disposed` after await. Follows the existing `_sseController` capture pattern at line 366. Includes new unit test.

- **ConnectionService reconnect robustness** — Three hardening changes: (1) cancel `_reconnectTimer` in `disconnect()` (was only cancelled in `dispose()`), (2) re-check `_isInBackground` after both the reconnect timer delay and token refresh await, (3) wrap SSE stream setup in try-catch so a failure doesn't leave the service thinking it's connected. Adds `@visibleForTesting` RelayClient factory for injection. Includes 3 new tests.

- **Bridge silent error logging** — Added `Log.d()` / `Log.w()` to 7 empty `catch (_) {}` blocks across `relay_client.dart`, `debug_server.dart`, and `login.dart`. No control flow changes — errors are still swallowed, just now visible in logs.

- **SseEventParser silent error logging** — Added `Log.w()` to both catch blocks in the bridge SSE event parser. Previously, unknown event types and parse failures vanished silently with zero visibility. Now logged with type context.

### Maintainability Refactors (2 commits)

- **Extract SseEventMapper from OpenCodePluginImpl** — Moved `_mapSseEvent()` (98-line switch over 40+ event types), `_mapMessagePart()`, and `_toPluginPartType()` into dedicated `SseEventMapper` class. Plugin impl reduced from 718 → 570 lines. All 105 existing tests pass unchanged.

- **Extract PromptSendService from SessionDetailCubit** — Moved prompt queue logic (`_isSending`, `sendMessage()`, `_sendNextQueued()`, queue management) into dedicated `PromptSendService` with callback-based notification. Cubit reduced from 780 → 722 lines. All 33 existing tests pass unchanged.

### Test Results

| Suite | Result |
|-------|--------|
| `dart test mobile/module_core` | ✅ 143 tests pass |
| `flutter test mobile/app` | ✅ All pass |
| `dart analyze mobile/module_core` | ✅ No issues |
| `dart test bridge/sesori_plugin_opencode` | ✅ 105 tests pass |

### Files Changed

12 files, +641 / -253 lines