### PR TITLE
feat(mobile): eager notification dismissal and same-session dedup

### DIFF
--- a/mobile/app/lib/core/platform/local_notification_manager.dart
+++ b/mobile/app/lib/core/platform/local_notification_manager.dart
@@ -88,7 +88,7 @@ class LocalNotificationManager implements NotificationCanceller {
     final channelId = category.id;
 
     final int id;
-    if (sessionId != null && category == NotificationCategory.aiInteraction) {
+    if (sessionId != null) {
       id = computeNotificationId(sessionId: sessionId, category: category);
     } else {
       id = DateTime.now().millisecondsSinceEpoch ~/ 1000;

--- a/mobile/app/lib/features/session_detail/session_detail_screen.dart
+++ b/mobile/app/lib/features/session_detail/session_detail_screen.dart
@@ -65,7 +65,9 @@ class _SessionDetailBodyState extends State<_SessionDetailBody> {
   @override
   void initState() {
     super.initState();
-    _questionSub = context.read<SessionDetailCubit>().questionStream.listen(_onNewQuestion);
+    final cubit = context.read<SessionDetailCubit>();
+    _questionSub = cubit.questionStream.listen(_onNewQuestion);
+    cubit.clearNotifications();
   }
 
   @override
@@ -108,6 +110,7 @@ class _SessionDetailBodyState extends State<_SessionDetailBody> {
   }
 
   void _showQuestionModal(SesoriQuestionAsked question) {
+    context.read<SessionDetailCubit>().clearNotifications();
     QuestionModal.show(
       context,
       question: question,

--- a/mobile/app/test/core/platform/local_notification_manager_test.dart
+++ b/mobile/app/test/core/platform/local_notification_manager_test.dart
@@ -83,12 +83,12 @@ void main() {
       ).called(1);
     });
 
-    test('with sessionId but non-aiInteraction category uses timestamp-based ID', () async {
+    test('with sessionId and non-aiInteraction category also uses deterministic ID', () async {
       stubPluginShow();
 
       const sessionId = 'ses_abc';
       const category = NotificationCategory.sessionMessage;
-      final deterministicId = computeNotificationId(sessionId: sessionId, category: category);
+      final expectedId = computeNotificationId(sessionId: sessionId, category: category);
 
       await manager.show(
         title: 'Test Title',
@@ -98,20 +98,15 @@ void main() {
         projectId: null,
       );
 
-      // Capture the actual ID used
-      final captured = verify(
+      verify(
         () => mockPlugin.show(
-          id: captureAny(named: 'id'),
+          id: expectedId,
           title: any(named: 'title'),
           body: any(named: 'body'),
           notificationDetails: any(named: 'notificationDetails'),
           payload: any(named: 'payload'),
         ),
-      ).captured;
-
-      final actualId = captured[0] as int;
-      // Verify it's NOT the deterministic ID (should be timestamp-based)
-      expect(actualId, isNot(deterministicId));
+      ).called(1);
     });
 
     test('without sessionId uses timestamp-based ID even for aiInteraction', () async {

--- a/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -359,6 +359,41 @@ void main() {
     );
 
     blocTest<SessionDetailCubit, SessionDetailState>(
+      "clearNotifications cancels all non-unknown notification categories",
+      build: () => SessionDetailCubit(
+        mockSessionService,
+        mockConnectionService,
+        sessionId: sessionId,
+        notificationCanceller: mockNotificationCanceller,
+        failureReporter: mockFailureReporter,
+      ),
+      act: (cubit) async {
+        await _awaitLoaded(cubit);
+        cubit.clearNotifications();
+      },
+      expect: () => [
+        isA<SessionDetailLoaded>(),
+      ],
+      verify: (_) {
+        for (final category in NotificationCategory.values) {
+          if (category == NotificationCategory.unknown) continue;
+          verify(
+            () => mockNotificationCanceller.cancelForSession(
+              sessionId: sessionId,
+              category: category,
+            ),
+          ).called(1);
+        }
+        verifyNever(
+          () => mockNotificationCanceller.cancelForSession(
+            sessionId: sessionId,
+            category: NotificationCategory.unknown,
+          ),
+        );
+      },
+    );
+
+    blocTest<SessionDetailCubit, SessionDetailState>(
       "SSE message.updated adds message to state",
       build: () {
         when(

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -681,14 +681,13 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
   /// prompt becomes visible — the notification has served its purpose once the
   /// user is already looking at the content.
   void clearNotifications() {
-    _notificationCanceller.cancelForSession(
-      sessionId: _sessionId,
-      category: NotificationCategory.aiInteraction,
-    );
-    _notificationCanceller.cancelForSession(
-      sessionId: _sessionId,
-      category: NotificationCategory.sessionMessage,
-    );
+    for (final category in NotificationCategory.values) {
+      if (category == NotificationCategory.unknown) continue;
+      _notificationCanceller.cancelForSession(
+        sessionId: _sessionId,
+        category: category,
+      );
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -672,6 +672,26 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
   }
 
   // ---------------------------------------------------------------------------
+  // Notifications
+  // ---------------------------------------------------------------------------
+
+  /// Clears all push notifications for this session.
+  ///
+  /// Call when the session detail screen is entered or when a question/permission
+  /// prompt becomes visible — the notification has served its purpose once the
+  /// user is already looking at the content.
+  void clearNotifications() {
+    _notificationCanceller.cancelForSession(
+      sessionId: _sessionId,
+      category: NotificationCategory.aiInteraction,
+    );
+    _notificationCanceller.cancelForSession(
+      sessionId: _sessionId,
+      category: NotificationCategory.sessionMessage,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
   // Questions
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **Same-session notifications replace each other** — extend deterministic notification IDs to all session-bound categories (not just `aiInteraction`), so multiple notifications for the same session + category produce the same ID and the latest one replaces the previous.
- **Dismiss notifications when content is seen** — clear `aiInteraction` notifications when the question modal is shown, not just when the user answers/rejects.
- **Clear notifications on session detail entry** — both `aiInteraction` and `sessionMessage` notifications are cancelled in `initState()` when the user navigates to the session screen.

## Changes

| File | Change |
|------|--------|
| `local_notification_manager.dart` | Widen deterministic ID condition from `aiInteraction`-only to any notification with a `sessionId` |
| `session_detail_cubit.dart` | Add `clearNotifications()` method that cancels both `aiInteraction` and `sessionMessage` for the session |
| `session_detail_screen.dart` | Call `clearNotifications()` in `initState()` and `_showQuestionModal()` |

Existing `cancelForSession` calls in `replyToQuestion`/`rejectQuestion` are kept as idempotent safety nets.