### PR TITLE
refactor(mobile): type-safe navigation with sealed class AppRoute

### DIFF
--- a/mobile/app/lib/core/platform/go_router_route_source.dart
+++ b/mobile/app/lib/core/platform/go_router_route_source.dart
@@ -9,7 +9,7 @@ import "../routing/app_router.dart";
 
 @Singleton(as: RouteSource)
 class GoRouterRouteSource implements RouteSource, Disposable {
-  final BehaviorSubject<AppRoute?> _currentRouteStream;
+  final BehaviorSubject<AppRouteDef?> _currentRouteStream;
 
   GoRouterRouteSource()
     : _currentRouteStream = BehaviorSubject.seeded(
@@ -19,7 +19,7 @@ class GoRouterRouteSource implements RouteSource, Disposable {
   }
 
   @override
-  ValueStream<AppRoute?> get currentRouteStream => _currentRouteStream.stream;
+  ValueStream<AppRouteDef?> get currentRouteStream => _currentRouteStream.stream;
 
   @override
   FutureOr<void> onDispose() {
@@ -37,13 +37,13 @@ class GoRouterRouteSource implements RouteSource, Disposable {
 
   /// Routes sorted longest-path-first so `/projects/:id/sessions` is tried
   /// before `/projects`. Computed once — the route table is static.
-  static final _orderedRoutes = AppRoute.values.toList()..sort((a, b) => b.path.length.compareTo(a.path.length));
+  static final _orderedRoutes = AppRouteDef.values.toList()..sort((a, b) => b.path.length.compareTo(a.path.length));
 
   static final _regexByRoute = {
-    for (final route in AppRoute.values) route: _buildRegex(route),
+    for (final route in AppRouteDef.values) route: _buildRegex(route),
   };
 
-  static AppRoute? _matchRoute(String path) {
+  static AppRouteDef? _matchRoute(String path) {
     for (final route in _orderedRoutes) {
       if (_regexByRoute[route]!.hasMatch(path)) {
         return route;
@@ -52,7 +52,7 @@ class GoRouterRouteSource implements RouteSource, Disposable {
     return null;
   }
 
-  static RegExp _buildRegex(AppRoute route) {
+  static RegExp _buildRegex(AppRouteDef route) {
     final regexPath = route.path
         .split("/")
         .map((segment) {

--- a/mobile/app/lib/core/platform/notification_service.dart
+++ b/mobile/app/lib/core/platform/notification_service.dart
@@ -129,20 +129,21 @@ class NotificationService {
 
   void _pushSessionRoute({required String sessionId, required String? projectId}) {
     if (projectId == null) {
-      goForTesting(AppRoute.projects.path);
+      goForTesting(const AppRoute.projects().path);
       return;
     }
 
-    final sessionDetailPath = AppRoute.sessionDetail.buildPath(
-      pathParams: {"projectId": projectId, "sessionId": sessionId},
-    );
+    final sessionDetailPath = AppRoute.sessionDetail(
+      projectId: projectId,
+      sessionId: sessionId,
+    ).buildPath();
 
     if (currentPathProviderForTesting() == sessionDetailPath) {
       return;
     }
 
-    final sessionPath = AppRoute.sessions.buildPath(pathParams: {"projectId": projectId});
-    goForTesting(AppRoute.projects.path);
+    final sessionPath = AppRoute.sessions(projectId: projectId).buildPath();
+    goForTesting(const AppRoute.projects().path);
     unawaited(pushForTesting(sessionPath));
     unawaited(pushForTesting(sessionDetailPath));
   }

--- a/mobile/app/lib/core/platform/notification_service.dart
+++ b/mobile/app/lib/core/platform/notification_service.dart
@@ -129,21 +129,23 @@ class NotificationService {
 
   void _pushSessionRoute({required String sessionId, required String? projectId}) {
     if (projectId == null) {
-      goForTesting(const AppRoute.projects().path);
+      goForTesting(AppRouteDef.projects.path);
       return;
     }
 
     final sessionDetailPath = AppRoute.sessionDetail(
       projectId: projectId,
       sessionId: sessionId,
+      sessionTitle: null,
+      readOnly: false,
     ).buildPath();
 
     if (currentPathProviderForTesting() == sessionDetailPath) {
       return;
     }
 
-    final sessionPath = AppRoute.sessions(projectId: projectId).buildPath();
-    goForTesting(const AppRoute.projects().path);
+    final sessionPath = AppRoute.sessions(projectId: projectId, projectName: null).buildPath();
+    goForTesting(AppRouteDef.projects.path);
     unawaited(pushForTesting(sessionPath));
     unawaited(pushForTesting(sessionDetailPath));
   }

--- a/mobile/app/lib/core/routing/app_router.dart
+++ b/mobile/app/lib/core/routing/app_router.dart
@@ -10,31 +10,38 @@ import "../../features/session_list/session_list_screen.dart";
 import "../../features/settings/notification_settings_screen.dart";
 import "../di/injection.dart";
 
-extension AppRouteToGoRoute on AppRoute {
-  /// Returns the [GoRoute] for this route with an exhaustive builder switch.
-  ///
-  /// Adding a new [AppRoute] subclass without handling it here will cause a
-  /// compile-time error.
+extension AppRouteToGoRoute on AppRouteDef {
+  /// Returns the [GoRoute] for this route definition with an exhaustive
+  /// builder switch over decoded [AppRoute] values.
   GoRoute toGoRoute() {
     return GoRoute(
       path: path,
-      builder: (context, state) => switch (this) {
-        AppRouteLogin() => const LoginScreen(),
-        AppRouteProjects() => const ProjectListScreen(),
-        AppRouteNotificationSettings() => const NotificationSettingsScreen(),
-        AppRouteSessions() => SessionListScreen(
-          projectId: state.pathParameters["projectId"] ?? "",
-          projectName: state.uri.queryParameters["name"],
-        ),
-        AppRouteNewSession() => NewSessionScreen(
-          projectId: state.pathParameters["projectId"] ?? "",
-        ),
-        AppRouteSessionDetail() => SessionDetailScreen(
-          projectId: state.pathParameters["projectId"],
-          sessionId: state.pathParameters["sessionId"] ?? "",
-          sessionTitle: state.uri.queryParameters["title"],
-          readOnly: state.uri.queryParameters["readOnly"] == "true",
-        ),
+      builder: (context, state) {
+        final route = AppRoute.fromDef(
+          def: this,
+          pathParams: state.pathParameters,
+          queryParams: state.uri.queryParameters,
+        );
+
+        return switch (route) {
+          AppRouteLogin() => const LoginScreen(),
+          AppRouteProjects() => const ProjectListScreen(),
+          AppRouteNotificationSettings() => const NotificationSettingsScreen(),
+          AppRouteSessions(:final projectId, :final projectName) => SessionListScreen(
+            projectId: projectId,
+            projectName: projectName,
+          ),
+          AppRouteNewSession(:final projectId) => NewSessionScreen(
+            projectId: projectId,
+          ),
+          AppRouteSessionDetail(:final projectId, :final sessionId, :final sessionTitle, :final readOnly) =>
+            SessionDetailScreen(
+              projectId: projectId,
+              sessionId: sessionId,
+              sessionTitle: sessionTitle,
+              readOnly: readOnly,
+            ),
+        };
       },
     );
   }
@@ -65,10 +72,10 @@ extension GoRouterNavigation on GoRouter {
 // ---------------------------------------------------------------------------
 
 final appRouter = GoRouter(
-  initialLocation: const AppRoute.login().path,
+  initialLocation: AppRouteDef.login.path,
   redirect: (context, state) async {
     // Session restore: if on login and tokens exist, skip to projects
-    if (state.matchedLocation == const AppRoute.login().path) {
+    if (state.matchedLocation == AppRouteDef.login.path) {
       final authRedirect = getIt<AuthRedirectService>();
       return (await authRedirect.tryRestoreSession())?.path;
     }
@@ -89,5 +96,5 @@ final appRouter = GoRouter(
     // Unexpected routing error — log it. GoRouter stays on the current page.
     loge("GoRouter could not match route: $uri");
   },
-  routes: AppRoute.values.map((route) => route.toGoRoute()).toList(),
+  routes: AppRouteDef.values.map((def) => def.toGoRoute()).toList(),
 );

--- a/mobile/app/lib/core/routing/app_router.dart
+++ b/mobile/app/lib/core/routing/app_router.dart
@@ -13,23 +13,23 @@ import "../di/injection.dart";
 extension AppRouteToGoRoute on AppRoute {
   /// Returns the [GoRoute] for this route with an exhaustive builder switch.
   ///
-  /// Adding a new [AppRoute] value without handling it here will cause a
+  /// Adding a new [AppRoute] subclass without handling it here will cause a
   /// compile-time error.
   GoRoute toGoRoute() {
     return GoRoute(
       path: path,
       builder: (context, state) => switch (this) {
-        AppRoute.login => const LoginScreen(),
-        AppRoute.projects => const ProjectListScreen(),
-        AppRoute.notificationSettings => const NotificationSettingsScreen(),
-        AppRoute.sessions => SessionListScreen(
+        AppRouteLogin() => const LoginScreen(),
+        AppRouteProjects() => const ProjectListScreen(),
+        AppRouteNotificationSettings() => const NotificationSettingsScreen(),
+        AppRouteSessions() => SessionListScreen(
           projectId: state.pathParameters["projectId"] ?? "",
           projectName: state.uri.queryParameters["name"],
         ),
-        AppRoute.newSession => NewSessionScreen(
+        AppRouteNewSession() => NewSessionScreen(
           projectId: state.pathParameters["projectId"] ?? "",
         ),
-        AppRoute.sessionDetail => SessionDetailScreen(
+        AppRouteSessionDetail() => SessionDetailScreen(
           projectId: state.pathParameters["projectId"],
           sessionId: state.pathParameters["sessionId"] ?? "",
           sessionTitle: state.uri.queryParameters["title"],
@@ -45,34 +45,18 @@ extension AppRouteToGoRoute on AppRoute {
 // ---------------------------------------------------------------------------
 
 extension BuildContextNavigation on BuildContext {
-  void goRoute(
-    AppRoute route, {
-    Map<String, String>? pathParams,
-    Map<String, String>? queryParams,
-  }) {
-    GoRouter.of(this).go(
-      route.buildPath(pathParams: pathParams, queryParams: queryParams),
-    );
+  void goRoute(AppRoute route) {
+    GoRouter.of(this).go(route.buildPath());
   }
 
-  Future<T?> pushRoute<T extends Object?>(
-    AppRoute route, {
-    Map<String, String>? pathParams,
-    Map<String, String>? queryParams,
-  }) {
-    return GoRouter.of(this).push<T>(
-      route.buildPath(pathParams: pathParams, queryParams: queryParams),
-    );
+  Future<T?> pushRoute<T extends Object?>(AppRoute route) {
+    return GoRouter.of(this).push<T>(route.buildPath());
   }
 }
 
 extension GoRouterNavigation on GoRouter {
-  void goRoute(
-    AppRoute route, {
-    Map<String, String>? pathParams,
-    Map<String, String>? queryParams,
-  }) {
-    go(route.buildPath(pathParams: pathParams, queryParams: queryParams));
+  void goRoute(AppRoute route) {
+    go(route.buildPath());
   }
 }
 
@@ -81,10 +65,10 @@ extension GoRouterNavigation on GoRouter {
 // ---------------------------------------------------------------------------
 
 final appRouter = GoRouter(
-  initialLocation: AppRoute.login.path,
+  initialLocation: const AppRoute.login().path,
   redirect: (context, state) async {
     // Session restore: if on login and tokens exist, skip to projects
-    if (state.matchedLocation == AppRoute.login.path) {
+    if (state.matchedLocation == const AppRoute.login().path) {
       final authRedirect = getIt<AuthRedirectService>();
       return (await authRedirect.tryRestoreSession())?.path;
     }

--- a/mobile/app/lib/core/routing/app_router.dart
+++ b/mobile/app/lib/core/routing/app_router.dart
@@ -77,7 +77,7 @@ final appRouter = GoRouter(
     // Session restore: if on login and tokens exist, skip to projects
     if (state.matchedLocation == AppRouteDef.login.path) {
       final authRedirect = getIt<AuthRedirectService>();
-      return (await authRedirect.tryRestoreSession())?.path;
+      return (await authRedirect.tryRestoreSession())?.buildPath();
     }
 
     return null;

--- a/mobile/app/lib/core/routing/deep_link_service.dart
+++ b/mobile/app/lib/core/routing/deep_link_service.dart
@@ -52,7 +52,7 @@ class DeepLinkService {
       final route = await _authRedirectService.handleOAuthCallback(uri);
       if (route != null) {
         try {
-          appRouter.goRoute(route);
+          appRouter.go(route.path);
         } catch (e, st) {
           loge("Failed to navigate after OAuth callback", e, st);
         }

--- a/mobile/app/lib/core/routing/deep_link_service.dart
+++ b/mobile/app/lib/core/routing/deep_link_service.dart
@@ -52,7 +52,7 @@ class DeepLinkService {
       final route = await _authRedirectService.handleOAuthCallback(uri);
       if (route != null) {
         try {
-          appRouter.goRoute(AppRoute.fromDef(def: route, pathParams: {}, queryParams: {}));
+          appRouter.goRoute(route);
         } catch (e, st) {
           loge("Failed to navigate after OAuth callback", e, st);
         }

--- a/mobile/app/lib/core/routing/deep_link_service.dart
+++ b/mobile/app/lib/core/routing/deep_link_service.dart
@@ -52,7 +52,7 @@ class DeepLinkService {
       final route = await _authRedirectService.handleOAuthCallback(uri);
       if (route != null) {
         try {
-          appRouter.go(route.path);
+          appRouter.goRoute(AppRoute.fromDef(def: route, pathParams: {}, queryParams: {}));
         } catch (e, st) {
           loge("Failed to navigate after OAuth callback", e, st);
         }

--- a/mobile/app/lib/core/widgets/connection_overlay.dart
+++ b/mobile/app/lib/core/widgets/connection_overlay.dart
@@ -95,7 +95,7 @@ class _ConnectionOverlayBody extends StatelessWidget {
                 onReconnect: () => context.read<ConnectionOverlayCubit>().reconnect(),
                 onDisconnect: () async {
                   await context.read<ConnectionOverlayCubit>().disconnect();
-                  router.goRoute(AppRoute.login);
+                  router.goRoute(const AppRoute.login());
                 },
               ),
             ),

--- a/mobile/app/lib/core/widgets/connection_overlay.dart
+++ b/mobile/app/lib/core/widgets/connection_overlay.dart
@@ -8,6 +8,7 @@ import "package:sesori_dart_core/sesori_dart_core.dart";
 
 import "../di/injection.dart";
 import "../extensions/build_context_x.dart";
+import "../routing/app_router.dart";
 
 /// App-wide overlay that reacts to [ConnectionService] status changes.
 ///
@@ -94,7 +95,7 @@ class _ConnectionOverlayBody extends StatelessWidget {
                 onReconnect: () => context.read<ConnectionOverlayCubit>().reconnect(),
                 onDisconnect: () async {
                   await context.read<ConnectionOverlayCubit>().disconnect();
-                  router.go(AppRouteDef.login.path);
+                  router.goRoute(const AppRoute.login());
                 },
               ),
             ),

--- a/mobile/app/lib/core/widgets/connection_overlay.dart
+++ b/mobile/app/lib/core/widgets/connection_overlay.dart
@@ -8,7 +8,6 @@ import "package:sesori_dart_core/sesori_dart_core.dart";
 
 import "../di/injection.dart";
 import "../extensions/build_context_x.dart";
-import "../routing/app_router.dart";
 
 /// App-wide overlay that reacts to [ConnectionService] status changes.
 ///
@@ -95,7 +94,7 @@ class _ConnectionOverlayBody extends StatelessWidget {
                 onReconnect: () => context.read<ConnectionOverlayCubit>().reconnect(),
                 onDisconnect: () async {
                   await context.read<ConnectionOverlayCubit>().disconnect();
-                  router.goRoute(const AppRoute.login());
+                  router.go(AppRouteDef.login.path);
                 },
               ),
             ),

--- a/mobile/app/lib/features/new_session/new_session_screen.dart
+++ b/mobile/app/lib/features/new_session/new_session_screen.dart
@@ -41,9 +41,11 @@ class _NewSessionBody extends StatelessWidget {
         if (state case NewSessionCreated(:final session)) {
           Navigator.of(context).pop();
           context.pushRoute(
-            AppRoute.sessionDetail,
-            pathParams: {"projectId": session.projectID, "sessionId": session.id},
-            queryParams: {"title": session.title ?? ""},
+            AppRoute.sessionDetail(
+              projectId: session.projectID,
+              sessionId: session.id,
+              sessionTitle: session.title ?? "",
+            ),
           );
         }
       },

--- a/mobile/app/lib/features/new_session/new_session_screen.dart
+++ b/mobile/app/lib/features/new_session/new_session_screen.dart
@@ -45,6 +45,7 @@ class _NewSessionBody extends StatelessWidget {
               projectId: session.projectID,
               sessionId: session.id,
               sessionTitle: session.title ?? "",
+              readOnly: false,
             ),
           );
         }

--- a/mobile/app/lib/features/project_list/project_list_screen.dart
+++ b/mobile/app/lib/features/project_list/project_list_screen.dart
@@ -108,7 +108,7 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
           IconButton(
             icon: const Icon(Icons.notifications_outlined),
             tooltip: loc.notificationSettingsTitle,
-            onPressed: () => context.pushRoute(AppRoute.notificationSettings),
+            onPressed: () => context.pushRoute(const AppRoute.notificationSettings()),
           ),
         ],
       ),
@@ -260,9 +260,7 @@ class _ProjectTile extends StatelessWidget {
       onTap: () {
         context.read<ProjectListCubit>().setActiveProject(project);
         context.pushRoute(
-          AppRoute.sessions,
-          pathParams: {"projectId": project.id},
-          queryParams: {"name": displayName},
+          AppRoute.sessions(projectId: project.id, projectName: displayName),
         );
       },
       onLongPress: onLongPress,

--- a/mobile/app/lib/features/session_detail/widgets/background_tasks_bar.dart
+++ b/mobile/app/lib/features/session_detail/widgets/background_tasks_bar.dart
@@ -268,17 +268,13 @@ class _TaskRow extends StatelessWidget {
 
     return InkWell(
       onTap: () {
-        final queryParams = <String, String>{"readOnly": "true"};
-        if (session.title != null) {
-          queryParams["title"] = session.title!;
-        }
         context.pushRoute(
-          AppRoute.sessionDetail,
-          pathParams: {
-            "projectId": session.projectID,
-            "sessionId": session.id,
-          },
-          queryParams: queryParams,
+          AppRoute.sessionDetail(
+            projectId: session.projectID,
+            sessionId: session.id,
+            readOnly: true,
+            sessionTitle: session.title,
+          ),
         );
       },
       child: Padding(

--- a/mobile/app/lib/features/session_detail/widgets/subtask_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/subtask_part_widget.dart
@@ -39,15 +39,12 @@ class SubtaskPartWidget extends StatelessWidget {
           onTap: childSession != null
               ? () {
                   context.pushRoute(
-                    AppRoute.sessionDetail,
-                    pathParams: {
-                      "projectId": childSession.projectID,
-                      "sessionId": childSession.id,
-                    },
-                    queryParams: {
-                      "readOnly": "true",
-                      "title": ?childSession.title,
-                    },
+                    AppRoute.sessionDetail(
+                      projectId: childSession.projectID,
+                      sessionId: childSession.id,
+                      readOnly: true,
+                      sessionTitle: childSession.title,
+                    ),
                   );
                 }
               : null,

--- a/mobile/app/lib/features/session_list/session_list_screen.dart
+++ b/mobile/app/lib/features/session_list/session_list_screen.dart
@@ -45,8 +45,7 @@ class _SessionListBody extends StatelessWidget {
   void _goToNewSession(BuildContext context) {
     final projectId = context.read<SessionListCubit>().projectId;
     context.pushRoute(
-      AppRoute.newSession,
-      pathParams: {"projectId": projectId},
+      AppRoute.newSession(projectId: projectId),
     );
   }
 
@@ -412,9 +411,11 @@ class _SessionTile extends StatelessWidget {
         trailing: const Icon(Icons.chevron_right),
         onTap: () {
           context.pushRoute(
-            AppRoute.sessionDetail,
-            pathParams: {"projectId": session.projectID, "sessionId": session.id},
-            queryParams: {"title": session.title ?? ""},
+            AppRoute.sessionDetail(
+              projectId: session.projectID,
+              sessionId: session.id,
+              sessionTitle: session.title ?? "",
+            ),
           );
         },
         onLongPress: onLongPress,

--- a/mobile/app/lib/features/session_list/session_list_screen.dart
+++ b/mobile/app/lib/features/session_list/session_list_screen.dart
@@ -415,6 +415,7 @@ class _SessionTile extends StatelessWidget {
               projectId: session.projectID,
               sessionId: session.id,
               sessionTitle: session.title ?? "",
+              readOnly: false,
             ),
           );
         },

--- a/mobile/app/test/core/platform/notification_service_test.dart
+++ b/mobile/app/test/core/platform/notification_service_test.dart
@@ -76,12 +76,12 @@ void main() {
         buildTapMessage(sessionId: "ses_1", projectId: "proj_1"),
       );
 
-      expect(goCalls, equals([AppRoute.projects.path]));
+      expect(goCalls, equals([const AppRoute.projects().path]));
       expect(
         pushCalls,
         equals([
-          AppRoute.sessions.buildPath(pathParams: {"projectId": "proj_1"}),
-          AppRoute.sessionDetail.buildPath(pathParams: {"projectId": "proj_1", "sessionId": "ses_1"}),
+          const AppRoute.sessions(projectId: "proj_1").buildPath(),
+          const AppRoute.sessionDetail(projectId: "proj_1", sessionId: "ses_1").buildPath(),
         ]),
       );
     });
@@ -100,7 +100,7 @@ void main() {
         buildTapMessage(sessionId: "ses_1", projectId: null),
       );
 
-      expect(goCalls, equals([AppRoute.projects.path]));
+      expect(goCalls, equals([const AppRoute.projects().path]));
       expect(pushCalls, isEmpty);
     });
 
@@ -136,12 +136,12 @@ void main() {
         const NotificationTapEvent(sessionId: "ses_local", projectId: "proj_local"),
       );
 
-      expect(goCalls, equals([AppRoute.projects.path]));
+      expect(goCalls, equals([const AppRoute.projects().path]));
       expect(
         pushCalls,
         equals([
-          AppRoute.sessions.buildPath(pathParams: {"projectId": "proj_local"}),
-          AppRoute.sessionDetail.buildPath(pathParams: {"projectId": "proj_local", "sessionId": "ses_local"}),
+          const AppRoute.sessions(projectId: "proj_local").buildPath(),
+          const AppRoute.sessionDetail(projectId: "proj_local", sessionId: "ses_local").buildPath(),
         ]),
       );
     });
@@ -176,12 +176,12 @@ void main() {
         ),
       );
 
-      expect(goCalls, equals([AppRoute.projects.path]));
+      expect(goCalls, equals([const AppRoute.projects().path]));
       expect(
         pushCalls,
         equals([
-          AppRoute.sessions.buildPath(pathParams: {"projectId": "proj_pending"}),
-          AppRoute.sessionDetail.buildPath(pathParams: {"projectId": "proj_pending", "sessionId": "ses_pending"}),
+          const AppRoute.sessions(projectId: "proj_pending").buildPath(),
+          const AppRoute.sessionDetail(projectId: "proj_pending", sessionId: "ses_pending").buildPath(),
         ]),
       );
     });
@@ -190,9 +190,10 @@ void main() {
       final goCalls = <String>[];
       final pushCalls = <String>[];
 
-      final targetPath = AppRoute.sessionDetail.buildPath(
-        pathParams: {"projectId": "proj_1", "sessionId": "ses_1"},
-      );
+      final targetPath = const AppRoute.sessionDetail(
+        projectId: "proj_1",
+        sessionId: "ses_1",
+      ).buildPath();
 
       service.goForTesting = goCalls.add;
       service.pushForTesting = (route) async {

--- a/mobile/app/test/core/platform/notification_service_test.dart
+++ b/mobile/app/test/core/platform/notification_service_test.dart
@@ -76,12 +76,17 @@ void main() {
         buildTapMessage(sessionId: "ses_1", projectId: "proj_1"),
       );
 
-      expect(goCalls, equals([const AppRoute.projects().path]));
+      expect(goCalls, equals([AppRouteDef.projects.path]));
       expect(
         pushCalls,
         equals([
-          const AppRoute.sessions(projectId: "proj_1").buildPath(),
-          const AppRoute.sessionDetail(projectId: "proj_1", sessionId: "ses_1").buildPath(),
+          const AppRoute.sessions(projectId: "proj_1", projectName: null).buildPath(),
+          const AppRoute.sessionDetail(
+            projectId: "proj_1",
+            sessionId: "ses_1",
+            sessionTitle: null,
+            readOnly: false,
+          ).buildPath(),
         ]),
       );
     });
@@ -100,7 +105,7 @@ void main() {
         buildTapMessage(sessionId: "ses_1", projectId: null),
       );
 
-      expect(goCalls, equals([const AppRoute.projects().path]));
+      expect(goCalls, equals([AppRouteDef.projects.path]));
       expect(pushCalls, isEmpty);
     });
 
@@ -136,12 +141,17 @@ void main() {
         const NotificationTapEvent(sessionId: "ses_local", projectId: "proj_local"),
       );
 
-      expect(goCalls, equals([const AppRoute.projects().path]));
+      expect(goCalls, equals([AppRouteDef.projects.path]));
       expect(
         pushCalls,
         equals([
-          const AppRoute.sessions(projectId: "proj_local").buildPath(),
-          const AppRoute.sessionDetail(projectId: "proj_local", sessionId: "ses_local").buildPath(),
+          const AppRoute.sessions(projectId: "proj_local", projectName: null).buildPath(),
+          const AppRoute.sessionDetail(
+            projectId: "proj_local",
+            sessionId: "ses_local",
+            sessionTitle: null,
+            readOnly: false,
+          ).buildPath(),
         ]),
       );
     });
@@ -176,12 +186,17 @@ void main() {
         ),
       );
 
-      expect(goCalls, equals([const AppRoute.projects().path]));
+      expect(goCalls, equals([AppRouteDef.projects.path]));
       expect(
         pushCalls,
         equals([
-          const AppRoute.sessions(projectId: "proj_pending").buildPath(),
-          const AppRoute.sessionDetail(projectId: "proj_pending", sessionId: "ses_pending").buildPath(),
+          const AppRoute.sessions(projectId: "proj_pending", projectName: null).buildPath(),
+          const AppRoute.sessionDetail(
+            projectId: "proj_pending",
+            sessionId: "ses_pending",
+            sessionTitle: null,
+            readOnly: false,
+          ).buildPath(),
         ]),
       );
     });
@@ -193,6 +208,8 @@ void main() {
       final targetPath = const AppRoute.sessionDetail(
         projectId: "proj_1",
         sessionId: "ses_1",
+        sessionTitle: null,
+        readOnly: false,
       ).buildPath();
 
       service.goForTesting = goCalls.add;

--- a/mobile/app/test/core/routing/app_route_test.dart
+++ b/mobile/app/test/core/routing/app_route_test.dart
@@ -12,9 +12,9 @@ import "package:sesori_mobile/features/session_list/session_list_screen.dart";
 void main() {
   group("AppRoute", () {
     test("each value has a non-empty path starting with /", () {
-      for (final route in AppRoute.values) {
-        expect(route.path, isNotEmpty, reason: "${route.runtimeType} should have a path");
-        expect(route.path.startsWith("/"), isTrue, reason: "${route.runtimeType} path should start with /");
+      for (final def in AppRouteDef.values) {
+        expect(def.path, isNotEmpty, reason: "${def.name} should have a path");
+        expect(def.path.startsWith("/"), isTrue, reason: "${def.name} path should start with /");
       }
     });
   });
@@ -27,7 +27,7 @@ void main() {
     });
 
     test("substitutes projectId for sessions", () {
-      final result = const AppRoute.sessions(projectId: "proj-123").buildPath();
+      final result = const AppRoute.sessions(projectId: "proj-123", projectName: null).buildPath();
       expect(result, "/projects/proj-123/sessions");
     });
 
@@ -35,8 +35,10 @@ void main() {
       final result = const AppRoute.sessionDetail(
         projectId: "proj-123",
         sessionId: "ses-456",
+        sessionTitle: null,
+        readOnly: false,
       ).buildPath();
-      expect(result, "/projects/proj-123/sessions/ses-456");
+      expect(result, "/projects/proj-123/sessions/ses-456?readOnly=false");
     });
 
     test("includes projectName as query param for sessions", () {
@@ -49,7 +51,7 @@ void main() {
     });
 
     test("omits query string when no query params set", () {
-      final result = const AppRoute.sessions(projectId: "proj-123").buildPath();
+      final result = const AppRoute.sessions(projectId: "proj-123", projectName: null).buildPath();
       expect(result, "/projects/proj-123/sessions");
       expect(result, isNot(contains("?")));
     });
@@ -67,24 +69,27 @@ void main() {
       expect(result, contains("readOnly=true"));
     });
 
-    test("omits readOnly from query when false", () {
+    test("always includes readOnly in query when false", () {
       final result = const AppRoute.sessionDetail(
         projectId: "proj-1",
         sessionId: "ses-1",
+        sessionTitle: null,
+        readOnly: false,
       ).buildPath();
-      expect(result, "/projects/proj-1/sessions/ses-1");
-      expect(result, isNot(contains("readOnly")));
+      expect(result, "/projects/proj-1/sessions/ses-1?readOnly=false");
     });
 
     test("encodes path params with special characters", () {
       final result = const AppRoute.sessionDetail(
         projectId: "project/with?special&chars",
         sessionId: "id/with?special&chars",
+        sessionTitle: null,
+        readOnly: false,
       ).buildPath();
       // Special characters in the param value must be percent-encoded
       expect(
         result,
-        "/projects/project%2Fwith%3Fspecial%26chars/sessions/id%2Fwith%3Fspecial%26chars",
+        "/projects/project%2Fwith%3Fspecial%26chars/sessions/id%2Fwith%3Fspecial%26chars?readOnly=false",
       );
     });
 
@@ -96,14 +101,14 @@ void main() {
 
   group("AppRoute.toGoRoute", () {
     test("returns GoRoute with matching path for every route", () {
-      for (final route in AppRoute.values) {
-        final goRoute = route.toGoRoute();
-        expect(goRoute.path, route.path, reason: "${route.runtimeType} GoRoute path should match");
+      for (final def in AppRouteDef.values) {
+        final goRoute = def.toGoRoute();
+        expect(goRoute.path, def.path, reason: "${def.name} GoRoute path should match");
       }
     });
 
     test("login route builds LoginScreen", () {
-      final goRoute = const AppRoute.login().toGoRoute();
+      final goRoute = AppRouteDef.login.toGoRoute();
       final widget = goRoute.builder!(
         _FakeBuildContext(),
         _FakeGoRouterState(),
@@ -112,7 +117,7 @@ void main() {
     });
 
     test("projects route builds ProjectListScreen", () {
-      final goRoute = const AppRoute.projects().toGoRoute();
+      final goRoute = AppRouteDef.projects.toGoRoute();
       final widget = goRoute.builder!(
         _FakeBuildContext(),
         _FakeGoRouterState(),
@@ -121,7 +126,7 @@ void main() {
     });
 
     test("sessions route builds SessionListScreen with path and query params", () {
-      final goRoute = const AppRoute.sessions(projectId: "").toGoRoute();
+      final goRoute = AppRouteDef.sessions.toGoRoute();
       final widget = goRoute.builder!(
         _FakeBuildContext(),
         _FakeGoRouterState(
@@ -136,7 +141,7 @@ void main() {
     });
 
     test("sessions route defaults missing params to empty strings", () {
-      final goRoute = const AppRoute.sessions(projectId: "").toGoRoute();
+      final goRoute = AppRouteDef.sessions.toGoRoute();
       final widget = goRoute.builder!(
         _FakeBuildContext(),
         _FakeGoRouterState(),
@@ -147,7 +152,7 @@ void main() {
     });
 
     test("sessionDetail route builds SessionDetailScreen with params", () {
-      final goRoute = const AppRoute.sessionDetail(projectId: "", sessionId: "").toGoRoute();
+      final goRoute = AppRouteDef.sessionDetail.toGoRoute();
       final widget = goRoute.builder!(
         _FakeBuildContext(),
         _FakeGoRouterState(
@@ -164,7 +169,7 @@ void main() {
     });
 
     test("sessionDetail route defaults readOnly to false when absent", () {
-      final goRoute = const AppRoute.sessionDetail(projectId: "", sessionId: "").toGoRoute();
+      final goRoute = AppRouteDef.sessionDetail.toGoRoute();
       final widget = goRoute.builder!(
         _FakeBuildContext(),
         _FakeGoRouterState(

--- a/mobile/app/test/core/routing/app_route_test.dart
+++ b/mobile/app/test/core/routing/app_route_test.dart
@@ -13,72 +13,74 @@ void main() {
   group("AppRoute", () {
     test("each value has a non-empty path starting with /", () {
       for (final route in AppRoute.values) {
-        expect(route.path, isNotEmpty, reason: "${route.name} should have a path");
-        expect(route.path.startsWith("/"), isTrue, reason: "${route.name} path should start with /");
+        expect(route.path, isNotEmpty, reason: "${route.runtimeType} should have a path");
+        expect(route.path.startsWith("/"), isTrue, reason: "${route.runtimeType} path should start with /");
       }
     });
   });
 
   group("AppRoute.buildPath", () {
-    test("returns raw path when no params given", () {
-      expect(AppRoute.login.buildPath(), "/login");
-      expect(AppRoute.projects.buildPath(), "/projects");
+    test("returns raw path for parameterless routes", () {
+      expect(const AppRoute.login().buildPath(), "/login");
+      expect(const AppRoute.projects().buildPath(), "/projects");
+      expect(const AppRoute.notificationSettings().buildPath(), "/settings/notifications");
     });
 
-    test("substitutes path params", () {
-      final result = AppRoute.sessions.buildPath(
-        pathParams: {"projectId": "proj-123"},
-      );
+    test("substitutes projectId for sessions", () {
+      final result = const AppRoute.sessions(projectId: "proj-123").buildPath();
       expect(result, "/projects/proj-123/sessions");
     });
 
     test("substitutes path params for sessionDetail", () {
-      final result = AppRoute.sessionDetail.buildPath(
-        pathParams: {"projectId": "proj-123", "sessionId": "ses-456"},
-      );
+      final result = const AppRoute.sessionDetail(
+        projectId: "proj-123",
+        sessionId: "ses-456",
+      ).buildPath();
       expect(result, "/projects/proj-123/sessions/ses-456");
     });
 
-    test("builds /projects/p1/sessions/s1 for sessionDetail", () {
-      final result = AppRoute.sessionDetail.buildPath(
-        pathParams: {"projectId": "p1", "sessionId": "s1"},
-      );
-      expect(result, "/projects/p1/sessions/s1");
-    });
-
-    test("appends query params", () {
-      final result = AppRoute.projects.buildPath(
-        queryParams: {"filter": "active"},
-      );
-      expect(result, "/projects?filter=active");
-    });
-
-    test("combines path and query params", () {
-      final result = AppRoute.sessions.buildPath(
-        pathParams: {"projectId": "proj-123"},
-        queryParams: {"name": "My Project"},
-      );
+    test("includes projectName as query param for sessions", () {
+      final result = const AppRoute.sessions(
+        projectId: "proj-123",
+        projectName: "My Project",
+      ).buildPath();
       expect(result, contains("/projects/proj-123/sessions?"));
       expect(result, contains("name=My+Project"));
     });
 
-    test("encodes query param values automatically", () {
-      final result = AppRoute.sessionDetail.buildPath(
-        pathParams: {"projectId": "proj-1", "sessionId": "ses-1"},
-        queryParams: {"title": "hello world & more"},
-      );
-      expect(result, contains("/projects/proj-1/sessions/ses-1?"));
-      // Verify the value is encoded (space becomes + or %20, & becomes %26)
-      expect(result, isNot(contains("& more")));
+    test("omits query string when no query params set", () {
+      final result = const AppRoute.sessions(projectId: "proj-123").buildPath();
+      expect(result, "/projects/proj-123/sessions");
+      expect(result, isNot(contains("?")));
     });
 
-    test("encodes sessionDetail path params with special characters", () {
-      final result = AppRoute.sessionDetail.buildPath(
-        pathParams: {
-          "projectId": "project/with?special&chars",
-          "sessionId": "id/with?special&chars",
-        },
-      );
+    test("includes title and readOnly as query params for sessionDetail", () {
+      final result = const AppRoute.sessionDetail(
+        projectId: "proj-1",
+        sessionId: "ses-1",
+        sessionTitle: "hello world & more",
+        readOnly: true,
+      ).buildPath();
+      expect(result, contains("/projects/proj-1/sessions/ses-1?"));
+      // Verify values are encoded (& becomes %26)
+      expect(result, isNot(contains("& more")));
+      expect(result, contains("readOnly=true"));
+    });
+
+    test("omits readOnly from query when false", () {
+      final result = const AppRoute.sessionDetail(
+        projectId: "proj-1",
+        sessionId: "ses-1",
+      ).buildPath();
+      expect(result, "/projects/proj-1/sessions/ses-1");
+      expect(result, isNot(contains("readOnly")));
+    });
+
+    test("encodes path params with special characters", () {
+      final result = const AppRoute.sessionDetail(
+        projectId: "project/with?special&chars",
+        sessionId: "id/with?special&chars",
+      ).buildPath();
       // Special characters in the param value must be percent-encoded
       expect(
         result,
@@ -86,17 +88,9 @@ void main() {
       );
     });
 
-    test("ignores empty query params map", () {
-      final result = AppRoute.login.buildPath(queryParams: {});
-      expect(result, "/login");
-    });
-
-    test("ignores null params", () {
-      final result = AppRoute.login.buildPath(
-        pathParams: null,
-        queryParams: null,
-      );
-      expect(result, "/login");
+    test("substitutes projectId for newSession", () {
+      final result = const AppRoute.newSession(projectId: "proj-42").buildPath();
+      expect(result, "/projects/proj-42/sessions/new");
     });
   });
 
@@ -104,12 +98,12 @@ void main() {
     test("returns GoRoute with matching path for every route", () {
       for (final route in AppRoute.values) {
         final goRoute = route.toGoRoute();
-        expect(goRoute.path, route.path, reason: "${route.name} GoRoute path should match enum path");
+        expect(goRoute.path, route.path, reason: "${route.runtimeType} GoRoute path should match");
       }
     });
 
     test("login route builds LoginScreen", () {
-      final goRoute = AppRoute.login.toGoRoute();
+      final goRoute = const AppRoute.login().toGoRoute();
       final widget = goRoute.builder!(
         _FakeBuildContext(),
         _FakeGoRouterState(),
@@ -118,7 +112,7 @@ void main() {
     });
 
     test("projects route builds ProjectListScreen", () {
-      final goRoute = AppRoute.projects.toGoRoute();
+      final goRoute = const AppRoute.projects().toGoRoute();
       final widget = goRoute.builder!(
         _FakeBuildContext(),
         _FakeGoRouterState(),
@@ -127,7 +121,7 @@ void main() {
     });
 
     test("sessions route builds SessionListScreen with path and query params", () {
-      final goRoute = AppRoute.sessions.toGoRoute();
+      final goRoute = const AppRoute.sessions(projectId: "").toGoRoute();
       final widget = goRoute.builder!(
         _FakeBuildContext(),
         _FakeGoRouterState(
@@ -142,7 +136,7 @@ void main() {
     });
 
     test("sessions route defaults missing params to empty strings", () {
-      final goRoute = AppRoute.sessions.toGoRoute();
+      final goRoute = const AppRoute.sessions(projectId: "").toGoRoute();
       final widget = goRoute.builder!(
         _FakeBuildContext(),
         _FakeGoRouterState(),
@@ -153,7 +147,7 @@ void main() {
     });
 
     test("sessionDetail route builds SessionDetailScreen with params", () {
-      final goRoute = AppRoute.sessionDetail.toGoRoute();
+      final goRoute = const AppRoute.sessionDetail(projectId: "", sessionId: "").toGoRoute();
       final widget = goRoute.builder!(
         _FakeBuildContext(),
         _FakeGoRouterState(
@@ -170,7 +164,7 @@ void main() {
     });
 
     test("sessionDetail route defaults readOnly to false when absent", () {
-      final goRoute = AppRoute.sessionDetail.toGoRoute();
+      final goRoute = const AppRoute.sessionDetail(projectId: "", sessionId: "").toGoRoute();
       final widget = goRoute.builder!(
         _FakeBuildContext(),
         _FakeGoRouterState(

--- a/mobile/app/test/core/routing/auth_redirect_service_test.dart
+++ b/mobile/app/test/core/routing/auth_redirect_service_test.dart
@@ -39,7 +39,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, equals(AppRoute.login));
+      expect(result, isA<AppRouteLogin>());
       verifyNever(
         () => mockOAuthFlowProvider.exchangeCode(
           code: any(named: "code"),
@@ -58,7 +58,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, equals(AppRoute.login));
+      expect(result, isA<AppRouteLogin>());
       verifyNever(
         () => mockOAuthFlowProvider.exchangeCode(
           code: any(named: "code"),
@@ -84,7 +84,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, equals(AppRoute.login));
+      expect(result, isA<AppRouteLogin>());
       verifyNever(() => mockConnectionService.connect(any()));
     });
 
@@ -110,7 +110,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, equals(AppRoute.projects));
+      expect(result, isA<AppRouteProjects>());
       final captured = verify(() => mockConnectionService.connect(captureAny())).captured;
       expect(captured.length, equals(1));
       final config = captured.single as ServerConnectionConfig;
@@ -136,7 +136,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, equals(AppRoute.projects));
+      expect(result, isA<AppRouteProjects>());
       verifyNever(() => mockConnectionService.connect(any()));
     });
 
@@ -158,7 +158,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, equals(AppRoute.projects));
+      expect(result, isA<AppRouteProjects>());
     });
   });
 
@@ -213,7 +213,7 @@ void main() {
       final result = await service.tryRestoreSession();
 
       // then
-      expect(result, equals(AppRoute.projects));
+      expect(result, isA<AppRouteProjects>());
       final captured = verify(() => mockConnectionService.connect(captureAny())).captured;
       expect(captured.length, equals(1));
       final config = captured.single as ServerConnectionConfig;
@@ -232,7 +232,7 @@ void main() {
       final result = await service.tryRestoreSession();
 
       // then
-      expect(result, equals(AppRoute.projects));
+      expect(result, isA<AppRouteProjects>());
     });
   });
 }

--- a/mobile/app/test/core/routing/auth_redirect_service_test.dart
+++ b/mobile/app/test/core/routing/auth_redirect_service_test.dart
@@ -39,7 +39,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, equals(AppRouteDef.login));
+      expect(result, isA<AppRouteLogin>());
       verifyNever(
         () => mockOAuthFlowProvider.exchangeCode(
           code: any(named: "code"),
@@ -58,7 +58,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, equals(AppRouteDef.login));
+      expect(result, isA<AppRouteLogin>());
       verifyNever(
         () => mockOAuthFlowProvider.exchangeCode(
           code: any(named: "code"),
@@ -84,7 +84,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, equals(AppRouteDef.login));
+      expect(result, isA<AppRouteLogin>());
       verifyNever(() => mockConnectionService.connect(any()));
     });
 
@@ -110,7 +110,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, equals(AppRouteDef.projects));
+      expect(result, isA<AppRouteProjects>());
       final captured = verify(() => mockConnectionService.connect(captureAny())).captured;
       expect(captured.length, equals(1));
       final config = captured.single as ServerConnectionConfig;
@@ -136,7 +136,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, equals(AppRouteDef.projects));
+      expect(result, isA<AppRouteProjects>());
       verifyNever(() => mockConnectionService.connect(any()));
     });
 
@@ -158,7 +158,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, equals(AppRouteDef.projects));
+      expect(result, isA<AppRouteProjects>());
     });
   });
 
@@ -213,7 +213,7 @@ void main() {
       final result = await service.tryRestoreSession();
 
       // then
-      expect(result, equals(AppRouteDef.projects));
+      expect(result, isA<AppRouteProjects>());
       final captured = verify(() => mockConnectionService.connect(captureAny())).captured;
       expect(captured.length, equals(1));
       final config = captured.single as ServerConnectionConfig;
@@ -232,7 +232,7 @@ void main() {
       final result = await service.tryRestoreSession();
 
       // then
-      expect(result, equals(AppRouteDef.projects));
+      expect(result, isA<AppRouteProjects>());
     });
   });
 }

--- a/mobile/app/test/core/routing/auth_redirect_service_test.dart
+++ b/mobile/app/test/core/routing/auth_redirect_service_test.dart
@@ -39,7 +39,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, isA<AppRouteLogin>());
+      expect(result, equals(AppRouteDef.login));
       verifyNever(
         () => mockOAuthFlowProvider.exchangeCode(
           code: any(named: "code"),
@@ -58,7 +58,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, isA<AppRouteLogin>());
+      expect(result, equals(AppRouteDef.login));
       verifyNever(
         () => mockOAuthFlowProvider.exchangeCode(
           code: any(named: "code"),
@@ -84,7 +84,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, isA<AppRouteLogin>());
+      expect(result, equals(AppRouteDef.login));
       verifyNever(() => mockConnectionService.connect(any()));
     });
 
@@ -110,7 +110,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, isA<AppRouteProjects>());
+      expect(result, equals(AppRouteDef.projects));
       final captured = verify(() => mockConnectionService.connect(captureAny())).captured;
       expect(captured.length, equals(1));
       final config = captured.single as ServerConnectionConfig;
@@ -136,7 +136,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, isA<AppRouteProjects>());
+      expect(result, equals(AppRouteDef.projects));
       verifyNever(() => mockConnectionService.connect(any()));
     });
 
@@ -158,7 +158,7 @@ void main() {
       final result = await service.handleOAuthCallback(uri);
 
       // then
-      expect(result, isA<AppRouteProjects>());
+      expect(result, equals(AppRouteDef.projects));
     });
   });
 
@@ -213,7 +213,7 @@ void main() {
       final result = await service.tryRestoreSession();
 
       // then
-      expect(result, isA<AppRouteProjects>());
+      expect(result, equals(AppRouteDef.projects));
       final captured = verify(() => mockConnectionService.connect(captureAny())).captured;
       expect(captured.length, equals(1));
       final config = captured.single as ServerConnectionConfig;
@@ -232,7 +232,7 @@ void main() {
       final result = await service.tryRestoreSession();
 
       // then
-      expect(result, isA<AppRouteProjects>());
+      expect(result, equals(AppRouteDef.projects));
     });
   });
 }

--- a/mobile/app/test/core/routing/deep_link_service_test.dart
+++ b/mobile/app/test/core/routing/deep_link_service_test.dart
@@ -22,7 +22,7 @@ void main() {
       controller = StreamController<Uri>.broadcast();
 
       when(() => mockDeepLinkSource.linkStream).thenAnswer((_) => controller.stream);
-      when(() => mockAuthRedirectService.handleOAuthCallback(any())).thenAnswer((_) async => AppRouteDef.projects);
+      when(() => mockAuthRedirectService.handleOAuthCallback(any())).thenAnswer((_) async => const AppRoute.projects());
 
       service = DeepLinkService(mockAuthRedirectService, mockDeepLinkSource);
     });
@@ -136,7 +136,7 @@ void main() {
 
     test("concurrent callback processing is guarded", () async {
       // given
-      final completer = Completer<AppRouteDef?>();
+      final completer = Completer<AppRoute?>();
       when(() => mockAuthRedirectService.handleOAuthCallback(any())).thenAnswer((_) => completer.future);
       service.init();
 
@@ -148,7 +148,7 @@ void main() {
       // then
       verify(() => mockAuthRedirectService.handleOAuthCallback(any())).called(1);
 
-      completer.complete(AppRouteDef.projects);
+      completer.complete(const AppRoute.projects());
       await Future<void>.delayed(Duration.zero);
     });
   });

--- a/mobile/app/test/core/routing/deep_link_service_test.dart
+++ b/mobile/app/test/core/routing/deep_link_service_test.dart
@@ -22,7 +22,7 @@ void main() {
       controller = StreamController<Uri>.broadcast();
 
       when(() => mockDeepLinkSource.linkStream).thenAnswer((_) => controller.stream);
-      when(() => mockAuthRedirectService.handleOAuthCallback(any())).thenAnswer((_) async => AppRoute.projects);
+      when(() => mockAuthRedirectService.handleOAuthCallback(any())).thenAnswer((_) async => const AppRoute.projects());
 
       service = DeepLinkService(mockAuthRedirectService, mockDeepLinkSource);
     });
@@ -148,7 +148,7 @@ void main() {
       // then
       verify(() => mockAuthRedirectService.handleOAuthCallback(any())).called(1);
 
-      completer.complete(AppRoute.projects);
+      completer.complete(const AppRoute.projects());
       await Future<void>.delayed(Duration.zero);
     });
   });

--- a/mobile/app/test/core/routing/deep_link_service_test.dart
+++ b/mobile/app/test/core/routing/deep_link_service_test.dart
@@ -22,7 +22,7 @@ void main() {
       controller = StreamController<Uri>.broadcast();
 
       when(() => mockDeepLinkSource.linkStream).thenAnswer((_) => controller.stream);
-      when(() => mockAuthRedirectService.handleOAuthCallback(any())).thenAnswer((_) async => const AppRoute.projects());
+      when(() => mockAuthRedirectService.handleOAuthCallback(any())).thenAnswer((_) async => AppRouteDef.projects);
 
       service = DeepLinkService(mockAuthRedirectService, mockDeepLinkSource);
     });
@@ -136,7 +136,7 @@ void main() {
 
     test("concurrent callback processing is guarded", () async {
       // given
-      final completer = Completer<AppRoute?>();
+      final completer = Completer<AppRouteDef?>();
       when(() => mockAuthRedirectService.handleOAuthCallback(any())).thenAnswer((_) => completer.future);
       service.init();
 
@@ -148,7 +148,7 @@ void main() {
       // then
       verify(() => mockAuthRedirectService.handleOAuthCallback(any())).called(1);
 
-      completer.complete(const AppRoute.projects());
+      completer.complete(AppRouteDef.projects);
       await Future<void>.delayed(Duration.zero);
     });
   });

--- a/mobile/app/test/helpers/test_helpers.dart
+++ b/mobile/app/test/helpers/test_helpers.dart
@@ -7,7 +7,7 @@ import "package:mocktail/mocktail.dart";
 import "package:record/record.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
-import "package:sesori_dart_core/sesori_dart_core.dart" show AppRoute, RouteSource;
+import "package:sesori_dart_core/sesori_dart_core.dart" show AppRouteDef, RouteSource;
 import "package:sesori_dart_core/src/api/client/relay_http_client.dart";
 import "package:sesori_dart_core/src/capabilities/project/project_service.dart";
 import "package:sesori_dart_core/src/capabilities/relay/relay_client.dart";
@@ -92,16 +92,16 @@ class MockLifecycleSource extends Mock implements LifecycleSource {
 class MockNotificationCanceller extends Mock implements NotificationCanceller {}
 
 class MockRouteSource extends Mock implements RouteSource {
-  final BehaviorSubject<AppRoute?> _currentRoute;
+  final BehaviorSubject<AppRouteDef?> _currentRoute;
 
-  MockRouteSource({AppRoute? initialRoute}) : _currentRoute = BehaviorSubject.seeded(initialRoute);
+  MockRouteSource({AppRouteDef? initialRoute}) : _currentRoute = BehaviorSubject.seeded(initialRoute);
 
   @override
-  ValueStream<AppRoute?> get currentRouteStream => _currentRoute.stream;
+  ValueStream<AppRouteDef?> get currentRouteStream => _currentRoute.stream;
 
-  AppRoute? get currentRoute => _currentRoute.value;
+  AppRouteDef? get currentRoute => _currentRoute.value;
 
-  void emitRoute(AppRoute? route) => _currentRoute.add(route);
+  void emitRoute(AppRouteDef? route) => _currentRoute.add(route);
 }
 
 class MockSseEventRepository extends Mock implements SseEventRepository {

--- a/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -51,7 +51,7 @@ class ProjectListCubit extends Cubit<ProjectListState> {
     _subscriptions.add(
       routeSource.currentRouteStream
           .switchMap((route) {
-            if (route is! AppRouteProjects) return const Stream<void>.empty();
+            if (route != AppRouteDef.projects) return const Stream<void>.empty();
             return _sseEventRepository.projectActivity.throttleTime(
               refreshThrottleDuration,
               trailing: true,
@@ -71,7 +71,7 @@ class ProjectListCubit extends Cubit<ProjectListState> {
       routeSource.currentRouteStream
           .distinct()
           .pairwise()
-          .where((pair) => pair.first is! AppRouteProjects && pair.last is AppRouteProjects)
+          .where((pair) => pair.first != AppRouteDef.projects && pair.last == AppRouteDef.projects)
           .listen((_) {
             if (isClosed) return;
             unawaited(refreshProjects());

--- a/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -51,7 +51,7 @@ class ProjectListCubit extends Cubit<ProjectListState> {
     _subscriptions.add(
       routeSource.currentRouteStream
           .switchMap((route) {
-            if (route != AppRoute.projects) return const Stream<void>.empty();
+            if (route is! AppRouteProjects) return const Stream<void>.empty();
             return _sseEventRepository.projectActivity.throttleTime(
               refreshThrottleDuration,
               trailing: true,
@@ -71,7 +71,7 @@ class ProjectListCubit extends Cubit<ProjectListState> {
       routeSource.currentRouteStream
           .distinct()
           .pairwise()
-          .where((pair) => pair.first != AppRoute.projects && pair.last == AppRoute.projects)
+          .where((pair) => pair.first is! AppRouteProjects && pair.last is AppRouteProjects)
           .listen((_) {
             if (isClosed) return;
             unawaited(refreshProjects());

--- a/mobile/module_core/lib/src/platform/route_source.dart
+++ b/mobile/module_core/lib/src/platform/route_source.dart
@@ -2,15 +2,16 @@ import "package:rxdart/rxdart.dart";
 
 import "../routing/app_routes.dart";
 
-/// Exposes the currently active [AppRoute] so pure-Dart code (cubits, services)
-/// can check which page is visible without depending on Flutter or GoRouter.
+/// Exposes the currently active [AppRouteDef] so pure-Dart code (cubits,
+/// services) can check which page is visible without depending on Flutter
+/// or GoRouter.
 ///
 /// The Flutter app provides a concrete implementation backed by GoRouter.
 /// See also: [LifecycleSource] for app-level lifecycle.
 abstract interface class RouteSource {
-  ValueStream<AppRoute?> get currentRouteStream;
+  ValueStream<AppRouteDef?> get currentRouteStream;
 }
 
 extension RouteSourceX on RouteSource {
-  AppRoute? get currentRoute => currentRouteStream.value;
+  AppRouteDef? get currentRoute => currentRouteStream.value;
 }

--- a/mobile/module_core/lib/src/routing/app_routes.dart
+++ b/mobile/module_core/lib/src/routing/app_routes.dart
@@ -1,20 +1,42 @@
 const bundleId = "com.sesori.app";
 const redirectUri = "$bundleId://auth/callback";
 
-/// Type-safe route definitions for the app.
+/// Path-template enum for GoRouter registration and route matching.
+///
+/// [AppRouteDef.values] is compile-time complete, so every route is
+/// guaranteed to be registered — no manual list to keep in sync.
+enum AppRouteDef {
+  login("/login"),
+  projects("/projects"),
+  notificationSettings("/settings/notifications"),
+  sessions("/projects/:projectId/sessions"),
+  newSession("/projects/:projectId/sessions/new"),
+  sessionDetail("/projects/:projectId/sessions/:sessionId"),
+  ;
+
+  const AppRouteDef(this.path);
+  final String path;
+}
+
+/// Type-safe route definitions for navigation.
 ///
 /// Each subclass carries exactly the parameters its screen needs, so
-/// navigation call sites can never forget a required param.
+/// call sites can never forget a required param.
 ///
 /// Use factory constructors for ergonomic creation:
 /// ```dart
-/// context.pushRoute(AppRoute.sessionDetail(projectId: 'p1', sessionId: 's1'));
+/// context.pushRoute(AppRoute.sessionDetail(
+///   projectId: 'p1',
+///   sessionId: 's1',
+///   sessionTitle: null,
+///   readOnly: false,
+/// ));
 /// ```
 sealed class AppRoute {
   const AppRoute();
 
-  /// Path template with `:param` placeholders (used for GoRouter registration).
-  String get path;
+  /// The matching [AppRouteDef] for this route.
+  AppRouteDef get def;
 
   /// Builds a concrete URI string from this route's parameters.
   ///
@@ -25,71 +47,99 @@ sealed class AppRoute {
   const factory AppRoute.login() = AppRouteLogin;
   const factory AppRoute.projects() = AppRouteProjects;
   const factory AppRoute.notificationSettings() = AppRouteNotificationSettings;
-  const factory AppRoute.sessions({required String projectId, String? projectName}) = AppRouteSessions;
+  const factory AppRoute.sessions({
+    required String projectId,
+    required String? projectName,
+  }) = AppRouteSessions;
   const factory AppRoute.newSession({required String projectId}) = AppRouteNewSession;
   const factory AppRoute.sessionDetail({
     required String projectId,
     required String sessionId,
-    String? sessionTitle,
-    bool readOnly,
+    required String? sessionTitle,
+    required bool readOnly,
   }) = AppRouteSessionDetail;
 
-  /// One instance per route type — used for GoRouter registration and route
-  /// matching. Parameter values are irrelevant; only [path] templates matter.
-  static const values = <AppRoute>[
-    AppRouteLogin(),
-    AppRouteProjects(),
-    AppRouteNotificationSettings(),
-    AppRouteSessions(projectId: ""),
-    AppRouteNewSession(projectId: ""),
-    AppRouteSessionDetail(projectId: "", sessionId: ""),
-  ];
+  /// Creates the correct subclass by decoding path/query params for [def].
+  ///
+  /// This is the inverse of [buildPath] — encoding and decoding are
+  /// co-located in each subclass so they cannot fall out of sync.
+  static AppRoute fromDef({
+    required AppRouteDef def,
+    required Map<String, String> pathParams,
+    required Map<String, String> queryParams,
+  }) {
+    return switch (def) {
+      AppRouteDef.login => const AppRoute.login(),
+      AppRouteDef.projects => const AppRoute.projects(),
+      AppRouteDef.notificationSettings => const AppRoute.notificationSettings(),
+      AppRouteDef.sessions => AppRouteSessions.fromParams(pathParams: pathParams, queryParams: queryParams),
+      AppRouteDef.newSession => AppRouteNewSession.fromParams(pathParams: pathParams, queryParams: queryParams),
+      AppRouteDef.sessionDetail => AppRouteSessionDetail.fromParams(
+        pathParams: pathParams,
+        queryParams: queryParams,
+      ),
+    };
+  }
 }
 
 class AppRouteLogin extends AppRoute {
   const AppRouteLogin();
 
   @override
-  String get path => "/login";
+  AppRouteDef get def => AppRouteDef.login;
 
   @override
-  String buildPath() => path;
+  String buildPath() => def.path;
 }
 
 class AppRouteProjects extends AppRoute {
   const AppRouteProjects();
 
   @override
-  String get path => "/projects";
+  AppRouteDef get def => AppRouteDef.projects;
 
   @override
-  String buildPath() => path;
+  String buildPath() => def.path;
 }
 
 class AppRouteNotificationSettings extends AppRoute {
   const AppRouteNotificationSettings();
 
   @override
-  String get path => "/settings/notifications";
+  AppRouteDef get def => AppRouteDef.notificationSettings;
 
   @override
-  String buildPath() => path;
+  String buildPath() => def.path;
 }
 
 class AppRouteSessions extends AppRoute {
   final String projectId;
   final String? projectName;
 
-  const AppRouteSessions({required this.projectId, this.projectName});
+  const AppRouteSessions({required this.projectId, required this.projectName});
+
+  /// Decodes from path/query parameter maps (inverse of [buildPath]).
+  factory AppRouteSessions.fromParams({
+    required Map<String, String> pathParams,
+    required Map<String, String> queryParams,
+  }) {
+    return AppRouteSessions(
+      projectId: pathParams["projectId"] ?? "",
+      projectName: queryParams["name"],
+    );
+  }
 
   @override
-  String get path => "/projects/:projectId/sessions";
+  AppRouteDef get def => AppRouteDef.sessions;
 
   @override
   String buildPath() {
     final base = "/projects/${Uri.encodeComponent(projectId)}/sessions";
-    if (projectName != null) {
-      return Uri(path: base, queryParameters: {"name": projectName}).toString();
+    final queryParams = <String, String>{
+      "name": ?projectName,
+    };
+    if (queryParams.isNotEmpty) {
+      return Uri(path: base, queryParameters: queryParams).toString();
     }
     return base;
   }
@@ -100,8 +150,17 @@ class AppRouteNewSession extends AppRoute {
 
   const AppRouteNewSession({required this.projectId});
 
+  /// Decodes from path/query parameter maps (inverse of [buildPath]).
+  factory AppRouteNewSession.fromParams({
+    required Map<String, String> pathParams,
+    // ignore: avoid_unused_constructor_parameters — uniform fromParams signature
+    required Map<String, String> queryParams,
+  }) {
+    return AppRouteNewSession(projectId: pathParams["projectId"] ?? "");
+  }
+
   @override
-  String get path => "/projects/:projectId/sessions/new";
+  AppRouteDef get def => AppRouteDef.newSession;
 
   @override
   String buildPath() => "/projects/${Uri.encodeComponent(projectId)}/sessions/new";
@@ -116,22 +175,33 @@ class AppRouteSessionDetail extends AppRoute {
   const AppRouteSessionDetail({
     required this.projectId,
     required this.sessionId,
-    this.sessionTitle,
-    this.readOnly = false,
+    required this.sessionTitle,
+    required this.readOnly,
   });
 
+  /// Decodes from path/query parameter maps (inverse of [buildPath]).
+  factory AppRouteSessionDetail.fromParams({
+    required Map<String, String> pathParams,
+    required Map<String, String> queryParams,
+  }) {
+    return AppRouteSessionDetail(
+      projectId: pathParams["projectId"] ?? "",
+      sessionId: pathParams["sessionId"] ?? "",
+      sessionTitle: queryParams["title"],
+      readOnly: queryParams["readOnly"] == "true",
+    );
+  }
+
   @override
-  String get path => "/projects/:projectId/sessions/:sessionId";
+  AppRouteDef get def => AppRouteDef.sessionDetail;
 
   @override
   String buildPath() {
     final base = "/projects/${Uri.encodeComponent(projectId)}/sessions/${Uri.encodeComponent(sessionId)}";
-    final queryParams = <String, String>{};
-    if (sessionTitle != null) queryParams["title"] = sessionTitle!;
-    if (readOnly) queryParams["readOnly"] = "true";
-    if (queryParams.isNotEmpty) {
-      return Uri(path: base, queryParameters: queryParams).toString();
-    }
-    return base;
+    final queryParams = <String, String>{
+      "readOnly": readOnly.toString(),
+      "title": ?sessionTitle,
+    };
+    return Uri(path: base, queryParameters: queryParams).toString();
   }
 }

--- a/mobile/module_core/lib/src/routing/app_routes.dart
+++ b/mobile/module_core/lib/src/routing/app_routes.dart
@@ -1,35 +1,137 @@
 const bundleId = "com.sesori.app";
 const redirectUri = "$bundleId://auth/callback";
 
-enum AppRoute {
-  login("/login"),
-  projects("/projects"),
-  notificationSettings("/settings/notifications"),
-  sessions("/projects/:projectId/sessions"),
-  newSession("/projects/:projectId/sessions/new"),
-  sessionDetail("/projects/:projectId/sessions/:sessionId")
-  ;
+/// Type-safe route definitions for the app.
+///
+/// Each subclass carries exactly the parameters its screen needs, so
+/// navigation call sites can never forget a required param.
+///
+/// Use factory constructors for ergonomic creation:
+/// ```dart
+/// context.pushRoute(AppRoute.sessionDetail(projectId: 'p1', sessionId: 's1'));
+/// ```
+sealed class AppRoute {
+  const AppRoute();
 
-  const AppRoute(this.path);
-  final String path;
+  /// Path template with `:param` placeholders (used for GoRouter registration).
+  String get path;
 
-  /// Builds a concrete URI string from this route's path template.
+  /// Builds a concrete URI string from this route's parameters.
   ///
-  /// Substitutes [pathParams] into `:param` placeholders and appends
-  /// [queryParams] as a query string (values are automatically encoded).
-  String buildPath({
-    Map<String, String>? pathParams,
-    Map<String, String>? queryParams,
-  }) {
-    var result = path;
-    if (pathParams != null) {
-      for (final entry in pathParams.entries) {
-        result = result.replaceFirst(":${entry.key}", Uri.encodeComponent(entry.value));
-      }
+  /// Path parameters are percent-encoded. Query parameters (when present)
+  /// are appended and encoded via [Uri].
+  String buildPath();
+
+  const factory AppRoute.login() = AppRouteLogin;
+  const factory AppRoute.projects() = AppRouteProjects;
+  const factory AppRoute.notificationSettings() = AppRouteNotificationSettings;
+  const factory AppRoute.sessions({required String projectId, String? projectName}) = AppRouteSessions;
+  const factory AppRoute.newSession({required String projectId}) = AppRouteNewSession;
+  const factory AppRoute.sessionDetail({
+    required String projectId,
+    required String sessionId,
+    String? sessionTitle,
+    bool readOnly,
+  }) = AppRouteSessionDetail;
+
+  /// One instance per route type — used for GoRouter registration and route
+  /// matching. Parameter values are irrelevant; only [path] templates matter.
+  static const values = <AppRoute>[
+    AppRouteLogin(),
+    AppRouteProjects(),
+    AppRouteNotificationSettings(),
+    AppRouteSessions(projectId: ""),
+    AppRouteNewSession(projectId: ""),
+    AppRouteSessionDetail(projectId: "", sessionId: ""),
+  ];
+}
+
+class AppRouteLogin extends AppRoute {
+  const AppRouteLogin();
+
+  @override
+  String get path => "/login";
+
+  @override
+  String buildPath() => path;
+}
+
+class AppRouteProjects extends AppRoute {
+  const AppRouteProjects();
+
+  @override
+  String get path => "/projects";
+
+  @override
+  String buildPath() => path;
+}
+
+class AppRouteNotificationSettings extends AppRoute {
+  const AppRouteNotificationSettings();
+
+  @override
+  String get path => "/settings/notifications";
+
+  @override
+  String buildPath() => path;
+}
+
+class AppRouteSessions extends AppRoute {
+  final String projectId;
+  final String? projectName;
+
+  const AppRouteSessions({required this.projectId, this.projectName});
+
+  @override
+  String get path => "/projects/:projectId/sessions";
+
+  @override
+  String buildPath() {
+    final base = "/projects/${Uri.encodeComponent(projectId)}/sessions";
+    if (projectName != null) {
+      return Uri(path: base, queryParameters: {"name": projectName}).toString();
     }
-    if (queryParams != null && queryParams.isNotEmpty) {
-      return Uri(path: result, queryParameters: queryParams).toString();
+    return base;
+  }
+}
+
+class AppRouteNewSession extends AppRoute {
+  final String projectId;
+
+  const AppRouteNewSession({required this.projectId});
+
+  @override
+  String get path => "/projects/:projectId/sessions/new";
+
+  @override
+  String buildPath() => "/projects/${Uri.encodeComponent(projectId)}/sessions/new";
+}
+
+class AppRouteSessionDetail extends AppRoute {
+  final String projectId;
+  final String sessionId;
+  final String? sessionTitle;
+  final bool readOnly;
+
+  const AppRouteSessionDetail({
+    required this.projectId,
+    required this.sessionId,
+    this.sessionTitle,
+    this.readOnly = false,
+  });
+
+  @override
+  String get path => "/projects/:projectId/sessions/:sessionId";
+
+  @override
+  String buildPath() {
+    final base = "/projects/${Uri.encodeComponent(projectId)}/sessions/${Uri.encodeComponent(sessionId)}";
+    final queryParams = <String, String>{};
+    if (sessionTitle != null) queryParams["title"] = sessionTitle!;
+    if (readOnly) queryParams["readOnly"] = "true";
+    if (queryParams.isNotEmpty) {
+      return Uri(path: base, queryParameters: queryParams).toString();
     }
-    return result;
+    return base;
   }
 }

--- a/mobile/module_core/lib/src/routing/app_routes.dart
+++ b/mobile/module_core/lib/src/routing/app_routes.dart
@@ -113,6 +113,9 @@ class AppRouteNotificationSettings extends AppRoute {
 }
 
 class AppRouteSessions extends AppRoute {
+  static const _projectIdPathParam = "projectId";
+  static const _nameQueryParam = "name";
+
   final String projectId;
   final String? projectName;
 
@@ -124,8 +127,8 @@ class AppRouteSessions extends AppRoute {
     required Map<String, String> queryParams,
   }) {
     return AppRouteSessions(
-      projectId: pathParams["projectId"] ?? "",
-      projectName: queryParams["name"],
+      projectId: pathParams[_projectIdPathParam] ?? "",
+      projectName: queryParams[_nameQueryParam],
     );
   }
 
@@ -136,7 +139,7 @@ class AppRouteSessions extends AppRoute {
   String buildPath() {
     final base = "/projects/${Uri.encodeComponent(projectId)}/sessions";
     final queryParams = <String, String>{
-      "name": ?projectName,
+      _nameQueryParam: ?projectName,
     };
     if (queryParams.isNotEmpty) {
       return Uri(path: base, queryParameters: queryParams).toString();
@@ -146,6 +149,8 @@ class AppRouteSessions extends AppRoute {
 }
 
 class AppRouteNewSession extends AppRoute {
+  static const _projectIdPathParam = "projectId";
+
   final String projectId;
 
   const AppRouteNewSession({required this.projectId});
@@ -156,7 +161,7 @@ class AppRouteNewSession extends AppRoute {
     // ignore: avoid_unused_constructor_parameters — uniform fromParams signature
     required Map<String, String> queryParams,
   }) {
-    return AppRouteNewSession(projectId: pathParams["projectId"] ?? "");
+    return AppRouteNewSession(projectId: pathParams[_projectIdPathParam] ?? "");
   }
 
   @override
@@ -167,6 +172,11 @@ class AppRouteNewSession extends AppRoute {
 }
 
 class AppRouteSessionDetail extends AppRoute {
+  static const _projectIdPathParam = "projectId";
+  static const _sessionIdPathParam = "sessionId";
+  static const _titleQueryParam = "title";
+  static const _readOnlyQueryParam = "readOnly";
+
   final String projectId;
   final String sessionId;
   final String? sessionTitle;
@@ -185,10 +195,10 @@ class AppRouteSessionDetail extends AppRoute {
     required Map<String, String> queryParams,
   }) {
     return AppRouteSessionDetail(
-      projectId: pathParams["projectId"] ?? "",
-      sessionId: pathParams["sessionId"] ?? "",
-      sessionTitle: queryParams["title"],
-      readOnly: queryParams["readOnly"] == "true",
+      projectId: pathParams[_projectIdPathParam] ?? "",
+      sessionId: pathParams[_sessionIdPathParam] ?? "",
+      sessionTitle: queryParams[_titleQueryParam],
+      readOnly: queryParams[_readOnlyQueryParam] == "true",
     );
   }
 
@@ -199,8 +209,8 @@ class AppRouteSessionDetail extends AppRoute {
   String buildPath() {
     final base = "/projects/${Uri.encodeComponent(projectId)}/sessions/${Uri.encodeComponent(sessionId)}";
     final queryParams = <String, String>{
-      "readOnly": readOnly.toString(),
-      "title": ?sessionTitle,
+      _readOnlyQueryParam: readOnly.toString(),
+      _titleQueryParam: ?sessionTitle,
     };
     return Uri(path: base, queryParameters: queryParams).toString();
   }

--- a/mobile/module_core/lib/src/routing/auth_redirect_service.dart
+++ b/mobile/module_core/lib/src/routing/auth_redirect_service.dart
@@ -30,14 +30,14 @@ class AuthRedirectService {
 
   /// Exchanges an OAuth authorization code from a deep link callback
   /// and returns the route to navigate to.
-  Future<AppRouteDef?> handleOAuthCallback(Uri uri) async {
+  Future<AppRoute?> handleOAuthCallback(Uri uri) async {
     try {
       final code = uri.queryParameters["code"];
       final callbackState = uri.queryParameters["state"];
 
       if (code == null || callbackState == null || code.isEmpty || callbackState.isEmpty) {
         loge("OAuth callback missing code or state params");
-        return AppRouteDef.login;
+        return const AppRoute.login();
       }
 
       logd("Exchanging OAuth code for tokens");
@@ -46,21 +46,21 @@ class AuthRedirectService {
       await _autoConnectToRelay();
 
       logd("Login successful — navigating to projects");
-      return AppRouteDef.projects;
+      return const AppRoute.projects();
     } catch (e, st) {
       loge("OAuth code exchange failed", e, st);
-      return AppRouteDef.login;
+      return const AppRoute.login();
     }
   }
 
   /// Checks for stored tokens and tries to restore a previous session,
-  /// returning [AppRouteDef.projects] to skip login if successful.
-  Future<AppRouteDef?> tryRestoreSession() async {
+  /// returning [AppRoute.projects] to skip login if successful.
+  Future<AppRoute?> tryRestoreSession() async {
     final restored = await _authSession.restoreSession();
     if (restored) {
       logd("Session restored — auto-connecting to relay");
       await _autoConnectToRelay();
-      return AppRouteDef.projects;
+      return const AppRoute.projects();
     }
 
     return null;

--- a/mobile/module_core/lib/src/routing/auth_redirect_service.dart
+++ b/mobile/module_core/lib/src/routing/auth_redirect_service.dart
@@ -30,14 +30,14 @@ class AuthRedirectService {
 
   /// Exchanges an OAuth authorization code from a deep link callback
   /// and returns the route to navigate to.
-  Future<AppRoute?> handleOAuthCallback(Uri uri) async {
+  Future<AppRouteDef?> handleOAuthCallback(Uri uri) async {
     try {
       final code = uri.queryParameters["code"];
       final callbackState = uri.queryParameters["state"];
 
       if (code == null || callbackState == null || code.isEmpty || callbackState.isEmpty) {
         loge("OAuth callback missing code or state params");
-        return const AppRoute.login();
+        return AppRouteDef.login;
       }
 
       logd("Exchanging OAuth code for tokens");
@@ -46,21 +46,21 @@ class AuthRedirectService {
       await _autoConnectToRelay();
 
       logd("Login successful — navigating to projects");
-      return const AppRoute.projects();
+      return AppRouteDef.projects;
     } catch (e, st) {
       loge("OAuth code exchange failed", e, st);
-      return const AppRoute.login();
+      return AppRouteDef.login;
     }
   }
 
   /// Checks for stored tokens and tries to restore a previous session,
-  /// returning [AppRoute.projects] to skip login if successful.
-  Future<AppRoute?> tryRestoreSession() async {
+  /// returning [AppRouteDef.projects] to skip login if successful.
+  Future<AppRouteDef?> tryRestoreSession() async {
     final restored = await _authSession.restoreSession();
     if (restored) {
       logd("Session restored — auto-connecting to relay");
       await _autoConnectToRelay();
-      return const AppRoute.projects();
+      return AppRouteDef.projects;
     }
 
     return null;

--- a/mobile/module_core/lib/src/routing/auth_redirect_service.dart
+++ b/mobile/module_core/lib/src/routing/auth_redirect_service.dart
@@ -37,7 +37,7 @@ class AuthRedirectService {
 
       if (code == null || callbackState == null || code.isEmpty || callbackState.isEmpty) {
         loge("OAuth callback missing code or state params");
-        return AppRoute.login;
+        return const AppRoute.login();
       }
 
       logd("Exchanging OAuth code for tokens");
@@ -46,10 +46,10 @@ class AuthRedirectService {
       await _autoConnectToRelay();
 
       logd("Login successful — navigating to projects");
-      return AppRoute.projects;
+      return const AppRoute.projects();
     } catch (e, st) {
       loge("OAuth code exchange failed", e, st);
-      return AppRoute.login;
+      return const AppRoute.login();
     }
   }
 
@@ -60,7 +60,7 @@ class AuthRedirectService {
     if (restored) {
       logd("Session restored — auto-connecting to relay");
       await _autoConnectToRelay();
-      return AppRoute.projects;
+      return const AppRoute.projects();
     }
 
     return null;

--- a/mobile/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/mobile/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -551,7 +551,7 @@ void main() {
             fetchCount++;
             return ApiResponse.success([testProject()]);
           });
-          mockRouteSource.emitRoute(AppRoute.projects);
+          mockRouteSource.emitRoute(const AppRoute.projects());
           final cubit = buildCubit();
           async.elapse(Duration.zero);
           final baseline = fetchCount;
@@ -573,7 +573,7 @@ void main() {
             fetchCount++;
             return ApiResponse.success([testProject()]);
           });
-          mockRouteSource.emitRoute(AppRoute.projects);
+          mockRouteSource.emitRoute(const AppRoute.projects());
           final cubit = buildCubit();
           async.elapse(Duration.zero);
           final baseline = fetchCount;
@@ -617,16 +617,16 @@ void main() {
             return ApiResponse.success([testProject()]);
           });
           // Start on projects, navigate away, navigate back.
-          mockRouteSource.emitRoute(AppRoute.projects);
+          mockRouteSource.emitRoute(const AppRoute.projects());
           final cubit = buildCubit();
           async.elapse(Duration.zero);
           final baseline = fetchCount;
 
-          mockRouteSource.emitRoute(AppRoute.sessions);
+          mockRouteSource.emitRoute(const AppRoute.sessions(projectId: "p1"));
           async.elapse(Duration.zero);
           expect(fetchCount, baseline, reason: "no fetch on navigate away");
 
-          mockRouteSource.emitRoute(AppRoute.projects);
+          mockRouteSource.emitRoute(const AppRoute.projects());
           async.elapse(Duration.zero);
           expect(fetchCount, baseline + 1, reason: "immediate refresh on navigate back");
           cubit.close();
@@ -640,7 +640,7 @@ void main() {
             fetchCount++;
             return ApiResponse.success([testProject()]);
           });
-          mockRouteSource.emitRoute(AppRoute.projects);
+          mockRouteSource.emitRoute(const AppRoute.projects());
           final cubit = buildCubit();
           async.elapse(Duration.zero);
           final baseline = fetchCount;

--- a/mobile/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/mobile/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -5,7 +5,7 @@ import "package:fake_async/fake_async.dart";
 import "package:mocktail/mocktail.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
-import "package:sesori_dart_core/sesori_dart_core.dart" show AppRoute;
+import "package:sesori_dart_core/sesori_dart_core.dart" show AppRouteDef;
 import "package:sesori_dart_core/src/capabilities/server_connection/models/connection_status.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/server_connection_config.dart";
 import "package:sesori_dart_core/src/cubits/project_list/project_list_cubit.dart";
@@ -551,7 +551,7 @@ void main() {
             fetchCount++;
             return ApiResponse.success([testProject()]);
           });
-          mockRouteSource.emitRoute(const AppRoute.projects());
+          mockRouteSource.emitRoute(AppRouteDef.projects);
           final cubit = buildCubit();
           async.elapse(Duration.zero);
           final baseline = fetchCount;
@@ -573,7 +573,7 @@ void main() {
             fetchCount++;
             return ApiResponse.success([testProject()]);
           });
-          mockRouteSource.emitRoute(const AppRoute.projects());
+          mockRouteSource.emitRoute(AppRouteDef.projects);
           final cubit = buildCubit();
           async.elapse(Duration.zero);
           final baseline = fetchCount;
@@ -617,16 +617,16 @@ void main() {
             return ApiResponse.success([testProject()]);
           });
           // Start on projects, navigate away, navigate back.
-          mockRouteSource.emitRoute(const AppRoute.projects());
+          mockRouteSource.emitRoute(AppRouteDef.projects);
           final cubit = buildCubit();
           async.elapse(Duration.zero);
           final baseline = fetchCount;
 
-          mockRouteSource.emitRoute(const AppRoute.sessions(projectId: "p1"));
+          mockRouteSource.emitRoute(AppRouteDef.sessions);
           async.elapse(Duration.zero);
           expect(fetchCount, baseline, reason: "no fetch on navigate away");
 
-          mockRouteSource.emitRoute(const AppRoute.projects());
+          mockRouteSource.emitRoute(AppRouteDef.projects);
           async.elapse(Duration.zero);
           expect(fetchCount, baseline + 1, reason: "immediate refresh on navigate back");
           cubit.close();
@@ -640,7 +640,7 @@ void main() {
             fetchCount++;
             return ApiResponse.success([testProject()]);
           });
-          mockRouteSource.emitRoute(const AppRoute.projects());
+          mockRouteSource.emitRoute(AppRouteDef.projects);
           final cubit = buildCubit();
           async.elapse(Duration.zero);
           final baseline = fetchCount;

--- a/mobile/module_core/test/helpers/test_helpers.dart
+++ b/mobile/module_core/test/helpers/test_helpers.dart
@@ -28,16 +28,16 @@ class MockConnectionService extends Mock implements ConnectionService {
 }
 
 class MockRouteSource extends Mock implements RouteSource {
-  final BehaviorSubject<AppRoute?> _currentRoute;
+  final BehaviorSubject<AppRouteDef?> _currentRoute;
 
-  MockRouteSource({AppRoute? initialRoute}) : _currentRoute = BehaviorSubject.seeded(initialRoute);
+  MockRouteSource({AppRouteDef? initialRoute}) : _currentRoute = BehaviorSubject.seeded(initialRoute);
 
   @override
-  ValueStream<AppRoute?> get currentRouteStream => _currentRoute.stream;
+  ValueStream<AppRouteDef?> get currentRouteStream => _currentRoute.stream;
 
-  AppRoute? get currentRoute => _currentRoute.value;
+  AppRouteDef? get currentRoute => _currentRoute.value;
 
-  void emitRoute(AppRoute? route) => _currentRoute.add(route);
+  void emitRoute(AppRouteDef? route) => _currentRoute.add(route);
 }
 
 class MockSseEventRepository extends Mock implements SseEventRepository {


### PR DESCRIPTION
## Summary

- Replaces the `AppRoute` enum with a sealed class hierarchy where each route subclass defines its required parameters as constructor arguments
- Navigation extensions (`goRoute`, `pushRoute`) now take an `AppRoute` instance directly — no more `Map<String, String>` params that could silently miss required keys
- Route comparisons in cubits use idiomatic `is` checks instead of enum equality

## Before

```dart
context.pushRoute(
  AppRoute.sessionDetail,
  pathParams: {"projectId": session.projectID, "sessionId": session.id},
  queryParams: {"title": session.title ?? ""},
);
```

## After

```dart
context.pushRoute(
  AppRoute.sessionDetail(
    projectId: session.projectID,
    sessionId: session.id,
    sessionTitle: session.title ?? "",
  ),
);
```

Compile-time enforcement — forgetting `sessionId` is now a type error, not a silent runtime bug.

## Files changed (16)

- **`module_core/.../app_routes.dart`** — sealed class + 6 subclasses with factory constructors
- **`app/.../app_router.dart`** — simplified extensions, exhaustive switch on sealed subtypes
- **`app/.../go_router_route_source.dart`** — route matching unchanged (uses `path` templates)
- **`module_core/.../auth_redirect_service.dart`** — returns `const AppRoute.login()` / `const AppRoute.projects()`
- **`module_core/.../project_list_cubit.dart`** — `is AppRouteProjects` instead of `== AppRoute.projects`
- **6 screen files** — all navigation calls use typed constructors
- **`app/.../notification_service.dart`** — builds paths from sealed class instances
- **4 test files** — updated for new API