### PR TITLE
feat(mobile): add agent/model selection to new session screen

### DIFF
--- a/mobile/app/lib/core/widgets/agent_model_buttons.dart
+++ b/mobile/app/lib/core/widgets/agent_model_buttons.dart
@@ -1,0 +1,84 @@
+import "package:flutter/material.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../../l10n/app_localizations.dart";
+import "../extensions/build_context_x.dart";
+
+class AgentModelButtons extends StatelessWidget {
+  final List<ProviderInfo> providers;
+  final String selectedAgent;
+  final String selectedProviderID;
+  final String selectedModelID;
+  final VoidCallback onAgentTap;
+  final VoidCallback onModelTap;
+
+  const AgentModelButtons({
+    super.key,
+    required this.providers,
+    required this.selectedAgent,
+    required this.selectedProviderID,
+    required this.selectedModelID,
+    required this.onAgentTap,
+    required this.onModelTap,
+  });
+
+  String _resolveModelName(AppLocalizations loc) {
+    for (final provider in providers) {
+      if (provider.id == selectedProviderID) {
+        final model = provider.models[selectedModelID];
+        if (model != null) return model.name;
+      }
+    }
+    if (selectedModelID.isNotEmpty) return selectedModelID;
+    return loc.sessionDetailPickerModel;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final loc = context.loc;
+    final buttonStyle = OutlinedButton.styleFrom(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      minimumSize: .zero,
+      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      textStyle: theme.textTheme.labelSmall,
+      side: BorderSide(color: theme.colorScheme.outlineVariant),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+    );
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 6, 12, 2),
+      child: Row(
+        children: [
+          Flexible(
+            child: OutlinedButton.icon(
+              onPressed: onAgentTap,
+              icon: Icon(Icons.smart_toy_outlined, size: 14, color: theme.colorScheme.onSurfaceVariant),
+              label: Text(
+                selectedAgent,
+                style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+                overflow: .ellipsis,
+                maxLines: 1,
+              ),
+              style: buttonStyle,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Flexible(
+            child: OutlinedButton.icon(
+              onPressed: onModelTap,
+              icon: Icon(Icons.memory_outlined, size: 14, color: theme.colorScheme.onSurfaceVariant),
+              label: Text(
+                _resolveModelName(loc),
+                style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+                overflow: .ellipsis,
+                maxLines: 1,
+              ),
+              style: buttonStyle,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/app/lib/core/widgets/agent_picker_sheet.dart
+++ b/mobile/app/lib/core/widgets/agent_picker_sheet.dart
@@ -1,7 +1,8 @@
 import "package:flutter/material.dart";
 import "package:sesori_shared/sesori_shared.dart";
-import "../../../core/extensions/build_context_x.dart";
-import "../../../core/widgets/app_modal_bottom_sheet.dart";
+
+import "../extensions/build_context_x.dart";
+import "app_modal_bottom_sheet.dart";
 
 /// Bottom sheet for selecting an agent.
 ///

--- a/mobile/app/lib/core/widgets/model_picker_sheet.dart
+++ b/mobile/app/lib/core/widgets/model_picker_sheet.dart
@@ -1,7 +1,8 @@
 import "package:flutter/material.dart";
 import "package:sesori_shared/sesori_shared.dart";
-import "../../../core/extensions/build_context_x.dart";
-import "../../../core/widgets/app_modal_bottom_sheet.dart";
+
+import "../extensions/build_context_x.dart";
+import "app_modal_bottom_sheet.dart";
 
 /// Bottom sheet for selecting a model, grouped by provider.
 ///

--- a/mobile/app/lib/features/new_session/new_session_screen.dart
+++ b/mobile/app/lib/features/new_session/new_session_screen.dart
@@ -5,6 +5,9 @@ import "package:sesori_dart_core/sesori_dart_core.dart";
 import "../../core/di/injection.dart";
 import "../../core/extensions/build_context_x.dart";
 import "../../core/routing/app_router.dart";
+import "../../core/widgets/agent_model_buttons.dart";
+import "../../core/widgets/agent_picker_sheet.dart";
+import "../../core/widgets/model_picker_sheet.dart";
 import "../session_detail/widgets/prompt_input.dart";
 
 class NewSessionScreen extends StatelessWidget {
@@ -36,6 +39,65 @@ class _NewSessionBody extends StatefulWidget {
 
 class _NewSessionBodyState extends State<_NewSessionBody> {
   bool _dedicatedWorktree = true;
+
+  void _openAgentPicker(AgentModelData data) {
+    final cubit = context.read<NewSessionCubit>();
+    AgentPickerSheet.show(
+      context,
+      agents: data.agents,
+      selectedAgent: data.agent ?? "",
+      onAgentChanged: cubit.selectAgent,
+    );
+  }
+
+  void _openModelPicker(AgentModelData data) {
+    final cubit = context.read<NewSessionCubit>();
+    ModelPickerSheet.show(
+      context,
+      providers: data.providers,
+      selectedProviderID: data.providerID ?? "",
+      selectedModelID: data.modelID ?? "",
+      onModelChanged: cubit.selectModel,
+    );
+  }
+
+  Widget? _buildHeader(NewSessionState state) {
+    final data = state.agentModelData;
+    final agentButtons = data != null && data.agents.isNotEmpty && data.agent != null
+        ? AgentModelButtons(
+            providers: data.providers,
+            selectedAgent: data.agent!,
+            selectedProviderID: data.providerID ?? "",
+            selectedModelID: data.modelID ?? "",
+            onAgentTap: () => _openAgentPicker(data),
+            onModelTap: () => _openModelPicker(data),
+          )
+        : null;
+
+    final errorBanner = switch (state) {
+      NewSessionError(:final message) => Padding(
+        padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                message,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ),
+          ],
+        ),
+      ),
+      _ => null,
+    };
+
+    if (agentButtons == null && errorBanner == null) return null;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [agentButtons, errorBanner].whereType<Widget>().toList(),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -87,28 +149,11 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
               onSend: (text) {
                 context.read<NewSessionCubit>().createSessionWithMessage(
                   text: text,
-                  agent: null,
-                  model: null,
                   dedicatedWorktree: _dedicatedWorktree,
                 );
               },
               onAbort: () => Navigator.of(context).pop(),
-              header: switch (state) {
-                NewSessionError(:final message) => Padding(
-                  padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: Text(
-                          message,
-                          style: TextStyle(color: Theme.of(context).colorScheme.error),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                _ => null,
-              },
+              header: _buildHeader(state),
             ),
           ],
         ),

--- a/mobile/app/lib/features/session_detail/session_detail_screen.dart
+++ b/mobile/app/lib/features/session_detail/session_detail_screen.dart
@@ -8,11 +8,12 @@ import "package:sesori_shared/sesori_shared.dart";
 import "../../core/constants.dart";
 import "../../core/di/injection.dart";
 import "../../core/extensions/build_context_x.dart";
+import "../../core/widgets/agent_model_buttons.dart";
+import "../../core/widgets/agent_picker_sheet.dart";
+import "../../core/widgets/model_picker_sheet.dart";
 import "../../l10n/app_localizations.dart";
-import "widgets/agent_picker_sheet.dart";
 import "widgets/assistant_message_card.dart";
 import "widgets/background_tasks_bar.dart";
-import "widgets/model_picker_sheet.dart";
 import "widgets/prompt_input.dart";
 import "widgets/question_modal.dart";
 import "widgets/queued_message_bubble.dart";
@@ -275,7 +276,7 @@ class _SessionDetailBodyState extends State<_SessionDetailBody> {
                   isBusy: sessionStatus is! SessionStatusIdle,
                   onSend: (text) => context.read<SessionDetailCubit>().sendMessage(text),
                   onAbort: () => context.read<SessionDetailCubit>().abort(),
-                  header: _AgentModelButtons(
+                  header: AgentModelButtons(
                     providers: availableProviders,
                     selectedAgent: selectedAgent,
                     selectedProviderID: selectedProviderID,
@@ -561,88 +562,6 @@ class _ErrorView extends StatelessWidget {
 // -----------------------------------------------------------------------------
 // Queued messages section
 // -----------------------------------------------------------------------------
-
-// -----------------------------------------------------------------------------
-// Agent + Model selection buttons (above prompt input)
-// -----------------------------------------------------------------------------
-
-class _AgentModelButtons extends StatelessWidget {
-  final List<ProviderInfo> providers;
-  final String selectedAgent;
-  final String selectedProviderID;
-  final String selectedModelID;
-  final VoidCallback onAgentTap;
-  final VoidCallback onModelTap;
-
-  const _AgentModelButtons({
-    required this.providers,
-    required this.selectedAgent,
-    required this.selectedProviderID,
-    required this.selectedModelID,
-    required this.onAgentTap,
-    required this.onModelTap,
-  });
-
-  String _resolveModelName(AppLocalizations loc) {
-    for (final provider in providers) {
-      if (provider.id == selectedProviderID) {
-        final model = provider.models[selectedModelID];
-        if (model != null) return model.name;
-      }
-    }
-    if (selectedModelID.isNotEmpty) return selectedModelID;
-    return loc.sessionDetailPickerModel;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final loc = context.loc;
-    final buttonStyle = OutlinedButton.styleFrom(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-      minimumSize: .zero,
-      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-      textStyle: theme.textTheme.labelSmall,
-      side: BorderSide(color: theme.colorScheme.outlineVariant),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-    );
-
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(12, 6, 12, 2),
-      child: Row(
-        children: [
-          Flexible(
-            child: OutlinedButton.icon(
-              onPressed: onAgentTap,
-              icon: Icon(Icons.smart_toy_outlined, size: 14, color: theme.colorScheme.onSurfaceVariant),
-              label: Text(
-                selectedAgent,
-                style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
-                overflow: .ellipsis,
-                maxLines: 1,
-              ),
-              style: buttonStyle,
-            ),
-          ),
-          const SizedBox(width: 8),
-          Flexible(
-            child: OutlinedButton.icon(
-              onPressed: onModelTap,
-              icon: Icon(Icons.memory_outlined, size: 14, color: theme.colorScheme.onSurfaceVariant),
-              label: Text(
-                _resolveModelName(loc),
-                style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
-                overflow: .ellipsis,
-                maxLines: 1,
-              ),
-              style: buttonStyle,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
 
 class _QueuedMessagesSection extends StatelessWidget {
   final List<String> messages;

--- a/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
@@ -14,12 +14,117 @@ class NewSessionCubit extends Cubit<NewSessionState> {
     required String projectId,
   }) : _sessionService = sessionService,
        _projectId = projectId,
-       super(const NewSessionState.idle());
+       super(const NewSessionState.idle()) {
+    _loadAgentModelData();
+  }
+
+  Future<void> _loadAgentModelData() async {
+    try {
+      final (agentsResponse, providersResponse) = await (
+        _sessionService.listAgents(),
+        _sessionService.listProviders(),
+      ).wait;
+
+      if (isClosed) return;
+
+      final agents = switch (agentsResponse) {
+        SuccessResponse(:final data) => data.where((a) => !a.hidden && a.mode != AgentMode.subagent).toList(),
+        ErrorResponse() => <AgentInfo>[],
+      };
+
+      final providers = switch (providersResponse) {
+        SuccessResponse(:final data) => data.items,
+        ErrorResponse() => <ProviderInfo>[],
+      };
+
+      final defaultAgent = agents.isNotEmpty ? agents.first.name : "build";
+      final agentModel = agents.isNotEmpty ? agents.first.model : null;
+      final String defaultProviderID;
+      final String defaultModelID;
+      if (agentModel != null) {
+        defaultProviderID = agentModel.providerID;
+        defaultModelID = agentModel.modelID;
+      } else if (providers.isNotEmpty) {
+        defaultProviderID = providers.first.id;
+        final firstProviderDefaultModelId = providers.first.defaultModelID;
+        defaultModelID =
+            firstProviderDefaultModelId != null && providers.first.models.containsKey(firstProviderDefaultModelId)
+            ? firstProviderDefaultModelId
+            : providers.first.models.values.first.id;
+      } else {
+        defaultProviderID = "";
+        defaultModelID = "";
+      }
+
+      _emitAgentModelUpdate(
+        availableAgents: agents,
+        availableProviders: providers,
+        selectedAgent: defaultAgent,
+        selectedProviderID: defaultProviderID,
+        selectedModelID: defaultModelID,
+      );
+    } catch (_) {
+      return;
+    }
+  }
+
+  /// Applies agent/model field updates to the current state, regardless of
+  /// which variant is active. No-op when the cubit is closed or in `created`.
+  void _emitAgentModelUpdate({
+    List<AgentInfo>? availableAgents,
+    List<ProviderInfo>? availableProviders,
+    String? selectedAgent,
+    String? selectedProviderID,
+    String? selectedModelID,
+  }) {
+    if (isClosed) return;
+    final current = state;
+    switch (current) {
+      case NewSessionIdle():
+        emit(
+          current.copyWith(
+            availableAgents: availableAgents ?? current.availableAgents,
+            availableProviders: availableProviders ?? current.availableProviders,
+            selectedAgent: selectedAgent ?? current.selectedAgent,
+            selectedProviderID: selectedProviderID ?? current.selectedProviderID,
+            selectedModelID: selectedModelID ?? current.selectedModelID,
+          ),
+        );
+      case NewSessionSending():
+        emit(
+          current.copyWith(
+            availableAgents: availableAgents ?? current.availableAgents,
+            availableProviders: availableProviders ?? current.availableProviders,
+            selectedAgent: selectedAgent ?? current.selectedAgent,
+            selectedProviderID: selectedProviderID ?? current.selectedProviderID,
+            selectedModelID: selectedModelID ?? current.selectedModelID,
+          ),
+        );
+      case NewSessionError():
+        emit(
+          current.copyWith(
+            availableAgents: availableAgents ?? current.availableAgents,
+            availableProviders: availableProviders ?? current.availableProviders,
+            selectedAgent: selectedAgent ?? current.selectedAgent,
+            selectedProviderID: selectedProviderID ?? current.selectedProviderID,
+            selectedModelID: selectedModelID ?? current.selectedModelID,
+          ),
+        );
+      case NewSessionCreated():
+        break;
+    }
+  }
+
+  void selectAgent(String agent) {
+    _emitAgentModelUpdate(selectedAgent: agent);
+  }
+
+  void selectModel(String providerID, String modelID) {
+    _emitAgentModelUpdate(selectedProviderID: providerID, selectedModelID: modelID);
+  }
 
   Future<void> createSessionWithMessage({
     required String text,
-    required String? agent,
-    required PromptModel? model,
     required bool dedicatedWorktree,
   }) async {
     if (state is NewSessionSending) return;
@@ -27,12 +132,31 @@ class NewSessionCubit extends Cubit<NewSessionState> {
     final trimmed = text.trim();
     if (trimmed.isEmpty) return;
 
-    emit(const NewSessionState.sending());
+    final config = state.agentModelData;
+    final selectedProviderID = config?.providerID;
+    final selectedModelID = config?.modelID;
+    final model =
+        selectedProviderID != null &&
+            selectedProviderID.isNotEmpty &&
+            selectedModelID != null &&
+            selectedModelID.isNotEmpty
+        ? PromptModel(providerID: selectedProviderID, modelID: selectedModelID)
+        : null;
+
+    emit(
+      NewSessionState.sending(
+        availableAgents: config?.agents ?? const [],
+        availableProviders: config?.providers ?? const [],
+        selectedAgent: config?.agent,
+        selectedProviderID: selectedProviderID,
+        selectedModelID: selectedModelID,
+      ),
+    );
 
     final response = await _sessionService.createSessionWithMessage(
       projectId: _projectId,
       text: trimmed,
-      agent: agent,
+      agent: config?.agent,
       model: model,
       dedicatedWorktree: dedicatedWorktree,
     );
@@ -43,7 +167,20 @@ class NewSessionCubit extends Cubit<NewSessionState> {
       case SuccessResponse(:final data):
         emit(NewSessionState.created(session: data));
       case ErrorResponse(:final error):
-        emit(NewSessionState.error(message: _describeError(error: error)));
+        // Read from current state (not pre-request snapshot) so that any
+        // agent/provider data loaded while the request was in-flight is
+        // preserved.
+        final current = state.agentModelData;
+        emit(
+          NewSessionState.error(
+            message: _describeError(error: error),
+            availableAgents: current?.agents ?? const [],
+            availableProviders: current?.providers ?? const [],
+            selectedAgent: current?.agent,
+            selectedProviderID: current?.providerID,
+            selectedModelID: current?.modelID,
+          ),
+        );
     }
   }
 

--- a/mobile/module_core/lib/src/cubits/new_session/new_session_state.dart
+++ b/mobile/module_core/lib/src/cubits/new_session/new_session_state.dart
@@ -5,11 +5,89 @@ part "new_session_state.freezed.dart";
 
 @Freezed()
 sealed class NewSessionState with _$NewSessionState {
-  const factory NewSessionState.idle() = NewSessionIdle;
+  const factory NewSessionState.idle({
+    @Default([]) List<AgentInfo> availableAgents,
+    @Default([]) List<ProviderInfo> availableProviders,
+    String? selectedAgent,
+    String? selectedProviderID,
+    String? selectedModelID,
+  }) = NewSessionIdle;
 
-  const factory NewSessionState.sending() = NewSessionSending;
+  const factory NewSessionState.sending({
+    @Default([]) List<AgentInfo> availableAgents,
+    @Default([]) List<ProviderInfo> availableProviders,
+    String? selectedAgent,
+    String? selectedProviderID,
+    String? selectedModelID,
+  }) = NewSessionSending;
 
-  const factory NewSessionState.error({required String message}) = NewSessionError;
+  const factory NewSessionState.error({
+    required String message,
+    @Default([]) List<AgentInfo> availableAgents,
+    @Default([]) List<ProviderInfo> availableProviders,
+    String? selectedAgent,
+    String? selectedProviderID,
+    String? selectedModelID,
+  }) = NewSessionError;
 
   const factory NewSessionState.created({required Session session}) = NewSessionCreated;
+}
+
+/// Convenience accessor for agent/model selection data shared across
+/// the [NewSessionIdle], [NewSessionSending], and [NewSessionError] variants.
+/// Returns `null` for [NewSessionCreated] (where the data is irrelevant).
+typedef AgentModelData = ({
+  List<AgentInfo> agents,
+  List<ProviderInfo> providers,
+  String? agent,
+  String? providerID,
+  String? modelID,
+});
+
+extension NewSessionStateAgentModel on NewSessionState {
+  AgentModelData? get agentModelData => switch (this) {
+    NewSessionIdle(
+      :final availableAgents,
+      :final availableProviders,
+      :final selectedAgent,
+      :final selectedProviderID,
+      :final selectedModelID,
+    ) =>
+      (
+        agents: availableAgents,
+        providers: availableProviders,
+        agent: selectedAgent,
+        providerID: selectedProviderID,
+        modelID: selectedModelID,
+      ),
+    NewSessionSending(
+      :final availableAgents,
+      :final availableProviders,
+      :final selectedAgent,
+      :final selectedProviderID,
+      :final selectedModelID,
+    ) =>
+      (
+        agents: availableAgents,
+        providers: availableProviders,
+        agent: selectedAgent,
+        providerID: selectedProviderID,
+        modelID: selectedModelID,
+      ),
+    NewSessionError(
+      :final availableAgents,
+      :final availableProviders,
+      :final selectedAgent,
+      :final selectedProviderID,
+      :final selectedModelID,
+    ) =>
+      (
+        agents: availableAgents,
+        providers: availableProviders,
+        agent: selectedAgent,
+        providerID: selectedProviderID,
+        modelID: selectedModelID,
+      ),
+    NewSessionCreated() => null,
+  };
 }

--- a/mobile/module_core/lib/src/cubits/new_session/new_session_state.freezed.dart
+++ b/mobile/module_core/lib/src/cubits/new_session/new_session_state.freezed.dart
@@ -46,74 +46,199 @@ $NewSessionStateCopyWith(NewSessionState _, $Res Function(NewSessionState) __);
 
 
 class NewSessionIdle implements NewSessionState {
-  const NewSessionIdle();
+  const NewSessionIdle({final  List<AgentInfo> availableAgents = const [], final  List<ProviderInfo> availableProviders = const [], this.selectedAgent, this.selectedProviderID, this.selectedModelID}): _availableAgents = availableAgents,_availableProviders = availableProviders;
   
 
+ final  List<AgentInfo> _availableAgents;
+@JsonKey() List<AgentInfo> get availableAgents {
+  if (_availableAgents is EqualUnmodifiableListView) return _availableAgents;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_availableAgents);
+}
 
+ final  List<ProviderInfo> _availableProviders;
+@JsonKey() List<ProviderInfo> get availableProviders {
+  if (_availableProviders is EqualUnmodifiableListView) return _availableProviders;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_availableProviders);
+}
 
+ final  String? selectedAgent;
+ final  String? selectedProviderID;
+ final  String? selectedModelID;
+
+/// Create a copy of NewSessionState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$NewSessionIdleCopyWith<NewSessionIdle> get copyWith => _$NewSessionIdleCopyWithImpl<NewSessionIdle>(this, _$identity);
 
 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionIdle);
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionIdle&&const DeepCollectionEquality().equals(other._availableAgents, _availableAgents)&&const DeepCollectionEquality().equals(other._availableProviders, _availableProviders)&&(identical(other.selectedAgent, selectedAgent) || other.selectedAgent == selectedAgent)&&(identical(other.selectedProviderID, selectedProviderID) || other.selectedProviderID == selectedProviderID)&&(identical(other.selectedModelID, selectedModelID) || other.selectedModelID == selectedModelID));
 }
 
 
 @override
-int get hashCode => runtimeType.hashCode;
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_availableAgents),const DeepCollectionEquality().hash(_availableProviders),selectedAgent,selectedProviderID,selectedModelID);
 
 @override
 String toString() {
-  return 'NewSessionState.idle()';
+  return 'NewSessionState.idle(availableAgents: $availableAgents, availableProviders: $availableProviders, selectedAgent: $selectedAgent, selectedProviderID: $selectedProviderID, selectedModelID: $selectedModelID)';
 }
 
 
 }
 
+/// @nodoc
+abstract mixin class $NewSessionIdleCopyWith<$Res> implements $NewSessionStateCopyWith<$Res> {
+  factory $NewSessionIdleCopyWith(NewSessionIdle value, $Res Function(NewSessionIdle) _then) = _$NewSessionIdleCopyWithImpl;
+@useResult
+$Res call({
+ List<AgentInfo> availableAgents, List<ProviderInfo> availableProviders, String? selectedAgent, String? selectedProviderID, String? selectedModelID
+});
 
 
+
+
+}
+/// @nodoc
+class _$NewSessionIdleCopyWithImpl<$Res>
+    implements $NewSessionIdleCopyWith<$Res> {
+  _$NewSessionIdleCopyWithImpl(this._self, this._then);
+
+  final NewSessionIdle _self;
+  final $Res Function(NewSessionIdle) _then;
+
+/// Create a copy of NewSessionState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? availableAgents = null,Object? availableProviders = null,Object? selectedAgent = freezed,Object? selectedProviderID = freezed,Object? selectedModelID = freezed,}) {
+  return _then(NewSessionIdle(
+availableAgents: null == availableAgents ? _self._availableAgents : availableAgents // ignore: cast_nullable_to_non_nullable
+as List<AgentInfo>,availableProviders: null == availableProviders ? _self._availableProviders : availableProviders // ignore: cast_nullable_to_non_nullable
+as List<ProviderInfo>,selectedAgent: freezed == selectedAgent ? _self.selectedAgent : selectedAgent // ignore: cast_nullable_to_non_nullable
+as String?,selectedProviderID: freezed == selectedProviderID ? _self.selectedProviderID : selectedProviderID // ignore: cast_nullable_to_non_nullable
+as String?,selectedModelID: freezed == selectedModelID ? _self.selectedModelID : selectedModelID // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
 
 /// @nodoc
 
 
 class NewSessionSending implements NewSessionState {
-  const NewSessionSending();
+  const NewSessionSending({final  List<AgentInfo> availableAgents = const [], final  List<ProviderInfo> availableProviders = const [], this.selectedAgent, this.selectedProviderID, this.selectedModelID}): _availableAgents = availableAgents,_availableProviders = availableProviders;
   
 
+ final  List<AgentInfo> _availableAgents;
+@JsonKey() List<AgentInfo> get availableAgents {
+  if (_availableAgents is EqualUnmodifiableListView) return _availableAgents;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_availableAgents);
+}
 
+ final  List<ProviderInfo> _availableProviders;
+@JsonKey() List<ProviderInfo> get availableProviders {
+  if (_availableProviders is EqualUnmodifiableListView) return _availableProviders;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_availableProviders);
+}
 
+ final  String? selectedAgent;
+ final  String? selectedProviderID;
+ final  String? selectedModelID;
+
+/// Create a copy of NewSessionState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$NewSessionSendingCopyWith<NewSessionSending> get copyWith => _$NewSessionSendingCopyWithImpl<NewSessionSending>(this, _$identity);
 
 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionSending);
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionSending&&const DeepCollectionEquality().equals(other._availableAgents, _availableAgents)&&const DeepCollectionEquality().equals(other._availableProviders, _availableProviders)&&(identical(other.selectedAgent, selectedAgent) || other.selectedAgent == selectedAgent)&&(identical(other.selectedProviderID, selectedProviderID) || other.selectedProviderID == selectedProviderID)&&(identical(other.selectedModelID, selectedModelID) || other.selectedModelID == selectedModelID));
 }
 
 
 @override
-int get hashCode => runtimeType.hashCode;
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_availableAgents),const DeepCollectionEquality().hash(_availableProviders),selectedAgent,selectedProviderID,selectedModelID);
 
 @override
 String toString() {
-  return 'NewSessionState.sending()';
+  return 'NewSessionState.sending(availableAgents: $availableAgents, availableProviders: $availableProviders, selectedAgent: $selectedAgent, selectedProviderID: $selectedProviderID, selectedModelID: $selectedModelID)';
 }
 
 
 }
 
+/// @nodoc
+abstract mixin class $NewSessionSendingCopyWith<$Res> implements $NewSessionStateCopyWith<$Res> {
+  factory $NewSessionSendingCopyWith(NewSessionSending value, $Res Function(NewSessionSending) _then) = _$NewSessionSendingCopyWithImpl;
+@useResult
+$Res call({
+ List<AgentInfo> availableAgents, List<ProviderInfo> availableProviders, String? selectedAgent, String? selectedProviderID, String? selectedModelID
+});
 
 
+
+
+}
+/// @nodoc
+class _$NewSessionSendingCopyWithImpl<$Res>
+    implements $NewSessionSendingCopyWith<$Res> {
+  _$NewSessionSendingCopyWithImpl(this._self, this._then);
+
+  final NewSessionSending _self;
+  final $Res Function(NewSessionSending) _then;
+
+/// Create a copy of NewSessionState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? availableAgents = null,Object? availableProviders = null,Object? selectedAgent = freezed,Object? selectedProviderID = freezed,Object? selectedModelID = freezed,}) {
+  return _then(NewSessionSending(
+availableAgents: null == availableAgents ? _self._availableAgents : availableAgents // ignore: cast_nullable_to_non_nullable
+as List<AgentInfo>,availableProviders: null == availableProviders ? _self._availableProviders : availableProviders // ignore: cast_nullable_to_non_nullable
+as List<ProviderInfo>,selectedAgent: freezed == selectedAgent ? _self.selectedAgent : selectedAgent // ignore: cast_nullable_to_non_nullable
+as String?,selectedProviderID: freezed == selectedProviderID ? _self.selectedProviderID : selectedProviderID // ignore: cast_nullable_to_non_nullable
+as String?,selectedModelID: freezed == selectedModelID ? _self.selectedModelID : selectedModelID // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
 
 /// @nodoc
 
 
 class NewSessionError implements NewSessionState {
-  const NewSessionError({required this.message});
+  const NewSessionError({required this.message, final  List<AgentInfo> availableAgents = const [], final  List<ProviderInfo> availableProviders = const [], this.selectedAgent, this.selectedProviderID, this.selectedModelID}): _availableAgents = availableAgents,_availableProviders = availableProviders;
   
 
  final  String message;
+ final  List<AgentInfo> _availableAgents;
+@JsonKey() List<AgentInfo> get availableAgents {
+  if (_availableAgents is EqualUnmodifiableListView) return _availableAgents;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_availableAgents);
+}
+
+ final  List<ProviderInfo> _availableProviders;
+@JsonKey() List<ProviderInfo> get availableProviders {
+  if (_availableProviders is EqualUnmodifiableListView) return _availableProviders;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_availableProviders);
+}
+
+ final  String? selectedAgent;
+ final  String? selectedProviderID;
+ final  String? selectedModelID;
 
 /// Create a copy of NewSessionState
 /// with the given fields replaced by the non-null parameter values.
@@ -125,16 +250,16 @@ $NewSessionErrorCopyWith<NewSessionError> get copyWith => _$NewSessionErrorCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionError&&(identical(other.message, message) || other.message == message));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionError&&(identical(other.message, message) || other.message == message)&&const DeepCollectionEquality().equals(other._availableAgents, _availableAgents)&&const DeepCollectionEquality().equals(other._availableProviders, _availableProviders)&&(identical(other.selectedAgent, selectedAgent) || other.selectedAgent == selectedAgent)&&(identical(other.selectedProviderID, selectedProviderID) || other.selectedProviderID == selectedProviderID)&&(identical(other.selectedModelID, selectedModelID) || other.selectedModelID == selectedModelID));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,message);
+int get hashCode => Object.hash(runtimeType,message,const DeepCollectionEquality().hash(_availableAgents),const DeepCollectionEquality().hash(_availableProviders),selectedAgent,selectedProviderID,selectedModelID);
 
 @override
 String toString() {
-  return 'NewSessionState.error(message: $message)';
+  return 'NewSessionState.error(message: $message, availableAgents: $availableAgents, availableProviders: $availableProviders, selectedAgent: $selectedAgent, selectedProviderID: $selectedProviderID, selectedModelID: $selectedModelID)';
 }
 
 
@@ -145,7 +270,7 @@ abstract mixin class $NewSessionErrorCopyWith<$Res> implements $NewSessionStateC
   factory $NewSessionErrorCopyWith(NewSessionError value, $Res Function(NewSessionError) _then) = _$NewSessionErrorCopyWithImpl;
 @useResult
 $Res call({
- String message
+ String message, List<AgentInfo> availableAgents, List<ProviderInfo> availableProviders, String? selectedAgent, String? selectedProviderID, String? selectedModelID
 });
 
 
@@ -162,10 +287,15 @@ class _$NewSessionErrorCopyWithImpl<$Res>
 
 /// Create a copy of NewSessionState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? message = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? message = null,Object? availableAgents = null,Object? availableProviders = null,Object? selectedAgent = freezed,Object? selectedProviderID = freezed,Object? selectedModelID = freezed,}) {
   return _then(NewSessionError(
 message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
-as String,
+as String,availableAgents: null == availableAgents ? _self._availableAgents : availableAgents // ignore: cast_nullable_to_non_nullable
+as List<AgentInfo>,availableProviders: null == availableProviders ? _self._availableProviders : availableProviders // ignore: cast_nullable_to_non_nullable
+as List<ProviderInfo>,selectedAgent: freezed == selectedAgent ? _self.selectedAgent : selectedAgent // ignore: cast_nullable_to_non_nullable
+as String?,selectedProviderID: freezed == selectedProviderID ? _self.selectedProviderID : selectedProviderID // ignore: cast_nullable_to_non_nullable
+as String?,selectedModelID: freezed == selectedModelID ? _self.selectedModelID : selectedModelID // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/mobile/module_core/test/cubits/new_session/new_session_cubit_test.dart
+++ b/mobile/module_core/test/cubits/new_session/new_session_cubit_test.dart
@@ -3,6 +3,7 @@ import "package:mocktail/mocktail.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_dart_core/src/cubits/new_session/new_session_cubit.dart";
 import "package:sesori_dart_core/src/cubits/new_session/new_session_state.dart";
+import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
 import "../../helpers/test_helpers.dart";
@@ -13,6 +14,16 @@ void main() {
 
     setUp(() {
       mockSessionService = MockSessionService();
+
+      // Stub agent/provider fetches that fire on cubit construction.
+      when(
+        () => mockSessionService.listAgents(),
+      ).thenAnswer((_) async => ApiResponse<List<AgentInfo>>.success(<AgentInfo>[]));
+      when(() => mockSessionService.listProviders()).thenAnswer(
+        (_) async => ApiResponse<ProviderListResponse>.success(
+          const ProviderListResponse(items: [], connectedOnly: false),
+        ),
+      );
     });
 
     NewSessionCubit buildCubit() => NewSessionCubit(
@@ -37,14 +48,16 @@ void main() {
       act: (cubit) async {
         await cubit.createSessionWithMessage(
           text: "hello",
-          agent: null,
-          model: null,
           dedicatedWorktree: false,
         );
       },
       expect: () => [
-        const NewSessionState.sending(),
-        NewSessionState.created(session: testSession(id: "s1")),
+        // First sending is from createSessionWithMessage.
+        isA<NewSessionSending>(),
+        // _loadAgentModelData may resolve during the request, emitting an
+        // updated NewSessionSending with default agent/model values.
+        isA<NewSessionSending>(),
+        isA<NewSessionCreated>(),
       ],
       verify: (_) {
         verify(


### PR DESCRIPTION
## Summary

- Extract agent/model selection widgets (`AgentModelButtons`, `AgentPickerSheet`, `ModelPickerSheet`) from the session detail screen into shared components under `core/widgets/`, eliminating duplication between screens.
- Add agent and model selection to the new session (preemptive) screen — users can now pick an agent and model before sending their first message, matching the session detail screen's capability.
- Update `NewSessionCubit` to fetch available agents/providers on init, resolve sensible defaults, and pass the selection when creating a session.

## Changes

### State Management (`module_core`)
- **`NewSessionState`** — Added `availableAgents`, `availableProviders`, `selectedAgent`, `selectedProviderID`, `selectedModelID` fields to `idle`, `sending`, and `error` variants so selection persists across state transitions.
- **`NewSessionCubit`** — Fetches agents and providers on construction (fire-and-forget, non-blocking). Calculates defaults using the same resolution logic as `SessionDetailCubit`. Added `selectAgent()` and `selectModel()` methods. `createSessionWithMessage()` now reads selection from state instead of accepting parameters.

### UI Extraction (`app`)
- **`AgentModelButtons`** — Extracted from private `_AgentModelButtons` in `session_detail_screen.dart` → new shared widget at `core/widgets/agent_model_buttons.dart`.
- **`AgentPickerSheet`** — Moved from `features/session_detail/widgets/` → `core/widgets/` with updated internal imports.
- **`ModelPickerSheet`** — Same treatment as `AgentPickerSheet`.
- **`session_detail_screen.dart`** — Now imports shared widgets, private class removed.

### Integration
- **`new_session_screen.dart`** — Converted to `StatefulWidget`, wired `AgentModelButtons` as `PromptInput` header (shown once agents load), added picker sheet callbacks. Error banner preserved alongside agent/model buttons.

## Behavior

- If agents/providers haven't loaded when the user sends their first message, the cubit falls back to `null` — same as current behavior (graceful degradation).
- Agent/provider fetch failures are silently swallowed (buttons don't appear). Matches existing `SessionDetailCubit` behavior.

## Verification

- `dart analyze` — 0 issues in both `module_core` and `app`
- `dart test` in `module_core` — 145 tests pass
- `flutter test` in `app` — 352 tests pass