### PR TITLE
chore: lint-suppressions workflow, CLA runner fix, EventQueue guard

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   cla:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: CLA Assistant
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'

--- a/.github/workflows/lint-suppressions.yml
+++ b/.github/workflows/lint-suppressions.yml
@@ -1,0 +1,151 @@
+name: Lint Suppressions Check
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "bridge/**"
+      - "mobile/**"
+      - "shared/**"
+
+# Cancel in-progress runs when a new commit is pushed to the same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-suppressions:
+    name: Check for New Lint Suppressions
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+        with:
+          # Checkout the PR head commit, not the merge commit
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }}
+
+      - name: Check for new lint suppressions
+        id: check
+        run: |
+          BASE_REF="origin/${{ github.base_ref }}"
+          PR_HEAD="${{ github.event.pull_request.head.sha }}"
+
+          # Parse diff to extract file:line for each new // ignore comment
+          # Excludes: generated files (.g.dart, .freezed.dart, .gr.dart) and test files (_test.dart)
+          NEW_SUPPRESSIONS=$(git diff $BASE_REF...$PR_HEAD -- '*.dart' \
+            ':!*.g.dart' ':!*.freezed.dart' ':!*.gr.dart' ':!*_test.dart' \
+            | awk '
+              /^diff --git/ {
+                # Extract filename from "diff --git a/path b/path"
+                split($0, parts, " ")
+                file = parts[3]
+                sub(/^a\//, "", file)
+              }
+              /^@@ / {
+                # Extract new file line number from "@@ -old,count +new,count @@"
+                match($0, /\+([0-9]+)/, arr)
+                line = arr[1]
+              }
+              /^\+/ && !/^\+\+\+/ {
+                # Added line - check for ignore comment
+                if ($0 ~ /\/\/ ignore/) {
+                  print file ":" line ": " substr($0, 2)
+                }
+                line++
+              }
+              /^ / {
+                # Context line - increment line counter
+                line++
+              }
+            ')
+
+          if [ -z "$NEW_SUPPRESSIONS" ]; then
+            echo "## ✅ No New Lint Suppressions" >> $GITHUB_STEP_SUMMARY
+            echo "No new \`// ignore:\` or \`// ignore_for_file:\` comments added in this PR." >> $GITHUB_STEP_SUMMARY
+            echo "✅ No new lint suppressions found"
+            echo "found=false" >> $GITHUB_OUTPUT
+          else
+            # Count suppressions
+            COUNT=$(echo "$NEW_SUPPRESSIONS" | wc -l | tr -d ' ')
+
+            # Save to output for PR comment step
+            echo "found=true" >> $GITHUB_OUTPUT
+            echo "count=$COUNT" >> $GITHUB_OUTPUT
+
+            # Save suppressions to file for PR comment (multiline)
+            echo "$NEW_SUPPRESSIONS" > /tmp/suppressions.txt
+
+            # Emit warning annotations for each suppression (shows in PR Files changed)
+            echo "$NEW_SUPPRESSIONS" | while IFS=: read -r file line content; do
+              echo "::warning file=$file,line=$line::New lint suppression: $content"
+            done
+
+            # Summary for the Actions tab
+            echo "## ⚠️ New Lint Suppressions Detected" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "This PR adds **$COUNT** new lint suppression comment(s). Please review and ensure each is justified:" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "$NEW_SUPPRESSIONS" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "---" >> $GITHUB_STEP_SUMMARY
+            echo "*Reviewers: Verify each suppression is necessary and properly justified in code comments.*" >> $GITHUB_STEP_SUMMARY
+
+            echo "⚠️ $COUNT new lint suppression(s) added in this PR (see warnings)"
+          fi
+
+      - name: Delete old PR comment if no suppressions
+        if: steps.check.outputs.found == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | contains("<!-- lint-suppressions-bot -->")) | .id' | head -1 || true)
+          if [ -n "$EXISTING_COMMENT_ID" ]; then
+            gh api -X DELETE "repos/${{ github.repository }}/issues/comments/${EXISTING_COMMENT_ID}"
+            echo "Deleted previous lint suppression comment"
+          fi
+
+      - name: Comment on PR
+        if: steps.check.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          MARKER="<!-- lint-suppressions-bot -->"
+
+          # Delete any existing comment from this bot
+          EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --jq '.[] | select(.body | contains("<!-- lint-suppressions-bot -->")) | .id' | head -1 || true)
+
+          if [ -n "$EXISTING_COMMENT_ID" ]; then
+            gh api -X DELETE "repos/${{ github.repository }}/issues/comments/${EXISTING_COMMENT_ID}"
+          fi
+
+          # Post new comment
+          SUPPRESSIONS=$(cat /tmp/suppressions.txt)
+          {
+            echo "${MARKER}"
+            echo "## ⚠️ New Lint Suppressions Detected"
+            echo ""
+            echo "This PR adds **${{ steps.check.outputs.count }}** new lint suppression comment(s). Please review and ensure each is justified:"
+            echo ""
+            echo '```'
+            echo "$SUPPRESSIONS"
+            echo '```'
+            echo ""
+            echo "---"
+            echo "*Reviewers: Verify each suppression is necessary and properly justified in code comments.*"
+          } > /tmp/comment.md
+          gh pr comment $PR_NUMBER --body-file /tmp/comment.md

--- a/shared/sesori_shared/lib/src/concurrency/event_queue.dart
+++ b/shared/sesori_shared/lib/src/concurrency/event_queue.dart
@@ -226,12 +226,23 @@ class EventQueueSubscription<T extends Object> {
   final EventQueue<T> _queue;
   EventQueueSubscription._(this._queue);
 
+  bool get _isActive => identical(_queue._activeSubscription, this);
+
   /// Detaches the listener. Pending events remain buffered in the queue.
-  void cancel() => _queue._detach();
+  /// No-op if this subscription is no longer active.
+  void cancel() {
+    if (_isActive) _queue._detach();
+  }
 
   /// Pauses event delivery. Events continue to buffer.
-  void pause() => _queue.pause();
+  /// No-op if this subscription is no longer active.
+  void pause() {
+    if (_isActive) _queue.pause();
+  }
 
   /// Resumes event delivery.
-  void resume() => _queue.resume();
+  /// No-op if this subscription is no longer active.
+  void resume() {
+    if (_isActive) _queue.resume();
+  }
 }

--- a/shared/sesori_shared/test/concurrency/event_queue_test.dart
+++ b/shared/sesori_shared/test/concurrency/event_queue_test.dart
@@ -731,6 +731,25 @@ void main() {
         );
         queue.dispose();
       });
+
+      test("stale subscription cancel does not detach newer listener", () async {
+        final log = <String>[];
+        final queue = EventQueue<String>();
+
+        final stale = queue.listen((e) async => log.add("v1:$e"));
+        stale.cancel();
+
+        final active = queue.listen((e) async => log.add("v2:$e"));
+        stale.cancel(); // stale — should be a no-op
+
+        queue.enqueue("a");
+        await pumpEventQueue();
+
+        expect(queue.hasListener, isTrue);
+        expect(log, ["v2:a"]);
+        active.cancel();
+        queue.dispose();
+      });
     });
   });
 }

--- a/shared/sesori_shared/test/concurrency/event_queue_test.dart
+++ b/shared/sesori_shared/test/concurrency/event_queue_test.dart
@@ -750,6 +750,52 @@ void main() {
         active.cancel();
         queue.dispose();
       });
+
+      test("stale subscription pause does not pause newer listener", () async {
+        final log = <String>[];
+        final queue = EventQueue<String>();
+
+        final stale = queue.listen((e) async => log.add("v1:$e"));
+        stale.cancel();
+
+        final active = queue.listen((e) async => log.add("v2:$e"));
+        stale.pause(); // stale — should be a no-op
+
+        queue.enqueue("a");
+        await pumpEventQueue();
+
+        expect(queue.isPaused, isFalse);
+        expect(log, ["v2:a"]);
+        active.cancel();
+        queue.dispose();
+      });
+
+      test("stale subscription resume does not affect newer listener", () async {
+        final log = <String>[];
+        final queue = EventQueue<String>();
+
+        final stale = queue.listen((e) async => log.add("v1:$e"));
+        stale.cancel();
+
+        final active = queue.listen((e) async => log.add("v2:$e"));
+        active.pause();
+        expect(queue.isPaused, isTrue);
+
+        stale.resume(); // stale — should be a no-op
+
+        queue.enqueue("a");
+        await pumpEventQueue();
+
+        expect(queue.isPaused, isTrue);
+        expect(log, isEmpty);
+
+        active.resume();
+        await pumpEventQueue();
+        expect(log, ["v2:a"]);
+
+        active.cancel();
+        queue.dispose();
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary
- Add `lint-suppressions.yml` CI workflow that detects new `// ignore` comments in PRs and posts a review comment (paths configured for this monorepo: `bridge/**`, `mobile/**`, `shared/**`)
- Switch CLA workflow runner from `ubuntu-latest` to `blacksmith-2vcpu-ubuntu-2404` for consistency with other workflows
- Guard `EventQueueSubscription.cancel()`/`pause()`/`resume()` so a stale handle is a no-op — prevents an old subscription from accidentally detaching a newer listener (addresses PR #65 review comment)

## Test plan
- [x] New `stale subscription cancel does not detach newer listener` test added and passing
- [x] All 39 EventQueue tests pass
- [ ] Verify lint-suppressions workflow triggers on next PR touching Dart files

🤖 Generated with [Claude Code](https://claude.com/claude-code)