### PR TITLE
fix: use git merge-base for session diff instead of branch tip

### DIFF
--- a/bridge/app/lib/src/bridge/session_diffs/compute_session_diffs.dart
+++ b/bridge/app/lib/src/bridge/session_diffs/compute_session_diffs.dart
@@ -26,10 +26,26 @@ Future<List<FileDiff>> computeSessionDiffs({
     throw BaseBranchUnreachableException(message: "base branch '$baseBranch' is not reachable");
   }
 
+  final mergeBaseResult = await _runGit(
+    processRunner: processRunner,
+    worktreePath: worktreePath,
+    arguments: ["merge-base", baseBranch, "HEAD"],
+  );
+  if (mergeBaseResult.exitCode != 0) {
+    if (mergeBaseResult.exitCode == 1) {
+      throw BaseBranchUnreachableException(message: "no common ancestor between '$baseBranch' and HEAD");
+    }
+    throw const GitDiffQueryException(message: "git merge-base failed");
+  }
+  final mergeBaseSha = decodeOutput(mergeBaseResult.stdout).trim();
+  if (mergeBaseSha.isEmpty) {
+    throw const GitDiffQueryException(message: "git merge-base returned empty result");
+  }
+
   final nameStatusResult = await _runGit(
     processRunner: processRunner,
     worktreePath: worktreePath,
-    arguments: ["diff", "--no-ext-diff", "--no-color", "--no-renames", "--name-status", baseBranch],
+    arguments: ["diff", "--no-ext-diff", "--no-color", "--no-renames", "--name-status", mergeBaseSha],
   );
   if (nameStatusResult.exitCode != 0) {
     throw const GitDiffQueryException(message: "git diff --name-status failed");
@@ -38,7 +54,7 @@ Future<List<FileDiff>> computeSessionDiffs({
   final numstatResult = await _runGit(
     processRunner: processRunner,
     worktreePath: worktreePath,
-    arguments: ["diff", "--no-ext-diff", "--no-color", "--no-renames", "--numstat", baseBranch],
+    arguments: ["diff", "--no-ext-diff", "--no-color", "--no-renames", "--numstat", mergeBaseSha],
   );
   if (numstatResult.exitCode != 0) {
     throw const GitDiffQueryException(message: "git diff --numstat failed");
@@ -53,7 +69,7 @@ Future<List<FileDiff>> computeSessionDiffs({
     final beforeResult = await readBefore(
       processRunner: processRunner,
       worktreePath: worktreePath,
-      baseBranch: baseBranch,
+      baseBranch: mergeBaseSha,
       file: entry.file,
       status: entry.status,
     );

--- a/bridge/app/lib/src/bridge/session_diffs/compute_session_diffs.dart
+++ b/bridge/app/lib/src/bridge/session_diffs/compute_session_diffs.dart
@@ -29,17 +29,20 @@ Future<List<FileDiff>> computeSessionDiffs({
   final mergeBaseResult = await _runGit(
     processRunner: processRunner,
     worktreePath: worktreePath,
-    arguments: ["merge-base", baseBranch, "HEAD"],
+    arguments: ["merge-base", "--", baseBranch, "HEAD"],
   );
   if (mergeBaseResult.exitCode != 0) {
+    final stderr = decodeOutput(mergeBaseResult.stderr).trim();
     if (mergeBaseResult.exitCode == 1) {
       throw BaseBranchUnreachableException(message: "no common ancestor between '$baseBranch' and HEAD");
     }
-    throw const GitDiffQueryException(message: "git merge-base failed");
+    throw GitDiffQueryException(
+      message: "git merge-base failed (exit ${mergeBaseResult.exitCode}): $stderr",
+    );
   }
-  final mergeBaseSha = decodeOutput(mergeBaseResult.stdout).trim();
-  if (mergeBaseSha.isEmpty) {
-    throw const GitDiffQueryException(message: "git merge-base returned empty result");
+  final mergeBaseSha = _parseSingleSha(decodeOutput(mergeBaseResult.stdout));
+  if (mergeBaseSha == null) {
+    throw const GitDiffQueryException(message: "git merge-base returned unexpected output");
   }
 
   final nameStatusResult = await _runGit(
@@ -138,6 +141,14 @@ Future<List<FileDiff>> computeSessionDiffs({
   }
 
   return diffs;
+}
+
+/// Parses stdout that should contain exactly one non-empty SHA line.
+/// Returns `null` if stdout is empty or contains multiple non-empty lines.
+String? _parseSingleSha(String stdout) {
+  final lines = stdout.split("\n").where((l) => l.trim().isNotEmpty).toList();
+  if (lines.length != 1) return null;
+  return lines.first.trim();
 }
 
 Future<ProcessResult> _runGit({

--- a/bridge/app/test/bridge/routing/get_session_diffs_handler_success_test.dart
+++ b/bridge/app/test/bridge/routing/get_session_diffs_handler_success_test.dart
@@ -57,6 +57,9 @@ void main() {
         if (arguments.length >= 2 && arguments[0] == "rev-parse" && arguments[1] == "--verify") {
           return ProcessResult(1, 0, "abc123\n", "");
         }
+        if (arguments.length >= 2 && arguments[0] == "merge-base") {
+          return ProcessResult(1, 0, "abc123\n", "");
+        }
         if (arguments.contains("--name-status")) {
           return ProcessResult(
             1,
@@ -74,10 +77,10 @@ void main() {
           );
         }
         if (arguments.length >= 2 && arguments[0] == "show") {
-          if (arguments[1] == "main:lib/modified.dart") {
+          if (arguments[1] == "abc123:lib/modified.dart") {
             return ProcessResult(1, 0, "modified before\n", "");
           }
-          if (arguments[1] == "main:lib/deleted.dart") {
+          if (arguments[1] == "abc123:lib/deleted.dart") {
             return ProcessResult(1, 0, "deleted before\n", "");
           }
           return ProcessResult(1, 128, "", "fatal");
@@ -150,6 +153,9 @@ void main() {
         if (arguments.length >= 2 && arguments[0] == "rev-parse" && arguments[1] == "--verify") {
           return ProcessResult(1, 0, "abc123\n", "");
         }
+        if (arguments.length >= 2 && arguments[0] == "merge-base") {
+          return ProcessResult(1, 0, "abc123\n", "");
+        }
         if (arguments.contains("--name-status")) {
           return ProcessResult(1, 0, "M\tlib/kept.dart\nM\tlib/model.freezed.dart\n", "");
         }
@@ -202,6 +208,9 @@ void main() {
 
       processRunner.responder = ({required List<String> arguments}) {
         if (arguments.length >= 2 && arguments[0] == "rev-parse" && arguments[1] == "--verify") {
+          return ProcessResult(1, 0, "abc123\n", "");
+        }
+        if (arguments.length >= 2 && arguments[0] == "merge-base") {
           return ProcessResult(1, 0, "abc123\n", "");
         }
         if (arguments.contains("--name-status")) {
@@ -259,6 +268,9 @@ void main() {
 
       processRunner.responder = ({required List<String> arguments}) {
         if (arguments.length >= 2 && arguments[0] == "rev-parse" && arguments[1] == "--verify") {
+          return ProcessResult(1, 0, "abc123\n", "");
+        }
+        if (arguments.length >= 2 && arguments[0] == "merge-base") {
           return ProcessResult(1, 0, "abc123\n", "");
         }
         if (arguments.contains("--name-status")) {

--- a/bridge/app/test/bridge/routing/get_session_diffs_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_session_diffs_handler_test.dart
@@ -178,6 +178,43 @@ void main() {
       expect(response.body, equals("base branch 'main' is not reachable"));
     });
 
+    test("returns 422 when merge-base finds no common ancestor", () async {
+      await sessionDao.insertSession(
+        sessionId: "s1",
+        projectId: "project-1",
+        isDedicated: true,
+        createdAt: 123,
+        worktreePath: tempDir.path,
+        branchName: "session-001",
+        baseBranch: "main",
+        baseCommit: "main",
+      );
+
+      processRunner.responder = ({required List<String> arguments}) {
+        if (arguments.length >= 2 && arguments[0] == "rev-parse" && arguments[1] == "--verify") {
+          return ProcessResult(1, 0, "abc123\n", "");
+        }
+        if (arguments.length >= 2 && arguments[0] == "merge-base") {
+          return ProcessResult(1, 1, "", "fatal: no common ancestor");
+        }
+        throw StateError("Unexpected git call: $arguments");
+      };
+
+      final response = await handler.handleInternal(
+        makeRequest(
+          "POST",
+          "/session/diffs",
+          body: jsonEncode(const SessionIdRequest(sessionId: "s1")),
+        ),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(response.status, equals(422));
+      expect(response.body, contains("no common ancestor"));
+    });
+
     test("returns 500 when git diff fails", () async {
       await sessionDao.insertSession(
         sessionId: "s1",
@@ -192,6 +229,9 @@ void main() {
 
       processRunner.responder = ({required List<String> arguments}) {
         if (arguments.length >= 2 && arguments[0] == "rev-parse" && arguments[1] == "--verify") {
+          return ProcessResult(1, 0, "abc123\n", "");
+        }
+        if (arguments.length >= 2 && arguments[0] == "merge-base") {
           return ProcessResult(1, 0, "abc123\n", "");
         }
         if (arguments.contains("--name-status")) {

--- a/bridge/app/test/bridge/routing/get_session_diffs_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_session_diffs_handler_test.dart
@@ -215,6 +215,43 @@ void main() {
       expect(response.body, contains("no common ancestor"));
     });
 
+    test("returns 500 when merge-base returns unexpected multi-line output", () async {
+      await sessionDao.insertSession(
+        sessionId: "s1",
+        projectId: "project-1",
+        isDedicated: true,
+        createdAt: 123,
+        worktreePath: tempDir.path,
+        branchName: "session-001",
+        baseBranch: "main",
+        baseCommit: "main",
+      );
+
+      processRunner.responder = ({required List<String> arguments}) {
+        if (arguments.length >= 2 && arguments[0] == "rev-parse" && arguments[1] == "--verify") {
+          return ProcessResult(1, 0, "abc123\n", "");
+        }
+        if (arguments.length >= 2 && arguments[0] == "merge-base") {
+          return ProcessResult(1, 0, "abc123\ndef456\n", "");
+        }
+        throw StateError("Unexpected git call: $arguments");
+      };
+
+      final response = await handler.handleInternal(
+        makeRequest(
+          "POST",
+          "/session/diffs",
+          body: jsonEncode(const SessionIdRequest(sessionId: "s1")),
+        ),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(response.status, equals(500));
+      expect(response.body, contains("unexpected output"));
+    });
+
     test("returns 500 when git diff fails", () async {
       await sessionDao.insertSession(
         sessionId: "s1",


### PR DESCRIPTION
## Summary

- **Fix diff viewer to use `git merge-base` instead of diffing against the base branch tip.** When a feature branch hasn't been rebased on the latest base branch, the diff previously showed unrelated changes from base branch progress. Now it computes the common ancestor first and diffs against that SHA — matching GitHub/GitLab PR diff behavior.
- Adds error handling for merge-base failures: exit code 1 (no common ancestor) returns 422, other failures return 500, with descriptive error messages.
- All existing tests updated with merge-base mock responders + new test for merge-base failure scenario.

## Changes

- `compute_session_diffs.dart` — Added `git merge-base <baseBranch> HEAD` step after `rev-parse --verify`. All downstream `git diff` and `readBefore` calls now use the merge-base SHA instead of the branch name.
- `get_session_diffs_handler_test.dart` — New test for 422 on merge-base failure + updated existing responder.
- `get_session_diffs_handler_success_test.dart` — Updated all 4 test responders with merge-base handler + updated `git show` assertions to use merge-base SHA.

## Verification

- `make test` — 618 tests pass (0 failures)
- `make analyze` — No issues found across all modules