### PR TITLE
fix: retry button triggers relay reconnection before fetching data

### DIFF
--- a/mobile/app/lib/features/project_list/project_list_screen.dart
+++ b/mobile/app/lib/features/project_list/project_list_screen.dart
@@ -195,7 +195,7 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
         ),
         ProjectListFailed(:final error) => _ErrorView(
           error: error,
-          onRetry: () => context.read<ProjectListCubit>().loadProjects(),
+          onRetry: () => context.read<ProjectListCubit>().retryLoadProjects(),
         ),
       },
     );

--- a/mobile/app/lib/features/session_list/session_list_screen.dart
+++ b/mobile/app/lib/features/session_list/session_list_screen.dart
@@ -208,7 +208,7 @@ class _SessionListBody extends StatelessWidget {
         ),
         SessionListFailed(:final error) => _ErrorView(
           error: error,
-          onRetry: () => context.read<SessionListCubit>().loadSessions(),
+          onRetry: () => context.read<SessionListCubit>().retryLoadSessions(),
         ),
       },
     );

--- a/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -160,6 +160,48 @@ class ProjectListCubit extends Cubit<ProjectListState> {
     await _fetchProjects();
   }
 
+  /// Retries loading projects after a failure.
+  ///
+  /// Unlike [loadProjects], this method triggers a relay reconnection
+  /// when the connection is not active, then waits for the result before
+  /// fetching. This ensures the retry actually reaches the bridge instead
+  /// of failing immediately with a "not connected" error.
+  Future<void> retryLoadProjects() async {
+    emit(const ProjectListState.loading());
+    // Yield to the event loop so the loading indicator renders before
+    // the reconnection / fetch attempt (which may resolve synchronously
+    // when the relay is disconnected).
+    await Future<void>.delayed(Duration.zero);
+    if (isClosed) return;
+    await _reconnectIfNeeded();
+    if (isClosed) return;
+    await _fetchProjects();
+  }
+
+  /// Attempts to reconnect the relay when it is not in the
+  /// [ConnectionConnected] state. Returns once the connection resolves
+  /// (connected, lost, or timed out).
+  Future<void> _reconnectIfNeeded() async {
+    if (_connectionService.currentStatus is ConnectionConnected) return;
+
+    if (_connectionService.currentStatus is! ConnectionReconnecting) {
+      _connectionService.reconnect();
+    }
+    // If reconnect is now in progress, wait for the outcome.
+    if (_connectionService.currentStatus is! ConnectionReconnecting) return;
+
+    try {
+      await _connectionService.status
+          .where(
+            (s) => s is ConnectionConnected || s is ConnectionLost || s is ConnectionDisconnected,
+          )
+          .first
+          .timeout(const Duration(seconds: 15));
+    } on TimeoutException catch (_) {
+      // Fall through — fetch will fail gracefully with a user-visible error.
+    }
+  }
+
   /// In-flight silent refresh, used for coalescing.
   Future<bool>? _activeRefresh;
 

--- a/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -192,9 +192,7 @@ class ProjectListCubit extends Cubit<ProjectListState> {
 
     try {
       await _connectionService.status
-          .where(
-            (s) => s is ConnectionConnected || s is ConnectionLost || s is ConnectionDisconnected,
-          )
+          .where((s) => s is! ConnectionReconnecting)
           .first
           .timeout(const Duration(seconds: 15));
     } on TimeoutException catch (_) {

--- a/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -230,8 +230,15 @@ class SessionListCubit extends Cubit<SessionListState> {
   void _onConnectionStatusChanged(ConnectionStatus status) {
     logd("[SessionList] connection status: ${status.runtimeType}");
     if (isClosed) return;
-    if (status is ConnectionConnected && state is SessionListLoaded) {
-      unawaited(refreshSessions());
+    if (status is ConnectionConnected) {
+      switch (state) {
+        case SessionListLoaded():
+          unawaited(refreshSessions());
+        case SessionListFailed():
+          unawaited(loadSessions());
+        case SessionListLoading() || SessionListStaleProject():
+          break;
+      }
     }
   }
 
@@ -496,6 +503,44 @@ class SessionListCubit extends Cubit<SessionListState> {
   Future<void> loadSessions() async {
     emit(const SessionListState.loading());
     await _fetchSessions();
+  }
+
+  /// Retries loading sessions after a failure.
+  ///
+  /// Unlike [loadSessions], this method triggers a relay reconnection
+  /// when the connection is not active, then waits for the result before
+  /// fetching. This ensures the retry actually reaches the bridge instead
+  /// of failing immediately with a "not connected" error.
+  Future<void> retryLoadSessions() async {
+    emit(const SessionListState.loading());
+    await Future<void>.delayed(Duration.zero);
+    if (isClosed) return;
+    await _reconnectIfNeeded();
+    if (isClosed) return;
+    await _fetchSessions();
+  }
+
+  /// Attempts to reconnect the relay when it is not in the
+  /// [ConnectionConnected] state. Returns once the connection resolves
+  /// (connected, lost, or timed out).
+  Future<void> _reconnectIfNeeded() async {
+    if (_connectionService.currentStatus is ConnectionConnected) return;
+
+    if (_connectionService.currentStatus is! ConnectionReconnecting) {
+      _connectionService.reconnect();
+    }
+    if (_connectionService.currentStatus is! ConnectionReconnecting) return;
+
+    try {
+      await _connectionService.status
+          .where(
+            (s) => s is ConnectionConnected || s is ConnectionLost || s is ConnectionDisconnected,
+          )
+          .first
+          .timeout(const Duration(seconds: 15));
+    } on TimeoutException catch (_) {
+      // Fall through — fetch will fail gracefully with a user-visible error.
+    }
   }
 
   /// In-flight silent refresh, used for coalescing.

--- a/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -533,9 +533,7 @@ class SessionListCubit extends Cubit<SessionListState> {
 
     try {
       await _connectionService.status
-          .where(
-            (s) => s is ConnectionConnected || s is ConnectionLost || s is ConnectionDisconnected,
-          )
+          .where((s) => s is! ConnectionReconnecting)
           .first
           .timeout(const Duration(seconds: 15));
     } on TimeoutException catch (_) {

--- a/mobile/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/mobile/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -833,6 +833,100 @@ void main() {
     );
 
     // -------------------------------------------------------------------------
+    // retryLoadProjects
+    // -------------------------------------------------------------------------
+
+    blocTest<ProjectListCubit, ProjectListState>(
+      "retryLoadProjects: reconnects and loads projects when connection is lost",
+      build: () {
+        when(() => mockProjectService.listProjects()).thenAnswer(
+          (_) async => ApiResponse.error(ApiError.generic()),
+        );
+        const config = ServerConnectionConfig(
+          relayHost: "relay.example.com",
+          authToken: "test-token",
+        );
+        when(() => mockConnectionService.currentStatus).thenReturn(
+          const ConnectionStatus.connectionLost(config: config),
+        );
+        return buildCubit();
+      },
+      act: (cubit) async {
+        await Future<void>.delayed(Duration.zero);
+        when(() => mockProjectService.listProjects()).thenAnswer(
+          (_) async => ApiResponse.success(Projects(data: [testProject()])),
+        );
+        const config = ServerConnectionConfig(
+          relayHost: "relay.example.com",
+          authToken: "test-token",
+        );
+        when(() => mockConnectionService.reconnect()).thenAnswer((_) {
+          when(() => mockConnectionService.currentStatus).thenReturn(
+            const ConnectionStatus.reconnecting(config: config),
+          );
+          statusController.add(const ConnectionStatus.reconnecting(config: config));
+        });
+        final retryFuture = cubit.retryLoadProjects();
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        const health = HealthResponse(healthy: true, version: "0.1.200");
+        statusController.add(
+          const ConnectionStatus.connected(config: config, health: health),
+        );
+        await retryFuture;
+      },
+      skip: 1,
+      expect: () => [
+        isA<ProjectListLoading>(),
+        isA<ProjectListLoaded>().having(
+          (s) => s.projects.length,
+          "projects count after retry",
+          1,
+        ),
+      ],
+      verify: (_) {
+        verify(() => mockConnectionService.reconnect()).called(1);
+      },
+    );
+
+    blocTest<ProjectListCubit, ProjectListState>(
+      "retryLoadProjects: loads directly when already connected",
+      build: () {
+        when(() => mockProjectService.listProjects()).thenAnswer(
+          (_) async => ApiResponse.error(ApiError.generic()),
+        );
+        const config = ServerConnectionConfig(
+          relayHost: "relay.example.com",
+          authToken: "test-token",
+        );
+        const health = HealthResponse(healthy: true, version: "0.1.200");
+        when(() => mockConnectionService.currentStatus).thenReturn(
+          const ConnectionStatus.connected(config: config, health: health),
+        );
+        return buildCubit();
+      },
+      act: (cubit) async {
+        await Future<void>.delayed(Duration.zero);
+        when(() => mockProjectService.listProjects()).thenAnswer(
+          (_) async => ApiResponse.success(Projects(data: [testProject()])),
+        );
+        await cubit.retryLoadProjects();
+      },
+      skip: 1,
+      expect: () => [
+        isA<ProjectListLoading>(),
+        isA<ProjectListLoaded>().having(
+          (s) => s.projects.length,
+          "projects count after retry",
+          1,
+        ),
+      ],
+      verify: (_) {
+        verifyNever(() => mockConnectionService.reconnect());
+      },
+    );
+
+    // -------------------------------------------------------------------------
     // Stale reconnect
     // -------------------------------------------------------------------------
 

--- a/mobile/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/mobile/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -1042,6 +1042,41 @@ void main() {
     );
 
     blocTest<SessionListCubit, SessionListState>(
+      "connection reconnect triggers loadSessions when state is SessionListFailed",
+      build: () {
+        when(() => mockSessionService.listSessions(projectId: projectId)).thenAnswer(
+          (_) async => ApiResponse.error(ApiError.generic()),
+        );
+        return buildCubit();
+      },
+      act: (cubit) async {
+        await Future<void>.delayed(Duration.zero);
+        // Switch mock to succeed so the reconnect-triggered load works.
+        when(() => mockSessionService.listSessions(projectId: projectId)).thenAnswer(
+          (_) async => ApiResponse.success(SessionListResponse(items: [testSession(id: "s1")])),
+        );
+        const config = ServerConnectionConfig(
+          relayHost: "relay.example.com",
+          authToken: "test-token",
+        );
+        const health = HealthResponse(healthy: true, version: "0.1.200");
+        statusController.add(
+          const ConnectionStatus.connected(config: config, health: health),
+        );
+        await Future<void>.delayed(Duration.zero);
+      },
+      skip: 1, // Skip the initial SessionListFailed from constructor.
+      expect: () => [
+        isA<SessionListLoading>(),
+        isA<SessionListLoaded>().having(
+          (s) => s.sessions.length,
+          "sessions count after reconnect retry",
+          1,
+        ),
+      ],
+    );
+
+    blocTest<SessionListCubit, SessionListState>(
       "rapid ConnectionConnected events coalesce into single refresh",
       build: () {
         when(() => mockSessionService.listSessions(projectId: projectId)).thenAnswer(


### PR DESCRIPTION
## Summary

- **Fixes non-functional retry button** on the project list and session list error screens when the relay connection is not active (e.g. bridge not started on app launch)
- Adds `retryLoadProjects()` / `retryLoadSessions()` methods that yield a frame for the loading indicator, attempt relay reconnection when needed, then fetch data
- Fixes `SessionListCubit._onConnectionStatusChanged` to auto-load sessions on reconnect when in `Failed` state (matching existing `ProjectListCubit` behavior)

## Root Cause

When the relay client was disconnected, `RelayHttpApiClient` returned a synchronous "not connected" error. This caused `loadProjects()` to transition `Loading → Failed` within the same rendering frame — the user never saw a loading indicator and perceived the retry button as broken.

## Changes

| File | Change |
|------|--------|
| `project_list_cubit.dart` | Add `retryLoadProjects()` + `_reconnectIfNeeded()` |
| `session_list_cubit.dart` | Add `retryLoadSessions()` + `_reconnectIfNeeded()`, fix `_onConnectionStatusChanged` to handle `Failed` state |
| `project_list_screen.dart` | Wire retry button to `retryLoadProjects()` |
| `session_list_screen.dart` | Wire retry button to `retryLoadSessions()` |
| `project_list_cubit_test.dart` | Add tests for retry with reconnection and retry when already connected |
| `session_list_cubit_test.dart` | Add test for auto-load on reconnect when in `Failed` state |