### PR TITLE
refactor(bridge): use single HTTP client per OpenCodeApi instance

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -18,12 +18,14 @@ class OpenCodeApi {
   final String serverURL;
   final String? _password;
   final http.Client _client;
+  final bool _isClientOwned;
 
   OpenCodeApi({
     required this.serverURL,
     required String? password,
     http.Client? client,
   }) : _password = password,
+       _isClientOwned = client == null,
        _client = client ?? http.Client();
 
   Map<String, String> get _authHeaders {
@@ -33,14 +35,20 @@ class OpenCodeApi {
   }
 
   void close() {
-    _client.close();
+    if (_isClientOwned) {
+      _client.close();
+    }
   }
 
   Future<bool> healthCheck() async {
-    final response = await _client
-        .get(Uri.parse("$serverURL/global/health"), headers: _authHeaders)
-        .timeout(const Duration(seconds: 5));
-    return response.statusCode >= 200 && response.statusCode < 300;
+    try {
+      final response = await _client
+          .get(Uri.parse("$serverURL/global/health"), headers: _authHeaders)
+          .timeout(const Duration(seconds: 5));
+      return response.statusCode >= 200 && response.statusCode < 300;
+    } catch (_) {
+      return false;
+    }
   }
 
   Future<List<Project>> listProjects() async {

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -17,11 +17,14 @@ const _directoryOpenCodeHeader = "x-opencode-directory";
 class OpenCodeApi {
   final String serverURL;
   final String? _password;
+  final http.Client _client;
 
   OpenCodeApi({
     required this.serverURL,
     required String? password,
-  }) : _password = password;
+    http.Client? client,
+  }) : _password = password,
+       _client = client ?? http.Client();
 
   Map<String, String> get _authHeaders {
     if (_password == null) return const {};
@@ -29,8 +32,19 @@ class OpenCodeApi {
     return {"Authorization": "Basic $creds"};
   }
 
+  void close() {
+    _client.close();
+  }
+
+  Future<bool> healthCheck() async {
+    final response = await _client
+        .get(Uri.parse("$serverURL/global/health"), headers: _authHeaders)
+        .timeout(const Duration(seconds: 5));
+    return response.statusCode >= 200 && response.statusCode < 300;
+  }
+
   Future<List<Project>> listProjects() async {
-    final response = await http.get(
+    final response = await _client.get(
       Uri.parse("$serverURL/project"),
       headers: _authHeaders,
     );
@@ -41,7 +55,7 @@ class OpenCodeApi {
   }
 
   Future<List<Session>> listRootSessions() async {
-    final response = await http.get(
+    final response = await _client.get(
       Uri.parse("$serverURL/session?roots=true"),
       headers: _authHeaders,
     );
@@ -57,7 +71,7 @@ class OpenCodeApi {
       _directoryOpenCodeHeader: ?directory,
     };
 
-    final response = await http.get(
+    final response = await _client.get(
       Uri.parse("$serverURL/session"),
       headers: headers,
     );
@@ -71,33 +85,28 @@ class OpenCodeApi {
     required String directory,
     String? parentSessionId,
   }) async {
-    final client = http.Client();
-    try {
-      // Supported body:
-      //  {
-      //   "parentID": "<sessionID>",   // optional - set this to make it a child
-      //   "title": "string",           // optional - title gets auto-generated after first message
-      //   "permission": "...",         // optional
-      //   "workspaceID": "string"      // optional
-      // }
-      final body = <String, dynamic>{};
-      if (parentSessionId case final id?) {
-        body["parentID"] = id;
-      }
-      final response = await client.post(
-        Uri.parse("$serverURL/session"),
-        headers: {
-          ..._authHeaders,
-          "content-type": "application/json",
-          _directoryOpenCodeHeader: directory,
-        },
-        body: jsonEncode(body),
-      );
-      _ensureSuccess(response, "POST /session");
-      return Session.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
-    } finally {
-      client.close();
+    // Supported body:
+    //  {
+    //   "parentID": "<sessionID>",   // optional - set this to make it a child
+    //   "title": "string",           // optional - title gets auto-generated after first message
+    //   "permission": "...",         // optional
+    //   "workspaceID": "string"      // optional
+    // }
+    final body = <String, dynamic>{};
+    if (parentSessionId case final id?) {
+      body["parentID"] = id;
     }
+    final response = await _client.post(
+      Uri.parse("$serverURL/session"),
+      headers: {
+        ..._authHeaders,
+        "content-type": "application/json",
+        _directoryOpenCodeHeader: directory,
+      },
+      body: jsonEncode(body),
+    );
+    _ensureSuccess(response, "POST /session");
+    return Session.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
   }
 
   Future<Session> getSession({
@@ -108,7 +117,7 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory,
     };
-    final response = await http.get(
+    final response = await _client.get(
       Uri.parse("$serverURL/session/$sessionId"),
       headers: headers,
     );
@@ -121,22 +130,17 @@ class OpenCodeApi {
     required Map<String, dynamic> body,
     required String? directory,
   }) async {
-    final client = http.Client();
-    try {
-      final response = await client.patch(
-        Uri.parse("$serverURL/session/$sessionId"),
-        headers: {
-          ..._authHeaders,
-          "content-type": "application/json",
-          _directoryOpenCodeHeader: ?directory,
-        },
-        body: jsonEncode(body),
-      );
-      _ensureSuccess(response, "PATCH /session/$sessionId");
-      return Session.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
-    } finally {
-      client.close();
-    }
+    final response = await _client.patch(
+      Uri.parse("$serverURL/session/$sessionId"),
+      headers: {
+        ..._authHeaders,
+        "content-type": "application/json",
+        _directoryOpenCodeHeader: ?directory,
+      },
+      body: jsonEncode(body),
+    );
+    _ensureSuccess(response, "PATCH /session/$sessionId");
+    return Session.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
   }
 
   /// Updates a project by its OpenCode-assigned ID (NOT the worktree path
@@ -146,42 +150,32 @@ class OpenCodeApi {
     required String directory,
     required Map<String, dynamic> body,
   }) async {
-    final client = http.Client();
-    try {
-      final response = await client.patch(
-        Uri.parse("$serverURL/project/$projectId"),
-        headers: {
-          ..._authHeaders,
-          "content-type": "application/json",
-          _directoryOpenCodeHeader: directory,
-        },
-        body: jsonEncode(body),
-      );
-      _ensureSuccess(response, "PATCH /project/$projectId");
-      return Project.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
-    } finally {
-      client.close();
-    }
+    final response = await _client.patch(
+      Uri.parse("$serverURL/project/$projectId"),
+      headers: {
+        ..._authHeaders,
+        "content-type": "application/json",
+        _directoryOpenCodeHeader: directory,
+      },
+      body: jsonEncode(body),
+    );
+    _ensureSuccess(response, "PATCH /project/$projectId");
+    return Project.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
   }
 
   Future<void> deleteSession({
     required String sessionId,
     required String? directory,
   }) async {
-    final client = http.Client();
-    try {
-      final headers = <String, String>{
-        ..._authHeaders,
-        _directoryOpenCodeHeader: ?directory,
-      };
-      final response = await client.delete(
-        Uri.parse("$serverURL/session/$sessionId"),
-        headers: headers,
-      );
-      _ensureSuccess(response, "DELETE /session/$sessionId");
-    } finally {
-      client.close();
-    }
+    final headers = <String, String>{
+      ..._authHeaders,
+      _directoryOpenCodeHeader: ?directory,
+    };
+    final response = await _client.delete(
+      Uri.parse("$serverURL/session/$sessionId"),
+      headers: headers,
+    );
+    _ensureSuccess(response, "DELETE /session/$sessionId");
   }
 
   Future<List<Session>> getChildren({
@@ -192,7 +186,7 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory, // probably irrelevant for this endpoint
     };
-    final response = await http.get(
+    final response = await _client.get(
       Uri.parse("$serverURL/session/$sessionId/children"),
       headers: headers,
     );
@@ -206,20 +200,15 @@ class OpenCodeApi {
     required String sessionId,
     required String directory,
   }) async {
-    final client = http.Client();
-    try {
-      final response = await client.post(
-        Uri.parse("$serverURL/session/$sessionId/fork"),
-        headers: {
-          ..._authHeaders,
-          _directoryOpenCodeHeader: directory,
-        },
-      );
-      _ensureSuccess(response, "POST /session/$sessionId/fork");
-      return Session.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
-    } finally {
-      client.close();
-    }
+    final response = await _client.post(
+      Uri.parse("$serverURL/session/$sessionId/fork"),
+      headers: {
+        ..._authHeaders,
+        _directoryOpenCodeHeader: directory,
+      },
+    );
+    _ensureSuccess(response, "POST /session/$sessionId/fork");
+    return Session.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
   }
 
   Future<List<MessageWithParts>> getMessages({
@@ -230,7 +219,7 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory, // probably irrelevant for this endpoint
     };
-    final response = await http.get(
+    final response = await _client.get(
       Uri.parse("$serverURL/session/$sessionId/message"),
       headers: headers,
     );
@@ -247,46 +236,36 @@ class OpenCodeApi {
     // because otherwise it picks the CWD of where bridge is running
     required String? directory,
   }) async {
-    final client = http.Client();
-    try {
-      final response = await client.post(
-        Uri.parse("$serverURL/session/$sessionId/prompt_async"),
-        headers: {
-          ..._authHeaders,
-          "content-type": "application/json",
-          _directoryOpenCodeHeader: ?directory,
-        },
-        body: jsonEncode(body.toJson()),
-      );
-      _ensureSuccess(response, "POST /session/$sessionId/prompt_async");
-    } finally {
-      client.close();
-    }
+    final response = await _client.post(
+      Uri.parse("$serverURL/session/$sessionId/prompt_async"),
+      headers: {
+        ..._authHeaders,
+        "content-type": "application/json",
+        _directoryOpenCodeHeader: ?directory,
+      },
+      body: jsonEncode(body.toJson()),
+    );
+    _ensureSuccess(response, "POST /session/$sessionId/prompt_async");
   }
 
   Future<void> abortSession({
     required String sessionId,
     required String? directory,
   }) async {
-    final client = http.Client();
-    try {
-      final headers = <String, String>{
-        ..._authHeaders,
-        _directoryOpenCodeHeader: ?directory,
-      };
-      final response = await client.post(
-        Uri.parse("$serverURL/session/$sessionId/abort"),
-        headers: headers,
-        body: "",
-      );
-      _ensureSuccess(response, "POST /session/$sessionId/abort");
-    } finally {
-      client.close();
-    }
+    final headers = <String, String>{
+      ..._authHeaders,
+      _directoryOpenCodeHeader: ?directory,
+    };
+    final response = await _client.post(
+      Uri.parse("$serverURL/session/$sessionId/abort"),
+      headers: headers,
+      body: "",
+    );
+    _ensureSuccess(response, "POST /session/$sessionId/abort");
   }
 
   Future<List<AgentInfo>> listAgents() async {
-    final response = await http.get(Uri.parse("$serverURL/agent"), headers: _authHeaders);
+    final response = await _client.get(Uri.parse("$serverURL/agent"), headers: _authHeaders);
     _ensureSuccess(response, "GET /agent");
 
     final decoded = jsonDecode(response.body) as List;
@@ -300,7 +279,7 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory,
     };
-    final response = await http.get(Uri.parse("$serverURL/question"), headers: headers);
+    final response = await _client.get(Uri.parse("$serverURL/question"), headers: headers);
     Log.v("[getPendingQuestions] response: ${response.body}");
     _ensureSuccess(response, "GET /question");
 
@@ -313,48 +292,38 @@ class OpenCodeApi {
     required String? directory,
     required Map<String, dynamic> body,
   }) async {
-    final client = http.Client();
-    try {
-      final encodedBody = jsonEncode(body);
-      Log.d("[question-api] POST /question/$questionId/reply body=$encodedBody");
-      final response = await client.post(
-        Uri.parse("$serverURL/question/$questionId/reply"),
-        headers: {
-          ..._authHeaders,
-          _directoryOpenCodeHeader: ?directory, // doesn't work well with the directory header
-          "content-type": "application/json",
-        },
-        body: encodedBody,
-      );
-      Log.d("[question-api] POST /question/$questionId/reply => ${response.statusCode} body=${response.body}");
-      _ensureSuccess(response, "POST /question/$questionId/reply");
-    } finally {
-      client.close();
-    }
+    final encodedBody = jsonEncode(body);
+    Log.d("[question-api] POST /question/$questionId/reply body=$encodedBody");
+    final response = await _client.post(
+      Uri.parse("$serverURL/question/$questionId/reply"),
+      headers: {
+        ..._authHeaders,
+        _directoryOpenCodeHeader: ?directory, // doesn't work well with the directory header
+        "content-type": "application/json",
+      },
+      body: encodedBody,
+    );
+    Log.d("[question-api] POST /question/$questionId/reply => ${response.statusCode} body=${response.body}");
+    _ensureSuccess(response, "POST /question/$questionId/reply");
   }
 
   Future<void> rejectQuestion({
     required String questionId,
   }) async {
-    final client = http.Client();
-    try {
-      Log.d("[question-api] POST /question/$questionId/reject");
-      final response = await client.post(
-        Uri.parse("$serverURL/question/$questionId/reject"),
-        headers: _authHeaders,
-        body: "",
-      );
-      Log.d("[question-api] POST /question/$questionId/reject => ${response.statusCode} body=${response.body}");
-      _ensureSuccess(response, "POST /question/$questionId/reject");
-    } finally {
-      client.close();
-    }
+    Log.d("[question-api] POST /question/$questionId/reject");
+    final response = await _client.post(
+      Uri.parse("$serverURL/question/$questionId/reject"),
+      headers: _authHeaders,
+      body: "",
+    );
+    Log.d("[question-api] POST /question/$questionId/reject => ${response.statusCode} body=${response.body}");
+    _ensureSuccess(response, "POST /question/$questionId/reject");
   }
 
   Future<Project> getProject({
     required String directory,
   }) async {
-    final response = await http.get(
+    final response = await _client.get(
       Uri.parse("$serverURL/project/current"),
       headers: {
         ..._authHeaders,
@@ -393,7 +362,7 @@ class OpenCodeApi {
     final uri = Uri.parse(
       "$serverURL/experimental/session",
     ).replace(queryParameters: queryParams.isEmpty ? null : queryParams);
-    final response = await http.get(uri, headers: _authHeaders);
+    final response = await _client.get(uri, headers: _authHeaders);
     _ensureSuccess(response, "GET /experimental/session");
 
     final decoded = jsonDecode(response.body) as List;
@@ -401,7 +370,7 @@ class OpenCodeApi {
   }
 
   Future<ProviderListResponse> listProviders() async {
-    final response = await http.get(
+    final response = await _client.get(
       Uri.parse("$serverURL/provider"),
       headers: _authHeaders,
     );
@@ -410,7 +379,7 @@ class OpenCodeApi {
   }
 
   Future<Map<String, SessionStatus>> getSessionStatuses() async {
-    final response = await http.get(
+    final response = await _client.get(
       Uri.parse("$serverURL/session/status"),
       headers: _authHeaders,
     );

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -1,7 +1,5 @@
 import "dart:async";
-import "dart:convert";
 
-import "package:http/http.dart" as http;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "../opencode_plugin.dart";
@@ -12,17 +10,13 @@ class OpenCodePlugin implements BridgePlugin {
   final OpenCodeService _service;
   final SseEventParser _parser;
   final BufferedUntilFirstListener<BridgeSseEvent> _eventBuffer;
-  final String _serverUrl;
-  final String? _password;
   final SseEventMapper _mapper = SseEventMapper();
   late final SseConnection _sseConnection;
 
   OpenCodePlugin({
     required String serverUrl,
     String? password,
-  }) : _serverUrl = serverUrl,
-       _password = password,
-       _service = _createService(serverUrl, password),
+  }) : _service = _createService(serverUrl, password),
        _parser = SseEventParser(),
        _eventBuffer = BufferedUntilFirstListener<BridgeSseEvent>() {
     _sseConnection = SseConnection(
@@ -70,21 +64,8 @@ class OpenCodePlugin implements BridgePlugin {
   Stream<BridgeSseEvent> get events => _eventBuffer.stream;
 
   @override
-  Future<bool> healthCheck() async {
-    final client = http.Client();
-    try {
-      final headers = <String, String>{};
-      if (_password != null) {
-        final creds = base64.encode(utf8.encode("opencode:$_password"));
-        headers["Authorization"] = "Basic $creds";
-      }
-      final response = await client
-          .get(Uri.parse("$_serverUrl/global/health"), headers: headers)
-          .timeout(const Duration(seconds: 5));
-      return response.statusCode >= 200 && response.statusCode < 300;
-    } finally {
-      client.close();
-    }
+  Future<bool> healthCheck() {
+    return _service.repository.api.healthCheck();
   }
 
   @override
@@ -191,6 +172,7 @@ class OpenCodePlugin implements BridgePlugin {
   @override
   Future<void> dispose() async {
     _sseConnection.stop();
+    _service.repository.api.close();
     await _eventBuffer.close();
   }
 

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -723,6 +723,12 @@ class _FakeApi implements OpenCodeApi {
   String get serverURL => "http://fake";
 
   @override
+  void close() {}
+
+  @override
+  Future<bool> healthCheck() async => true;
+
+  @override
   Future<List<Project>> listProjects() async => _projects;
 
   @override

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -374,6 +374,12 @@ class _FakeApi implements OpenCodeApi {
   String get serverURL => "http://fake";
 
   @override
+  void close() {}
+
+  @override
+  Future<bool> healthCheck() async => true;
+
+  @override
   Future<List<Project>> listProjects() async => _projects;
 
   @override

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -309,6 +309,12 @@ class FakeOpenCodeApi implements OpenCodeApi {
   FakeOpenCodeApi({this.messages = const [], this.messagesError});
 
   @override
+  void close() {}
+
+  @override
+  Future<bool> healthCheck() async => true;
+
+  @override
   Future<List<MessageWithParts>> getMessages({required String sessionId, required String? directory}) async {
     lastRequestedSessionId = sessionId;
     lastRequestedDirectory = directory;


### PR DESCRIPTION
## Summary

- **Replaced mixed HTTP client patterns in `OpenCodeApi`** — the class previously used both global `http.get/post` top-level functions (which create+close a client per call) and per-method `http.Client()` instances with try/finally cleanup. Now a single `http.Client` field is created once in the constructor and reused across all requests.
- **Consolidated `healthCheck()` into `OpenCodeApi`** — `OpenCodePlugin` no longer manages its own HTTP client for the health endpoint; it delegates to `api.healthCheck()`. The plugin's `dispose()` now calls `api.close()` to properly release the shared client.
- **Updated all test fakes** — three test files implementing `OpenCodeApi` as an interface received `close()` and `healthCheck()` stub methods.