### PR TITLE
fix(bridge): force-close shared HTTP client on shutdown

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -18,26 +18,18 @@ class OpenCodeApi {
   final String serverURL;
   final String? _password;
   final http.Client _client;
-  final bool _isClientOwned;
 
   OpenCodeApi({
     required this.serverURL,
     required String? password,
-    http.Client? client,
+    required http.Client client,
   }) : _password = password,
-       _isClientOwned = client == null,
-       _client = client ?? http.Client();
+       _client = client;
 
   Map<String, String> get _authHeaders {
     if (_password == null) return const {};
     final creds = base64.encode(utf8.encode("opencode:$_password"));
     return {"Authorization": "Basic $creds"};
-  }
-
-  void close() {
-    if (_isClientOwned) {
-      _client.close();
-    }
   }
 
   Future<bool> healthCheck() async {

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -1,5 +1,7 @@
 import "dart:async";
+import "dart:io" as io;
 
+import "package:http/io_client.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "../opencode_plugin.dart";
@@ -10,13 +12,37 @@ class OpenCodePlugin implements BridgePlugin {
   final OpenCodeService _service;
   final SseEventParser _parser;
   final BufferedUntilFirstListener<BridgeSseEvent> _eventBuffer;
+  final io.HttpClient _httpClient;
   final SseEventMapper _mapper = SseEventMapper();
   late final SseConnection _sseConnection;
 
-  OpenCodePlugin({
+  factory OpenCodePlugin({
     required String serverUrl,
     String? password,
-  }) : _service = _createService(serverUrl, password),
+  }) {
+    final httpClient = io.HttpClient();
+    final api = OpenCodeApi(
+      serverURL: serverUrl,
+      password: password,
+      client: IOClient(httpClient),
+    );
+    final repository = OpenCodeRepository(api);
+    final tracker = ActiveSessionTracker(repository);
+    return OpenCodePlugin._(
+      service: OpenCodeService(repository, tracker),
+      httpClient: httpClient,
+      serverUrl: serverUrl,
+      password: password,
+    );
+  }
+
+  OpenCodePlugin._({
+    required OpenCodeService service,
+    required io.HttpClient httpClient,
+    required String serverUrl,
+    required String? password,
+  }) : _service = service,
+       _httpClient = httpClient,
        _parser = SseEventParser(),
        _eventBuffer = BufferedUntilFirstListener<BridgeSseEvent>() {
     _sseConnection = SseConnection(
@@ -30,13 +56,6 @@ class OpenCodePlugin implements BridgePlugin {
       },
     );
     unawaited(_initialize());
-  }
-
-  static OpenCodeService _createService(String serverUrl, String? password) {
-    final api = OpenCodeApi(serverURL: serverUrl, password: password);
-    final repository = OpenCodeRepository(api);
-    final tracker = ActiveSessionTracker(repository);
-    return OpenCodeService(repository, tracker);
   }
 
   Future<void> _initialize() async {
@@ -172,7 +191,7 @@ class OpenCodePlugin implements BridgePlugin {
   @override
   Future<void> dispose() async {
     _sseConnection.stop();
-    _service.repository.api.close();
+    _httpClient.close(force: true);
     await _eventBuffer.close();
   }
 

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -723,9 +723,6 @@ class _FakeApi implements OpenCodeApi {
   String get serverURL => "http://fake";
 
   @override
-  void close() {}
-
-  @override
   Future<bool> healthCheck() async => true;
 
   @override

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -374,9 +374,6 @@ class _FakeApi implements OpenCodeApi {
   String get serverURL => "http://fake";
 
   @override
-  void close() {}
-
-  @override
   Future<bool> healthCheck() async => true;
 
   @override

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -309,9 +309,6 @@ class FakeOpenCodeApi implements OpenCodeApi {
   FakeOpenCodeApi({this.messages = const [], this.messagesError});
 
   @override
-  void close() {}
-
-  @override
   Future<bool> healthCheck() async => true;
 
   @override


### PR DESCRIPTION
## Summary

- Fixes slow bridge shutdown introduced by #75 (shared HTTP client refactor)
- The shared `http.Client` maintains keep-alive connections in a pool. On shutdown, `HttpClient.close(force: false)` — the only option through the `http.Client` abstraction — lets those connections linger until their idle timeout expires (~15s), blocking process exit
- Stores the underlying `dart:io` `HttpClient` and calls `close(force: true)` to immediately terminate all pooled connections on shutdown

## Changes

`OpenCodeApi` now uses a factory constructor that, when no external client is injected, creates a `dart:io` `HttpClient` wrapped in `IOClient`. The `close()` method calls `HttpClient.close(force: true)` instead of relying on the `http.Client.close()` default behavior. When an external client is provided (tests), we don't force-close it — the caller owns its lifecycle.