### PR TITLE
fix(bridge): filter reasoning parts from metadata generation response

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/session_metadata_generator.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/session_metadata_generator.dart
@@ -24,48 +24,33 @@ class SessionMetadataGenerator {
         return null;
       }
 
-      Log.d(
-        "SessionMetadataGenerator: using model "
-        "${model.providerID}/${model.modelID}",
-      );
-
       final truncated = firstMessage.length > 500 ? firstMessage.substring(0, 500) : firstMessage;
 
       final session = await _api.createSession(directory: directory);
-      Log.d("SessionMetadataGenerator: created ephemeral session ${session.id}");
       try {
-        final body = SendMessageSyncBody(
-          parts: [
-            {"type": "text", "text": truncated},
-          ],
-          system: _systemPrompt,
-          model: model,
-        );
-        Log.d("SessionMetadataGenerator: sendMessageSync request body: ${body.toJson()}");
-
         final response = await _api.sendMessageSync(
           sessionId: session.id,
           directory: directory,
-          body: body,
-        );
-
-        final rawText = response.parts
-            .where((part) => part.type == "text")
-            .map((part) => part.text)
-            .whereType<String>()
-            .join();
-        Log.d(
-          "SessionMetadataGenerator: raw API response "
-          "(${response.parts.length} part(s)): $rawText",
+          body: SendMessageSyncBody(
+            parts: [
+              {"type": "text", "text": truncated},
+            ],
+            system: _systemPrompt,
+            model: model,
+          ),
         );
 
         final result = _parseResponse(response);
         if (result == null) {
-          Log.w("SessionMetadataGenerator: failed to parse response into metadata");
-        } else {
-          Log.d(
-            "SessionMetadataGenerator: generated metadata — "
-            'title="${result.title}", branch="${result.branchName}"',
+          final rawText = response.parts
+              .where((part) => part.type == "text")
+              .map((part) => part.text)
+              .whereType<String>()
+              .join();
+          Log.w(
+            "SessionMetadataGenerator: failed to parse response into metadata. "
+            "Model: ${model.providerID}/${model.modelID}. "
+            "Raw text response: $rawText",
           );
         }
         return result;
@@ -81,8 +66,8 @@ class SessionMetadataGenerator {
           );
         }
       }
-    } catch (e, st) {
-      Log.w("SessionMetadataGenerator: failed to generate metadata: $e\n$st");
+    } catch (e) {
+      Log.w("SessionMetadataGenerator: failed to generate metadata: $e");
       return null;
     }
   }
@@ -94,27 +79,12 @@ class SessionMetadataGenerator {
   Future<({String providerID, String modelID})?> _resolveModel() async {
     // 1. Explicit small_model in config — user's choice, always wins.
     final config = await _api.getConfig();
-    Log.d(
-      "SessionMetadataGenerator: config — "
-      'model="${config.model}", smallModel="${config.smallModel}"',
-    );
     final explicit = _parseModelStr(config.smallModel);
-    if (explicit != null) {
-      Log.d(
-        "SessionMetadataGenerator: using explicit small_model from config: "
-        "${explicit.providerID}/${explicit.modelID}",
-      );
-      return explicit;
-    }
+    if (explicit != null) return explicit;
 
     // 2. Scan connected providers for the cheapest/fastest model.
     final providers = await _api.listProviders();
     final connectedIds = providers.connected.toSet();
-    Log.d(
-      "SessionMetadataGenerator: connected providers: "
-      "${providers.connected}, "
-      "defaults: ${providers.defaults}",
-    );
 
     ({String providerID, String modelID})? best;
     var bestScore = -1;
@@ -125,14 +95,6 @@ class SessionMetadataGenerator {
       for (final model in provider.models.values) {
         if (model.status != "active") continue;
         final score = _smallModelScore(model: model);
-        if (score > 0) {
-          Log.d(
-            "SessionMetadataGenerator: candidate — "
-            "${provider.id}/${model.id} "
-            '(name="${model.name}", family="${model.family}", '
-            "score=$score, releaseDate=${model.releaseDate})",
-          );
-        }
         if (score > bestScore || (score == bestScore && _isNewer(model.releaseDate, bestReleaseDate))) {
           bestScore = score;
           best = (providerID: provider.id, modelID: model.id);
@@ -141,23 +103,12 @@ class SessionMetadataGenerator {
       }
     }
 
-    if (best != null) {
-      Log.d(
-        "SessionMetadataGenerator: best model by score: "
-        "${best.providerID}/${best.modelID} (score=$bestScore)",
-      );
-      return best;
-    }
+    if (best != null) return best;
 
     // 3. Last resort: first connected provider's default.
-    Log.d("SessionMetadataGenerator: no scored model found, trying provider defaults");
     for (final connectedId in providers.connected) {
       final defaultModelId = providers.defaults[connectedId];
       if (defaultModelId != null && defaultModelId.isNotEmpty) {
-        Log.d(
-          "SessionMetadataGenerator: falling back to default — "
-          "$connectedId/$defaultModelId",
-        );
         return (providerID: connectedId, modelID: defaultModelId);
       }
     }

--- a/bridge/sesori_plugin_opencode/lib/src/session_metadata_generator.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/session_metadata_generator.dart
@@ -42,15 +42,9 @@ class SessionMetadataGenerator {
 
         final result = _parseResponse(response);
         if (result == null) {
-          final rawText = response.parts
-              .where((part) => part.type == "text")
-              .map((part) => part.text)
-              .whereType<String>()
-              .join();
           Log.w(
             "SessionMetadataGenerator: failed to parse response into metadata. "
-            "Model: ${model.providerID}/${model.modelID}. "
-            "Raw text response: $rawText",
+            "Model: ${model.providerID}/${model.modelID}.",
           );
         }
         return result;

--- a/bridge/sesori_plugin_opencode/lib/src/session_metadata_generator.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/session_metadata_generator.dart
@@ -24,22 +24,51 @@ class SessionMetadataGenerator {
         return null;
       }
 
+      Log.d(
+        "SessionMetadataGenerator: using model "
+        "${model.providerID}/${model.modelID}",
+      );
+
       final truncated = firstMessage.length > 500 ? firstMessage.substring(0, 500) : firstMessage;
 
       final session = await _api.createSession(directory: directory);
+      Log.d("SessionMetadataGenerator: created ephemeral session ${session.id}");
       try {
+        final body = SendMessageSyncBody(
+          parts: [
+            {"type": "text", "text": truncated},
+          ],
+          system: _systemPrompt,
+          model: model,
+        );
+        Log.d("SessionMetadataGenerator: sendMessageSync request body: ${body.toJson()}");
+
         final response = await _api.sendMessageSync(
           sessionId: session.id,
           directory: directory,
-          body: SendMessageSyncBody(
-            parts: [
-              {"type": "text", "text": truncated},
-            ],
-            system: _systemPrompt,
-            model: model,
-          ),
+          body: body,
         );
-        return _parseResponse(response);
+
+        final rawText = response.parts
+            .where((part) => part.type == "text")
+            .map((part) => part.text)
+            .whereType<String>()
+            .join();
+        Log.d(
+          "SessionMetadataGenerator: raw API response "
+          "(${response.parts.length} part(s)): $rawText",
+        );
+
+        final result = _parseResponse(response);
+        if (result == null) {
+          Log.w("SessionMetadataGenerator: failed to parse response into metadata");
+        } else {
+          Log.d(
+            "SessionMetadataGenerator: generated metadata — "
+            'title="${result.title}", branch="${result.branchName}"',
+          );
+        }
+        return result;
       } finally {
         try {
           await _api.deleteSession(
@@ -52,8 +81,8 @@ class SessionMetadataGenerator {
           );
         }
       }
-    } catch (e) {
-      Log.w("SessionMetadataGenerator: failed to generate metadata: $e");
+    } catch (e, st) {
+      Log.w("SessionMetadataGenerator: failed to generate metadata: $e\n$st");
       return null;
     }
   }
@@ -65,12 +94,27 @@ class SessionMetadataGenerator {
   Future<({String providerID, String modelID})?> _resolveModel() async {
     // 1. Explicit small_model in config — user's choice, always wins.
     final config = await _api.getConfig();
+    Log.d(
+      "SessionMetadataGenerator: config — "
+      'model="${config.model}", smallModel="${config.smallModel}"',
+    );
     final explicit = _parseModelStr(config.smallModel);
-    if (explicit != null) return explicit;
+    if (explicit != null) {
+      Log.d(
+        "SessionMetadataGenerator: using explicit small_model from config: "
+        "${explicit.providerID}/${explicit.modelID}",
+      );
+      return explicit;
+    }
 
     // 2. Scan connected providers for the cheapest/fastest model.
     final providers = await _api.listProviders();
     final connectedIds = providers.connected.toSet();
+    Log.d(
+      "SessionMetadataGenerator: connected providers: "
+      "${providers.connected}, "
+      "defaults: ${providers.defaults}",
+    );
 
     ({String providerID, String modelID})? best;
     var bestScore = -1;
@@ -81,6 +125,14 @@ class SessionMetadataGenerator {
       for (final model in provider.models.values) {
         if (model.status != "active") continue;
         final score = _smallModelScore(model: model);
+        if (score > 0) {
+          Log.d(
+            "SessionMetadataGenerator: candidate — "
+            "${provider.id}/${model.id} "
+            '(name="${model.name}", family="${model.family}", '
+            "score=$score, releaseDate=${model.releaseDate})",
+          );
+        }
         if (score > bestScore || (score == bestScore && _isNewer(model.releaseDate, bestReleaseDate))) {
           bestScore = score;
           best = (providerID: provider.id, modelID: model.id);
@@ -89,12 +141,23 @@ class SessionMetadataGenerator {
       }
     }
 
-    if (best != null) return best;
+    if (best != null) {
+      Log.d(
+        "SessionMetadataGenerator: best model by score: "
+        "${best.providerID}/${best.modelID} (score=$bestScore)",
+      );
+      return best;
+    }
 
     // 3. Last resort: first connected provider's default.
+    Log.d("SessionMetadataGenerator: no scored model found, trying provider defaults");
     for (final connectedId in providers.connected) {
       final defaultModelId = providers.defaults[connectedId];
       if (defaultModelId != null && defaultModelId.isNotEmpty) {
+        Log.d(
+          "SessionMetadataGenerator: falling back to default — "
+          "$connectedId/$defaultModelId",
+        );
         return (providerID: connectedId, modelID: defaultModelId);
       }
     }
@@ -147,7 +210,11 @@ class SessionMetadataGenerator {
   }
 
   SessionMetadata? _parseResponse(MessageWithParts response) {
-    final mergedText = response.parts.map((part) => part.text).whereType<String>().join();
+    final mergedText = response.parts
+        .where((part) => part.type == "text")
+        .map((part) => part.text)
+        .whereType<String>()
+        .join();
 
     if (mergedText.isEmpty) {
       return null;


### PR DESCRIPTION
## Summary

- **Fix**: `SessionMetadataGenerator._parseResponse()` was joining ALL response parts (including `type=reasoning` thinking parts) into a single string before JSON extraction. Models like Claude Haiku 4.5 return reasoning parts alongside text parts, which polluted the merged text and caused JSON parsing to fail silently.
- **Fix**: Filter response parts to `type == "text"` only before parsing, excluding reasoning/thinking content.
- **Debug**: Added logging throughout the metadata generation pipeline (model resolution, config values, API request/response, parse results) to aid future diagnosis.

## Root Cause

When calling `sendMessageSync`, the LLM response contains multiple parts with different types (`text`, `reasoning`, `tool`, etc.). The existing code joined all parts' `.text` fields indiscriminately. For models that emit reasoning/thinking parts (e.g. Claude Haiku 4.5), this prepended the model's internal reasoning to the actual JSON response, breaking all three JSON extraction strategies.