### PR TITLE
fix(mobile): show archive confirmation sheet on swipe-to-archive

### DIFF
--- a/mobile/app/lib/features/session_list/session_list_screen.dart
+++ b/mobile/app/lib/features/session_list/session_list_screen.dart
@@ -195,8 +195,8 @@ class _SessionListBody extends StatelessWidget {
                             onLongPress: () => _showSessionActions(context: context, session: session),
                             onSwipe: () => isArchived
                                 ? _unarchiveSession(context: context, cubit: cubit, sessionId: session.id)
-                                : _archiveSession(context: context, cubit: cubit, sessionId: session.id),
-                          ); // swipe uses defaults: deleteWorktree=true, deleteBranch=true
+                                : _showArchiveSheet(context: context, cubit: cubit, session: session),
+                          );
                         },
                       ),
               ),


### PR DESCRIPTION
## Summary

- Swipe-to-archive on sessions now shows the same confirmation bottom sheet (with worktree/branch deletion checkboxes) that the long-press archive menu already uses, instead of archiving immediately with default options.