### PR TITLE
feat(bridge): propagate session archive to OpenCode

### DIFF
--- a/bridge/app/lib/src/bridge/routing/update_session_archive_status_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/update_session_archive_status_handler.dart
@@ -179,15 +179,11 @@ class UpdateSessionArchiveStatusHandler extends BodyRequestHandler<UpdateSession
 
     // Fire-and-forget: notify the backend so it can reflect the archive state.
     // The local DB is authoritative — we don't block on or fail for this.
-    try {
-      unawaited(
-        _plugin.archiveSession(sessionId: sessionDto.sessionId).catchError((Object e) {
-          Log.w("[archive] failed to notify plugin for session ${sessionDto.sessionId}: $e");
-        }),
-      );
-    } on Object catch (e) {
-      Log.w("[archive] failed to notify plugin for session ${sessionDto.sessionId}: $e");
-    }
+    unawaited(
+      _plugin.archiveSession(sessionId: sessionDto.sessionId).catchError((Object e) {
+        Log.w("[archive] failed to notify plugin for session ${sessionDto.sessionId}: $e");
+      }),
+    );
 
     final responseSession = _withArchivedTime(
       session: pluginSession.toSharedSession(),

--- a/bridge/app/lib/src/bridge/routing/update_session_archive_status_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/update_session_archive_status_handler.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:convert";
 import "dart:io";
 
@@ -175,6 +176,18 @@ class UpdateSessionArchiveStatusHandler extends BodyRequestHandler<UpdateSession
     }
 
     await _sessionDao.setArchived(sessionId: sessionDto.sessionId, archivedAt: archivedAt);
+
+    // Fire-and-forget: notify the backend so it can reflect the archive state.
+    // The local DB is authoritative — we don't block on or fail for this.
+    try {
+      unawaited(
+        _plugin.archiveSession(sessionId: sessionDto.sessionId).catchError((Object e) {
+          Log.w("[archive] failed to notify plugin for session ${sessionDto.sessionId}: $e");
+        }),
+      );
+    } on Object catch (e) {
+      Log.w("[archive] failed to notify plugin for session ${sessionDto.sessionId}: $e");
+    }
 
     final responseSession = _withArchivedTime(
       session: pluginSession.toSharedSession(),

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -304,6 +304,9 @@ class _FakeBridgePlugin implements BridgePlugin {
   Future<void> deleteSession(String sessionId) async {}
 
   @override
+  Future<void> archiveSession({required String sessionId}) async {}
+
+  @override
   Future<List<PluginSession>> getChildSessions(String sessionId) async => [];
 
   @override
@@ -439,6 +442,9 @@ class _TrackingBridgePlugin implements BridgePlugin {
 
   @override
   Future<void> deleteSession(String sessionId) async {}
+
+  @override
+  Future<void> archiveSession({required String sessionId}) async {}
 
   @override
   Future<List<PluginSession>> getChildSessions(String sessionId) async => [];

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -238,6 +238,9 @@ class _ThrowingSummaryPlugin implements BridgePlugin {
   Future<void> deleteSession(String sessionId) async {}
 
   @override
+  Future<void> archiveSession({required String sessionId}) async {}
+
+  @override
   Future<List<PluginSession>> getChildSessions(String sessionId) async => [];
 
   @override

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -61,6 +61,7 @@ class FakeBridgePlugin implements BridgePlugin {
   String? lastRenameProjectId;
   String? lastRenameProjectName;
   String? lastDeleteSessionId;
+  String? lastArchiveSessionId;
   String? lastGetChildSessionsSessionId;
   String? lastSendPromptSessionId;
   List<PluginPromptPart>? lastSendPromptParts;
@@ -83,6 +84,8 @@ class FakeBridgePlugin implements BridgePlugin {
   Object? throwOnGetProjectError;
   bool throwOnGetSessions = false;
   Object? throwOnDeleteSessionError;
+  Object? throwOnArchiveSessionError;
+  Completer<void>? archiveSessionCompleter;
 
   // ── BridgePlugin implementation ──────────────────────────────────────────
 
@@ -180,6 +183,17 @@ class FakeBridgePlugin implements BridgePlugin {
     lastDeleteSessionId = sessionId;
     if (throwOnDeleteSessionError case final error?) {
       throw error;
+    }
+  }
+
+  @override
+  Future<void> archiveSession({required String sessionId}) async {
+    lastArchiveSessionId = sessionId;
+    if (throwOnArchiveSessionError case final error?) {
+      throw error;
+    }
+    if (archiveSessionCompleter case final completer?) {
+      await completer.future;
     }
   }
 

--- a/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
+++ b/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:io";
 
 import "package:sesori_bridge/src/bridge/persistence/database.dart";
@@ -423,6 +424,186 @@ void main() {
       expect(worktreeService.deleteBranchCallCount, equals(0));
       final persisted = await db.sessionDao.getSession(sessionId: "s1");
       expect(persisted?.archivedAt, isNull);
+    });
+
+    test("archive fires plugin archiveSession", () async {
+      await _insertSession(
+        db: db,
+        sessionId: "s1",
+        projectId: "/repo",
+        isDedicated: false,
+        worktreePath: null,
+        branchName: null,
+        baseBranch: null,
+        archivedAt: null,
+        baseCommit: null,
+      );
+      plugin.sessionsResult = const [
+        PluginSession(
+          id: "s1",
+          projectID: "/repo",
+          directory: "/repo",
+          parentID: null,
+          title: "Session 1",
+          time: PluginSessionTime(created: 10, updated: 20, archived: null),
+          summary: null,
+        ),
+      ];
+
+      await handler.handle(
+        makeRequest("PATCH", "/session/update/archive"),
+        body: _archiveRequest(
+          sessionId: "s1",
+          archived: true,
+          deleteWorktree: false,
+          deleteBranch: false,
+          force: false,
+        ),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      // Fire-and-forget — give the microtask a chance to run.
+      await Future<void>.delayed(Duration.zero);
+      expect(plugin.lastArchiveSessionId, equals("s1"));
+    });
+
+    test("unarchive does not fire plugin archiveSession", () async {
+      final existingDir = Directory.systemTemp.createTempSync("archive-handler-");
+      addTearDown(() {
+        if (existingDir.existsSync()) {
+          existingDir.deleteSync(recursive: true);
+        }
+      });
+
+      await _insertSession(
+        db: db,
+        sessionId: "s1",
+        projectId: "/repo",
+        isDedicated: true,
+        worktreePath: existingDir.path,
+        branchName: "session-001",
+        baseBranch: null,
+        archivedAt: 123,
+        baseCommit: null,
+      );
+      plugin.sessionsResult = [
+        PluginSession(
+          id: "s1",
+          projectID: "/repo",
+          directory: existingDir.path,
+          parentID: null,
+          title: "Session 1",
+          time: const PluginSessionTime(created: 10, updated: 20, archived: 123),
+          summary: null,
+        ),
+      ];
+
+      await handler.handle(
+        makeRequest("PATCH", "/session/update/archive"),
+        body: _archiveRequest(
+          sessionId: "s1",
+          archived: false,
+          deleteWorktree: false,
+          deleteBranch: false,
+          force: false,
+        ),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      expect(plugin.lastArchiveSessionId, isNull);
+    });
+
+    test("archive succeeds even when plugin archiveSession throws", () async {
+      await _insertSession(
+        db: db,
+        sessionId: "s1",
+        projectId: "/repo",
+        isDedicated: false,
+        worktreePath: null,
+        branchName: null,
+        baseBranch: null,
+        archivedAt: null,
+        baseCommit: null,
+      );
+      plugin.sessionsResult = const [
+        PluginSession(
+          id: "s1",
+          projectID: "/repo",
+          directory: "/repo",
+          parentID: null,
+          title: "Session 1",
+          time: PluginSessionTime(created: 10, updated: 20, archived: null),
+          summary: null,
+        ),
+      ];
+      plugin.throwOnArchiveSessionError = Exception("OpenCode unavailable");
+
+      final result = await handler.handle(
+        makeRequest("PATCH", "/session/update/archive"),
+        body: _archiveRequest(
+          sessionId: "s1",
+          archived: true,
+          deleteWorktree: false,
+          deleteBranch: false,
+          force: false,
+        ),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      final persisted = await db.sessionDao.getSession(sessionId: "s1");
+      expect(persisted?.archivedAt, isNotNull);
+      expect(result.time?.archived, equals(persisted?.archivedAt));
+    });
+
+    test("archive does not await plugin archiveSession", () async {
+      await _insertSession(
+        db: db,
+        sessionId: "s1",
+        projectId: "/repo",
+        isDedicated: false,
+        worktreePath: null,
+        branchName: null,
+        baseBranch: null,
+        archivedAt: null,
+        baseCommit: null,
+      );
+      plugin.sessionsResult = const [
+        PluginSession(
+          id: "s1",
+          projectID: "/repo",
+          directory: "/repo",
+          parentID: null,
+          title: "Session 1",
+          time: PluginSessionTime(created: 10, updated: 20, archived: null),
+          summary: null,
+        ),
+      ];
+      // Plugin never completes — if handler awaited, this test would hang.
+      plugin.archiveSessionCompleter = Completer<void>();
+
+      final result = await handler.handle(
+        makeRequest("PATCH", "/session/update/archive"),
+        body: _archiveRequest(
+          sessionId: "s1",
+          archived: true,
+          deleteWorktree: false,
+          deleteBranch: false,
+          force: false,
+        ),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(result.id, equals("s1"));
+      expect(result.time?.archived, isNotNull);
     });
 
     test("archive simple session sets archivedAt and skips cleanup", () async {

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -46,6 +46,12 @@ abstract class BridgePlugin {
 
   Future<void> deleteSession(String sessionId);
 
+  /// Notify the backend that a session has been archived.
+  ///
+  /// This is best-effort — the local database archive state is authoritative.
+  /// Unarchive is not propagated to the backend; it only clears the local DB.
+  Future<void> archiveSession({required String sessionId});
+
   Future<List<PluginSession>> getChildSessions(String sessionId);
 
   Future<Map<String, PluginSessionStatus>> getSessionStatuses();

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -270,6 +270,19 @@ class OpenCodePlugin implements BridgePlugin {
   }
 
   @override
+  Future<PluginSession> renameSession({required String sessionId, required String title}) async {
+    final directory = _service.tracker.getSessionDirectory(sessionId: sessionId);
+    final session = await _call(
+      () => _service.repository.api.updateSession(
+        sessionId: sessionId,
+        directory: directory,
+        body: {"title": title},
+      ),
+    );
+    return session.toPlugin();
+  }
+
+  @override
   Future<List<PluginSession>> getChildSessions(String sessionId) async {
     final directory = _service.tracker.getSessionDirectory(sessionId: sessionId);
     final sessions = await _call(
@@ -419,16 +432,17 @@ class OpenCodePlugin implements BridgePlugin {
   }
 
   @override
-  Future<PluginSession> renameSession({required String sessionId, required String title}) async {
+  Future<void> archiveSession({required String sessionId}) async {
     final directory = _service.tracker.getSessionDirectory(sessionId: sessionId);
-    final session = await _call(
+    await _call(
       () => _service.repository.api.updateSession(
         sessionId: sessionId,
         directory: directory,
-        body: {"title": title},
+        body: {
+          "time": {"archived": DateTime.now().millisecondsSinceEpoch},
+        },
       ),
     );
-    return session.toPlugin();
   }
 
   @override

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -274,6 +274,23 @@ void main() {
       });
     });
 
+    group("archiveSession", () {
+      test("sends PATCH with time.archived body", () async {
+        final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
+        await server.waitForSseConnection();
+        server.requestLog.clear();
+
+        await plugin.archiveSession(sessionId: "s-root");
+
+        expect(server.requestLog, equals(["PATCH /session/s-root"]));
+
+        // Verify the fake server applied the archived timestamp.
+        final sessionTime = server.getSessionTime("s-root");
+        expect(sessionTime, isNotNull);
+        expect(sessionTime!["archived"], isA<int>());
+      });
+    });
+
     group("renameProject", () {
       test("resolves worktree to project UUID then sends PATCH with name", () async {
         final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
@@ -910,6 +927,12 @@ class _FakeOpenCodeServer {
       request.response.statusCode = HttpStatus.notFound;
       await request.response.close();
     });
+  }
+
+  Map<String, dynamic>? getSessionTime(String sessionId) {
+    final session = _sessions[sessionId];
+    if (session == null) return null;
+    return (session["time"] as Map?)?.cast<String, dynamic>();
   }
 
   Future<void> waitForSseConnection() => _firstSseClient.future;


### PR DESCRIPTION
## Summary

- Adds `archiveSession` to the `BridgePlugin` interface and implements it in `OpenCodePlugin` via `PATCH /session/{id}` with `{"time": {"archived": <now>}}`
- The archive handler fires the plugin notification as fire-and-forget (`unawaited` + `try/catch` + `catchError`) — the local DB is authoritative, so the request never blocks on or fails for a plugin error
- Unarchive is intentionally NOT propagated to OpenCode; the existing merge logic in `GetSessionsHandler` already overrides the plugin's stale `archived` timestamp with the DB's `null` value

## Test coverage

- **Handler**: archive fires plugin call, unarchive does not, plugin error doesn't fail the request, handler doesn't await plugin (never-completing future test)
- **Plugin**: verifies `PATCH /session/{id}` is sent and `time.archived` is set as an `int` on the server
- **Merge (pre-existing)**: plugin returns `archived: 300` + DB has `archivedAt: null` → result is `archived: null`