### PR TITLE
fix(mobile): resolve diff viewer crash from invalid SliverGeometry

### DIFF
--- a/mobile/app/lib/features/session_diffs/session_diffs_screen.dart
+++ b/mobile/app/lib/features/session_diffs/session_diffs_screen.dart
@@ -101,11 +101,11 @@ class _SessionDiffsBodyState extends State<_SessionDiffsBody> {
 
   Widget _buildLoadedState(BuildContext context, List<FileDiff> files) {
     _maybeComputeViewModels(files: files);
-    if (_isComputing || _viewModels == null) {
-      return const Center(child: CircularProgressIndicator());
-    }
     if (_computeError != null) {
       return Center(child: Text("Error computing diffs: $_computeError"));
+    }
+    if (_isComputing || _viewModels == null) {
+      return const Center(child: CircularProgressIndicator());
     }
     return CustomScrollView(slivers: _buildSlivers(viewModels: _viewModels!));
   }
@@ -123,7 +123,10 @@ class _SessionDiffsBodyState extends State<_SessionDiffsBody> {
                 onToggle: () => _toggleFile(i),
               ),
             ),
-            if (_expandedFileIndices.contains(i)) _buildFileContentSliver(viewModels[i]),
+            if (_expandedFileIndices.contains(i))
+              _buildFileContentSliver(viewModels[i])
+            else
+              const SliverToBoxAdapter(child: SizedBox.shrink()),
           ],
         ),
     ];

--- a/mobile/app/lib/features/session_diffs/session_diffs_screen.dart
+++ b/mobile/app/lib/features/session_diffs/session_diffs_screen.dart
@@ -102,7 +102,7 @@ class _SessionDiffsBodyState extends State<_SessionDiffsBody> {
   Widget _buildLoadedState(BuildContext context, List<FileDiff> files) {
     _maybeComputeViewModels(files: files);
     if (_computeError != null) {
-      return Center(child: Text("Error computing diffs: $_computeError"));
+      return _buildErrorState(context, _computeError!);
     }
     if (_isComputing || _viewModels == null) {
       return const Center(child: CircularProgressIndicator());

--- a/mobile/app/lib/features/session_diffs/widgets/diff_file_header_delegate.dart
+++ b/mobile/app/lib/features/session_diffs/widgets/diff_file_header_delegate.dart
@@ -28,10 +28,18 @@ class DiffFileHeaderDelegate extends SliverPersistentHeaderDelegate {
 
   @override
   Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
-    return DiffFileWidget(
-      viewModel: viewModel,
-      isExpanded: isExpanded,
-      onToggle: onToggle,
+    // SliverPersistentHeader gives the child BoxConstraints(minHeight: 0,
+    // maxHeight: maxExtent) — the child is NOT forced to fill the extent.
+    // If the child renders shorter than maxExtent, paintExtent < layoutExtent
+    // which is an invalid SliverGeometry (assertion failure in debug,
+    // rendering glitch in release). Forcing exact height prevents this.
+    return SizedBox(
+      height: maxExtent,
+      child: DiffFileWidget(
+        viewModel: viewModel,
+        isExpanded: isExpanded,
+        onToggle: onToggle,
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary

- **Fix crash**: `SliverPersistentHeader` gives its child `BoxConstraints(minHeight: 0)`, so `DiffFileWidget` rendered at its intrinsic height (~31.5px) instead of the delegate's declared extent (36px). This caused `layoutExtent (36) > paintExtent (31.5)` — an invalid `SliverGeometry` that crashes the screen. Fixed by wrapping the child in `SizedBox(height: maxExtent)`.
- **Prevent collapsed-file rendering bug**: When a file is collapsed, `SliverMainAxisGroup` previously had only a single pinned header child — a known Flutter bug area where the group's paint correction can zero out `paintExtent`. Now always includes an empty `SliverToBoxAdapter` companion.
- **Fix error masking**: The error check in `_buildLoadedState` was unreachable — `_viewModels == null` was caught first, showing an eternal spinner instead of the error message. Reordered so errors are displayed.