### PR TITLE
fix: make session.error sessionID nullable to match OpenCode schema

### DIFF
--- a/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
@@ -42,7 +42,7 @@ class BridgeSseSessionDiff extends BridgeSseEvent {
 }
 
 class BridgeSseSessionError extends BridgeSseEvent {
-  final String sessionID;
+  final String? sessionID;
   const BridgeSseSessionError({required this.sessionID});
 }
 

--- a/bridge/sesori_plugin_opencode/lib/src/models/sse_event_data.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/sse_event_data.dart
@@ -76,7 +76,7 @@ sealed class SseEventData with _$SseEventData {
   @FreezedUnionValue("session.error")
   @Implements<SseSessionEventData>()
   const factory SseEventData.sessionError({
-    required String sessionID,
+    required String? sessionID,
   }) = SseSessionError;
 
   @FreezedUnionValue("session.compacted")

--- a/bridge/sesori_plugin_opencode/lib/src/models/sse_event_data.freezed.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/sse_event_data.freezed.dart
@@ -756,7 +756,7 @@ class SseSessionError implements SseEventData, SseSessionEventData {
   const SseSessionError({required this.sessionID, final  String? $type}): $type = $type ?? 'session.error';
   factory SseSessionError.fromJson(Map<String, dynamic> json) => _$SseSessionErrorFromJson(json);
 
- final  String sessionID;
+ final  String? sessionID;
 
 @JsonKey(name: 'type')
 final String $type;
@@ -795,7 +795,7 @@ abstract mixin class $SseSessionErrorCopyWith<$Res> implements $SseEventDataCopy
   factory $SseSessionErrorCopyWith(SseSessionError value, $Res Function(SseSessionError) _then) = _$SseSessionErrorCopyWithImpl;
 @useResult
 $Res call({
- String sessionID
+ String? sessionID
 });
 
 
@@ -812,10 +812,10 @@ class _$SseSessionErrorCopyWithImpl<$Res>
 
 /// Create a copy of SseEventData
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? sessionID = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? sessionID = freezed,}) {
   return _then(SseSessionError(
-sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
-as String,
+sessionID: freezed == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/bridge/sesori_plugin_opencode/lib/src/models/sse_event_data.g.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/sse_event_data.g.dart
@@ -74,7 +74,7 @@ Map<String, dynamic> _$SseSessionDiffToJson(SseSessionDiff instance) =>
     };
 
 SseSessionError _$SseSessionErrorFromJson(Map json) => SseSessionError(
-  sessionID: json['sessionID'] as String,
+  sessionID: json['sessionID'] as String?,
   $type: json['type'] as String?,
 );
 

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
@@ -75,7 +75,7 @@ sealed class SesoriSseEvent with _$SesoriSseEvent {
   @FreezedUnionValue("session.error")
   @Implements<SesoriSessionEvent>()
   const factory SesoriSseEvent.sessionError({
-    required String sessionID,
+    required String? sessionID,
   }) = SesoriSessionError;
 
   @FreezedUnionValue("session.compacted")

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
@@ -756,7 +756,7 @@ class SesoriSessionError implements SesoriSseEvent, SesoriSessionEvent {
   const SesoriSessionError({required this.sessionID, final  String? $type}): $type = $type ?? 'session.error';
   factory SesoriSessionError.fromJson(Map<String, dynamic> json) => _$SesoriSessionErrorFromJson(json);
 
- final  String sessionID;
+ final  String? sessionID;
 
 @JsonKey(name: 'type')
 final String $type;
@@ -795,7 +795,7 @@ abstract mixin class $SesoriSessionErrorCopyWith<$Res> implements $SesoriSseEven
   factory $SesoriSessionErrorCopyWith(SesoriSessionError value, $Res Function(SesoriSessionError) _then) = _$SesoriSessionErrorCopyWithImpl;
 @useResult
 $Res call({
- String sessionID
+ String? sessionID
 });
 
 
@@ -812,10 +812,10 @@ class _$SesoriSessionErrorCopyWithImpl<$Res>
 
 /// Create a copy of SesoriSseEvent
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? sessionID = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? sessionID = freezed,}) {
   return _then(SesoriSessionError(
-sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
-as String,
+sessionID: freezed == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
@@ -76,7 +76,7 @@ Map<String, dynamic> _$SesoriSessionDiffToJson(SesoriSessionDiff instance) =>
     <String, dynamic>{'sessionID': instance.sessionID, 'type': instance.$type};
 
 SesoriSessionError _$SesoriSessionErrorFromJson(Map json) => SesoriSessionError(
-  sessionID: json['sessionID'] as String,
+  sessionID: json['sessionID'] as String?,
   $type: json['type'] as String?,
 );
 


### PR DESCRIPTION
## Summary

- **Fix**: `SseEventParser` crashes with `type 'Null' is not a subtype of type 'String' in type cast` when receiving `session.error` SSE events from OpenCode
- **Root cause**: OpenCode defines `sessionID` as optional on `session.error` events ([source](https://github.com/sst/opencode/blob/main/packages/opencode/src/session/index.ts#L232)), but our models declared it as `required String sessionID`
- **Change**: Made `sessionID` nullable (`String?`) across all three layers — bridge plugin model (`SseEventData.sessionError`), plugin interface (`BridgeSseSessionError`), and shared model (`SesoriSseEvent.sessionError`) — plus regenerated Freezed/JSON code