### PR TITLE
feat: show "Awaiting input" status for sessions with pending questions/permissions

### DIFF
--- a/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
@@ -176,6 +176,7 @@ class BridgeEventMapper {
                       (a) => ActiveSession(
                         id: a.id,
                         mainAgentRunning: a.mainAgentRunning,
+                        awaitingInput: a.awaitingInput,
                         childSessionIds: a.childSessionIds,
                       ),
                     )

--- a/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
@@ -93,10 +93,12 @@ class BridgeEventMapper {
             tool: tool,
             description: description,
           ),
-        BridgeSsePermissionReplied(:final requestID, :final reply) => SesoriSseEvent.permissionReplied(
-          requestID: requestID,
-          reply: reply,
-        ),
+        BridgeSsePermissionReplied(:final requestID, :final sessionID, :final reply) =>
+          SesoriSseEvent.permissionReplied(
+            requestID: requestID,
+            sessionID: sessionID,
+            reply: reply,
+          ),
         BridgeSsePermissionUpdated() => const SesoriSseEvent.permissionUpdated(),
         BridgeSseQuestionAsked(:final id, :final sessionID, :final questions) => _tryParseSseEvent({
           "type": "question.asked",

--- a/bridge/app/test/push/completion_notifier_test.dart
+++ b/bridge/app/test/push/completion_notifier_test.dart
@@ -207,7 +207,7 @@ void main() {
           ),
         );
         harness.dispatch(
-          const SesoriSseEvent.permissionReplied(requestID: "perm-1", reply: "allow"),
+          const SesoriSseEvent.permissionReplied(requestID: "perm-1", sessionID: "s1", reply: "allow"),
         );
 
         async.elapse(const Duration(milliseconds: 500));

--- a/bridge/app/test/push/push_session_state_tracker_test.dart
+++ b/bridge/app/test/push/push_session_state_tracker_test.dart
@@ -240,6 +240,7 @@ void main() {
       tracker.handleEvent(
         const SesoriSseEvent.permissionReplied(
           requestID: "req-1",
+          sessionID: "session-a",
           reply: "allow",
         ),
       );

--- a/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
@@ -138,8 +138,13 @@ class BridgeSsePermissionAsked extends BridgeSseEvent {
 
 class BridgeSsePermissionReplied extends BridgeSseEvent {
   final String requestID;
+  final String sessionID;
   final String reply;
-  const BridgeSsePermissionReplied({required this.requestID, required this.reply});
+  const BridgeSsePermissionReplied({
+    required this.requestID,
+    required this.sessionID,
+    required this.reply,
+  });
 }
 
 class BridgeSsePermissionUpdated extends BridgeSseEvent {

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_active_session.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_active_session.dart
@@ -12,6 +12,7 @@ sealed class PluginActiveSession with _$PluginActiveSession {
   const factory PluginActiveSession({
     required String id,
     @Default(false) bool mainAgentRunning,
+    @Default(false) bool awaitingInput,
     @Default([]) List<String> childSessionIds,
   }) = _PluginActiveSession;
 }

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_active_session.freezed.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_active_session.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$PluginActiveSession {
 
- String get id; bool get mainAgentRunning; List<String> get childSessionIds;
+ String get id; bool get mainAgentRunning; bool get awaitingInput; List<String> get childSessionIds;
 /// Create a copy of PluginActiveSession
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -27,16 +27,16 @@ $PluginActiveSessionCopyWith<PluginActiveSession> get copyWith => _$PluginActive
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&const DeepCollectionEquality().equals(other.childSessionIds, childSessionIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&const DeepCollectionEquality().equals(other.childSessionIds, childSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,const DeepCollectionEquality().hash(childSessionIds));
+int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,awaitingInput,const DeepCollectionEquality().hash(childSessionIds));
 
 @override
 String toString() {
-  return 'PluginActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, childSessionIds: $childSessionIds)';
+  return 'PluginActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, childSessionIds: $childSessionIds)';
 }
 
 
@@ -47,7 +47,7 @@ abstract mixin class $PluginActiveSessionCopyWith<$Res>  {
   factory $PluginActiveSessionCopyWith(PluginActiveSession value, $Res Function(PluginActiveSession) _then) = _$PluginActiveSessionCopyWithImpl;
 @useResult
 $Res call({
- String id, bool mainAgentRunning, List<String> childSessionIds
+ String id, bool mainAgentRunning, bool awaitingInput, List<String> childSessionIds
 });
 
 
@@ -64,10 +64,11 @@ class _$PluginActiveSessionCopyWithImpl<$Res>
 
 /// Create a copy of PluginActiveSession
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? mainAgentRunning = null,Object? childSessionIds = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? mainAgentRunning = null,Object? awaitingInput = null,Object? childSessionIds = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
+as bool,awaitingInput: null == awaitingInput ? _self.awaitingInput : awaitingInput // ignore: cast_nullable_to_non_nullable
 as bool,childSessionIds: null == childSessionIds ? _self.childSessionIds : childSessionIds // ignore: cast_nullable_to_non_nullable
 as List<String>,
   ));
@@ -81,11 +82,12 @@ as List<String>,
 @JsonSerializable(createFactory: false)
 
 class _PluginActiveSession implements PluginActiveSession {
-  const _PluginActiveSession({required this.id, this.mainAgentRunning = false, final  List<String> childSessionIds = const []}): _childSessionIds = childSessionIds;
+  const _PluginActiveSession({required this.id, this.mainAgentRunning = false, this.awaitingInput = false, final  List<String> childSessionIds = const []}): _childSessionIds = childSessionIds;
   
 
 @override final  String id;
 @override@JsonKey() final  bool mainAgentRunning;
+@override@JsonKey() final  bool awaitingInput;
  final  List<String> _childSessionIds;
 @override@JsonKey() List<String> get childSessionIds {
   if (_childSessionIds is EqualUnmodifiableListView) return _childSessionIds;
@@ -107,16 +109,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&const DeepCollectionEquality().equals(other._childSessionIds, _childSessionIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&const DeepCollectionEquality().equals(other._childSessionIds, _childSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,const DeepCollectionEquality().hash(_childSessionIds));
+int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,awaitingInput,const DeepCollectionEquality().hash(_childSessionIds));
 
 @override
 String toString() {
-  return 'PluginActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, childSessionIds: $childSessionIds)';
+  return 'PluginActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, childSessionIds: $childSessionIds)';
 }
 
 
@@ -127,7 +129,7 @@ abstract mixin class _$PluginActiveSessionCopyWith<$Res> implements $PluginActiv
   factory _$PluginActiveSessionCopyWith(_PluginActiveSession value, $Res Function(_PluginActiveSession) _then) = __$PluginActiveSessionCopyWithImpl;
 @override @useResult
 $Res call({
- String id, bool mainAgentRunning, List<String> childSessionIds
+ String id, bool mainAgentRunning, bool awaitingInput, List<String> childSessionIds
 });
 
 
@@ -144,10 +146,11 @@ class __$PluginActiveSessionCopyWithImpl<$Res>
 
 /// Create a copy of PluginActiveSession
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? mainAgentRunning = null,Object? childSessionIds = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? mainAgentRunning = null,Object? awaitingInput = null,Object? childSessionIds = null,}) {
   return _then(_PluginActiveSession(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
+as bool,awaitingInput: null == awaitingInput ? _self.awaitingInput : awaitingInput // ignore: cast_nullable_to_non_nullable
 as bool,childSessionIds: null == childSessionIds ? _self._childSessionIds : childSessionIds // ignore: cast_nullable_to_non_nullable
 as List<String>,
   ));

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_active_session.g.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_active_session.g.dart
@@ -11,5 +11,6 @@ Map<String, dynamic> _$PluginActiveSessionToJson(
 ) => <String, dynamic>{
   'id': instance.id,
   'mainAgentRunning': instance.mainAgentRunning,
+  'awaitingInput': instance.awaitingInput,
   'childSessionIds': instance.childSessionIds,
 };

--- a/bridge/sesori_plugin_opencode/lib/opencode_plugin.dart
+++ b/bridge/sesori_plugin_opencode/lib/opencode_plugin.dart
@@ -8,6 +8,7 @@ export "src/models/message.dart";
 export "src/models/message_part.dart";
 export "src/models/message_with_parts.dart";
 // Models
+export "src/models/pending_permission.dart";
 export "src/models/pending_question.dart";
 export "src/models/project.dart";
 export "src/models/provider_info.dart";

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -1,6 +1,7 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart" show ActiveSession, ProjectActivitySummary, wait3;
 
+import "models/pending_question.dart";
 import "models/session_status.dart";
 import "models/sse_event_data.dart";
 import "opencode_repository.dart";
@@ -12,12 +13,16 @@ class ActiveSessionTracker {
   final Map<String, String> _sessionWorktrees = {};
   final Map<String, String> _sessionDirectories = {}; // directory where the session is located
   final Map<String, SessionStatus> _sessionStatuses = {};
+  final Map<String, Set<String>> _pendingQuestions = {};
+  final Map<String, Set<String>> _pendingPermissions = {};
+  final Map<String, String> _permissionSessionIds = {};
 
   /// Tracks parent IDs for all known sessions.
   /// `null` value = root session, non-null value = parent session ID.
   final Map<String, String?> _sessionParentIds = {};
 
   Map<String, int> _lastEmittedActiveSessions = {};
+  Set<String> _lastEmittedPendingInputSessions = {};
 
   ActiveSessionTracker(this._repository);
 
@@ -67,6 +72,7 @@ class ActiveSessionTracker {
     }
 
     _lastEmittedActiveSessions = _activeSessionCounts;
+    _lastEmittedPendingInputSessions = _pendingInputSessions;
   }
 
   bool handleEvent(SseEventData event, String? directory) {
@@ -96,6 +102,7 @@ class ActiveSessionTracker {
         _sessionWorktrees.remove(event.info.id);
         _sessionStatuses.remove(event.info.id);
         _sessionParentIds.remove(event.info.id);
+        _clearPendingInputForSession(event.info.id);
       case SseSessionStatus():
         if (!_sessionWorktrees.containsKey(event.sessionID) && directory != null) {
           _updateSessionWorktree(event.sessionID, directory);
@@ -103,19 +110,41 @@ class ActiveSessionTracker {
         switch (event.status) {
           case SessionStatusIdle():
             _sessionStatuses.remove(event.sessionID);
+            _clearPendingInputForSession(event.sessionID);
           case SessionStatusBusy():
           case SessionStatusRetry():
             _sessionStatuses[event.sessionID] = event.status;
         }
       case SseSessionIdle():
         _sessionStatuses.remove(event.sessionID);
+        _clearPendingInputForSession(event.sessionID);
+      case SseQuestionAsked():
+        _pendingQuestions.putIfAbsent(event.sessionID, () => <String>{}).add(event.id);
+      case SseQuestionReplied():
+        _removePendingQuestion(sessionId: event.sessionID, requestId: event.requestID);
+      case SseQuestionRejected():
+        _removePendingQuestion(sessionId: event.sessionID, requestId: event.requestID);
+      case SsePermissionAsked():
+        _pendingPermissions.putIfAbsent(event.sessionID, () => <String>{}).add(event.requestID);
+        _permissionSessionIds[event.requestID] = event.sessionID;
+      case SsePermissionReplied():
+        final sessionId = _permissionSessionIds.remove(event.requestID);
+        if (sessionId != null) {
+          _removePendingPermission(sessionId: sessionId, requestId: event.requestID);
+        }
       default:
         return false;
     }
 
     final next = _activeSessionCounts;
-    if (!forceReemit && _mapsEqual(_lastEmittedActiveSessions, next)) return false;
+    final nextPendingInputSessions = _pendingInputSessions;
+    if (!forceReemit &&
+        _mapsEqual(_lastEmittedActiveSessions, next) &&
+        _setsEqual(_lastEmittedPendingInputSessions, nextPendingInputSessions)) {
+      return false;
+    }
     _lastEmittedActiveSessions = next;
+    _lastEmittedPendingInputSessions = nextPendingInputSessions;
     return true;
   }
 
@@ -125,7 +154,18 @@ class ActiveSessionTracker {
     _sessionDirectories.clear();
     _sessionStatuses.clear();
     _sessionParentIds.clear();
+    _pendingQuestions.clear();
+    _pendingPermissions.clear();
+    _permissionSessionIds.clear();
     _lastEmittedActiveSessions = {};
+    _lastEmittedPendingInputSessions = {};
+  }
+
+  void populatePendingQuestions({required List<PendingQuestion> questions}) {
+    _pendingQuestions
+      ..clear()
+      ..addEntries(_groupPendingQuestionsBySession(questions).entries);
+    _lastEmittedPendingInputSessions = _pendingInputSessions;
   }
 
   /// Register a known session -> directory mapping (e.g., after session creation).
@@ -200,6 +240,7 @@ class ActiveSessionTracker {
             ActiveSession(
               id: rootId,
               mainAgentRunning: activeRoots.contains(rootId),
+              awaitingInput: _hasPendingInput(rootId),
               childSessionIds: activeChildrenByParent[rootId] ?? [],
             ),
           );
@@ -232,6 +273,25 @@ class ActiveSessionTracker {
   /// Exposed for testing: raw count of all busy/retry sessions per worktree.
   Map<String, int> get activeSessions => _activeSessionCounts;
 
+  bool _hasPendingInput(String sessionId) {
+    return (_pendingQuestions[sessionId]?.isNotEmpty ?? false) || (_pendingPermissions[sessionId]?.isNotEmpty ?? false);
+  }
+
+  Set<String> get _pendingInputSessions {
+    final sessionIds = <String>{};
+    for (final entry in _pendingQuestions.entries) {
+      if (entry.value.isNotEmpty) {
+        sessionIds.add(entry.key);
+      }
+    }
+    for (final entry in _pendingPermissions.entries) {
+      if (entry.value.isNotEmpty) {
+        sessionIds.add(entry.key);
+      }
+    }
+    return sessionIds;
+  }
+
   String? _resolveWorktree(String directory) {
     final normalizedDirectory = _normalizePath(directory);
     String? bestMatch;
@@ -257,11 +317,52 @@ class ActiveSessionTracker {
     _sessionWorktrees[sessionID] = worktree;
   }
 
+  Map<String, Set<String>> _groupPendingQuestionsBySession(List<PendingQuestion> questions) {
+    final grouped = <String, Set<String>>{};
+    for (final question in questions) {
+      grouped.putIfAbsent(question.sessionID, () => <String>{}).add(question.id);
+    }
+    return grouped;
+  }
+
+  void _removePendingQuestion({required String sessionId, required String requestId}) {
+    final questionIds = _pendingQuestions[sessionId];
+    if (questionIds == null) return;
+    questionIds.remove(requestId);
+    if (questionIds.isEmpty) {
+      _pendingQuestions.remove(sessionId);
+    }
+  }
+
+  void _removePendingPermission({required String sessionId, required String requestId}) {
+    final requestIds = _pendingPermissions[sessionId];
+    if (requestIds == null) return;
+    requestIds.remove(requestId);
+    if (requestIds.isEmpty) {
+      _pendingPermissions.remove(sessionId);
+    }
+  }
+
+  void _clearPendingInputForSession(String sessionId) {
+    _pendingQuestions.remove(sessionId);
+    _pendingPermissions.remove(sessionId);
+    _permissionSessionIds.removeWhere((_, mappedSessionId) => mappedSessionId == sessionId);
+  }
+
   bool _mapsEqual(Map<String, int> a, Map<String, int> b) {
     if (identical(a, b)) return true;
     if (a.length != b.length) return false;
     for (final entry in a.entries) {
       if (b[entry.key] != entry.value) return false;
+    }
+    return true;
+  }
+
+  bool _setsEqual(Set<String> a, Set<String> b) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    for (final value in a) {
+      if (!b.contains(value)) return false;
     }
     return true;
   }

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -1,6 +1,7 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart" show ActiveSession, ProjectActivitySummary, wait3;
 
+import "models/pending_permission.dart";
 import "models/pending_question.dart";
 import "models/session_status.dart";
 import "models/sse_event_data.dart";
@@ -15,7 +16,6 @@ class ActiveSessionTracker {
   final Map<String, SessionStatus> _sessionStatuses = {};
   final Map<String, Set<String>> _pendingQuestions = {};
   final Map<String, Set<String>> _pendingPermissions = {};
-  final Map<String, String> _permissionSessionIds = {};
 
   /// Tracks parent IDs for all known sessions.
   /// `null` value = root session, non-null value = parent session ID.
@@ -126,12 +126,8 @@ class ActiveSessionTracker {
         _removePendingQuestion(sessionId: event.sessionID, requestId: event.requestID);
       case SsePermissionAsked():
         _pendingPermissions.putIfAbsent(event.sessionID, () => <String>{}).add(event.requestID);
-        _permissionSessionIds[event.requestID] = event.sessionID;
       case SsePermissionReplied():
-        final sessionId = _permissionSessionIds.remove(event.requestID);
-        if (sessionId != null) {
-          _removePendingPermission(sessionId: sessionId, requestId: event.requestID);
-        }
+        _removePendingPermission(sessionId: event.sessionID, requestId: event.requestID);
       default:
         return false;
     }
@@ -156,7 +152,6 @@ class ActiveSessionTracker {
     _sessionParentIds.clear();
     _pendingQuestions.clear();
     _pendingPermissions.clear();
-    _permissionSessionIds.clear();
     _lastEmittedActiveSessions = {};
     _lastEmittedPendingInputSessions = {};
   }
@@ -164,7 +159,14 @@ class ActiveSessionTracker {
   void populatePendingQuestions({required List<PendingQuestion> questions}) {
     _pendingQuestions
       ..clear()
-      ..addEntries(_groupPendingQuestionsBySession(questions).entries);
+      ..addEntries(_groupBySessionId(questions.map((q) => (q.sessionID, q.id))).entries);
+    _lastEmittedPendingInputSessions = _pendingInputSessions;
+  }
+
+  void populatePendingPermissions({required List<PendingPermission> permissions}) {
+    _pendingPermissions
+      ..clear()
+      ..addEntries(_groupBySessionId(permissions.map((p) => (p.sessionID, p.id))).entries);
     _lastEmittedPendingInputSessions = _pendingInputSessions;
   }
 
@@ -234,14 +236,15 @@ class ActiveSessionTracker {
         Log.w("buildSummary: no worktree for session $rootId");
         continue;
       }
+      final children = activeChildrenByParent[rootId] ?? const <String>[];
       byWorktree
           .putIfAbsent(worktree, () => [])
           .add(
             ActiveSession(
               id: rootId,
               mainAgentRunning: activeRoots.contains(rootId),
-              awaitingInput: _hasPendingInput(rootId),
-              childSessionIds: activeChildrenByParent[rootId] ?? [],
+              awaitingInput: _rootHasPendingInput(rootId, children),
+              childSessionIds: children,
             ),
           );
     }
@@ -277,20 +280,23 @@ class ActiveSessionTracker {
     return (_pendingQuestions[sessionId]?.isNotEmpty ?? false) || (_pendingPermissions[sessionId]?.isNotEmpty ?? false);
   }
 
-  Set<String> get _pendingInputSessions {
-    final sessionIds = <String>{};
-    for (final entry in _pendingQuestions.entries) {
-      if (entry.value.isNotEmpty) {
-        sessionIds.add(entry.key);
-      }
-    }
-    for (final entry in _pendingPermissions.entries) {
-      if (entry.value.isNotEmpty) {
-        sessionIds.add(entry.key);
-      }
-    }
-    return sessionIds;
+  /// Returns true if the root session OR any of its direct child sessions
+  /// has pending input (question or permission).
+  ///
+  /// Child sessions are included so that sub-agent questions/permissions
+  /// surface on the root session row in the session list.
+  bool _rootHasPendingInput(String rootId, List<String> childIds) {
+    if (_hasPendingInput(rootId)) return true;
+    return childIds.any(_hasPendingInput);
   }
+
+  /// Raw set of session IDs (including children) that currently have any
+  /// pending input. Used only for change detection — re-emit triggers when
+  /// this set changes, even if active-session counts did not.
+  Set<String> get _pendingInputSessions => {
+    ..._pendingQuestions.keys,
+    ..._pendingPermissions.keys,
+  };
 
   String? _resolveWorktree(String directory) {
     final normalizedDirectory = _normalizePath(directory);
@@ -317,10 +323,10 @@ class ActiveSessionTracker {
     _sessionWorktrees[sessionID] = worktree;
   }
 
-  Map<String, Set<String>> _groupPendingQuestionsBySession(List<PendingQuestion> questions) {
+  Map<String, Set<String>> _groupBySessionId(Iterable<(String, String)> sessionIdAndEntryId) {
     final grouped = <String, Set<String>>{};
-    for (final question in questions) {
-      grouped.putIfAbsent(question.sessionID, () => <String>{}).add(question.id);
+    for (final (sessionId, entryId) in sessionIdAndEntryId) {
+      grouped.putIfAbsent(sessionId, () => <String>{}).add(entryId);
     }
     return grouped;
   }
@@ -346,7 +352,6 @@ class ActiveSessionTracker {
   void _clearPendingInputForSession(String sessionId) {
     _pendingQuestions.remove(sessionId);
     _pendingPermissions.remove(sessionId);
-    _permissionSessionIds.removeWhere((_, mappedSessionId) => mappedSessionId == sessionId);
   }
 
   bool _mapsEqual(Map<String, int> a, Map<String, int> b) {
@@ -360,10 +365,6 @@ class ActiveSessionTracker {
 
   bool _setsEqual(Set<String> a, Set<String> b) {
     if (identical(a, b)) return true;
-    if (a.length != b.length) return false;
-    for (final value in a) {
-      if (!b.contains(value)) return false;
-    }
-    return true;
+    return a.length == b.length && a.containsAll(b);
   }
 }

--- a/bridge/sesori_plugin_opencode/lib/src/models/pending_permission.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/pending_permission.dart
@@ -1,0 +1,14 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "pending_permission.freezed.dart";
+part "pending_permission.g.dart";
+
+@Freezed(fromJson: true, toJson: true)
+sealed class PendingPermission with _$PendingPermission {
+  const factory PendingPermission({
+    required String id,
+    required String sessionID,
+    required String permission,
+  }) = _PendingPermission;
+  factory PendingPermission.fromJson(Map<String, dynamic> json) => _$PendingPermissionFromJson(json);
+}

--- a/bridge/sesori_plugin_opencode/lib/src/models/pending_permission.freezed.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/pending_permission.freezed.dart
@@ -1,0 +1,154 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'pending_permission.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PendingPermission {
+
+ String get id; String get sessionID; String get permission;
+/// Create a copy of PendingPermission
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PendingPermissionCopyWith<PendingPermission> get copyWith => _$PendingPermissionCopyWithImpl<PendingPermission>(this as PendingPermission, _$identity);
+
+  /// Serializes this PendingPermission to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PendingPermission&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.permission, permission) || other.permission == permission));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,sessionID,permission);
+
+@override
+String toString() {
+  return 'PendingPermission(id: $id, sessionID: $sessionID, permission: $permission)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PendingPermissionCopyWith<$Res>  {
+  factory $PendingPermissionCopyWith(PendingPermission value, $Res Function(PendingPermission) _then) = _$PendingPermissionCopyWithImpl;
+@useResult
+$Res call({
+ String id, String sessionID, String permission
+});
+
+
+
+
+}
+/// @nodoc
+class _$PendingPermissionCopyWithImpl<$Res>
+    implements $PendingPermissionCopyWith<$Res> {
+  _$PendingPermissionCopyWithImpl(this._self, this._then);
+
+  final PendingPermission _self;
+  final $Res Function(PendingPermission) _then;
+
+/// Create a copy of PendingPermission
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? sessionID = null,Object? permission = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
+as String,permission: null == permission ? _self.permission : permission // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _PendingPermission implements PendingPermission {
+  const _PendingPermission({required this.id, required this.sessionID, required this.permission});
+  factory _PendingPermission.fromJson(Map<String, dynamic> json) => _$PendingPermissionFromJson(json);
+
+@override final  String id;
+@override final  String sessionID;
+@override final  String permission;
+
+/// Create a copy of PendingPermission
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PendingPermissionCopyWith<_PendingPermission> get copyWith => __$PendingPermissionCopyWithImpl<_PendingPermission>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PendingPermissionToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PendingPermission&&(identical(other.id, id) || other.id == id)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.permission, permission) || other.permission == permission));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,sessionID,permission);
+
+@override
+String toString() {
+  return 'PendingPermission(id: $id, sessionID: $sessionID, permission: $permission)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PendingPermissionCopyWith<$Res> implements $PendingPermissionCopyWith<$Res> {
+  factory _$PendingPermissionCopyWith(_PendingPermission value, $Res Function(_PendingPermission) _then) = __$PendingPermissionCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String sessionID, String permission
+});
+
+
+
+
+}
+/// @nodoc
+class __$PendingPermissionCopyWithImpl<$Res>
+    implements _$PendingPermissionCopyWith<$Res> {
+  __$PendingPermissionCopyWithImpl(this._self, this._then);
+
+  final _PendingPermission _self;
+  final $Res Function(_PendingPermission) _then;
+
+/// Create a copy of PendingPermission
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? sessionID = null,Object? permission = null,}) {
+  return _then(_PendingPermission(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
+as String,permission: null == permission ? _self.permission : permission // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/sesori_plugin_opencode/lib/src/models/pending_permission.g.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/pending_permission.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pending_permission.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PendingPermission _$PendingPermissionFromJson(Map json) => _PendingPermission(
+  id: json['id'] as String,
+  sessionID: json['sessionID'] as String,
+  permission: json['permission'] as String,
+);
+
+Map<String, dynamic> _$PendingPermissionToJson(_PendingPermission instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'sessionID': instance.sessionID,
+      'permission': instance.permission,
+    };

--- a/bridge/sesori_plugin_opencode/lib/src/models/sse_event_data.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/sse_event_data.dart
@@ -177,8 +177,10 @@ sealed class SseEventData with _$SseEventData {
   }) = SsePermissionAsked;
 
   @FreezedUnionValue("permission.replied")
+  @Implements<SseSessionEventData>()
   const factory SseEventData.permissionReplied({
     required String requestID,
+    required String sessionID,
     required String reply,
   }) = SsePermissionReplied;
 

--- a/bridge/sesori_plugin_opencode/lib/src/models/sse_event_data.freezed.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/sse_event_data.freezed.dart
@@ -1757,11 +1757,12 @@ as String,
 /// @nodoc
 @JsonSerializable()
 
-class SsePermissionReplied implements SseEventData {
-  const SsePermissionReplied({required this.requestID, required this.reply, final  String? $type}): $type = $type ?? 'permission.replied';
+class SsePermissionReplied implements SseEventData, SseSessionEventData {
+  const SsePermissionReplied({required this.requestID, required this.sessionID, required this.reply, final  String? $type}): $type = $type ?? 'permission.replied';
   factory SsePermissionReplied.fromJson(Map<String, dynamic> json) => _$SsePermissionRepliedFromJson(json);
 
  final  String requestID;
+ final  String sessionID;
  final  String reply;
 
 @JsonKey(name: 'type')
@@ -1781,16 +1782,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SsePermissionReplied&&(identical(other.requestID, requestID) || other.requestID == requestID)&&(identical(other.reply, reply) || other.reply == reply));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SsePermissionReplied&&(identical(other.requestID, requestID) || other.requestID == requestID)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.reply, reply) || other.reply == reply));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,requestID,reply);
+int get hashCode => Object.hash(runtimeType,requestID,sessionID,reply);
 
 @override
 String toString() {
-  return 'SseEventData.permissionReplied(requestID: $requestID, reply: $reply)';
+  return 'SseEventData.permissionReplied(requestID: $requestID, sessionID: $sessionID, reply: $reply)';
 }
 
 
@@ -1801,7 +1802,7 @@ abstract mixin class $SsePermissionRepliedCopyWith<$Res> implements $SseEventDat
   factory $SsePermissionRepliedCopyWith(SsePermissionReplied value, $Res Function(SsePermissionReplied) _then) = _$SsePermissionRepliedCopyWithImpl;
 @useResult
 $Res call({
- String requestID, String reply
+ String requestID, String sessionID, String reply
 });
 
 
@@ -1818,9 +1819,10 @@ class _$SsePermissionRepliedCopyWithImpl<$Res>
 
 /// Create a copy of SseEventData
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? requestID = null,Object? reply = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? requestID = null,Object? sessionID = null,Object? reply = null,}) {
   return _then(SsePermissionReplied(
 requestID: null == requestID ? _self.requestID : requestID // ignore: cast_nullable_to_non_nullable
+as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
 as String,reply: null == reply ? _self.reply : reply // ignore: cast_nullable_to_non_nullable
 as String,
   ));

--- a/bridge/sesori_plugin_opencode/lib/src/models/sse_event_data.g.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/sse_event_data.g.dart
@@ -236,6 +236,7 @@ Map<String, dynamic> _$SsePermissionAskedToJson(SsePermissionAsked instance) =>
 SsePermissionReplied _$SsePermissionRepliedFromJson(Map json) =>
     SsePermissionReplied(
       requestID: json['requestID'] as String,
+      sessionID: json['sessionID'] as String,
       reply: json['reply'] as String,
       $type: json['type'] as String?,
     );
@@ -244,6 +245,7 @@ Map<String, dynamic> _$SsePermissionRepliedToJson(
   SsePermissionReplied instance,
 ) => <String, dynamic>{
   'requestID': instance.requestID,
+  'sessionID': instance.sessionID,
   'reply': instance.reply,
   'type': instance.$type,
 };

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -6,6 +6,7 @@ import "package:sesori_shared/sesori_shared.dart" show jsonDecodeListMap, jsonDe
 
 import "models/agent_info.dart";
 import "models/message_with_parts.dart";
+import "models/pending_permission.dart";
 import "models/pending_question.dart";
 import "models/project.dart";
 import "models/provider_info.dart";
@@ -286,6 +287,15 @@ class OpenCodeApi {
 
     final decoded = jsonDecodeListMap(response.body);
     return decoded.map(PendingQuestion.fromJson).toList();
+  }
+
+  Future<List<PendingPermission>> getPendingPermissions() async {
+    final response = await _client.get(Uri.parse("$serverURL/permission"), headers: _authHeaders);
+    Log.v("[getPendingPermissions] response: ${response.body}");
+    _ensureSuccess(response, "GET /permission");
+
+    final decoded = jsonDecodeListMap(response.body);
+    return decoded.map(PendingPermission.fromJson).toList();
   }
 
   Future<void> replyToQuestion({

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -289,8 +289,16 @@ class OpenCodeApi {
     return decoded.map(PendingQuestion.fromJson).toList();
   }
 
-  Future<List<PendingPermission>> getPendingPermissions() async {
-    final response = await _client.get(Uri.parse("$serverURL/permission"), headers: _authHeaders);
+  Future<List<PendingPermission>> getPendingPermissions({
+    required String? directory,
+  }) async {
+    final response = await _client.get(
+      Uri.parse("$serverURL/permission"),
+      headers: {
+        ..._authHeaders,
+        _directoryOpenCodeHeader: ?directory,
+      },
+    );
     Log.v("[getPendingPermissions] response: ${response.body}");
     _ensureSuccess(response, "GET /permission");
 

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -414,6 +414,7 @@ class OpenCodePlugin implements BridgePlugin {
                   (a) => PluginActiveSession(
                     id: a.id,
                     mainAgentRunning: a.mainAgentRunning,
+                    awaitingInput: a.awaitingInput,
                     childSessionIds: a.childSessionIds,
                   ),
                 )

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
@@ -158,7 +158,7 @@ class OpenCodeRepository {
   }
 
   Future<List<PendingPermission>> getPendingPermissions() {
-    return _api.getPendingPermissions();
+    return _api.getPendingPermissions(directory: null);
   }
 
   /// Collects all sessions whose directory is equal to or under [worktree],

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
@@ -1,6 +1,7 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginProvidersResult;
 import "package:sesori_shared/sesori_shared.dart" show wait2;
 
+import "models/pending_question.dart";
 import "models/project.dart";
 import "models/session.dart";
 import "opencode_api.dart";
@@ -149,6 +150,10 @@ class OpenCodeRepository {
   Future<PluginProvidersResult> getProviders({required bool connectedOnly}) async {
     final response = await _api.listProviders();
     return mapProviderResponse(response: response, connectedOnly: connectedOnly);
+  }
+
+  Future<List<PendingQuestion>> getPendingQuestions() {
+    return _api.getPendingQuestions(directory: null);
   }
 
   /// Collects all sessions whose directory is equal to or under [worktree],

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
@@ -1,6 +1,7 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginProvidersResult;
 import "package:sesori_shared/sesori_shared.dart" show wait2;
 
+import "models/pending_permission.dart";
 import "models/pending_question.dart";
 import "models/project.dart";
 import "models/session.dart";
@@ -154,6 +155,10 @@ class OpenCodeRepository {
 
   Future<List<PendingQuestion>> getPendingQuestions() {
     return _api.getPendingQuestions(directory: null);
+  }
+
+  Future<List<PendingPermission>> getPendingPermissions() {
+    return _api.getPendingPermissions();
   }
 
   /// Collects all sessions whose directory is equal to or under [worktree],

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -44,8 +44,10 @@ class OpenCodeService {
     return tracker.handleEvent(event, directory);
   }
 
-  Future<void> coldStart() {
-    return tracker.coldStart();
+  Future<void> coldStart() async {
+    await tracker.coldStart();
+    final questions = await repository.getPendingQuestions();
+    tracker.populatePendingQuestions(questions: questions);
   }
 
   void reset() {

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -46,7 +46,11 @@ class OpenCodeService {
 
   Future<void> coldStart() async {
     await tracker.coldStart();
-    await _hydratePendingInput();
+    try {
+      await _hydratePendingInput();
+    } catch (e, st) {
+      Log.w("coldStart: failed to hydrate pending input: $e\n$st");
+    }
   }
 
   /// Best-effort hydration of pending questions and permissions from the
@@ -54,18 +58,20 @@ class OpenCodeService {
   /// active-session tracking from [ActiveSessionTracker.coldStart] succeeds
   /// independently.
   Future<void> _hydratePendingInput() async {
-    try {
-      final questions = await repository.getPendingQuestions();
-      tracker.populatePendingQuestions(questions: questions);
-    } catch (e, st) {
-      Log.w("coldStart: failed to hydrate pending questions: $e\n$st");
-    }
-    try {
-      final permissions = await repository.getPendingPermissions();
-      tracker.populatePendingPermissions(permissions: permissions);
-    } catch (e, st) {
-      Log.w("coldStart: failed to hydrate pending permissions: $e\n$st");
-    }
+    await (
+      repository
+          .getPendingQuestions()
+          .then((questions) => tracker.populatePendingQuestions(questions: questions))
+          .catchError((Object e, StackTrace st) {
+            Log.w("coldStart: failed to hydrate pending questions: $e\n$st");
+          }),
+      repository
+          .getPendingPermissions()
+          .then((permissions) => tracker.populatePendingPermissions(permissions: permissions))
+          .catchError((Object e, StackTrace st) {
+            Log.w("coldStart: failed to hydrate pending permissions: $e\n$st");
+          }),
+    ).wait;
   }
 
   void reset() {

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -46,8 +46,26 @@ class OpenCodeService {
 
   Future<void> coldStart() async {
     await tracker.coldStart();
-    final questions = await repository.getPendingQuestions();
-    tracker.populatePendingQuestions(questions: questions);
+    await _hydratePendingInput();
+  }
+
+  /// Best-effort hydration of pending questions and permissions from the
+  /// OpenCode API. Failures are logged but do NOT abort cold start — core
+  /// active-session tracking from [ActiveSessionTracker.coldStart] succeeds
+  /// independently.
+  Future<void> _hydratePendingInput() async {
+    try {
+      final questions = await repository.getPendingQuestions();
+      tracker.populatePendingQuestions(questions: questions);
+    } catch (e, st) {
+      Log.w("coldStart: failed to hydrate pending questions: $e\n$st");
+    }
+    try {
+      final permissions = await repository.getPendingPermissions();
+      tracker.populatePendingPermissions(permissions: permissions);
+    } catch (e, st) {
+      Log.w("coldStart: failed to hydrate pending permissions: $e\n$st");
+    }
   }
 
   void reset() {

--- a/bridge/sesori_plugin_opencode/lib/src/sse_event_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse_event_mapper.dart
@@ -66,8 +66,9 @@ class SseEventMapper {
           tool: tool,
           description: description,
         ),
-      SsePermissionReplied(:final requestID, :final reply) => BridgeSsePermissionReplied(
+      SsePermissionReplied(:final requestID, :final sessionID, :final reply) => BridgeSsePermissionReplied(
         requestID: requestID,
+        sessionID: sessionID,
         reply: reply,
       ),
       SsePermissionUpdated() => const BridgeSsePermissionUpdated(),

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -694,8 +694,7 @@ void main() {
 
         expect(tracker.buildSummary().first.activeSessions.first.awaitingInput, isTrue);
 
-        // SsePermissionReplied has no sessionID — tracker uses requestID→sessionID map.
-        tracker.handleEvent(_permissionReplied("p1"), null);
+        tracker.handleEvent(_permissionReplied(requestId: "p1", sessionId: "s1"), null);
 
         expect(tracker.buildSummary().first.activeSessions.first.awaitingInput, isFalse);
       });
@@ -797,10 +796,73 @@ void main() {
         tracker.handleEvent(_sessionBusy("s1"), null);
 
         // Reply to a permission that was never asked — should not crash.
-        final changed = tracker.handleEvent(_permissionReplied("unknown"), null);
+        final changed = tracker.handleEvent(_permissionReplied(requestId: "unknown", sessionId: "s1"), null);
 
         expect(changed, isFalse);
         expect(tracker.buildSummary().first.activeSessions.first.awaitingInput, isFalse);
+      });
+
+      test("child session pending question bubbles up to root awaitingInput", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+        );
+
+        tracker.handleEvent(_sessionCreated("root", "/repo"), null);
+        tracker.handleEvent(_sessionBusy("root"), null);
+
+        // Register child session under root, mark it busy.
+        tracker.handleEvent(_childSessionCreated("child", "root", "/repo"), null);
+        tracker.handleEvent(_sessionBusy("child"), null);
+
+        // Question asked on child — root should show awaitingInput.
+        final changed = tracker.handleEvent(_questionAsked("q1", "child"), null);
+
+        expect(changed, isTrue, reason: "bubble-up must trigger re-emit");
+        final summary = tracker.buildSummary();
+        final rootSession = summary.first.activeSessions.firstWhere((s) => s.id == "root");
+        expect(rootSession.awaitingInput, isTrue, reason: "child question must bubble to root");
+      });
+
+      test("child session pending permission bubbles up to root awaitingInput", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+        );
+
+        tracker.handleEvent(_sessionCreated("root", "/repo"), null);
+        tracker.handleEvent(_sessionBusy("root"), null);
+        tracker.handleEvent(_childSessionCreated("child", "root", "/repo"), null);
+        tracker.handleEvent(_sessionBusy("child"), null);
+
+        tracker.handleEvent(_permissionAsked("p1", "child"), null);
+
+        final summary = tracker.buildSummary();
+        final rootSession = summary.first.activeSessions.firstWhere((s) => s.id == "root");
+        expect(rootSession.awaitingInput, isTrue);
+
+        // Resolving the child permission should clear the root's awaitingInput.
+        tracker.handleEvent(_permissionReplied(requestId: "p1", sessionId: "child"), null);
+        final afterSummary = tracker.buildSummary();
+        final afterRoot = afterSummary.first.activeSessions.firstWhere((s) => s.id == "root");
+        expect(afterRoot.awaitingInput, isFalse);
+      });
+
+      test("populatePendingPermissions hydrates from cold start data", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+          statuses: {"s1": const SessionStatus.busy()},
+          sessions: [
+            const Session(id: "s1", projectID: "p1", directory: "/repo"),
+          ],
+        );
+
+        tracker.populatePendingPermissions(
+          permissions: [
+            const PendingPermission(id: "perm1", sessionID: "s1", permission: "bash"),
+          ],
+        );
+
+        final summary = tracker.buildSummary();
+        expect(summary.first.activeSessions.first.awaitingInput, isTrue);
       });
     });
   });
@@ -809,6 +871,12 @@ void main() {
 SseEventData _sessionCreated(String id, String directory) {
   return SseEventData.sessionCreated(
     info: Session(id: id, projectID: "project", directory: directory),
+  );
+}
+
+SseEventData _childSessionCreated(String id, String parentId, String directory) {
+  return SseEventData.sessionCreated(
+    info: Session(id: id, projectID: "project", directory: directory, parentID: parentId),
   );
 }
 
@@ -873,9 +941,10 @@ SseEventData _permissionAsked(String requestId, String sessionId) {
   );
 }
 
-SseEventData _permissionReplied(String requestId) {
+SseEventData _permissionReplied({required String requestId, required String sessionId}) {
   return SseEventData.permissionReplied(
     requestID: requestId,
+    sessionID: sessionId,
     reply: "approve",
   );
 }
@@ -975,6 +1044,9 @@ class _FakeApi implements OpenCodeApi {
 
   @override
   Future<List<PendingQuestion>> getPendingQuestions({required String? directory}) async => [];
+
+  @override
+  Future<List<PendingPermission>> getPendingPermissions() async => [];
 
   @override
   Future<void> replyToQuestion({

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -1046,7 +1046,7 @@ class _FakeApi implements OpenCodeApi {
   Future<List<PendingQuestion>> getPendingQuestions({required String? directory}) async => [];
 
   @override
-  Future<List<PendingPermission>> getPendingPermissions() async => [];
+  Future<List<PendingPermission>> getPendingPermissions({required String? directory}) async => [];
 
   @override
   Future<void> replyToQuestion({

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -645,6 +645,164 @@ void main() {
       expect(summary.first.activeSessions.first.id, equals("s1"));
       expect(summary.first.activeSessions.first.childSessionIds, equals(["c1"]));
     });
+
+    group("pending input tracking", () {
+      test("question asked sets awaitingInput true, replied clears it", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+        );
+
+        tracker.handleEvent(_sessionCreated("s1", "/repo"), null);
+        tracker.handleEvent(_sessionBusy("s1"), null);
+
+        tracker.handleEvent(_questionAsked("q1", "s1"), null);
+
+        final summary = tracker.buildSummary();
+        expect(summary.first.activeSessions.first.awaitingInput, isTrue);
+
+        tracker.handleEvent(_questionReplied("q1", "s1"), null);
+
+        final afterReply = tracker.buildSummary();
+        expect(afterReply.first.activeSessions.first.awaitingInput, isFalse);
+      });
+
+      test("question rejected clears awaitingInput", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+        );
+
+        tracker.handleEvent(_sessionCreated("s1", "/repo"), null);
+        tracker.handleEvent(_sessionBusy("s1"), null);
+        tracker.handleEvent(_questionAsked("q1", "s1"), null);
+
+        expect(tracker.buildSummary().first.activeSessions.first.awaitingInput, isTrue);
+
+        tracker.handleEvent(_questionRejected("q1", "s1"), null);
+
+        expect(tracker.buildSummary().first.activeSessions.first.awaitingInput, isFalse);
+      });
+
+      test("permission asked sets awaitingInput, replied clears it via requestID mapping", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+        );
+
+        tracker.handleEvent(_sessionCreated("s1", "/repo"), null);
+        tracker.handleEvent(_sessionBusy("s1"), null);
+
+        tracker.handleEvent(_permissionAsked("p1", "s1"), null);
+
+        expect(tracker.buildSummary().first.activeSessions.first.awaitingInput, isTrue);
+
+        // SsePermissionReplied has no sessionID — tracker uses requestID→sessionID map.
+        tracker.handleEvent(_permissionReplied("p1"), null);
+
+        expect(tracker.buildSummary().first.activeSessions.first.awaitingInput, isFalse);
+      });
+
+      test("multiple pending questions require all resolved to clear", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+        );
+
+        tracker.handleEvent(_sessionCreated("s1", "/repo"), null);
+        tracker.handleEvent(_sessionBusy("s1"), null);
+
+        tracker.handleEvent(_questionAsked("q1", "s1"), null);
+        tracker.handleEvent(_questionAsked("q2", "s1"), null);
+
+        expect(tracker.buildSummary().first.activeSessions.first.awaitingInput, isTrue);
+
+        tracker.handleEvent(_questionReplied("q1", "s1"), null);
+
+        // One question still pending.
+        expect(tracker.buildSummary().first.activeSessions.first.awaitingInput, isTrue);
+
+        tracker.handleEvent(_questionReplied("q2", "s1"), null);
+
+        expect(tracker.buildSummary().first.activeSessions.first.awaitingInput, isFalse);
+      });
+
+      test("session deleted cleans up pending input state", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+        );
+
+        tracker.handleEvent(_sessionCreated("s1", "/repo"), null);
+        tracker.handleEvent(_sessionBusy("s1"), null);
+        tracker.handleEvent(_questionAsked("q1", "s1"), null);
+
+        expect(tracker.buildSummary().first.activeSessions.first.awaitingInput, isTrue);
+
+        tracker.handleEvent(_sessionDeleted("s1", "/repo"), null);
+
+        // Session gone — no summary entries at all.
+        expect(tracker.buildSummary(), isEmpty);
+      });
+
+      test("session idle cleans up pending input state", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+        );
+
+        tracker.handleEvent(_sessionCreated("s1", "/repo"), null);
+        tracker.handleEvent(_sessionBusy("s1"), null);
+        tracker.handleEvent(_questionAsked("q1", "s1"), null);
+
+        expect(tracker.buildSummary().first.activeSessions.first.awaitingInput, isTrue);
+
+        tracker.handleEvent(_sessionIdle("s1"), null);
+
+        // Session no longer active — summary empty.
+        expect(tracker.buildSummary(), isEmpty);
+      });
+
+      test("question asked on active session triggers change detection", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+        );
+
+        tracker.handleEvent(_sessionCreated("s1", "/repo"), null);
+        tracker.handleEvent(_sessionBusy("s1"), null);
+
+        // Active session count unchanged, but pending input state changed.
+        final changed = tracker.handleEvent(_questionAsked("q1", "s1"), null);
+
+        expect(changed, isTrue);
+      });
+
+      test("populatePendingQuestions populates from cold start data", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+          sessions: [_session("s1", "/repo")],
+          statuses: {"s1": const SessionStatus.busy()},
+        );
+
+        tracker.populatePendingQuestions(
+          questions: [
+            const PendingQuestion(id: "q1", sessionID: "s1", questions: []),
+          ],
+        );
+
+        final summary = tracker.buildSummary();
+        expect(summary.first.activeSessions.first.awaitingInput, isTrue);
+      });
+
+      test("permission replied for unknown requestID is a no-op", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+        );
+
+        tracker.handleEvent(_sessionCreated("s1", "/repo"), null);
+        tracker.handleEvent(_sessionBusy("s1"), null);
+
+        // Reply to a permission that was never asked — should not crash.
+        final changed = tracker.handleEvent(_permissionReplied("unknown"), null);
+
+        expect(changed, isFalse);
+        expect(tracker.buildSummary().first.activeSessions.first.awaitingInput, isFalse);
+      });
+    });
   });
 }
 
@@ -681,6 +839,44 @@ SseEventData _sessionIdle(String id) {
   return SseEventData.sessionStatus(
     sessionID: id,
     status: const SessionStatus.idle(),
+  );
+}
+
+SseEventData _questionAsked(String id, String sessionId) {
+  return SseEventData.questionAsked(
+    id: id,
+    sessionID: sessionId,
+    questions: const [],
+  );
+}
+
+SseEventData _questionReplied(String requestId, String sessionId) {
+  return SseEventData.questionReplied(
+    requestID: requestId,
+    sessionID: sessionId,
+  );
+}
+
+SseEventData _questionRejected(String requestId, String sessionId) {
+  return SseEventData.questionRejected(
+    requestID: requestId,
+    sessionID: sessionId,
+  );
+}
+
+SseEventData _permissionAsked(String requestId, String sessionId) {
+  return SseEventData.permissionAsked(
+    requestID: requestId,
+    sessionID: sessionId,
+    tool: "test-tool",
+    description: "test permission",
+  );
+}
+
+SseEventData _permissionReplied(String requestId) {
+  return SseEventData.permissionReplied(
+    requestID: requestId,
+    reply: "approve",
   );
 }
 

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -198,14 +198,12 @@ void main() {
     test("events stream emits bridge events", () async {
       final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
 
-      final stream = plugin.events;
-      final collected = <BridgeSseEvent>[];
-      final sub = stream.listen(collected.add);
-
-      await Future<void>.delayed(const Duration(milliseconds: 50));
-      await sub.cancel();
-
-      expect(collected.whereType<BridgeSseProjectUpdated>(), isNotEmpty);
+      // Wait for the actual event instead of a blind delay.
+      // _initialize() emits BridgeSseProjectUpdated after coldStart().
+      await expectLater(
+        plugin.events,
+        emitsThrough(isA<BridgeSseProjectUpdated>()),
+      );
     });
 
     test("getSessionStatuses merges tracker data with API response", () async {
@@ -365,6 +363,11 @@ class _DynamicStatusServer {
 
       if (request.method == "GET" && path == "/experimental/session") {
         await _json(request.response, <Map<String, dynamic>>[]);
+        return;
+      }
+
+      if (request.method == "GET" && path == "/question") {
+        await _json(request.response, <Object>[]);
         return;
       }
 
@@ -915,6 +918,11 @@ class _FakeOpenCodeServer {
             ],
           },
         ]);
+        return;
+      }
+
+      if (request.method == "GET" && path == "/question") {
+        await _sendJson(request.response, <Object>[]);
         return;
       }
 

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -371,6 +371,11 @@ class _DynamicStatusServer {
         return;
       }
 
+      if (request.method == "GET" && path == "/permission") {
+        await _json(request.response, <Object>[]);
+        return;
+      }
+
       if (request.method == "GET" && path == "/global/event") {
         request.response.statusCode = HttpStatus.ok;
         request.response.headers.contentType = ContentType("text", "event-stream");
@@ -922,6 +927,11 @@ class _FakeOpenCodeServer {
       }
 
       if (request.method == "GET" && path == "/question") {
+        await _sendJson(request.response, <Object>[]);
+        return;
+      }
+
+      if (request.method == "GET" && path == "/permission") {
         await _sendJson(request.response, <Object>[]);
         return;
       }

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -432,6 +432,9 @@ class _FakeApi implements OpenCodeApi {
   Future<List<PendingQuestion>> getPendingQuestions({required String? directory}) async => [];
 
   @override
+  Future<List<PendingPermission>> getPendingPermissions() async => [];
+
+  @override
   Future<void> replyToQuestion({
     required String questionId,
     required String? directory,

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -432,7 +432,7 @@ class _FakeApi implements OpenCodeApi {
   Future<List<PendingQuestion>> getPendingQuestions({required String? directory}) async => [];
 
   @override
-  Future<List<PendingPermission>> getPendingPermissions() async => [];
+  Future<List<PendingPermission>> getPendingPermissions({required String? directory}) async => [];
 
   @override
   Future<void> replyToQuestion({

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -360,7 +360,7 @@ class FakeOpenCodeApi implements OpenCodeApi {
   Future<List<PendingQuestion>> getPendingQuestions({required String? directory}) async => [];
 
   @override
-  Future<List<PendingPermission>> getPendingPermissions() async => [];
+  Future<List<PendingPermission>> getPendingPermissions({required String? directory}) async => [];
 
   @override
   Future<void> replyToQuestion({

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -360,6 +360,9 @@ class FakeOpenCodeApi implements OpenCodeApi {
   Future<List<PendingQuestion>> getPendingQuestions({required String? directory}) async => [];
 
   @override
+  Future<List<PendingPermission>> getPendingPermissions() async => [];
+
+  @override
   Future<void> replyToQuestion({
     required String questionId,
     required String? directory,

--- a/mobile/app/lib/core/status_colors.dart
+++ b/mobile/app/lib/core/status_colors.dart
@@ -1,0 +1,10 @@
+import "package:flutter/material.dart";
+
+/// Semantic status colors shared across session and PR status indicators.
+///
+/// GitHub-inspired palette chosen for strong light/dark contrast. Kept in a
+/// single location so the amber "attention needed" / green "active" /
+/// purple "merged" signals stay visually consistent across the app.
+const kStatusGreen = Color(0xFF3FB950);
+const kStatusAmber = Color(0xFFD29922);
+const kStatusPurple = Color(0xFFA371F7);

--- a/mobile/app/lib/features/session_list/session_list_screen.dart
+++ b/mobile/app/lib/features/session_list/session_list_screen.dart
@@ -8,6 +8,7 @@ import "../../core/constants.dart";
 import "../../core/di/injection.dart";
 import "../../core/extensions/build_context_x.dart";
 import "../../core/routing/app_router.dart";
+import "../../core/status_colors.dart";
 import "../../core/widgets/app_modal_bottom_sheet.dart";
 import "../../l10n/app_localizations.dart";
 import "pr_status_row.dart";

--- a/mobile/app/lib/features/session_list/session_list_screen.dart
+++ b/mobile/app/lib/features/session_list/session_list_screen.dart
@@ -192,6 +192,7 @@ class _SessionListBody extends StatelessWidget {
                             session: session,
                             isArchived: isArchived,
                             isActive: activityInfo != null,
+                            awaitingInput: activityInfo?.awaitingInput ?? false,
                             backgroundTaskCount: activityInfo?.backgroundTaskCount ?? 0,
                             onLongPress: () => _showSessionActions(context: context, session: session),
                             onSwipe: () => isArchived

--- a/mobile/app/lib/features/session_list/session_list_widgets.dart
+++ b/mobile/app/lib/features/session_list/session_list_widgets.dart
@@ -1,7 +1,5 @@
 part of "session_list_screen.dart";
 
-const _kSessionAmber = Color(0xFFD29922);
-
 class _SessionTile extends StatelessWidget {
   final Session session;
   final bool isArchived;
@@ -108,7 +106,7 @@ Widget _buildActivityRow({
   required bool awaitingInput,
   required int backgroundTaskCount,
 }) {
-  final color = awaitingInput ? _kSessionAmber : theme.colorScheme.primary;
+  final color = awaitingInput ? kStatusAmber : theme.colorScheme.primary;
   final label = awaitingInput ? loc.sessionListAwaitingInput : loc.sessionListRunning;
 
   return Row(

--- a/mobile/app/lib/features/session_list/session_list_widgets.dart
+++ b/mobile/app/lib/features/session_list/session_list_widgets.dart
@@ -1,9 +1,12 @@
 part of "session_list_screen.dart";
 
+const _kSessionAmber = Color(0xFFD29922);
+
 class _SessionTile extends StatelessWidget {
   final Session session;
   final bool isArchived;
   final bool isActive;
+  final bool awaitingInput;
   final int backgroundTaskCount;
   final VoidCallback onLongPress;
   final VoidCallback onSwipe;
@@ -12,6 +15,7 @@ class _SessionTile extends StatelessWidget {
     required this.session,
     required this.isArchived,
     required this.isActive,
+    this.awaitingInput = false,
     this.backgroundTaskCount = 0,
     required this.onLongPress,
     required this.onSwipe,
@@ -72,35 +76,11 @@ class _SessionTile extends StatelessWidget {
               ),
             if (session.pullRequest case final pr?) PrStatusRow(pr: pr),
             if (isActive)
-              Row(
-                children: [
-                  Icon(Icons.circle, size: 8, color: theme.colorScheme.primary),
-                  const SizedBox(width: 4),
-                  Text(
-                    loc.sessionListRunning,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.primary,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  if (backgroundTaskCount > 0) ...[
-                    Padding(
-                      padding: const EdgeInsetsDirectional.symmetric(horizontal: 6),
-                      child: Icon(
-                        Icons.circle,
-                        size: 3,
-                        color: theme.colorScheme.primary,
-                      ),
-                    ),
-                    Text(
-                      loc.sessionListBackgroundTasks(backgroundTaskCount),
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.primary,
-                        fontWeight: FontWeight.w500,
-                      ),
-                    ),
-                  ],
-                ],
+              _buildActivityRow(
+                theme: theme,
+                loc: loc,
+                awaitingInput: awaitingInput,
+                backgroundTaskCount: backgroundTaskCount,
               ),
           ],
         ),
@@ -120,6 +100,43 @@ class _SessionTile extends StatelessWidget {
       ),
     );
   }
+}
+
+Widget _buildActivityRow({
+  required ThemeData theme,
+  required AppLocalizations loc,
+  required bool awaitingInput,
+  required int backgroundTaskCount,
+}) {
+  final color = awaitingInput ? _kSessionAmber : theme.colorScheme.primary;
+  final label = awaitingInput ? loc.sessionListAwaitingInput : loc.sessionListRunning;
+
+  return Row(
+    children: [
+      Icon(Icons.circle, size: 8, color: color),
+      const SizedBox(width: 4),
+      Text(
+        label,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: color,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+      if (backgroundTaskCount > 0) ...[
+        Padding(
+          padding: const EdgeInsetsDirectional.symmetric(horizontal: 6),
+          child: Icon(Icons.circle, size: 3, color: color),
+        ),
+        Text(
+          loc.sessionListBackgroundTasks(backgroundTaskCount),
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: color,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ],
+    ],
+  );
 }
 
 String _formatTimestamp({required int ms}) {

--- a/mobile/app/lib/l10n/app_en.arb
+++ b/mobile/app/lib/l10n/app_en.arb
@@ -204,6 +204,10 @@
     "@sessionListRunning": {
       "description": "Label shown next to the green dot for sessions that are currently active"
     },
+    "sessionListAwaitingInput": "Awaiting input",
+    "@sessionListAwaitingInput": {
+      "description": "Label shown next to the amber dot for sessions that are waiting for user input (question or permission)"
+    },
     "sessionListBackgroundTasks": "{count, plural, =1{1 background task} other{{count} background tasks}}",
     "@sessionListBackgroundTasks": {
       "description": "Label showing the number of active background tasks for a session",

--- a/mobile/app/lib/l10n/app_localizations.dart
+++ b/mobile/app/lib/l10n/app_localizations.dart
@@ -739,6 +739,12 @@ abstract class AppLocalizations {
   /// **'Running'**
   String get sessionListRunning;
 
+  /// Label shown next to the amber dot for sessions that are waiting for user input (question or permission)
+  ///
+  /// In en, this message translates to:
+  /// **'Awaiting input'**
+  String get sessionListAwaitingInput;
+
   /// Label showing the number of active background tasks for a session
   ///
   /// In en, this message translates to:

--- a/mobile/app/lib/l10n/app_localizations_en.dart
+++ b/mobile/app/lib/l10n/app_localizations_en.dart
@@ -377,6 +377,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionListRunning => 'Running';
 
   @override
+  String get sessionListAwaitingInput => 'Awaiting input';
+
+  @override
   String sessionListBackgroundTasks(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/mobile/module_core/lib/src/capabilities/sse/session_activity_info.dart
+++ b/mobile/module_core/lib/src/capabilities/sse/session_activity_info.dart
@@ -10,6 +10,7 @@ part "session_activity_info.freezed.dart";
 sealed class SessionActivityInfo with _$SessionActivityInfo {
   const factory SessionActivityInfo({
     @Default(false) bool mainAgentRunning,
+    @Default(false) bool awaitingInput,
     @Default(0) int backgroundTaskCount,
   }) = _SessionActivityInfo;
 }

--- a/mobile/module_core/lib/src/capabilities/sse/session_activity_info.freezed.dart
+++ b/mobile/module_core/lib/src/capabilities/sse/session_activity_info.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$SessionActivityInfo {
 
- bool get mainAgentRunning; int get backgroundTaskCount;
+ bool get mainAgentRunning; bool get awaitingInput; int get backgroundTaskCount;
 /// Create a copy of SessionActivityInfo
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $SessionActivityInfoCopyWith<SessionActivityInfo> get copyWith => _$SessionActiv
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionActivityInfo&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.backgroundTaskCount, backgroundTaskCount) || other.backgroundTaskCount == backgroundTaskCount));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionActivityInfo&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&(identical(other.backgroundTaskCount, backgroundTaskCount) || other.backgroundTaskCount == backgroundTaskCount));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,mainAgentRunning,backgroundTaskCount);
+int get hashCode => Object.hash(runtimeType,mainAgentRunning,awaitingInput,backgroundTaskCount);
 
 @override
 String toString() {
-  return 'SessionActivityInfo(mainAgentRunning: $mainAgentRunning, backgroundTaskCount: $backgroundTaskCount)';
+  return 'SessionActivityInfo(mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, backgroundTaskCount: $backgroundTaskCount)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $SessionActivityInfoCopyWith<$Res>  {
   factory $SessionActivityInfoCopyWith(SessionActivityInfo value, $Res Function(SessionActivityInfo) _then) = _$SessionActivityInfoCopyWithImpl;
 @useResult
 $Res call({
- bool mainAgentRunning, int backgroundTaskCount
+ bool mainAgentRunning, bool awaitingInput, int backgroundTaskCount
 });
 
 
@@ -62,9 +62,10 @@ class _$SessionActivityInfoCopyWithImpl<$Res>
 
 /// Create a copy of SessionActivityInfo
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? mainAgentRunning = null,Object? backgroundTaskCount = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? mainAgentRunning = null,Object? awaitingInput = null,Object? backgroundTaskCount = null,}) {
   return _then(_self.copyWith(
 mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
+as bool,awaitingInput: null == awaitingInput ? _self.awaitingInput : awaitingInput // ignore: cast_nullable_to_non_nullable
 as bool,backgroundTaskCount: null == backgroundTaskCount ? _self.backgroundTaskCount : backgroundTaskCount // ignore: cast_nullable_to_non_nullable
 as int,
   ));
@@ -78,10 +79,11 @@ as int,
 
 
 class _SessionActivityInfo implements SessionActivityInfo {
-  const _SessionActivityInfo({this.mainAgentRunning = false, this.backgroundTaskCount = 0});
+  const _SessionActivityInfo({this.mainAgentRunning = false, this.awaitingInput = false, this.backgroundTaskCount = 0});
   
 
 @override@JsonKey() final  bool mainAgentRunning;
+@override@JsonKey() final  bool awaitingInput;
 @override@JsonKey() final  int backgroundTaskCount;
 
 /// Create a copy of SessionActivityInfo
@@ -94,16 +96,16 @@ _$SessionActivityInfoCopyWith<_SessionActivityInfo> get copyWith => __$SessionAc
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionActivityInfo&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.backgroundTaskCount, backgroundTaskCount) || other.backgroundTaskCount == backgroundTaskCount));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionActivityInfo&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&(identical(other.backgroundTaskCount, backgroundTaskCount) || other.backgroundTaskCount == backgroundTaskCount));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,mainAgentRunning,backgroundTaskCount);
+int get hashCode => Object.hash(runtimeType,mainAgentRunning,awaitingInput,backgroundTaskCount);
 
 @override
 String toString() {
-  return 'SessionActivityInfo(mainAgentRunning: $mainAgentRunning, backgroundTaskCount: $backgroundTaskCount)';
+  return 'SessionActivityInfo(mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, backgroundTaskCount: $backgroundTaskCount)';
 }
 
 
@@ -114,7 +116,7 @@ abstract mixin class _$SessionActivityInfoCopyWith<$Res> implements $SessionActi
   factory _$SessionActivityInfoCopyWith(_SessionActivityInfo value, $Res Function(_SessionActivityInfo) _then) = __$SessionActivityInfoCopyWithImpl;
 @override @useResult
 $Res call({
- bool mainAgentRunning, int backgroundTaskCount
+ bool mainAgentRunning, bool awaitingInput, int backgroundTaskCount
 });
 
 
@@ -131,9 +133,10 @@ class __$SessionActivityInfoCopyWithImpl<$Res>
 
 /// Create a copy of SessionActivityInfo
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? mainAgentRunning = null,Object? backgroundTaskCount = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? mainAgentRunning = null,Object? awaitingInput = null,Object? backgroundTaskCount = null,}) {
   return _then(_SessionActivityInfo(
 mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
+as bool,awaitingInput: null == awaitingInput ? _self.awaitingInput : awaitingInput // ignore: cast_nullable_to_non_nullable
 as bool,backgroundTaskCount: null == backgroundTaskCount ? _self.backgroundTaskCount : backgroundTaskCount // ignore: cast_nullable_to_non_nullable
 as int,
   ));

--- a/mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart
+++ b/mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart
@@ -63,6 +63,7 @@ class SseEventRepository with Disposable {
             for (final session in summary.activeSessions) {
               infoMap[session.id] = SessionActivityInfo(
                 mainAgentRunning: session.mainAgentRunning,
+                awaitingInput: session.awaitingInput,
                 backgroundTaskCount: session.childSessionIds.length,
               );
             }

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -351,6 +351,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
             // ignore: deprecated_member_use, legacy idle event is still emitted for backward compatibility
             SesoriSessionIdle() ||
             SesoriPermissionAsked() ||
+            SesoriPermissionReplied() ||
             SesoriTodoUpdated():
           break;
       }

--- a/mobile/module_core/test/capabilities/sse/sse_event_repository_test.dart
+++ b/mobile/module_core/test/capabilities/sse/sse_event_repository_test.dart
@@ -318,6 +318,82 @@ void main() {
     // 9. Non-projectsSummary events are ignored
     // -------------------------------------------------------------------------
 
+    // -------------------------------------------------------------------------
+    // 10. awaitingInput true is mapped to SessionActivityInfo
+    // -------------------------------------------------------------------------
+
+    test("sessionActivity maps awaitingInput true from ActiveSession", () async {
+      final repo = SseEventRepository(mockConnectionService, failureReporter: mockFailureReporter);
+
+      final completer = Completer<Map<String, Map<String, SessionActivityInfo>>>();
+      final subscription = repo.sessionActivity.listen((activity) {
+        if (activity.isNotEmpty) {
+          completer.complete(activity);
+        }
+      });
+
+      final event = SseEvent(
+        data: const SesoriProjectsSummary(
+          projects: [
+            ProjectActivitySummary(
+              id: "/foo",
+              activeSessions: [
+                ActiveSession(id: "s1", mainAgentRunning: true, awaitingInput: true),
+              ],
+            ),
+          ],
+        ),
+      );
+      eventController.add(event);
+
+      final activity = await completer.future;
+      expect(activity["/foo"]!["s1"]!.awaitingInput, isTrue);
+      expect(activity["/foo"]!["s1"]!.mainAgentRunning, isTrue);
+
+      await subscription.cancel();
+      repo.onDispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // 11. awaitingInput false is mapped to SessionActivityInfo
+    // -------------------------------------------------------------------------
+
+    test("sessionActivity maps awaitingInput false from ActiveSession", () async {
+      final repo = SseEventRepository(mockConnectionService, failureReporter: mockFailureReporter);
+
+      final completer = Completer<Map<String, Map<String, SessionActivityInfo>>>();
+      final subscription = repo.sessionActivity.listen((activity) {
+        if (activity.isNotEmpty) {
+          completer.complete(activity);
+        }
+      });
+
+      final event = SseEvent(
+        data: const SesoriProjectsSummary(
+          projects: [
+            ProjectActivitySummary(
+              id: "/foo",
+              activeSessions: [
+                ActiveSession(id: "s1", mainAgentRunning: true, awaitingInput: false),
+              ],
+            ),
+          ],
+        ),
+      );
+      eventController.add(event);
+
+      final activity = await completer.future;
+      expect(activity["/foo"]!["s1"]!.awaitingInput, isFalse);
+      expect(activity["/foo"]!["s1"]!.mainAgentRunning, isTrue);
+
+      await subscription.cancel();
+      repo.onDispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // 12. Non-projectsSummary events are ignored
+    // -------------------------------------------------------------------------
+
     test("non-projectsSummary events are ignored", () async {
       final repo = SseEventRepository(mockConnectionService, failureReporter: mockFailureReporter);
 

--- a/mobile/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/mobile/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -1553,6 +1553,40 @@ void main() {
     );
 
     // -------------------------------------------------------------------------
+    // 23. activeSessionIds propagates awaitingInput from SessionActivityInfo
+    // -------------------------------------------------------------------------
+
+    blocTest<SessionListCubit, SessionListState>(
+      "activeSessionIds propagates awaitingInput true from SessionActivityInfo",
+      build: () {
+        when(() => mockSessionService.listSessions(projectId: projectId)).thenAnswer(
+          (_) async => ApiResponse.success(
+            SessionListResponse(
+              items: [
+                testSession(id: "s1", title: "Session 1"),
+              ],
+            ),
+          ),
+        );
+        mockSseEventRepository.emitSessionActivity({
+          projectId: {
+            "s1": const SessionActivityInfo(mainAgentRunning: true, awaitingInput: true),
+          },
+        });
+        return buildCubit();
+      },
+      expect: () => [
+        isA<SessionListLoaded>().having((s) => s.sessions.length, "sessions count", 1).having(
+          (s) => s.activeSessionIds,
+          "activeSessionIds with awaitingInput",
+          {
+            "s1": const SessionActivityInfo(mainAgentRunning: true, awaitingInput: true),
+          },
+        ),
+      ],
+    );
+
+    // -------------------------------------------------------------------------
     // Stale reconnect
     // -------------------------------------------------------------------------
 

--- a/shared/sesori_shared/lib/src/models/sesori/active_session.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/active_session.dart
@@ -14,6 +14,7 @@ sealed class ActiveSession with _$ActiveSession {
   const factory ActiveSession({
     required String id,
     @Default(false) bool mainAgentRunning,
+    @Default(false) bool awaitingInput,
     @Default([]) List<String> childSessionIds,
   }) = _ActiveSession;
 

--- a/shared/sesori_shared/lib/src/models/sesori/active_session.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/active_session.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ActiveSession {
 
- String get id; bool get mainAgentRunning; List<String> get childSessionIds;
+ String get id; bool get mainAgentRunning; bool get awaitingInput; List<String> get childSessionIds;
 /// Create a copy of ActiveSession
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $ActiveSessionCopyWith<ActiveSession> get copyWith => _$ActiveSessionCopyWithImp
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&const DeepCollectionEquality().equals(other.childSessionIds, childSessionIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&const DeepCollectionEquality().equals(other.childSessionIds, childSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,const DeepCollectionEquality().hash(childSessionIds));
+int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,awaitingInput,const DeepCollectionEquality().hash(childSessionIds));
 
 @override
 String toString() {
-  return 'ActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, childSessionIds: $childSessionIds)';
+  return 'ActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, childSessionIds: $childSessionIds)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $ActiveSessionCopyWith<$Res>  {
   factory $ActiveSessionCopyWith(ActiveSession value, $Res Function(ActiveSession) _then) = _$ActiveSessionCopyWithImpl;
 @useResult
 $Res call({
- String id, bool mainAgentRunning, List<String> childSessionIds
+ String id, bool mainAgentRunning, bool awaitingInput, List<String> childSessionIds
 });
 
 
@@ -65,10 +65,11 @@ class _$ActiveSessionCopyWithImpl<$Res>
 
 /// Create a copy of ActiveSession
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? mainAgentRunning = null,Object? childSessionIds = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? mainAgentRunning = null,Object? awaitingInput = null,Object? childSessionIds = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
+as bool,awaitingInput: null == awaitingInput ? _self.awaitingInput : awaitingInput // ignore: cast_nullable_to_non_nullable
 as bool,childSessionIds: null == childSessionIds ? _self.childSessionIds : childSessionIds // ignore: cast_nullable_to_non_nullable
 as List<String>,
   ));
@@ -82,11 +83,12 @@ as List<String>,
 @JsonSerializable()
 
 class _ActiveSession implements ActiveSession {
-  const _ActiveSession({required this.id, this.mainAgentRunning = false, final  List<String> childSessionIds = const []}): _childSessionIds = childSessionIds;
+  const _ActiveSession({required this.id, this.mainAgentRunning = false, this.awaitingInput = false, final  List<String> childSessionIds = const []}): _childSessionIds = childSessionIds;
   factory _ActiveSession.fromJson(Map<String, dynamic> json) => _$ActiveSessionFromJson(json);
 
 @override final  String id;
 @override@JsonKey() final  bool mainAgentRunning;
+@override@JsonKey() final  bool awaitingInput;
  final  List<String> _childSessionIds;
 @override@JsonKey() List<String> get childSessionIds {
   if (_childSessionIds is EqualUnmodifiableListView) return _childSessionIds;
@@ -108,16 +110,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&const DeepCollectionEquality().equals(other._childSessionIds, _childSessionIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&const DeepCollectionEquality().equals(other._childSessionIds, _childSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,const DeepCollectionEquality().hash(_childSessionIds));
+int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,awaitingInput,const DeepCollectionEquality().hash(_childSessionIds));
 
 @override
 String toString() {
-  return 'ActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, childSessionIds: $childSessionIds)';
+  return 'ActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, childSessionIds: $childSessionIds)';
 }
 
 
@@ -128,7 +130,7 @@ abstract mixin class _$ActiveSessionCopyWith<$Res> implements $ActiveSessionCopy
   factory _$ActiveSessionCopyWith(_ActiveSession value, $Res Function(_ActiveSession) _then) = __$ActiveSessionCopyWithImpl;
 @override @useResult
 $Res call({
- String id, bool mainAgentRunning, List<String> childSessionIds
+ String id, bool mainAgentRunning, bool awaitingInput, List<String> childSessionIds
 });
 
 
@@ -145,10 +147,11 @@ class __$ActiveSessionCopyWithImpl<$Res>
 
 /// Create a copy of ActiveSession
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? mainAgentRunning = null,Object? childSessionIds = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? mainAgentRunning = null,Object? awaitingInput = null,Object? childSessionIds = null,}) {
   return _then(_ActiveSession(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
+as bool,awaitingInput: null == awaitingInput ? _self.awaitingInput : awaitingInput // ignore: cast_nullable_to_non_nullable
 as bool,childSessionIds: null == childSessionIds ? _self._childSessionIds : childSessionIds // ignore: cast_nullable_to_non_nullable
 as List<String>,
   ));

--- a/shared/sesori_shared/lib/src/models/sesori/active_session.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/active_session.g.dart
@@ -9,6 +9,7 @@ part of 'active_session.dart';
 _ActiveSession _$ActiveSessionFromJson(Map json) => _ActiveSession(
   id: json['id'] as String,
   mainAgentRunning: json['mainAgentRunning'] as bool? ?? false,
+  awaitingInput: json['awaitingInput'] as bool? ?? false,
   childSessionIds:
       (json['childSessionIds'] as List<dynamic>?)
           ?.map((e) => e as String)
@@ -20,5 +21,6 @@ Map<String, dynamic> _$ActiveSessionToJson(_ActiveSession instance) =>
     <String, dynamic>{
       'id': instance.id,
       'mainAgentRunning': instance.mainAgentRunning,
+      'awaitingInput': instance.awaitingInput,
       'childSessionIds': instance.childSessionIds,
     };

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.dart
@@ -176,8 +176,10 @@ sealed class SesoriSseEvent with _$SesoriSseEvent {
   }) = SesoriPermissionAsked;
 
   @FreezedUnionValue("permission.replied")
+  @Implements<SesoriSessionEvent>()
   const factory SesoriSseEvent.permissionReplied({
     required String requestID,
+    required String sessionID,
     required String reply,
   }) = SesoriPermissionReplied;
 

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.freezed.dart
@@ -1757,11 +1757,12 @@ as String,
 /// @nodoc
 @JsonSerializable()
 
-class SesoriPermissionReplied implements SesoriSseEvent {
-  const SesoriPermissionReplied({required this.requestID, required this.reply, final  String? $type}): $type = $type ?? 'permission.replied';
+class SesoriPermissionReplied implements SesoriSseEvent, SesoriSessionEvent {
+  const SesoriPermissionReplied({required this.requestID, required this.sessionID, required this.reply, final  String? $type}): $type = $type ?? 'permission.replied';
   factory SesoriPermissionReplied.fromJson(Map<String, dynamic> json) => _$SesoriPermissionRepliedFromJson(json);
 
  final  String requestID;
+ final  String sessionID;
  final  String reply;
 
 @JsonKey(name: 'type')
@@ -1781,16 +1782,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SesoriPermissionReplied&&(identical(other.requestID, requestID) || other.requestID == requestID)&&(identical(other.reply, reply) || other.reply == reply));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SesoriPermissionReplied&&(identical(other.requestID, requestID) || other.requestID == requestID)&&(identical(other.sessionID, sessionID) || other.sessionID == sessionID)&&(identical(other.reply, reply) || other.reply == reply));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,requestID,reply);
+int get hashCode => Object.hash(runtimeType,requestID,sessionID,reply);
 
 @override
 String toString() {
-  return 'SesoriSseEvent.permissionReplied(requestID: $requestID, reply: $reply)';
+  return 'SesoriSseEvent.permissionReplied(requestID: $requestID, sessionID: $sessionID, reply: $reply)';
 }
 
 
@@ -1801,7 +1802,7 @@ abstract mixin class $SesoriPermissionRepliedCopyWith<$Res> implements $SesoriSs
   factory $SesoriPermissionRepliedCopyWith(SesoriPermissionReplied value, $Res Function(SesoriPermissionReplied) _then) = _$SesoriPermissionRepliedCopyWithImpl;
 @useResult
 $Res call({
- String requestID, String reply
+ String requestID, String sessionID, String reply
 });
 
 
@@ -1818,9 +1819,10 @@ class _$SesoriPermissionRepliedCopyWithImpl<$Res>
 
 /// Create a copy of SesoriSseEvent
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? requestID = null,Object? reply = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? requestID = null,Object? sessionID = null,Object? reply = null,}) {
   return _then(SesoriPermissionReplied(
 requestID: null == requestID ? _self.requestID : requestID // ignore: cast_nullable_to_non_nullable
+as String,sessionID: null == sessionID ? _self.sessionID : sessionID // ignore: cast_nullable_to_non_nullable
 as String,reply: null == reply ? _self.reply : reply // ignore: cast_nullable_to_non_nullable
 as String,
   ));

--- a/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/sesori_sse_event.g.dart
@@ -246,6 +246,7 @@ Map<String, dynamic> _$SesoriPermissionAskedToJson(
 SesoriPermissionReplied _$SesoriPermissionRepliedFromJson(Map json) =>
     SesoriPermissionReplied(
       requestID: json['requestID'] as String,
+      sessionID: json['sessionID'] as String,
       reply: json['reply'] as String,
       $type: json['type'] as String?,
     );
@@ -254,6 +255,7 @@ Map<String, dynamic> _$SesoriPermissionRepliedToJson(
   SesoriPermissionReplied instance,
 ) => <String, dynamic>{
   'requestID': instance.requestID,
+  'sessionID': instance.sessionID,
   'reply': instance.reply,
   'type': instance.$type,
 };


### PR DESCRIPTION
## Summary

- Sessions waiting for user input (questions or permission requests) now show amber **"Awaiting input"** instead of green **"Running"** in the sessions list
- `ActiveSessionTracker` tracks `SseQuestionAsked/Replied/Rejected` and `SsePermissionAsked/Replied` SSE events per session
- Cold start recovers pending questions via `OpenCodeService` → `OpenCodeRepository.getPendingQuestions()` → `tracker.populatePendingQuestions()`

## Changes

### Shared (`sesori_shared`)
- Added `@Default(false) bool awaitingInput` to `ActiveSession` model

### Bridge
- **`ActiveSessionTracker`**: 5 new SSE event handlers, pending question/permission tracking maps, `_hasPendingInput()` helper, `populatePendingQuestions()` for cold start, extended change detection
- **`OpenCodeRepository`**: Added `getPendingQuestions()` wrapper (architectural fix — tracker doesn't call API directly)
- **`OpenCodeService`**: `coldStart()` orchestrates pending question recovery through repository → tracker
- **`PluginActiveSession`**: Added `awaitingInput` field
- **Mappings**: Both `OpenCodePlugin` and `bridge_event_mapper` pass `awaitingInput` through

### Mobile
- **`SessionActivityInfo`**: Added `awaitingInput` field
- **`SseEventRepository`**: Maps `ActiveSession.awaitingInput` → `SessionActivityInfo.awaitingInput`
- **`_SessionTile`**: Amber dot + "Awaiting input" text when `awaitingInput == true`, green "Running" otherwise
- **Localization**: Added `sessionListAwaitingInput` key

### Tests
- **Bridge**: 9 new test cases (question lifecycle, permission lifecycle, multiple pending, session deletion/idle cleanup, change detection, cold start)
- **Mobile**: 3 new test cases (awaitingInput true/false mapping, cubit state propagation)

## Architecture Notes
- `awaitingInput` is a derived property (not a protocol-level `SessionStatus` variant)
- Permissions tracked via SSE only (no cold start recovery — accepted limitation, no `getPendingPermissions` API exists)
- `SsePermissionReplied` lacks `sessionID` — tracker maintains `requestID → sessionID` mapping from `SsePermissionAsked`