### PR TITLE
fix(push): include projectId in notification payloads from projects summary

### DIFF
--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -156,6 +156,11 @@ class OrchestratorSession {
     final kxManager = KeyExchangeManager(_roomKey);
     final activePhones = <int, bool>{};
 
+    final startupSummary = _mapper.buildProjectsSummaryEvent();
+    if (startupSummary != null) {
+      _pushNotificationService.handleSseEvent(startupSummary);
+    }
+
     Log.d("[dbg] subscribing to plugin event stream...");
     _eventSubscription = _plugin.events.listen(
       (BridgeSseEvent event) {
@@ -506,6 +511,7 @@ class OrchestratorSession {
           final projSummary = _mapper.buildProjectsSummaryEvent();
           if (projSummary != null) {
             _sseManager.enqueueEvent(projSummary);
+            _pushNotificationService.handleSseEvent(projSummary);
           }
           Log.v("[dbg] initial projectsSummary enqueued");
         } catch (e) {

--- a/bridge/app/lib/src/push/push_session_state_tracker.dart
+++ b/bridge/app/lib/src/push/push_session_state_tracker.dart
@@ -149,30 +149,7 @@ class PushSessionStateTracker {
   }
 
   String? getSessionProjectId({required String sessionId}) {
-    var current = sessionId;
-    final visited = <String>{};
-
-    while (true) {
-      if (!visited.add(current)) {
-        return null;
-      }
-
-      final state = _sessions[current];
-      if (state == null) {
-        return null;
-      }
-
-      if (state.projectId != null) {
-        return state.projectId;
-      }
-
-      final parentId = state.parentId;
-      if (parentId == null) {
-        return null;
-      }
-
-      current = parentId;
-    }
+    return _sessions[sessionId]?.projectId;
   }
 
   String? getLatestAssistantText(String sessionId) {

--- a/bridge/app/lib/src/push/push_session_state_tracker.dart
+++ b/bridge/app/lib/src/push/push_session_state_tracker.dart
@@ -149,7 +149,30 @@ class PushSessionStateTracker {
   }
 
   String? getSessionProjectId({required String sessionId}) {
-    return _sessions[sessionId]?.projectId;
+    var current = sessionId;
+    final visited = <String>{};
+
+    while (true) {
+      if (!visited.add(current)) {
+        return null;
+      }
+
+      final state = _sessions[current];
+      if (state == null) {
+        return null;
+      }
+
+      if (state.projectId != null) {
+        return state.projectId;
+      }
+
+      final parentId = state.parentId;
+      if (parentId == null) {
+        return null;
+      }
+
+      current = parentId;
+    }
   }
 
   String? getLatestAssistantText(String sessionId) {
@@ -249,8 +272,10 @@ class PushSessionStateTracker {
     for (final project in projects) {
       for (final activeSession in project.activeSessions) {
         final parentId = activeSession.id;
+        _stateForWrite(parentId).projectId = project.id;
         for (final childId in activeSession.childSessionIds) {
           final childState = _stateForWrite(childId);
+          childState.projectId = project.id;
           if (childState.parentId == null) {
             childState.parentId = parentId;
             _stateForWrite(parentId).childIds.add(childId);

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -110,6 +110,87 @@ void main() {
     await database.close();
     await relayServer.close();
   });
+
+  test("pre-seeds and forwards projects summary to push service", () async {
+    final relayServer = await TestRelayServer.start();
+    final database = createTestDatabase();
+    final pushService = _CapturingPushNotificationService();
+    final plugin = _SummaryPlugin(
+      onSubscribe: () {
+        expect(pushService.events.length, 1);
+      },
+    );
+    final fakePrSyncService = _FakePrSyncService();
+    final pullRequestRepository = PullRequestRepository(pullRequestDao: database.pullRequestDao);
+    final sessionRepository = SessionRepository(
+      plugin: plugin,
+      sessionDao: database.sessionDao,
+      pullRequestRepository: pullRequestRepository,
+    );
+    final relayClient = RelayClient(
+      relayURL: "ws://127.0.0.1:${relayServer.port}",
+      accessTokenProvider: FakeAccessTokenProvider(""),
+    );
+
+    final orchestrator = Orchestrator(
+      config: BridgeConfig(
+        relayURL: "ws://127.0.0.1:${relayServer.port}",
+        serverURL: "http://127.0.0.1:4096",
+        serverPassword: null,
+        authBackendURL: "http://127.0.0.1:8080",
+        sseReplayWindow: const Duration(minutes: 1),
+      ),
+      client: relayClient,
+      plugin: plugin,
+      metadataService: _FakeMetadataService(),
+      pushNotificationService: pushService,
+      tokenRefresher: _FakeTokenRefresher(),
+      projectsDao: database.projectsDao,
+      failureReporter: FakeFailureReporter(),
+      prSyncService: fakePrSyncService,
+      sessionRepository: sessionRepository,
+    );
+
+    final session = orchestrator.create();
+    final runFuture = session.run();
+
+    final bridgeSocket = await relayServer.nextClient();
+    final messages = bridgeSocket.asBroadcastStream();
+
+    const connID = 8;
+    bridgeSocket.add(jsonEncode(<String, Object>{"type": "phone_connected", "connId": connID}));
+
+    final crypto = RelayCryptoService();
+    final phoneKp = await crypto.generateKeyPair();
+    final phonePub = await phoneKp.extractPublicKey();
+    final kxMessage = RelayMessage.keyExchange(
+      publicKey: base64Url.encode(phonePub.bytes).replaceAll("=", ""),
+    );
+    bridgeSocket.add(_withConnID(connID: connID, payload: utf8.encode(jsonEncode(kxMessage.toJson()))));
+
+    final readyFrame = await _nextBinaryMessage(messages: messages);
+    final roomKey = await _extractRoomKeyFromReady(
+      framedWithConnID: readyFrame,
+      phoneKp: phoneKp,
+    );
+
+    final encryptor = crypto.createSessionEncryptor(SecretKey(roomKey));
+    final subscribeFrame = await frame(
+      utf8.encode(jsonEncode(const RelayMessage.sseSubscribe(path: "/events").toJson())),
+      encryptor: encryptor,
+    );
+    bridgeSocket.add(_withConnID(connID: connID, payload: subscribeFrame));
+
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+
+    expect(pushService.events, hasLength(2));
+
+    await session.cancel();
+    await runFuture.timeout(const Duration(seconds: 5));
+    await plugin.close();
+    await database.close();
+    await relayServer.close();
+  });
 }
 
 Future<List<int>> _nextBinaryMessage({required Stream<dynamic> messages}) async {
@@ -191,6 +272,169 @@ PushNotificationService _createPushNotificationService() {
     tracker: tracker,
     completionNotifier: completionNotifier,
   );
+}
+
+class _CapturingPushNotificationService extends PushNotificationService {
+  final List<SesoriSseEvent> events = <SesoriSseEvent>[];
+
+  _CapturingPushNotificationService()
+    : this._(
+        tracker: PushSessionStateTracker(),
+      );
+
+  _CapturingPushNotificationService._({required PushSessionStateTracker tracker})
+    : super(
+        client: _NoopPushNotificationClient(),
+        rateLimiter: PushRateLimiter(),
+        tracker: tracker,
+        completionNotifier: CompletionNotifier(tracker: tracker),
+      );
+
+  @override
+  void handleSseEvent(SesoriSseEvent event) {
+    events.add(event);
+  }
+
+  @override
+  Future<void> dispose() async {}
+}
+
+class _SummaryPlugin implements BridgePlugin {
+  final void Function() onSubscribe;
+  final StreamController<BridgeSseEvent> _controller = StreamController<BridgeSseEvent>.broadcast();
+
+  _SummaryPlugin({required this.onSubscribe});
+
+  @override
+  String get id => "summary-plugin";
+
+  @override
+  Stream<BridgeSseEvent> get events {
+    return Stream<BridgeSseEvent>.multi((controller) {
+      onSubscribe();
+      final sub = _controller.stream.listen(
+        controller.add,
+        onError: controller.addError,
+        onDone: controller.close,
+      );
+      controller.onCancel = sub.cancel;
+    });
+  }
+
+  @override
+  Future<List<PluginProject>> getProjects() async => <PluginProject>[];
+
+  @override
+  Future<List<PluginSession>> getSessions(String worktree, {int? start, int? limit}) async {
+    return <PluginSession>[];
+  }
+
+  @override
+  Future<PluginSession> createSession({
+    required String directory,
+    required String? parentSessionId,
+    required List<PluginPromptPart> parts,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<PluginSession> renameSession({required String sessionId, required String title}) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<PluginProject> renameProject({required String projectId, required String name}) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> deleteSession(String sessionId) async {}
+
+  @override
+  Future<List<PluginSession>> getChildSessions(String sessionId) async => <PluginSession>[];
+
+  @override
+  Future<Map<String, PluginSessionStatus>> getSessionStatuses() async => <String, PluginSessionStatus>{};
+
+  @override
+  Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId) async {
+    return <PluginMessageWithParts>[];
+  }
+
+  @override
+  Future<void> sendPrompt({
+    required String sessionId,
+    required List<PluginPromptPart> parts,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async {}
+
+  @override
+  Future<void> abortSession({required String sessionId}) async {}
+
+  @override
+  Future<List<PluginAgent>> getAgents() async => <PluginAgent>[];
+
+  @override
+  Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async {
+    return <PluginPendingQuestion>[];
+  }
+
+  @override
+  Future<List<PluginPendingQuestion>> getProjectQuestions({required String projectId}) async {
+    return <PluginPendingQuestion>[];
+  }
+
+  @override
+  Future<void> replyToQuestion({
+    required String questionId,
+    required String sessionId,
+    required List<List<String>> answers,
+  }) async {}
+
+  @override
+  Future<void> rejectQuestion(String questionId) async {}
+
+  @override
+  Future<void> replyToPermission({
+    required String requestId,
+    required String sessionId,
+    required PluginPermissionReply reply,
+  }) async {}
+
+  @override
+  Future<PluginProject> getProject(String projectId) async => const PluginProject(id: "");
+
+  @override
+  Future<bool> healthCheck() async => true;
+
+  @override
+  List<PluginProjectActivitySummary> getActiveSessionsSummary() {
+    return <PluginProjectActivitySummary>[
+      const PluginProjectActivitySummary(
+        id: "project-1",
+        activeSessions: <PluginActiveSession>[
+          PluginActiveSession(id: "session-1"),
+        ],
+      ),
+    ];
+  }
+
+  @override
+  Future<PluginProvidersResult> getProviders({required bool connectedOnly}) async {
+    return const PluginProvidersResult(providers: <PluginProvider>[]);
+  }
+
+  @override
+  Future<void> archiveSession({required String sessionId}) async {}
+
+  @override
+  Future<void> dispose() async {}
+
+  Future<void> close() => _controller.close();
 }
 
 class _NoopPlugin implements BridgePlugin {

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -36,11 +36,12 @@ void main() {
       harness.plugin.add(const BridgeSseProjectUpdated());
       harness.plugin.add(const BridgeSseProjectUpdated());
 
-      await harness.waitForFailureCount(expected: 2);
+      await harness.waitForFailureCount(expected: 3);
 
       expect(
         harness.failureReporter.recordedIdentifiers,
         equals([
+          "sse_projects_summary",
           "sse_projects_summary",
           "sse_projects_summary",
         ]),

--- a/bridge/app/test/push/push_session_state_tracker_test.dart
+++ b/bridge/app/test/push/push_session_state_tracker_test.dart
@@ -1,5 +1,3 @@
-import "dart:mirrors";
-
 import "package:sesori_bridge/src/push/push_session_state_tracker.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -898,28 +896,6 @@ void main() {
     });
 
     group("getSessionProjectId parent-chain walk", () {
-      test("getSessionProjectId walks parent chain when child has no projectId", () {
-        final tracker = PushSessionStateTracker();
-
-        tracker.handleEvent(
-          SesoriSseEvent.sessionCreated(
-            info: _session(id: "parent", projectID: "proj-a"),
-          ),
-        );
-        tracker.handleEvent(
-          SesoriSseEvent.sessionCreated(
-            info: _session(id: "child", projectID: "proj-b", parentID: "parent"),
-          ),
-        );
-        _setSessionProjectId(
-          tracker: tracker,
-          sessionId: "child",
-          projectId: null,
-        );
-
-        expect(tracker.getSessionProjectId(sessionId: "child"), equals("proj-a"));
-      });
-
       test("getSessionProjectId returns direct projectId without walking parent", () {
         final tracker = PushSessionStateTracker();
 
@@ -937,23 +913,10 @@ void main() {
         expect(tracker.getSessionProjectId(sessionId: "child"), equals("proj-b"));
       });
 
-      test("getSessionProjectId returns null when no session in ancestry has projectId", () {
+      test("getSessionProjectId returns null for unknown session", () {
         final tracker = PushSessionStateTracker();
 
-        tracker.handleEvent(
-          SesoriSseEvent.sessionCreated(
-            info: _session(id: "parent", projectID: "proj-a"),
-          ),
-        );
-        tracker.handleEvent(
-          SesoriSseEvent.sessionCreated(
-            info: _session(id: "child", projectID: "proj-b", parentID: "parent"),
-          ),
-        );
-        _setSessionProjectId(tracker: tracker, sessionId: "parent", projectId: null);
-        _setSessionProjectId(tracker: tracker, sessionId: "child", projectId: null);
-
-        expect(tracker.getSessionProjectId(sessionId: "child"), isNull);
+        expect(tracker.getSessionProjectId(sessionId: "unknown"), isNull);
       });
     });
 
@@ -1046,19 +1009,4 @@ Session _session({
     summary: null,
     pullRequest: null,
   );
-}
-
-void _setSessionProjectId({
-  required PushSessionStateTracker tracker,
-  required String sessionId,
-  required String? projectId,
-}) {
-  final trackerLibrary = reflectClass(PushSessionStateTracker).owner! as LibraryMirror;
-  final trackerMirror = reflect(tracker);
-  final state = trackerMirror.invoke(
-    MirrorSystem.getSymbol("_stateForWrite", trackerLibrary),
-    [sessionId],
-  ).reflectee;
-
-  reflect(state).setField(const Symbol("projectId"), projectId);
 }

--- a/bridge/app/test/push/push_session_state_tracker_test.dart
+++ b/bridge/app/test/push/push_session_state_tracker_test.dart
@@ -895,31 +895,6 @@ void main() {
       expect(tracker.getSessionProjectId(sessionId: "sess-1"), equals("proj-new"));
     });
 
-    group("getSessionProjectId parent-chain walk", () {
-      test("getSessionProjectId returns direct projectId without walking parent", () {
-        final tracker = PushSessionStateTracker();
-
-        tracker.handleEvent(
-          SesoriSseEvent.sessionCreated(
-            info: _session(id: "parent", projectID: "proj-a"),
-          ),
-        );
-        tracker.handleEvent(
-          SesoriSseEvent.sessionCreated(
-            info: _session(id: "child", projectID: "proj-b", parentID: "parent"),
-          ),
-        );
-
-        expect(tracker.getSessionProjectId(sessionId: "child"), equals("proj-b"));
-      });
-
-      test("getSessionProjectId returns null for unknown session", () {
-        final tracker = PushSessionStateTracker();
-
-        expect(tracker.getSessionProjectId(sessionId: "unknown"), isNull);
-      });
-    });
-
     test("projectsSummary establishes multi-level hierarchy for status-only sessions", () {
       final tracker = PushSessionStateTracker();
 

--- a/bridge/app/test/push/push_session_state_tracker_test.dart
+++ b/bridge/app/test/push/push_session_state_tracker_test.dart
@@ -1,3 +1,5 @@
+import "dart:mirrors";
+
 import "package:sesori_bridge/src/push/push_session_state_tracker.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -829,6 +831,132 @@ void main() {
       expect(tracker.resolveRootSessionId("child"), equals("root"));
     });
 
+    test("root session gets projectId from projects summary", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(
+        const SesoriSseEvent.projectsSummary(
+          projects: [
+            ProjectActivitySummary(
+              id: "proj-a",
+              activeSessions: [
+                ActiveSession(id: "sess-root", mainAgentRunning: true),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect(tracker.getSessionProjectId(sessionId: "sess-root"), equals("proj-a"));
+    });
+
+    test("child session gets projectId from projects summary", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(
+        const SesoriSseEvent.projectsSummary(
+          projects: [
+            ProjectActivitySummary(
+              id: "proj-a",
+              activeSessions: [
+                ActiveSession(
+                  id: "sess-root",
+                  mainAgentRunning: true,
+                  childSessionIds: ["sess-child"],
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect(tracker.getSessionProjectId(sessionId: "sess-child"), equals("proj-a"));
+    });
+
+    test("projects summary overwrites existing projectId", () {
+      final tracker = PushSessionStateTracker();
+
+      tracker.handleEvent(
+        SesoriSseEvent.sessionCreated(
+          info: _session(id: "sess-1", projectID: "proj-old"),
+        ),
+      );
+      tracker.handleEvent(
+        const SesoriSseEvent.projectsSummary(
+          projects: [
+            ProjectActivitySummary(
+              id: "proj-new",
+              activeSessions: [
+                ActiveSession(id: "sess-1", mainAgentRunning: true),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      expect(tracker.getSessionProjectId(sessionId: "sess-1"), equals("proj-new"));
+    });
+
+    group("getSessionProjectId parent-chain walk", () {
+      test("getSessionProjectId walks parent chain when child has no projectId", () {
+        final tracker = PushSessionStateTracker();
+
+        tracker.handleEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "parent", projectID: "proj-a"),
+          ),
+        );
+        tracker.handleEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "child", projectID: "proj-b", parentID: "parent"),
+          ),
+        );
+        _setSessionProjectId(
+          tracker: tracker,
+          sessionId: "child",
+          projectId: null,
+        );
+
+        expect(tracker.getSessionProjectId(sessionId: "child"), equals("proj-a"));
+      });
+
+      test("getSessionProjectId returns direct projectId without walking parent", () {
+        final tracker = PushSessionStateTracker();
+
+        tracker.handleEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "parent", projectID: "proj-a"),
+          ),
+        );
+        tracker.handleEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "child", projectID: "proj-b", parentID: "parent"),
+          ),
+        );
+
+        expect(tracker.getSessionProjectId(sessionId: "child"), equals("proj-b"));
+      });
+
+      test("getSessionProjectId returns null when no session in ancestry has projectId", () {
+        final tracker = PushSessionStateTracker();
+
+        tracker.handleEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "parent", projectID: "proj-a"),
+          ),
+        );
+        tracker.handleEvent(
+          SesoriSseEvent.sessionCreated(
+            info: _session(id: "child", projectID: "proj-b", parentID: "parent"),
+          ),
+        );
+        _setSessionProjectId(tracker: tracker, sessionId: "parent", projectId: null);
+        _setSessionProjectId(tracker: tracker, sessionId: "child", projectId: null);
+
+        expect(tracker.getSessionProjectId(sessionId: "child"), isNull);
+      });
+    });
+
     test("projectsSummary establishes multi-level hierarchy for status-only sessions", () {
       final tracker = PushSessionStateTracker();
 
@@ -918,4 +1046,19 @@ Session _session({
     summary: null,
     pullRequest: null,
   );
+}
+
+void _setSessionProjectId({
+  required PushSessionStateTracker tracker,
+  required String sessionId,
+  required String? projectId,
+}) {
+  final trackerLibrary = reflectClass(PushSessionStateTracker).owner! as LibraryMirror;
+  final trackerMirror = reflect(tracker);
+  final state = trackerMirror.invoke(
+    MirrorSystem.getSymbol("_stateForWrite", trackerLibrary),
+    [sessionId],
+  ).reflectee;
+
+  reflect(state).setField(const Symbol("projectId"), projectId);
 }


### PR DESCRIPTION
## Summary

Push notification taps were navigating to the project list instead of the correct session page because `projectId` was `null` in the notification payload.

**Root cause**: `PushSessionStateTracker` only learned `projectId` from `SesoriSessionCreated`/`SesoriSessionUpdated` events. Sessions that existed before bridge startup never received these events, so their `projectId` was always `null`. The projects summary already carried this data (`ProjectActivitySummary.id` is the projectId) — it was just unused.

## Changes

### Bridge production code (2 files)

**`push_session_state_tracker.dart`**
- `_applyProjectsSummaryChildLinks()` now sets `projectId` on both root sessions and child sessions from the projects summary (authoritative source, unconditional overwrite)
- `getSessionProjectId()` enhanced with parent-chain walk — if a session has no direct `projectId`, walks up the parent chain and returns the first inherited one

**`orchestrator.dart`**
- Pre-seeds the push tracker on startup by calling `buildProjectsSummaryEvent()` and feeding it to the push service **before** the plugin event subscription starts (avoids race condition)
- SSE subscribe handler now feeds the projects summary to the push service alongside the SSE manager (covers phone reconnection)

### Tests (3 files)
- New tracker tests: root/child projectId from summary, overwrite behavior, parent-chain walk (direct, inherited, null ancestry)
- New orchestrator test: verifies pre-seed on startup and summary forwarding on SSE subscribe
- Adjusted error-recovery test expectations for the additional startup summary call

## Verification
- `make test` from `bridge/` — all 743 tests pass (115 + 628)
- `make analyze` from `bridge/` — zero errors/warnings
- Aristotel architectural review (Mode B): **APPROVED**