### PR TITLE
fix(opencode-plugin): fix session status not showing after OpenCode reinstall

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -1,5 +1,5 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
-import "package:sesori_shared/sesori_shared.dart" show ActiveSession, ProjectActivitySummary, wait3;
+import "package:sesori_shared/sesori_shared.dart" show ActiveSession, ProjectActivitySummary;
 
 import "models/pending_permission.dart";
 import "models/pending_question.dart";
@@ -27,11 +27,10 @@ class ActiveSessionTracker {
   ActiveSessionTracker(this._repository);
 
   Future<void> coldStart() async {
-    final (projects, statuses, sessions) = await wait3(
+    final (projects, sessions) = await (
       _repository.getProjects(),
-      _repository.api.getSessionStatuses(),
       _repository.api.listSessions(),
-    );
+    ).wait;
 
     _projectWorktrees
       ..clear()
@@ -52,17 +51,39 @@ class ActiveSessionTracker {
       ..clear()
       ..addAll(sessionDirectories);
 
+    // Fetch statuses per-project-directory so each call targets the correct
+    // OpenCode Instance. Errors for individual directories are logged and
+    // skipped so that one unavailable project doesn't block the rest.
+    final allStatuses = <String, SessionStatus>{};
+    final statusFutures = _projectWorktrees.map((worktree) async {
+      try {
+        final statuses = await _repository.api.getSessionStatuses(directory: worktree);
+        for (final entry in statuses.entries) {
+          allStatuses[entry.key] = entry.value;
+          // Map session → worktree directly from the call context.
+          _sessionWorktrees[entry.key] = worktree;
+        }
+      } catch (e) {
+        Log.w("coldStart: failed to fetch session statuses for $worktree: $e");
+      }
+    });
+    await Future.wait(statusFutures);
+
     _sessionStatuses
       ..clear()
       ..addAll(
         Map.fromEntries(
-          statuses.entries.where(
+          allStatuses.entries.where(
             (e) => e.value is SessionStatusBusy || e.value is SessionStatusRetry,
           ),
         ),
       );
 
+    // Also resolve worktrees for sessions whose directory is known but that
+    // were not returned by the per-directory status calls (e.g. sessions in
+    // subdirectories of a worktree).
     for (final sessionId in _sessionStatuses.keys.toList()) {
+      if (_sessionWorktrees.containsKey(sessionId)) continue;
       final directory = sessionDirectories[sessionId];
       if (directory == null) continue;
       final worktree = _resolveWorktree(directory);
@@ -167,6 +188,34 @@ class ActiveSessionTracker {
     _pendingPermissions
       ..clear()
       ..addEntries(_groupBySessionId(permissions.map((p) => (p.sessionID, p.id))).entries);
+    _lastEmittedPendingInputSessions = _pendingInputSessions;
+  }
+
+  /// Replaces the set of known project worktrees and re-resolves worktree
+  /// mappings for any active sessions that currently lack one.
+  ///
+  /// Called from [OpenCodePlugin.getProjects] to keep the tracker's worktree
+  /// knowledge in sync with the latest project list. This is important because
+  /// [coldStart] may run before all projects are known (e.g. fresh OpenCode
+  /// install), and new projects discovered later would otherwise be invisible
+  /// to the activity summary.
+  void updateProjectWorktrees({required Set<String> worktrees}) {
+    _projectWorktrees
+      ..clear()
+      ..addAll(worktrees);
+
+    // Re-resolve worktrees for active sessions that don't have one yet.
+    for (final sessionId in _sessionStatuses.keys.toList()) {
+      if (_sessionWorktrees.containsKey(sessionId)) continue;
+      final directory = _sessionDirectories[sessionId];
+      if (directory == null) continue;
+      final worktree = _resolveWorktree(directory);
+      if (worktree != null) {
+        _sessionWorktrees[sessionId] = worktree;
+      }
+    }
+
+    _lastEmittedActiveSessions = _activeSessionCounts;
     _lastEmittedPendingInputSessions = _pendingInputSessions;
   }
 

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -199,7 +199,7 @@ class ActiveSessionTracker {
   /// [coldStart] may run before all projects are known (e.g. fresh OpenCode
   /// install), and new projects discovered later would otherwise be invisible
   /// to the activity summary.
-  void updateProjectWorktrees({required Set<String> worktrees}) {
+  bool updateProjectWorktrees({required Set<String> worktrees}) {
     _projectWorktrees
       ..clear()
       ..addAll(worktrees);
@@ -215,8 +215,17 @@ class ActiveSessionTracker {
       }
     }
 
-    _lastEmittedActiveSessions = _activeSessionCounts;
-    _lastEmittedPendingInputSessions = _pendingInputSessions;
+    final nextActive = _activeSessionCounts;
+    final nextPending = _pendingInputSessions;
+
+    if (_mapsEqual(_lastEmittedActiveSessions, nextActive) &&
+        _setsEqual(_lastEmittedPendingInputSessions, nextPending)) {
+      return false;
+    }
+
+    _lastEmittedActiveSessions = nextActive;
+    _lastEmittedPendingInputSessions = nextPending;
+    return true;
   }
 
   /// Register a known session -> directory mapping (e.g., after session creation).

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -418,10 +418,15 @@ class OpenCodeApi {
     return ProviderListResponse.fromJson(jsonDecodeMap(response.body));
   }
 
-  Future<Map<String, SessionStatus>> getSessionStatuses() async {
+  Future<Map<String, SessionStatus>> getSessionStatuses({required String? directory}) async {
+    final headers = <String, String>{
+      ..._authHeaders,
+      _directoryOpenCodeHeader: ?directory,
+    };
+
     final response = await _client.get(
       Uri.parse("$serverURL/session/status"),
-      headers: _authHeaders,
+      headers: headers,
     );
     _ensureSuccess(response, "GET /session/status");
 

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -101,7 +101,11 @@ class OpenCodePlugin implements BridgePlugin {
 
   @override
   Future<List<PluginProject>> getProjects() async {
-    return (await _call(_service.getProjects)).map((project) => project.toPlugin()).toList();
+    final projects = await _call(_service.getProjects);
+    _service.tracker.updateProjectWorktrees(
+      worktrees: projects.map((p) => p.worktree).toSet(),
+    );
+    return projects.map((project) => project.toPlugin()).toList();
   }
 
   @override
@@ -196,7 +200,9 @@ class OpenCodePlugin implements BridgePlugin {
 
   @override
   Future<Map<String, PluginSessionStatus>> getSessionStatuses() async {
-    final apiStatuses = await _call(_service.repository.api.getSessionStatuses);
+    final apiStatuses = await _call(
+      () => _service.repository.api.getSessionStatuses(directory: null),
+    );
 
     // Start with the API response as a baseline.
     final merged = apiStatuses.map((key, value) => MapEntry(key, value.toPlugin()));

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -102,9 +102,10 @@ class OpenCodePlugin implements BridgePlugin {
   @override
   Future<List<PluginProject>> getProjects() async {
     final projects = await _call(_service.getProjects);
-    _service.tracker.updateProjectWorktrees(
+    final changed = _service.tracker.updateProjectWorktrees(
       worktrees: projects.map((p) => p.worktree).toSet(),
     );
+    if (changed) _emitProjectsSummary();
     return projects.map((project) => project.toPlugin()).toList();
   }
 

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -866,6 +866,98 @@ void main() {
         expect(summary.first.activeSessions.first.awaitingInput, isTrue);
       });
     });
+
+    group("multi-project cold start", () {
+      test("populates statuses and worktrees correctly", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [
+            const Project(id: "p1", worktree: "/repo-a"),
+            const Project(id: "p2", worktree: "/repo-b"),
+          ],
+          sessions: [
+            _session("session-a", "/repo-a"),
+            _session("session-b", "/repo-b"),
+          ],
+          statuses: {
+            "session-a": const SessionStatus.busy(),
+            "session-b": const SessionStatus.busy(),
+          },
+        );
+
+        final active = tracker.getActiveStatuses();
+        expect(active, hasLength(2));
+        expect(active["session-a"], isA<SessionStatusBusy>());
+        expect(active["session-b"], isA<SessionStatusBusy>());
+
+        expect(
+          tracker.activeSessions,
+          equals({"/repo-a": 1, "/repo-b": 1}),
+        );
+
+        final summary = tracker.buildSummary();
+        expect(summary, hasLength(2));
+      });
+
+      test("per-directory error does not break other directories", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [
+            const Project(id: "p1", worktree: "/repo-a"),
+            const Project(id: "p2", worktree: "/repo-b"),
+          ],
+          sessions: [
+            _session("session-b", "/repo-b"),
+          ],
+          statuses: {
+            "session-b": const SessionStatus.busy(),
+          },
+          throwForDirectories: {"/repo-a"},
+        );
+
+        final active = tracker.getActiveStatuses();
+        expect(active, hasLength(1));
+        expect(active["session-b"], isA<SessionStatusBusy>());
+
+        final summary = tracker.buildSummary();
+        expect(summary, hasLength(1));
+        expect(summary.first.id, equals("/repo-b"));
+      });
+    });
+
+    group("updateProjectWorktrees", () {
+      test("resolves pending sessions", () async {
+        final tracker = await _coldStartedTracker(projects: []);
+
+        tracker.handleEvent(_sessionCreated("s1", "/repo/sub"), null);
+        tracker.handleEvent(_sessionBusy("s1"), null);
+
+        expect(tracker.buildSummary(), isEmpty);
+
+        tracker.updateProjectWorktrees(worktrees: {"/repo"});
+
+        final summary = tracker.buildSummary();
+        expect(summary, hasLength(1));
+        expect(summary.first.id, equals("/repo"));
+      });
+
+      test("replaces old worktrees", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/old-repo")],
+        );
+
+        tracker.handleEvent(_sessionCreated("s1", "/old-repo/sub"), null);
+        tracker.handleEvent(_sessionBusy("s1"), null);
+        expect(tracker.buildSummary(), hasLength(1));
+        expect(tracker.buildSummary().first.id, equals("/old-repo"));
+
+        tracker.updateProjectWorktrees(worktrees: {"/new-repo"});
+
+        // s1 keeps its resolved worktree mapping from before the update,
+        // but new sessions arriving after this will resolve against /new-repo.
+        // The worktree set itself is replaced — _projectWorktrees is {/new-repo}.
+        expect(tracker.buildSummary(), hasLength(1));
+        expect(tracker.buildSummary().first.id, equals("/old-repo"));
+      });
+    });
   });
 }
 
@@ -954,9 +1046,15 @@ OpenCodeRepository _fakeRepository({
   List<Project>? projects,
   List<Session>? sessions,
   Map<String, SessionStatus>? statuses,
+  Set<String>? throwForDirectories,
 }) {
   return OpenCodeRepository(
-    _FakeApi(projects: projects, sessions: sessions, statuses: statuses),
+    _FakeApi(
+      projects: projects,
+      sessions: sessions,
+      statuses: statuses,
+      throwForDirectories: throwForDirectories,
+    ),
   );
 }
 
@@ -964,9 +1062,15 @@ Future<ActiveSessionTracker> _coldStartedTracker({
   required List<Project> projects,
   List<Session> sessions = const [],
   Map<String, SessionStatus> statuses = const {},
+  Set<String> throwForDirectories = const {},
 }) async {
   final tracker = ActiveSessionTracker(
-    _fakeRepository(projects: projects, sessions: sessions, statuses: statuses),
+    _fakeRepository(
+      projects: projects,
+      sessions: sessions,
+      statuses: statuses,
+      throwForDirectories: throwForDirectories,
+    ),
   );
   await tracker.coldStart();
   return tracker;
@@ -976,14 +1080,17 @@ class _FakeApi implements OpenCodeApi {
   final List<Project> _projects;
   final List<Session> _sessions;
   final Map<String, SessionStatus> _statuses;
+  final Set<String> _throwForDirectories;
 
   _FakeApi({
     List<Project>? projects,
     List<Session>? sessions,
     Map<String, SessionStatus>? statuses,
+    Set<String>? throwForDirectories,
   }) : _projects = projects ?? [],
        _sessions = sessions ?? [],
-       _statuses = statuses ?? {};
+       _statuses = statuses ?? {},
+       _throwForDirectories = throwForDirectories ?? {};
 
   @override
   String get serverURL => "http://fake";
@@ -1070,7 +1177,19 @@ class _FakeApi implements OpenCodeApi {
   Future<Project> getProject({required String directory}) async => throw UnimplementedError();
 
   @override
-  Future<Map<String, SessionStatus>> getSessionStatuses() async => _statuses;
+  Future<Map<String, SessionStatus>> getSessionStatuses({required String? directory}) async {
+    if (directory != null && _throwForDirectories.contains(directory)) {
+      throw Exception("Fake error for directory: $directory");
+    }
+    if (directory == null) return _statuses;
+    final sessionIdsInDirectory = _sessions
+        .where((s) => s.directory == directory || s.directory.startsWith("$directory/"))
+        .map((s) => s.id)
+        .toSet();
+    return Map.fromEntries(
+      _statuses.entries.where((e) => sessionIdsInDirectory.contains(e.key)),
+    );
+  }
 
   @override
   Future<ProviderListResponse> listProviders() async =>

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -456,7 +456,7 @@ class _FakeApi implements OpenCodeApi {
   Future<Project> getProject({required String directory}) async => throw UnimplementedError();
 
   @override
-  Future<Map<String, SessionStatus>> getSessionStatuses() async => {};
+  Future<Map<String, SessionStatus>> getSessionStatuses({required String? directory}) async => {};
 
   @override
   Future<ProviderListResponse> listProviders() async =>

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -342,7 +342,8 @@ class FakeOpenCodeApi implements OpenCodeApi {
   Future<List<Session>> getChildren({required String sessionId, required String? directory}) async => [];
 
   @override
-  Future<Map<String, SessionStatus>> getSessionStatuses() async => <String, SessionStatus>{};
+  Future<Map<String, SessionStatus>> getSessionStatuses({required String? directory}) async =>
+      <String, SessionStatus>{};
 
   @override
   Future<void> sendPrompt({


### PR DESCRIPTION
## Summary

- **Send `x-opencode-directory` header with `GET /session/status`** — OpenCode's `SessionStatus.list()` uses `InstanceState` scoped per-directory. Without the header, OpenCode defaults to `process.cwd()` and returns empty. Now `getSessionStatuses()` accepts a `directory` parameter and sends the header.
- **Keep `_projectWorktrees` up-to-date in `ActiveSessionTracker`** — Previously only populated during `coldStart()` and never refreshed. Now `coldStart()` fetches statuses per-project-directory (parallel, with per-directory error resilience), and `getProjects()` calls `updateProjectWorktrees()` to keep the tracker in sync.

## Root Cause

After reinstalling OpenCode, session running statuses stopped showing on the mobile app because:

1. The bridge called `GET /session/status` without the `x-opencode-directory` header. OpenCode's router defaults to `process.cwd()`, which resolves to a different `InstanceState` cache than the project directories where sessions are running → empty response.
2. `_projectWorktrees` in `ActiveSessionTracker` was populated once during `coldStart()` and never updated. New projects created after cold start couldn't be resolved → `BridgeSseProjectUpdated` events were never emitted → mobile app's session activity indicators stayed empty.

## Changes

### Production (`sesori_plugin_opencode`)
- `opencode_api.dart`: Add `{required String? directory}` parameter to `getSessionStatuses()`, send `x-opencode-directory` header conditionally
- `active_session_tracker.dart`: Rewrite `coldStart()` to fetch statuses per-project-directory in parallel with error resilience; add `updateProjectWorktrees()` method for dynamic worktree set refresh
- `opencode_plugin_impl.dart`: Wire `getProjects()` to call `updateProjectWorktrees()` after fetching; fix `getSessionStatuses()` tearoff for new required parameter

### Tests
- Updated `_FakeApi` in 3 test files for the new `directory` parameter
- Added 4 new tests: multi-project cold start, per-directory error resilience, worktree resolution after update, worktree replacement

## Verification
- `make test` from `bridge/`: **621 tests pass**
- `make analyze` from `bridge/`: **zero issues across all 3 modules**
- Aristotle architectural review: **APPROVED** (no violations)