### PR TITLE
fix: session delete silently fails when cleanup is rejected

### DIFF
--- a/mobile/app/lib/features/session_list/session_list_screen.dart
+++ b/mobile/app/lib/features/session_list/session_list_screen.dart
@@ -185,7 +185,7 @@ class _SessionListBody extends StatelessWidget {
                         physics: const AlwaysScrollableScrollPhysics(),
                         padding: const EdgeInsets.symmetric(vertical: 8),
                         itemCount: sessions.length,
-                        itemBuilder: (context, index) {
+                        itemBuilder: (_, index) {
                           final session = sessions[index];
                           final cubit = context.read<SessionListCubit>();
                           final isArchived = session.time?.archived != null;

--- a/mobile/module_core/lib/src/capabilities/session/session_service.dart
+++ b/mobile/module_core/lib/src/capabilities/session/session_service.dart
@@ -3,6 +3,7 @@ import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../../api/client/relay_http_client.dart";
+import "../../logging/logging.dart";
 
 class SessionCleanupRejectedException implements Exception {
   final SessionCleanupRejection rejection;
@@ -137,7 +138,8 @@ class SessionService {
         throw SessionCleanupRejectedException(rejection: rejection);
       } on SessionCleanupRejectedException {
         rethrow;
-      } on Object {
+      } on Object catch (e) {
+        logw("Failed to parse 409 cleanup rejection body: $e");
         return;
       }
     }

--- a/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -432,6 +432,7 @@ class SessionListCubit extends Cubit<SessionListState> {
         force: force,
       );
     } on SessionCleanupRejectedException catch (error) {
+      logd("[SessionList] delete rejected: cleanup issues=${error.rejection.issues}");
       _lastCleanupRejection = error.rejection;
       _reinsertSession(originalSession);
       return false;


### PR DESCRIPTION
## Summary

- Fix session deletion appearing to silently fail (session disappears then reappears with no feedback) when the bridge returns a 409 cleanup rejection

## Root Cause

The `itemBuilder` in `ListView.builder` shadowed the outer `BuildContext` with an item-scoped context. When the cubit optimistically removed the session from the list, Flutter rebuilt the ListView without that item, **unmounting the item-scoped context**. The `context.mounted` check in `_deleteSession` then returned `false`, silently skipping both the force-delete dialog and the error snackbar.

This affected any action triggered from a list item (delete, archive) that performed optimistic removal — the action handler's context died with the removed list item.

## Fix

Use the stable `_SessionListBody.build()` context (which survives list item removal) instead of the `itemBuilder`'s item-scoped context for all action handlers. Single character change: `(context, index)` → `(_, index)`.

Also adds:
- `logd` in the cubit's cleanup rejection catch so this path is visible in debug logs
- `logw` in `_throwIfCleanupRejected`'s silent `on Object` catch so parse failures are never completely swallowed