### PR TITLE
fix(push): suppress completion notification when session is user-aborted

### DIFF
--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -142,6 +142,7 @@ class OrchestratorSession {
          sessionDao: projectsDao.attachedDatabase.sessionDao,
          sessionRepository: sessionRepository,
          prSyncService: prSyncService,
+         onSessionAborted: pushNotificationService.markSessionAborted,
        ),
        _mapper = BridgeEventMapper(plugin: plugin, failureReporter: failureReporter);
 

--- a/bridge/app/lib/src/bridge/routing/abort_session_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/abort_session_handler.dart
@@ -6,13 +6,17 @@ import "request_handler.dart";
 /// Handles `POST /session/:id/abort` — aborts in-progress session execution.
 class AbortSessionHandler extends BodyRequestHandler<SessionIdRequest, SuccessEmptyResponse> {
   final BridgePlugin _plugin;
+  final void Function(String sessionId) _onSessionAborted;
 
-  AbortSessionHandler(this._plugin)
-    : super(
-        HttpMethod.post,
-        "/session/abort",
-        fromJson: SessionIdRequest.fromJson,
-      );
+  AbortSessionHandler(
+    this._plugin, {
+    required void Function(String sessionId) onSessionAborted,
+  }) : _onSessionAborted = onSessionAborted,
+       super(
+         HttpMethod.post,
+         "/session/abort",
+         fromJson: SessionIdRequest.fromJson,
+       );
 
   @override
   Future<SuccessEmptyResponse> handle(
@@ -22,6 +26,7 @@ class AbortSessionHandler extends BodyRequestHandler<SessionIdRequest, SuccessEm
     required Map<String, String> queryParams,
     String? fragment,
   }) async {
+    _onSessionAborted(body.sessionId);
     await _plugin.abortSession(sessionId: body.sessionId);
     return const SuccessEmptyResponse();
   }

--- a/bridge/app/lib/src/bridge/routing/request_router.dart
+++ b/bridge/app/lib/src/bridge/routing/request_router.dart
@@ -59,6 +59,7 @@ class RequestRouter {
     required SessionDao sessionDao,
     required SessionRepository sessionRepository,
     required PrSyncService prSyncService,
+    required void Function(String sessionId) onSessionAborted,
   }) : _handlers = _buildHandlers(
          plugin: plugin,
          metadataService: metadataService,
@@ -66,6 +67,7 @@ class RequestRouter {
          sessionDao: sessionDao,
          sessionRepository: sessionRepository,
          prSyncService: prSyncService,
+         onSessionAborted: onSessionAborted,
        );
 
   static List<RequestHandlerBase> _buildHandlers({
@@ -75,6 +77,7 @@ class RequestRouter {
     required SessionDao sessionDao,
     required SessionRepository sessionRepository,
     required PrSyncService prSyncService,
+    required void Function(String sessionId) onSessionAborted,
   }) {
     final hiddenStore = projectsDao;
     final permissionRepository = PermissionRepository(plugin: plugin);
@@ -113,7 +116,7 @@ class RequestRouter {
         sessionRepository: sessionRepository,
       ),
       SendPromptHandler(plugin),
-      AbortSessionHandler(plugin),
+      AbortSessionHandler(plugin, onSessionAborted: onSessionAborted),
       GetProvidersHandler(ProviderRepository(plugin: plugin)),
       GetAgentsHandler(plugin),
       GetSessionQuestionsHandler(plugin),

--- a/bridge/app/lib/src/push/completion_notifier.dart
+++ b/bridge/app/lib/src/push/completion_notifier.dart
@@ -15,6 +15,7 @@ class CompletionNotifier {
   final StreamController<String> _completionController = StreamController<String>.broadcast();
   final Map<String, Timer> _debounceTimers = {};
   final Set<String> _completionSentForRoots = {};
+  final Set<String> _abortedRoots = {};
   final Map<String, String> _permissionRequestToSession = {};
 
   Stream<String> get completions => _completionController.stream;
@@ -24,6 +25,15 @@ class CompletionNotifier {
     Duration debounceDuration = const Duration(milliseconds: 500),
   }) : _tracker = tracker,
        _debounceDuration = debounceDuration;
+
+  /// Marks a session as user-aborted so the next idle transition does not
+  /// trigger a completion notification. The flag is cleared when the session
+  /// becomes busy again (new turn) or is deleted.
+  void markSessionAborted(String sessionId) {
+    final rootSessionId = _tracker.resolveRootSessionId(sessionId);
+    _abortedRoots.add(rootSessionId);
+    _cancelDebounceForRoot(rootSessionId);
+  }
 
   /// Process an SSE event for completion tracking.
   /// Call AFTER tracker.handleEvent() has already updated state.
@@ -43,6 +53,7 @@ class CompletionNotifier {
           case SessionStatusBusy():
           case SessionStatusRetry():
             _completionSentForRoots.remove(rootSessionId);
+            _abortedRoots.remove(rootSessionId);
             _cancelDebounceForRoot(rootSessionId);
           case SessionStatusIdle():
             _maybeScheduleCompletion(sessionID);
@@ -51,6 +62,7 @@ class CompletionNotifier {
       case SesoriSessionDeleted(:final info):
         _cancelDebounceForSessionGroup(info.id);
         _completionSentForRoots.remove(info.id);
+        _abortedRoots.remove(info.id);
         _permissionRequestToSession.removeWhere((_, sessionId) => sessionId == info.id);
       // User already handled the question, so cancel any pending completion ping.
       case SesoriQuestionReplied(:final sessionID):
@@ -82,6 +94,7 @@ class CompletionNotifier {
   void reset() {
     _cancelAllDebounceTimers();
     _completionSentForRoots.clear();
+    _abortedRoots.clear();
     _permissionRequestToSession.clear();
   }
 
@@ -130,7 +143,8 @@ class CompletionNotifier {
     return _tracker.wasPreviouslyBusy(rootSessionId) &&
         _tracker.isSessionGroupFullyIdle(rootSessionId) &&
         !_tracker.hasPendingInteraction(rootSessionId) &&
-        !_completionSentForRoots.contains(rootSessionId);
+        !_completionSentForRoots.contains(rootSessionId) &&
+        !_abortedRoots.contains(rootSessionId);
   }
 
   /// Cancels debounce timers for a session and its current root session.

--- a/bridge/app/lib/src/push/push_notification_service.dart
+++ b/bridge/app/lib/src/push/push_notification_service.dart
@@ -36,6 +36,12 @@ class PushNotificationService {
     _sendImmediateNotificationIfApplicable(event);
   }
 
+  /// Marks a session as user-aborted so the completion notification is
+  /// suppressed for the current busy→idle transition.
+  void markSessionAborted(String sessionId) {
+    _completionNotifier.markSessionAborted(sessionId);
+  }
+
   Future<void> dispose() async {
     await _completionSubscription.cancel();
     _completionNotifier.dispose();

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -46,6 +46,7 @@ DebugServer _createDebugServer({
     sessionDao: db.sessionDao,
     sessionRepository: sessionRepository,
     prSyncService: prSyncService,
+    onSessionAborted: (_) {},
   );
   return DebugServer(
     plugin: plugin,

--- a/bridge/app/test/bridge/routing/abort_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/abort_session_handler_test.dart
@@ -9,9 +9,15 @@ void main() {
     late FakeBridgePlugin plugin;
     late AbortSessionHandler handler;
 
+    late List<String> abortedSessionIds;
+
     setUp(() {
       plugin = FakeBridgePlugin();
-      handler = AbortSessionHandler(plugin);
+      abortedSessionIds = [];
+      handler = AbortSessionHandler(
+        plugin,
+        onSessionAborted: abortedSessionIds.add,
+      );
     });
 
     tearDown(() => plugin.close());
@@ -51,6 +57,17 @@ void main() {
       );
 
       expect(plugin.lastAbortSessionId, equals("session-xyz"));
+    });
+
+    test("calls onSessionAborted before plugin abort", () async {
+      await handler.handle(
+        makeRequest("POST", "/session/abort"),
+        body: const SessionIdRequest(sessionId: "s1"),
+        pathParams: {},
+        queryParams: {},
+      );
+
+      expect(abortedSessionIds, equals(["s1"]));
     });
   });
 }

--- a/bridge/app/test/bridge/routing/request_router_test.dart
+++ b/bridge/app/test/bridge/routing/request_router_test.dart
@@ -35,6 +35,7 @@ void main() {
         sessionDao: db.sessionDao,
         sessionRepository: sessionRepository,
         prSyncService: FakePrSyncService(),
+        onSessionAborted: (_) {},
       );
     });
 
@@ -265,6 +266,7 @@ void main() {
         sessionRepository: sessionRepository,
         prSyncService: spyPrSyncService,
         metadataService: metadataService,
+        onSessionAborted: (_) {},
       );
 
       final response = await router.route(


### PR DESCRIPTION
## Summary

- When the user presses the stop button, the session transitions from busy→idle identically to a natural completion, which incorrectly triggers a "session completed" push notification.
- This PR tracks user-initiated abort requests in `CompletionNotifier` via a new `_abortedRoots` set, and suppresses the completion notification for those sessions.
- The abort flag is set synchronously when the bridge handles `POST /session/abort` (before the async plugin call), ensuring it's in place before the idle SSE event arrives. The flag is cleared when the session goes busy again (new turn) or is deleted.

## Changes

| File | What changed |
|------|-------------|
| `completion_notifier.dart` | Added `_abortedRoots` set + `markSessionAborted()` method. `_shouldTriggerCompletion()` now checks the set. Flag cleared on busy/delete/reset. |
| `push_notification_service.dart` | Exposed `markSessionAborted()` pass-through. |
| `abort_session_handler.dart` | Accepts `onSessionAborted` callback, calls it before the plugin abort. |
| `request_router.dart` | Passes `onSessionAborted` through to `AbortSessionHandler`. |
| `orchestrator.dart` | Wires `pushNotificationService.markSessionAborted` as the callback. |
| Test files | Updated constructor calls + added test for the callback. |

## Scope

Bridge-only. No protocol changes, no mobile changes, no new event types.