### PR TITLE
fix(bridge): start worktrees from latest of local/origin base branch

### DIFF
--- a/bridge/app/lib/src/bridge/routing/get_session_diffs_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_session_diffs_handler.dart
@@ -37,15 +37,15 @@ class GetSessionDiffsHandler extends BodyRequestHandler<SessionIdRequest, Sessio
     }
 
     final worktreePath = session.worktreePath;
-    final baseBranch = session.baseBranch;
-    if (worktreePath == null || baseBranch == null) return const SessionDiffsResponse(diffs: []);
+    final baseCommit = session.baseCommit;
+    if (worktreePath == null || baseCommit == null) return const SessionDiffsResponse(diffs: []);
     if (!Directory(worktreePath).existsSync()) return const SessionDiffsResponse(diffs: []);
 
     final List<FileDiff> diffs;
     try {
       diffs = await computeSessionDiffs(
         worktreePath: worktreePath,
-        baseBranch: baseBranch,
+        baseBranch: baseCommit,
         processRunner: _processRunner,
       );
     } on BaseBranchUnreachableException catch (error) {

--- a/bridge/app/lib/src/bridge/routing/get_session_diffs_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_session_diffs_handler.dart
@@ -37,15 +37,15 @@ class GetSessionDiffsHandler extends BodyRequestHandler<SessionIdRequest, Sessio
     }
 
     final worktreePath = session.worktreePath;
-    final baseCommit = session.baseCommit;
-    if (worktreePath == null || baseCommit == null) return const SessionDiffsResponse(diffs: []);
+    final baseBranch = session.baseBranch;
+    if (worktreePath == null || baseBranch == null) return const SessionDiffsResponse(diffs: []);
     if (!Directory(worktreePath).existsSync()) return const SessionDiffsResponse(diffs: []);
 
     final List<FileDiff> diffs;
     try {
       diffs = await computeSessionDiffs(
         worktreePath: worktreePath,
-        baseBranch: baseCommit,
+        baseBranch: baseBranch,
         processRunner: _processRunner,
       );
     } on BaseBranchUnreachableException catch (error) {

--- a/bridge/app/lib/src/bridge/worktree_git_queries.dart
+++ b/bridge/app/lib/src/bridge/worktree_git_queries.dart
@@ -77,6 +77,36 @@ extension WorktreeGitQueries on WorktreeService {
     );
   }
 
+  Future<({String ref, String commit})> resolveStartPointForBranch({
+    required String projectPath,
+    required String baseBranch,
+    required String localCommit,
+  }) async {
+    final originRef = "origin/$baseBranch";
+    final originResult = await _runGit(
+      projectPath: projectPath,
+      arguments: ["rev-parse", originRef],
+    );
+    if (originResult.exitCode != 0) {
+      return (ref: baseBranch, commit: localCommit);
+    }
+
+    final originCommit = originResult.stdout.toString().trim();
+    if (originCommit == localCommit) {
+      return (ref: baseBranch, commit: localCommit);
+    }
+
+    final mergeBaseResult = await _runGit(
+      projectPath: projectPath,
+      arguments: ["merge-base", "--is-ancestor", originCommit, localCommit],
+    );
+    if (mergeBaseResult.exitCode == 0) {
+      return (ref: baseBranch, commit: localCommit);
+    }
+
+    return (ref: originRef, commit: originCommit);
+  }
+
   Future<ProcessResult> _runGit({
     required String projectPath,
     required List<String> arguments,

--- a/bridge/app/lib/src/bridge/worktree_service.dart
+++ b/bridge/app/lib/src/bridge/worktree_service.dart
@@ -188,7 +188,7 @@ class WorktreeService {
       );
 
       return (
-        baseBranch: baseBranch,
+        baseBranch: startPointResult.ref,
         baseCommit: startPointResult.commit,
         startPoint: startPointResult.ref,
       );

--- a/bridge/app/lib/src/bridge/worktree_service.dart
+++ b/bridge/app/lib/src/bridge/worktree_service.dart
@@ -97,6 +97,7 @@ class WorktreeService {
     }
     final baseBranch = baseBranchAndCommit.baseBranch;
     final baseCommit = baseBranchAndCommit.baseCommit;
+    final startPoint = baseBranchAndCommit.startPoint;
 
     // 4.5. Try preferred branch name if provided.
     if (preferredBranchAndWorktreeName != null && parentSessionId == null) {
@@ -115,7 +116,7 @@ class WorktreeService {
           projectPath: projectId,
           worktreePath: worktreePath,
           branchName: branchName,
-          baseBranch: baseBranch,
+          baseBranch: startPoint,
         );
         if (result.exitCode == 0) {
           return WorktreeSuccess(
@@ -139,7 +140,7 @@ class WorktreeService {
         projectPath: projectId,
         worktreePath: worktreePath,
         branchName: branchName,
-        baseBranch: baseBranch,
+        baseBranch: startPoint,
       );
 
       if (result.exitCode == 0) {
@@ -159,7 +160,7 @@ class WorktreeService {
     );
   }
 
-  Future<({String baseBranch, String baseCommit})?> resolveBaseBranchAndCommit({
+  Future<({String baseBranch, String baseCommit, String startPoint})?> resolveBaseBranchAndCommit({
     required String projectPath,
   }) async {
     try {
@@ -177,10 +178,20 @@ class WorktreeService {
       );
       if (revParseResult.exitCode != 0) return null;
 
-      final baseCommit = revParseResult.stdout.toString().trim();
-      if (baseCommit.isEmpty) return null;
+      final localCommit = revParseResult.stdout.toString().trim();
+      if (localCommit.isEmpty) return null;
 
-      return (baseBranch: baseBranch, baseCommit: baseCommit);
+      final startPointResult = await resolveStartPointForBranch(
+        projectPath: projectPath,
+        baseBranch: baseBranch,
+        localCommit: localCommit,
+      );
+
+      return (
+        baseBranch: baseBranch,
+        baseCommit: startPointResult.commit,
+        startPoint: startPointResult.ref,
+      );
     } on Object {
       return null;
     }

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -120,6 +120,7 @@ void main() {
       worktreeService.resolveBaseBranchAndCommitResult = (
         baseBranch: "main",
         baseCommit: "abc123def456",
+        startPoint: "main",
       );
 
       final result = await handler.handle(
@@ -607,7 +608,7 @@ class _FakeWorktreeService extends WorktreeService {
     originalPath: "/repo",
     reason: "default",
   );
-  ({String baseBranch, String baseCommit})? resolveBaseBranchAndCommitResult;
+  ({String baseBranch, String baseCommit, String startPoint})? resolveBaseBranchAndCommitResult;
 
   _FakeWorktreeService({required AppDatabase database})
     : super(
@@ -631,7 +632,7 @@ class _FakeWorktreeService extends WorktreeService {
   }
 
   @override
-  Future<({String baseBranch, String baseCommit})?> resolveBaseBranchAndCommit({
+  Future<({String baseBranch, String baseCommit, String startPoint})?> resolveBaseBranchAndCommit({
     required String projectPath,
   }) async {
     resolveBaseBranchAndCommitCallCount++;

--- a/bridge/app/test/bridge/worktree_service_git_test.dart
+++ b/bridge/app/test/bridge/worktree_service_git_test.dart
@@ -165,6 +165,113 @@ void main() {
       );
       expect(processRunner.invocations.single.workingDirectory, equals("/repo/project"));
     });
+
+    group("resolveStartPointForBranch", () {
+      test("returns local when origin ref does not exist", () async {
+        processRunner.enqueue(result: _processResult(exitCode: 128, stderr: "fatal"));
+
+        final result = await service.resolveStartPointForBranch(
+          projectPath: "/repo/project",
+          baseBranch: "main",
+          localCommit: "abc123",
+        );
+
+        expect(result.ref, equals("main"));
+        expect(result.commit, equals("abc123"));
+        expect(processRunner.invocations, hasLength(1));
+        expect(processRunner.invocations.single.arguments, equals(["rev-parse", "origin/main"]));
+        expect(processRunner.invocations.single.workingDirectory, equals("/repo/project"));
+      });
+
+      test("returns local when commits are the same", () async {
+        processRunner.enqueue(result: _processResult(exitCode: 0, stdout: "abc123\n"));
+
+        final result = await service.resolveStartPointForBranch(
+          projectPath: "/repo/project",
+          baseBranch: "main",
+          localCommit: "abc123",
+        );
+
+        expect(result.ref, equals("main"));
+        expect(result.commit, equals("abc123"));
+        expect(processRunner.invocations, hasLength(1));
+        expect(processRunner.invocations.single.arguments, equals(["rev-parse", "origin/main"]));
+      });
+
+      test("returns local when local is strictly ahead", () async {
+        processRunner
+          ..enqueue(result: _processResult(exitCode: 0, stdout: "def456\n"))
+          ..enqueue(result: _processResult(exitCode: 0));
+
+        final result = await service.resolveStartPointForBranch(
+          projectPath: "/repo/project",
+          baseBranch: "main",
+          localCommit: "abc123",
+        );
+
+        expect(result.ref, equals("main"));
+        expect(result.commit, equals("abc123"));
+        expect(processRunner.invocations, hasLength(2));
+        expect(processRunner.invocations[0].arguments, equals(["rev-parse", "origin/main"]));
+        expect(
+          processRunner.invocations[1].arguments,
+          equals(["merge-base", "--is-ancestor", "def456", "abc123"]),
+        );
+      });
+
+      test("returns origin when origin is strictly ahead", () async {
+        processRunner
+          ..enqueue(result: _processResult(exitCode: 0, stdout: "def456\n"))
+          ..enqueue(result: _processResult(exitCode: 1));
+
+        final result = await service.resolveStartPointForBranch(
+          projectPath: "/repo/project",
+          baseBranch: "main",
+          localCommit: "abc123",
+        );
+
+        expect(result.ref, equals("origin/main"));
+        expect(result.commit, equals("def456"));
+        expect(processRunner.invocations, hasLength(2));
+        expect(processRunner.invocations[0].arguments, equals(["rev-parse", "origin/main"]));
+        expect(
+          processRunner.invocations[1].arguments,
+          equals(["merge-base", "--is-ancestor", "def456", "abc123"]),
+        );
+      });
+
+      test("returns origin when branches have diverged", () async {
+        processRunner
+          ..enqueue(result: _processResult(exitCode: 0, stdout: "diverged-origin\n"))
+          ..enqueue(result: _processResult(exitCode: 1));
+
+        final result = await service.resolveStartPointForBranch(
+          projectPath: "/repo/project",
+          baseBranch: "main",
+          localCommit: "diverged-local",
+        );
+
+        expect(result.ref, equals("origin/main"));
+        expect(result.commit, equals("diverged-origin"));
+        expect(processRunner.invocations, hasLength(2));
+      });
+
+      test("returns origin when merge-base command fails", () async {
+        processRunner
+          ..enqueue(result: _processResult(exitCode: 0, stdout: "def456\n"))
+          ..enqueue(result: _processResult(exitCode: 128, stderr: "fatal"));
+
+        final result = await service.resolveStartPointForBranch(
+          projectPath: "/repo/project",
+          baseBranch: "main",
+          localCommit: "abc123",
+        );
+
+        expect(result.ref, equals("origin/main"));
+        expect(result.commit, equals("def456"));
+        expect(processRunner.invocations, hasLength(2));
+      });
+    });
   });
 }
 

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -477,7 +477,7 @@ void main() {
 
       expect(result, isA<WorktreeSuccess>());
       final success = result as WorktreeSuccess;
-      expect(success.baseBranch, equals("main"));
+      expect(success.baseBranch, equals("origin/main"));
       expect(success.baseCommit, equals("origin222"));
 
       // Verify worktree add used "origin/main" as start point

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -49,6 +49,8 @@ void main() {
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
+      // git rev-parse origin/main → no remote tracking branch
+      processRunner.enqueue(result: _fail(exitCode: 128));
       // git branch --list session-001 → empty (branch does not exist)
       processRunner.enqueue(result: _ok(stdout: ""));
       // git worktree add → success
@@ -105,6 +107,8 @@ void main() {
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
+      // git rev-parse origin/main → no remote tracking branch
+      processRunner.enqueue(result: _fail(exitCode: 128));
       // git branch --list session-001 → empty
       processRunner.enqueue(result: _ok(stdout: ""));
       // git worktree add → success
@@ -169,6 +173,8 @@ void main() {
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
+      // git rev-parse origin/main → no remote tracking branch
+      processRunner.enqueue(result: _fail(exitCode: 128));
       // branch --list session-001 → non-empty (collision!)
       processRunner.enqueue(result: _ok(stdout: "  session-001\n"));
       // branch --list session-002 → empty (free)
@@ -198,6 +204,8 @@ void main() {
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
+      // git rev-parse origin/main → no remote tracking branch
+      processRunner.enqueue(result: _fail(exitCode: 128));
       // Attempt 1: branch --list session-001 → empty, worktree add → fail
       processRunner.enqueue(result: _ok(stdout: ""));
       processRunner.enqueue(result: _fail(exitCode: 128, stderr: "error"));
@@ -235,6 +243,8 @@ void main() {
       processRunner.enqueue(result: _ok(stdout: "  develop\n"));
       // git rev-parse develop → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "deadbeef1234\n"));
+      // git rev-parse origin/develop → no remote tracking branch
+      processRunner.enqueue(result: _fail(exitCode: 128));
       // branch --list session-001 → empty
       processRunner.enqueue(result: _ok(stdout: ""));
       // worktree add → success
@@ -280,6 +290,8 @@ void main() {
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
+      // git rev-parse origin/main → no remote tracking branch
+      processRunner.enqueue(result: _fail(exitCode: 128));
       // branch --list session-001 → empty
       processRunner.enqueue(result: _ok(stdout: ""));
       // worktree add → success
@@ -309,6 +321,8 @@ void main() {
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
+      // git rev-parse origin/main → no remote tracking branch
+      processRunner.enqueue(result: _fail(exitCode: 128));
       // branch --list my-feature → empty (preferred name available)
       processRunner.enqueue(result: _ok(stdout: ""));
       // worktree add → success
@@ -335,6 +349,8 @@ void main() {
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
+      // git rev-parse origin/main → no remote tracking branch
+      processRunner.enqueue(result: _fail(exitCode: 128));
       // branch --list my-feature → non-empty (collision!)
       processRunner.enqueue(result: _ok(stdout: "  my-feature\n"));
       // worktree add with suffixed name → success
@@ -360,6 +376,8 @@ void main() {
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
+      // git rev-parse origin/main → no remote tracking branch
+      processRunner.enqueue(result: _fail(exitCode: 128));
       // branch --list my-feature → empty (available)
       processRunner.enqueue(result: _ok(stdout: ""));
       // worktree add → failure
@@ -387,6 +405,8 @@ void main() {
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
       // git rev-parse main → base commit SHA
       processRunner.enqueue(result: _ok(stdout: "abc123def456\n"));
+      // git rev-parse origin/main → no remote tracking branch
+      processRunner.enqueue(result: _fail(exitCode: 128));
       // branch --list session-001 → empty
       processRunner.enqueue(result: _ok(stdout: ""));
       // worktree add → success
@@ -428,6 +448,185 @@ void main() {
       expect(success.branchName, equals("session-001"));
       // No git commands should have been called — worktree already exists.
       expect(processRunner.invocations, isEmpty);
+    });
+
+    // -----------------------------------------------------------------------
+    // Origin comparison scenarios
+    // -----------------------------------------------------------------------
+
+    test("origin ahead: worktree starts from origin ref", () async {
+      // rev-parse HEAD → ok
+      processRunner.enqueue(result: _ok());
+      // symbolic-ref → main
+      processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // rev-parse main → local commit
+      processRunner.enqueue(result: _ok(stdout: "local111\n"));
+      // rev-parse origin/main → origin commit (different)
+      processRunner.enqueue(result: _ok(stdout: "origin222\n"));
+      // merge-base --is-ancestor origin222 local111 → exit 1 (origin NOT ancestor of local)
+      processRunner.enqueue(result: _fail(exitCode: 1));
+      // branch --list session-001 → empty
+      processRunner.enqueue(result: _ok(stdout: ""));
+      // worktree add → success
+      processRunner.enqueue(result: _ok());
+
+      final result = await service.prepareWorktreeForSession(
+        projectId: _projectId,
+        parentSessionId: null,
+      );
+
+      expect(result, isA<WorktreeSuccess>());
+      final success = result as WorktreeSuccess;
+      expect(success.baseBranch, equals("main"));
+      expect(success.baseCommit, equals("origin222"));
+
+      // Verify worktree add used "origin/main" as start point
+      final worktreeAddArgs = processRunner.invocations.last.arguments;
+      expect(worktreeAddArgs.last, equals("origin/main"));
+    });
+
+    test("local ahead: worktree starts from local branch", () async {
+      // rev-parse HEAD → ok
+      processRunner.enqueue(result: _ok());
+      // symbolic-ref → main
+      processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // rev-parse main → local commit
+      processRunner.enqueue(result: _ok(stdout: "local111\n"));
+      // rev-parse origin/main → origin commit (different)
+      processRunner.enqueue(result: _ok(stdout: "origin222\n"));
+      // merge-base --is-ancestor origin222 local111 → exit 0 (origin IS ancestor of local)
+      processRunner.enqueue(result: _ok());
+      // branch --list session-001 → empty
+      processRunner.enqueue(result: _ok(stdout: ""));
+      // worktree add → success
+      processRunner.enqueue(result: _ok());
+
+      final result = await service.prepareWorktreeForSession(
+        projectId: _projectId,
+        parentSessionId: null,
+      );
+
+      expect(result, isA<WorktreeSuccess>());
+      final success = result as WorktreeSuccess;
+      expect(success.baseBranch, equals("main"));
+      expect(success.baseCommit, equals("local111"));
+
+      // Verify worktree add used "main" as start point
+      final worktreeAddArgs = processRunner.invocations.last.arguments;
+      expect(worktreeAddArgs.last, equals("main"));
+    });
+
+    test("same commit: worktree starts from local branch", () async {
+      // rev-parse HEAD → ok
+      processRunner.enqueue(result: _ok());
+      // symbolic-ref → main
+      processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // rev-parse main → local commit
+      processRunner.enqueue(result: _ok(stdout: "samecommit\n"));
+      // rev-parse origin/main → same commit
+      processRunner.enqueue(result: _ok(stdout: "samecommit\n"));
+      // branch --list session-001 → empty
+      processRunner.enqueue(result: _ok(stdout: ""));
+      // worktree add → success
+      processRunner.enqueue(result: _ok());
+
+      final result = await service.prepareWorktreeForSession(
+        projectId: _projectId,
+        parentSessionId: null,
+      );
+
+      expect(result, isA<WorktreeSuccess>());
+      final success = result as WorktreeSuccess;
+      expect(success.baseCommit, equals("samecommit"));
+
+      // Verify worktree add used "main" as start point
+      final worktreeAddArgs = processRunner.invocations.last.arguments;
+      expect(worktreeAddArgs.last, equals("main"));
+    });
+
+    test("diverged: worktree starts from origin ref", () async {
+      // rev-parse HEAD → ok
+      processRunner.enqueue(result: _ok());
+      // symbolic-ref → main
+      processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // rev-parse main → local commit
+      processRunner.enqueue(result: _ok(stdout: "diverged-local\n"));
+      // rev-parse origin/main → origin commit
+      processRunner.enqueue(result: _ok(stdout: "diverged-origin\n"));
+      // merge-base --is-ancestor diverged-origin diverged-local → exit 1 (not ancestor)
+      processRunner.enqueue(result: _fail(exitCode: 1));
+      // branch --list session-001 → empty
+      processRunner.enqueue(result: _ok(stdout: ""));
+      // worktree add → success
+      processRunner.enqueue(result: _ok());
+
+      final result = await service.prepareWorktreeForSession(
+        projectId: _projectId,
+        parentSessionId: null,
+      );
+
+      expect(result, isA<WorktreeSuccess>());
+      final success = result as WorktreeSuccess;
+      expect(success.baseCommit, equals("diverged-origin"));
+
+      final worktreeAddArgs = processRunner.invocations.last.arguments;
+      expect(worktreeAddArgs.last, equals("origin/main"));
+    });
+
+    test("no origin ref: worktree starts from local branch", () async {
+      // rev-parse HEAD → ok
+      processRunner.enqueue(result: _ok());
+      // symbolic-ref → main
+      processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // rev-parse main → local commit
+      processRunner.enqueue(result: _ok(stdout: "local111\n"));
+      // rev-parse origin/main → fail (no remote tracking branch)
+      processRunner.enqueue(result: _fail(exitCode: 128));
+      // branch --list session-001 → empty
+      processRunner.enqueue(result: _ok(stdout: ""));
+      // worktree add → success
+      processRunner.enqueue(result: _ok());
+
+      final result = await service.prepareWorktreeForSession(
+        projectId: _projectId,
+        parentSessionId: null,
+      );
+
+      expect(result, isA<WorktreeSuccess>());
+      final success = result as WorktreeSuccess;
+      expect(success.baseCommit, equals("local111"));
+
+      final worktreeAddArgs = processRunner.invocations.last.arguments;
+      expect(worktreeAddArgs.last, equals("main"));
+    });
+
+    test("merge-base fails: worktree starts from origin ref", () async {
+      // rev-parse HEAD → ok
+      processRunner.enqueue(result: _ok());
+      // symbolic-ref → main
+      processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // rev-parse main → local commit
+      processRunner.enqueue(result: _ok(stdout: "local111\n"));
+      // rev-parse origin/main → origin commit (different)
+      processRunner.enqueue(result: _ok(stdout: "origin222\n"));
+      // merge-base --is-ancestor → exit 128 (fatal error, e.g. shallow clone)
+      processRunner.enqueue(result: _fail(exitCode: 128, stderr: "fatal"));
+      // branch --list session-001 → empty
+      processRunner.enqueue(result: _ok(stdout: ""));
+      // worktree add → success
+      processRunner.enqueue(result: _ok());
+
+      final result = await service.prepareWorktreeForSession(
+        projectId: _projectId,
+        parentSessionId: null,
+      );
+
+      expect(result, isA<WorktreeSuccess>());
+      final success = result as WorktreeSuccess;
+      expect(success.baseCommit, equals("origin222"));
+
+      final worktreeAddArgs = processRunner.invocations.last.arguments;
+      expect(worktreeAddArgs.last, equals("origin/main"));
     });
   });
 


### PR DESCRIPTION
## Summary

- Worktree creation now compares local base branch with `origin/<baseBranch>` and starts from whichever is further ahead
- When branches have diverged or ancestry can't be determined, prefers origin
- Falls back gracefully to local branch when origin ref doesn't exist (no behavior change for repos without remotes)

## Changes

### Production (`bridge/app/lib/src/bridge/`)

- **`worktree_git_queries.dart`**: Added `resolveStartPointForBranch` method that compares local vs origin commits using `git merge-base --is-ancestor`
- **`worktree_service.dart`**: Updated `resolveBaseBranchAndCommit` return type to include `startPoint` field; `prepareWorktreeForSession` now passes the resolved start point to `createWorktree`

### Tests (`bridge/app/test/bridge/`)

- **`worktree_service_git_test.dart`**: 6 new unit tests for `resolveStartPointForBranch` (origin ahead, local ahead, same commit, diverged, no remote, merge-base failure)
- **`worktree_service_test.dart`**: 6 new integration tests for origin comparison scenarios + 10 existing tests updated for new FIFO queue order
- **`routing/create_session_handler_test.dart`**: Updated fake to match new return type

## Verification

- `make test` from `bridge/` — 756 tests pass (119 plugin + 637 app)
- `make analyze` from `bridge/` — no errors (1 pre-existing info)