### PR TITLE
feat: enable auto_vacuum on OpenCode database at bridge startup

### DIFF
--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -11,21 +11,25 @@ import 'package:sesori_bridge/src/auth/token_manager.dart';
 import 'package:sesori_bridge/src/auth/validate.dart';
 import 'package:sesori_bridge/src/bridge/api/gh_cli_api.dart';
 import 'package:sesori_bridge/src/bridge/api/git_cli_api.dart';
+import 'package:sesori_bridge/src/bridge/api/opencode_db_api.dart';
 import 'package:sesori_bridge/src/bridge/bandwidth_tracker.dart';
 import 'package:sesori_bridge/src/bridge/debug_server.dart';
 import 'package:sesori_bridge/src/bridge/foundation/process_runner.dart';
 import 'package:sesori_bridge/src/bridge/log_failure_reporter.dart';
 import 'package:sesori_bridge/src/bridge/metadata_service.dart';
+
 import 'package:sesori_bridge/src/bridge/models/bridge_config.dart';
 import 'package:sesori_bridge/src/bridge/orchestrator.dart';
 import 'package:sesori_bridge/src/bridge/persistence/bridge_diagnostics.dart';
 import 'package:sesori_bridge/src/bridge/persistence/database.dart';
 import 'package:sesori_bridge/src/bridge/relay_client.dart';
+import 'package:sesori_bridge/src/bridge/repositories/opencode_db_repository.dart';
 import 'package:sesori_bridge/src/bridge/repositories/permission_repository.dart';
 import 'package:sesori_bridge/src/bridge/repositories/pr_source_repository.dart';
 import 'package:sesori_bridge/src/bridge/repositories/project_repository.dart';
 import 'package:sesori_bridge/src/bridge/repositories/pull_request_repository.dart';
 import 'package:sesori_bridge/src/bridge/repositories/session_repository.dart';
+import 'package:sesori_bridge/src/bridge/services/opencode_db_maintenance_service.dart';
 import 'package:sesori_bridge/src/bridge/services/pr_sync_service.dart';
 import 'package:sesori_bridge/src/bridge/services/session_persistence_service.dart';
 import 'package:sesori_bridge/src/bridge/sse/sse_manager.dart';
@@ -147,7 +151,19 @@ Future<void> main(List<String> args) async {
     Log.w('Authenticated (unable to fetch profile username: $e)');
   }
 
-  // Server resolution
+  // OpenCode DB maintenance (opportunistic — runs before server start to
+  // maximize the chance that OpenCode hasn't opened the DB yet)
+  final homeDir = Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'];
+  if (homeDir != null) {
+    final xdgDataHome = Platform.environment['XDG_DATA_HOME'] ?? '$homeDir/.local/share';
+    final openCodeDbPath = '$xdgDataHome/opencode/opencode.db';
+    final dbMaintenanceService = OpenCodeDbMaintenanceService(
+      repository: OpenCodeDbRepository(api: OpenCodeDbApi()),
+    );
+    dbMaintenanceService.optimizeIfNeeded(dbPath: openCodeDbPath);
+  }
+
+  // Server resolution (may auto-start OpenCode process)
   final (serverURL, serverPassword, cmd) = await resolveServer(
     noAutoStart: noAutoStart,
     port: port,

--- a/bridge/app/lib/src/bridge/api/opencode_db_api.dart
+++ b/bridge/app/lib/src/bridge/api/opencode_db_api.dart
@@ -1,0 +1,49 @@
+import "dart:io";
+
+import "package:sqlite3/sqlite3.dart";
+
+/// Layer 1 API for direct SQLite operations on the OpenCode database.
+///
+/// This class performs raw PRAGMA and VACUUM operations on an external
+/// SQLite database owned by OpenCode. It does not read or modify any
+/// tables or data — only database-level maintenance commands.
+class OpenCodeDbApi {
+  /// Returns the current `auto_vacuum` mode.
+  ///
+  /// - `0` = NONE (default — no automatic vacuuming)
+  /// - `1` = FULL (freed pages reclaimed after every DELETE)
+  /// - `2` = INCREMENTAL (freed pages reclaimed on explicit request)
+  ///
+  /// Throws [SqliteException] if the database cannot be opened or queried.
+  int getAutoVacuumMode({required String dbPath}) {
+    final db = sqlite3.open(dbPath);
+    try {
+      final result = db.select("PRAGMA auto_vacuum");
+      return result.first["auto_vacuum"] as int;
+    } finally {
+      db.close();
+    }
+  }
+
+  /// Enables `auto_vacuum = FULL` and runs `VACUUM` to convert the database.
+  ///
+  /// After this one-time conversion, all future DELETE operations by OpenCode
+  /// will automatically reclaim disk space.
+  ///
+  /// Returns `(sizeBefore, sizeAfter)` in bytes.
+  ///
+  /// Throws [SqliteException] with result code 5 (SQLITE_BUSY) if another
+  /// process holds the database open.
+  (int, int) enableAutoVacuumAndVacuum({required String dbPath}) {
+    final sizeBefore = File(dbPath).lengthSync();
+    final db = sqlite3.open(dbPath);
+    try {
+      db.execute("PRAGMA auto_vacuum = FULL");
+      db.execute("VACUUM");
+    } finally {
+      db.close();
+    }
+    final sizeAfter = File(dbPath).lengthSync();
+    return (sizeBefore, sizeAfter);
+  }
+}

--- a/bridge/app/lib/src/bridge/repositories/opencode_db_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/opencode_db_repository.dart
@@ -1,0 +1,68 @@
+import "dart:io";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+import "package:sqlite3/sqlite3.dart";
+
+import "../api/opencode_db_api.dart";
+
+/// Layer 2 Repository wrapping [OpenCodeDbApi].
+///
+/// Translates raw SQLite results and exceptions into domain-level
+/// values that the service layer can consume without knowing about
+/// the underlying database implementation.
+class OpenCodeDbRepository {
+  final OpenCodeDbApi _api;
+
+  OpenCodeDbRepository({required OpenCodeDbApi api}) : _api = api;
+
+  /// Returns the current auto_vacuum mode, or `null` if the database
+  /// file does not exist or cannot be read.
+  int? getAutoVacuumMode({required String dbPath}) {
+    if (!File(dbPath).existsSync()) {
+      Log.d("[DbMaintenance] OpenCode database not found — skipping");
+      return null;
+    }
+
+    try {
+      return _api.getAutoVacuumMode(dbPath: dbPath);
+    } on SqliteException catch (e) {
+      _logError(error: e);
+      return null;
+    }
+  }
+
+  /// Returns the database file size in bytes, or `0` if the file
+  /// does not exist.
+  int getDbSizeBytes({required String dbPath}) {
+    final file = File(dbPath);
+    if (!file.existsSync()) return 0;
+    return file.lengthSync();
+  }
+
+  /// Enables auto_vacuum=FULL and runs VACUUM.
+  ///
+  /// Returns `(sizeBefore, sizeAfter)` in bytes on success, or `null`
+  /// if the operation failed (database locked, corrupted, etc.).
+  (int, int)? enableAutoVacuumAndVacuum({required String dbPath}) {
+    try {
+      return _api.enableAutoVacuumAndVacuum(dbPath: dbPath);
+    } on SqliteException catch (e) {
+      _logError(error: e);
+      return null;
+    } on Object catch (e) {
+      Log.w("[DbMaintenance] Database optimization failed: $e");
+      return null;
+    }
+  }
+
+  void _logError({required SqliteException error}) {
+    if (error.resultCode == 5 /* SQLITE_BUSY */ ) {
+      Log.d(
+        "[DbMaintenance] OpenCode database is in use — "
+        "will retry next startup",
+      );
+    } else {
+      Log.w("[DbMaintenance] Database optimization failed: $error");
+    }
+  }
+}

--- a/bridge/app/lib/src/bridge/services/opencode_db_maintenance_service.dart
+++ b/bridge/app/lib/src/bridge/services/opencode_db_maintenance_service.dart
@@ -1,0 +1,63 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
+import "../repositories/opencode_db_repository.dart";
+
+/// Opportunistically enables `auto_vacuum = FULL` on the OpenCode SQLite
+/// database during bridge startup.
+///
+/// This is a one-time conversion. Once the database header is updated, all
+/// future DELETE operations by OpenCode automatically reclaim disk space.
+/// If the database is in use, the operation is silently skipped and retried
+/// on the next bridge startup.
+class OpenCodeDbMaintenanceService {
+  /// Conservative estimate of VACUUM throughput on modern SSDs (MB/s).
+  static const _estimatedVacuumMbPerSecond = 75;
+
+  final OpenCodeDbRepository _repository;
+
+  OpenCodeDbMaintenanceService({required OpenCodeDbRepository repository}) : _repository = repository;
+
+  /// Checks whether the OpenCode database needs auto-vacuum enabled,
+  /// and if so, attempts to enable it.
+  ///
+  /// This method never throws — all errors are handled by the repository.
+  void optimizeIfNeeded({required String dbPath}) {
+    final mode = _repository.getAutoVacuumMode(dbPath: dbPath);
+    if (mode == null) return;
+    if (mode != 0) {
+      Log.d(
+        "[DbMaintenance] auto_vacuum already enabled (mode=$mode) — skipping",
+      );
+      return;
+    }
+
+    final sizeBytes = _repository.getDbSizeBytes(dbPath: dbPath);
+    final sizeMB = sizeBytes / (1024 * 1024);
+    final estimatedSeconds = (sizeMB / _estimatedVacuumMbPerSecond).ceil().clamp(1, 600);
+
+    Log.i(
+      "[DbMaintenance] OpenCode database found "
+      "(${sizeMB.toStringAsFixed(0)} MB). "
+      "Enabling auto-vacuum — estimated duration: "
+      "~${_formatDuration(estimatedSeconds)}",
+    );
+
+    final result = _repository.enableAutoVacuumAndVacuum(dbPath: dbPath);
+    if (result == null) return;
+
+    final (sizeBefore, sizeAfter) = result;
+    final savedMB = (sizeBefore - sizeAfter) / (1024 * 1024);
+
+    Log.i(
+      "[DbMaintenance] Auto-vacuum enabled successfully. "
+      "Reclaimed ${savedMB.toStringAsFixed(0)} MB "
+      "(${(sizeAfter / (1024 * 1024)).toStringAsFixed(0)} MB remaining)",
+    );
+  }
+
+  static String _formatDuration(int seconds) {
+    if (seconds < 60) return "$seconds seconds";
+    final minutes = (seconds / 60).ceil();
+    return "$minutes minute${minutes > 1 ? "s" : ""}";
+  }
+}

--- a/bridge/app/test/bridge/api/opencode_db_api_test.dart
+++ b/bridge/app/test/bridge/api/opencode_db_api_test.dart
@@ -1,0 +1,116 @@
+import "dart:io";
+
+import "package:sesori_bridge/src/bridge/api/opencode_db_api.dart";
+import "package:sqlite3/sqlite3.dart";
+import "package:test/test.dart";
+
+void main() {
+  late Directory tempDir;
+  late String dbPath;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync("opencode_db_api_test_");
+    dbPath = "${tempDir.path}/test.db";
+  });
+
+  tearDown(() {
+    tempDir.deleteSync(recursive: true);
+  });
+
+  group("getAutoVacuumMode", () {
+    test("returns 0 for a new database", () {
+      final db = sqlite3.open(dbPath);
+      db.execute("CREATE TABLE test (id INTEGER)");
+      db.close();
+
+      final api = OpenCodeDbApi();
+      expect(api.getAutoVacuumMode(dbPath: dbPath), 0);
+    });
+
+    test("returns 1 when auto_vacuum is FULL", () {
+      final db = sqlite3.open(dbPath);
+      db.execute("PRAGMA auto_vacuum = FULL");
+      db.execute("VACUUM");
+      db.execute("CREATE TABLE test (id INTEGER)");
+      db.close();
+
+      final api = OpenCodeDbApi();
+      expect(api.getAutoVacuumMode(dbPath: dbPath), 1);
+    });
+
+    test("throws when database file does not exist", () {
+      final api = OpenCodeDbApi();
+      // sqlite3.open on a nonexistent path creates the file,
+      // but we test a truly invalid path
+      expect(
+        () => api.getAutoVacuumMode(dbPath: "/nonexistent/dir/test.db"),
+        throwsA(isA<SqliteException>()),
+      );
+    });
+  });
+
+  group("enableAutoVacuumAndVacuum", () {
+    test("sets auto_vacuum to FULL", () {
+      final db = sqlite3.open(dbPath);
+      db.execute("CREATE TABLE test (id INTEGER, data TEXT)");
+      db.close();
+
+      final api = OpenCodeDbApi();
+      api.enableAutoVacuumAndVacuum(dbPath: dbPath);
+      expect(api.getAutoVacuumMode(dbPath: dbPath), 1);
+    });
+
+    test("returns size before and after", () {
+      final db = sqlite3.open(dbPath);
+      db.execute("CREATE TABLE test (id INTEGER, data TEXT)");
+      // Insert data to grow the file
+      for (var i = 0; i < 100; i++) {
+        db.execute("INSERT INTO test VALUES ($i, '${List.filled(1000, "x").join()}')");
+      }
+      // Delete to create free pages
+      db.execute("DELETE FROM test");
+      db.close();
+
+      final api = OpenCodeDbApi();
+      final (sizeBefore, sizeAfter) = api.enableAutoVacuumAndVacuum(
+        dbPath: dbPath,
+      );
+
+      expect(sizeBefore, greaterThan(0));
+      expect(sizeAfter, greaterThan(0));
+      expect(sizeAfter, lessThanOrEqualTo(sizeBefore));
+    });
+
+    test("throws SqliteException when database is locked", () {
+      final db = sqlite3.open(dbPath);
+      db.execute("CREATE TABLE test (id INTEGER)");
+      db.execute("BEGIN EXCLUSIVE");
+
+      final api = OpenCodeDbApi();
+      expect(
+        () => api.enableAutoVacuumAndVacuum(dbPath: dbPath),
+        throwsA(isA<SqliteException>()),
+      );
+
+      db.execute("ROLLBACK");
+      db.close();
+    });
+
+    test("reclaims space from deleted rows", () {
+      final db = sqlite3.open(dbPath);
+      db.execute("CREATE TABLE test (id INTEGER, data TEXT)");
+      for (var i = 0; i < 500; i++) {
+        db.execute("INSERT INTO test VALUES ($i, '${List.filled(500, "x").join()}')");
+      }
+      db.execute("DELETE FROM test");
+      db.close();
+
+      final sizeBefore = File(dbPath).lengthSync();
+      final api = OpenCodeDbApi();
+      final (_, sizeAfter) = api.enableAutoVacuumAndVacuum(dbPath: dbPath);
+
+      // After VACUUM with deleted data, file should be significantly smaller
+      expect(sizeAfter, lessThan(sizeBefore));
+    });
+  });
+}

--- a/bridge/app/test/bridge/services/opencode_db_maintenance_service_test.dart
+++ b/bridge/app/test/bridge/services/opencode_db_maintenance_service_test.dart
@@ -1,0 +1,109 @@
+import "dart:io";
+
+import "package:sesori_bridge/src/bridge/api/opencode_db_api.dart";
+import "package:sesori_bridge/src/bridge/repositories/opencode_db_repository.dart";
+import "package:sesori_bridge/src/bridge/services/opencode_db_maintenance_service.dart";
+import "package:sqlite3/sqlite3.dart";
+import "package:test/test.dart";
+
+void main() {
+  late Directory tempDir;
+  late String dbPath;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync("db_maintenance_test_");
+    dbPath = "${tempDir.path}/opencode.db";
+  });
+
+  tearDown(() {
+    tempDir.deleteSync(recursive: true);
+  });
+
+  group("optimizeIfNeeded", () {
+    test("skips when database file does not exist", () {
+      final service = OpenCodeDbMaintenanceService(
+        repository: OpenCodeDbRepository(api: OpenCodeDbApi()),
+      );
+      // Should not throw — repository returns null, service returns
+      service.optimizeIfNeeded(dbPath: "${tempDir.path}/missing.db");
+    });
+
+    test("skips when auto_vacuum is already FULL", () {
+      final db = sqlite3.open(dbPath);
+      db.execute("PRAGMA auto_vacuum = FULL");
+      db.execute("VACUUM");
+      db.execute("CREATE TABLE test (id INTEGER)");
+      db.close();
+
+      final service = OpenCodeDbMaintenanceService(
+        repository: OpenCodeDbRepository(api: OpenCodeDbApi()),
+      );
+      service.optimizeIfNeeded(dbPath: dbPath);
+
+      final api = OpenCodeDbApi();
+      expect(api.getAutoVacuumMode(dbPath: dbPath), 1);
+    });
+
+    test("skips when auto_vacuum is INCREMENTAL", () {
+      final db = sqlite3.open(dbPath);
+      db.execute("PRAGMA auto_vacuum = INCREMENTAL");
+      db.execute("VACUUM");
+      db.execute("CREATE TABLE test (id INTEGER)");
+      db.close();
+
+      final service = OpenCodeDbMaintenanceService(
+        repository: OpenCodeDbRepository(api: OpenCodeDbApi()),
+      );
+      service.optimizeIfNeeded(dbPath: dbPath);
+
+      final api = OpenCodeDbApi();
+      expect(api.getAutoVacuumMode(dbPath: dbPath), 2);
+    });
+
+    test("enables auto_vacuum when mode is NONE", () {
+      final db = sqlite3.open(dbPath);
+      db.execute("CREATE TABLE test (id INTEGER, data TEXT)");
+      for (var i = 0; i < 50; i++) {
+        db.execute(
+          "INSERT INTO test VALUES ($i, '${List.filled(500, "x").join()}')",
+        );
+      }
+      db.close();
+
+      final api = OpenCodeDbApi();
+      expect(api.getAutoVacuumMode(dbPath: dbPath), 0);
+
+      final service = OpenCodeDbMaintenanceService(
+        repository: OpenCodeDbRepository(api: api),
+      );
+      service.optimizeIfNeeded(dbPath: dbPath);
+
+      expect(api.getAutoVacuumMode(dbPath: dbPath), 1);
+    });
+
+    test("handles locked database gracefully", () {
+      final db = sqlite3.open(dbPath);
+      db.execute("CREATE TABLE test (id INTEGER)");
+      db.execute("BEGIN EXCLUSIVE");
+
+      final service = OpenCodeDbMaintenanceService(
+        repository: OpenCodeDbRepository(api: OpenCodeDbApi()),
+      );
+      // Should not throw — repository catches SQLITE_BUSY
+      service.optimizeIfNeeded(dbPath: dbPath);
+
+      db.execute("ROLLBACK");
+      db.close();
+    });
+
+    test("handles corrupt database gracefully", () {
+      File(dbPath).writeAsBytesSync(List.filled(4096, 0xFF));
+
+      final service = OpenCodeDbMaintenanceService(
+        repository: OpenCodeDbRepository(api: OpenCodeDbApi()),
+      );
+      // Should not throw — repository catches error
+      service.optimizeIfNeeded(dbPath: dbPath);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- On bridge startup, opportunistically enables `auto_vacuum = FULL` on OpenCode's SQLite database and runs `VACUUM`
- One-time conversion — once the DB header is updated, all future `DELETE` operations automatically reclaim disk space
- Non-destructive: if the DB is locked by OpenCode (`SQLITE_BUSY`), silently skips and retries next startup

## Problem

OpenCode stores every tool output in full as JSON in its SQLite `part` table. This causes unbounded database growth (500MB for 5 sessions, up to 25GB observed). OpenCode never runs `VACUUM` and never enables `auto_vacuum`. After session deletion, cascade deletes work correctly but freed pages are never reclaimed. Performance degrades severely — 30s per query at 25GB due to cache pollution, index fragmentation, and bloated WAL.

## Solution

On bridge startup, before plugin creation:
1. Find OpenCode's DB at `$XDG_DATA_HOME/opencode/opencode.db`
2. Check `PRAGMA auto_vacuum` — if already non-zero, skip
3. Set `PRAGMA auto_vacuum = FULL` and run `VACUUM`
4. If `SQLITE_BUSY` (OpenCode has the DB open), skip and retry next startup
5. Log database size, estimated duration, and space reclaimed

## Architecture

```
L1 OpenCodeDbApi → L2 OpenCodeDbRepository → L3 DbMaintenanceService
```

- **OpenCodeDbApi** (L1): Raw sqlite3 operations — open/close DB, read/set PRAGMAs, execute VACUUM
- **OpenCodeDbRepository** (L2): Wraps API, translates SqliteExceptions into nullable returns, handles file existence checks
- **DbMaintenanceService** (L3): Decision logic — should we optimize? Log with estimates, orchestrate the flow

## Files Changed

| File | Lines | Purpose |
|---|---|---|
| `bridge/app/lib/src/bridge/api/opencode_db_api.dart` | 49 | L1 — raw sqlite3 ops |
| `bridge/app/lib/src/bridge/repositories/opencode_db_repository.dart` | 69 | L2 — error translation, file checks |
| `bridge/app/lib/src/bridge/services/db_maintenance_service.dart` | 62 | L3 — decision logic, logging |
| `bridge/app/bin/bridge.dart` | +12 | Startup wiring |
| `bridge/app/test/bridge/api/opencode_db_api_test.dart` | 116 | API layer tests |
| `bridge/app/test/bridge/services/db_maintenance_service_test.dart` | 104 | Service layer tests |

## Verification

- `make analyze` — clean (1 pre-existing info-level issue)
- `make test` — 638 tests pass