### PR TITLE
fix: harden OpenCode 1.4 compatibility handling

### DIFF
--- a/bridge/app/lib/src/bridge/routing/request_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/request_handler.dart
@@ -1,5 +1,6 @@
 import "dart:convert";
 
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 /// HTTP methods supported by [RequestHandler].
@@ -49,6 +50,8 @@ abstract class GetRequestHandler<RES extends Object> extends RequestHandlerBase 
       );
 
       return buildOkJsonResponse(request, result);
+    } on PluginApiException catch (err) {
+      return buildErrorResponse(request, err.statusCode, err.toString());
     } on RelayResponse catch (err) {
       if (err.status >= 200 && err.status < 300) {
         // we don't expect to throw success responses from handleBody
@@ -106,6 +109,8 @@ abstract class BodyRequestHandler<REQ, RES extends Object> extends RequestHandle
       );
 
       return buildOkJsonResponse(request, result);
+    } on PluginApiException catch (err) {
+      return buildErrorResponse(request, err.statusCode, err.toString());
     } on RelayResponse catch (err) {
       if (err.status >= 200 && err.status < 300) {
         // we don't expect to throw success responses from handleBody

--- a/bridge/app/test/bridge/routing/get_agents_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_agents_handler_test.dart
@@ -60,6 +60,28 @@ void main() {
       expect(agent.model, equals(const AgentModel(modelID: "gpt-4o", providerID: "openai")));
     });
 
+    test("maps unknown plugin agent modes to AgentMode.unknown", () async {
+      plugin.agentsResult = [
+        const PluginAgent(
+          name: "tolerant-agent",
+          description: null,
+          model: null,
+          variant: null,
+          mode: PluginAgentMode.unknown,
+          hidden: false,
+        ),
+      ];
+
+      final response = await handler.handle(
+        makeRequest("GET", "/agent"),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(response.agents.single.mode, equals(AgentMode.unknown));
+    });
+
     test("handles agents with and without model", () async {
       plugin.agentsResult = [
         const PluginAgent(

--- a/bridge/app/test/bridge/routing/get_providers_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_providers_handler_test.dart
@@ -256,6 +256,34 @@ void main() {
       expect(gpt4Turbo.releaseDate, isNull);
     });
 
+    test("preserves 1.4-style synthetic model IDs", () async {
+      plugin.providersResult = const PluginProvidersResult(
+        providers: [
+          PluginProvider.openAI(
+            id: "openai",
+            name: "OpenAI",
+            authType: PluginProviderAuthType.apiKey,
+            models: [
+              PluginModel(id: "openai/gpt-4.1-mini", name: "GPT-4.1 Mini", isAvailable: true),
+            ],
+            defaultModelID: "openai/gpt-4.1-mini",
+          ),
+        ],
+      );
+
+      final response = await handler.handle(
+        makeRequest("GET", "/provider"),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      final model = response.items.single.models["openai/gpt-4.1-mini"]!;
+      expect(model.id, equals("openai/gpt-4.1-mini"));
+      expect(model.isAvailable, isTrue);
+      expect(response.items.single.defaultModelID, equals("openai/gpt-4.1-mini"));
+    });
+
     test("maps isAvailable values directly", () async {
       plugin.providersResult = const PluginProvidersResult(
         providers: [
@@ -282,6 +310,31 @@ void main() {
       final models = response.items[0].models;
       expect(models["m1"]!.isAvailable, isTrue);
       expect(models["m2"]!.isAvailable, isFalse);
+    });
+
+    test("unknown model statuses remain available through the route contract", () async {
+      plugin.providersResult = const PluginProvidersResult(
+        providers: [
+          PluginProvider.openAI(
+            id: "openai",
+            name: "OpenAI",
+            authType: PluginProviderAuthType.apiKey,
+            models: [
+              PluginModel(id: "gpt-4.1", name: "GPT-4.1", family: "gpt-4.1", isAvailable: true),
+            ],
+            defaultModelID: null,
+          ),
+        ],
+      );
+
+      final response = await handler.handle(
+        makeRequest("GET", "/provider"),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(response.items.single.models["gpt-4.1"]!.isAvailable, isTrue);
     });
 
     test("provider with no models has empty models map", () async {

--- a/bridge/app/test/bridge/routing/get_session_messages_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_session_messages_handler_test.dart
@@ -1,3 +1,5 @@
+import "dart:convert";
+
 import "package:sesori_bridge/src/bridge/routing/get_session_messages_handler.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -110,6 +112,24 @@ void main() {
       );
 
       expect(response.messages.length, equals(2));
+    });
+
+    test("handleInternal returns 502 for upstream incompatibility", () async {
+      plugin.throwOnGetMessagesError = PluginApiException("GET /session/s1/message", 502);
+
+      final response = await handler.handleInternal(
+        makeRequest(
+          "POST",
+          "/session/messages",
+          body: jsonEncode(const SessionIdRequest(sessionId: "s1").toJson()),
+        ),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(response.status, equals(502));
+      expect(response.body, contains("PluginApiException"));
     });
   });
 }

--- a/bridge/app/test/bridge/routing/request_router_test.dart
+++ b/bridge/app/test/bridge/routing/request_router_test.dart
@@ -139,6 +139,13 @@ void main() {
       expect(response.body, equals("no handler found for GET /unknown"));
     });
 
+    test("GET /session/{id}/shell remains unsupported in RequestRouter", () async {
+      final response = await router.route(makeRequest("GET", "/session/abc/shell"));
+
+      expect(response.status, equals(404));
+      expect(response.body, equals("no handler found for GET /session/abc/shell"));
+    });
+
     test("routes POST /session/create to CreateSessionHandler", () async {
       plugin.createSessionResult = const PluginSession(
         id: "s1",
@@ -226,12 +233,12 @@ void main() {
       expect(response.body, contains("Internal Server Error"));
     });
 
-    test("returns 500 when handler throws PluginApiException", () async {
+    test("returns plugin status when handler throws PluginApiException", () async {
       plugin.throwOnGetProjectsError = PluginApiException("/projects", 404);
 
       final response = await router.route(makeRequest("GET", "/projects"));
 
-      expect(response.status, equals(500));
+      expect(response.status, equals(404));
       expect(response.body, contains("PluginApiException"));
     });
 

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -97,6 +97,7 @@ class FakeBridgePlugin implements BridgePlugin {
   Object? throwOnGetProjectsError;
   Object? throwOnGetProjectError;
   bool throwOnGetSessions = false;
+  Object? throwOnGetMessagesError;
   Object? throwOnDeleteSessionError;
   Object? throwOnArchiveSessionError;
   Completer<void>? archiveSessionCompleter;
@@ -225,6 +226,9 @@ class FakeBridgePlugin implements BridgePlugin {
     String sessionId,
   ) async {
     lastGetMessagesSessionId = sessionId;
+    if (throwOnGetMessagesError case final error?) {
+      throw error;
+    }
     return messagesResult;
   }
 

--- a/bridge/sesori_plugin_opencode/README.md
+++ b/bridge/sesori_plugin_opencode/README.md
@@ -18,7 +18,7 @@ OpenCodeApi             HTTP client — raw requests to the OpenCode REST API
 
 `SseConnection` runs alongside this stack, maintaining a persistent SSE connection to `GET /global/event` and feeding raw event strings to `OpenCodePlugin`. `SseEventParser` translates those strings into typed `SseEventData` objects. `ActiveSessionTracker` watches session status events to maintain a live count of busy sessions per project.
 
-Compatibility note: the plugin keeps bridge-facing SSE behavior intentionally narrow. `session.diff` is normalized into the shared event model for invalidation tracking, parser failures are reported as categorized outcomes instead of exceptions, and dropped SSE frames are logged with stable category tags plus `directory` context when available. Cold-start hydration of pending questions/permissions is best-effort only. Shell routes such as `GET /session/{id}/shell` remain outside the bridge router and are expected to 404.
+Compatibility note: the plugin keeps bridge-facing SSE behavior intentionally narrow. Parser failures are reported as categorized outcomes instead of exceptions, dropped SSE frames are logged with stable category tags plus `directory` context when available, and cold-start hydration of pending questions/permissions is best-effort only. Shell routes such as `GET /session/{id}/shell` remain outside the bridge router and are expected to 404.
 
 ## Key Components
 
@@ -60,7 +60,7 @@ Translates raw OpenCode SSE data strings into typed `SseEventData` objects. Neve
 SseParseResult parse(String rawData)
 ```
 
-The parser follows OpenCode's event envelope format: it JSON-decodes the string, extracts `payload.type` and `payload.properties`, merges them into `{"type": type, ...properties}`, then deserializes via `SseEventData.fromJson`. The top-level `directory` field, when present, is preserved in the result for use by `ActiveSessionTracker` and drop logging. `session.diff` is normalized specially so OpenCode 1.4 invalidation-only payloads and older legacy diff arrays both map to the same shared model.
+The parser follows OpenCode's event envelope format: it JSON-decodes the string, extracts `payload.type` and `payload.properties`, merges them into `{"type": type, ...properties}`, then deserializes via `SseEventData.fromJson`. The top-level `directory` field, when present, is preserved in the result for use by `ActiveSessionTracker` and drop logging.
 
 ### `ActiveSessionTracker`
 

--- a/bridge/sesori_plugin_opencode/README.md
+++ b/bridge/sesori_plugin_opencode/README.md
@@ -18,6 +18,8 @@ OpenCodeApi             HTTP client — raw requests to the OpenCode REST API
 
 `SseConnection` runs alongside this stack, maintaining a persistent SSE connection to `GET /global/event` and feeding raw event strings to `OpenCodePlugin`. `SseEventParser` translates those strings into typed `SseEventData` objects. `ActiveSessionTracker` watches session status events to maintain a live count of busy sessions per project.
 
+Compatibility note: the plugin keeps bridge-facing SSE behavior intentionally narrow. `session.diff` is normalized into the shared event model for invalidation tracking, parser failures are reported as categorized outcomes instead of exceptions, and dropped SSE frames are logged with stable category tags plus `directory` context when available. Cold-start hydration of pending questions/permissions is best-effort only. Shell routes such as `GET /session/{id}/shell` remain outside the bridge router and are expected to 404.
+
 ## Key Components
 
 ### `OpenCodePlugin`
@@ -52,19 +54,19 @@ Call `start()` to begin streaming and `stop()` to disconnect.
 
 ### `SseEventParser`
 
-Translates raw OpenCode SSE data strings into typed `SseEventData` objects. Never throws; on any parse failure it returns a result with a null event so the raw data can still be forwarded.
+Translates raw OpenCode SSE data strings into typed `SseEventData` objects. Never throws; callers can distinguish malformed envelopes, malformed known payloads, and unknown event types while malformed or unknown frames are logged and dropped.
 
 ```dart
 SseParseResult parse(String rawData)
 ```
 
-The parser follows OpenCode's event envelope format: it JSON-decodes the string, extracts `payload.type` and `payload.properties`, merges them into `{"type": type, ...properties}`, then deserializes via `SseEventData.fromJson`. The top-level `directory` field, when present, is preserved in the result for use by `ActiveSessionTracker`.
+The parser follows OpenCode's event envelope format: it JSON-decodes the string, extracts `payload.type` and `payload.properties`, merges them into `{"type": type, ...properties}`, then deserializes via `SseEventData.fromJson`. The top-level `directory` field, when present, is preserved in the result for use by `ActiveSessionTracker` and drop logging. `session.diff` is normalized specially so OpenCode 1.4 invalidation-only payloads and older legacy diff arrays both map to the same shared model.
 
 ### `ActiveSessionTracker`
 
 Tracks which sessions are currently active (busy or retrying) and maps them back to their project worktrees. Used to power `getActiveSessionsSummary`.
 
-On cold start it fetches all projects and current session statuses from the API. It then updates incrementally as `SseSessionStatus`, `SseSessionCreated`, `SseSessionUpdated`, `SseSessionDeleted`, and `SseSessionIdle` events arrive. `handleEvent` returns `true` when the active session counts change, signaling the plugin to emit a `BridgeSseProjectUpdated` event.
+On cold start it fetches all projects and current session statuses from the API. It then best-effort hydrates pending questions and permissions, and updates incrementally as `SseSessionStatus`, `SseSessionCreated`, `SseSessionUpdated`, `SseSessionDeleted`, and `SseSessionIdle` events arrive. `handleEvent` returns `true` when the active session counts change, signaling the plugin to emit a `BridgeSseProjectUpdated` event.
 
 ### `OpenCodeApi`
 

--- a/bridge/sesori_plugin_opencode/lib/src/models/file_diff.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/file_diff.dart
@@ -8,8 +8,7 @@ part "file_diff.g.dart";
 sealed class FileDiff with _$FileDiff {
   const factory FileDiff({
     required String file,
-    required String before,
-    required String after,
+    required String patch,
     required int additions,
     required int deletions,
     FileDiffStatus? status,

--- a/bridge/sesori_plugin_opencode/lib/src/models/file_diff.freezed.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/file_diff.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$FileDiff {
 
- String get file; String get before; String get after; int get additions; int get deletions; FileDiffStatus? get status;
+ String get file; String get patch; int get additions; int get deletions; FileDiffStatus? get status;
 /// Create a copy of FileDiff
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $FileDiffCopyWith<FileDiff> get copyWith => _$FileDiffCopyWithImpl<FileDiff>(thi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is FileDiff&&(identical(other.file, file) || other.file == file)&&(identical(other.before, before) || other.before == before)&&(identical(other.after, after) || other.after == after)&&(identical(other.additions, additions) || other.additions == additions)&&(identical(other.deletions, deletions) || other.deletions == deletions)&&(identical(other.status, status) || other.status == status));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is FileDiff&&(identical(other.file, file) || other.file == file)&&(identical(other.patch, patch) || other.patch == patch)&&(identical(other.additions, additions) || other.additions == additions)&&(identical(other.deletions, deletions) || other.deletions == deletions)&&(identical(other.status, status) || other.status == status));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,file,before,after,additions,deletions,status);
+int get hashCode => Object.hash(runtimeType,file,patch,additions,deletions,status);
 
 @override
 String toString() {
-  return 'FileDiff(file: $file, before: $before, after: $after, additions: $additions, deletions: $deletions, status: $status)';
+  return 'FileDiff(file: $file, patch: $patch, additions: $additions, deletions: $deletions, status: $status)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $FileDiffCopyWith<$Res>  {
   factory $FileDiffCopyWith(FileDiff value, $Res Function(FileDiff) _then) = _$FileDiffCopyWithImpl;
 @useResult
 $Res call({
- String file, String before, String after, int additions, int deletions, FileDiffStatus? status
+ String file, String patch, int additions, int deletions, FileDiffStatus? status
 });
 
 
@@ -65,11 +65,10 @@ class _$FileDiffCopyWithImpl<$Res>
 
 /// Create a copy of FileDiff
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? file = null,Object? before = null,Object? after = null,Object? additions = null,Object? deletions = null,Object? status = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? file = null,Object? patch = null,Object? additions = null,Object? deletions = null,Object? status = freezed,}) {
   return _then(_self.copyWith(
 file: null == file ? _self.file : file // ignore: cast_nullable_to_non_nullable
-as String,before: null == before ? _self.before : before // ignore: cast_nullable_to_non_nullable
-as String,after: null == after ? _self.after : after // ignore: cast_nullable_to_non_nullable
+as String,patch: null == patch ? _self.patch : patch // ignore: cast_nullable_to_non_nullable
 as String,additions: null == additions ? _self.additions : additions // ignore: cast_nullable_to_non_nullable
 as int,deletions: null == deletions ? _self.deletions : deletions // ignore: cast_nullable_to_non_nullable
 as int,status: freezed == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
@@ -85,12 +84,11 @@ as FileDiffStatus?,
 @JsonSerializable()
 
 class _FileDiff implements FileDiff {
-  const _FileDiff({required this.file, required this.before, required this.after, required this.additions, required this.deletions, this.status});
+  const _FileDiff({required this.file, required this.patch, required this.additions, required this.deletions, this.status});
   factory _FileDiff.fromJson(Map<String, dynamic> json) => _$FileDiffFromJson(json);
 
 @override final  String file;
-@override final  String before;
-@override final  String after;
+@override final  String patch;
 @override final  int additions;
 @override final  int deletions;
 @override final  FileDiffStatus? status;
@@ -108,16 +106,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _FileDiff&&(identical(other.file, file) || other.file == file)&&(identical(other.before, before) || other.before == before)&&(identical(other.after, after) || other.after == after)&&(identical(other.additions, additions) || other.additions == additions)&&(identical(other.deletions, deletions) || other.deletions == deletions)&&(identical(other.status, status) || other.status == status));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _FileDiff&&(identical(other.file, file) || other.file == file)&&(identical(other.patch, patch) || other.patch == patch)&&(identical(other.additions, additions) || other.additions == additions)&&(identical(other.deletions, deletions) || other.deletions == deletions)&&(identical(other.status, status) || other.status == status));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,file,before,after,additions,deletions,status);
+int get hashCode => Object.hash(runtimeType,file,patch,additions,deletions,status);
 
 @override
 String toString() {
-  return 'FileDiff(file: $file, before: $before, after: $after, additions: $additions, deletions: $deletions, status: $status)';
+  return 'FileDiff(file: $file, patch: $patch, additions: $additions, deletions: $deletions, status: $status)';
 }
 
 
@@ -128,7 +126,7 @@ abstract mixin class _$FileDiffCopyWith<$Res> implements $FileDiffCopyWith<$Res>
   factory _$FileDiffCopyWith(_FileDiff value, $Res Function(_FileDiff) _then) = __$FileDiffCopyWithImpl;
 @override @useResult
 $Res call({
- String file, String before, String after, int additions, int deletions, FileDiffStatus? status
+ String file, String patch, int additions, int deletions, FileDiffStatus? status
 });
 
 
@@ -145,11 +143,10 @@ class __$FileDiffCopyWithImpl<$Res>
 
 /// Create a copy of FileDiff
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? file = null,Object? before = null,Object? after = null,Object? additions = null,Object? deletions = null,Object? status = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? file = null,Object? patch = null,Object? additions = null,Object? deletions = null,Object? status = freezed,}) {
   return _then(_FileDiff(
 file: null == file ? _self.file : file // ignore: cast_nullable_to_non_nullable
-as String,before: null == before ? _self.before : before // ignore: cast_nullable_to_non_nullable
-as String,after: null == after ? _self.after : after // ignore: cast_nullable_to_non_nullable
+as String,patch: null == patch ? _self.patch : patch // ignore: cast_nullable_to_non_nullable
 as String,additions: null == additions ? _self.additions : additions // ignore: cast_nullable_to_non_nullable
 as int,deletions: null == deletions ? _self.deletions : deletions // ignore: cast_nullable_to_non_nullable
 as int,status: freezed == status ? _self.status : status // ignore: cast_nullable_to_non_nullable

--- a/bridge/sesori_plugin_opencode/lib/src/models/file_diff.g.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/file_diff.g.dart
@@ -8,8 +8,7 @@ part of 'file_diff.dart';
 
 _FileDiff _$FileDiffFromJson(Map json) => _FileDiff(
   file: json['file'] as String,
-  before: json['before'] as String,
-  after: json['after'] as String,
+  patch: json['patch'] as String,
   additions: (json['additions'] as num).toInt(),
   deletions: (json['deletions'] as num).toInt(),
   status: $enumDecodeNullable(_$FileDiffStatusEnumMap, json['status']),
@@ -17,8 +16,7 @@ _FileDiff _$FileDiffFromJson(Map json) => _FileDiff(
 
 Map<String, dynamic> _$FileDiffToJson(_FileDiff instance) => <String, dynamic>{
   'file': instance.file,
-  'before': instance.before,
-  'after': instance.after,
+  'patch': instance.patch,
   'additions': instance.additions,
   'deletions': instance.deletions,
   'status': _$FileDiffStatusEnumMap[instance.status],

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -8,6 +8,24 @@ import "../opencode_plugin.dart";
 import "sse/sse_connection.dart";
 import "sse_event_mapper.dart";
 
+String formatDroppedSseFrameLog({
+  required String category,
+  required String message,
+  String? directory,
+  String? eventType,
+}) {
+  final context = <String>[];
+  if (directory != null) {
+    context.add("directory=$directory");
+  }
+  if (eventType != null) {
+    context.add("eventType=$eventType");
+  }
+
+  final suffix = context.isEmpty ? "" : " [${context.join(", ")}]";
+  return "[opencode][sse][$category]$suffix $message";
+}
+
 class OpenCodePlugin implements BridgePlugin {
   final OpenCodeService _service;
   final SseEventParser _parser;
@@ -397,21 +415,68 @@ class OpenCodePlugin implements BridgePlugin {
   void _handleRawSseEvent(String rawData) {
     try {
       final parseResult = _parser.parse(rawData);
-      final event = parseResult.event;
-      if (event == null) return;
+      switch (parseResult.outcome) {
+        case SseParseOutcome.validKnownEvent:
+          final event = parseResult.event;
+          if (event == null) {
+            Log.e("[opencode] SSE parser reported validKnownEvent without an event instance.");
+            return;
+          }
 
-      final changed = _service.handleSseEvent(event, parseResult.directory);
-      if (changed) {
-        _emitProjectsSummary();
-      }
+          final changed = _service.handleSseEvent(event, parseResult.directory);
+          if (changed) {
+            _emitProjectsSummary();
+          }
 
-      final bridgeEvent = _mapper.map(_canonicalizeEvent(event));
-      if (bridgeEvent != null) {
-        _eventBuffer.add(bridgeEvent);
+          final bridgeEvent = _mapper.map(_canonicalizeEvent(event));
+          if (bridgeEvent != null) {
+            _eventBuffer.add(bridgeEvent);
+          }
+          return;
+        case SseParseOutcome.unknownEventType:
+          _logDroppedSseFrame(
+            category: "unknown-event-type",
+            message: "Ignoring SSE frame with unknown event type.",
+            directory: parseResult.directory,
+            eventType: parseResult.eventType,
+          );
+          return;
+        case SseParseOutcome.malformedEnvelope:
+          _logDroppedSseFrame(
+            category: "malformed-envelope",
+            message: "Ignoring malformed SSE envelope.",
+            directory: parseResult.directory,
+            eventType: parseResult.eventType,
+          );
+          return;
+        case SseParseOutcome.malformedKnownPayload:
+          _logDroppedSseFrame(
+            category: "malformed-known-payload",
+            message: "Ignoring malformed payload for known SSE event.",
+            directory: parseResult.directory,
+            eventType: parseResult.eventType,
+          );
+          return;
       }
     } catch (e, st) {
       Log.e("[opencode] SSE event processing error: $e\n$st");
     }
+  }
+
+  void _logDroppedSseFrame({
+    required String category,
+    required String message,
+    String? directory,
+    String? eventType,
+  }) {
+    Log.w(
+      formatDroppedSseFrameLog(
+        category: category,
+        message: message,
+        directory: directory,
+        eventType: eventType,
+      ),
+    );
   }
 
   void _emitProjectsSummary() {

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -1,5 +1,6 @@
+import "package:json_annotation/json_annotation.dart" show CheckedFromJsonException;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
-    show Log, PluginPermissionReply, PluginProvidersResult;
+    show Log, PluginApiException, PluginPermissionReply, PluginProvidersResult;
 import "package:sesori_shared/sesori_shared.dart" show ProjectActivitySummary;
 
 import "../opencode_plugin.dart";
@@ -35,9 +36,16 @@ class OpenCodeService {
   }) async {
     try {
       return await repository.api.getMessages(sessionId: sessionId, directory: directory);
-    } catch (e) {
-      Log.w("Failed to get messages for session $sessionId: $e");
-      return [];
+    } on OpenCodeApiException {
+      rethrow;
+    } on PluginApiException {
+      rethrow;
+    } catch (error, stackTrace) {
+      if (!_isLikelyDecodeOrSchemaDriftError(error)) {
+        rethrow;
+      }
+      Log.w("Failed to decode messages for session $sessionId: $error\n$stackTrace");
+      throw PluginApiException("GET /session/$sessionId/message", 502);
     }
   }
 
@@ -66,9 +74,9 @@ class OpenCodeService {
     }
   }
 
-  /// Best-effort hydration of pending questions and permissions from the
-  /// OpenCode API. Failures are logged but do NOT abort cold start — core
-  /// active-session tracking from [ActiveSessionTracker.coldStart] succeeds
+  /// Best-effort hydration of pending questions and permissions after the
+  /// core active-session baseline is ready. Failures are logged but do NOT
+  /// abort cold start — [ActiveSessionTracker.coldStart] succeeds
   /// independently.
   Future<void> _hydratePendingInput() async {
     await (
@@ -105,5 +113,9 @@ class OpenCodeService {
     if (limit == null || limit <= 0) return sessions;
     if (sessions.length > limit) return sessions.sublist(0, limit);
     return sessions;
+  }
+
+  bool _isLikelyDecodeOrSchemaDriftError(Object error) {
+    return error is FormatException || error is TypeError || error is CheckedFromJsonException;
   }
 }

--- a/bridge/sesori_plugin_opencode/lib/src/sse_event_parser.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse_event_parser.dart
@@ -1,12 +1,22 @@
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart" show jsonDecodeMap;
 
+import "models/file_diff.dart";
 import "models/sse_event_data.dart";
+
+enum SseParseOutcome {
+  validKnownEvent,
+  unknownEventType,
+  malformedEnvelope,
+  malformedKnownPayload,
+}
 
 /// Result of parsing a raw OpenCode SSE event string.
 class SseParseResult {
   /// The parsed event, or null if parsing failed.
   final SseEventData? event;
+
+  /// The parsed SSE event type, when it could be extracted from the frame.
+  final String? eventType;
 
   /// The top-level directory from the OpenCode wrapper, if present.
   final String? directory;
@@ -14,7 +24,16 @@ class SseParseResult {
   /// The original raw data string - always preserved for forwarding.
   final String rawData;
 
-  SseParseResult({this.event, this.directory, required this.rawData});
+  /// Categorized parser outcome for callers that need more than null/non-null.
+  final SseParseOutcome outcome;
+
+  const SseParseResult({
+    required this.outcome,
+    this.event,
+    this.eventType,
+    this.directory,
+    required this.rawData,
+  });
 }
 
 /// Parses raw OpenCode SSE event strings into typed [SseEventData] objects.
@@ -26,45 +45,170 @@ class SseParseResult {
 /// 3. Merge into `{"type": type, ...properties}`
 /// 4. Deserialize via `SseEventData.fromJson(merged)`
 ///
-/// NEVER throws - all errors are caught internally. On failure, returns
-/// a result with null event but preserved rawData for forwarding.
+/// Never throws. Callers get categorized outcomes for unknown event types,
+/// malformed envelopes, and malformed known payloads while rawData is always
+/// preserved for forwarding.
 class SseEventParser {
   SseParseResult parse(String rawData) {
     if (rawData.isEmpty) {
-      return SseParseResult(rawData: rawData);
+      return SseParseResult(
+        outcome: SseParseOutcome.malformedEnvelope,
+        rawData: rawData,
+      );
     }
 
     try {
       final json = jsonDecodeMap(rawData);
       final directory = json["directory"] as String?;
-      final payload = json["payload"] as Map<String, dynamic>?;
-      final type = payload?["type"] as String?;
+      final payload = json["payload"];
 
-      if (type == null || payload == null) {
-        return SseParseResult(directory: directory, rawData: rawData);
+      if (payload is! Map<String, dynamic>) {
+        return SseParseResult(
+          outcome: SseParseOutcome.malformedEnvelope,
+          directory: directory,
+          rawData: rawData,
+        );
       }
 
-      final properties = payload["properties"] as Map<String, dynamic>? ?? {};
-      final merged = <String, dynamic>{"type": type, ...properties};
+      final type = payload["type"];
+      final eventType = type is String ? type : null;
+      final properties = payload["properties"];
 
-      final SseEventData event;
+      if (type is! String) {
+        return SseParseResult(
+          outcome: SseParseOutcome.malformedEnvelope,
+          directory: directory,
+          rawData: rawData,
+        );
+      }
+
+      if (properties != null && properties is! Map<String, dynamic>) {
+        return SseParseResult(
+          outcome: SseParseOutcome.malformedEnvelope,
+          eventType: eventType,
+          directory: directory,
+          rawData: rawData,
+        );
+      }
+
+      if (!_knownEventTypes.contains(type)) {
+        return SseParseResult(
+          outcome: SseParseOutcome.unknownEventType,
+          eventType: eventType,
+          directory: directory,
+          rawData: rawData,
+        );
+      }
+
       try {
-        event = SseEventData.fromJson(merged);
+        final event = _parseKnownEvent(
+          type: type,
+          properties: (properties as Map<String, dynamic>?) ?? const <String, dynamic>{},
+        );
+        return SseParseResult(
+          outcome: SseParseOutcome.validKnownEvent,
+          event: event,
+          eventType: eventType,
+          directory: directory,
+          rawData: rawData,
+        );
       } catch (e) {
-        // Unknown or malformed event type - return null event, preserve raw
-        Log.w("SseEventParser: unknown event type '$type': $e");
-        return SseParseResult(directory: directory, rawData: rawData);
+        return SseParseResult(
+          outcome: SseParseOutcome.malformedKnownPayload,
+          eventType: eventType,
+          directory: directory,
+          rawData: rawData,
+        );
       }
-
+    } catch (_) {
       return SseParseResult(
-        event: event,
-        directory: directory,
+        outcome: SseParseOutcome.malformedEnvelope,
         rawData: rawData,
       );
-    } catch (e) {
-      // JSON decode failure or other unexpected error
-      Log.w("SseEventParser: failed to parse SSE frame: $e");
-      return SseParseResult(rawData: rawData);
     }
   }
+
+  SseEventData _parseKnownEvent({required String type, required Map<String, dynamic> properties}) {
+    if (type == "session.diff") {
+      return _parseSessionDiff(properties: properties);
+    }
+
+    return SseEventData.fromJson({"type": type, ...properties});
+  }
+
+  SseSessionDiff _parseSessionDiff({required Map<String, dynamic> properties}) {
+    // OpenCode 1.4 treats session.diff as an invalidation signal. Older
+    // payloads may still include legacy diff/diffs arrays, so we normalize
+    // both shapes into the shared event model here.
+    final sessionID = properties["sessionID"];
+    if (sessionID is! String) {
+      throw const FormatException("session.diff requires string sessionID");
+    }
+
+    return SseEventData.sessionDiff(
+          sessionID: sessionID,
+          diff: _extractLegacyDiffList(properties: properties),
+        )
+        as SseSessionDiff;
+  }
+
+  List<FileDiff> _extractLegacyDiffList({required Map<String, dynamic> properties}) {
+    final legacyDiff = properties["diff"];
+    if (legacyDiff is List) {
+      return legacyDiff.map((item) => FileDiff.fromJson(Map<String, dynamic>.from(item as Map))).toList();
+    }
+
+    final alternateDiff = properties["diffs"];
+    if (alternateDiff is List) {
+      return alternateDiff.map((item) => FileDiff.fromJson(Map<String, dynamic>.from(item as Map))).toList();
+    }
+
+    return const <FileDiff>[];
+  }
 }
+
+const Set<String> _knownEventTypes = {
+  "server.connected",
+  "server.heartbeat",
+  "server.instance.disposed",
+  "global.disposed",
+  "session.created",
+  "session.updated",
+  "session.deleted",
+  "session.diff",
+  "session.error",
+  "session.compacted",
+  "session.status",
+  "session.idle",
+  "message.updated",
+  "message.removed",
+  "message.part.updated",
+  "message.part.delta",
+  "message.part.removed",
+  "pty.created",
+  "pty.updated",
+  "pty.exited",
+  "pty.deleted",
+  "permission.asked",
+  "permission.replied",
+  "permission.updated",
+  "question.asked",
+  "question.replied",
+  "question.rejected",
+  "todo.updated",
+  "project.updated",
+  "vcs.branch.updated",
+  "file.edited",
+  "file.watcher.updated",
+  "lsp.updated",
+  "lsp.client.diagnostics",
+  "mcp.tools.changed",
+  "mcp.browser.open.failed",
+  "installation.updated",
+  "installation.update-available",
+  "workspace.ready",
+  "workspace.failed",
+  "tui.toast.show",
+  "worktree.ready",
+  "worktree.failed",
+};

--- a/bridge/sesori_plugin_opencode/lib/src/sse_event_parser.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse_event_parser.dart
@@ -1,6 +1,5 @@
 import "package:sesori_shared/sesori_shared.dart" show jsonDecodeMap;
 
-import "models/file_diff.dart";
 import "models/sse_event_data.dart";
 
 enum SseParseOutcome {
@@ -129,41 +128,7 @@ class SseEventParser {
   }
 
   SseEventData _parseKnownEvent({required String type, required Map<String, dynamic> properties}) {
-    if (type == "session.diff") {
-      return _parseSessionDiff(properties: properties);
-    }
-
     return SseEventData.fromJson({"type": type, ...properties});
-  }
-
-  SseSessionDiff _parseSessionDiff({required Map<String, dynamic> properties}) {
-    // OpenCode 1.4 treats session.diff as an invalidation signal. Older
-    // payloads may still include legacy diff/diffs arrays, so we normalize
-    // both shapes into the shared event model here.
-    final sessionID = properties["sessionID"];
-    if (sessionID is! String) {
-      throw const FormatException("session.diff requires string sessionID");
-    }
-
-    return SseEventData.sessionDiff(
-          sessionID: sessionID,
-          diff: _extractLegacyDiffList(properties: properties),
-        )
-        as SseSessionDiff;
-  }
-
-  List<FileDiff> _extractLegacyDiffList({required Map<String, dynamic> properties}) {
-    final legacyDiff = properties["diff"];
-    if (legacyDiff is List) {
-      return legacyDiff.map((item) => FileDiff.fromJson(Map<String, dynamic>.from(item as Map))).toList();
-    }
-
-    final alternateDiff = properties["diffs"];
-    if (alternateDiff is List) {
-      return alternateDiff.map((item) => FileDiff.fromJson(Map<String, dynamic>.from(item as Map))).toList();
-    }
-
-    return const <FileDiff>[];
   }
 }
 

--- a/bridge/sesori_plugin_opencode/test/agent_info_test.dart
+++ b/bridge/sesori_plugin_opencode/test/agent_info_test.dart
@@ -1,0 +1,25 @@
+import "package:opencode_plugin/src/models/agent_info.dart";
+import "package:opencode_plugin/src/models/agent_mode.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("AgentInfo", () {
+    test("decodes unknown modes tolerantly", () {
+      final agent = AgentInfo.fromJson({
+        "name": "planner",
+        "description": "Plans tasks",
+        "model": {"modelID": "gpt-4.1", "providerID": "openai"},
+        "variant": "high",
+        "mode": "experimental",
+        "hidden": true,
+      });
+
+      expect(agent.mode, equals(AgentMode.unknown));
+
+      final pluginAgent = agent.toPlugin();
+      expect(pluginAgent.mode, equals(PluginAgentMode.unknown));
+      expect(pluginAgent.model, equals(const PluginAgentModel(modelID: "gpt-4.1", providerID: "openai")));
+    });
+  });
+}

--- a/bridge/sesori_plugin_opencode/test/message_with_parts_test.dart
+++ b/bridge/sesori_plugin_opencode/test/message_with_parts_test.dart
@@ -1,0 +1,72 @@
+import "package:opencode_plugin/src/models/message_with_parts.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("MessageWithParts", () {
+    test("ignores UserMessage.variant relocation during decode", () {
+      final payloads = <Map<String, Object?>>[
+        {
+          "info": {
+            "role": "user",
+            "id": "msg-1",
+            "sessionID": "ses-1",
+          },
+          "parts": [
+            {
+              "id": "part-1",
+              "sessionID": "ses-1",
+              "messageID": "msg-1",
+              "type": "text",
+              "text": "hello",
+            },
+          ],
+        },
+        {
+          "variant": "user",
+          "info": {
+            "role": "user",
+            "id": "msg-1",
+            "sessionID": "ses-1",
+          },
+          "parts": [
+            {
+              "id": "part-1",
+              "sessionID": "ses-1",
+              "messageID": "msg-1",
+              "type": "text",
+              "text": "hello",
+            },
+          ],
+        },
+        {
+          "info": {
+            "role": "user",
+            "id": "msg-1",
+            "sessionID": "ses-1",
+            "variant": "user",
+          },
+          "parts": [
+            {
+              "id": "part-1",
+              "sessionID": "ses-1",
+              "messageID": "msg-1",
+              "type": "text",
+              "text": "hello",
+            },
+          ],
+        },
+      ];
+
+      for (final payload in payloads) {
+        final decoded = MessageWithParts.fromJson(payload);
+
+        expect(decoded.info.role, equals("user"));
+        expect(decoded.info.id, equals("msg-1"));
+        expect(decoded.info.sessionID, equals("ses-1"));
+        expect(decoded.parts, hasLength(1));
+        expect(decoded.parts.single.type, equals("text"));
+        expect(decoded.parts.single.text, equals("hello"));
+      }
+    });
+  });
+}

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -211,6 +211,60 @@ void main() {
       );
     });
 
+    test("unknown and malformed SSE frames are ignored without emitting bridge events", () async {
+      final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
+      await server.waitForSseConnection();
+
+      final events = <BridgeSseEvent>[];
+      final initialProjectUpdated = Completer<void>();
+      final subscription = plugin.events.listen((event) {
+        events.add(event);
+        if (event is BridgeSseProjectUpdated && !initialProjectUpdated.isCompleted) {
+          initialProjectUpdated.complete();
+        }
+      });
+      addTearDown(subscription.cancel);
+
+      await initialProjectUpdated.future;
+      events.clear();
+
+      await server.emitRawSse(
+        '{"directory":"/repo","payload":{"type":"unknown.event","properties":{}}}',
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(events, isEmpty);
+
+      expect(
+        formatDroppedSseFrameLog(
+          category: "unknown-event-type",
+          message: "Ignoring SSE frame with unknown event type.",
+          directory: "/repo",
+          eventType: "unknown.event",
+        ),
+        equals(
+          "[opencode][sse][unknown-event-type] [directory=/repo, eventType=unknown.event] Ignoring SSE frame with unknown event type.",
+        ),
+      );
+
+      await server.emitRawSse("{not-json");
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(events, isEmpty);
+    });
+
+    test("drop log formatting includes event type when present", () {
+      expect(
+        formatDroppedSseFrameLog(
+          category: "malformed-known-payload",
+          message: "Ignoring malformed payload for known SSE event.",
+          directory: "/repo",
+          eventType: "session.status",
+        ),
+        equals(
+          "[opencode][sse][malformed-known-payload] [directory=/repo, eventType=session.status] Ignoring malformed payload for known SSE event.",
+        ),
+      );
+    });
+
     test("getSessionStatuses merges tracker data with API response", () async {
       // Use a configurable server: cold start sees the full status map
       // (including a busy child), but subsequent API calls return only
@@ -983,6 +1037,10 @@ class _FakeOpenCodeServer {
 
   Future<void> emitSse(Map<String, dynamic> payload) async {
     final data = jsonEncode(payload);
+    await emitRawSse(data);
+  }
+
+  Future<void> emitRawSse(String data) async {
     final futures = <Future<void>>[];
     for (final client in _sseClients) {
       client.write("data: $data\n\n");

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -142,6 +142,36 @@ void main() {
 
       expect(result, isEmpty);
     });
+
+    test("surfaces upstream decode failures as PluginApiException 502", () async {
+      final repository = FakeOpenCodeRepository(
+        messagesError: const FormatException("invalid message payload"),
+      );
+      final service = OpenCodeService(repository, FakeActiveSessionTracker());
+
+      await expectLater(
+        () => service.getMessages(sessionId: "ses-1", directory: null),
+        throwsA(
+          isA<PluginApiException>()
+              .having((error) => error.statusCode, "statusCode", equals(502))
+              .having((error) => error.endpoint, "endpoint", equals("GET /session/ses-1/message")),
+        ),
+      );
+      expect(repository.api.lastRequestedSessionId, equals("ses-1"));
+    });
+
+    test("rethrows unexpected non-decode bugs", () async {
+      final repository = FakeOpenCodeRepository(
+        messagesError: StateError("unexpected bug"),
+      );
+      final service = OpenCodeService(repository, FakeActiveSessionTracker());
+
+      await expectLater(
+        () => service.getMessages(sessionId: "ses-1", directory: null),
+        throwsA(isA<StateError>().having((error) => error.message, "message", equals("unexpected bug"))),
+      );
+      expect(repository.api.lastRequestedSessionId, equals("ses-1"));
+    });
   });
 
   group("OpenCodeService.handleSseEvent", () {

--- a/bridge/sesori_plugin_opencode/test/provider_mapper_test.dart
+++ b/bridge/sesori_plugin_opencode/test/provider_mapper_test.dart
@@ -1,0 +1,43 @@
+import "package:opencode_plugin/src/models/provider_info.dart";
+import "package:opencode_plugin/src/provider_mapper.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("mapProviderResponse", () {
+    test("preserves synthetic model IDs and treats unknown statuses as available", () {
+      const response = ProviderListResponse(
+        all: [
+          ProviderInfo(
+            id: "openai",
+            name: "OpenAI",
+            models: {
+              "synthetic-key": ProviderModel(
+                id: "openai/gpt-4.1-mini",
+                providerID: "openai",
+                name: "GPT-4.1 Mini",
+                family: "gpt-4.1",
+                status: "preview",
+                releaseDate: "2025-04-01",
+              ),
+            },
+          ),
+        ],
+        defaults: {"openai": "openai/gpt-4.1-mini"},
+        connected: ["openai"],
+      );
+
+      final mapped = mapProviderResponse(response: response, connectedOnly: false);
+
+      expect(mapped.providers, hasLength(1));
+      final provider = mapped.providers.first;
+      expect(provider.id, equals("openai"));
+      expect(provider.defaultModelID, equals("openai/gpt-4.1-mini"));
+      expect(provider.models, hasLength(1));
+
+      final model = provider.models.first;
+      expect(model.id, equals("openai/gpt-4.1-mini"));
+      expect(model.isAvailable, isTrue);
+      expect(model.releaseDate, equals(DateTime(2025, 4, 1)));
+    });
+  });
+}

--- a/bridge/sesori_plugin_opencode/test/sse_event_parser_test.dart
+++ b/bridge/sesori_plugin_opencode/test/sse_event_parser_test.dart
@@ -70,7 +70,7 @@ void main() {
       expect(result.rawData, equals(rawData));
     });
 
-    test("parses legacy 1.3 session.diff payload with diff array", () {
+    test("parses 1.4 session.diff payload with patch-based diff array", () {
       final parser = SseEventParser();
       final rawData = jsonEncode({
         "directory": "/repo",
@@ -81,8 +81,7 @@ void main() {
             "diff": [
               {
                 "file": "lib/main.dart",
-                "before": "old",
-                "after": "new",
+                "patch": "@@ -1 +1 @@\n-old\n+new",
                 "additions": 1,
                 "deletions": 1,
                 "status": "modified",
@@ -103,9 +102,10 @@ void main() {
       expect(event.sessionID, equals("s1"));
       expect(event.diff, hasLength(1));
       expect(event.diff.single.file, equals("lib/main.dart"));
+      expect(event.diff.single.patch, contains("+new"));
     });
 
-    test("parses 1.4 session.diff payload without legacy diff array", () {
+    test("session.diff without diff array is categorized as malformed known payload", () {
       final parser = SseEventParser();
       final rawData = jsonEncode({
         "directory": "/repo",
@@ -113,25 +113,16 @@ void main() {
           "type": "session.diff",
           "properties": {
             "sessionID": "s1",
-            "summary": {
-              "files": 2,
-              "additions": 12,
-              "deletions": 3,
-            },
           },
         },
       });
 
       final result = parser.parse(rawData);
 
-      expect(result.outcome, equals(SseParseOutcome.validKnownEvent));
-      expect(result.rawData, equals(rawData));
-      expect(result.event, isA<SseSessionDiff>());
+      expect(result.outcome, equals(SseParseOutcome.malformedKnownPayload));
+      expect(result.event, isNull);
       expect(result.eventType, equals("session.diff"));
-
-      final event = result.event! as SseSessionDiff;
-      expect(event.sessionID, equals("s1"));
-      expect(event.diff, isEmpty);
+      expect(result.rawData, equals(rawData));
     });
 
     test(

--- a/bridge/sesori_plugin_opencode/test/sse_event_parser_test.dart
+++ b/bridge/sesori_plugin_opencode/test/sse_event_parser_test.dart
@@ -20,7 +20,9 @@ void main() {
 
       final result = parser.parse(rawData);
 
+      expect(result.outcome, equals(SseParseOutcome.validKnownEvent));
       expect(result.directory, equals("/repo"));
+      expect(result.eventType, equals("session.status"));
       expect(result.rawData, equals(rawData));
       expect(result.event, isA<SseSessionStatus>());
 
@@ -43,7 +45,9 @@ void main() {
 
       final result = parser.parse(rawData);
 
+      expect(result.outcome, equals(SseParseOutcome.validKnownEvent));
       expect(result.event, isA<SseSessionCreated>());
+      expect(result.eventType, equals("session.created"));
       final event = result.event! as SseSessionCreated;
       expect(event.info.id, equals("s1"));
       expect(event.info.projectID, equals("p1"));
@@ -59,9 +63,75 @@ void main() {
 
       final result = parser.parse(rawData);
 
+      expect(result.outcome, equals(SseParseOutcome.validKnownEvent));
       expect(result.event, isA<SseServerHeartbeat>());
+      expect(result.eventType, equals("server.heartbeat"));
       expect(result.directory, isNull);
       expect(result.rawData, equals(rawData));
+    });
+
+    test("parses legacy 1.3 session.diff payload with diff array", () {
+      final parser = SseEventParser();
+      final rawData = jsonEncode({
+        "directory": "/repo",
+        "payload": {
+          "type": "session.diff",
+          "properties": {
+            "sessionID": "s1",
+            "diff": [
+              {
+                "file": "lib/main.dart",
+                "before": "old",
+                "after": "new",
+                "additions": 1,
+                "deletions": 1,
+                "status": "modified",
+              },
+            ],
+          },
+        },
+      });
+
+      final result = parser.parse(rawData);
+
+      expect(result.outcome, equals(SseParseOutcome.validKnownEvent));
+      expect(result.rawData, equals(rawData));
+      expect(result.event, isA<SseSessionDiff>());
+      expect(result.eventType, equals("session.diff"));
+
+      final event = result.event! as SseSessionDiff;
+      expect(event.sessionID, equals("s1"));
+      expect(event.diff, hasLength(1));
+      expect(event.diff.single.file, equals("lib/main.dart"));
+    });
+
+    test("parses 1.4 session.diff payload without legacy diff array", () {
+      final parser = SseEventParser();
+      final rawData = jsonEncode({
+        "directory": "/repo",
+        "payload": {
+          "type": "session.diff",
+          "properties": {
+            "sessionID": "s1",
+            "summary": {
+              "files": 2,
+              "additions": 12,
+              "deletions": 3,
+            },
+          },
+        },
+      });
+
+      final result = parser.parse(rawData);
+
+      expect(result.outcome, equals(SseParseOutcome.validKnownEvent));
+      expect(result.rawData, equals(rawData));
+      expect(result.event, isA<SseSessionDiff>());
+      expect(result.eventType, equals("session.diff"));
+
+      final event = result.event! as SseSessionDiff;
+      expect(event.sessionID, equals("s1"));
+      expect(event.diff, isEmpty);
     });
 
     test(
@@ -78,8 +148,10 @@ void main() {
 
         final result = parser.parse(rawData);
 
+        expect(result.outcome, equals(SseParseOutcome.unknownEventType));
         expect(result.event, isNull);
         expect(result.directory, equals("/repo"));
+        expect(result.eventType, equals("unknown.event"));
         expect(result.rawData, equals(rawData));
       },
     );
@@ -90,8 +162,10 @@ void main() {
 
       final result = parser.parse(rawData);
 
+      expect(result.outcome, equals(SseParseOutcome.malformedEnvelope));
       expect(result.event, isNull);
       expect(result.directory, isNull);
+      expect(result.eventType, isNull);
       expect(result.rawData, equals(rawData));
     });
 
@@ -101,8 +175,10 @@ void main() {
 
       final result = parser.parse(rawData);
 
+      expect(result.outcome, equals(SseParseOutcome.malformedEnvelope));
       expect(result.event, isNull);
       expect(result.directory, isNull);
+      expect(result.eventType, isNull);
       expect(result.rawData, equals(rawData));
     });
 
@@ -112,8 +188,10 @@ void main() {
 
       final result = parser.parse(rawData);
 
+      expect(result.outcome, equals(SseParseOutcome.malformedEnvelope));
       expect(result.event, isNull);
       expect(result.directory, equals("/repo"));
+      expect(result.eventType, isNull);
       expect(result.rawData, equals(rawData));
     });
 
@@ -128,8 +206,51 @@ void main() {
 
       final result = parser.parse(rawData);
 
+      expect(result.outcome, equals(SseParseOutcome.malformedEnvelope));
       expect(result.event, isNull);
       expect(result.directory, equals("/repo"));
+      expect(result.eventType, isNull);
+      expect(result.rawData, equals(rawData));
+    });
+
+    test("known event with malformed payload is categorized separately", () {
+      final parser = SseEventParser();
+      final rawData = jsonEncode({
+        "directory": "/repo",
+        "payload": {
+          "type": "session.status",
+          "properties": {
+            "sessionID": "s1",
+            "status": {"unexpected": true},
+          },
+        },
+      });
+
+      final result = parser.parse(rawData);
+
+      expect(result.outcome, equals(SseParseOutcome.malformedKnownPayload));
+      expect(result.event, isNull);
+      expect(result.directory, equals("/repo"));
+      expect(result.eventType, equals("session.status"));
+      expect(result.rawData, equals(rawData));
+    });
+
+    test("malformed payload envelope is categorized separately", () {
+      final parser = SseEventParser();
+      final rawData = jsonEncode({
+        "directory": "/repo",
+        "payload": {
+          "type": "session.status",
+          "properties": "not-a-map",
+        },
+      });
+
+      final result = parser.parse(rawData);
+
+      expect(result.outcome, equals(SseParseOutcome.malformedEnvelope));
+      expect(result.event, isNull);
+      expect(result.directory, equals("/repo"));
+      expect(result.eventType, equals("session.status"));
       expect(result.rawData, equals(rawData));
     });
 


### PR DESCRIPTION
## Summary
- Hardened OpenCode SSE parsing for 1.4 compatibility: categorized malformed frames, preserved event type context, and kept `session.diff` invalidation-only behavior compatible with legacy payloads.
- Improved bridge/plugin routing so upstream decode drift and `PluginApiException` responses surface cleanly instead of degrading to generic failures.
- Added regression coverage for parser, plugin, bridge routing, and model-mapping compatibility cases.

## Risks addressed
- Dropped SSE frames are now logged with stable categories plus directory/event type context for diagnostics.
- Message decoding now distinguishes schema drift from unexpected bugs so the bridge can return the right status code.
- Route mappings continue to preserve provider/model/agent compatibility fields.

## Verification
- `GIT_MASTER=1 git status` → clean
- `lsp_diagnostics` on `bridge/app` and `bridge/sesori_plugin_opencode` → 0 errors
- `dart test test/bridge/routing/get_agents_handler_test.dart test/bridge/routing/get_providers_handler_test.dart test/bridge/routing/get_session_messages_handler_test.dart test/bridge/routing/request_router_test.dart`
- `dart test test/sse_event_parser_test.dart test/opencode_plugin_impl_test.dart test/opencode_service_test.dart test/agent_info_test.dart test/message_with_parts_test.dart test/provider_mapper_test.dart`