### PR TITLE
fix: bootstrap npx bridge installs from tagged release assets

### DIFF
--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -387,6 +387,9 @@ jobs:
             if (metadata.runtimeBundleSource !== "github-release-assets") {
               throw new Error("runtimeBundleSource drift in " + packageJsonPath + ": expected github-release-assets, got " + metadata.runtimeBundleSource);
             }
+            if (metadata.releaseTag !== releaseTag) {
+              throw new Error("releaseTag drift in " + packageJsonPath + ": expected " + releaseTag + ", got " + metadata.releaseTag);
+            }
           ' bridge/app/npm/sesori-bridge/package.json "$RELEASE_TAG" "${{ steps.version.outputs.VERSION }}"
 
       - name: Publish wrapper package

--- a/bridge/INSTALL.md
+++ b/bridge/INSTALL.md
@@ -77,8 +77,8 @@ sesori-bridge
 - `npx @sesori/bridge` is a bootstrap option, not the long-lived runtime. Use it to install or refresh the managed runtime, then run `sesori-bridge` from the managed launcher path.
 - The npm bootstrap prefers the published platform payload when npm provides it, and otherwise falls back to the exact tagged GitHub Release asset that matches the wrapper version.
 - To bootstrap with npm instead of the shell installer:
-  - macOS / Linux: `npx @sesori/bridge --version`, then `sesori-bridge`
-  - Windows: `npx @sesori/bridge --version`, then `sesori-bridge`
+  - macOS / Linux: `npx @sesori/bridge`, then `sesori-bridge`
+  - Windows: `npx @sesori/bridge`, then `sesori-bridge`
 - PATH updates are written for future shells. On a first-time install, open a new terminal if `sesori-bridge` is not immediately available from PATH, or use the managed binary path directly.
 - Re-running either the shell installer or `npx @sesori/bridge` is the supported manual refresh path if you want to update immediately instead of waiting for automatic updates.
 - `npm uninstall @sesori/bridge` does not remove the managed install under `~/.sesori/` or `%LOCALAPPDATA%\sesori\`. Remove that directory manually if you want a full uninstall.

--- a/bridge/INSTALL.md
+++ b/bridge/INSTALL.md
@@ -75,6 +75,7 @@ sesori-bridge
   - Windows: `%LOCALAPPDATA%\sesori\`
 - Shell installers remain supported and install the same managed runtime that `sesori-bridge` runs afterward.
 - `npx @sesori/bridge` is a bootstrap option, not the long-lived runtime. Use it to install or refresh the managed runtime, then run `sesori-bridge` from the managed launcher path.
+- The npm bootstrap prefers the published platform payload when npm provides it, and otherwise falls back to the exact tagged GitHub Release asset that matches the wrapper version.
 - To bootstrap with npm instead of the shell installer:
   - macOS / Linux: `npx @sesori/bridge --version`, then `sesori-bridge`
   - Windows: `npx @sesori/bridge --version`, then `sesori-bridge`

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -61,6 +61,8 @@ irm https://raw.githubusercontent.com/sesori-ai/sesori_apps_monorepo/main/instal
 
 Both install paths update PATH for future shells. On a first-time install, you may need to open a new terminal before `sesori-bridge` resolves from PATH.
 
+The npm bootstrap path uses `npx @sesori/bridge` only as a launcher: it installs or refreshes the managed native runtime under the Sesori install root and then gets out of the way. The steady-state command remains `sesori-bridge`, not a binary inside `node_modules`.
+
 ## Uninstall
 
 Delete the managed install directory to fully remove the packaged bridge runtime:

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -43,7 +43,7 @@ Quick packaged install options:
 
 ```bash
 # npm bootstrap
-npx @sesori/bridge --version
+npx @sesori/bridge
 
 # If PATH has not refreshed in this shell yet, open a new terminal
 # or run ~/.sesori/bin/sesori-bridge directly on macOS/Linux.

--- a/bridge/RELEASING.md
+++ b/bridge/RELEASING.md
@@ -127,14 +127,14 @@ The expected result is that `sesori-bridge --version` prints `X.Y.Z` from the ma
 After the tagged workflow finishes, test the exact npm package version:
 
 ```bash
-npx @sesori/bridge@X.Y.Z --version
+npx @sesori/bridge@X.Y.Z
 
 # If PATH has not refreshed in this shell yet, open a new terminal
 # or run ~/.sesori/bin/sesori-bridge directly on macOS/Linux.
 sesori-bridge --version
 ```
 
-The expected result is that `npx` bootstraps or refreshes the managed runtime, and the long-lived command is still `sesori-bridge`, not a binary inside `node_modules`. If npm does not materialize the platform package in the exec tree, the wrapper must fall back to the exact tagged GitHub Release asset for `bridge-vX.Y.Z` and still install the same managed runtime.
+The expected result is that `npx` installs or refreshes the managed runtime, then exits with a clear next-step message. The long-lived command is still `sesori-bridge`, not a binary inside `node_modules`. If npm does not materialize the platform package in the exec tree, the wrapper must fall back to the exact tagged GitHub Release asset for `bridge-vX.Y.Z` and still install the same managed runtime.
 
 ### C. Manual uninstall verification
 

--- a/bridge/RELEASING.md
+++ b/bridge/RELEASING.md
@@ -134,7 +134,7 @@ npx @sesori/bridge@X.Y.Z --version
 sesori-bridge --version
 ```
 
-The expected result is that `npx` bootstraps or refreshes the managed runtime, and the long-lived command is still `sesori-bridge`, not a binary inside `node_modules`.
+The expected result is that `npx` bootstraps or refreshes the managed runtime, and the long-lived command is still `sesori-bridge`, not a binary inside `node_modules`. If npm does not materialize the platform package in the exec tree, the wrapper must fall back to the exact tagged GitHub Release asset for `bridge-vX.Y.Z` and still install the same managed runtime.
 
 ### C. Manual uninstall verification
 

--- a/bridge/app/README.md
+++ b/bridge/app/README.md
@@ -26,7 +26,7 @@ npx @sesori/bridge --version
 sesori-bridge
 ```
 
-`npx @sesori/bridge` only installs or refreshes the managed runtime under `~/.sesori/` on macOS/Linux or `%LOCALAPPDATA%\sesori\` on Windows. `sesori-bridge` is the long-lived command you keep running after that bootstrap step. Shell installers are still supported if you prefer them. `npm uninstall @sesori/bridge` does not remove the managed install, so delete that Sesori directory manually if you want a full uninstall.
+`npx @sesori/bridge` only installs or refreshes the managed runtime under `~/.sesori/` on macOS/Linux or `%LOCALAPPDATA%\sesori\` on Windows. It prefers the published platform payload when npm provides it, and otherwise falls back to the exact tagged GitHub Release asset for the wrapper version. `sesori-bridge` is the long-lived command you keep running after that bootstrap step. Shell installers are still supported if you prefer them. `npm uninstall @sesori/bridge` does not remove the managed install, so delete that Sesori directory manually if you want a full uninstall.
 
 ## Install
 
@@ -42,7 +42,7 @@ npx @sesori/bridge --version
 sesori-bridge
 ```
 
-Use `npx @sesori/bridge` when you want npm to bootstrap or refresh the managed runtime, then keep running `sesori-bridge` from your PATH. On a first-time install, the PATH change is written for future terminals, so you may need to open a new terminal first.
+Use `npx @sesori/bridge` when you want npm to bootstrap or refresh the managed runtime, then keep running `sesori-bridge` from your PATH. The bootstrap path installs the same managed runtime that the GitHub release assets and shell installers publish. On a first-time install, the PATH change is written for future terminals, so you may need to open a new terminal first.
 
 ### Shell installer
 

--- a/bridge/app/README.md
+++ b/bridge/app/README.md
@@ -19,7 +19,7 @@ Press `Ctrl+C` to stop. This shuts down both the bridge and the OpenCode server 
 No Dart SDK? You can bootstrap the managed install with npm:
 
 ```bash
-npx @sesori/bridge --version
+npx @sesori/bridge
 
 # If PATH has not refreshed in this shell yet, open a new terminal
 # or run ~/.sesori/bin/sesori-bridge directly on macOS/Linux.
@@ -35,14 +35,14 @@ Choose one supported packaged install path:
 ### npm bootstrap
 
 ```bash
-npx @sesori/bridge --version
+npx @sesori/bridge
 
 # If PATH has not refreshed in this shell yet, open a new terminal
 # or run ~/.sesori/bin/sesori-bridge directly on macOS/Linux.
 sesori-bridge
 ```
 
-Use `npx @sesori/bridge` when you want npm to bootstrap or refresh the managed runtime, then keep running `sesori-bridge` from your PATH. The bootstrap path installs the same managed runtime that the GitHub release assets and shell installers publish. On a first-time install, the PATH change is written for future terminals, so you may need to open a new terminal first.
+Use `npx @sesori/bridge` when you want npm to bootstrap or refresh the managed runtime, then keep running `sesori-bridge` from your PATH. The bootstrap path installs the same managed runtime that the GitHub release assets and shell installers publish, but it does not launch the service for you. On a first-time install, the PATH change is written for future terminals, so you may need to open a new terminal first.
 
 ### Shell installer
 
@@ -196,7 +196,7 @@ dart run bin/bridge.dart
 ./dist/bridge-linux-x64
 
 # npm bootstrap, then run the managed launcher
-npx @sesori/bridge --version
+npx @sesori/bridge
 sesori-bridge
 ```
 

--- a/bridge/app/npm/sesori-bridge/lib/bootstrap.js
+++ b/bridge/app/npm/sesori-bridge/lib/bootstrap.js
@@ -48,14 +48,6 @@ function recordInstallAttempt() {
   fs.writeFileSync(counterPath, String(currentValue + 1), "utf8");
 }
 
-async function resolveBootstrapPayload(pkgName) {
-  var localPayload = runtimeInstall.tryResolvePayload(pkgName);
-  if (localPayload) {
-    return localPayload;
-  }
-  return releaseAssetRuntime.resolvePayload();
-}
-
 async function bootstrapManagedRuntime(pkgName) {
   var installRoot = runtimeInstall.managedInstallRoot();
   var localPayload = runtimeInstall.tryResolvePayload(pkgName);

--- a/bridge/app/npm/sesori-bridge/lib/bootstrap.js
+++ b/bridge/app/npm/sesori-bridge/lib/bootstrap.js
@@ -5,6 +5,7 @@ var path = require("path");
 var child_process = require("child_process");
 var launcher = require("./launcher");
 var bootstrapLock = require("./bootstrap_lock");
+var releaseAssetRuntime = require("./release_asset_runtime");
 var runtimeInstall = require("./runtime_install");
 
 var PLATFORM_PACKAGES = {
@@ -47,51 +48,71 @@ function recordInstallAttempt() {
   fs.writeFileSync(counterPath, String(currentValue + 1), "utf8");
 }
 
-function bootstrapManagedRuntime(pkgName) {
-  var payload = runtimeInstall.resolvePayload(pkgName);
+async function resolveBootstrapPayload(pkgName) {
+  var localPayload = runtimeInstall.tryResolvePayload(pkgName);
+  if (localPayload) {
+    return localPayload;
+  }
+  return releaseAssetRuntime.resolvePayload();
+}
+
+async function bootstrapManagedRuntime(pkgName) {
   var installRoot = runtimeInstall.managedInstallRoot();
-  return bootstrapLock.withBootstrapLock({
-    installRoot: installRoot,
-    onWait: function() {
-      console.error("sesori-bridge: Another bootstrap is already in progress. Waiting for the managed install lock...");
-    },
-  }, function() {
-    var currentVersion = runtimeInstall.readManagedVersion(installRoot);
-    var runtimeReady = runtimeInstall.isManagedRuntimeReady(installRoot);
-    if (currentVersion !== null) {
-      var comparison = runtimeInstall.compareVersions(currentVersion, payload.version);
-      if (comparison > 0) {
-        if (!runtimeReady) {
-          throw new Error(
-            "sesori-bridge: Managed runtime " + currentVersion + " is incomplete/corrupt and newer than npm payload " + payload.version + ".\n" +
-            "Refusing to repair it with an older npm payload. Reinstall the managed runtime explicitly, or delete the managed install directory and bootstrap again with npx."
-          );
-        }
-        return { binaryPath: runtimeInstall.managedBinaryPath(installRoot), installRoot: installRoot };
-      }
-      if (comparison === 0 && runtimeReady) {
-        return { binaryPath: runtimeInstall.managedBinaryPath(installRoot), installRoot: installRoot };
-      }
-    }
-    try {
-      runtimeInstall.installManagedRuntime(payload, installRoot, {
-        beforeInstallSwap: function() {
-          recordInstallAttempt();
-          sleepForTest();
-          if (process.env.SESORI_BRIDGE_TEST_WRITE_FAIL === "1") {
-            throw new Error("Simulated managed install write failure.");
+  var localPayload = runtimeInstall.tryResolvePayload(pkgName);
+  var preferredVersion = localPayload ? localPayload.version : releaseAssetRuntime.wrapperVersion();
+  var payload = null;
+  try {
+    return await bootstrapLock.withBootstrapLock({
+      installRoot: installRoot,
+      onWait: function() {
+        console.error("sesori-bridge: Another bootstrap is already in progress. Waiting for the managed install lock...");
+      },
+    }, async function() {
+      var currentVersion = runtimeInstall.readManagedVersion(installRoot);
+      var runtimeReady = runtimeInstall.isManagedRuntimeReady(installRoot);
+      if (currentVersion !== null) {
+        var comparison = runtimeInstall.compareVersions(currentVersion, preferredVersion);
+        if (comparison > 0) {
+          if (!runtimeReady) {
+            throw new Error(
+              "sesori-bridge: Managed runtime " + currentVersion + " is incomplete/corrupt and newer than npm payload " + preferredVersion + ".\n" +
+              "Refusing to repair it with an older npm payload. Reinstall the managed runtime explicitly, or delete the managed install directory and bootstrap again with npx."
+            );
           }
-        },
-      });
-    } catch (error) {
-      throw new Error(
-        "sesori-bridge: Failed to install the managed runtime.\n" +
-        errorMessage(error) + "\n" +
-        "Refusing to run runtime binaries from npm-owned paths. Delete the managed install directory and rerun npx @sesori/bridge if you need a clean bootstrap."
-      );
+          return { binaryPath: runtimeInstall.managedBinaryPath(installRoot), installRoot: installRoot };
+        }
+        if (comparison === 0 && runtimeReady) {
+          return { binaryPath: runtimeInstall.managedBinaryPath(installRoot), installRoot: installRoot };
+        }
+      }
+      payload = localPayload;
+      if (!payload) {
+        payload = await releaseAssetRuntime.resolvePayload();
+      }
+      try {
+        runtimeInstall.installManagedRuntime(payload, installRoot, {
+          beforeInstallSwap: function() {
+            recordInstallAttempt();
+            sleepForTest();
+            if (process.env.SESORI_BRIDGE_TEST_WRITE_FAIL === "1") {
+              throw new Error("Simulated managed install write failure.");
+            }
+          },
+        });
+      } catch (error) {
+        throw new Error(
+          "sesori-bridge: Failed to install the managed runtime.\n" +
+          errorMessage(error) + "\n" +
+          "Refusing to run runtime binaries from npm-owned paths. Delete the managed install directory and rerun npx @sesori/bridge if you need a clean bootstrap."
+        );
+      }
+      return { binaryPath: runtimeInstall.managedBinaryPath(installRoot), installRoot: installRoot };
+    });
+  } finally {
+    if (payload && typeof payload.cleanup === "function") {
+      payload.cleanup();
     }
-    return { binaryPath: runtimeInstall.managedBinaryPath(installRoot), installRoot: installRoot };
-  });
+  }
 }
 
 function spawnManagedRuntime(binaryPath, args) {
@@ -106,13 +127,8 @@ function spawnManagedRuntime(binaryPath, args) {
   process.exit(result.status === null ? 1 : result.status);
 }
 
-function main(options) {
-  var bootstrapResult;
-  try {
-    bootstrapResult = bootstrapManagedRuntime(options && options.pkgName);
-  } catch (error) {
-    fail(errorMessage(error));
-  }
+async function runMain(options) {
+  var bootstrapResult = await bootstrapManagedRuntime(options && options.pkgName);
   try {
     var launcherResult = launcher.ensureManagedCommandPath({
       binDir: managedBinDir(bootstrapResult.installRoot),
@@ -131,6 +147,12 @@ function main(options) {
     );
   }
   spawnManagedRuntime(bootstrapResult.binaryPath, process.argv.slice(2));
+}
+
+function main(options) {
+  runMain(options).catch(function(error) {
+    fail(errorMessage(error));
+  });
 }
 
 module.exports = {

--- a/bridge/app/npm/sesori-bridge/lib/bootstrap.js
+++ b/bridge/app/npm/sesori-bridge/lib/bootstrap.js
@@ -64,12 +64,13 @@ function printInstallSummary(options) {
   console.log("Managed binary : " + options.binaryPath);
   console.log("PATH update    : " + options.pathStatus);
   console.log("");
-  console.log("Next step");
-  console.log("---------");
-  console.log(commands.pathCommand);
+  console.log("Next steps");
+  console.log("----------");
+  console.log("1. Start the bridge:");
+  console.log("   " + commands.pathCommand);
   console.log("");
-  console.log("If `sesori-bridge` is not available in this shell yet, run:");
-  console.log(commands.managed);
+  console.log("2. If `sesori-bridge` is not available in this shell yet, run:");
+  console.log("   " + commands.managed);
 }
 
 function managedBinDir(installRoot) { return path.dirname(runtimeInstall.managedBinaryPath(installRoot)); }

--- a/bridge/app/npm/sesori-bridge/lib/bootstrap.js
+++ b/bridge/app/npm/sesori-bridge/lib/bootstrap.js
@@ -2,7 +2,6 @@
 
 var fs = require("fs");
 var path = require("path");
-var child_process = require("child_process");
 var launcher = require("./launcher");
 var bootstrapLock = require("./bootstrap_lock");
 var releaseAssetRuntime = require("./release_asset_runtime");
@@ -23,6 +22,54 @@ function fail(message) {
 
 function errorMessage(error) {
   return String(error && error.message ? error.message : error);
+}
+
+function shellQuote(value) {
+  if (!value) {
+    return "''";
+  }
+  if (/^[A-Za-z0-9_./:-]+$/.test(value)) {
+    return value;
+  }
+  return "'" + String(value).replace(/'/g, "'\\''") + "'";
+}
+
+function powershellQuote(value) {
+  if (!value) {
+    return "''";
+  }
+  return "'" + String(value).replace(/'/g, "''") + "'";
+}
+
+function nextCommand(binaryPath, args) {
+  var commandArgs = Array.isArray(args) ? args : [];
+  var managedCommand;
+  if (process.platform === "win32") {
+    managedCommand = "& " + [binaryPath].concat(commandArgs).map(powershellQuote).join(" ");
+  } else {
+    managedCommand = [binaryPath].concat(commandArgs).map(shellQuote).join(" ");
+  }
+  return {
+    managed: managedCommand,
+    pathCommand: ["sesori-bridge"].concat(commandArgs).map(shellQuote).join(" "),
+  };
+}
+
+function printInstallSummary(options) {
+  var commands = nextCommand(options.binaryPath, options.args);
+  console.log("");
+  console.log("Sesori Bridge install complete");
+  console.log("============================");
+  console.log("Managed install: " + options.installRoot);
+  console.log("Managed binary : " + options.binaryPath);
+  console.log("PATH update    : " + options.pathStatus);
+  console.log("");
+  console.log("Next step");
+  console.log("---------");
+  console.log(commands.pathCommand);
+  console.log("");
+  console.log("If `sesori-bridge` is not available in this shell yet, run:");
+  console.log(commands.managed);
 }
 
 function managedBinDir(installRoot) { return path.dirname(runtimeInstall.managedBinaryPath(installRoot)); }
@@ -107,38 +154,32 @@ async function bootstrapManagedRuntime(pkgName) {
   }
 }
 
-function spawnManagedRuntime(binaryPath, args) {
-  var managedBinDir = path.dirname(binaryPath);
-  var result = child_process.spawnSync(binaryPath, args, {
-    env: Object.assign({}, process.env, { PATH: managedBinDir + path.delimiter + (process.env.PATH || "") }),
-    stdio: "inherit",
-  });
-  if (result.error) {
-    fail("sesori-bridge: Failed to launch managed runtime.\n" + result.error.message);
-  }
-  process.exit(result.status === null ? 1 : result.status);
-}
-
 async function runMain(options) {
   var bootstrapResult = await bootstrapManagedRuntime(options && options.pkgName);
+  var launcherResult = null;
+  var pathStatus = "already configured";
   try {
-    var launcherResult = launcher.ensureManagedCommandPath({
+    launcherResult = launcher.ensureManagedCommandPath({
       binDir: managedBinDir(bootstrapResult.installRoot),
       homeDir: process.env.HOME,
       platform: process.platform,
       shellPath: process.env.SHELL || "",
     });
-    if (launcherResult && launcherResult.message) {
-      console.error(launcherResult.message);
-    }
+    pathStatus = launcherResult && launcherResult.message ? launcherResult.message : "already configured";
   } catch (error) {
+    pathStatus = "manual action required";
     console.error(
       "sesori-bridge: Failed to persist the managed command path.\n" +
       errorMessage(error) + "\n" +
-      "Continuing with the managed runtime for this launch."
+      "The managed runtime is installed, but you may need to add it to PATH manually."
     );
   }
-  spawnManagedRuntime(bootstrapResult.binaryPath, process.argv.slice(2));
+  printInstallSummary({
+    installRoot: bootstrapResult.installRoot,
+    binaryPath: bootstrapResult.binaryPath,
+    pathStatus: pathStatus,
+    args: process.argv.slice(2),
+  });
 }
 
 function main(options) {

--- a/bridge/app/npm/sesori-bridge/lib/bootstrap_lock.js
+++ b/bridge/app/npm/sesori-bridge/lib/bootstrap_lock.js
@@ -122,7 +122,7 @@ function withBootstrapLock(options, callback) {
     }
   }
   if (callbackResult && typeof callbackResult.then === "function") {
-    return callbackResult.finally(function() {
+    return Promise.resolve(callbackResult).finally(function() {
       stopHeartbeat(heartbeatProcess);
       removeRecursive(lockPath);
     });

--- a/bridge/app/npm/sesori-bridge/lib/bootstrap_lock.js
+++ b/bridge/app/npm/sesori-bridge/lib/bootstrap_lock.js
@@ -112,12 +112,22 @@ function withBootstrapLock(options, callback) {
   var lockPath = path.join(path.dirname(options.installRoot), ".sesori-bootstrap.lock");
   fs.mkdirSync(path.dirname(options.installRoot), { recursive: true });
   var heartbeatProcess = acquireLock(lockPath, options);
+  var callbackResult;
   try {
-    return callback();
+    callbackResult = callback();
   } finally {
-    stopHeartbeat(heartbeatProcess);
-    removeRecursive(lockPath);
+    if (!callbackResult || typeof callbackResult.then !== "function") {
+      stopHeartbeat(heartbeatProcess);
+      removeRecursive(lockPath);
+    }
   }
+  if (callbackResult && typeof callbackResult.then === "function") {
+    return callbackResult.finally(function() {
+      stopHeartbeat(heartbeatProcess);
+      removeRecursive(lockPath);
+    });
+  }
+  return callbackResult;
 }
 
 module.exports = {

--- a/bridge/app/npm/sesori-bridge/lib/launcher.js
+++ b/bridge/app/npm/sesori-bridge/lib/launcher.js
@@ -14,14 +14,24 @@ function sourceHint(filePath, shellName) {
   return "Run `source " + filePath + "` or open a new terminal.";
 }
 
-function unixPathFile(homeDir, shellName) {
+function unixPathFiles(homeDir, shellName) {
   if (shellName === "bash") {
-    return path.join(homeDir, ".bashrc");
+    return [path.join(homeDir, ".bashrc"), path.join(homeDir, ".profile")];
   }
   if (shellName === "zsh") {
-    return path.join(homeDir, ".zshrc");
+    return [path.join(homeDir, ".zshrc"), path.join(homeDir, ".zprofile")];
   }
-  return path.join(homeDir, ".profile");
+  return [path.join(homeDir, ".profile")];
+}
+
+function joinWithAnd(values) {
+  if (values.length === 1) {
+    return values[0];
+  }
+  if (values.length === 2) {
+    return values[0] + " and " + values[1];
+  }
+  return values.slice(0, -1).join(", ") + ", and " + values[values.length - 1];
 }
 
 function ensureLine(filePath, line) {
@@ -49,10 +59,18 @@ function ensureUnixPathEntry(homeDir, shellPath) {
     }
   } else {
     var exportLine = 'export PATH="' + unixManagedBinDir() + ':$PATH"';
-    var rcFile = unixPathFile(homeDir, shellName);
-    if (ensureLine(rcFile, exportLine)) {
-      changed = true;
-      messages.push("Persisted ~/.sesori/bin in " + rcFile + ". " + sourceHint(rcFile, shellName));
+    var rcFiles = unixPathFiles(homeDir, shellName);
+    var updatedFiles = [];
+    rcFiles.forEach(function(filePath) {
+      if (ensureLine(filePath, exportLine)) {
+        changed = true;
+        updatedFiles.push(filePath);
+      }
+    });
+    if (updatedFiles.length > 0) {
+      messages.push(
+        "Persisted ~/.sesori/bin in " + joinWithAnd(updatedFiles) + ". " + sourceHint(updatedFiles[0], shellName)
+      );
     }
   }
 

--- a/bridge/app/npm/sesori-bridge/lib/launcher.js
+++ b/bridge/app/npm/sesori-bridge/lib/launcher.js
@@ -7,6 +7,16 @@ var child_process = require("child_process");
 function unixManagedBinDir() { return "$HOME/.sesori/bin"; }
 function fishManagedBinDir() { return '"$HOME/.sesori/bin"'; }
 
+function unixPathFile(homeDir, shellName) {
+  if (shellName === "bash") {
+    return path.join(homeDir, ".bashrc");
+  }
+  if (shellName === "zsh") {
+    return path.join(homeDir, ".zshrc");
+  }
+  return path.join(homeDir, ".profile");
+}
+
 function ensureLine(filePath, line) {
   var existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf8") : "";
   var normalized = existing.replace(/\r\n/g, "\n");
@@ -28,28 +38,20 @@ function ensureUnixPathEntry(homeDir, shellPath) {
     var fishConfig = path.join(homeDir, ".config", "fish", "config.fish");
     if (ensureLine(fishConfig, "fish_add_path " + fishManagedBinDir())) {
       changed = true;
-      messages.push("Added ~/.sesori/bin to PATH in " + fishConfig + ".");
+      messages.push("Persisted ~/.sesori/bin in " + fishConfig + ".");
     }
   } else {
     var exportLine = 'export PATH="' + unixManagedBinDir() + ':$PATH"';
-    var rcFiles = [path.join(homeDir, ".profile")];
-    if (shellName === "bash") {
-      rcFiles.unshift(path.join(homeDir, ".bashrc"));
-    } else if (shellName === "zsh") {
-      rcFiles.unshift(path.join(homeDir, ".zshrc"));
-      rcFiles.push(path.join(homeDir, ".zprofile"));
+    var rcFile = unixPathFile(homeDir, shellName);
+    if (ensureLine(rcFile, exportLine)) {
+      changed = true;
+      messages.push("Persisted ~/.sesori/bin in " + rcFile + ".");
     }
-    rcFiles.forEach(function(filePath) {
-      if (ensureLine(filePath, exportLine)) {
-        changed = true;
-        messages.push("Added ~/.sesori/bin to PATH in " + filePath + ".");
-      }
-    });
   }
 
   return {
     changed: changed,
-    message: changed ? messages.join("\n") + "\nOpen a new terminal to use sesori-bridge." : null,
+    message: changed ? messages.join("\n") : null,
   };
 }
 
@@ -79,7 +81,7 @@ function ensureWindowsPathEntry(binDir) {
   return {
     changed: String(result.stdout || "").indexOf("UPDATED") !== -1,
     message: String(result.stdout || "").indexOf("UPDATED") !== -1
-      ? "Added %LOCALAPPDATA%\\sesori\\bin to the user PATH.\nOpen a new terminal to use sesori-bridge."
+      ? "Persisted %LOCALAPPDATA%\\sesori\\bin in the user PATH."
       : null,
   };
 }

--- a/bridge/app/npm/sesori-bridge/lib/launcher.js
+++ b/bridge/app/npm/sesori-bridge/lib/launcher.js
@@ -7,6 +7,13 @@ var child_process = require("child_process");
 function unixManagedBinDir() { return "$HOME/.sesori/bin"; }
 function fishManagedBinDir() { return '"$HOME/.sesori/bin"'; }
 
+function sourceHint(filePath, shellName) {
+  if (shellName === "fish") {
+    return "Run `source " + filePath + "` or open a new terminal.";
+  }
+  return "Run `source " + filePath + "` or open a new terminal.";
+}
+
 function unixPathFile(homeDir, shellName) {
   if (shellName === "bash") {
     return path.join(homeDir, ".bashrc");
@@ -38,14 +45,14 @@ function ensureUnixPathEntry(homeDir, shellPath) {
     var fishConfig = path.join(homeDir, ".config", "fish", "config.fish");
     if (ensureLine(fishConfig, "fish_add_path " + fishManagedBinDir())) {
       changed = true;
-      messages.push("Persisted ~/.sesori/bin in " + fishConfig + ".");
+      messages.push("Persisted ~/.sesori/bin in " + fishConfig + ". " + sourceHint(fishConfig, shellName));
     }
   } else {
     var exportLine = 'export PATH="' + unixManagedBinDir() + ':$PATH"';
     var rcFile = unixPathFile(homeDir, shellName);
     if (ensureLine(rcFile, exportLine)) {
       changed = true;
-      messages.push("Persisted ~/.sesori/bin in " + rcFile + ".");
+      messages.push("Persisted ~/.sesori/bin in " + rcFile + ". " + sourceHint(rcFile, shellName));
     }
   }
 

--- a/bridge/app/npm/sesori-bridge/lib/release_asset_runtime.js
+++ b/bridge/app/npm/sesori-bridge/lib/release_asset_runtime.js
@@ -10,6 +10,7 @@ var path = require("path");
 
 var WRAPPER_MANIFEST_PATH = path.join(__dirname, "..", "package.json");
 var DEFAULT_REPO_SLUG = "sesori-ai/sesori_apps_monorepo";
+var DOWNLOAD_TIMEOUT_MS = 30000;
 var PLATFORM_ASSETS = {
   "darwin arm64": "sesori-bridge-macos-arm64.tar.gz",
   "darwin x64": "sesori-bridge-macos-x64.tar.gz",
@@ -118,7 +119,7 @@ function downloadToFile(url, destinationPath, redirectsRemaining) {
         redirectsRemaining > 0
       ) {
         response.resume();
-        downloadToFile(response.headers.location, destinationPath, redirectsRemaining - 1)
+        downloadToFile(new URL(response.headers.location, url).toString(), destinationPath, redirectsRemaining - 1)
           .then(resolve, reject);
         return;
       }
@@ -143,28 +144,27 @@ function downloadToFile(url, destinationPath, redirectsRemaining) {
       });
       response.pipe(file);
     });
+    request.setTimeout(DOWNLOAD_TIMEOUT_MS, function() {
+      request.destroy(new Error("Request timed out for " + url + "."));
+    });
     request.on("error", reject);
   });
 }
 
 function extractArchive(archivePath, extractRoot) {
   fs.mkdirSync(extractRoot, { recursive: true });
-  if (/\.zip$/i.test(archivePath)) {
-    if (process.platform === "win32") {
-      child_process.execFileSync(
-        "powershell.exe",
-        [
-          "-NoProfile",
-          "-Command",
-          "Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force",
-          archivePath,
-          extractRoot,
-        ],
-        { stdio: "pipe" }
-      );
-      return;
-    }
-    child_process.execFileSync("unzip", ["-q", archivePath, "-d", extractRoot], { stdio: "pipe" });
+  if (/\.zip$/i.test(archivePath) && process.platform === "win32") {
+    child_process.execFileSync(
+      "powershell.exe",
+      [
+        "-NoProfile",
+        "-Command",
+        "Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force",
+        archivePath,
+        extractRoot,
+      ],
+      { stdio: "pipe" }
+    );
     return;
   }
   child_process.execFileSync("tar", ["-xzf", archivePath, "-C", extractRoot], { stdio: "pipe" });

--- a/bridge/app/npm/sesori-bridge/lib/release_asset_runtime.js
+++ b/bridge/app/npm/sesori-bridge/lib/release_asset_runtime.js
@@ -1,0 +1,225 @@
+"use strict";
+
+var child_process = require("child_process");
+var crypto = require("crypto");
+var fs = require("fs");
+var http = require("http");
+var https = require("https");
+var os = require("os");
+var path = require("path");
+
+var WRAPPER_MANIFEST_PATH = path.join(__dirname, "..", "package.json");
+var DEFAULT_REPO_SLUG = "sesori-ai/sesori_apps_monorepo";
+var PLATFORM_ASSETS = {
+  "darwin arm64": "sesori-bridge-macos-arm64.tar.gz",
+  "darwin x64": "sesori-bridge-macos-x64.tar.gz",
+  "linux x64": "sesori-bridge-linux-x64.tar.gz",
+  "linux arm64": "sesori-bridge-linux-arm64.tar.gz",
+  "win32 x64": "sesori-bridge-windows-x64.zip",
+};
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function removeRecursive(filePath) {
+  fs.rmSync(filePath, { force: true, recursive: true });
+}
+
+function wrapperManifest() {
+  return readJson(WRAPPER_MANIFEST_PATH);
+}
+
+function currentPlatformKey() {
+  return process.platform + " " + process.arch;
+}
+
+function currentAssetName() {
+  var assetName = PLATFORM_ASSETS[currentPlatformKey()];
+  if (!assetName) {
+    throw new Error(
+      "sesori-bridge: Unsupported platform for GitHub release bootstrap: " + currentPlatformKey() + "."
+    );
+  }
+  return assetName;
+}
+
+function releaseTag(manifest) {
+  var metadata = manifest.sesoriBridge || {};
+  return metadata.releaseTag || ("bridge-v" + manifest.version);
+}
+
+function wrapperVersion() {
+  return wrapperManifest().version;
+}
+
+function wrapperReleaseTag() {
+  return releaseTag(wrapperManifest());
+}
+
+function repositorySlug(manifest) {
+  var repository = manifest.repository && manifest.repository.url ? String(manifest.repository.url) : "";
+  var match = repository.match(/github\.com[/:]([^/]+\/[^/.]+)(?:\.git)?$/);
+  return match ? match[1] : DEFAULT_REPO_SLUG;
+}
+
+function releasesBaseUrl(manifest) {
+  if (process.env.SESORI_BRIDGE_RELEASES_BASE_URL) {
+    return process.env.SESORI_BRIDGE_RELEASES_BASE_URL.replace(/\/$/, "");
+  }
+  return "https://github.com/" + repositorySlug(manifest) + "/releases/download";
+}
+
+function downloadUrl(manifest, fileName) {
+  return releasesBaseUrl(manifest) + "/" + releaseTag(manifest) + "/" + fileName;
+}
+
+function checksumFor(content, fileName) {
+  var lines = content.split(/\r?\n/);
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i].trim();
+    if (!line) {
+      continue;
+    }
+    var parts = line.split(/\s+/);
+    if (parts.length < 2) {
+      continue;
+    }
+    var candidate = parts.slice(1).join(" ").replace(/^\*/, "");
+    if (candidate === fileName) {
+      return parts[0];
+    }
+  }
+  throw new Error("Missing checksum entry for " + fileName + ".");
+}
+
+function sha256File(filePath) {
+  return new Promise(function(resolve, reject) {
+    var hash = crypto.createHash("sha256");
+    var stream = fs.createReadStream(filePath);
+    stream.on("error", reject);
+    stream.on("data", function(chunk) {
+      hash.update(chunk);
+    });
+    stream.on("end", function() {
+      resolve(hash.digest("hex"));
+    });
+  });
+}
+
+function downloadToFile(url, destinationPath, redirectsRemaining) {
+  return new Promise(function(resolve, reject) {
+    var client = url.indexOf("https://") === 0 ? https : http;
+    var request = client.get(url, function(response) {
+      if (
+        response.statusCode >= 300 &&
+        response.statusCode < 400 &&
+        response.headers.location &&
+        redirectsRemaining > 0
+      ) {
+        response.resume();
+        downloadToFile(response.headers.location, destinationPath, redirectsRemaining - 1)
+          .then(resolve, reject);
+        return;
+      }
+      if (response.statusCode !== 200) {
+        response.resume();
+        reject(new Error("Unexpected HTTP " + response.statusCode + " for " + url + "."));
+        return;
+      }
+      var file = fs.createWriteStream(destinationPath);
+      file.on("error", function(error) {
+        response.destroy(error);
+      });
+      response.on("error", reject);
+      file.on("finish", function() {
+        file.close(function(closeError) {
+          if (closeError) {
+            reject(closeError);
+            return;
+          }
+          resolve();
+        });
+      });
+      response.pipe(file);
+    });
+    request.on("error", reject);
+  });
+}
+
+function extractArchive(archivePath, extractRoot) {
+  fs.mkdirSync(extractRoot, { recursive: true });
+  if (/\.zip$/i.test(archivePath)) {
+    if (process.platform === "win32") {
+      child_process.execFileSync(
+        "powershell.exe",
+        [
+          "-NoProfile",
+          "-Command",
+          "Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force",
+          archivePath,
+          extractRoot,
+        ],
+        { stdio: "pipe" }
+      );
+      return;
+    }
+    child_process.execFileSync("unzip", ["-q", archivePath, "-d", extractRoot], { stdio: "pipe" });
+    return;
+  }
+  child_process.execFileSync("tar", ["-xzf", archivePath, "-C", extractRoot], { stdio: "pipe" });
+}
+
+function validateExtractedRuntime(runtimeRoot) {
+  var binPath = path.join(runtimeRoot, "bin", process.platform === "win32" ? "sesori-bridge.exe" : "sesori-bridge");
+  var libPath = path.join(runtimeRoot, "lib");
+  if (!fs.existsSync(binPath) || !fs.existsSync(libPath)) {
+    throw new Error("Bootstrap payload is incomplete. Expected archive contents with bin/ and lib/.");
+  }
+}
+
+async function resolvePayload() {
+  var manifest = wrapperManifest();
+  var version = manifest.version;
+  var tag = releaseTag(manifest);
+  var assetName = currentAssetName();
+  var tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "sesori-bridge-release-"));
+  var archivePath = path.join(tempRoot, assetName);
+  var checksumPath = path.join(tempRoot, "checksums.txt");
+  var extractRoot = path.join(tempRoot, "payload");
+  try {
+    await downloadToFile(downloadUrl(manifest, assetName), archivePath, 10);
+    await downloadToFile(downloadUrl(manifest, "checksums.txt"), checksumPath, 10);
+    var expected = checksumFor(fs.readFileSync(checksumPath, "utf8"), assetName);
+    var actual = await sha256File(archivePath);
+    if (actual !== expected) {
+      throw new Error(
+        "Checksum mismatch for " + assetName + ". Expected " + expected + ", got " + actual + "."
+      );
+    }
+    extractArchive(archivePath, extractRoot);
+    validateExtractedRuntime(extractRoot);
+    return {
+      runtimeBundlePath: extractRoot,
+      version: version,
+      cleanup: function() {
+        removeRecursive(tempRoot);
+      },
+      releaseTag: tag,
+      assetName: assetName,
+    };
+  } catch (error) {
+    removeRecursive(tempRoot);
+    throw new Error(
+      "sesori-bridge: Failed to download managed runtime from GitHub release assets for " +
+        tag + ".\n" +
+        String(error && error.message ? error.message : error)
+    );
+  }
+}
+
+module.exports = {
+  wrapperReleaseTag: wrapperReleaseTag,
+  wrapperVersion: wrapperVersion,
+  resolvePayload: resolvePayload,
+};

--- a/bridge/app/npm/sesori-bridge/lib/release_asset_runtime.js
+++ b/bridge/app/npm/sesori-bridge/lib/release_asset_runtime.js
@@ -119,7 +119,14 @@ function downloadToFile(url, destinationPath, redirectsRemaining) {
         redirectsRemaining > 0
       ) {
         response.resume();
-        downloadToFile(new URL(response.headers.location, url).toString(), destinationPath, redirectsRemaining - 1)
+        var redirectUrl;
+        try {
+          redirectUrl = new URL(response.headers.location, url).toString();
+        } catch (error) {
+          reject(new Error("Invalid redirect URL '" + response.headers.location + "' for " + url + "."));
+          return;
+        }
+        downloadToFile(redirectUrl, destinationPath, redirectsRemaining - 1)
           .then(resolve, reject);
         return;
       }

--- a/bridge/app/npm/sesori-bridge/lib/runtime_install.js
+++ b/bridge/app/npm/sesori-bridge/lib/runtime_install.js
@@ -104,16 +104,17 @@ function copyRecursive(sourcePath, targetPath) {
   fs.chmodSync(targetPath, stat.mode);
 }
 
-function resolvePayload(pkgName) {
+function packageRootFor(pkgName) {
   var packageRoot;
   try {
     packageRoot = path.dirname(require.resolve(pkgName + "/package.json"));
   } catch (_) {
-    fail(
-      "sesori-bridge: Failed to find platform package '" + pkgName + "'.\n" +
-      "Try installing it manually:\n  npm install " + pkgName
-    );
+    return null;
   }
+  return packageRoot;
+}
+
+function payloadFromPackageRoot(packageRoot) {
   var manifest = readJson(path.join(packageRoot, "package.json"));
   return {
     runtimeBundlePath: path.join(
@@ -124,6 +125,25 @@ function resolvePayload(pkgName) {
     ),
     version: manifest.version,
   };
+}
+
+function resolvePayload(pkgName) {
+  var packageRoot = packageRootFor(pkgName);
+  if (!packageRoot) {
+    fail(
+      "sesori-bridge: Failed to find platform package '" + pkgName + "'.\n" +
+      "Try installing it manually:\n  npm install " + pkgName
+    );
+  }
+  return payloadFromPackageRoot(packageRoot);
+}
+
+function tryResolvePayload(pkgName) {
+  var packageRoot = packageRootFor(pkgName);
+  if (!packageRoot) {
+    return null;
+  }
+  return payloadFromPackageRoot(packageRoot);
 }
 
 function writeManagedManifest(installRoot, version) {
@@ -168,5 +188,6 @@ module.exports = {
   managedInstallRoot: managedInstallRoot,
   readManagedVersion: readManagedVersion,
   resolvePayload: resolvePayload,
+  tryResolvePayload: tryResolvePayload,
   isManagedRuntimeReady: isManagedRuntimeReady,
 };

--- a/bridge/app/npm/sesori-bridge/package.json
+++ b/bridge/app/npm/sesori-bridge/package.json
@@ -15,6 +15,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
+    "releaseTag": "bridge-v0.3.1",
     "runtimeBundleSource": "github-release-assets"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/bridge/app/test/tool/bump_version_test.dart
+++ b/bridge/app/test/tool/bump_version_test.dart
@@ -74,6 +74,7 @@ dependencies:
       'sesoriBridge': {
         'bootstrapOnly': true,
         'managedRuntimeOwner': false,
+        'releaseTag': 'bridge-v$oldVersion',
         'runtimeBundleSource': 'github-release-assets',
       },
       'optionalDependencies': {
@@ -165,6 +166,10 @@ void main() {
       expect(pubspec, isNot(contains('version: ${fixture.oldVersion}')));
       expect(versionDart, equals("const String appVersion = '${fixture.newVersion}';\n"));
       expect(wrapperPackage['version'], equals(fixture.newVersion));
+      expect(
+        (wrapperPackage['sesoriBridge'] as Map<String, dynamic>)['releaseTag'],
+        equals('bridge-v${fixture.newVersion}'),
+      );
 
       final optionalDependencies = wrapperPackage['optionalDependencies'] as Map<String, dynamic>;
       expect(optionalDependencies['@sesori/bridge-darwin-arm64'], equals(fixture.newVersion));

--- a/bridge/app/test/tool/installers_test.dart
+++ b/bridge/app/test/tool/installers_test.dart
@@ -344,7 +344,7 @@ cat "\$HOME/.zshrc"
         RegExp(r'export PATH="\$HOME/.sesori/bin:\$PATH"').allMatches(result.stdout as String).length,
         equals(1),
       );
-      expect(result.stdout, contains('Added ~/.sesori/bin to PATH in ${p.join(tempDir.path, '.zshrc')}.'));
+      expect(result.stdout, contains('PATH: persisted ~/.sesori/bin in ${p.join(tempDir.path, '.zshrc')}.'));
     });
 
     test('writes managed runtime manifest with resolved version', () {
@@ -392,7 +392,9 @@ cat "\$HOME/.zshrc"
       expect(script, contains("Write-Warning \"Another sesori-bridge was found at '"));
       expect(script, contains(r'''$pathEntries | Where-Object { $_.TrimEnd('\') -ieq $BinDir.TrimEnd('\') }'''));
       expect(script, contains(r"[Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')"));
-      expect(script, contains('Open a new terminal to use sesori-bridge.'));
+      expect(script, contains(r'PATH: persisted $BinDir in the user PATH.'));
+      expect(script, contains('Write-Host "sesori-bridge"'));
+      expect(script, contains(r'Write-Host "& \"$BinaryPath\""'));
     });
 
     test('writes managed runtime manifest with resolved version', () {

--- a/bridge/app/test/tool/installers_test.dart
+++ b/bridge/app/test/tool/installers_test.dart
@@ -331,6 +331,7 @@ source ${jsonEncode(libraryPath)}
 add_to_path "\$HOME/.sesori/bin"
 add_to_path "\$HOME/.sesori/bin"
 cat "\$HOME/.zshrc"
+cat "\$HOME/.zprofile"
 ''',
         environment: {
           'PATH': '/usr/bin:/bin',

--- a/bridge/app/test/tool/installers_test.dart
+++ b/bridge/app/test/tool/installers_test.dart
@@ -342,12 +342,12 @@ cat "\$HOME/.zshrc"
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
       expect(
         RegExp(r'export PATH="\$HOME/.sesori/bin:\$PATH"').allMatches(result.stdout as String).length,
-        equals(1),
+        equals(2),
       );
       expect(
         result.stdout,
         contains(
-          "PATH: persisted ~/.sesori/bin in ${p.join(tempDir.path, '.zshrc')}. Run 'source ${p.join(tempDir.path, '.zshrc')}' or open a new terminal.",
+          "PATH: persisted ~/.sesori/bin in ${p.join(tempDir.path, '.zshrc')} and ${p.join(tempDir.path, '.zprofile')}. Run 'source ${p.join(tempDir.path, '.zshrc')}' or open a new terminal.",
         ),
       );
     });

--- a/bridge/app/test/tool/installers_test.dart
+++ b/bridge/app/test/tool/installers_test.dart
@@ -344,7 +344,12 @@ cat "\$HOME/.zshrc"
         RegExp(r'export PATH="\$HOME/.sesori/bin:\$PATH"').allMatches(result.stdout as String).length,
         equals(1),
       );
-      expect(result.stdout, contains('PATH: persisted ~/.sesori/bin in ${p.join(tempDir.path, '.zshrc')}.'));
+      expect(
+        result.stdout,
+        contains(
+          "PATH: persisted ~/.sesori/bin in ${p.join(tempDir.path, '.zshrc')}. Run 'source ${p.join(tempDir.path, '.zshrc')}' or open a new terminal.",
+        ),
+      );
     });
 
     test('writes managed runtime manifest with resolved version', () {
@@ -393,8 +398,9 @@ cat "\$HOME/.zshrc"
       expect(script, contains(r'''$pathEntries | Where-Object { $_.TrimEnd('\') -ieq $BinDir.TrimEnd('\') }'''));
       expect(script, contains(r"[Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')"));
       expect(script, contains(r'PATH: persisted $BinDir in the user PATH.'));
-      expect(script, contains('Write-Host "sesori-bridge"'));
-      expect(script, contains(r'Write-Host "& \"$BinaryPath\""'));
+      expect(script, contains('Write-Host "1. Start the bridge:"'));
+      expect(script, contains('Write-Host "   sesori-bridge"'));
+      expect(script, contains(r'Write-Host "   & \"$BinaryPath\""'));
     });
 
     test('writes managed runtime manifest with resolved version', () {

--- a/bridge/app/test/tool/npm_wrapper_test.dart
+++ b/bridge/app/test/tool/npm_wrapper_test.dart
@@ -438,6 +438,7 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       final wrapperRoot = await _createWrapperFixture();
       final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
       addTearDown(() => homeDir.delete(recursive: true));
+      final bootstrapRecordPath = p.join(homeDir.path, 'bootstrap-record.json');
       final recordPath = p.join(homeDir.path, 'record.json');
       final releaseAsset = await _createReleaseAsset(
         version: '0.3.1',
@@ -455,13 +456,14 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         homePath: homeDir.path,
         args: ['doctor'],
         environment: {
+          'SESORI_BRIDGE_RECORD_PATH': bootstrapRecordPath,
           'SESORI_BRIDGE_RELEASES_BASE_URL': releasesBaseUrl,
         },
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
       _expectInstallSummary(result: result, homePath: homeDir.path, args: ['doctor']);
-      expect(File(recordPath).existsSync(), isFalse);
+      expect(File(bootstrapRecordPath).existsSync(), isFalse);
       final directRun = await _runManagedBinary(
         homePath: homeDir.path,
         args: ['doctor'],
@@ -590,11 +592,15 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       expect(
         bootstrapResult.stdout,
         contains(
-          'PATH update    : Persisted ~/.sesori/bin in ${p.join(homeDir.path, '.bashrc')}. Run `source ${p.join(homeDir.path, '.bashrc')}` or open a new terminal.',
+          'PATH update    : Persisted ~/.sesori/bin in ${p.join(homeDir.path, '.bashrc')} and ${p.join(homeDir.path, '.profile')}. Run `source ${p.join(homeDir.path, '.bashrc')}` or open a new terminal.',
         ),
       );
       expect(
         File(p.join(homeDir.path, '.bashrc')).readAsStringSync(),
+        contains(r'export PATH="$HOME/.sesori/bin:$PATH"'),
+      );
+      expect(
+        File(p.join(homeDir.path, '.profile')).readAsStringSync(),
         contains(r'export PATH="$HOME/.sesori/bin:$PATH"'),
       );
 

--- a/bridge/app/test/tool/npm_wrapper_test.dart
+++ b/bridge/app/test/tool/npm_wrapper_test.dart
@@ -365,8 +365,9 @@ void _expectInstallSummary({
   final nextStep = ['sesori-bridge', ...args].join(' ');
   expect(result.stdout, contains('Sesori Bridge install complete'));
   expect(result.stdout, contains('Managed binary : ${_managedBinaryPath(homePath: homePath)}'));
-  expect(result.stdout, contains('Next step'));
-  expect(result.stdout, contains(nextStep));
+  expect(result.stdout, contains('Next steps'));
+  expect(result.stdout, contains('1. Start the bridge:'));
+  expect(result.stdout, contains('   $nextStep'));
 }
 
 Future<({int exitCode, String stdout, String stderr})> _waitForProcess(Process process) async {
@@ -586,6 +587,12 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
 
       expect(bootstrapResult.exitCode, equals(0), reason: '${bootstrapResult.stdout}\n${bootstrapResult.stderr}');
       _expectInstallSummary(result: bootstrapResult, homePath: homeDir.path, args: ['serve']);
+      expect(
+        bootstrapResult.stdout,
+        contains(
+          'PATH update    : Persisted ~/.sesori/bin in ${p.join(homeDir.path, '.bashrc')}. Run `source ${p.join(homeDir.path, '.bashrc')}` or open a new terminal.',
+        ),
+      );
       expect(
         File(p.join(homeDir.path, '.bashrc')).readAsStringSync(),
         contains(r'export PATH="$HOME/.sesori/bin:$PATH"'),

--- a/bridge/app/test/tool/npm_wrapper_test.dart
+++ b/bridge/app/test/tool/npm_wrapper_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
@@ -26,6 +27,26 @@ String _currentPlatformPackage() {
 
 String _wrapperPackageRoot() {
   return p.join(Directory.current.path, 'npm', 'sesori-bridge');
+}
+
+String _currentPlatformAssetName() {
+  const assets = <String, String>{
+    'darwin arm64': 'sesori-bridge-macos-arm64.tar.gz',
+    'darwin x64': 'sesori-bridge-macos-x64.tar.gz',
+    'linux x64': 'sesori-bridge-linux-x64.tar.gz',
+    'linux arm64': 'sesori-bridge-linux-arm64.tar.gz',
+    'win32 x64': 'sesori-bridge-windows-x64.zip',
+  };
+
+  if (Platform.isWindows) {
+    return 'sesori-bridge-windows-x64.zip';
+  }
+
+  final uname = Process.runSync('uname', ['-m']);
+  final machine = '${uname.stdout}'.toLowerCase().trim();
+  final arch = machine.contains('arm64') || machine.contains('aarch64') ? 'arm64' : 'x64';
+  final platform = Platform.isMacOS ? 'darwin' : Platform.operatingSystem;
+  return assets['$platform $arch']!;
 }
 
 String _managedInstallRoot({required String homePath}) {
@@ -158,6 +179,92 @@ Future<void> _createPlatformPayload({
   expect(chmod.exitCode, equals(0), reason: '${chmod.stdout}\n${chmod.stderr}');
 }
 
+Future<({String assetName, String archivePath, String checksumsPath})> _createReleaseAsset({
+  required String version,
+  required String binaryMarker,
+  required String libMarker,
+}) async {
+  final tempDir = await Directory.systemTemp.createTemp('npm-wrapper-release-asset-');
+  addTearDown(() => tempDir.delete(recursive: true));
+  final payloadRoot = Directory(p.join(tempDir.path, 'payload'));
+  final assetName = _currentPlatformAssetName();
+  final binaryPath = p.join(
+    payloadRoot.path,
+    'bin',
+    Platform.isWindows ? 'sesori-bridge.exe' : 'sesori-bridge',
+  );
+  final libPath = p.join(payloadRoot.path, 'lib', 'runtime-marker.txt');
+
+  await Directory(p.dirname(binaryPath)).create(recursive: true);
+  await Directory(p.dirname(libPath)).create(recursive: true);
+  await File(binaryPath).writeAsString(_runtimeBinarySource(marker: binaryMarker));
+  await File(libPath).writeAsString(libMarker);
+  if (!Platform.isWindows) {
+    final chmod = await Process.run('chmod', ['+x', binaryPath]);
+    expect(chmod.exitCode, equals(0), reason: '${chmod.stdout}\n${chmod.stderr}');
+  }
+
+  final archivePath = p.join(tempDir.path, assetName);
+  late ProcessResult archiveResult;
+  if (assetName.endsWith('.zip')) {
+    archiveResult = await Process.run(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-Command',
+        'Compress-Archive -LiteralPath \$args[0] -DestinationPath \$args[1] -Force',
+        payloadRoot.path,
+        archivePath,
+      ],
+    );
+  } else {
+    archiveResult = await Process.run(
+      'tar',
+      ['-czf', archivePath, '-C', payloadRoot.path, '.'],
+    );
+  }
+  expect(archiveResult.exitCode, equals(0), reason: '${archiveResult.stdout}\n${archiveResult.stderr}');
+
+  final checksum = sha256.convert(await File(archivePath).readAsBytes()).toString();
+  final checksumsPath = p.join(tempDir.path, 'checksums.txt');
+  await File(checksumsPath).writeAsString('$checksum  $assetName\n');
+
+  return (assetName: assetName, archivePath: archivePath, checksumsPath: checksumsPath);
+}
+
+Future<String> _serveReleaseAssets({
+  required String version,
+  required String archivePath,
+  required String checksumsPath,
+}) async {
+  final assetName = p.basename(archivePath);
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  addTearDown(() => server.close(force: true));
+  server.listen((request) async {
+    final expectedPrefix = '/releases/download/bridge-v$version/';
+    if (!request.uri.path.startsWith(expectedPrefix)) {
+      request.response.statusCode = HttpStatus.notFound;
+      await request.response.close();
+      return;
+    }
+    final fileName = request.uri.path.substring(expectedPrefix.length);
+    final filePath = switch (fileName) {
+      'checksums.txt' => checksumsPath,
+      _ when fileName == assetName => archivePath,
+      _ => '',
+    };
+    if (filePath.isEmpty) {
+      request.response.statusCode = HttpStatus.notFound;
+      await request.response.close();
+      return;
+    }
+    request.response.statusCode = HttpStatus.ok;
+    await request.response.addStream(File(filePath).openRead());
+    await request.response.close();
+  });
+  return 'http://${server.address.host}:${server.port}/releases/download';
+}
+
 String _runtimeBinarySource({required String marker}) {
   return '''
 #!/usr/bin/env node
@@ -270,21 +377,68 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       expect(stderr, contains('npm install @sesori/bridge-darwin-arm64'));
     });
 
-    test('fails when the optional platform package cannot be resolved', () async {
+    test('falls back to the tagged GitHub release asset when the platform package is missing', () async {
       final wrapperRoot = await _createWrapperFixture();
-      final expectedPackage = _currentPlatformPackage();
       final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
       addTearDown(() => homeDir.delete(recursive: true));
+      final recordPath = p.join(homeDir.path, 'record.json');
+      final releaseAsset = await _createReleaseAsset(
+        version: '0.3.1',
+        binaryMarker: 'release-runtime',
+        libMarker: 'release-lib',
+      );
+      final releasesBaseUrl = await _serveReleaseAssets(
+        version: '0.3.1',
+        archivePath: releaseAsset.archivePath,
+        checksumsPath: releaseAsset.checksumsPath,
+      );
+
+      final result = await _runWrapperProcess(
+        packageRoot: wrapperRoot,
+        homePath: homeDir.path,
+        args: ['doctor'],
+        environment: {
+          'SESORI_BRIDGE_RECORD_PATH': recordPath,
+          'SESORI_BRIDGE_RELEASES_BASE_URL': releasesBaseUrl,
+        },
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      final recorded = await _readRecordedInvocation(recordPath: recordPath);
+      expect(recorded['marker'], equals('release-runtime'));
+      expect(recorded['libMarker'], equals('release-lib'));
+      expect(recorded['executedPath'], equals(_managedBinaryPath(homePath: homeDir.path)));
+    });
+
+    test('fails closed when release asset checksums do not match', () async {
+      final wrapperRoot = await _createWrapperFixture();
+      final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
+      addTearDown(() => homeDir.delete(recursive: true));
+      final releaseAsset = await _createReleaseAsset(
+        version: '0.3.1',
+        binaryMarker: 'release-runtime',
+        libMarker: 'release-lib',
+      );
+      await File(releaseAsset.checksumsPath).writeAsString('deadbeef  ${releaseAsset.assetName}\n');
+      final releasesBaseUrl = await _serveReleaseAssets(
+        version: '0.3.1',
+        archivePath: releaseAsset.archivePath,
+        checksumsPath: releaseAsset.checksumsPath,
+      );
 
       final result = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
         args: ['--version'],
+        environment: {'SESORI_BRIDGE_RELEASES_BASE_URL': releasesBaseUrl},
       );
 
       expect(result.exitCode, equals(1));
-      expect(result.stderr, contains("Failed to find platform package '$expectedPackage'."));
-      expect(result.stderr, contains('npm install $expectedPackage'));
+      expect(
+        result.stderr,
+        contains('Failed to download managed runtime from GitHub release assets for bridge-v0.3.1'),
+      );
+      expect(result.stderr, contains('Checksum mismatch for ${releaseAsset.assetName}'));
     });
 
     test('bootstraps a missing managed install and executes the managed binary', () async {
@@ -409,6 +563,37 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       expect(recorded['libMarker'], equals('existing-lib'));
     });
 
+    test('same-version managed runtime does not require release download fallback', () async {
+      final wrapperRoot = await _createWrapperFixture();
+      final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
+      addTearDown(() => homeDir.delete(recursive: true));
+      final recordPath = p.join(homeDir.path, 'record.json');
+
+      await _seedManagedRuntime(
+        homePath: homeDir.path,
+        version: '0.3.1',
+        binaryMarker: 'existing-managed',
+        libMarker: 'existing-lib',
+        includeBinary: true,
+        includeLib: true,
+      );
+
+      final result = await _runWrapperProcess(
+        packageRoot: wrapperRoot,
+        homePath: homeDir.path,
+        args: ['status'],
+        environment: {
+          'SESORI_BRIDGE_RECORD_PATH': recordPath,
+          'SESORI_BRIDGE_RELEASES_BASE_URL': 'http://127.0.0.1:1/releases/download',
+        },
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      final recorded = await _readRecordedInvocation(recordPath: recordPath);
+      expect(recorded['marker'], equals('existing-managed'));
+      expect(recorded['libMarker'], equals('existing-lib'));
+    });
+
     test('newer managed runtime is not downgraded by an older npm payload', () async {
       final wrapperRoot = await _createWrapperFixture();
       final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
@@ -447,6 +632,37 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
               )
               as Map<String, dynamic>;
       expect(manifest['version'], equals('9.9.9'));
+    });
+
+    test('newer managed runtime does not require release download fallback', () async {
+      final wrapperRoot = await _createWrapperFixture();
+      final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
+      addTearDown(() => homeDir.delete(recursive: true));
+      final recordPath = p.join(homeDir.path, 'record.json');
+
+      await _seedManagedRuntime(
+        homePath: homeDir.path,
+        version: '9.9.9',
+        binaryMarker: 'newer-managed',
+        libMarker: 'newer-lib',
+        includeBinary: true,
+        includeLib: true,
+      );
+
+      final result = await _runWrapperProcess(
+        packageRoot: wrapperRoot,
+        homePath: homeDir.path,
+        args: ['doctor'],
+        environment: {
+          'SESORI_BRIDGE_RECORD_PATH': recordPath,
+          'SESORI_BRIDGE_RELEASES_BASE_URL': 'http://127.0.0.1:1/releases/download',
+        },
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      final recorded = await _readRecordedInvocation(recordPath: recordPath);
+      expect(recorded['marker'], equals('newer-managed'));
+      expect(recorded['libMarker'], equals('newer-lib'));
     });
 
     test('older managed runtime is upgraded to the npm payload version', () async {

--- a/bridge/app/test/tool/npm_wrapper_test.dart
+++ b/bridge/app/test/tool/npm_wrapper_test.dart
@@ -90,6 +90,22 @@ Future<ProcessResult> _runWrapperProcess({
   );
 }
 
+Future<ProcessResult> _runManagedBinary({
+  required String homePath,
+  required List<String> args,
+  Map<String, String> environment = const {},
+}) {
+  return Process.run(
+    _managedBinaryPath(homePath: homePath),
+    args,
+    environment: {
+      'HOME': homePath,
+      if (Platform.isWindows) 'LOCALAPPDATA': p.join(homePath, 'AppData', 'Local'),
+      ...environment,
+    },
+  );
+}
+
 Future<Process> _startWrapperProcess({
   required Directory packageRoot,
   required String homePath,
@@ -265,6 +281,24 @@ Future<String> _serveReleaseAssets({
   return 'http://${server.address.host}:${server.port}/releases/download';
 }
 
+Future<String> _serveInvalidRedirectReleaseAssets({required String version}) async {
+  final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+  addTearDown(() => server.close(force: true));
+  server.listen((request) async {
+    final expectedPrefix = '/releases/download/bridge-v$version/';
+    if (!request.uri.path.startsWith(expectedPrefix)) {
+      request.response.statusCode = HttpStatus.notFound;
+      await request.response.close();
+      return;
+    }
+
+    request.response.statusCode = HttpStatus.found;
+    request.response.headers.set(HttpHeaders.locationHeader, 'http://[invalid');
+    await request.response.close();
+  });
+  return 'http://${server.address.host}:${server.port}/releases/download';
+}
+
 String _runtimeBinarySource({required String marker}) {
   return '''
 #!/usr/bin/env node
@@ -323,6 +357,18 @@ Future<Map<String, dynamic>> _readRecordedInvocation({required String recordPath
   return jsonDecode(await File(recordPath).readAsString()) as Map<String, dynamic>;
 }
 
+void _expectInstallSummary({
+  required ProcessResult result,
+  required String homePath,
+  required List<String> args,
+}) {
+  final nextStep = ['sesori-bridge', ...args].join(' ');
+  expect(result.stdout, contains('Sesori Bridge install complete'));
+  expect(result.stdout, contains('Managed binary : ${_managedBinaryPath(homePath: homePath)}'));
+  expect(result.stdout, contains('Next step'));
+  expect(result.stdout, contains(nextStep));
+}
+
 Future<({int exitCode, String stdout, String stderr})> _waitForProcess(Process process) async {
   final stdoutFuture = process.stdout.transform(utf8.decoder).join();
   final stderrFuture = process.stderr.transform(utf8.decoder).join();
@@ -377,6 +423,16 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       expect(stderr, contains('npm install @sesori/bridge-darwin-arm64'));
     });
 
+    test('bootstrap source renders Windows managed fallback commands via PowerShell invocation', () async {
+      final source = await File(p.join(_wrapperPackageRoot(), 'lib', 'bootstrap.js')).readAsString();
+
+      expect(source, contains('function powershellQuote(value)'));
+      expect(
+        source,
+        contains('managedCommand = "& " + [binaryPath].concat(commandArgs).map(powershellQuote).join(" ")'),
+      );
+    });
+
     test('falls back to the tagged GitHub release asset when the platform package is missing', () async {
       final wrapperRoot = await _createWrapperFixture();
       final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
@@ -398,12 +454,19 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         homePath: homeDir.path,
         args: ['doctor'],
         environment: {
-          'SESORI_BRIDGE_RECORD_PATH': recordPath,
           'SESORI_BRIDGE_RELEASES_BASE_URL': releasesBaseUrl,
         },
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      _expectInstallSummary(result: result, homePath: homeDir.path, args: ['doctor']);
+      expect(File(recordPath).existsSync(), isFalse);
+      final directRun = await _runManagedBinary(
+        homePath: homeDir.path,
+        args: ['doctor'],
+        environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
+      );
+      expect(directRun.exitCode, equals(0), reason: '${directRun.stdout}\n${directRun.stderr}');
       final recorded = await _readRecordedInvocation(recordPath: recordPath);
       expect(recorded['marker'], equals('release-runtime'));
       expect(recorded['libMarker'], equals('release-lib'));
@@ -441,7 +504,28 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       expect(result.stderr, contains('Checksum mismatch for ${releaseAsset.assetName}'));
     });
 
-    test('bootstraps a missing managed install and executes the managed binary', () async {
+    test('fails closed when a redirect location is malformed', () async {
+      final wrapperRoot = await _createWrapperFixture();
+      final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
+      addTearDown(() => homeDir.delete(recursive: true));
+      final releasesBaseUrl = await _serveInvalidRedirectReleaseAssets(version: '0.3.1');
+
+      final result = await _runWrapperProcess(
+        packageRoot: wrapperRoot,
+        homePath: homeDir.path,
+        args: ['doctor'],
+        environment: {'SESORI_BRIDGE_RELEASES_BASE_URL': releasesBaseUrl},
+      );
+
+      expect(result.exitCode, equals(1));
+      expect(
+        result.stderr,
+        contains('Failed to download managed runtime from GitHub release assets for bridge-v0.3.1'),
+      );
+      expect(result.stderr, contains('Invalid redirect URL'));
+    });
+
+    test('bootstraps a missing managed install without launching it', () async {
       final wrapperRoot = await _createWrapperFixture();
       final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
       addTearDown(() => homeDir.delete(recursive: true));
@@ -458,19 +542,22 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
         args: ['serve', '--port', '4096'],
-        environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
-      final recorded = await _readRecordedInvocation(recordPath: recordPath);
+      _expectInstallSummary(result: result, homePath: homeDir.path, args: ['serve', '--port', '4096']);
+      expect(File(recordPath).existsSync(), isFalse);
       final managedBinary = _managedBinaryPath(homePath: homeDir.path);
+      final directRun = await _runManagedBinary(
+        homePath: homeDir.path,
+        args: ['serve', '--port', '4096'],
+        environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
+      );
+      expect(directRun.exitCode, equals(0), reason: '${directRun.stdout}\n${directRun.stderr}');
+      final recorded = await _readRecordedInvocation(recordPath: recordPath);
       expect(recorded['marker'], equals('payload-runtime'));
       expect(recorded['executedPath'], equals(managedBinary));
       expect(recorded['args'], equals(['serve', '--port', '4096']));
-      expect(
-        (recorded['path'] as String).split(Platform.isWindows ? ';' : ':').first,
-        equals(p.dirname(managedBinary)),
-      );
       expect(recorded['libMarker'], equals('payload-lib'));
       expect(File(p.join(_managedInstallRoot(homePath: homeDir.path), '.managed-runtime.json')).existsSync(), isTrue);
     });
@@ -479,7 +566,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       final wrapperRoot = await _createWrapperFixture();
       final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
       addTearDown(() => homeDir.delete(recursive: true));
-      final bootstrapRecordPath = p.join(homeDir.path, 'bootstrap-record.json');
       final freshShellRecordPath = p.join(homeDir.path, 'fresh-shell-record.json');
 
       await _createPlatformPayload(
@@ -495,11 +581,11 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         args: ['serve'],
         environment: {
           'SHELL': '/bin/bash',
-          'SESORI_BRIDGE_RECORD_PATH': bootstrapRecordPath,
         },
       );
 
       expect(bootstrapResult.exitCode, equals(0), reason: '${bootstrapResult.stdout}\n${bootstrapResult.stderr}');
+      _expectInstallSummary(result: bootstrapResult, homePath: homeDir.path, args: ['serve']);
       expect(
         File(p.join(homeDir.path, '.bashrc')).readAsStringSync(),
         contains(r'export PATH="$HOME/.sesori/bin:$PATH"'),
@@ -554,10 +640,15 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
         args: ['status'],
-        environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      final directRun = await _runManagedBinary(
+        homePath: homeDir.path,
+        args: ['status'],
+        environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
+      );
+      expect(directRun.exitCode, equals(0), reason: '${directRun.stdout}\n${directRun.stderr}');
       final recorded = await _readRecordedInvocation(recordPath: recordPath);
       expect(recorded['marker'], equals('existing-managed'));
       expect(recorded['libMarker'], equals('existing-lib'));
@@ -583,12 +674,17 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         homePath: homeDir.path,
         args: ['status'],
         environment: {
-          'SESORI_BRIDGE_RECORD_PATH': recordPath,
           'SESORI_BRIDGE_RELEASES_BASE_URL': 'http://127.0.0.1:1/releases/download',
         },
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      final directRun = await _runManagedBinary(
+        homePath: homeDir.path,
+        args: ['status'],
+        environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
+      );
+      expect(directRun.exitCode, equals(0), reason: '${directRun.stdout}\n${directRun.stderr}');
       final recorded = await _readRecordedInvocation(recordPath: recordPath);
       expect(recorded['marker'], equals('existing-managed'));
       expect(recorded['libMarker'], equals('existing-lib'));
@@ -619,10 +715,15 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
         args: ['doctor'],
-        environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      final directRun = await _runManagedBinary(
+        homePath: homeDir.path,
+        args: ['doctor'],
+        environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
+      );
+      expect(directRun.exitCode, equals(0), reason: '${directRun.stdout}\n${directRun.stderr}');
       final recorded = await _readRecordedInvocation(recordPath: recordPath);
       expect(recorded['marker'], equals('newer-managed'));
       expect(recorded['libMarker'], equals('newer-lib'));
@@ -654,12 +755,17 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         homePath: homeDir.path,
         args: ['doctor'],
         environment: {
-          'SESORI_BRIDGE_RECORD_PATH': recordPath,
           'SESORI_BRIDGE_RELEASES_BASE_URL': 'http://127.0.0.1:1/releases/download',
         },
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      final directRun = await _runManagedBinary(
+        homePath: homeDir.path,
+        args: ['doctor'],
+        environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
+      );
+      expect(directRun.exitCode, equals(0), reason: '${directRun.stdout}\n${directRun.stderr}');
       final recorded = await _readRecordedInvocation(recordPath: recordPath);
       expect(recorded['marker'], equals('newer-managed'));
       expect(recorded['libMarker'], equals('newer-lib'));
@@ -690,10 +796,15 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
         args: ['status'],
-        environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      final directRun = await _runManagedBinary(
+        homePath: homeDir.path,
+        args: ['status'],
+        environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
+      );
+      expect(directRun.exitCode, equals(0), reason: '${directRun.stdout}\n${directRun.stderr}');
       final recorded = await _readRecordedInvocation(recordPath: recordPath);
       expect(recorded['marker'], equals('payload-runtime'));
       expect(recorded['libMarker'], equals('payload-lib'));
@@ -730,10 +841,15 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
         args: ['status'],
-        environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      final directRun = await _runManagedBinary(
+        homePath: homeDir.path,
+        args: ['status'],
+        environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
+      );
+      expect(directRun.exitCode, equals(0), reason: '${directRun.stdout}\n${directRun.stderr}');
       final recorded = await _readRecordedInvocation(recordPath: recordPath);
       expect(recorded['marker'], equals('payload-runtime'));
       expect(recorded['libMarker'], equals('payload-lib'));
@@ -793,7 +909,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         homePath: homeDir.path,
         args: ['status'],
         environment: {
-          'SESORI_BRIDGE_RECORD_PATH': recordPath,
           'SESORI_BRIDGE_TEST_WRITE_FAIL': '1',
         },
       );
@@ -826,13 +941,20 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         args: ['status'],
         environment: {
           'SHELL': '/usr/bin/fish',
-          'SESORI_BRIDGE_RECORD_PATH': recordPath,
         },
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
       expect(result.stderr, contains('Failed to persist the managed command path'));
-      expect(result.stderr, contains('Continuing with the managed runtime for this launch.'));
+      expect(result.stderr, contains('The managed runtime is installed, but you may need to add it to PATH manually.'));
+      expect(result.stdout, contains('PATH update    : manual action required'));
+      expect(result.stdout, isNot(contains('PATH update    : already configured')));
+      final directRun = await _runManagedBinary(
+        homePath: homeDir.path,
+        args: ['status'],
+        environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
+      );
+      expect(directRun.exitCode, equals(0), reason: '${directRun.stdout}\n${directRun.stderr}');
       final recorded = await _readRecordedInvocation(recordPath: recordPath);
       expect(recorded['marker'], equals('payload-runtime'));
     });
@@ -841,7 +963,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       final wrapperRoot = await _createWrapperFixture();
       final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
       addTearDown(() => homeDir.delete(recursive: true));
-      final bootstrapRecordPath = p.join(homeDir.path, 'bootstrap-record.json');
       final directRecordPath = p.join(homeDir.path, 'direct-record.json');
 
       await _createPlatformPayload(
@@ -855,7 +976,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
         args: ['serve'],
-        environment: {'SESORI_BRIDGE_RECORD_PATH': bootstrapRecordPath},
       );
       expect(bootstrapResult.exitCode, equals(0), reason: '${bootstrapResult.stdout}\n${bootstrapResult.stderr}');
 
@@ -924,8 +1044,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       final wrapperRoot = await _createWrapperFixture();
       final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
       addTearDown(() => homeDir.delete(recursive: true));
-      final firstRecordPath = p.join(homeDir.path, 'first-record.json');
-      final secondRecordPath = p.join(homeDir.path, 'second-record.json');
       final installCounterPath = p.join(homeDir.path, 'install-count.txt');
 
       await _createPlatformPayload(
@@ -940,7 +1058,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         homePath: homeDir.path,
         args: ['serve', 'first'],
         environment: {
-          'SESORI_BRIDGE_RECORD_PATH': firstRecordPath,
           'SESORI_BRIDGE_TEST_BOOTSTRAP_HOLD_MS': '800',
           'SESORI_BRIDGE_TEST_INSTALL_COUNTER_PATH': installCounterPath,
         },
@@ -953,7 +1070,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         homePath: homeDir.path,
         args: ['serve', 'second'],
         environment: {
-          'SESORI_BRIDGE_RECORD_PATH': secondRecordPath,
           'SESORI_BRIDGE_TEST_INSTALL_COUNTER_PATH': installCounterPath,
         },
       );
@@ -968,20 +1084,13 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         contains('Another bootstrap is already in progress. Waiting for the managed install lock'),
       );
       expect(await File(installCounterPath).readAsString(), equals('1'));
-
-      final firstRecorded = await _readRecordedInvocation(recordPath: firstRecordPath);
-      final secondRecorded = await _readRecordedInvocation(recordPath: secondRecordPath);
-      expect(firstRecorded['marker'], equals('payload-runtime'));
-      expect(secondRecorded['marker'], equals('payload-runtime'));
-      expect(secondRecorded['executedPath'], equals(_managedBinaryPath(homePath: homeDir.path)));
+      expect(File(_managedBinaryPath(homePath: homeDir.path)).existsSync(), isTrue);
     });
 
     test('active bootstrap holder is not evicted after crossing the stale threshold', () async {
       final wrapperRoot = await _createWrapperFixture();
       final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
       addTearDown(() => homeDir.delete(recursive: true));
-      final firstRecordPath = p.join(homeDir.path, 'first-record.json');
-      final secondRecordPath = p.join(homeDir.path, 'second-record.json');
       final installCounterPath = p.join(homeDir.path, 'install-count.txt');
 
       await _createPlatformPayload(
@@ -996,7 +1105,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         homePath: homeDir.path,
         args: ['serve', 'first'],
         environment: {
-          'SESORI_BRIDGE_RECORD_PATH': firstRecordPath,
           'SESORI_BRIDGE_TEST_BOOTSTRAP_HOLD_MS': '1200',
           'SESORI_BRIDGE_TEST_BOOTSTRAP_LOCK_STALE_MS': '300',
           'SESORI_BRIDGE_TEST_BOOTSTRAP_LOCK_TIMEOUT_MS': '4000',
@@ -1011,7 +1119,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         homePath: homeDir.path,
         args: ['serve', 'second'],
         environment: {
-          'SESORI_BRIDGE_RECORD_PATH': secondRecordPath,
           'SESORI_BRIDGE_TEST_BOOTSTRAP_LOCK_STALE_MS': '300',
           'SESORI_BRIDGE_TEST_BOOTSTRAP_LOCK_TIMEOUT_MS': '4000',
           'SESORI_BRIDGE_TEST_INSTALL_COUNTER_PATH': installCounterPath,
@@ -1028,12 +1135,7 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         contains('Another bootstrap is already in progress. Waiting for the managed install lock'),
       );
       expect(await File(installCounterPath).readAsString(), equals('1'));
-
-      final firstRecorded = await _readRecordedInvocation(recordPath: firstRecordPath);
-      final secondRecorded = await _readRecordedInvocation(recordPath: secondRecordPath);
-      expect(firstRecorded['marker'], equals('payload-runtime'));
-      expect(secondRecorded['marker'], equals('payload-runtime'));
-      expect(secondRecorded['executedPath'], equals(_managedBinaryPath(homePath: homeDir.path)));
+      expect(File(_managedBinaryPath(homePath: homeDir.path)).existsSync(), isTrue);
     });
 
     test('stale abandoned bootstrap locks are reclaimed', () async {
@@ -1063,13 +1165,18 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
         homePath: homeDir.path,
         args: ['status'],
         environment: {
-          'SESORI_BRIDGE_RECORD_PATH': recordPath,
           'SESORI_BRIDGE_TEST_BOOTSTRAP_LOCK_STALE_MS': '200',
           'SESORI_BRIDGE_TEST_BOOTSTRAP_LOCK_TIMEOUT_MS': '2000',
         },
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      final directRun = await _runManagedBinary(
+        homePath: homeDir.path,
+        args: ['status'],
+        environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
+      );
+      expect(directRun.exitCode, equals(0), reason: '${directRun.stdout}\n${directRun.stderr}');
       final recorded = await _readRecordedInvocation(recordPath: recordPath);
       expect(recorded['marker'], equals('payload-runtime'));
       expect(recorded['executedPath'], equals(_managedBinaryPath(homePath: homeDir.path)));

--- a/bridge/app/test/updater/release_contract_test.dart
+++ b/bridge/app/test/updater/release_contract_test.dart
@@ -177,17 +177,15 @@ void main() {
       expect(script, contains(r'''if ($filePart -eq $ArchiveName) {'''));
     });
 
-    test('workflow and docs lock basename checksums and manual npm release-tag path', () async {
+    test('workflow and docs lock basename checksums and automatic trusted publishing', () async {
       final workflow = await _readRepoFile(relativePath: '.github/workflows/bridge-release.yml');
       final docs = await _readRepoFile(relativePath: 'bridge/RELEASING.md');
 
-      expect(workflow, contains('release_tag:'));
-      expect(workflow, contains('release_tag is required when publish_npm=true'));
-      expect(workflow, contains('release_tag must start with bridge-v'));
-      expect(workflow, contains(r'ref: ${{ github.event.inputs.release_tag }}'));
+      expect(workflow, contains('needs: release'));
+      expect(workflow, contains('id-token: write'));
+      expect(workflow, contains('registry-url: "https://registry.npmjs.org"'));
       expect(workflow, contains(r'gh release download "$RELEASE_TAG"'));
       expect(workflow, contains('--pattern "*.tar.gz" --pattern "*.zip" --pattern "checksums.txt"'));
-      expect(workflow, contains(r'if [[ "$CURRENT_VERSION" == "${{ steps.version.outputs.VERSION }}" ]]'));
       expect(workflow, contains('Verify release archive checksums'));
       expect(workflow, contains('checksum_for()'));
       expect(workflow, contains('verify_archive_checksum()'));
@@ -198,17 +196,23 @@ void main() {
       expect(workflow, contains(r'diff -r "$source_root/bin" "$package_root/lib/runtime/bin"'));
       expect(workflow, contains(r'diff -r "$source_root/lib" "$package_root/lib/runtime/lib"'));
       expect(workflow, contains(r'sha256sum "$file" | awk -v name="$(basename "$file")"'));
-      expect(workflow, contains(r'Version already set to $CURRENT_VERSION; skipping bump.'));
+      expect(workflow, contains('Validate wrapper package metadata'));
+      expect(workflow, isNot(contains('NPM_TOKEN')));
 
-      expect(docs, contains('- `publish_npm=true`'));
-      expect(docs, contains('- `release_tag=bridge-vX.Y.Z`'));
+      expect(docs, contains('publishes the five platform npm bootstrap packages from those tagged release assets'));
+      expect(docs, contains('publishes the `@sesori/bridge` wrapper package through npm trusted publishing'));
       expect(
         docs,
         contains(
-          'The manual npm publish path checks out the tagged bridge release, verifies its archived asset checksums against `checksums.txt`, and then derives each platform npm package payload directly from those existing GitHub Release assets before publishing.',
+          'Configure npm trusted publishing for all six packages in this repo against the exact workflow file `.github/workflows/bridge-release.yml`',
         ),
       );
-      expect(docs, contains('package metadata, copied runtime payload, or recorded release provenance drifts'));
+      expect(
+        docs,
+        contains(
+          'The tag-triggered workflow verifies the archived GitHub Release assets against `checksums.txt`, derives each platform npm payload from those exact release artifacts, and then publishes through npm trusted publishing on `ubuntu-latest`.',
+        ),
+      );
     });
 
     test('workflow asset names and npm package manifests stay aligned', () async {
@@ -259,6 +263,7 @@ void main() {
         equals({
           'bootstrapOnly': true,
           'managedRuntimeOwner': false,
+          'releaseTag': 'bridge-v$appVersion',
           'runtimeBundleSource': 'github-release-assets',
         }),
       );

--- a/bridge/app/test/version_test.dart
+++ b/bridge/app/test/version_test.dart
@@ -40,6 +40,7 @@ void main() {
         equals({
           'bootstrapOnly': true,
           'managedRuntimeOwner': false,
+          'releaseTag': 'bridge-v$appVersion',
           'runtimeBundleSource': 'github-release-assets',
         }),
       );

--- a/install.ps1
+++ b/install.ps1
@@ -208,12 +208,13 @@ try {
     Write-Host "============================" -ForegroundColor Green
     Write-Host "Managed binary : $BinaryPath"
     Write-Host ""
-    Write-Host "Next step" -ForegroundColor Cyan
-    Write-Host "---------" -ForegroundColor Cyan
-    Write-Host "sesori-bridge"
+    Write-Host "Next steps" -ForegroundColor Cyan
+    Write-Host "----------" -ForegroundColor Cyan
+    Write-Host "1. Start the bridge:"
+    Write-Host "   sesori-bridge"
     Write-Host ""
-    Write-Host "If 'sesori-bridge' is not available in this shell yet, run:" -ForegroundColor Cyan
-    Write-Host "& \"$BinaryPath\""
+    Write-Host "2. If 'sesori-bridge' is not available in this shell yet, run:" -ForegroundColor Cyan
+    Write-Host "   & \"$BinaryPath\""
 
 } finally {
     # ── Cleanup temp files ────────────────────────────────────────────────────

--- a/install.ps1
+++ b/install.ps1
@@ -110,8 +110,9 @@ $TempDir       = Join-Path ([System.IO.Path]::GetTempPath()) "sesori-install-$([
 $TempZip       = Join-Path $TempDir $ArchiveName
 $TempChecksums = Join-Path $TempDir 'checksums.txt'
 
-Write-Host "Sesori Bridge CLI Installer" -ForegroundColor Cyan
-Write-Host "Architecture : $arch"
+Write-Host "Sesori Bridge installer" -ForegroundColor Cyan
+Write-Host "=======================" -ForegroundColor Cyan
+Write-Host "Platform     : windows/$arch"
 Write-Host "Release      : $($Release.TagName)"
 Write-Host "Install root : $InstallRoot"
 Write-Host ""
@@ -121,15 +122,14 @@ try {
     New-Item -ItemType Directory -Force -Path $TempDir | Out-Null
 
     # ── Download archive ──────────────────────────────────────────────────────
-    Write-Host "Downloading $ArchiveName ..." -ForegroundColor Yellow
+    Write-Host "[1/3] Downloading release assets..." -ForegroundColor Yellow
     Invoke-WebRequest -Uri $AssetUrl -OutFile $TempZip -UseBasicParsing
 
     # ── Download checksums ────────────────────────────────────────────────────
-    Write-Host "Downloading checksums.txt ..." -ForegroundColor Yellow
     Invoke-WebRequest -Uri $ChecksumsUrl -OutFile $TempChecksums -UseBasicParsing
 
     # ── Verify SHA256 ─────────────────────────────────────────────────────────
-    Write-Host "Verifying checksum ..." -ForegroundColor Yellow
+    Write-Host "[2/3] Verifying checksum..." -ForegroundColor Yellow
 
     $actualHash = (Get-FileHash -Path $TempZip -Algorithm SHA256).Hash.ToLower()
 
@@ -161,7 +161,7 @@ try {
     New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
 
     # ── Extract archive ───────────────────────────────────────────────────────
-    Write-Host "Extracting to $InstallRoot ..." -ForegroundColor Yellow
+    Write-Host "[3/3] Installing managed runtime..." -ForegroundColor Yellow
     Expand-Archive -Path $TempZip -DestinationPath $InstallRoot -Force
 
     # ── Verify binary ─────────────────────────────────────────────────────────
@@ -193,10 +193,9 @@ try {
     if (-not $alreadyInPath) {
         $newPath = ($pathEntries + $BinDir) -join ';'
         [Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')
-        Write-Host "Added $BinDir to user PATH." -ForegroundColor Green
-        Write-Host "Open a new terminal to use sesori-bridge." -ForegroundColor Cyan
+        Write-Host "PATH: persisted $BinDir in the user PATH." -ForegroundColor Green
     } else {
-        Write-Host "$BinDir is already in user PATH." -ForegroundColor Green
+        Write-Host "PATH: already configured." -ForegroundColor Green
     }
 
     # Also update the current session PATH so --version works immediately
@@ -204,11 +203,17 @@ try {
         $env:PATH = "$env:PATH;$BinDir"
     }
 
-    # ── Print version ─────────────────────────────────────────────────────────
     Write-Host ""
-    Write-Host "Installation complete!" -ForegroundColor Green
-    Write-Host "Running: sesori-bridge --version" -ForegroundColor Cyan
-    & $BinaryPath --version
+    Write-Host "Sesori Bridge install complete" -ForegroundColor Green
+    Write-Host "============================" -ForegroundColor Green
+    Write-Host "Managed binary : $BinaryPath"
+    Write-Host ""
+    Write-Host "Next step" -ForegroundColor Cyan
+    Write-Host "---------" -ForegroundColor Cyan
+    Write-Host "sesori-bridge"
+    Write-Host ""
+    Write-Host "If 'sesori-bridge' is not available in this shell yet, run:" -ForegroundColor Cyan
+    Write-Host "& \"$BinaryPath\""
 
 } finally {
     # ── Cleanup temp files ────────────────────────────────────────────────────

--- a/install.sh
+++ b/install.sh
@@ -225,10 +225,6 @@ verify_checksum() {
 add_to_path() {
     local bin_dir="${1}"
 
-    case ":${PATH}:" in
-        *":${bin_dir}:"*) return 0 ;;
-    esac
-
     local shell_name
     shell_name="$(basename "${SHELL:-}")"
 
@@ -241,8 +237,7 @@ add_to_path() {
             mkdir -p "$(dirname "${rc_file}")"
             if ! grep -qF 'fish_add_path "$HOME/.sesori/bin"' "${rc_file}" 2>/dev/null; then
                 echo 'fish_add_path "$HOME/.sesori/bin"' >> "${rc_file}"
-                echo "Added ~/.sesori/bin to PATH in ${rc_file}."
-                echo "Run 'source ${rc_file}' or open a new terminal."
+                echo "PATH: persisted ~/.sesori/bin in ${rc_file}."
             fi
             return 0
             ;;
@@ -252,8 +247,7 @@ add_to_path() {
     local export_line='export PATH="$HOME/.sesori/bin:$PATH"'
     if ! grep -qF "${export_line}" "${rc_file}" 2>/dev/null; then
         echo "${export_line}" >> "${rc_file}"
-        echo "Added ~/.sesori/bin to PATH in ${rc_file}."
-        echo "Run 'source ${rc_file}' or open a new terminal."
+        echo "PATH: persisted ~/.sesori/bin in ${rc_file}."
     fi
 }
 
@@ -281,9 +275,13 @@ main() {
     archive_url="${RESOLVED_ARCHIVE_URL}"
     checksums_url="${RESOLVED_CHECKSUMS_URL}"
 
-    echo "Detected platform: ${os}/${arch}"
-    echo "Resolved release: ${RESOLVED_RELEASE_TAG}"
-    echo "Downloading sesori-bridge..."
+    echo "Sesori Bridge installer"
+    echo "======================="
+    echo "Platform     : ${os}/${arch}"
+    echo "Release      : ${RESOLVED_RELEASE_TAG}"
+    echo "Install root : ${INSTALL_DIR}"
+    echo ""
+    echo "[1/3] Downloading release assets..."
 
     TMPDIR_WORK="$(mktemp -d)"
     local archive="${TMPDIR_WORK}/${filename}"
@@ -292,11 +290,11 @@ main() {
     download "${archive_url}" "${archive}"
     download "${checksums_url}" "${checksums}"
 
-    echo "Verifying checksum..."
+    echo "[2/3] Verifying checksum..."
     verify_checksum "${archive}" "${checksums}" "${filename}" "${os}"
     echo "Checksum OK."
 
-    echo "Installing to ${INSTALL_DIR}..."
+    echo "[3/3] Installing managed runtime..."
     mkdir -p "${BIN_DIR}"
     tar -xzf "${archive}" -C "${INSTALL_DIR}"
 
@@ -310,10 +308,17 @@ main() {
     check_conflicts
     add_to_path "${BIN_DIR}"
 
-    echo "Installation complete."
     echo ""
-    echo "Installed version:"
-    "${BINARY}" --version
+    echo "Sesori Bridge install complete"
+    echo "============================"
+    echo "Managed binary : ${BINARY}"
+    echo ""
+    echo "Next step"
+    echo "---------"
+    echo "sesori-bridge"
+    echo ""
+    echo "If sesori-bridge is not available in this shell yet, open a new terminal or run:"
+    echo "${BINARY}"
 }
 
 main

--- a/install.sh
+++ b/install.sh
@@ -228,12 +228,12 @@ add_to_path() {
     local shell_name
     shell_name="$(basename "${SHELL:-}")"
 
-    local rc_file
+    local rc_files=()
     case "${shell_name}" in
-        bash) rc_file="${HOME}/.bashrc" ;;
-        zsh)  rc_file="${HOME}/.zshrc" ;;
+        bash) rc_files=("${HOME}/.bashrc" "${HOME}/.profile") ;;
+        zsh)  rc_files=("${HOME}/.zshrc" "${HOME}/.zprofile") ;;
         fish)
-            rc_file="${HOME}/.config/fish/config.fish"
+            local rc_file="${HOME}/.config/fish/config.fish"
             mkdir -p "$(dirname "${rc_file}")"
             if ! grep -qF 'fish_add_path "$HOME/.sesori/bin"' "${rc_file}" 2>/dev/null; then
                 echo 'fish_add_path "$HOME/.sesori/bin"' >> "${rc_file}"
@@ -241,13 +241,30 @@ add_to_path() {
             fi
             return 0
             ;;
-        *) rc_file="${HOME}/.profile" ;;
+        *) rc_files=("${HOME}/.profile") ;;
     esac
 
     local export_line='export PATH="$HOME/.sesori/bin:$PATH"'
-    if ! grep -qF "${export_line}" "${rc_file}" 2>/dev/null; then
-        echo "${export_line}" >> "${rc_file}"
-        echo "PATH: persisted ~/.sesori/bin in ${rc_file}. Run 'source ${rc_file}' or open a new terminal."
+    local updated_files=()
+    local rc_file
+    for rc_file in "${rc_files[@]}"; do
+        if ! grep -qF "${export_line}" "${rc_file}" 2>/dev/null; then
+            echo "${export_line}" >> "${rc_file}"
+            updated_files+=("${rc_file}")
+        fi
+    done
+
+    if [ ${#updated_files[@]} -gt 0 ]; then
+        local joined_files="${updated_files[0]}"
+        local index
+        for (( index=1; index<${#updated_files[@]}; index++ )); do
+            if [ ${index} -eq $((${#updated_files[@]} - 1)) ]; then
+                joined_files+=" and ${updated_files[index]}"
+            else
+                joined_files+=", ${updated_files[index]}"
+            fi
+        done
+        echo "PATH: persisted ~/.sesori/bin in ${joined_files}. Run 'source ${updated_files[0]}' or open a new terminal."
     fi
 }
 

--- a/install.sh
+++ b/install.sh
@@ -237,7 +237,7 @@ add_to_path() {
             mkdir -p "$(dirname "${rc_file}")"
             if ! grep -qF 'fish_add_path "$HOME/.sesori/bin"' "${rc_file}" 2>/dev/null; then
                 echo 'fish_add_path "$HOME/.sesori/bin"' >> "${rc_file}"
-                echo "PATH: persisted ~/.sesori/bin in ${rc_file}."
+                echo "PATH: persisted ~/.sesori/bin in ${rc_file}. Run 'source ${rc_file}' or open a new terminal."
             fi
             return 0
             ;;
@@ -247,7 +247,7 @@ add_to_path() {
     local export_line='export PATH="$HOME/.sesori/bin:$PATH"'
     if ! grep -qF "${export_line}" "${rc_file}" 2>/dev/null; then
         echo "${export_line}" >> "${rc_file}"
-        echo "PATH: persisted ~/.sesori/bin in ${rc_file}."
+        echo "PATH: persisted ~/.sesori/bin in ${rc_file}. Run 'source ${rc_file}' or open a new terminal."
     fi
 }
 
@@ -313,12 +313,13 @@ main() {
     echo "============================"
     echo "Managed binary : ${BINARY}"
     echo ""
-    echo "Next step"
-    echo "---------"
-    echo "sesori-bridge"
+    echo "Next steps"
+    echo "----------"
+    echo "1. Start the bridge:"
+    echo "   sesori-bridge"
     echo ""
-    echo "If sesori-bridge is not available in this shell yet, open a new terminal or run:"
-    echo "${BINARY}"
+    echo "2. If sesori-bridge is not available in this shell yet, open a new terminal or run:"
+    echo "   ${BINARY}"
 }
 
 main


### PR DESCRIPTION
## Summary
- make `npx @sesori/bridge` fall back to the exact tagged GitHub release asset when npm does not materialize the platform payload
- keep the managed-runtime contract intact by reusing up-to-date installs without network access and by validating wrapper release tag drift in CI
- document the `npx` bootstrap fallback and add wrapper tests covering fallback success, checksum failures, and no-download reuse paths

## Verification
- dart test test/tool/npm_wrapper_test.dart
- dart test test/updater/release_contract_test.dart
- dart test test/version_test.dart
- dart test test/tool/bump_version_test.dart

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `npx @sesori/bridge` reliably bootstrap by falling back to the exact tagged GitHub Release asset when npm doesn’t provide a platform payload. Bootstrap is now install‑only with a clear two‑step handoff, and PATH persistence covers login shells.

- **Bug Fixes**
  - Added release-asset bootstrap with SHA‑256 verification, platform‑aware asset selection, timeouts, relative redirect handling, and clean failure on malformed redirects; pinned to the wrapper’s `bridge-vX.Y.Z` tag.
  - Made npm bootstrap and shell installers install‑only with a two‑step “Next steps” summary (run `sesori-bridge`, or the managed path); PATH updates are idempotent, persist to login shells (`.bashrc`/`.profile`, `.zshrc`/`.zprofile`), and report status with safe quoting on Windows/Unix.
  - Preserved managed‑runtime rules: reuse same/newer versions without network; block downgrades or incomplete repairs; bootstrap lock cleanup is async‑safe and temporary payloads are removed.
  - Introduced `sesoriBridge.releaseTag` and CI validation to prevent tag drift; kept `runtimeBundleSource` checks.
  - Updated docs and tests for release fallback, install‑only UX, redirect failures, PATH messaging (including login‑shell coverage and reading both zsh files in CI), and the two‑step handoff.

<sup>Written for commit ab5c3ad6cad5dadab2cb1f43897367d70d0a5f40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

