### PR TITLE
fix(opencode-plugin): recognize alpha and beta model statuses

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/provider_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/provider_mapper.dart
@@ -61,8 +61,11 @@ _ProviderModelStatus _parseProviderModelStatus({
 
 bool _isModelAvailable({required _ProviderModelStatus status}) {
   return switch (status) {
+    _ProviderModelStatus.active ||
+    _ProviderModelStatus.alpha ||
+    _ProviderModelStatus.beta ||
+    _ProviderModelStatus.unknown => true,
     _ProviderModelStatus.deprecated => false,
-    _ => true,
   };
 }
 

--- a/bridge/sesori_plugin_opencode/lib/src/provider_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/provider_mapper.dart
@@ -3,6 +3,14 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
 
 import "models/provider_info.dart";
 
+enum _ProviderModelStatus {
+  active,
+  alpha,
+  beta,
+  deprecated,
+  unknown,
+}
+
 /// Maps an OpenCode [ProviderListResponse] to the plugin interface
 /// [PluginProvidersResult], optionally filtering to connected providers only.
 PluginProvidersResult mapProviderResponse({
@@ -19,14 +27,9 @@ PluginProvidersResult mapProviderResponse({
             id: m.id,
             name: m.name,
             family: m.family,
-            isAvailable: switch (m.status) {
-              "active" => true,
-              "deprecated" => false,
-              final unknown => () {
-                Log.w("Unknown model status: $unknown for model ${m.id}, treating as available");
-                return true;
-              }(),
-            },
+            isAvailable: _isModelAvailable(
+              status: _parseProviderModelStatus(rawStatus: m.status, modelId: m.id),
+            ),
             releaseDate: switch (m.releaseDate) {
               final dateStr? => DateTime.tryParse(dateStr),
               null => null,
@@ -38,6 +41,29 @@ PluginProvidersResult mapProviderResponse({
   }).toList();
 
   return PluginProvidersResult(providers: providers);
+}
+
+_ProviderModelStatus _parseProviderModelStatus({
+  required String rawStatus,
+  required String modelId,
+}) {
+  return switch (rawStatus) {
+    "active" => _ProviderModelStatus.active,
+    "alpha" => _ProviderModelStatus.alpha,
+    "beta" => _ProviderModelStatus.beta,
+    "deprecated" => _ProviderModelStatus.deprecated,
+    final unknown => () {
+      Log.w("Unknown model status: $unknown for model $modelId, treating as available");
+      return _ProviderModelStatus.unknown;
+    }(),
+  };
+}
+
+bool _isModelAvailable({required _ProviderModelStatus status}) {
+  return switch (status) {
+    _ProviderModelStatus.deprecated => false,
+    _ => true,
+  };
 }
 
 PluginProvider _mapProvider({

--- a/bridge/sesori_plugin_opencode/test/provider_mapper_test.dart
+++ b/bridge/sesori_plugin_opencode/test/provider_mapper_test.dart
@@ -4,19 +4,26 @@ import "package:test/test.dart";
 
 void main() {
   group("mapProviderResponse", () {
-    test("preserves synthetic model IDs and treats unknown statuses as available", () {
+    test("preserves synthetic model IDs and treats alpha/beta statuses as available", () {
       const response = ProviderListResponse(
         all: [
           ProviderInfo(
             id: "openai",
             name: "OpenAI",
             models: {
-              "synthetic-key": ProviderModel(
+              "alpha-key": ProviderModel(
+                id: "openai/gpt-4.1-alpha",
+                providerID: "openai",
+                name: "GPT-4.1 Alpha",
+                family: "gpt-4.1",
+                status: "alpha",
+              ),
+              "beta-key": ProviderModel(
                 id: "openai/gpt-4.1-mini",
                 providerID: "openai",
                 name: "GPT-4.1 Mini",
                 family: "gpt-4.1",
-                status: "preview",
+                status: "beta",
                 releaseDate: "2025-04-01",
               ),
             },
@@ -32,12 +39,41 @@ void main() {
       final provider = mapped.providers.first;
       expect(provider.id, equals("openai"));
       expect(provider.defaultModelID, equals("openai/gpt-4.1-mini"));
-      expect(provider.models, hasLength(1));
+      expect(provider.models, hasLength(2));
 
-      final model = provider.models.first;
-      expect(model.id, equals("openai/gpt-4.1-mini"));
-      expect(model.isAvailable, isTrue);
-      expect(model.releaseDate, equals(DateTime(2025, 4, 1)));
+      final alphaModel = provider.models.firstWhere((model) => model.id == "openai/gpt-4.1-alpha");
+      expect(alphaModel.isAvailable, isTrue);
+
+      final betaModel = provider.models.firstWhere((model) => model.id == "openai/gpt-4.1-mini");
+      expect(betaModel.isAvailable, isTrue);
+      expect(betaModel.releaseDate, equals(DateTime(2025, 4, 1)));
+    });
+
+    test("treats still-unknown statuses as available", () {
+      const response = ProviderListResponse(
+        all: [
+          ProviderInfo(
+            id: "openai",
+            name: "OpenAI",
+            models: {
+              "synthetic-key": ProviderModel(
+                id: "openai/gpt-4.1-mini",
+                providerID: "openai",
+                name: "GPT-4.1 Mini",
+                family: "gpt-4.1",
+                status: "preview",
+              ),
+            },
+          ),
+        ],
+        defaults: {"openai": "openai/gpt-4.1-mini"},
+        connected: ["openai"],
+      );
+
+      final mapped = mapProviderResponse(response: response, connectedOnly: false);
+
+      expect(mapped.providers, hasLength(1));
+      expect(mapped.providers.single.models.single.isAvailable, isTrue);
     });
   });
 }


### PR DESCRIPTION
## Summary
- recognize OpenCode's upstream `alpha` and `beta` provider model statuses as known available statuses instead of sending them through the unknown-status warning path
- keep the fallback behavior for truly unknown statuses so new upstream values still degrade safely and remain selectable
- add mapper coverage for explicit `alpha`/`beta` handling while preserving the regression test for unknown statuses

## Validation
- `cd bridge && dart pub get`
- `cd bridge/sesori_plugin_opencode && dart analyze`
- `cd bridge/sesori_plugin_opencode && dart test test/provider_mapper_test.dart`
- `cd bridge && make analyze`
- `cd bridge && make test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recognize OpenCode `alpha` and `beta` model statuses as available in `sesori_plugin_opencode`, removing false “unknown status” warnings. The availability switch is now exhaustive; unknown statuses still default to available, and `deprecated` stays unavailable.

- **Bug Fixes**
  - Parse `alpha`/`beta` as known statuses and mark them available.
  - Centralize and exhaustively handle statuses via `_ProviderModelStatus`, `_parseProviderModelStatus`, and `_isModelAvailable`.
  - Preserve fallback: log and treat unknown statuses as available.
  - Updated tests for `alpha`/`beta`; kept regression for unknown (`preview`).

<sup>Written for commit bfa61dc566bf14bbc600d387b8733aaebdaab4cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

