### PR TITLE
fix: remove stale mobile camera permissions

### DIFF
--- a/mobile/app/android/app/src/main/AndroidManifest.xml
+++ b/mobile/app/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 

--- a/mobile/app/android/gradle.properties
+++ b/mobile/app/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-dev.steenbakker.mobile_scanner.useUnbundled=true

--- a/mobile/app/ios/Runner/Info.plist
+++ b/mobile/app/ios/Runner/Info.plist
@@ -84,8 +84,6 @@
 			<string>UIInterfaceOrientationLandscapeLeft</string>
 			<string>UIInterfaceOrientationLandscapeRight</string>
 		</array>
-		<key>NSCameraUsageDescription</key>
-		<string>Camera access is needed to scan QR codes for connecting to your server</string>
 		<key>NSMicrophoneUsageDescription</key>
 		<string>Microphone access is needed for voice-to-text transcription</string>
 		<key>CFBundleURLTypes</key>


### PR DESCRIPTION
## Summary
- remove stale Android and iOS camera permission declarations left behind after QR scanning was removed
- remove the unused Android `mobile_scanner` Gradle flag so native config matches the current dependency set
- verify there is no remaining camera or QR scanning usage in the mobile app and confirm Android and iOS builds still pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove stale camera permissions on Android and iOS and drop an unused Gradle flag after the QR scanner was removed. This prevents unnecessary permission prompts and aligns native configs with current features.

- **Bug Fixes**
  - Android: removed CAMERA permission in AndroidManifest and unused `dev.steenbakker.mobile_scanner.useUnbundled` flag.
  - iOS: removed `NSCameraUsageDescription` from `Info.plist`.
  - Verified no remaining camera/QR code usage; Android and iOS builds pass.

<sup>Written for commit c2e4b558f6f87b5b2d4acf03f18880ab55d68bb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

