### PR TITLE
fix: stop session detail follow mode from fighting user scroll

### DIFF
--- a/mobile/app/lib/features/session_detail/widgets/reasoning_modal.dart
+++ b/mobile/app/lib/features/session_detail/widgets/reasoning_modal.dart
@@ -1,4 +1,6 @@
+import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
+import "package:flutter/rendering.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
@@ -25,9 +27,14 @@ class ReasoningModal extends StatefulWidget {
 }
 
 class _ReasoningModalState extends State<ReasoningModal> {
+  static const _kNearLatestThreshold = 20.0;
+  static const _kListViewKey = Key("reasoning-modal-list-view");
+  static const _kFollowOutputKey = Key("reasoning-modal-follow-output");
+
   final ScrollController _scrollController = ScrollController();
   bool _following = true;
   bool _sheetOpen = true;
+  bool _userScrollActive = false;
 
   @override
   void dispose() {
@@ -105,32 +112,41 @@ class _ReasoningModalState extends State<ReasoningModal> {
           Expanded(
             child: Stack(
               children: [
-                NotificationListener<ScrollNotification>(
-                  onNotification: (notification) {
-                    if (notification is ScrollUpdateNotification && notification.dragDetails != null && _following) {
-                      final metrics = notification.metrics;
-                      if (metrics.pixels < metrics.maxScrollExtent - 20) {
-                        setState(() => _following = false);
+                Listener(
+                  onPointerSignal: _handlePointerSignal,
+                  onPointerPanZoomStart: (_) => _detachForUserScroll(),
+                  child: NotificationListener<ScrollNotification>(
+                    onNotification: (notification) {
+                      if (notification.depth != 0) return false;
+
+                      if (_isUserScrollStart(notification)) {
+                        _detachForUserScroll();
+                      } else if (notification is ScrollEndNotification && _userScrollActive) {
+                        _settleUserScroll(
+                          shouldFollow: notification.metrics.pixels >=
+                              notification.metrics.maxScrollExtent - _kNearLatestThreshold,
+                        );
                       }
-                    }
-                    return false;
-                  },
-                  child: ListView(
-                    controller: _scrollController,
-                    padding: const EdgeInsets.all(16),
-                    children: [
-                      MarkdownBody(
-                        data: data.text,
-                        selectable: true,
-                        onTapLink: handleMarkdownLinkTap,
-                        styleSheet: buildSessionMarkdownStyleSheet(
-                          theme,
-                          paragraphStyle: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.onSurfaceVariant,
+                      return false;
+                    },
+                    child: ListView(
+                      key: _kListViewKey,
+                      controller: _scrollController,
+                      padding: const EdgeInsets.all(16),
+                      children: [
+                        MarkdownBody(
+                          data: data.text,
+                          selectable: true,
+                          onTapLink: handleMarkdownLinkTap,
+                          styleSheet: buildSessionMarkdownStyleSheet(
+                            theme,
+                            paragraphStyle: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
                           ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
                 if (!_following && data.isStreaming) _buildFollowFab(theme: theme),
@@ -153,9 +169,13 @@ class _ReasoningModalState extends State<ReasoningModal> {
           borderRadius: BorderRadius.circular(20),
           color: theme.colorScheme.primaryContainer,
           child: InkWell(
+            key: _kFollowOutputKey,
             borderRadius: BorderRadius.circular(20),
             onTap: () {
-              setState(() => _following = true);
+              setState(() {
+                _following = true;
+                _userScrollActive = false;
+              });
               if (_scrollController.hasClients) {
                 _scrollController.animateTo(
                   _scrollController.position.maxScrollExtent,
@@ -191,5 +211,34 @@ class _ReasoningModalState extends State<ReasoningModal> {
         ),
       ),
     );
+  }
+
+  bool _isUserScrollStart(ScrollNotification notification) {
+    return (notification is ScrollStartNotification && notification.dragDetails != null) ||
+        (notification is UserScrollNotification && notification.direction != ScrollDirection.idle);
+  }
+
+  void _handlePointerSignal(PointerSignalEvent event) {
+    if (event is PointerScrollEvent) {
+      _detachForUserScroll();
+    }
+  }
+
+  void _detachForUserScroll() {
+    if (_userScrollActive && !_following) return;
+
+    setState(() {
+      _userScrollActive = true;
+      _following = false;
+    });
+  }
+
+  void _settleUserScroll({required bool shouldFollow}) {
+    if (!_userScrollActive && _following == shouldFollow) return;
+
+    setState(() {
+      _userScrollActive = false;
+      _following = shouldFollow;
+    });
   }
 }

--- a/mobile/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/mobile/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -1,4 +1,6 @@
+import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
+import "package:flutter/rendering.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../../../core/extensions/build_context_x.dart";
@@ -32,6 +34,7 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
 
   late final ScrollController _scrollController;
   bool _following = true;
+  bool _userScrollActive = false;
 
   @override
   void initState() {
@@ -61,6 +64,10 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
         return;
       }
 
+      if (_userScrollActive) {
+        return;
+      }
+
       final position = _scrollController.position;
       final delta = position.maxScrollExtent - oldMaxScrollExtent;
       final target = (oldPixels + delta).clamp(position.minScrollExtent, position.maxScrollExtent);
@@ -69,7 +76,10 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
   }
 
   void _jumpToLatest() {
-    setState(() => _following = true);
+    setState(() {
+      _following = true;
+      _userScrollActive = false;
+    });
     if (_scrollController.hasClients) {
       _scrollController.animateTo(
         0,
@@ -86,35 +96,40 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
 
     return Stack(
       children: [
-        NotificationListener<ScrollNotification>(
-          onNotification: (notification) {
-            if (notification is ScrollUpdateNotification) {
-              // Desktop wheel/trackpad scrolling can update pixels without drag details.
-              _updateFollowingFromPixels();
-            } else if (notification is ScrollEndNotification) {
-              _updateFollowingFromPixels();
-            }
-            return false;
-          },
-          child: ListView.builder(
-            key: _kListViewKey,
-            controller: _scrollController,
-            reverse: true,
-            padding: const EdgeInsets.symmetric(vertical: 8),
-            itemCount: widget.messages.length,
-            itemBuilder: (context, index) {
-              final message = widget.messages[widget.messages.length - 1 - index];
-              final child = message.info.role == "user"
-                  ? UserMessageCard(message: message)
-                  : AssistantMessageCard(
-                      projectId: widget.projectId,
-                      message: message,
-                      streamingText: widget.streamingText,
-                      children: widget.children,
-                      childStatuses: widget.childStatuses,
-                    );
-              return KeyedSubtree(key: ValueKey(message.info.id), child: child);
+        Listener(
+          onPointerSignal: _handlePointerSignal,
+          onPointerPanZoomStart: (_) => _detachForUserScroll(),
+          child: NotificationListener<ScrollNotification>(
+            onNotification: (notification) {
+              if (notification.depth != 0) return false;
+
+              if (_isUserScrollStart(notification)) {
+                _detachForUserScroll();
+              } else if (notification is ScrollEndNotification && _userScrollActive) {
+                _settleUserScroll(shouldFollow: notification.metrics.pixels <= _kNearBottomThreshold);
+              }
+              return false;
             },
+            child: ListView.builder(
+              key: _kListViewKey,
+              controller: _scrollController,
+              reverse: true,
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              itemCount: widget.messages.length,
+              itemBuilder: (context, index) {
+                final message = widget.messages[widget.messages.length - 1 - index];
+                final child = message.info.role == "user"
+                    ? UserMessageCard(message: message)
+                    : AssistantMessageCard(
+                        projectId: widget.projectId,
+                        message: message,
+                        streamingText: widget.streamingText,
+                        children: widget.children,
+                        childStatuses: widget.childStatuses,
+                      );
+                return KeyedSubtree(key: ValueKey(message.info.id), child: child);
+              },
+            ),
           ),
         ),
         if (!_following)
@@ -155,13 +170,32 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
     );
   }
 
-  void _updateFollowingFromPixels() {
-    if (!_scrollController.hasClients) return;
+  bool _isUserScrollStart(ScrollNotification notification) {
+    return (notification is ScrollStartNotification && notification.dragDetails != null) ||
+        (notification is UserScrollNotification && notification.direction != ScrollDirection.idle);
+  }
 
-    final pixels = _scrollController.position.pixels;
-    final shouldFollow = pixels <= _kNearBottomThreshold;
-    if (_following != shouldFollow) {
-      setState(() => _following = shouldFollow);
+  void _handlePointerSignal(PointerSignalEvent event) {
+    if (event is PointerScrollEvent) {
+      _detachForUserScroll();
     }
+  }
+
+  void _detachForUserScroll() {
+    if (_userScrollActive && !_following) return;
+
+    setState(() {
+      _userScrollActive = true;
+      _following = false;
+    });
+  }
+
+  void _settleUserScroll({required bool shouldFollow}) {
+    if (!_userScrollActive && _following == shouldFollow) return;
+
+    setState(() {
+      _userScrollActive = false;
+      _following = shouldFollow;
+    });
   }
 }

--- a/mobile/app/test/features/session_detail/widgets/reasoning_modal_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/reasoning_modal_test.dart
@@ -1,6 +1,7 @@
 import "dart:async";
 
 import "package:bloc_test/bloc_test.dart";
+import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
@@ -93,6 +94,27 @@ Widget _buildApp({required SessionDetailCubit cubit}) {
       ),
     ),
   );
+}
+
+String _reasoningText({required int paragraphs}) {
+  return List.generate(
+    paragraphs,
+    (index) => "Thought $index\n\n${List.generate(4, (line) => "detail $index.$line").join(" ")}",
+  ).join("\n\n");
+}
+
+const _reasoningListViewKey = Key("reasoning-modal-list-view");
+const _followOutputKey = Key("reasoning-modal-follow-output");
+
+ScrollPosition _position(WidgetTester tester) {
+  return tester.widget<ListView>(find.byKey(_reasoningListViewKey)).controller!.position;
+}
+
+Future<void> _sendPointerScroll({required WidgetTester tester, required Finder target, required Offset delta}) async {
+  final pointer = TestPointer(1, PointerDeviceKind.mouse);
+  await tester.sendEventToBinding(pointer.hover(tester.getCenter(target)));
+  await tester.pump();
+  await tester.sendEventToBinding(pointer.scroll(delta));
 }
 
 void main() {
@@ -203,5 +225,66 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text("Thought"), findsOneWidget);
+  });
+
+  testWidgets("small user drag detaches immediately and reattaches on settle while streaming", (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    whenListen(
+      mockCubit,
+      const Stream<SessionDetailState>.empty(),
+      initialState: _loadedState(
+        streamingText: {"part-1": _reasoningText(paragraphs: 40)},
+        messages: [_messageWithPart()],
+      ),
+    );
+
+    await tester.pumpWidget(_buildApp(cubit: mockCubit));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(_followOutputKey), findsNothing);
+
+    final gesture = await tester.startGesture(tester.getCenter(find.byKey(_reasoningListViewKey)));
+    await gesture.moveBy(const Offset(0, -12));
+    await tester.pump();
+
+    expect(find.byKey(_followOutputKey), findsOneWidget);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(_followOutputKey), findsNothing);
+    expect(_position(tester).pixels, greaterThanOrEqualTo(_position(tester).maxScrollExtent - 20));
+  });
+
+  testWidgets("desktop pointer scroll detaches immediately while streaming", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    whenListen(
+      mockCubit,
+      const Stream<SessionDetailState>.empty(),
+      initialState: _loadedState(
+        streamingText: {"part-1": _reasoningText(paragraphs: 40)},
+        messages: [_messageWithPart()],
+      ),
+    );
+
+    await tester.pumpWidget(_buildApp(cubit: mockCubit));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(_followOutputKey), findsNothing);
+
+    await _sendPointerScroll(
+      tester: tester,
+      target: find.byKey(_reasoningListViewKey),
+      delta: const Offset(0, -500),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(_followOutputKey), findsOneWidget);
   });
 }

--- a/mobile/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -1,3 +1,4 @@
+import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:sesori_mobile/features/session_detail/widgets/session_detail_message_list.dart";
@@ -121,6 +122,13 @@ Future<void> _pumpListUpdate(WidgetTester tester) async {
   await tester.pump();
 }
 
+Future<void> _sendPointerScroll({required WidgetTester tester, required Finder target, required Offset delta}) async {
+  final pointer = TestPointer(1, PointerDeviceKind.mouse);
+  await tester.sendEventToBinding(pointer.hover(tester.getCenter(target)));
+  await tester.pump();
+  await tester.sendEventToBinding(pointer.scroll(delta));
+}
+
 Future<void> _detachViewport(WidgetTester tester) async {
   await tester.drag(find.byKey(_listViewKey), const Offset(0, -500));
   await tester.pumpAndSettle();
@@ -128,19 +136,6 @@ Future<void> _detachViewport(WidgetTester tester) async {
     await tester.drag(find.byKey(_listViewKey), const Offset(0, 500));
   }
   await tester.pumpAndSettle();
-  expect(_position(tester).pixels, greaterThan(20));
-  expect(find.byKey(_jumpToLatestKey), findsOneWidget);
-}
-
-Future<void> _detachViewportWithoutDrag(WidgetTester tester) async {
-  final position = _position(tester);
-  final target = position.maxScrollExtent > 40 ? position.maxScrollExtent / 2 : position.maxScrollExtent;
-
-  expect(target, greaterThan(20));
-  position.jumpTo(target);
-  await tester.pump();
-  await tester.pump();
-
   expect(_position(tester).pixels, greaterThan(20));
   expect(find.byKey(_jumpToLatestKey), findsOneWidget);
 }
@@ -249,35 +244,80 @@ void main() {
     expect(_messageKey("user-following"), findsOneWidget);
   });
 
-  testWidgets("non-drag scroll updates also detach follow mode", (tester) async {
+  testWidgets("small user drag detaches immediately and only reattaches after settling near latest", (
+    tester,
+  ) async {
     await tester.binding.setSurfaceSize(const Size(900, 700));
     addTearDown(() => tester.binding.setSurfaceSize(null));
 
-    final harnessKey = GlobalKey<_SessionDetailMessageListHarnessState>();
     await tester.pumpWidget(
       _SessionDetailMessageListHarness(
-        key: harnessKey,
         initialMessages: _userMessages(count: 12),
         initialStreamingText: const {},
       ),
     );
     await tester.pumpAndSettle();
 
-    await _detachViewportWithoutDrag(tester);
-    final anchor = _messageKey("user-7");
-    final before = tester.getTopLeft(anchor).dy;
+    expect(find.byKey(_jumpToLatestKey), findsNothing);
 
-    harnessKey.currentState!.appendNewestMessage(
-      _message(
-        messageId: "user-wheel",
-        role: "user",
-        text: _multilineText(label: "Wheel newest", lines: 10),
+    final gesture = await tester.startGesture(tester.getCenter(find.byKey(_listViewKey)));
+    await gesture.moveBy(const Offset(0, -12));
+    await tester.pump();
+
+    expect(find.byKey(_jumpToLatestKey), findsOneWidget);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(_position(tester).pixels, lessThanOrEqualTo(20));
+    expect(find.byKey(_jumpToLatestKey), findsNothing);
+  });
+
+  testWidgets("desktop pointer scroll detaches immediately", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        initialMessages: _userMessages(count: 12),
+        initialStreamingText: const {},
       ),
     );
-    await _pumpListUpdate(tester);
+    await tester.pumpAndSettle();
 
-    final after = tester.getTopLeft(anchor).dy;
-    expect(after, closeTo(before, 0.1));
+    expect(find.byKey(_jumpToLatestKey), findsNothing);
+
+    await _sendPointerScroll(
+      tester: tester,
+      target: find.byKey(_listViewKey),
+      delta: const Offset(0, 500),
+    );
+    await tester.pumpAndSettle();
+
     expect(find.byKey(_jumpToLatestKey), findsOneWidget);
+  });
+
+  testWidgets("programmatic scroll changes do not detach follow mode", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        initialMessages: _userMessages(count: 12),
+        initialStreamingText: const {},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await _detachViewport(tester);
+
+    await tester.tap(find.byKey(_jumpToLatestKey));
+    await tester.pump();
+
+    expect(find.byKey(_jumpToLatestKey), findsNothing);
+
+    await tester.pumpAndSettle();
+
+    expect(_position(tester).pixels, 0);
   });
 }


### PR DESCRIPTION
## Summary
- detach the reversed session detail list immediately for drag, wheel, and trackpad-style pointer input, and only reattach after scroll settle when the viewport is back near the latest message
- avoid message-list `jumpTo(...)` compensation while the user is actively scrolling so live updates no longer fight manual reading of older content
- mirror the same follow/detach model in the reasoning modal and add widget coverage for drag-based and desktop pointer-scroll regressions

## Verification
- `cd mobile && dart pub get`
- `cd mobile/app && dart analyze`
- `cd mobile/app && flutter test`
- `cd mobile/module_core && dart analyze && dart test`
- `cd mobile/module_auth && dart analyze && dart test`