### PR TITLE
fix(mobile): catch async errors in VoiceApi.transcribe

### DIFF
--- a/mobile/app/test/capabilities/voice/voice_api_test.dart
+++ b/mobile/app/test/capabilities/voice/voice_api_test.dart
@@ -97,6 +97,10 @@ void main() {
 
     test("timeout: maps TimeoutException to dartHttpClient error", () async {
       final audioPath = await createAudioPath();
+      // Use thenAnswer with Future.error to simulate an async failure from the
+      // underlying HTTP client — matches how `.timeout()` surfaces
+      // TimeoutException in production and protects against the try/catch
+      // regression where the returned Future isn't awaited.
       when(
         () => mockAuthenticatedHttpApiClient.postMultipart<String>(
           any(),
@@ -104,7 +108,9 @@ void main() {
           createFiles: any(named: "createFiles"),
           timeout: any(named: "timeout"),
         ),
-      ).thenThrow(TimeoutException("Request timed out"));
+      ).thenAnswer(
+        (_) => Future<ApiResponse<String>>.error(TimeoutException("Request timed out")),
+      );
 
       final result = await voiceApi.transcribe(audioPath, mimeType: "audio/mp4");
 
@@ -121,7 +127,9 @@ void main() {
           createFiles: any(named: "createFiles"),
           timeout: any(named: "timeout"),
         ),
-      ).thenThrow(const SocketException("Network unreachable"));
+      ).thenAnswer(
+        (_) => Future<ApiResponse<String>>.error(const SocketException("Network unreachable")),
+      );
 
       final result = await voiceApi.transcribe(audioPath, mimeType: "audio/mp4");
 
@@ -154,7 +162,9 @@ void main() {
           createFiles: any(named: "createFiles"),
           timeout: any(named: "timeout"),
         ),
-      ).thenThrow(const HandshakeException("TLS failed"));
+      ).thenAnswer(
+        (_) => Future<ApiResponse<String>>.error(const HandshakeException("TLS failed")),
+      );
 
       final result = await voiceApi.transcribe(audioPath, mimeType: "audio/mp4");
 

--- a/mobile/module_core/lib/src/capabilities/voice/voice_api.dart
+++ b/mobile/module_core/lib/src/capabilities/voice/voice_api.dart
@@ -28,7 +28,11 @@ class VoiceApi {
     final uri = Uri.parse("$authBaseUrl/voice/transcribe");
 
     try {
-      return _client.postMultipart(
+      // `await` is required here so async errors thrown inside the returned
+      // Future (TimeoutException, SocketException, HandshakeException) are
+      // caught by the handlers below. Without the await, the Future's failure
+      // escapes this try/catch and propagates to the caller unwrapped.
+      return await _client.postMultipart(
         uri,
         fromJson: _parseTranscript,
         createFiles: () async => [


### PR DESCRIPTION
## Summary
- `VoiceApi.transcribe` returned the `postMultipart` Future without awaiting it, so the `on TimeoutException`/`SocketException`/`HandshakeException` handlers were dead code — those exceptions propagated to the caller unwrapped instead of being mapped to `ApiError.dartHttpClient`.
- Added `await` to bind the Future's failure to the enclosing async frame so the existing handlers fire as intended.
- Updated the three network-error tests to use `thenAnswer(Future.error(...))` instead of `thenThrow(...)`. The old tests masked the bug because `thenThrow` throws synchronously on method invocation (caught even without `await`), whereas real HTTP clients surface timeouts/socket/TLS failures asynchronously from within the Future.

## Verification
- With the fix reverted, the three updated tests fail with the raw exception escaping the try/catch (reproduced locally).
- With the fix applied: `flutter test test/capabilities/voice/` — all 28 voice tests pass.
- `dart test` in `mobile/module_core` — all 231 tests pass.
- `dart analyze --fatal-infos` — clean for both `mobile/module_core` and the touched test files. (`unnecessary_await_in_return` does not flag `return await` inside a try block, so the fix is lint-compliant.)

## Test plan
- [x] `flutter test mobile/app/test/capabilities/voice/voice_api_test.dart`
- [x] `flutter test mobile/app/test/capabilities/voice/voice_transcription_service_test.dart`
- [x] `dart test` in `mobile/module_core`
- [x] `dart analyze --fatal-infos` in `mobile/module_core`
- [ ] Exercise the voice transcription flow on a real device with network interruption (timeout / airplane mode) and confirm the user sees a graceful error rather than an unhandled exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes async error handling in `VoiceApi.transcribe` so timeouts and socket/TLS failures are caught and mapped to `ApiError.dartHttpClient` instead of bubbling up. Users now see a graceful error during voice transcription when the network fails.

- **Bug Fixes**
  - Added `await` to `_client.postMultipart(...)` so async errors are caught by existing handlers.
  - Updated tests to use `thenAnswer(Future.error(...))` for timeout/socket/handshake cases to reflect real async failures.

<sup>Written for commit ce1c99697ed4eccb33adc09c0fc64ef433edde0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

