### PR TITLE
fix(mobile): rewrite session detail scroll-detach from scratch

### DIFF
--- a/mobile/app/lib/features/session_detail/widgets/follow_detach_scrollable.dart
+++ b/mobile/app/lib/features/session_detail/widgets/follow_detach_scrollable.dart
@@ -1,0 +1,85 @@
+import "package:flutter/widgets.dart";
+
+import "scroll_follow_tracker.dart";
+
+/// Wraps a scrollable [child] with the gesture plumbing a
+/// [ScrollFollowTracker] needs:
+///
+/// - `Listener.onPointerSignal` — trackpad two-finger scroll / mouse
+///   wheel. Forwards to [ScrollFollowTracker.handlePointerSignal].
+/// - `Listener.onPointerPanZoomStart` — trackpad pan-zoom gesture.
+///   Forwards to [ScrollFollowTracker.handlePointerPanZoomStart].
+/// - `NotificationListener<ScrollNotification>` — drag, momentum,
+///   programmatic events. Forwards to
+///   [ScrollFollowTracker.handleScrollNotification].
+///
+/// Rebuilds when [tracker] notifies so [detachedOverlayBuilder]
+/// toggles with `tracker.following`. The overlay is stacked on top
+/// of [child] using a [Stack]; [detachedOverlayBuilder] should return
+/// a `Positioned` (or equivalent) child.
+///
+/// [child] is expected to be a scrollable configured with
+/// `tracker.scrollController`. The widget does not create or own the
+/// scroll controller — it only wires gesture intent.
+class FollowDetachScrollable extends StatefulWidget {
+  final ScrollFollowTracker tracker;
+  final Widget child;
+  final WidgetBuilder? detachedOverlayBuilder;
+
+  const FollowDetachScrollable({
+    super.key,
+    required this.tracker,
+    required this.child,
+    required this.detachedOverlayBuilder,
+  });
+
+  @override
+  State<FollowDetachScrollable> createState() => _FollowDetachScrollableState();
+}
+
+class _FollowDetachScrollableState extends State<FollowDetachScrollable> {
+  @override
+  void initState() {
+    super.initState();
+    widget.tracker.addListener(_onFollowChanged);
+  }
+
+  @override
+  void didUpdateWidget(covariant FollowDetachScrollable oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.tracker, widget.tracker)) {
+      oldWidget.tracker.removeListener(_onFollowChanged);
+      widget.tracker.addListener(_onFollowChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.tracker.removeListener(_onFollowChanged);
+    super.dispose();
+  }
+
+  void _onFollowChanged() {
+    if (!mounted) return;
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final overlayBuilder = widget.detachedOverlayBuilder;
+    return Stack(
+      children: [
+        Listener(
+          onPointerSignal: (event) => widget.tracker.handlePointerSignal(event: event),
+          onPointerPanZoomStart: (_) => widget.tracker.handlePointerPanZoomStart(),
+          child: NotificationListener<ScrollNotification>(
+            onNotification: (notification) =>
+                widget.tracker.handleScrollNotification(notification: notification),
+            child: widget.child,
+          ),
+        ),
+        if (!widget.tracker.following && overlayBuilder != null) overlayBuilder(context),
+      ],
+    );
+  }
+}

--- a/mobile/app/lib/features/session_detail/widgets/jump_to_edge_pill.dart
+++ b/mobile/app/lib/features/session_detail/widgets/jump_to_edge_pill.dart
@@ -1,0 +1,62 @@
+import "package:flutter/material.dart";
+
+/// Floating pill overlay shown over a detached scrollable, inviting the
+/// user to jump back to the follow edge (top or bottom depending on
+/// scrollable orientation).
+///
+/// Bottom-anchored, horizontally centered. Intended to be stacked as
+/// an overlay (returned from `FollowDetachScrollable.detachedOverlayBuilder`).
+///
+/// [tapTargetKey] is applied to the `InkWell` so tests can locate the
+/// tappable region directly; the widget's own [key] is for outer
+/// element reconciliation.
+class JumpToEdgePill extends StatelessWidget {
+  final Key? tapTargetKey;
+  final String label;
+  final VoidCallback onTap;
+
+  const JumpToEdgePill({
+    super.key,
+    required this.tapTargetKey,
+    required this.label,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Positioned(
+      bottom: 12,
+      left: 0,
+      right: 0,
+      child: Center(
+        child: Material(
+          elevation: 4,
+          borderRadius: BorderRadius.circular(20),
+          color: theme.colorScheme.primaryContainer,
+          child: InkWell(
+            key: tapTargetKey,
+            borderRadius: BorderRadius.circular(20),
+            onTap: onTap,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.arrow_downward, size: 16, color: theme.colorScheme.onPrimaryContainer),
+                  const SizedBox(width: 6),
+                  Text(
+                    label,
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: theme.colorScheme.onPrimaryContainer,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/app/lib/features/session_detail/widgets/reasoning_modal.dart
+++ b/mobile/app/lib/features/session_detail/widgets/reasoning_modal.dart
@@ -1,17 +1,33 @@
-import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
-import "package:flutter/rendering.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/widgets/markdown_styles.dart";
+import "../../../l10n/app_localizations.dart";
+import "follow_detach_scrollable.dart";
+import "jump_to_edge_pill.dart";
+import "scroll_follow_tracker.dart";
 
 /// Modal body for displaying AI reasoning/thinking content.
 ///
 /// Self-subscribes to [SessionDetailCubit] via [context.select] for
-/// real-time streaming updates — replaces the stale ValueNotifier pattern.
+/// real-time streaming updates — replaces the stale ValueNotifier
+/// pattern.
+///
+/// Scroll behaviour — "follow / detach":
+///
+/// - Uses a non-reversed `ListView`, so the latest streamed tokens
+///   live at `maxScrollExtent`. While **following**, a single
+///   coalesced post-frame `jumpTo(maxScrollExtent)` is scheduled per
+///   rebuild (via [ScrollFollowTracker.scheduleJumpToEdge]) so
+///   fast streaming updates never stack overlapping animations.
+/// - Detach triggers (drag start, trackpad scroll, trackpad pan) are
+///   wired through [FollowDetachScrollable]. While detached, live
+///   updates keep arriving but the scroll position is left alone.
+/// - The "Follow" button tap performs one explicit animated scroll to
+///   the tail via [ScrollFollowTracker.animateToEdge].
 class ReasoningModal extends StatefulWidget {
   final String partId;
   final String messageId;
@@ -27,19 +43,20 @@ class ReasoningModal extends StatefulWidget {
 }
 
 class _ReasoningModalState extends State<ReasoningModal> {
-  static const _kNearLatestThreshold = 20.0;
   static const _kListViewKey = Key("reasoning-modal-list-view");
   static const _kFollowOutputKey = Key("reasoning-modal-follow-output");
 
-  final ScrollController _scrollController = ScrollController();
-  bool _following = true;
-  bool _sheetOpen = true;
-  bool _userScrollActive = false;
+  late final ScrollFollowTracker _follow;
+
+  @override
+  void initState() {
+    super.initState();
+    _follow = ScrollFollowTracker(edge: ScrollFollowEdge.max);
+  }
 
   @override
   void dispose() {
-    _sheetOpen = false;
-    _scrollController.dispose();
+    _follow.dispose();
     super.dispose();
   }
 
@@ -56,15 +73,12 @@ class _ReasoningModalState extends State<ReasoningModal> {
     final loc = context.loc;
     final height = MediaQuery.of(context).size.height * 0.7;
 
-    if (_following && data.isStreaming) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!_sheetOpen || !_scrollController.hasClients) return;
-        _scrollController.animateTo(
-          _scrollController.position.maxScrollExtent,
-          duration: const Duration(milliseconds: 150),
-          curve: Curves.easeOut,
-        );
-      });
+    // Coalesced post-frame tail-jump. Safe to call every rebuild;
+    // repeated calls within a frame collapse into one jump. Gated on
+    // isStreaming so a settled modal does not re-pin when the user
+    // has scrolled into historical reasoning.
+    if (data.isStreaming) {
+      _follow.scheduleJumpToEdge();
     }
 
     return Container(
@@ -75,82 +89,37 @@ class _ReasoningModalState extends State<ReasoningModal> {
       ),
       child: Column(
         children: [
-          // Drag handle
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8),
-            child: Container(
-              width: 32,
-              height: 4,
-              decoration: BoxDecoration(
-                color: theme.colorScheme.outlineVariant,
-                borderRadius: BorderRadius.circular(2),
-              ),
-            ),
-          ),
-          // Header
-          Padding(
-            padding: const EdgeInsetsDirectional.fromSTEB(16, 4, 16, 12),
-            child: Row(
-              children: [
-                Icon(
-                  Icons.psychology,
-                  size: 20,
-                  color: theme.colorScheme.outline,
-                ),
-                const SizedBox(width: 8),
-                Text(
-                  data.isStreaming ? loc.sessionDetailThinking : loc.sessionDetailThought,
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    fontStyle: .italic,
-                  ),
-                ),
-              ],
-            ),
-          ),
+          _buildDragHandle(theme: theme),
+          _buildHeader(theme: theme, isStreaming: data.isStreaming, loc: loc),
           const Divider(height: 1),
-          // Content
           Expanded(
-            child: Stack(
-              children: [
-                Listener(
-                  onPointerSignal: _handlePointerSignal,
-                  onPointerPanZoomStart: (_) => _detachForUserScroll(),
-                  child: NotificationListener<ScrollNotification>(
-                    onNotification: (notification) {
-                      if (notification.depth != 0) return false;
-
-                      if (_isUserScrollStart(notification)) {
-                        _detachForUserScroll();
-                      } else if (notification is ScrollEndNotification && _userScrollActive) {
-                        _settleUserScroll(
-                          shouldFollow: notification.metrics.pixels >=
-                              notification.metrics.maxScrollExtent - _kNearLatestThreshold,
-                        );
-                      }
-                      return false;
-                    },
-                    child: ListView(
-                      key: _kListViewKey,
-                      controller: _scrollController,
-                      padding: const EdgeInsets.all(16),
-                      children: [
-                        MarkdownBody(
-                          data: data.text,
-                          selectable: true,
-                          onTapLink: handleMarkdownLinkTap,
-                          styleSheet: buildSessionMarkdownStyleSheet(
-                            theme,
-                            paragraphStyle: theme.textTheme.bodySmall?.copyWith(
-                              color: theme.colorScheme.onSurfaceVariant,
-                            ),
-                          ),
-                        ),
-                      ],
+            child: FollowDetachScrollable(
+              tracker: _follow,
+              detachedOverlayBuilder: data.isStreaming
+                  ? (ctx) => JumpToEdgePill(
+                        tapTargetKey: _kFollowOutputKey,
+                        label: loc.sessionDetailFollowOutput,
+                        onTap: () => _follow.animateToEdge(),
+                      )
+                  : null,
+              child: ListView(
+                key: _kListViewKey,
+                controller: _follow.scrollController,
+                padding: const EdgeInsets.all(16),
+                children: [
+                  MarkdownBody(
+                    data: data.text,
+                    selectable: true,
+                    onTapLink: handleMarkdownLinkTap,
+                    styleSheet: buildSessionMarkdownStyleSheet(
+                      theme,
+                      paragraphStyle: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
                     ),
                   ),
-                ),
-                if (!_following && data.isStreaming) _buildFollowFab(theme: theme),
-              ],
+                ],
+              ),
             ),
           ),
         ],
@@ -158,87 +127,37 @@ class _ReasoningModalState extends State<ReasoningModal> {
     );
   }
 
-  Widget _buildFollowFab({required ThemeData theme}) {
-    return Positioned(
-      bottom: 12,
-      left: 0,
-      right: 0,
-      child: Center(
-        child: Material(
-          elevation: 4,
-          borderRadius: BorderRadius.circular(20),
-          color: theme.colorScheme.primaryContainer,
-          child: InkWell(
-            key: _kFollowOutputKey,
-            borderRadius: BorderRadius.circular(20),
-            onTap: () {
-              setState(() {
-                _following = true;
-                _userScrollActive = false;
-              });
-              if (_scrollController.hasClients) {
-                _scrollController.animateTo(
-                  _scrollController.position.maxScrollExtent,
-                  duration: const Duration(milliseconds: 150),
-                  curve: Curves.easeOut,
-                );
-              }
-            },
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 16,
-                vertical: 8,
-              ),
-              child: Row(
-                mainAxisSize: .min,
-                children: [
-                  Icon(
-                    Icons.arrow_downward,
-                    size: 16,
-                    color: theme.colorScheme.onPrimaryContainer,
-                  ),
-                  const SizedBox(width: 6),
-                  Text(
-                    context.loc.sessionDetailFollowOutput,
-                    style: theme.textTheme.labelMedium?.copyWith(
-                      color: theme.colorScheme.onPrimaryContainer,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
+  Widget _buildDragHandle({required ThemeData theme}) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Container(
+        width: 32,
+        height: 4,
+        decoration: BoxDecoration(
+          color: theme.colorScheme.outlineVariant,
+          borderRadius: BorderRadius.circular(2),
         ),
       ),
     );
   }
 
-  bool _isUserScrollStart(ScrollNotification notification) {
-    return (notification is ScrollStartNotification && notification.dragDetails != null) ||
-        (notification is UserScrollNotification && notification.direction != ScrollDirection.idle);
-  }
-
-  void _handlePointerSignal(PointerSignalEvent event) {
-    if (event is PointerScrollEvent) {
-      _detachForUserScroll();
-    }
-  }
-
-  void _detachForUserScroll() {
-    if (_userScrollActive && !_following) return;
-
-    setState(() {
-      _userScrollActive = true;
-      _following = false;
-    });
-  }
-
-  void _settleUserScroll({required bool shouldFollow}) {
-    if (!_userScrollActive && _following == shouldFollow) return;
-
-    setState(() {
-      _userScrollActive = false;
-      _following = shouldFollow;
-    });
+  Widget _buildHeader({
+    required ThemeData theme,
+    required bool isStreaming,
+    required AppLocalizations loc,
+  }) {
+    return Padding(
+      padding: const EdgeInsetsDirectional.fromSTEB(16, 4, 16, 12),
+      child: Row(
+        children: [
+          Icon(Icons.psychology, size: 20, color: theme.colorScheme.outline),
+          const SizedBox(width: 8),
+          Text(
+            isStreaming ? loc.sessionDetailThinking : loc.sessionDetailThought,
+            style: theme.textTheme.titleMedium?.copyWith(fontStyle: FontStyle.italic),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/mobile/app/lib/features/session_detail/widgets/scroll_follow_tracker.dart
+++ b/mobile/app/lib/features/session_detail/widgets/scroll_follow_tracker.dart
@@ -1,0 +1,158 @@
+import "package:flutter/gestures.dart";
+import "package:flutter/rendering.dart";
+import "package:flutter/widgets.dart";
+
+/// Which edge a scrollable should "follow" when auto-pinned.
+///
+/// - [min] — follows offset `0`. Matches the visual bottom of a
+///   `reverse: true` ListView (newest-at-bottom chat list).
+/// - [max] — follows `maxScrollExtent`. Matches the visual bottom of a
+///   normal non-reversed ListView (growing output tailed from the end).
+enum ScrollFollowEdge { min, max }
+
+/// Maintains the "following vs detached" state of a scrollable derived
+/// from scroll and pointer events, and exposes snapshot access via
+/// [following] plus `ChangeNotifier` subscription.
+///
+/// Owns a [ScrollController] and exposes small hooks the scrollable
+/// wires to `Listener` / `NotificationListener`:
+///
+/// - [handlePointerSignal] — trackpad/wheel scroll. Detaches.
+/// - [handlePointerPanZoomStart] — trackpad two-finger pan. Detaches.
+/// - [handleScrollNotification] — drag / momentum events. Detaches on
+///   user-initiated starts, reattaches on settle near the follow edge.
+///
+/// Design rules (enforced by deliberately small API surface):
+///
+/// - A single `_following` flag is the only state. No `_userScrollActive`
+///   flag, no race-prone captures of old pixels/maxScrollExtent.
+/// - The tracker never rewrites `position.pixels` except when the
+///   caller explicitly asks via [animateToEdge] or [scheduleJumpToEdge].
+/// - For a `reverse: true` list following [ScrollFollowEdge.min],
+///   nothing needs to happen on each rebuild — Flutter's native
+///   sliver offset correction keeps offset `0` pinned to the newest
+///   item as data is appended. [scheduleJumpToEdge] exists for the
+///   [ScrollFollowEdge.max] tailing case only.
+class ScrollFollowTracker extends ChangeNotifier {
+  ScrollFollowTracker({
+    required this.edge,
+    double edgeTolerance = 20.0,
+  }) : _edgeTolerance = edgeTolerance,
+       scrollController = ScrollController();
+
+  final ScrollFollowEdge edge;
+  final double _edgeTolerance;
+  final ScrollController scrollController;
+
+  bool _following = true;
+  bool _snapScheduled = false;
+
+  /// Whether the scrollable is currently pinned to [edge].
+  bool get following => _following;
+
+  /// Immediately enter detached mode if not already detached.
+  void detach() {
+    if (!_following) return;
+    _following = false;
+    notifyListeners();
+  }
+
+  /// Hook for `Listener.onPointerSignal` (trackpad two-finger scroll,
+  /// mouse wheel). Detaches on any pointer scroll event.
+  void handlePointerSignal({required PointerSignalEvent event}) {
+    if (event is PointerScrollEvent) detach();
+  }
+
+  /// Hook for `Listener.onPointerPanZoomStart` (trackpad pan-zoom).
+  /// Detaches on gesture start.
+  void handlePointerPanZoomStart() => detach();
+
+  /// Hook for `NotificationListener<ScrollNotification>.onNotification`.
+  /// Returns `false` so the notification continues to bubble.
+  bool handleScrollNotification({required ScrollNotification notification}) {
+    if (notification.depth != 0) return false;
+
+    if (_isUserScrollStart(notification: notification)) {
+      detach();
+    } else if (notification is ScrollEndNotification) {
+      _maybeReattach(metrics: notification.metrics);
+    }
+    return false;
+  }
+
+  /// Animate to [edge] and enter follow mode. Used for "Jump to latest"
+  /// / "Follow output" button taps.
+  Future<void> animateToEdge({
+    Duration duration = const Duration(milliseconds: 180),
+    Curve curve = Curves.easeOut,
+  }) async {
+    if (!_following) {
+      _following = true;
+      notifyListeners();
+    }
+    if (!scrollController.hasClients) return;
+    await scrollController.animateTo(
+      _edgeOffset(metrics: scrollController.position),
+      duration: duration,
+      curve: curve,
+    );
+  }
+
+  /// Coalesces a single post-frame `jumpTo(edge)` while following. Safe
+  /// to call on every rebuild — repeated calls within a frame collapse
+  /// into one jump, so tailing a high-frequency streaming source never
+  /// stacks overlapping animations.
+  ///
+  /// Only relevant for [ScrollFollowEdge.max] tailing (non-reversed
+  /// lists). Reversed chat lists following [ScrollFollowEdge.min] do
+  /// not need this — pixel offset `0` stays at the newest item
+  /// naturally.
+  void scheduleJumpToEdge() {
+    if (!_following || _snapScheduled) return;
+    _snapScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _snapScheduled = false;
+      if (!_following || !scrollController.hasClients) return;
+      final position = scrollController.position;
+      final target = _edgeOffset(metrics: position);
+      if ((position.pixels - target).abs() > 0.5) {
+        position.jumpTo(target);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    scrollController.dispose();
+    super.dispose();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  bool _isUserScrollStart({required ScrollNotification notification}) {
+    if (notification is ScrollStartNotification && notification.dragDetails != null) {
+      return true;
+    }
+    if (notification is UserScrollNotification && notification.direction != ScrollDirection.idle) {
+      return true;
+    }
+    return false;
+  }
+
+  void _maybeReattach({required ScrollMetrics metrics}) {
+    final distance = (metrics.pixels - _edgeOffset(metrics: metrics)).abs();
+    final shouldFollow = distance <= _edgeTolerance;
+    if (shouldFollow == _following) return;
+    _following = shouldFollow;
+    notifyListeners();
+  }
+
+  double _edgeOffset({required ScrollMetrics metrics}) {
+    return switch (edge) {
+      ScrollFollowEdge.min => metrics.minScrollExtent,
+      ScrollFollowEdge.max => metrics.maxScrollExtent,
+    };
+  }
+}

--- a/mobile/app/lib/features/session_detail/widgets/scroll_follow_tracker.dart
+++ b/mobile/app/lib/features/session_detail/widgets/scroll_follow_tracker.dart
@@ -28,11 +28,13 @@ enum ScrollFollowEdge { min, max }
 ///   flag, no race-prone captures of old pixels/maxScrollExtent.
 /// - The tracker never rewrites `position.pixels` except when the
 ///   caller explicitly asks via [animateToEdge] or [scheduleJumpToEdge].
-/// - For a `reverse: true` list following [ScrollFollowEdge.min],
-///   nothing needs to happen on each rebuild — Flutter's native
-///   sliver offset correction keeps offset `0` pinned to the newest
-///   item as data is appended. [scheduleJumpToEdge] exists for the
-///   [ScrollFollowEdge.max] tailing case only.
+/// - [scheduleJumpToEdge] works for both edges and is cheap to call
+///   on every rebuild (coalesced to one post-frame jump per frame,
+///   skipped entirely when `pixels` is already at the edge). It is
+///   necessary for [ScrollFollowEdge.max] tailing to track growing
+///   content, and serves as a belt-and-braces pin for
+///   [ScrollFollowEdge.min] in case `reverse: true` sliver correction
+///   leaves `pixels` even slightly off `0` after an append.
 class ScrollFollowTracker extends ChangeNotifier {
   ScrollFollowTracker({
     required this.edge,
@@ -101,12 +103,15 @@ class ScrollFollowTracker extends ChangeNotifier {
   /// Coalesces a single post-frame `jumpTo(edge)` while following. Safe
   /// to call on every rebuild — repeated calls within a frame collapse
   /// into one jump, so tailing a high-frequency streaming source never
-  /// stacks overlapping animations.
+  /// stacks overlapping animations. The jump is also skipped when
+  /// `pixels` is already within half a pixel of the edge, so it is a
+  /// no-op in the common case.
   ///
-  /// Only relevant for [ScrollFollowEdge.max] tailing (non-reversed
-  /// lists). Reversed chat lists following [ScrollFollowEdge.min] do
-  /// not need this — pixel offset `0` stays at the newest item
-  /// naturally.
+  /// Primary use is [ScrollFollowEdge.max] tailing of growing content
+  /// (e.g. the reasoning modal). For [ScrollFollowEdge.min] reversed
+  /// chat lists, it doubles as a belt-and-braces pin — Flutter's
+  /// native sliver offset correction usually keeps `pixels` at `0` as
+  /// new newest items are appended, but calling this guarantees it.
   void scheduleJumpToEdge() {
     if (!_following || _snapScheduled) return;
     _snapScheduled = true;

--- a/mobile/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/mobile/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -74,12 +74,16 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
   _DetachedSnapshot? _snapshot;
 
   /// Cache for the id → builder-index map consumed by
-  /// `findChildIndexCallback`. Rebuilt only when the source
-  /// `messages` list identity changes — during streaming, the cubit
-  /// keeps the `messages` reference stable across
-  /// `streamingText`-only emits, so most rebuilds hit this cache
-  /// instead of paying O(N) to reconstruct the map.
-  List<MessageWithParts>? _indexByIdSource;
+  /// `findChildIndexCallback`. Keyed on a content signature of
+  /// `(length, firstId, lastId)` — NOT list identity. The cubit's
+  /// `state.messages` getter is the Freezed-generated
+  /// `EqualUnmodifiableListView` wrapper which is recreated on every
+  /// access, so an `identical(...)` cache would miss on every emit.
+  /// The content signature is cheap (three reads) and correct for
+  /// every mutation the cubit performs today: append, remove, and
+  /// same-order part updates all either change the signature or
+  /// preserve the full id ordering. `null` means "cache empty".
+  int? _indexSignature;
   Map<String, int> _indexById = const <String, int>{};
 
   @override
@@ -124,8 +128,8 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
     // Map message id → data-source index. Consulted by
     // `findChildIndexCallback` so the reversed builder keeps stable
     // element identity across appends that shift every existing index.
-    // Recomputed only when the `messages` list identity changes — skips
-    // O(N) work on every streaming-text rebuild.
+    // Recomputed only when the content signature changes — skips the
+    // O(N) rebuild on every streaming-text emit.
     final indexById = _indexByIdFor(messages: messages);
 
     // Coalesced post-frame pin-to-edge while following. The scheduler
@@ -170,11 +174,17 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
   }
 
   Map<String, int> _indexByIdFor({required List<MessageWithParts> messages}) {
-    if (identical(messages, _indexByIdSource)) return _indexById;
-    _indexByIdSource = messages;
+    final signature = _signatureOf(messages: messages);
+    if (signature == _indexSignature) return _indexById;
+    _indexSignature = signature;
     return _indexById = <String, int>{
       for (var i = 0; i < messages.length; i++) messages[i].info.id: i,
     };
+  }
+
+  int _signatureOf({required List<MessageWithParts> messages}) {
+    if (messages.isEmpty) return 0;
+    return Object.hash(messages.length, messages.first.info.id, messages.last.info.id);
   }
 
   int? _findChildIndex({

--- a/mobile/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/mobile/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -1,12 +1,38 @@
-import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
-import "package:flutter/rendering.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 import "assistant_message_card.dart";
+import "follow_detach_scrollable.dart";
+import "jump_to_edge_pill.dart";
+import "scroll_follow_tracker.dart";
 import "user_message_card.dart";
 
+/// Chat-style message list for the session detail screen.
+///
+/// Scroll behaviour — "follow / detach":
+///
+/// - Uses a `reverse: true` `ListView.builder` so the newest message
+///   renders at the visual bottom (scroll offset `0`).
+/// - While **following**, a coalesced post-frame `jumpTo(0)` runs via
+///   the [ScrollFollowTracker] — race-free pin-to-edge, never a
+///   delta-based compensation.
+/// - While **detached** (user dragged / trackpad-scrolled / pan-zoomed
+///   away from the bottom), the full set of rendered inputs
+///   (`messages`, `streamingText`, `children`, `childStatuses`) is
+///   snapshotted and rendered in place of the live values. New data
+///   still arrives in the background but nothing below (or above) the
+///   user's viewport can grow, shrink, or reorder under them. The
+///   snapshot is cleared the moment the user reattaches.
+/// - `findChildIndexCallback` is mandatory: every append shifts every
+///   existing item's builder index by 1 (we append to the data list
+///   then flip with `messages.length - 1 - index`), so without it
+///   `SliverChildBuilderDelegate` loses child identity and preserved
+///   element state.
+///
+/// Gesture plumbing and the detached overlay toggle live in
+/// [FollowDetachScrollable]; this widget only owns message rendering,
+/// the detached snapshot, and the follow controller lifecycle.
 class SessionDetailMessageList extends StatefulWidget {
   final String? projectId;
   final List<MessageWithParts> messages;
@@ -27,175 +53,138 @@ class SessionDetailMessageList extends StatefulWidget {
   State<SessionDetailMessageList> createState() => _SessionDetailMessageListState();
 }
 
+/// Immutable snapshot of the rendered inputs taken the moment the user
+/// detaches. Rendered in place of live widget props while detached so
+/// the viewport stays pinned to what the user was reading.
+typedef _DetachedSnapshot = ({
+  List<MessageWithParts> messages,
+  Map<String, String> streamingText,
+  List<Session> children,
+  Map<String, SessionStatus> childStatuses,
+});
+
 class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
-  static const _kNearBottomThreshold = 20.0;
   static const _kListViewKey = Key("session-detail-message-list-view");
   static const _kJumpToLatestKey = Key("session-detail-jump-to-latest");
 
-  late final ScrollController _scrollController;
-  bool _following = true;
-  bool _userScrollActive = false;
+  late final ScrollFollowTracker _follow;
+
+  /// Snapshot taken at the moment of detach. `null` means "not frozen
+  /// — use live `widget.*` props".
+  _DetachedSnapshot? _snapshot;
 
   @override
   void initState() {
     super.initState();
-    _scrollController = ScrollController();
+    _follow = ScrollFollowTracker(edge: ScrollFollowEdge.min);
+    _follow.addListener(_syncSnapshot);
   }
 
   @override
   void dispose() {
-    _scrollController.dispose();
+    _follow.removeListener(_syncSnapshot);
+    _follow.dispose();
     super.dispose();
   }
 
-  @override
-  void didUpdateWidget(covariant SessionDetailMessageList oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (!_scrollController.hasClients) return;
-
-    final oldPixels = _scrollController.position.pixels;
-    final oldMaxScrollExtent = _scrollController.position.maxScrollExtent;
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || !_scrollController.hasClients) return;
-
-      if (_following) {
-        _scrollController.jumpTo(0);
-        return;
-      }
-
-      if (_userScrollActive) {
-        return;
-      }
-
-      final position = _scrollController.position;
-      final delta = position.maxScrollExtent - oldMaxScrollExtent;
-      final target = (oldPixels + delta).clamp(position.minScrollExtent, position.maxScrollExtent);
-      _scrollController.jumpTo(target.toDouble());
-    });
-  }
-
-  void _jumpToLatest() {
+  void _syncSnapshot() {
+    if (!mounted) return;
     setState(() {
-      _following = true;
-      _userScrollActive = false;
+      if (_follow.following) {
+        _snapshot = null;
+      } else {
+        _snapshot ??= (
+          messages: List<MessageWithParts>.unmodifiable(widget.messages),
+          streamingText: Map<String, String>.unmodifiable(widget.streamingText),
+          children: List<Session>.unmodifiable(widget.children),
+          childStatuses: Map<String, SessionStatus>.unmodifiable(widget.childStatuses),
+        );
+      }
     });
-    if (_scrollController.hasClients) {
-      _scrollController.animateTo(
-        0,
-        duration: const Duration(milliseconds: 150),
-        curve: Curves.easeOut,
-      );
-    }
   }
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final loc = context.loc;
+    final snap = _snapshot;
+    final messages = snap?.messages ?? widget.messages;
+    final streamingText = snap?.streamingText ?? widget.streamingText;
+    final children = snap?.children ?? widget.children;
+    final childStatuses = snap?.childStatuses ?? widget.childStatuses;
 
-    return Stack(
-      children: [
-        Listener(
-          onPointerSignal: _handlePointerSignal,
-          onPointerPanZoomStart: (_) => _detachForUserScroll(),
-          child: NotificationListener<ScrollNotification>(
-            onNotification: (notification) {
-              if (notification.depth != 0) return false;
+    // Map message id → data-source index. Consulted by
+    // `findChildIndexCallback` so the reversed builder keeps stable
+    // element identity across appends that shift every existing index.
+    final indexById = <String, int>{
+      for (var i = 0; i < messages.length; i++) messages[i].info.id: i,
+    };
 
-              if (_isUserScrollStart(notification)) {
-                _detachForUserScroll();
-              } else if (notification is ScrollEndNotification && _userScrollActive) {
-                _settleUserScroll(shouldFollow: notification.metrics.pixels <= _kNearBottomThreshold);
-              }
-              return false;
-            },
-            child: ListView.builder(
-              key: _kListViewKey,
-              controller: _scrollController,
-              reverse: true,
-              padding: const EdgeInsets.symmetric(vertical: 8),
-              itemCount: widget.messages.length,
-              itemBuilder: (context, index) {
-                final message = widget.messages[widget.messages.length - 1 - index];
-                final child = message.info.role == "user"
-                    ? UserMessageCard(message: message)
-                    : AssistantMessageCard(
-                        projectId: widget.projectId,
-                        message: message,
-                        streamingText: widget.streamingText,
-                        children: widget.children,
-                        childStatuses: widget.childStatuses,
-                      );
-                return KeyedSubtree(key: ValueKey(message.info.id), child: child);
-              },
-            ),
-          ),
+    // Coalesced post-frame pin-to-edge while following. The scheduler
+    // collapses repeated calls within a frame and the jump is skipped
+    // when `position.pixels` is already at the edge. Completely
+    // different from the old delta-compensation logic — there are no
+    // stale captures and the target is always `0`.
+    _follow.scheduleJumpToEdge();
+
+    return FollowDetachScrollable(
+      tracker: _follow,
+      detachedOverlayBuilder: (ctx) => JumpToEdgePill(
+        tapTargetKey: _kJumpToLatestKey,
+        label: loc.sessionDetailJumpToLatest,
+        onTap: () => _follow.animateToEdge(),
+      ),
+      child: ListView.builder(
+        key: _kListViewKey,
+        controller: _follow.scrollController,
+        reverse: true,
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: messages.length,
+        findChildIndexCallback: (key) => _findChildIndex(
+          key: key,
+          indexById: indexById,
+          totalCount: messages.length,
         ),
-        if (!_following)
-          Positioned(
-            bottom: 12,
-            left: 0,
-            right: 0,
-            child: Center(
-              child: Material(
-                elevation: 4,
-                borderRadius: BorderRadius.circular(20),
-                color: theme.colorScheme.primaryContainer,
-                child: InkWell(
-                  key: _kJumpToLatestKey,
-                  borderRadius: BorderRadius.circular(20),
-                  onTap: _jumpToLatest,
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(Icons.arrow_downward, size: 16, color: theme.colorScheme.onPrimaryContainer),
-                        const SizedBox(width: 6),
-                        Text(
-                          loc.sessionDetailJumpToLatest,
-                          style: theme.textTheme.labelMedium?.copyWith(
-                            color: theme.colorScheme.onPrimaryContainer,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
+        itemBuilder: (context, index) {
+          final message = messages[messages.length - 1 - index];
+          return KeyedSubtree(
+            key: ValueKey(message.info.id),
+            child: _buildCard(
+              message: message,
+              streamingText: streamingText,
+              children: children,
+              childStatuses: childStatuses,
             ),
-          ),
-      ],
+          );
+        },
+      ),
     );
   }
 
-  bool _isUserScrollStart(ScrollNotification notification) {
-    return (notification is ScrollStartNotification && notification.dragDetails != null) ||
-        (notification is UserScrollNotification && notification.direction != ScrollDirection.idle);
+  int? _findChildIndex({
+    required Key key,
+    required Map<String, int> indexById,
+    required int totalCount,
+  }) {
+    if (key is! ValueKey<String>) return null;
+    final sourceIndex = indexById[key.value];
+    if (sourceIndex == null) return null;
+    return totalCount - 1 - sourceIndex;
   }
 
-  void _handlePointerSignal(PointerSignalEvent event) {
-    if (event is PointerScrollEvent) {
-      _detachForUserScroll();
-    }
-  }
-
-  void _detachForUserScroll() {
-    if (_userScrollActive && !_following) return;
-
-    setState(() {
-      _userScrollActive = true;
-      _following = false;
-    });
-  }
-
-  void _settleUserScroll({required bool shouldFollow}) {
-    if (!_userScrollActive && _following == shouldFollow) return;
-
-    setState(() {
-      _userScrollActive = false;
-      _following = shouldFollow;
-    });
+  Widget _buildCard({
+    required MessageWithParts message,
+    required Map<String, String> streamingText,
+    required List<Session> children,
+    required Map<String, SessionStatus> childStatuses,
+  }) {
+    return message.info.role == "user"
+        ? UserMessageCard(message: message)
+        : AssistantMessageCard(
+            projectId: widget.projectId,
+            message: message,
+            streamingText: streamingText,
+            children: children,
+            childStatuses: childStatuses,
+          );
   }
 }

--- a/mobile/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/mobile/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -73,6 +73,15 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
   /// — use live `widget.*` props".
   _DetachedSnapshot? _snapshot;
 
+  /// Cache for the id → builder-index map consumed by
+  /// `findChildIndexCallback`. Rebuilt only when the source
+  /// `messages` list identity changes — during streaming, the cubit
+  /// keeps the `messages` reference stable across
+  /// `streamingText`-only emits, so most rebuilds hit this cache
+  /// instead of paying O(N) to reconstruct the map.
+  List<MessageWithParts>? _indexByIdSource;
+  Map<String, int> _indexById = const <String, int>{};
+
   @override
   void initState() {
     super.initState();
@@ -115,9 +124,9 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
     // Map message id → data-source index. Consulted by
     // `findChildIndexCallback` so the reversed builder keeps stable
     // element identity across appends that shift every existing index.
-    final indexById = <String, int>{
-      for (var i = 0; i < messages.length; i++) messages[i].info.id: i,
-    };
+    // Recomputed only when the `messages` list identity changes — skips
+    // O(N) work on every streaming-text rebuild.
+    final indexById = _indexByIdFor(messages: messages);
 
     // Coalesced post-frame pin-to-edge while following. The scheduler
     // collapses repeated calls within a frame and the jump is skipped
@@ -158,6 +167,14 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
         },
       ),
     );
+  }
+
+  Map<String, int> _indexByIdFor({required List<MessageWithParts> messages}) {
+    if (identical(messages, _indexByIdSource)) return _indexById;
+    _indexByIdSource = messages;
+    return _indexById = <String, int>{
+      for (var i = 0; i < messages.length; i++) messages[i].info.id: i,
+    };
   }
 
   int? _findChildIndex({

--- a/mobile/app/test/features/session_detail/widgets/reasoning_modal_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/reasoning_modal_test.dart
@@ -287,4 +287,47 @@ void main() {
 
     expect(find.byKey(_followOutputKey), findsOneWidget);
   });
+
+  testWidgets("following mode tails rapid streaming updates without stacking animations", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final controller = StreamController<SessionDetailState>.broadcast();
+    addTearDown(controller.close);
+
+    whenListen(
+      mockCubit,
+      controller.stream,
+      initialState: _loadedState(
+        streamingText: {"part-1": _reasoningText(paragraphs: 2)},
+        messages: [_messageWithPart()],
+      ),
+    );
+
+    await tester.pumpWidget(_buildApp(cubit: mockCubit));
+    await tester.pumpAndSettle();
+
+    // Fire a burst of state updates at ~streaming cadence. Before the
+    // rewrite, every build queued a 150ms `animateTo(maxScrollExtent)`
+    // that stacked on the in-flight animation, producing jitter and
+    // occasional follow-mode detachment. With coalesced `jumpTo` via
+    // `ScrollFollowTracker.scheduleJumpToEdge`, each frame performs
+    // at most one tail-pin.
+    for (var i = 2; i < 18; i++) {
+      controller.add(
+        _loadedState(
+          streamingText: {"part-1": _reasoningText(paragraphs: i)},
+          messages: [_messageWithPart()],
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+    await tester.pumpAndSettle();
+
+    // Viewport should be pinned at the tail, and follow mode never
+    // detached despite the high-frequency update burst.
+    expect(find.byKey(_followOutputKey), findsNothing);
+    final position = _position(tester);
+    expect(position.pixels, closeTo(position.maxScrollExtent, 0.5));
+  });
 }

--- a/mobile/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -344,7 +344,9 @@ void main() {
     // Simulates a burst of SSE-driven appends while the user reads
     // history. Before the rewrite, stale-capture post-frame jumps
     // would clamp the viewport back toward `0` — reproducing the
-    // "jumps all the way to the oldest message" symptom.
+    // "jumps all the way to the oldest message" symptom. The two-pump
+    // helper lets any delayed post-frame scroll adjustment run before
+    // we assert.
     for (var i = 0; i < 10; i++) {
       harnessKey.currentState!.appendNewestMessage(
         _message(
@@ -353,7 +355,7 @@ void main() {
           text: _multilineText(label: "Burst $i", lines: 6),
         ),
       );
-      await tester.pump();
+      await _pumpListUpdate(tester);
       expect(_position(tester).pixels, greaterThan(20));
       expect(find.byKey(_jumpToLatestKey), findsOneWidget);
     }

--- a/mobile/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -320,4 +320,105 @@ void main() {
 
     expect(_position(tester).pixels, 0);
   });
+
+  // --- Regression tests for the old "jump to top" / "view shifts" bugs ---
+
+  testWidgets("detached chat stays away from edge during rapid appends", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final harnessKey = GlobalKey<_SessionDetailMessageListHarnessState>();
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        key: harnessKey,
+        initialMessages: _userMessages(count: 12),
+        initialStreamingText: const {},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await _detachViewport(tester);
+    final detachedOffset = _position(tester).pixels;
+    expect(detachedOffset, greaterThan(20));
+
+    // Simulates a burst of SSE-driven appends while the user reads
+    // history. Before the rewrite, stale-capture post-frame jumps
+    // would clamp the viewport back toward `0` — reproducing the
+    // "jumps all the way to the oldest message" symptom.
+    for (var i = 0; i < 10; i++) {
+      harnessKey.currentState!.appendNewestMessage(
+        _message(
+          messageId: "burst-$i",
+          role: "user",
+          text: _multilineText(label: "Burst $i", lines: 6),
+        ),
+      );
+      await tester.pump();
+      expect(_position(tester).pixels, greaterThan(20));
+      expect(find.byKey(_jumpToLatestKey), findsOneWidget);
+    }
+
+    // Scroll offset must not have collapsed anywhere near the edge
+    // during the burst — assert we're still comfortably detached.
+    expect(_position(tester).pixels, greaterThan(20));
+  });
+
+  testWidgets("rapid streaming updates during an active drag never jump to edge", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    const streamingPartId = "assistant-stream-part";
+    final harnessKey = GlobalKey<_SessionDetailMessageListHarnessState>();
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        key: harnessKey,
+        initialMessages: [
+          ..._userMessages(count: 12),
+          _message(
+            messageId: "assistant-newest",
+            role: "assistant",
+            text: "",
+            partId: streamingPartId,
+          ),
+        ],
+        initialStreamingText: {streamingPartId: _multilineText(label: "Streaming", lines: 2)},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Start a live drag INTO history. `reverse: true` maps positive-y
+    // gesture to increasing scroll offset (i.e. scrolling toward older
+    // content, away from the newest-at-bottom edge).
+    final gesture = await tester.startGesture(tester.getCenter(find.byKey(_listViewKey)));
+    await gesture.moveBy(const Offset(0, 300));
+    await tester.pump();
+    expect(find.byKey(_jumpToLatestKey), findsOneWidget);
+    expect(_position(tester).pixels, greaterThan(20));
+
+    // Interleave rapid streaming text updates with further drag
+    // movement. Before the rewrite, each update queued a stale
+    // post-frame jump that could yank the viewport to offset 0 mid-
+    // drag — this test locks that door shut.
+    for (var i = 0; i < 8; i++) {
+      harnessKey.currentState!.updateStreamingText(
+        partId: streamingPartId,
+        text: _multilineText(label: "Streaming", lines: 2 + i * 2),
+      );
+      await tester.pump(const Duration(milliseconds: 16));
+
+      await gesture.moveBy(const Offset(0, 24));
+      await tester.pump(const Duration(milliseconds: 16));
+
+      expect(_position(tester).pixels, greaterThan(20));
+    }
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    // After release we're still detached — drag moved well away from
+    // the reattach zone — so the pill remains and the viewport has
+    // not snapped to the newest message.
+    expect(find.byKey(_jumpToLatestKey), findsOneWidget);
+    expect(_position(tester).pixels, greaterThan(20));
+  });
 }


### PR DESCRIPTION
## Summary

Four prior fixes (#42, #48, #114, #116) layered patches on a fundamentally broken approach: delta-based scroll compensation in `didUpdateWidget` that captured `oldPixels` / `oldMaxScrollExtent` synchronously and applied `jumpTo(target)` inside `addPostFrameCallback`. Under high-frequency SSE emits (up to ~20 Hz during streaming), stacked stale post-frame callbacks occasionally clamped the viewport all the way to offset 0, and the same logic routinely shifted history under a user reading older messages on both touch and macOS trackpad.

This PR deletes the compensation entirely and replaces it with three small shared UI primitives plus a freeze-while-detached snapshot.

## What changed

**New shared primitives** under `mobile/app/lib/features/session_detail/widgets/`:

| File | Role | Purpose |
|---|---|---|
| `scroll_follow_tracker.dart` | Tracker | `ChangeNotifier` owning a `ScrollController` + a single `_following` bool. Hooks for `Listener.onPointerSignal`, `Listener.onPointerPanZoomStart`, `NotificationListener<ScrollNotification>`. Coalesced `scheduleJumpToEdge()` — at most one `jumpTo(edge)` per frame. No stacked animations, no stale captures. |
| `follow_detach_scrollable.dart` | Widget | Wraps any scrollable with gesture plumbing + listener lifecycle + detached-overlay toggle rebuild. |
| `jump_to_edge_pill.dart` | Widget | The floating "jump to latest" / "follow output" pill, shared between message list and reasoning modal. |

**Refactored consumers** — both delete their own duplicated gesture-wiring / overlay / pill code and delegate to the primitives:

- `session_detail_message_list.dart` (`reverse: true`, follows `ScrollFollowEdge.min`)
- `reasoning_modal.dart` (non-reverse tailing, follows `ScrollFollowEdge.max`)

**Two follow-ups anchored to the reported symptoms:**

1. **`findChildIndexCallback` on the reversed builder** — every append shifts every existing builder index (`messages[messages.length - 1 - i]`). Without this, `SliverChildBuilderDelegate` loses element identity across appends.
2. **Freeze snapshot while detached** on the message list — captures a record of `(messages, streamingText, children, childStatuses)` at detach and renders it until reattach. New data still streams into widget props in the background, but nothing under the user's viewport can grow, shrink, or reorder. This is what prevents new text from shifting history — the user's dominant complaint.

## Symptom → fix mapping

| Reported symptom | Root cause in old code | Fix |
|---|---|---|
| Scroll sometimes jumps all the way to offset 0 mid-scroll | Stacked stale post-frame `jumpTo(oldPixels + delta)` where `oldMaxScrollExtent` was captured before layout changed again | Delete `didUpdateWidget` compensation; only write offset via `animateToEdge()` (pill tap) or coalesced `scheduleJumpToEdge()` (tail pin) |
| New text shifts the whole view while reading history | `reverse: true` preserves **pixel** offset but not **visible-content** anchor; existing items growing below the viewport push content | Freeze the rendered inputs while detached so no item can change size/count |
| Broken on both mobile (finger) and macOS (trackpad) | Race-prone `_userScrollActive` flag + inconsistent handling across input paths | Unified detach hooks: drag (`dragDetails`), user scroll, pointer signal, pan-zoom — all route through the tracker |
| Scroll should detach the moment the gesture starts | Mixed triggers with varied activation thresholds | `ScrollStartNotification(dragDetails: non-null)` + `UserScrollNotification` + pointer-signal + pan-zoom-start all detach immediately |

## Regression tests

Added tests that would have caught the bugs the previous 4 PRs shipped:

- **\`detached chat stays away from edge during rapid appends\`** — simulates an SSE burst of 10 appends while detached; asserts offset never collapses toward the edge.
- **\`rapid streaming updates during an active drag never jump to edge\`** — interleaves streaming-text updates with drag movements mid-gesture; asserts no mid-drag jump-to-0.
- **\`reasoning modal tails rapid streaming updates without stacking animations\`** — 16 rapid state emits; asserts the viewport stays within 0.5 px of `maxScrollExtent` and follow mode never detaches.

All pre-existing tests are retained (they now pass for the right reasons — natural sliver behaviour + snapshot, not manual compensation).

## Verification

- \`cd mobile && dart pub get\`
- \`cd mobile/app && dart analyze --fatal-infos\` — clean
- \`cd mobile/module_core && dart analyze --fatal-infos\` — clean
- \`cd mobile/module_auth && dart analyze --fatal-infos\` — clean
- \`cd mobile/app && flutter test\` — 373 pass
- \`cd mobile/module_core && dart test\` — 231 pass
- \`aristotle-impl-review\` — approved after renaming \`ScrollFollowController\` → \`ScrollFollowTracker\` to match the approved naming vocabulary

## Architecture notes

All changes are Layer 4 UI, scoped to \`mobile/app/lib/features/session_detail/widgets/\`. No cubit, repository, or API touched. Scroll behaviour stays widget-local and never leaks into \`SessionDetailCubit\`. \`ScrollFollowTracker\` follows the root \`AGENTS.md\` \`Tracker\` role definition: "maintains state derived from events; exposes stream or snapshot access." Every production file is well under the 250-line limit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote scroll follow/detach in session detail for stability under streaming. Removes delta-based compensation to stop surprise jumps and history shifts on touch and trackpad.

- **Refactors**
  - Replaced old logic with `ScrollFollowTracker`; clarified `scheduleJumpToEdge` (works for both edges, skips sub‑pixel), and coalesced `jumpTo`/`animateToEdge` scheduling.
  - Added `FollowDetachScrollable` and `JumpToEdgePill`; message list and reasoning modal now delegate to them.
  - Implemented `findChildIndexCallback` for the reversed list and cached the id→index map keyed on content signature (`length`, `firstId`, `lastId`) to avoid O(N) rebuilds during streaming despite `EqualUnmodifiableListView` wrappers.

- **Bug Fixes**
  - No more jumps to offset 0 during rapid updates; removes stacked post-frame callbacks.
  - View no longer shifts while reading history; detached mode renders a frozen snapshot until reattach.
  - Unified detach across drag, wheel, and pan-zoom; detaches immediately on gesture start.
  - Added regression tests for rapid appends, mid-drag updates, and follow-mode tailing.

<sup>Written for commit 3251468cadd0144367b680909eebc83033c03e74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

