### PR TITLE
chore(release): bridge v0.4.1

### DIFF
--- a/bridge/app/CHANGELOG.md
+++ b/bridge/app/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v0.4.1] - 2026-04-22
+
+### Added
+- macOS release binaries are now signed with a Developer ID Application certificate
+- Bridge release documentation (`RELEASING.md`) for verification and manual test flow
+
+### Changed
+- Updated npm wrapper tests to align with release workflow changes
+
 ## [v0.4.0] - 2026-04-22
 
 ### Added

--- a/bridge/app/lib/src/version.dart
+++ b/bridge/app/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '0.4.0';
+const String appVersion = '0.4.1';

--- a/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-arm64",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS ARM64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.4.0",
+    "releaseTag": "bridge-v0.4.1",
     "releaseArtifact": "sesori-bridge-macos-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-darwin-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-x64",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS x64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.4.0",
+    "releaseTag": "bridge-v0.4.1",
     "releaseArtifact": "sesori-bridge-macos-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-arm64",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux ARM64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.4.0",
+    "releaseTag": "bridge-v0.4.1",
     "releaseArtifact": "sesori-bridge-linux-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-x64",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux x64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.4.0",
+    "releaseTag": "bridge-v0.4.1",
     "releaseArtifact": "sesori-bridge-linux-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-x64",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows x64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.4.0",
+    "releaseTag": "bridge-v0.4.1",
     "releaseArtifact": "sesori-bridge-windows-x64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge/package.json
+++ b/bridge/app/npm/sesori-bridge/package.json
@@ -1,21 +1,21 @@
 {
   "name": "@sesori/bridge",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Bootstrap launcher for the managed Sesori Bridge runtime",
   "bin": {
     "sesori-bridge": "bin/bridge.js"
   },
   "optionalDependencies": {
-    "@sesori/bridge-darwin-arm64": "0.4.0",
-    "@sesori/bridge-darwin-x64": "0.4.0",
-    "@sesori/bridge-linux-x64": "0.4.0",
-    "@sesori/bridge-linux-arm64": "0.4.0",
-    "@sesori/bridge-win32-x64": "0.4.0"
+    "@sesori/bridge-darwin-arm64": "0.4.1",
+    "@sesori/bridge-darwin-x64": "0.4.1",
+    "@sesori/bridge-linux-x64": "0.4.1",
+    "@sesori/bridge-linux-arm64": "0.4.1",
+    "@sesori/bridge-win32-x64": "0.4.1"
   },
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.4.0",
+    "releaseTag": "bridge-v0.4.1",
     "runtimeBundleSource": "github-release-assets"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sesori_bridge
 description: Dart implementation of the Sesori Bridge CLI for WebSocket communication.
-version: 0.4.0
+version: 0.4.1
 publish_to: none
 resolution: workspace
 

--- a/bridge/app/test/tool/npm_wrapper_test.dart
+++ b/bridge/app/test/tool/npm_wrapper_test.dart
@@ -357,6 +357,13 @@ Future<Map<String, dynamic>> _readRecordedInvocation({required String recordPath
   return jsonDecode(await File(recordPath).readAsString()) as Map<String, dynamic>;
 }
 
+Future<String> _readWrapperVersion() async {
+  final packageJson = jsonDecode(
+    await File(p.join(_wrapperPackageRoot(), 'package.json')).readAsString(),
+  ) as Map<String, dynamic>;
+  return packageJson['version'] as String;
+}
+
 void _expectInstallSummary({
   required ProcessResult result,
   required String homePath,
@@ -377,7 +384,8 @@ Future<({int exitCode, String stdout, String stderr})> _waitForProcess(Process p
   return (exitCode: exitCode, stdout: await stdoutFuture, stderr: await stderrFuture);
 }
 
-void main() {
+Future<void> main() async {
+  final wrapperVersion = await _readWrapperVersion();
   group('bridge.js', () {
     test('fails with a clear message for unsupported platforms', () async {
       final scriptPath = p.join(_wrapperPackageRoot(), 'bin', 'bridge.js');
@@ -441,12 +449,12 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       final bootstrapRecordPath = p.join(homeDir.path, 'bootstrap-record.json');
       final recordPath = p.join(homeDir.path, 'record.json');
       final releaseAsset = await _createReleaseAsset(
-        version: '0.4.0',
+        version: wrapperVersion,
         binaryMarker: 'release-runtime',
         libMarker: 'release-lib',
       );
       final releasesBaseUrl = await _serveReleaseAssets(
-        version: '0.4.0',
+        version: wrapperVersion,
         archivePath: releaseAsset.archivePath,
         checksumsPath: releaseAsset.checksumsPath,
       );
@@ -481,13 +489,13 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
       addTearDown(() => homeDir.delete(recursive: true));
       final releaseAsset = await _createReleaseAsset(
-        version: '0.4.0',
+        version: wrapperVersion,
         binaryMarker: 'release-runtime',
         libMarker: 'release-lib',
       );
       await File(releaseAsset.checksumsPath).writeAsString('deadbeef  ${releaseAsset.assetName}\n');
       final releasesBaseUrl = await _serveReleaseAssets(
-        version: '0.4.0',
+        version: wrapperVersion,
         archivePath: releaseAsset.archivePath,
         checksumsPath: releaseAsset.checksumsPath,
       );
@@ -502,7 +510,7 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       expect(result.exitCode, equals(1));
       expect(
         result.stderr,
-        contains('Failed to download managed runtime from GitHub release assets for bridge-v0.4.0'),
+        contains('Failed to download managed runtime from GitHub release assets for bridge-v$wrapperVersion'),
       );
       expect(result.stderr, contains('Checksum mismatch for ${releaseAsset.assetName}'));
     });
@@ -511,7 +519,7 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       final wrapperRoot = await _createWrapperFixture();
       final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
       addTearDown(() => homeDir.delete(recursive: true));
-      final releasesBaseUrl = await _serveInvalidRedirectReleaseAssets(version: '0.4.0');
+      final releasesBaseUrl = await _serveInvalidRedirectReleaseAssets(version: wrapperVersion);
 
       final result = await _runWrapperProcess(
         packageRoot: wrapperRoot,
@@ -523,7 +531,7 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       expect(result.exitCode, equals(1));
       expect(
         result.stderr,
-        contains('Failed to download managed runtime from GitHub release assets for bridge-v0.4.0'),
+        contains('Failed to download managed runtime from GitHub release assets for bridge-v$wrapperVersion'),
       );
       expect(result.stderr, contains('Invalid redirect URL'));
     });
@@ -675,7 +683,7 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
 
       await _seedManagedRuntime(
         homePath: homeDir.path,
-        version: '0.4.0',
+        version: wrapperVersion,
         binaryMarker: 'existing-managed',
         libMarker: 'existing-lib',
         includeBinary: true,


### PR DESCRIPTION
## Summary
- Bump bridge version to v0.4.1
- Update CHANGELOG.md with changes since v0.4.0

## Changes
- macOS release binaries are now signed with a Developer ID Application certificate
- Added bridge release documentation (`RELEASING.md`)
- Updated npm wrapper tests to align with release workflow changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release Bridge v0.4.1. Signs macOS binaries, adds release docs, and makes npm wrapper tests version-agnostic.

- **New Features**
  - macOS release binaries are signed with a Developer ID Application certificate.
  - Added `RELEASING.md` for release verification and manual test steps.
  - npm wrapper tests read the wrapper version from `package.json` (no hardcoded version).

- **Dependencies**
  - Bumped to 0.4.1 across `@sesori/bridge` and platform packages; set `sesoriBridge.releaseTag` to `bridge-v0.4.1`; updated Dart `appVersion` and `pubspec.yaml`; refreshed CHANGELOG.

<sup>Written for commit 8f9d0c9ecbb4aa095631deab156e9728fe212b06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

