### PR TITLE
ci(bridge-release): enable auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,28 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - dependabot
+      - dependabot[bot]
+  categories:
+    - title: Added
+      labels:
+        - feat
+        - enhancement
+    - title: Fixed
+      labels:
+        - fix
+        - bug
+    - title: Changed
+      labels:
+        - chore
+        - refactor
+        - docs
+        - perf
+        - test
+        - ci
+        - build
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -175,6 +175,7 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: Bridge ${{ github.ref_name }}
           make_latest: "true"
+          generate_release_notes: true
           files: |
             artifacts/**/*.tar.gz
             artifacts/**/*.zip


### PR DESCRIPTION
## Summary
Enables GitHub's auto-generated release notes for bridge releases.

## Changes
- Add `generate_release_notes: true` to the `softprops/action-gh-release@v2` step in `.github/workflows/bridge-release.yml`
- Add `.github/release.yml` to categorize changes into Added, Fixed, Changed, and Other Changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable auto-generated release notes for bridge releases. Sets `generate_release_notes: true` in the `softprops/action-gh-release@v2` step and adds `.github/release.yml` to group labels into Added, Fixed, Changed, and Other.

<sup>Written for commit 33ef70cea1c28c6293cb107b088081f9522c2c90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

