### PR TITLE
fix(bridge): recognize command.executed SSE frames

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/sse_event_parser.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse_event_parser.dart
@@ -157,6 +157,7 @@ const Set<String> _knownEventTypes = {
   "session.compacted",
   "session.status",
   "session.idle",
+  "command.executed",
   "message.updated",
   "message.removed",
   "message.part.updated",

--- a/bridge/sesori_plugin_opencode/test/sse_event_parser_test.dart
+++ b/bridge/sesori_plugin_opencode/test/sse_event_parser_test.dart
@@ -55,6 +55,35 @@ void main() {
       expect(result.directory, equals("/repo"));
     });
 
+    test("parses command.executed event", () {
+      final parser = SseEventParser();
+      final rawData = jsonEncode({
+        "directory": "/repo",
+        "payload": {
+          "type": "command.executed",
+          "properties": {
+            "name": "review",
+            "sessionID": "s1",
+            "arguments": "lib/main.dart",
+            "messageID": "m1",
+          },
+        },
+      });
+
+      final result = parser.parse(rawData);
+
+      expect(result.outcome, equals(SseParseOutcome.validKnownEvent));
+      expect(result.eventType, equals("command.executed"));
+      expect(result.directory, equals("/repo"));
+      expect(result.event, isA<SseCommandExecuted>());
+
+      final event = result.event! as SseCommandExecuted;
+      expect(event.name, equals("review"));
+      expect(event.sessionID, equals("s1"));
+      expect(event.arguments, equals("lib/main.dart"));
+      expect(event.messageID, equals("m1"));
+    });
+
     test("parses server.heartbeat event", () {
       final parser = SseEventParser();
       final rawData = jsonEncode({


### PR DESCRIPTION
## Summary

The bridge was dropping every `command.executed` SSE frame emitted by OpenCode (when a slash command like `/review` runs in a session), logging:

```
[opencode][sse][unknown-event-type] [directory=..., eventType=command.executed] Ignoring SSE frame with unknown event type.
```

The event type was already wired end-to-end — `SseEventData.commandExecuted`, `BridgeSseCommandExecuted`, `SesoriSseEvent.commandExecuted`, the `BridgeEventMapper` conversion, and the mobile `SessionDetailCubit` refresh handler all existed. Only the parser's `_knownEventTypes` allow-list was missing `"command.executed"`, so every frame of that type was classified as `unknownEventType` and dropped before it reached the mapper.

## Changes

- **bridge/sesori_plugin_opencode/lib/src/sse_event_parser.dart**: add `"command.executed"` to `_knownEventTypes`
- **bridge/sesori_plugin_opencode/test/sse_event_parser_test.dart**: add parser test exercising the full envelope → `SseCommandExecuted` path

No mobile or shared-protocol changes needed: the mobile side already handles `SesoriCommandExecuted` (session detail triggers a data refresh; session list intentionally ignores it, since command execution doesn't reorder the list).

## Verification

- `make analyze` clean across `sesori_plugin_interface`, `sesori_plugin_opencode`, and `app`
- `make test` — 944 tests pass (including the new parser test)
- Targeted run: `dart test test/sse_event_parser_test.dart --name "command.executed"` → passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recognize `command.executed` SSE frames so slash-command executions are no longer dropped. The parser now allows this event and forwards it to existing handlers.

- **Bug Fixes**
  - Added "command.executed" to `_knownEventTypes` in `sse_event_parser.dart`.
  - Added a parser test covering the envelope → `SseCommandExecuted` path.

<sup>Written for commit 75d078712ca988398f360b2b77775be1219261e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

