### PR TITLE
fix(mobile): enable cross-paragraph text selection in chat

### DIFF
--- a/mobile/app/lib/features/session_detail/widgets/assistant_message_card.dart
+++ b/mobile/app/lib/features/session_detail/widgets/assistant_message_card.dart
@@ -29,11 +29,13 @@ class AssistantMessageCard extends StatelessWidget {
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-      child: Column(
-        crossAxisAlignment: .start,
-        children: [
-          for (final part in visibleParts) _buildPart(context: context, part: part),
-        ],
+      child: SelectionArea(
+        child: Column(
+          crossAxisAlignment: .start,
+          children: [
+            for (final part in visibleParts) _buildPart(context: context, part: part),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/app/lib/features/session_detail/widgets/text_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/text_part_widget.dart
@@ -23,7 +23,7 @@ class TextPartWidget extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: MarkdownBody(
         data: text,
-        selectable: true,
+        selectable: false,
         onTapLink: handleMarkdownLinkTap,
         styleSheet: buildSessionMarkdownStyleSheet(theme),
       ),

--- a/mobile/app/test/features/session_detail/widgets/assistant_message_card_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/assistant_message_card_test.dart
@@ -1,0 +1,170 @@
+import "package:flutter/material.dart";
+import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:sesori_mobile/features/session_detail/widgets/assistant_message_card.dart";
+import "package:sesori_mobile/features/session_detail/widgets/tool_part_widget.dart";
+import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+class _AssistantMessageCardHarness extends StatefulWidget {
+  final MessageWithParts message;
+  final Map<String, String> streamingText;
+
+  const _AssistantMessageCardHarness({
+    super.key,
+    required this.message,
+    required this.streamingText,
+  });
+
+  @override
+  State<_AssistantMessageCardHarness> createState() => _AssistantMessageCardHarnessState();
+}
+
+class _AssistantMessageCardHarnessState extends State<_AssistantMessageCardHarness> {
+  late Map<String, String> _streamingText;
+
+  @override
+  void initState() {
+    super.initState();
+    _streamingText = widget.streamingText;
+  }
+
+  void updateStreamingText({required String partId, required String text}) {
+    setState(() => _streamingText = {..._streamingText, partId: text});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: AssistantMessageCard(
+          projectId: null,
+          message: widget.message,
+          streamingText: _streamingText,
+          children: const <Session>[],
+          childStatuses: const <String, SessionStatus>{},
+        ),
+      ),
+    );
+  }
+}
+
+MessageWithParts _assistantMessage({required List<MessagePart> parts}) {
+  return MessageWithParts(
+    info: const Message.assistant(
+      id: "assistant-1",
+      sessionID: "session-1",
+      agent: null,
+      modelID: null,
+      providerID: null,
+    ),
+    parts: parts,
+  );
+}
+
+MessagePart _textPart({required String id, required String text}) {
+  return MessagePart(
+    id: id,
+    sessionID: "session-1",
+    messageID: "assistant-1",
+    type: MessagePartType.text,
+    text: text,
+    tool: null,
+    state: null,
+    prompt: null,
+    description: null,
+    agent: null,
+    agentName: null,
+    attempt: null,
+    retryError: null,
+  );
+}
+
+MessagePart _toolPart({required String id, required String toolName}) {
+  return MessagePart(
+    id: id,
+    sessionID: "session-1",
+    messageID: "assistant-1",
+    type: MessagePartType.tool,
+    text: null,
+    tool: toolName,
+    state: null,
+    prompt: null,
+    description: null,
+    agent: null,
+    agentName: null,
+    attempt: null,
+    retryError: null,
+  );
+}
+
+void main() {
+  testWidgets("renders one SelectionArea and two markdown parts for assistant text", (tester) async {
+    await tester.pumpWidget(
+      _AssistantMessageCardHarness(
+        message: _assistantMessage(
+          parts: [
+            _textPart(id: "part-1", text: "First paragraph"),
+            _textPart(id: "part-2", text: "Second paragraph"),
+          ],
+        ),
+        streamingText: const {},
+      ),
+    );
+
+    expect(find.byType(SelectionArea), findsOneWidget);
+    expect(find.byType(MarkdownBody), findsNWidgets(2));
+
+    final markdownBodies = tester.widgetList<MarkdownBody>(find.byType(MarkdownBody)).toList();
+    expect(markdownBodies.map((widget) => widget.data), ['First paragraph', 'Second paragraph']);
+  });
+
+  testWidgets("preserves mixed text-tool-text rendering inside one SelectionArea", (tester) async {
+    await tester.pumpWidget(
+      _AssistantMessageCardHarness(
+        message: _assistantMessage(
+          parts: [
+            _textPart(id: "part-1", text: "Before tool"),
+            _toolPart(id: "part-2", toolName: "Search files"),
+            _textPart(id: "part-3", text: "After tool"),
+          ],
+        ),
+        streamingText: const {},
+      ),
+    );
+
+    expect(find.byType(SelectionArea), findsOneWidget);
+    expect(find.byType(MarkdownBody), findsNWidgets(2));
+    expect(find.byType(ToolPartWidget), findsOneWidget);
+
+    final markdownBodies = tester.widgetList<MarkdownBody>(find.byType(MarkdownBody)).toList();
+    expect(markdownBodies.map((widget) => widget.data), ['Before tool', 'After tool']);
+  });
+
+  testWidgets("streaming text updates the rendered markdown without breaking the SelectionArea", (tester) async {
+    final harnessKey = GlobalKey<_AssistantMessageCardHarnessState>();
+    const partId = "streaming-part";
+
+    await tester.pumpWidget(
+      _AssistantMessageCardHarness(
+        key: harnessKey,
+        message: _assistantMessage(
+          parts: [_textPart(id: partId, text: "final text")],
+        ),
+        streamingText: const {partId: "draft text"},
+      ),
+    );
+
+    expect(find.byType(SelectionArea), findsOneWidget);
+    expect(tester.widget<MarkdownBody>(find.byType(MarkdownBody)).data, "draft text");
+
+    harnessKey.currentState!.updateStreamingText(partId: partId, text: "updated draft text");
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(SelectionArea), findsOneWidget);
+    expect(tester.widget<MarkdownBody>(find.byType(MarkdownBody)).data, "updated draft text");
+  });
+}

--- a/mobile/app/test/features/session_detail/widgets/assistant_message_card_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/assistant_message_card_test.dart
@@ -119,6 +119,11 @@ void main() {
 
     final markdownBodies = tester.widgetList<MarkdownBody>(find.byType(MarkdownBody)).toList();
     expect(markdownBodies.map((widget) => widget.data), ['First paragraph', 'Second paragraph']);
+
+    // Verify selectable is disabled so SelectionArea owns selection.
+    for (final body in markdownBodies) {
+      expect(body.selectable, isFalse);
+    }
   });
 
   testWidgets("preserves mixed text-tool-text rendering inside one SelectionArea", (tester) async {


### PR DESCRIPTION
## Summary
- Fix text selection across message parts in chat

## Problem
Text selection was blocked across message parts because each part rendered as a separate selectable widget.

## Solution
Wrap assistant message content in `SelectionArea` and disable `selectable` on individual `MarkdownBody` widgets.

## Files Changed
- `mobile/app/lib/features/session_detail/widgets/text_part_widget.dart`
- `mobile/app/lib/features/session_detail/widgets/assistant_message_card.dart`
- `mobile/app/test/features/session_detail/widgets/assistant_message_card_test.dart`

## Verification
- All tests pass: `flutter test`
- Analyzer clean: `flutter analyze`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables cross-paragraph text selection in chat assistant messages. Users can now select text across multiple message parts without the selection breaking.

- **Bug Fixes**
  - Wrap assistant message content in `SelectionArea` to unify selection across parts.
  - Set `MarkdownBody.selectable` to false to avoid nested selection conflicts.
  - Add widget tests verifying a single `SelectionArea`, mixed text/tool rendering, streaming updates, and asserting `MarkdownBody.selectable: false`.

<sup>Written for commit 84786dbeb48d9a92e8c7933eeb2dd0c743ea2c16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

