### PR TITLE
fix: use LifecycleState.paused instead of .hidden for backgrounding

### DIFF
--- a/mobile/app/test/capabilities/server_connection/connection_service_test.dart
+++ b/mobile/app/test/capabilities/server_connection/connection_service_test.dart
@@ -112,11 +112,11 @@ void main() {
     // 6. Lifecycle stream integration
     // ------------------------------------------------------------------
 
-    test("LifecycleState.hidden triggers backgrounding (idempotent)", () async {
-      lifecycleSource.emitState(LifecycleState.hidden);
+    test("LifecycleState.paused triggers backgrounding (idempotent)", () async {
+      lifecycleSource.emitState(LifecycleState.paused);
       await Future<void>.delayed(Duration.zero);
       // Second emission is a no-op — should not throw.
-      lifecycleSource.emitState(LifecycleState.hidden);
+      lifecycleSource.emitState(LifecycleState.paused);
       await Future<void>.delayed(Duration.zero);
     });
 
@@ -126,15 +126,15 @@ void main() {
       await Future<void>.delayed(Duration.zero);
     });
 
-    test("hidden then resumed: round-trip completes without error", () async {
-      lifecycleSource.emitState(LifecycleState.hidden);
+    test("paused then resumed: round-trip completes without error", () async {
+      lifecycleSource.emitState(LifecycleState.paused);
       await Future<void>.delayed(Duration.zero);
       lifecycleSource.emitState(LifecycleState.resumed);
       await Future<void>.delayed(Duration.zero);
     });
 
     test("resumed is idempotent after round-trip", () async {
-      lifecycleSource.emitState(LifecycleState.hidden);
+      lifecycleSource.emitState(LifecycleState.paused);
       await Future<void>.delayed(Duration.zero);
       lifecycleSource.emitState(LifecycleState.resumed);
       await Future<void>.delayed(Duration.zero);
@@ -143,10 +143,10 @@ void main() {
       await Future<void>.delayed(Duration.zero);
     });
 
-    test("inactive and paused states do not throw", () async {
+    test("inactive and hidden states do not throw", () async {
       lifecycleSource.emitState(LifecycleState.inactive);
       await Future<void>.delayed(Duration.zero);
-      lifecycleSource.emitState(LifecycleState.paused);
+      lifecycleSource.emitState(LifecycleState.hidden);
       await Future<void>.delayed(Duration.zero);
     });
 

--- a/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -103,9 +103,9 @@ class ConnectionService {
           case .inactive:
             break;
           case .hidden:
-            _onAppBackgrounded();
-          case .paused:
             break;
+          case .paused:
+            _onAppBackgrounded();
           case .detached:
             break;
         }

--- a/mobile/module_core/test/capabilities/connection_service_stale_test.dart
+++ b/mobile/module_core/test/capabilities/connection_service_stale_test.dart
@@ -88,7 +88,7 @@ void main() {
       var staleEmissions = 0;
       final sub = service.dataMayBeStale.listen((_) => staleEmissions++);
 
-      lifecycleController.add(LifecycleState.hidden);
+      lifecycleController.add(LifecycleState.paused);
       await flush();
       now = now.add(const Duration(minutes: 5));
       lifecycleController.add(LifecycleState.resumed);
@@ -104,7 +104,7 @@ void main() {
       var staleEmissions = 0;
       final sub = service.dataMayBeStale.listen((_) => staleEmissions++);
 
-      lifecycleController.add(LifecycleState.hidden);
+      lifecycleController.add(LifecycleState.paused);
       await flush();
       // 4 minutes is safely under the 4:30 stale threshold (90% of 5 min)
       now = now.add(const Duration(minutes: 4));
@@ -121,7 +121,7 @@ void main() {
       var staleEmissions = 0;
       final sub = service.dataMayBeStale.listen((_) => staleEmissions++);
 
-      lifecycleController.add(LifecycleState.hidden);
+      lifecycleController.add(LifecycleState.paused);
       await flush();
       now = now.add(const Duration(minutes: 6));
       lifecycleController.add(LifecycleState.resumed);
@@ -137,7 +137,7 @@ void main() {
       var staleEmissions = 0;
       final sub = service.dataMayBeStale.listen((_) => staleEmissions++);
 
-      lifecycleController.add(LifecycleState.hidden);
+      lifecycleController.add(LifecycleState.paused);
       await flush();
       now = now.add(const Duration(minutes: 6));
       lifecycleController.add(LifecycleState.resumed);
@@ -153,14 +153,14 @@ void main() {
       var staleEmissions = 0;
       final sub = service.dataMayBeStale.listen((_) => staleEmissions++);
 
-      lifecycleController.add(LifecycleState.hidden);
+      lifecycleController.add(LifecycleState.paused);
       await flush();
       now = now.add(const Duration(minutes: 2));
       lifecycleController.add(LifecycleState.resumed);
       await flush();
       expect(staleEmissions, 0);
 
-      lifecycleController.add(LifecycleState.hidden);
+      lifecycleController.add(LifecycleState.paused);
       await flush();
       now = now.add(const Duration(minutes: 6));
       lifecycleController.add(LifecycleState.resumed);
@@ -176,7 +176,7 @@ void main() {
       var staleEmissions = 0;
       final sub = service.dataMayBeStale.listen((_) => staleEmissions++);
 
-      lifecycleController.add(LifecycleState.hidden);
+      lifecycleController.add(LifecycleState.paused);
       await flush();
       now = now.add(const Duration(minutes: 6));
       lifecycleController.add(LifecycleState.resumed);

--- a/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
+++ b/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
@@ -166,7 +166,7 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 1400));
       verify(() => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl"))).called(1);
 
-      lifecycleController.add(LifecycleState.hidden);
+      lifecycleController.add(LifecycleState.paused);
       await Future<void>.delayed(Duration.zero);
       tokenCompleter.complete("fresh-token");
 


### PR DESCRIPTION
## Problem

`ConnectionService` treated `.hidden` as the background state, which incorrectly affected desktop and web platforms.

- **Desktop**: `.hidden` fires when the window is minimized. The app is still running and should maintain its WebSocket connection. Previously, minimizing paused reconnect attempts.
- **Web**: `.hidden` fires when the tab is no longer visible. Same issue — the tab may still be alive and should not lose reconnect logic.
- **Mobile**: `.hidden` is just a transient state before `.paused`. The real background state is `.paused`.

## Fix

React to `.paused` for backgrounding instead of `.hidden`:

```dart
// Before
.hidden => _onAppBackgrounded()
.paused => break

// After
.hidden => break
.paused => _onAppBackgrounded()
```

## Impact

| Platform | Before | After |
|----------|--------|-------|
| Mobile | reconnect paused at `.hidden` (before full background) | reconnect paused at `.paused` (correct) |
| Desktop | reconnect paused on minimize | reconnect continues on minimize |
| Web | reconnect paused on tab-hide | reconnect continues on tab-hide |

## Tests

- Updated `connection_service_test.dart` to use `.paused` for backgrounding scenarios
- Updated `connection_service_stale_test.dart` to use `.paused`
- Updated `connection_service_reconnect_test.dart` to use `.paused`
- All tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch background detection to LifecycleState.paused instead of .hidden. Prevents reconnect from pausing on desktop minimize and web tab-hide, while keeping correct pause-on-background behavior on mobile.

- **Bug Fixes**
  - `ConnectionService`: trigger background handling on `.paused`; ignore `.hidden`.
  - Updated lifecycle tests to use `.paused` for backgrounding scenarios.

<sup>Written for commit fd9e76bddcb644bec591c178a0a4254781ceb0e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

