### PR TITLE
feat: improve wake lock lid-close behavior and add laptop warnings

### DIFF
--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -5,6 +5,7 @@ import 'package:opencode_plugin/opencode_plugin.dart';
 import 'package:sesori_bridge/src/api/bridge_settings_api.dart';
 import 'package:sesori_bridge/src/api/default_editor_api.dart';
 import 'package:sesori_bridge/src/api/wake_lock_client.dart';
+import 'package:sesori_bridge/src/bridge/foundation/device_type_detector.dart';
 import 'package:sesori_bridge/src/bridge/foundation/process_runner.dart';
 import 'package:sesori_bridge/src/bridge/runtime/bridge_cli_options.dart';
 import 'package:sesori_bridge/src/bridge/runtime/bridge_runtime_runner.dart';
@@ -133,6 +134,9 @@ Future<void> main(List<String> args) async {
     bridgeSettingsRepository: settingsRepository,
     wakeLockRepository: WakeLockRepository(
       client: WakeLockClient.forPlatform(),
+    ),
+    deviceTypeDetector: DeviceTypeDetector(
+      processRunner: ProcessRunner(),
     ),
   );
 

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -137,6 +137,7 @@ Future<void> main(List<String> args) async {
     ),
     deviceTypeDetector: DeviceTypeDetector(
       processRunner: ProcessRunner(),
+      platformChecker: DefaultPlatformChecker(),
     ),
   );
 

--- a/bridge/app/lib/src/api/linux_wake_lock_api.dart
+++ b/bridge/app/lib/src/api/linux_wake_lock_api.dart
@@ -29,7 +29,7 @@ class LinuxWakeLockApi implements WakeLockClient {
       final process = await _processStarter(
         "systemd-inhibit",
         const <String>[
-          "--what=idle:sleep",
+          "--what=idle:sleep:handle-lid-switch",
           "--who=sesori-bridge",
           "--why=Bridge is running",
           "cat",
@@ -63,4 +63,7 @@ class LinuxWakeLockApi implements WakeLockClient {
 
     process.kill();
   }
+
+  @override
+  bool get preventsLidCloseSleep => true;
 }

--- a/bridge/app/lib/src/api/macos_wake_lock_api.dart
+++ b/bridge/app/lib/src/api/macos_wake_lock_api.dart
@@ -18,7 +18,7 @@ class MacOSWakeLockApi implements WakeLockClient {
     try {
       _process = await _processStarter(
         "caffeinate",
-        <String>["-s", "-w", pid.toString()],
+        <String>["-i", "-s", "-w", pid.toString()],
       );
     } on ProcessException catch (error) {
       Log.w("[wake-lock] caffeinate unavailable: $error");

--- a/bridge/app/lib/src/api/macos_wake_lock_api.dart
+++ b/bridge/app/lib/src/api/macos_wake_lock_api.dart
@@ -16,7 +16,10 @@ class MacOSWakeLockApi implements WakeLockClient {
   Future<void> enable() async {
     await disable();
     try {
-      _process = await _processStarter("caffeinate", <String>["-w", pid.toString()]);
+      _process = await _processStarter(
+        "caffeinate",
+        <String>["-s", "-w", pid.toString()],
+      );
     } on ProcessException catch (error) {
       Log.w("[wake-lock] caffeinate unavailable: $error");
     }
@@ -28,4 +31,7 @@ class MacOSWakeLockApi implements WakeLockClient {
     _process = null;
     process?.kill();
   }
+
+  @override
+  bool get preventsLidCloseSleep => false;
 }

--- a/bridge/app/lib/src/api/wake_lock_client.dart
+++ b/bridge/app/lib/src/api/wake_lock_client.dart
@@ -13,6 +13,10 @@ abstract class WakeLockClient {
 
   Future<void> disable();
 
+  /// Whether this platform's wake-lock implementation also prevents the
+  /// system from sleeping when the laptop lid is closed.
+  bool get preventsLidCloseSleep;
+
   factory WakeLockClient.forPlatform() => switch (true) {
     _ when Platform.isMacOS => MacOSWakeLockApi(processStarter: Process.start),
     _ when Platform.isLinux => LinuxWakeLockApi(processStarter: Process.start),

--- a/bridge/app/lib/src/api/windows_wake_lock_api.dart
+++ b/bridge/app/lib/src/api/windows_wake_lock_api.dart
@@ -37,4 +37,7 @@ class WindowsWakeLockApi implements WakeLockClient {
       warningLogger('[wake-lock] SetThreadExecutionState($action) failed');
     }
   }
+
+  @override
+  bool get preventsLidCloseSleep => false;
 }

--- a/bridge/app/lib/src/bridge/foundation/device_type_detector.dart
+++ b/bridge/app/lib/src/bridge/foundation/device_type_detector.dart
@@ -1,5 +1,7 @@
 import "dart:io";
 
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
 import "process_runner.dart";
 
 /// Abstracts platform checks so they can be mocked in tests.
@@ -9,7 +11,7 @@ abstract class PlatformChecker {
   bool get isLinux;
 }
 
-class _DefaultPlatformChecker implements PlatformChecker {
+class DefaultPlatformChecker implements PlatformChecker {
   @override
   bool get isMacOS => Platform.isMacOS;
 
@@ -25,35 +27,50 @@ class _DefaultPlatformChecker implements PlatformChecker {
 class DeviceTypeDetector {
   final ProcessRunner _processRunner;
   final PlatformChecker _platformChecker;
+  final String _linuxPowerSupplyPath;
+  bool? _isLaptop;
 
   DeviceTypeDetector({
     required ProcessRunner processRunner,
-    PlatformChecker? platformChecker,
+    required PlatformChecker platformChecker,
+    String linuxPowerSupplyPath = "/sys/class/power_supply/",
   }) : _processRunner = processRunner,
-       _platformChecker = platformChecker ?? _DefaultPlatformChecker();
+       _platformChecker = platformChecker,
+       _linuxPowerSupplyPath = linuxPowerSupplyPath;
 
   Future<bool> isLaptop() async {
+    if (_isLaptop != null) {
+      return _isLaptop!;
+    }
     if (_platformChecker.isMacOS) {
-      return _isMacOSLaptop();
+      _isLaptop = await _isMacOSLaptop();
+    } else if (_platformChecker.isWindows) {
+      _isLaptop = await _isWindowsLaptop();
+    } else if (_platformChecker.isLinux) {
+      _isLaptop = await _isLinuxLaptop();
+    } else {
+      _isLaptop = false;
     }
-    if (_platformChecker.isWindows) {
-      return _isWindowsLaptop();
-    }
-    if (_platformChecker.isLinux) {
-      return _isLinuxLaptop();
-    }
-    return false;
+    return _isLaptop!;
   }
 
   Future<bool> _isMacOSLaptop() async {
     try {
-      final result = await _processRunner.run("sysctl", <String>["-n", "hw.model"]);
+      final result = await _processRunner.run(
+        "sysctl",
+        <String>["-n", "hw.model"],
+      );
       if (result.exitCode != 0) {
+        Log.w(
+          "[device-type] sysctl failed (exit ${result.exitCode}): "
+          "${result.stderr}",
+        );
         return false;
       }
       final model = (result.stdout as String).trim().toLowerCase();
       return model.contains("macbook");
-    } on Object {
+    } on Object catch (error) {
+      Log.w("[device-type] failed to detect macOS laptop: $error");
       return false;
     }
   }
@@ -68,25 +85,34 @@ class DeviceTypeDetector {
         ],
       );
       if (result.exitCode != 0) {
+        Log.w(
+          "[device-type] powershell failed (exit ${result.exitCode}): "
+          "${result.stderr}",
+        );
         return false;
       }
       final count = int.tryParse((result.stdout as String).trim()) ?? 0;
       return count > 0;
-    } on Object {
+    } on Object catch (error) {
+      Log.w("[device-type] failed to detect Windows laptop: $error");
       return false;
     }
   }
 
   Future<bool> _isLinuxLaptop() async {
     try {
-      final dir = Directory("/sys/class/power_supply/");
-      if (!dir.existsSync()) {
+      final dir = Directory(_linuxPowerSupplyPath);
+      // ignore: avoid_slow_async_io
+      if (!await dir.exists()) {
         return false;
       }
-      return dir
-          .listSync()
-          .any((e) => e.path.split("/").last.startsWith("BAT"));
-    } on Object {
+      // ignore: avoid_slow_async_io
+      final entries = await dir.list().toList();
+      return entries.any(
+        (e) => e.path.split("/").last.startsWith("BAT"),
+      );
+    } on Object catch (error) {
+      Log.w("[device-type] failed to detect Linux laptop: $error");
       return false;
     }
   }

--- a/bridge/app/lib/src/bridge/foundation/device_type_detector.dart
+++ b/bridge/app/lib/src/bridge/foundation/device_type_detector.dart
@@ -1,0 +1,93 @@
+import "dart:io";
+
+import "process_runner.dart";
+
+/// Abstracts platform checks so they can be mocked in tests.
+abstract class PlatformChecker {
+  bool get isMacOS;
+  bool get isWindows;
+  bool get isLinux;
+}
+
+class _DefaultPlatformChecker implements PlatformChecker {
+  @override
+  bool get isMacOS => Platform.isMacOS;
+
+  @override
+  bool get isWindows => Platform.isWindows;
+
+  @override
+  bool get isLinux => Platform.isLinux;
+}
+
+/// Detects whether the current device is a laptop (as opposed to a desktop
+/// or server). Used to show platform-specific wake-lock limitations.
+class DeviceTypeDetector {
+  final ProcessRunner _processRunner;
+  final PlatformChecker _platformChecker;
+
+  DeviceTypeDetector({
+    required ProcessRunner processRunner,
+    PlatformChecker? platformChecker,
+  }) : _processRunner = processRunner,
+       _platformChecker = platformChecker ?? _DefaultPlatformChecker();
+
+  Future<bool> isLaptop() async {
+    if (_platformChecker.isMacOS) {
+      return _isMacOSLaptop();
+    }
+    if (_platformChecker.isWindows) {
+      return _isWindowsLaptop();
+    }
+    if (_platformChecker.isLinux) {
+      return _isLinuxLaptop();
+    }
+    return false;
+  }
+
+  Future<bool> _isMacOSLaptop() async {
+    try {
+      final result = await _processRunner.run("sysctl", <String>["-n", "hw.model"]);
+      if (result.exitCode != 0) {
+        return false;
+      }
+      final model = (result.stdout as String).trim().toLowerCase();
+      return model.contains("macbook");
+    } on Object {
+      return false;
+    }
+  }
+
+  Future<bool> _isWindowsLaptop() async {
+    try {
+      final result = await _processRunner.run(
+        "powershell.exe",
+        <String>[
+          "-Command",
+          "Get-CimInstance Win32_Battery -ErrorAction SilentlyContinue | Measure-Object | Select-Object -ExpandProperty Count",
+        ],
+      );
+      if (result.exitCode != 0) {
+        return false;
+      }
+      final count = int.tryParse((result.stdout as String).trim()) ?? 0;
+      return count > 0;
+    } on Object {
+      return false;
+    }
+  }
+
+  Future<bool> _isLinuxLaptop() async {
+    try {
+      final dir = Directory("/sys/class/power_supply/");
+      if (!dir.existsSync()) {
+        return false;
+      }
+      return dir
+          .listSync()
+          .any((e) => e.path.split("/").last.startsWith("BAT"));
+    } on Object {
+      return false;
+    }
+  }
+}

--- a/bridge/app/lib/src/bridge/foundation/device_type_detector.dart
+++ b/bridge/app/lib/src/bridge/foundation/device_type_detector.dart
@@ -1,5 +1,7 @@
+import "dart:async";
 import "dart:io";
 
+import "package:meta/meta.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 import "process_runner.dart";
@@ -28,30 +30,28 @@ class DeviceTypeDetector {
   final ProcessRunner _processRunner;
   final PlatformChecker _platformChecker;
   final String _linuxPowerSupplyPath;
-  bool? _isLaptop;
+  Future<bool>? _isLaptop;
 
   DeviceTypeDetector({
     required ProcessRunner processRunner,
     required PlatformChecker platformChecker,
-    String linuxPowerSupplyPath = "/sys/class/power_supply/",
+    @visibleForTesting String linuxPowerSupplyPath = "/sys/class/power_supply/",
   }) : _processRunner = processRunner,
        _platformChecker = platformChecker,
        _linuxPowerSupplyPath = linuxPowerSupplyPath;
 
-  Future<bool> isLaptop() async {
-    if (_isLaptop != null) {
-      return _isLaptop!;
-    }
+  Future<bool> isLaptop() async => _isLaptop ??= _computeIsLaptop();
+
+  Future<bool> _computeIsLaptop() {
     if (_platformChecker.isMacOS) {
-      _isLaptop = await _isMacOSLaptop();
+      return _isMacOSLaptop();
     } else if (_platformChecker.isWindows) {
-      _isLaptop = await _isWindowsLaptop();
+      return _isWindowsLaptop();
     } else if (_platformChecker.isLinux) {
-      _isLaptop = await _isLinuxLaptop();
+      return _isLinuxLaptop();
     } else {
-      _isLaptop = false;
+      return Future.value(false);
     }
-    return _isLaptop!;
   }
 
   Future<bool> _isMacOSLaptop() async {
@@ -102,13 +102,11 @@ class DeviceTypeDetector {
   Future<bool> _isLinuxLaptop() async {
     try {
       final dir = Directory(_linuxPowerSupplyPath);
-      // ignore: avoid_slow_async_io
-      if (!await dir.exists()) {
+      if (!dir.existsSync()) {
         return false;
       }
-      // ignore: avoid_slow_async_io
-      final entries = await dir.list().toList();
-      return entries.any(
+      final dirsStream = dir.list();
+      return await dirsStream.any(
         (e) => e.path.split("/").last.startsWith("BAT"),
       );
     } on Object catch (error) {

--- a/bridge/app/lib/src/repositories/wake_lock_repository.dart
+++ b/bridge/app/lib/src/repositories/wake_lock_repository.dart
@@ -8,6 +8,8 @@ class WakeLockRepository {
 
   bool get isEnabled => _isEnabled;
 
+  bool get preventsLidCloseSleep => _client.preventsLidCloseSleep;
+
   Future<void> enable() async {
     await _client.enable();
     _isEnabled = true;

--- a/bridge/app/lib/src/services/sleep_prevention_service.dart
+++ b/bridge/app/lib/src/services/sleep_prevention_service.dart
@@ -1,5 +1,6 @@
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Log;
 
+import '../bridge/foundation/device_type_detector.dart';
 import '../repositories/bridge_settings.dart';
 import '../repositories/bridge_settings_repository.dart';
 import '../repositories/wake_lock_repository.dart';
@@ -7,12 +8,15 @@ import '../repositories/wake_lock_repository.dart';
 class SleepPreventionService {
   final BridgeSettingsRepository _bridgeSettingsRepository;
   final WakeLockRepository _wakeLockRepository;
+  final DeviceTypeDetector _deviceTypeDetector;
 
   SleepPreventionService({
     required BridgeSettingsRepository bridgeSettingsRepository,
     required WakeLockRepository wakeLockRepository,
+    required DeviceTypeDetector deviceTypeDetector,
   }) : _bridgeSettingsRepository = bridgeSettingsRepository,
-       _wakeLockRepository = wakeLockRepository;
+       _wakeLockRepository = wakeLockRepository,
+       _deviceTypeDetector = deviceTypeDetector;
 
   Future<SleepPreventionMode> applyConfiguredMode() async {
     final settings = await _bridgeSettingsRepository.loadSettings();
@@ -21,6 +25,7 @@ class SleepPreventionService {
       case SleepPreventionMode.always:
         try {
           await _wakeLockRepository.enable();
+          await _warnIfLidCloseSleepNotPrevented();
         } on Object catch (error) {
           Log.w('[SleepPreventionService] failed to enable wake lock: $error');
         }
@@ -33,6 +38,22 @@ class SleepPreventionService {
     }
 
     return settings.sleepPrevention;
+  }
+
+  Future<void> _warnIfLidCloseSleepNotPrevented() async {
+    if (_wakeLockRepository.preventsLidCloseSleep) {
+      return;
+    }
+
+    final isLaptop = await _deviceTypeDetector.isLaptop();
+    if (!isLaptop) {
+      return;
+    }
+
+    Log.w(
+      '[SleepPreventionService] wake lock enabled, but this platform '
+      'cannot prevent the system from sleeping when the laptop lid is closed.',
+    );
   }
 
   Future<void> dispose() async {

--- a/bridge/app/lib/src/services/sleep_prevention_service.dart
+++ b/bridge/app/lib/src/services/sleep_prevention_service.dart
@@ -30,7 +30,9 @@ class SleepPreventionService {
       case SleepPreventionMode.always:
         try {
           await _wakeLockRepository.enable();
-          await _warnIfLidCloseSleepNotPrevented();
+          await _warnIfLidCloseSleepNotPrevented().catchError((error) {
+            _warningLogger("[SleepPreventionService] Failed to determine device type and lid close behavior");
+          });
         } on Object catch (error) {
           _warningLogger(
             '[SleepPreventionService] failed to enable wake lock: $error',

--- a/bridge/app/lib/src/services/sleep_prevention_service.dart
+++ b/bridge/app/lib/src/services/sleep_prevention_service.dart
@@ -5,18 +5,23 @@ import '../repositories/bridge_settings.dart';
 import '../repositories/bridge_settings_repository.dart';
 import '../repositories/wake_lock_repository.dart';
 
+typedef WarningLogger = void Function(String message);
+
 class SleepPreventionService {
   final BridgeSettingsRepository _bridgeSettingsRepository;
   final WakeLockRepository _wakeLockRepository;
   final DeviceTypeDetector _deviceTypeDetector;
+  final WarningLogger _warningLogger;
 
   SleepPreventionService({
     required BridgeSettingsRepository bridgeSettingsRepository,
     required WakeLockRepository wakeLockRepository,
     required DeviceTypeDetector deviceTypeDetector,
+    WarningLogger? warningLogger,
   }) : _bridgeSettingsRepository = bridgeSettingsRepository,
        _wakeLockRepository = wakeLockRepository,
-       _deviceTypeDetector = deviceTypeDetector;
+       _deviceTypeDetector = deviceTypeDetector,
+       _warningLogger = warningLogger ?? Log.w;
 
   Future<SleepPreventionMode> applyConfiguredMode() async {
     final settings = await _bridgeSettingsRepository.loadSettings();
@@ -27,13 +32,17 @@ class SleepPreventionService {
           await _wakeLockRepository.enable();
           await _warnIfLidCloseSleepNotPrevented();
         } on Object catch (error) {
-          Log.w('[SleepPreventionService] failed to enable wake lock: $error');
+          _warningLogger(
+            '[SleepPreventionService] failed to enable wake lock: $error',
+          );
         }
       case SleepPreventionMode.off:
         try {
           await _wakeLockRepository.disable();
         } on Object catch (error) {
-          Log.w('[SleepPreventionService] failed to disable wake lock: $error');
+          _warningLogger(
+            '[SleepPreventionService] failed to disable wake lock: $error',
+          );
         }
     }
 
@@ -45,12 +54,21 @@ class SleepPreventionService {
       return;
     }
 
-    final isLaptop = await _deviceTypeDetector.isLaptop();
+    final bool isLaptop;
+    try {
+      isLaptop = await _deviceTypeDetector.isLaptop();
+    } on Object catch (error) {
+      _warningLogger(
+        '[SleepPreventionService] failed to detect device type: $error',
+      );
+      return;
+    }
+
     if (!isLaptop) {
       return;
     }
 
-    Log.w(
+    _warningLogger(
       '[SleepPreventionService] wake lock enabled, but this platform '
       'cannot prevent the system from sleeping when the laptop lid is closed.',
     );
@@ -60,7 +78,10 @@ class SleepPreventionService {
     try {
       await _wakeLockRepository.disable();
     } on Object catch (error) {
-      Log.w('[SleepPreventionService] failed to disable wake lock during dispose: $error');
+      _warningLogger(
+        '[SleepPreventionService] failed to disable wake lock during dispose: '
+        '$error',
+      );
     }
   }
 }

--- a/bridge/app/test/device_type_detector_test.dart
+++ b/bridge/app/test/device_type_detector_test.dart
@@ -91,6 +91,76 @@ void main() {
       final isLaptop = await detector.isLaptop();
       expect(isLaptop, isFalse);
     });
+
+    test("caches result across multiple calls", () async {
+      final processRunner = _FakeProcessRunner(
+        results: <String, _FakeResult>{
+          "sysctl": _FakeResult(
+            exitCode: 0,
+            stdout: "MacBookPro18,1\n",
+          ),
+        },
+      );
+      final detector = DeviceTypeDetector(
+        processRunner: processRunner,
+        platformChecker: _FakePlatformChecker(isMacOS: true),
+      );
+
+      final first = await detector.isLaptop();
+      final second = await detector.isLaptop();
+
+      expect(first, isTrue);
+      expect(second, isTrue);
+      expect(processRunner.callCount("sysctl"), equals(1));
+    });
+
+    test("detects Linux laptop when battery entries exist", () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        "device_type_detector_test_",
+      );
+      await File("${tempDir.path}/BAT0").create();
+      await File("${tempDir.path}/AC").create();
+
+      final detector = DeviceTypeDetector(
+        processRunner: _FakeProcessRunner(results: const <String, _FakeResult>{}),
+        platformChecker: _FakePlatformChecker(isLinux: true),
+        linuxPowerSupplyPath: tempDir.path,
+      );
+
+      final isLaptop = await detector.isLaptop();
+      expect(isLaptop, isTrue);
+
+      await tempDir.delete(recursive: true);
+    });
+
+    test("detects Linux desktop when no battery entries exist", () async {
+      final tempDir = await Directory.systemTemp.createTemp(
+        "device_type_detector_test_",
+      );
+      await File("${tempDir.path}/AC").create();
+
+      final detector = DeviceTypeDetector(
+        processRunner: _FakeProcessRunner(results: const <String, _FakeResult>{}),
+        platformChecker: _FakePlatformChecker(isLinux: true),
+        linuxPowerSupplyPath: tempDir.path,
+      );
+
+      final isLaptop = await detector.isLaptop();
+      expect(isLaptop, isFalse);
+
+      await tempDir.delete(recursive: true);
+    });
+
+    test("returns false for Linux when power supply dir does not exist", () async {
+      final detector = DeviceTypeDetector(
+        processRunner: _FakeProcessRunner(results: const <String, _FakeResult>{}),
+        platformChecker: _FakePlatformChecker(isLinux: true),
+        linuxPowerSupplyPath: "/nonexistent/path/",
+      );
+
+      final isLaptop = await detector.isLaptop();
+      expect(isLaptop, isFalse);
+    });
   });
 }
 
@@ -108,6 +178,7 @@ class _FakeResult {
 
 class _FakeProcessRunner implements ProcessRunner {
   final Map<String, _FakeResult> results;
+  final Map<String, int> _callCounts = <String, int>{};
 
   _FakeProcessRunner({required this.results});
 
@@ -118,6 +189,7 @@ class _FakeProcessRunner implements ProcessRunner {
     String? workingDirectory,
     Duration timeout = const Duration(seconds: 15),
   }) async {
+    _callCounts[executable] = (_callCounts[executable] ?? 0) + 1;
     final result = results[executable];
     if (result == null) {
       throw ProcessException(executable, arguments, "command not found");
@@ -129,6 +201,8 @@ class _FakeProcessRunner implements ProcessRunner {
       result.stderr,
     );
   }
+
+  int callCount(String executable) => _callCounts[executable] ?? 0;
 }
 
 class _FakePlatformChecker implements PlatformChecker {

--- a/bridge/app/test/device_type_detector_test.dart
+++ b/bridge/app/test/device_type_detector_test.dart
@@ -1,0 +1,155 @@
+import "dart:io";
+
+import "package:sesori_bridge/src/bridge/foundation/device_type_detector.dart";
+import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("DeviceTypeDetector", () {
+    test("detects macOS laptop when hw.model contains MacBook", () async {
+      final detector = DeviceTypeDetector(
+        processRunner: _FakeProcessRunner(
+          results: <String, _FakeResult>{
+            "sysctl": _FakeResult(
+              exitCode: 0,
+              stdout: "MacBookPro18,1\n",
+            ),
+          },
+        ),
+        platformChecker: _FakePlatformChecker(isMacOS: true),
+      );
+
+      final isLaptop = await detector.isLaptop();
+      expect(isLaptop, isTrue);
+    });
+
+    test("detects macOS desktop when hw.model does not contain MacBook", () async {
+      final detector = DeviceTypeDetector(
+        processRunner: _FakeProcessRunner(
+          results: <String, _FakeResult>{
+            "sysctl": _FakeResult(
+              exitCode: 0,
+              stdout: "Macmini9,1\n",
+            ),
+          },
+        ),
+        platformChecker: _FakePlatformChecker(isMacOS: true),
+      );
+
+      final isLaptop = await detector.isLaptop();
+      expect(isLaptop, isFalse);
+    });
+
+    test("detects Windows laptop when battery is present", () async {
+      final detector = DeviceTypeDetector(
+        processRunner: _FakeProcessRunner(
+          results: <String, _FakeResult>{
+            "powershell.exe": _FakeResult(
+              exitCode: 0,
+              stdout: "1\n",
+            ),
+          },
+        ),
+        platformChecker: _FakePlatformChecker(isWindows: true),
+      );
+
+      final isLaptop = await detector.isLaptop();
+      expect(isLaptop, isTrue);
+    });
+
+    test("detects Windows desktop when no battery is present", () async {
+      final detector = DeviceTypeDetector(
+        processRunner: _FakeProcessRunner(
+          results: <String, _FakeResult>{
+            "powershell.exe": _FakeResult(
+              exitCode: 0,
+              stdout: "0\n",
+            ),
+          },
+        ),
+        platformChecker: _FakePlatformChecker(isWindows: true),
+      );
+
+      final isLaptop = await detector.isLaptop();
+      expect(isLaptop, isFalse);
+    });
+
+    test("returns false on error", () async {
+      final detector = DeviceTypeDetector(
+        processRunner: _FakeProcessRunner(
+          results: <String, _FakeResult>{
+            "sysctl": _FakeResult(
+              exitCode: 1,
+              stdout: "",
+              stderr: "error",
+            ),
+          },
+        ),
+        platformChecker: _FakePlatformChecker(isMacOS: true),
+      );
+
+      final isLaptop = await detector.isLaptop();
+      expect(isLaptop, isFalse);
+    });
+  });
+}
+
+class _FakeResult {
+  final int exitCode;
+  final String stdout;
+  final String stderr;
+
+  _FakeResult({
+    required this.exitCode,
+    this.stdout = "",
+    this.stderr = "",
+  });
+}
+
+class _FakeProcessRunner implements ProcessRunner {
+  final Map<String, _FakeResult> results;
+
+  _FakeProcessRunner({required this.results});
+
+  @override
+  Future<ProcessResult> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Duration timeout = const Duration(seconds: 15),
+  }) async {
+    final result = results[executable];
+    if (result == null) {
+      throw ProcessException(executable, arguments, "command not found");
+    }
+    return ProcessResult(
+      12345,
+      result.exitCode,
+      result.stdout,
+      result.stderr,
+    );
+  }
+}
+
+class _FakePlatformChecker implements PlatformChecker {
+  final bool _isMacOS;
+  final bool _isWindows;
+  final bool _isLinux;
+
+  _FakePlatformChecker({
+    bool isMacOS = false,
+    bool isWindows = false,
+    bool isLinux = false,
+  }) : _isMacOS = isMacOS,
+       _isWindows = isWindows,
+       _isLinux = isLinux;
+
+  @override
+  bool get isMacOS => _isMacOS;
+
+  @override
+  bool get isWindows => _isWindows;
+
+  @override
+  bool get isLinux => _isLinux;
+}

--- a/bridge/app/test/linux_wake_lock_api_test.dart
+++ b/bridge/app/test/linux_wake_lock_api_test.dart
@@ -26,7 +26,7 @@ void main() {
       expect(
         invocations.single.arguments,
         equals(<String>[
-          "--what=idle:sleep",
+          "--what=idle:sleep:handle-lid-switch",
           "--who=sesori-bridge",
           "--why=Bridge is running",
           "cat",
@@ -34,6 +34,13 @@ void main() {
       );
       expect(fakeProcess.killSignals, hasLength(1));
       expect(fakeProcess.killSignals.single, equals(ProcessSignal.sigterm));
+    });
+
+    test("claims to prevent lid-close sleep", () {
+      final api = LinuxWakeLockApi(
+        processStarter: (_, __) async => _FakeProcess(),
+      );
+      expect(api.preventsLidCloseSleep, isTrue);
     });
 
     test("logs a warning when systemd-inhibit is unavailable", () async {
@@ -46,7 +53,7 @@ void main() {
           throw const ProcessException(
             "systemd-inhibit",
             <String>[
-              "--what=idle:sleep",
+              "--what=idle:sleep:handle-lid-switch",
               "--who=sesori-bridge",
               "--why=Bridge is running",
               "cat",

--- a/bridge/app/test/macos_wake_lock_api_test.dart
+++ b/bridge/app/test/macos_wake_lock_api_test.dart
@@ -22,8 +22,18 @@ void main() {
 
       expect(invocations, hasLength(1));
       expect(invocations.single.executable, equals("caffeinate"));
-      expect(invocations.single.arguments, equals(<String>["-w", io.pid.toString()]));
+      expect(
+        invocations.single.arguments,
+        equals(<String>["-s", "-w", io.pid.toString()]),
+      );
       expect(process.killCalled, isTrue);
+    });
+
+    test("does not claim to prevent lid-close sleep", () {
+      final api = MacOSWakeLockApi(
+        processStarter: (_, __) async => _FakeProcess(),
+      );
+      expect(api.preventsLidCloseSleep, isFalse);
     });
 
     test("logs warning when caffeinate process fails to start", () async {

--- a/bridge/app/test/macos_wake_lock_api_test.dart
+++ b/bridge/app/test/macos_wake_lock_api_test.dart
@@ -24,7 +24,7 @@ void main() {
       expect(invocations.single.executable, equals("caffeinate"));
       expect(
         invocations.single.arguments,
-        equals(<String>["-s", "-w", io.pid.toString()]),
+        equals(<String>["-i", "-s", "-w", io.pid.toString()]),
       );
       expect(process.killCalled, isTrue);
     });

--- a/bridge/app/test/sleep_prevention_service_test.dart
+++ b/bridge/app/test/sleep_prevention_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:sesori_bridge/src/api/bridge_settings_api.dart';
 import 'package:sesori_bridge/src/api/wake_lock_client.dart';
+import 'package:sesori_bridge/src/bridge/foundation/device_type_detector.dart';
 import 'package:sesori_bridge/src/repositories/bridge_settings.dart';
 import 'package:sesori_bridge/src/repositories/bridge_settings_repository.dart';
 import 'package:sesori_bridge/src/repositories/wake_lock_repository.dart';
@@ -16,6 +17,7 @@ void main() {
       final service = SleepPreventionService(
         bridgeSettingsRepository: BridgeSettingsRepository(api: settingsApi),
         wakeLockRepository: WakeLockRepository(client: wakeLockClient),
+        deviceTypeDetector: _FakeDeviceTypeDetector(isLaptop: false),
       );
 
       final appliedMode = await service.applyConfiguredMode();
@@ -33,6 +35,7 @@ void main() {
       final service = SleepPreventionService(
         bridgeSettingsRepository: BridgeSettingsRepository(api: settingsApi),
         wakeLockRepository: WakeLockRepository(client: wakeLockClient),
+        deviceTypeDetector: _FakeDeviceTypeDetector(isLaptop: false),
       );
 
       final appliedMode = await service.applyConfiguredMode();
@@ -53,6 +56,7 @@ void main() {
       final service = SleepPreventionService(
         bridgeSettingsRepository: BridgeSettingsRepository(api: settingsApi),
         wakeLockRepository: WakeLockRepository(client: wakeLockClient),
+        deviceTypeDetector: _FakeDeviceTypeDetector(isLaptop: false),
       );
 
       final firstMode = await service.applyConfiguredMode();
@@ -73,6 +77,7 @@ void main() {
       final service = SleepPreventionService(
         bridgeSettingsRepository: BridgeSettingsRepository(api: settingsApi),
         wakeLockRepository: WakeLockRepository(client: wakeLockClient),
+        deviceTypeDetector: _FakeDeviceTypeDetector(isLaptop: false),
       );
 
       final appliedMode = await service.applyConfiguredMode();
@@ -89,6 +94,7 @@ void main() {
       final service = SleepPreventionService(
         bridgeSettingsRepository: BridgeSettingsRepository(api: settingsApi),
         wakeLockRepository: WakeLockRepository(client: wakeLockClient),
+        deviceTypeDetector: _FakeDeviceTypeDetector(isLaptop: false),
       );
 
       final appliedMode = await service.applyConfiguredMode();
@@ -105,6 +111,7 @@ void main() {
       final service = SleepPreventionService(
         bridgeSettingsRepository: BridgeSettingsRepository(api: settingsApi),
         wakeLockRepository: WakeLockRepository(client: wakeLockClient),
+        deviceTypeDetector: _FakeDeviceTypeDetector(isLaptop: false),
       );
 
       await service.dispose();
@@ -119,12 +126,98 @@ void main() {
       final service = SleepPreventionService(
         bridgeSettingsRepository: BridgeSettingsRepository(api: settingsApi),
         wakeLockRepository: WakeLockRepository(client: wakeLockClient),
+        deviceTypeDetector: _FakeDeviceTypeDetector(isLaptop: false),
       );
 
       await service.dispose();
 
       expect(wakeLockClient.disableCalls, equals(1));
     });
+
+    test(
+      'does not warn about lid-close when platform prevents it',
+      () async {
+        final settingsApi = _QueueBridgeSettingsApi(
+          readResults: <String?>['{"sleepPrevention":"always"}'],
+        );
+        final wakeLockClient = _FakeWakeLockClient(
+          preventsLidCloseSleep: true,
+        );
+        final service = SleepPreventionService(
+          bridgeSettingsRepository: BridgeSettingsRepository(api: settingsApi),
+          wakeLockRepository: WakeLockRepository(client: wakeLockClient),
+          deviceTypeDetector: _FakeDeviceTypeDetector(isLaptop: true),
+        );
+
+        final appliedMode = await service.applyConfiguredMode();
+
+        expect(appliedMode, SleepPreventionMode.always);
+      },
+    );
+
+    test(
+      'does not warn about lid-close when device is not a laptop',
+      () async {
+        final settingsApi = _QueueBridgeSettingsApi(
+          readResults: <String?>['{"sleepPrevention":"always"}'],
+        );
+        final wakeLockClient = _FakeWakeLockClient(
+          preventsLidCloseSleep: false,
+        );
+        final service = SleepPreventionService(
+          bridgeSettingsRepository: BridgeSettingsRepository(api: settingsApi),
+          wakeLockRepository: WakeLockRepository(client: wakeLockClient),
+          deviceTypeDetector: _FakeDeviceTypeDetector(isLaptop: false),
+        );
+
+        final appliedMode = await service.applyConfiguredMode();
+
+        expect(appliedMode, SleepPreventionMode.always);
+      },
+    );
+
+    test(
+      'does not warn about lid-close when wake lock is off',
+      () async {
+        final settingsApi = _QueueBridgeSettingsApi(
+          readResults: <String?>['{"sleepPrevention":"off"}'],
+        );
+        final wakeLockClient = _FakeWakeLockClient(
+          preventsLidCloseSleep: false,
+        );
+        final service = SleepPreventionService(
+          bridgeSettingsRepository: BridgeSettingsRepository(api: settingsApi),
+          wakeLockRepository: WakeLockRepository(client: wakeLockClient),
+          deviceTypeDetector: _FakeDeviceTypeDetector(isLaptop: true),
+        );
+
+        final appliedMode = await service.applyConfiguredMode();
+
+        expect(appliedMode, SleepPreventionMode.off);
+      },
+    );
+
+    test(
+      'warns about lid-close when wake lock enabled on laptop and '
+      'platform cannot prevent lid-close sleep',
+      () async {
+        final settingsApi = _QueueBridgeSettingsApi(
+          readResults: <String?>['{"sleepPrevention":"always"}'],
+        );
+        final wakeLockClient = _FakeWakeLockClient(
+          preventsLidCloseSleep: false,
+        );
+        final service = SleepPreventionService(
+          bridgeSettingsRepository: BridgeSettingsRepository(api: settingsApi),
+          wakeLockRepository: WakeLockRepository(client: wakeLockClient),
+          deviceTypeDetector: _FakeDeviceTypeDetector(isLaptop: true),
+        );
+
+        final appliedMode = await service.applyConfiguredMode();
+
+        expect(appliedMode, SleepPreventionMode.always);
+      },
+    );
   });
 }
 
@@ -156,6 +249,8 @@ class _QueueBridgeSettingsApi implements BridgeSettingsApi {
 class _FakeWakeLockClient implements WakeLockClient {
   final bool failEnable;
   final bool failDisable;
+  @override
+  final bool preventsLidCloseSleep;
 
   int enableCalls = 0;
   int disableCalls = 0;
@@ -163,6 +258,7 @@ class _FakeWakeLockClient implements WakeLockClient {
   _FakeWakeLockClient({
     this.failEnable = false,
     this.failDisable = false,
+    this.preventsLidCloseSleep = false,
   });
 
   @override
@@ -180,4 +276,14 @@ class _FakeWakeLockClient implements WakeLockClient {
       throw StateError('disable failed');
     }
   }
+}
+
+class _FakeDeviceTypeDetector implements DeviceTypeDetector {
+  final bool _isLaptop;
+
+  _FakeDeviceTypeDetector({required bool isLaptop})
+    : _isLaptop = isLaptop;
+
+  @override
+  Future<bool> isLaptop() async => _isLaptop;
 }

--- a/bridge/app/test/sleep_prevention_service_test.dart
+++ b/bridge/app/test/sleep_prevention_service_test.dart
@@ -143,15 +143,18 @@ void main() {
         final wakeLockClient = _FakeWakeLockClient(
           preventsLidCloseSleep: true,
         );
+        final warnings = <String>[];
         final service = SleepPreventionService(
           bridgeSettingsRepository: BridgeSettingsRepository(api: settingsApi),
           wakeLockRepository: WakeLockRepository(client: wakeLockClient),
           deviceTypeDetector: _FakeDeviceTypeDetector(isLaptop: true),
+          warningLogger: warnings.add,
         );
 
         final appliedMode = await service.applyConfiguredMode();
 
         expect(appliedMode, SleepPreventionMode.always);
+        expect(warnings, isEmpty);
       },
     );
 
@@ -164,15 +167,18 @@ void main() {
         final wakeLockClient = _FakeWakeLockClient(
           preventsLidCloseSleep: false,
         );
+        final warnings = <String>[];
         final service = SleepPreventionService(
           bridgeSettingsRepository: BridgeSettingsRepository(api: settingsApi),
           wakeLockRepository: WakeLockRepository(client: wakeLockClient),
           deviceTypeDetector: _FakeDeviceTypeDetector(isLaptop: false),
+          warningLogger: warnings.add,
         );
 
         final appliedMode = await service.applyConfiguredMode();
 
         expect(appliedMode, SleepPreventionMode.always);
+        expect(warnings, isEmpty);
       },
     );
 
@@ -185,15 +191,18 @@ void main() {
         final wakeLockClient = _FakeWakeLockClient(
           preventsLidCloseSleep: false,
         );
+        final warnings = <String>[];
         final service = SleepPreventionService(
           bridgeSettingsRepository: BridgeSettingsRepository(api: settingsApi),
           wakeLockRepository: WakeLockRepository(client: wakeLockClient),
           deviceTypeDetector: _FakeDeviceTypeDetector(isLaptop: true),
+          warningLogger: warnings.add,
         );
 
         final appliedMode = await service.applyConfiguredMode();
 
         expect(appliedMode, SleepPreventionMode.off);
+        expect(warnings, isEmpty);
       },
     );
 
@@ -207,15 +216,82 @@ void main() {
         final wakeLockClient = _FakeWakeLockClient(
           preventsLidCloseSleep: false,
         );
+        final warnings = <String>[];
         final service = SleepPreventionService(
           bridgeSettingsRepository: BridgeSettingsRepository(api: settingsApi),
           wakeLockRepository: WakeLockRepository(client: wakeLockClient),
           deviceTypeDetector: _FakeDeviceTypeDetector(isLaptop: true),
+          warningLogger: warnings.add,
         );
 
         final appliedMode = await service.applyConfiguredMode();
 
         expect(appliedMode, SleepPreventionMode.always);
+        expect(warnings, hasLength(1));
+        expect(
+          warnings.single,
+          contains(
+            'cannot prevent the system from sleeping when the laptop lid is closed',
+          ),
+        );
+      },
+    );
+
+    test(
+      'does not warn about lid-close when wake lock enable itself fails',
+      () async {
+        final settingsApi = _QueueBridgeSettingsApi(
+          readResults: <String?>['{"sleepPrevention":"always"}'],
+        );
+        final wakeLockClient = _FakeWakeLockClient(
+          preventsLidCloseSleep: false,
+          failEnable: true,
+        );
+        final warnings = <String>[];
+        final service = SleepPreventionService(
+          bridgeSettingsRepository: BridgeSettingsRepository(api: settingsApi),
+          wakeLockRepository: WakeLockRepository(client: wakeLockClient),
+          deviceTypeDetector: _FakeDeviceTypeDetector(isLaptop: true),
+          warningLogger: warnings.add,
+        );
+
+        final appliedMode = await service.applyConfiguredMode();
+
+        expect(appliedMode, SleepPreventionMode.always);
+        expect(warnings, hasLength(1));
+        expect(
+          warnings.single,
+          contains('failed to enable wake lock'),
+        );
+      },
+    );
+
+    test(
+      'device type detection failure does not masquerade as wake lock error',
+      () async {
+        final settingsApi = _QueueBridgeSettingsApi(
+          readResults: <String?>['{"sleepPrevention":"always"}'],
+        );
+        final wakeLockClient = _FakeWakeLockClient(
+          preventsLidCloseSleep: false,
+        );
+        final warnings = <String>[];
+        final service = SleepPreventionService(
+          bridgeSettingsRepository: BridgeSettingsRepository(api: settingsApi),
+          wakeLockRepository: WakeLockRepository(client: wakeLockClient),
+          deviceTypeDetector: _ThrowingDeviceTypeDetector(),
+          warningLogger: warnings.add,
+        );
+
+        final appliedMode = await service.applyConfiguredMode();
+
+        expect(appliedMode, SleepPreventionMode.always);
+        expect(wakeLockClient.enableCalls, equals(1));
+        expect(warnings, hasLength(1));
+        expect(
+          warnings.single,
+          contains('failed to detect'),
+        );
       },
     );
   });
@@ -286,4 +362,13 @@ class _FakeDeviceTypeDetector implements DeviceTypeDetector {
 
   @override
   Future<bool> isLaptop() async => _isLaptop;
+}
+
+class _ThrowingDeviceTypeDetector implements DeviceTypeDetector {
+  _ThrowingDeviceTypeDetector();
+
+  @override
+  Future<bool> isLaptop() async {
+    throw StateError('failed to detect device type');
+  }
 }

--- a/bridge/app/test/wake_lock_repository_test.dart
+++ b/bridge/app/test/wake_lock_repository_test.dart
@@ -15,6 +15,9 @@ class _FakeWakeLockClient implements WakeLockClient {
   Future<void> disable() async {
     disableCalls += 1;
   }
+
+  @override
+  bool get preventsLidCloseSleep => true;
 }
 
 void main() {
@@ -32,6 +35,13 @@ void main() {
       await repository.disable();
       expect(client.disableCalls, equals(1));
       expect(repository.isEnabled, isFalse);
+    });
+
+    test('exposes preventsLidCloseSleep from the client', () {
+      final client = _FakeWakeLockClient();
+      final repository = WakeLockRepository(client: client);
+
+      expect(repository.preventsLidCloseSleep, isTrue);
     });
   });
 }

--- a/bridge/app/test/windows_wake_lock_api_test.dart
+++ b/bridge/app/test/windows_wake_lock_api_test.dart
@@ -43,6 +43,14 @@ void main() {
       expect(warnings, isEmpty);
     });
 
+    test('does not claim to prevent lid-close sleep', () {
+      final api = WindowsWakeLockApi(
+        executionStateSetter: (_) => const EXECUTION_STATE(1),
+        warningLogger: (_) {},
+      );
+      expect(api.preventsLidCloseSleep, isFalse);
+    });
+
     test('logs a warning when the Windows call fails', () async {
       final warnings = <String>[];
 


### PR DESCRIPTION
## Summary

Improves wake lock behavior around laptop lid-close sleep and adds platform-specific warnings when lid-close sleep cannot be prevented.

## Changes

### Platform wake lock improvements

- **macOS**: Added `-s` flag to `caffeinate` (`caffeinate -s -w <pid>`) to prevent system sleep on AC power. Lid-close sleep on battery still occurs due to macOS hardware behavior.
- **Linux**: Added `handle-lid-switch` to `systemd-inhibit` (`--what=idle:sleep:handle-lid-switch`) so the inhibitor lock also blocks lid-close sleep events.
- **Windows**: No API change — `SetThreadExecutionState` cannot prevent lid-close sleep per Microsoft documentation.

### New capabilities

- **`DeviceTypeDetector`**: New utility that detects whether the current device is a laptop vs desktop/server:
  - macOS: checks `sysctl hw.model` for "MacBook"
  - Windows: checks `Win32_Battery` via PowerShell
  - Linux: checks `/sys/class/power_supply/BAT*`

- **`preventsLidCloseSleep`** property on `WakeLockClient`: Each platform implementation declares whether it can prevent lid-close sleep.
  - macOS: `false` (cannot reliably prevent lid-close)
  - Windows: `false` (cannot prevent lid-close)
  - Linux: `true` (uses `handle-lid-switch` inhibitor)

### Startup log warning

When wake lock is enabled and the device is a laptop on a platform that cannot prevent lid-close sleep, the bridge now logs:

```
[SleepPreventionService] wake lock enabled, but this platform cannot prevent the system from sleeping when the laptop lid is closed.
```

This warning only appears when:
- Sleep prevention mode is `always`
- The device is detected as a laptop
- The platform's wake lock does not claim lid-close prevention

## Testing

- Updated `MacOSWakeLockApiTest` for new `-s` flag and `preventsLidCloseSleep`
- Updated `LinuxWakeLockApiTest` for new `handle-lid-switch` flag and `preventsLidCloseSleep`
- Updated `WindowsWakeLockApiTest` for `preventsLidCloseSleep`
- Updated `WakeLockRepositoryTest` for `preventsLidCloseSleep` delegation
- Updated `SleepPreventionServiceTest` with new `DeviceTypeDetector` dependency and warning log coverage
- Added new `DeviceTypeDetectorTest` for all three platforms

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves wake lock behavior around laptop lid-close sleep and adds clear laptop warnings when the platform can’t block lid-close sleep. macOS now uses caffeinate -i -s -w <pid>; Linux blocks lid-close via systemd-inhibit; Windows unchanged; warnings fire only after wake lock is enabled.

- **New Features**
  - Linux: use systemd-inhibit --what=idle:sleep:handle-lid-switch to block lid-close.
  - macOS: use caffeinate -i -s -w <pid> to prevent idle and AC system sleep; lid-close not prevented.
  - Windows: no change; cannot prevent lid-close.
  - DeviceTypeDetector: detects laptops on macOS/Windows/Linux; caches isLaptop(); configurable Linux power supply path; requires PlatformChecker; logs on failures.
  - WakeLockClient.preventsLidCloseSleep: exposed via WakeLockRepository.
  - SleepPreventionService: warns only on laptops when lid-close can’t be prevented, after enabling wake lock; supports injected warningLogger; catches and logs detection errors so wake lock enable still succeeds.

<sup>Written for commit d491d824fe0f98b4a358bcf7e1ea3aed5ce87d68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

