### PR TITLE
fix: model variant picker not reflecting selection

### DIFF
--- a/mobile/app/lib/core/widgets/agent_model_buttons.dart
+++ b/mobile/app/lib/core/widgets/agent_model_buttons.dart
@@ -7,7 +7,7 @@ class AgentModelButtons extends StatelessWidget {
   final List<SessionVariant> availableVariants;
   final String modelName;
   final String selectedAgent;
-  final SessionVariant? selectedVariant;
+  final AgentModel? selectedAgentModel;
   final VoidCallback onAgentTap;
   final VoidCallback onModelTap;
   final VoidCallback onVariantTap;
@@ -17,7 +17,7 @@ class AgentModelButtons extends StatelessWidget {
     required this.availableVariants,
     required this.modelName,
     required this.selectedAgent,
-    required this.selectedVariant,
+    required this.selectedAgentModel,
     required this.onAgentTap,
     required this.onModelTap,
     required this.onVariantTap,
@@ -74,7 +74,7 @@ class AgentModelButtons extends StatelessWidget {
                 onPressed: onVariantTap,
                 icon: Icon(Icons.speed_outlined, size: 14, color: theme.colorScheme.onSurfaceVariant),
                 label: Text(
-                  selectedVariant?.id ?? loc.sessionDetailVariantDefault,
+                  selectedAgentModel?.variant ?? loc.sessionDetailVariantDefault,
                   style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
                   overflow: .ellipsis,
                   maxLines: 1,

--- a/mobile/app/lib/core/widgets/variant_picker_sheet.dart
+++ b/mobile/app/lib/core/widgets/variant_picker_sheet.dart
@@ -6,27 +6,27 @@ import "../extensions/build_context_x.dart";
 import "app_modal_bottom_sheet.dart";
 
 class VariantPickerSheet extends StatelessWidget {
-  final SessionVariant? selectedVariant;
+  final String? selectedVariantId;
   final List<SessionVariant> availableVariants;
   final ValueChanged<SessionVariant?> onVariantChanged;
 
   const VariantPickerSheet({
     super.key,
-    required this.selectedVariant,
+    required this.selectedVariantId,
     required this.availableVariants,
     required this.onVariantChanged,
   });
 
   static Future<void> show(
     BuildContext context, {
-    required SessionVariant? selectedVariant,
+    required String? selectedVariantId,
     required List<SessionVariant> availableVariants,
     required ValueChanged<SessionVariant?> onVariantChanged,
   }) {
     return showAppModalBottomSheet(
       context: context,
       builder: (_) => VariantPickerSheet(
-        selectedVariant: selectedVariant,
+        selectedVariantId: selectedVariantId,
         availableVariants: availableVariants,
         onVariantChanged: (variant) {
           onVariantChanged(variant);
@@ -66,13 +66,13 @@ class VariantPickerSheet extends StatelessWidget {
         ),
         _VariantTile(
           label: loc.sessionDetailVariantDefault,
-          isSelected: selectedVariant == null,
+          isSelected: selectedVariantId == null,
           onTap: () => onVariantChanged(null),
         ),
         for (final variant in availableVariants)
           _VariantTile(
             label: variant.id,
-            isSelected: variant == selectedVariant,
+            isSelected: variant.id == selectedVariantId,
             onTap: () => onVariantChanged(variant),
           ),
         const SizedBox(height: 8),

--- a/mobile/app/lib/features/new_session/new_session_screen.dart
+++ b/mobile/app/lib/features/new_session/new_session_screen.dart
@@ -73,7 +73,7 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
   void _openVariantPicker(AgentModelData data) {
     VariantPickerSheet.show(
       context,
-      selectedVariant: data.selectedVariant,
+      selectedVariantId: data.agentModel?.variant,
       availableVariants: data.availableVariants,
       onVariantChanged: context.read<NewSessionCubit>().selectVariant,
     );
@@ -110,7 +110,7 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
       availableVariants: data.availableVariants,
       modelName: modelName,
       selectedAgent: selectedAgent,
-      selectedVariant: data.selectedVariant,
+      selectedAgentModel: data.agentModel,
       onAgentTap: () => _openAgentPicker(data),
       onModelTap: () => _openModelPicker(data),
       onVariantTap: () => _openVariantPicker(data),

--- a/mobile/app/lib/features/session_detail/widgets/session_detail_body.dart
+++ b/mobile/app/lib/features/session_detail/widgets/session_detail_body.dart
@@ -172,7 +172,7 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
     if (state is! SessionDetailLoaded) return;
     VariantPickerSheet.show(
       context,
-      selectedVariant: state.selectedVariant,
+      selectedVariantId: state.selectedAgentModel?.variant,
       availableVariants: state.availableVariants,
       onVariantChanged: cubit.selectVariant,
     );

--- a/mobile/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
+++ b/mobile/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
@@ -103,7 +103,7 @@ class SessionDetailLoadedView extends StatelessWidget {
               availableVariants: state.availableVariants,
               modelName: _resolveModelName(state),
               selectedAgent: state.selectedAgent,
-              selectedVariant: state.selectedVariant,
+              selectedAgentModel: state.selectedAgentModel,
               onAgentTap: onOpenAgentPicker,
               onModelTap: onOpenModelPicker,
               onVariantTap: onOpenVariantPicker,

--- a/mobile/app/test/core/widgets/variant_picker_sheet_test.dart
+++ b/mobile/app/test/core/widgets/variant_picker_sheet_test.dart
@@ -14,7 +14,7 @@ Widget _buildApp({required ValueChanged<SessionVariant?> onVariantChanged}) {
           body: FilledButton(
             onPressed: () => VariantPickerSheet.show(
               context,
-              selectedVariant: null,
+              selectedVariantId: null,
               availableVariants: const [
                 SessionVariant(id: "low"),
                 SessionVariant(id: "xhigh"),

--- a/mobile/app/test/features/new_session/new_session_screen_test.dart
+++ b/mobile/app/test/features/new_session/new_session_screen_test.dart
@@ -98,6 +98,96 @@ void main() {
     expect(find.widgetWithText(OutlinedButton, "xhigh"), findsOneWidget);
   });
 
+  testWidgets("selecting a different variant updates the displayed variant", (tester) async {
+    when(() => sessionService.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+      (_) async => ApiResponse.success(
+        const ProviderListResponse(
+          connectedOnly: false,
+          items: [
+            ProviderInfo(
+              id: "anthropic",
+              name: "Anthropic",
+              defaultModelID: "claude-3-5-sonnet",
+              models: {
+                "claude-3-5-sonnet": ProviderModel(
+                  id: "claude-3-5-sonnet",
+                  providerID: "anthropic",
+                  name: "Claude 3.5 Sonnet",
+                  variants: ["xhigh", "low"],
+                  family: null,
+                  releaseDate: null,
+                ),
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+
+    // Initially shows the agent's default variant.
+    expect(find.widgetWithText(OutlinedButton, "xhigh"), findsOneWidget);
+
+    // Open variant picker.
+    await tester.tap(find.widgetWithText(OutlinedButton, "xhigh"));
+    await tester.pumpAndSettle();
+
+    // Select a different variant.
+    await tester.tap(find.widgetWithText(ListTile, "low"));
+    await tester.pumpAndSettle();
+
+    // The UI should now reflect the newly selected variant.
+    expect(find.widgetWithText(OutlinedButton, "low"), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, "xhigh"), findsNothing);
+  });
+
+  testWidgets("selecting Default clears the displayed variant", (tester) async {
+    when(() => sessionService.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+      (_) async => ApiResponse.success(
+        const ProviderListResponse(
+          connectedOnly: false,
+          items: [
+            ProviderInfo(
+              id: "anthropic",
+              name: "Anthropic",
+              defaultModelID: "claude-3-5-sonnet",
+              models: {
+                "claude-3-5-sonnet": ProviderModel(
+                  id: "claude-3-5-sonnet",
+                  providerID: "anthropic",
+                  name: "Claude 3.5 Sonnet",
+                  variants: ["xhigh", "low"],
+                  family: null,
+                  releaseDate: null,
+                ),
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+
+    // Initially shows the agent's default variant.
+    expect(find.widgetWithText(OutlinedButton, "xhigh"), findsOneWidget);
+
+    // Open variant picker.
+    await tester.tap(find.widgetWithText(OutlinedButton, "xhigh"));
+    await tester.pumpAndSettle();
+
+    // Select Default (null variant).
+    await tester.tap(find.widgetWithText(ListTile, "Default"));
+    await tester.pumpAndSettle();
+
+    // The UI should now show "Default".
+    expect(find.widgetWithText(OutlinedButton, "Default"), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, "xhigh"), findsNothing);
+  });
+
   testWidgets("preserves selectedAgentModel variant when changing agent", (tester) async {
     await tester.pumpWidget(_buildApp());
     await tester.pumpAndSettle();

--- a/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -357,7 +357,7 @@ void main() {
     );
 
     blocTest<SessionDetailCubit, SessionDetailState>(
-      "selectVariant updates selectedVariant in state",
+      "selectVariant updates selectedAgentModel variant",
       build: () {
         when(
           () => mockSessionService.listProviders(projectId: any(named: "projectId")),
@@ -402,26 +402,20 @@ void main() {
       },
       expect: () => [
         isA<SessionDetailLoaded>().having(
-          (state) => state.selectedVariant,
-          "initial selectedVariant",
+          (state) => state.selectedAgentModel?.variant,
+          "initial variant",
           isNull,
         ),
-        isA<SessionDetailLoaded>()
-            .having(
-              (state) => state.selectedVariant,
-              "selectedVariant",
-              const SessionVariant(id: "fast"),
-            )
-            .having(
-              (state) => state.selectedAgentModel?.variant,
-              "selectedAgentModel.variant",
-              "fast",
-            ),
+        isA<SessionDetailLoaded>().having(
+          (state) => state.selectedAgentModel?.variant,
+          "variant",
+          "fast",
+        ),
       ],
     );
 
     blocTest<SessionDetailCubit, SessionDetailState>(
-      "selectVariant to null clears selectedVariant in state",
+      "selectVariant to null clears selectedAgentModel variant",
       build: () {
         when(
           () => mockSessionService.listProviders(projectId: any(named: "projectId")),
@@ -467,32 +461,20 @@ void main() {
       },
       expect: () => [
         isA<SessionDetailLoaded>().having(
-          (state) => state.selectedVariant,
-          "initial selectedVariant",
+          (state) => state.selectedAgentModel?.variant,
+          "initial variant",
           isNull,
         ),
-        isA<SessionDetailLoaded>()
-            .having(
-              (state) => state.selectedVariant,
-              "selectedVariant after fast",
-              const SessionVariant(id: "fast"),
-            )
-            .having(
-              (state) => state.selectedAgentModel?.variant,
-              "selectedAgentModel.variant after fast",
-              "fast",
-            ),
-        isA<SessionDetailLoaded>()
-            .having(
-              (state) => state.selectedVariant,
-              "selectedVariant after null",
-              isNull,
-            )
-            .having(
-              (state) => state.selectedAgentModel?.variant,
-              "selectedAgentModel.variant after null",
-              isNull,
-            ),
+        isA<SessionDetailLoaded>().having(
+          (state) => state.selectedAgentModel?.variant,
+          "variant after fast",
+          "fast",
+        ),
+        isA<SessionDetailLoaded>().having(
+          (state) => state.selectedAgentModel?.variant,
+          "variant after null",
+          isNull,
+        ),
       ],
     );
 

--- a/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -357,6 +357,146 @@ void main() {
     );
 
     blocTest<SessionDetailCubit, SessionDetailState>(
+      "selectVariant updates selectedVariant in state",
+      build: () {
+        when(
+          () => mockSessionService.listProviders(projectId: any(named: "projectId")),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(
+            const ProviderListResponse(
+              connectedOnly: false,
+              items: [
+                ProviderInfo(
+                  id: "openai",
+                  name: "OpenAI",
+                  defaultModelID: "gpt-4",
+                  models: {
+                    "gpt-4": ProviderModel(
+                      id: "gpt-4",
+                      providerID: "openai",
+                      name: "GPT-4",
+                      variants: ["fast", "slow"],
+                      family: null,
+                      releaseDate: null,
+                    ),
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+        return SessionDetailCubit(
+          mockConnectionService,
+          loadService: loadService,
+          promptDispatcher: promptDispatcher,
+          permissionRepository: mockPermissionRepository,
+          sessionId: sessionId,
+          projectId: "project-1",
+          notificationCanceller: mockNotificationCanceller,
+          failureReporter: mockFailureReporter,
+        );
+      },
+      act: (cubit) async {
+        await _awaitLoaded(cubit);
+        cubit.selectVariant(const SessionVariant(id: "fast"));
+      },
+      expect: () => [
+        isA<SessionDetailLoaded>().having(
+          (state) => state.selectedVariant,
+          "initial selectedVariant",
+          isNull,
+        ),
+        isA<SessionDetailLoaded>()
+            .having(
+              (state) => state.selectedVariant,
+              "selectedVariant",
+              const SessionVariant(id: "fast"),
+            )
+            .having(
+              (state) => state.selectedAgentModel?.variant,
+              "selectedAgentModel.variant",
+              "fast",
+            ),
+      ],
+    );
+
+    blocTest<SessionDetailCubit, SessionDetailState>(
+      "selectVariant to null clears selectedVariant in state",
+      build: () {
+        when(
+          () => mockSessionService.listProviders(projectId: any(named: "projectId")),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(
+            const ProviderListResponse(
+              connectedOnly: false,
+              items: [
+                ProviderInfo(
+                  id: "openai",
+                  name: "OpenAI",
+                  defaultModelID: "gpt-4",
+                  models: {
+                    "gpt-4": ProviderModel(
+                      id: "gpt-4",
+                      providerID: "openai",
+                      name: "GPT-4",
+                      variants: ["fast", "slow"],
+                      family: null,
+                      releaseDate: null,
+                    ),
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+        return SessionDetailCubit(
+          mockConnectionService,
+          loadService: loadService,
+          promptDispatcher: promptDispatcher,
+          permissionRepository: mockPermissionRepository,
+          sessionId: sessionId,
+          projectId: "project-1",
+          notificationCanceller: mockNotificationCanceller,
+          failureReporter: mockFailureReporter,
+        );
+      },
+      act: (cubit) async {
+        await _awaitLoaded(cubit);
+        cubit.selectVariant(const SessionVariant(id: "fast"));
+        cubit.selectVariant(null);
+      },
+      expect: () => [
+        isA<SessionDetailLoaded>().having(
+          (state) => state.selectedVariant,
+          "initial selectedVariant",
+          isNull,
+        ),
+        isA<SessionDetailLoaded>()
+            .having(
+              (state) => state.selectedVariant,
+              "selectedVariant after fast",
+              const SessionVariant(id: "fast"),
+            )
+            .having(
+              (state) => state.selectedAgentModel?.variant,
+              "selectedAgentModel.variant after fast",
+              "fast",
+            ),
+        isA<SessionDetailLoaded>()
+            .having(
+              (state) => state.selectedVariant,
+              "selectedVariant after null",
+              isNull,
+            )
+            .having(
+              (state) => state.selectedAgentModel?.variant,
+              "selectedAgentModel.variant after null",
+              isNull,
+            ),
+      ],
+    );
+
+    blocTest<SessionDetailCubit, SessionDetailState>(
       "abort delegates to service.abortSession",
       build: () => SessionDetailCubit(
         mockConnectionService,

--- a/mobile/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -70,7 +70,6 @@ SessionDetailState _loadedState() {
     stagedCommand: null,
     isRefreshing: false,
     availableVariants: const [SessionVariant(id: "xhigh")],
-    selectedVariant: const SessionVariant(id: "xhigh"),
   );
 }
 
@@ -133,7 +132,7 @@ void main() {
       availableProviders: testProviderListResponse().items,
       availableCommands: const [],
       selectedAgent: "coder",
-      selectedAgentModel: AgentModel(
+      selectedAgentModel: const AgentModel(
         providerID: "anthropic",
         modelID: "claude-3-5-sonnet",
         variant: null,
@@ -141,7 +140,6 @@ void main() {
       stagedCommand: null,
       isRefreshing: false,
       availableVariants: const [SessionVariant(id: "xhigh")],
-      selectedVariant: null,
     );
 
     final controller = StreamController<SessionDetailState>.broadcast();

--- a/mobile/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -114,4 +114,64 @@ void main() {
 
     verify(() => cubit.selectVariant(const SessionVariant(id: "xhigh"))).called(1);
   });
+
+  testWidgets("selecting a different variant updates the displayed variant", (tester) async {
+    final initialState = _loadedState();
+    final updatedState = SessionDetailState.loaded(
+      messages: const [],
+      streamingText: const {},
+      sessionStatus: const SessionStatus.idle(),
+      pendingQuestions: const [],
+      pendingPermissions: const [],
+      sessionTitle: "Session",
+      agent: null,
+      assistantAgentModel: null,
+      children: const [],
+      childStatuses: const {},
+      queuedMessages: const [],
+      availableAgents: [testAgentInfo()],
+      availableProviders: testProviderListResponse().items,
+      availableCommands: const [],
+      selectedAgent: "coder",
+      selectedAgentModel: AgentModel(
+        providerID: "anthropic",
+        modelID: "claude-3-5-sonnet",
+        variant: null,
+      ),
+      stagedCommand: null,
+      isRefreshing: false,
+      availableVariants: const [SessionVariant(id: "xhigh")],
+      selectedVariant: null,
+    );
+
+    final controller = StreamController<SessionDetailState>.broadcast();
+    addTearDown(controller.close);
+    when(() => cubit.state).thenReturn(initialState);
+    when(() => cubit.stream).thenAnswer((_) => controller.stream);
+
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    // Initially shows the selected variant.
+    expect(find.widgetWithText(OutlinedButton, "xhigh"), findsOneWidget);
+
+    // Open variant picker.
+    await tester.tap(find.widgetWithText(OutlinedButton, "xhigh"));
+    await tester.pumpAndSettle();
+
+    // Select Default (null variant).
+    await tester.tap(find.widgetWithText(ListTile, "Default"));
+    await tester.pumpAndSettle();
+
+    verify(() => cubit.selectVariant(null)).called(1);
+
+    // Emit the updated state to simulate the cubit update.
+    when(() => cubit.state).thenReturn(updatedState);
+    controller.add(updatedState);
+    await tester.pumpAndSettle();
+
+    // The UI should now show "Default".
+    expect(find.widgetWithText(OutlinedButton, "Default"), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, "xhigh"), findsNothing);
+  });
 }

--- a/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
@@ -15,19 +15,19 @@ class NewSessionCubit extends Cubit<NewSessionState> {
     required String projectId,
   }) : _sessionService = sessionService,
        _projectId = projectId,
-         super(
-          const NewSessionState.idle(
-            availableAgents: [],
-            availableProviders: [],
-            availableCommands: [],
-            selectedAgent: null,
-            selectedAgentModel: null,
-            stagedCommand: null,
-            availableVariants: [],
-          ),
-        ) {
-     _loadComposerData();
-   }
+          super(
+           const NewSessionState.idle(
+             availableAgents: [],
+             availableProviders: [],
+             availableCommands: [],
+             selectedAgent: null,
+             selectedAgentModel: null,
+             stagedCommand: null,
+             availableVariants: [],
+           ),
+         ) {
+      _loadComposerData();
+    }
 
   Future<void> _loadComposerData() async {
     try {
@@ -102,7 +102,6 @@ class NewSessionCubit extends Cubit<NewSessionState> {
       providers: availableProviders ?? data.providers,
       model: selectedAgentModel ?? data.agentModel,
     );
-    final selectedVariant = _deriveSelectedVariant(selectedAgentModel ?? data.agentModel);
     switch (current) {
       case NewSessionIdle():
         emit(
@@ -113,7 +112,6 @@ class NewSessionCubit extends Cubit<NewSessionState> {
             selectedAgent: selectedAgent ?? current.selectedAgent,
             selectedAgentModel: selectedAgentModel ?? current.selectedAgentModel,
             availableVariants: derivedVariants,
-            selectedVariant: selectedVariant,
           ),
         );
       case NewSessionSending():
@@ -125,7 +123,6 @@ class NewSessionCubit extends Cubit<NewSessionState> {
             selectedAgent: selectedAgent ?? current.selectedAgent,
             selectedAgentModel: selectedAgentModel ?? current.selectedAgentModel,
             availableVariants: derivedVariants,
-            selectedVariant: selectedVariant,
           ),
         );
       case NewSessionError():
@@ -137,7 +134,6 @@ class NewSessionCubit extends Cubit<NewSessionState> {
             selectedAgent: selectedAgent ?? current.selectedAgent,
             selectedAgentModel: selectedAgentModel ?? current.selectedAgentModel,
             availableVariants: derivedVariants,
-            selectedVariant: selectedVariant,
           ),
         );
       case NewSessionCreated():
@@ -162,14 +158,6 @@ class NewSessionCubit extends Cubit<NewSessionState> {
         [];
   }
 
-  SessionVariant? _deriveSelectedVariant(AgentModel? model) {
-    final variant = model?.variant;
-    if (variant != null && variant != "none") {
-      return SessionVariant(id: variant);
-    }
-    return null;
-  }
-
   void selectAgent(String agent) {
     final current = state;
     final agentInfo = switch (current) {
@@ -188,30 +176,15 @@ class NewSessionCubit extends Cubit<NewSessionState> {
       case NewSessionIdle():
         final agentModel = current.selectedAgentModel;
         if (agentModel == null) return;
-        emit(
-          current.copyWith(
-            selectedAgentModel: agentModel.copyWith(variant: variant?.id),
-            selectedVariant: variant,
-          ),
-        );
+        emit(current.copyWith(selectedAgentModel: agentModel.copyWith(variant: variant?.id)));
       case NewSessionSending():
         final agentModel = current.selectedAgentModel;
         if (agentModel == null) return;
-        emit(
-          current.copyWith(
-            selectedAgentModel: agentModel.copyWith(variant: variant?.id),
-            selectedVariant: variant,
-          ),
-        );
+        emit(current.copyWith(selectedAgentModel: agentModel.copyWith(variant: variant?.id)));
       case NewSessionError():
         final agentModel = current.selectedAgentModel;
         if (agentModel == null) return;
-        emit(
-          current.copyWith(
-            selectedAgentModel: agentModel.copyWith(variant: variant?.id),
-            selectedVariant: variant,
-          ),
-        );
+        emit(current.copyWith(selectedAgentModel: agentModel.copyWith(variant: variant?.id)));
       case NewSessionCreated():
         return;
     }
@@ -316,7 +289,6 @@ class NewSessionCubit extends Cubit<NewSessionState> {
         selectedAgentModel: config?.agentModel,
         stagedCommand: config?.stagedCommand,
         availableVariants: config?.availableVariants ?? const [],
-        selectedVariant: config?.selectedVariant,
       ),
     );
 
@@ -351,7 +323,6 @@ class NewSessionCubit extends Cubit<NewSessionState> {
             selectedAgentModel: current?.agentModel,
             stagedCommand: current?.stagedCommand,
             availableVariants: current?.availableVariants ?? const [],
-            selectedVariant: current?.selectedVariant,
           ),
         );
     }

--- a/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
@@ -188,15 +188,30 @@ class NewSessionCubit extends Cubit<NewSessionState> {
       case NewSessionIdle():
         final agentModel = current.selectedAgentModel;
         if (agentModel == null) return;
-        emit(current.copyWith(selectedAgentModel: agentModel.copyWith(variant: variant?.id)));
+        emit(
+          current.copyWith(
+            selectedAgentModel: agentModel.copyWith(variant: variant?.id),
+            selectedVariant: variant,
+          ),
+        );
       case NewSessionSending():
         final agentModel = current.selectedAgentModel;
         if (agentModel == null) return;
-        emit(current.copyWith(selectedAgentModel: agentModel.copyWith(variant: variant?.id)));
+        emit(
+          current.copyWith(
+            selectedAgentModel: agentModel.copyWith(variant: variant?.id),
+            selectedVariant: variant,
+          ),
+        );
       case NewSessionError():
         final agentModel = current.selectedAgentModel;
         if (agentModel == null) return;
-        emit(current.copyWith(selectedAgentModel: agentModel.copyWith(variant: variant?.id)));
+        emit(
+          current.copyWith(
+            selectedAgentModel: agentModel.copyWith(variant: variant?.id),
+            selectedVariant: variant,
+          ),
+        );
       case NewSessionCreated():
         return;
     }

--- a/mobile/module_core/lib/src/cubits/new_session/new_session_state.dart
+++ b/mobile/module_core/lib/src/cubits/new_session/new_session_state.dart
@@ -13,7 +13,6 @@ sealed class NewSessionState with _$NewSessionState {
     required AgentModel? selectedAgentModel,
     required CommandInfo? stagedCommand,
     @Default([]) List<SessionVariant> availableVariants,
-    SessionVariant? selectedVariant,
   }) = NewSessionIdle;
 
   const factory NewSessionState.sending({
@@ -24,7 +23,6 @@ sealed class NewSessionState with _$NewSessionState {
     required AgentModel? selectedAgentModel,
     required CommandInfo? stagedCommand,
     @Default([]) List<SessionVariant> availableVariants,
-    SessionVariant? selectedVariant,
   }) = NewSessionSending;
 
   const factory NewSessionState.error({
@@ -36,7 +34,6 @@ sealed class NewSessionState with _$NewSessionState {
     required AgentModel? selectedAgentModel,
     required CommandInfo? stagedCommand,
     @Default([]) List<SessionVariant> availableVariants,
-    SessionVariant? selectedVariant,
   }) = NewSessionError;
 
   const factory NewSessionState.created({required Session session}) = NewSessionCreated;
@@ -53,7 +50,6 @@ typedef AgentModelData = ({
   AgentModel? agentModel,
   CommandInfo? stagedCommand,
   List<SessionVariant> availableVariants,
-  SessionVariant? selectedVariant,
 });
 
 extension NewSessionStateAgentModel on NewSessionState {
@@ -66,7 +62,6 @@ extension NewSessionStateAgentModel on NewSessionState {
       :final selectedAgentModel,
       :final stagedCommand,
       :final availableVariants,
-      :final selectedVariant,
     ) =>
       (
         agents: availableAgents,
@@ -76,7 +71,6 @@ extension NewSessionStateAgentModel on NewSessionState {
         agentModel: selectedAgentModel,
         stagedCommand: stagedCommand,
         availableVariants: availableVariants,
-        selectedVariant: selectedVariant,
       ),
     NewSessionSending(
       :final availableAgents,
@@ -86,7 +80,6 @@ extension NewSessionStateAgentModel on NewSessionState {
       :final selectedAgentModel,
       :final stagedCommand,
       :final availableVariants,
-      :final selectedVariant,
     ) =>
       (
         agents: availableAgents,
@@ -96,7 +89,6 @@ extension NewSessionStateAgentModel on NewSessionState {
         agentModel: selectedAgentModel,
         stagedCommand: stagedCommand,
         availableVariants: availableVariants,
-        selectedVariant: selectedVariant,
       ),
     NewSessionError(
       :final availableAgents,
@@ -106,7 +98,6 @@ extension NewSessionStateAgentModel on NewSessionState {
       :final selectedAgentModel,
       :final stagedCommand,
       :final availableVariants,
-      :final selectedVariant,
     ) =>
       (
         agents: availableAgents,
@@ -116,7 +107,6 @@ extension NewSessionStateAgentModel on NewSessionState {
         agentModel: selectedAgentModel,
         stagedCommand: stagedCommand,
         availableVariants: availableVariants,
-        selectedVariant: selectedVariant,
       ),
     NewSessionCreated() => null,
   };

--- a/mobile/module_core/lib/src/cubits/new_session/new_session_state.freezed.dart
+++ b/mobile/module_core/lib/src/cubits/new_session/new_session_state.freezed.dart
@@ -46,7 +46,7 @@ $NewSessionStateCopyWith(NewSessionState _, $Res Function(NewSessionState) __);
 
 
 class NewSessionIdle implements NewSessionState {
-  const NewSessionIdle({required final  List<AgentInfo> availableAgents, required final  List<ProviderInfo> availableProviders, required final  List<CommandInfo> availableCommands, required this.selectedAgent, required this.selectedAgentModel, required this.stagedCommand, final  List<SessionVariant> availableVariants = const [], this.selectedVariant}): _availableAgents = availableAgents,_availableProviders = availableProviders,_availableCommands = availableCommands,_availableVariants = availableVariants;
+  const NewSessionIdle({required final  List<AgentInfo> availableAgents, required final  List<ProviderInfo> availableProviders, required final  List<CommandInfo> availableCommands, required this.selectedAgent, required this.selectedAgentModel, required this.stagedCommand, final  List<SessionVariant> availableVariants = const []}): _availableAgents = availableAgents,_availableProviders = availableProviders,_availableCommands = availableCommands,_availableVariants = availableVariants;
   
 
  final  List<AgentInfo> _availableAgents;
@@ -80,7 +80,6 @@ class NewSessionIdle implements NewSessionState {
   return EqualUnmodifiableListView(_availableVariants);
 }
 
- final  SessionVariant? selectedVariant;
 
 /// Create a copy of NewSessionState
 /// with the given fields replaced by the non-null parameter values.
@@ -92,16 +91,16 @@ $NewSessionIdleCopyWith<NewSessionIdle> get copyWith => _$NewSessionIdleCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionIdle&&const DeepCollectionEquality().equals(other._availableAgents, _availableAgents)&&const DeepCollectionEquality().equals(other._availableProviders, _availableProviders)&&const DeepCollectionEquality().equals(other._availableCommands, _availableCommands)&&(identical(other.selectedAgent, selectedAgent) || other.selectedAgent == selectedAgent)&&(identical(other.selectedAgentModel, selectedAgentModel) || other.selectedAgentModel == selectedAgentModel)&&(identical(other.stagedCommand, stagedCommand) || other.stagedCommand == stagedCommand)&&const DeepCollectionEquality().equals(other._availableVariants, _availableVariants)&&(identical(other.selectedVariant, selectedVariant) || other.selectedVariant == selectedVariant));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionIdle&&const DeepCollectionEquality().equals(other._availableAgents, _availableAgents)&&const DeepCollectionEquality().equals(other._availableProviders, _availableProviders)&&const DeepCollectionEquality().equals(other._availableCommands, _availableCommands)&&(identical(other.selectedAgent, selectedAgent) || other.selectedAgent == selectedAgent)&&(identical(other.selectedAgentModel, selectedAgentModel) || other.selectedAgentModel == selectedAgentModel)&&(identical(other.stagedCommand, stagedCommand) || other.stagedCommand == stagedCommand)&&const DeepCollectionEquality().equals(other._availableVariants, _availableVariants));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_availableAgents),const DeepCollectionEquality().hash(_availableProviders),const DeepCollectionEquality().hash(_availableCommands),selectedAgent,selectedAgentModel,stagedCommand,const DeepCollectionEquality().hash(_availableVariants),selectedVariant);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_availableAgents),const DeepCollectionEquality().hash(_availableProviders),const DeepCollectionEquality().hash(_availableCommands),selectedAgent,selectedAgentModel,stagedCommand,const DeepCollectionEquality().hash(_availableVariants));
 
 @override
 String toString() {
-  return 'NewSessionState.idle(availableAgents: $availableAgents, availableProviders: $availableProviders, availableCommands: $availableCommands, selectedAgent: $selectedAgent, selectedAgentModel: $selectedAgentModel, stagedCommand: $stagedCommand, availableVariants: $availableVariants, selectedVariant: $selectedVariant)';
+  return 'NewSessionState.idle(availableAgents: $availableAgents, availableProviders: $availableProviders, availableCommands: $availableCommands, selectedAgent: $selectedAgent, selectedAgentModel: $selectedAgentModel, stagedCommand: $stagedCommand, availableVariants: $availableVariants)';
 }
 
 
@@ -112,11 +111,11 @@ abstract mixin class $NewSessionIdleCopyWith<$Res> implements $NewSessionStateCo
   factory $NewSessionIdleCopyWith(NewSessionIdle value, $Res Function(NewSessionIdle) _then) = _$NewSessionIdleCopyWithImpl;
 @useResult
 $Res call({
- List<AgentInfo> availableAgents, List<ProviderInfo> availableProviders, List<CommandInfo> availableCommands, String? selectedAgent, AgentModel? selectedAgentModel, CommandInfo? stagedCommand, List<SessionVariant> availableVariants, SessionVariant? selectedVariant
+ List<AgentInfo> availableAgents, List<ProviderInfo> availableProviders, List<CommandInfo> availableCommands, String? selectedAgent, AgentModel? selectedAgentModel, CommandInfo? stagedCommand, List<SessionVariant> availableVariants
 });
 
 
-$AgentModelCopyWith<$Res>? get selectedAgentModel;$CommandInfoCopyWith<$Res>? get stagedCommand;$SessionVariantCopyWith<$Res>? get selectedVariant;
+$AgentModelCopyWith<$Res>? get selectedAgentModel;$CommandInfoCopyWith<$Res>? get stagedCommand;
 
 }
 /// @nodoc
@@ -129,7 +128,7 @@ class _$NewSessionIdleCopyWithImpl<$Res>
 
 /// Create a copy of NewSessionState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? availableAgents = null,Object? availableProviders = null,Object? availableCommands = null,Object? selectedAgent = freezed,Object? selectedAgentModel = freezed,Object? stagedCommand = freezed,Object? availableVariants = null,Object? selectedVariant = freezed,}) {
+@pragma('vm:prefer-inline') $Res call({Object? availableAgents = null,Object? availableProviders = null,Object? availableCommands = null,Object? selectedAgent = freezed,Object? selectedAgentModel = freezed,Object? stagedCommand = freezed,Object? availableVariants = null,}) {
   return _then(NewSessionIdle(
 availableAgents: null == availableAgents ? _self._availableAgents : availableAgents // ignore: cast_nullable_to_non_nullable
 as List<AgentInfo>,availableProviders: null == availableProviders ? _self._availableProviders : availableProviders // ignore: cast_nullable_to_non_nullable
@@ -138,8 +137,7 @@ as List<CommandInfo>,selectedAgent: freezed == selectedAgent ? _self.selectedAge
 as String?,selectedAgentModel: freezed == selectedAgentModel ? _self.selectedAgentModel : selectedAgentModel // ignore: cast_nullable_to_non_nullable
 as AgentModel?,stagedCommand: freezed == stagedCommand ? _self.stagedCommand : stagedCommand // ignore: cast_nullable_to_non_nullable
 as CommandInfo?,availableVariants: null == availableVariants ? _self._availableVariants : availableVariants // ignore: cast_nullable_to_non_nullable
-as List<SessionVariant>,selectedVariant: freezed == selectedVariant ? _self.selectedVariant : selectedVariant // ignore: cast_nullable_to_non_nullable
-as SessionVariant?,
+as List<SessionVariant>,
   ));
 }
 
@@ -167,18 +165,6 @@ $CommandInfoCopyWith<$Res>? get stagedCommand {
   return $CommandInfoCopyWith<$Res>(_self.stagedCommand!, (value) {
     return _then(_self.copyWith(stagedCommand: value));
   });
-}/// Create a copy of NewSessionState
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$SessionVariantCopyWith<$Res>? get selectedVariant {
-    if (_self.selectedVariant == null) {
-    return null;
-  }
-
-  return $SessionVariantCopyWith<$Res>(_self.selectedVariant!, (value) {
-    return _then(_self.copyWith(selectedVariant: value));
-  });
 }
 }
 
@@ -186,7 +172,7 @@ $SessionVariantCopyWith<$Res>? get selectedVariant {
 
 
 class NewSessionSending implements NewSessionState {
-  const NewSessionSending({required final  List<AgentInfo> availableAgents, required final  List<ProviderInfo> availableProviders, required final  List<CommandInfo> availableCommands, required this.selectedAgent, required this.selectedAgentModel, required this.stagedCommand, final  List<SessionVariant> availableVariants = const [], this.selectedVariant}): _availableAgents = availableAgents,_availableProviders = availableProviders,_availableCommands = availableCommands,_availableVariants = availableVariants;
+  const NewSessionSending({required final  List<AgentInfo> availableAgents, required final  List<ProviderInfo> availableProviders, required final  List<CommandInfo> availableCommands, required this.selectedAgent, required this.selectedAgentModel, required this.stagedCommand, final  List<SessionVariant> availableVariants = const []}): _availableAgents = availableAgents,_availableProviders = availableProviders,_availableCommands = availableCommands,_availableVariants = availableVariants;
   
 
  final  List<AgentInfo> _availableAgents;
@@ -220,7 +206,6 @@ class NewSessionSending implements NewSessionState {
   return EqualUnmodifiableListView(_availableVariants);
 }
 
- final  SessionVariant? selectedVariant;
 
 /// Create a copy of NewSessionState
 /// with the given fields replaced by the non-null parameter values.
@@ -232,16 +217,16 @@ $NewSessionSendingCopyWith<NewSessionSending> get copyWith => _$NewSessionSendin
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionSending&&const DeepCollectionEquality().equals(other._availableAgents, _availableAgents)&&const DeepCollectionEquality().equals(other._availableProviders, _availableProviders)&&const DeepCollectionEquality().equals(other._availableCommands, _availableCommands)&&(identical(other.selectedAgent, selectedAgent) || other.selectedAgent == selectedAgent)&&(identical(other.selectedAgentModel, selectedAgentModel) || other.selectedAgentModel == selectedAgentModel)&&(identical(other.stagedCommand, stagedCommand) || other.stagedCommand == stagedCommand)&&const DeepCollectionEquality().equals(other._availableVariants, _availableVariants)&&(identical(other.selectedVariant, selectedVariant) || other.selectedVariant == selectedVariant));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionSending&&const DeepCollectionEquality().equals(other._availableAgents, _availableAgents)&&const DeepCollectionEquality().equals(other._availableProviders, _availableProviders)&&const DeepCollectionEquality().equals(other._availableCommands, _availableCommands)&&(identical(other.selectedAgent, selectedAgent) || other.selectedAgent == selectedAgent)&&(identical(other.selectedAgentModel, selectedAgentModel) || other.selectedAgentModel == selectedAgentModel)&&(identical(other.stagedCommand, stagedCommand) || other.stagedCommand == stagedCommand)&&const DeepCollectionEquality().equals(other._availableVariants, _availableVariants));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_availableAgents),const DeepCollectionEquality().hash(_availableProviders),const DeepCollectionEquality().hash(_availableCommands),selectedAgent,selectedAgentModel,stagedCommand,const DeepCollectionEquality().hash(_availableVariants),selectedVariant);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_availableAgents),const DeepCollectionEquality().hash(_availableProviders),const DeepCollectionEquality().hash(_availableCommands),selectedAgent,selectedAgentModel,stagedCommand,const DeepCollectionEquality().hash(_availableVariants));
 
 @override
 String toString() {
-  return 'NewSessionState.sending(availableAgents: $availableAgents, availableProviders: $availableProviders, availableCommands: $availableCommands, selectedAgent: $selectedAgent, selectedAgentModel: $selectedAgentModel, stagedCommand: $stagedCommand, availableVariants: $availableVariants, selectedVariant: $selectedVariant)';
+  return 'NewSessionState.sending(availableAgents: $availableAgents, availableProviders: $availableProviders, availableCommands: $availableCommands, selectedAgent: $selectedAgent, selectedAgentModel: $selectedAgentModel, stagedCommand: $stagedCommand, availableVariants: $availableVariants)';
 }
 
 
@@ -252,11 +237,11 @@ abstract mixin class $NewSessionSendingCopyWith<$Res> implements $NewSessionStat
   factory $NewSessionSendingCopyWith(NewSessionSending value, $Res Function(NewSessionSending) _then) = _$NewSessionSendingCopyWithImpl;
 @useResult
 $Res call({
- List<AgentInfo> availableAgents, List<ProviderInfo> availableProviders, List<CommandInfo> availableCommands, String? selectedAgent, AgentModel? selectedAgentModel, CommandInfo? stagedCommand, List<SessionVariant> availableVariants, SessionVariant? selectedVariant
+ List<AgentInfo> availableAgents, List<ProviderInfo> availableProviders, List<CommandInfo> availableCommands, String? selectedAgent, AgentModel? selectedAgentModel, CommandInfo? stagedCommand, List<SessionVariant> availableVariants
 });
 
 
-$AgentModelCopyWith<$Res>? get selectedAgentModel;$CommandInfoCopyWith<$Res>? get stagedCommand;$SessionVariantCopyWith<$Res>? get selectedVariant;
+$AgentModelCopyWith<$Res>? get selectedAgentModel;$CommandInfoCopyWith<$Res>? get stagedCommand;
 
 }
 /// @nodoc
@@ -269,7 +254,7 @@ class _$NewSessionSendingCopyWithImpl<$Res>
 
 /// Create a copy of NewSessionState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? availableAgents = null,Object? availableProviders = null,Object? availableCommands = null,Object? selectedAgent = freezed,Object? selectedAgentModel = freezed,Object? stagedCommand = freezed,Object? availableVariants = null,Object? selectedVariant = freezed,}) {
+@pragma('vm:prefer-inline') $Res call({Object? availableAgents = null,Object? availableProviders = null,Object? availableCommands = null,Object? selectedAgent = freezed,Object? selectedAgentModel = freezed,Object? stagedCommand = freezed,Object? availableVariants = null,}) {
   return _then(NewSessionSending(
 availableAgents: null == availableAgents ? _self._availableAgents : availableAgents // ignore: cast_nullable_to_non_nullable
 as List<AgentInfo>,availableProviders: null == availableProviders ? _self._availableProviders : availableProviders // ignore: cast_nullable_to_non_nullable
@@ -278,8 +263,7 @@ as List<CommandInfo>,selectedAgent: freezed == selectedAgent ? _self.selectedAge
 as String?,selectedAgentModel: freezed == selectedAgentModel ? _self.selectedAgentModel : selectedAgentModel // ignore: cast_nullable_to_non_nullable
 as AgentModel?,stagedCommand: freezed == stagedCommand ? _self.stagedCommand : stagedCommand // ignore: cast_nullable_to_non_nullable
 as CommandInfo?,availableVariants: null == availableVariants ? _self._availableVariants : availableVariants // ignore: cast_nullable_to_non_nullable
-as List<SessionVariant>,selectedVariant: freezed == selectedVariant ? _self.selectedVariant : selectedVariant // ignore: cast_nullable_to_non_nullable
-as SessionVariant?,
+as List<SessionVariant>,
   ));
 }
 
@@ -307,18 +291,6 @@ $CommandInfoCopyWith<$Res>? get stagedCommand {
   return $CommandInfoCopyWith<$Res>(_self.stagedCommand!, (value) {
     return _then(_self.copyWith(stagedCommand: value));
   });
-}/// Create a copy of NewSessionState
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$SessionVariantCopyWith<$Res>? get selectedVariant {
-    if (_self.selectedVariant == null) {
-    return null;
-  }
-
-  return $SessionVariantCopyWith<$Res>(_self.selectedVariant!, (value) {
-    return _then(_self.copyWith(selectedVariant: value));
-  });
 }
 }
 
@@ -326,7 +298,7 @@ $SessionVariantCopyWith<$Res>? get selectedVariant {
 
 
 class NewSessionError implements NewSessionState {
-  const NewSessionError({required this.message, required final  List<AgentInfo> availableAgents, required final  List<ProviderInfo> availableProviders, required final  List<CommandInfo> availableCommands, required this.selectedAgent, required this.selectedAgentModel, required this.stagedCommand, final  List<SessionVariant> availableVariants = const [], this.selectedVariant}): _availableAgents = availableAgents,_availableProviders = availableProviders,_availableCommands = availableCommands,_availableVariants = availableVariants;
+  const NewSessionError({required this.message, required final  List<AgentInfo> availableAgents, required final  List<ProviderInfo> availableProviders, required final  List<CommandInfo> availableCommands, required this.selectedAgent, required this.selectedAgentModel, required this.stagedCommand, final  List<SessionVariant> availableVariants = const []}): _availableAgents = availableAgents,_availableProviders = availableProviders,_availableCommands = availableCommands,_availableVariants = availableVariants;
   
 
  final  String message;
@@ -361,7 +333,6 @@ class NewSessionError implements NewSessionState {
   return EqualUnmodifiableListView(_availableVariants);
 }
 
- final  SessionVariant? selectedVariant;
 
 /// Create a copy of NewSessionState
 /// with the given fields replaced by the non-null parameter values.
@@ -373,16 +344,16 @@ $NewSessionErrorCopyWith<NewSessionError> get copyWith => _$NewSessionErrorCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionError&&(identical(other.message, message) || other.message == message)&&const DeepCollectionEquality().equals(other._availableAgents, _availableAgents)&&const DeepCollectionEquality().equals(other._availableProviders, _availableProviders)&&const DeepCollectionEquality().equals(other._availableCommands, _availableCommands)&&(identical(other.selectedAgent, selectedAgent) || other.selectedAgent == selectedAgent)&&(identical(other.selectedAgentModel, selectedAgentModel) || other.selectedAgentModel == selectedAgentModel)&&(identical(other.stagedCommand, stagedCommand) || other.stagedCommand == stagedCommand)&&const DeepCollectionEquality().equals(other._availableVariants, _availableVariants)&&(identical(other.selectedVariant, selectedVariant) || other.selectedVariant == selectedVariant));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NewSessionError&&(identical(other.message, message) || other.message == message)&&const DeepCollectionEquality().equals(other._availableAgents, _availableAgents)&&const DeepCollectionEquality().equals(other._availableProviders, _availableProviders)&&const DeepCollectionEquality().equals(other._availableCommands, _availableCommands)&&(identical(other.selectedAgent, selectedAgent) || other.selectedAgent == selectedAgent)&&(identical(other.selectedAgentModel, selectedAgentModel) || other.selectedAgentModel == selectedAgentModel)&&(identical(other.stagedCommand, stagedCommand) || other.stagedCommand == stagedCommand)&&const DeepCollectionEquality().equals(other._availableVariants, _availableVariants));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,message,const DeepCollectionEquality().hash(_availableAgents),const DeepCollectionEquality().hash(_availableProviders),const DeepCollectionEquality().hash(_availableCommands),selectedAgent,selectedAgentModel,stagedCommand,const DeepCollectionEquality().hash(_availableVariants),selectedVariant);
+int get hashCode => Object.hash(runtimeType,message,const DeepCollectionEquality().hash(_availableAgents),const DeepCollectionEquality().hash(_availableProviders),const DeepCollectionEquality().hash(_availableCommands),selectedAgent,selectedAgentModel,stagedCommand,const DeepCollectionEquality().hash(_availableVariants));
 
 @override
 String toString() {
-  return 'NewSessionState.error(message: $message, availableAgents: $availableAgents, availableProviders: $availableProviders, availableCommands: $availableCommands, selectedAgent: $selectedAgent, selectedAgentModel: $selectedAgentModel, stagedCommand: $stagedCommand, availableVariants: $availableVariants, selectedVariant: $selectedVariant)';
+  return 'NewSessionState.error(message: $message, availableAgents: $availableAgents, availableProviders: $availableProviders, availableCommands: $availableCommands, selectedAgent: $selectedAgent, selectedAgentModel: $selectedAgentModel, stagedCommand: $stagedCommand, availableVariants: $availableVariants)';
 }
 
 
@@ -393,11 +364,11 @@ abstract mixin class $NewSessionErrorCopyWith<$Res> implements $NewSessionStateC
   factory $NewSessionErrorCopyWith(NewSessionError value, $Res Function(NewSessionError) _then) = _$NewSessionErrorCopyWithImpl;
 @useResult
 $Res call({
- String message, List<AgentInfo> availableAgents, List<ProviderInfo> availableProviders, List<CommandInfo> availableCommands, String? selectedAgent, AgentModel? selectedAgentModel, CommandInfo? stagedCommand, List<SessionVariant> availableVariants, SessionVariant? selectedVariant
+ String message, List<AgentInfo> availableAgents, List<ProviderInfo> availableProviders, List<CommandInfo> availableCommands, String? selectedAgent, AgentModel? selectedAgentModel, CommandInfo? stagedCommand, List<SessionVariant> availableVariants
 });
 
 
-$AgentModelCopyWith<$Res>? get selectedAgentModel;$CommandInfoCopyWith<$Res>? get stagedCommand;$SessionVariantCopyWith<$Res>? get selectedVariant;
+$AgentModelCopyWith<$Res>? get selectedAgentModel;$CommandInfoCopyWith<$Res>? get stagedCommand;
 
 }
 /// @nodoc
@@ -410,7 +381,7 @@ class _$NewSessionErrorCopyWithImpl<$Res>
 
 /// Create a copy of NewSessionState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? message = null,Object? availableAgents = null,Object? availableProviders = null,Object? availableCommands = null,Object? selectedAgent = freezed,Object? selectedAgentModel = freezed,Object? stagedCommand = freezed,Object? availableVariants = null,Object? selectedVariant = freezed,}) {
+@pragma('vm:prefer-inline') $Res call({Object? message = null,Object? availableAgents = null,Object? availableProviders = null,Object? availableCommands = null,Object? selectedAgent = freezed,Object? selectedAgentModel = freezed,Object? stagedCommand = freezed,Object? availableVariants = null,}) {
   return _then(NewSessionError(
 message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
 as String,availableAgents: null == availableAgents ? _self._availableAgents : availableAgents // ignore: cast_nullable_to_non_nullable
@@ -420,8 +391,7 @@ as List<CommandInfo>,selectedAgent: freezed == selectedAgent ? _self.selectedAge
 as String?,selectedAgentModel: freezed == selectedAgentModel ? _self.selectedAgentModel : selectedAgentModel // ignore: cast_nullable_to_non_nullable
 as AgentModel?,stagedCommand: freezed == stagedCommand ? _self.stagedCommand : stagedCommand // ignore: cast_nullable_to_non_nullable
 as CommandInfo?,availableVariants: null == availableVariants ? _self._availableVariants : availableVariants // ignore: cast_nullable_to_non_nullable
-as List<SessionVariant>,selectedVariant: freezed == selectedVariant ? _self.selectedVariant : selectedVariant // ignore: cast_nullable_to_non_nullable
-as SessionVariant?,
+as List<SessionVariant>,
   ));
 }
 
@@ -448,18 +418,6 @@ $CommandInfoCopyWith<$Res>? get stagedCommand {
 
   return $CommandInfoCopyWith<$Res>(_self.stagedCommand!, (value) {
     return _then(_self.copyWith(stagedCommand: value));
-  });
-}/// Create a copy of NewSessionState
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$SessionVariantCopyWith<$Res>? get selectedVariant {
-    if (_self.selectedVariant == null) {
-    return null;
-  }
-
-  return $SessionVariantCopyWith<$Res>(_self.selectedVariant!, (value) {
-    return _then(_self.copyWith(selectedVariant: value));
   });
 }
 }

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -160,7 +160,6 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
             providers: availableProviders,
             model: preservedSelectedAgentModel,
           );
-          final selectedVariant = _deriveSelectedVariant(preservedSelectedAgentModel);
 
           emit(
             current.copyWith(
@@ -185,7 +184,6 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
               ),
               isRefreshing: false,
               availableVariants: availableVariants,
-              selectedVariant: selectedVariant,
             ),
           );
         case SessionDetailLoadResultWaitingForConnection():
@@ -866,7 +864,6 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
           providers: current.availableProviders,
           model: agentModel,
         ),
-        selectedVariant: _deriveSelectedVariant(agentModel),
       ),
     );
   }
@@ -896,7 +893,6 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       current.copyWith(
         selectedAgentModel: agentModel?.copyWith(variant: variant),
         availableVariants: availableVariants,
-        selectedVariant: _deriveSelectedVariant(agentModel?.copyWith(variant: variant)),
       ),
     );
   }
@@ -908,12 +904,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     if (agentModel == null) return;
 
     if (isClosed) return;
-    emit(
-      current.copyWith(
-        selectedAgentModel: agentModel.copyWith(variant: variant?.id),
-        selectedVariant: variant,
-      ),
-    );
+    emit(current.copyWith(selectedAgentModel: agentModel.copyWith(variant: variant?.id)));
   }
 
   void stageCommand(CommandInfo command) {
@@ -1009,7 +1000,6 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       providers: providers,
       model: defaultAgentModel,
     );
-    final selectedVariant = _deriveSelectedVariant(defaultAgentModel);
 
     return SessionDetailState.loaded(
           messages: snapshot.messages,
@@ -1031,7 +1021,6 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
           stagedCommand: null,
           isRefreshing: false,
           availableVariants: availableVariants,
-          selectedVariant: selectedVariant,
         )
         as SessionDetailLoaded;
   }
@@ -1045,14 +1034,6 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     final provider = providerID != null ? providers.firstWhereOrNull((p) => p.id == providerID) : null;
     final m = provider?.models[modelID];
     return m?.variants.where((v) => v != "none").map((v) => SessionVariant(id: v)).toList() ?? [];
-  }
-
-  SessionVariant? _deriveSelectedVariant(AgentModel? model) {
-    final variant = model?.variant;
-    if (variant != null && variant != "none") {
-      return SessionVariant(id: variant);
-    }
-    return null;
   }
 
   List<SesoriQuestionAsked> _mapPendingQuestions(List<PendingQuestion> pendingQuestions) {

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -908,7 +908,12 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     if (agentModel == null) return;
 
     if (isClosed) return;
-    emit(current.copyWith(selectedAgentModel: agentModel.copyWith(variant: variant?.id)));
+    emit(
+      current.copyWith(
+        selectedAgentModel: agentModel.copyWith(variant: variant?.id),
+        selectedVariant: variant,
+      ),
+    );
   }
 
   void stageCommand(CommandInfo command) {

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_state.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_state.dart
@@ -37,7 +37,6 @@ sealed class SessionDetailState with _$SessionDetailState {
     required CommandInfo? stagedCommand,
     required bool isRefreshing,
     @Default([]) List<SessionVariant> availableVariants,
-    SessionVariant? selectedVariant,
   }) = SessionDetailLoaded;
 
   const factory SessionDetailState.failed({required ApiError error}) = SessionDetailFailed;

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_state.freezed.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_state.freezed.dart
@@ -78,7 +78,7 @@ String toString() {
 
 
 class SessionDetailLoaded implements SessionDetailState {
-  const SessionDetailLoaded({required final  List<MessageWithParts> messages, required final  Map<String, String> streamingText, required this.sessionStatus, required final  List<SesoriQuestionAsked> pendingQuestions, required final  List<SesoriPermissionAsked> pendingPermissions, required this.sessionTitle, required this.agent, required this.assistantAgentModel, required final  List<Session> children, required final  Map<String, SessionStatus> childStatuses, required final  List<QueuedSessionSubmission> queuedMessages, required final  List<AgentInfo> availableAgents, required final  List<ProviderInfo> availableProviders, required final  List<CommandInfo> availableCommands, required this.selectedAgent, required this.selectedAgentModel, required this.stagedCommand, required this.isRefreshing, final  List<SessionVariant> availableVariants = const [], this.selectedVariant}): _messages = messages,_streamingText = streamingText,_pendingQuestions = pendingQuestions,_pendingPermissions = pendingPermissions,_children = children,_childStatuses = childStatuses,_queuedMessages = queuedMessages,_availableAgents = availableAgents,_availableProviders = availableProviders,_availableCommands = availableCommands,_availableVariants = availableVariants;
+  const SessionDetailLoaded({required final  List<MessageWithParts> messages, required final  Map<String, String> streamingText, required this.sessionStatus, required final  List<SesoriQuestionAsked> pendingQuestions, required final  List<SesoriPermissionAsked> pendingPermissions, required this.sessionTitle, required this.agent, required this.assistantAgentModel, required final  List<Session> children, required final  Map<String, SessionStatus> childStatuses, required final  List<QueuedSessionSubmission> queuedMessages, required final  List<AgentInfo> availableAgents, required final  List<ProviderInfo> availableProviders, required final  List<CommandInfo> availableCommands, required this.selectedAgent, required this.selectedAgentModel, required this.stagedCommand, required this.isRefreshing, final  List<SessionVariant> availableVariants = const []}): _messages = messages,_streamingText = streamingText,_pendingQuestions = pendingQuestions,_pendingPermissions = pendingPermissions,_children = children,_childStatuses = childStatuses,_queuedMessages = queuedMessages,_availableAgents = availableAgents,_availableProviders = availableProviders,_availableCommands = availableCommands,_availableVariants = availableVariants;
   
 
  final  List<MessageWithParts> _messages;
@@ -175,7 +175,6 @@ class SessionDetailLoaded implements SessionDetailState {
   return EqualUnmodifiableListView(_availableVariants);
 }
 
- final  SessionVariant? selectedVariant;
 
 /// Create a copy of SessionDetailState
 /// with the given fields replaced by the non-null parameter values.
@@ -187,16 +186,16 @@ $SessionDetailLoadedCopyWith<SessionDetailLoaded> get copyWith => _$SessionDetai
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionDetailLoaded&&const DeepCollectionEquality().equals(other._messages, _messages)&&const DeepCollectionEquality().equals(other._streamingText, _streamingText)&&(identical(other.sessionStatus, sessionStatus) || other.sessionStatus == sessionStatus)&&const DeepCollectionEquality().equals(other._pendingQuestions, _pendingQuestions)&&const DeepCollectionEquality().equals(other._pendingPermissions, _pendingPermissions)&&(identical(other.sessionTitle, sessionTitle) || other.sessionTitle == sessionTitle)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.assistantAgentModel, assistantAgentModel) || other.assistantAgentModel == assistantAgentModel)&&const DeepCollectionEquality().equals(other._children, _children)&&const DeepCollectionEquality().equals(other._childStatuses, _childStatuses)&&const DeepCollectionEquality().equals(other._queuedMessages, _queuedMessages)&&const DeepCollectionEquality().equals(other._availableAgents, _availableAgents)&&const DeepCollectionEquality().equals(other._availableProviders, _availableProviders)&&const DeepCollectionEquality().equals(other._availableCommands, _availableCommands)&&(identical(other.selectedAgent, selectedAgent) || other.selectedAgent == selectedAgent)&&(identical(other.selectedAgentModel, selectedAgentModel) || other.selectedAgentModel == selectedAgentModel)&&(identical(other.stagedCommand, stagedCommand) || other.stagedCommand == stagedCommand)&&(identical(other.isRefreshing, isRefreshing) || other.isRefreshing == isRefreshing)&&const DeepCollectionEquality().equals(other._availableVariants, _availableVariants)&&(identical(other.selectedVariant, selectedVariant) || other.selectedVariant == selectedVariant));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionDetailLoaded&&const DeepCollectionEquality().equals(other._messages, _messages)&&const DeepCollectionEquality().equals(other._streamingText, _streamingText)&&(identical(other.sessionStatus, sessionStatus) || other.sessionStatus == sessionStatus)&&const DeepCollectionEquality().equals(other._pendingQuestions, _pendingQuestions)&&const DeepCollectionEquality().equals(other._pendingPermissions, _pendingPermissions)&&(identical(other.sessionTitle, sessionTitle) || other.sessionTitle == sessionTitle)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.assistantAgentModel, assistantAgentModel) || other.assistantAgentModel == assistantAgentModel)&&const DeepCollectionEquality().equals(other._children, _children)&&const DeepCollectionEquality().equals(other._childStatuses, _childStatuses)&&const DeepCollectionEquality().equals(other._queuedMessages, _queuedMessages)&&const DeepCollectionEquality().equals(other._availableAgents, _availableAgents)&&const DeepCollectionEquality().equals(other._availableProviders, _availableProviders)&&const DeepCollectionEquality().equals(other._availableCommands, _availableCommands)&&(identical(other.selectedAgent, selectedAgent) || other.selectedAgent == selectedAgent)&&(identical(other.selectedAgentModel, selectedAgentModel) || other.selectedAgentModel == selectedAgentModel)&&(identical(other.stagedCommand, stagedCommand) || other.stagedCommand == stagedCommand)&&(identical(other.isRefreshing, isRefreshing) || other.isRefreshing == isRefreshing)&&const DeepCollectionEquality().equals(other._availableVariants, _availableVariants));
 }
 
 
 @override
-int get hashCode => Object.hashAll([runtimeType,const DeepCollectionEquality().hash(_messages),const DeepCollectionEquality().hash(_streamingText),sessionStatus,const DeepCollectionEquality().hash(_pendingQuestions),const DeepCollectionEquality().hash(_pendingPermissions),sessionTitle,agent,assistantAgentModel,const DeepCollectionEquality().hash(_children),const DeepCollectionEquality().hash(_childStatuses),const DeepCollectionEquality().hash(_queuedMessages),const DeepCollectionEquality().hash(_availableAgents),const DeepCollectionEquality().hash(_availableProviders),const DeepCollectionEquality().hash(_availableCommands),selectedAgent,selectedAgentModel,stagedCommand,isRefreshing,const DeepCollectionEquality().hash(_availableVariants),selectedVariant]);
+int get hashCode => Object.hashAll([runtimeType,const DeepCollectionEquality().hash(_messages),const DeepCollectionEquality().hash(_streamingText),sessionStatus,const DeepCollectionEquality().hash(_pendingQuestions),const DeepCollectionEquality().hash(_pendingPermissions),sessionTitle,agent,assistantAgentModel,const DeepCollectionEquality().hash(_children),const DeepCollectionEquality().hash(_childStatuses),const DeepCollectionEquality().hash(_queuedMessages),const DeepCollectionEquality().hash(_availableAgents),const DeepCollectionEquality().hash(_availableProviders),const DeepCollectionEquality().hash(_availableCommands),selectedAgent,selectedAgentModel,stagedCommand,isRefreshing,const DeepCollectionEquality().hash(_availableVariants)]);
 
 @override
 String toString() {
-  return 'SessionDetailState.loaded(messages: $messages, streamingText: $streamingText, sessionStatus: $sessionStatus, pendingQuestions: $pendingQuestions, pendingPermissions: $pendingPermissions, sessionTitle: $sessionTitle, agent: $agent, assistantAgentModel: $assistantAgentModel, children: $children, childStatuses: $childStatuses, queuedMessages: $queuedMessages, availableAgents: $availableAgents, availableProviders: $availableProviders, availableCommands: $availableCommands, selectedAgent: $selectedAgent, selectedAgentModel: $selectedAgentModel, stagedCommand: $stagedCommand, isRefreshing: $isRefreshing, availableVariants: $availableVariants, selectedVariant: $selectedVariant)';
+  return 'SessionDetailState.loaded(messages: $messages, streamingText: $streamingText, sessionStatus: $sessionStatus, pendingQuestions: $pendingQuestions, pendingPermissions: $pendingPermissions, sessionTitle: $sessionTitle, agent: $agent, assistantAgentModel: $assistantAgentModel, children: $children, childStatuses: $childStatuses, queuedMessages: $queuedMessages, availableAgents: $availableAgents, availableProviders: $availableProviders, availableCommands: $availableCommands, selectedAgent: $selectedAgent, selectedAgentModel: $selectedAgentModel, stagedCommand: $stagedCommand, isRefreshing: $isRefreshing, availableVariants: $availableVariants)';
 }
 
 
@@ -207,11 +206,11 @@ abstract mixin class $SessionDetailLoadedCopyWith<$Res> implements $SessionDetai
   factory $SessionDetailLoadedCopyWith(SessionDetailLoaded value, $Res Function(SessionDetailLoaded) _then) = _$SessionDetailLoadedCopyWithImpl;
 @useResult
 $Res call({
- List<MessageWithParts> messages, Map<String, String> streamingText, SessionStatus sessionStatus, List<SesoriQuestionAsked> pendingQuestions, List<SesoriPermissionAsked> pendingPermissions, String? sessionTitle, String? agent, AgentModel? assistantAgentModel, List<Session> children, Map<String, SessionStatus> childStatuses, List<QueuedSessionSubmission> queuedMessages, List<AgentInfo> availableAgents, List<ProviderInfo> availableProviders, List<CommandInfo> availableCommands, String selectedAgent, AgentModel? selectedAgentModel, CommandInfo? stagedCommand, bool isRefreshing, List<SessionVariant> availableVariants, SessionVariant? selectedVariant
+ List<MessageWithParts> messages, Map<String, String> streamingText, SessionStatus sessionStatus, List<SesoriQuestionAsked> pendingQuestions, List<SesoriPermissionAsked> pendingPermissions, String? sessionTitle, String? agent, AgentModel? assistantAgentModel, List<Session> children, Map<String, SessionStatus> childStatuses, List<QueuedSessionSubmission> queuedMessages, List<AgentInfo> availableAgents, List<ProviderInfo> availableProviders, List<CommandInfo> availableCommands, String selectedAgent, AgentModel? selectedAgentModel, CommandInfo? stagedCommand, bool isRefreshing, List<SessionVariant> availableVariants
 });
 
 
-$SessionStatusCopyWith<$Res> get sessionStatus;$AgentModelCopyWith<$Res>? get assistantAgentModel;$AgentModelCopyWith<$Res>? get selectedAgentModel;$CommandInfoCopyWith<$Res>? get stagedCommand;$SessionVariantCopyWith<$Res>? get selectedVariant;
+$SessionStatusCopyWith<$Res> get sessionStatus;$AgentModelCopyWith<$Res>? get assistantAgentModel;$AgentModelCopyWith<$Res>? get selectedAgentModel;$CommandInfoCopyWith<$Res>? get stagedCommand;
 
 }
 /// @nodoc
@@ -224,7 +223,7 @@ class _$SessionDetailLoadedCopyWithImpl<$Res>
 
 /// Create a copy of SessionDetailState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? messages = null,Object? streamingText = null,Object? sessionStatus = null,Object? pendingQuestions = null,Object? pendingPermissions = null,Object? sessionTitle = freezed,Object? agent = freezed,Object? assistantAgentModel = freezed,Object? children = null,Object? childStatuses = null,Object? queuedMessages = null,Object? availableAgents = null,Object? availableProviders = null,Object? availableCommands = null,Object? selectedAgent = null,Object? selectedAgentModel = freezed,Object? stagedCommand = freezed,Object? isRefreshing = null,Object? availableVariants = null,Object? selectedVariant = freezed,}) {
+@pragma('vm:prefer-inline') $Res call({Object? messages = null,Object? streamingText = null,Object? sessionStatus = null,Object? pendingQuestions = null,Object? pendingPermissions = null,Object? sessionTitle = freezed,Object? agent = freezed,Object? assistantAgentModel = freezed,Object? children = null,Object? childStatuses = null,Object? queuedMessages = null,Object? availableAgents = null,Object? availableProviders = null,Object? availableCommands = null,Object? selectedAgent = null,Object? selectedAgentModel = freezed,Object? stagedCommand = freezed,Object? isRefreshing = null,Object? availableVariants = null,}) {
   return _then(SessionDetailLoaded(
 messages: null == messages ? _self._messages : messages // ignore: cast_nullable_to_non_nullable
 as List<MessageWithParts>,streamingText: null == streamingText ? _self._streamingText : streamingText // ignore: cast_nullable_to_non_nullable
@@ -245,8 +244,7 @@ as String,selectedAgentModel: freezed == selectedAgentModel ? _self.selectedAgen
 as AgentModel?,stagedCommand: freezed == stagedCommand ? _self.stagedCommand : stagedCommand // ignore: cast_nullable_to_non_nullable
 as CommandInfo?,isRefreshing: null == isRefreshing ? _self.isRefreshing : isRefreshing // ignore: cast_nullable_to_non_nullable
 as bool,availableVariants: null == availableVariants ? _self._availableVariants : availableVariants // ignore: cast_nullable_to_non_nullable
-as List<SessionVariant>,selectedVariant: freezed == selectedVariant ? _self.selectedVariant : selectedVariant // ignore: cast_nullable_to_non_nullable
-as SessionVariant?,
+as List<SessionVariant>,
   ));
 }
 
@@ -294,18 +292,6 @@ $CommandInfoCopyWith<$Res>? get stagedCommand {
 
   return $CommandInfoCopyWith<$Res>(_self.stagedCommand!, (value) {
     return _then(_self.copyWith(stagedCommand: value));
-  });
-}/// Create a copy of SessionDetailState
-/// with the given fields replaced by the non-null parameter values.
-@override
-@pragma('vm:prefer-inline')
-$SessionVariantCopyWith<$Res>? get selectedVariant {
-    if (_self.selectedVariant == null) {
-    return null;
-  }
-
-  return $SessionVariantCopyWith<$Res>(_self.selectedVariant!, (value) {
-    return _then(_self.copyWith(selectedVariant: value));
   });
 }
 }

--- a/mobile/module_core/test/cubits/new_session/new_session_cubit_test.dart
+++ b/mobile/module_core/test/cubits/new_session/new_session_cubit_test.dart
@@ -330,7 +330,7 @@ void main() {
     );
 
     blocTest<NewSessionCubit, NewSessionState>(
-      "selectVariant updates selectedVariant in state",
+      "selectVariant updates selectedAgentModel variant",
       build: () {
         when(() => mockSessionService.listAgents()).thenAnswer(
           (_) async => ApiResponse.success(
@@ -378,26 +378,20 @@ void main() {
       },
       expect: () => [
         isA<NewSessionIdle>().having(
-          (state) => state.selectedVariant,
-          "initial selectedVariant",
+          (state) => state.selectedAgentModel?.variant,
+          "initial variant",
           isNull,
         ),
-        isA<NewSessionIdle>()
-            .having(
-              (state) => state.selectedVariant,
-              "selectedVariant",
-              const SessionVariant(id: "fast"),
-            )
-            .having(
-              (state) => state.selectedAgentModel?.variant,
-              "selectedAgentModel.variant",
-              "fast",
-            ),
+        isA<NewSessionIdle>().having(
+          (state) => state.selectedAgentModel?.variant,
+          "variant",
+          "fast",
+        ),
       ],
     );
 
     blocTest<NewSessionCubit, NewSessionState>(
-      "selectVariant to null clears selectedVariant in state",
+      "selectVariant to null clears selectedAgentModel variant",
       build: () {
         when(() => mockSessionService.listAgents()).thenAnswer(
           (_) async => ApiResponse.success(
@@ -445,21 +439,15 @@ void main() {
       },
       expect: () => [
         isA<NewSessionIdle>().having(
-          (state) => state.selectedVariant,
-          "initial selectedVariant",
-          const SessionVariant(id: "fast"),
+          (state) => state.selectedAgentModel?.variant,
+          "initial variant",
+          "fast",
         ),
-        isA<NewSessionIdle>()
-            .having(
-              (state) => state.selectedVariant,
-              "selectedVariant",
-              isNull,
-            )
-            .having(
-              (state) => state.selectedAgentModel?.variant,
-              "selectedAgentModel.variant",
-              isNull,
-            ),
+        isA<NewSessionIdle>().having(
+          (state) => state.selectedAgentModel?.variant,
+          "variant",
+          isNull,
+        ),
       ],
     );
   });

--- a/mobile/module_core/test/cubits/new_session/new_session_cubit_test.dart
+++ b/mobile/module_core/test/cubits/new_session/new_session_cubit_test.dart
@@ -328,5 +328,139 @@ void main() {
             ),
       ],
     );
+
+    blocTest<NewSessionCubit, NewSessionState>(
+      "selectVariant updates selectedVariant in state",
+      build: () {
+        when(() => mockSessionService.listAgents()).thenAnswer(
+          (_) async => ApiResponse.success(
+            const Agents(
+              agents: [
+                AgentInfo(
+                  name: "build",
+                  description: "Build",
+                  model: AgentModel(providerID: "openai", modelID: "gpt-4", variant: null),
+                  mode: AgentMode.primary,
+                ),
+              ],
+            ),
+          ),
+        );
+        when(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+          (_) async => ApiResponse.success(
+            const ProviderListResponse(
+              connectedOnly: false,
+              items: [
+                ProviderInfo(
+                  id: "openai",
+                  name: "OpenAI",
+                  defaultModelID: "gpt-4",
+                  models: {
+                    "gpt-4": ProviderModel(
+                      id: "gpt-4",
+                      providerID: "openai",
+                      name: "GPT-4",
+                      variants: ["fast", "slow"],
+                      family: null,
+                      releaseDate: null,
+                    ),
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+        return buildCubit();
+      },
+      act: (cubit) async {
+        await Future<void>.delayed(Duration.zero);
+        cubit.selectVariant(const SessionVariant(id: "fast"));
+      },
+      expect: () => [
+        isA<NewSessionIdle>().having(
+          (state) => state.selectedVariant,
+          "initial selectedVariant",
+          isNull,
+        ),
+        isA<NewSessionIdle>()
+            .having(
+              (state) => state.selectedVariant,
+              "selectedVariant",
+              const SessionVariant(id: "fast"),
+            )
+            .having(
+              (state) => state.selectedAgentModel?.variant,
+              "selectedAgentModel.variant",
+              "fast",
+            ),
+      ],
+    );
+
+    blocTest<NewSessionCubit, NewSessionState>(
+      "selectVariant to null clears selectedVariant in state",
+      build: () {
+        when(() => mockSessionService.listAgents()).thenAnswer(
+          (_) async => ApiResponse.success(
+            const Agents(
+              agents: [
+                AgentInfo(
+                  name: "build",
+                  description: "Build",
+                  model: AgentModel(providerID: "openai", modelID: "gpt-4", variant: "fast"),
+                  mode: AgentMode.primary,
+                ),
+              ],
+            ),
+          ),
+        );
+        when(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+          (_) async => ApiResponse.success(
+            const ProviderListResponse(
+              connectedOnly: false,
+              items: [
+                ProviderInfo(
+                  id: "openai",
+                  name: "OpenAI",
+                  defaultModelID: "gpt-4",
+                  models: {
+                    "gpt-4": ProviderModel(
+                      id: "gpt-4",
+                      providerID: "openai",
+                      name: "GPT-4",
+                      variants: ["fast", "slow"],
+                      family: null,
+                      releaseDate: null,
+                    ),
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+        return buildCubit();
+      },
+      act: (cubit) async {
+        await Future<void>.delayed(Duration.zero);
+        cubit.selectVariant(null);
+      },
+      expect: () => [
+        isA<NewSessionIdle>().having(
+          (state) => state.selectedVariant,
+          "initial selectedVariant",
+          const SessionVariant(id: "fast"),
+        ),
+        isA<NewSessionIdle>()
+            .having(
+              (state) => state.selectedVariant,
+              "selectedVariant",
+              isNull,
+            )
+            .having(
+              (state) => state.selectedAgentModel?.variant,
+              "selectedAgentModel.variant",
+              isNull,
+            ),
+      ],
+    );
   });
 }


### PR DESCRIPTION
## Bug

The variant picker in both the new session screen and session detail screen appeared to not reflect the selected variant when tapped. The picker would close, but the UI button label would remain unchanged.

## Root Cause

`selectVariant()` in both `NewSessionCubit` and `SessionDetailCubit` was updating `selectedAgentModel.variant` but **not** the standalone `selectedVariant` field in the state. Since the UI widgets (`AgentModelButtons`, `VariantPickerSheet`) read from `selectedVariant` to display the current selection, the visual update was missed even though the underlying model was correctly mutated.

## Fix

- Updated `NewSessionCubit.selectVariant` to also set `selectedVariant` in the emitted state.
- Updated `SessionDetailCubit.selectVariant` to also set `selectedVariant` in the emitted state.

## Tests

Added failing tests that reproduced the issue, then verified they pass after the fix:

- **Cubit tests** (`new_session_cubit_test.dart`, `session_detail_cubit_test.dart`):
  - `selectVariant updates selectedVariant in state`
  - `selectVariant to null clears selectedVariant in state`

- **Widget tests** (`new_session_screen_test.dart`, `session_detail_body_test.dart`):
  - `selecting a different variant updates the displayed variant`
  - `selecting Default clears the displayed variant`

All existing tests continue to pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the variant picker not reflecting the selected variant on New Session and Session Detail screens. The UI now reads the variant directly from the selected agent model and updates immediately when a variant is chosen or cleared.

- **Bug Fixes**
  - Picker and button now bind to `selectedAgentModel.variant`; `selectVariant` updates it in both cubits.
  - Added cubit and widget tests for selecting/clearing variants and the label update.

- **Refactors**
  - Removed redundant `selectedVariant` from `NewSessionState` and `SessionDetailState`; derive from `selectedAgentModel.variant`.
  - `AgentModelButtons` now receives `selectedAgentModel`; `VariantPickerSheet` accepts `selectedVariantId` (String). Updated screens and cubits to use a single source of truth.

<sup>Written for commit 1dae6a8b717b322d64eb08cfc7391fb40237e2b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

