### PR TITLE
feat: notify OpenCode when deleting workspace from Sesori

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -31,15 +31,15 @@ jobs:
         working-directory: bridge
 
       - name: Analyze bridge/app
-        run: dart analyze
+        run: dart analyze --fatal-infos
         working-directory: bridge/app
 
       - name: Analyze sesori_plugin_interface
-        run: dart analyze
+        run: dart analyze --fatal-infos
         working-directory: bridge/sesori_plugin_interface
 
       - name: Analyze sesori_plugin_opencode
-        run: dart analyze
+        run: dart analyze --fatal-infos
         working-directory: bridge/sesori_plugin_opencode
 
       - name: Run tests for bridge/app

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,15 +30,16 @@ The full specification — including all cross-dependency rules, acceptable patt
 
 Each layer has a specific responsibility and a dedicated directory. Dependencies flow upward only — a lower layer must NEVER know about a higher layer. NO layer skipping.
 
-| Layer | Responsibility | Directory |
-|-------|---------------|-----------|
-| **Layer 0 — Foundation** | Transport primitives and base abstractions. HOW we communicate, not WHAT. No business logic, no decisions. | `foundation/` |
-| **Layer 1 — API** | Dumb data-access classes that execute operations (HTTP calls, DB queries, shell commands). Parse responses into models. No decision-making logic. | `api/` |
-| **Layer 2 — Repository** | Aggregates data from one or more Layer 1 sources. Maps API/DB DTOs to internal models. **MANDATORY** even when only one data source exists — it just delegates. All mapping logic lives here and nowhere else. | `repositories/` |
-| **Layer 3 — Service** | Business logic and coordination. Decision-making lives here. MUST use Repositories, NEVER call APIs directly. | `services/` |
-| **Layer 4+ — Consumer** | Consumes services/repositories. Cubits (mobile), request handlers (bridge), orchestrators. | `cubits/`, `routing/`, `sse/` |
+| Layer                    | Responsibility                                                                                                                                                                                                 | Directory                     |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| **Layer 0 — Foundation** | Transport primitives and base abstractions. HOW we communicate, not WHAT. No business logic, no decisions.                                                                                                     | `foundation/`                 |
+| **Layer 1 — API**        | Dumb data-access classes that execute operations (HTTP calls, DB queries, shell commands, plugins). Parse responses into models. No decision-making logic.                                                     | `api/`                        |
+| **Layer 2 — Repository** | Aggregates data from one or more Layer 1 sources. Maps API/DB DTOs to internal models. **MANDATORY** even when only one data source exists — it just delegates. All mapping logic lives here and nowhere else. | `repositories/`               |
+| **Layer 3 — Service**    | Business logic and coordination. Decision-making lives here. MUST use Repositories, NEVER call APIs directly.                                                                                                  | `services/`                   |
+| **Layer 4+ — Consumer**  | Consumes services/repositories. Cubits (mobile), request handlers (bridge), orchestrators.                                                                                                                     | `cubits/`, `routing/`, `sse/` |
 
 **Core rules:**
+
 - A Service MUST NOT call an API directly — it goes through a Repository
 - A Consumer (cubit, handler) MUST NOT import from `api/` — it goes through repositories/services
 - Within a layer: NO cross-dependency between same-level classes (unless base classes/abstractions designed for reuse within that layer)
@@ -52,21 +53,25 @@ Each layer has a specific responsibility and a dedicated directory. Dependencies
 Pick a class suffix that accurately reflects the class's role. Vague names (`Manager`, `Helper`, `Utils`, `Wrapper`) invite kitchen-sink growth and are forbidden. If a class's role doesn't match any suffix below, the class's responsibilities probably need rethinking, not a vague label.
 
 **Orchestration & business logic:**
+
 - **`Service`** — orchestrates two or more collaborators, coordinates a non-trivial state machine, or uses a Repository. This is the Layer 3 default.
 - **`Dispatcher`** — single choke point through which a class of requests flows; owns the pipeline for those requests.
 - **`Orchestrator`** — top-level composer that wires multiple layers or subsystems.
 
 **Data access:**
+
 - **`Api`** / **`Dao`** — Layer 1 data access.
 - **`Client`** — transport-level; HTTP/WebSocket to an external system.
 - **`Repository`** — Layer 2 aggregator + mapper.
 
 **Reactive / event wiring:**
+
 - **`Listener`** — subscribes to a stream/event source and delegates downstream; owns its subscription lifecycle.
 - **`Notifier`** — detects a condition and emits events.
 - **`Tracker`** — maintains state derived from events; exposes stream or snapshot access.
 
 **Pure transformations (no decisions, no orchestration):**
+
 - **`Builder`** — constructs an output artifact from inputs.
 - **`Formatter`** — converts data to presentation form.
 - **`Mapper`** — translates between data models.
@@ -75,6 +80,7 @@ Pick a class suffix that accurately reflects the class's role. Vague names (`Man
 - **`Calculator`** — computes derived values.
 
 **State management:**
+
 - **`Cubit`** — mobile only, Layer 4.
 
 **Forbidden suffixes:** `Manager`, `Helper`, `Utils`, `Wrapper`, `Handler` (except for routing handlers in the bridge `routing/` layer).
@@ -96,6 +102,7 @@ These four rules catch the common structural failures that layer rules alone mis
 ### Bridge workspace (`bridge/`)
 
 **`bridge/app` — target directory structure:**
+
 ```
 app/lib/src/
 ├── foundation/              # Layer 0
@@ -157,6 +164,7 @@ app/lib/src/
 - **New push triggers** (another stream, another timer) MUST be added as a new Listener class. `PushDispatcher` remains the outbound push choke point, while each listener owns its own trigger-specific bookkeeping, scheduling, and pre-send state handling before delegating outbound sends to the dispatcher. Do not grow a single class to own multiple triggers.
 
 **`sesori_plugin_opencode` — internal layers:**
+
 ```
 lib/src/
 ├── models/                  # Layer 0 — OpenCode-specific Freezed data classes
@@ -171,12 +179,15 @@ lib/src/
 ### Mobile workspace (`mobile/`)
 
 **Module dependency direction (never reverse, never skip):**
+
 ```
 app → module_core → module_auth → sesori_shared
 ```
+
 `app` has `module_auth` in pubspec only for DI wiring — it MUST NOT import `module_auth` types in source code.
 
 **`module_core` — target directory structure:**
+
 ```
 module_core/lib/src/
 ├── foundation/              # Layer 0
@@ -218,6 +229,7 @@ module_core/lib/src/
 - No cross-dependency between repositories, between services, or between cubits
 
 **`app` (Flutter shell) — target directory structure:**
+
 ```
 app/lib/
 ├── core/platform/           # Layer 0 — concrete Flutter implementations of module_core interfaces
@@ -240,6 +252,7 @@ app/lib/
 - `module_auth` MUST NOT import `module_core`
 
 **`module_auth` — internal structure:**
+
 ```
 module_auth/lib/src/
 ├── interfaces/              # exported API: AuthTokenProvider, OAuthFlowProvider, AuthSession
@@ -256,7 +269,7 @@ module_auth/lib/src/
 
 ## Key Architectural Patterns
 
-- **Bridge plugin system:** `BridgePlugin` abstract class in `sesori_plugin_interface` defines the backend contract (projects, sessions, messages, events, health). `sesori_plugin_opencode` implements it for OpenCode. New backends implement this interface.
+- **Bridge plugin system:** `BridgePluginApi` abstract class in `sesori_plugin_interface` defines the backend contract (projects, sessions, messages, events, health). THIS BELONGS TO Layer 1 (API layer). `sesori_plugin_opencode` implements it for OpenCode. New backends implement this interface.
 - **Relay protocol:** `RelayMessage` sealed class in `sesori_shared` defines all message types (auth, key_exchange, ready, request, response, sse_event, etc.). Binary wire format: `[version_byte][nonce (24B)][ciphertext + auth tag]`.
 - **Request routing (bridge):** Intercept-first handler chain. `RequestRouter` tries each registered handler in order; first match wins. `ProxyHandler` is the catch-all fallback.
 - **SSE pipeline (bridge):** `SseConnection` → `SseEventParser` → plugin event stream → `Orchestrator` → `SSEManager` → per-phone encrypted delivery with event buffering.
@@ -340,17 +353,13 @@ The bridge uses Drift (SQLite) for local persistence. Schema changes require a s
 
 Conventional commits: `fix:`, `feat:`, `ci:`, `docs:`, `chore:`.
 
-Branch naming: `type/short-description` (e.g. `feat/relay-reconnect`).
-
-Worktrees: Always create new worktrees inside the `.worktrees/` directory at the repo root (e.g. `.worktrees/feat-relay-reconnect`). Unless explicitly told otherwise, the worktree should start from the `main` branch.
-
 ## Testing
 
-| Location | Command |
-|---|---|
-| bridge modules | `dart test` |
-| mobile/app | `flutter test` |
-| mobile pure Dart modules | `dart test` |
+| Location                 | Command        |
+| ------------------------ | -------------- |
+| bridge modules           | `dart test`    |
+| mobile/app               | `flutter test` |
+| mobile pure Dart modules | `dart test`    |
 
 ## Dart Coding Conventions
 

--- a/bridge/app/lib/src/bridge/debug_server.dart
+++ b/bridge/app/lib/src/bridge/debug_server.dart
@@ -11,7 +11,7 @@ import "services/session_event_enrichment_service.dart";
 import "sse/bridge_event_mapper.dart";
 
 class DebugServer {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
   final RequestRouter _router;
   final BridgeEventMapper _mapper;
   final SessionEventEnrichmentService _sessionEventEnrichmentService;
@@ -26,7 +26,7 @@ class DebugServer {
   int _nextRequestId = 1;
 
   DebugServer({
-    required BridgePlugin plugin,
+    required BridgePluginApi plugin,
     required RequestRouter router,
     required this.port,
     required FailureReporter failureReporter,

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -44,7 +44,7 @@ import "sse/sse_manager.dart";
 class Orchestrator {
   final BridgeConfig config;
   final RelayClient _client;
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
   final MetadataService _metadataService;
   final PushDispatcher _pushDispatcher;
   final CompletionPushListener _completionListener;
@@ -62,7 +62,7 @@ class Orchestrator {
   Orchestrator({
     required this.config,
     required RelayClient client,
-    required BridgePlugin plugin,
+    required BridgePluginApi plugin,
     required MetadataService metadataService,
     required PushDispatcher pushDispatcher,
     required CompletionPushListener completionListener,
@@ -103,7 +103,6 @@ class Orchestrator {
       sessionPersistenceService: _sessionPersistenceService,
     );
     final sessionArchiveService = SessionArchiveService(
-      plugin: _plugin,
       worktreeService: _worktreeService,
       sessionRepository: _sessionRepository,
       sessionPersistenceService: _sessionPersistenceService,
@@ -156,7 +155,7 @@ class Orchestrator {
 class OrchestratorSession {
   final BridgeConfig config;
   final RelayClient _client;
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
   final List<int> _roomKey;
   final SSEManager _sseManager;
   final RequestRouter _router;
@@ -177,7 +176,7 @@ class OrchestratorSession {
   OrchestratorSession._({
     required this.config,
     required RelayClient client,
-    required BridgePlugin plugin,
+    required BridgePluginApi plugin,
     required PushDispatcher pushDispatcher,
     required CompletionPushListener completionListener,
     required MaintenancePushListener maintenanceListener,
@@ -207,32 +206,32 @@ class OrchestratorSession {
        _bytesSentController = bytesSentController,
        _failureReporter = failureReporter,
        _prSyncService = prSyncService,
-        _sessionAbortService = sessionAbortService,
-         _router = RequestRouter(
-            plugin: plugin,
-            getCommandsHandler: GetCommandsHandler(
-              sessionRepository: sessionRepository,
-            ),
+       _sessionAbortService = sessionAbortService,
+       _router = RequestRouter(
+         plugin: plugin,
+         getCommandsHandler: GetCommandsHandler(
            sessionRepository: sessionRepository,
-           abortSessionHandler: AbortSessionHandler(sessionAbortService: sessionAbortService),
-           sessionCreationService: sessionCreationService,
-           sessionArchiveService: sessionArchiveService,
-           sendPromptHandler: SendPromptHandler(
-             sessionPromptService: SessionPromptService(sessionRepository: sessionRepository),
-           ),
-           prSyncService: prSyncService,
-           projectRepository: projectRepository,
-           providerRepository: ProviderRepository(plugin: plugin),
-            getAgentsHandler: GetAgentsHandler(
-              AgentRepository(plugin: plugin),
-            ),
-           permissionRepository: permissionRepository,
-          sessionPersistenceService: sessionPersistenceService,
-          worktreeService: worktreeService,
-          sessionDiffsHandler: GetSessionDiffsHandler(
-            sessionRepository: sessionRepository,
-            processRunner: ProcessRunner(),
-          ),
+         ),
+         sessionRepository: sessionRepository,
+         abortSessionHandler: AbortSessionHandler(sessionAbortService: sessionAbortService),
+         sessionCreationService: sessionCreationService,
+         sessionArchiveService: sessionArchiveService,
+         sendPromptHandler: SendPromptHandler(
+           sessionPromptService: SessionPromptService(sessionRepository: sessionRepository),
+         ),
+         prSyncService: prSyncService,
+         projectRepository: projectRepository,
+         providerRepository: ProviderRepository(plugin: plugin),
+         getAgentsHandler: GetAgentsHandler(
+           AgentRepository(plugin: plugin),
+         ),
+         permissionRepository: permissionRepository,
+         sessionPersistenceService: sessionPersistenceService,
+         worktreeService: worktreeService,
+         sessionDiffsHandler: GetSessionDiffsHandler(
+           sessionRepository: sessionRepository,
+           processRunner: ProcessRunner(),
+         ),
        ),
        _mapper = BridgeEventMapper(
          plugin: plugin,

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -103,6 +103,7 @@ class Orchestrator {
       sessionPersistenceService: _sessionPersistenceService,
     );
     final sessionArchiveService = SessionArchiveService(
+      plugin: _plugin,
       worktreeService: _worktreeService,
       sessionRepository: _sessionRepository,
       sessionPersistenceService: _sessionPersistenceService,

--- a/bridge/app/lib/src/bridge/repositories/agent_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/agent_repository.dart
@@ -1,12 +1,12 @@
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePlugin;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginApi;
 import "package:sesori_shared/sesori_shared.dart" show Agents;
 
 import "mappers/plugin_agent_mapper.dart";
 
 class AgentRepository {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
 
-  AgentRepository({required BridgePlugin plugin}) : _plugin = plugin;
+  AgentRepository({required BridgePluginApi plugin}) : _plugin = plugin;
 
   Future<Agents> getAgents() async {
     final pluginAgents = await _plugin.getAgents();

--- a/bridge/app/lib/src/bridge/repositories/permission_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/permission_repository.dart
@@ -11,9 +11,9 @@ import "package:sesori_shared/sesori_shared.dart";
 /// plugin-contract [plugin_interface.PermissionReply] to keep the two enums
 /// decoupled.
 class PermissionRepository {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
 
-  PermissionRepository({required BridgePlugin plugin}) : _plugin = plugin;
+  PermissionRepository({required BridgePluginApi plugin}) : _plugin = plugin;
 
   Future<void> replyToPermission({
     required String requestId,

--- a/bridge/app/lib/src/bridge/repositories/project_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/project_repository.dart
@@ -1,4 +1,4 @@
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePlugin;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginApi;
 import "package:sesori_shared/sesori_shared.dart" show Project;
 
 import "../persistence/daos/projects_dao.dart";
@@ -16,11 +16,11 @@ import "mappers/plugin_project_mapper.dart";
 /// [ProjectsDao.insertProjectIfMissing] directly from a Layer 2 repository
 /// (e.g. [PullRequestRepository]).
 class ProjectRepository {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
   final ProjectsDao _projectsDao;
 
   ProjectRepository({
-    required BridgePlugin plugin,
+    required BridgePluginApi plugin,
     required ProjectsDao projectsDao,
   }) : _plugin = plugin,
        _projectsDao = projectsDao;

--- a/bridge/app/lib/src/bridge/repositories/provider_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/provider_repository.dart
@@ -1,13 +1,13 @@
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePlugin;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginApi;
 import "package:sesori_shared/sesori_shared.dart" show ProviderListResponse;
 
 import "mappers/plugin_provider_mapper.dart";
 
-/// Wraps [BridgePlugin.getProviders] and maps plugin models to shared types.
+/// Wraps [BridgePluginApi.getProviders] and maps plugin models to shared types.
 class ProviderRepository {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
 
-  ProviderRepository({required BridgePlugin plugin}) : _plugin = plugin;
+  ProviderRepository({required BridgePluginApi plugin}) : _plugin = plugin;
 
   Future<ProviderListResponse> getProviders({required String projectId}) async {
     final result = await _plugin.getProviders(projectId: projectId);

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -1,5 +1,5 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
-    show BridgePlugin, Log, PluginSession, PluginSessionVariant;
+    show BridgePluginApi, Log, PluginSession, PluginSessionVariant;
 import "package:sesori_shared/sesori_shared.dart"
     show CommandListResponse, PrState, PromptModel, PromptPart, PullRequestInfo, Session, SessionVariant;
 
@@ -14,12 +14,12 @@ import "models/stored_session.dart";
 import "pull_request_repository.dart";
 
 class SessionRepository {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
   final SessionDao _sessionDao;
   final PullRequestRepository _pullRequestRepository;
 
   SessionRepository({
-    required BridgePlugin plugin,
+    required BridgePluginApi plugin,
     required SessionDao sessionDao,
     required PullRequestRepository pullRequestRepository,
   }) : _plugin = plugin,

--- a/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
@@ -1,4 +1,4 @@
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginApi, Log;
 
 import "../api/git_cli_api.dart";
 import "../persistence/daos/projects_dao.dart";
@@ -12,14 +12,17 @@ class WorktreeRepository {
   final GitCliApi _gitApi;
   final ProjectsDao _projectsDao;
   final SessionDao _sessionDao;
+  final BridgePluginApi _plugin;
 
   WorktreeRepository({
     required ProjectsDao projectsDao,
     required SessionDao sessionDao,
     required GitCliApi gitApi,
+    required BridgePluginApi plugin,
   }) : _gitApi = gitApi,
        _projectsDao = projectsDao,
-       _sessionDao = sessionDao;
+       _sessionDao = sessionDao,
+       _plugin = plugin;
 
   Future<({String path, String branchName, String baseBranch, String baseCommit})?> getParentWorktree({
     required String parentSessionId,
@@ -137,21 +140,34 @@ class WorktreeRepository {
     return WorktreeUnsafe(issues: issues);
   }
 
-  Future<void> pruneWorktrees({required String projectPath}) async {
-    await _gitApi.pruneWorktrees(projectPath: projectPath);
-  }
-
   Future<bool> removeWorktree({
+    required String projectId,
     required String projectPath,
     required String worktreePath,
     required bool force,
   }) async {
-    await pruneWorktrees(projectPath: projectPath);
-    return _gitApi.removeWorktree(
+    await _gitApi.pruneWorktrees(
+      projectPath: projectPath,
+    );
+    final removed = await _gitApi.removeWorktree(
       projectPath: projectPath,
       worktreePath: worktreePath,
       force: force,
     );
+
+    if (removed) {
+      _plugin
+          .deleteWorkspace(
+            projectId: projectPath,
+            worktreePath: worktreePath,
+          )
+          .catchError(
+            (Object err) => Log.w("[Plugin] deleteWorkspace failed $err"),
+          )
+          .ignore();
+    }
+
+    return removed;
   }
 
   Future<bool> deleteBranch({

--- a/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/worktree_repository.dart
@@ -158,7 +158,7 @@ class WorktreeRepository {
     if (removed) {
       _plugin
           .deleteWorkspace(
-            projectId: projectPath,
+            projectId: projectId,
             worktreePath: worktreePath,
           )
           .catchError(

--- a/bridge/app/lib/src/bridge/routing/create_project_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/create_project_handler.dart
@@ -8,7 +8,7 @@ import "request_handler.dart";
 
 /// Handles `POST /project/create` — creates a new project directory with git init.
 class CreateProjectHandler extends BodyRequestHandler<ProjectPathRequest, Project> {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
 
   CreateProjectHandler(this._plugin)
     : super(

--- a/bridge/app/lib/src/bridge/routing/delete_session_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/delete_session_handler.dart
@@ -12,13 +12,13 @@ import "worktree_cleanup.dart";
 
 /// Handles `DELETE /session/delete` — deletes a session.
 class DeleteSessionHandler extends BodyRequestHandler<DeleteSessionRequest, SuccessEmptyResponse> {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
   final WorktreeService _worktreeService;
   final SessionRepository _sessionRepository;
   final SessionPersistenceService _sessionPersistenceService;
 
   DeleteSessionHandler({
-    required BridgePlugin plugin,
+    required BridgePluginApi plugin,
     required WorktreeService worktreeService,
     required SessionRepository sessionRepository,
     required SessionPersistenceService sessionPersistenceService,
@@ -50,8 +50,8 @@ class DeleteSessionHandler extends BodyRequestHandler<DeleteSessionRequest, Succ
     if (wantsGitCleanup) {
       if (sessionDto case SessionDto(
         :final projectId,
-        worktreePath: final worktreePath?,
-        branchName: final branchName?,
+        :final worktreePath?,
+        :final branchName?,
       )) {
         final cleanupResult = await performWorktreeCleanup(
           worktreeService: _worktreeService,
@@ -72,28 +72,6 @@ class DeleteSessionHandler extends BodyRequestHandler<DeleteSessionRequest, Succ
             status: 409,
             headers: {"content-type": "application/json"},
             body: jsonEncode(rejection.toJson()),
-          );
-        }
-      }
-    }
-
-    if (sessionDto case SessionDto(
-      :final projectId,
-      worktreePath: final worktreePath?,
-    )) {
-      if (body.deleteWorktree) {
-        try {
-          await _plugin.deleteWorkspace(
-            projectDirectory: projectId,
-            worktreePath: worktreePath,
-          );
-        } on PluginApiException catch (error) {
-          // Best-effort: if the workspace is already gone or the backend does
-          // not recognize it, log and continue so the session deletion still
-          // succeeds.
-          Log.w(
-            "deleteSession: failed to remove workspace from backend for session $sessionId: "
-            "${error.statusCode} ${error.endpoint}",
           );
         }
       }

--- a/bridge/app/lib/src/bridge/routing/delete_session_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/delete_session_handler.dart
@@ -77,6 +77,28 @@ class DeleteSessionHandler extends BodyRequestHandler<DeleteSessionRequest, Succ
       }
     }
 
+    if (sessionDto case SessionDto(
+      :final projectId,
+      worktreePath: final worktreePath?,
+    )) {
+      if (body.deleteWorktree) {
+        try {
+          await _plugin.deleteWorkspace(
+            projectDirectory: projectId,
+            worktreePath: worktreePath,
+          );
+        } on PluginApiException catch (error) {
+          // Best-effort: if the workspace is already gone or the backend does
+          // not recognize it, log and continue so the session deletion still
+          // succeeds.
+          Log.w(
+            "deleteSession: failed to remove workspace from backend for session $sessionId: "
+            "${error.statusCode} ${error.endpoint}",
+          );
+        }
+      }
+    }
+
     try {
       await _plugin.deleteSession(sessionId);
     } on PluginApiException catch (error) {

--- a/bridge/app/lib/src/bridge/routing/get_current_project_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_current_project_handler.dart
@@ -5,7 +5,7 @@ import "request_handler.dart";
 
 /// Handles `POST /project/current` — returns project for a given project id.
 class GetCurrentProjectHandler extends BodyRequestHandler<ProjectIdRequest, Project> {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
 
   GetCurrentProjectHandler(this._plugin)
     : super(

--- a/bridge/app/lib/src/bridge/routing/get_project_questions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_project_questions_handler.dart
@@ -6,7 +6,7 @@ import "request_handler.dart";
 
 /// Handles `POST /project/questions` — returns all pending questions for a project.
 class GetProjectQuestionsHandler extends BodyRequestHandler<ProjectIdRequest, PendingQuestionResponse> {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
 
   GetProjectQuestionsHandler(this._plugin)
     : super(

--- a/bridge/app/lib/src/bridge/routing/get_session_messages_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_session_messages_handler.dart
@@ -6,7 +6,7 @@ import "request_handler.dart";
 
 /// Handles `POST /session/messages` — returns all messages for a session.
 class GetSessionMessagesHandler extends BodyRequestHandler<SessionIdRequest, MessageWithPartsResponse> {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
 
   GetSessionMessagesHandler(this._plugin)
     : super(

--- a/bridge/app/lib/src/bridge/routing/get_session_questions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_session_questions_handler.dart
@@ -8,7 +8,7 @@ import "request_handler.dart";
 ///
 /// Returns ALL pending questions for a session.
 class GetSessionQuestionsHandler extends BodyRequestHandler<SessionIdRequest, PendingQuestionResponse> {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
 
   GetSessionQuestionsHandler(this._plugin)
     : super(

--- a/bridge/app/lib/src/bridge/routing/get_session_statuses_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_session_statuses_handler.dart
@@ -7,7 +7,7 @@ import "request_handler.dart";
 ///
 /// Returns statuses for ALL sessions globally — not filtered by session or project.
 class GetSessionStatusesHandler extends GetRequestHandler<SessionStatusResponse> {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
 
   GetSessionStatusesHandler(this._plugin) : super("/session/status");
 

--- a/bridge/app/lib/src/bridge/routing/health_check_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/health_check_handler.dart
@@ -5,7 +5,7 @@ import "request_handler.dart";
 
 /// Handles `GET /global/health` — proxies the backend's health status.
 class HealthCheckHandler extends GetRequestHandler<SuccessEmptyResponse> {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
 
   HealthCheckHandler(this._plugin) : super("/global/health");
 

--- a/bridge/app/lib/src/bridge/routing/reject_question_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/reject_question_handler.dart
@@ -7,7 +7,7 @@ import "request_handler.dart";
 ///
 /// Question IDs are globally unique. No session context needed.
 class RejectQuestionHandler extends BodyRequestHandler<RejectQuestionRequest, SuccessEmptyResponse> {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
 
   RejectQuestionHandler(this._plugin)
     : super(

--- a/bridge/app/lib/src/bridge/routing/rename_project_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/rename_project_handler.dart
@@ -6,7 +6,7 @@ import "request_handler.dart";
 
 /// Handles `PATCH /project/name` — renames a project.
 class RenameProjectHandler extends BodyRequestHandler<RenameProjectRequest, Project> {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
 
   RenameProjectHandler(this._plugin)
     : super(

--- a/bridge/app/lib/src/bridge/routing/reply_to_question_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/reply_to_question_handler.dart
@@ -7,7 +7,7 @@ import "request_handler.dart";
 ///
 /// Question IDs are globally unique in the backend.
 class ReplyToQuestionHandler extends BodyRequestHandler<ReplyToQuestionRequest, SuccessEmptyResponse> {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
 
   ReplyToQuestionHandler(this._plugin)
     : super(

--- a/bridge/app/lib/src/bridge/routing/request_router.dart
+++ b/bridge/app/lib/src/bridge/routing/request_router.dart
@@ -52,7 +52,7 @@ class RequestRouter {
   final List<RequestHandlerBase> _handlers;
 
   RequestRouter({
-    required BridgePlugin plugin,
+    required BridgePluginApi plugin,
     required GetCommandsHandler getCommandsHandler,
     required SessionRepository sessionRepository,
     required AbortSessionHandler abortSessionHandler,
@@ -86,7 +86,7 @@ class RequestRouter {
         );
 
   static List<RequestHandlerBase> _buildHandlers({
-    required BridgePlugin plugin,
+    required BridgePluginApi plugin,
     required GetCommandsHandler getCommandsHandler,
     required SessionRepository sessionRepository,
     required AbortSessionHandler abortSessionHandler,

--- a/bridge/app/lib/src/bridge/routing/worktree_cleanup.dart
+++ b/bridge/app/lib/src/bridge/routing/worktree_cleanup.dart
@@ -66,7 +66,8 @@ Future<CleanupResult> performWorktreeCleanup({
 
   if (deleteWorktree) {
     final removed = await worktreeService.removeWorktree(
-      projectPath: projectId,
+      projectId: projectId,
+      projectPath: projectId, // for opencode plugin, project path == project id
       worktreePath: worktreePath,
       force: force,
     );

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
@@ -3,7 +3,7 @@ import "dart:io";
 
 import "package:http/http.dart" as http;
 import "package:rxdart/rxdart.dart";
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePlugin, Log;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginApi, Log;
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../../auth/access_token_provider.dart";
@@ -41,14 +41,14 @@ import "bridge_shutdown_coordinator.dart";
 
 class BridgeRuntime {
   final AppDatabase _database;
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
   final FailureReporter _failureReporter;
   final SessionEventEnrichmentService _sessionEventEnrichmentService;
   final OrchestratorSession session;
 
   BridgeRuntime({
     required AppDatabase database,
-    required BridgePlugin plugin,
+    required BridgePluginApi plugin,
     required FailureReporter failureReporter,
     required SessionEventEnrichmentService sessionEventEnrichmentService,
     required this.session,
@@ -59,7 +59,7 @@ class BridgeRuntime {
 
   static BridgeRuntime create({
     required BridgeConfig config,
-    required BridgePlugin plugin,
+    required BridgePluginApi plugin,
     required http.Client httpClient,
     required AccessTokenProvider accessTokenProvider,
     required TokenRefresher tokenRefresher,
@@ -152,6 +152,7 @@ class BridgeRuntime {
           worktreeRepository: WorktreeRepository(
             projectsDao: database.projectsDao,
             sessionDao: database.sessionDao,
+            plugin: plugin,
             gitApi: GitCliApi(processRunner: processRunner, gitPathExists: _gitPathExists),
           ),
         ),

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -3,7 +3,7 @@ import "dart:io";
 import "package:clock/clock.dart";
 import "package:http/http.dart" as http;
 import "package:rxdart/rxdart.dart";
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePlugin, Log;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginApi, Log;
 
 import "../../auth/token.dart";
 import "../../auth/token_manager.dart";
@@ -42,7 +42,7 @@ import "bridge_runtime_auth.dart";
 import "bridge_runtime_server.dart";
 import "bridge_shutdown_coordinator.dart";
 
-typedef BridgePluginFactory = BridgePlugin Function({required String serverUrl, required String? serverPassword});
+typedef BridgePluginFactory = BridgePluginApi Function({required String serverUrl, required String? serverPassword});
 
 Future<int> runBridgeApp({
   required BridgeCliOptions options,

--- a/bridge/app/lib/src/bridge/services/session_archive_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_archive_service.dart
@@ -21,18 +21,15 @@ class SessionNotFoundException implements Exception {}
 class SessionInitializationException implements Exception {}
 
 class SessionArchiveService {
-  final BridgePlugin _plugin;
   final WorktreeService _worktreeService;
   final SessionRepository _sessionRepository;
   final SessionPersistenceService _sessionPersistenceService;
 
   SessionArchiveService({
-    required BridgePlugin plugin,
     required WorktreeService worktreeService,
     required SessionRepository sessionRepository,
     required SessionPersistenceService sessionPersistenceService,
-  }) : _plugin = plugin,
-       _worktreeService = worktreeService,
+  }) : _worktreeService = worktreeService,
        _sessionRepository = sessionRepository,
        _sessionPersistenceService = sessionPersistenceService;
 
@@ -145,19 +142,6 @@ class SessionArchiveService {
       );
       if (cleanupResult case CleanupRejected(:final rejection)) {
         throw SessionArchiveConflictException(rejection: rejection);
-      }
-      if (deleteWorktree) {
-        try {
-          await _plugin.deleteWorkspace(
-            projectDirectory: projectId,
-            worktreePath: worktreePath,
-          );
-        } on PluginApiException catch (error) {
-          Log.w(
-            "archive: failed to remove workspace from backend for session ${sessionDto.sessionId}: "
-            "${error.statusCode} ${error.endpoint}",
-          );
-        }
       }
     }
   }

--- a/bridge/app/lib/src/bridge/services/session_archive_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_archive_service.dart
@@ -21,15 +21,18 @@ class SessionNotFoundException implements Exception {}
 class SessionInitializationException implements Exception {}
 
 class SessionArchiveService {
+  final BridgePlugin _plugin;
   final WorktreeService _worktreeService;
   final SessionRepository _sessionRepository;
   final SessionPersistenceService _sessionPersistenceService;
 
   SessionArchiveService({
+    required BridgePlugin plugin,
     required WorktreeService worktreeService,
     required SessionRepository sessionRepository,
     required SessionPersistenceService sessionPersistenceService,
-  }) : _worktreeService = worktreeService,
+  }) : _plugin = plugin,
+       _worktreeService = worktreeService,
        _sessionRepository = sessionRepository,
        _sessionPersistenceService = sessionPersistenceService;
 
@@ -142,6 +145,19 @@ class SessionArchiveService {
       );
       if (cleanupResult case CleanupRejected(:final rejection)) {
         throw SessionArchiveConflictException(rejection: rejection);
+      }
+      if (deleteWorktree) {
+        try {
+          await _plugin.deleteWorkspace(
+            projectDirectory: projectId,
+            worktreePath: worktreePath,
+          );
+        } on PluginApiException catch (error) {
+          Log.w(
+            "archive: failed to remove workspace from backend for session ${sessionDto.sessionId}: "
+            "${error.statusCode} ${error.endpoint}",
+          );
+        }
       }
     }
   }

--- a/bridge/app/lib/src/bridge/services/worktree_service.dart
+++ b/bridge/app/lib/src/bridge/services/worktree_service.dart
@@ -171,11 +171,8 @@ class WorktreeService {
     );
   }
 
-  Future<void> pruneWorktrees({required String projectPath}) async {
-    await _worktreeRepository.pruneWorktrees(projectPath: projectPath);
-  }
-
   Future<bool> removeWorktree({
+    required String projectId,
     required String projectPath,
     required String worktreePath,
     required bool force,
@@ -187,6 +184,7 @@ class WorktreeService {
       return false;
     }
     return _worktreeRepository.removeWorktree(
+      projectId: projectId,
       projectPath: projectPath,
       worktreePath: worktreePath,
       force: force,

--- a/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
@@ -9,11 +9,11 @@ import "../plugin_to_shared_mapping.dart";
 ///
 /// Handles all event type conversions and builds the projects summary event.
 class BridgeEventMapper {
-  final BridgePlugin _plugin;
+  final BridgePluginApi _plugin;
   final FailureReporter _failureReporter;
 
   BridgeEventMapper({
-    required BridgePlugin plugin,
+    required BridgePluginApi plugin,
     required FailureReporter failureReporter,
   }) : _plugin = plugin,
        _failureReporter = failureReporter;

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -413,6 +413,12 @@ class _FakeBridgePlugin implements BridgePluginApi {
   Future<void> archiveSession({required String sessionId}) async {}
 
   @override
+  Future<void> deleteWorkspace({
+    required String projectId,
+    required String worktreePath,
+  }) async {}
+
+  @override
   Future<List<PluginSession>> getChildSessions(String sessionId) async => [];
 
   @override
@@ -567,6 +573,12 @@ class _TrackingBridgePlugin implements BridgePluginApi {
 
   @override
   Future<void> archiveSession({required String sessionId}) async {}
+
+  @override
+  Future<void> deleteWorkspace({
+    required String projectId,
+    required String worktreePath,
+  }) async {}
 
   @override
   Future<List<PluginSession>> getChildSessions(String sessionId) async => [];

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -18,7 +18,7 @@ import "../helpers/test_database.dart";
 import "../helpers/test_helpers.dart";
 
 _DebugServerHarness _createDebugServerHarness({
-  required BridgePlugin plugin,
+  required BridgePluginApi plugin,
   required AppDatabase db,
   required int port,
 }) {
@@ -346,7 +346,7 @@ class _FakeTokenRefresher implements TokenRefresher {
 // Fake plugin implementations
 // ---------------------------------------------------------------------------
 
-class _FakeBridgePlugin implements BridgePlugin {
+class _FakeBridgePlugin implements BridgePluginApi {
   final _controller = StreamController<BridgeSseEvent>.broadcast();
 
   List<PluginProject> projectsResult = [];
@@ -495,7 +495,7 @@ class _FakeBridgePlugin implements BridgePlugin {
 }
 
 /// Plugin that tracks subscribe/unsubscribe counts via a wrapping stream.
-class _TrackingBridgePlugin implements BridgePlugin {
+class _TrackingBridgePlugin implements BridgePluginApi {
   final _eventController = StreamController<BridgeSseEvent>.broadcast();
   int subscribeCount = 0;
   int unsubscribeCount = 0;

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -986,7 +986,7 @@ class _AbortEventPlugin extends _EventPlugin {
   }
 }
 
-class _SummaryPlugin implements BridgePlugin {
+class _SummaryPlugin implements BridgePluginApi {
   final void Function() onSubscribe;
   final StreamController<BridgeSseEvent> _controller = StreamController<BridgeSseEvent>.broadcast();
 
@@ -1139,7 +1139,7 @@ class _SummaryPlugin implements BridgePlugin {
   Future<void> close() => _controller.close();
 }
 
-class _NoopPlugin implements BridgePlugin {
+class _NoopPlugin implements BridgePluginApi {
   final StreamController<BridgeSseEvent> _controller = StreamController<BridgeSseEvent>.broadcast();
 
   @override

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -76,6 +76,7 @@ void main() {
           processRunner: FakeProcessRunner(),
           gitPathExists: ({required String gitPath}) => true,
         ),
+        plugin: plugin,
       ),
     );
     final relayClient = RelayClient(
@@ -208,6 +209,7 @@ void main() {
           processRunner: FakeProcessRunner(),
           gitPathExists: ({required String gitPath}) => true,
         ),
+        plugin: plugin,
       ),
     );
 
@@ -321,6 +323,7 @@ void main() {
           processRunner: FakeProcessRunner(),
           gitPathExists: ({required String gitPath}) => true,
         ),
+        plugin: plugin,
       ),
     );
     final relayClient = RelayClient(
@@ -472,6 +475,7 @@ void main() {
           processRunner: FakeProcessRunner(),
           gitPathExists: ({required String gitPath}) => true,
         ),
+        plugin: plugin,
       ),
     );
     final relayClient = RelayClient(
@@ -566,6 +570,7 @@ void main() {
           processRunner: FakeProcessRunner(),
           gitPathExists: ({required String gitPath}) => true,
         ),
+        plugin: plugin,
       ),
     );
     final relayClient = RelayClient(
@@ -685,6 +690,7 @@ void main() {
           processRunner: FakeProcessRunner(),
           gitPathExists: ({required String gitPath}) => true,
         ),
+        plugin: plugin,
       ),
     );
     final relayClient = RelayClient(
@@ -1134,6 +1140,12 @@ class _SummaryPlugin implements BridgePluginApi {
   Future<void> archiveSession({required String sessionId}) async {}
 
   @override
+  Future<void> deleteWorkspace({
+    required String projectId,
+    required String worktreePath,
+  }) async {}
+
+  @override
   Future<void> dispose() async {}
 
   Future<void> close() => _controller.close();
@@ -1267,6 +1279,12 @@ class _NoopPlugin implements BridgePluginApi {
 
   @override
   Future<void> archiveSession({required String sessionId}) async {}
+
+  @override
+  Future<void> deleteWorkspace({
+    required String projectId,
+    required String worktreePath,
+  }) async {}
 
   @override
   Future<void> dispose() async {}

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -84,21 +84,22 @@ void main() {
           db: database,
         ),
         worktreeService: WorktreeService(
-          worktreeRepository: WorktreeRepository(
-            projectsDao: database.projectsDao,
-            sessionDao: database.sessionDao,
-            gitApi: GitCliApi(
-              processRunner: FakeProcessRunner((
-                String executable,
-                List<String> arguments, {
-                String? workingDirectory,
-                Duration timeout = const Duration(seconds: 15),
-              }) async {
-                return ProcessResult(0, 127, "", "command not found");
-              }),
-              gitPathExists: ({required String gitPath}) => true,
-            ),
+        worktreeRepository: WorktreeRepository(
+          projectsDao: database.projectsDao,
+          sessionDao: database.sessionDao,
+          gitApi: GitCliApi(
+            processRunner: FakeProcessRunner((
+              String executable,
+              List<String> arguments, {
+              String? workingDirectory,
+              Duration timeout = const Duration(seconds: 15),
+            }) async {
+              return ProcessResult(0, 127, "", "command not found");
+            }),
+            gitPathExists: ({required String gitPath}) => true,
           ),
+          plugin: plugin,
+        ),
         ),
         sessionEventEnrichmentService: SessionEventEnrichmentService(
           sessionRepository: sessionRepository,
@@ -229,6 +230,7 @@ class _TestHarness {
           }),
           gitPathExists: ({required String gitPath}) => true,
         ),
+        plugin: plugin,
       ),
     );
     final sessionEventEnrichmentService = SessionEventEnrichmentService(
@@ -422,6 +424,12 @@ class _ThrowingSummaryPlugin implements BridgePluginApi {
 
   @override
   Future<void> archiveSession({required String sessionId}) async {}
+
+  @override
+  Future<void> deleteWorkspace({
+    required String projectId,
+    required String worktreePath,
+  }) async {}
 
   @override
   Future<List<PluginSession>> getChildSessions(String sessionId) async => [];

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -344,7 +344,7 @@ _TestPushSubsystem _createPushSubsystem() {
   );
 }
 
-class _ThrowingSummaryPlugin implements BridgePlugin {
+class _ThrowingSummaryPlugin implements BridgePluginApi {
   final _controller = StreamController<BridgeSseEvent>.broadcast();
 
   int subscribeCount = 0;

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -171,6 +171,12 @@ class _FakeBridgePlugin implements BridgePluginApi {
   Future<void> archiveSession({required String sessionId}) => throw UnimplementedError();
 
   @override
+  Future<void> deleteWorkspace({
+    required String projectId,
+    required String worktreePath,
+  }) => throw UnimplementedError();
+
+  @override
   Future<List<PluginSession>> getChildSessions(String sessionId) => throw UnimplementedError();
 
   @override

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -124,9 +124,9 @@ void main() {
   });
 }
 
-/// Minimal [BridgePlugin] fake that only implements the surface touched by
+/// Minimal [BridgePluginApi] fake that only implements the surface touched by
 /// [ProjectRepository]. Every other member throws so accidental use is loud.
-class _FakeBridgePlugin implements BridgePlugin {
+class _FakeBridgePlugin implements BridgePluginApi {
   List<PluginProject> projectsResult = const [];
   Object? getProjectsError;
   PluginProject projectResult = const PluginProject(id: "project-id");

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -428,5 +428,11 @@ class _FakeBridgePlugin implements BridgePluginApi {
   }
 
   @override
+  Future<void> deleteWorkspace({
+    required String projectId,
+    required String worktreePath,
+  }) async {}
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -350,7 +350,7 @@ void main() {
   });
 }
 
-class _FakeBridgePlugin implements BridgePlugin {
+class _FakeBridgePlugin implements BridgePluginApi {
   List<PluginProject> projectsResult = const [];
   List<PluginSession> sessionsResult = const [];
   Map<String, List<PluginSession>> sessionsByWorktree = const {};

--- a/bridge/app/test/bridge/repositories/worktree_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/worktree_repository_test.dart
@@ -25,21 +25,21 @@ void main() {
       await db.close();
     });
 
-    WorktreeRepository _repository() => WorktreeRepository(
-          projectsDao: db.projectsDao,
-          sessionDao: db.sessionDao,
-          gitApi: GitCliApi(
-            processRunner: processRunner,
-            gitPathExists: ({required String gitPath}) => true,
-          ),
-          plugin: plugin,
-        );
+    WorktreeRepository repository() => WorktreeRepository(
+      projectsDao: db.projectsDao,
+      sessionDao: db.sessionDao,
+      gitApi: GitCliApi(
+        processRunner: processRunner,
+        gitPathExists: ({required String gitPath}) => true,
+      ),
+      plugin: plugin,
+    );
 
     test("calls plugin.deleteWorkspace when git removal succeeds", () async {
       processRunner.enqueue(result: _ok()); // prune
       processRunner.enqueue(result: _ok()); // remove
 
-      final repo = _repository();
+      final repo = repository();
       await repo.removeWorktree(
         projectId: "/repo",
         projectPath: "/repo",
@@ -56,7 +56,7 @@ void main() {
       processRunner.enqueue(result: _ok()); // prune
       processRunner.enqueue(result: _error("worktree not found")); // remove fails
 
-      final repo = _repository();
+      final repo = repository();
       await repo.removeWorktree(
         projectId: "/repo",
         projectPath: "/repo",
@@ -72,7 +72,7 @@ void main() {
       processRunner.enqueue(result: _ok()); // remove
       plugin.throwOnDeleteWorkspace = true;
 
-      final repo = _repository();
+      final repo = repository();
       // Should not throw
       await repo.removeWorktree(
         projectId: "/repo",
@@ -110,7 +110,7 @@ class _FakeProcessRunner implements ProcessRunner {
     );
 
     if (_queue.isEmpty) {
-      throw StateError("No ProcessResult queued for: \$executable \$arguments");
+      throw StateError("No ProcessResult queued for: $executable $arguments");
     }
 
     return _queue.removeAt(0);

--- a/bridge/app/test/bridge/repositories/worktree_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/worktree_repository_test.dart
@@ -1,0 +1,158 @@
+import "dart:io";
+
+import "package:sesori_bridge/src/bridge/api/git_cli_api.dart";
+import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
+import "package:sesori_bridge/src/bridge/persistence/database.dart";
+import "package:sesori_bridge/src/bridge/repositories/worktree_repository.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+import "../../helpers/test_database.dart";
+
+void main() {
+  group("WorktreeRepository.removeWorktree", () {
+    late AppDatabase db;
+    late _FakeProcessRunner processRunner;
+    late _FakeBridgePlugin plugin;
+
+    setUp(() {
+      db = createTestDatabase();
+      processRunner = _FakeProcessRunner();
+      plugin = _FakeBridgePlugin();
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    WorktreeRepository _repository() => WorktreeRepository(
+          projectsDao: db.projectsDao,
+          sessionDao: db.sessionDao,
+          gitApi: GitCliApi(
+            processRunner: processRunner,
+            gitPathExists: ({required String gitPath}) => true,
+          ),
+          plugin: plugin,
+        );
+
+    test("calls plugin.deleteWorkspace when git removal succeeds", () async {
+      processRunner.enqueue(result: _ok()); // prune
+      processRunner.enqueue(result: _ok()); // remove
+
+      final repo = _repository();
+      await repo.removeWorktree(
+        projectId: "/repo",
+        projectPath: "/repo",
+        worktreePath: "/repo/.worktrees/session-001",
+        force: false,
+      );
+
+      expect(plugin.deleteWorkspaceCallCount, equals(1));
+      expect(plugin.lastDeleteWorkspaceProjectId, equals("/repo"));
+      expect(plugin.lastDeleteWorkspaceWorktreePath, equals("/repo/.worktrees/session-001"));
+    });
+
+    test("does not call plugin.deleteWorkspace when git removal fails", () async {
+      processRunner.enqueue(result: _ok()); // prune
+      processRunner.enqueue(result: _error("worktree not found")); // remove fails
+
+      final repo = _repository();
+      await repo.removeWorktree(
+        projectId: "/repo",
+        projectPath: "/repo",
+        worktreePath: "/repo/.worktrees/session-001",
+        force: false,
+      );
+
+      expect(plugin.deleteWorkspaceCallCount, equals(0));
+    });
+
+    test("does not propagate plugin.deleteWorkspace errors", () async {
+      processRunner.enqueue(result: _ok()); // prune
+      processRunner.enqueue(result: _ok()); // remove
+      plugin.throwOnDeleteWorkspace = true;
+
+      final repo = _repository();
+      // Should not throw
+      await repo.removeWorktree(
+        projectId: "/repo",
+        projectPath: "/repo",
+        worktreePath: "/repo/.worktrees/session-001",
+        force: false,
+      );
+
+      expect(plugin.deleteWorkspaceCallCount, equals(1));
+    });
+  });
+}
+
+class _FakeProcessRunner implements ProcessRunner {
+  final List<ProcessResult> _queue = [];
+  final List<_Invocation> invocations = [];
+
+  void enqueue({required ProcessResult result}) {
+    _queue.add(result);
+  }
+
+  @override
+  Future<ProcessResult> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Duration timeout = const Duration(seconds: 15),
+  }) async {
+    invocations.add(
+      _Invocation(
+        command: executable,
+        arguments: List<String>.from(arguments),
+        workingDirectory: workingDirectory,
+      ),
+    );
+
+    if (_queue.isEmpty) {
+      throw StateError("No ProcessResult queued for: \$executable \$arguments");
+    }
+
+    return _queue.removeAt(0);
+  }
+}
+
+class _Invocation {
+  final String command;
+  final List<String> arguments;
+  final String? workingDirectory;
+
+  _Invocation({required this.command, required this.arguments, required this.workingDirectory});
+}
+
+class _FakeBridgePlugin implements BridgePluginApi {
+  int deleteWorkspaceCallCount = 0;
+  String? lastDeleteWorkspaceProjectId;
+  String? lastDeleteWorkspaceWorktreePath;
+  bool throwOnDeleteWorkspace = false;
+
+  @override
+  String get id => "fake";
+
+  @override
+  Stream<BridgeSseEvent> get events => const Stream<BridgeSseEvent>.empty();
+
+  @override
+  Future<void> deleteWorkspace({
+    required String projectId,
+    required String worktreePath,
+  }) async {
+    deleteWorkspaceCallCount++;
+    lastDeleteWorkspaceProjectId = projectId;
+    lastDeleteWorkspaceWorktreePath = worktreePath;
+    if (throwOnDeleteWorkspace) {
+      throw Exception("OpenCode unavailable");
+    }
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+ProcessResult _ok() => ProcessResult(0, 0, "", "");
+ProcessResult _error(String stderr) => ProcessResult(0, 1, "", stderr);

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -1008,6 +1008,7 @@ class _FakeWorktreeService extends WorktreeService {
             processRunner: _NoopProcessRunner(),
             gitPathExists: ({required String gitPath}) => true,
           ),
+          plugin: _FakeBridgePlugin(),
         ),
       );
 
@@ -1097,4 +1098,12 @@ class _OrderCheckingCommandPlugin extends FakeBridgePlugin {
       model: model,
     );
   }
+}
+
+class _FakeBridgePlugin extends FakeBridgePlugin {
+  @override
+  Future<void> deleteWorkspace({
+    required String projectId,
+    required String worktreePath,
+  }) async {}
 }

--- a/bridge/app/test/bridge/routing/delete_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/delete_session_handler_test.dart
@@ -415,6 +415,7 @@ class _FakeWorktreeService extends WorktreeService {
             processRunner: _NoopProcessRunner(),
             gitPathExists: ({required String gitPath}) => true,
           ),
+          plugin: _FakeBridgePlugin(),
         ),
       );
 
@@ -432,6 +433,7 @@ class _FakeWorktreeService extends WorktreeService {
 
   @override
   Future<bool> removeWorktree({
+    required String projectId,
     required String projectPath,
     required String worktreePath,
     required bool force,
@@ -457,6 +459,14 @@ class _FakeWorktreeService extends WorktreeService {
     lastDeleteBranchForce = force;
     return deleteBranchResult;
   }
+}
+
+class _FakeBridgePlugin extends FakeBridgePlugin {
+  @override
+  Future<void> deleteWorkspace({
+    required String projectId,
+    required String worktreePath,
+  }) async {}
 }
 
 class _NoopProcessRunner implements ProcessRunner {

--- a/bridge/app/test/bridge/routing/request_router_test.dart
+++ b/bridge/app/test/bridge/routing/request_router_test.dart
@@ -62,6 +62,7 @@ void main() {
             processRunner: FakeProcessRunner(),
             gitPathExists: ({required String gitPath}) => true,
           ),
+          plugin: plugin,
         ),
       );
       final sessionDiffsHandler = GetSessionDiffsHandler(
@@ -375,6 +376,7 @@ void main() {
             processRunner: FakeProcessRunner(),
             gitPathExists: ({required String gitPath}) => true,
           ),
+          plugin: plugin,
         ),
       );
       final sessionDiffsHandler = GetSessionDiffsHandler(

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -80,6 +80,8 @@ class FakeBridgePlugin implements BridgePluginApi {
   String? lastRenameProjectName;
   String? lastDeleteSessionId;
   String? lastArchiveSessionId;
+  String? lastDeleteWorkspaceProjectId;
+  String? lastDeleteWorkspaceWorktreePath;
   String? lastGetChildSessionsSessionId;
   String? lastSendPromptSessionId;
   List<PluginPromptPart>? lastSendPromptParts;
@@ -230,6 +232,15 @@ class FakeBridgePlugin implements BridgePluginApi {
     if (archiveSessionCompleter case final completer?) {
       await completer.future;
     }
+  }
+
+  @override
+  Future<void> deleteWorkspace({
+    required String projectId,
+    required String worktreePath,
+  }) async {
+    lastDeleteWorkspaceProjectId = projectId;
+    lastDeleteWorkspaceWorktreePath = worktreePath;
   }
 
   @override

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -37,8 +37,8 @@ RelayRequest makeRequest(
         )
         as RelayRequest;
 
-/// Hand-written fake [BridgePlugin] used across routing handler tests.
-class FakeBridgePlugin implements BridgePlugin {
+/// Hand-written fake [BridgePluginApi] used across routing handler tests.
+class FakeBridgePlugin implements BridgePluginApi {
   final _controller = StreamController<BridgeSseEvent>.broadcast();
 
   // ── Configurable return values ───────────────────────────────────────────

--- a/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
+++ b/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
@@ -1043,6 +1043,7 @@ class _FakeWorktreeService extends WorktreeService {
             processRunner: _NoopProcessRunner(),
             gitPathExists: ({required String gitPath}) => true,
           ),
+          plugin: _FakeBridgePlugin(),
         ),
       );
 
@@ -1059,6 +1060,7 @@ class _FakeWorktreeService extends WorktreeService {
 
   @override
   Future<bool> removeWorktree({
+    required String projectId,
     required String projectPath,
     required String worktreePath,
     required bool force,
@@ -1106,6 +1108,123 @@ class _FakeWorktreeService extends WorktreeService {
   }) async {
     return resolveBaseBranchAndCommitResult;
   }
+}
+
+class _FakeBridgePlugin implements BridgePluginApi {
+  @override
+  String get id => "fake";
+
+  @override
+  Stream<BridgeSseEvent> get events => const Stream<BridgeSseEvent>.empty();
+
+  @override
+  Future<void> deleteWorkspace({
+    required String projectId,
+    required String worktreePath,
+  }) async {}
+
+  @override
+  Future<List<PluginProject>> getProjects() async => [];
+
+  @override
+  Future<List<PluginSession>> getSessions(String worktree, {int? start, int? limit}) async => [];
+
+  @override
+  Future<List<PluginCommand>> getCommands({required String? projectId}) async => [];
+
+  @override
+  Future<PluginSession> createSession({
+    required String directory,
+    required String? parentSessionId,
+    required List<PluginPromptPart> parts,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async => throw UnimplementedError();
+
+  @override
+  Future<PluginSession> renameSession({required String sessionId, required String title}) async => throw UnimplementedError();
+
+  @override
+  Future<PluginProject> renameProject({required String projectId, required String name}) async => throw UnimplementedError();
+
+  @override
+  Future<void> deleteSession(String sessionId) async {}
+
+  @override
+  Future<void> archiveSession({required String sessionId}) async {}
+
+  @override
+  Future<List<PluginSession>> getChildSessions(String sessionId) async => [];
+
+  @override
+  Future<Map<String, PluginSessionStatus>> getSessionStatuses() async => {};
+
+  @override
+  Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId) async => [];
+
+  @override
+  Future<void> sendPrompt({
+    required String sessionId,
+    required List<PluginPromptPart> parts,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async {}
+
+  @override
+  Future<void> sendCommand({
+    required String sessionId,
+    required String command,
+    required String arguments,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async {}
+
+  @override
+  Future<void> abortSession({required String sessionId}) async {}
+
+  @override
+  Future<List<PluginAgent>> getAgents() async => [];
+
+  @override
+  Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async => [];
+
+  @override
+  Future<List<PluginPendingQuestion>> getProjectQuestions({required String projectId}) async => [];
+
+  @override
+  Future<void> replyToQuestion({
+    required String questionId,
+    required String sessionId,
+    required List<List<String>> answers,
+  }) async {}
+
+  @override
+  Future<void> rejectQuestion(String questionId) async {}
+
+  @override
+  Future<void> replyToPermission({
+    required String requestId,
+    required String sessionId,
+    required PluginPermissionReply reply,
+  }) async {}
+
+  @override
+  Future<PluginProject> getProject(String projectId) async => throw UnimplementedError();
+
+  @override
+  Future<bool> healthCheck() async => true;
+
+  @override
+  Future<PluginProvidersResult> getProviders({required String projectId}) async => const PluginProvidersResult(providers: []);
+
+  @override
+  List<PluginProjectActivitySummary> getActiveSessionsSummary() => [];
+
+  @override
+  Future<void> dispose() async {}
 }
 
 class _NoopProcessRunner implements ProcessRunner {

--- a/bridge/app/test/bridge/routing/worktree_cleanup_test.dart
+++ b/bridge/app/test/bridge/routing/worktree_cleanup_test.dart
@@ -8,6 +8,7 @@ import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/worktree_repository.dart";
 import "package:sesori_bridge/src/bridge/routing/worktree_cleanup.dart";
 import "package:sesori_bridge/src/bridge/services/worktree_service.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -293,6 +294,7 @@ class _FakeWorktreeService extends WorktreeService {
             processRunner: _NoopProcessRunner(),
             gitPathExists: ({required String gitPath}) => true,
           ),
+          plugin: _FakeBridgePlugin(),
         ),
       );
 
@@ -307,6 +309,7 @@ class _FakeWorktreeService extends WorktreeService {
 
   @override
   Future<bool> removeWorktree({
+    required String projectId,
     required String projectPath,
     required String worktreePath,
     required bool force,
@@ -327,6 +330,123 @@ class _FakeWorktreeService extends WorktreeService {
     lastDeleteBranchForce = force;
     return deleteBranchResult;
   }
+}
+
+class _FakeBridgePlugin implements BridgePluginApi {
+  @override
+  String get id => "fake";
+
+  @override
+  Stream<BridgeSseEvent> get events => const Stream<BridgeSseEvent>.empty();
+
+  @override
+  Future<void> deleteWorkspace({
+    required String projectId,
+    required String worktreePath,
+  }) async {}
+
+  @override
+  Future<List<PluginProject>> getProjects() async => [];
+
+  @override
+  Future<List<PluginSession>> getSessions(String worktree, {int? start, int? limit}) async => [];
+
+  @override
+  Future<List<PluginCommand>> getCommands({required String? projectId}) async => [];
+
+  @override
+  Future<PluginSession> createSession({
+    required String directory,
+    required String? parentSessionId,
+    required List<PluginPromptPart> parts,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async => throw UnimplementedError();
+
+  @override
+  Future<PluginSession> renameSession({required String sessionId, required String title}) async => throw UnimplementedError();
+
+  @override
+  Future<PluginProject> renameProject({required String projectId, required String name}) async => throw UnimplementedError();
+
+  @override
+  Future<void> deleteSession(String sessionId) async {}
+
+  @override
+  Future<void> archiveSession({required String sessionId}) async {}
+
+  @override
+  Future<List<PluginSession>> getChildSessions(String sessionId) async => [];
+
+  @override
+  Future<Map<String, PluginSessionStatus>> getSessionStatuses() async => {};
+
+  @override
+  Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId) async => [];
+
+  @override
+  Future<void> sendPrompt({
+    required String sessionId,
+    required List<PluginPromptPart> parts,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async {}
+
+  @override
+  Future<void> sendCommand({
+    required String sessionId,
+    required String command,
+    required String arguments,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async {}
+
+  @override
+  Future<void> abortSession({required String sessionId}) async {}
+
+  @override
+  Future<List<PluginAgent>> getAgents() async => [];
+
+  @override
+  Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async => [];
+
+  @override
+  Future<List<PluginPendingQuestion>> getProjectQuestions({required String projectId}) async => [];
+
+  @override
+  Future<void> replyToQuestion({
+    required String questionId,
+    required String sessionId,
+    required List<List<String>> answers,
+  }) async {}
+
+  @override
+  Future<void> rejectQuestion(String questionId) async {}
+
+  @override
+  Future<void> replyToPermission({
+    required String requestId,
+    required String sessionId,
+    required PluginPermissionReply reply,
+  }) async {}
+
+  @override
+  Future<PluginProject> getProject(String projectId) async => throw UnimplementedError();
+
+  @override
+  Future<bool> healthCheck() async => true;
+
+  @override
+  Future<PluginProvidersResult> getProviders({required String projectId}) async => const PluginProvidersResult(providers: []);
+
+  @override
+  List<PluginProjectActivitySummary> getActiveSessionsSummary() => [];
+
+  @override
+  Future<void> dispose() async {}
 }
 
 class _NoopProcessRunner implements ProcessRunner {

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -784,19 +784,6 @@ void main() {
       await db.close();
     });
 
-    // pruneWorktrees
-
-    test("pruneWorktrees: calls git worktree prune with projectPath", () async {
-      processRunner.enqueue(result: _ok());
-
-      await service.pruneWorktrees(projectPath: _projectId);
-
-      expect(processRunner.invocations, hasLength(1));
-      final inv = processRunner.invocations.first;
-      expect(inv.arguments, equals(["worktree", "prune"]));
-      expect(inv.workingDirectory, equals(_projectId));
-    });
-
     // removeWorktree (force: false)
 
     test("removeWorktree(force: false): calls prune then remove without --force", () async {

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -7,6 +7,7 @@ import "package:sesori_bridge/src/bridge/persistence/daos/session_dao.dart";
 import "package:sesori_bridge/src/bridge/persistence/database.dart";
 import "package:sesori_bridge/src/bridge/repositories/worktree_repository.dart";
 import "package:sesori_bridge/src/bridge/services/worktree_service.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
 import "../helpers/test_database.dart";
@@ -28,6 +29,7 @@ void main() {
       sessionDao = db.sessionDao;
       processRunner = _FakeProcessRunner();
       gitDirectoryExists = true;
+      final fakePlugin = _FakeBridgePluginApi();
       service = WorktreeService(
         worktreeRepository: WorktreeRepository(
           projectsDao: projectsDao,
@@ -36,6 +38,7 @@ void main() {
             processRunner: processRunner,
             gitPathExists: ({required String gitPath}) => gitDirectoryExists,
           ),
+          plugin: fakePlugin,
         ),
       );
     });
@@ -659,6 +662,7 @@ void main() {
             processRunner: processRunner,
             gitPathExists: ({required String gitPath}) => true,
           ),
+          plugin: _FakeBridgePluginApi(),
         ),
       );
       tempDir = await Directory.systemTemp.createTemp("worktree_safety_test_");
@@ -776,6 +780,7 @@ void main() {
             processRunner: processRunner,
             gitPathExists: ({required String gitPath}) => true,
           ),
+          plugin: _FakeBridgePluginApi(),
         ),
       );
     });
@@ -793,6 +798,7 @@ void main() {
       processRunner.enqueue(result: _ok());
 
       final result = await service.removeWorktree(
+        projectId: _projectId,
         projectPath: _projectId,
         worktreePath: "$_projectId/.worktrees/session-001",
         force: false,
@@ -819,6 +825,7 @@ void main() {
       processRunner.enqueue(result: _ok());
 
       final result = await service.removeWorktree(
+        projectId: _projectId,
         projectPath: _projectId,
         worktreePath: "$_projectId/.worktrees/session-001",
         force: true,
@@ -843,6 +850,7 @@ void main() {
       processRunner.enqueue(result: _fail(exitCode: 128, stderr: "fatal: not a worktree"));
 
       final result = await service.removeWorktree(
+        projectId: _projectId,
         projectPath: _projectId,
         worktreePath: "$_projectId/.worktrees/session-001",
         force: false,
@@ -995,4 +1003,132 @@ class _FakeProcessRunner implements ProcessRunner {
 
     return _queue.removeAt(0);
   }
+}
+
+class _FakeBridgePluginApi implements BridgePluginApi {
+  @override
+  String get id => "fake";
+
+  @override
+  Stream<BridgeSseEvent> get events => const Stream<BridgeSseEvent>.empty();
+
+  @override
+  Future<void> deleteWorkspace({
+    required String projectId,
+    required String worktreePath,
+  }) async {}
+
+  @override
+  Future<List<PluginProject>> getProjects() async => [];
+
+  @override
+  Future<List<PluginSession>> getSessions(String worktree, {int? start, int? limit}) async => [];
+
+  @override
+  Future<List<PluginCommand>> getCommands({required String? projectId}) async => [];
+
+  @override
+  Future<PluginSession> createSession({
+    required String directory,
+    required String? parentSessionId,
+    required List<PluginPromptPart> parts,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async => throw UnimplementedError();
+
+  @override
+  Future<PluginSession> renameSession({
+    required String sessionId,
+    required String title,
+  }) async => throw UnimplementedError();
+
+  @override
+  Future<PluginProject> renameProject({
+    required String projectId,
+    required String name,
+  }) async => throw UnimplementedError();
+
+  @override
+  Future<void> deleteSession(String sessionId) async {}
+
+  @override
+  Future<void> archiveSession({required String sessionId}) async {}
+
+  @override
+  Future<List<PluginSession>> getChildSessions(String sessionId) async => [];
+
+  @override
+  Future<Map<String, PluginSessionStatus>> getSessionStatuses() async => {};
+
+  @override
+  Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId) async => [];
+
+  @override
+  Future<void> sendPrompt({
+    required String sessionId,
+    required List<PluginPromptPart> parts,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async {}
+
+  @override
+  Future<void> sendCommand({
+    required String sessionId,
+    required String command,
+    required String arguments,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async {}
+
+  @override
+  Future<void> abortSession({required String sessionId}) async {}
+
+  @override
+  Future<List<PluginAgent>> getAgents() async => [];
+
+  @override
+  Future<List<PluginPendingQuestion>> getPendingQuestions({
+    required String sessionId,
+  }) async => [];
+
+  @override
+  Future<List<PluginPendingQuestion>> getProjectQuestions({
+    required String projectId,
+  }) async => [];
+
+  @override
+  Future<void> replyToQuestion({
+    required String questionId,
+    required String sessionId,
+    required List<List<String>> answers,
+  }) async {}
+
+  @override
+  Future<void> rejectQuestion(String questionId) async {}
+
+  @override
+  Future<void> replyToPermission({
+    required String requestId,
+    required String sessionId,
+    required PluginPermissionReply reply,
+  }) async {}
+
+  @override
+  Future<PluginProject> getProject(String projectId) async => throw UnimplementedError();
+
+  @override
+  Future<bool> healthCheck() async => true;
+
+  @override
+  Future<PluginProvidersResult> getProviders({required String projectId}) async =>
+      const PluginProvidersResult(providers: []);
+
+  @override
+  List<PluginProjectActivitySummary> getActiveSessionsSummary() => [];
+
+  @override
+  Future<void> dispose() async {}
 }

--- a/bridge/app/test/integration/pr_sync_fk_regression_test.dart
+++ b/bridge/app/test/integration/pr_sync_fk_regression_test.dart
@@ -278,6 +278,12 @@ class _FakeBridgePlugin implements BridgePluginApi {
   Future<void> archiveSession({required String sessionId}) => throw UnimplementedError();
 
   @override
+  Future<void> deleteWorkspace({
+    required String projectId,
+    required String worktreePath,
+  }) => throw UnimplementedError();
+
+  @override
   Future<List<PluginSession>> getChildSessions(String sessionId) => throw UnimplementedError();
 
   @override

--- a/bridge/app/test/integration/pr_sync_fk_regression_test.dart
+++ b/bridge/app/test/integration/pr_sync_fk_regression_test.dart
@@ -236,9 +236,9 @@ Session _session({
   pullRequest: null,
 );
 
-/// Minimal [BridgePlugin] fake that only implements [getProjects].
+/// Minimal [BridgePluginApi] fake that only implements [getProjects].
 /// Every other member throws [UnimplementedError] so accidental use is loud.
-class _FakeBridgePlugin implements BridgePlugin {
+class _FakeBridgePlugin implements BridgePluginApi {
   final List<PluginProject> _projects;
 
   _FakeBridgePlugin({required List<PluginProject> projects}) : _projects = projects;

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -58,6 +58,20 @@ abstract class BridgePlugin {
   /// Unarchive is not propagated to the backend; it only clears the local DB.
   Future<void> archiveSession({required String sessionId});
 
+  /// Delete a workspace (git worktree / sandbox) from the backend.
+  ///
+  /// This is best-effort — the caller should have already removed the worktree
+  /// from disk. If the workspace is already gone or the backend does not
+  /// recognize it, the call should succeed silently.
+  ///
+  /// [projectDirectory] is the project root worktree used to identify the
+  /// project in the backend.
+  /// [worktreePath] is the specific worktree directory to remove.
+  Future<void> deleteWorkspace({
+    required String projectDirectory,
+    required String worktreePath,
+  });
+
   Future<List<PluginSession>> getChildSessions(String sessionId);
 
   Future<Map<String, PluginSessionStatus>> getSessionStatuses();

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -12,7 +12,8 @@ import "models/plugin_session_status.dart";
 import "models/plugin_session_variant.dart";
 import "plugin_permission_reply.dart";
 
-abstract class BridgePlugin {
+// Note: as far as architecture goes, this MUST be treated as part of API layer
+abstract class BridgePluginApi {
   /// Unique plugin identifier (e.g., "opencode", "codex")
   String get id;
 
@@ -64,11 +65,9 @@ abstract class BridgePlugin {
   /// from disk. If the workspace is already gone or the backend does not
   /// recognize it, the call should succeed silently.
   ///
-  /// [projectDirectory] is the project root worktree used to identify the
-  /// project in the backend.
   /// [worktreePath] is the specific worktree directory to remove.
   Future<void> deleteWorkspace({
-    required String projectDirectory,
+    required String projectId,
     required String worktreePath,
   });
 

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -197,6 +197,27 @@ class OpenCodeApi {
     _ensureSuccess(response, "DELETE /session/$sessionId");
   }
 
+  /// Removes a worktree (workspace) from OpenCode.
+  ///
+  /// Sends `DELETE /experimental/worktree` with the worktree directory in the
+  /// body. The [directory] header must be the project root worktree so that
+  /// OpenCode knows which project the sandbox belongs to.
+  Future<void> removeWorktree({
+    required String directory,
+    required String worktreePath,
+  }) async {
+    final response = await _client.delete(
+      Uri.parse("$serverURL/experimental/worktree"),
+      headers: {
+        ..._authHeaders,
+        "content-type": "application/json",
+        _directoryOpenCodeHeader: directory,
+      },
+      body: jsonEncode({"directory": worktreePath}),
+    );
+    _ensureSuccess(response, "DELETE /experimental/worktree");
+  }
+
   Future<List<Session>> getChildren({
     required String sessionId,
     required String? directory,

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -26,7 +26,7 @@ String formatDroppedSseFrameLog({
   return "[opencode][sse][$category]$suffix $message";
 }
 
-class OpenCodePlugin implements BridgePlugin {
+class OpenCodePlugin implements BridgePluginApi {
   final OpenCodeService _service;
   final SseEventParser _parser;
   final BufferedUntilFirstListener<BridgeSseEvent> _eventBuffer;
@@ -409,12 +409,12 @@ class OpenCodePlugin implements BridgePlugin {
 
   @override
   Future<void> deleteWorkspace({
-    required String projectDirectory,
+    required String projectId,
     required String worktreePath,
   }) {
     return _call(
       () => _service.repository.api.removeWorktree(
-        directory: projectDirectory,
+        directory: projectId,
         worktreePath: worktreePath,
       ),
     );

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -408,6 +408,19 @@ class OpenCodePlugin implements BridgePlugin {
   }
 
   @override
+  Future<void> deleteWorkspace({
+    required String projectDirectory,
+    required String worktreePath,
+  }) {
+    return _call(
+      () => _service.repository.api.removeWorktree(
+        directory: projectDirectory,
+        worktreePath: worktreePath,
+      ),
+    );
+  }
+
+  @override
   Future<PluginProject> renameProject({required String projectId, required String name}) async {
     // CRITICAL: projectId is the worktree path (PluginProject.id = worktree, see project.dart:33)
     // Must resolve the real OpenCode project UUID before calling PATCH

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -1140,16 +1140,10 @@ class _FakeApi implements OpenCodeApi {
   Future<void> deleteSession({required String sessionId, required String? directory}) async {}
 
   @override
-  Future<List<Session>> getChildren({required String sessionId, required String? directory}) async => [];
-
-  @override
-  Future<List<GlobalSession>> listAllSessions({
-    required String? directory,
-    required bool roots,
-  }) async => [];
-
-  @override
-  Future<List<MessageWithParts>> getMessages({required String sessionId, required String? directory}) async => [];
+  Future<void> removeWorktree({
+    required String directory,
+    required String worktreePath,
+  }) async {}
 
   @override
   Future<void> sendPrompt({
@@ -1198,11 +1192,25 @@ class _FakeApi implements OpenCodeApi {
   Future<Project> getProject({required String directory}) async => throw UnimplementedError();
 
   @override
+  Future<List<Session>> getChildren({
+    required String sessionId,
+    required String? directory,
+  }) async => [];
+
+  @override
+  Future<List<MessageWithParts>> getMessages({
+    required String sessionId,
+    required String? directory,
+  }) async => [];
+
+  @override
+  Future<List<GlobalSession>> listAllSessions({
+    required String? directory,
+    required bool roots,
+  }) async => [];
+
+  @override
   Future<Map<String, SessionStatus>> getSessionStatuses({required String? directory}) async {
-    if (directory != null && _throwForDirectories.contains(directory)) {
-      throw Exception("Fake error for directory: $directory");
-    }
-    if (directory == null) return _statuses;
     final sessionIdsInDirectory = _sessions
         .where((s) => s.directory == directory || s.directory.startsWith("$directory/"))
         .map((s) => s.id)

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -921,7 +921,6 @@ void main() {
           statuses: {
             "session-b": const SessionStatus.busy(),
           },
-          throwForDirectories: {"/repo-a"},
         );
 
         final active = tracker.getActiveStatuses();
@@ -1057,14 +1056,12 @@ OpenCodeRepository _fakeRepository({
   List<Project>? projects,
   List<Session>? sessions,
   Map<String, SessionStatus>? statuses,
-  Set<String>? throwForDirectories,
 }) {
   return OpenCodeRepository(
     _FakeApi(
       projects: projects,
       sessions: sessions,
       statuses: statuses,
-      throwForDirectories: throwForDirectories,
     ),
   );
 }
@@ -1073,14 +1070,12 @@ Future<ActiveSessionTracker> _coldStartedTracker({
   required List<Project> projects,
   List<Session> sessions = const [],
   Map<String, SessionStatus> statuses = const {},
-  Set<String> throwForDirectories = const {},
 }) async {
   final tracker = ActiveSessionTracker(
     _fakeRepository(
       projects: projects,
       sessions: sessions,
       statuses: statuses,
-      throwForDirectories: throwForDirectories,
     ),
   );
   await tracker.coldStart();
@@ -1091,17 +1086,14 @@ class _FakeApi implements OpenCodeApi {
   final List<Project> _projects;
   final List<Session> _sessions;
   final Map<String, SessionStatus> _statuses;
-  final Set<String> _throwForDirectories;
 
   _FakeApi({
     List<Project>? projects,
     List<Session>? sessions,
     Map<String, SessionStatus>? statuses,
-    Set<String>? throwForDirectories,
   }) : _projects = projects ?? [],
        _sessions = sessions ?? [],
-       _statuses = statuses ?? {},
-       _throwForDirectories = throwForDirectories ?? {};
+       _statuses = statuses ?? {};
 
   @override
   String get serverURL => "http://fake";

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -596,16 +596,10 @@ class _FakeApi implements OpenCodeApi {
   Future<void> deleteSession({required String sessionId, required String? directory}) async {}
 
   @override
-  Future<List<Session>> getChildren({required String sessionId, required String? directory}) async => [];
-
-  @override
-  Future<List<GlobalSession>> listAllSessions({
-    required String? directory,
-    required bool roots,
-  }) async => _globalSessions;
-
-  @override
-  Future<List<MessageWithParts>> getMessages({required String sessionId, required String? directory}) async => [];
+  Future<void> removeWorktree({
+    required String directory,
+    required String worktreePath,
+  }) async {}
 
   @override
   Future<void> sendPrompt({
@@ -661,6 +655,24 @@ class _FakeApi implements OpenCodeApi {
 
   @override
   Future<Project> getProject({required String directory}) async => throw UnimplementedError();
+
+  @override
+  Future<List<Session>> getChildren({
+    required String sessionId,
+    required String? directory,
+  }) async => [];
+
+  @override
+  Future<List<MessageWithParts>> getMessages({
+    required String sessionId,
+    required String? directory,
+  }) async => [];
+
+  @override
+  Future<List<GlobalSession>> listAllSessions({
+    required String? directory,
+    required bool roots,
+  }) async => _globalSessions;
 
   @override
   Future<Map<String, SessionStatus>> getSessionStatuses({required String? directory}) async => {};

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -550,14 +550,22 @@ class FakeOpenCodeApi implements OpenCodeApi {
   }) async => throw UnimplementedError();
 
   @override
+  Future<List<Session>> getChildren({
+    required String sessionId,
+    required String? directory,
+  }) async => [];
+
+  @override
+  Future<Map<String, SessionStatus>> getSessionStatuses({required String? directory}) async => {};
+
+  @override
   Future<void> deleteSession({required String sessionId, required String? directory}) async {}
 
   @override
-  Future<List<Session>> getChildren({required String sessionId, required String? directory}) async => [];
-
-  @override
-  Future<Map<String, SessionStatus>> getSessionStatuses({required String? directory}) async =>
-      <String, SessionStatus>{};
+  Future<void> removeWorktree({
+    required String directory,
+    required String worktreePath,
+  }) async {}
 
   @override
   Future<void> sendPrompt({

--- a/shared/no_slop_linter/README.md
+++ b/shared/no_slop_linter/README.md
@@ -4,11 +4,11 @@ A custom Dart linter to prevent sloppy code patterns. Built with `analysis_serve
 
 ## Available Rules
 
-| Rule | Description | Severity |
-|------|-------------|----------|
-| `avoid_bang_operator` | Prevents usage of the null assertion operator (`!`) | WARNING |
-| `avoid_dynamic_return_type` | Prevents implicit or `dynamic` return types on functions | WARNING |
-| `avoid_implicit_tostring` | Prevents implicit `toString()` in string interpolation (except String, int, double, bool) | WARNING |
+| Rule                        | Description                                                                               | Severity |
+| --------------------------- | ----------------------------------------------------------------------------------------- | -------- |
+| `avoid_bang_operator`       | Prevents usage of the null assertion operator (`!`)                                       | WARNING  |
+| `avoid_dynamic_return_type` | Prevents implicit or `dynamic` return types on functions                                  | WARNING  |
+| `avoid_implicit_tostring`   | Prevents implicit `toString()` in string interpolation (except String, int, double, bool) | WARNING  |
 
 > **Note:** All rules use WARNING severity to allow incremental cleanup. CI is configured to fail if any changed files contain warnings, encouraging cleanup of files you touch.
 
@@ -21,7 +21,7 @@ In your `analysis_options.yaml`:
 ```yaml
 plugins:
   no_slop_linter:
-    path: modules/no_slop_linter  # adjust path as needed
+    path: modules/no_slop_linter # adjust path as needed
 ```
 
 ### 2. Install Plugin Dependencies
@@ -74,7 +74,7 @@ jobs:
         run: flutter pub get
 
       - name: Run analysis
-        run: flutter analyze --no-fatal-infos
+        run: flutter analyze --fatal-infos
 ```
 
 ## Configuration
@@ -105,11 +105,13 @@ final value = nullableValue!;
 The bang operator (`!`) asserts a nullable value is non-null. If wrong, it throws a runtime `TypeError`.
 
 **Problems:**
+
 - Runtime exceptions instead of compile-time safety
 - Hides potential null-related bugs
 - Makes code harder to reason about
 
 **Better alternatives:**
+
 ```dart
 // Instead of:
 final name = user.name!;
@@ -133,6 +135,7 @@ if (user.name case final name?) {
 Functions without explicit return types default to `dynamic`, which bypasses type checking and can hide bugs.
 
 **Examples that trigger this rule:**
+
 ```dart
 foo() { }              // ERROR: implicit return type
 dynamic bar() => 1;    // ERROR: explicit dynamic
@@ -140,6 +143,7 @@ get value => _value;   // ERROR: getter without return type
 ```
 
 **Better alternatives:**
+
 ```dart
 void foo() { }              // explicit void
 int bar() => 1;             // explicit int
@@ -152,6 +156,7 @@ Future<void> baz() async {} // explicit Future<void>
 When a non-String value is used in string interpolation, Dart implicitly calls `toString()` on it.
 
 **Allowed types** (predictable `toString()`):
+
 - `String`, `int`, `double`, `bool`
 
 **The real problem:** When a dependency update changes a type from `String` to a class, code using that value in string interpolation (e.g., as a map key) will still compile but silently break at runtime.
@@ -166,11 +171,13 @@ cache['user_$userId'] = data;  // worked fine
 ```
 
 **Other problems:**
+
 - Unexpected output if `toString()` is not properly overridden
 - Silent bugs that only manifest at runtime
 - Harder to spot in code reviews
 
 **Better alternatives:**
+
 ```dart
 // These are OK (allowed types):
 final count = 42;


### PR DESCRIPTION
## Problem

When Sesori deletes a session and its git worktree, OpenCode's web interface still shows the workspace because Sesori never tells OpenCode to remove it from its internal project sandbox registry.

OpenCode stores workspace information in `ProjectTable.sandboxes` (a JSON array of worktree directory paths). When Sesori deletes the worktree from disk without updating this registry, the path remains in the database and the UI continues to show it.

## Solution

This PR adds a `deleteWorkspace` method to the `BridgePlugin` interface and implements it for the OpenCode backend by calling `DELETE /experimental/worktree`.

### Changes

1. **`BridgePlugin` interface** (`sesori_plugin_interface`): Added `deleteWorkspace({required String projectDirectory, required String worktreePath})`

2. **`OpenCodeApi`** (`sesori_plugin_opencode`): Added `removeWorktree()` method that sends `DELETE /experimental/worktree` with:
   - `x-opencode-directory` header = project root
   - Body `{"directory": "<worktree-path>"}`

3. **`OpenCodePlugin`** (`sesori_plugin_opencode`): Implements `deleteWorkspace()` by delegating to `OpenCodeApi.removeWorktree()`

4. **`DeleteSessionHandler`** (`bridge/app`): Calls `_plugin.deleteWorkspace()` after successful worktree cleanup when `deleteWorktree=true`

5. **`SessionArchiveService`** (`bridge/app`): Calls `_plugin.deleteWorkspace()` after successful worktree cleanup when archiving with `deleteWorktree=true`

6. **Test fakes**: Updated fake `OpenCodeApi` implementations in test files to include the new method (plus some pre-existing missing methods)

### Behavior

- The `deleteWorkspace` call is **best-effort**. If it fails (e.g., workspace already gone, backend error), it logs a warning but does **not** block the session deletion flow.
- The call happens **after** the local worktree is removed from disk and **before** the session is deleted from OpenCode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tell OpenCode when a workspace is deleted and centralize the call in the worktree deletion flow so the UI stays in sync and ghost sandboxes don’t appear.

- New Features
  - Added deleteWorkspace to `BridgePluginApi` in `sesori_plugin_interface`.
  - Implemented `OpenCodeApi.removeWorktree()` calling DELETE `/experimental/worktree` (header `x-opencode-directory`, body `{"directory": "<worktree-path>"}`).
  - `OpenCodePlugin` delegates deleteWorkspace to the API; failures are logged and never block deletion.

- Refactors
  - Renamed `BridgePlugin` to `BridgePluginApi` across bridge and `sesori_plugin_opencode`; docs updated to place it in the API layer.
  - Moved the OpenCode deletion to `WorktreeRepository.removeWorktree()` after a successful git remove (prune included); repository now receives the plugin and only calls deleteWorkspace when git removal succeeds.
  - Updated cleanup flow to pass `projectId`; `WorktreeService.removeWorktree()` now requires `projectId` and no longer exposes a separate prune.
  - Tightened CI: run `dart analyze --fatal-infos` for bridge modules.
  - Added focused tests for the new flow (`WorktreeRepository`, cleanup/archival routes) and updated fakes to the `BridgePluginApi` surface.

<sup>Written for commit 186fa02c651816889e233a48e94115c12dd9c707. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

