### PR TITLE
chore(release): bridge v0.5.0

### DIFF
--- a/bridge/app/CHANGELOG.md
+++ b/bridge/app/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [v0.5.0] - 2026-04-27
+
+### Added
+- OS sleep prevention with configurable settings file (#131)
+- Session effort selection support across mobile and bridge (#125)
+- Inline chat error display in session detail (#126)
+- OpenCode notification when deleting workspace from Sesori (#134)
+- Improved wake lock lid-close behavior with laptop device-type warnings (#132)
+
+### Fixed
+- Pass `roots=true` to OpenCode `/session` API to prevent child sessions from crowding out root sessions (#135)
+- Model-aware variant recomputation in agent picker (#128)
+- Recognize `command.executed` SSE frames instead of dropping them (#124)
+
+### Changed
+- Updated Yaak API definitions
+
 ## [v0.4.1] - 2026-04-22
 
 ### Added

--- a/bridge/app/lib/src/version.dart
+++ b/bridge/app/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '0.4.1';
+const String appVersion = '0.5.0';

--- a/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-arm64",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS ARM64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.4.1",
+    "releaseTag": "bridge-v0.5.0",
     "releaseArtifact": "sesori-bridge-macos-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-darwin-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-x64",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS x64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.4.1",
+    "releaseTag": "bridge-v0.5.0",
     "releaseArtifact": "sesori-bridge-macos-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-arm64",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux ARM64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.4.1",
+    "releaseTag": "bridge-v0.5.0",
     "releaseArtifact": "sesori-bridge-linux-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-x64",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux x64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.4.1",
+    "releaseTag": "bridge-v0.5.0",
     "releaseArtifact": "sesori-bridge-linux-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-x64",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows x64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.4.1",
+    "releaseTag": "bridge-v0.5.0",
     "releaseArtifact": "sesori-bridge-windows-x64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge/package.json
+++ b/bridge/app/npm/sesori-bridge/package.json
@@ -1,21 +1,21 @@
 {
   "name": "@sesori/bridge",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Bootstrap launcher for the managed Sesori Bridge runtime",
   "bin": {
     "sesori-bridge": "bin/bridge.js"
   },
   "optionalDependencies": {
-    "@sesori/bridge-darwin-arm64": "0.4.1",
-    "@sesori/bridge-darwin-x64": "0.4.1",
-    "@sesori/bridge-linux-x64": "0.4.1",
-    "@sesori/bridge-linux-arm64": "0.4.1",
-    "@sesori/bridge-win32-x64": "0.4.1"
+    "@sesori/bridge-darwin-arm64": "0.5.0",
+    "@sesori/bridge-darwin-x64": "0.5.0",
+    "@sesori/bridge-linux-x64": "0.5.0",
+    "@sesori/bridge-linux-arm64": "0.5.0",
+    "@sesori/bridge-win32-x64": "0.5.0"
   },
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.4.1",
+    "releaseTag": "bridge-v0.5.0",
     "runtimeBundleSource": "github-release-assets"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sesori_bridge
 description: Dart implementation of the Sesori Bridge CLI for WebSocket communication.
-version: 0.4.1
+version: 0.5.0
 publish_to: none
 resolution: workspace
 


### PR DESCRIPTION
## Summary
- Bump bridge version to v0.5.0
- Update CHANGELOG.md with changes since v0.4.1

## Changes

### Added
- OS sleep prevention with configurable settings file (#131)
- Session effort selection support across mobile and bridge (#125)
- Inline chat error display in session detail (#126)
- OpenCode notification when deleting workspace from Sesori (#134)
- Improved wake lock lid-close behavior with laptop device-type warnings (#132)

### Fixed
- Pass `roots=true` to OpenCode `/session` API to prevent child sessions from crowding out root sessions (#135)
- Model-aware variant recomputation in agent picker (#128)
- Recognize `command.executed` SSE frames instead of dropping them (#124)

### Changed
- Updated Yaak API definitions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release Bridge v0.5.0 with OS sleep prevention, session effort selection, and stability fixes. Bumps `@sesori/bridge` and platform bootstrap packages to 0.5.0 and updates the changelog.

- **New Features**
  - OS sleep prevention, configurable via settings file.
  - Session effort selection across mobile and Bridge. Inline chat errors and workspace delete notification in OpenCode.
  - Better wake lock behavior with laptop lid-close warnings.

- **Bug Fixes**
  - Pass `roots=true` to OpenCode `/session` to keep root sessions visible.
  - Model-aware variant recomputation in agent picker and proper handling of `command.executed` SSE frames.

<sup>Written for commit 101110bc8c8032b83ddda45205838c5092c260d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

