### PR TITLE
fix(mobile): keep child sessions sorted newest-first after refresh and update

### DIFF
--- a/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -861,6 +861,114 @@ void main() {
     );
 
     blocTest<SessionDetailCubit, SessionDetailState>(
+      "silent refresh re-sorts children by updated descending",
+      build: () {
+        final oldChild = testSession(id: "child-old", parentID: sessionId, updatedAt: 1000);
+        final newChild = testSession(id: "child-new", parentID: sessionId, updatedAt: 3000);
+
+        // Initial load returns sorted newest-first.
+        when(
+          () => mockSessionService.getChildren(sessionId: sessionId),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(SessionListResponse(items: [newChild, oldChild])),
+        );
+
+        return SessionDetailCubit(
+          mockConnectionService,
+          loadService: loadService,
+          promptDispatcher: promptDispatcher,
+          permissionRepository: mockPermissionRepository,
+          sessionId: sessionId,
+          projectId: "project-1",
+          notificationCanceller: mockNotificationCanceller,
+          failureReporter: mockFailureReporter,
+        );
+      },
+      act: (cubit) async {
+        await _awaitLoaded(cubit);
+
+        // Silent refresh returns children in oldest-first API order.
+        final oldChild = testSession(id: "child-old", parentID: sessionId, updatedAt: 1000);
+        final newChild = testSession(id: "child-new", parentID: sessionId, updatedAt: 3000);
+        when(
+          () => mockSessionService.getChildren(sessionId: sessionId),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(SessionListResponse(items: [oldChild, newChild])),
+        );
+
+        globalEvents.add(SseEvent(data: SesoriSessionsUpdated(projectID: "project-1")));
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      },
+      expect: () => [
+        // Initial load: newest first.
+        isA<SessionDetailLoaded>().having(
+          (state) => state.children.map((c) => c.id).toList(),
+          "children ids (DESC)",
+          ["child-new", "child-old"],
+        ),
+        // Refresh in progress.
+        isA<SessionDetailLoaded>().having(
+          (state) => state.isRefreshing,
+          "isRefreshing",
+          isTrue,
+        ),
+        // After silent refresh: still newest first.
+        isA<SessionDetailLoaded>().having(
+          (state) => state.children.map((c) => c.id).toList(),
+          "children ids after refresh (DESC)",
+          ["child-new", "child-old"],
+        ),
+      ],
+    );
+
+    blocTest<SessionDetailCubit, SessionDetailState>(
+      "session.updated SSE re-sorts children by updated descending",
+      build: () {
+        final oldChild = testSession(id: "child-old", parentID: sessionId, updatedAt: 1000);
+        final newChild = testSession(id: "child-new", parentID: sessionId, updatedAt: 3000);
+
+        when(
+          () => mockSessionService.getChildren(sessionId: sessionId),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(SessionListResponse(items: [newChild, oldChild])),
+        );
+
+        return SessionDetailCubit(
+          mockConnectionService,
+          loadService: loadService,
+          promptDispatcher: promptDispatcher,
+          permissionRepository: mockPermissionRepository,
+          sessionId: sessionId,
+          projectId: "project-1",
+          notificationCanceller: mockNotificationCanceller,
+          failureReporter: mockFailureReporter,
+        );
+      },
+      act: (cubit) async {
+        await _awaitLoaded(cubit);
+
+        // Old child gets a newer updated timestamp.
+        final updatedOldChild = testSession(id: "child-old", parentID: sessionId, updatedAt: 5000);
+        globalEvents.add(SseEvent(data: SesoriSessionUpdated(info: updatedOldChild)));
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      },
+      expect: () => [
+        // Initial load: newest first.
+        isA<SessionDetailLoaded>().having(
+          (state) => state.children.map((c) => c.id).toList(),
+          "children ids (DESC)",
+          ["child-new", "child-old"],
+        ),
+        // After update: re-sorted so child-old (now 5000) comes first.
+        isA<SessionDetailLoaded>().having(
+          (state) => state.children.map((c) => c.id).toList(),
+          "children ids after update (DESC)",
+          ["child-old", "child-new"],
+        ),
+      ],
+    );
+
+    blocTest<SessionDetailCubit, SessionDetailState>(
       "close disposes event subscriptions",
       build: () => SessionDetailCubit(
         mockConnectionService,

--- a/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -896,7 +896,7 @@ void main() {
           (_) async => ApiResponse.success(SessionListResponse(items: [oldChild, newChild])),
         );
 
-        globalEvents.add(SseEvent(data: SesoriSessionsUpdated(projectID: "project-1")));
+        globalEvents.add(SseEvent(data: const SesoriSessionsUpdated(projectID: "project-1")));
         await Future<void>.delayed(const Duration(milliseconds: 10));
       },
       expect: () => [

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -161,8 +161,8 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
             model: preservedSelectedAgentModel,
           );
 
-          final refreshedChildSessions = [...snapshot.childSessions]
-            ..sort((a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0));
+          final refreshedChildSessions = [...snapshot.childSessions];
+          _sortChildrenByUpdatedDesc(refreshedChildSessions);
 
           emit(
             current.copyWith(
@@ -373,8 +373,8 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     if (current.children.any((c) => c.id == child.id)) return;
 
     if (isClosed) return;
-    final updated = [...current.children, child]
-      ..sort((a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0));
+    final updated = [...current.children, child];
+    _sortChildrenByUpdatedDesc(updated);
     emit(current.copyWith(children: updated));
   }
 
@@ -402,9 +402,9 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     if (index < 0) return;
 
     if (isClosed) return;
-    final updatedChildren = List<Session>.of(current.children);
-    updatedChildren[index] = updatedChild;
-    updatedChildren.sort((a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0));
+    final updatedChildren = List<Session>.of(current.children)
+      ..[index] = updatedChild;
+    _sortChildrenByUpdatedDesc(updatedChildren);
     emit(current.copyWith(children: updatedChildren));
   }
 
@@ -955,8 +955,8 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
 
   SessionDetailLoaded _buildLoadedState({required SessionDetailSnapshot snapshot}) {
     final latestAssistant = _latestAssistantMessage(snapshot.messages);
-    final childSessions = [...snapshot.childSessions]
-      ..sort((a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0));
+    final childSessions = [...snapshot.childSessions];
+    _sortChildrenByUpdatedDesc(childSessions);
     final childIds = childSessions.map((c) => c.id).toSet();
     final childStatuses = Map<String, SessionStatus>.fromEntries(
       snapshot.statuses.entries.where((e) => childIds.contains(e.key)),
@@ -1065,6 +1065,10 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
           ),
         )
         .toList();
+  }
+
+  static void _sortChildrenByUpdatedDesc(List<Session> children) {
+    children.sort((a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0));
   }
 
   // ---------------------------------------------------------------------------

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -161,6 +161,9 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
             model: preservedSelectedAgentModel,
           );
 
+          final refreshedChildSessions = [...snapshot.childSessions]
+            ..sort((a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0));
+
           emit(
             current.copyWith(
               messages: snapshot.messages,
@@ -170,7 +173,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
               pendingPermissions: _mapPendingPermissions(snapshot.pendingPermissions),
               agent: latestAssistant?.agent,
               assistantAgentModel: assistantAgentModel,
-              children: snapshot.childSessions,
+              children: refreshedChildSessions,
               childStatuses: childStatuses,
               availableAgents: availableAgents,
               availableProviders: availableProviders,
@@ -401,6 +404,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     if (isClosed) return;
     final updatedChildren = List<Session>.of(current.children);
     updatedChildren[index] = updatedChild;
+    updatedChildren.sort((a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0));
     emit(current.copyWith(children: updatedChildren));
   }
 


### PR DESCRIPTION
## Summary

Fixed a bug on mobile where completed tasks would appear in reverse chronological order (oldest at the top) after a silent refresh.

## Root Cause

The `SessionDetailCubit` correctly sorted child sessions by `updated` descending (newest first) on initial load, but **two code paths did not re-sort**:

1. **`_doSilentRefresh`** — after a background refresh (triggered by SSE events or reconnection), children were set directly from the API response without sorting. The API returns children in oldest-first order, so the list would revert.
2. **`_onChildSessionUpdated`** — when a child session was updated via SSE (e.g. title change), it was replaced in-place without re-sorting.

## Changes

- Added `updated` descending sort to `_doSilentRefresh` to match `_buildLoadedState`
- Added `updated` descending sort to `_onChildSessionUpdated` to maintain order after in-place replacements
- Added tests covering both scenarios

## Verification

- `dart analyze` passes in `module_core`
- All 388 `flutter test` tests pass in `mobile/app`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a mobile bug where child sessions could switch to oldest-first after a silent refresh or SSE update. Children are now consistently sorted by updated timestamp (newest first).

- **Bug Fixes**
  - Introduced `_sortChildrenByUpdatedDesc` and applied it across load, silent refresh, child add, and update paths to keep children sorted by `updated` desc.
  - Added tests covering silent refresh and SSE update flows.

<sup>Written for commit 33cceaa83248bd3529c3ca56f0fa59ab719c91c7. Summary will update on new commits. <a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/139?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

