### PR TITLE
chore(release): bridge v0.6.0

### DIFF
--- a/bridge/app/CHANGELOG.md
+++ b/bridge/app/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [v0.6.0] - 2026-04-29
+
+### Added
+- Google OAuth and email/password login support with PKCE flow (#137)
+- `AuthProvider` enum to track last used authentication provider
+- Comprehensive auth test coverage for login, profile, token validation, and token management
+- Mobile login UI with provider selection buttons and email login form
+- Migrated install paths to `~/.local/share/sesori` for XDG compliance (#138)
+- Automatic symlink creation at `~/.local/bin/sesori-bridge` for immediate PATH access
+- Updated shell and PowerShell installers to use XDG-compliant directories
+
+### Changed
+- Config directory moved from `~/.config/sesori-bridge` to `~/.local/share/sesori`
+- Token persistence now includes `lastProvider` field for multi-provider auth tracking
+- Updated all documentation (README, INSTALL, RELEASING) with new install paths
+
 ## [v0.5.0] - 2026-04-27
 
 ### Added

--- a/bridge/app/lib/src/version.dart
+++ b/bridge/app/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '0.5.0';
+const String appVersion = '0.6.0';

--- a/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-arm64",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS ARM64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.5.0",
+    "releaseTag": "bridge-v0.6.0",
     "releaseArtifact": "sesori-bridge-macos-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-darwin-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-x64",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS x64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.5.0",
+    "releaseTag": "bridge-v0.6.0",
     "releaseArtifact": "sesori-bridge-macos-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-arm64",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux ARM64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.5.0",
+    "releaseTag": "bridge-v0.6.0",
     "releaseArtifact": "sesori-bridge-linux-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-x64",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux x64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.5.0",
+    "releaseTag": "bridge-v0.6.0",
     "releaseArtifact": "sesori-bridge-linux-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-x64",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows x64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.5.0",
+    "releaseTag": "bridge-v0.6.0",
     "releaseArtifact": "sesori-bridge-windows-x64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge/package.json
+++ b/bridge/app/npm/sesori-bridge/package.json
@@ -1,21 +1,21 @@
 {
   "name": "@sesori/bridge",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Bootstrap launcher for the managed Sesori Bridge runtime",
   "bin": {
     "sesori-bridge": "bin/bridge.js"
   },
   "optionalDependencies": {
-    "@sesori/bridge-darwin-arm64": "0.5.0",
-    "@sesori/bridge-darwin-x64": "0.5.0",
-    "@sesori/bridge-linux-x64": "0.5.0",
-    "@sesori/bridge-linux-arm64": "0.5.0",
-    "@sesori/bridge-win32-x64": "0.5.0"
+    "@sesori/bridge-darwin-arm64": "0.6.0",
+    "@sesori/bridge-darwin-x64": "0.6.0",
+    "@sesori/bridge-linux-x64": "0.6.0",
+    "@sesori/bridge-linux-arm64": "0.6.0",
+    "@sesori/bridge-win32-x64": "0.6.0"
   },
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.5.0",
+    "releaseTag": "bridge-v0.6.0",
     "runtimeBundleSource": "github-release-assets"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sesori_bridge
 description: Dart implementation of the Sesori Bridge CLI for WebSocket communication.
-version: 0.5.0
+version: 0.6.0
 publish_to: none
 resolution: workspace
 


### PR DESCRIPTION
## Summary
- Bump bridge version to v0.6.0
- Update CHANGELOG.md with changes since v0.5.0

## Changes

### Added
- Google OAuth and email/password login support with PKCE flow (#137)
- `AuthProvider` enum to track last used authentication provider
- Comprehensive auth test coverage for login, profile, token validation, and token management
- Mobile login UI with provider selection buttons and email login form
- Migrated install paths to `~/.local/share/sesori` for XDG compliance (#138)
- Automatic symlink creation at `~/.local/bin/sesori-bridge` for immediate PATH access
- Updated shell and PowerShell installers to use XDG-compliant directories

### Changed
- Config directory moved from `~/.config/sesori-bridge` to `~/.local/share/sesori`
- Token persistence now includes `lastProvider` field for multi-provider auth tracking
- Updated all documentation (README, INSTALL, RELEASING) with new install paths

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release Bridge v0.6.0 with multi-provider auth and XDG-compliant install paths. Bumps the app and all `@sesori/bridge` packages to 0.6.0 and updates the changelog.

- **New Features**
  - Google OAuth and email/password login using PKCE.
  - Mobile login UI with provider selection.
  - Tracks last used provider via `AuthProvider`.

- **Migration**
  - Config/data moved to `~/.local/share/sesori` (from `~/.config/sesori-bridge`).
  - Installers create `~/.local/bin/sesori-bridge`; ensure `~/.local/bin` is in PATH.
  - Tokens now include `lastProvider`; upgrade is backward compatible.

<sup>Written for commit 97e1074420467f660f9f424069a1f9c1162c4bb3. Summary will update on new commits. <a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/140?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

