### PR TITLE
fix: remove hardened runtime from macOS signing and strip xattrs on all install paths

### DIFF
--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -135,7 +135,6 @@ jobs:
           APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
         run: |
           codesign -s "Developer ID Application: DigitalBlock Labs LTD ($APPLE_TEAM_ID)" \
-            --options runtime \
             --timestamp \
             --force \
             --verbose \

--- a/bridge/app/lib/src/updater/api/file_replacement_api.dart
+++ b/bridge/app/lib/src/updater/api/file_replacement_api.dart
@@ -199,8 +199,8 @@ class FileReplacementApi {
     for (final String attr in attrs) {
       try {
         await _processRunner.run('xattr', ['-dr', attr, path]);
-      } on Object {
-        // Best-effort: ignore failures.
+      } on Object catch (error) {
+        stderr.writeln('Warning: failed to strip $attr from $path: $error');
       }
     }
   }

--- a/bridge/app/lib/src/updater/api/file_replacement_api.dart
+++ b/bridge/app/lib/src/updater/api/file_replacement_api.dart
@@ -71,6 +71,12 @@ class FileReplacementApi {
 
       _deleteIfExists(entity: backupBinary);
       _deleteIfExists(entity: backupLibDir);
+
+      if (Platform.isMacOS) {
+        await _stripMacOSAttributes(targetBinary.path);
+        await _stripMacOSAttributes(targetLibDir.path);
+      }
+
       return true;
     } on Object {
       _rollbackUnixReplacement(
@@ -186,6 +192,17 @@ class FileReplacementApi {
     ].join('\n');
     await File(scriptPath).writeAsString(script);
     return scriptPath;
+  }
+
+  Future<void> _stripMacOSAttributes(String path) async {
+    const List<String> attrs = ['com.apple.quarantine', 'com.apple.provenance'];
+    for (final String attr in attrs) {
+      try {
+        await _processRunner.run('xattr', ['-dr', attr, path]);
+      } on Object {
+        // Best-effort: ignore failures.
+      }
+    }
   }
 
   String escapePowerShellSingleQuoted(String value) {

--- a/bridge/app/lib/src/updater/api/file_replacement_api.dart
+++ b/bridge/app/lib/src/updater/api/file_replacement_api.dart
@@ -73,8 +73,7 @@ class FileReplacementApi {
       _deleteIfExists(entity: backupLibDir);
 
       if (Platform.isMacOS) {
-        await _stripMacOSAttributes(targetBinary.path);
-        await _stripMacOSAttributes(targetLibDir.path);
+        await _stripMacOSAttributes(installRoot);
       }
 
       return true;

--- a/bridge/app/npm/sesori-bridge/lib/runtime_install.js
+++ b/bridge/app/npm/sesori-bridge/lib/runtime_install.js
@@ -185,13 +185,13 @@ function stripMacOSAttributes(installRoot) {
   attrs.forEach(function(attr) {
     try {
       child_process.execFileSync("xattr", ["-dr", attr, binaryPath], { stdio: "pipe" });
-    } catch (_) {
-      // Best-effort: ignore failures.
+    } catch (error) {
+      console.warn("sesori-bridge: Failed to strip " + attr + " from " + binaryPath + ": " + error.message);
     }
     try {
       child_process.execFileSync("xattr", ["-dr", attr, libPath], { stdio: "pipe" });
-    } catch (_) {
-      // Best-effort: ignore failures.
+    } catch (error) {
+      console.warn("sesori-bridge: Failed to strip " + attr + " from " + libPath + ": " + error.message);
     }
   });
 }

--- a/bridge/app/npm/sesori-bridge/lib/runtime_install.js
+++ b/bridge/app/npm/sesori-bridge/lib/runtime_install.js
@@ -179,19 +179,12 @@ function stripMacOSAttributes(installRoot) {
   if (process.platform !== "darwin") {
     return;
   }
-  var binaryPath = managedBinaryPath(installRoot);
-  var libPath = managedLibPath(installRoot);
   var attrs = ["com.apple.quarantine", "com.apple.provenance"];
   attrs.forEach(function(attr) {
     try {
-      child_process.execFileSync("xattr", ["-dr", attr, binaryPath], { stdio: "pipe" });
+      child_process.execFileSync("xattr", ["-dr", attr, installRoot], { stdio: "pipe" });
     } catch (error) {
-      console.warn("sesori-bridge: Failed to strip " + attr + " from " + binaryPath + ": " + error.message);
-    }
-    try {
-      child_process.execFileSync("xattr", ["-dr", attr, libPath], { stdio: "pipe" });
-    } catch (error) {
-      console.warn("sesori-bridge: Failed to strip " + attr + " from " + libPath + ": " + error.message);
+      console.warn("sesori-bridge: Failed to strip " + attr + " from " + installRoot + ": " + error.message);
     }
   });
 }

--- a/bridge/app/npm/sesori-bridge/lib/runtime_install.js
+++ b/bridge/app/npm/sesori-bridge/lib/runtime_install.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var child_process = require("child_process");
 var fs = require("fs");
 var os = require("os");
 var path = require("path");
@@ -174,6 +175,27 @@ function createManagedSymlink(installRoot) {
   }
 }
 
+function stripMacOSAttributes(installRoot) {
+  if (process.platform !== "darwin") {
+    return;
+  }
+  var binaryPath = managedBinaryPath(installRoot);
+  var libPath = managedLibPath(installRoot);
+  var attrs = ["com.apple.quarantine", "com.apple.provenance"];
+  attrs.forEach(function(attr) {
+    try {
+      child_process.execFileSync("xattr", ["-dr", attr, binaryPath], { stdio: "pipe" });
+    } catch (_) {
+      // Best-effort: ignore failures.
+    }
+    try {
+      child_process.execFileSync("xattr", ["-dr", attr, libPath], { stdio: "pipe" });
+    } catch (_) {
+      // Best-effort: ignore failures.
+    }
+  });
+}
+
 function installManagedRuntime(payload, installRoot, options) {
   var parentRoot = path.dirname(installRoot);
   var stageRoot = path.join(parentRoot, ".sesori-stage-" + process.pid);
@@ -196,6 +218,7 @@ function installManagedRuntime(payload, installRoot, options) {
     }
     fs.renameSync(stageRoot, installRoot);
     removeRecursive(backupRoot);
+    stripMacOSAttributes(installRoot);
   } catch (error) {
     if (!exists(installRoot) && exists(backupRoot)) {
       fs.renameSync(backupRoot, installRoot);

--- a/install.sh
+++ b/install.sh
@@ -353,8 +353,8 @@ main() {
     printf '{"version":"%s"}\n' "${RESOLVED_RELEASE_TAG#bridge-v}" > "${MANAGED_MANIFEST}"
 
     if [ "${os}" = "macos" ]; then
-        xattr -dr com.apple.quarantine "${BINARY}" 2>/dev/null || true
-        xattr -dr com.apple.provenance "${BINARY}" 2>/dev/null || true
+        xattr -dr com.apple.quarantine "${INSTALL_DIR}" 2>/dev/null || true
+        xattr -dr com.apple.provenance "${INSTALL_DIR}" 2>/dev/null || true
     fi
 
     echo "[4/4] Creating symlink..."

--- a/install.sh
+++ b/install.sh
@@ -354,6 +354,7 @@ main() {
 
     if [ "${os}" = "macos" ]; then
         xattr -dr com.apple.quarantine "${BINARY}" 2>/dev/null || true
+        xattr -dr com.apple.provenance "${BINARY}" 2>/dev/null || true
     fi
 
     echo "[4/4] Creating symlink..."


### PR DESCRIPTION
## Problem

The bridge binary was being killed immediately on macOS with `SIGKILL (Code Signature Invalid)`. The crash report showed:

```
"signal":"SIGKILL (Code Signature Invalid)"
"termination": {"namespace":"CODESIGNING","indicator":"Invalid Page"}
```

Root cause: the release workflow signed macOS binaries with `--options runtime` (hardened runtime) but did not notarize them. On modern macOS, a binary with hardened runtime that isn't notarized gets killed immediately by AMFI at the page level.

## Changes

1. **`.github/workflows/bridge-release.yml`** — Removed `--options runtime` from the `codesign` command. The binary stays signed with the Developer ID certificate, just without hardened runtime, which doesn't require notarization.

2. **`install.sh`** — Added removal of `com.apple.provenance` alongside the existing `com.apple.quarantine` stripping. Modern macOS versions set this attribute in addition to (or instead of) quarantine.

3. **`bridge/app/lib/src/updater/api/file_replacement_api.dart`** — Added xattr stripping (`com.apple.quarantine` and `com.apple.provenance`) in the self-update path after the new binary is moved into place. Best-effort: failures are ignored so the update doesn't fail just because xattr removal fails.

4. **`bridge/app/npm/sesori-bridge/lib/runtime_install.js`** — Added xattr stripping in the npm bootstrap path after the managed runtime is installed. Same best-effort behavior.

## Verification

- All three install paths (shell installer, self-update, npm bootstrap) now consistently remove macOS extended attributes.
- All 1028 bridge tests pass.
- Dart analysis is clean across all modules.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop macOS from killing the bridge with “Code Signature Invalid” by removing hardened runtime from signing and recursively stripping quarantine/provenance xattrs from install roots across all install paths. The bridge now runs reliably on modern macOS without requiring notarization.

- **Bug Fixes**
  - Release workflow: removed `--options runtime` from `codesign` (keep Developer ID; no notarization).
  - Shell installer: strip `com.apple.quarantine` and `com.apple.provenance` recursively from the install dir.
  - Self-update: strip these xattrs recursively from the install root after replace; warn on failures.
  - npm bootstrap: strip these xattrs recursively from the install root after managed runtime install; warn on failures.

<sup>Written for commit 9a1b09f7548e800fafd5039b5aaad5031a0a914f. Summary will update on new commits. <a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/141?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

