### PR TITLE
chore(release): bridge v0.6.1

### DIFF
--- a/bridge/app/CHANGELOG.md
+++ b/bridge/app/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.6.1] - 2026-04-29
+
+### Fixed
+- Remove hardened runtime from macOS signing and strip xattrs on all install paths (#141)
+
 ## [v0.6.0] - 2026-04-29
 
 ### Added

--- a/bridge/app/lib/src/version.dart
+++ b/bridge/app/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '0.6.0';
+const String appVersion = '0.6.1';

--- a/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-arm64",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS ARM64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.6.0",
+    "releaseTag": "bridge-v0.6.1",
     "releaseArtifact": "sesori-bridge-macos-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-darwin-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-x64",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS x64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.6.0",
+    "releaseTag": "bridge-v0.6.1",
     "releaseArtifact": "sesori-bridge-macos-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-arm64",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux ARM64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.6.0",
+    "releaseTag": "bridge-v0.6.1",
     "releaseArtifact": "sesori-bridge-linux-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-x64",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux x64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.6.0",
+    "releaseTag": "bridge-v0.6.1",
     "releaseArtifact": "sesori-bridge-linux-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-x64",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows x64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.6.0",
+    "releaseTag": "bridge-v0.6.1",
     "releaseArtifact": "sesori-bridge-windows-x64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge/package.json
+++ b/bridge/app/npm/sesori-bridge/package.json
@@ -1,21 +1,21 @@
 {
   "name": "@sesori/bridge",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Bootstrap launcher for the managed Sesori Bridge runtime",
   "bin": {
     "sesori-bridge": "bin/bridge.js"
   },
   "optionalDependencies": {
-    "@sesori/bridge-darwin-arm64": "0.6.0",
-    "@sesori/bridge-darwin-x64": "0.6.0",
-    "@sesori/bridge-linux-x64": "0.6.0",
-    "@sesori/bridge-linux-arm64": "0.6.0",
-    "@sesori/bridge-win32-x64": "0.6.0"
+    "@sesori/bridge-darwin-arm64": "0.6.1",
+    "@sesori/bridge-darwin-x64": "0.6.1",
+    "@sesori/bridge-linux-x64": "0.6.1",
+    "@sesori/bridge-linux-arm64": "0.6.1",
+    "@sesori/bridge-win32-x64": "0.6.1"
   },
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.6.0",
+    "releaseTag": "bridge-v0.6.1",
     "runtimeBundleSource": "github-release-assets"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sesori_bridge
 description: Dart implementation of the Sesori Bridge CLI for WebSocket communication.
-version: 0.6.0
+version: 0.6.1
 publish_to: none
 resolution: workspace
 


### PR DESCRIPTION
## Summary
- Bump bridge version to v0.6.1
- Update CHANGELOG.md with changes since v0.6.0

## Changes
### Fixed
- Remove hardened runtime from macOS signing and strip xattrs on all install paths (#141)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release Bridge v0.6.1 with a fix to macOS signing and safer install behavior. Versions and release tags are updated across `@sesori/bridge` packages and the CHANGELOG is updated.

- **Bug Fixes**
  - Remove hardened runtime from macOS signing and strip extended attributes on all install paths (#141).

- **Dependencies**
  - Bump `@sesori/bridge` and platform packages to 0.6.1, set `releaseTag` to `bridge-v0.6.1`, and update Dart versions and CHANGELOG.

<sup>Written for commit 48b2ca2560ba5ec28721bca0abcb6c7083f9808a. Summary will update on new commits. <a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/142?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

