### PR TITLE
chore: update Flutter to 3.41.9

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-flutter 3.41.7-stable
+flutter 3.41.9-stable

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.11.5
 
 dependencies:
   args: ^2.6.0

--- a/bridge/pubspec.lock
+++ b/bridge/pubspec.lock
@@ -689,4 +689,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
+  dart: ">=3.11.5 <4.0.0"

--- a/bridge/pubspec.yaml
+++ b/bridge/pubspec.yaml
@@ -2,7 +2,7 @@ name: sesori_bridge_workspace
 publish_to: none
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.11.5
 
 workspace:
   - app

--- a/bridge/sesori_plugin_interface/pubspec.yaml
+++ b/bridge/sesori_plugin_interface/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.11.5
 
 dependencies:
   freezed_annotation: ^3.1.0

--- a/bridge/sesori_plugin_opencode/pubspec.yaml
+++ b/bridge/sesori_plugin_opencode/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.11.5
 
 dependencies:
   sesori_plugin_interface:

--- a/mobile/app/pubspec.yaml
+++ b/mobile/app/pubspec.yaml
@@ -20,7 +20,7 @@ resolution: workspace
 version: 1.0.4+6
 
 environment:
-  sdk: ^3.11.1
+  sdk: ^3.11.5
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/mobile/module_auth/pubspec.yaml
+++ b/mobile/module_auth/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.11.1
+  sdk: ^3.11.5
 
 dependencies:
   cryptography: ^2.8.1

--- a/mobile/module_core/pubspec.yaml
+++ b/mobile/module_core/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.11.1
+  sdk: ^3.11.5
 
 dependencies:
   bloc: ^9.0.0

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1441,5 +1441,5 @@ packages:
     source: hosted
     version: "2.2.4"
 sdks:
-  dart: ">=3.11.1 <4.0.0"
+  dart: ">=3.11.5 <4.0.0"
   flutter: ">=3.41.0"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -2,7 +2,7 @@ name: sesori_mobile_workspace
 publish_to: none
 
 environment:
-  sdk: ^3.11.1
+  sdk: ^3.11.5
 
 workspace:
   - app

--- a/shared/no_slop_linter/pubspec.yaml
+++ b/shared/no_slop_linter/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 publish_to: "none"
 
 environment:
-  sdk: ">=3.11.0 <4.0.0"
+  sdk: ">=3.11.5 <4.0.0"
 
 dependencies:
   analysis_server_plugin: ">=0.3.5 <0.4.0" # 0.3.5 works with analyzer 10.0.0

--- a/shared/no_slop_linter/pubspec.yaml
+++ b/shared/no_slop_linter/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.0.1
 publish_to: "none"
 
 environment:
-  sdk: ">=3.11.5 <4.0.0"
+  sdk: ">=3.11.0 <4.0.0"
 
 dependencies:
   analysis_server_plugin: ">=0.3.5 <0.4.0" # 0.3.5 works with analyzer 10.0.0

--- a/shared/sesori_shared/pubspec.lock
+++ b/shared/sesori_shared/pubspec.lock
@@ -562,4 +562,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.11.0 <4.0.0"
+  dart: ">=3.11.5 <4.0.0"

--- a/shared/sesori_shared/pubspec.yaml
+++ b/shared/sesori_shared/pubspec.yaml
@@ -4,7 +4,7 @@ description: Shared crypto and protocol for Sesori relay. Pure Dart, no Flutter.
 version: 0.3.0
 
 environment:
-  sdk: ^3.11.0
+  sdk: ^3.11.5
 
 dependencies:
   cryptography: ^2.9.0


### PR DESCRIPTION
## Summary

- Bumps Flutter from `3.41.7-stable` to `3.41.9-stable` across the monorepo
- Updates `.tool-versions` and all `pubspec.yaml` / `pubspec.lock` files in `bridge`, `mobile`, and `shared` packages

## Test plan

- [ ] CI passes on the updated Flutter version
- [ ] `flutter pub get` succeeds in `bridge`, `mobile`, and `shared` packages
- [ ] App builds on Android and iOS