### PR TITLE
fix(mobile): enable no-slop linter for app analysis

### DIFF
--- a/mobile/analysis_options.yaml
+++ b/mobile/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: app/all_lint_rules.yaml
+
 plugins:
   no_slop_linter:
     path: ../shared/no_slop_linter

--- a/mobile/app/analysis_options.yaml
+++ b/mobile/app/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: ./all_lint_rules.yaml
+include: ../analysis_options.yaml
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options


### PR DESCRIPTION
## Summary
- Route mobile app analysis through the workspace-level analysis options so the shared `no_slop_linter` plugin is loaded.
- Keep `app/all_lint_rules.yaml` included from the mobile workspace root, avoiding unsupported nested plugin declarations.

## Verification
- Temporary probe confirmed `flutter analyze lib/no_slop_probe.dart` reports `avoid_bang_operator`.
- `dart analyze` in `shared/no_slop_linter` passed.
- `dart test` in `shared/no_slop_linter` passed.
- `flutter analyze` in `mobile/app` now surfaces existing no-slop info diagnostics.
- `dart analyze` in `mobile/module_core` and `mobile/module_auth` now surfaces existing no-slop info diagnostics.

## Notes
- Full mobile analysis now exits non-zero because the restored linter reports pre-existing info-level no-slop findings.