### PR TITLE
feat: add autofill support to email login form

### DIFF
--- a/mobile/app/lib/features/login/email_login_form.dart
+++ b/mobile/app/lib/features/login/email_login_form.dart
@@ -65,7 +65,7 @@ class _EmailLoginFormState extends State<EmailLoginForm> {
               textInputAction: TextInputAction.next,
               autocorrect: false,
               enabled: !isLoading,
-              autofillHints: const [AutofillHints.email],
+              autofillHints: const [AutofillHints.email, AutofillHints.username],
               decoration: InputDecoration(
                 labelText: loc.emailLabel,
                 hintText: loc.emailHint,

--- a/mobile/app/lib/features/login/email_login_form.dart
+++ b/mobile/app/lib/features/login/email_login_form.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:flutter/services.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 
@@ -36,10 +37,14 @@ class _EmailLoginFormState extends State<EmailLoginForm> {
     final email = _emailController.text.trim();
     final password = _passwordController.text;
 
-    await context.read<LoginCubit>().loginWithEmail(
+    final success = await context.read<LoginCubit>().loginWithEmail(
       email: email,
       password: password,
     );
+
+    if (success && mounted) {
+      TextInput.finishAutofillContext();
+    }
   }
 
   @override
@@ -48,88 +53,92 @@ class _EmailLoginFormState extends State<EmailLoginForm> {
     final state = context.watch<LoginCubit>().state;
     final isLoading = state is LoginAuthenticating;
 
-    return Form(
-      key: _formKey,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          TextFormField(
-            controller: _emailController,
-            keyboardType: TextInputType.emailAddress,
-            textInputAction: TextInputAction.next,
-            autocorrect: false,
-            enabled: !isLoading,
-            decoration: InputDecoration(
-              labelText: loc.emailLabel,
-              hintText: loc.emailHint,
-              prefixIcon: const Icon(Icons.email_outlined),
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
-            ),
-            validator: (value) {
-              if (value == null || value.trim().isEmpty) {
-                return loc.emailRequired;
-              }
-              final emailRegex = RegExp(r"^.+@.+\..+$");
-              if (!emailRegex.hasMatch(value.trim())) {
-                return loc.emailInvalid;
-              }
-              return null;
-            },
-          ),
-          const SizedBox(height: 16),
-          TextFormField(
-            controller: _passwordController,
-            obscureText: _obscurePassword,
-            textInputAction: TextInputAction.done,
-            enabled: !isLoading,
-            onFieldSubmitted: (_) => _submit(),
-            decoration: InputDecoration(
-              labelText: loc.passwordLabel,
-              prefixIcon: const Icon(Icons.lock_outlined),
-              suffixIcon: IconButton(
-                icon: Icon(
-                  _obscurePassword ? Icons.visibility_outlined : Icons.visibility_off_outlined,
+    return AutofillGroup(
+      child: Form(
+        key: _formKey,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextFormField(
+              controller: _emailController,
+              keyboardType: TextInputType.emailAddress,
+              textInputAction: TextInputAction.next,
+              autocorrect: false,
+              enabled: !isLoading,
+              autofillHints: const [AutofillHints.email],
+              decoration: InputDecoration(
+                labelText: loc.emailLabel,
+                hintText: loc.emailHint,
+                prefixIcon: const Icon(Icons.email_outlined),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
                 ),
-                onPressed: () {
-                  setState(() {
-                    _obscurePassword = !_obscurePassword;
-                  });
-                },
               ),
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-              ),
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return loc.emailRequired;
+                }
+                final emailRegex = RegExp(r"^.+@.+\..+$");
+                if (!emailRegex.hasMatch(value.trim())) {
+                  return loc.emailInvalid;
+                }
+                return null;
+              },
             ),
-            validator: (value) {
-              if (value == null || value.isEmpty) {
-                return loc.passwordRequired;
-              }
-              return null;
-            },
-          ),
-          const SizedBox(height: 24),
-          FilledButton(
-            onPressed: isLoading ? null : _submit,
-            style: FilledButton.styleFrom(
-              minimumSize: const Size(double.infinity, 52),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(12),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _passwordController,
+              obscureText: _obscurePassword,
+              textInputAction: TextInputAction.done,
+              enabled: !isLoading,
+              autofillHints: const [AutofillHints.password],
+              onFieldSubmitted: (_) => _submit(),
+              decoration: InputDecoration(
+                labelText: loc.passwordLabel,
+                prefixIcon: const Icon(Icons.lock_outlined),
+                suffixIcon: IconButton(
+                  icon: Icon(
+                    _obscurePassword ? Icons.visibility_outlined : Icons.visibility_off_outlined,
+                  ),
+                  onPressed: () {
+                    setState(() {
+                      _obscurePassword = !_obscurePassword;
+                    });
+                  },
+                ),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
               ),
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return loc.passwordRequired;
+                }
+                return null;
+              },
             ),
-            child: isLoading
-                ? const SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      color: Colors.white,
-                    ),
-                  )
-                : Text(loc.signIn),
-          ),
-        ],
+            const SizedBox(height: 24),
+            FilledButton(
+              onPressed: isLoading ? null : _submit,
+              style: FilledButton.styleFrom(
+                minimumSize: const Size(double.infinity, 52),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              child: isLoading
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Colors.white,
+                      ),
+                    )
+                  : Text(loc.signIn),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/app/lib/features/login/email_login_form.dart
+++ b/mobile/app/lib/features/login/email_login_form.dart
@@ -42,7 +42,7 @@ class _EmailLoginFormState extends State<EmailLoginForm> {
       password: password,
     );
 
-    if (success && mounted) {
+    if (success) {
       TextInput.finishAutofillContext();
     }
   }


### PR DESCRIPTION
Adds AutofillGroup wrapper and autofillHints to email/password fields so password managers correctly recognize the login form fields.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add autofill support to the email login form and ensure the system autofill UI closes after a successful sign-in.

- **New Features**
  - Wrapped the form in `AutofillGroup` and added `AutofillHints.email`/`AutofillHints.username` and `AutofillHints.password` for better password manager support.
  - Calls `TextInput.finishAutofillContext()` on successful login.

- **Bug Fixes**
  - Removed a mounted check that could block finishing the autofill context.

<sup>Written for commit 356029b5cca15c7a5eed9f11962a569c2aa1a604. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

