### PR TITLE
Add new session loading state

### DIFF
--- a/mobile/app/lib/features/new_session/new_session_loading_overlay.dart
+++ b/mobile/app/lib/features/new_session/new_session_loading_overlay.dart
@@ -1,0 +1,149 @@
+import "dart:async";
+
+import "package:cue/cue.dart";
+import "package:flutter/material.dart";
+
+/// A full-screen loading overlay shown while a new session is being created.
+///
+/// Fills its parent and visually dims underlying content. Displays a centered
+/// card with a progress indicator and a cycling playful message.
+///
+/// Uses [Cue] entrance animation when motion is not disabled by accessibility
+/// settings. Safe to place inside a [Stack] with [Positioned.fill].
+class NewSessionLoadingOverlay extends StatefulWidget {
+  const NewSessionLoadingOverlay({
+    super.key = const Key("new_session_loading_overlay"),
+  });
+
+  @override
+  State<NewSessionLoadingOverlay> createState() => _NewSessionLoadingOverlayState();
+}
+
+class _NewSessionLoadingOverlayState extends State<NewSessionLoadingOverlay> {
+  static const _messages = [
+    "Warming up the engines…",
+    "Generating session telemetry…",
+    "Preparing for takeoff…",
+  ];
+
+  int _messageIndex = 0;
+  Timer? _timer;
+
+  bool get _isReducedMotion {
+    final disableAnimations = MediaQuery.disableAnimationsOf(context);
+    final accessibleNav = MediaQuery.maybeAccessibleNavigationOf(context) ?? false;
+    return disableAnimations || accessibleNav;
+  }
+
+  void _startTimer() {
+    if (_timer?.isActive ?? false) return;
+    _timer = Timer.periodic(const Duration(seconds: 2), (_) {
+      if (mounted) {
+        setState(() => _messageIndex = (_messageIndex + 1) % _messages.length);
+      }
+    });
+  }
+
+  void _stopTimer() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_isReducedMotion) {
+      _stopTimer();
+    } else {
+      _startTimer();
+    }
+  }
+
+  @override
+  void dispose() {
+    _stopTimer();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final reducedMotion = _isReducedMotion;
+
+    return SizedBox.expand(
+      child: Semantics(
+        label: "Creating session",
+        child: ColoredBox(
+          color: Colors.black.withAlpha(160),
+          child: Center(
+            child: reducedMotion
+                ? _buildContent(context, reducedMotion: true)
+                : Cue.onMount(
+                    motion: const CueMotion.smooth(),
+                    child: Actor(
+                      acts: const [
+                        Act.fadeIn(),
+                        Act.scale(from: 0.9),
+                        Act.slideY(from: 0.2),
+                      ],
+                      child: _buildContent(context, reducedMotion: false),
+                    ),
+                  ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, {required bool reducedMotion}) {
+    final theme = Theme.of(context);
+    final message = _messages[_messageIndex];
+
+    return Card(
+      elevation: 8,
+      margin: const EdgeInsets.symmetric(horizontal: 32),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 280),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CircularProgressIndicator(
+                key: const Key("new_session_loading_progress"),
+                color: theme.colorScheme.primary,
+              ),
+              const SizedBox(height: 24),
+              reducedMotion
+                  ? Text(
+                      message,
+                      key: const Key("new_session_loading_message"),
+                      style: theme.textTheme.bodyLarge?.copyWith(
+                        color: theme.colorScheme.onSurface,
+                      ),
+                      textAlign: TextAlign.center,
+                    )
+                  : Cue.onChange(
+                      value: message,
+                      motion: const CueMotion.smooth(),
+                      child: Actor(
+                        acts: const [
+                          Act.fadeIn(),
+                          Act.slideY(from: 0.1),
+                        ],
+                        child: Text(
+                          message,
+                          key: const Key("new_session_loading_message"),
+                          style: theme.textTheme.bodyLarge?.copyWith(
+                            color: theme.colorScheme.onSurface,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/app/lib/features/new_session/new_session_loading_overlay.dart
+++ b/mobile/app/lib/features/new_session/new_session_loading_overlay.dart
@@ -13,19 +13,18 @@ import "package:flutter/material.dart";
 class NewSessionLoadingOverlay extends StatefulWidget {
   const NewSessionLoadingOverlay({
     super.key = const Key("new_session_loading_overlay"),
+    required this.semanticsLabel,
+    required this.messages,
   });
+
+  final String semanticsLabel;
+  final List<String> messages;
 
   @override
   State<NewSessionLoadingOverlay> createState() => _NewSessionLoadingOverlayState();
 }
 
 class _NewSessionLoadingOverlayState extends State<NewSessionLoadingOverlay> {
-  static const _messages = [
-    "Warming up the engines…",
-    "Generating session telemetry…",
-    "Preparing for takeoff…",
-  ];
-
   int _messageIndex = 0;
   Timer? _timer;
 
@@ -39,7 +38,7 @@ class _NewSessionLoadingOverlayState extends State<NewSessionLoadingOverlay> {
     if (_timer?.isActive ?? false) return;
     _timer = Timer.periodic(const Duration(seconds: 2), (_) {
       if (mounted) {
-        setState(() => _messageIndex = (_messageIndex + 1) % _messages.length);
+        setState(() => _messageIndex = (_messageIndex + 1) % widget.messages.length);
       }
     });
   }
@@ -71,9 +70,9 @@ class _NewSessionLoadingOverlayState extends State<NewSessionLoadingOverlay> {
 
     return SizedBox.expand(
       child: Semantics(
-        label: "Creating session",
+        label: widget.semanticsLabel,
         child: ColoredBox(
-          color: Colors.black.withAlpha(160),
+          color: Theme.of(context).colorScheme.scrim.withAlpha(160),
           child: Center(
             child: reducedMotion
                 ? _buildContent(context, reducedMotion: true)
@@ -96,7 +95,7 @@ class _NewSessionLoadingOverlayState extends State<NewSessionLoadingOverlay> {
 
   Widget _buildContent(BuildContext context, {required bool reducedMotion}) {
     final theme = Theme.of(context);
-    final message = _messages[_messageIndex];
+    final message = widget.messages[_messageIndex];
 
     return Card(
       elevation: 8,

--- a/mobile/app/lib/features/new_session/new_session_loading_overlay.dart
+++ b/mobile/app/lib/features/new_session/new_session_loading_overlay.dart
@@ -36,7 +36,7 @@ class _NewSessionLoadingOverlayState extends State<NewSessionLoadingOverlay> {
 
   void _startTimer() {
     if (_timer?.isActive ?? false) return;
-    _timer = Timer.periodic(const Duration(seconds: 2), (_) {
+    _timer = Timer.periodic(const Duration(seconds: 3, milliseconds: 500), (_) {
       if (mounted) {
         setState(() => _messageIndex = (_messageIndex + 1) % widget.messages.length);
       }
@@ -121,22 +121,32 @@ class _NewSessionLoadingOverlayState extends State<NewSessionLoadingOverlay> {
                       ),
                       textAlign: TextAlign.center,
                     )
-                  : Cue.onChange(
-                      value: message,
-                      motion: const CueMotion.smooth(),
-                      child: Actor(
-                        acts: const [
-                          Act.fadeIn(),
-                          Act.slideY(from: 0.1),
-                        ],
-                        child: Text(
-                          message,
-                          key: const Key("new_session_loading_message"),
-                          style: theme.textTheme.bodyLarge?.copyWith(
-                            color: theme.colorScheme.onSurface,
+                  : AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 500),
+                      transitionBuilder: (child, animation) {
+                        return FadeTransition(
+                          opacity: animation,
+                          child: SlideTransition(
+                            position: Tween<Offset>(
+                              begin: const Offset(0, 0.4),
+                              end: Offset.zero,
+                            ).animate(
+                              CurvedAnimation(
+                                parent: animation,
+                                curve: Curves.easeOutCubic,
+                              ),
+                            ),
+                            child: child,
                           ),
-                          textAlign: TextAlign.center,
+                        );
+                      },
+                      child: Text(
+                        message,
+                        key: ValueKey<String>(message),
+                        style: theme.textTheme.bodyLarge?.copyWith(
+                          color: theme.colorScheme.onSurface,
                         ),
+                        textAlign: TextAlign.center,
                       ),
                     ),
             ],

--- a/mobile/app/lib/features/new_session/new_session_loading_overlay.dart
+++ b/mobile/app/lib/features/new_session/new_session_loading_overlay.dart
@@ -2,6 +2,7 @@ import "dart:async";
 
 import "package:cue/cue.dart";
 import "package:flutter/material.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 /// A full-screen loading overlay shown while a new session is being created.
 ///
@@ -72,7 +73,7 @@ class _NewSessionLoadingOverlayState extends State<NewSessionLoadingOverlay> {
       child: Semantics(
         label: widget.semanticsLabel,
         child: ColoredBox(
-          color: Theme.of(context).colorScheme.scrim.withAlpha(160),
+          color: Colors.black.withAlpha(160),
           child: Center(
             child: reducedMotion
                 ? _buildContent(context, reducedMotion: true)
@@ -94,7 +95,7 @@ class _NewSessionLoadingOverlayState extends State<NewSessionLoadingOverlay> {
   }
 
   Widget _buildContent(BuildContext context, {required bool reducedMotion}) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final message = widget.messages[_messageIndex];
 
     return Card(
@@ -109,15 +110,15 @@ class _NewSessionLoadingOverlayState extends State<NewSessionLoadingOverlay> {
             children: [
               CircularProgressIndicator(
                 key: const Key("new_session_loading_progress"),
-                color: theme.colorScheme.primary,
+                color: zyra.colors.bgBrandSolid,
               ),
               const SizedBox(height: 24),
               reducedMotion
                   ? Text(
                       message,
                       key: const Key("new_session_loading_message"),
-                      style: theme.textTheme.bodyLarge?.copyWith(
-                        color: theme.colorScheme.onSurface,
+                      style: zyra.textTheme.textSm.regular.copyWith(
+                        color: zyra.colors.textPrimary,
                       ),
                       textAlign: TextAlign.center,
                     )
@@ -143,8 +144,8 @@ class _NewSessionLoadingOverlayState extends State<NewSessionLoadingOverlay> {
                       child: Text(
                         message,
                         key: ValueKey<String>(message),
-                        style: theme.textTheme.bodyLarge?.copyWith(
-                          color: theme.colorScheme.onSurface,
+                        style: zyra.textTheme.textSm.regular.copyWith(
+                          color: zyra.colors.textPrimary,
                         ),
                         textAlign: TextAlign.center,
                       ),

--- a/mobile/app/lib/features/new_session/new_session_screen.dart
+++ b/mobile/app/lib/features/new_session/new_session_screen.dart
@@ -12,6 +12,7 @@ import "../../core/widgets/agent_picker_sheet.dart";
 import "../../core/widgets/model_picker_sheet.dart";
 import "../../core/widgets/variant_picker_sheet.dart";
 import "../session_detail/widgets/prompt_input.dart";
+import "new_session_loading_overlay.dart";
 
 class NewSessionScreen extends StatelessWidget {
   final String projectId;
@@ -139,6 +140,7 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
     final state = context.watch<NewSessionCubit>().state;
     final loc = context.loc;
     final zyra = context.zyra;
+    final isSending = state is NewSessionSending;
 
     return BlocListener<NewSessionCubit, NewSessionState>(
       listenWhen: (_, current) => current is NewSessionCreated,
@@ -155,49 +157,79 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
           );
         }
       },
-      child: Scaffold(
-        appBar: AppBar(title: Text(loc.sessionListNewSession)),
-        body: Column(
-          children: [
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: PopScope(
+        canPop: true,
+        onPopInvokedWithResult: (didPop, result) {
+          if (didPop && isSending) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(loc.newSessionLaunchingInBackground),
+                duration: const Duration(seconds: 3),
+              ),
+            );
+          }
+        },
+        child: Scaffold(
+          appBar: AppBar(title: Text(loc.sessionListNewSession)),
+          body: Stack(
+            fit: StackFit.expand,
+            children: [
+              AbsorbPointer(
+                absorbing: isSending,
                 child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    SwitchListTile(
-                      title: Text(loc.newSessionDedicatedWorktree),
-                      subtitle: Text(
-                        loc.newSessionDedicatedWorktreeDescription,
-                        style: zyra.textTheme.textXs.regular.copyWith(
-                          color: zyra.colors.textSecondary,
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            SwitchListTile(
+                              title: Text(loc.newSessionDedicatedWorktree),
+                              subtitle: Text(
+                                loc.newSessionDedicatedWorktreeDescription,
+                                style: zyra.textTheme.textXs.regular.copyWith(
+                                  color: zyra.colors.textSecondary,
+                                ),
+                              ),
+                              value: _dedicatedWorktree,
+                              onChanged: (value) => setState(() => _dedicatedWorktree = value),
+                            ),
+                          ],
                         ),
                       ),
-                      value: _dedicatedWorktree,
-                      onChanged: (value) => setState(() => _dedicatedWorktree = value),
+                    ),
+                    PromptInput(
+                      isBusy: state is NewSessionSending,
+                      onSend: (String text, String? command) {
+                        context.read<NewSessionCubit>().createSession(
+                          text: text,
+                          command: command,
+                          dedicatedWorktree: _dedicatedWorktree,
+                        );
+                      },
+                      onAbort: _dismissScreen,
+                      header: _buildErrorBanner(state),
+                      composerHeader: _buildComposerHeader(state),
+                      availableCommands: state.agentModelData?.commands ?? const [],
+                      stagedCommand: state.agentModelData?.stagedCommand,
+                      onCommandSelected: context.read<NewSessionCubit>().stageCommand,
+                      onCommandCleared: context.read<NewSessionCubit>().clearStagedCommand,
                     ),
                   ],
                 ),
               ),
-            ),
-            PromptInput(
-              isBusy: state is NewSessionSending,
-              onSend: (String text, String? command) {
-                context.read<NewSessionCubit>().createSession(
-                  text: text,
-                  command: command,
-                  dedicatedWorktree: _dedicatedWorktree,
-                );
-              },
-              onAbort: _dismissScreen,
-              header: _buildErrorBanner(state),
-              composerHeader: _buildComposerHeader(state),
-              availableCommands: state.agentModelData?.commands ?? const [],
-              stagedCommand: state.agentModelData?.stagedCommand,
-              onCommandSelected: context.read<NewSessionCubit>().stageCommand,
-              onCommandCleared: context.read<NewSessionCubit>().clearStagedCommand,
-            ),
-          ],
+              if (isSending)
+                NewSessionLoadingOverlay(
+                  semanticsLabel: loc.newSessionLoadingSemantics,
+                  messages: [
+                    loc.newSessionLoadingMessage1,
+                    loc.newSessionLoadingMessage2,
+                    loc.newSessionLoadingMessage3,
+                  ],
+                ),
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/app/lib/l10n/app_en.arb
+++ b/mobile/app/lib/l10n/app_en.arb
@@ -358,8 +358,9 @@
           "diffRetry": "Retry",
    "splashWelcomeTo": "Welcome to",
    "splashTitle": "Sesori",
-   "newSessionLoadingSemantics": "Creating session",
-   "newSessionLoadingMessage1": "Warming up the engines…",
-   "newSessionLoadingMessage2": "Generating session telemetry…",
-   "newSessionLoadingMessage3": "Preparing for takeoff…"
+    "newSessionLoadingSemantics": "Creating session",
+    "newSessionLoadingMessage1": "Warming up the engines…",
+    "newSessionLoadingMessage2": "Generating session telemetry…",
+    "newSessionLoadingMessage3": "Preparing for takeoff…",
+    "newSessionLaunchingInBackground": "Your new session will appear in the list once it's launched"
 }

--- a/mobile/app/lib/l10n/app_en.arb
+++ b/mobile/app/lib/l10n/app_en.arb
@@ -357,5 +357,9 @@
           },
           "diffRetry": "Retry",
    "splashWelcomeTo": "Welcome to",
-   "splashTitle": "Sesori"
+   "splashTitle": "Sesori",
+   "newSessionLoadingSemantics": "Creating session",
+   "newSessionLoadingMessage1": "Warming up the engines…",
+   "newSessionLoadingMessage2": "Generating session telemetry…",
+   "newSessionLoadingMessage3": "Preparing for takeoff…"
 }

--- a/mobile/app/lib/l10n/app_localizations.dart
+++ b/mobile/app/lib/l10n/app_localizations.dart
@@ -1380,6 +1380,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Sesori'**
   String get splashTitle;
+
+  /// No description provided for @newSessionLoadingSemantics.
+  ///
+  /// In en, this message translates to:
+  /// **'Creating session'**
+  String get newSessionLoadingSemantics;
+
+  /// No description provided for @newSessionLoadingMessage1.
+  ///
+  /// In en, this message translates to:
+  /// **'Warming up the engines…'**
+  String get newSessionLoadingMessage1;
+
+  /// No description provided for @newSessionLoadingMessage2.
+  ///
+  /// In en, this message translates to:
+  /// **'Generating session telemetry…'**
+  String get newSessionLoadingMessage2;
+
+  /// No description provided for @newSessionLoadingMessage3.
+  ///
+  /// In en, this message translates to:
+  /// **'Preparing for takeoff…'**
+  String get newSessionLoadingMessage3;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/mobile/app/lib/l10n/app_localizations.dart
+++ b/mobile/app/lib/l10n/app_localizations.dart
@@ -1404,6 +1404,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Preparing for takeoff…'**
   String get newSessionLoadingMessage3;
+
+  /// No description provided for @newSessionLaunchingInBackground.
+  ///
+  /// In en, this message translates to:
+  /// **'Your new session will appear in the list once it\'s launched'**
+  String get newSessionLaunchingInBackground;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/mobile/app/lib/l10n/app_localizations_en.dart
+++ b/mobile/app/lib/l10n/app_localizations_en.dart
@@ -721,4 +721,16 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get splashTitle => 'Sesori';
+
+  @override
+  String get newSessionLoadingSemantics => 'Creating session';
+
+  @override
+  String get newSessionLoadingMessage1 => 'Warming up the engines…';
+
+  @override
+  String get newSessionLoadingMessage2 => 'Generating session telemetry…';
+
+  @override
+  String get newSessionLoadingMessage3 => 'Preparing for takeoff…';
 }

--- a/mobile/app/lib/l10n/app_localizations_en.dart
+++ b/mobile/app/lib/l10n/app_localizations_en.dart
@@ -733,4 +733,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get newSessionLoadingMessage3 => 'Preparing for takeoff…';
+
+  @override
+  String get newSessionLaunchingInBackground => "Your new session will appear in the list once it's launched";
 }

--- a/mobile/app/lib/l10n/app_localizations_en.dart
+++ b/mobile/app/lib/l10n/app_localizations_en.dart
@@ -735,5 +735,5 @@ class AppLocalizationsEn extends AppLocalizations {
   String get newSessionLoadingMessage3 => 'Preparing for takeoff…';
 
   @override
-  String get newSessionLaunchingInBackground => "Your new session will appear in the list once it's launched";
+  String get newSessionLaunchingInBackground => 'Your new session will appear in the list once it\'s launched';
 }

--- a/mobile/app/pubspec.yaml
+++ b/mobile/app/pubspec.yaml
@@ -75,6 +75,7 @@ dependencies:
   firebase_messaging: ^16.1.3
   flutter_local_notifications: ^21.0.0
   flutter_svg: ^2.2.4
+  cue: ^0.2.1
 
 dev_dependencies:
   flutter_test:

--- a/mobile/app/test/features/new_session/new_session_screen_test.dart
+++ b/mobile/app/test/features/new_session/new_session_screen_test.dart
@@ -258,7 +258,6 @@ void main() {
 
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
     expect(find.byKey(const Key("new_session_loading_progress")), findsOneWidget);
-    expect(find.byKey(const Key("new_session_loading_message")), findsOneWidget);
     expect(find.bySemanticsLabel(loc.newSessionLoadingSemantics), findsOneWidget);
     expect(find.text(loc.newSessionLoadingMessage1), findsOneWidget);
   });
@@ -306,6 +305,44 @@ void main() {
         dedicatedWorktree: any(named: "dedicatedWorktree"),
       ),
     ).called(1);
+  });
+
+  testWidgets("shows snackbar and allows navigation when aborting while sending", (tester) async {
+    final createCompleter = Completer<ApiResponse<Session>>();
+    when(
+      () => sessionService.createSessionWithMessage(
+        projectId: any(named: "projectId"),
+        text: any(named: "text"),
+        agent: any(named: "agent"),
+        providerID: any(named: "providerID"),
+        modelID: any(named: "modelID"),
+        variant: any(named: "variant"),
+        command: any(named: "command"),
+        dedicatedWorktree: any(named: "dedicatedWorktree"),
+      ),
+    ).thenAnswer((_) => createCompleter.future);
+
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+
+    final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
+
+    await tester.enterText(find.byType(TextField), "test message");
+    await tester.tap(find.byIcon(Icons.send), warnIfMissed: false);
+    await tester.pump();
+
+    expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
+
+    // Simulate system back navigation (which should be allowed while sending).
+    await tester.pageBack();
+    await tester.pump();
+
+    // Snackbar should appear before the screen pops.
+    expect(find.text(loc.newSessionLaunchingInBackground), findsOneWidget);
+
+    // The screen should have popped (no longer showing NewSessionScreen).
+    await tester.pumpAndSettle();
+    expect(find.byType(NewSessionScreen), findsNothing);
   });
 
   testWidgets("still navigates to session detail after creating a session", (tester) async {

--- a/mobile/app/test/features/new_session/new_session_screen_test.dart
+++ b/mobile/app/test/features/new_session/new_session_screen_test.dart
@@ -250,6 +250,8 @@ void main() {
     await tester.pumpWidget(_buildApp());
     await tester.pumpAndSettle();
 
+    final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
+
     await tester.enterText(find.byType(TextField), "test message");
     await tester.tap(find.byIcon(Icons.send), warnIfMissed: false);
     await tester.pump();
@@ -257,8 +259,8 @@ void main() {
     expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
     expect(find.byKey(const Key("new_session_loading_progress")), findsOneWidget);
     expect(find.byKey(const Key("new_session_loading_message")), findsOneWidget);
-    expect(find.bySemanticsLabel("Creating session"), findsOneWidget);
-    expect(find.text("Warming up the engines…"), findsOneWidget);
+    expect(find.bySemanticsLabel(loc.newSessionLoadingSemantics), findsOneWidget);
+    expect(find.text(loc.newSessionLoadingMessage1), findsOneWidget);
   });
 
   testWidgets("blocks submit UI while a session is sending", (tester) async {

--- a/mobile/app/test/features/new_session/new_session_screen_test.dart
+++ b/mobile/app/test/features/new_session/new_session_screen_test.dart
@@ -27,10 +27,27 @@ AgentInfo _testAgent({required String name, required String description, require
 
 Widget _buildApp() {
   final router = GoRouter(
+    initialLocation: "/new",
     routes: [
       GoRoute(
         path: "/",
-        builder: (context, state) => const NewSessionScreen(projectId: "project-1"),
+        builder: (context, state) => const SizedBox.shrink(),
+        routes: [
+          GoRoute(
+            path: "new",
+            builder: (context, state) => const NewSessionScreen(projectId: "project-1"),
+          ),
+        ],
+      ),
+      GoRoute(
+        path: "/projects/:projectId/sessions/:sessionId",
+        builder: (context, state) {
+          return Material(
+            child: Text(
+              "session-detail:${state.pathParameters['sessionId']}",
+            ),
+          );
+        },
       ),
     ],
   );
@@ -213,5 +230,148 @@ void main() {
     // Changing the agent seeds the variant from the agent's default.
     // Reviewer has variant: null, so the button shows "Default".
     expect(find.widgetWithText(OutlinedButton, "Default"), findsOneWidget);
+  });
+
+  testWidgets("shows the loading overlay with accessible message during sending", (tester) async {
+    final createCompleter = Completer<ApiResponse<Session>>();
+    when(
+      () => sessionService.createSessionWithMessage(
+        projectId: any(named: "projectId"),
+        text: any(named: "text"),
+        agent: any(named: "agent"),
+        providerID: any(named: "providerID"),
+        modelID: any(named: "modelID"),
+        variant: any(named: "variant"),
+        command: any(named: "command"),
+        dedicatedWorktree: any(named: "dedicatedWorktree"),
+      ),
+    ).thenAnswer((_) => createCompleter.future);
+
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), "test message");
+    await tester.tap(find.byIcon(Icons.send), warnIfMissed: false);
+    await tester.pump();
+
+    expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
+    expect(find.byKey(const Key("new_session_loading_progress")), findsOneWidget);
+    expect(find.byKey(const Key("new_session_loading_message")), findsOneWidget);
+    expect(find.bySemanticsLabel("Creating session"), findsOneWidget);
+    expect(find.text("Warming up the engines…"), findsOneWidget);
+  });
+
+  testWidgets("blocks submit UI while a session is sending", (tester) async {
+    final createCompleter = Completer<ApiResponse<Session>>();
+    when(
+      () => sessionService.createSessionWithMessage(
+        projectId: any(named: "projectId"),
+        text: any(named: "text"),
+        agent: any(named: "agent"),
+        providerID: any(named: "providerID"),
+        modelID: any(named: "modelID"),
+        variant: any(named: "variant"),
+        command: any(named: "command"),
+        dedicatedWorktree: any(named: "dedicatedWorktree"),
+      ),
+    ).thenAnswer((_) => createCompleter.future);
+
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), "test message");
+    await tester.tap(find.byIcon(Icons.send), warnIfMissed: false);
+    await tester.pump();
+
+    final absorbingFinder = find.byWidgetPredicate(
+      (widget) => widget is AbsorbPointer && widget.absorbing,
+    );
+    expect(absorbingFinder, findsOneWidget);
+    expect(find.byIcon(Icons.stop_circle), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.send), warnIfMissed: false);
+    await tester.pump();
+
+    verify(
+      () => sessionService.createSessionWithMessage(
+        projectId: any(named: "projectId"),
+        text: any(named: "text"),
+        agent: any(named: "agent"),
+        providerID: any(named: "providerID"),
+        modelID: any(named: "modelID"),
+        variant: any(named: "variant"),
+        command: any(named: "command"),
+        dedicatedWorktree: any(named: "dedicatedWorktree"),
+      ),
+    ).called(1);
+  });
+
+  testWidgets("still navigates to session detail after creating a session", (tester) async {
+    final createCompleter = Completer<ApiResponse<Session>>();
+    when(
+      () => sessionService.createSessionWithMessage(
+        projectId: any(named: "projectId"),
+        text: any(named: "text"),
+        agent: any(named: "agent"),
+        providerID: any(named: "providerID"),
+        modelID: any(named: "modelID"),
+        variant: any(named: "variant"),
+        command: any(named: "command"),
+        dedicatedWorktree: any(named: "dedicatedWorktree"),
+      ),
+    ).thenAnswer((_) => createCompleter.future);
+
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), "test message");
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pump();
+
+    expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
+
+    createCompleter.complete(ApiResponse.success(testSession(id: "session-1", title: "Created session")));
+    await tester.pumpAndSettle();
+
+    expect(find.text("session-detail:session-1"), findsOneWidget);
+    expect(find.byType(NewSessionScreen), findsNothing);
+  });
+
+  testWidgets("removes the loading overlay and keeps retry UI usable after an error", (tester) async {
+    final createCompleter = Completer<ApiResponse<Session>>();
+    when(
+      () => sessionService.createSessionWithMessage(
+        projectId: any(named: "projectId"),
+        text: any(named: "text"),
+        agent: any(named: "agent"),
+        providerID: any(named: "providerID"),
+        modelID: any(named: "modelID"),
+        variant: any(named: "variant"),
+        command: any(named: "command"),
+        dedicatedWorktree: any(named: "dedicatedWorktree"),
+      ),
+    ).thenAnswer((_) => createCompleter.future);
+
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), "test message");
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pump();
+
+    expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
+
+    createCompleter.complete(ApiResponse.error(ApiError.generic()));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key("new_session_loading_overlay")), findsNothing);
+    expect(find.text("Failed to create session."), findsOneWidget);
+    expect(find.byType(TextField), findsOneWidget);
+    expect(find.byIcon(Icons.send), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), "retry message");
+    await tester.pump();
+
+    expect(find.text("retry message"), findsOneWidget);
   });
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -281,6 +281,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  cue:
+    dependency: transitive
+    description:
+      name: cue
+      sha256: "4afd93d6a1d352d6509816cd0a45d71a06be3107b84c3f85259e73afde3cff2c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   cupertino_icons:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary
- Adds a Cue-powered full-screen loading overlay to the new-session page while `NewSessionSending` is active
- Uses playful launch-themed rotating messages to reduce perceived wait time
- Blocks UI interactions and back navigation during session creation
- Preserves existing session creation/navigation flow unchanged

## Changes
- **Dependency**: Added `cue: ^0.2.1` to `mobile/app/pubspec.yaml` (app-layer only)
- **Widget**: `NewSessionLoadingOverlay` with Cue entrance + message transition animations
- **Integration**: `NewSessionScreen` shows overlay via `Stack` + `AbsorbPointer` + `PopScope`
- **Tests**: 4 new widget tests covering loading state, UI blocking, success navigation, and error recovery

## Validation
- `flutter test app/test/features/new_session/new_session_screen_test.dart` ✅ (8/8 pass)
- `flutter test` ✅ (404/404 pass)
- `flutter analyze` ✅ (no issues)
- `dart format` ✅

## Scope
App-layer only — no changes to `module_core`, backend APIs, routing definitions, or session lifecycle.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a full-screen, localized loading overlay on the new-session screen that blocks input during creation, allows system back with a background-launch toast, and keeps success/error flows unchanged.

- **New Features**
  - Shows the overlay during `NewSessionSending` with rotating launch-themed messages (3.5s cycle).
  - Cue entrance; message swaps via AnimatedSwitcher (500ms fade + slide-up), respecting reduced motion.
  - Blocks input via AbsorbPointer; system back allowed with a localized snackbar; success navigates to detail; errors dismiss overlay and keep retry UI.
  - Uses the theme scrim, and adds localized semantics + messages.

- **Dependencies**
  - Added `cue: ^0.2.1` (app layer only).

<sup>Written for commit e5ace1e39c409bbdd3958ae40757208ab3ab61f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

