### PR TITLE
feat: fully apply zyra theme across mobile app

### DIFF
--- a/mobile/app/AGENTS.md
+++ b/mobile/app/AGENTS.md
@@ -40,6 +40,44 @@ lib/
 - Localize all user-facing text in `lib/l10n/app_en.arb`, access via `context.loc.myResource`
 - English only for now
 
+## Theming
+
+The app uses the **Zyra design system** via `theme_zyra`. The theme is wired into `MaterialApp.router` in `main.dart` using `ZyraColors`, `ZyraTextTheme`, and `ZyraDesignSystem` for both light and dark modes.
+
+**ALWAYS access colors, text styles, spacing, radius, and shadows through `context.zyra`.** Never reach for `Theme.of(context).colorScheme` or `Theme.of(context).textTheme` when a Zyra token exists. This ensures every screen stays consistent with the Figma design system.
+
+### Correct usage
+
+```dart
+// Colors
+context.zyra.colors.textPrimary
+context.zyra.colors.bgBrandSolid
+context.zyra.colors.fgErrorPrimary
+
+// Text styles
+context.zyra.textTheme.textMd.bold
+context.zyra.textTheme.textSm.regular
+
+// Spacing / radius / shadows
+context.zyra.spacing.md
+context.zyra.radius.lg
+context.zyra.shadows.sm
+```
+
+### Incorrect usage
+
+```dart
+// Do NOT use Material colorScheme directly
+Theme.of(context).colorScheme.primary
+Theme.of(context).colorScheme.error
+
+// Do NOT use Material textTheme directly
+Theme.of(context).textTheme.titleMedium
+Theme.of(context).textTheme.bodySmall
+```
+
+The only exception is reading `Theme.of(context).brightness` for light/dark checks, which is still acceptable.
+
 ## Navigation
 
 - GoRouter for routing (`go_router`)

--- a/mobile/app/lib/core/widgets/agent_model_buttons.dart
+++ b/mobile/app/lib/core/widgets/agent_model_buttons.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../extensions/build_context_x.dart";
 
@@ -25,14 +26,14 @@ class AgentModelButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
     final buttonStyle = OutlinedButton.styleFrom(
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
       minimumSize: .zero,
       tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-      textStyle: theme.textTheme.labelSmall,
-      side: BorderSide(color: theme.colorScheme.outlineVariant),
+      textStyle: zyra.textTheme.textXs.medium,
+      side: BorderSide(color: zyra.colors.borderPrimary),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
     );
 
@@ -43,10 +44,10 @@ class AgentModelButtons extends StatelessWidget {
           Flexible(
             child: OutlinedButton.icon(
               onPressed: onAgentTap,
-              icon: Icon(Icons.smart_toy_outlined, size: 14, color: theme.colorScheme.onSurfaceVariant),
+              icon: Icon(Icons.smart_toy_outlined, size: 14, color: zyra.colors.textSecondary),
               label: Text(
                 selectedAgent,
-                style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+                style: TextStyle(color: zyra.colors.textSecondary),
                 overflow: .ellipsis,
                 maxLines: 1,
               ),
@@ -57,10 +58,10 @@ class AgentModelButtons extends StatelessWidget {
           Flexible(
             child: OutlinedButton.icon(
               onPressed: onModelTap,
-              icon: Icon(Icons.memory_outlined, size: 14, color: theme.colorScheme.onSurfaceVariant),
+              icon: Icon(Icons.memory_outlined, size: 14, color: zyra.colors.textSecondary),
               label: Text(
                 modelName,
-                style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+                style: TextStyle(color: zyra.colors.textSecondary),
                 overflow: .ellipsis,
                 maxLines: 1,
               ),
@@ -72,10 +73,10 @@ class AgentModelButtons extends StatelessWidget {
             Flexible(
               child: OutlinedButton.icon(
                 onPressed: onVariantTap,
-                icon: Icon(Icons.speed_outlined, size: 14, color: theme.colorScheme.onSurfaceVariant),
+                icon: Icon(Icons.speed_outlined, size: 14, color: zyra.colors.textSecondary),
                 label: Text(
                   selectedAgentModel?.variant ?? loc.sessionDetailVariantDefault,
-                  style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+                  style: TextStyle(color: zyra.colors.textSecondary),
                   overflow: .ellipsis,
                   maxLines: 1,
                 ),

--- a/mobile/app/lib/core/widgets/agent_picker_sheet.dart
+++ b/mobile/app/lib/core/widgets/agent_picker_sheet.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:go_router/go_router.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../extensions/build_context_x.dart";
 import "app_modal_bottom_sheet.dart";
@@ -43,7 +44,7 @@ class AgentPickerSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
 
     return Column(
@@ -56,7 +57,7 @@ class AgentPickerSheet extends StatelessWidget {
             width: 32,
             height: 4,
             decoration: BoxDecoration(
-              color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
+              color: zyra.colors.textSecondary.withValues(alpha: 0.4),
               borderRadius: BorderRadius.circular(2),
             ),
           ),
@@ -65,7 +66,7 @@ class AgentPickerSheet extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: Text(
             loc.sessionDetailPickerAgent,
-            style: theme.textTheme.titleMedium,
+            style: zyra.textTheme.textMd.bold,
           ),
         ),
         for (final agent in agents)
@@ -77,8 +78,8 @@ class AgentPickerSheet extends StatelessWidget {
               null => null,
             },
             leading: agent.name == selectedAgent
-                ? Icon(Icons.radio_button_checked, color: theme.colorScheme.primary)
-                : Icon(Icons.radio_button_unchecked, color: theme.colorScheme.outline),
+                ? Icon(Icons.radio_button_checked, color: zyra.colors.bgBrandSolid)
+                : Icon(Icons.radio_button_unchecked, color: zyra.colors.borderPrimary),
             onTap: () => onAgentChanged(agent.name),
           ),
         const SizedBox(height: 8),

--- a/mobile/app/lib/core/widgets/command_picker_sheet.dart
+++ b/mobile/app/lib/core/widgets/command_picker_sheet.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:go_router/go_router.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../extensions/build_context_x.dart";
 import "app_modal_bottom_sheet.dart";
@@ -23,10 +24,11 @@ class CommandPickerSheet extends StatefulWidget {
       backgroundColor: Colors.transparent,
       builder: (sheetContext) {
         final height = MediaQuery.sizeOf(sheetContext).height * 0.7;
+        final zyra = sheetContext.zyra;
         return Container(
           height: height,
           decoration: BoxDecoration(
-            color: Theme.of(sheetContext).colorScheme.surface,
+            color: zyra.colors.bgPrimary,
             borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
           ),
           child: CommandPickerSheet(commands: commands),
@@ -63,7 +65,7 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
     final commands = _filteredCommands;
 
@@ -75,7 +77,7 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
             width: 32,
             height: 4,
             decoration: BoxDecoration(
-              color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
+              color: zyra.colors.textSecondary.withValues(alpha: 0.4),
               borderRadius: BorderRadius.circular(2),
             ),
           ),
@@ -84,7 +86,7 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: Text(
             loc.sessionDetailCommandPickerTitle,
-            style: theme.textTheme.titleMedium,
+            style: zyra.textTheme.textMd.bold,
           ),
         ),
         Padding(
@@ -100,7 +102,7 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
                 borderSide: BorderSide.none,
               ),
               filled: true,
-              fillColor: theme.colorScheme.surfaceContainerHighest,
+              fillColor: zyra.colors.bgPrimary,
             ),
             onChanged: (value) => setState(() => _query = value),
           ),
@@ -114,8 +116,8 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
                 child: Text(
                   loc.sessionDetailNoCommands,
                   textAlign: TextAlign.center,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
+                  style: zyra.textTheme.textSm.regular.copyWith(
+                    color: zyra.colors.textSecondary,
                   ),
                 ),
               ),
@@ -125,7 +127,7 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
               itemCount: commands.length,
               separatorBuilder: (_, _) => Divider(
                 height: 1,
-                color: theme.colorScheme.outlineVariant,
+                color: zyra.colors.borderPrimary,
               ),
               itemBuilder: (context, index) {
                 final command = commands[index];
@@ -150,8 +152,8 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
                             hints,
                             maxLines: 2,
                             overflow: TextOverflow.ellipsis,
-                            style: theme.textTheme.bodySmall?.copyWith(
-                              color: theme.colorScheme.onSurfaceVariant,
+                            style: zyra.textTheme.textXs.regular.copyWith(
+                              color: zyra.colors.textSecondary,
                             ),
                           ),
                         ),
@@ -160,13 +162,13 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
                   trailing: Container(
                     padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                     decoration: BoxDecoration(
-                      color: theme.colorScheme.secondaryContainer,
+                      color: zyra.colors.bgBrandSolid,
                       borderRadius: BorderRadius.circular(12),
                     ),
                     child: Text(
                       _sourceLabel(command.source),
-                      style: theme.textTheme.labelSmall?.copyWith(
-                        color: theme.colorScheme.onSecondaryContainer,
+                      style: zyra.textTheme.textXs.medium.copyWith(
+                        color: zyra.colors.bgPrimary,
                         fontWeight: FontWeight.w600,
                       ),
                     ),

--- a/mobile/app/lib/core/widgets/connection_overlay.dart
+++ b/mobile/app/lib/core/widgets/connection_overlay.dart
@@ -4,6 +4,7 @@ import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:go_router/go_router.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../di/injection.dart";
 import "../extensions/build_context_x.dart";
@@ -37,6 +38,7 @@ class _ConnectionOverlayBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final zyra = context.zyra;
     final status = context.watch<ConnectionOverlayCubit>().state;
     final showOverlay = status is ConnectionLost;
     final isReconnecting = status is ConnectionReconnecting;
@@ -72,7 +74,7 @@ class _ConnectionOverlayBody extends StatelessWidget {
                     padding: const EdgeInsets.all(8),
                     child: Text(
                       context.loc.relayReconnecting,
-                      style: Theme.of(context).textTheme.labelSmall,
+                      style: zyra.textTheme.textXs.medium,
                     ),
                   ),
                 ],
@@ -110,7 +112,7 @@ class _BridgeOfflineBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
 
     return Material(
@@ -129,14 +131,14 @@ class _BridgeOfflineBanner extends StatelessWidget {
                 children: [
                   Text(
                     loc.bridgeOfflineTitle,
-                    style: theme.textTheme.labelMedium?.copyWith(
+                    style: zyra.textTheme.textXs.medium.copyWith(
                       color: Colors.white,
                       fontWeight: FontWeight.bold,
                     ),
                   ),
                   Text(
                     loc.bridgeOfflineMessage,
-                    style: theme.textTheme.labelSmall?.copyWith(
+                    style: zyra.textTheme.textXs.regular.copyWith(
                       color: Colors.white70,
                     ),
                   ),
@@ -161,7 +163,7 @@ class _ConnectionLostCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
 
     return Card(
@@ -175,18 +177,18 @@ class _ConnectionLostCard extends StatelessWidget {
             Icon(
               Icons.cloud_off_rounded,
               size: 48,
-              color: theme.colorScheme.error,
+              color: zyra.colors.fgErrorPrimary,
             ),
             const SizedBox(height: 16),
             Text(
               loc.connectionLostTitle,
-              style: theme.textTheme.titleLarge,
+              style: zyra.textTheme.textMd.bold,
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 8),
             Text(
               loc.relayConnectionLost,
-              style: theme.textTheme.bodyMedium,
+              style: zyra.textTheme.textSm.regular,
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 24),

--- a/mobile/app/lib/core/widgets/markdown_styles.dart
+++ b/mobile/app/lib/core/widgets/markdown_styles.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../di/injection.dart";
 
@@ -15,20 +16,20 @@ void handleMarkdownLinkTap(String text, String? href, String title) {
 }
 
 // ignore: no_slop_linter/prefer_required_named_parameters, paragraphStyle is an optional override
-MarkdownStyleSheet buildSessionMarkdownStyleSheet(
-  ThemeData theme, {
+MarkdownStyleSheet buildSessionMarkdownStyleSheet({
+  required ZyraDesignSystem zyra,
   TextStyle? paragraphStyle,
 }) {
-  return MarkdownStyleSheet.fromTheme(theme).copyWith(
-    p: paragraphStyle,
+  return MarkdownStyleSheet(
+    p: paragraphStyle ?? zyra.textTheme.textSm.regular,
     codeblockDecoration: BoxDecoration(
-      color: theme.colorScheme.surfaceContainerHighest,
+      color: zyra.colors.bgQuaternary,
       borderRadius: BorderRadius.circular(8),
     ),
     code: TextStyle(
       fontFamily: "monospace",
       fontSize: 13,
-      color: theme.colorScheme.onSurface,
+      color: zyra.colors.textPrimary,
     ),
   );
 }

--- a/mobile/app/lib/core/widgets/model_picker_sheet.dart
+++ b/mobile/app/lib/core/widgets/model_picker_sheet.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:go_router/go_router.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../extensions/build_context_x.dart";
 import "app_modal_bottom_sheet.dart";
@@ -34,10 +35,11 @@ class ModelPickerSheet extends StatefulWidget {
       backgroundColor: Colors.transparent,
       builder: (sheetContext) {
         final height = MediaQuery.sizeOf(sheetContext).height * 0.7;
+        final zyra = sheetContext.zyra;
         return Container(
           height: height,
           decoration: BoxDecoration(
-            color: Theme.of(sheetContext).colorScheme.surface,
+            color: zyra.colors.bgPrimary,
             borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
           ),
           child: ModelPickerSheet(
@@ -111,7 +113,7 @@ class _ModelPickerSheetState extends State<ModelPickerSheet> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
 
     return Column(
@@ -122,7 +124,7 @@ class _ModelPickerSheetState extends State<ModelPickerSheet> {
             width: 32,
             height: 4,
             decoration: BoxDecoration(
-              color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
+              color: zyra.colors.textSecondary.withValues(alpha: 0.4),
               borderRadius: BorderRadius.circular(2),
             ),
           ),
@@ -131,7 +133,7 @@ class _ModelPickerSheetState extends State<ModelPickerSheet> {
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: Text(
             loc.sessionDetailSelectModel,
-            style: theme.textTheme.titleMedium,
+            style: zyra.textTheme.textMd.bold,
           ),
         ),
         Padding(
@@ -148,7 +150,7 @@ class _ModelPickerSheetState extends State<ModelPickerSheet> {
                 borderSide: BorderSide.none,
               ),
               filled: true,
-              fillColor: theme.colorScheme.surfaceContainerHighest,
+              fillColor: zyra.colors.bgPrimary,
             ),
             onChanged: (value) => setState(() => _query = value.trim()),
           ),
@@ -158,7 +160,7 @@ class _ModelPickerSheetState extends State<ModelPickerSheet> {
           child: ListView(
             padding: .zero,
             children: [
-              for (final provider in _sortedProviders) ..._buildProviderSection(provider: provider, theme: theme),
+              for (final provider in _sortedProviders) ..._buildProviderSection(provider: provider, context: context),
             ],
           ),
         ),
@@ -166,7 +168,8 @@ class _ModelPickerSheetState extends State<ModelPickerSheet> {
     );
   }
 
-  List<Widget> _buildProviderSection({required ProviderInfo provider, required ThemeData theme}) {
+  List<Widget> _buildProviderSection({required ProviderInfo provider, required BuildContext context}) {
+    final zyra = context.zyra;
     final isSearching = _query.isNotEmpty;
     final visibleIds = isSearching ? null : _defaultVisibleIds(provider);
 
@@ -199,8 +202,8 @@ class _ModelPickerSheetState extends State<ModelPickerSheet> {
         padding: const EdgeInsetsDirectional.fromSTEB(16, 16, 16, 4),
         child: Text(
           provider.name,
-          style: theme.textTheme.labelLarge?.copyWith(
-            color: theme.colorScheme.primary,
+          style: zyra.textTheme.textXs.medium.copyWith(
+            color: zyra.colors.bgBrandSolid,
             fontWeight: FontWeight.w600,
           ),
         ),
@@ -231,7 +234,7 @@ class _ModelTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
 
     return ListTile(
       dense: true,
@@ -241,8 +244,8 @@ class _ModelTile extends StatelessWidget {
         null => null,
       },
       leading: isSelected
-          ? Icon(Icons.radio_button_checked, color: theme.colorScheme.primary)
-          : Icon(Icons.radio_button_unchecked, color: theme.colorScheme.outline),
+          ? Icon(Icons.radio_button_checked, color: zyra.colors.bgBrandSolid)
+          : Icon(Icons.radio_button_unchecked, color: zyra.colors.borderPrimary),
       onTap: onTap,
     );
   }

--- a/mobile/app/lib/core/widgets/variant_picker_sheet.dart
+++ b/mobile/app/lib/core/widgets/variant_picker_sheet.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:go_router/go_router.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../extensions/build_context_x.dart";
 import "app_modal_bottom_sheet.dart";
@@ -40,7 +41,7 @@ class VariantPickerSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
 
     return Column(
@@ -52,7 +53,7 @@ class VariantPickerSheet extends StatelessWidget {
             width: 32,
             height: 4,
             decoration: BoxDecoration(
-              color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
+              color: zyra.colors.textSecondary.withValues(alpha: 0.4),
               borderRadius: BorderRadius.circular(2),
             ),
           ),
@@ -61,7 +62,7 @@ class VariantPickerSheet extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: Text(
             loc.sessionDetailPickerVariant,
-            style: theme.textTheme.titleMedium,
+            style: zyra.textTheme.textMd.bold,
           ),
         ),
         _VariantTile(
@@ -94,14 +95,14 @@ class _VariantTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
 
     return ListTile(
       dense: true,
       title: Text(label),
       leading: isSelected
-          ? Icon(Icons.radio_button_checked, color: theme.colorScheme.primary)
-          : Icon(Icons.radio_button_unchecked, color: theme.colorScheme.outline),
+          ? Icon(Icons.radio_button_checked, color: zyra.colors.bgBrandSolid)
+          : Icon(Icons.radio_button_unchecked, color: zyra.colors.borderPrimary),
       onTap: onTap,
     );
   }

--- a/mobile/app/lib/features/login/login_provider_buttons.dart
+++ b/mobile/app/lib/features/login/login_provider_buttons.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 
@@ -20,7 +21,7 @@ class LoginProviderButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
 
     return Column(
@@ -63,21 +64,20 @@ class LoginProviderButtons extends StatelessWidget {
                     height: 18,
                     child: CircularProgressIndicator(
                       strokeWidth: 2,
-                      color: theme.colorScheme.primary,
+                      color: zyra.colors.bgBrandSolid,
                     ),
                   )
                 : Text(
                     "G",
-                    style: TextStyle(
+                    style: zyra.textTheme.textMd.bold.copyWith(
                       fontSize: 20,
-                      fontWeight: FontWeight.bold,
-                      color: theme.colorScheme.onSurface,
+                      color: zyra.colors.textPrimary,
                     ),
                   ),
             label: Text(loc.loginWithGoogle),
             style: OutlinedButton.styleFrom(
-              foregroundColor: theme.colorScheme.onSurface,
-              side: BorderSide(color: theme.colorScheme.outline),
+              foregroundColor: zyra.colors.textPrimary,
+              side: BorderSide(color: zyra.colors.borderPrimary),
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(12),
               ),
@@ -92,7 +92,7 @@ class LoginProviderButtons extends StatelessWidget {
             child: TextButton(
               onPressed: isLoading ? null : onShowEmailForm,
               style: TextButton.styleFrom(
-                foregroundColor: theme.colorScheme.primary,
+                foregroundColor: zyra.colors.bgBrandSolid,
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(12),
                 ),

--- a/mobile/app/lib/features/login/login_screen.dart
+++ b/mobile/app/lib/features/login/login_screen.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../core/di/injection.dart";
 import "../../core/extensions/build_context_x.dart";
@@ -48,7 +49,7 @@ class _LoginScreenBodyState extends State<_LoginScreenBody> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
     final state = context.watch<LoginCubit>().state;
     final isLoading = state is LoginAuthenticating || state is LoginAwaitingCallback;
@@ -74,27 +75,25 @@ class _LoginScreenBodyState extends State<_LoginScreenBody> {
                     width: 96,
                     height: 96,
                     decoration: BoxDecoration(
-                      color: theme.colorScheme.primaryContainer.withAlpha(102),
+                      color: zyra.colors.bgBrandSolid.withAlpha(102),
                       borderRadius: BorderRadius.circular(24),
                     ),
                     child: Icon(
                       Icons.terminal_rounded,
                       size: 56,
-                      color: theme.colorScheme.primary,
+                      color: zyra.colors.bgBrandSolid,
                     ),
                   ),
                   const SizedBox(height: 24),
                   Text(
                     loc.appTitle,
-                    style: theme.textTheme.headlineMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
+                    style: zyra.textTheme.textXl.bold,
                   ),
                   const SizedBox(height: 8),
                   Text(
                     loc.loginSubtitle,
-                    style: theme.textTheme.bodyLarge?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
+                    style: zyra.textTheme.textSm.regular.copyWith(
+                      color: zyra.colors.textSecondary,
                     ),
                     textAlign: TextAlign.center,
                   ),
@@ -117,8 +116,8 @@ class _LoginScreenBodyState extends State<_LoginScreenBody> {
                       padding: const EdgeInsetsDirectional.only(top: 16),
                       child: Text(
                         loc.loginAuthenticating,
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
+                        style: zyra.textTheme.textSm.regular.copyWith(
+                          color: zyra.colors.textSecondary,
                         ),
                         textAlign: TextAlign.center,
                       ),
@@ -127,8 +126,8 @@ class _LoginScreenBodyState extends State<_LoginScreenBody> {
                       padding: const EdgeInsetsDirectional.only(top: 16),
                       child: Text(
                         loc.loginAwaitingCallback,
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
+                        style: zyra.textTheme.textSm.regular.copyWith(
+                          color: zyra.colors.textSecondary,
                         ),
                         textAlign: TextAlign.center,
                       ),
@@ -141,21 +140,21 @@ class _LoginScreenBodyState extends State<_LoginScreenBody> {
                     LoginFailed(:final error) => Padding(
                       padding: const EdgeInsetsDirectional.only(top: 24),
                       child: Card(
-                        color: theme.colorScheme.errorContainer,
+                        color: zyra.colors.bgErrorPrimary,
                         child: Padding(
                           padding: const EdgeInsets.all(16),
                           child: Row(
                             children: [
                               Icon(
                                 Icons.error_outline,
-                                color: theme.colorScheme.error,
+                                color: zyra.colors.fgErrorPrimary,
                               ),
                               const SizedBox(width: 12),
                               Expanded(
                                 child: Text(
                                   _getErrorMessage(loc: loc, error: error),
-                                  style: TextStyle(
-                                    color: theme.colorScheme.onErrorContainer,
+                                  style: zyra.textTheme.textSm.regular.copyWith(
+                                    color: zyra.colors.fgErrorPrimary,
                                   ),
                                 ),
                               ),

--- a/mobile/app/lib/features/new_session/new_session_screen.dart
+++ b/mobile/app/lib/features/new_session/new_session_screen.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:go_router/go_router.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../core/di/injection.dart";
 import "../../core/extensions/build_context_x.dart";
@@ -80,6 +81,7 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
   }
 
   Widget? _buildErrorBanner(NewSessionState state) {
+    final zyra = context.zyra;
     return switch (state) {
       NewSessionError(:final message) => Padding(
         padding: const EdgeInsetsDirectional.fromSTEB(12, 8, 12, 4),
@@ -88,7 +90,7 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
             Expanded(
               child: Text(
                 message,
-                style: TextStyle(color: Theme.of(context).colorScheme.error),
+                style: TextStyle(color: zyra.colors.fgErrorPrimary),
               ),
             ),
           ],
@@ -136,6 +138,7 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
   Widget build(BuildContext context) {
     final state = context.watch<NewSessionCubit>().state;
     final loc = context.loc;
+    final zyra = context.zyra;
 
     return BlocListener<NewSessionCubit, NewSessionState>(
       listenWhen: (_, current) => current is NewSessionCreated,
@@ -166,8 +169,8 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
                       title: Text(loc.newSessionDedicatedWorktree),
                       subtitle: Text(
                         loc.newSessionDedicatedWorktreeDescription,
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        style: zyra.textTheme.textXs.regular.copyWith(
+                          color: zyra.colors.textSecondary,
                         ),
                       ),
                       value: _dedicatedWorktree,

--- a/mobile/app/lib/features/project_list/add_project_dialog.dart
+++ b/mobile/app/lib/features/project_list/add_project_dialog.dart
@@ -3,6 +3,7 @@ import "package:get_it/get_it.dart";
 import "package:go_router/go_router.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../core/constants.dart";
 import "../../core/extensions/build_context_x.dart";
@@ -114,6 +115,7 @@ class _AddProjectDialogState extends State<AddProjectDialog> {
   Widget build(BuildContext context) {
     final loc = context.loc;
     final screenHeight = MediaQuery.sizeOf(context).height;
+    final zyra = context.zyra;
 
     return SizedBox(
       height: screenHeight * 0.7,
@@ -127,7 +129,7 @@ class _AddProjectDialogState extends State<AddProjectDialog> {
                 width: 32,
                 height: 4,
                 decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
+                  color: zyra.colors.textSecondary.withValues(alpha: 0.4),
                   borderRadius: BorderRadius.circular(2),
                 ),
               ),
@@ -137,7 +139,7 @@ class _AddProjectDialogState extends State<AddProjectDialog> {
               padding: const EdgeInsets.symmetric(horizontal: 16),
               child: Align(
                 alignment: Alignment.centerLeft,
-                child: Text(loc.addProject, style: Theme.of(context).textTheme.titleMedium),
+                child: Text(loc.addProject, style: zyra.textTheme.textMd.bold),
               ),
             ),
             const SizedBox(height: 8),
@@ -276,7 +278,7 @@ class _DirectoryBrowserState extends State<_DirectoryBrowser> {
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -296,8 +298,8 @@ class _DirectoryBrowserState extends State<_DirectoryBrowser> {
                 Expanded(
                   child: Text(
                     _currentPath,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
+                    style: zyra.textTheme.textXs.regular.copyWith(
+                      color: zyra.colors.textSecondary,
                     ),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
@@ -316,14 +318,14 @@ class _DirectoryBrowserState extends State<_DirectoryBrowser> {
                     padding: const EdgeInsets.symmetric(horizontal: 32),
                     child: Column(
                       mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(Icons.error_outline, size: 48, color: theme.colorScheme.error),
+                        children: [
+                        Icon(Icons.error_outline, size: 48, color: zyra.colors.fgErrorPrimary),
                         const SizedBox(height: 12),
                         Text(
                           loc.fetchDirectoryFailed,
                           textAlign: TextAlign.center,
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            color: theme.colorScheme.error,
+                          style: zyra.textTheme.textSm.regular.copyWith(
+                            color: zyra.colors.fgErrorPrimary,
                           ),
                         ),
                         const SizedBox(height: 16),
@@ -345,11 +347,11 @@ class _DirectoryBrowserState extends State<_DirectoryBrowser> {
                   ),
                 )
               : _entries.isEmpty
-              ? Center(
+                ? Center(
                   child: Text(
                     loc.emptyDirectory,
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: theme.colorScheme.outline,
+                    style: zyra.textTheme.textSm.regular.copyWith(
+                      color: zyra.colors.borderPrimary,
                     ),
                   ),
                 )
@@ -377,11 +379,11 @@ class _DirectoryTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final loc = context.loc;
+    final zyra = context.zyra;
 
     return ListTile(
-      leading: Icon(Icons.folder, color: theme.colorScheme.primary),
+      leading: Icon(Icons.folder, color: zyra.colors.bgBrandSolid),
       title: Row(
         children: [
           Flexible(child: Text(entry.name, overflow: TextOverflow.ellipsis)),
@@ -390,13 +392,13 @@ class _DirectoryTile extends StatelessWidget {
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
               decoration: BoxDecoration(
-                color: theme.colorScheme.tertiaryContainer,
+                color: zyra.colors.bgPrimary,
                 borderRadius: BorderRadius.circular(4),
               ),
               child: Text(
                 loc.gitRepoBadge,
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: theme.colorScheme.onTertiaryContainer,
+                style: zyra.textTheme.textXs.medium.copyWith(
+                  color: zyra.colors.textPrimary,
                 ),
               ),
             ),

--- a/mobile/app/lib/features/project_list/project_list_screen.dart
+++ b/mobile/app/lib/features/project_list/project_list_screen.dart
@@ -5,6 +5,7 @@ import "package:flutter_bloc/flutter_bloc.dart";
 import "package:go_router/go_router.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 import "../../core/constants.dart";
 import "../../core/di/injection.dart";
 import "../../core/extensions/build_context_x.dart";
@@ -105,6 +106,7 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
   Widget build(BuildContext context) {
     final loc = context.loc;
     final state = context.watch<ProjectListCubit>().state;
+    final zyra = context.zyra;
 
     return Scaffold(
       appBar: AppBar(
@@ -153,15 +155,15 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
                                   Icon(
                                     Icons.folder_off_outlined,
                                     size: 48,
-                                    color: Theme.of(context).colorScheme.outline,
+                                    color: zyra.colors.borderPrimary,
                                   ),
                                   const SizedBox(height: 16),
-                                  Text(loc.noProjects, style: Theme.of(context).textTheme.titleMedium),
+                                  Text(loc.noProjects, style: zyra.textTheme.textMd.bold),
                                   const SizedBox(height: 8),
                                   Text(
                                     loc.addProjectPrompt,
-                                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                                      color: Theme.of(context).colorScheme.outline,
+                                    style: zyra.textTheme.textSm.regular.copyWith(
+                                      color: zyra.colors.borderPrimary,
                                     ),
                                   ),
                                   const SizedBox(height: 24),
@@ -215,8 +217,8 @@ class _ProjectTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final loc = context.loc;
+    final zyra = context.zyra;
     final lastSegment = project.id.split("/").last;
     final displayName = project.name ?? (lastSegment.isNotEmpty ? lastSegment : loc.projectListDefaultName);
     final updatedAt = project.time?.updated;
@@ -224,10 +226,10 @@ class _ProjectTile extends StatelessWidget {
 
     return ListTile(
       leading: CircleAvatar(
-        backgroundColor: theme.colorScheme.primaryContainer,
+        backgroundColor: zyra.colors.bgBrandSolid,
         child: Icon(
           Icons.folder_outlined,
-          color: theme.colorScheme.onPrimaryContainer,
+          color: zyra.colors.textPrimary,
         ),
       ),
       title: Text(displayName),
@@ -236,26 +238,26 @@ class _ProjectTile extends StatelessWidget {
         children: [
           Text(
             project.id,
-            style: theme.textTheme.bodySmall,
+            style: zyra.textTheme.textXs.regular,
             maxLines: 1,
             overflow: .ellipsis,
           ),
           if (updatedAt != null)
             Text(
               loc.projectListUpdated(_formatTimestamp(updatedAt)),
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.outline,
+              style: zyra.textTheme.textXs.regular.copyWith(
+                color: zyra.colors.borderPrimary,
               ),
             ),
           if (isActive)
             Row(
               children: [
-                Icon(Icons.circle, size: 8, color: theme.colorScheme.primary),
+                Icon(Icons.circle, size: 8, color: zyra.colors.bgBrandSolid),
                 const SizedBox(width: 4),
                 Text(
                   loc.projectListActiveSessions(activeSessions),
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.primary,
+                  style: zyra.textTheme.textXs.regular.copyWith(
+                    color: zyra.colors.bgBrandSolid,
                     fontWeight: FontWeight.w500,
                   ),
                 ),
@@ -297,6 +299,7 @@ class _ErrorView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
+    final zyra = context.zyra;
 
     return Center(
       child: Padding(
@@ -307,12 +310,12 @@ class _ErrorView extends StatelessWidget {
             Icon(
               Icons.error_outline,
               size: 48,
-              color: Theme.of(context).colorScheme.error,
+              color: zyra.colors.fgErrorPrimary,
             ),
             const SizedBox(height: 16),
             Text(
               loc.projectListErrorTitle,
-              style: Theme.of(context).textTheme.titleMedium,
+              style: zyra.textTheme.textMd.bold,
             ),
             const SizedBox(height: 8),
             Text(

--- a/mobile/app/lib/features/project_list/rename_project_dialog.dart
+++ b/mobile/app/lib/features/project_list/rename_project_dialog.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:go_router/go_router.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../core/constants.dart";
 import "../../core/extensions/build_context_x.dart";
@@ -97,6 +98,7 @@ class _RenameProjectDialogState extends State<RenameProjectDialog> {
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
+    final zyra = context.zyra;
 
     return Padding(
       padding: const EdgeInsetsDirectional.fromSTEB(16, 8, 16, 16),
@@ -108,7 +110,7 @@ class _RenameProjectDialogState extends State<RenameProjectDialog> {
               width: 32,
               height: 4,
               decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.onSurfaceVariant.withValues(alpha: 0.4),
+                color: zyra.colors.textSecondary.withValues(alpha: 0.4),
                 borderRadius: BorderRadius.circular(2),
               ),
             ),
@@ -116,7 +118,7 @@ class _RenameProjectDialogState extends State<RenameProjectDialog> {
           const SizedBox(height: 8),
           Align(
             alignment: Alignment.centerLeft,
-            child: Text(loc.renameProjectTitle, style: Theme.of(context).textTheme.titleMedium),
+            child: Text(loc.renameProjectTitle, style: zyra.textTheme.textMd.bold),
           ),
           const SizedBox(height: 16),
           TextField(

--- a/mobile/app/lib/features/session_detail/widgets/agent_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/agent_part_widget.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 class AgentPartWidget extends StatelessWidget {
   final String? agentName;
@@ -7,7 +8,7 @@ class AgentPartWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final label = agentName ?? "Agent";
 
     return Padding(
@@ -17,13 +18,13 @@ class AgentPartWidget extends StatelessWidget {
           Icon(
             Icons.smart_toy_outlined,
             size: 14,
-            color: theme.colorScheme.outline,
+            color: zyra.colors.borderPrimary,
           ),
           const SizedBox(width: 6),
           Text(
             label,
-            style: theme.textTheme.labelSmall?.copyWith(
-              color: theme.colorScheme.outline,
+            style: zyra.textTheme.textXs.medium.copyWith(
+              color: zyra.colors.borderPrimary,
             ),
           ),
         ],

--- a/mobile/app/lib/features/session_detail/widgets/background_tasks_bar.dart
+++ b/mobile/app/lib/features/session_detail/widgets/background_tasks_bar.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/routing/app_router.dart";
 import "../../../l10n/app_localizations.dart";
@@ -46,13 +47,13 @@ class _BackgroundTasksBarState extends State<BackgroundTasksBar> {
   Widget build(BuildContext context) {
     if (widget.children.isEmpty) return const SizedBox.shrink();
 
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final running = _runningTasks;
     final completed = _completedTasks;
 
     return Material(
       elevation: 2,
-      color: theme.colorScheme.surfaceContainerHigh,
+      color: zyra.colors.bgTertiary,
       borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -97,7 +98,7 @@ class _CollapsedHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
     final hasRunning = runningCount > 0;
 
@@ -114,28 +115,28 @@ class _CollapsedHeader extends StatelessWidget {
                 height: 16,
                 child: CircularProgressIndicator(
                   strokeWidth: 2,
-                  color: theme.colorScheme.primary,
+                  color: zyra.colors.bgBrandSolid,
                 ),
               )
             else
               Icon(
                 Icons.check_circle,
                 size: 16,
-                color: theme.colorScheme.primary,
+                color: zyra.colors.bgBrandSolid,
               ),
             const SizedBox(width: 10),
             Expanded(
               child: Text(
                 hasRunning ? loc.backgroundTasksRunning(runningCount) : loc.backgroundTasksCompleted,
-                style: theme.textTheme.labelLarge?.copyWith(
-                  color: theme.colorScheme.onSurface,
+                style: zyra.textTheme.textMd.bold.copyWith(
+                  color: zyra.colors.textPrimary,
                 ),
               ),
             ),
             Icon(
               expanded ? Icons.keyboard_arrow_down : Icons.keyboard_arrow_up,
               size: 20,
-              color: theme.colorScheme.onSurfaceVariant,
+              color: zyra.colors.textSecondary,
             ),
           ],
         ),
@@ -163,7 +164,7 @@ class _ExpandedTaskList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final hasRunning = runningTasks.isNotEmpty;
     final hasCompleted = completedTasks.isNotEmpty;
 
@@ -178,7 +179,7 @@ class _ExpandedTaskList extends StatelessWidget {
       decoration: BoxDecoration(
         border: Border(
           top: BorderSide(
-            color: theme.colorScheme.outlineVariant,
+            color: zyra.colors.borderSecondary,
             width: 0.5,
           ),
         ),
@@ -190,7 +191,7 @@ class _ExpandedTaskList extends StatelessWidget {
         separatorBuilder: (_, __) => Divider(
           height: 1,
           indent: 42,
-          color: theme.colorScheme.outlineVariant.withValues(alpha: 0.5),
+          color: zyra.colors.borderSecondary.withValues(alpha: 0.5),
         ),
         itemBuilder: (context, index) {
           // Toggle button goes after visible tasks.
@@ -227,7 +228,7 @@ class _CompletedToggle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
 
     return InkWell(
@@ -239,14 +240,14 @@ class _CompletedToggle extends StatelessWidget {
             Icon(
               showCompleted ? Icons.visibility_off_outlined : Icons.visibility_outlined,
               size: 16,
-              color: theme.colorScheme.primary,
+              color: zyra.colors.bgBrandSolid,
             ),
             const SizedBox(width: 10),
             Expanded(
               child: Text(
                 showCompleted ? loc.backgroundTasksHideCompleted : loc.backgroundTasksShowCompleted(completedCount),
-                style: theme.textTheme.labelMedium?.copyWith(
-                  color: theme.colorScheme.primary,
+                style: zyra.textTheme.textSm.bold.copyWith(
+                  color: zyra.colors.bgBrandSolid,
                 ),
               ),
             ),
@@ -270,7 +271,7 @@ class _TaskRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
     final title = session.title ?? loc.sessionDetailSubtaskUnnamed;
 
@@ -289,7 +290,7 @@ class _TaskRow extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
         child: Row(
           children: [
-            _statusIcon(status: status, theme: theme),
+            _statusIcon(status: status, zyra: zyra),
             const SizedBox(width: 10),
             Expanded(
               child: Column(
@@ -297,14 +298,14 @@ class _TaskRow extends StatelessWidget {
                 children: [
                   Text(
                     title,
-                    style: theme.textTheme.bodyMedium,
+                    style: zyra.textTheme.textSm.regular,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
                   Text(
                     _statusLabel(loc: loc, status: status),
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
+                    style: zyra.textTheme.textXs.regular.copyWith(
+                      color: zyra.colors.textSecondary,
                     ),
                   ),
                 ],
@@ -313,7 +314,7 @@ class _TaskRow extends StatelessWidget {
             Icon(
               Icons.chevron_right,
               size: 20,
-              color: theme.colorScheme.onSurfaceVariant,
+              color: zyra.colors.textSecondary,
             ),
           ],
         ),
@@ -321,29 +322,29 @@ class _TaskRow extends StatelessWidget {
     );
   }
 
-  Widget _statusIcon({required SessionStatus? status, required ThemeData theme}) => switch (status) {
+  Widget _statusIcon({required SessionStatus? status, required ZyraDesignSystem zyra}) => switch (status) {
     SessionStatusBusy() => SizedBox(
       width: 16,
       height: 16,
       child: CircularProgressIndicator(
         strokeWidth: 2,
-        color: theme.colorScheme.primary,
+        color: zyra.colors.bgBrandSolid,
       ),
     ),
     SessionStatusRetry() => Icon(
       Icons.refresh,
       size: 16,
-      color: theme.colorScheme.tertiary,
+      color: zyra.colors.fgSuccessPrimary,
     ),
     SessionStatusIdle() => Icon(
       Icons.check_circle,
       size: 16,
-      color: theme.colorScheme.primary,
+      color: zyra.colors.bgBrandSolid,
     ),
     null => Icon(
       Icons.play_circle_outline,
       size: 16,
-      color: theme.colorScheme.outline,
+      color: zyra.colors.borderPrimary,
     ),
   };
   String _statusLabel({required AppLocalizations loc, required SessionStatus? status}) => switch (status) {

--- a/mobile/app/lib/features/session_detail/widgets/error_message_card.dart
+++ b/mobile/app/lib/features/session_detail/widgets/error_message_card.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 /// Inline error display for a [MessageError].
 ///
@@ -22,7 +23,7 @@ class ErrorMessageCard extends StatelessWidget {
           message.errorMessage,
           textAlign: TextAlign.center,
           style: TextStyle(
-            color: Theme.of(context).colorScheme.error,
+              color: context.zyra.colors.fgErrorPrimary,
             fontSize: 14,
           ),
         ),

--- a/mobile/app/lib/features/session_detail/widgets/jump_to_edge_pill.dart
+++ b/mobile/app/lib/features/session_detail/widgets/jump_to_edge_pill.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 /// Floating pill overlay shown over a detached scrollable, inviting the
 /// user to jump back to the follow edge (top or bottom depending on
@@ -24,7 +25,7 @@ class JumpToEdgePill extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     return Positioned(
       bottom: 12,
       left: 0,
@@ -33,7 +34,7 @@ class JumpToEdgePill extends StatelessWidget {
         child: Material(
           elevation: 4,
           borderRadius: BorderRadius.circular(20),
-          color: theme.colorScheme.primaryContainer,
+          color: zyra.colors.bgBrandPrimary,
           child: InkWell(
             key: tapTargetKey,
             borderRadius: BorderRadius.circular(20),
@@ -43,12 +44,12 @@ class JumpToEdgePill extends StatelessWidget {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Icon(Icons.arrow_downward, size: 16, color: theme.colorScheme.onPrimaryContainer),
+                  Icon(Icons.arrow_downward, size: 16, color: zyra.colors.bgBrandPrimaryAlt),
                   const SizedBox(width: 6),
                   Text(
                     label,
-                    style: theme.textTheme.labelMedium?.copyWith(
-                      color: theme.colorScheme.onPrimaryContainer,
+                    style: zyra.textTheme.textSm.bold.copyWith(
+                      color: zyra.colors.bgBrandPrimaryAlt,
                     ),
                   ),
                 ],

--- a/mobile/app/lib/features/session_detail/widgets/permission_modal.dart
+++ b/mobile/app/lib/features/session_detail/widgets/permission_modal.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
 import "package:go_router/go_router.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/widgets/app_modal_bottom_sheet.dart";
@@ -59,11 +60,11 @@ class PermissionModal extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
 
     return Container(
       decoration: BoxDecoration(
-        color: theme.colorScheme.surface,
+        color: zyra.colors.bgPrimary,
         borderRadius: const BorderRadius.vertical(
           top: Radius.circular(16),
         ),
@@ -78,7 +79,7 @@ class PermissionModal extends StatelessWidget {
               width: 32,
               height: 4,
               decoration: BoxDecoration(
-                color: theme.colorScheme.outlineVariant,
+                color: zyra.colors.borderSecondary,
                 borderRadius: BorderRadius.circular(2),
               ),
             ),
@@ -92,13 +93,13 @@ class PermissionModal extends StatelessWidget {
                 Icon(
                   Icons.shield_outlined,
                   size: 20,
-                  color: theme.colorScheme.primary,
+                  color: zyra.colors.bgBrandSolid,
                 ),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
                     context.loc.diffPermissionRequestTitle,
-                    style: theme.textTheme.titleMedium,
+                    style: zyra.textTheme.textMd.bold,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
@@ -126,7 +127,7 @@ class PermissionModal extends StatelessWidget {
                     vertical: 8,
                   ),
                   decoration: BoxDecoration(
-                    color: theme.colorScheme.surfaceContainerHighest,
+                    color: zyra.colors.bgQuaternary,
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Row(
@@ -134,12 +135,12 @@ class PermissionModal extends StatelessWidget {
                       Icon(
                         Icons.terminal,
                         size: 16,
-                        color: theme.colorScheme.onSurfaceVariant,
+                        color: zyra.colors.textSecondary,
                       ),
                       const SizedBox(width: 8),
                       Text(
                         permission.tool,
-                        style: theme.textTheme.titleSmall?.copyWith(
+                        style: zyra.textTheme.textSm.bold.copyWith(
                           fontWeight: FontWeight.bold,
                           fontFamily: "monospace",
                         ),
@@ -154,10 +155,10 @@ class PermissionModal extends StatelessWidget {
                   data: permission.description,
                   selectable: true,
                   onTapLink: handleMarkdownLinkTap,
-                  styleSheet: buildSessionMarkdownStyleSheet(
-                    theme,
-                    paragraphStyle: theme.textTheme.bodyMedium,
-                  ),
+                    styleSheet: buildSessionMarkdownStyleSheet(
+                      zyra: zyra,
+                      paragraphStyle: zyra.textTheme.textSm.regular,
+                    ),
                 ),
               ],
             ),
@@ -171,8 +172,8 @@ class PermissionModal extends StatelessWidget {
                 Expanded(
                   child: OutlinedButton(
                     style: OutlinedButton.styleFrom(
-                      foregroundColor: theme.colorScheme.error,
-                      side: BorderSide(color: theme.colorScheme.error),
+                      foregroundColor: zyra.colors.fgErrorPrimary,
+                      side: BorderSide(color: zyra.colors.fgErrorPrimary),
                     ),
                     onPressed: () => _reply(context, reply: PermissionReply.reject),
                     child: Text(context.loc.diffPermissionReject),

--- a/mobile/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/mobile/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -4,6 +4,7 @@ import "dart:math" as math;
 import "package:flutter/material.dart";
 import "package:sesori_dart_core/logging.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../../capabilities/voice/voice_transcription_service.dart";
 import "../../../core/constants.dart";
@@ -214,14 +215,14 @@ class _PromptInputState extends State<PromptInput> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
 
     return Container(
       decoration: BoxDecoration(
-        color: theme.colorScheme.surface,
+        color: zyra.colors.bgPrimary,
         border: Border(
-          top: BorderSide(color: theme.colorScheme.outlineVariant),
+          top: BorderSide(color: zyra.colors.borderSecondary),
         ),
       ),
       child: Column(
@@ -237,11 +238,11 @@ class _PromptInputState extends State<PromptInput> {
                 child: InputChip(
                   label: Text("/${commandInfo.name}"),
                   avatar: CircleAvatar(
-                    backgroundColor: theme.colorScheme.primaryContainer,
+                    backgroundColor: zyra.colors.bgBrandPrimary,
                     child: Text(
                       "/",
-                      style: theme.textTheme.labelLarge?.copyWith(
-                        color: theme.colorScheme.onPrimaryContainer,
+                      style: zyra.textTheme.textMd.bold.copyWith(
+                        color: zyra.colors.bgBrandPrimaryAlt,
                         fontWeight: FontWeight.w700,
                       ),
                     ),
@@ -285,7 +286,7 @@ class _PromptInputState extends State<PromptInput> {
                           borderSide: BorderSide.none,
                         ),
                         filled: true,
-                        fillColor: theme.colorScheme.surfaceContainerHighest,
+                        fillColor: zyra.colors.bgQuaternary,
                         contentPadding: const EdgeInsets.symmetric(
                           horizontal: 16,
                           vertical: 10,
@@ -304,14 +305,14 @@ class _PromptInputState extends State<PromptInput> {
                   IconButton(
                     onPressed: _handleSend,
                     icon: const Icon(Icons.send),
-                    color: theme.colorScheme.primary,
+                    color: zyra.colors.bgBrandSolid,
                     tooltip: loc.sessionDetailSend,
                   ),
                   if (widget.isBusy)
                     IconButton(
                       onPressed: widget.onAbort,
                       icon: const Icon(Icons.stop_circle),
-                      color: theme.colorScheme.error,
+                    color: zyra.colors.fgErrorPrimary,
                       tooltip: loc.sessionDetailAbort,
                     ),
                 ],
@@ -339,12 +340,12 @@ class _SlashButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
 
     return Material(
       color: enabled
-          ? theme.colorScheme.surfaceContainerHighest
-          : theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+          ? zyra.colors.bgQuaternary
+          : zyra.colors.bgQuaternary.withValues(alpha: 0.5),
       shape: const CircleBorder(),
       child: InkWell(
         customBorder: const CircleBorder(),
@@ -355,8 +356,8 @@ class _SlashButton extends StatelessWidget {
           child: Center(
             child: Text(
               "/",
-              style: theme.textTheme.titleMedium?.copyWith(
-                color: enabled ? theme.colorScheme.onSurfaceVariant : theme.colorScheme.outline,
+              style: zyra.textTheme.textMd.bold.copyWith(
+                color: enabled ? zyra.colors.textSecondary : zyra.colors.borderPrimary,
                 fontWeight: FontWeight.w700,
               ),
             ),
@@ -379,26 +380,26 @@ class _MicButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
 
     return switch (voiceState) {
       _VoiceState.idle => IconButton(
         onPressed: onTap,
         icon: const Icon(Icons.mic_none),
-        color: theme.colorScheme.onSurfaceVariant,
+        color: zyra.colors.textSecondary,
         tooltip: loc.voiceRecord,
       ),
       _VoiceState.recording => IconButton(
         onPressed: onTap,
         icon: const Icon(Icons.stop_circle_outlined),
-        color: theme.colorScheme.error,
+        color: zyra.colors.fgErrorPrimary,
         tooltip: loc.voiceStopRecording,
       ),
       _VoiceState.transcribing => IconButton(
         onPressed: onTap,
         icon: const Icon(Icons.close),
-        color: theme.colorScheme.error,
+        color: zyra.colors.fgErrorPrimary,
         tooltip: loc.voiceCancelTranscription,
       ),
     };
@@ -447,13 +448,13 @@ class _RecordingIndicatorState extends State<_RecordingIndicator> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final barColor = theme.colorScheme.error;
+    final zyra = context.zyra;
+    final barColor = zyra.colors.fgErrorPrimary;
 
     return Container(
       height: 48,
       decoration: BoxDecoration(
-        color: theme.colorScheme.errorContainer.withValues(alpha: 0.3),
+        color: zyra.colors.bgErrorPrimary.withValues(alpha: 0.3),
         borderRadius: BorderRadius.circular(24),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 12),
@@ -479,13 +480,13 @@ class _TranscribingIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
 
     return Container(
       height: 48,
       decoration: BoxDecoration(
-        color: theme.colorScheme.primaryContainer.withValues(alpha: 0.3),
+        color: zyra.colors.bgBrandPrimary.withValues(alpha: 0.3),
         borderRadius: BorderRadius.circular(24),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -496,14 +497,14 @@ class _TranscribingIndicator extends StatelessWidget {
             height: 16,
             child: CircularProgressIndicator(
               strokeWidth: 2,
-              color: theme.colorScheme.primary,
+              color: zyra.colors.bgBrandSolid,
             ),
           ),
           const SizedBox(width: 12),
           Text(
             loc.voiceTranscribing,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.primary,
+            style: zyra.textTheme.textSm.regular.copyWith(
+              color: zyra.colors.bgBrandSolid,
             ),
           ),
         ],

--- a/mobile/app/lib/features/session_detail/widgets/question_modal.dart
+++ b/mobile/app/lib/features/session_detail/widgets/question_modal.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
 import "package:go_router/go_router.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/widgets/app_modal_bottom_sheet.dart";
@@ -192,7 +193,7 @@ class _QuestionModalState extends State<QuestionModal> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
     final height = MediaQuery.sizeOf(context).height * 0.7;
     final info = _currentInfo;
@@ -200,7 +201,7 @@ class _QuestionModalState extends State<QuestionModal> {
     return Container(
       height: height,
       decoration: BoxDecoration(
-        color: theme.colorScheme.surface,
+        color: zyra.colors.bgPrimary,
         borderRadius: const BorderRadius.vertical(
           top: Radius.circular(16),
         ),
@@ -214,7 +215,7 @@ class _QuestionModalState extends State<QuestionModal> {
               width: 32,
               height: 4,
               decoration: BoxDecoration(
-                color: theme.colorScheme.outlineVariant,
+                color: zyra.colors.borderSecondary,
                 borderRadius: BorderRadius.circular(2),
               ),
             ),
@@ -228,13 +229,13 @@ class _QuestionModalState extends State<QuestionModal> {
                 Icon(
                   Icons.help_outline,
                   size: 20,
-                  color: theme.colorScheme.primary,
+                  color: zyra.colors.bgBrandSolid,
                 ),
                 const SizedBox(width: 8),
                 Expanded(
                   child: Text(
                     info.header.isNotEmpty ? info.header : loc.questionModalTitle,
-                    style: theme.textTheme.titleMedium,
+                    style: zyra.textTheme.textMd.bold,
                     maxLines: 1,
                     overflow: .ellipsis,
                   ),
@@ -258,8 +259,8 @@ class _QuestionModalState extends State<QuestionModal> {
                       _currentIndex + 1,
                       _totalQuestions,
                     ),
-                    style: theme.textTheme.labelMedium?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
+                    style: zyra.textTheme.textSm.bold.copyWith(
+                      color: zyra.colors.textSecondary,
                     ),
                   ),
                   const SizedBox(width: 12),
@@ -269,8 +270,8 @@ class _QuestionModalState extends State<QuestionModal> {
                       child: LinearProgressIndicator(
                         value: (_currentIndex + 1) / _totalQuestions,
                         minHeight: 4,
-                        backgroundColor: theme.colorScheme.surfaceContainerHighest,
-                        color: theme.colorScheme.primary,
+                        backgroundColor: zyra.colors.bgQuaternary,
+                        color: zyra.colors.bgBrandSolid,
                       ),
                     ),
                   ),
@@ -290,10 +291,10 @@ class _QuestionModalState extends State<QuestionModal> {
                   data: info.question,
                   selectable: true,
                   onTapLink: handleMarkdownLinkTap,
-                  styleSheet: buildSessionMarkdownStyleSheet(
-                    theme,
-                    paragraphStyle: theme.textTheme.bodyLarge,
-                  ),
+                    styleSheet: buildSessionMarkdownStyleSheet(
+                      zyra: zyra,
+                      paragraphStyle: zyra.textTheme.textSm.medium,
+                    ),
                 ),
                 const SizedBox(height: 16),
 
@@ -360,12 +361,12 @@ class _OptionTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
 
     return Padding(
       padding: const EdgeInsetsDirectional.only(bottom: 8),
       child: Material(
-        color: isSelected ? theme.colorScheme.primaryContainer : theme.colorScheme.surfaceContainerLow,
+        color: isSelected ? zyra.colors.bgBrandPrimary : zyra.colors.bgSecondary,
         borderRadius: BorderRadius.circular(12),
         child: InkWell(
           borderRadius: BorderRadius.circular(12),
@@ -378,7 +379,7 @@ class _OptionTile extends StatelessWidget {
                   isMultiple
                       ? (isSelected ? Icons.check_box : Icons.check_box_outline_blank)
                       : (isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked),
-                  color: isSelected ? theme.colorScheme.primary : theme.colorScheme.outline,
+                  color: isSelected ? zyra.colors.bgBrandSolid : zyra.colors.borderPrimary,
                 ),
                 const SizedBox(width: 12),
                 Expanded(
@@ -387,7 +388,7 @@ class _OptionTile extends StatelessWidget {
                     children: [
                       Text(
                         option.label,
-                        style: theme.textTheme.titleSmall?.copyWith(
+                        style: zyra.textTheme.textSm.bold.copyWith(
                           fontWeight: .bold,
                         ),
                       ),
@@ -395,9 +396,9 @@ class _OptionTile extends StatelessWidget {
                         const SizedBox(height: 2),
                         Text(
                           option.description,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.onSurfaceVariant,
-                          ),
+                            style: zyra.textTheme.textXs.regular.copyWith(
+                              color: zyra.colors.textSecondary,
+                            ),
                         ),
                       ],
                     ],
@@ -433,13 +434,13 @@ class _CustomAnswerTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
 
     return Padding(
       padding: const EdgeInsetsDirectional.only(bottom: 8),
       child: Material(
-        color: isSelected ? theme.colorScheme.primaryContainer : theme.colorScheme.surfaceContainerLow,
+        color: isSelected ? zyra.colors.bgBrandPrimary : zyra.colors.bgSecondary,
         borderRadius: BorderRadius.circular(12),
         child: InkWell(
           borderRadius: BorderRadius.circular(12),
@@ -456,7 +457,7 @@ class _CustomAnswerTile extends StatelessWidget {
                     isMultiple
                         ? (isSelected ? Icons.check_box : Icons.check_box_outline_blank)
                         : (isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked),
-                    color: isSelected ? theme.colorScheme.primary : theme.colorScheme.outline,
+                    color: isSelected ? zyra.colors.bgBrandSolid : zyra.colors.borderPrimary,
                   ),
                 ),
                 const SizedBox(width: 12),

--- a/mobile/app/lib/features/session_detail/widgets/queued_message_bubble.dart
+++ b/mobile/app/lib/features/session_detail/widgets/queued_message_bubble.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 
@@ -15,7 +16,7 @@ class QueuedMessageBubble extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
 
     return Padding(
@@ -28,10 +29,10 @@ class QueuedMessageBubble extends StatelessWidget {
             flex: 3,
             child: Container(
               decoration: BoxDecoration(
-                color: theme.colorScheme.tertiaryContainer.withValues(alpha: 0.5),
+                color: zyra.colors.bgSuccessSecondary.withValues(alpha: 0.5),
                 borderRadius: BorderRadius.circular(16),
                 border: Border.all(
-                  color: theme.colorScheme.tertiary.withValues(alpha: 0.3),
+                  color: zyra.colors.fgSuccessPrimary.withValues(alpha: 0.3),
                   style: BorderStyle.solid,
                 ),
               ),
@@ -49,13 +50,13 @@ class QueuedMessageBubble extends StatelessWidget {
                             Icon(
                               submission.isCommand ? Icons.terminal : Icons.schedule,
                               size: 14,
-                              color: theme.colorScheme.onTertiaryContainer.withValues(alpha: 0.7),
+                              color: zyra.colors.fgSuccessPrimary.withValues(alpha: 0.7),
                             ),
                             const SizedBox(width: 4),
                             Text(
                               submission.isCommand ? loc.sessionDetailQueuedCommand : loc.sessionDetailQueuedMessage,
-                              style: theme.textTheme.labelSmall?.copyWith(
-                                color: theme.colorScheme.onTertiaryContainer.withValues(alpha: 0.7),
+                              style: zyra.textTheme.textXs.medium.copyWith(
+                                color: zyra.colors.fgSuccessPrimary.withValues(alpha: 0.7),
                                 fontWeight: FontWeight.w600,
                               ),
                             ),
@@ -64,9 +65,9 @@ class QueuedMessageBubble extends StatelessWidget {
                         const SizedBox(height: 4),
                         Text(
                           submission.displayText,
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            color: theme.colorScheme.onTertiaryContainer,
-                          ),
+                            style: zyra.textTheme.textSm.regular.copyWith(
+                              color: zyra.colors.fgSuccessPrimary,
+                            ),
                         ),
                       ],
                     ),
@@ -81,11 +82,11 @@ class QueuedMessageBubble extends StatelessWidget {
                           icon: const Icon(Icons.close, size: 14),
                           label: Text(loc.sessionDetailCancelQueued),
                           style: TextButton.styleFrom(
-                            foregroundColor: theme.colorScheme.outline,
+                            foregroundColor: zyra.colors.borderPrimary,
                             padding: const EdgeInsets.symmetric(horizontal: 8),
                             minimumSize: .zero,
                             tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                            textStyle: theme.textTheme.labelSmall,
+                            textStyle: zyra.textTheme.textXs.medium,
                           ),
                         ),
                       ],

--- a/mobile/app/lib/features/session_detail/widgets/reasoning_modal.dart
+++ b/mobile/app/lib/features/session_detail/widgets/reasoning_modal.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/widgets/markdown_styles.dart";
@@ -69,7 +70,7 @@ class _ReasoningModalState extends State<ReasoningModal> {
       ),
     );
 
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
     final height = MediaQuery.of(context).size.height * 0.7;
 
@@ -84,13 +85,13 @@ class _ReasoningModalState extends State<ReasoningModal> {
     return Container(
       height: height,
       decoration: BoxDecoration(
-        color: theme.colorScheme.surface,
+        color: zyra.colors.bgPrimary,
         borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
       ),
       child: Column(
         children: [
-          _buildDragHandle(theme: theme),
-          _buildHeader(theme: theme, isStreaming: data.isStreaming, loc: loc),
+          _buildDragHandle(zyra: zyra),
+          _buildHeader(zyra: zyra, isStreaming: data.isStreaming, loc: loc),
           const Divider(height: 1),
           Expanded(
             child: FollowDetachScrollable(
@@ -113,9 +114,9 @@ class _ReasoningModalState extends State<ReasoningModal> {
                       selectable: false,
                       onTapLink: handleMarkdownLinkTap,
                       styleSheet: buildSessionMarkdownStyleSheet(
-                        theme,
-                        paragraphStyle: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
+                        zyra: zyra,
+                        paragraphStyle: zyra.textTheme.textXs.regular.copyWith(
+                          color: zyra.colors.textSecondary,
                         ),
                       ),
                     ),
@@ -129,14 +130,14 @@ class _ReasoningModalState extends State<ReasoningModal> {
     );
   }
 
-  Widget _buildDragHandle({required ThemeData theme}) {
+  Widget _buildDragHandle({required ZyraDesignSystem zyra}) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 8),
       child: Container(
         width: 32,
         height: 4,
         decoration: BoxDecoration(
-          color: theme.colorScheme.outlineVariant,
+          color: zyra.colors.borderSecondary,
           borderRadius: BorderRadius.circular(2),
         ),
       ),
@@ -144,7 +145,7 @@ class _ReasoningModalState extends State<ReasoningModal> {
   }
 
   Widget _buildHeader({
-    required ThemeData theme,
+    required ZyraDesignSystem zyra,
     required bool isStreaming,
     required AppLocalizations loc,
   }) {
@@ -152,11 +153,11 @@ class _ReasoningModalState extends State<ReasoningModal> {
       padding: const EdgeInsetsDirectional.fromSTEB(16, 4, 16, 12),
       child: Row(
         children: [
-          Icon(Icons.psychology, size: 20, color: theme.colorScheme.outline),
+          Icon(Icons.psychology, size: 20, color: zyra.colors.borderPrimary),
           const SizedBox(width: 8),
           Text(
             isStreaming ? loc.sessionDetailThinking : loc.sessionDetailThought,
-            style: theme.textTheme.titleMedium?.copyWith(fontStyle: FontStyle.italic),
+            style: zyra.textTheme.textMd.bold.copyWith(fontStyle: FontStyle.italic),
           ),
         ],
       ),

--- a/mobile/app/lib/features/session_detail/widgets/reasoning_part_card.dart
+++ b/mobile/app/lib/features/session_detail/widgets/reasoning_part_card.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:markdown/markdown.dart" as md;
 import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/widgets/app_modal_bottom_sheet.dart";
@@ -52,7 +53,7 @@ class _ReasoningPartCardState extends State<ReasoningPartCard> {
       return const SizedBox.shrink();
     }
 
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
 
     return Padding(
@@ -62,9 +63,9 @@ class _ReasoningPartCardState extends State<ReasoningPartCard> {
         onTap: () => _showFullText(context: context),
         child: Container(
           decoration: BoxDecoration(
-            color: theme.colorScheme.surfaceContainerLow,
+            color: zyra.colors.bgSecondary,
             borderRadius: BorderRadius.circular(8),
-            border: Border.all(color: theme.colorScheme.outlineVariant),
+            border: Border.all(color: zyra.colors.borderSecondary),
           ),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -80,7 +81,7 @@ class _ReasoningPartCardState extends State<ReasoningPartCard> {
                     Icon(
                       Icons.psychology,
                       size: 18,
-                      color: theme.colorScheme.outline,
+                      color: zyra.colors.borderPrimary,
                     ),
                     const SizedBox(width: 8),
                     Expanded(
@@ -88,8 +89,8 @@ class _ReasoningPartCardState extends State<ReasoningPartCard> {
                         widget.isStreaming
                             ? loc.sessionDetailThinking
                             : loc.sessionDetailThought,
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.outline,
+                        style: zyra.textTheme.textXs.regular.copyWith(
+                          color: zyra.colors.borderPrimary,
                           fontStyle: FontStyle.italic,
                         ),
                       ),
@@ -97,7 +98,7 @@ class _ReasoningPartCardState extends State<ReasoningPartCard> {
                     Icon(
                       Icons.unfold_more,
                       size: 16,
-                      color: theme.colorScheme.outline,
+                      color: zyra.colors.borderPrimary,
                     ),
                   ],
                 ),
@@ -123,8 +124,8 @@ class _ReasoningPartCardState extends State<ReasoningPartCard> {
                         maxHeight: double.infinity,
                         child: Text(
                           widget.text,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.onSurfaceVariant,
+                          style: zyra.textTheme.textXs.regular.copyWith(
+                            color: zyra.colors.textSecondary,
                           ),
                         ),
                       ),
@@ -138,9 +139,9 @@ class _ReasoningPartCardState extends State<ReasoningPartCard> {
                     _previewText,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
-                    ),
+                      style: zyra.textTheme.textXs.regular.copyWith(
+                        color: zyra.colors.textSecondary,
+                      ),
                   ),
                 ),
             ],

--- a/mobile/app/lib/features/session_detail/widgets/retry_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/retry_part_widget.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 class RetryPartWidget extends StatelessWidget {
   final int? attempt;
@@ -12,7 +13,7 @@ class RetryPartWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final label = StringBuffer("Retry");
     if (attempt != null) {
       label.write(" #$attempt");
@@ -28,14 +29,14 @@ class RetryPartWidget extends StatelessWidget {
           Icon(
             Icons.refresh,
             size: 14,
-            color: theme.colorScheme.tertiary,
+            color: zyra.colors.fgSuccessPrimary,
           ),
           const SizedBox(width: 6),
           Expanded(
             child: Text(
               label.toString(),
-              style: theme.textTheme.labelSmall?.copyWith(
-                color: theme.colorScheme.tertiary,
+              style: zyra.textTheme.textXs.medium.copyWith(
+                color: zyra.colors.fgSuccessPrimary,
               ),
               maxLines: 2,
               overflow: TextOverflow.ellipsis,

--- a/mobile/app/lib/features/session_detail/widgets/session_detail_body.dart
+++ b/mobile/app/lib/features/session_detail/widgets/session_detail_body.dart
@@ -4,6 +4,7 @@ import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../../core/constants.dart";
 import "../../../core/extensions/build_context_x.dart";
@@ -92,7 +93,7 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
                 height: 16,
                 child: CircularProgressIndicator(
                   strokeWidth: 2,
-                  color: Theme.of(context).colorScheme.primary,
+                  color: context.zyra.colors.bgBrandSolid,
                 ),
               ),
             ),

--- a/mobile/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
+++ b/mobile/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/widgets/agent_model_buttons.dart";
@@ -53,16 +54,16 @@ class SessionDetailLoadedView extends StatelessWidget {
         if (state.pendingQuestions.isNotEmpty)
           SessionDetailPendingBanner(
             icon: Icons.help_outline,
-            backgroundColor: Theme.of(context).colorScheme.primaryContainer,
-            foregroundColor: Theme.of(context).colorScheme.onPrimaryContainer,
+            backgroundColor: context.zyra.colors.bgBrandPrimary,
+            foregroundColor: context.zyra.colors.bgBrandPrimaryAlt,
             label: questionCount == 1 ? loc.questionBannerSingle : loc.questionBannerMultiple(questionCount),
             onTap: onShowPendingQuestions,
           ),
         if (state.pendingPermissions.isNotEmpty)
           SessionDetailPendingBanner(
             icon: Icons.shield_outlined,
-            backgroundColor: Theme.of(context).colorScheme.tertiaryContainer,
-            foregroundColor: Theme.of(context).colorScheme.onTertiaryContainer,
+            backgroundColor: context.zyra.colors.bgSuccessSecondary,
+            foregroundColor: context.zyra.colors.fgSuccessPrimary,
             label: state.pendingPermissions.length == 1
                 ? loc.permissionBannerSingle
                 : loc.permissionBannerMultiple(state.pendingPermissions.length),

--- a/mobile/app/lib/features/session_detail/widgets/session_detail_scaffold_sections.dart
+++ b/mobile/app/lib/features/session_detail/widgets/session_detail_scaffold_sections.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 import "../../../l10n/app_localizations.dart";
@@ -33,8 +34,8 @@ class SessionDetailTitle extends StatelessWidget {
         if (subtitle.isNotEmpty)
           Text(
             subtitle,
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            style: context.zyra.textTheme.textXs.regular.copyWith(
+              color: context.zyra.colors.textSecondary,
             ),
           ),
       ],
@@ -74,7 +75,7 @@ class SessionDetailPendingBanner extends StatelessWidget {
               Expanded(
                 child: Text(
                   label,
-                  style: Theme.of(context).textTheme.labelLarge?.copyWith(color: foregroundColor),
+                   style: context.zyra.textTheme.textMd.bold.copyWith(color: foregroundColor),
                 ),
               ),
               Icon(Icons.chevron_right, size: 20, color: foregroundColor),
@@ -122,9 +123,9 @@ class SessionDetailErrorView extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(Icons.error_outline, size: 48, color: Theme.of(context).colorScheme.error),
+            Icon(Icons.error_outline, size: 48, color: context.zyra.colors.fgErrorPrimary),
             const SizedBox(height: 16),
-            Text(loc.sessionDetailErrorTitle, style: Theme.of(context).textTheme.titleMedium),
+            Text(loc.sessionDetailErrorTitle, style: context.zyra.textTheme.textMd.bold),
             const SizedBox(height: 8),
             Text(
               _describeError(loc: loc, error: error),

--- a/mobile/app/lib/features/session_detail/widgets/subtask_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/subtask_part_widget.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/routing/app_router.dart";
 
@@ -20,7 +21,7 @@ class SubtaskPartWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
     final description = part.description ?? part.prompt ?? loc.sessionDetailSubtaskUnnamed;
     final agent = part.agent;
@@ -34,7 +35,7 @@ class SubtaskPartWidget extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: Material(
-        color: theme.colorScheme.surfaceContainerLow,
+        color: zyra.colors.bgSecondary,
         borderRadius: BorderRadius.circular(8),
         child: InkWell(
           borderRadius: BorderRadius.circular(8),
@@ -53,12 +54,12 @@ class SubtaskPartWidget extends StatelessWidget {
           child: Container(
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(8),
-              border: Border.all(color: theme.colorScheme.outlineVariant),
+              border: Border.all(color: zyra.colors.borderSecondary),
             ),
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
             child: Row(
               children: [
-                _statusIcon(status: status, theme: theme),
+                _statusIcon(status: status, zyra: zyra),
                 const SizedBox(width: 10),
                 Expanded(
                   child: Column(
@@ -66,7 +67,7 @@ class SubtaskPartWidget extends StatelessWidget {
                     children: [
                       Text(
                         description,
-                        style: theme.textTheme.bodyMedium?.copyWith(
+                        style: zyra.textTheme.textSm.regular.copyWith(
                           fontWeight: FontWeight.w500,
                         ),
                         maxLines: 2,
@@ -75,8 +76,8 @@ class SubtaskPartWidget extends StatelessWidget {
                       if (agent != null)
                         Text(
                           agent,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.onSurfaceVariant,
+                          style: zyra.textTheme.textXs.regular.copyWith(
+                            color: zyra.colors.textSecondary,
                           ),
                         ),
                     ],
@@ -86,7 +87,7 @@ class SubtaskPartWidget extends StatelessWidget {
                   Icon(
                     Icons.chevron_right,
                     size: 20,
-                    color: theme.colorScheme.onSurfaceVariant,
+                    color: zyra.colors.textSecondary,
                   ),
               ],
             ),
@@ -96,29 +97,29 @@ class SubtaskPartWidget extends StatelessWidget {
     );
   }
 
-  Widget _statusIcon({required SessionStatus? status, required ThemeData theme}) => switch (status) {
+  Widget _statusIcon({required SessionStatus? status, required ZyraDesignSystem zyra}) => switch (status) {
     SessionStatusBusy() => SizedBox(
       width: 16,
       height: 16,
       child: CircularProgressIndicator(
         strokeWidth: 2,
-        color: theme.colorScheme.primary,
+        color: zyra.colors.bgBrandSolid,
       ),
     ),
     SessionStatusRetry() => Icon(
       Icons.refresh,
       size: 16,
-      color: theme.colorScheme.tertiary,
+      color: zyra.colors.fgSuccessPrimary,
     ),
     SessionStatusIdle() => Icon(
       Icons.check_circle,
       size: 16,
-      color: theme.colorScheme.primary,
+      color: zyra.colors.bgBrandSolid,
     ),
     null => Icon(
       Icons.play_circle_outline,
       size: 16,
-      color: theme.colorScheme.outline,
+      color: zyra.colors.borderPrimary,
     ),
   };
 

--- a/mobile/app/lib/features/session_detail/widgets/text_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/text_part_widget.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../../core/widgets/markdown_styles.dart";
 
@@ -17,15 +18,13 @@ class TextPartWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     if (text.isEmpty) return const SizedBox.shrink();
 
-    final theme = Theme.of(context);
-
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: MarkdownBody(
         data: text,
         selectable: false,
         onTapLink: handleMarkdownLinkTap,
-        styleSheet: buildSessionMarkdownStyleSheet(theme),
+        styleSheet: buildSessionMarkdownStyleSheet(zyra: context.zyra),
       ),
     );
   }

--- a/mobile/app/lib/features/session_detail/widgets/tool_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/tool_part_widget.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 import "../../../core/extensions/build_context_x.dart";
 import "../../../l10n/app_localizations.dart";
 
@@ -10,7 +11,7 @@ class ToolPartWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final loc = context.loc;
     final state = part.state;
     final toolName = part.state?.title ?? part.tool ?? loc.sessionDetailToolUnknown;
@@ -22,9 +23,9 @@ class ToolPartWidget extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: Container(
         decoration: BoxDecoration(
-          color: theme.colorScheme.surfaceContainerLow,
+          color: zyra.colors.bgSecondary,
           borderRadius: BorderRadius.circular(8),
-          border: Border.all(color: theme.colorScheme.outlineVariant),
+          border: Border.all(color: zyra.colors.borderSecondary),
         ),
         child: Column(
           crossAxisAlignment: .start,
@@ -33,12 +34,12 @@ class ToolPartWidget extends StatelessWidget {
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
               child: Row(
                 children: [
-                  _statusIcon(status: status, theme: theme),
+                  _statusIcon(status: status, zyra: zyra),
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
                       toolName,
-                      style: theme.textTheme.bodyMedium?.copyWith(
+                      style: zyra.textTheme.textSm.regular.copyWith(
                         fontWeight: FontWeight.w500,
                       ),
                       maxLines: 1,
@@ -47,8 +48,8 @@ class ToolPartWidget extends StatelessWidget {
                   ),
                   Text(
                     _statusLabel(loc: loc, status: status),
-                    style: theme.textTheme.labelSmall?.copyWith(
-                      color: theme.colorScheme.outline,
+                    style: zyra.textTheme.textXs.medium.copyWith(
+                      color: zyra.colors.borderPrimary,
                     ),
                   ),
                 ],
@@ -61,12 +62,12 @@ class ToolPartWidget extends StatelessWidget {
                   width: double.infinity,
                   padding: const EdgeInsets.all(8),
                   decoration: BoxDecoration(
-                    color: theme.colorScheme.surfaceContainerHighest,
+                    color: zyra.colors.bgQuaternary,
                     borderRadius: BorderRadius.circular(4),
                   ),
                   child: Text(
                     _truncateOutput(output),
-                    style: theme.textTheme.bodySmall?.copyWith(
+                    style: zyra.textTheme.textXs.regular.copyWith(
                       fontFamily: "monospace",
                       fontSize: 11,
                     ),
@@ -80,8 +81,8 @@ class ToolPartWidget extends StatelessWidget {
                 padding: const EdgeInsetsDirectional.fromSTEB(12, 0, 12, 8),
                 child: Text(
                   errorText,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.error,
+                    style: zyra.textTheme.textXs.regular.copyWith(
+                      color: zyra.colors.fgErrorPrimary,
                   ),
                   maxLines: 4,
                   overflow: .ellipsis,
@@ -93,25 +94,25 @@ class ToolPartWidget extends StatelessWidget {
     );
   }
 
-  Widget _statusIcon({required String status, required ThemeData theme}) => switch (status) {
+  Widget _statusIcon({required String status, required ZyraDesignSystem zyra}) => switch (status) {
     "pending" || "running" => SizedBox(
       width: 16,
       height: 16,
       child: CircularProgressIndicator(
         strokeWidth: 2,
-        color: theme.colorScheme.primary,
+        color: zyra.colors.bgBrandSolid,
       ),
     ),
     "completed" => Icon(
       Icons.check_circle,
       size: 16,
-      color: theme.colorScheme.primary,
+      color: zyra.colors.bgBrandSolid,
     ),
-    "error" => Icon(Icons.error, size: 16, color: theme.colorScheme.error),
+    "error" => Icon(Icons.error, size: 16, color: zyra.colors.fgErrorPrimary),
     _ => Icon(
       Icons.circle_outlined,
       size: 16,
-      color: theme.colorScheme.outline,
+      color: zyra.colors.borderPrimary,
     ),
   };
 

--- a/mobile/app/lib/features/session_detail/widgets/user_message_card.dart
+++ b/mobile/app/lib/features/session_detail/widgets/user_message_card.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 class UserMessageCard extends StatelessWidget {
   final MessageWithParts message;
@@ -8,7 +9,7 @@ class UserMessageCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final zyra = context.zyra;
     final text = message.parts
         .where((part) => part.type == MessagePartType.text)
         .map((part) => part.text ?? "")
@@ -23,13 +24,13 @@ class UserMessageCard extends StatelessWidget {
           maxWidth: MediaQuery.of(context).size.width * 0.85,
         ),
         decoration: BoxDecoration(
-          color: theme.colorScheme.primaryContainer,
+          color: zyra.colors.bgBrandPrimary,
           borderRadius: BorderRadius.circular(16),
         ),
         child: SelectableText(
           text,
-          style: theme.textTheme.bodyMedium?.copyWith(
-            color: theme.colorScheme.onPrimaryContainer,
+          style: zyra.textTheme.textSm.regular.copyWith(
+            color: zyra.colors.bgBrandPrimaryAlt,
           ),
         ),
       ),

--- a/mobile/app/lib/features/session_diffs/session_diffs_screen.dart
+++ b/mobile/app/lib/features/session_diffs/session_diffs_screen.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../core/di/injection.dart";
 import "../../core/extensions/build_context_x.dart";
@@ -68,7 +69,7 @@ class _SessionDiffsBodyState extends State<_SessionDiffsBody> {
                       additions,
                       deletions,
                     ),
-                    style: Theme.of(context).textTheme.bodySmall,
+                    style: context.zyra.textTheme.textXs.regular,
                   ),
               ],
             );

--- a/mobile/app/lib/features/session_list/pr_status_row.dart
+++ b/mobile/app/lib/features/session_list/pr_status_row.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../core/extensions/build_context_x.dart";
 import "../../l10n/app_localizations.dart";
@@ -20,11 +21,10 @@ class PrStatusRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final loc = context.loc;
-    final stateColor = _stateColor(scheme: theme.colorScheme, state: pr.state);
+    final stateColor = _stateColor(colors: context.zyra.colors, state: pr.state);
     final mergeIcon = _mergeIcon(status: pr.mergeableStatus);
-    final mergeColor = _mergeColor(scheme: theme.colorScheme, status: pr.mergeableStatus) ?? stateColor;
+    final mergeColor = _mergeColor(colors: context.zyra.colors, status: pr.mergeableStatus) ?? stateColor;
 
     return Row(
       children: [
@@ -35,16 +35,16 @@ class PrStatusRow extends StatelessWidget {
         const SizedBox(width: 4),
         Text(
           loc.prLabel(pr.number),
-          style: theme.textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w500),
+          style: context.zyra.textTheme.textXs.medium,
         ),
         const SizedBox(width: 6),
         Text(
           _stateText(loc: loc, state: pr.state),
-          style: theme.textTheme.bodySmall?.copyWith(color: stateColor),
+          style: context.zyra.textTheme.textXs.regular.copyWith(color: stateColor),
         ),
         // Review/check indicators are only relevant for open PRs.
         if (pr.state == PrState.open) ...[
-          if (_reviewIndicator(scheme: theme.colorScheme, loc: loc, decision: pr.reviewDecision)
+          if (_reviewIndicator(colors: context.zyra.colors, loc: loc, decision: pr.reviewDecision)
               case (:final icon, :final color, :final tooltip)?) ...[
             const SizedBox(width: 8),
             Tooltip(
@@ -52,7 +52,7 @@ class PrStatusRow extends StatelessWidget {
               child: Icon(icon, size: 12, color: color),
             ),
           ],
-          if (_checkIndicator(scheme: theme.colorScheme, loc: loc, status: pr.checkStatus)
+          if (_checkIndicator(colors: context.zyra.colors, loc: loc, status: pr.checkStatus)
               case (:final icon, :final color, :final tooltip)?) ...[
             const SizedBox(width: 4),
             Tooltip(
@@ -70,11 +70,11 @@ class PrStatusRow extends StatelessWidget {
 // State helpers
 // ---------------------------------------------------------------------------
 
-Color _stateColor({required ColorScheme scheme, required PrState state}) => switch (state) {
+Color _stateColor({required ZyraColors colors, required PrState state}) => switch (state) {
   PrState.open => _kPrGreen,
   PrState.merged => _kPrPurple,
-  PrState.closed => scheme.outline,
-  PrState.unknown => scheme.outline,
+  PrState.closed => colors.borderPrimary,
+  PrState.unknown => colors.borderPrimary,
 };
 
 String _stateText({required AppLocalizations loc, required PrState state}) => switch (state) {
@@ -89,9 +89,9 @@ String _stateText({required AppLocalizations loc, required PrState state}) => sw
 // ---------------------------------------------------------------------------
 
 /// Returns a color for the merge icon, or null to fall back to the state color.
-Color? _mergeColor({required ColorScheme scheme, required PrMergeableStatus status}) => switch (status) {
+Color? _mergeColor({required ZyraColors colors, required PrMergeableStatus status}) => switch (status) {
   PrMergeableStatus.mergeable => _kPrGreen,
-  PrMergeableStatus.conflicting => scheme.error,
+  PrMergeableStatus.conflicting => colors.fgErrorPrimary,
   PrMergeableStatus.unknown => null,
 };
 
@@ -113,19 +113,19 @@ String _mergeTooltip({required AppLocalizations loc, required PrMergeableStatus 
 
 /// Returns icon, color, and tooltip for the review decision, or null to hide it.
 ({IconData icon, Color color, String tooltip})? _reviewIndicator({
-  required ColorScheme scheme,
+  required ZyraColors colors,
   required AppLocalizations loc,
   required PrReviewDecision decision,
 }) => switch (decision) {
   PrReviewDecision.approved => (icon: Icons.check_circle_outline, color: _kPrGreen, tooltip: loc.prReviewApproved),
   PrReviewDecision.changesRequested => (
     icon: Icons.cancel_outlined,
-    color: scheme.error,
+    color: colors.fgErrorPrimary,
     tooltip: loc.prReviewChangesRequested,
   ),
   PrReviewDecision.reviewRequired => (
     icon: Icons.pending_outlined,
-    color: scheme.outline,
+    color: colors.borderPrimary,
     tooltip: loc.prReviewRequired,
   ),
   PrReviewDecision.unknown => null,
@@ -137,12 +137,12 @@ String _mergeTooltip({required AppLocalizations loc, required PrMergeableStatus 
 
 /// Returns icon, color, and tooltip for the check status, or null to hide it.
 ({IconData icon, Color color, String tooltip})? _checkIndicator({
-  required ColorScheme scheme,
+  required ZyraColors colors,
   required AppLocalizations loc,
   required PrCheckStatus status,
 }) => switch (status) {
   PrCheckStatus.success => (icon: Icons.check_circle_outline, color: _kPrGreen, tooltip: loc.prChecksSuccess),
-  PrCheckStatus.failure => (icon: Icons.error_outline, color: scheme.error, tooltip: loc.prChecksFailing),
+  PrCheckStatus.failure => (icon: Icons.error_outline, color: colors.fgErrorPrimary, tooltip: loc.prChecksFailing),
   PrCheckStatus.pending => (icon: Icons.schedule, color: _kPrAmber, tooltip: loc.prChecksPending),
   PrCheckStatus.none => null,
   PrCheckStatus.unknown => null,

--- a/mobile/app/lib/features/session_list/rename_session_dialog.dart
+++ b/mobile/app/lib/features/session_list/rename_session_dialog.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:go_router/go_router.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../core/constants.dart";
 import "../../core/extensions/build_context_x.dart";
@@ -101,7 +102,7 @@ class _RenameSessionDialogState extends State<_RenameSessionDialog> {
         children: [
           Align(
             alignment: Alignment.centerLeft,
-            child: Text(loc.renameSessionTitle, style: Theme.of(context).textTheme.titleMedium),
+            child: Text(loc.renameSessionTitle, style: context.zyra.textTheme.textMd.bold),
           ),
           const SizedBox(height: 16),
           TextField(

--- a/mobile/app/lib/features/session_list/session_cleanup_dialogs.dart
+++ b/mobile/app/lib/features/session_list/session_cleanup_dialogs.dart
@@ -21,7 +21,6 @@ class _DeleteSessionSheetState extends State<_DeleteSessionSheet> {
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
-    final theme = Theme.of(context);
 
     return Padding(
       padding: const EdgeInsetsDirectional.fromSTEB(16, 8, 16, 16),
@@ -31,13 +30,13 @@ class _DeleteSessionSheetState extends State<_DeleteSessionSheet> {
         children: [
           Text(
             loc.sessionListDeleteConfirmTitle,
-            style: theme.textTheme.titleMedium,
+            style: context.zyra.textTheme.textMd.bold,
           ),
           const SizedBox(height: 8),
           Text(
             loc.sessionListDeleteConfirmMessage,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
+            style: context.zyra.textTheme.textSm.regular.copyWith(
+              color: context.zyra.colors.textSecondary,
             ),
           ),
           const SizedBox(height: 12),
@@ -67,7 +66,7 @@ class _DeleteSessionSheetState extends State<_DeleteSessionSheet> {
               ),
               const SizedBox(width: 8),
               FilledButton(
-                style: FilledButton.styleFrom(backgroundColor: theme.colorScheme.error),
+                style: FilledButton.styleFrom(backgroundColor: context.zyra.colors.fgErrorPrimary),
                 onPressed: () {
                   context.pop();
                   widget.onConfirm(
@@ -106,7 +105,6 @@ class _ArchiveSessionSheetState extends State<_ArchiveSessionSheet> {
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
-    final theme = Theme.of(context);
 
     return Padding(
       padding: const EdgeInsetsDirectional.fromSTEB(16, 8, 16, 16),
@@ -116,13 +114,13 @@ class _ArchiveSessionSheetState extends State<_ArchiveSessionSheet> {
         children: [
           Text(
             loc.sessionListArchiveConfirmTitle,
-            style: theme.textTheme.titleMedium,
+            style: context.zyra.textTheme.textMd.bold,
           ),
           const SizedBox(height: 8),
           Text(
             loc.sessionListArchiveConfirmMessage,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
+            style: context.zyra.textTheme.textSm.regular.copyWith(
+              color: context.zyra.colors.textSecondary,
             ),
           ),
           const SizedBox(height: 12),

--- a/mobile/app/lib/features/session_list/session_force_dialog.dart
+++ b/mobile/app/lib/features/session_list/session_force_dialog.dart
@@ -35,7 +35,7 @@ void _showForceDialog({
                     Icon(
                       Icons.warning_amber_rounded,
                       size: 18,
-                      color: Theme.of(context).colorScheme.error,
+                      color: context.zyra.colors.fgErrorPrimary,
                     ),
                     const SizedBox(width: 8),
                     Expanded(
@@ -76,7 +76,7 @@ void _showForceDialog({
             },
             child: Text(
               isDelete ? loc.sessionListForceDeleteAction : loc.sessionListForceArchiveAction,
-              style: TextStyle(color: Theme.of(context).colorScheme.error),
+              style: TextStyle(color: context.zyra.colors.fgErrorPrimary),
             ),
           ),
         ],

--- a/mobile/app/lib/features/session_list/session_list_screen.dart
+++ b/mobile/app/lib/features/session_list/session_list_screen.dart
@@ -3,6 +3,7 @@ import "package:flutter_bloc/flutter_bloc.dart";
 import "package:go_router/go_router.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../core/constants.dart";
 import "../../core/di/injection.dart";
@@ -94,10 +95,10 @@ class _SessionListBody extends StatelessWidget {
               },
             ),
             ListTile(
-              leading: Icon(Icons.delete_outlined, color: Theme.of(context).colorScheme.error),
+              leading: Icon(Icons.delete_outlined, color: context.zyra.colors.fgErrorPrimary),
               title: Text(
                 loc.sessionListDelete,
-                style: TextStyle(color: Theme.of(context).colorScheme.error),
+                style: TextStyle(color: context.zyra.colors.fgErrorPrimary),
               ),
               onTap: () {
                 sheetContext.pop();
@@ -131,8 +132,8 @@ class _SessionListBody extends StatelessWidget {
             if (baseBranch != null)
               Text(
                 baseBranch,
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                style: context.zyra.textTheme.textXs.regular.copyWith(
+                  color: context.zyra.colors.textSecondary,
                 ),
               ),
           ],

--- a/mobile/app/lib/features/session_list/session_list_widgets.dart
+++ b/mobile/app/lib/features/session_list/session_list_widgets.dart
@@ -23,7 +23,6 @@ class _SessionTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final loc = context.loc;
     final updatedAt = session.time?.updated;
     final filesChanged = session.summary?.files ?? 0;
@@ -33,29 +32,27 @@ class _SessionTile extends StatelessWidget {
       direction: .startToEnd,
       confirmDismiss: (_) async {
         onSwipe();
-        // Return false — the cubit removes the item from the list, so we
-        // don't need Dismissible to animate the removal itself.
         return false;
       },
       background: ColoredBox(
-        color: theme.colorScheme.secondaryContainer,
+        color: context.zyra.colors.bgPrimary,
         child: Align(
           alignment: .centerLeft,
           child: Padding(
             padding: const EdgeInsetsDirectional.only(start: 24),
             child: Icon(
               isArchived ? Icons.unarchive_outlined : Icons.archive_outlined,
-              color: theme.colorScheme.onSecondaryContainer,
+              color: context.zyra.colors.textPrimary,
             ),
           ),
         ),
       ),
       child: ListTile(
         leading: CircleAvatar(
-          backgroundColor: theme.colorScheme.primaryContainer,
+          backgroundColor: context.zyra.colors.bgBrandSolid,
           child: Icon(
             Icons.chat_outlined,
-            color: theme.colorScheme.onPrimaryContainer,
+            color: context.zyra.colors.bgPrimary,
           ),
         ),
         title: Text(session.title ?? loc.sessionListUntitled),
@@ -65,19 +62,19 @@ class _SessionTile extends StatelessWidget {
             if (updatedAt != null)
               Text(
                 loc.sessionListUpdated(_formatTimestamp(ms: updatedAt)),
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.outline,
+                style: context.zyra.textTheme.textXs.regular.copyWith(
+                  color: context.zyra.colors.borderPrimary,
                 ),
               ),
             if (filesChanged > 0)
               Text(
                 loc.sessionListFilesChanged(filesChanged),
-                style: theme.textTheme.bodySmall,
+                style: context.zyra.textTheme.textXs.regular,
               ),
             if (session.pullRequest case final pr?) PrStatusRow(pr: pr),
             if (isActive)
               _buildActivityRow(
-                theme: theme,
+                context: context,
                 loc: loc,
                 awaitingInput: awaitingInput,
                 backgroundTaskCount: backgroundTaskCount,
@@ -103,12 +100,12 @@ class _SessionTile extends StatelessWidget {
 }
 
 Widget _buildActivityRow({
-  required ThemeData theme,
+  required BuildContext context,
   required AppLocalizations loc,
   required bool awaitingInput,
   required int backgroundTaskCount,
 }) {
-  final color = awaitingInput ? kStatusAmber : theme.colorScheme.primary;
+  final color = awaitingInput ? kStatusAmber : context.zyra.colors.bgBrandSolid;
   final label = awaitingInput ? loc.sessionListAwaitingInput : loc.sessionListRunning;
 
   return Row(
@@ -117,10 +114,7 @@ Widget _buildActivityRow({
       const SizedBox(width: 4),
       Text(
         label,
-        style: theme.textTheme.bodySmall?.copyWith(
-          color: color,
-          fontWeight: FontWeight.w500,
-        ),
+        style: context.zyra.textTheme.textXs.regular.copyWith(color: color),
       ),
       if (backgroundTaskCount > 0) ...[
         Padding(
@@ -129,10 +123,7 @@ Widget _buildActivityRow({
         ),
         Text(
           loc.sessionListBackgroundTasks(backgroundTaskCount),
-          style: theme.textTheme.bodySmall?.copyWith(
-            color: color,
-            fontWeight: FontWeight.w500,
-          ),
+          style: context.zyra.textTheme.textXs.regular.copyWith(color: color),
         ),
       ],
     ],
@@ -169,12 +160,12 @@ class _StaleProjectView extends StatelessWidget {
             Icon(
               Icons.folder_off_outlined,
               size: 48,
-              color: Theme.of(context).colorScheme.error,
+              color: context.zyra.colors.fgErrorPrimary,
             ),
             const SizedBox(height: 16),
             Text(
               loc.sessionListStaleProjectTitle,
-              style: Theme.of(context).textTheme.titleMedium,
+              style: context.zyra.textTheme.textMd.bold,
             ),
             const SizedBox(height: 8),
             Text(loc.sessionListStaleProjectMessage, textAlign: .center),
@@ -210,12 +201,12 @@ class _ErrorView extends StatelessWidget {
             Icon(
               Icons.error_outline,
               size: 48,
-              color: Theme.of(context).colorScheme.error,
+              color: context.zyra.colors.fgErrorPrimary,
             ),
             const SizedBox(height: 16),
             Text(
               loc.sessionListErrorTitle,
-              style: Theme.of(context).textTheme.titleMedium,
+              style: context.zyra.textTheme.textMd.bold,
             ),
             const SizedBox(height: 8),
             Text(

--- a/mobile/app/lib/features/settings/settings_screen.dart
+++ b/mobile/app/lib/features/settings/settings_screen.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../core/di/injection.dart";
 import "../../core/extensions/build_context_x.dart";
@@ -32,6 +33,7 @@ class _SettingsBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
+    final zyra = context.zyra;
     final notificationState = context.watch<NotificationPreferencesCubit>().state;
     final settingsState = context.watch<SettingsCubit>().state;
     final isLoggingOut = settingsState is SettingsLoggingOut;
@@ -107,8 +109,8 @@ class _SettingsBody extends StatelessWidget {
             ListTile(
               leading: const Icon(Icons.logout),
               title: Text(loc.settingsLogout),
-              textColor: Theme.of(context).colorScheme.error,
-              iconColor: Theme.of(context).colorScheme.error,
+              textColor: zyra.colors.fgErrorPrimary,
+              iconColor: zyra.colors.fgErrorPrimary,
               trailing: isLoggingOut
                   ? const SizedBox(
                       width: 20,

--- a/mobile/app/lib/features/splash/splash_screen.dart
+++ b/mobile/app/lib/features/splash/splash_screen.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../core/di/injection.dart";
 import "../../core/extensions/build_context_x.dart";
@@ -41,6 +42,7 @@ class _SplashView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final zyra = context.zyra;
     return Stack(
       clipBehavior: .none,
       children: [
@@ -59,11 +61,11 @@ class _SplashView extends StatelessWidget {
               const SizedBox(height: 13),
               Text(
                 context.loc.splashWelcomeTo,
-                style: Theme.of(context).textTheme.bodyMedium,
+                style: zyra.textTheme.textSm.regular,
               ),
               Text(
                 context.loc.splashTitle,
-                style: Theme.of(context).textTheme.titleLarge,
+                style: zyra.textTheme.textMd.bold,
               ),
             ],
           ),

--- a/mobile/app/lib/main.dart
+++ b/mobile/app/lib/main.dart
@@ -166,10 +166,19 @@ class SesoriApp extends StatelessWidget {
     return MaterialApp.router(
       onGenerateTitle: (context) => context.loc.appTitle,
       theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        colorScheme: ZyraColors.light.toFlutterColorScheme(),
+        textTheme: ZyraTextTheme.light.asFlutterTextTheme(),
+        fontFamily: ZyraTextTheme.fontFamily,
+        fontFamilyFallback: ZyraTextTheme.fontFamilyFallback,
         extensions: [ZyraDesignSystem.light],
       ),
-      darkTheme: ThemeData.dark().copyWith(extensions: [ZyraDesignSystem.dark]),
+      darkTheme: ThemeData(
+        colorScheme: ZyraColors.dark.toFlutterColorScheme(),
+        textTheme: ZyraTextTheme.dark.asFlutterTextTheme(),
+        fontFamily: ZyraTextTheme.fontFamily,
+        fontFamilyFallback: ZyraTextTheme.fontFamilyFallback,
+        extensions: [ZyraDesignSystem.dark],
+      ),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       routerConfig: appRouter,

--- a/mobile/app/test/core/widgets/markdown_styles_test.dart
+++ b/mobile/app/test/core/widgets/markdown_styles_test.dart
@@ -1,32 +1,27 @@
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:sesori_mobile/core/widgets/markdown_styles.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 void main() {
-  final theme = ThemeData.light().copyWith(
-    colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
-    textTheme: const TextTheme(
-      bodyMedium: TextStyle(fontSize: 14),
-      bodyLarge: TextStyle(fontSize: 16),
-    ),
-  );
+  final zyra = ZyraDesignSystem.light;
 
   test("buildSessionMarkdownStyleSheet applies shared code styling", () {
-    final styleSheet = buildSessionMarkdownStyleSheet(theme);
+    final styleSheet = buildSessionMarkdownStyleSheet(zyra: zyra);
 
     expect(styleSheet.code?.fontFamily, "monospace");
     expect(styleSheet.code?.fontSize, 13);
-    expect(styleSheet.code?.color, theme.colorScheme.onSurface);
+    expect(styleSheet.code?.color, zyra.colors.textPrimary);
 
     final decoration = styleSheet.codeblockDecoration as BoxDecoration?;
-    expect(decoration?.color, theme.colorScheme.surfaceContainerHighest);
+    expect(decoration?.color, zyra.colors.bgQuaternary);
     expect(decoration?.borderRadius, BorderRadius.circular(8));
   });
 
   test("buildSessionMarkdownStyleSheet overrides paragraph style when provided", () {
     const paragraphStyle = TextStyle(fontSize: 18, fontWeight: FontWeight.w600);
 
-    final styleSheet = buildSessionMarkdownStyleSheet(theme, paragraphStyle: paragraphStyle);
+    final styleSheet = buildSessionMarkdownStyleSheet(zyra: zyra, paragraphStyle: paragraphStyle);
 
     expect(styleSheet.p, paragraphStyle);
   });

--- a/mobile/app/test/core/widgets/variant_picker_sheet_test.dart
+++ b/mobile/app/test/core/widgets/variant_picker_sheet_test.dart
@@ -4,6 +4,7 @@ import "package:go_router/go_router.dart";
 import "package:sesori_mobile/core/widgets/variant_picker_sheet.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 Widget _buildApp({required ValueChanged<SessionVariant?> onVariantChanged}) {
   final router = GoRouter(
@@ -30,6 +31,9 @@ Widget _buildApp({required ValueChanged<SessionVariant?> onVariantChanged}) {
 
   return MaterialApp.router(
     routerConfig: router,
+    theme: ThemeData(
+      extensions: [ZyraDesignSystem.light],
+    ),
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
   );

--- a/mobile/app/test/features/new_session/new_session_screen_test.dart
+++ b/mobile/app/test/features/new_session/new_session_screen_test.dart
@@ -10,6 +10,7 @@ import "package:sesori_mobile/capabilities/voice/voice_transcription_service.dar
 import "package:sesori_mobile/features/new_session/new_session_screen.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../helpers/test_helpers.dart";
 
@@ -36,6 +37,8 @@ Widget _buildApp() {
 
   return MaterialApp.router(
     routerConfig: router,
+    theme: ThemeData(extensions: [ZyraDesignSystem.light]),
+    darkTheme: ThemeData(extensions: [ZyraDesignSystem.dark]),
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
   );

--- a/mobile/app/test/features/project_list/add_project_dialog_test.dart
+++ b/mobile/app/test/features/project_list/add_project_dialog_test.dart
@@ -11,6 +11,7 @@ import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/features/project_list/add_project_dialog.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../helpers/test_helpers.dart";
 
@@ -54,6 +55,20 @@ Widget _buildApp({required ProjectListCubit cubit, required Widget child}) {
 
   return MaterialApp.router(
     routerConfig: router,
+    theme: ThemeData(
+      colorScheme: ZyraColors.light.toFlutterColorScheme(),
+      textTheme: ZyraTextTheme.light.asFlutterTextTheme(),
+      fontFamily: ZyraTextTheme.fontFamily,
+      fontFamilyFallback: ZyraTextTheme.fontFamilyFallback,
+      extensions: [ZyraDesignSystem.light],
+    ),
+    darkTheme: ThemeData(
+      colorScheme: ZyraColors.dark.toFlutterColorScheme(),
+      textTheme: ZyraTextTheme.dark.asFlutterTextTheme(),
+      fontFamily: ZyraTextTheme.fontFamily,
+      fontFamilyFallback: ZyraTextTheme.fontFamilyFallback,
+      extensions: [ZyraDesignSystem.dark],
+    ),
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
   );

--- a/mobile/app/test/features/session_detail/session_detail_title_hydration_test.dart
+++ b/mobile/app/test/features/session_detail/session_detail_title_hydration_test.dart
@@ -10,6 +10,7 @@ import "package:sesori_mobile/capabilities/voice/voice_transcription_service.dar
 import "package:sesori_mobile/features/session_detail/session_detail_screen.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../helpers/test_helpers.dart";
 
@@ -23,6 +24,8 @@ class MockVoiceTranscriptionService extends Mock implements VoiceTranscriptionSe
 
 Widget _buildApp({required String? sessionTitle}) {
   return MaterialApp(
+    theme: ThemeData(extensions: [ZyraDesignSystem.light]),
+    darkTheme: ThemeData(extensions: [ZyraDesignSystem.dark]),
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
     home: SessionDetailScreen(

--- a/mobile/app/test/features/session_detail/widgets/assistant_message_card_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/assistant_message_card_test.dart
@@ -5,6 +5,7 @@ import "package:sesori_mobile/features/session_detail/widgets/assistant_message_
 import "package:sesori_mobile/features/session_detail/widgets/tool_part_widget.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 class _AssistantMessageCardHarness extends StatefulWidget {
   final MessageWithParts message;
@@ -36,6 +37,8 @@ class _AssistantMessageCardHarnessState extends State<_AssistantMessageCardHarne
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      theme: ThemeData(extensions: [ZyraDesignSystem.light]),
+      darkTheme: ThemeData(extensions: [ZyraDesignSystem.dark]),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(

--- a/mobile/app/test/features/session_detail/widgets/question_modal_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/question_modal_test.dart
@@ -4,6 +4,7 @@ import "package:go_router/go_router.dart";
 import "package:sesori_mobile/features/session_detail/widgets/question_modal.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 class _ReplyCapture {
   String? requestId;
@@ -49,6 +50,8 @@ GoRouter _createRouter({
 Widget _buildApp({required GoRouter router}) {
   return MaterialApp.router(
     routerConfig: router,
+    theme: ThemeData(extensions: [ZyraDesignSystem.light]),
+    darkTheme: ThemeData(extensions: [ZyraDesignSystem.dark]),
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
   );

--- a/mobile/app/test/features/session_detail/widgets/reasoning_modal_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/reasoning_modal_test.dart
@@ -10,6 +10,7 @@ import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/features/session_detail/widgets/reasoning_modal.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 // ---------------------------------------------------------------------------
 // Mock
@@ -86,6 +87,8 @@ MessageWithParts _messageWithPart({
 
 Widget _buildApp({required SessionDetailCubit cubit}) {
   return MaterialApp(
+    theme: ThemeData(extensions: [ZyraDesignSystem.light]),
+    darkTheme: ThemeData(extensions: [ZyraDesignSystem.dark]),
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
     home: BlocProvider<SessionDetailCubit>.value(

--- a/mobile/app/test/features/session_detail/widgets/reasoning_part_card_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/reasoning_part_card_test.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:sesori_mobile/features/session_detail/widgets/reasoning_part_card.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 void main() {
   Widget buildApp({
@@ -11,6 +12,8 @@ void main() {
     String messageId = "msg-1",
   }) {
     return MaterialApp(
+      theme: ThemeData(extensions: [ZyraDesignSystem.light]),
+      darkTheme: ThemeData(extensions: [ZyraDesignSystem.dark]),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(

--- a/mobile/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -12,6 +12,7 @@ import "package:sesori_mobile/capabilities/voice/voice_transcription_service.dar
 import "package:sesori_mobile/features/session_detail/widgets/session_detail_body.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../../helpers/test_helpers.dart";
 
@@ -39,6 +40,8 @@ Widget _buildApp({required SessionDetailCubit cubit}) {
 
   return MaterialApp.router(
     routerConfig: router,
+    theme: ThemeData(extensions: [ZyraDesignSystem.light]),
+    darkTheme: ThemeData(extensions: [ZyraDesignSystem.dark]),
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
   );

--- a/mobile/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -4,6 +4,7 @@ import "package:flutter_test/flutter_test.dart";
 import "package:sesori_mobile/features/session_detail/widgets/session_detail_message_list.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 class _SessionDetailMessageListHarness extends StatefulWidget {
   final List<MessageWithParts> initialMessages;
@@ -41,6 +42,8 @@ class _SessionDetailMessageListHarnessState extends State<_SessionDetailMessageL
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      theme: ThemeData(extensions: [ZyraDesignSystem.light]),
+      darkTheme: ThemeData(extensions: [ZyraDesignSystem.dark]),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       home: Scaffold(

--- a/mobile/app/test/features/session_list/session_lifecycle_ui_test.dart
+++ b/mobile/app/test/features/session_list/session_lifecycle_ui_test.dart
@@ -9,6 +9,7 @@ import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/features/session_list/session_list_screen.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
 
 import "../../helpers/test_helpers.dart";
 
@@ -32,6 +33,16 @@ class MockSessionListCubit extends MockCubit<SessionListState> implements Sessio
 
 Widget _buildApp({required SessionListCubit cubit}) {
   return MaterialApp(
+    theme: ThemeData(
+      colorScheme: ZyraColors.light.toFlutterColorScheme(),
+      textTheme: ZyraTextTheme.light.asFlutterTextTheme(),
+      extensions: [ZyraDesignSystem.light],
+    ),
+    darkTheme: ThemeData(
+      colorScheme: ZyraColors.dark.toFlutterColorScheme(),
+      textTheme: ZyraTextTheme.dark.asFlutterTextTheme(),
+      extensions: [ZyraDesignSystem.dark],
+    ),
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
     home: BlocProvider<SessionListCubit>.value(
@@ -43,6 +54,16 @@ Widget _buildApp({required SessionListCubit cubit}) {
 
 Widget _buildScreenApp({required Widget child}) {
   return MaterialApp(
+    theme: ThemeData(
+      colorScheme: ZyraColors.light.toFlutterColorScheme(),
+      textTheme: ZyraTextTheme.light.asFlutterTextTheme(),
+      extensions: [ZyraDesignSystem.light],
+    ),
+    darkTheme: ThemeData(
+      colorScheme: ZyraColors.dark.toFlutterColorScheme(),
+      textTheme: ZyraTextTheme.dark.asFlutterTextTheme(),
+      extensions: [ZyraDesignSystem.dark],
+    ),
     localizationsDelegates: AppLocalizations.localizationsDelegates,
     supportedLocales: AppLocalizations.supportedLocales,
     home: child,


### PR DESCRIPTION
## Summary

Fully applies the Zyra design system to the mobile app, replacing ad-hoc Material theme lookups with consistent design token access.

## Changes

### Theme wiring
- Updated `main.dart` to use Zyra colors, text theme, and font family for both light and dark Material themes
- Added `ZyraColors.light/dark.toFlutterColorScheme()`, `ZyraTextTheme.light/dark.asFlutterTextTheme()`, and `ZyraDesignSystem.light/dark` to `ThemeData`
- Set `fontFamily: ZyraTextTheme.fontFamily` and `fontFamilyFallback: ZyraTextTheme.fontFamilyFallback`

### Widget migration
- Migrated ~40 widget files across all features (login, project_list, session_list, session_detail, session_diffs, settings, splash, core widgets) to use `context.zyra` for:
  - Colors (`context.zyra.colors.*`)
  - Text styles (`context.zyra.textTheme.*`)
  - Spacing, radius, and shadows where applicable
- Kept `Theme.of(context).brightness` unchanged for light/dark checks

### Documentation
- Added theming section to `mobile/app/AGENTS.md` mandating `context.zyra` usage and prohibiting direct `Theme.of(context).colorScheme` / `Theme.of(context).textTheme` access

### Tests
- Updated test harnesses to include `ZyraDesignSystem` theme extension
- Fixed `markdown_styles_test.dart` to match updated API
- Updated `variant_picker_sheet_test.dart` to provide Zyra theme
- All 401 tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply the Zyra design system across the mobile app for a consistent look and feel. Replaces Material theme lookups with `context.zyra` tokens and wires `theme_zyra` into light/dark themes.

- **Refactors**
  - Wired `ZyraColors`, `ZyraTextTheme`, and `ZyraDesignSystem` into `MaterialApp` light/dark themes (fonts included).
  - Migrated widgets to `context.zyra` for colors, text styles, spacing, radius, and shadows; left brightness checks unchanged.
  - Updated tests to use the Zyra theme extension; all tests pass.

- **Migration**
  - Use `context.zyra` for all design tokens. Stop using `Theme.of(context).colorScheme` and `Theme.of(context).textTheme`.
  - Test harnesses must add `ZyraDesignSystem` to `ThemeData` (light/dark).

<sup>Written for commit e664a58af6b26c957d0df419cd8d74eb205cdc32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

