### PR TITLE
fix: dark mode theme color inconsistencies

### DIFF
--- a/mobile/app/lib/core/widgets/command_picker_sheet.dart
+++ b/mobile/app/lib/core/widgets/command_picker_sheet.dart
@@ -168,7 +168,7 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
                     child: Text(
                       _sourceLabel(command.source),
                       style: zyra.textTheme.textXs.medium.copyWith(
-                        color: zyra.colors.bgPrimary,
+                        color: zyra.colors.textBrandPrimary,
                         fontWeight: FontWeight.w600,
                       ),
                     ),

--- a/mobile/app/lib/core/widgets/connection_overlay.dart
+++ b/mobile/app/lib/core/widgets/connection_overlay.dart
@@ -66,18 +66,27 @@ class _ConnectionOverlayBody extends StatelessWidget {
             left: 0,
             right: 0,
             child: SafeArea(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const LinearProgressIndicator(),
-                  Padding(
-                    padding: const EdgeInsets.all(8),
-                    child: Text(
-                      context.loc.relayReconnecting,
-                      style: zyra.textTheme.textXs.medium,
+              child: Material(
+                elevation: 2,
+                color: Theme.of(context).colorScheme.surfaceContainer,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    LinearProgressIndicator(
+                      color: zyra.colors.bgBrandSolid,
+                      backgroundColor: zyra.colors.bgTertiary,
                     ),
-                  ),
-                ],
+                    Padding(
+                      padding: const EdgeInsets.all(8),
+                      child: Text(
+                        context.loc.relayReconnecting,
+                        style: zyra.textTheme.textXs.medium.copyWith(
+                          color: zyra.colors.textPrimary,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/mobile/app/lib/features/session_detail/widgets/jump_to_edge_pill.dart
+++ b/mobile/app/lib/features/session_detail/widgets/jump_to_edge_pill.dart
@@ -44,12 +44,12 @@ class JumpToEdgePill extends StatelessWidget {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Icon(Icons.arrow_downward, size: 16, color: zyra.colors.bgBrandPrimaryAlt),
+                  Icon(Icons.arrow_downward, size: 16, color: zyra.colors.textBrandPrimary),
                   const SizedBox(width: 6),
                   Text(
                     label,
                     style: zyra.textTheme.textSm.bold.copyWith(
-                      color: zyra.colors.bgBrandPrimaryAlt,
+                      color: zyra.colors.textBrandPrimary,
                     ),
                   ),
                 ],

--- a/mobile/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/mobile/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -242,7 +242,7 @@ class _PromptInputState extends State<PromptInput> {
                     child: Text(
                       "/",
                       style: zyra.textTheme.textMd.bold.copyWith(
-                        color: zyra.colors.bgBrandPrimaryAlt,
+                        color: zyra.colors.textBrandPrimary,
                         fontWeight: FontWeight.w700,
                       ),
                     ),

--- a/mobile/app/lib/features/session_detail/widgets/user_message_card.dart
+++ b/mobile/app/lib/features/session_detail/widgets/user_message_card.dart
@@ -30,7 +30,7 @@ class UserMessageCard extends StatelessWidget {
         child: SelectableText(
           text,
           style: zyra.textTheme.textSm.regular.copyWith(
-            color: zyra.colors.bgBrandPrimaryAlt,
+            color: zyra.colors.fgWhite,
           ),
         ),
       ),

--- a/mobile/app/lib/features/session_detail/widgets/user_message_card.dart
+++ b/mobile/app/lib/features/session_detail/widgets/user_message_card.dart
@@ -30,7 +30,7 @@ class UserMessageCard extends StatelessWidget {
         child: SelectableText(
           text,
           style: zyra.textTheme.textSm.regular.copyWith(
-            color: zyra.colors.fgWhite,
+            color: zyra.colors.textBrandPrimary,
           ),
         ),
       ),

--- a/mobile/app/lib/features/session_list/session_list_widgets.dart
+++ b/mobile/app/lib/features/session_list/session_list_widgets.dart
@@ -52,7 +52,7 @@ class _SessionTile extends StatelessWidget {
           backgroundColor: context.zyra.colors.bgBrandSolid,
           child: Icon(
             Icons.chat_outlined,
-            color: context.zyra.colors.bgPrimary,
+            color: context.zyra.colors.textPrimary,
           ),
         ),
         title: Text(session.title ?? loc.sessionListUntitled),

--- a/mobile/app/lib/features/splash/splash_screen.dart
+++ b/mobile/app/lib/features/splash/splash_screen.dart
@@ -49,25 +49,28 @@ class _SplashView extends StatelessWidget {
         const Positioned.fill(child: SesoriBackgroundWidget()),
         Align(
           alignment: .center,
-          child: Column(
-            mainAxisSize: .min,
-            children: [
-              Image.asset(
-                "assets/images/sesori_icon_with_shadow.png",
-                fit: .none,
-              ),
-              // Image has some embedded "bottom padding"
-              // caused by the shadow
-              const SizedBox(height: 13),
-              Text(
-                context.loc.splashWelcomeTo,
-                style: zyra.textTheme.textSm.regular,
-              ),
-              Text(
-                context.loc.splashTitle,
-                style: zyra.textTheme.textMd.bold,
-              ),
-            ],
+          child: Material(
+            type: MaterialType.transparency,
+            child: Column(
+              mainAxisSize: .min,
+              children: [
+                Image.asset(
+                  "assets/images/sesori_icon_with_shadow.png",
+                  fit: .none,
+                ),
+                // Image has some embedded "bottom padding"
+                // caused by the shadow
+                const SizedBox(height: 13),
+                Text(
+                  context.loc.splashWelcomeTo,
+                  style: zyra.textTheme.textSm.regular,
+                ),
+                Text(
+                  context.loc.splashTitle,
+                  style: zyra.textTheme.textMd.bold,
+                ),
+              ],
+            ),
           ),
         ),
       ],

--- a/mobile/module_zyra/lib/theme/primitives/zyra_colors_x.dart
+++ b/mobile/module_zyra/lib/theme/primitives/zyra_colors_x.dart
@@ -40,7 +40,7 @@ extension ZyraColorsX on ZyraColors {
     onSurface: textPrimary,
     onSurfaceVariant: brightness == .light ? textTertiary : textSecondary,
     outline: borderPrimary,
-    onInverseSurface: brightness == .light ? bgBrandPrimaryAlt : bgBrandPrimary,
+    onInverseSurface: brightness == .light ? bgBrandPrimaryAlt : fgWhite,
     inverseSurface: brightness == .light ? bgPrimarySolid : bgBrandPrimary,
     inversePrimary: brightness == .light ? bgBrandSecondary : bgBrandSectionSubtle,
     shadow: brightness == .light ? bgPrimarySolid : bgOverlay,


### PR DESCRIPTION
## Summary

Fixes three dark mode color discrepancies after the recent theming PR:

1. **Session list icon color** — The chat icon in the sessions list used `bgPrimary` (dark gray in dark mode) instead of `textPrimary` (white). Now matches the project list folder icon.

2. **SnackBar text invisible** — The `onInverseSurface` ColorScheme mapping in dark mode was incorrectly set to `bgBrandPrimary` (bright blue), same as `inverseSurface`. This made SnackBar text invisible because background and text were the same color. Fixed to use `fgWhite` (white text on blue background).

3. **User message bubble text** — The user message card in session detail used `bgBrandPrimaryAlt` for text, which in dark mode is `bgSecondary` (dark gray) on a `bgBrandPrimary` (bright blue) background — very poor contrast. Changed to `fgWhite` for consistent white text on the blue bubble.

All fixes use existing Zyra theme tokens (`textPrimary`, `fgWhite`) — no hardcoded colors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dark mode color inconsistencies and a splash-screen text issue. Restores contrast across key components using Zyra theme tokens.

- **Bug Fixes**
  - Session list chat icon: use textPrimary (white) instead of bgPrimary.
  - SnackBar text: map onInverseSurface to fgWhite in dark mode.
  - User message bubble: use textBrandPrimary for legible text in light/dark.
  - Reconnecting overlay: add surfaceContainer background; progress bar to bgBrandSolid with bgTertiary track; label text to textPrimary.
  - Jump-to-edge pill and command InputChip: icon and "/" use textBrandPrimary for contrast on bgBrandPrimary.
  - Command picker source pill badge: use textBrandPrimary for contrast on bgBrandSolid.
  - Splash screen text: wrap in Material to remove yellow underlines.

<sup>Written for commit a1b6ee90745ed5f5a3fe6e162245f4daae5045cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

