### PR TITLE
fix: light mode theme color improvements

### DIFF
--- a/mobile/app/lib/core/widgets/command_picker_sheet.dart
+++ b/mobile/app/lib/core/widgets/command_picker_sheet.dart
@@ -162,7 +162,7 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
                   trailing: Container(
                     padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                     decoration: BoxDecoration(
-                      color: zyra.colors.bgBrandSolid,
+                      color: zyra.colors.bgBrandPrimary,
                       borderRadius: BorderRadius.circular(12),
                     ),
                     child: Text(

--- a/mobile/app/lib/features/project_list/add_project_dialog.dart
+++ b/mobile/app/lib/features/project_list/add_project_dialog.dart
@@ -351,7 +351,7 @@ class _DirectoryBrowserState extends State<_DirectoryBrowser> {
                   child: Text(
                     loc.emptyDirectory,
                     style: zyra.textTheme.textSm.regular.copyWith(
-                      color: zyra.colors.borderPrimary,
+                      color: zyra.colors.textSecondary,
                     ),
                   ),
                 )

--- a/mobile/app/lib/features/project_list/project_list_screen.dart
+++ b/mobile/app/lib/features/project_list/project_list_screen.dart
@@ -229,7 +229,7 @@ class _ProjectTile extends StatelessWidget {
         backgroundColor: zyra.colors.bgBrandSolid,
         child: Icon(
           Icons.folder_outlined,
-          color: zyra.colors.textPrimary,
+          color: zyra.colors.fgWhite,
         ),
       ),
       title: Text(displayName),
@@ -246,7 +246,7 @@ class _ProjectTile extends StatelessWidget {
             Text(
               loc.projectListUpdated(_formatTimestamp(updatedAt)),
               style: zyra.textTheme.textXs.regular.copyWith(
-                color: zyra.colors.borderPrimary,
+                color: zyra.colors.textSecondary,
               ),
             ),
           if (isActive)

--- a/mobile/app/lib/features/session_detail/widgets/agent_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/agent_part_widget.dart
@@ -18,13 +18,13 @@ class AgentPartWidget extends StatelessWidget {
           Icon(
             Icons.smart_toy_outlined,
             size: 14,
-            color: zyra.colors.borderPrimary,
+            color: zyra.colors.textSecondary,
           ),
           const SizedBox(width: 6),
           Text(
             label,
             style: zyra.textTheme.textXs.medium.copyWith(
-              color: zyra.colors.borderPrimary,
+              color: zyra.colors.textSecondary,
             ),
           ),
         ],

--- a/mobile/app/lib/features/session_detail/widgets/reasoning_modal.dart
+++ b/mobile/app/lib/features/session_detail/widgets/reasoning_modal.dart
@@ -153,7 +153,7 @@ class _ReasoningModalState extends State<ReasoningModal> {
       padding: const EdgeInsetsDirectional.fromSTEB(16, 4, 16, 12),
       child: Row(
         children: [
-          Icon(Icons.psychology, size: 20, color: zyra.colors.borderPrimary),
+          Icon(Icons.psychology, size: 20, color: zyra.colors.textSecondary),
           const SizedBox(width: 8),
           Text(
             isStreaming ? loc.sessionDetailThinking : loc.sessionDetailThought,

--- a/mobile/app/lib/features/session_detail/widgets/reasoning_part_card.dart
+++ b/mobile/app/lib/features/session_detail/widgets/reasoning_part_card.dart
@@ -81,7 +81,7 @@ class _ReasoningPartCardState extends State<ReasoningPartCard> {
                     Icon(
                       Icons.psychology,
                       size: 18,
-                      color: zyra.colors.borderPrimary,
+                      color: zyra.colors.textSecondary,
                     ),
                     const SizedBox(width: 8),
                     Expanded(
@@ -90,7 +90,7 @@ class _ReasoningPartCardState extends State<ReasoningPartCard> {
                             ? loc.sessionDetailThinking
                             : loc.sessionDetailThought,
                         style: zyra.textTheme.textXs.regular.copyWith(
-                          color: zyra.colors.borderPrimary,
+                          color: zyra.colors.textSecondary,
                           fontStyle: FontStyle.italic,
                         ),
                       ),
@@ -98,7 +98,7 @@ class _ReasoningPartCardState extends State<ReasoningPartCard> {
                     Icon(
                       Icons.unfold_more,
                       size: 16,
-                      color: zyra.colors.borderPrimary,
+                      color: zyra.colors.textSecondary,
                     ),
                   ],
                 ),

--- a/mobile/app/lib/features/session_detail/widgets/tool_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/tool_part_widget.dart
@@ -49,7 +49,7 @@ class ToolPartWidget extends StatelessWidget {
                   Text(
                     _statusLabel(loc: loc, status: status),
                     style: zyra.textTheme.textXs.medium.copyWith(
-                      color: zyra.colors.borderPrimary,
+                      color: zyra.colors.textSecondary,
                     ),
                   ),
                 ],

--- a/mobile/app/lib/features/session_list/session_list_widgets.dart
+++ b/mobile/app/lib/features/session_list/session_list_widgets.dart
@@ -52,7 +52,7 @@ class _SessionTile extends StatelessWidget {
           backgroundColor: context.zyra.colors.bgBrandSolid,
           child: Icon(
             Icons.chat_outlined,
-            color: context.zyra.colors.textPrimary,
+            color: context.zyra.colors.fgWhite,
           ),
         ),
         title: Text(session.title ?? loc.sessionListUntitled),
@@ -63,7 +63,7 @@ class _SessionTile extends StatelessWidget {
               Text(
                 loc.sessionListUpdated(_formatTimestamp(ms: updatedAt)),
                 style: context.zyra.textTheme.textXs.regular.copyWith(
-                  color: context.zyra.colors.borderPrimary,
+                  color: context.zyra.colors.textSecondary,
                 ),
               ),
             if (filesChanged > 0)


### PR DESCRIPTION
## Summary

Fixes several light mode visibility and contrast issues:

### 1. Command picker source pills background
Changed from `bgBrandSolid` (dark blue in light mode) to `bgBrandPrimary` (light blue) so the pills match the Jump to Latest pill background.

### 2. Project & session list icon colors
Changed from `textPrimary` (black in light mode) to `fgWhite` so the icons are white-on-blue in both light and dark modes for proper contrast.

### 3. Timestamp text too light
Changed session and project list timestamp text from `borderPrimary` (very light gray) to `textSecondary` (darker gray) for better readability in light mode.

### 4. Reasoning/thought card labels too light
Changed the psychology icon, "Thinking"/"Thought" label, and expand icon from `borderPrimary` to `textSecondary` for better visibility in light mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves light mode contrast and readability across the app. Switches command picker pills to `bgBrandPrimary`, uses `fgWhite` icons on brand blue for project/session lists, and applies `textSecondary` to timestamps, the empty-directory hint, tool/agent labels, and reasoning modal/card icons and labels.

<sup>Written for commit 7b7f9eaf66eb67043503c2ee0d7edb52fcf7be1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

