### PR TITLE
fix: suppress snackbar on auto-navigation after session creation

### DIFF
--- a/mobile/app/lib/features/new_session/new_session_screen.dart
+++ b/mobile/app/lib/features/new_session/new_session_screen.dart
@@ -45,6 +45,7 @@ class _NewSessionBody extends StatefulWidget {
 
 class _NewSessionBodyState extends State<_NewSessionBody> {
   bool _dedicatedWorktree = true;
+  bool _navigatingToCreatedSession = false;
 
   void _dismissScreen() {
     context.pop();
@@ -146,6 +147,7 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
       listenWhen: (_, current) => current is NewSessionCreated,
       listener: (context, state) {
         if (state case NewSessionCreated(:final session)) {
+          _navigatingToCreatedSession = true;
           _dismissScreen();
           context.pushRoute(
             AppRoute.sessionDetail(
@@ -160,7 +162,7 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
       child: PopScope(
         canPop: true,
         onPopInvokedWithResult: (didPop, result) {
-          if (didPop && isSending) {
+          if (didPop && isSending && !_navigatingToCreatedSession) {
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
                 content: Text(loc.newSessionLaunchingInBackground),

--- a/mobile/app/test/features/new_session/new_session_screen_test.dart
+++ b/mobile/app/test/features/new_session/new_session_screen_test.dart
@@ -376,6 +376,40 @@ void main() {
     expect(find.byType(NewSessionScreen), findsNothing);
   });
 
+  testWidgets("does not show snackbar when auto-navigating after creating a session", (tester) async {
+    final createCompleter = Completer<ApiResponse<Session>>();
+    when(
+      () => sessionService.createSessionWithMessage(
+        projectId: any(named: "projectId"),
+        text: any(named: "text"),
+        agent: any(named: "agent"),
+        providerID: any(named: "providerID"),
+        modelID: any(named: "modelID"),
+        variant: any(named: "variant"),
+        command: any(named: "command"),
+        dedicatedWorktree: any(named: "dedicatedWorktree"),
+      ),
+    ).thenAnswer((_) => createCompleter.future);
+
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+
+    final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
+
+    await tester.enterText(find.byType(TextField), "test message");
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pump();
+
+    expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
+
+    createCompleter.complete(ApiResponse.success(testSession(id: "session-1", title: "Created session")));
+    await tester.pumpAndSettle();
+
+    expect(find.text("session-detail:session-1"), findsOneWidget);
+    expect(find.byType(NewSessionScreen), findsNothing);
+    expect(find.text(loc.newSessionLaunchingInBackground), findsNothing);
+  });
+
   testWidgets("removes the loading overlay and keeps retry UI usable after an error", (tester) async {
     final createCompleter = Completer<ApiResponse<Session>>();
     when(


### PR DESCRIPTION
## Problem

When a new session was successfully created after sending the first message, the app would auto-navigate to the session detail screen. However, the \"session launching in background\" snackbar would still appear, which is incorrect — the snackbar should only show when the user manually navigates away from the screen while the session is still being created.

## Root Cause

The `BlocListener` for `NewSessionCreated` calls `_dismissScreen()` which triggers `PopScope.onPopInvokedWithResult`. At that moment, the widget hasn't rebuilt yet with the new state, so `isSending` is still `true` in the closure, causing the snackbar to fire.

## Fix

- Added a `_navigatingToCreatedSession` flag that gets set to `true` in the `BlocListener` before calling `_dismissScreen()`.
- Updated `PopScope.onPopInvokedWithResult` to check `!_navigatingToCreatedSession` before showing the snackbar.

## Testing

- Added a new test: `does not show snackbar when auto-navigating after creating a session`
- All 407 tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress the “session launching in background” snackbar when the app auto-navigates to the newly created session. The snackbar now only shows if the user manually leaves while creation is still in progress.

- **Bug Fixes**
  - Set `_navigatingToCreatedSession = true` in `BlocListener` before calling `_dismissScreen()`.
  - Gate snackbar in `PopScope.onPopInvokedWithResult` with `!_navigatingToCreatedSession`.
  - Add test: skips snackbar on auto-navigation after session creation.

<sup>Written for commit 9feb6f7ba832352932caed88aa750fa1c4216977. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

