### PR TITLE
fix: pin flutter_secure_storage to 10.0.0 to avoid iOS 13 build failure

### DIFF
--- a/mobile/app/pubspec.yaml
+++ b/mobile/app/pubspec.yaml
@@ -60,7 +60,11 @@ dependencies:
   cryptography: ^2.9.0
   cryptography_flutter: ^2.3.4
   web_socket_channel: ^3.0.3
-  flutter_secure_storage: ^10.0.0
+  # Pinned to 10.0.0 because 10.1.0 pulls in flutter_secure_storage_darwin 0.3.0,
+  # which uses CryptoKit APIs (SymmetricKey, AES.GCM) that require iOS 13.0+ but
+  # incorrectly guards them with an iOS 11.3 availability check. This causes Swift
+  # compiler errors when archiving for iOS. See upstream issue #1119.
+  flutter_secure_storage: 10.0.0
   app_links: ^7.0.0
   url_launcher: ^6.3.2
   universal_platform: ^1.1.0

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -519,18 +519,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage
-      sha256: "8b302d17096ba88f911b7eb317c71d5e691da60a259549f42b38c658d1776d87"
+      sha256: da922f2aab2d733db7e011a6bcc4a825b844892d4edd6df83ff156b09a9b2e40
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.0"
+    version: "10.0.0"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
       name: flutter_secure_storage_darwin
-      sha256: "3af15a3cb2bf5b8b776832bd01776f8018766aece55623176e28b406481fb320"
+      sha256: "8878c25136a79def1668c75985e8e193d9d7d095453ec28730da0315dc69aee3"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.2.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:


### PR DESCRIPTION
## Problem
`flutter_secure_storage_darwin` 0.3.0 (pulled in by `flutter_secure_storage` 10.1.0) uses CryptoKit APIs (`SymmetricKey`, `AES.GCM`) that require iOS 13.0+, but incorrectly guards them with an `iOS 11.3` availability check. This causes Swift compiler errors when archiving for iOS:

```
'SymmetricKey' is only available in iOS 13.0 or newer
'AES' is only available in iOS 13.0 or newer
```

## Changes
- Pin `flutter_secure_storage` to exactly `10.0.0` (no caret)
- This keeps the transitive `flutter_secure_storage_darwin` dependency at `0.2.0`, which does not include the buggy Secure Enclave code path

## Upstream issue
- juliansteenbakker/flutter_secure_storage#1119

## Testing
- [ ] Re-archive for iOS device after merging

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `flutter_secure_storage` to `10.0.0` to stop iOS archive failures caused by `flutter_secure_storage_darwin` 0.3.0 using CryptoKit behind the wrong availability check. This keeps the darwin plugin at `0.2.0` and restores compatibility for targets below iOS 13.

<sup>Written for commit 628ccd6c2bb3fd26fade0369d7a237a53961a223. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

