### PR TITLE
fix: handle OpenCode v1.14.48 schema changes and missing SSE event types

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/models/file_diff.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/file_diff.dart
@@ -8,7 +8,7 @@ part "file_diff.g.dart";
 sealed class FileDiff with _$FileDiff {
   const factory FileDiff({
     required String file,
-    required String patch,
+    required String? patch,
     required int additions,
     required int deletions,
     FileDiffStatus? status,

--- a/bridge/sesori_plugin_opencode/lib/src/models/file_diff.freezed.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/file_diff.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$FileDiff {
 
- String get file; String get patch; int get additions; int get deletions; FileDiffStatus? get status;
+ String get file; String? get patch; int get additions; int get deletions; FileDiffStatus? get status;
 /// Create a copy of FileDiff
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $FileDiffCopyWith<$Res>  {
   factory $FileDiffCopyWith(FileDiff value, $Res Function(FileDiff) _then) = _$FileDiffCopyWithImpl;
 @useResult
 $Res call({
- String file, String patch, int additions, int deletions, FileDiffStatus? status
+ String file, String? patch, int additions, int deletions, FileDiffStatus? status
 });
 
 
@@ -65,11 +65,11 @@ class _$FileDiffCopyWithImpl<$Res>
 
 /// Create a copy of FileDiff
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? file = null,Object? patch = null,Object? additions = null,Object? deletions = null,Object? status = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? file = null,Object? patch = freezed,Object? additions = null,Object? deletions = null,Object? status = freezed,}) {
   return _then(_self.copyWith(
 file: null == file ? _self.file : file // ignore: cast_nullable_to_non_nullable
-as String,patch: null == patch ? _self.patch : patch // ignore: cast_nullable_to_non_nullable
-as String,additions: null == additions ? _self.additions : additions // ignore: cast_nullable_to_non_nullable
+as String,patch: freezed == patch ? _self.patch : patch // ignore: cast_nullable_to_non_nullable
+as String?,additions: null == additions ? _self.additions : additions // ignore: cast_nullable_to_non_nullable
 as int,deletions: null == deletions ? _self.deletions : deletions // ignore: cast_nullable_to_non_nullable
 as int,status: freezed == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as FileDiffStatus?,
@@ -84,11 +84,11 @@ as FileDiffStatus?,
 @JsonSerializable()
 
 class _FileDiff implements FileDiff {
-  const _FileDiff({required this.file, required this.patch, required this.additions, required this.deletions, this.status});
+  const _FileDiff({required this.file, this.patch, required this.additions, required this.deletions, this.status});
   factory _FileDiff.fromJson(Map<String, dynamic> json) => _$FileDiffFromJson(json);
 
 @override final  String file;
-@override final  String patch;
+@override final  String? patch;
 @override final  int additions;
 @override final  int deletions;
 @override final  FileDiffStatus? status;
@@ -126,7 +126,7 @@ abstract mixin class _$FileDiffCopyWith<$Res> implements $FileDiffCopyWith<$Res>
   factory _$FileDiffCopyWith(_FileDiff value, $Res Function(_FileDiff) _then) = __$FileDiffCopyWithImpl;
 @override @useResult
 $Res call({
- String file, String patch, int additions, int deletions, FileDiffStatus? status
+ String file, String? patch, int additions, int deletions, FileDiffStatus? status
 });
 
 
@@ -143,11 +143,11 @@ class __$FileDiffCopyWithImpl<$Res>
 
 /// Create a copy of FileDiff
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? file = null,Object? patch = null,Object? additions = null,Object? deletions = null,Object? status = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? file = null,Object? patch = freezed,Object? additions = null,Object? deletions = null,Object? status = freezed,}) {
   return _then(_FileDiff(
 file: null == file ? _self.file : file // ignore: cast_nullable_to_non_nullable
-as String,patch: null == patch ? _self.patch : patch // ignore: cast_nullable_to_non_nullable
-as String,additions: null == additions ? _self.additions : additions // ignore: cast_nullable_to_non_nullable
+as String,patch: freezed == patch ? _self.patch : patch // ignore: cast_nullable_to_non_nullable
+as String?,additions: null == additions ? _self.additions : additions // ignore: cast_nullable_to_non_nullable
 as int,deletions: null == deletions ? _self.deletions : deletions // ignore: cast_nullable_to_non_nullable
 as int,status: freezed == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as FileDiffStatus?,

--- a/bridge/sesori_plugin_opencode/lib/src/models/file_diff.g.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/file_diff.g.dart
@@ -8,7 +8,7 @@ part of 'file_diff.dart';
 
 _FileDiff _$FileDiffFromJson(Map json) => _FileDiff(
   file: json['file'] as String,
-  patch: json['patch'] as String,
+  patch: json['patch'] as String?,
   additions: (json['additions'] as num).toInt(),
   deletions: (json['deletions'] as num).toInt(),
   status: $enumDecodeNullable(_$FileDiffStatusEnumMap, json['status']),

--- a/bridge/sesori_plugin_opencode/lib/src/sse_event_parser.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse_event_parser.dart
@@ -191,4 +191,39 @@ const Set<String> _knownEventTypes = {
   "worktree.failed",
 };
 
-const Set<String> _ignoredEventTypes = {"sync"};
+const Set<String> _ignoredEventTypes = {
+  "sync",
+  // session.next.* — internal lifecycle events, not useful for mobile UI
+  "session.next.agent.switched",
+  "session.next.model.switched",
+  "session.next.prompted",
+  "session.next.synthetic",
+  "session.next.shell.started",
+  "session.next.shell.ended",
+  "session.next.step.started",
+  "session.next.step.ended",
+  "session.next.step.failed",
+  "session.next.text.started",
+  "session.next.text.delta",
+  "session.next.text.ended",
+  "session.next.reasoning.started",
+  "session.next.reasoning.delta",
+  "session.next.reasoning.ended",
+  "session.next.tool.input.started",
+  "session.next.tool.input.delta",
+  "session.next.tool.input.ended",
+  "session.next.tool.called",
+  "session.next.tool.progress",
+  "session.next.tool.success",
+  "session.next.tool.failed",
+  "session.next.retried",
+  "session.next.compaction.started",
+  "session.next.compaction.delta",
+  "session.next.compaction.ended",
+  // TUI events — only relevant for terminal UI
+  "tui.prompt.append",
+  "tui.command.execute",
+  "tui.session.select",
+  // workspace status — already handled by workspace.ready / workspace.failed
+  "workspace.status",
+};


### PR DESCRIPTION
## Summary

Updates the bridge to handle changes introduced in OpenCode v1.14.48.

### Changes

1. **FileDiff.patch is now optional** — OpenCode v1.14.48 changed `SnapshotFileDiff.patch` from required to optional. Updated our `FileDiff` model to use `required String? patch` to match the new schema.

2. **Silenced warning spam from missing SSE event types** — Added 31 event types to the ignored list that the bridge was previously warning about as "unknown":
   - All `session.next.*` lifecycle events (28 types): agent/model/tool/reasoning/compaction/step/text/shell operations
   - TUI events: `tui.prompt.append`, `tui.command.execute`, `tui.session.select`
   - `workspace.status`

   These are internal implementation-detail events that don't need to be forwarded to the mobile app (content updates already flow through `message.updated` / `message.part.delta`).

3. **Regenerated Freezed code** via `make codegen`.

### Verification

- `make analyze` — clean across all modules
- `make test` — all 1028 tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `sesori_plugin_opencode` bridge to align with `OpenCode` v1.14.48 and silence noisy SSE warnings. Keeps mobile behavior unchanged while ensuring compatibility.

- **Bug Fixes**
  - Made `FileDiff.patch` nullable to match `OpenCode` v1.14.48 (`SnapshotFileDiff.patch` is now optional).
  - Added 31 SSE event types to `_ignoredEventTypes` to stop "unknown" warnings:
    - All `session.next.*` lifecycle events, TUI events (`tui.prompt.append`, `tui.command.execute`, `tui.session.select`), and `workspace.status`.
  - Regenerated Freezed code.

<sup>Written for commit b497febd72c3012f3e31417588bd50362849ba6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

