### PR TITLE
fix: prevent stale silent refresh from restoring drained queued commands

### DIFF
--- a/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -347,12 +347,11 @@ void main() {
       },
       expect: () => [
         isA<SessionDetailLoaded>(),
-        isA<SessionDetailLoaded>()
-            .having(
-              (state) => state.selectedAgentModel,
-              "selectedAgentModel",
-              const AgentModel(providerID: "openai", modelID: "gpt-4.1", variant: null),
-            ),
+        isA<SessionDetailLoaded>().having(
+          (state) => state.selectedAgentModel,
+          "selectedAgentModel",
+          const AgentModel(providerID: "openai", modelID: "gpt-4.1", variant: null),
+        ),
       ],
     );
 
@@ -921,6 +920,58 @@ void main() {
       ],
     );
 
+    test("slow silent refresh preserves model selection changed while refresh is in flight", () async {
+      var getMessagesCallCount = 0;
+      final slowRefreshStarted = Completer<void>();
+      final completeSlowRefresh = Completer<void>();
+
+      when(
+        () => mockSessionRepository.getMessages(sessionId: any(named: "sessionId")),
+      ).thenAnswer((_) {
+        getMessagesCallCount += 1;
+        if (getMessagesCallCount == 2) {
+          slowRefreshStarted.complete();
+          return completeSlowRefresh.future.then(
+            (_) => ApiResponse.success(MessageWithPartsResponse(messages: [testMessageWithParts()])),
+          );
+        }
+
+        return Future<ApiResponse<MessageWithPartsResponse>>.value(
+          ApiResponse.success(MessageWithPartsResponse(messages: [testMessageWithParts()])),
+        );
+      });
+
+      final cubit = SessionDetailCubit(
+        mockConnectionService,
+        loadService: loadService,
+        promptDispatcher: promptDispatcher,
+        permissionRepository: mockPermissionRepository,
+        sessionId: sessionId,
+        projectId: "project-1",
+        notificationCanceller: mockNotificationCanceller,
+        failureReporter: mockFailureReporter,
+      );
+      addTearDown(cubit.close);
+      await _awaitLoaded(cubit);
+
+      globalEvents.add(SseEvent(data: const SesoriSessionsUpdated(projectID: "project-1")));
+      await slowRefreshStarted.future;
+
+      cubit.selectModel(providerID: "openai", modelID: "gpt-4.1");
+      expect(
+        (cubit.state as SessionDetailLoaded).selectedAgentModel,
+        const AgentModel(providerID: "openai", modelID: "gpt-4.1", variant: null),
+      );
+
+      completeSlowRefresh.complete();
+      await _awaitNotRefreshing(cubit);
+
+      expect(
+        (cubit.state as SessionDetailLoaded).selectedAgentModel,
+        const AgentModel(providerID: "openai", modelID: "gpt-4.1", variant: null),
+      );
+    });
+
     blocTest<SessionDetailCubit, SessionDetailState>(
       "session.updated SSE re-sorts children by updated descending",
       build: () {
@@ -1337,6 +1388,84 @@ void main() {
       ).called(1);
     });
 
+    test("slow silent refresh does not restore a queued command after it drains", () async {
+      var getMessagesCallCount = 0;
+      final slowRefreshStarted = Completer<void>();
+      final completeSlowRefresh = Completer<void>();
+
+      when(
+        () => mockSessionRepository.getMessages(sessionId: any(named: "sessionId")),
+      ).thenAnswer((_) {
+        getMessagesCallCount += 1;
+        if (getMessagesCallCount == 2) {
+          slowRefreshStarted.complete();
+          return completeSlowRefresh.future.then(
+            (_) => ApiResponse.success(MessageWithPartsResponse(messages: [testMessageWithParts()])),
+          );
+        }
+
+        return Future<ApiResponse<MessageWithPartsResponse>>.value(
+          ApiResponse.success(MessageWithPartsResponse(messages: [testMessageWithParts()])),
+        );
+      });
+
+      final cubit = SessionDetailCubit(
+        mockConnectionService,
+        loadService: loadService,
+        promptDispatcher: promptDispatcher,
+        permissionRepository: mockPermissionRepository,
+        sessionId: sessionId,
+        projectId: "project-1",
+        notificationCanceller: mockNotificationCanceller,
+        failureReporter: mockFailureReporter,
+      );
+      addTearDown(cubit.close);
+      await _awaitLoaded(cubit);
+
+      final connected = ConnectionStatus.connected(
+        config: const ServerConnectionConfig(relayHost: "fake.example.com"),
+        health: testHealthResponse(),
+      );
+      connectionStatus.add(connected);
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      when(() => mockConnectionService.currentStatus).thenReturn(
+        const ConnectionStatus.connectionLost(
+          config: ServerConnectionConfig(relayHost: "fake.example.com"),
+        ),
+      );
+      await cubit.sendMessage(text: "lib/main.dart", command: "review");
+      expect(
+        (cubit.state as SessionDetailLoaded).queuedMessages.map((message) => message.displayText).toList(),
+        equals(["/review lib/main.dart"]),
+      );
+
+      when(() => mockConnectionService.currentStatus).thenReturn(connected);
+      globalEvents.add(
+        SseEvent(data: const SesoriSessionsUpdated(projectID: "project-1")),
+      );
+      await slowRefreshStarted.future;
+
+      connectionStatus.add(connected);
+      await _awaitQueuedMessages(cubit, isEmpty);
+
+      completeSlowRefresh.complete();
+      await _awaitNotRefreshing(cubit);
+
+      expect((cubit.state as SessionDetailLoaded).queuedMessages, isEmpty);
+      verify(
+        () => mockSessionService.sendMessage(
+          sessionId: sessionId,
+          text: "lib/main.dart",
+          agent: "coder",
+          providerID: "anthropic",
+          modelID: "claude-3-5-sonnet",
+          variant: null,
+          command: "review",
+        ),
+      ).called(1);
+    });
+
     test("connected send while queued drain is in flight stays queued until earlier work finishes", () async {
       final firstSendStarted = Completer<void>();
       final allowFirstSendToComplete = Completer<void>();
@@ -1578,6 +1707,22 @@ void main() {
 Future<void> _awaitLoaded(SessionDetailCubit cubit) async {
   for (var i = 0; i < 50; i++) {
     if (cubit.state is SessionDetailLoaded) return;
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+  }
+}
+
+Future<void> _awaitQueuedMessages(SessionDetailCubit cubit, Matcher matcher) async {
+  for (var i = 0; i < 50; i++) {
+    final state = cubit.state;
+    if (state is SessionDetailLoaded && matcher.matches(state.queuedMessages, <Object, Object>{})) return;
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+  }
+}
+
+Future<void> _awaitNotRefreshing(SessionDetailCubit cubit) async {
+  for (var i = 0; i < 50; i++) {
+    final state = cubit.state;
+    if (state is SessionDetailLoaded && !state.isRefreshing) return;
     await Future<void>.delayed(const Duration(milliseconds: 1));
   }
 }

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -115,11 +115,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     final current = state;
     if (current is! SessionDetailLoaded) return;
 
-    final preservedSelectedAgent = current.selectedAgent;
-    final preservedSelectedAgentModel = current.selectedAgentModel;
-    final preservedStagedCommand = current.stagedCommand;
-
-    emit(current.copyWith(isRefreshing: true));
+    emit(current.copyWith(isRefreshing: true, queuedMessages: _promptQueue.items));
 
     try {
       final result = await _loadService.reload(sessionId: _sessionId, projectId: _projectId);
@@ -156,16 +152,21 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
             MessageUser() || null => null,
           };
 
+          final refreshedChildSessions = [...snapshot.childSessions];
+          _sortChildrenByUpdatedDesc(refreshedChildSessions);
+
+          final latest = state;
+          if (latest is! SessionDetailLoaded) return;
+          final preservedSelectedAgent = latest.selectedAgent;
+          final preservedSelectedAgentModel = latest.selectedAgentModel;
+          final preservedStagedCommand = latest.stagedCommand;
           final availableVariants = _deriveAvailableVariants(
             providers: availableProviders,
             model: preservedSelectedAgentModel,
           );
 
-          final refreshedChildSessions = [...snapshot.childSessions];
-          _sortChildrenByUpdatedDesc(refreshedChildSessions);
-
           emit(
-            current.copyWith(
+            latest.copyWith(
               messages: snapshot.messages,
               streamingText: streamingText,
               sessionStatus: snapshot.statuses[_sessionId] ?? const SessionStatus.idle(),
@@ -178,28 +179,38 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
               availableAgents: availableAgents,
               availableProviders: availableProviders,
               availableCommands: snapshot.commands,
-              sessionTitle: snapshot.canonicalSessionTitle ?? current.sessionTitle,
+              sessionTitle: snapshot.canonicalSessionTitle ?? latest.sessionTitle,
               selectedAgent: preservedSelectedAgent,
               selectedAgentModel: preservedSelectedAgentModel,
               stagedCommand: _resolveStagedCommand(
                 availableCommands: snapshot.commands,
                 stagedCommand: preservedStagedCommand,
               ),
+              queuedMessages: _promptQueue.items,
               isRefreshing: false,
               availableVariants: availableVariants,
             ),
           );
         case SessionDetailLoadResultWaitingForConnection():
           _waitingForConnection = true;
-          emit(current.copyWith(isRefreshing: false));
+          final latest = state;
+          if (latest is SessionDetailLoaded) {
+            emit(latest.copyWith(isRefreshing: false, queuedMessages: _promptQueue.items));
+          }
         case SessionDetailLoadResultFailed(:final error):
           logw("Silent refresh failed: ${error.toString()}");
-          emit(current.copyWith(isRefreshing: false));
+          final latest = state;
+          if (latest is SessionDetailLoaded) {
+            emit(latest.copyWith(isRefreshing: false, queuedMessages: _promptQueue.items));
+          }
       }
     } catch (error) {
       logw("Silent refresh failed: ${error.toString()}");
       if (isClosed) return;
-      emit(current.copyWith(isRefreshing: false));
+      final latest = state;
+      if (latest is SessionDetailLoaded) {
+        emit(latest.copyWith(isRefreshing: false, queuedMessages: _promptQueue.items));
+      }
     }
   }
 
@@ -1013,7 +1024,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       assistantAgentModel: assistantAgentModel,
       children: childSessions,
       childStatuses: childStatuses,
-      queuedMessages: const [],
+      queuedMessages: _promptQueue.items,
       availableAgents: agents,
       availableProviders: providers,
       availableCommands: snapshot.commands,


### PR DESCRIPTION
## Summary

Fixes a client-side race condition where a command could be visibly sent (drained from the internal queue) but later reappear as "queued" in the UI state after a silent refresh completed.

## Root Cause

`SessionDetailCubit._doSilentRefresh()` captured the current `SessionDetailLoaded` state before `await _loadService.reload(...)`. If a queued command drained from `_promptQueue` during that async gap, the stale captured state's `queuedMessages` still contained the old command. When the refresh completed, emitting `current.copyWith(...)` restored the stale queue in the UI even though `_promptQueue` was actually empty.

## Changes

### `mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart`
- Re-read `state` after the async reload and emit from the **latest** loaded state instead of the pre-await snapshot.
- Derive `queuedMessages` consistently from `_promptQueue.items` in all refresh paths (success, waiting-for-connection, failure) and in `_buildLoadedState`.
- Preserve user-mutable selections (agent, model, staged command) from the post-await `latest` state to prevent concurrent UI changes from being overwritten.

### `mobile/app/test/features/session_detail/session_detail_cubit_test.dart`
- Regression test: slow silent refresh does not restore a queued command after it drains.
- Regression test: slow silent refresh preserves model selection changed while refresh is in flight.
- Added test helpers `_awaitQueuedMessages` and `_awaitNotRefreshing`.

## Verification

- `flutter test "test/features/session_detail/session_detail_cubit_test.dart"` → **35 tests passed**
- `dart analyze` in `mobile/module_core` → **No issues found**
- `flutter analyze` in `mobile/app` → **No issues found**

## Related

Addresses the bug where a sent command could later show up as queued, especially during reconnect/refresh timing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where a sent command could reappear as “queued” after a silent refresh. The refresh now uses the latest state and always reflects the real prompt queue, while preserving user selections made mid-refresh.

- **Bug Fixes**
  - Emit from the latest loaded state after the async reload, not a pre-await snapshot.
  - Always derive `queuedMessages` from `_promptQueue.items` in all refresh paths and in `_buildLoadedState`.
  - Preserve user-selected agent, model, and staged command from the post-await state.
  - Added regression tests for: queued command not restored after draining; model selection preserved during a slow refresh. Added small test helpers.

<sup>Written for commit 656ef1f8b134d5dcc501819e1cac051104a96f5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

