### PR TITLE
fix(bridge): await PR refresh before returning sessions list

### DIFF
--- a/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
@@ -15,14 +15,17 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
   final SessionRepository _sessionRepository;
   final PrSyncService _prSyncService;
   final SessionPersistenceService _sessionPersistenceService;
+  final Duration _prRefreshTimeout;
 
   GetSessionsHandler({
     required SessionRepository sessionRepository,
     required PrSyncService prSyncService,
     required SessionPersistenceService sessionPersistenceService,
+    Duration prRefreshTimeout = const Duration(seconds: 5),
   }) : _sessionRepository = sessionRepository,
        _prSyncService = prSyncService,
        _sessionPersistenceService = sessionPersistenceService,
+       _prRefreshTimeout = prRefreshTimeout,
        super(
          HttpMethod.post,
          "/sessions",
@@ -66,10 +69,24 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
       Log.w("GetSessionsHandler: persistSessionsForProject failed for projectId=$projectId: $e\n$st");
     }
 
-    final response = SessionListResponse(items: sessions);
-
-    unawaited(_triggerPrRefresh(projectId: projectId, sessions: sessions));
-    return response;
+    try {
+      await _triggerPrRefresh(projectId: projectId, sessions: sessions).timeout(_prRefreshTimeout);
+      // Refresh succeeded within timeout — enrich the already-fetched sessions
+      // with updated PR/CI metadata from the database (no extra plugin round-trip).
+      final enrichedSessions = await _sessionRepository.enrichSessions(
+        sessions: sessions,
+      );
+      return SessionListResponse(items: enrichedSessions);
+    } catch (err, st) {
+      Log.w(
+        "[GetSessionsHandler] PR refresh timed out after "
+        "${_prRefreshTimeout.inSeconds}s for $projectId — "
+        "returning current data; SSE will deliver updates when ready",
+        err,
+        st,
+      );
+      return SessionListResponse(items: sessions);
+    }
   }
 
   Future<void> _triggerPrRefresh({
@@ -79,7 +96,7 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
     try {
       final projectPath = await _sessionRepository.getProjectPath(projectId: projectId);
       if (projectPath != null) {
-        unawaited(_prSyncService.triggerRefresh(projectId: projectId, projectPath: projectPath));
+        await _prSyncService.triggerRefresh(projectId: projectId, projectPath: projectPath);
         return;
       }
 
@@ -87,7 +104,7 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
       if (fallbackDirectory == null || fallbackDirectory.isEmpty) {
         return;
       }
-      unawaited(_prSyncService.triggerRefresh(projectId: projectId, projectPath: fallbackDirectory));
+      await _prSyncService.triggerRefresh(projectId: projectId, projectPath: fallbackDirectory);
     } on Object catch (e, st) {
       Log.w("[GetSessionsHandler] PR refresh trigger failed for $projectId: $e\n$st");
     }

--- a/bridge/app/lib/src/bridge/services/pr_sync_service.dart
+++ b/bridge/app/lib/src/bridge/services/pr_sync_service.dart
@@ -65,7 +65,7 @@ class PrSyncService {
     }
 
     _activeRefreshes.add(projectId);
-    unawaited(_refresh(projectId: projectId, projectPath: projectPath));
+    await _refresh(projectId: projectId, projectPath: projectPath);
   }
 
   Future<void> _refresh({required String projectId, required String projectPath}) async {

--- a/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
@@ -801,7 +801,6 @@ void main() {
         fragment: null,
       );
 
-      await Future<void>.delayed(const Duration(milliseconds: 10));
       expect(prSyncService.calls, hasLength(1));
       expect(prSyncService.calls.single, equals((projectId: "project-1", projectPath: "/tmp/project")));
     });
@@ -828,9 +827,91 @@ void main() {
         fragment: null,
       );
 
-      await Future<void>.delayed(const Duration(milliseconds: 10));
       expect(prSyncService.calls, hasLength(1));
       expect(prSyncService.calls.single, equals((projectId: "project-1", projectPath: "/tmp/fallback-project")));
+    });
+
+    test("returns original sessions when PR refresh times out", () async {
+      plugin.sessionsResult = const [
+        PluginSession(
+          id: "s1",
+          projectID: "p1",
+          directory: "/tmp",
+          parentID: null,
+          title: "session one",
+          time: null,
+          summary: null,
+        ),
+      ];
+      final slowPrSyncService = FakePrSyncService(delay: const Duration(seconds: 10));
+      final timeoutHandler = GetSessionsHandler(
+        sessionRepository: sessionRepository,
+        prSyncService: slowPrSyncService,
+        sessionPersistenceService: sessionPersistenceService,
+        prRefreshTimeout: const Duration(milliseconds: 50),
+      );
+
+      final result = await timeoutHandler.handle(
+        makeRequest("POST", "/sessions"),
+        body: const SessionListRequest(projectId: "p1", start: null, limit: null),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(result.items, hasLength(1));
+      expect(result.items.single.title, equals("session one"));
+      expect(sessionRepository.getSessionsCallCount, equals(1));
+    });
+
+    test("enriches sessions when PR refresh succeeds within timeout", () async {
+      plugin.sessionsResult = const [
+        PluginSession(
+          id: "s1",
+          projectID: "p1",
+          directory: "/tmp",
+          parentID: null,
+          title: "session one",
+          time: null,
+          summary: null,
+        ),
+      ];
+      pullRequestRepository.setPr(
+        sessionId: "s1",
+        pullRequest: const PullRequestDto(
+          projectId: "p1",
+          prNumber: 99,
+          branchName: "feature/enriched",
+          url: "https://github.com/org/repo/pull/99",
+          title: "Enriched PR",
+          state: PrState.open,
+          mergeableStatus: PrMergeableStatus.mergeable,
+          reviewDecision: PrReviewDecision.approved,
+          checkStatus: PrCheckStatus.success,
+          lastCheckedAt: 1,
+          createdAt: 1,
+        ),
+      );
+      final fastPrSyncService = FakePrSyncService();
+      final enrichedHandler = GetSessionsHandler(
+        sessionRepository: sessionRepository,
+        prSyncService: fastPrSyncService,
+        sessionPersistenceService: sessionPersistenceService,
+      );
+
+      final result = await enrichedHandler.handle(
+        makeRequest("POST", "/sessions"),
+        body: const SessionListRequest(projectId: "p1", start: null, limit: null),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(result.items, hasLength(1));
+      expect(result.items.single.title, equals("session one"));
+      expect(result.items.single.pullRequest?.number, equals(99));
+      expect(result.items.single.pullRequest?.mergeableStatus, equals(PrMergeableStatus.mergeable));
+      expect(sessionRepository.getSessionsCallCount, equals(1));
     });
   });
 }

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -525,8 +525,10 @@ class FakePullRequestRepository implements PullRequestRepository {
 
 class FakePrSyncService extends PrSyncService {
   final List<({String projectId, String projectPath})> calls = <({String projectId, String projectPath})>[];
+  final Duration? delay;
 
   FakePrSyncService({
+    this.delay,
     PrSourceRepository? prSource,
     PullRequestRepository? pullRequestRepository,
     SessionRepository? sessionRepository,
@@ -539,6 +541,9 @@ class FakePrSyncService extends PrSyncService {
   @override
   Future<void> triggerRefresh({required String projectId, required String projectPath}) async {
     calls.add((projectId: projectId, projectPath: projectPath));
+    if (delay != null) {
+      await Future<void>.delayed(delay!);
+    }
   }
 }
 

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -188,15 +188,17 @@ void main() {
       );
       addTearDown(service.dispose);
 
-      await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
+      // Start first refresh without awaiting so we can test concurrent behavior.
+      final firstRefresh = service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
       await _waitFor(() => prSource.listOpenPrsCallCount == 1);
+
+      // Second refresh should be skipped because first is still active.
       await service.triggerRefresh(projectId: "project-1", projectPath: "/tmp/project-1");
 
-      await Future<void>.delayed(const Duration(milliseconds: 30));
       expect(prSource.listOpenPrsCallCount, equals(1));
 
       block.complete();
-      await Future<void>.delayed(const Duration(milliseconds: 30));
+      await firstRefresh;
     });
   });
 }


### PR DESCRIPTION
Previously `GetSessionsHandler` returned session data immediately and triggered PR refresh asynchronously. This caused the mobile app to receive stale PR/CI data on pull-to-refresh, followed by a second update via SSE once the refresh completed.

Now the handler waits for the PR sync to finish and re-fetches the sessions before returning, so the response includes fully-updated PR metadata (mergeable status, review decision, check status) in a single round-trip. The RefreshIndicator on the mobile side naturally stays visible until the complete data arrives.

Changes:
- `PrSyncService.triggerRefresh` now awaits `_refresh` instead of fire-and-forget `unawaited()`.
- `GetSessionsHandler` awaits PR refresh, then re-fetches sessions and returns the enriched response.
- Updated tests to reflect the synchronous await behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the sessions API returns fresh PR/CI data by awaiting a PR sync (up to 5s) before responding. On success, sessions are enriched with updated PR metadata; on timeout, current data is returned and SSE delivers updates later.

- **Bug Fixes**
  - `GetSessionsHandler` waits for PR refresh with a configurable timeout, then calls `enrichSessions()` to include latest mergeable/review/check status.
  - `PrSyncService.triggerRefresh` now awaits `_refresh` and skips concurrent runs.
  - Tests cover timeout and enrichment paths; `FakePrSyncService` supports an optional delay.

<sup>Written for commit 8a3937bc096986cc7f8e78b5e0cfc45e1a9f2d3a. Summary will update on new commits. <a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/164?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

