### PR TITLE
chore(release): bridge v0.7.0

### DIFF
--- a/bridge/app/CHANGELOG.md
+++ b/bridge/app/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v0.7.0] - 2026-05-17
+
+### Fixed
+- Manage OpenCode and Bridge lifecycle conflicts with robust process identity tracking, singleton enforcement, and graceful shutdown coordination (#162)
+- Handle OpenCode v1.14.48 schema changes and missing SSE event types (#159)
+
+### Changed
+- Update Flutter to 3.41.9 (#143)
+
 ## [v0.6.1] - 2026-04-29
 
 ### Fixed

--- a/bridge/app/lib/src/version.dart
+++ b/bridge/app/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '0.6.1';
+const String appVersion = '0.7.0';

--- a/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-arm64",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS ARM64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.6.1",
+    "releaseTag": "bridge-v0.7.0",
     "releaseArtifact": "sesori-bridge-macos-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-darwin-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-x64",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS x64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.6.1",
+    "releaseTag": "bridge-v0.7.0",
     "releaseArtifact": "sesori-bridge-macos-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-arm64",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux ARM64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.6.1",
+    "releaseTag": "bridge-v0.7.0",
     "releaseArtifact": "sesori-bridge-linux-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-x64",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux x64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.6.1",
+    "releaseTag": "bridge-v0.7.0",
     "releaseArtifact": "sesori-bridge-linux-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-x64",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows x64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.6.1",
+    "releaseTag": "bridge-v0.7.0",
     "releaseArtifact": "sesori-bridge-windows-x64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge/package.json
+++ b/bridge/app/npm/sesori-bridge/package.json
@@ -1,21 +1,21 @@
 {
   "name": "@sesori/bridge",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Bootstrap launcher for the managed Sesori Bridge runtime",
   "bin": {
     "sesori-bridge": "bin/bridge.js"
   },
   "optionalDependencies": {
-    "@sesori/bridge-darwin-arm64": "0.6.1",
-    "@sesori/bridge-darwin-x64": "0.6.1",
-    "@sesori/bridge-linux-x64": "0.6.1",
-    "@sesori/bridge-linux-arm64": "0.6.1",
-    "@sesori/bridge-win32-x64": "0.6.1"
+    "@sesori/bridge-darwin-arm64": "0.7.0",
+    "@sesori/bridge-darwin-x64": "0.7.0",
+    "@sesori/bridge-linux-x64": "0.7.0",
+    "@sesori/bridge-linux-arm64": "0.7.0",
+    "@sesori/bridge-win32-x64": "0.7.0"
   },
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v0.6.1",
+    "releaseTag": "bridge-v0.7.0",
     "runtimeBundleSource": "github-release-assets"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sesori_bridge
 description: Dart implementation of the Sesori Bridge CLI for WebSocket communication.
-version: 0.6.1
+version: 0.7.0
 publish_to: none
 resolution: workspace
 


### PR DESCRIPTION
## Summary
- Bump bridge version to v0.7.0
- Update CHANGELOG.md with changes since v0.6.1

## Changes

### Fixed
- **Manage OpenCode and Bridge lifecycle conflicts** (#162) — Introduces robust process identity tracking, singleton enforcement (prevents multiple bridge instances), startup mutex coordination, graceful shutdown with SIGTERM/SIGKILL fallback, stale OpenCode server cleanup, and dynamic port discovery when the default port is occupied.
- **Handle OpenCode v1.14.48 schema changes and missing SSE event types** (#159) — Updates file diff model parsing and adds recognition for previously unhandled SSE event frames.

### Changed
- **Update Flutter to 3.41.9** (#143)

## Files Changed
- `pubspec.yaml` — version bumped to 0.7.0
- `lib/src/version.dart` — version constant updated
- `npm/*/package.json` — all npm wrapper packages bumped to 0.7.0
- `CHANGELOG.md` — new v0.7.0 section added

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release Bridge v0.7.0 to improve stability with OpenCode and align with v1.14.48 schema. Adds singleton safeguards, better shutdown handling, SSE fixes, and Flutter 3.41.9, with version bumps across npm and Dart.

- **Bug Fixes**
  - Enforce a single Bridge instance with startup mutex and process identity; add graceful shutdown and stale OpenCode cleanup; choose a free port if the default is in use.
  - Parse OpenCode v1.14.48 diff schema and recognize previously missing SSE event types.

- **Dependencies**
  - Update Flutter to 3.41.9.
  - Bump app version to 0.7.0 and update CHANGELOG.
  - Bump `@sesori/bridge` and platform packages (`@sesori/bridge-darwin-arm64`, `@sesori/bridge-darwin-x64`, `@sesori/bridge-linux-arm64`, `@sesori/bridge-linux-x64`, `@sesori/bridge-win32-x64`) to 0.7.0 and set `releaseTag` to `bridge-v0.7.0`.

<sup>Written for commit bc9a03c53a46d26e82b337d29ea046488619341d. Summary will update on new commits. <a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/165?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

