### PR TITLE
fix: reduce bridge update check cache from 24 hours to 10 minutes

### DIFF
--- a/bridge/app/lib/src/updater/api/github_releases_api.dart
+++ b/bridge/app/lib/src/updater/api/github_releases_api.dart
@@ -8,7 +8,7 @@ import '../models/github_release_dto.dart';
 
 const _kGithubApiBaseUrl = 'https://api.github.com/repos/sesori-ai/sesori_apps_monorepo/releases';
 const _kGithubReleasesPerPage = 100;
-const _kGithubReleasesMaxPages = 10;
+const _kGithubReleasesMaxPages = 1;
 
 class GitHubReleasesApi {
   final http.Client _httpClient;

--- a/bridge/app/lib/src/updater/repositories/release_repository.dart
+++ b/bridge/app/lib/src/updater/repositories/release_repository.dart
@@ -25,7 +25,7 @@ class ReleaseRepository {
        _target = target;
 
   Future<ReleaseInfo?> checkForNewerRelease() async {
-    final cached = await _cache.read(ttl: const Duration(hours: 24));
+    final cached = await _cache.read(ttl: const Duration(minutes: 10));
     if (cached != null) {
       if (cached.assetName == _target.assetName) {
         return _evaluateCached(cached: cached);

--- a/bridge/app/test/updater/release_repository_test.dart
+++ b/bridge/app/test/updater/release_repository_test.dart
@@ -196,7 +196,7 @@ void main() {
         expect(result.assetUrl, endsWith('/sesori-bridge-macos-arm64.tar.gz'));
       });
 
-      test('paginates release discovery until later pages to find the highest eligible stable release', () async {
+      test('only fetches one page of releases', () async {
         final requestedPages = <int>[];
         final firstPage = List.generate(100, (index) {
           return _releaseJson(
@@ -210,9 +210,6 @@ void main() {
           if (page == 1) {
             return http.Response(jsonEncode(firstPage), 200);
           }
-          if (page == 2) {
-            return http.Response(jsonEncode([_releaseJson(version: '0.4.0')]), 200);
-          }
           return http.Response(jsonEncode(<Map<String, dynamic>>[]), 200);
         });
 
@@ -223,9 +220,8 @@ void main() {
 
         final result = await repository.checkForNewerRelease();
 
-        expect(result, isNotNull);
-        expect(result!.version, equals('0.4.0'));
-        expect(requestedPages, equals([1, 2]));
+        expect(result, isNull);
+        expect(requestedPages, equals([1]));
       });
     });
 


### PR DESCRIPTION
Reduces the TTL for cached update check results from 24 hours to 10 minutes, so the bridge will check for updates more frequently when starting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced the cache TTL for bridge update checks from 24 hours to 10 minutes. Limited GitHub releases pagination to a single page to speed up checks and cut unnecessary API calls, and updated tests to reflect the new single-page behavior.

<sup>Written for commit 9d497b88dcceef48a735bed95d2a25e287f6c3fc. Summary will update on new commits. <a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/166?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

