### PR TITLE
ci: fix next-build-number lookup by installing fastlane gems

### DIFF
--- a/.github/workflows/_reusable-next-build-number.yml
+++ b/.github/workflows/_reusable-next-build-number.yml
@@ -53,14 +53,25 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: mobile/app/ios
+
+      - name: Install Android Fastlane gems
+        working-directory: mobile/app/android
+        run: bundle install --jobs 4 --retry 3
 
       - name: Compute next iOS build number
         id: ios
         working-directory: mobile/app/ios
         run: |
-          set -euo pipefail
+          set -uo pipefail
           output=$(bundle exec fastlane next_build_number 2>&1)
+          status=$?
           echo "$output"
+          if [ "$status" -ne 0 ]; then
+            echo "::error::iOS fastlane next_build_number exited with status $status"
+            exit "$status"
+          fi
           n=$(printf '%s\n' "$output" | grep -oE 'NEXT_BUILD_NUMBER=[0-9]+' | tail -n1 | cut -d= -f2)
           if [ -z "${n:-}" ]; then
             echo "::error::Failed to parse NEXT_BUILD_NUMBER from iOS fastlane output"
@@ -78,9 +89,14 @@ jobs:
         id: android
         working-directory: mobile/app/android
         run: |
-          set -euo pipefail
+          set -uo pipefail
           output=$(bundle exec fastlane next_version_code 2>&1)
+          status=$?
           echo "$output"
+          if [ "$status" -ne 0 ]; then
+            echo "::error::Android fastlane next_version_code exited with status $status"
+            exit "$status"
+          fi
           n=$(printf '%s\n' "$output" | grep -oE 'NEXT_VERSION_CODE=[0-9]+' | tail -n1 | cut -d= -f2)
           if [ -z "${n:-}" ]; then
             echo "::error::Failed to parse NEXT_VERSION_CODE from Android fastlane output"

--- a/mobile/app/android/Gemfile.lock
+++ b/mobile/app/android/Gemfile.lock
@@ -230,6 +230,7 @@ GEM
 PLATFORMS
   arm64-darwin-25
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   fastlane (~> 2.232)

--- a/mobile/app/ios/Gemfile.lock
+++ b/mobile/app/ios/Gemfile.lock
@@ -183,6 +183,7 @@ GEM
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
     fastlane-sirp (1.1.0)
     ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -306,6 +307,7 @@ GEM
 
 PLATFORMS
   arm64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   cocoapods (= 1.16.2)
@@ -370,6 +372,7 @@ CHECKSUMS
   fastlane (2.234.0) sha256=b74835681ad9a8e9c0931a5727dad1bab433895ac534c864a1ed5749625d26e9
   fastlane-sirp (1.1.0) sha256=10bc94f9682efd8e1badfb31452a76dd8981f1f3a33717c765fde6d75b54d847
   ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
+  ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   fourflusher (2.3.1) sha256=1b3de61c7c791b6a4e64f31e3719eb25203d151746bb519a0292bff1065ccaa9
   fuzzy_match (2.0.4) sha256=b5de4f95816589c5b5c3ad13770c0af539b75131c158135b3f3bbba75d0cfca5
   gh_inspector (1.1.3) sha256=04cca7171b87164e053aa43147971d3b7f500fcb58177698886b48a9fc4a1939
@@ -437,4 +440,4 @@ CHECKSUMS
   xcpretty-travis-formatter (1.0.1) sha256=aacc332f17cb7b2cba222994e2adc74223db88724fe76341483ad3098e232f93
 
 BUNDLED WITH
-  4.0.10
+  4.0.11


### PR DESCRIPTION
## Summary
- Install iOS fastlane gems via `bundler-cache` and Android gems via explicit `bundle install` so `bundle exec fastlane next_build_number` / `next_version_code` actually have their dependencies on the runner.
- Surface the real fastlane exit status in the workflow (replaces `set -euo pipefail` early-exit pattern that swallowed the captured output before the error message could be logged).
- Add `x86_64-linux` platform (and matching `ffi` checksum) to iOS/Android `Gemfile.lock` so bundler can resolve gems on Linux CI runners.

## Test plan
- [ ] Trigger a workflow run that calls `_reusable-next-build-number.yml` and confirm both iOS and Android steps produce a `NEXT_BUILD_NUMBER` / `NEXT_VERSION_CODE`
- [ ] Confirm a forced fastlane failure now surfaces a `::error::` line with the captured output instead of dying silently

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CI “next build number” job by installing `fastlane` gems and properly surfacing `fastlane` failures. Adds Linux platform entries so `bundler` can resolve gems on Ubuntu runners.

- **Bug Fixes**
  - Install iOS gems via `ruby/setup-ruby` with `bundler-cache`; install Android gems with `bundle install`.
  - Capture and log `fastlane` exit status; replace `set -e` with explicit status checks.
  - Job now outputs NEXT_BUILD_NUMBER and NEXT_VERSION_CODE.

- **Dependencies**
  - Add `x86_64-linux` to both `Gemfile.lock` files and include the matching `ffi` checksum.
  - Update iOS lockfile “BUNDLED WITH” to 4.0.11.

<sup>Written for commit 3658a74b1a8e5ec7d5a64d2c4d493969a272157d. Summary will update on new commits. <a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/168?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

