### PR TITLE
fix: unify retrying task icon with running and show retry message in red

### DIFF
--- a/mobile/app/lib/features/session_detail/widgets/background_tasks_bar.dart
+++ b/mobile/app/lib/features/session_detail/widgets/background_tasks_bar.dart
@@ -302,11 +302,10 @@ class _TaskRow extends StatelessWidget {
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
-                  Text(
-                    _statusLabel(loc: loc, status: status),
-                    style: zyra.textTheme.textXs.regular.copyWith(
-                      color: zyra.colors.textSecondary,
-                    ),
+                  _statusTextWidget(
+                    loc: loc,
+                    status: status,
+                    zyra: zyra,
                   ),
                 ],
               ),
@@ -323,18 +322,13 @@ class _TaskRow extends StatelessWidget {
   }
 
   Widget _statusIcon({required SessionStatus? status, required ZyraDesignSystem zyra}) => switch (status) {
-    SessionStatusBusy() => SizedBox(
+    SessionStatusBusy() || SessionStatusRetry() => SizedBox(
       width: 16,
       height: 16,
       child: CircularProgressIndicator(
         strokeWidth: 2,
         color: zyra.colors.bgBrandSolid,
       ),
-    ),
-    SessionStatusRetry() => Icon(
-      Icons.refresh,
-      size: 16,
-      color: zyra.colors.fgSuccessPrimary,
     ),
     SessionStatusIdle() => Icon(
       Icons.check_circle,
@@ -347,11 +341,48 @@ class _TaskRow extends StatelessWidget {
       color: zyra.colors.borderPrimary,
     ),
   };
-  String _statusLabel({required AppLocalizations loc, required SessionStatus? status}) => switch (status) {
-    SessionStatusBusy() => loc.backgroundTaskStatusBusy,
-    SessionStatusRetry() => loc.backgroundTaskStatusRetry,
-    SessionStatusIdle() => _completedLabel(loc),
-    null => _completedLabel(loc),
+
+  Widget _statusTextWidget({
+    required AppLocalizations loc,
+    required SessionStatus? status,
+    required ZyraDesignSystem zyra,
+  }) => switch (status) {
+    SessionStatusBusy() => Text(
+      loc.backgroundTaskStatusBusy,
+      style: zyra.textTheme.textXs.regular.copyWith(
+        color: zyra.colors.textSecondary,
+      ),
+    ),
+    SessionStatusRetry(:final message) => Text.rich(
+      TextSpan(
+        children: [
+          TextSpan(
+            text: loc.backgroundTaskStatusRetry,
+            style: zyra.textTheme.textXs.regular.copyWith(
+              color: zyra.colors.textSecondary,
+            ),
+          ),
+          TextSpan(
+            text: ' ($message)',
+            style: zyra.textTheme.textXs.regular.copyWith(
+              color: zyra.colors.fgErrorPrimary,
+            ),
+          ),
+        ],
+      ),
+    ),
+    SessionStatusIdle() => Text(
+      _completedLabel(loc),
+      style: zyra.textTheme.textXs.regular.copyWith(
+        color: zyra.colors.textSecondary,
+      ),
+    ),
+    null => Text(
+      _completedLabel(loc),
+      style: zyra.textTheme.textXs.regular.copyWith(
+        color: zyra.colors.textSecondary,
+      ),
+    ),
   };
 
   String _completedLabel(AppLocalizations loc) {

--- a/mobile/app/lib/features/session_detail/widgets/subtask_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/subtask_part_widget.dart
@@ -98,18 +98,13 @@ class SubtaskPartWidget extends StatelessWidget {
   }
 
   Widget _statusIcon({required SessionStatus? status, required ZyraDesignSystem zyra}) => switch (status) {
-    SessionStatusBusy() => SizedBox(
+    SessionStatusBusy() || SessionStatusRetry() => SizedBox(
       width: 16,
       height: 16,
       child: CircularProgressIndicator(
         strokeWidth: 2,
         color: zyra.colors.bgBrandSolid,
       ),
-    ),
-    SessionStatusRetry() => Icon(
-      Icons.refresh,
-      size: 16,
-      color: zyra.colors.fgSuccessPrimary,
     ),
     SessionStatusIdle() => Icon(
       Icons.check_circle,


### PR DESCRIPTION
## Summary

When a background task enters the retrying state, the UI now:

- **Keeps the same loading spinner** as the running state (instead of switching to a refresh icon). This better communicates that the task is still actively running, just retrying due to an error.
- **Shows the retry message in brackets** next to the "Retrying" label, styled in red using . The message (e.g., "provider overloaded") gives the user context on why the retry is happening.

## Files Changed

- 
  - :  now uses the same  as 
  -  replaced with : returns a  instead of , enabling  with styled spans for the retry message
- 
  - :  now uses the same  as 

## Screenshots

| Before | After |
|--------|-------|
| Retry icon + "Retrying" text | Loading spinner + "Retrying (provider overloaded)" with red message |

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retrying tasks now use the same spinner as running tasks. The retry reason appears in red in parentheses next to “Retrying” for clearer context.

<sup>Written for commit 3b814c358e0711d0c87572a3c1add9143e5dbda6. Summary will update on new commits. <a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/169?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

