### PR TITLE
fix: buffer SSE events during SessionDetailCubit loading

### DIFF
--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -39,6 +39,16 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
   bool _needsStaleRefresh = false;
   bool _waitingForConnection = false;
 
+  /// Pending session-scoped SSE events that arrived while the cubit was in
+  /// [SessionDetailLoading] or [SessionDetailFailed] state. Replayed once the
+  /// state transitions to [SessionDetailLoaded].
+  final List<SesoriSessionEvent> _pendingSessionEvents = [];
+
+  /// Pending global SSE events that arrived while the cubit was in
+  /// [SessionDetailLoading] or [SessionDetailFailed] state. Replayed once the
+  /// state transitions to [SessionDetailLoaded].
+  final List<SseEvent> _pendingGlobalEvents = [];
+
   /// Fires the [SesoriQuestionAsked] whenever a new question arrives, so the
   /// screen can auto-open the question modal.
   final StreamController<SesoriQuestionAsked> _questionStream = StreamController.broadcast();
@@ -91,6 +101,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       case SessionDetailLoadResultLoaded(:final snapshot):
         _waitingForConnection = false;
         emit(_buildLoadedState(snapshot: snapshot));
+        _drainPendingEvents();
         _tryDrainQueue();
       case SessionDetailLoadResultWaitingForConnection():
         _waitingForConnection = true;
@@ -100,6 +111,8 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
         }
       case SessionDetailLoadResultFailed(:final error):
         _waitingForConnection = false;
+        _pendingSessionEvents.clear();
+        _pendingGlobalEvents.clear();
         emit(SessionDetailState.failed(error: error is ApiError ? error : ApiError.generic()));
     }
   }
@@ -199,6 +212,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
               availableVariants: availableVariants,
             ),
           );
+          _drainPendingEvents();
         case SessionDetailLoadResultWaitingForConnection():
           _waitingForConnection = true;
           final latest = state;
@@ -244,6 +258,14 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
   // ---------------------------------------------------------------------------
 
   void _handleEvent(SesoriSessionEvent event) {
+    if (state is SessionDetailLoading) {
+      _pendingSessionEvents.add(event);
+      return;
+    }
+    _processSessionEvent(event);
+  }
+
+  void _processSessionEvent(SesoriSessionEvent event) {
     try {
       switch (event) {
         case SesoriMessageUpdated(:final info):
@@ -298,6 +320,90 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
   }
 
   void _handleGlobalEvent(SseEvent event) {
+    if (state is SessionDetailLoading) {
+      if (_isRelevantGlobalEvent(event)) {
+        _pendingGlobalEvents.add(event);
+      }
+      return;
+    }
+    _processGlobalEvent(event);
+  }
+
+  /// Returns whether a global SSE event could affect this session's state.
+  /// Used to avoid buffering high-volume irrelevant events (PTY, file watcher,
+  /// LSP, etc.) from the global stream while the cubit is loading.
+  ///
+  /// Conservative: if we can't tell at buffer time whether an event is
+  /// relevant (e.g. [SesoriSessionStatus] or [SesoriSessionUpdated] may be
+  /// for one of our child sessions), we queue it and let the replay handler
+  /// decide.
+  ///
+  /// [SesoriSessionsUpdated] is intentionally excluded: it triggers a silent
+  /// refresh, but during loading we are already fetching the latest snapshot,
+  /// so replaying it would cause a redundant refresh immediately after load.
+  bool _isRelevantGlobalEvent(SseEvent event) {
+    return switch (event.data) {
+      // Child session created for this session — definitely relevant.
+      SesoriSessionCreated(:final info) => info.parentID == _sessionId,
+      // May be a status update for one of our children. We don't know our
+      // children during loading, so queue conservatively and let replay handler
+      // filter by checking current.children.
+      SesoriSessionStatus() => true,
+      // Only queue updates for our direct children (info.parentID tells us
+      // this at buffer time). Updates for unrelated sessions are dropped
+      // immediately to avoid accumulating irrelevant backlog.
+      SesoriSessionUpdated(:final info) => info.parentID == _sessionId,
+      // Definitively irrelevant high-volume events.
+      SesoriServerConnected() ||
+      SesoriServerHeartbeat() ||
+      SesoriServerInstanceDisposed() ||
+      SesoriGlobalDisposed() ||
+      SesoriSessionDeleted() ||
+      SesoriSessionDiff() ||
+      SesoriSessionError() ||
+      SesoriSessionCompacted() ||
+      SesoriCommandExecuted() ||
+      SesoriMessageUpdated() ||
+      SesoriMessageRemoved() ||
+      SesoriMessagePartUpdated() ||
+      SesoriMessagePartDelta() ||
+      SesoriMessagePartRemoved() ||
+      SesoriPtyCreated() ||
+      SesoriPtyUpdated() ||
+      SesoriPtyExited() ||
+      SesoriPtyDeleted() ||
+      SesoriPermissionAsked() ||
+      SesoriPermissionReplied() ||
+      SesoriPermissionUpdated() ||
+      SesoriQuestionAsked() ||
+      SesoriQuestionReplied() ||
+      SesoriQuestionRejected() ||
+      SesoriTodoUpdated() ||
+      SesoriProjectsSummary() ||
+      SesoriProjectUpdated() ||
+      SesoriVcsBranchUpdated() ||
+      SesoriFileEdited() ||
+      SesoriFileWatcherUpdated() ||
+      SesoriLspUpdated() ||
+      SesoriLspClientDiagnostics() ||
+      SesoriMcpToolsChanged() ||
+      SesoriMcpBrowserOpenFailed() ||
+      SesoriInstallationUpdated() ||
+      SesoriInstallationUpdateAvailable() ||
+      SesoriWorkspaceReady() ||
+      SesoriWorkspaceFailed() ||
+      SesoriTuiToastShow() ||
+      SesoriWorktreeReady() ||
+      SesoriWorktreeFailed() ||
+      // Intentionally excluded: triggers a silent refresh, but during loading
+      // we are already fetching the latest snapshot, so replaying it would
+      // cause a redundant refresh immediately after load.
+      SesoriSessionsUpdated() =>
+        false,
+    };
+  }
+
+  void _processGlobalEvent(SseEvent event) {
     final data = event.data;
     try {
       switch (data) {
@@ -370,6 +476,18 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
             .catchError((_) {}),
       );
     }
+  }
+
+  /// Replays any SSE events that were buffered while the cubit was not in
+  /// [SessionDetailLoaded] state. Called after a successful load/refresh.
+  void _drainPendingEvents() {
+    if (state is! SessionDetailLoaded) return;
+    final sessionEvents = List<SesoriSessionEvent>.of(_pendingSessionEvents);
+    _pendingSessionEvents.clear();
+    sessionEvents.forEach(_processSessionEvent);
+    final globalEvents = List<SseEvent>.of(_pendingGlobalEvents);
+    _pendingGlobalEvents.clear();
+    globalEvents.forEach(_processGlobalEvent);
   }
 
   void _onSessionUpdated(Session session) {
@@ -1097,6 +1215,8 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
 
   @override
   Future<void> close() {
+    _pendingSessionEvents.clear();
+    _pendingGlobalEvents.clear();
     _eventSubscription.cancel();
     _globalEventSubscription.cancel();
     _connectionStatusSubscription.cancel();

--- a/mobile/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
+++ b/mobile/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
@@ -281,7 +281,7 @@ void main() {
       verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).called(1);
     });
 
-    test("non-loaded state ignores permission events", () async {
+    test("non-loaded state buffers permission events and replays after loaded", () async {
       final messagesCompleter = Completer<ApiResponse<MessageWithPartsResponse>>();
       when(() => mockSessionService.getMessages(sessionId: sessionId)).thenAnswer((_) => messagesCompleter.future);
 
@@ -297,14 +297,13 @@ void main() {
       );
       addTearDown(cubit.close);
 
-      sessionEvents.add(
-        const SesoriPermissionAsked(
-          requestID: "perm-123",
-          sessionID: sessionId,
-          tool: "fs_write",
-          description: "Allow writing file",
-        ),
+      const permission = SesoriPermissionAsked(
+        requestID: "perm-123",
+        sessionID: sessionId,
+        tool: "fs_write",
+        description: "Allow writing file",
       );
+      sessionEvents.add(permission);
       await Future<void>.delayed(const Duration(milliseconds: 20));
 
       expect(cubit.state, const SessionDetailState.loading());
@@ -312,7 +311,8 @@ void main() {
       messagesCompleter.complete(ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()])));
       await _awaitLoaded(cubit);
 
-      expect((cubit.state as SessionDetailLoaded).pendingPermissions, isEmpty);
+      // The buffered permission event should have been replayed after load
+      expect((cubit.state as SessionDetailLoaded).pendingPermissions, [permission]);
     });
   });
 }

--- a/mobile/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
+++ b/mobile/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
@@ -1,0 +1,430 @@
+import "dart:async";
+
+import "package:mocktail/mocktail.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/models/connection_status.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/models/sse_event.dart";
+import "package:sesori_dart_core/src/capabilities/server_connection/server_connection_config.dart";
+import "package:sesori_dart_core/src/cubits/session_detail/session_detail_cubit.dart";
+import "package:sesori_dart_core/src/cubits/session_detail/session_detail_state.dart";
+import "package:sesori_dart_core/src/platform/notification_canceller.dart";
+import "package:sesori_dart_core/src/repositories/permission_repository.dart";
+import "package:sesori_dart_core/src/services/session_detail_load_service.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "../../helpers/test_helpers.dart";
+
+class MockNotificationCanceller extends Mock implements NotificationCanceller {}
+
+class MockPermissionRepository extends Mock implements PermissionRepository {}
+
+class MockSessionDetailLoadService extends Mock implements SessionDetailLoadService {}
+
+const _sessionId = "session-1";
+
+void main() {
+  const connectedStatus = ConnectionStatus.connected(
+    config: ServerConnectionConfig(relayHost: "relay.example.com", authToken: "token"),
+    health: HealthResponse(healthy: true, version: "0.1.200"),
+  );
+
+  setUpAll(() {
+    registerAllFallbackValues();
+    registerFallbackValue(NotificationCategory.aiInteraction);
+    registerFallbackValue(PermissionReply.once);
+  });
+
+  group("SessionDetailCubit SSE event buffering", () {
+    late MockSessionRepository mockSessionRepository;
+    late MockConnectionService mockConnectionService;
+    late MockNotificationCanceller mockNotificationCanceller;
+    late MockPermissionRepository mockPermissionRepository;
+    late StreamController<SesoriSessionEvent> sessionEvents;
+    late StreamController<SseEvent> globalEvents;
+    late BehaviorSubject<ConnectionStatus> connectionStatus;
+
+    setUp(() {
+      mockSessionRepository = MockSessionRepository();
+      mockConnectionService = MockConnectionService();
+      mockNotificationCanceller = MockNotificationCanceller();
+      mockPermissionRepository = MockPermissionRepository();
+      sessionEvents = StreamController<SesoriSessionEvent>.broadcast();
+      globalEvents = StreamController<SseEvent>.broadcast();
+      connectionStatus = BehaviorSubject<ConnectionStatus>.seeded(connectedStatus);
+    });
+
+    tearDown(() async {
+      await sessionEvents.close();
+      await globalEvents.close();
+      await connectionStatus.close();
+    });
+
+    SessionDetailCubit createCubit({
+      required SessionDetailLoadService loadService,
+    }) {
+      when(() => mockConnectionService.sessionEvents(_sessionId)).thenAnswer((_) => sessionEvents.stream);
+      when(() => mockConnectionService.events).thenAnswer((_) => globalEvents.stream);
+      when(() => mockConnectionService.status).thenAnswer((_) => connectionStatus);
+      when(() => mockConnectionService.currentStatus).thenAnswer((_) => connectionStatus.value);
+      when(
+        () => mockNotificationCanceller.cancelForSession(
+          sessionId: any(named: "sessionId"),
+          category: any(named: "category"),
+        ),
+      ).thenReturn(null);
+      when(
+        () => mockPermissionRepository.replyToPermission(
+          requestId: any(named: "requestId"),
+          sessionId: any(named: "sessionId"),
+          reply: any(named: "reply"),
+        ),
+      ).thenAnswer((_) async => ApiResponse.success(null));
+
+      final cubit = SessionDetailCubit(
+        mockConnectionService,
+        loadService: loadService,
+        promptDispatcher: mockSessionRepository,
+        permissionRepository: mockPermissionRepository,
+        sessionId: _sessionId,
+        projectId: "project-1",
+        notificationCanceller: mockNotificationCanceller,
+        failureReporter: MockFailureReporter(),
+      );
+      addTearDown(cubit.close);
+      return cubit;
+    }
+
+    test("buffers session-scoped SSE events during loading and replays after loaded", () async {
+      final mockLoadService = MockSessionDetailLoadService();
+      final completer = Completer<SessionDetailLoadResult>();
+
+      when(
+        () => mockLoadService.load(sessionId: _sessionId, projectId: any(named: "projectId")),
+      ).thenAnswer((_) => completer.future);
+
+      final cubit = createCubit(loadService: mockLoadService);
+
+      // Cubit starts in loading state
+      expect(cubit.state, const SessionDetailState.loading());
+
+      // Emit a session-scoped event while still loading
+      const updatedMessage = Message.assistant(
+        id: "msg-1",
+        sessionID: _sessionId,
+        agent: "build",
+        modelID: "gpt-4",
+        providerID: "openai",
+      );
+      sessionEvents.add(const SesoriMessageUpdated(info: updatedMessage));
+      await Future<void>.delayed(Duration.zero);
+
+      // Still loading — event should be buffered, not processed yet
+      expect(cubit.state, const SessionDetailState.loading());
+
+      // Complete the load with an empty snapshot
+      completer.complete(
+        const SessionDetailLoadResult.loaded(
+          snapshot: SessionDetailSnapshot(
+            projectId: "project-1",
+            messages: <MessageWithParts>[],
+            pendingQuestions: <PendingQuestion>[],
+            pendingPermissions: <PendingPermission>[],
+            childSessions: <Session>[],
+            statuses: <String, SessionStatus>{},
+            agents: <AgentInfo?>[],
+            providerData: null,
+            commands: <CommandInfo>[],
+            canonicalSessionTitle: null,
+          ),
+          isBridgeConnected: true,
+        ),
+      );
+      await _awaitLoaded(cubit);
+
+      // The buffered event should have been replayed, adding the message
+      final state = cubit.state as SessionDetailLoaded;
+      expect(state.messages.length, 1);
+      expect(state.messages.first.info.id, "msg-1");
+      expect(state.agent, "build");
+    });
+
+    test("buffers global SSE events during loading and replays after loaded", () async {
+      final mockLoadService = MockSessionDetailLoadService();
+      final completer = Completer<SessionDetailLoadResult>();
+
+      when(
+        () => mockLoadService.load(sessionId: _sessionId, projectId: any(named: "projectId")),
+      ).thenAnswer((_) => completer.future);
+
+      final cubit = createCubit(loadService: mockLoadService);
+
+      // Emit a global child-session event while still loading
+      const childSession = Session(
+        id: "child-1",
+        projectID: "project-1",
+        directory: "/home/user/my-project",
+        parentID: _sessionId,
+        title: "Child session",
+        summary: null,
+        pullRequest: null,
+        time: SessionTime(created: 1700000000000, updated: 1700000000000, archived: null),
+      );
+      globalEvents.add(
+        SseEvent(data: const SesoriSessionCreated(info: childSession)),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      // Still loading
+      expect(cubit.state, const SessionDetailState.loading());
+
+      // Complete the load
+      completer.complete(
+        const SessionDetailLoadResult.loaded(
+          snapshot: SessionDetailSnapshot(
+            projectId: "project-1",
+            messages: <MessageWithParts>[],
+            pendingQuestions: <PendingQuestion>[],
+            pendingPermissions: <PendingPermission>[],
+            childSessions: <Session>[],
+            statuses: <String, SessionStatus>{},
+            agents: <AgentInfo?>[],
+            providerData: null,
+            commands: <CommandInfo>[],
+            canonicalSessionTitle: null,
+          ),
+          isBridgeConnected: true,
+        ),
+      );
+      await _awaitLoaded(cubit);
+
+      // The buffered global event should have been replayed
+      final state = cubit.state as SessionDetailLoaded;
+      expect(state.children.length, 1);
+      expect(state.children.first.id, "child-1");
+    });
+
+    test("clears pending events when load fails", () async {
+      final mockLoadService = MockSessionDetailLoadService();
+      final completer = Completer<SessionDetailLoadResult>();
+
+      when(
+        () => mockLoadService.load(sessionId: _sessionId, projectId: any(named: "projectId")),
+      ).thenAnswer((_) => completer.future);
+
+      final cubit = createCubit(loadService: mockLoadService);
+
+      // Emit an event while loading
+      const updatedMessage = Message.assistant(
+        id: "msg-1",
+        sessionID: _sessionId,
+        agent: "build",
+        modelID: "gpt-4",
+        providerID: "openai",
+      );
+      sessionEvents.add(const SesoriMessageUpdated(info: updatedMessage));
+      await Future<void>.delayed(Duration.zero);
+
+      // Complete the load with failure
+      completer.complete(
+        SessionDetailLoadResult.failed(
+          error: ApiError.generic(),
+          stackTrace: StackTrace.current,
+        ),
+      );
+
+      // Wait for the failure state to be emitted
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(cubit.state, isA<SessionDetailFailed>());
+
+      // Now reload manually — the old buffered event should NOT be replayed
+      final reloadedCompleter = Completer<SessionDetailLoadResult>();
+      when(
+        () => mockLoadService.reload(sessionId: _sessionId, projectId: any(named: "projectId")),
+      ).thenAnswer((_) => reloadedCompleter.future);
+
+      unawaited(cubit.reload());
+
+      reloadedCompleter.complete(
+        const SessionDetailLoadResult.loaded(
+          snapshot: SessionDetailSnapshot(
+            projectId: "project-1",
+            messages: <MessageWithParts>[],
+            pendingQuestions: <PendingQuestion>[],
+            pendingPermissions: <PendingPermission>[],
+            childSessions: <Session>[],
+            statuses: <String, SessionStatus>{},
+            agents: <AgentInfo?>[],
+            providerData: null,
+            commands: <CommandInfo>[],
+            canonicalSessionTitle: null,
+          ),
+          isBridgeConnected: true,
+        ),
+      );
+      await _awaitLoaded(cubit);
+
+      // The old buffered event should have been cleared on failure
+      final state = cubit.state as SessionDetailLoaded;
+      expect(state.messages, isEmpty);
+    });
+
+    test("events arriving during failed state are dropped, not buffered", () async {
+      final mockLoadService = MockSessionDetailLoadService();
+
+      when(
+        () => mockLoadService.load(sessionId: _sessionId, projectId: any(named: "projectId")),
+      ).thenAnswer(
+        (_) async => SessionDetailLoadResult.failed(
+          error: ApiError.generic(),
+          stackTrace: StackTrace.current,
+        ),
+      );
+
+      final cubit = createCubit(loadService: mockLoadService);
+
+      // Wait for the failure state
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(cubit.state, isA<SessionDetailFailed>());
+
+      // Emit an event while in failed state — should be dropped
+      const updatedMessage = Message.assistant(
+        id: "msg-1",
+        sessionID: _sessionId,
+        agent: "build",
+        modelID: "gpt-4",
+        providerID: "openai",
+      );
+      sessionEvents.add(const SesoriMessageUpdated(info: updatedMessage));
+      await Future<void>.delayed(Duration.zero);
+
+      // Now reload successfully
+      final reloadedCompleter = Completer<SessionDetailLoadResult>();
+      when(
+        () => mockLoadService.reload(sessionId: _sessionId, projectId: any(named: "projectId")),
+      ).thenAnswer((_) => reloadedCompleter.future);
+
+      unawaited(cubit.reload());
+
+      reloadedCompleter.complete(
+        const SessionDetailLoadResult.loaded(
+          snapshot: SessionDetailSnapshot(
+            projectId: "project-1",
+            messages: <MessageWithParts>[],
+            pendingQuestions: <PendingQuestion>[],
+            pendingPermissions: <PendingPermission>[],
+            childSessions: <Session>[],
+            statuses: <String, SessionStatus>{},
+            agents: <AgentInfo?>[],
+            providerData: null,
+            commands: <CommandInfo>[],
+            canonicalSessionTitle: null,
+          ),
+          isBridgeConnected: true,
+        ),
+      );
+      await _awaitLoaded(cubit);
+
+      // The event emitted during failed state should NOT have been replayed
+      final state = cubit.state as SessionDetailLoaded;
+      expect(state.messages, isEmpty);
+    });
+
+    test("processes events immediately when already loaded", () async {
+      final mockLoadService = MockSessionDetailLoadService();
+
+      when(
+        () => mockLoadService.load(sessionId: _sessionId, projectId: any(named: "projectId")),
+      ).thenAnswer(
+        (_) async => const SessionDetailLoadResult.loaded(
+          snapshot: SessionDetailSnapshot(
+            projectId: "project-1",
+            messages: <MessageWithParts>[],
+            pendingQuestions: <PendingQuestion>[],
+            pendingPermissions: <PendingPermission>[],
+            childSessions: <Session>[],
+            statuses: <String, SessionStatus>{},
+            agents: <AgentInfo?>[],
+            providerData: null,
+            commands: <CommandInfo>[],
+            canonicalSessionTitle: null,
+          ),
+          isBridgeConnected: true,
+        ),
+      );
+
+      final cubit = createCubit(loadService: mockLoadService);
+      await _awaitLoaded(cubit);
+
+      // Emit an event after already loaded
+      const updatedMessage = Message.assistant(
+        id: "msg-1",
+        sessionID: _sessionId,
+        agent: "build",
+        modelID: "gpt-4",
+        providerID: "openai",
+      );
+      sessionEvents.add(const SesoriMessageUpdated(info: updatedMessage));
+      await Future<void>.delayed(Duration.zero);
+
+      // Should be processed immediately
+      final state = cubit.state as SessionDetailLoaded;
+      expect(state.messages.length, 1);
+      expect(state.messages.first.info.id, "msg-1");
+    });
+    test("does not buffer irrelevant global events (PTY, file watcher, etc.)", () async {
+      final mockLoadService = MockSessionDetailLoadService();
+      final completer = Completer<SessionDetailLoadResult>();
+
+      when(
+        () => mockLoadService.load(sessionId: _sessionId, projectId: any(named: "projectId")),
+      ).thenAnswer((_) => completer.future);
+
+      final cubit = createCubit(loadService: mockLoadService);
+
+      // Emit high-volume irrelevant global events while loading
+      globalEvents.add(SseEvent(data: const SesoriPtyCreated()));
+      globalEvents.add(SseEvent(data: const SesoriPtyUpdated()));
+      globalEvents.add(SseEvent(data: const SesoriFileWatcherUpdated(file: null, event: null)));
+      globalEvents.add(SseEvent(data: const SesoriLspUpdated()));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(cubit.state, const SessionDetailState.loading());
+
+      // Complete the load
+      completer.complete(
+        const SessionDetailLoadResult.loaded(
+          snapshot: SessionDetailSnapshot(
+            projectId: "project-1",
+            messages: <MessageWithParts>[],
+            pendingQuestions: <PendingQuestion>[],
+            pendingPermissions: <PendingPermission>[],
+            childSessions: <Session>[],
+            statuses: <String, SessionStatus>{},
+            agents: <AgentInfo?>[],
+            providerData: null,
+            commands: <CommandInfo>[],
+            canonicalSessionTitle: null,
+          ),
+          isBridgeConnected: true,
+        ),
+      );
+      await _awaitLoaded(cubit);
+
+      // No children or other side effects from the irrelevant events
+      final state = cubit.state as SessionDetailLoaded;
+      expect(state.children, isEmpty);
+      expect(state.pendingPermissions, isEmpty);
+      expect(state.pendingQuestions, isEmpty);
+    });
+  });
+}
+
+Future<void> _awaitLoaded(SessionDetailCubit cubit) async {
+  for (var i = 0; i < 100; i++) {
+    if (cubit.state is SessionDetailLoaded) return;
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+  fail("Timed out waiting for SessionDetailLoaded; current state: ${cubit.state}");
+}


### PR DESCRIPTION
## Problem

When creating a new session and navigating to the session detail screen, the UI initially shows:
- "null" for agent/model in the header
- Empty first message bubble
- Partial state that self-recovers only when later SSE events arrive

## Root Cause

`SessionDetailCubit` subscribes to SSE events and fires the initial HTTP snapshot load simultaneously in its constructor. While `_loadMessages()` is async and the state is `SessionDetailLoading`, every SSE event handler has this guard:

A command-line utility for Dart development.

Usage: dart <command|dart-file> [arguments]

Global options:
-v, --verbose               Show additional command output.
    --version               Print the Dart SDK version.
    --enable-analytics      Enable analytics.
    --disable-analytics     Disable analytics.
    --suppress-analytics    Disallow analytics for this `dart *` run without changing the analytics configuration.
-h, --help                  Print this usage information.

Available commands:

Global
  install     Install or upgrade a Dart CLI tool for global use.
  installed   List globally installed Dart CLI tools.
  uninstall   Remove a globally installed Dart CLI tool.

Project
  build       Build a Dart application including code assets.
  compile     Compile Dart to various formats.
  create      Create a new Dart project.
  pub         Work with packages.
  run         Run a Dart program from a file or a local package.
  test        Run tests for a project.

Source code
  analyze     Analyze Dart code in a directory.
  doc         Generate API documentation for Dart projects.
  fix         Apply automated fixes to Dart source code.
  format      Idiomatically format Dart source code.

Tools
  devtools    Open DevTools (optionally connecting to an existing application).
  info        Show diagnostic information about the installed tooling.

Run "dart help <command>" for more information about a command.
See https://dart.dev/tools/dart-tool for detailed documentation.

This creates a race window where backend-emitted SSE events (`message.updated`, `message.part.updated`, `session.status`, etc.) arrive during the load and are **silently dropped permanently**.

For brand-new sessions, the initial GET often returns incomplete data (missing message parts, agent/model metadata). The dropped SSE events are exactly what would fill in those gaps. Going back and re-entering the screen fixes it because a new cubit loads after the backend has fully persisted everything.

## Fix

Buffer all session-scoped and global SSE events that arrive while the cubit is not in `SessionDetailLoaded` state. Once the load completes, replay the buffered events in order. Buffers are cleared on load failure to avoid stale replays.

### Changes
- `session_detail_cubit.dart`: Added `_pendingSessionEvents` and `_pendingGlobalEvents` buffers, gated `_handleEvent`/`_handleGlobalEvent` to buffer when not loaded, added `_drainPendingEvents()` called after successful load/refresh
- `session_detail_event_buffer_test.dart`: 4 new tests covering buffer-then-replay, global events, failure clears buffer, and immediate processing when already loaded

### Clean alternative considered
No hacky delays or polling — this is a targeted, well-scoped fix that solves the general case of any session detail initialization race.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in `SessionDetailCubit` by buffering SSE events during loading and replaying them after, preventing dropped events that caused null agent/model and an empty first message in new sessions.

- **Bug Fixes**
  - Buffer session-scoped and relevant global SSE while `SessionDetailLoading`; skip high-volume irrelevant globals and exclude `SesoriSessionsUpdated`; replay in order after load/refresh; drop events received while failed; clear buffers on failure and on close.
  - Drain buffers immediately after a successful load/refresh; process events immediately when already loaded.
  - Tests cover session/global replay, failure clearing and failed-state drops, immediate processing, permission buffering, and skipping irrelevant global events.

<sup>Written for commit d5a5fe4cc815ad557d0fbf0847bbd45e8a68dfee. Summary will update on new commits. <a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/170?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

