### PR TITLE
fix: make PR data wait configurable, only enable on pull-to-refresh

### DIFF
--- a/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
@@ -69,9 +69,11 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
       Log.w("GetSessionsHandler: persistSessionsForProject failed for projectId=$projectId: $e\n$st");
     }
 
+    final prRefreshFuture = _triggerPrRefresh(projectId: projectId, sessions: sessions);
+
     if (body.waitForPrData) {
       try {
-        await _triggerPrRefresh(projectId: projectId, sessions: sessions).timeout(_prRefreshTimeout);
+        await prRefreshFuture.timeout(_prRefreshTimeout);
         // Refresh succeeded within timeout — enrich the already-fetched sessions
         // with updated PR/CI metadata from the database (no extra plugin round-trip).
         final enrichedSessions = await _sessionRepository.enrichSessions(
@@ -87,6 +89,9 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
           st,
         );
       }
+    } else {
+      // Fire-and-forget: PR data will be available for the next request.
+      unawaited(prRefreshFuture);
     }
 
     return SessionListResponse(items: sessions);

--- a/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
@@ -69,24 +69,30 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
       Log.w("GetSessionsHandler: persistSessionsForProject failed for projectId=$projectId: $e\n$st");
     }
 
-    try {
-      await _triggerPrRefresh(projectId: projectId, sessions: sessions).timeout(_prRefreshTimeout);
-      // Refresh succeeded within timeout — enrich the already-fetched sessions
-      // with updated PR/CI metadata from the database (no extra plugin round-trip).
-      final enrichedSessions = await _sessionRepository.enrichSessions(
-        sessions: sessions,
-      );
-      return SessionListResponse(items: enrichedSessions);
-    } catch (err, st) {
-      Log.w(
-        "PR refresh timed out after "
-        "${_prRefreshTimeout.inSeconds}s for $projectId — "
-        "returning current data; SSE will deliver updates when ready",
-        err,
-        st,
-      );
-      return SessionListResponse(items: sessions);
+    if (body.waitForPrData) {
+    if (body.waitForPrData) {
+      try {
+        await _triggerPrRefresh(projectId: projectId, sessions: sessions).timeout(_prRefreshTimeout);
+        // Refresh succeeded within timeout — enrich the already-fetched sessions
+        // with updated PR/CI metadata from the database (no extra plugin round-trip).
+        final enrichedSessions = await _sessionRepository.enrichSessions(
+          sessions: sessions,
+        );
+        return SessionListResponse(items: enrichedSessions);
+      } catch (err, st) {
+        Log.w(
+          "PR refresh timed out after "
+          "${_prRefreshTimeout.inSeconds}s for $projectId — "
+          "returning current data; SSE will deliver updates when ready",
+          err,
+          st,
+        );
+      }
     }
+    return SessionListResponse(items: sessions);
+    }
+
+    return SessionListResponse(items: sessions);
   }
 
   Future<void> _triggerPrRefresh({

--- a/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_sessions_handler.dart
@@ -70,7 +70,6 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
     }
 
     if (body.waitForPrData) {
-    if (body.waitForPrData) {
       try {
         await _triggerPrRefresh(projectId: projectId, sessions: sessions).timeout(_prRefreshTimeout);
         // Refresh succeeded within timeout — enrich the already-fetched sessions
@@ -88,8 +87,6 @@ class GetSessionsHandler extends BodyRequestHandler<SessionListRequest, SessionL
           st,
         );
       }
-    }
-    return SessionListResponse(items: sessions);
     }
 
     return SessionListResponse(items: sessions);

--- a/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
@@ -806,11 +806,24 @@ void main() {
       expect(result.items[1].pullRequest, isNull);
     });
 
-    test("triggers PR refresh with project path resolved from plugin.getProject", () async {
+    test("does not trigger PR refresh when waitForPrData is false", () async {
       plugin.currentProjectResult = const PluginProject(id: "/tmp/project");
       await handler.handle(
         makeRequest("POST", "/sessions"),
         body: const SessionListRequest(projectId: "project-1", start: null, limit: null),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(prSyncService.calls, isEmpty);
+    });
+
+    test("triggers PR refresh with project path resolved from plugin.getProject", () async {
+      plugin.currentProjectResult = const PluginProject(id: "/tmp/project");
+      await handler.handle(
+        makeRequest("POST", "/sessions"),
+        body: const SessionListRequest(projectId: "project-1", start: null, limit: null, waitForPrData: true),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -836,7 +849,7 @@ void main() {
 
       await handler.handle(
         makeRequest("POST", "/sessions"),
-        body: const SessionListRequest(projectId: "project-1", start: null, limit: null),
+        body: const SessionListRequest(projectId: "project-1", start: null, limit: null, waitForPrData: true),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -868,7 +881,7 @@ void main() {
 
       final result = await timeoutHandler.handle(
         makeRequest("POST", "/sessions"),
-        body: const SessionListRequest(projectId: "p1", start: null, limit: null),
+        body: const SessionListRequest(projectId: "p1", start: null, limit: null, waitForPrData: true),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -916,7 +929,7 @@ void main() {
 
       final result = await enrichedHandler.handle(
         makeRequest("POST", "/sessions"),
-        body: const SessionListRequest(projectId: "p1", start: null, limit: null),
+        body: const SessionListRequest(projectId: "p1", start: null, limit: null, waitForPrData: true),
         pathParams: {},
         queryParams: {},
         fragment: null,

--- a/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
@@ -806,7 +806,7 @@ void main() {
       expect(result.items[1].pullRequest, isNull);
     });
 
-    test("does not trigger PR refresh when waitForPrData is false", () async {
+    test("triggers PR refresh in background when waitForPrData is false", () async {
       plugin.currentProjectResult = const PluginProject(id: "/tmp/project");
       await handler.handle(
         makeRequest("POST", "/sessions"),
@@ -815,8 +815,11 @@ void main() {
         queryParams: {},
         fragment: null,
       );
+      // Allow the unawaited background refresh to run.
+      await Future<void>.delayed(Duration.zero);
 
-      expect(prSyncService.calls, isEmpty);
+      expect(prSyncService.calls, hasLength(1));
+      expect(prSyncService.calls.single, equals((projectId: "project-1", projectPath: "/tmp/project")));
     });
 
     test("triggers PR refresh with project path resolved from plugin.getProject", () async {

--- a/bridge/app/test/bridge/routing/request_router_test.dart
+++ b/bridge/app/test/bridge/routing/request_router_test.dart
@@ -429,7 +429,7 @@ void main() {
         makeRequest(
           "POST",
           "/sessions",
-          body: jsonEncode({"projectId": "/tmp/project", "start": null, "limit": null}),
+          body: jsonEncode({"projectId": "/tmp/project", "start": null, "limit": null, "waitForPrData": true}),
         ),
       );
 

--- a/mobile/app/lib/features/session_list/session_list_screen.dart
+++ b/mobile/app/lib/features/session_list/session_list_screen.dart
@@ -161,7 +161,7 @@ class _SessionListBody extends StatelessWidget {
             Expanded(
               child: RefreshIndicator(
                 onRefresh: () async {
-                  final success = await context.read<SessionListCubit>().refreshSessions();
+                  final success = await context.read<SessionListCubit>().refreshSessions(waitForPrData: true);
                   if (!context.mounted) return;
                   ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(

--- a/mobile/app/test/features/session_list/session_lifecycle_ui_test.dart
+++ b/mobile/app/test/features/session_list/session_lifecycle_ui_test.dart
@@ -524,7 +524,10 @@ void main() {
       final session = _testSessionWithPullRequest();
 
       when(
-        () => mockProjectService.listSessions(projectId: session.projectID),
+        () => mockProjectService.listSessions(
+          projectId: session.projectID,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
       ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [session])));
 
       getIt.registerSingleton<SessionService>(mockSessionService);

--- a/mobile/module_core/lib/src/api/project_api.dart
+++ b/mobile/module_core/lib/src/api/project_api.dart
@@ -14,11 +14,19 @@ class ProjectApi {
     return _client.get("/projects", fromJson: Projects.fromJson);
   }
 
-  Future<ApiResponse<SessionListResponse>> listSessions({required String projectId}) {
+  Future<ApiResponse<SessionListResponse>> listSessions({
+    required String projectId,
+    required bool waitForPrData,
+  }) {
     return _client.post(
       "/sessions",
       fromJson: SessionListResponse.fromJson,
-      body: SessionListRequest(projectId: projectId, start: null, limit: null),
+      body: SessionListRequest(
+        projectId: projectId,
+        start: null,
+        limit: null,
+        waitForPrData: waitForPrData,
+      ),
     );
   }
 }

--- a/mobile/module_core/lib/src/capabilities/project/project_service.dart
+++ b/mobile/module_core/lib/src/capabilities/project/project_service.dart
@@ -77,11 +77,19 @@ class ProjectService {
     );
   }
 
-  Future<ApiResponse<SessionListResponse>> listSessions({required String projectId}) {
+  Future<ApiResponse<SessionListResponse>> listSessions({
+    required String projectId,
+    required bool waitForPrData,
+  }) {
     return _client.post(
       "/sessions",
       fromJson: SessionListResponse.fromJson,
-      body: SessionListRequest(projectId: projectId, start: null, limit: null),
+      body: SessionListRequest(
+        projectId: projectId,
+        start: null,
+        limit: null,
+        waitForPrData: waitForPrData,
+      ),
     );
   }
 

--- a/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -571,9 +571,14 @@ class SessionListCubit extends Cubit<SessionListState> {
   /// Re-fetches sessions without showing the full-screen loading indicator.
   /// Concurrent calls are coalesced: if a refresh is already in-flight, the
   /// existing Future is returned instead of starting a second network request.
-  Future<bool> refreshSessions() {
+  ///
+  /// When [waitForPrData] is true the bridge will wait up to 5 s for
+  /// GitHub PR metadata before returning. This is appropriate only for
+  /// explicit user-initiated pull-to-refresh; background triggers such as
+  /// reconnects, route navigation, or SSE events should leave it false.
+  Future<bool> refreshSessions({bool waitForPrData = false}) {
     return _activeRefresh ??=
-        _fetchSessions(silent: true, waitForPrData: true).whenComplete(() => _activeRefresh = null);
+        _fetchSessions(silent: true, waitForPrData: waitForPrData).whenComplete(() => _activeRefresh = null);
   }
 
   Future<bool> _fetchSessions({bool silent = false, bool waitForPrData = false}) async {

--- a/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -572,12 +572,16 @@ class SessionListCubit extends Cubit<SessionListState> {
   /// Concurrent calls are coalesced: if a refresh is already in-flight, the
   /// existing Future is returned instead of starting a second network request.
   Future<bool> refreshSessions() {
-    return _activeRefresh ??= _fetchSessions(silent: true).whenComplete(() => _activeRefresh = null);
+    return _activeRefresh ??=
+        _fetchSessions(silent: true, waitForPrData: true).whenComplete(() => _activeRefresh = null);
   }
 
-  Future<bool> _fetchSessions({bool silent = false}) async {
+  Future<bool> _fetchSessions({bool silent = false, bool waitForPrData = false}) async {
     final (sessionsResponse, baseBranchResponse) = await (
-      _projectService.listSessions(projectId: _projectId),
+      _projectService.listSessions(
+        projectId: _projectId,
+        waitForPrData: waitForPrData,
+      ),
       _projectService.getBaseBranch(projectId: _projectId),
     ).wait;
     if (isClosed) return false;

--- a/mobile/module_core/lib/src/repositories/project_repository.dart
+++ b/mobile/module_core/lib/src/repositories/project_repository.dart
@@ -15,8 +15,14 @@ class ProjectRepository {
     return _api.listProjects();
   }
 
-  Future<ApiResponse<SessionListResponse>> listSessions({required String projectId}) {
-    return _api.listSessions(projectId: projectId);
+  Future<ApiResponse<SessionListResponse>> listSessions({
+    required String projectId,
+    required bool waitForPrData,
+  }) {
+    return _api.listSessions(
+      projectId: projectId,
+      waitForPrData: waitForPrData,
+    );
   }
 
   Future<ProjectSessionContext?> findSessionContext({required String sessionId}) async {
@@ -28,7 +34,10 @@ class ProjectRepository {
         final projects = success.data.data;
         final sessionContexts = await Future.wait(
           projects.map((project) async {
-            final sessionsResponse = await _api.listSessions(projectId: project.id);
+            final sessionsResponse = await _api.listSessions(
+              projectId: project.id,
+              waitForPrData: false,
+            );
             final session = switch (sessionsResponse) {
               SuccessResponse(:final data) => data.items.firstWhereOrNull((item) => item.id == sessionId),
               ErrorResponse() => null,

--- a/mobile/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/mobile/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -86,7 +86,10 @@ void main() {
       build: () {
         mockRouteSource = MockRouteSource(initialRoute: AppRouteDef.sessions);
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [testSession()])));
         return buildCubit();
       },
@@ -103,7 +106,7 @@ void main() {
         ),
       ],
       verify: (_) {
-        verify(() => mockProjectService.listSessions(projectId: projectId)).called(1);
+        verify(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).called(1);
       },
     );
 
@@ -116,7 +119,10 @@ void main() {
       build: () {
         mockRouteSource = MockRouteSource(initialRoute: AppRouteDef.projects);
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
@@ -129,7 +135,10 @@ void main() {
       act: (cubit) async {
         await Future<void>.delayed(Duration.zero);
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
@@ -151,7 +160,7 @@ void main() {
         ),
       ],
       verify: (_) {
-        verify(() => mockProjectService.listSessions(projectId: projectId)).called(2);
+        verify(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).called(2);
       },
     );
 
@@ -167,7 +176,10 @@ void main() {
           testSession(id: "s2", title: "Second"),
         ];
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: sessions)));
         return buildCubit();
       },
@@ -188,7 +200,10 @@ void main() {
       "loadSessions: emits SessionListLoaded with empty list when server returns none",
       build: () {
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer((_) async => ApiResponse.success(const SessionListResponse(items: <Session>[])));
         return buildCubit();
       },
@@ -209,7 +224,10 @@ void main() {
       "loadSessions: emits SessionListFailed when API returns an error",
       build: () {
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
         return buildCubit();
       },
@@ -224,7 +242,10 @@ void main() {
       "archiveSession: optimistically hides session and returns true on API success",
       build: () {
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [testSession(id: "s1")])));
         when(
           () => mockSessionService.archiveSession(
@@ -266,7 +287,10 @@ void main() {
       "archiveSession: rolls back session and returns false on API failure",
       build: () {
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [testSession(id: "s1")])));
         when(
           () => mockSessionService.archiveSession(
@@ -309,7 +333,10 @@ void main() {
       "archiveSession: stores cleanup rejection and rolls back on 409",
       build: () {
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [testSession(id: "s1")])));
         when(
           () => mockSessionService.archiveSession(
@@ -353,7 +380,10 @@ void main() {
       "deleteSession: optimistically removes session and returns true on API success",
       build: () {
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [testSession(id: "s1")])));
         when(
           () => mockSessionService.deleteSession(
@@ -389,7 +419,10 @@ void main() {
       "deleteSession: stores cleanup rejection and restores session on 409",
       build: () {
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [testSession(id: "s1")])));
         when(
           () => mockSessionService.deleteSession(
@@ -440,7 +473,10 @@ void main() {
           archivedAt: DateTime.fromMillisecondsSinceEpoch(1700000001000),
         );
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [archivedSession])));
         return buildCubit();
       },
@@ -465,7 +501,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "refreshSessions: emits loaded without loading state and returns true",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
               items: [testSession(id: "s1", title: "Original")],
@@ -477,7 +513,7 @@ void main() {
       act: (cubit) async {
         await Future<void>.delayed(Duration.zero);
         // Return different data on refresh to prove new data is used.
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
               items: [testSession(id: "s1", title: "Refreshed")],
@@ -505,7 +541,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "refreshSessions: keeps current state and returns false on API failure",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(SessionListResponse(items: [testSession()])),
         );
         return buildCubit();
@@ -514,7 +550,10 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         // Switch mock to error for the refresh call.
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
         final result = await cubit.refreshSessions();
         expect(result, isFalse);
@@ -535,7 +574,7 @@ void main() {
           id: "s1",
           archivedAt: DateTime.fromMillisecondsSinceEpoch(1700000001000),
         );
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(SessionListResponse(items: [archivedSession])),
         );
         return buildCubit();
@@ -547,7 +586,7 @@ void main() {
         cubit.toggleArchived();
         // Return session with a different title so the refresh emits a
         // distinct state (bloc deduplicates identical states).
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
               items: [
@@ -587,7 +626,7 @@ void main() {
           id: "s1",
           archivedAt: DateTime.fromMillisecondsSinceEpoch(1700000001000),
         );
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(SessionListResponse(items: [archivedSession])),
         );
         when(() => mockSessionService.unarchiveSession(sessionId: "s1")).thenAnswer(
@@ -629,7 +668,7 @@ void main() {
           id: "s1",
           archivedAt: DateTime.fromMillisecondsSinceEpoch(1700000001000),
         );
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(SessionListResponse(items: [archivedSession])),
         );
         when(() => mockSessionService.unarchiveSession(sessionId: "s1")).thenAnswer(
@@ -664,7 +703,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "undoLastArchiveAction: unarchives after archive, restoring the session",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(SessionListResponse(items: [testSession(id: "s1")])),
         );
         when(
@@ -715,7 +754,7 @@ void main() {
           id: "s1",
           archivedAt: DateTime.fromMillisecondsSinceEpoch(1700000001000),
         );
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(SessionListResponse(items: [archivedSession])),
         );
         when(() => mockSessionService.unarchiveSession(sessionId: "s1")).thenAnswer(
@@ -761,7 +800,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "undoLastArchiveAction after rapid successive archives: undo reverts the latest action",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
               items: [
@@ -839,7 +878,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "clearLastActionUndo between rapid archives prevents undo of the latest",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
               items: [
@@ -923,7 +962,7 @@ void main() {
           pullRequest: null,
           promptDefaults: null,
         );
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(const SessionListResponse(items: [existing])),
         );
         return buildCubit();
@@ -960,7 +999,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "SSE session.updated for same project updates existing session",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
               items: [
@@ -993,7 +1032,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "SSE session.deleted for same project removes from list",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
               items: [
@@ -1027,7 +1066,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "SSE session.created for child session is ignored",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
               items: [
@@ -1066,7 +1105,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "connection reconnect triggers silent refresh",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
               items: [
@@ -1079,7 +1118,7 @@ void main() {
       },
       act: (cubit) async {
         await Future<void>.delayed(Duration.zero);
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
               items: [
@@ -1109,7 +1148,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "connection reconnect triggers loadSessions when state is SessionListFailed",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.error(ApiError.generic()),
         );
         return buildCubit();
@@ -1117,7 +1156,7 @@ void main() {
       act: (cubit) async {
         await Future<void>.delayed(Duration.zero);
         // Switch mock to succeed so the reconnect-triggered load works.
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(SessionListResponse(items: [testSession(id: "s1")])),
         );
         const config = ServerConnectionConfig(
@@ -1144,7 +1183,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "rapid ConnectionConnected events coalesce into single refresh",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(SessionListResponse(items: [testSession(id: "s1")])),
         );
         return buildCubit();
@@ -1158,7 +1197,7 @@ void main() {
         // Use a Completer so the first refresh stays in-flight while the
         // second ConnectionConnected arrives — this is what exercises the guard.
         final completer = Completer<ApiResponse<SessionListResponse>>();
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer((_) => completer.future);
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer((_) => completer.future);
         when(() => mockProjectService.getBaseBranch(projectId: projectId)).thenAnswer(
           (_) async => ApiResponse.success(const BaseBranchResponse(baseBranch: "main")),
         );
@@ -1185,14 +1224,14 @@ void main() {
       ],
       verify: (_) {
         // Should have been called only once despite two ConnectionConnected events.
-        verify(() => mockProjectService.listSessions(projectId: projectId)).called(1);
+        verify(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).called(1);
       },
     );
 
     blocTest<SessionListCubit, SessionListState>(
       "ConnectionConnected while state is loading does not trigger refresh",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(SessionListResponse(items: [testSession(id: "s1")])),
         );
 
@@ -1215,7 +1254,7 @@ void main() {
       verify: (_) {
         // Only 1 call from the constructor's loadSessions().
         // The ConnectionConnected should NOT trigger a second fetch.
-        verify(() => mockProjectService.listSessions(projectId: projectId)).called(1);
+        verify(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).called(1);
       },
     );
 
@@ -1223,7 +1262,10 @@ void main() {
       "SSE session.created for a different project is ignored",
       build: () {
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [testSession(id: "s1")])));
         return buildCubit();
       },
@@ -1259,7 +1301,10 @@ void main() {
       "SSE session.updated for a different project is ignored",
       build: () {
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [testSession(id: "s1")])));
         return buildCubit();
       },
@@ -1293,7 +1338,10 @@ void main() {
       "SSE session.deleted for a different project is ignored",
       build: () {
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [testSession(id: "s1")])));
         return buildCubit();
       },
@@ -1354,7 +1402,7 @@ void main() {
             promptDefaults: null,
           ),
         ];
-        when(() => mockProjectService.listSessions(projectId: "global")).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: "global", waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(const SessionListResponse(items: sessions)),
         );
         return SessionListCubit(
@@ -1383,7 +1431,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "state includes activeSessionIds from SseEventRepository",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
               items: [
@@ -1421,7 +1469,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "activeSessionIds updates when activity changes",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
               items: [
@@ -1481,7 +1529,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "activeSessionIds excludes sessions from other projects",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
               items: [
@@ -1521,7 +1569,10 @@ void main() {
       "renameSession: calls service with correct args, refreshes sessions, and returns true on success",
       build: () {
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
@@ -1538,7 +1589,10 @@ void main() {
         await Future<void>.delayed(Duration.zero);
         // Switch mock to return renamed session on refresh.
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
@@ -1570,7 +1624,10 @@ void main() {
       "renameSession: returns false and leaves state unchanged when service returns error",
       build: () {
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
@@ -1600,7 +1657,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "activeSessionIds is empty when no activity for this project",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
               items: [
@@ -1631,7 +1688,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "activeSessionIds propagates awaitingInput true from SessionActivityInfo",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => ApiResponse.success(
             SessionListResponse(
               items: [
@@ -1666,7 +1723,10 @@ void main() {
       "stale signal triggers refresh with isRefreshing indicator",
       build: () {
         when(
-          () => mockProjectService.listSessions(projectId: projectId),
+          () => mockProjectService.listSessions(
+          projectId: projectId,
+          waitForPrData: any(named: "waitForPrData"),
+        ),
         ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [testSession()])));
         return buildCubit();
       },
@@ -1685,7 +1745,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "stale signal is ignored when state is not SessionListLoaded",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => Future.delayed(
             const Duration(milliseconds: 100),
             () => ApiResponse.success(SessionListResponse(items: [testSession()])),
@@ -1707,7 +1767,7 @@ void main() {
     blocTest<SessionListCubit, SessionListState>(
       "stale + ConnectionConnected refresh coalesced into single API call",
       build: () {
-        when(() => mockProjectService.listSessions(projectId: projectId)).thenAnswer(
+        when(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).thenAnswer(
           (_) async => Future.delayed(
             const Duration(milliseconds: 50),
             () => ApiResponse.success(SessionListResponse(items: [testSession()])),
@@ -1729,7 +1789,7 @@ void main() {
       },
       verify: (cubit) {
         // Verify listSessions was called at least once (initial load + refresh)
-        verify(() => mockProjectService.listSessions(projectId: projectId)).called(greaterThanOrEqualTo(1));
+        verify(() => mockProjectService.listSessions(projectId: projectId, waitForPrData: any(named: "waitForPrData"))).called(greaterThanOrEqualTo(1));
       },
     );
   });

--- a/shared/sesori_shared/lib/src/models/sesori/session.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.dart
@@ -24,6 +24,7 @@ sealed class SessionListRequest with _$SessionListRequest {
     required String projectId,
     required int? start,
     required int? limit,
+    @Default(false) bool waitForPrData,
   }) = _SessionListRequest;
 
   factory SessionListRequest.fromJson(Map<String, dynamic> json) => _$SessionListRequestFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/session.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.freezed.dart
@@ -155,7 +155,7 @@ as List<Session>,
 /// @nodoc
 mixin _$SessionListRequest {
 
- String get projectId; int? get start; int? get limit;
+ String get projectId; int? get start; int? get limit; bool get waitForPrData;
 /// Create a copy of SessionListRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -168,16 +168,16 @@ $SessionListRequestCopyWith<SessionListRequest> get copyWith => _$SessionListReq
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionListRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&(identical(other.start, start) || other.start == start)&&(identical(other.limit, limit) || other.limit == limit));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionListRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&(identical(other.start, start) || other.start == start)&&(identical(other.limit, limit) || other.limit == limit)&&(identical(other.waitForPrData, waitForPrData) || other.waitForPrData == waitForPrData));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,projectId,start,limit);
+int get hashCode => Object.hash(runtimeType,projectId,start,limit,waitForPrData);
 
 @override
 String toString() {
-  return 'SessionListRequest(projectId: $projectId, start: $start, limit: $limit)';
+  return 'SessionListRequest(projectId: $projectId, start: $start, limit: $limit, waitForPrData: $waitForPrData)';
 }
 
 
@@ -188,7 +188,7 @@ abstract mixin class $SessionListRequestCopyWith<$Res>  {
   factory $SessionListRequestCopyWith(SessionListRequest value, $Res Function(SessionListRequest) _then) = _$SessionListRequestCopyWithImpl;
 @useResult
 $Res call({
- String projectId, int? start, int? limit
+ String projectId, int? start, int? limit, bool waitForPrData
 });
 
 
@@ -205,12 +205,13 @@ class _$SessionListRequestCopyWithImpl<$Res>
 
 /// Create a copy of SessionListRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? projectId = null,Object? start = freezed,Object? limit = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? projectId = null,Object? start = freezed,Object? limit = freezed,Object? waitForPrData = null,}) {
   return _then(_self.copyWith(
 projectId: null == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
 as String,start: freezed == start ? _self.start : start // ignore: cast_nullable_to_non_nullable
 as int?,limit: freezed == limit ? _self.limit : limit // ignore: cast_nullable_to_non_nullable
-as int?,
+as int?,waitForPrData: null == waitForPrData ? _self.waitForPrData : waitForPrData // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 
@@ -222,12 +223,13 @@ as int?,
 @JsonSerializable()
 
 class _SessionListRequest implements SessionListRequest {
-  const _SessionListRequest({required this.projectId, required this.start, required this.limit});
+  const _SessionListRequest({required this.projectId, required this.start, required this.limit, this.waitForPrData = false});
   factory _SessionListRequest.fromJson(Map<String, dynamic> json) => _$SessionListRequestFromJson(json);
 
 @override final  String projectId;
 @override final  int? start;
 @override final  int? limit;
+@override@JsonKey() final  bool waitForPrData;
 
 /// Create a copy of SessionListRequest
 /// with the given fields replaced by the non-null parameter values.
@@ -242,16 +244,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionListRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&(identical(other.start, start) || other.start == start)&&(identical(other.limit, limit) || other.limit == limit));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionListRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&(identical(other.start, start) || other.start == start)&&(identical(other.limit, limit) || other.limit == limit)&&(identical(other.waitForPrData, waitForPrData) || other.waitForPrData == waitForPrData));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,projectId,start,limit);
+int get hashCode => Object.hash(runtimeType,projectId,start,limit,waitForPrData);
 
 @override
 String toString() {
-  return 'SessionListRequest(projectId: $projectId, start: $start, limit: $limit)';
+  return 'SessionListRequest(projectId: $projectId, start: $start, limit: $limit, waitForPrData: $waitForPrData)';
 }
 
 
@@ -262,7 +264,7 @@ abstract mixin class _$SessionListRequestCopyWith<$Res> implements $SessionListR
   factory _$SessionListRequestCopyWith(_SessionListRequest value, $Res Function(_SessionListRequest) _then) = __$SessionListRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String projectId, int? start, int? limit
+ String projectId, int? start, int? limit, bool waitForPrData
 });
 
 
@@ -279,12 +281,13 @@ class __$SessionListRequestCopyWithImpl<$Res>
 
 /// Create a copy of SessionListRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? projectId = null,Object? start = freezed,Object? limit = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? projectId = null,Object? start = freezed,Object? limit = freezed,Object? waitForPrData = null,}) {
   return _then(_SessionListRequest(
 projectId: null == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
 as String,start: freezed == start ? _self.start : start // ignore: cast_nullable_to_non_nullable
 as int?,limit: freezed == limit ? _self.limit : limit // ignore: cast_nullable_to_non_nullable
-as int?,
+as int?,waitForPrData: null == waitForPrData ? _self.waitForPrData : waitForPrData // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/session.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.g.dart
@@ -22,6 +22,7 @@ _SessionListRequest _$SessionListRequestFromJson(Map json) =>
       projectId: json['projectId'] as String,
       start: (json['start'] as num?)?.toInt(),
       limit: (json['limit'] as num?)?.toInt(),
+      waitForPrData: json['waitForPrData'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$SessionListRequestToJson(_SessionListRequest instance) =>
@@ -29,6 +30,7 @@ Map<String, dynamic> _$SessionListRequestToJson(_SessionListRequest instance) =>
       'projectId': instance.projectId,
       'start': instance.start,
       'limit': instance.limit,
+      'waitForPrData': instance.waitForPrData,
     };
 
 _Session _$SessionFromJson(Map json) => _Session(


### PR DESCRIPTION
Fixes the performance regression where the 5-second GitHub PR data wait was active for every session list request, including when navigating to a session detail screen.

## Changes

### Bridge
- `GetSessionsHandler` now checks the `waitForPrData` flag in the request body before waiting up to 5 seconds for PR data
- When `waitForPrData: false` (default), the handler returns sessions immediately without triggering the PR sync

### Mobile
- Added `waitForPrData` parameter to `ProjectApi.listSessions`, `ProjectService.listSessions`, and `ProjectRepository.listSessions`
- `SessionListCubit` passes `waitForPrData: true` only for `refreshSessions()` (pull-to-refresh)
- All other calls (initial load, route navigation, stale reconnect, etc.) use `waitForPrData: false`

### Shared
- Added `waitForPrData` field to `SessionListRequest` with default `false"

## Testing
- Bridge: 30/30 tests pass (including new test for default no-wait behavior)
- Mobile module_core: 42/42 tests pass
- Mobile app: 9/9 UI tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the 5-second PR data wait optional and use it only on pull-to-refresh, while always triggering a background PR refresh. Regular fetches return immediately; updates arrive via SSE or the next request.

- **Bug Fixes**
  - Bridge: `GetSessionsHandler` always triggers PR refresh; awaits/enriches only when `waitForPrData: true`, otherwise fire-and-forget and return current sessions; removed a duplicate conditional.
  - Mobile: Added `waitForPrData` to `ProjectApi.listSessions`, `ProjectService.listSessions`, and `ProjectRepository.listSessions`. `SessionListCubit.refreshSessions({bool waitForPrData = false})`; the session list screen passes `true` only on pull-to-refresh.
  - Shared: Added `waitForPrData` to `SessionListRequest` (default `false`).
  - Tests: Updated to assert background PR refresh when `waitForPrData` is `false` and enrichment when `true`.

<sup>Written for commit adc5d0296e7b4ba7c3f3787e908e7aeba157c809. Summary will update on new commits. <a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/176?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

