### PR TITLE
feat(bridge): remove bridge-v tag backwards compatibility, keep only v tags

### DIFF
--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -215,7 +215,7 @@ jobs:
         id: version
         shell: bash
         run: |
-          VERSION="${RELEASE_TAG#bridge-v}"
+          VERSION="${RELEASE_TAG#v}"
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Download release assets
@@ -401,7 +401,7 @@ jobs:
         id: version
         shell: bash
         run: |
-          VERSION="${RELEASE_TAG#bridge-v}"
+          VERSION="${RELEASE_TAG#v}"
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Validate wrapper package metadata

--- a/.github/workflows/bridge-release.yml
+++ b/.github/workflows/bridge-release.yml
@@ -1,10 +1,12 @@
 name: Bridge Release
 
 on:
-  push:
-    tags: ["bridge-v*"]
   workflow_dispatch:
     inputs:
+      tag:
+        description: "Release tag (e.g., v1.0.0)"
+        required: true
+        type: string
       dry_run:
         description: "Dry run (build only, no publish)"
         required: false
@@ -60,11 +62,8 @@ jobs:
         id: version
         shell: bash
         run: |
-          if [[ "${GITHUB_REF_NAME}" == bridge-v* ]]; then
-            VERSION="${GITHUB_REF_NAME#bridge-v}"
-          else
-            VERSION=$(grep '^version:' bridge/app/pubspec.yaml | awk '{print $2}')
-          fi
+          RELEASE_TAG="${{ github.event.inputs.tag }}"
+          VERSION="${RELEASE_TAG#v}"
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Get dependencies
@@ -72,7 +71,7 @@ jobs:
         working-directory: bridge
 
       - name: Bump version
-        if: startsWith(github.ref_name, 'bridge-v')
+        if: github.event.inputs.tag != ''
         shell: bash
         run: |
           CURRENT_VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}')
@@ -163,7 +162,7 @@ jobs:
     name: Create GitHub Release
     needs: build
     runs-on: ubuntu-latest
-    if: github.event.inputs.dry_run != 'true' && startsWith(github.ref_name, 'bridge-v')
+    if: github.event.inputs.dry_run != 'true' && github.event.inputs.tag != ''
     permissions:
       contents: write
     steps:
@@ -183,8 +182,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
-          name: Bridge ${{ github.ref_name }}
+          tag_name: ${{ github.event.inputs.tag }}
+          name: Bridge ${{ github.event.inputs.tag }}
           make_latest: "true"
           generate_release_notes: true
           files: |
@@ -196,12 +195,12 @@ jobs:
     name: Publish platform npm packages
     needs: release
     runs-on: ubuntu-latest
-    if: github.event.inputs.dry_run != 'true' && startsWith(github.ref_name, 'bridge-v')
+    if: github.event.inputs.dry_run != 'true' && github.event.inputs.tag != ''
     permissions:
       contents: read
       id-token: write
     env:
-      RELEASE_TAG: ${{ github.ref_name }}
+      RELEASE_TAG: ${{ github.event.inputs.tag }}
     steps:
 
       - uses: actions/checkout@v4
@@ -383,12 +382,12 @@ jobs:
     name: Publish wrapper npm package
     needs: publish-platform
     runs-on: ubuntu-latest
-    if: github.event.inputs.dry_run != 'true' && startsWith(github.ref_name, 'bridge-v')
+    if: github.event.inputs.dry_run != 'true' && github.event.inputs.tag != ''
     permissions:
       contents: read
       id-token: write
     env:
-      RELEASE_TAG: ${{ github.ref_name }}
+      RELEASE_TAG: ${{ github.event.inputs.tag }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -28,10 +28,10 @@ Alternatively, the user may provide an explicit version: `make bump-version VERS
 
 ### Step 2: Find the Latest Release Tag
 
-Run the following to find the most recent release tag. Include both tag families while GitHub Actions still publishes bridge releases from `bridge-v*` tags:
+Run the following to find the most recent release tag:
 
 ```bash
-git tag -l "v*" "bridge-v*" --sort=-v:refname | head -n 1
+git tag -l "v*" --sort=-v:refname | head -n 1
 ```
 
 ### Step 3: Bump Versions

--- a/bridge/RELEASING.md
+++ b/bridge/RELEASING.md
@@ -4,23 +4,21 @@
 
 - **Enabled by default:** GitHub Releases
 - **Enabled by default:** npm publish via npm trusted publishing
-- **Release selector:** installers and updater accept stable GitHub releases tagged `bridge-v*` or `v*` during the shared-tag migration. GitHub Actions trigger migration to shared `v*` tags is deferred.
+- **Release selector:** installers and updater accept stable GitHub releases tagged `v*`.
 
 ## Release tag
 
-Until the GitHub Actions trigger migration lands, use tags in this format:
+Use shared `vX.Y.Z` tags:
 
 ```bash
-bridge-vX.Y.Z
+vX.Y.Z
 ```
 
 Example:
 
 ```bash
-bridge-v0.3.1
+v0.3.1
 ```
-
-After the workflow migration, use shared `vX.Y.Z` tags.
 
 ## Before release
 
@@ -101,11 +99,11 @@ git push
 ### 3. Tag and push
 
 ```bash
-git tag bridge-v0.3.1
-git push origin bridge-v0.3.1
+git tag v0.3.1
+git push origin v0.3.1
 ```
 
-## What the workflow does on tag push
+## What the workflow does on manual dispatch
 
 1. builds binaries for macOS arm64/x64, Linux x64/arm64, Windows x64
 2. renames `bridge` to `sesori-bridge`
@@ -236,4 +234,4 @@ Configure npm trusted publishing for all six packages in this repo against the e
 - `@sesori/bridge-linux-arm64`
 - `@sesori/bridge-win32-x64`
 
-Those trusted publisher entries must match the GitHub owner, repository, and workflow filename exactly. The tag-triggered workflow verifies the archived GitHub Release assets against `checksums.txt`, derives each platform npm payload from those exact release artifacts, and then publishes through npm trusted publishing on `ubuntu-latest`.
+Those trusted publisher entries must match the GitHub owner, repository, and workflow filename exactly. The workflow verifies the archived GitHub Release assets against `checksums.txt`, derives each platform npm payload from those exact release artifacts, and then publishes through npm trusted publishing on `ubuntu-latest`.

--- a/bridge/app/lib/src/updater/repositories/release_repository.dart
+++ b/bridge/app/lib/src/updater/repositories/release_repository.dart
@@ -74,14 +74,12 @@ class ReleaseRepository {
           (release) =>
               !release.draft &&
               !release.prerelease &&
-              (release.tagName.startsWith('v') || release.tagName.startsWith('bridge-v')),
+              release.tagName.startsWith('v'),
         )
         .map(
           (release) {
             final tagName = release.tagName;
-            final versionString = tagName.startsWith('bridge-v')
-                ? tagName.replaceFirst('bridge-v', '')
-                : tagName.replaceFirst('v', '');
+            final versionString = tagName.replaceFirst('v', '');
             final version = BridgeVersion.tryParse(value: versionString);
             return version != null && version.isStable
                 ? (
@@ -107,13 +105,11 @@ class ReleaseRepository {
 
   Future<ReleaseInfo?> _evaluateRelease({required GitHubReleaseDto release}) async {
     final tagName = release.tagName;
-    if (!tagName.startsWith('v') && !tagName.startsWith('bridge-v')) {
+    if (!tagName.startsWith('v')) {
       return null;
     }
 
-    final versionString = tagName.startsWith('bridge-v')
-        ? tagName.replaceFirst('bridge-v', '')
-        : tagName.replaceFirst('v', '');
+    final versionString = tagName.replaceFirst('v', '');
     final BridgeVersion? latestVersion = BridgeVersion.tryParse(
       value: versionString,
     );

--- a/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v1.0.7",
+    "releaseTag": "v1.0.7",
     "releaseArtifact": "sesori-bridge-macos-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-darwin-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-x64/package.json
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v1.0.7",
+    "releaseTag": "v1.0.7",
     "releaseArtifact": "sesori-bridge-macos-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-arm64/package.json
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v1.0.7",
+    "releaseTag": "v1.0.7",
     "releaseArtifact": "sesori-bridge-linux-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-x64/package.json
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v1.0.7",
+    "releaseTag": "v1.0.7",
     "releaseArtifact": "sesori-bridge-linux-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-x64/package.json
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v1.0.7",
+    "releaseTag": "v1.0.7",
     "releaseArtifact": "sesori-bridge-windows-x64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge/lib/release_asset_runtime.js
+++ b/bridge/app/npm/sesori-bridge/lib/release_asset_runtime.js
@@ -47,7 +47,7 @@ function currentAssetName() {
 
 function releaseTag(manifest) {
   var metadata = manifest.sesoriBridge || {};
-  return metadata.releaseTag || ("bridge-v" + manifest.version);
+  return metadata.releaseTag || ("v" + manifest.version);
 }
 
 function wrapperVersion() {

--- a/bridge/app/npm/sesori-bridge/package.json
+++ b/bridge/app/npm/sesori-bridge/package.json
@@ -15,7 +15,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "bridge-v1.0.7",
+    "releaseTag": "v1.0.7",
     "runtimeBundleSource": "github-release-assets"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/bridge/app/test/tool/bump_version_test.dart
+++ b/bridge/app/test/tool/bump_version_test.dart
@@ -74,7 +74,7 @@ dependencies:
       'sesoriBridge': {
         'bootstrapOnly': true,
         'managedRuntimeOwner': false,
-        'releaseTag': 'bridge-v$oldVersion',
+        'releaseTag': 'v$oldVersion',
         'runtimeBundleSource': 'github-release-assets',
       },
       'optionalDependencies': {
@@ -97,7 +97,7 @@ dependencies:
         'sesoriBridge': {
           'bootstrapOnly': true,
           'managedRuntimeOwner': false,
-          'releaseTag': 'bridge-v$oldVersion',
+          'releaseTag': 'v$oldVersion',
           'releaseArtifact': {
             'sesori-bridge-darwin-arm64': 'sesori-bridge-macos-arm64.tar.gz',
             'sesori-bridge-darwin-x64': 'sesori-bridge-macos-x64.tar.gz',
@@ -168,7 +168,7 @@ void main() {
       expect(wrapperPackage['version'], equals(fixture.newVersion));
       expect(
         (wrapperPackage['sesoriBridge'] as Map<String, dynamic>)['releaseTag'],
-        equals('bridge-v${fixture.newVersion}'),
+        equals('v${fixture.newVersion}'),
       );
 
       final optionalDependencies = wrapperPackage['optionalDependencies'] as Map<String, dynamic>;
@@ -186,7 +186,7 @@ void main() {
         expect(packageJson['version'], equals(fixture.newVersion), reason: 'failed for $package');
         expect(
           (packageJson['sesoriBridge'] as Map<String, dynamic>)['releaseTag'],
-          equals('bridge-v${fixture.newVersion}'),
+          equals('v${fixture.newVersion}'),
           reason: 'failed releaseTag update for $package',
         );
       }

--- a/bridge/app/test/tool/installers_test.dart
+++ b/bridge/app/test/tool/installers_test.dart
@@ -357,20 +357,18 @@ cat "\$HOME/.zprofile"
       final script = File(_installShPath()).readAsStringSync();
 
       expect(script, contains(r'MANAGED_MANIFEST="${INSTALL_DIR}/.managed-runtime.json"'));
-      expect(script, contains(r'resolved_version="${RESOLVED_RELEASE_TAG#bridge-v}"'));
-      expect(script, contains(r'resolved_version="${resolved_version#v}"'));
+      expect(script, contains(r'resolved_version="${RESOLVED_RELEASE_TAG#v}"'));
       expect(script, contains('printf'));
       expect(script, contains('"%s"'));
       expect(script, contains(r'"${resolved_version}" > "${MANAGED_MANIFEST}"'));
     });
 
-    test('accepts both bridge-v and v release tags for backwards compatibility', () {
+    test('accepts only v release tags', () {
       final script = File(_installShPath()).readAsStringSync();
 
-      expect(script, contains('if tag_name.startswith("bridge-v"):'));
-      expect(script, contains('elif tag_name.startswith("v"):'));
-      expect(script, contains('version = tag_name.replace("bridge-v", "", 1)'));
+      expect(script, contains('if tag_name.startswith("v"):'));
       expect(script, contains('version = tag_name.replace("v", "", 1)'));
+      expect(script, isNot(contains('bridge-v')));
     });
   });
 
@@ -421,20 +419,17 @@ cat "\$HOME/.zprofile"
     test('writes managed runtime manifest with resolved version', () {
       expect(script, contains(r"$ManagedManifest = Join-Path $InstallRoot '.managed-runtime.json'"));
       expect(script, contains(r'$resolvedVersion = $Release.TagName'));
-      expect(script, contains(r"if ($resolvedVersion.StartsWith('bridge-v'))"));
-      expect(script, contains(r'$resolvedVersion = $resolvedVersion.Substring(8)'));
-      expect(script, contains(r"} elseif ($resolvedVersion.StartsWith('v')) {"));
+      expect(script, contains(r"if ($resolvedVersion.StartsWith('v'))"));
       expect(script, contains(r'$resolvedVersion = $resolvedVersion.Substring(1)'));
       expect(script, contains(r'$managedManifestJson = @{ version = $resolvedVersion } | ConvertTo-Json -Compress'));
       expect(script, contains('[System.IO.File]::WriteAllText('));
       expect(script, contains(r'[System.Text.UTF8Encoding]::new($false)'));
     });
 
-    test('accepts both bridge-v and v release tags for backwards compatibility', () {
-      expect(script, contains(r"if ($tagName.StartsWith('bridge-v')) {"));
-      expect(script, contains(r'$versionText = $tagName.Substring(8)'));
-      expect(script, contains(r"} elseif ($tagName.StartsWith('v')) {"));
+    test('accepts only v release tags', () {
+      expect(script, contains(r"if ($tagName.StartsWith('v')) {"));
       expect(script, contains(r'$versionText = $tagName.Substring(1)'));
+      expect(script, isNot(contains('bridge-v')));
     });
   });
 }

--- a/bridge/app/test/tool/npm_wrapper_test.dart
+++ b/bridge/app/test/tool/npm_wrapper_test.dart
@@ -257,7 +257,7 @@ Future<String> _serveReleaseAssets({
   final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
   addTearDown(() => server.close(force: true));
   server.listen((request) async {
-    final expectedPrefix = '/releases/download/bridge-v$version/';
+    final expectedPrefix = '/releases/download/v$version/';
     if (!request.uri.path.startsWith(expectedPrefix)) {
       request.response.statusCode = HttpStatus.notFound;
       await request.response.close();
@@ -285,7 +285,7 @@ Future<String> _serveInvalidRedirectReleaseAssets({required String version}) asy
   final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
   addTearDown(() => server.close(force: true));
   server.listen((request) async {
-    final expectedPrefix = '/releases/download/bridge-v$version/';
+    final expectedPrefix = '/releases/download/v$version/';
     if (!request.uri.path.startsWith(expectedPrefix)) {
       request.response.statusCode = HttpStatus.notFound;
       await request.response.close();
@@ -510,7 +510,7 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       expect(result.exitCode, equals(1));
       expect(
         result.stderr,
-          contains('Failed to download managed runtime from GitHub release assets for bridge-v$wrapperVersion'),
+          contains('Failed to download managed runtime from GitHub release assets for v$wrapperVersion'),
       );
       expect(result.stderr, contains('Checksum mismatch for ${releaseAsset.assetName}'));
     });
@@ -531,7 +531,7 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       expect(result.exitCode, equals(1));
       expect(
         result.stderr,
-          contains('Failed to download managed runtime from GitHub release assets for bridge-v$wrapperVersion'),
+          contains('Failed to download managed runtime from GitHub release assets for v$wrapperVersion'),
       );
       expect(result.stderr, contains('Invalid redirect URL'));
     });

--- a/bridge/app/test/tool/sync_versions_test.dart
+++ b/bridge/app/test/tool/sync_versions_test.dart
@@ -90,7 +90,7 @@ resolution: workspace
         '@sesori/not-bridge': '4.5.6',
       },
       'sesoriBridge': <String, dynamic>{
-        'releaseTag': 'bridge-v$resolvedBridgeVersion',
+        'releaseTag': 'v$resolvedBridgeVersion',
         'runtimeBundleSource': 'github-release-assets',
       },
     },
@@ -103,7 +103,7 @@ resolution: workspace
         'name': '@sesori/${package.replaceFirst('sesori-bridge-', 'bridge-')}',
         'version': resolvedBridgeVersion,
         'sesoriBridge': <String, dynamic>{
-          'releaseTag': 'bridge-v$resolvedBridgeVersion',
+          'releaseTag': 'v$resolvedBridgeVersion',
         },
       },
     );
@@ -154,7 +154,7 @@ void main() {
       expect(patchResult.exitCode, equals(0), reason: '${patchResult.stdout}\n${patchResult.stderr}');
       expect(patchResult.stdout, contains('Target bridge version: 1.0.7'));
       expect(patchResult.stdout, contains('Target mobile version: 1.0.7+8'));
-      expect(patchResult.stdout, contains('Planned releaseTag: bridge-v1.0.7'));
+      expect(patchResult.stdout, contains('Planned releaseTag: v1.0.7'));
       expect(patchResult.stdout, contains('bridge/app/pubspec.yaml'));
       expect(patchResult.stdout, contains('mobile/app/pubspec.yaml'));
       expect(await File(currentFixture.bridgePubspecPath).readAsString(), equals(beforeBridgePubspec));
@@ -209,10 +209,10 @@ environment:
               '@sesori/bridge-win32-x64': '1.0.6',
               '@sesori/not-bridge': '4.5.6',
             },
-            'sesoriBridge': <String, dynamic>{
-              'releaseTag': 'bridge-v1.0.6',
-              'runtimeBundleSource': 'github-release-assets',
-            },
+        'sesoriBridge': <String, dynamic>{
+          'releaseTag': 'v1.0.6',
+          'runtimeBundleSource': 'github-release-assets',
+        },
           },
         );
         for (final packagePath in currentFixture.packagePaths) {
@@ -222,8 +222,8 @@ environment:
               'name': '@sesori/${p.basename(p.dirname(packagePath)).replaceFirst('sesori-bridge-', 'bridge-')}',
               'version': '1.0.6',
               'sesoriBridge': <String, dynamic>{
-                'releaseTag': 'bridge-v1.0.6',
-              },
+              'releaseTag': 'v1.0.6',
+            },
             },
           );
         }
@@ -241,7 +241,7 @@ environment:
         expect(bridgeVersion, equals("const String appVersion = '${testCase.bridgeVersion}';\n"));
         expect(mobilePubspec, contains('version: ${testCase.mobileVersion}'));
         expect(wrapperPackage['version'] as String, equals(testCase.bridgeVersion));
-        expect((wrapperPackage['sesoriBridge'] as Map<String, dynamic>)['releaseTag'], equals('bridge-v${testCase.bridgeVersion}'));
+        expect((wrapperPackage['sesoriBridge'] as Map<String, dynamic>)['releaseTag'], equals('v${testCase.bridgeVersion}'));
 
         final optionalDependencies = wrapperPackage['optionalDependencies'] as Map<String, dynamic>;
         expect(optionalDependencies['@sesori/bridge-darwin-arm64'], equals(testCase.bridgeVersion));
@@ -254,7 +254,7 @@ environment:
         for (final packagePath in currentFixture.packagePaths) {
           final package = await _readJson(path: packagePath);
           expect(package['version'], equals(testCase.bridgeVersion));
-          expect((package['sesoriBridge'] as Map<String, dynamic>)['releaseTag'], equals('bridge-v${testCase.bridgeVersion}'));
+          expect((package['sesoriBridge'] as Map<String, dynamic>)['releaseTag'], equals('v${testCase.bridgeVersion}'));
         }
       }
     });

--- a/bridge/app/test/updater/release_contract_test.dart
+++ b/bridge/app/test/updater/release_contract_test.dart
@@ -144,15 +144,14 @@ void main() {
       );
     });
 
-    test('install.sh encodes the same bridge-tagged asset and basename checksum contract', () async {
+    test('install.sh encodes the v-tagged asset and basename checksum contract', () async {
       final script = await _readRepoFile(relativePath: 'install.sh');
 
       expect(script, contains(r'GITHUB_RELEASES_API_URL="https://api.github.com/repos/${GITHUB_REPO}/releases"'));
       expect(script, contains('GITHUB_RELEASES_PER_PAGE=100'));
       expect(script, contains('GITHUB_RELEASES_MAX_PAGES=10'));
       expect(script, contains(r'?per_page=${GITHUB_RELEASES_PER_PAGE}&page=${page}'));
-      expect(script, contains('if tag_name.startswith("bridge-v"):'));
-      expect(script, contains('elif tag_name.startswith("v"):'));
+      expect(script, contains('if tag_name.startswith("v"):'));
       expect(script, contains('release.get("draft") or release.get("prerelease")'));
       expect(script, contains('eligible.sort('));
       expect(script, contains('asset_url = assets.get(filename)'));
@@ -163,7 +162,7 @@ void main() {
       );
     });
 
-    test('install.ps1 encodes the same bridge-tagged asset and basename checksum contract', () async {
+    test('install.ps1 encodes the v-tagged asset and basename checksum contract', () async {
       final script = await _readRepoFile(relativePath: 'install.ps1');
 
       expect(script, contains(r'$ReleasesApiUrl = "https://api.github.com/repos/$RepoOwner/$RepoName/releases"'));
@@ -182,14 +181,9 @@ void main() {
       final workflow = await _readRepoFile(relativePath: '.github/workflows/bridge-release.yml');
       final docs = await _readRepoFile(relativePath: 'bridge/RELEASING.md');
 
-      expect(workflow, contains('tags: ["bridge-v*"]'));
       expect(workflow, contains('workflow_dispatch:'));
       expect(workflow, contains('dry_run:'));
-      expect(
-        workflow,
-        contains("if: github.event.inputs.dry_run != 'true' && startsWith(github.ref_name, 'bridge-v')"),
-      );
-      expect(workflow, contains(r'RELEASE_TAG: ${{ github.ref_name }}'));
+      expect(workflow, contains('tag:'));
       expect(workflow, contains('needs: release'));
       expect(workflow, contains('id-token: write'));
       expect(workflow, contains('registry-url: "https://registry.npmjs.org"'));
@@ -208,14 +202,14 @@ void main() {
       expect(workflow, contains('Validate wrapper package metadata'));
       expect(workflow, isNot(contains('NPM_TOKEN')));
 
-      expect(docs, contains('## What the workflow does on tag push'));
+      expect(docs, contains('## What the workflow does on manual dispatch'));
       expect(docs, contains('6. publishes the five platform npm bootstrap packages from those tagged release assets'));
       expect(docs, contains('7. publishes the `@sesori/bridge` wrapper package through npm trusted publishing'));
       expect(docs, contains('gh workflow run bridge-release.yml -f dry_run=true'));
       expect(
         docs,
         contains(
-          'The tag-triggered workflow verifies the archived GitHub Release assets against `checksums.txt`, derives each platform npm payload from those exact release artifacts, and then publishes through npm trusted publishing on `ubuntu-latest`.',
+          'The workflow verifies the archived GitHub Release assets against `checksums.txt`, derives each platform npm payload from those exact release artifacts, and then publishes through npm trusted publishing on `ubuntu-latest`.',
         ),
       );
       expect(docs, contains('Use this sequence when you want to test the real packaged distribution flow end to end.'));
@@ -228,7 +222,7 @@ void main() {
       expect(
         docs,
         contains(
-          'The tag-triggered workflow verifies the archived GitHub Release assets against `checksums.txt`, derives each platform npm payload from those exact release artifacts, and then publishes through npm trusted publishing on `ubuntu-latest`.',
+          'The workflow verifies the archived GitHub Release assets against `checksums.txt`, derives each platform npm payload from those exact release artifacts, and then publishes through npm trusted publishing on `ubuntu-latest`.',
         ),
       );
     });
@@ -269,7 +263,7 @@ void main() {
           equals({
             'bootstrapOnly': true,
             'managedRuntimeOwner': false,
-            'releaseTag': 'bridge-v$appVersion',
+            'releaseTag': 'v$appVersion',
             'releaseArtifact': workflowAssets[packageName],
             'runtimeBundlePath': 'lib/runtime',
           }),
@@ -281,7 +275,7 @@ void main() {
         equals({
           'bootstrapOnly': true,
           'managedRuntimeOwner': false,
-            'releaseTag': 'bridge-v$appVersion',
+          'releaseTag': 'v$appVersion',
           'runtimeBundleSource': 'github-release-assets',
         }),
       );

--- a/bridge/app/test/updater/release_repository_test.dart
+++ b/bridge/app/test/updater/release_repository_test.dart
@@ -324,22 +324,6 @@ void main() {
         expect(await _makeRepository(httpClient: client).checkForNewerRelease(), isNull);
       });
 
-      test('bridge-v prefix is accepted during tag migration', () async {
-        final client = MockClient(
-          (_) async => http.Response(
-            jsonEncode([
-              _releaseJson(tagName: 'bridge-v0.3.0', version: '0.3.0'),
-            ]),
-            200,
-          ),
-        );
-
-        final result = await _makeRepository(httpClient: client).checkForNewerRelease();
-
-        expect(result, isNotNull);
-        expect(result!.version, equals('0.3.0'));
-      });
-
       test('generic exception from HTTP client → throws', () async {
         final client = MockClient((_) async => throw Exception('network error'));
 

--- a/bridge/app/test/version_test.dart
+++ b/bridge/app/test/version_test.dart
@@ -40,7 +40,7 @@ void main() {
         equals({
           'bootstrapOnly': true,
           'managedRuntimeOwner': false,
-          'releaseTag': 'bridge-v$appVersion',
+          'releaseTag': 'v$appVersion',
           'runtimeBundleSource': 'github-release-assets',
         }),
       );
@@ -68,7 +68,7 @@ void main() {
           equals({
             'bootstrapOnly': true,
             'managedRuntimeOwner': false,
-            'releaseTag': 'bridge-v$appVersion',
+            'releaseTag': 'v$appVersion',
             'releaseArtifact': {
               '@sesori/bridge-darwin-arm64': 'sesori-bridge-macos-arm64.tar.gz',
               '@sesori/bridge-darwin-x64': 'sesori-bridge-macos-x64.tar.gz',

--- a/bridge/app/tool/bump_version.dart
+++ b/bridge/app/tool/bump_version.dart
@@ -89,8 +89,8 @@ Future<void> updatePackageJson({
 
   if (json.containsKey('sesoriBridge')) {
     final metadata = json['sesoriBridge'] as Map<String, dynamic>;
-    if (metadata['releaseTag'] == 'bridge-v$oldVersion') {
-      metadata['releaseTag'] = 'bridge-v$newVersion';
+    if (metadata['releaseTag'] == 'v$oldVersion') {
+      metadata['releaseTag'] = 'v$newVersion';
     }
   }
 

--- a/install.ps1
+++ b/install.ps1
@@ -69,9 +69,7 @@ function Resolve-BridgeRelease {
     $eligible = @()
     foreach ($release in $releases) {
         $tagName = [string]$release.tag_name
-        if ($tagName.StartsWith('bridge-v')) {
-            $versionText = $tagName.Substring(8)
-        } elseif ($tagName.StartsWith('v')) {
+        if ($tagName.StartsWith('v')) {
             $versionText = $tagName.Substring(1)
         } else {
             continue
@@ -174,9 +172,7 @@ try {
     }
 
     $resolvedVersion = $Release.TagName
-    if ($resolvedVersion.StartsWith('bridge-v')) {
-        $resolvedVersion = $resolvedVersion.Substring(8)
-    } elseif ($resolvedVersion.StartsWith('v')) {
+    if ($resolvedVersion.StartsWith('v')) {
         $resolvedVersion = $resolvedVersion.Substring(1)
     }
     $managedManifestJson = @{ version = $resolvedVersion } | ConvertTo-Json -Compress

--- a/install.sh
+++ b/install.sh
@@ -149,9 +149,7 @@ releases = json.loads(os.environ["RELEASES_JSON"])
 eligible = []
 for release in releases:
     tag_name = release.get("tag_name", "")
-    if tag_name.startswith("bridge-v"):
-        version = tag_name.replace("bridge-v", "", 1)
-    elif tag_name.startswith("v"):
+    if tag_name.startswith("v"):
         version = tag_name.replace("v", "", 1)
     else:
         continue
@@ -353,8 +351,7 @@ main() {
     tar -xzf "${archive}" -C "${INSTALL_DIR}"
 
     chmod +x "${BINARY}"
-    resolved_version="${RESOLVED_RELEASE_TAG#bridge-v}"
-    resolved_version="${resolved_version#v}"
+    resolved_version="${RESOLVED_RELEASE_TAG#v}"
     printf '{"version":"%s"}\n' "${resolved_version}" > "${MANAGED_MANIFEST}"
 
     if [ "${os}" = "macos" ]; then

--- a/tool/sync_versions.dart
+++ b/tool/sync_versions.dart
@@ -105,9 +105,9 @@ Future<void> main(final List<String> args) async {
     ];
 
     if (parsed.dryRun) {
-      stdout.writeln('Target bridge version: $targetBridgeVersion');
-      stdout.writeln('Target mobile version: $targetMobileVersion');
-      stdout.writeln('Planned releaseTag: bridge-v$targetBridgeVersion');
+    stdout.writeln('Target bridge version: $targetBridgeVersion');
+    stdout.writeln('Target mobile version: $targetMobileVersion');
+    stdout.writeln('Planned releaseTag: v$targetBridgeVersion');
       stdout.writeln('Files that would change:');
       for (final relativePath in plannedPaths) {
         stdout.writeln('  - $relativePath');
@@ -368,7 +368,7 @@ Future<void> _writePackageJson({
   final sesoriBridge = decoded['sesoriBridge'];
   if (sesoriBridge is Map<String, dynamic> &&
       sesoriBridge.containsKey('releaseTag')) {
-    sesoriBridge['releaseTag'] = 'bridge-v$newVersion';
+    sesoriBridge['releaseTag'] = 'v$newVersion';
   }
 
   final formatted = const JsonEncoder.withIndent('  ').convert(decoded);


### PR DESCRIPTION
Removes  tag support and standardizes on  tags across the entire release pipeline.

### Changes
- **Install scripts** (, ): Only resolve  tagged releases. Removed  fallback.
- **Bridge release workflow** (): Removed automatic tag trigger. Now  only with a required  input.
- **Bridge updater** (): Only accepts  tags for update checks.
- **npm bootstrap** (): Fallback release tag changed from  to .
- **Version bump tools** (, ): Write  release tags to package manifests.
- **npm package manifests**: All 6  fields updated to  prefix.
- **Tests**: Updated across all test files to match new behavior.
- **Docs** (): Updated for  tags and manual dispatch workflow.

### Verification
- All 192 affected tests pass.
- Static analysis clean on changed Dart files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes Bridge releases on shared `v*` tags and removes `bridge-v*` compatibility. The release workflow is now manual-only with a required `tag` input.

- **Refactors**
  - Installers (`install.sh`, `install.ps1`) and the updater resolve only `v*` releases.
  - GitHub Actions (`.github/workflows/bridge-release.yml`) runs via `workflow_dispatch` with `tag`/`dry_run`; publish/version steps read `${{ github.event.inputs.tag }}` and strip `v`.
  - npm `releaseTag` defaults switched to `v` across all packages (including `@sesori/bridge`); wrapper runtime fallback now `v${version}`.
  - Version bump and sync tools write `v*` tags.
  - Tests and docs (including `.opencode` release skill) updated for `v*` and manual dispatch.

- **Migration**
  - Tag releases as `vX.Y.Z` (e.g., `v1.0.7`).
  - Run the “Bridge Release” workflow manually and set `tag` to that value.
  - Update any scripts or configs expecting `bridge-v*` to use `v*` (including `sesoriBridge.releaseTag`).

<sup>Written for commit 59336024773dda06f33962b8c25e534bfecfe1cc. Summary will update on new commits. <a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/178?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

