### PR TITLE
feat: Localize hardcoded UI strings in mobile app

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.14.28"
+        "@opencode-ai/plugin": "1.15.5"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -87,21 +87,25 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.14.28",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.14.28.tgz",
-      "integrity": "sha512-cHJo7t1jwrzbkIVmNgggdWh4cyOVGw5fnbSpuYeL6qwfmH3g/6YLWtw5ZYEP6detUkEebT08mHXDGmsMUpQa+A==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.15.5.tgz",
+      "integrity": "sha512-QvhrDLlQuLeFGET1zB2crMWPvou6PpAzYtKrbun9akWvaskyAcXIAVn3lNYX/InMcut5VzL6ERbPgvM7ucHfLA==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.14.28",
-        "effect": "4.0.0-beta.48",
+        "@opencode-ai/sdk": "1.15.5",
+        "effect": "4.0.0-beta.65",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.1.105",
-        "@opentui/solid": ">=0.1.105"
+        "@opentui/core": ">=0.2.14",
+        "@opentui/keymap": ">=0.2.14",
+        "@opentui/solid": ">=0.2.14"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/keymap": {
           "optional": true
         },
         "@opentui/solid": {
@@ -110,9 +114,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.14.28",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.14.28.tgz",
-      "integrity": "sha512-qRFJfD+Zdz3jHHSupW4F6Io1ZFrQ6gCRFlG50O6kEU9xRxrBpK0wGvP+Y5VwwvD/gH9WKMHYinlQpDVI9/lgJQ==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.15.5.tgz",
+      "integrity": "sha512-ozJuEmXzrOvia5n0L1KAuvpyf9ESGmTk1FiPhn0RK5X1whbzjlTXL0NAxqNCEkqETxL35jS1KHArEiTpvtJ6FQ==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"
@@ -149,9 +153,9 @@
       }
     },
     "node_modules/effect": {
-      "version": "4.0.0-beta.48",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.48.tgz",
-      "integrity": "sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==",
+      "version": "4.0.0-beta.65",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.65.tgz",
+      "integrity": "sha512-QYKvQPAj3CmtsvWkHQww15wX4KG2gNsszDWEcOO5sZCMknp66u6Si/Opmt3wwWCwsyvRmDAdIg+JIz5qzbbFIw==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
@@ -167,9 +171,9 @@
       }
     },
     "node_modules/fast-check": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.6.0.tgz",
-      "integrity": "sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
       "funding": [
         {
           "type": "individual",
@@ -216,9 +220,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/msgpackr": {
-      "version": "1.11.9",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.9.tgz",
-      "integrity": "sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==",
+      "version": "1.11.12",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.12.tgz",
+      "integrity": "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==",
       "license": "MIT",
       "optionalDependencies": {
         "msgpackr-extract": "^3.0.2"
@@ -323,9 +327,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.2.tgz",
+      "integrity": "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -351,9 +355,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/mobile/app/lib/core/extensions/build_context_x.dart
+++ b/mobile/app/lib/core/extensions/build_context_x.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:intl/intl.dart";
 
 import "../../l10n/app_localizations.dart";
 
@@ -21,5 +22,17 @@ extension BuildContextLocalization on BuildContext {
       throw StateError("AppLocalizations not found in BuildContext");
     }
     return localizations;
+  }
+
+  String formatTimestamp(int ms) {
+    final date = DateTime.fromMillisecondsSinceEpoch(ms);
+    final now = DateTime.now();
+    final diff = now.difference(date);
+
+    if (diff.inMinutes < 1) return loc.timestampJustNow;
+    if (diff.inHours < 1) return loc.timestampMinutesAgo(diff.inMinutes);
+    if (diff.inDays < 1) return loc.timestampHoursAgo(diff.inHours);
+    if (diff.inDays < 30) return loc.timestampDaysAgo(diff.inDays);
+    return DateFormat.yMd(loc.localeName).format(date);
   }
 }

--- a/mobile/app/lib/core/widgets/command_picker_sheet.dart
+++ b/mobile/app/lib/core/widgets/command_picker_sheet.dart
@@ -3,6 +3,7 @@ import "package:go_router/go_router.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_zyra/module_zyra.dart";
 
+import "../../l10n/app_localizations.dart";
 import "../extensions/build_context_x.dart";
 import "app_modal_bottom_sheet.dart";
 
@@ -56,11 +57,11 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
     }).toList();
   }
 
-  String _sourceLabel(CommandSource? source) => switch (source) {
-    CommandSource.command => "Command",
-    CommandSource.mcp => "MCP",
-    CommandSource.skill => "Skill",
-    CommandSource.unknown || null => "Custom",
+  String _sourceLabel(CommandSource? source, {required AppLocalizations loc}) => switch (source) {
+    CommandSource.command => loc.commandSourceCommand,
+    CommandSource.mcp => loc.commandSourceMcp,
+    CommandSource.skill => loc.commandSourceSkill,
+    CommandSource.unknown || null => loc.commandSourceCustom,
   };
 
   @override
@@ -166,7 +167,7 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
                       borderRadius: BorderRadius.circular(12),
                     ),
                     child: Text(
-                      _sourceLabel(command.source),
+                      _sourceLabel(command.source, loc: loc),
                       style: zyra.textTheme.textXs.medium.copyWith(
                         color: zyra.colors.textBrandPrimary,
                         fontWeight: FontWeight.w600,

--- a/mobile/app/lib/features/project_list/project_list_screen.dart
+++ b/mobile/app/lib/features/project_list/project_list_screen.dart
@@ -244,7 +244,7 @@ class _ProjectTile extends StatelessWidget {
           ),
           if (updatedAt != null)
             Text(
-              loc.projectListUpdated(_formatTimestamp(updatedAt)),
+              loc.projectListUpdated(_formatTimestamp(updatedAt, loc: loc)),
               style: zyra.textTheme.textXs.regular.copyWith(
                 color: zyra.colors.textSecondary,
               ),
@@ -277,15 +277,15 @@ class _ProjectTile extends StatelessWidget {
     );
   }
 
-  String _formatTimestamp(int ms) {
+  String _formatTimestamp(int ms, {required AppLocalizations loc}) {
     final date = DateTime.fromMillisecondsSinceEpoch(ms);
     final now = DateTime.now();
     final diff = now.difference(date);
 
-    if (diff.inMinutes < 1) return "just now";
-    if (diff.inHours < 1) return "${diff.inMinutes}m ago";
-    if (diff.inDays < 1) return "${diff.inHours}h ago";
-    if (diff.inDays < 30) return "${diff.inDays}d ago";
+    if (diff.inMinutes < 1) return loc.timestampJustNow;
+    if (diff.inHours < 1) return loc.timestampMinutesAgo(diff.inMinutes);
+    if (diff.inDays < 1) return loc.timestampHoursAgo(diff.inHours);
+    if (diff.inDays < 30) return loc.timestampDaysAgo(diff.inDays);
     return "${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}";
   }
 }

--- a/mobile/app/lib/features/project_list/project_list_screen.dart
+++ b/mobile/app/lib/features/project_list/project_list_screen.dart
@@ -244,7 +244,7 @@ class _ProjectTile extends StatelessWidget {
           ),
           if (updatedAt != null)
             Text(
-              loc.projectListUpdated(_formatTimestamp(updatedAt, loc: loc)),
+              loc.projectListUpdated(context.formatTimestamp(updatedAt)),
               style: zyra.textTheme.textXs.regular.copyWith(
                 color: zyra.colors.textSecondary,
               ),
@@ -277,17 +277,6 @@ class _ProjectTile extends StatelessWidget {
     );
   }
 
-  String _formatTimestamp(int ms, {required AppLocalizations loc}) {
-    final date = DateTime.fromMillisecondsSinceEpoch(ms);
-    final now = DateTime.now();
-    final diff = now.difference(date);
-
-    if (diff.inMinutes < 1) return loc.timestampJustNow;
-    if (diff.inHours < 1) return loc.timestampMinutesAgo(diff.inMinutes);
-    if (diff.inDays < 1) return loc.timestampHoursAgo(diff.inHours);
-    if (diff.inDays < 30) return loc.timestampDaysAgo(diff.inDays);
-    return "${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}";
-  }
 }
 
 class _ErrorView extends StatelessWidget {

--- a/mobile/app/lib/features/session_detail/widgets/agent_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/agent_part_widget.dart
@@ -1,6 +1,8 @@
 import "package:flutter/material.dart";
 import "package:theme_zyra/module_zyra.dart";
 
+import "../../../core/extensions/build_context_x.dart";
+
 class AgentPartWidget extends StatelessWidget {
   final String? agentName;
 
@@ -9,7 +11,8 @@ class AgentPartWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final zyra = context.zyra;
-    final label = agentName ?? "Agent";
+    final loc = context.loc;
+    final label = agentName ?? loc.sessionDetailAgentFallback;
 
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),

--- a/mobile/app/lib/features/session_detail/widgets/retry_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/retry_part_widget.dart
@@ -1,6 +1,8 @@
 import "package:flutter/material.dart";
 import "package:theme_zyra/module_zyra.dart";
 
+import "../../../core/extensions/build_context_x.dart";
+
 class RetryPartWidget extends StatelessWidget {
   final int? attempt;
   final String? retryError;
@@ -14,7 +16,8 @@ class RetryPartWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final zyra = context.zyra;
-    final label = StringBuffer("Retry");
+    final loc = context.loc;
+    final label = StringBuffer(loc.sessionDetailRetryLabel);
     if (attempt != null) {
       label.write(" #$attempt");
     }

--- a/mobile/app/lib/features/session_detail/widgets/session_detail_body.dart
+++ b/mobile/app/lib/features/session_detail/widgets/session_detail_body.dart
@@ -77,7 +77,7 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
         actions: [
           IconButton(
             icon: const Icon(Icons.difference_outlined),
-            tooltip: "File changes",
+            tooltip: loc.sessionDetailFileChangesTooltip,
             onPressed: () => context.pushRoute(
               AppRoute.sessionDiffs(
                 projectId: widget.projectId,

--- a/mobile/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
+++ b/mobile/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
@@ -6,6 +6,7 @@ import "package:theme_zyra/module_zyra.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/widgets/agent_model_buttons.dart";
+import "../../../l10n/app_localizations.dart";
 import "background_tasks_bar.dart";
 import "prompt_input.dart";
 import "session_detail_message_list.dart";
@@ -103,7 +104,7 @@ class SessionDetailLoadedView extends StatelessWidget {
             header: null,
             composerHeader: AgentModelButtons(
               availableVariants: state.availableVariants,
-              modelName: _resolveModelName(state),
+              modelName: _resolveModelName(state, loc: loc),
               selectedAgent: state.selectedAgent,
               selectedAgentModel: state.selectedAgentModel,
               onAgentTap: onOpenAgentPicker,
@@ -119,10 +120,10 @@ class SessionDetailLoadedView extends StatelessWidget {
     );
   }
 
-  String _resolveModelName(SessionDetailLoaded state) {
+  String _resolveModelName(SessionDetailLoaded state, {required AppLocalizations loc}) {
     final providerID = state.selectedAgentModel?.providerID;
     final modelID = state.selectedAgentModel?.modelID;
-    const fallback = 'Model';
+    final fallback = loc.sessionDetailModelFallback;
     if (providerID == null || modelID == null) return fallback;
     for (final provider in state.availableProviders) {
       if (provider.id == providerID) {

--- a/mobile/app/lib/features/session_diffs/session_diffs_screen.dart
+++ b/mobile/app/lib/features/session_diffs/session_diffs_screen.dart
@@ -225,10 +225,11 @@ class _SessionDiffsBodyState extends State<_SessionDiffsBody> {
   }
 
   Widget _buildSkippedPlaceholder(FileDiffSkipReason reason) {
+    final loc = context.loc;
     final message = switch (reason) {
-      FileDiffSkipReason.binary => "Binary file changed",
-      FileDiffSkipReason.tooLarge => "File diff too large to display",
-      FileDiffSkipReason.readError => "Could not read file",
+      FileDiffSkipReason.binary => loc.diffBinaryFileChanged,
+      FileDiffSkipReason.tooLarge => loc.diffFileTooLarge,
+      FileDiffSkipReason.readError => loc.diffCouldNotReadFile,
     };
     return Padding(
       padding: const EdgeInsets.all(16),

--- a/mobile/app/lib/features/session_list/session_list_widgets.dart
+++ b/mobile/app/lib/features/session_list/session_list_widgets.dart
@@ -61,7 +61,7 @@ class _SessionTile extends StatelessWidget {
           children: [
             if (updatedAt != null)
               Text(
-                loc.sessionListUpdated(_formatTimestamp(ms: updatedAt)),
+                loc.sessionListUpdated(_formatTimestamp(ms: updatedAt, loc: loc)),
                 style: context.zyra.textTheme.textXs.regular.copyWith(
                   color: context.zyra.colors.textSecondary,
                 ),
@@ -130,15 +130,15 @@ Widget _buildActivityRow({
   );
 }
 
-String _formatTimestamp({required int ms}) {
+String _formatTimestamp({required int ms, required AppLocalizations loc}) {
   final date = DateTime.fromMillisecondsSinceEpoch(ms);
   final now = DateTime.now();
   final diff = now.difference(date);
 
-  if (diff.inMinutes < 1) return "just now";
-  if (diff.inHours < 1) return "${diff.inMinutes}m ago";
-  if (diff.inDays < 1) return "${diff.inHours}h ago";
-  if (diff.inDays < 30) return "${diff.inDays}d ago";
+  if (diff.inMinutes < 1) return loc.timestampJustNow;
+  if (diff.inHours < 1) return loc.timestampMinutesAgo(diff.inMinutes);
+  if (diff.inDays < 1) return loc.timestampHoursAgo(diff.inHours);
+  if (diff.inDays < 30) return loc.timestampDaysAgo(diff.inDays);
   return "${date.year}-${date.month.toString().padLeft(2, "0")}-${date.day.toString().padLeft(2, "0")}";
 }
 

--- a/mobile/app/lib/features/session_list/session_list_widgets.dart
+++ b/mobile/app/lib/features/session_list/session_list_widgets.dart
@@ -61,7 +61,7 @@ class _SessionTile extends StatelessWidget {
           children: [
             if (updatedAt != null)
               Text(
-                loc.sessionListUpdated(_formatTimestamp(ms: updatedAt, loc: loc)),
+                loc.sessionListUpdated(context.formatTimestamp(updatedAt)),
                 style: context.zyra.textTheme.textXs.regular.copyWith(
                   color: context.zyra.colors.textSecondary,
                 ),
@@ -128,18 +128,6 @@ Widget _buildActivityRow({
       ],
     ],
   );
-}
-
-String _formatTimestamp({required int ms, required AppLocalizations loc}) {
-  final date = DateTime.fromMillisecondsSinceEpoch(ms);
-  final now = DateTime.now();
-  final diff = now.difference(date);
-
-  if (diff.inMinutes < 1) return loc.timestampJustNow;
-  if (diff.inHours < 1) return loc.timestampMinutesAgo(diff.inMinutes);
-  if (diff.inDays < 1) return loc.timestampHoursAgo(diff.inHours);
-  if (diff.inDays < 30) return loc.timestampDaysAgo(diff.inDays);
-  return "${date.year}-${date.month.toString().padLeft(2, "0")}-${date.day.toString().padLeft(2, "0")}";
 }
 
 class _StaleProjectView extends StatelessWidget {

--- a/mobile/app/lib/l10n/app_en.arb
+++ b/mobile/app/lib/l10n/app_en.arb
@@ -374,5 +374,41 @@
     "newSessionLoadingMessage1": "Warming up the engines…",
     "newSessionLoadingMessage2": "Generating session telemetry…",
     "newSessionLoadingMessage3": "Preparing for takeoff…",
-    "newSessionLaunchingInBackground": "Your new session will appear in the list once it's launched"
+    "newSessionLaunchingInBackground": "Your new session will appear in the list once it's launched",
+    "commandSourceCommand": "Command",
+    "commandSourceMcp": "MCP",
+    "commandSourceSkill": "Skill",
+    "commandSourceCustom": "Custom",
+    "sessionDetailFileChangesTooltip": "File changes",
+    "diffBinaryFileChanged": "Binary file changed",
+    "diffFileTooLarge": "File diff too large to display",
+    "diffCouldNotReadFile": "Could not read file",
+    "timestampJustNow": "just now",
+    "timestampMinutesAgo": "{minutes}m ago",
+    "@timestampMinutesAgo": {
+      "placeholders": {
+        "minutes": {
+          "type": "int"
+        }
+      }
+    },
+    "timestampHoursAgo": "{hours}h ago",
+    "@timestampHoursAgo": {
+      "placeholders": {
+        "hours": {
+          "type": "int"
+        }
+      }
+    },
+    "timestampDaysAgo": "{days}d ago",
+    "@timestampDaysAgo": {
+      "placeholders": {
+        "days": {
+          "type": "int"
+        }
+      }
+    },
+    "sessionDetailModelFallback": "Model",
+    "sessionDetailAgentFallback": "Agent",
+    "sessionDetailRetryLabel": "Retry"
 }

--- a/mobile/app/lib/l10n/app_localizations.dart
+++ b/mobile/app/lib/l10n/app_localizations.dart
@@ -1440,6 +1440,96 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Your new session will appear in the list once it\'s launched'**
   String get newSessionLaunchingInBackground;
+
+  /// No description provided for @commandSourceCommand.
+  ///
+  /// In en, this message translates to:
+  /// **'Command'**
+  String get commandSourceCommand;
+
+  /// No description provided for @commandSourceMcp.
+  ///
+  /// In en, this message translates to:
+  /// **'MCP'**
+  String get commandSourceMcp;
+
+  /// No description provided for @commandSourceSkill.
+  ///
+  /// In en, this message translates to:
+  /// **'Skill'**
+  String get commandSourceSkill;
+
+  /// No description provided for @commandSourceCustom.
+  ///
+  /// In en, this message translates to:
+  /// **'Custom'**
+  String get commandSourceCustom;
+
+  /// No description provided for @sessionDetailFileChangesTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'File changes'**
+  String get sessionDetailFileChangesTooltip;
+
+  /// No description provided for @diffBinaryFileChanged.
+  ///
+  /// In en, this message translates to:
+  /// **'Binary file changed'**
+  String get diffBinaryFileChanged;
+
+  /// No description provided for @diffFileTooLarge.
+  ///
+  /// In en, this message translates to:
+  /// **'File diff too large to display'**
+  String get diffFileTooLarge;
+
+  /// No description provided for @diffCouldNotReadFile.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not read file'**
+  String get diffCouldNotReadFile;
+
+  /// No description provided for @timestampJustNow.
+  ///
+  /// In en, this message translates to:
+  /// **'just now'**
+  String get timestampJustNow;
+
+  /// No description provided for @timestampMinutesAgo.
+  ///
+  /// In en, this message translates to:
+  /// **'{minutes}m ago'**
+  String timestampMinutesAgo(int minutes);
+
+  /// No description provided for @timestampHoursAgo.
+  ///
+  /// In en, this message translates to:
+  /// **'{hours}h ago'**
+  String timestampHoursAgo(int hours);
+
+  /// No description provided for @timestampDaysAgo.
+  ///
+  /// In en, this message translates to:
+  /// **'{days}d ago'**
+  String timestampDaysAgo(int days);
+
+  /// No description provided for @sessionDetailModelFallback.
+  ///
+  /// In en, this message translates to:
+  /// **'Model'**
+  String get sessionDetailModelFallback;
+
+  /// No description provided for @sessionDetailAgentFallback.
+  ///
+  /// In en, this message translates to:
+  /// **'Agent'**
+  String get sessionDetailAgentFallback;
+
+  /// No description provided for @sessionDetailRetryLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry'**
+  String get sessionDetailRetryLabel;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/mobile/app/lib/l10n/app_localizations_en.dart
+++ b/mobile/app/lib/l10n/app_localizations_en.dart
@@ -753,4 +753,55 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get newSessionLaunchingInBackground => 'Your new session will appear in the list once it\'s launched';
+
+  @override
+  String get commandSourceCommand => 'Command';
+
+  @override
+  String get commandSourceMcp => 'MCP';
+
+  @override
+  String get commandSourceSkill => 'Skill';
+
+  @override
+  String get commandSourceCustom => 'Custom';
+
+  @override
+  String get sessionDetailFileChangesTooltip => 'File changes';
+
+  @override
+  String get diffBinaryFileChanged => 'Binary file changed';
+
+  @override
+  String get diffFileTooLarge => 'File diff too large to display';
+
+  @override
+  String get diffCouldNotReadFile => 'Could not read file';
+
+  @override
+  String get timestampJustNow => 'just now';
+
+  @override
+  String timestampMinutesAgo(int minutes) {
+    return '${minutes}m ago';
+  }
+
+  @override
+  String timestampHoursAgo(int hours) {
+    return '${hours}h ago';
+  }
+
+  @override
+  String timestampDaysAgo(int days) {
+    return '${days}d ago';
+  }
+
+  @override
+  String get sessionDetailModelFallback => 'Model';
+
+  @override
+  String get sessionDetailAgentFallback => 'Agent';
+
+  @override
+  String get sessionDetailRetryLabel => 'Retry';
 }


### PR DESCRIPTION
- app_localizations_en.dart (generated)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized hardcoded UI strings across the mobile app and routed them through the `l10n` system (`AppLocalizations`). Added a shared, locale-aware timestamp formatter to standardize relative dates.

- **Refactors**
  - Added localization keys for command sources, relative timestamps, diff messages, tooltips, and agent/model/retry fallbacks in `app_en.arb`.
  - Replaced inline strings in the command picker, project/session lists, session detail, and diffs with `context.loc`.
  - Extracted `context.formatTimestamp()` and used `DateFormat.yMd(loc.localeName)` for long dates; removed duplicate helpers.
  - Regenerated `app_localizations.dart` and `app_localizations_en.dart`.

<sup>Written for commit ff0b565dcc74f30ce80afc3adc8bff9fb4abbcfe. Summary will update on new commits. <a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/180?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

