### PR TITLE
Fix iOS Debug code-signing identity for device builds

### DIFF
--- a/mobile/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/app/ios/Runner.xcodeproj/project.pbxproj
@@ -579,7 +579,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = Sesori;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Development";
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = AQNCF7663C;
 				ENABLE_BITCODE = NO;


### PR DESCRIPTION
The Runner target uses automatic signing, which produces an Apple Development certificate for device debug builds. However, the Debug build configuration hardcoded `CODE_SIGN_IDENTITY[sdk=iphoneos*] = "Apple Distribution"`, causing a conflict:

> Runner has conflicting provisioning settings. Runner is automatically signed for development, but a conflicting code signing identity Apple Distribution has been manually specified.

**Fix:** Change the Debug configuration's code-signing identity to `Apple Development` in `mobile/app/ios/Runner.xcodeproj/project.pbxproj`.

- Only the Debug block (identified by `CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements`) is changed.
- Release and Profile configurations intentionally keep `Apple Distribution` for TestFlight / App Store distribution builds.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS device Debug builds by aligning code signing with automatic development signing. Updates the Debug code-signing identity to Apple Development to remove the conflict.

Changed only the Debug configuration in `mobile/app/ios/Runner.xcodeproj/project.pbxproj`; Release and Profile stay Apple Distribution for distribution builds.

<sup>Written for commit f988c026f5ced6f23bdd581cb14e4242fbb92982. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/183?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

