### PR TITLE
chore: use static store release notes across all submission tracks

### DIFF
--- a/mobile/app/android/fastlane/Fastfile
+++ b/mobile/app/android/fastlane/Fastfile
@@ -94,6 +94,16 @@ platform :android do
     version_match ? version_match[1] : "1.0.0"
   end
 
+  # Reads the static, user-facing release notes shared across both platforms.
+  # Single source of truth lives at mobile/app/store_release_notes.txt so the
+  # Play Store copy never drifts from the App Store copy. Anchored to __dir__
+  # (the fastlane folder) so the path is correct regardless of cwd.
+  private_lane :_static_release_notes do
+    notes_path = File.expand_path("../../store_release_notes.txt", __dir__)
+    UI.user_error!("Release notes file not found at #{notes_path}") unless File.exist?(notes_path)
+    File.read(notes_path).strip
+  end
+
   desc "Print the next Google Play version code without building or uploading"
   lane :next_version_code do
     version_codes = _get_all_version_codes
@@ -158,18 +168,17 @@ platform :android do
         UI.user_error!("AAB not found at #{aab_path} after build.")
       end
 
-      # Embed the short commit SHA in the Play Console release notes so the
-      # originating commit survives even if the matching `build-<N>`
-      # git tag is ever lost — operators can recover it from Play Console.
+      # Write the static, user-facing release notes (shared with the App Store
+      # via store_release_notes.txt) for this version code. These notes carry
+      # over to beta/production when submit_android promotes the release.
       # Supply expects metadata_path to point directly at the directory
       # containing locale folders, i.e. `<metadata_path>/<lang>/changelogs/<versionCode>.txt`.
-      short_sha = ENV.fetch("GITHUB_SHA", `git rev-parse HEAD`.strip)[0, 7]
       metadata_path = File.expand_path("metadata/android", __dir__)
       changelog_dir = File.join(metadata_path, "en-US", "changelogs")
       FileUtils.mkdir_p(changelog_dir)
       File.write(
         File.join(changelog_dir, "#{new_build_number}.txt"),
-        "Internal build #{new_build_number} (v#{version_name})\ncommit: #{short_sha}\n"
+        "#{_static_release_notes}\n"
       )
 
       upload_to_play_store(

--- a/mobile/app/ios/fastlane/Fastfile
+++ b/mobile/app/ios/fastlane/Fastfile
@@ -51,6 +51,16 @@ platform :ios do
     version_match ? version_match[1] : "1.0.0"
   end
 
+  # Reads the static, user-facing release notes shared across both platforms.
+  # Single source of truth lives at mobile/app/store_release_notes.txt so the
+  # TestFlight / App Store copy never drifts from the Play Store copy. Anchored
+  # to __dir__ (the fastlane folder) so the path is correct regardless of cwd.
+  private_lane :_static_release_notes do
+    notes_path = File.expand_path("../../store_release_notes.txt", __dir__)
+    UI.user_error!("Release notes file not found at #{notes_path}") unless File.exist?(notes_path)
+    File.read(notes_path).strip
+  end
+
   desc "Print the next TestFlight build number without building or uploading"
   lane :next_build_number do
     api_key = app_store_connect_api_key(
@@ -142,16 +152,15 @@ platform :ios do
       output_name: "Runner.ipa"
     )
 
-    # Upload to TestFlight. Embed the short commit SHA in the TestFlight
-    # "What to Test" notes so it survives even if the matching `build-<N>`
-    # git tag is ever lost — operators can recover the originating commit by
-    # opening the build in App Store Connect.
-    short_sha = ENV.fetch("GITHUB_SHA", `git rev-parse HEAD`.strip)[0, 7]
+    # Upload to TestFlight. Testers see the static, user-facing release notes
+    # shared with the App Store and Play Store (store_release_notes.txt). Build
+    # number → commit stays recoverable from the `build-<N>` git tag pushed by
+    # release-all-platforms.yml and the submit workflow's CI step summary.
     upload_to_testflight(
       api_key: api_key,
       skip_waiting_for_build_processing: true,
       wait_for_uploaded_build: false,
-      changelog: "Build #{new_build_number} (v#{version}) commit=#{short_sha}"
+      changelog: _static_release_notes
     )
 
     # Write build info for CI summary
@@ -215,7 +224,7 @@ platform :ios do
         skip_waiting_for_build_processing: true,
         distribute_external: true,
         groups: ENV.fetch("TESTFLIGHT_EXTERNAL_GROUPS", "External Beta").split(",").map(&:strip).reject(&:empty?),
-        changelog: "Promoted build #{build_number} (v#{version}) to external beta"
+        changelog: _static_release_notes
       )
     end
 

--- a/mobile/app/store_release_notes.txt
+++ b/mobile/app/store_release_notes.txt
@@ -1,0 +1,3 @@
+We've made improvements behind the scenes for a smoother Sesori experience.
+
+Love Sesori? Please leave a review and let us know what you think.


### PR DESCRIPTION
## What

Adds a single source-of-truth release-notes file — `mobile/app/store_release_notes.txt` — and wires it into both Fastlane pipelines via a shared `_static_release_notes` helper, so the App Store and Play Store copy can never drift.

The static copy:

> We've made improvements behind the scenes for a smoother Sesori experience.
>
> Love Sesori? Please leave a review and let us know what you think.

## Coverage

| Surface | Lane | Result |
|---|---|---|
| iOS TestFlight (internal beta "What to Test") | `deploy_testflight` → `upload_to_testflight` | static copy ✅ |
| iOS external beta | `submit_ios` beta → `pilot` | static copy ✅ |
| iOS App Store **production** | `submit_ios` production → `deliver` | **unchanged** — `skip_metadata: true`, still managed manually in App Store Connect |
| Play Store internal → **beta & production** | `deploy_internal` writes the changelog; `submit_android` promotes it (`skip_upload_changelogs: true`) | static copy carries over ✅ |

## Notes

- Replaces the previous build-number + git-commit-SHA traceability lines in the beta/internal notes. That mapping stays recoverable via the `build-<N>` git tags pushed by `release-all-platforms.yml` and the commit SHA in the submit workflow's CI step summary.
- iOS App Store production "What's New" is intentionally left manual per the agreed scope.

## Verification

- Both Fastfiles pass `ruby -c`.
- No orphaned references to the old changelog strings remain.
- Android beta/production carry-over relies on `track_promote_to` forwarding existing release notes (documented Fastlane behavior); not exercised against a live promotion in this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized release notes in `mobile/app/store_release_notes.txt` and applied them across iOS and Android Fastlane lanes to keep store copy in sync. iOS App Store production “What’s New” remains manual.

- **Refactors**
  - Added `_static_release_notes` helper in both Fastfiles to read the shared file.
  - Used the static notes for TestFlight (`deploy_testflight`), iOS external beta (`submit_ios` via `pilot`), and Play Store internal changelogs (`deploy_internal`) that carry to beta/production on promotion.
  - Left iOS App Store production unchanged (`skip_metadata: true`).
  - Removed commit SHA/build-number lines from beta/internal notes; traceability remains via `build-<N>` tags and the submit workflow CI summary.

<sup>Written for commit a84f994c13e1516bd606041b2b3818ef9340adbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

