### PR TITLE
fix: model picker list clipped above the home indicator

### DIFF
--- a/mobile/app/lib/core/widgets/app_modal_bottom_sheet.dart
+++ b/mobile/app/lib/core/widgets/app_modal_bottom_sheet.dart
@@ -9,18 +9,26 @@ import "package:flutter/material.dart";
 ///
 /// Callers do **not** need to wrap their content in [SafeArea] or manually pad
 /// for the keyboard.
+///
+/// Set [handleBottomSafeArea] to `false` for sheets whose content scrolls to the
+/// bottom edge (e.g. a full-height list). The keyboard inset is still applied,
+/// but the home-indicator inset is left for the content to consume as scroll
+/// padding, so the list can scroll underneath the indicator instead of being
+/// clipped above it.
 // ignore: no_slop_linter/prefer_required_named_parameters, backgroundColor is intentionally optional for sheet defaults
 Future<T?> showAppModalBottomSheet<T>({
   required BuildContext context,
   required WidgetBuilder builder,
   bool isScrollControlled = false,
   Color? backgroundColor,
+  bool handleBottomSafeArea = true,
 }) {
   return showModalBottomSheet<T>(
     context: context,
     isScrollControlled: isScrollControlled,
     backgroundColor: backgroundColor,
     builder: (sheetContext) => _ModalSafeArea(
+      handleBottomSafeArea: handleBottomSafeArea,
       child: builder(sheetContext),
     ),
   );
@@ -33,8 +41,9 @@ Future<T?> showAppModalBottomSheet<T>({
 /// accessors so that the widget only rebuilds when the relevant values change.
 class _ModalSafeArea extends StatelessWidget {
   final Widget child;
+  final bool handleBottomSafeArea;
 
-  const _ModalSafeArea({required this.child});
+  const _ModalSafeArea({required this.child, this.handleBottomSafeArea = true});
 
   @override
   Widget build(BuildContext context) {
@@ -43,8 +52,12 @@ class _ModalSafeArea extends StatelessWidget {
 
     // When the keyboard is up its height already covers the home-indicator
     // region, so we only need the keyboard inset. When the keyboard is hidden
-    // we fall back to the safe-area bottom padding.
-    final bottomPadding = viewInsets.bottom > 0 ? viewInsets.bottom : viewPadding.bottom;
+    // we fall back to the safe-area bottom padding — unless the sheet content
+    // manages the bottom inset itself (handleBottomSafeArea: false), in which
+    // case we leave that region for the content to fill.
+    final bottomPadding = viewInsets.bottom > 0
+        ? viewInsets.bottom
+        : (handleBottomSafeArea ? viewPadding.bottom : 0.0);
 
     return Padding(
       padding: EdgeInsetsDirectional.only(bottom: bottomPadding),

--- a/mobile/app/lib/core/widgets/model_picker_sheet.dart
+++ b/mobile/app/lib/core/widgets/model_picker_sheet.dart
@@ -33,6 +33,10 @@ class ModelPickerSheet extends StatefulWidget {
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
+      // The model list scrolls to the bottom edge, so it consumes the
+      // home-indicator inset as scroll padding (see the ListView below) rather
+      // than having the whole sheet lifted above the indicator.
+      handleBottomSafeArea: false,
       builder: (sheetContext) {
         final height = MediaQuery.sizeOf(sheetContext).height * 0.7;
         final zyra = sheetContext.zyra;
@@ -158,7 +162,10 @@ class _ModelPickerSheetState extends State<ModelPickerSheet> {
         const SizedBox(height: 4),
         Expanded(
           child: ListView(
-            padding: .zero,
+            // Extend the scrollable area underneath the home indicator: the
+            // bottom inset is added as scroll padding so the last model can
+            // scroll clear of the indicator instead of being clipped above it.
+            padding: EdgeInsetsDirectional.only(bottom: MediaQuery.paddingOf(context).bottom),
             children: [
               for (final provider in _sortedProviders) ..._buildProviderSection(provider: provider, context: context),
             ],


### PR DESCRIPTION
## Problem

On the model picker bottom sheet (`ModelPickerSheet`), the list of models was clipped at the **top of the home indicator** on devices with a home indicator (e.g. iPhone 15 Pro Max), with empty space below the sheet. The last models could not be scrolled clear of the indicator.

## Root cause

`showAppModalBottomSheet` wraps every sheet in `_ModalSafeArea`, which applies a bottom `Padding` equal to the home-indicator inset. That lifted the **entire** sheet container above the indicator, so:

1. The fixed-height container no longer reached the screen's bottom edge → empty gap below the sheet.
2. The `ListView` viewport ended at the top of the indicator → last models clipped, unable to scroll into that region.

## Fix

- **`app_modal_bottom_sheet.dart`**: added a `handleBottomSafeArea` flag (default `true`, so all existing sheets are unaffected). When `false`, the keyboard inset is still applied, but the home-indicator inset is left for the content to consume.
- **`model_picker_sheet.dart`**: pass `handleBottomSafeArea: false` so the sheet sits flush to the bottom edge, and feed the home-indicator inset into the `ListView` as **scroll padding** (`EdgeInsetsDirectional.only(bottom: MediaQuery.paddingOf(context).bottom)`). The list now scrolls underneath the indicator and the last model clears it. Also reverted a debug `Colors.red` background back to `Colors.transparent`.

`MediaQuery.paddingOf(context).bottom` collapses to `0` when the keyboard is up, so the search-field keyboard flow is preserved (the wrapper lifts the sheet above the keyboard as before).

## Testing

- `flutter analyze` on both changed files: no issues.
- Not yet visually verified on a simulator/device — recommend a quick check on iPhone 15 Pro Max.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the model picker’s bottom sheet so the list no longer gets clipped above the home indicator on modern iPhones. The sheet now sits flush to the bottom, and the list scrolls under the indicator.

- **Bug Fixes**
  - Added `handleBottomSafeArea` to `showAppModalBottomSheet` (default `true`) so sheets can opt out of bottom safe-area padding.
  - Set `handleBottomSafeArea: false` in `ModelPickerSheet` and added `MediaQuery.paddingOf(context).bottom` as `ListView` scroll padding.
  - Keeps keyboard inset handling; no behavior change for other sheets.

<sup>Written for commit afc455ce63ed55265feef8fe2004c0cc1c434979. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

