### PR TITLE
chore: weekly dependency update (2026-06-02)

### DIFF
--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   args: ^2.6.0
-  cryptography: ^2.7.0
+  cryptography: ^2.9.0
   web_socket_channel: ^3.0.0
   http: ^1.3.0
   crypto: ^3.0.0
@@ -18,7 +18,7 @@ dependencies:
     path: ../../shared/sesori_shared
   clock: ^1.1.2
   freezed_annotation: ^3.1.0
-  json_annotation: ^4.11.0
+  json_annotation: ^4.12.0
   rxdart: ^0.28.0
   sesori_plugin_interface:
     path: ../sesori_plugin_interface
@@ -36,5 +36,5 @@ dev_dependencies:
   fake_async: ^1.3.3
   build_runner: any
   freezed: ^3.2.5
-  json_serializable: ^6.13.0
+  json_serializable: ^6.14.0
   drift_dev: ^2.32.1

--- a/bridge/pubspec.lock
+++ b/bridge/pubspec.lock
@@ -133,10 +133,10 @@ packages:
     dependency: transitive
     description:
       name: code_assets
-      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
+      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.1"
   collection:
     dependency: transitive
     description:
@@ -285,10 +285,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
+      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "2.0.2"
   http:
     dependency: transitive
     description:
@@ -381,10 +381,10 @@ packages:
     dependency: transitive
     description:
       name: native_toolchain_c
-      sha256: "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572"
+      sha256: f59351d28f49520cd3a74eb1f41c5f19ae15e53c65a3231d14af672e46510a96
       url: "https://pub.dev"
     source: hosted
-    version: "0.17.6"
+    version: "0.19.1"
   node_preamble:
     dependency: transitive
     description:
@@ -540,10 +540,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "56da3e13ed7d28a66f930aa2b2b29db6736a233f08283326e96321dd812030f5"
+      sha256: "9488c7d2cdb1091c91cacf7e207cff81b28bff8e366f042bad3afe7d34afe189"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.1"
+    version: "3.3.2"
   sqlparser:
     dependency: transitive
     description:

--- a/bridge/sesori_plugin_interface/pubspec.yaml
+++ b/bridge/sesori_plugin_interface/pubspec.yaml
@@ -8,11 +8,11 @@ environment:
 
 dependencies:
   freezed_annotation: ^3.1.0
-  json_annotation: ^4.11.0
+  json_annotation: ^4.12.0
   meta: ^1.0.0
 
 dev_dependencies:
   lints: ^6.1.0
   freezed: ^3.2.5
-  json_serializable: ^6.13.0
+  json_serializable: ^6.14.0
   build_runner: any

--- a/bridge/sesori_plugin_opencode/pubspec.yaml
+++ b/bridge/sesori_plugin_opencode/pubspec.yaml
@@ -13,11 +13,11 @@ dependencies:
     path: ../../shared/sesori_shared
   http: ^1.3.0
   freezed_annotation: ^3.1.0
-  json_annotation: ^4.11.0
+  json_annotation: ^4.12.0
 
 dev_dependencies:
   build_runner: any
   freezed: ^3.2.5
-  json_serializable: ^6.13.0
+  json_serializable: ^6.14.0
   test: ^1.25.0
   lints: ^6.1.0

--- a/mobile/app/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/app/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "46579c364d39b86ec9fb8f613e19f023700a929c",
-        "version" : "12.12.1"
+        "revision" : "8d5b4189f1f482df8d5c58c9985ea70491ef5382",
+        "version" : "12.14.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
       "state" : {
-        "revision" : "19dffda9a9caf8d86570ff846535902d8509d7bf",
-        "version" : "3.5.0"
+        "revision" : "9bfcc6cf435b2e7c5562c1900b8680c594fa9a64",
+        "version" : "3.6.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "5100f946bd32778662047a823bf145c6da32d85d",
-        "version" : "12.12.1"
+        "revision" : "219e564a8510e983e675c94f77f7f7c50049f22d",
+        "version" : "12.14.0"
       }
     },
     {

--- a/mobile/app/pubspec.yaml
+++ b/mobile/app/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   cupertino_icons: ^1.0.9
   http: ^1.6.0
   freezed_annotation: ^3.1.0
-  json_annotation: ^4.11.0
+  json_annotation: ^4.12.0
   collection: ^1.19.1
   rxdart: ^0.28.0
   flutter_bloc: ^9.1.1
@@ -85,7 +85,7 @@ dev_dependencies:
   no_slop_linter:
     path: "../../shared/no_slop_linter"
   freezed: ^3.2.5
-  json_serializable: ^6.13.1
+  json_serializable: ^6.14.0
   injectable_generator: ^3.0.2
   bloc_test: ^10.0.0
   build_runner: any

--- a/mobile/module_auth/pubspec.yaml
+++ b/mobile/module_auth/pubspec.yaml
@@ -8,12 +8,12 @@ environment:
   sdk: ^3.11.5
 
 dependencies:
-  cryptography: ^2.8.1
+  cryptography: ^2.9.0
   freezed_annotation: ^3.1.0
   get_it: ^9.2.1
   http: ^1.6.0
   injectable: ^3.0.0
-  json_annotation: ^4.11.0
+  json_annotation: ^4.12.0
   meta: ^1.16.0
   rxdart: ^0.28.0
   sesori_shared:
@@ -26,6 +26,6 @@ dev_dependencies:
   fake_async: ^1.3.3
   freezed: ^3.2.5
   injectable_generator: ^3.0.2
-  json_serializable: ^6.13.0
+  json_serializable: ^6.14.0
   mocktail: ^1.0.4
   test: ^1.25.0

--- a/mobile/module_core/pubspec.yaml
+++ b/mobile/module_core/pubspec.yaml
@@ -11,13 +11,13 @@ dependencies:
   bloc: ^9.0.0
   collection: ^1.19.1
   diff_match_patch: ^0.4.1
-  cryptography: ^2.8.1
+  cryptography: ^2.9.0
   freezed_annotation: ^3.1.0
   get_it: ^9.2.1
   http: ^1.6.0
   injectable: ^3.0.0
   intl: any
-  json_annotation: ^4.11.0
+  json_annotation: ^4.12.0
   meta: ^1.16.0
   rxdart: ^0.28.0
   sesori_auth:
@@ -33,7 +33,7 @@ dev_dependencies:
   build_runner: any
   freezed: ^3.2.5
   injectable_generator: ^3.0.2
-  json_serializable: ^6.13.0
+  json_serializable: ^6.14.0
   mocktail: ^1.0.4
   test: ^1.25.0
   fake_async: ^1.3.3

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -633,10 +633,10 @@ packages:
     dependency: transitive
     description:
       name: go_router
-      sha256: "92d8cee7c57dff0a6c409c05597b460002434eccf7424a712283225b3962d03f"
+      sha256: "5922b2861e2235a3504896f0d6fa07d84141b480cf52eecd2f42cd25585a9e8a"
       url: "https://pub.dev"
     source: hosted
-    version: "17.2.3"
+    version: "17.3.0"
   graphs:
     dependency: transitive
     description:

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "8f89e371e2883de35cdc78f648e725fa4da5f3b6c927269f00fa68f1ea92b598"
+      sha256: "0d1f0adfabbab9f46a1a80ce84a4d8b852b6e4dbf53ce413b30e0cf7d3631b71"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.71"
+    version: "1.3.72"
   analysis_server_plugin:
     dependency: transitive
     description:
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: code_assets
-      sha256: dad6bf6b9f4f378b0a69edbf42584d336efd1a9ce15deb1ba591cbb1b5ff440f
+      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.1"
   code_builder:
     dependency: transitive
     description:
@@ -357,34 +357,34 @@ packages:
     dependency: transitive
     description:
       name: firebase_analytics
-      sha256: "56641bc6dd7b6a8c63ad5f5d46664af5b66db452f1c5ad052b1eec0188cf3183"
+      sha256: "1f68d8a30265149035e9bb0b73962e43f3bf2debef4a7ae2d1d588361d5858a9"
       url: "https://pub.dev"
     source: hosted
-    version: "12.4.1"
+    version: "12.4.2"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
-      sha256: "432492ba57024a35dfb67ebcf0c64bac31e19d2c46b3dd222bccbc05f8839efe"
+      sha256: "65f97fb923f036d487aa95be99eab90e0f8f636e4783c94deeb52c0e6f5dbae7"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.1"
+    version: "6.0.2"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
-      sha256: e613fca6511ab8f13adb355f7bc486c49fa6aea72fb6703cfb34df29b3b568a6
+      sha256: ec49a95c6abaadbd6a4327cc2680d911f86e62fdf6f2c96a3a326603410e2abf
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1+7"
+    version: "0.6.1+8"
   firebase_core:
     dependency: transitive
     description:
       name: firebase_core
-      sha256: "93a5bde9775fd5adcc937f39dfa04ae0bc89c4d79bea6abc49de3f7b049d9ff6"
+      sha256: ec46a100a560d3bd5f97f2d89ba7492cb09b6dd0a4a28753d1258f360d6bd9f9
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.10.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -397,50 +397,50 @@ packages:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "7c98f10b8c8e5adedc0b810b66a877120696675e2c22d9ca9caca092da0d9e57"
+      sha256: "5ad1be848692ec148f2d6a8ad2a3838cb852ea5f3c9e6479a7afce479e1854f8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.7.0"
+    version: "3.8.0"
   firebase_crashlytics:
     dependency: transitive
     description:
       name: firebase_crashlytics
-      sha256: "9935ea36aaae0dfc789b80a1981fd70c6c7e9956791e9e7c2210ab83f9c963bd"
+      sha256: "5d111db2b40426e76e2da95d133c19a9dbcf6500c4e9b3785c68da51fb3f6602"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.2"
+    version: "5.2.3"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
-      sha256: ade20d7d86698ded596bf16ab0e7060ef1dae9258ab6705536a39ae047ccef59
+      sha256: "5bf4a83a1b9e0a5218f6d6491227440dd659242a55b16c279de0b8839791539a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.22"
+    version: "3.8.23"
   firebase_messaging:
     dependency: transitive
     description:
       name: firebase_messaging
-      sha256: "8d0dc81a31cd030170508dc3e89bfd14355b20a1b991340af5f018e37daab5d7"
+      sha256: "9651e833454156b9f0927eaedccffba0f7f6a6e20ceddef82517211e7017e9c4"
       url: "https://pub.dev"
     source: hosted
-    version: "16.2.2"
+    version: "16.3.0"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: "37abb0b0535c5497605ee94c12470e1ebbbe47e71a22d0c20bffcc912311f8cb"
+      sha256: "292bb5dc9c4a429078895406c347d7c7690deb858c1adeed8f4b4346f769dfa3"
       url: "https://pub.dev"
     source: hosted
-    version: "4.7.11"
+    version: "4.8.0"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: "54e22b43e2c26a2728a3f68c188de0f9011993ae19ae959a06d476dad935c776"
+      sha256: "08c565bc83729439f5de2dfea77b4832002b705eb2f840366cefa80e4e5c3c66"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.7"
+    version: "4.2.0"
   fixnum:
     dependency: transitive
     description:
@@ -527,10 +527,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage
-      sha256: d2a6ac2df7353f5ca47eb159a5407c1dba7ec48ca0e02dc38c9ff4d29447b261
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.0"
+    version: "10.3.1"
   flutter_secure_storage_darwin:
     dependency: transitive
     description:
@@ -657,10 +657,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: a41af4e8fc687cd6d33de9751eb936c8c0204ebe2bcb6c15ecf707504bf47f31
+      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.2"
   hotreloader:
     dependency: transitive
     description:
@@ -1191,10 +1191,10 @@ packages:
     dependency: transitive
     description:
       name: sign_in_with_apple
-      sha256: "5568378c3cc5993931955357d85e4c3344fa4365006915bdef965fa3de1dc0a5"
+      sha256: d284f8e235ab0c5be09a1e9146466912bae8f15f0bd5eb3c4cb999b57cd5c3f9
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "8.1.0"
   sign_in_with_apple_platform_interface:
     dependency: transitive
     description:
@@ -1436,10 +1436,10 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: b9b3f391857781aa96acacef96066f2f49b4cd03cf9fce3ca4d8da2ef5ea129e
+      sha256: "7ee12e6dffe0fc8e755179d6d91b3b34f5924223fc104d85572ef9180d73d172"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.2.5"
   vector_math:
     dependency: transitive
     description:

--- a/shared/sesori_shared/pubspec.yaml
+++ b/shared/sesori_shared/pubspec.yaml
@@ -9,13 +9,13 @@ environment:
 dependencies:
   cryptography: ^2.9.0
   freezed_annotation: ^3.1.0
-  json_annotation: ^4.11.0
-  collection: ^1.19.0
+  json_annotation: ^4.12.0
+  collection: ^1.19.1
   rxdart: ^0.28.0
 
 dev_dependencies:
   build_runner: any
   freezed: ^3.2.5
-  json_serializable: ^6.13.1
+  json_serializable: ^6.14.0
   lints: any
   test: any


### PR DESCRIPTION
## Summary

Automated weekly dependency update. Branch is based on the latest `upstream/main` (`e48db19`).

Bumped direct dependency constraints to the latest **resolvable** versions and regenerated the bridge + mobile workspace lockfiles. The standalone `sesori_shared` lockfile already pinned the latest versions, so only its constraints changed.

### Direct constraint bumps
| Package | From | To | Packages |
|---|---|---|---|
| `json_annotation` | `^4.11.0` | `^4.12.0` | shared, bridge/*, mobile/* |
| `json_serializable` | `^6.13.0` / `^6.13.1` | `^6.14.0` | shared, bridge/*, mobile/* |
| `collection` | `^1.19.0` | `^1.19.1` | sesori_shared |
| `cryptography` | `^2.7.0` / `^2.8.1` | `^2.9.0` | bridge/app, module_auth, module_core |

Plus transitive bumps captured in the regenerated lockfiles (firebase analytics/messaging/crashlytics, win32, sqlite3, vector_graphics, and others).

## Verification
- ✅ `make analyze` — shared, bridge, mobile (no issues)
- ✅ `make test` — shared (197), bridge (1150), mobile (409) all pass
- ✅ `make codegen` — shared & bridge clean

## Notes for reviewers
- **Flutter SDK kept at 3.41.9.** Latest stable is 3.44.1 (a two-minor jump). The `mobile/pubspec.yaml` flutter constraint is intentionally narrow (`>=3.41.7 <3.42.0`), so the SDK bump is left for a separate, human-reviewed PR. Several mobile packages are gated behind it (see Deferred).
- **Mobile codegen / DI discrepancy (pre-existing, not from this PR).** Running `make codegen` regenerates `mobile/module_auth/lib/src/di/injection.config.dart` in a way that drops the concrete `AuthManager` registration and warns about `VoiceApi` / `VoiceTranscriptionService`. This reproduces identically on a pristine `upstream/main` with **no** dependency changes and **no** generator-version change — the committed generated code is simply out of sync with the pinned `injectable_generator 3.0.2`. To avoid shipping a broken DI graph, generated files are left at their committed state. Worth a separate fix.
- **Fastlane** is already at the latest (2.235.0), already allowed by `~> 2.235`; no Gemfile change. The `cocoapods` gem entry was left untouched (iOS is SPM-only).

## Deferred (gated on Flutter SDK 3.41.9 → 3.44.x)
| Package | Current | Latest | Reason |
|---|---|---|---|
| `app_links` | 7.0.0 | 7.1.1 | not resolvable on current SDK |
| `meta` | 1.17.0 | 1.18.2 | requires newer Dart SDK |
| `record` | 6.2.1 | 7.0.0 | major; SDK-gated |
| `flutter_native_splash` | 2.4.7 | 2.4.8 | not resolvable on current SDK |
| `test` | 1.30.0 | 1.31.1 | SDK-gated |
| `analyzer` / `_fe_analyzer_shared` / `dart_style` / `cli_util` | — | — | pinned by the Dart SDK |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Weekly dependency refresh across shared, bridge, and mobile to the latest resolvable versions, with regenerated lockfiles and synced iOS SPM pins. No SDK bump; analysis and tests pass, and the iOS app builds and runs.

- **Dependencies**
  - Bumped direct constraints: `json_annotation` → `^4.12.0`, `json_serializable` → `^6.14.0`, `cryptography` → `^2.9.0` (bridge/app, `mobile/module_auth`, `mobile/module_core`), `collection` → `^1.19.1` (`shared/sesori_shared`).
  - Regenerated lockfiles (bridge, mobile). Mobile picked up `go_router` `17.2.3` → `17.3.0`, plus patches across Firebase, `sqlite3`, `hooks`, `vector_graphics_compiler`, and others.
  - Synced iOS SPM packages: `firebase-ios-sdk` `12.12.1` → `12.14.0`, `GoogleAppMeasurement` `12.12.1` → `12.14.0`, `google-ads-on-device-conversion-ios-sdk` `3.5.0` → `3.6.0`.
  - Kept Flutter SDK at `3.41.9` due to `mobile` constraint; defer `app_links`, `meta`, `record`, `flutter_native_splash`, and `test` until `3.44.x`.
  - Pre-existing mobile DI codegen mismatch remains; generated files left unchanged to avoid breaking the graph.

<sup>Written for commit e37c8089f2fd8ae3f501c570c76c7cd821331775. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

