### PR TITLE
feat: add address-pr-comments skill

### DIFF
--- a/.opencode/skills/address-pr-comments/SKILL.md
+++ b/.opencode/skills/address-pr-comments/SKILL.md
@@ -114,9 +114,18 @@ git push origin <branch-name>
 
 After the commit has been successfully pushed, post a reply to each comment thread explaining what was done.
 
-**Reply format:**
+**Reply format for Addressed and Partially addressed:**
 ```
-[Sesori reply] <status>: <explanation>
+[Sesori reply] <status> (in commit <commit_hash>)
+
+<explanation>
+```
+
+**Reply format for Not addressed and Question:**
+```
+[Sesori reply] <status>
+
+<explanation>
 ```
 
 Where `<status>` is one of:
@@ -129,27 +138,37 @@ Where `<status>` is one of:
 
 Addressed:
 ```
-[Sesori reply] Addressed: Fixed the off-by-one error in the loop boundary. Changed `i <= n` to `i < n`.
+[Sesori reply] Addressed (in commit a1b2c3d)
+
+Fixed the off-by-one error in the loop boundary. Changed `i <= n` to `i < n`.
 ```
 
 Not addressed (AI comment found invalid):
 ```
-[Sesori reply] Not addressed: This suggestion would introduce a race condition. The current implementation already handles synchronization correctly via the existing mutex.
+[Sesori reply] Not addressed
+
+This suggestion would introduce a race condition. The current implementation already handles synchronization correctly via the existing mutex.
 ```
 
 Not addressed (outdated):
 ```
-[Sesori reply] Not addressed: This comment refers to code that has been refactored in a subsequent commit. The variable in question no longer exists.
+[Sesori reply] Not addressed
+
+This comment refers to code that has been refactored in a subsequent commit. The variable in question no longer exists.
 ```
 
 Partially addressed:
 ```
-[Sesori reply] Partially addressed: Renamed the variable as requested. However, extracting the helper function is not viable here because it would require passing 5 parameters and reduce readability.
+[Sesori reply] Partially addressed (in commit a1b2c3d)
+
+Renamed the function as requested. However, calling this function directly without the platform interface abstraction is not viable because it would break the Windows support.
 ```
 
 Question:
 ```
-[Sesori reply] Question: Could you clarify what you mean by "optimize this"? Are you looking for time complexity improvements or reduced memory usage?
+[Sesori reply] Question
+
+Could you clarify what you mean by "optimize this"? Are you looking for time complexity improvements or reduced memory usage?
 ```
 
 **Posting replies via helper script:**
@@ -162,44 +181,11 @@ Use the included `reply.sh` helper script:
 
 The script automatically prefixes the body with `[Sesori reply]` if not already present.
 
-**Posting replies via GitHub API directly:**
-
-If you need to post a reply directly via the REST API:
-
-```bash
-gh api repos/<owner>/<repo>/pulls/<pr-number>/comments/<thread_id>/replies \
-  -f body="[Sesori reply] Addressed: ..."
-```
-
-Where `<thread_id>` is the `thread_id` field from the fetched comment data.
-
-If the reply is long, you can use a here-document:
-
-```bash
-gh api repos/<owner>/<repo>/pulls/<pr-number>/comments/<thread_id>/replies \
-  -f body="$(cat <<'EOF'
-[Sesori reply] Addressed: Fixed the null pointer exception by adding
-an explicit null check before dereferencing the variable.
-EOF
-)"
-```
-
-```bash
-git add -A
-git commit -m "fix: address PR review comments"
-```
-
-Or use a more specific message if the changes are purely stylistic or architectural:
-
-```bash
-git commit -m "refactor: address PR review feedback"
-```
-
 ## Edge Cases
 
 ### Comment on a file not in the working tree
 
-If the comment references a file that does not exist in your working tree (e.g., the PR added it and you are on a different branch), first check out the PR branch or the specific file.
+If the comment references a file that does not exist in your working tree (e.g., the PR added it and you are on a different branch), ask the user whether they want you to change the current branch or worktree before proceeding. There is a chance the user asked in the wrong session to review a PR.
 
 ### Multiple comments on the same line
 
@@ -241,6 +227,6 @@ User: "Address the comments on PR 42"
 4. Implement fixes for threads 1 and 3.
 5. Make a single commit and push
 6. Post replies:
-   - Thread 1: `[Sesori reply] Addressed: Fixed the loop boundary.`
-   - Thread 2: `[Sesori reply] Not addressed: The current approach is intentional and more readable for this use case. A functional approach would introduce unnecessary complexity.`
-   - Thread 3: `[Sesori reply] Addressed: Added explicit null check.`
+   - Thread 1: `[Sesori reply] Addressed (in commit a1b2c3d)\n\nFixed the loop boundary.`
+   - Thread 2: `[Sesori reply] Not addressed\n\nThe current approach is intentional and more readable for this use case. A functional approach would introduce unnecessary complexity.`
+   - Thread 3: `[Sesori reply] Addressed (in commit a1b2c3d)\n\nAdded explicit null check.`

--- a/.opencode/skills/address-pr-comments/SKILL.md
+++ b/.opencode/skills/address-pr-comments/SKILL.md
@@ -11,22 +11,31 @@ Addresses unresolved inline PR review comments by assessing their validity, impl
 
 1. **Unresolved comments only**: Unless explicitly told otherwise, only fetch and address comments where `is_resolved == false`. Use the `--unresolved` flag.
 2. **Every thread gets a reply**: After assessing and acting on a comment, you MUST post a reply to that comment thread. No thread should be left without a response.
-3. **Reply prefix**: Every reply must start with `[Sesori reply]` so it is clear the response comes from the agent, not the human user.
-4. **All comments are assessed**: Every comment must be evaluated for validity. Do not automatically assume any comment is correct.
-5. **Extra scrutiny for AI/bot comments**: Comments from AI reviewers or bots require more careful assessment. They are more likely to be incorrect, irrelevant, or based on stale context.
-6. **Human comments are trusted by default**: Comments from actual humans should be assumed valid unless you have a strong reason to believe they are wrong.
-7. **Single commit**: All fixes can be committed together in a single commit. The user squash-merges at the end.
-8. **Outdated comments**: If `is_outdated == true`, assess whether the comment is still relevant. If the issue still exists in the current code, address it. If not, reply explaining why it is no longer applicable.
+3. **Do not reply twice**: Before posting a reply, check the thread's `comments[]` for an existing body starting with `[Sesori reply]`. If the last comment in the thread is already a `[Sesori reply]`, skip the thread unless there is a new follow-up request from a reviewer. If the last comment is an acknowledgment like "Acknowledged" or similar that does not require action, skip it.
+4. **Reply prefix**: Every reply must start with `[Sesori reply]` so it is clear the response comes from the agent, not the human user.
+5. **All comments are assessed**: Every comment must be evaluated for validity. Do not automatically assume any comment is correct.
+6. **Extra scrutiny for AI/bot comments**: Comments from AI reviewers or bots require more careful assessment. They are more likely to be incorrect, irrelevant, or based on stale context.
+7. **Human comments are trusted by default**: Comments from actual humans should be assumed valid unless you have a strong reason to believe they are wrong, detrimental, or cause likely unintended side effects.
+8. **Single commit**: All fixes can be committed together in a single commit. The user squash-merges at the end.
+9. **Outdated comments**: If `is_outdated == true`, assess whether the comment is still relevant. If the issue still exists in the current code, address it. If not, reply explaining why it is no longer applicable.
 
 ## Workflow
 
 ### Step 1: Fetch Unresolved Comments
 
-Use the `pr-inline-comments` skill to fetch unresolved comments:
+Use the `pr-inline-comments` skill to fetch ONLY unresolved comments:
 
 ```bash
 ../pr-inline-comments/scripts/fetch.sh <pr-number> --unresolved [--repo OWNER/REPO]
 ```
+
+**Important:** The output can be large and may be truncated by the shell. To avoid missing comments, redirect the output to a file:
+
+```bash
+../pr-inline-comments/scripts/fetch.sh <pr-number> --unresolved > /tmp/pr_comments.json
+```
+
+Then read `/tmp/pr_comments.json` to parse the results.
 
 If the user specifies a time window (e.g., "since yesterday"), also pass `--since <ISO_8601>`.
 
@@ -52,13 +61,14 @@ A comment is **invalid** if:
 - It is based on a misunderstanding of the code
 - The suggestion would introduce a bug or worsen the code
 - It is stylistically opinionated without project convention backing
+- It suggests that the syntax is invalid but the analyzer accepts it
 - It is outdated and no longer applies
 - It is from an AI/bot and contains obvious hallucinations or generic advice
 
 #### AI/Bot Identification
 
 Apply extra scrutiny when the comment author (`user` field) matches any of these patterns:
-- Username contains: `bot`, `[bot]`, `github-actions`, `codex`, `gemini`, `copilot`, `claude`, `gpt`, `ai-`
+- Username indicates author is a bot — commonly name contains: `bot`, `[bot]`, `github-actions`, `codex`, `gemini`, `copilot`, `claude`, `gpt`, `ai-`
 - The comment uses very formal, mechanical, or templated language
 - The suggestion is generic and lacks specific context about this codebase
 
@@ -70,6 +80,7 @@ For AI/bot comments:
 For human comments:
 - Assume the comment is correct unless you have strong evidence otherwise
 - If you disagree, still explain your reasoning in the reply
+- If you disagreed with a given reason, but the human replied to still go ahead and do it, you must proceed with the requested task
 
 ### Step 3: Implement Fixes
 
@@ -85,11 +96,12 @@ Fix guidelines:
 - Fix minimally. Do not refactor unrelated code.
 - Follow existing codebase conventions (style, naming, patterns)
 - If a comment requests a specific approach and you disagree, use your judgment but explain in the reply
+- If you are changing logic or fixing logic bugs/edge case omissions/etc, use TDD (write a failing test first)
 - Do not suppress type errors with `as any`, `@ts-ignore`, or `@ts-expect-error`
 
 ### Step 4: Commit and Push Changes
 
-After all fixes have been implemented, commit all changes in a single commit:
+After all fixes have been implemented, commit all changes in a single **new** commit. **NEVER amend** an existing commit.
 
 ```bash
 git add -A
@@ -109,6 +121,10 @@ git push origin <branch-name>
 ```
 
 **Important:** Always commit and push BEFORE posting replies. If you post "Addressed" before pushing, the fixes won't be visible to reviewers, making the replies misleading.
+
+**Important:** DO NOT use force push without explicit per-instance consent. Do not assume that you can use force push again just because the user allowed it previously.
+
+**No changes to commit:** If all fetched comments were invalid, outdated, or questions requiring no code change, skip the commit and push steps. Proceed directly to posting replies.
 
 ### Step 5: Leave Replies
 

--- a/.opencode/skills/address-pr-comments/SKILL.md
+++ b/.opencode/skills/address-pr-comments/SKILL.md
@@ -144,7 +144,9 @@ After the commit has been successfully pushed, post a reply to each comment thre
 <detailed explanation>
 ```
 
-The `<detailed explanation>` must describe **what** was changed and **why**, not just restate the status. Be specific about files modified, logic changed, or decisions made. A reply that only says "Addressed" or "Fixed" is insufficient.
+The explanation must describe **what** was changed and **why**, not just restate the status. A reply that only says "Addressed" or "Fixed" is insufficient.
+
+**Be concise.** Most replies should be 1-2 short sentences. Only write a longer explanation when the change is complex, crosses multiple files, or requires architectural justification. Do not add pointless fluff.
 
 **Reply format for Not addressed and Question:**
 ```
@@ -161,11 +163,18 @@ Where `<status>` is one of:
 
 **Examples:**
 
-Addressed:
+Addressed (simple fix):
 ```
 [Sesori reply] Addressed (in commit a1b2c3d)
 
-Fixed the off-by-one error in `src/utils.ts` line 42. Changed the loop boundary from `i <= n` to `i < n` to prevent accessing the array at index `n` (which is out of bounds). Also added a unit test covering the edge case where `n` equals the array length.
+Changed the loop boundary from `i <= n` to `i < n` in `src/utils.ts` to fix the off-by-one error.
+```
+
+Addressed (complex fix requiring more context):
+```
+[Sesori reply] Addressed (in commit a1b2c3d)
+
+Extracted the retry logic into a separate `RetryService` in `src/services/retry_service.dart`. This centralizes the backoff strategy and makes it reusable across the HTTP client and the WebSocket reconnect flow.
 ```
 
 Not addressed (AI comment found invalid):
@@ -186,9 +195,7 @@ Partially addressed:
 ```
 [Sesori reply] Partially addressed (in commit a1b2c3d)
 
-Renamed `getPlatformPath()` to `resolvePlatformPath()` in `src/platform/path_resolver.dart` as requested. This better reflects that the function performs resolution logic, not just a simple getter.
-
-However, I did not remove the platform interface abstraction layer. Doing so would require adding OS-specific branching directly in the calling code (`src/services/file_service.dart`), which would break Windows support and duplicate platform detection logic that is already centralized in the abstraction. Keeping the abstraction is the correct architecture here.
+Renamed the function as requested. Did not remove the platform abstraction because it would break Windows support and duplicate OS detection logic.
 ```
 
 Question:
@@ -254,6 +261,6 @@ User: "Address the comments on PR 42"
 4. Implement fixes for threads 1 and 3.
 5. Make a single commit and push
 6. Post replies:
-   - Thread 1: `[Sesori reply] Addressed (in commit a1b2c3d)\n\nFixed the off-by-one error in src/utils.ts line 42. Changed the loop boundary from i <= n to i < n to prevent accessing the array at index n (which is out of bounds). Also added a unit test covering the edge case where n equals the array length.`
-   - Thread 2: `[Sesori reply] Not addressed\n\nThe current imperative approach is intentional and more readable for this use case. A functional approach would introduce unnecessary complexity.`
-   - Thread 3: `[Sesori reply] Addressed (in commit a1b2c3d)\n\nAdded explicit null check in src/services/user_service.dart line 87. The nullable user parameter is now validated before accessing user.email, preventing a NullPointerException when the user record is missing.`
+   - Thread 1: `[Sesori reply] Addressed (in commit a1b2c3d)\n\nChanged the loop boundary from i <= n to i < n in src/utils.ts to fix the off-by-one error.]`
+   - Thread 2: `[Sesori reply] Not addressed\n\nThe current imperative approach is intentional and more readable here.]`
+   - Thread 3: `[Sesori reply] Addressed (in commit a1b2c3d)\n\nAdded null check in src/services/user_service.dart before accessing user.email.`

--- a/.opencode/skills/address-pr-comments/SKILL.md
+++ b/.opencode/skills/address-pr-comments/SKILL.md
@@ -106,14 +106,7 @@ git add <file1> <file2> ...
 git commit -m "fix: address PR review comments"
 ```
 
-If you are certain no unrelated files are present, you may use:
-
-```bash
-git add -A
-git commit -m "fix: address PR review comments"
-```
-
-**Never** stage unrelated work in a PR feedback commit.
+**Never** stage unrelated work in a PR feedback commit. Do not use `git add -A`.
 
 Or use a more specific message if the changes are purely stylistic or architectural:
 

--- a/.opencode/skills/address-pr-comments/SKILL.md
+++ b/.opencode/skills/address-pr-comments/SKILL.md
@@ -135,8 +135,10 @@ After the commit has been successfully pushed, post a reply to each comment thre
 ```
 [Sesori reply] <status> (in commit <commit_hash>)
 
-<explanation>
+<detailed explanation>
 ```
+
+The `<detailed explanation>` must describe **what** was changed and **why**, not just restate the status. Be specific about files modified, logic changed, or decisions made. A reply that only says "Addressed" or "Fixed" is insufficient.
 
 **Reply format for Not addressed and Question:**
 ```
@@ -157,7 +159,7 @@ Addressed:
 ```
 [Sesori reply] Addressed (in commit a1b2c3d)
 
-Fixed the off-by-one error in the loop boundary. Changed `i <= n` to `i < n`.
+Fixed the off-by-one error in `src/utils.ts` line 42. Changed the loop boundary from `i <= n` to `i < n` to prevent accessing the array at index `n` (which is out of bounds). Also added a unit test covering the edge case where `n` equals the array length.
 ```
 
 Not addressed (AI comment found invalid):
@@ -178,7 +180,9 @@ Partially addressed:
 ```
 [Sesori reply] Partially addressed (in commit a1b2c3d)
 
-Renamed the function as requested. However, calling this function directly without the platform interface abstraction is not viable because it would break the Windows support.
+Renamed `getPlatformPath()` to `resolvePlatformPath()` in `src/platform/path_resolver.dart` as requested. This better reflects that the function performs resolution logic, not just a simple getter.
+
+However, I did not remove the platform interface abstraction layer. Doing so would require adding OS-specific branching directly in the calling code (`src/services/file_service.dart`), which would break Windows support and duplicate platform detection logic that is already centralized in the abstraction. Keeping the abstraction is the correct architecture here.
 ```
 
 Question:
@@ -244,6 +248,6 @@ User: "Address the comments on PR 42"
 4. Implement fixes for threads 1 and 3.
 5. Make a single commit and push
 6. Post replies:
-   - Thread 1: `[Sesori reply] Addressed (in commit a1b2c3d)\n\nFixed the loop boundary.`
-   - Thread 2: `[Sesori reply] Not addressed\n\nThe current approach is intentional and more readable for this use case. A functional approach would introduce unnecessary complexity.`
-   - Thread 3: `[Sesori reply] Addressed (in commit a1b2c3d)\n\nAdded explicit null check.`
+   - Thread 1: `[Sesori reply] Addressed (in commit a1b2c3d)\n\nFixed the off-by-one error in src/utils.ts line 42. Changed the loop boundary from i <= n to i < n to prevent accessing the array at index n (which is out of bounds). Also added a unit test covering the edge case where n equals the array length.]`
+   - Thread 2: `[Sesori reply] Not addressed\n\nThe current imperative approach is intentional and more readable for this use case. A functional approach would introduce unnecessary complexity.]`
+   - Thread 3: `[Sesori reply] Addressed (in commit a1b2c3d)\n\nAdded explicit null check in src/services/user_service.dart line 87. The nullable user parameter is now validated before accessing user.email, preventing a NullPointerException when the user record is missing.]`

--- a/.opencode/skills/address-pr-comments/SKILL.md
+++ b/.opencode/skills/address-pr-comments/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: address-pr-comments
+description: Address unresolved inline PR review comments on a GitHub pull request. Fetches unresolved comments, assesses validity (with extra scrutiny for AI/bot reviewers), implements fixes, leaves a reply on every comment thread, and commits changes. Use when the user asks to address PR comments, resolve review feedback, implement requested changes, or handle PR review threads.
+---
+
+# address-pr-comments
+
+Addresses unresolved inline PR review comments by assessing their validity, implementing fixes, and leaving a reply on each comment thread. Every thread gets a response — either confirming the fix or explaining why the comment was not addressed.
+
+## Core Rules
+
+1. **Unresolved comments only**: Unless explicitly told otherwise, only fetch and address comments where `is_resolved == false`. Use the `--unresolved` flag.
+2. **Every thread gets a reply**: After assessing and acting on a comment, you MUST post a reply to that comment thread. No thread should be left without a response.
+3. **Reply prefix**: Every reply must start with `[Sesori reply]` so it is clear the response comes from the agent, not the human user.
+4. **All comments are assessed**: Every comment must be evaluated for validity. Do not automatically assume any comment is correct.
+5. **Extra scrutiny for AI/bot comments**: Comments from AI reviewers or bots require more careful assessment. They are more likely to be incorrect, irrelevant, or based on stale context.
+6. **Human comments are trusted by default**: Comments from actual humans should be assumed valid unless you have a strong reason to believe they are wrong.
+7. **Single commit**: All fixes can be committed together in a single commit. The user squash-merges at the end.
+8. **Outdated comments**: If `is_outdated == true`, assess whether the comment is still relevant. If the issue still exists in the current code, address it. If not, reply explaining why it is no longer applicable.
+
+## Workflow
+
+### Step 1: Fetch Unresolved Comments
+
+Use the `pr-inline-comments` skill to fetch unresolved comments:
+
+```bash
+./scripts/fetch.sh <pr-number> --unresolved [--repo OWNER/REPO]
+```
+
+If the user specifies a time window (e.g., "since yesterday"), also pass `--since <ISO_8601>`.
+
+Parse the JSON output. You will receive an array of thread objects. Each thread contains:
+- `thread_id`: The root comment ID (use this for posting replies)
+- `path`: File path
+- `line`: Line number
+- `is_resolved`, `is_outdated`: Resolution status
+- `comments[]`: Array of comments in the thread, each with `user`, `body`, `created_at`
+
+### Step 2: Assess Each Comment
+
+For each comment thread, read the relevant code and assess the comment's validity.
+
+#### Validity Assessment
+
+A comment is **valid** if:
+- It correctly identifies a real issue (bug, style violation, architecture problem, missing test, etc.)
+- The suggested change is appropriate and correct
+- It is actionable and clear
+
+A comment is **invalid** if:
+- It is based on a misunderstanding of the code
+- The suggestion would introduce a bug or worsen the code
+- It is stylistically opinionated without project convention backing
+- It is outdated and no longer applies
+- It is from an AI/bot and contains obvious hallucinations or generic advice
+
+#### AI/Bot Identification
+
+Apply extra scrutiny when the comment author (`user` field) matches any of these patterns:
+- Username contains: `bot`, `[bot]`, `github-actions`, `codex`, `gemini`, `copilot`, `claude`, `gpt`, `ai-`
+- The comment uses very formal, mechanical, or templated language
+- The suggestion is generic and lacks specific context about this codebase
+
+For AI/bot comments:
+- Verify the claim by reading the actual code
+- Check if the suggestion aligns with existing codebase patterns
+- Do not implement blindly — apply the same critical thinking you would use on your own code
+
+For human comments:
+- Assume the comment is correct unless you have strong evidence otherwise
+- If you disagree, still explain your reasoning in the reply
+
+### Step 3: Implement Fixes
+
+For each valid comment:
+
+1. Read the file(s) referenced in the comment
+2. Understand the context around the commented line
+3. Make the minimal, correct fix
+4. Verify the fix does not break existing functionality
+5. If multiple comments affect the same file, batch the changes
+
+Fix guidelines:
+- Fix minimally. Do not refactor unrelated code.
+- Follow existing codebase conventions (style, naming, patterns)
+- If a comment requests a specific approach and you disagree, use your judgment but explain in the reply
+- Do not suppress type errors with `as any`, `@ts-ignore`, or `@ts-expect-error`
+
+### Step 4: Leave Replies
+
+After acting on each comment (whether you fixed it or not), post a reply to the comment thread.
+
+**Reply format:**
+```
+[Sesori reply] <status>: <explanation>
+```
+
+Where `<status>` is one of:
+- `Addressed` — The fix has been implemented
+- `Not addressed` — The comment was assessed as invalid or not applicable
+- `Partially addressed` — Part of the request was implemented, part was not
+- `Question` — The comment is unclear and needs clarification from the reviewer
+
+**Examples:**
+
+Addressed:
+```
+[Sesori reply] Addressed: Fixed the off-by-one error in the loop boundary. Changed `i <= n` to `i < n`.
+```
+
+Not addressed (AI comment found invalid):
+```
+[Sesori reply] Not addressed: This suggestion would introduce a race condition. The current implementation already handles synchronization correctly via the existing mutex.
+```
+
+Not addressed (outdated):
+```
+[Sesori reply] Not addressed: This comment refers to code that has been refactored in a subsequent commit. The variable in question no longer exists.
+```
+
+Partially addressed:
+```
+[Sesori reply] Partially addressed: Renamed the variable as requested. However, extracting the helper function is not viable here because it would require passing 5 parameters and reduce readability.
+```
+
+Question:
+```
+[Sesori reply] Question: Could you clarify what you mean by "optimize this"? Are you looking for time complexity improvements or reduced memory usage?
+```
+
+**Posting replies via GitHub API:**
+
+Use the REST API to reply to a comment thread:
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<pr-number>/comments/<thread_id>/replies \
+  -f body="[Sesori reply] Addressed: ..."
+```
+
+Where `<thread_id>` is the `thread_id` field from the fetched comment data.
+
+If the reply is long, you can use a here-document:
+
+```bash
+gh api repos/<owner>/<repo>/pulls/<pr-number>/comments/<thread_id>/replies \
+  -f body="$(cat <<'EOF'
+[Sesori reply] Addressed: Fixed the null pointer exception by adding
+an explicit null check before dereferencing the variable.
+EOF
+)"
+```
+
+### Step 5: Commit Changes
+
+After all comments have been addressed and replies posted, commit all changes in a single commit:
+
+```bash
+git add -A
+git commit -m "fix: address PR review comments"
+```
+
+Or use a more specific message if the changes are purely stylistic or architectural:
+
+```bash
+git commit -m "refactor: address PR review feedback"
+```
+
+## Edge Cases
+
+### Comment on a file not in the working tree
+
+If the comment references a file that does not exist in your working tree (e.g., the PR added it and you are on a different branch), first check out the PR branch or the specific file.
+
+### Multiple comments on the same line
+
+If multiple threads reference the same line, address each independently. They may be about different issues.
+
+### Comments requesting architectural changes
+
+If a comment requests a significant architectural change that would require refactoring multiple files, assess whether it is in scope. If it is a reasonable request, implement it. If it is too large, reply explaining that the change is out of scope for this PR and suggest creating a follow-up issue.
+
+### Comments with no clear action
+
+Some comments are questions or discussions without a clear requested change. Reply to these with `[Sesori reply] Question:` or `[Sesori reply] Not addressed:` and explain why no code change is needed.
+
+### Resolved comments that the user wants revisited
+
+If the user explicitly asks you to look at resolved comments, omit the `--unresolved` flag when fetching. Apply the same assessment and reply process.
+
+## Dependencies
+
+- `gh` (authenticated via `gh auth login`)
+- `pr-inline-comments` skill (for fetching comments)
+- Access to the repository working tree (to read and edit files)
+
+## Example Session
+
+User: "Address the comments on PR 42"
+
+1. Fetch unresolved comments: `./scripts/fetch.sh 42 --unresolved`
+2. Receive 3 threads:
+   - Thread 1 (human): "This loop has an off-by-one error"
+   - Thread 2 (bot): "Consider using a more functional approach"
+   - Thread 3 (human): "Missing null check here"
+3. Assess:
+   - Thread 1: Valid. Fix the loop boundary.
+   - Thread 2: AI suggestion. Current imperative approach is clearer here. Do not implement.
+   - Thread 3: Valid. Add null check.
+4. Implement fixes for threads 1 and 3.
+5. Post replies:
+   - Thread 1: `[Sesori reply] Addressed: Fixed the loop boundary.`
+   - Thread 2: `[Sesori reply] Not addressed: The current approach is intentional and more readable for this use case. A functional approach would introduce unnecessary complexity.`
+   - Thread 3: `[Sesori reply] Addressed: Added explicit null check.`
+6. Commit: `git commit -m "fix: address PR review comments"`

--- a/.opencode/skills/address-pr-comments/SKILL.md
+++ b/.opencode/skills/address-pr-comments/SKILL.md
@@ -25,7 +25,7 @@ Addresses unresolved inline PR review comments by assessing their validity, impl
 Use the `pr-inline-comments` skill to fetch unresolved comments:
 
 ```bash
-./scripts/fetch.sh <pr-number> --unresolved [--repo OWNER/REPO]
+../pr-inline-comments/scripts/fetch.sh <pr-number> --unresolved [--repo OWNER/REPO]
 ```
 
 If the user specifies a time window (e.g., "since yesterday"), also pass `--since <ISO_8601>`.
@@ -87,9 +87,32 @@ Fix guidelines:
 - If a comment requests a specific approach and you disagree, use your judgment but explain in the reply
 - Do not suppress type errors with `as any`, `@ts-ignore`, or `@ts-expect-error`
 
-### Step 4: Leave Replies
+### Step 4: Commit and Push Changes
 
-After acting on each comment (whether you fixed it or not), post a reply to the comment thread.
+After all fixes have been implemented, commit all changes in a single commit:
+
+```bash
+git add -A
+git commit -m "fix: address PR review comments"
+```
+
+Or use a more specific message if the changes are purely stylistic or architectural:
+
+```bash
+git commit -m "refactor: address PR review feedback"
+```
+
+Then push the commit so the fixes are visible on the remote branch:
+
+```bash
+git push origin <branch-name>
+```
+
+**Important:** Always commit and push BEFORE posting replies. If you post "Addressed" before pushing, the fixes won't be visible to reviewers, making the replies misleading.
+
+### Step 5: Leave Replies
+
+After the commit has been successfully pushed, post a reply to each comment thread explaining what was done.
 
 **Reply format:**
 ```
@@ -97,7 +120,7 @@ After acting on each comment (whether you fixed it or not), post a reply to the 
 ```
 
 Where `<status>` is one of:
-- `Addressed` — The fix has been implemented
+- `Addressed` — The fix has been implemented and pushed
 - `Not addressed` — The comment was assessed as invalid or not applicable
 - `Partially addressed` — Part of the request was implemented, part was not
 - `Question` — The comment is unclear and needs clarification from the reviewer
@@ -129,9 +152,19 @@ Question:
 [Sesori reply] Question: Could you clarify what you mean by "optimize this"? Are you looking for time complexity improvements or reduced memory usage?
 ```
 
-**Posting replies via GitHub API:**
+**Posting replies via helper script:**
 
-Use the REST API to reply to a comment thread:
+Use the included `reply.sh` helper script:
+
+```bash
+./scripts/reply.sh <pr-number> <thread_id> "Addressed: Fixed the null check."
+```
+
+The script automatically prefixes the body with `[Sesori reply]` if not already present.
+
+**Posting replies via GitHub API directly:**
+
+If you need to post a reply directly via the REST API:
 
 ```bash
 gh api repos/<owner>/<repo>/pulls/<pr-number>/comments/<thread_id>/replies \
@@ -150,10 +183,6 @@ an explicit null check before dereferencing the variable.
 EOF
 )"
 ```
-
-### Step 5: Commit Changes
-
-After all comments have been addressed and replies posted, commit all changes in a single commit:
 
 ```bash
 git add -A

--- a/.opencode/skills/address-pr-comments/SKILL.md
+++ b/.opencode/skills/address-pr-comments/SKILL.md
@@ -32,8 +32,9 @@ Use the `pr-inline-comments` skill to fetch ONLY unresolved comments:
 **Important:** The output can be large and may be truncated by the shell. To avoid missing comments, redirect the output to a uniquely-named file:
 
 ```bash
+PR_NUMBER="<pr-number>"
 OUTFILE="/tmp/pr_${PR_NUMBER}_comments_$(date +%Y%m%d_%H%M%S).json"
-../pr-inline-comments/scripts/fetch.sh <pr-number> --unresolved > "$OUTFILE"
+../pr-inline-comments/scripts/fetch.sh "$PR_NUMBER" --unresolved > "$OUTFILE"
 ```
 
 Then read `"$OUTFILE"` to parse the results. The timestamp ensures no stale file from a previous run or another PR is accidentally read.

--- a/.opencode/skills/address-pr-comments/SKILL.md
+++ b/.opencode/skills/address-pr-comments/SKILL.md
@@ -139,7 +139,7 @@ After the commit has been successfully pushed, post a reply to each comment thre
 
 The explanation must describe **what** was changed and **why**, not just restate the status. A reply that only says "Addressed" or "Fixed" is insufficient.
 
-**Be concise.** Most replies should be 1-2 short sentences. Only write a longer explanation when the change is complex, crosses multiple files, or requires architectural justification. Do not add pointless fluff.
+**Be concise.** Say only what is meaningful. If you did exactly what was requested with no side effects or additional context needed, a single sentence like "Renamed `foo` to `bar` as requested" is enough. Only add more detail when there is genuinely something worth communicating — e.g., the fix caused a related change elsewhere, you rejected part of the suggestion for a specific reason, or the change has implications the reviewer should know about. Do not add pointless fluff.
 
 **Reply format for Not addressed and Question:**
 ```

--- a/.opencode/skills/address-pr-comments/SKILL.md
+++ b/.opencode/skills/address-pr-comments/SKILL.md
@@ -207,7 +207,9 @@ If multiple threads reference the same line, address each independently. They ma
 
 ### Comments requesting architectural changes
 
-If a comment requests a significant architectural change that would require refactoring multiple files, assess whether it is in scope. If it is a reasonable request, implement it. If it is too large, reply explaining that the change is out of scope for this PR and suggest creating a follow-up issue.
+If a human reviewer requests a significant architectural change, implement it without complaining — even if it requires refactoring multiple files. Do not push back or suggest creating a follow-up issue unless you have a strong technical reason to believe the change is wrong.
+
+For AI/bot comments requesting large architectural changes, apply normal validity assessment. If the suggestion is genuinely reasonable, implement it. If it is misguided, reply explaining why it is not viable.
 
 ### Comments with no clear action
 
@@ -227,7 +229,7 @@ If the user explicitly asks you to look at resolved comments, omit the `--unreso
 
 User: "Address the comments on PR 42"
 
-1. Fetch unresolved comments: `./scripts/fetch.sh 42 --unresolved`
+1. Fetch unresolved comments using the `pr-inline-comments` skill
 2. Receive 3 threads:
    - Thread 1 (human): "This loop has an off-by-one error"
    - Thread 2 (bot): "Consider using a more functional approach"
@@ -237,8 +239,8 @@ User: "Address the comments on PR 42"
    - Thread 2: AI suggestion. Current imperative approach is clearer here. Do not implement.
    - Thread 3: Valid. Add null check.
 4. Implement fixes for threads 1 and 3.
-5. Post replies:
+5. Make a single commit and push
+6. Post replies:
    - Thread 1: `[Sesori reply] Addressed: Fixed the loop boundary.`
    - Thread 2: `[Sesori reply] Not addressed: The current approach is intentional and more readable for this use case. A functional approach would introduce unnecessary complexity.`
    - Thread 3: `[Sesori reply] Addressed: Added explicit null check.`
-6. Commit: `git commit -m "fix: address PR review comments"`

--- a/.opencode/skills/address-pr-comments/SKILL.md
+++ b/.opencode/skills/address-pr-comments/SKILL.md
@@ -29,13 +29,14 @@ Use the `pr-inline-comments` skill to fetch ONLY unresolved comments:
 ../pr-inline-comments/scripts/fetch.sh <pr-number> --unresolved [--repo OWNER/REPO]
 ```
 
-**Important:** The output can be large and may be truncated by the shell. To avoid missing comments, redirect the output to a file:
+**Important:** The output can be large and may be truncated by the shell. To avoid missing comments, redirect the output to a uniquely-named file:
 
 ```bash
-../pr-inline-comments/scripts/fetch.sh <pr-number> --unresolved > /tmp/pr_comments.json
+OUTFILE="/tmp/pr_${PR_NUMBER}_comments_$(date +%Y%m%d_%H%M%S).json"
+../pr-inline-comments/scripts/fetch.sh <pr-number> --unresolved > "$OUTFILE"
 ```
 
-Then read `/tmp/pr_comments.json` to parse the results.
+Then read `"$OUTFILE"` to parse the results. The timestamp ensures no stale file from a previous run or another PR is accidentally read.
 
 If the user specifies a time window (e.g., "since yesterday"), also pass `--since <ISO_8601>`.
 

--- a/.opencode/skills/address-pr-comments/SKILL.md
+++ b/.opencode/skills/address-pr-comments/SKILL.md
@@ -29,16 +29,6 @@ Use the `pr-inline-comments` skill to fetch ONLY unresolved comments:
 ../pr-inline-comments/scripts/fetch.sh <pr-number> --unresolved [--repo OWNER/REPO]
 ```
 
-**Important:** The output can be large and may be truncated by the shell. To avoid missing comments, redirect the output to a uniquely-named file:
-
-```bash
-PR_NUMBER="<pr-number>"
-OUTFILE="/tmp/pr_${PR_NUMBER}_comments_$(date +%Y%m%d_%H%M%S).json"
-../pr-inline-comments/scripts/fetch.sh "$PR_NUMBER" --unresolved > "$OUTFILE"
-```
-
-Then read `"$OUTFILE"` to parse the results. The timestamp ensures no stale file from a previous run or another PR is accidentally read.
-
 If the user specifies a time window (e.g., "since yesterday"), also pass `--since <ISO_8601>`.
 
 Parse the JSON output. You will receive an array of thread objects. Each thread contains:
@@ -103,12 +93,27 @@ Fix guidelines:
 
 ### Step 4: Commit and Push Changes
 
-After all fixes have been implemented, commit all changes in a single **new** commit. **NEVER amend** an existing commit.
+After all fixes have been implemented, check the worktree status first. If there are pre-existing modifications or untracked files unrelated to the PR comments, warn the user and ask whether to proceed before committing.
+
+```bash
+git status
+```
+
+If the worktree is clean except for the files you modified for the PR comments, stage and commit only those files:
+
+```bash
+git add <file1> <file2> ...
+git commit -m "fix: address PR review comments"
+```
+
+If you are certain no unrelated files are present, you may use:
 
 ```bash
 git add -A
 git commit -m "fix: address PR review comments"
 ```
+
+**Never** stage unrelated work in a PR feedback commit.
 
 Or use a more specific message if the changes are purely stylistic or architectural:
 
@@ -249,6 +254,6 @@ User: "Address the comments on PR 42"
 4. Implement fixes for threads 1 and 3.
 5. Make a single commit and push
 6. Post replies:
-   - Thread 1: `[Sesori reply] Addressed (in commit a1b2c3d)\n\nFixed the off-by-one error in src/utils.ts line 42. Changed the loop boundary from i <= n to i < n to prevent accessing the array at index n (which is out of bounds). Also added a unit test covering the edge case where n equals the array length.]`
-   - Thread 2: `[Sesori reply] Not addressed\n\nThe current imperative approach is intentional and more readable for this use case. A functional approach would introduce unnecessary complexity.]`
-   - Thread 3: `[Sesori reply] Addressed (in commit a1b2c3d)\n\nAdded explicit null check in src/services/user_service.dart line 87. The nullable user parameter is now validated before accessing user.email, preventing a NullPointerException when the user record is missing.]`
+   - Thread 1: `[Sesori reply] Addressed (in commit a1b2c3d)\n\nFixed the off-by-one error in src/utils.ts line 42. Changed the loop boundary from i <= n to i < n to prevent accessing the array at index n (which is out of bounds). Also added a unit test covering the edge case where n equals the array length.`
+   - Thread 2: `[Sesori reply] Not addressed\n\nThe current imperative approach is intentional and more readable for this use case. A functional approach would introduce unnecessary complexity.`
+   - Thread 3: `[Sesori reply] Addressed (in commit a1b2c3d)\n\nAdded explicit null check in src/services/user_service.dart line 87. The nullable user parameter is now validated before accessing user.email, preventing a NullPointerException when the user record is missing.`

--- a/.opencode/skills/address-pr-comments/scripts/reply.sh
+++ b/.opencode/skills/address-pr-comments/scripts/reply.sh
@@ -62,14 +62,14 @@ if [[ -z "$PR_NUMBER" || -z "$COMMENT_ID" || -z "$BODY" ]]; then
   usage; exit 2
 fi
 
-if [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+if [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
   :
 else
   echo "Error: PR number must be a positive integer, got: $PR_NUMBER" >&2
   exit 2
 fi
 
-if [[ "$COMMENT_ID" =~ ^[0-9]+$ ]]; then
+if [[ "$COMMENT_ID" =~ ^[1-9][0-9]*$ ]]; then
   :
 else
   echo "Error: Comment ID must be a positive integer, got: $COMMENT_ID" >&2

--- a/.opencode/skills/address-pr-comments/scripts/reply.sh
+++ b/.opencode/skills/address-pr-comments/scripts/reply.sh
@@ -28,7 +28,7 @@ REPO=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --repo)       REPO="${2:?--repo requires a value}";   shift 2 ;;
+    --repo) [[ $# -lt 2 ]] && { echo "Error: --repo requires a value" >&2; exit 2; }; REPO="$2"; shift 2 ;;
     -h|--help)    usage; exit 0 ;;
     -*)           echo "Unknown flag: $1" >&2; usage; exit 2 ;;
     *)

--- a/.opencode/skills/address-pr-comments/scripts/reply.sh
+++ b/.opencode/skills/address-pr-comments/scripts/reply.sh
@@ -28,8 +28,9 @@ REPO=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --repo) [[ $# -lt 2 ]] && { echo "Error: --repo requires a value" >&2; exit 2; }; REPO="$2"; shift 2 ;;
+    --repo) [[ $# -lt 2 ]] && { echo "Error: --repo requires a value" >&2; usage; exit 2; }; REPO="$2"; shift 2 ;;
     -h|--help)    usage; exit 0 ;;
+    --)           shift; break ;;
     -*)           echo "Unknown flag: $1" >&2; usage; exit 2 ;;
     *)
       if [[ -z "$PR_NUMBER" ]]; then
@@ -47,23 +48,46 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Collect any remaining arguments after -- as part of the body
+if [[ $# -gt 0 ]]; then
+  if [[ -z "$BODY" ]]; then
+    BODY="$*"
+  else
+    BODY="$BODY $*"
+  fi
+fi
+
 if [[ -z "$PR_NUMBER" || -z "$COMMENT_ID" || -z "$BODY" ]]; then
   echo "Error: Missing required arguments" >&2
   usage; exit 2
+fi
+
+if [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+  :
+else
+  echo "Error: PR number must be a positive integer, got: $PR_NUMBER" >&2
+  exit 2
+fi
+
+if [[ "$COMMENT_ID" =~ ^[0-9]+$ ]]; then
+  :
+else
+  echo "Error: Comment ID must be a positive integer, got: $COMMENT_ID" >&2
+  exit 2
 fi
 
 if [[ -z "$REPO" ]]; then
   REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
 fi
 
-OWNER="${REPO%%/*}"
-REPO_NAME="${REPO##*/}"
-
 if [[ "$BODY" != "[Sesori reply]"* ]]; then
   BODY="[Sesori reply] $BODY"
 fi
 
-gh api "repos/${OWNER}/${REPO_NAME}/pulls/${PR_NUMBER}/comments/${COMMENT_ID}/replies" \
-  -f body="$BODY" > /dev/null
+if ! gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments/${COMMENT_ID}/replies" \
+  -f body="$BODY" > /dev/null; then
+  echo "Error: failed to post reply to comment ${COMMENT_ID} on PR #${PR_NUMBER} in ${REPO}" >&2
+  exit 1
+fi
 
 echo "Reply posted to comment ${COMMENT_ID} on PR #${PR_NUMBER}"

--- a/.opencode/skills/address-pr-comments/scripts/reply.sh
+++ b/.opencode/skills/address-pr-comments/scripts/reply.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: reply.sh <pr-number> <comment-id> <body> [--repo OWNER/REPO]
+
+Posts a reply to a PR review comment thread via the GitHub API.
+
+Arguments:
+  pr-number    The pull request number
+  comment-id   The comment ID (thread_id from fetch.sh output)
+  body         The reply body text. Will be prefixed with [Sesori reply] if not already.
+
+Flags:
+  --repo OWNER/REPO  Override the current repo. Defaults to gh repo view.
+
+Examples:
+  reply.sh 42 12345 "Addressed: Fixed the null check."
+  reply.sh 42 12345 "Not addressed: This would break existing tests." --repo owner/repo
+EOF
+}
+
+PR_NUMBER=""
+COMMENT_ID=""
+BODY=""
+REPO=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)       REPO="${2:?--repo requires a value}";   shift 2 ;;
+    -h|--help)    usage; exit 0 ;;
+    -*)           echo "Unknown flag: $1" >&2; usage; exit 2 ;;
+    *)
+      if [[ -z "$PR_NUMBER" ]]; then
+        PR_NUMBER="$1"
+      elif [[ -z "$COMMENT_ID" ]]; then
+        COMMENT_ID="$1"
+      elif [[ -z "$BODY" ]]; then
+        BODY="$1"
+      else
+        echo "Unexpected positional argument: $1" >&2
+        usage; exit 2
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$PR_NUMBER" || -z "$COMMENT_ID" || -z "$BODY" ]]; then
+  echo "Error: Missing required arguments" >&2
+  usage; exit 2
+fi
+
+if [[ -z "$REPO" ]]; then
+  REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+fi
+
+OWNER="${REPO%%/*}"
+REPO_NAME="${REPO##*/}"
+
+if [[ "$BODY" != "[Sesori reply]"* ]]; then
+  BODY="[Sesori reply] $BODY"
+fi
+
+gh api "repos/${OWNER}/${REPO_NAME}/pulls/${PR_NUMBER}/comments/${COMMENT_ID}/replies" \
+  -f body="$BODY" > /dev/null
+
+echo "Reply posted to comment ${COMMENT_ID} on PR #${PR_NUMBER}"

--- a/.opencode/skills/pr-inline-comments/SKILL.md
+++ b/.opencode/skills/pr-inline-comments/SKILL.md
@@ -52,8 +52,9 @@ Threads are sorted by `path`, then `line`, then `thread_id`.
 **Avoiding output truncation:** The JSON output can be large. To prevent truncation by the shell or terminal, redirect stdout to a uniquely-named file and read from there:
 
 ```bash
+PR_NUMBER="<pr-number>"
 OUTFILE="/tmp/pr_${PR_NUMBER}_comments_$(date +%Y%m%d_%H%M%S).json"
-./scripts/fetch.sh <pr-number> --unresolved > "$OUTFILE"
+./scripts/fetch.sh "$PR_NUMBER" --unresolved > "$OUTFILE"
 # Then read "$OUTFILE"
 ```
 

--- a/.opencode/skills/pr-inline-comments/SKILL.md
+++ b/.opencode/skills/pr-inline-comments/SKILL.md
@@ -49,12 +49,15 @@ Threads are sorted by `path`, then `line`, then `thread_id`.
 ./scripts/fetch.sh <pr-number> [--since ISO_DATETIME] [--unresolved] [--repo OWNER/REPO]
 ```
 
-**Avoiding output truncation:** The JSON output can be large. To prevent truncation by the shell or terminal, redirect stdout to a file and read from there:
+**Avoiding output truncation:** The JSON output can be large. To prevent truncation by the shell or terminal, redirect stdout to a uniquely-named file and read from there:
 
 ```bash
-./scripts/fetch.sh <pr-number> --unresolved > /tmp/pr_comments.json
-# Then read /tmp/pr_comments.json
+OUTFILE="/tmp/pr_${PR_NUMBER}_comments_$(date +%Y%m%d_%H%M%S).json"
+./scripts/fetch.sh <pr-number> --unresolved > "$OUTFILE"
+# Then read "$OUTFILE"
 ```
+
+The timestamp in the filename prevents conflicts with stale files from previous runs or other PRs.
 
 Flags:
 

--- a/.opencode/skills/pr-inline-comments/SKILL.md
+++ b/.opencode/skills/pr-inline-comments/SKILL.md
@@ -49,6 +49,13 @@ Threads are sorted by `path`, then `line`, then `thread_id`.
 ./scripts/fetch.sh <pr-number> [--since ISO_DATETIME] [--unresolved] [--repo OWNER/REPO]
 ```
 
+**Avoiding output truncation:** The JSON output can be large. To prevent truncation by the shell or terminal, redirect stdout to a file and read from there:
+
+```bash
+./scripts/fetch.sh <pr-number> --unresolved > /tmp/pr_comments.json
+# Then read /tmp/pr_comments.json
+```
+
 Flags:
 
 - `--since ISO_DATETIME`: keep only threads whose **latest comment** is at or after the given datetime. Inclusive. The whole thread is returned (including older replies) when it qualifies.


### PR DESCRIPTION
Adds a new OpenCode skill for automatically handling PR review comments.

## What it does
- Fetches unresolved inline PR review comments using the existing pr-inline-comments skill
- Assesses each comment for validity (with extra scrutiny for AI/bot reviewers)
- Implements fixes for valid comments
- Posts a reply on every comment thread with [Sesori reply] prefix
- Commits all changes in a single commit

## Files added
- .opencode/skills/address-pr-comments/SKILL.md — workflow instructions
- .opencode/skills/address-pr-comments/scripts/reply.sh — helper to post comment replies

## Key behaviors
- Only unresolved comments are processed (unless explicitly told otherwise)
- Human comments are trusted by default; AI/bot comments get extra scrutiny
- Every thread gets a reply explaining what was done
- Single commit at the end (user squash-merges)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `address-pr-comments` skill to triage and fix unresolved inline PR comments with minimal changes, per-thread `[Sesori reply]` responses, and a single new commit. Defaults to unresolved-only, commits/pushes before replying, includes idempotent and concise replies, checks the worktree before committing, and requires explicit file staging (no `git add -A`).

- **New Features**
  - Adds `.opencode/skills/address-pr-comments` using `pr-inline-comments`; validates feedback (extra scrutiny for bots), supports a no-code-change path, defaults to `--unresolved`, and commits in one new commit (never amend; no force push) with a worktree cleanliness check and strict explicit staging (`git add <files>` only; forbid `git add -A`).
  - Enforces replies: per-thread `[Sesori reply] <status>` with clear what/why for Addressed/Partially addressed; keep replies concise and skip threads where the last comment is a `[Sesori reply]`; handle outdated threads; proceed when a human insists; use TDD for logic changes.

- **Bug Fixes**
  - `scripts/reply.sh`: fixed API endpoint, stricter arg/ID validation, `--` passthrough for full bodies, auto-prefix, clearer errors.
  - Docs: keep timestamped fetch output guidance in `pr-inline-comments` (and define `PR_NUMBER`); remove the redirect example from `address-pr-comments`; clean up examples; clarify that reply length depends on meaningful content, not complexity.

<sup>Written for commit f009be0cddfb97198af557b5a6ea339c8c1dd5bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

