### PR TITLE
chore: bump version to 1.0.8 and document bump-version target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,5 +27,10 @@ endef
 bump-version-check:
 	$(call run_sync_versions,--dry-run)
 
+# Bump the version of the bridge and mobile apps
+#
+# Two options to use it 
+# a) make bump-version TYPE=patch|minor|major 
+# b) make bump-version VERSION=x.y.z
 bump-version:
 	$(call run_sync_versions,)

--- a/bridge/app/lib/src/version.dart
+++ b/bridge/app/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '1.0.7';
+const String appVersion = '1.0.8';

--- a/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-arm64",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS ARM64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.0.7",
+    "releaseTag": "v1.0.8",
     "releaseArtifact": "sesori-bridge-macos-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-darwin-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-x64",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS x64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.0.7",
+    "releaseTag": "v1.0.8",
     "releaseArtifact": "sesori-bridge-macos-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-arm64",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux ARM64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.0.7",
+    "releaseTag": "v1.0.8",
     "releaseArtifact": "sesori-bridge-linux-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-x64",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux x64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.0.7",
+    "releaseTag": "v1.0.8",
     "releaseArtifact": "sesori-bridge-linux-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-x64",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows x64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.0.7",
+    "releaseTag": "v1.0.8",
     "releaseArtifact": "sesori-bridge-windows-x64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge/package.json
+++ b/bridge/app/npm/sesori-bridge/package.json
@@ -1,21 +1,21 @@
 {
   "name": "@sesori/bridge",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Bootstrap launcher for the managed Sesori Bridge runtime",
   "bin": {
     "sesori-bridge": "bin/bridge.js"
   },
   "optionalDependencies": {
-    "@sesori/bridge-darwin-arm64": "1.0.7",
-    "@sesori/bridge-darwin-x64": "1.0.7",
-    "@sesori/bridge-linux-x64": "1.0.7",
-    "@sesori/bridge-linux-arm64": "1.0.7",
-    "@sesori/bridge-win32-x64": "1.0.7"
+    "@sesori/bridge-darwin-arm64": "1.0.8",
+    "@sesori/bridge-darwin-x64": "1.0.8",
+    "@sesori/bridge-linux-x64": "1.0.8",
+    "@sesori/bridge-linux-arm64": "1.0.8",
+    "@sesori/bridge-win32-x64": "1.0.8"
   },
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.0.7",
+    "releaseTag": "v1.0.8",
     "runtimeBundleSource": "github-release-assets"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sesori_bridge
 description: Dart implementation of the Sesori Bridge CLI for WebSocket communication.
-version: 1.0.7
+version: 1.0.8
 publish_to: none
 resolution: workspace
 

--- a/mobile/app/pubspec.yaml
+++ b/mobile/app/pubspec.yaml
@@ -17,7 +17,7 @@ resolution: workspace
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.7+1
+version: 1.0.8+1
 environment:
   sdk: ^3.11.5
 


### PR DESCRIPTION
Bumps the bridge and mobile apps from 1.0.7 to 1.0.8 across all version sources (bridge `version.dart`, npm `@sesori/bridge*` packages, bridge and mobile `pubspec.yaml`, and the matching `releaseTag` in the platform npm packages).

Also adds a usage comment to the `bump-version` Makefile target so the two supported invocations are discoverable from the Makefile:

```
make bump-version TYPE=patch|minor|major
make bump-version VERSION=x.y.z
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Bridge and Mobile to version 1.0.8 across all sources and align npm `releaseTag` values to `v1.0.8`. Add inline usage to the `bump-version` Makefile target with `TYPE=patch|minor|major` and `VERSION=x.y.z` examples.

<sup>Written for commit 3a1a838f78ec0a827aa4c3715235bf0e956f3e7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

