### PR TITLE
fix: pending changes banner text contrast in light and dark mode

### DIFF
--- a/mobile/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
+++ b/mobile/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
@@ -63,7 +63,7 @@ class SessionDetailLoadedView extends StatelessWidget {
         if (state.pendingPermissions.isNotEmpty)
           SessionDetailPendingBanner(
             icon: Icons.shield_outlined,
-            backgroundColor: context.zyra.colors.bgSuccessSecondary,
+            backgroundColor: context.zyra.colors.bgSuccessPrimary,
             foregroundColor: context.zyra.colors.textSuccessPrimary,
             label: state.pendingPermissions.length == 1
                 ? loc.permissionBannerSingle

--- a/mobile/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
+++ b/mobile/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
@@ -56,7 +56,7 @@ class SessionDetailLoadedView extends StatelessWidget {
           SessionDetailPendingBanner(
             icon: Icons.help_outline,
             backgroundColor: context.zyra.colors.bgBrandPrimary,
-            foregroundColor: context.zyra.colors.bgBrandPrimaryAlt,
+            foregroundColor: context.zyra.colors.textBrandPrimary,
             label: questionCount == 1 ? loc.questionBannerSingle : loc.questionBannerMultiple(questionCount),
             onTap: onShowPendingQuestions,
           ),
@@ -64,7 +64,7 @@ class SessionDetailLoadedView extends StatelessWidget {
           SessionDetailPendingBanner(
             icon: Icons.shield_outlined,
             backgroundColor: context.zyra.colors.bgSuccessSecondary,
-            foregroundColor: context.zyra.colors.fgSuccessPrimary,
+            foregroundColor: context.zyra.colors.textSuccessPrimary,
             label: state.pendingPermissions.length == 1
                 ? loc.permissionBannerSingle
                 : loc.permissionBannerMultiple(state.pendingPermissions.length),


### PR DESCRIPTION
Fixes text/background color contrast for both pending banners:

- **Question banner**: Changed foreground from  to 
  - Light mode:  bg +  text (was same color, invisible)
  - Dark mode:  bg +  text

- **Permission banner**: Changed foreground from  to 
  - Light mode:  bg +  text (already worked)
  - Dark mode:  bg +  text (was same color, invisible)

Both banners now have legible text in both light and dark modes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes text/background contrast for the pending question and permission banners in Session Detail so text is readable in both light and dark mode.

- **Bug Fixes**
  - Question banner: use textBrandPrimary for the text to avoid invisible text in light mode.
  - Permission banner: use bgSuccessPrimary for the background and textSuccessPrimary for the text to avoid invisible text in dark mode.

<sup>Written for commit d16723b514b1f2aacc05186b350e442adb2c3d20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

