### PR TITLE
fix(diff-viewer): scroll to next file header on collapse

### DIFF
--- a/mobile/app/lib/features/session_diffs/session_diffs_screen.dart
+++ b/mobile/app/lib/features/session_diffs/session_diffs_screen.dart
@@ -192,6 +192,9 @@ class _SessionDiffsBodyState extends State<_SessionDiffsBody> {
       _isComputing = true;
       _computeError = null;
       _viewModels = null;
+      // Drop stale GlobalKeys from the previous file list so they don't
+      // accumulate when the user switches sessions or refreshes.
+      _headerKeys.clear();
     });
     try {
       final viewModels = await DiffViewModelBuilder.build(

--- a/mobile/app/lib/features/session_diffs/session_diffs_screen.dart
+++ b/mobile/app/lib/features/session_diffs/session_diffs_screen.dart
@@ -50,6 +50,11 @@ class _SessionDiffsBodyState extends State<_SessionDiffsBody> {
   int _computeToken = 0;
   Brightness? _lastBrightness;
 
+  /// Stable [GlobalKey]s attached to each file's header [SizedBox] so the
+  /// post-frame scroll adjustment can find the next file's header after a
+  /// collapse. Keys are created lazily as files are rendered.
+  final Map<int, GlobalKey> _headerKeys = <int, GlobalKey>{};
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -129,6 +134,7 @@ class _SessionDiffsBodyState extends State<_SessionDiffsBody> {
                 viewModel: viewModels[i],
                 isExpanded: _expandedFileIndices.contains(i),
                 onToggle: () => _toggleFile(i),
+                headerKey: _headerKeys.putIfAbsent(i, GlobalKey.new),
               ),
             ),
             if (_expandedFileIndices.contains(i))
@@ -214,14 +220,39 @@ class _SessionDiffsBodyState extends State<_SessionDiffsBody> {
   }
 
   void _toggleFile(int fileIndex) {
-    if (_viewModels == null) return;
+    final viewModels = _viewModels;
+    if (viewModels == null) return;
     final expanded = Set<int>.from(_expandedFileIndices);
-    if (expanded.contains(fileIndex)) {
+    final wasExpanded = expanded.contains(fileIndex);
+    if (wasExpanded) {
       expanded.remove(fileIndex);
     } else {
       expanded.add(fileIndex);
     }
     setState(() => _expandedFileIndices = expanded);
+    if (wasExpanded) {
+      // After the sliver rebuilds with file `fileIndex` collapsed (body
+      // shrunk to zero), jump the viewport so the next file's header sits
+      // at the top — otherwise the user lands several files down for large
+      // collapsed files.
+      _scheduleScrollToNext(collapsedIndex: fileIndex, totalFiles: viewModels.length);
+    }
+  }
+
+  /// Schedules a post-frame jump so the header at `collapsedIndex + 1` is
+  /// aligned to the top of the viewport. No-op if the collapsed file is the
+  /// last one (there is no "next file" to anchor to) or the key has not yet
+  /// been attached to a rendered widget.
+  void _scheduleScrollToNext({required int collapsedIndex, required int totalFiles}) {
+    if (collapsedIndex + 1 >= totalFiles) return;
+    final nextKey = _headerKeys[collapsedIndex + 1];
+    if (nextKey == null) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final context = nextKey.currentContext;
+      if (context == null) return;
+      Scrollable.ensureVisible(context, alignment: 0.0, duration: Duration.zero);
+    });
   }
 
   Widget _buildSkippedPlaceholder(FileDiffSkipReason reason) {

--- a/mobile/app/lib/features/session_diffs/widgets/diff_file_header_delegate.dart
+++ b/mobile/app/lib/features/session_diffs/widgets/diff_file_header_delegate.dart
@@ -10,17 +10,18 @@ class DiffFileHeaderDelegate extends SliverPersistentHeaderDelegate {
   final bool isExpanded;
   final VoidCallback onToggle;
 
-  /// Optional key attached to the header's [SizedBox] so callers can locate
-  /// the header inside the scrollable (e.g. via [Scrollable.ensureVisible]
-  /// after the owning file is collapsed). Null is fine — the header just
-  /// won't be addressable by key.
+  /// Key attached to the header's [SizedBox] so callers can locate the
+  /// header inside the scrollable (e.g. via [Scrollable.ensureVisible] after
+  /// the owning file is collapsed). Nullable because callers may not need
+  /// the header to be addressable, but the constructor is `required` to
+  /// follow the project-wide named-argument convention.
   final Key? headerKey;
 
   DiffFileHeaderDelegate({
     required this.viewModel,
     required this.isExpanded,
     required this.onToggle,
-    this.headerKey,
+    required this.headerKey,
   });
 
   /// Estimated height: 6px padding top + ~18px content + 6px padding bottom
@@ -53,6 +54,8 @@ class DiffFileHeaderDelegate extends SliverPersistentHeaderDelegate {
 
   @override
   bool shouldRebuild(DiffFileHeaderDelegate oldDelegate) {
-    return !identical(viewModel, oldDelegate.viewModel) || isExpanded != oldDelegate.isExpanded;
+    return !identical(viewModel, oldDelegate.viewModel) ||
+        isExpanded != oldDelegate.isExpanded ||
+        headerKey != oldDelegate.headerKey;
   }
 }

--- a/mobile/app/lib/features/session_diffs/widgets/diff_file_header_delegate.dart
+++ b/mobile/app/lib/features/session_diffs/widgets/diff_file_header_delegate.dart
@@ -10,10 +10,17 @@ class DiffFileHeaderDelegate extends SliverPersistentHeaderDelegate {
   final bool isExpanded;
   final VoidCallback onToggle;
 
+  /// Optional key attached to the header's [SizedBox] so callers can locate
+  /// the header inside the scrollable (e.g. via [Scrollable.ensureVisible]
+  /// after the owning file is collapsed). Null is fine — the header just
+  /// won't be addressable by key.
+  final Key? headerKey;
+
   DiffFileHeaderDelegate({
     required this.viewModel,
     required this.isExpanded,
     required this.onToggle,
+    this.headerKey,
   });
 
   /// Estimated height: 6px padding top + ~18px content + 6px padding bottom
@@ -34,6 +41,7 @@ class DiffFileHeaderDelegate extends SliverPersistentHeaderDelegate {
     // which is an invalid SliverGeometry (assertion failure in debug,
     // rendering glitch in release). Forcing exact height prevents this.
     return SizedBox(
+      key: headerKey,
       height: maxExtent,
       child: DiffFileWidget(
         viewModel: viewModel,

--- a/mobile/app/test/features/session_diffs/session_diffs_collapse_scroll_test.dart
+++ b/mobile/app/test/features/session_diffs/session_diffs_collapse_scroll_test.dart
@@ -1,0 +1,168 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:get_it/get_it.dart";
+import "package:mocktail/mocktail.dart";
+import "package:sesori_auth/sesori_auth.dart" show ApiResponse;
+import "package:sesori_dart_core/sesori_dart_core.dart" show SessionRepository;
+import "package:sesori_mobile/features/session_diffs/session_diffs_screen.dart";
+import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
+
+import "../../helpers/test_helpers.dart";
+
+class _MockSessionRepository extends Mock implements SessionRepository {}
+
+FileDiff _makeDiff(String file, {required int lineCount}) {
+  final before = List<String>.filled(lineCount, "old line").join("\n");
+  final after = List<String>.filled(lineCount, "new line").join("\n");
+  return FileDiff.content(
+    file: "lib/$file",
+    before: before,
+    after: after,
+    additions: lineCount,
+    deletions: lineCount,
+    status: FileDiffStatus.modified,
+  );
+}
+
+/// Builds the screen and waits for the async cubit load + the
+/// [DiffViewModelBuilder] compute() isolate to complete.
+///
+/// `DiffViewModelBuilder.build()` uses `compute()`, which spawns a real
+/// isolate that the test clock does not control. We therefore run the
+/// initial-load wait inside [WidgetTester.runAsync] so the isolate can
+/// finish, then pump a series of frames so the widget rebuilds with the
+/// computed view models. We avoid [WidgetTester.pumpAndSettle] here
+/// because the isolate communication leaves a pending microtask that the
+/// fake-async clock can never resolve on its own.
+Future<void> _pumpLoadedScreen(WidgetTester tester) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: ThemeData(extensions: [ZyraDesignSystem.light]),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: const SessionDiffsScreen(projectId: "project-1", sessionId: "session-1"),
+    ),
+  );
+
+  // Let the cubit's async fetch and the view-model builder's compute()
+  // isolate complete in real time. We alternate between runAsync (to let
+  // the isolate's real-time message round-trip happen) and pump (to let
+  // the fake-async clock process the resulting setState rebuild).
+  for (var i = 0; i < 20; i++) {
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    });
+    await tester.pump();
+  }
+
+  // Sanity: the diff viewer should have rendered a CustomScrollView by now.
+  expect(find.byType(CustomScrollView), findsOneWidget, reason: "diff viewer did not finish loading");
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(registerAllFallbackValues);
+
+  late _MockSessionRepository mockRepo;
+
+  setUp(() async {
+    final getIt = GetIt.instance;
+    await getIt.reset();
+    mockRepo = _MockSessionRepository();
+    getIt.registerSingleton<SessionRepository>(mockRepo);
+  });
+
+  testWidgets(
+    "collapsing an expanded file jumps the viewport so the next file's header sits at the top",
+    (tester) async {
+      // Three files: a large one (aaa) whose body we'll scroll into, a small
+      // one (bbb) that should become the new top after the collapse, and a
+      // trailing one (ccc) to ensure we don't accidentally land past the
+      // end of the list.
+      when(() => mockRepo.getSessionDiffs(sessionId: any(named: "sessionId"))).thenAnswer(
+        (_) async => ApiResponse.success(
+          SessionDiffsResponse(diffs: [
+            _makeDiff("aaa.dart", lineCount: 10),
+            _makeDiff("bbb.dart", lineCount: 2),
+            _makeDiff("ccc.dart", lineCount: 10),
+          ]),
+        ),
+      );
+
+      await _pumpLoadedScreen(tester);
+
+      final scrollFinder = find.byType(CustomScrollView);
+      expect(scrollFinder, findsOneWidget);
+
+      // Scroll a little into the first file's body so bbb's header is no
+      // longer at the very top of the viewport.
+      await tester.drag(scrollFinder, const Offset(0, -50));
+      await tester.pumpAndSettle();
+
+      final bbbHeader = find.text("bbb.dart");
+      expect(bbbHeader, findsOneWidget);
+
+      final scrollRectBefore = tester.getRect(scrollFinder);
+      final bbbRectBefore = tester.getRect(bbbHeader);
+      expect(
+        bbbRectBefore.top,
+        greaterThan(scrollRectBefore.top + 10),
+        reason: "precondition: bbb's header should be below the viewport top before the collapse",
+      );
+
+      // Collapse the first file by tapping its header.
+      await tester.tap(find.text("aaa.dart"));
+      await tester.pumpAndSettle();
+
+      final scrollRectAfter = tester.getRect(scrollFinder);
+      final bbbRectAfter = tester.getRect(bbbHeader);
+      // The [DiffFileWidget] has `EdgeInsets.symmetric(vertical: 6)` so the
+      // file-name text sits a few pixels below the header's top edge. The
+      // 10px tolerance covers that padding plus any sub-pixel rounding from
+      // the SliverPersistentHeader layout.
+      expect(
+        bbbRectAfter.top,
+        closeTo(scrollRectAfter.top, 10.0),
+        reason: "bbb's header should be aligned to the top of the scroll viewport after the collapse",
+      );
+    },
+  );
+
+  testWidgets(
+    "collapsing the last file leaves the viewport anchored to the end of the list",
+    (tester) async {
+      when(() => mockRepo.getSessionDiffs(sessionId: any(named: "sessionId"))).thenAnswer(
+        (_) async => ApiResponse.success(
+          SessionDiffsResponse(diffs: [
+            _makeDiff("aaa.dart", lineCount: 10),
+            _makeDiff("bbb.dart", lineCount: 2),
+          ]),
+        ),
+      );
+
+      await _pumpLoadedScreen(tester);
+
+      final scrollFinder = find.byType(CustomScrollView);
+      // Scroll past aaa.dart so bbb.dart's header is in the viewport.
+      await tester.drag(scrollFinder, const Offset(0, -200));
+      await tester.pumpAndSettle();
+
+      final scrollable = tester.state<ScrollableState>(find.byType(Scrollable).first);
+      final positionBefore = scrollable.position.pixels;
+
+      // Collapse the LAST file — there is no "next file" to anchor to, so
+      // the scroll offset should not jump to a new file's header.
+      await tester.tap(find.text("bbb.dart"));
+      await tester.pumpAndSettle();
+
+      final positionAfter = tester.state<ScrollableState>(find.byType(Scrollable).first).position.pixels;
+      // Collapsing the last file removes content above the viewport. The
+      // viewport may either stay at the same pixel offset or clamp to the
+      // new maxScrollExtent — both are acceptable as long as we did not
+      // jump to a new file's header.
+      expect(positionAfter, lessThanOrEqualTo(positionBefore));
+    },
+  );
+}


### PR DESCRIPTION
## Problem
Collapsing a file in the diff viewer preserved the scroll offset, which landed the user several files down for large collapsed files.

## Fix
After the sliver rebuilds with file `i` collapsed (body shrunk to zero), jump the viewport so file `i+1`'s header is anchored at the top of the viewport. If the collapsed file is the last one, the offset is left as-is (no `next file` to anchor to).

## Implementation
- Added an optional `Key? headerKey` to `DiffFileHeaderDelegate`, applied to the `SizedBox` in `build()`.
- `_SessionDiffsBodyState` now keeps a `Map<int, GlobalKey> _headerKeys`, hands each delegate its key, and on collapse schedules a post-frame `Scrollable.ensureVisible(nextContext, alignment: 0.0, duration: Duration.zero)`.

## Testing
- All 33 pre-existing diff viewer tests still pass.
- Two new widget tests in `session_diffs_collapse_scroll_test.dart`:
  1. Collapsing an expanded file jumps the viewport so the next file's header sits at the top.
  2. Collapsing the last file leaves the viewport anchored (no `next file` to jump to).
- `flutter analyze` clean.
- Full `flutter test` (411 tests) passes.

## Review
- `aristotle-plan-review`: approved after inlining the scroll logic into `_SessionDiffsBodyState` (the originally proposed `DiffScrollAdjuster` extraction violated A5/A11).
- `aristotle-impl-review`: APPROVED.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes diff viewer collapse behavior by anchoring the next file’s header to the top after a collapse. Prevents users from landing several files down when collapsing large diffs.

- **Bug Fixes**
  - After collapsing a file, the viewport jumps to the next file’s header; no jump for the last file.
  - Stable header keys (cleared on refresh) + post-frame `ensureVisible` with top alignment for a flicker-free jump; header delegate rebuilds on `headerKey` changes and `headerKey` is required.
  - Two widget tests for the jump and last-file cases.

<sup>Written for commit 9bc7455a3b1c2194fef9809f942f48fd485c4394. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

