### PR TITLE
feat: add Claude Code address-pr-comments skill

### DIFF
--- a/.claude/skills/address-pr-comments/SKILL.md
+++ b/.claude/skills/address-pr-comments/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: address-pr-comments
+description: Address unresolved inline PR review comments on a GitHub pull request. Fetches unresolved comments, assesses validity (with extra scrutiny for AI/bot reviewers), implements fixes, leaves a reply on every comment thread, and commits changes. Use when the user asks to address PR comments, resolve review feedback, implement requested changes, or handle PR review threads.
+---
+
+# address-pr-comments (Claude Code shim)
+
+This is the Claude Code entry point for the shared `address-pr-comments` skill. The full procedure — core rules, validity assessment, AI/bot scrutiny, commit/push ordering, reply formats, and edge cases — is **not duplicated here**. It lives in one canonical file.
+
+**Read `.opencode/skills/address-pr-comments/SKILL.md` now and follow it in full.** (Path is relative to the repository root, which is the Claude Code working directory.)
+
+## Path resolution
+
+The canonical file uses paths relative to its own directory, `.opencode/skills/address-pr-comments/`. Claude Code runs `bash` from the repo root, so resolve its two script references against that directory:
+
+| Canonical file says | Run from repo root |
+| --- | --- |
+| `../pr-inline-comments/scripts/fetch.sh` | `.opencode/skills/pr-inline-comments/scripts/fetch.sh` |
+| `./scripts/reply.sh` | `.claude/skills/address-pr-comments/scripts/reply.sh` |
+
+The `reply.sh` in this skill's `scripts/` is a thin wrapper that `exec`s the canonical `.opencode/skills/address-pr-comments/scripts/reply.sh`, so either path runs identical code. The fetch script is shared directly with no wrapper.
+
+For resolving natural-language `--since` time windows into ISO 8601, the canonical file points at `.opencode/skills/pr-inline-comments/SKILL.md` — follow that section as written.

--- a/.claude/skills/address-pr-comments/scripts/reply.sh
+++ b/.claude/skills/address-pr-comments/scripts/reply.sh
@@ -3,4 +3,8 @@
 # [Sesori reply] prefixing, gh API call) lives there, so it stays a single
 # source of truth across harnesses. All arguments are forwarded verbatim.
 set -euo pipefail
-exec "$(git rev-parse --show-toplevel)/.opencode/skills/address-pr-comments/scripts/reply.sh" "$@"
+# Resolve the repo root from this script's own location (the directory layout is
+# static) rather than `git rev-parse`, so it works without a git subprocess and
+# survives strict ownership rules in CI/containers.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/../../../../.opencode/skills/address-pr-comments/scripts/reply.sh" "$@"

--- a/.claude/skills/address-pr-comments/scripts/reply.sh
+++ b/.claude/skills/address-pr-comments/scripts/reply.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Thin wrapper around the shared OpenCode reply.sh. The real logic (arg parsing,
+# [Sesori reply] prefixing, gh API call) lives there, so it stays a single
+# source of truth across harnesses. All arguments are forwarded verbatim.
+set -euo pipefail
+exec "$(git rev-parse --show-toplevel)/.opencode/skills/address-pr-comments/scripts/reply.sh" "$@"


### PR DESCRIPTION
## What

Adds a Claude Code skill at `.claude/skills/address-pr-comments/` that mirrors the existing OpenCode `address-pr-comments` skill (added in #191), so the same PR-review workflow is available from the Claude Code harness.

## Approach: thin shims, single source of truth

To avoid duplicating the procedure and script logic across harnesses, both Claude files only carry what's harness-specific and **reference** the canonical `.opencode` originals:

- **`SKILL.md`** — keeps just the frontmatter (`name`/`description`, required for Claude to discover/trigger the skill) plus a short body that tells the model to read and follow `.opencode/skills/address-pr-comments/SKILL.md`, with a path-resolution table mapping that file's skill-dir-relative script paths to repo-root paths (Claude Code runs `bash` from the repo root).
- **`scripts/reply.sh`** — a 6-line wrapper: `exec "$(git rev-parse --show-toplevel)/.opencode/skills/address-pr-comments/scripts/reply.sh" "$@"`.
- The `pr-inline-comments` `fetch.sh` is referenced directly (no wrapper, not duplicated).

Net effect: the rules, validity assessment, reply formats, and all bash logic live in exactly one place (`.opencode/`); editing there propagates to both harnesses.

## Notes

- `pr-inline-comments` is **not** ported as a standalone Claude skill. In OpenCode it's a deny-listed "library skill" (used only for its `fetch.sh`); Claude Code has no equivalent hide-from-invocation mechanism, so only its script is referenced.
- The Claude skill is intentionally coupled to the `.opencode/` directory — if those shared scripts move, the paths in `SKILL.md` and `reply.sh` need updating.

## Verification

- `reply.sh` passes `bash -n`; the wrapper correctly delegates to the canonical script (`-h` prints its usage, and bad args hit its validation).
- `.claude/skills/` is tracked by git (not ignored), so the skill is committed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Claude Code `address-pr-comments` skill that mirrors the OpenCode version, enabling the same PR-review workflow in the Claude Code harness. Uses thin shims to keep `.opencode` as the single source of truth.

- New Features
  - `SKILL.md` carries frontmatter and points to `.opencode/skills/address-pr-comments/SKILL.md`, with repo-root path mapping for scripts.
  - `scripts/reply.sh` is a tiny wrapper that execs `.opencode/skills/address-pr-comments/scripts/reply.sh`, resolving the repo root via `BASH_SOURCE` (no `git`) for CI/containers.
  - Reuses `.opencode/skills/pr-inline-comments/scripts/fetch.sh` directly (no duplication).

<sup>Written for commit 8499551c6844b51c6599774d35395d36eff44831. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

