### PR TITLE
chore(auth): type AuthUser.provider as AuthProvider

### DIFF
--- a/bridge/app/test/auth/login_test.dart
+++ b/bridge/app/test/auth/login_test.dart
@@ -25,7 +25,7 @@ void main() {
               refreshToken: 'github-refresh-token',
               user: AuthUser(
                 id: 'user-1',
-                provider: 'github',
+                provider: AuthProvider.github,
                 providerUserId: 'gh-1',
                 providerUsername: 'octocat',
               ),
@@ -95,7 +95,7 @@ void main() {
               refreshToken: 'google-refresh-token',
               user: AuthUser(
                 id: 'user-1',
-                provider: 'google',
+                provider: AuthProvider.google,
                 providerUserId: 'google-1',
                 providerUsername: null,
               ),
@@ -326,7 +326,7 @@ class _MockLoginEmailApi implements LoginEmailApi {
         refreshToken: 'test-refresh-token',
         user: AuthUser(
           id: 'user-1',
-          provider: 'email',
+          provider: AuthProvider.email,
           providerUserId: 'user-1',
           providerUsername: 'testuser',
         ),
@@ -341,7 +341,7 @@ class _MockLoginEmailApi implements LoginEmailApi {
     AuthResponse(
       accessToken: '',
       refreshToken: '',
-      user: AuthUser(id: '', provider: '', providerUserId: '', providerUsername: null),
+      user: AuthUser(id: '', provider: AuthProvider.email, providerUserId: '', providerUsername: null),
     ),
     401,
   );
@@ -350,7 +350,7 @@ class _MockLoginEmailApi implements LoginEmailApi {
     AuthResponse(
       accessToken: '',
       refreshToken: '',
-      user: AuthUser(id: '', provider: '', providerUserId: '', providerUsername: null),
+      user: AuthUser(id: '', provider: AuthProvider.email, providerUserId: '', providerUsername: null),
     ),
     429,
   );
@@ -361,7 +361,7 @@ class _MockLoginEmailApi implements LoginEmailApi {
       refreshToken: '',
       user: AuthUser(
         id: 'user-1',
-        provider: 'email',
+        provider: AuthProvider.email,
         providerUserId: 'user-1',
         providerUsername: 'testuser',
       ),

--- a/mobile/app/test/helpers/test_helpers.dart
+++ b/mobile/app/test/helpers/test_helpers.dart
@@ -458,7 +458,7 @@ ProviderListResponse testProviderListResponse() {
 AuthUser testAuthUser() {
   return const AuthUser(
     id: "user-1",
-    provider: "github",
+    provider: AuthProvider.github,
     providerUserId: "12345678",
     providerUsername: "testuser",
   );

--- a/mobile/module_auth/test/auth_manager_test.dart
+++ b/mobile/module_auth/test/auth_manager_test.dart
@@ -30,7 +30,7 @@ void main() {
 
   const user = AuthUser(
     id: "user-1",
-    provider: "github",
+    provider: AuthProvider.github,
     providerUserId: "12345678",
     providerUsername: "testuser",
   );
@@ -81,7 +81,7 @@ void main() {
         "refreshToken": "new-refresh-token",
         "user": {
           "id": user.id,
-          "provider": user.provider,
+          "provider": user.provider.key,
           "providerUserId": user.providerUserId,
           "providerUsername": user.providerUsername,
         },
@@ -123,7 +123,7 @@ void main() {
         "refreshToken": "bg-refresh-token",
         "user": {
           "id": user.id,
-          "provider": user.provider,
+          "provider": user.provider.key,
           "providerUserId": user.providerUserId,
           "providerUsername": user.providerUsername,
         },
@@ -166,7 +166,7 @@ void main() {
         "refreshToken": "new-refresh-token",
         "user": {
           "id": user.id,
-          "provider": user.provider,
+          "provider": user.provider.key,
           "providerUserId": user.providerUserId,
           "providerUsername": user.providerUsername,
         },
@@ -228,7 +228,7 @@ void main() {
             "refreshToken": "singleflight-refresh",
             "user": {
               "id": user.id,
-              "provider": user.provider,
+              "provider": user.provider.key,
               "providerUserId": user.providerUserId,
               "providerUsername": user.providerUsername,
             },
@@ -346,7 +346,7 @@ void main() {
             "refreshToken": "oauth-refresh-token",
             "user": {
               "id": user.id,
-              "provider": user.provider,
+              "provider": user.provider.key,
               "providerUserId": user.providerUserId,
               "providerUsername": user.providerUsername,
             },
@@ -549,7 +549,7 @@ void main() {
           jsonEncode({
             "user": {
               "id": user.id,
-              "provider": user.provider,
+              "provider": user.provider.key,
               "providerUserId": user.providerUserId,
               "providerUsername": user.providerUsername,
             },

--- a/mobile/module_core/test/capabilities/server_connection/connection_service_auth_state_test.dart
+++ b/mobile/module_core/test/capabilities/server_connection/connection_service_auth_state_test.dart
@@ -109,7 +109,7 @@ void main() {
       addTearDown(service.dispose);
 
       authStateController.add(
-        const AuthState.authenticated(user: AuthUser(id: "u", provider: "github", providerUserId: "1", providerUsername: "u")),
+        const AuthState.authenticated(user: AuthUser(id: "u", provider: AuthProvider.github, providerUserId: "1", providerUsername: "u")),
       );
       await Future<void>.delayed(const Duration(milliseconds: 50));
 
@@ -137,7 +137,7 @@ void main() {
       addTearDown(service.dispose);
 
       authStateController.add(
-        const AuthState.authenticated(user: AuthUser(id: "u", provider: "github", providerUserId: "1", providerUsername: "u")),
+        const AuthState.authenticated(user: AuthUser(id: "u", provider: AuthProvider.github, providerUserId: "1", providerUsername: "u")),
       );
       await Future<void>.delayed(const Duration(milliseconds: 50));
 
@@ -163,7 +163,7 @@ void main() {
       addTearDown(service.dispose);
 
       authStateController.add(
-        const AuthState.authenticated(user: AuthUser(id: "u", provider: "github", providerUserId: "1", providerUsername: "u")),
+        const AuthState.authenticated(user: AuthUser(id: "u", provider: AuthProvider.github, providerUserId: "1", providerUsername: "u")),
       );
       await Future<void>.delayed(const Duration(milliseconds: 50));
 

--- a/mobile/module_core/test/cubits/login/login_cubit_test.dart
+++ b/mobile/module_core/test/cubits/login/login_cubit_test.dart
@@ -29,7 +29,7 @@ const testAuthInitResponse = AuthInitResponse(
 
 const testAuthUser = AuthUser(
   id: "id",
-  provider: "google",
+  provider: AuthProvider.google,
   providerUserId: "user123",
   providerUsername: null,
 );

--- a/mobile/module_core/test/routing/notification_open_dispatcher_test.dart
+++ b/mobile/module_core/test/routing/notification_open_dispatcher_test.dart
@@ -283,7 +283,7 @@ AuthState _authenticatedState() {
   return const AuthState.authenticated(
     user: AuthUser(
       id: "user-1",
-      provider: "github",
+      provider: AuthProvider.github,
       providerUserId: "provider-user-1",
       providerUsername: "alex",
     ),

--- a/mobile/module_core/test/services/notification_registration_service_test.dart
+++ b/mobile/module_core/test/services/notification_registration_service_test.dart
@@ -314,7 +314,7 @@ AuthState _authenticatedState() {
   return const AuthState.authenticated(
     user: AuthUser(
       id: "user-1",
-      provider: "github",
+      provider: AuthProvider.github,
       providerUserId: "provider-user-1",
       providerUsername: "alex",
     ),

--- a/shared/sesori_shared/lib/sesori_shared.dart
+++ b/shared/sesori_shared/lib/sesori_shared.dart
@@ -4,6 +4,7 @@ export "src/concurrency/event_queue.dart";
 export "src/concurrency/future_x.dart";
 export "src/concurrency/isolate/isolate.dart";
 export "src/constants/sse_constants.dart";
+export "src/converters/auth_provider_converter.dart";
 export "src/converters/date_converter.dart";
 export "src/crypto/crypto_service.dart";
 export "src/crypto/session_encryptor.dart";

--- a/shared/sesori_shared/lib/src/converters/auth_provider_converter.dart
+++ b/shared/sesori_shared/lib/src/converters/auth_provider_converter.dart
@@ -1,0 +1,21 @@
+import "package:json_annotation/json_annotation.dart";
+
+import "../models/auth/auth_provider.dart";
+
+const authProviderConverter = AuthProviderConverter();
+
+class AuthProviderConverter implements JsonConverter<AuthProvider, String> {
+  const AuthProviderConverter();
+
+  @override
+  AuthProvider fromJson(String json) {
+    final provider = AuthProvider.fromKey(json);
+    if (provider == null) {
+      throw FormatException("Unknown AuthProvider key: $json");
+    }
+    return provider;
+  }
+
+  @override
+  String toJson(AuthProvider object) => object.key;
+}

--- a/shared/sesori_shared/lib/src/models/auth/auth_user.dart
+++ b/shared/sesori_shared/lib/src/models/auth/auth_user.dart
@@ -1,5 +1,8 @@
 import "package:freezed_annotation/freezed_annotation.dart";
 
+import "../../converters/auth_provider_converter.dart";
+import "auth_provider.dart";
+
 part "auth_user.freezed.dart";
 part "auth_user.g.dart";
 
@@ -7,7 +10,7 @@ part "auth_user.g.dart";
 sealed class AuthUser with _$AuthUser {
   const factory AuthUser({
     required String id,
-    required String provider,
+    @authProviderConverter required AuthProvider provider,
     required String providerUserId,
     required String? providerUsername,
   }) = _AuthUser;

--- a/shared/sesori_shared/lib/src/models/auth/auth_user.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/auth/auth_user.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$AuthUser {
 
- String get id; String get provider; String get providerUserId; String? get providerUsername;
+ String get id;@authProviderConverter AuthProvider get provider; String get providerUserId; String? get providerUsername;
 /// Create a copy of AuthUser
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $AuthUserCopyWith<$Res>  {
   factory $AuthUserCopyWith(AuthUser value, $Res Function(AuthUser) _then) = _$AuthUserCopyWithImpl;
 @useResult
 $Res call({
- String id, String provider, String providerUserId, String? providerUsername
+ String id,@authProviderConverter AuthProvider provider, String providerUserId, String? providerUsername
 });
 
 
@@ -69,7 +69,7 @@ class _$AuthUserCopyWithImpl<$Res>
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,provider: null == provider ? _self.provider : provider // ignore: cast_nullable_to_non_nullable
-as String,providerUserId: null == providerUserId ? _self.providerUserId : providerUserId // ignore: cast_nullable_to_non_nullable
+as AuthProvider,providerUserId: null == providerUserId ? _self.providerUserId : providerUserId // ignore: cast_nullable_to_non_nullable
 as String,providerUsername: freezed == providerUsername ? _self.providerUsername : providerUsername // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
@@ -83,11 +83,11 @@ as String?,
 @JsonSerializable()
 
 class _AuthUser implements AuthUser {
-  const _AuthUser({required this.id, required this.provider, required this.providerUserId, required this.providerUsername});
+  const _AuthUser({required this.id, @authProviderConverter required this.provider, required this.providerUserId, required this.providerUsername});
   factory _AuthUser.fromJson(Map<String, dynamic> json) => _$AuthUserFromJson(json);
 
 @override final  String id;
-@override final  String provider;
+@override@authProviderConverter final  AuthProvider provider;
 @override final  String providerUserId;
 @override final  String? providerUsername;
 
@@ -124,7 +124,7 @@ abstract mixin class _$AuthUserCopyWith<$Res> implements $AuthUserCopyWith<$Res>
   factory _$AuthUserCopyWith(_AuthUser value, $Res Function(_AuthUser) _then) = __$AuthUserCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String provider, String providerUserId, String? providerUsername
+ String id,@authProviderConverter AuthProvider provider, String providerUserId, String? providerUsername
 });
 
 
@@ -145,7 +145,7 @@ class __$AuthUserCopyWithImpl<$Res>
   return _then(_AuthUser(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,provider: null == provider ? _self.provider : provider // ignore: cast_nullable_to_non_nullable
-as String,providerUserId: null == providerUserId ? _self.providerUserId : providerUserId // ignore: cast_nullable_to_non_nullable
+as AuthProvider,providerUserId: null == providerUserId ? _self.providerUserId : providerUserId // ignore: cast_nullable_to_non_nullable
 as String,providerUsername: freezed == providerUsername ? _self.providerUsername : providerUsername // ignore: cast_nullable_to_non_nullable
 as String?,
   ));

--- a/shared/sesori_shared/lib/src/models/auth/auth_user.g.dart
+++ b/shared/sesori_shared/lib/src/models/auth/auth_user.g.dart
@@ -8,14 +8,14 @@ part of 'auth_user.dart';
 
 _AuthUser _$AuthUserFromJson(Map json) => _AuthUser(
   id: json['id'] as String,
-  provider: json['provider'] as String,
+  provider: authProviderConverter.fromJson(json['provider'] as String),
   providerUserId: json['providerUserId'] as String,
   providerUsername: json['providerUsername'] as String?,
 );
 
 Map<String, dynamic> _$AuthUserToJson(_AuthUser instance) => <String, dynamic>{
   'id': instance.id,
-  'provider': instance.provider,
+  'provider': authProviderConverter.toJson(instance.provider),
   'providerUserId': instance.providerUserId,
   'providerUsername': instance.providerUsername,
 };

--- a/shared/sesori_shared/test/models/auth_flow_models_test.dart
+++ b/shared/sesori_shared/test/models/auth_flow_models_test.dart
@@ -86,7 +86,7 @@ void main() {
         refreshToken: "refresh-token",
         user: AuthUser(
           id: "user-1",
-          provider: "github",
+          provider: AuthProvider.github,
           providerUserId: "12345",
           providerUsername: "octocat",
         ),


### PR DESCRIPTION
## Summary

Replace the untyped `String provider` field on the shared `AuthUser` Freezed model with the existing `AuthProvider` sealed class (`GitHubAuthProvider`, `GoogleAuthProvider`, `AppleAuthProvider`, `EmailAuthProvider`). The on-the-wire JSON stays byte-identical: a new `AuthProviderConverter` (modeled on the existing `HttpMethodConverter` in mobile and `DateConverter` in shared) reads and writes the same provider key strings ("github", "google", "apple", email).

## Motivation

`AuthUser.provider` was a `String` even though the package already defines a sealed `AuthProvider` class with `key`, `label`, `apiAuthPath`, and a `fromKey` helper. An opaque `String` field:

- Invites typos ("githhub") that no analyzer catches
- Bypasses exhaustiveness — `switch (provider)` over a `String` can't warn about unhandled values
- Makes equality / pattern matching less safe
- Forces every call site to re-validate the same way

Switching to the existing sealed class gives compile-time exhaustiveness, the same way `bridge/app/lib/src/auth/token.dart` already handles `lastProvider`.

## What changed

- **New** `shared/sesori_shared/lib/src/converters/auth_provider_converter.dart` — `AuthProviderConverter` implementing `JsonConverter<AuthProvider, String>`. Uses the existing `AuthProvider.fromKey` and `AuthProvider.key` helpers so the wire format is byte-identical to the previous `String` field. Throws `FormatException` on unknown keys.
- **Modified** `shared/sesori_shared/lib/src/models/auth/auth_user.dart` — `provider` is now `AuthProvider` annotated with `@authProviderConverter`.
- **Regenerated** `auth_user.freezed.dart` and `auth_user.g.dart` via `dart run build_runner build`.
- **Modified** `shared/sesori_shared/lib/sesori_shared.dart` — exports the new converter.
- **Updated** all call sites that built `AuthUser(provider: "github")` strings to use the typed `AuthProvider.github` / `.google` / `.email` singletons.
- **Updated** the one test that re-serialized `user.provider` into a JSON map (`auth_manager_test.dart`) to use `user.provider.key` so the emitted wire string is unchanged.

## Validation

- `shared/sesori_shared`: `dart analyze` clean, 214 tests pass
- `bridge/`: `make analyze` clean, 1150 tests pass
- `mobile/app/`: `dart analyze` clean, `flutter test` 411 pass
- `mobile/module_core/`: `dart analyze` clean, 276 tests pass
- `mobile/module_auth/`: `dart analyze` clean, 57 tests pass

## Architecture review

Both plan and implementation were reviewed by the monorepo's `aristotle-plan-review` and `aristotle-impl-review` agents. Plan approved; implementation approved with zero violations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Typed `AuthUser.provider` to the `AuthProvider` sealed class and added a JSON converter so the wire format stays the same. This prevents string-typo bugs and enables exhaustive switches.

- **Refactors**
  - Replaced `String provider` with `AuthProvider` in `AuthUser` and annotated with `@authProviderConverter`.
  - Added `AuthProviderConverter` (`JsonConverter<AuthProvider, String>`) and exported via `sesori_shared.dart`; JSON still uses "github", "google", "apple", "email"; unknown keys throw `FormatException`.
  - Updated tests and call sites to use `AuthProvider.github`/`.google`/`.email` and `user.provider.key` where a raw string is needed.
  - Regenerated Freezed/JSON files.

<sup>Written for commit e9f8020275cb06bcc7211a2266ac7153f2c1e3fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

