### PR TITLE
fix: show the best available model by default in the picker and on new sessions

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/provider_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/provider_mapper.dart
@@ -27,10 +27,7 @@ PluginProvidersResult mapProviderResponse({
             isAvailable: _isModelAvailable(
               status: _parseProviderModelStatus(rawStatus: m.status, modelId: m.id),
             ),
-            releaseDate: switch (m.releaseDate) {
-              final dateStr? => DateTime.tryParse(dateStr),
-              null => null,
-            },
+            releaseDate: _parseReleaseDate(m.releaseDate),
           ),
         )
         .toList();
@@ -60,6 +57,22 @@ _ProviderModelStatus _parseProviderModelStatus({
       return _ProviderModelStatus.unknown;
     }(),
   };
+}
+
+/// Parses a `release_date` string from models.dev into a [DateTime].
+///
+/// Dart's [DateTime.tryParse] only accepts `YYYY-MM-DD` (and full ISO 8601);
+/// models.dev emits the shorter `YYYY-MM` form for some providers (e.g.
+/// `kimi-for-coding`, where `release_date` is `2025-11` rather than
+/// `2025-11-01`). Without the `YYYY-MM-01` fallback, every model in those
+/// providers gets a `null` `releaseDate`, which makes any date-based
+/// downstream filter (e.g. the mobile model picker's "newest in family"
+/// default) fall back to iteration order — and on `kimi-for-coding` that
+/// surfaced the oldest model ("Kimi K2 Thinking") instead of the newest
+/// ("Kimi K2.6").
+DateTime? _parseReleaseDate(String? dateStr) {
+  if (dateStr == null) return null;
+  return DateTime.tryParse(dateStr) ?? DateTime.tryParse("$dateStr-01");
 }
 
 bool _isModelAvailable({required _ProviderModelStatus status}) {

--- a/bridge/sesori_plugin_opencode/test/provider_mapper_test.dart
+++ b/bridge/sesori_plugin_opencode/test/provider_mapper_test.dart
@@ -1,5 +1,6 @@
 import "package:opencode_plugin/src/models/provider_info.dart";
 import "package:opencode_plugin/src/provider_mapper.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginModel;
 import "package:test/test.dart";
 
 void main() {
@@ -107,6 +108,141 @@ void main() {
       final mapped = mapProviderResponse(response: response);
 
       expect(mapped.providers.single.models.single.variants, equals(["low", "high"]));
+    });
+
+    group("releaseDate parsing", () {
+      test("parses full YYYY-MM-DD release_date", () {
+        const response = ProviderListResponse(
+          providers: [
+            ProviderInfo(
+              id: "moonshotai",
+              name: "Moonshot AI",
+              models: {
+                "kimi-k2-thinking": ProviderModel(
+                  id: "moonshotai/kimi-k2-thinking",
+                  providerID: "moonshotai",
+                  name: "Kimi K2 Thinking",
+                  family: "kimi-thinking",
+                  releaseDate: "2025-11-06",
+                ),
+              },
+            ),
+          ],
+          defaults: {},
+          connected: ["moonshotai"],
+        );
+
+        final mapped = mapProviderResponse(response: response);
+        final model = mapped.providers.single.models.single;
+        expect(model.releaseDate, equals(DateTime(2025, 11, 6)));
+      });
+
+      test(
+        "parses short YYYY-MM release_date as the first of the month "
+        "(regression: kimi-for-coding models were getting null releaseDate)",
+        () {
+          // Mirrors the live models.dev entry for `kimi-for-coding`:
+          //   kimi-k2-thinking -> "2025-11"
+          //   k2p5             -> "2026-01"
+          //   k2p6             -> "2026-04"
+          //
+          // Before this fix, `DateTime.tryParse("2025-11")` returned null
+          // (Dart only accepts YYYY-MM-DD and full ISO 8601), so every
+          // model in the family ended up with a null `releaseDate`. The
+          // mobile picker then fell back to iteration order and surfaced
+          // "Kimi K2 Thinking" instead of "Kimi K2.6".
+          const response = ProviderListResponse(
+            providers: [
+              ProviderInfo(
+                id: "kimi-for-coding",
+                name: "Kimi For Coding",
+                models: {
+                  "kimi-k2-thinking": ProviderModel(
+                    id: "kimi-k2-thinking",
+                    providerID: "kimi-for-coding",
+                    name: "Kimi K2 Thinking",
+                    family: "kimi-thinking",
+                    releaseDate: "2025-11",
+                  ),
+                  "k2p5": ProviderModel(
+                    id: "k2p5",
+                    providerID: "kimi-for-coding",
+                    name: "Kimi K2.5",
+                    family: "kimi-thinking",
+                    releaseDate: "2026-01",
+                  ),
+                  "k2p6": ProviderModel(
+                    id: "k2p6",
+                    providerID: "kimi-for-coding",
+                    name: "Kimi K2.6",
+                    family: "kimi-thinking",
+                    releaseDate: "2026-04",
+                  ),
+                },
+              ),
+            ],
+            defaults: {},
+            connected: ["kimi-for-coding"],
+          );
+
+          final mapped = mapProviderResponse(response: response);
+          final modelsById = <String, PluginModel>{
+            for (final m in mapped.providers.single.models) m.id: m,
+          };
+          expect(modelsById["kimi-k2-thinking"]!.releaseDate, equals(DateTime(2025, 11, 1)));
+          expect(modelsById["k2p5"]!.releaseDate, equals(DateTime(2026, 1, 1)));
+          expect(modelsById["k2p6"]!.releaseDate, equals(DateTime(2026, 4, 1)));
+        },
+      );
+
+      test("leaves releaseDate null when the field is absent", () {
+        const response = ProviderListResponse(
+          providers: [
+            ProviderInfo(
+              id: "openai",
+              name: "OpenAI",
+              models: {
+                "gpt-4.1": ProviderModel(
+                  id: "openai/gpt-4.1",
+                  providerID: "openai",
+                  name: "GPT-4.1",
+                  family: "gpt-4.1",
+                ),
+              },
+            ),
+          ],
+          defaults: {},
+          connected: ["openai"],
+        );
+
+        final mapped = mapProviderResponse(response: response);
+        expect(mapped.providers.single.models.single.releaseDate, isNull);
+      });
+
+      test("leaves releaseDate null when the value is unparseable", () {
+        const response = ProviderListResponse(
+          providers: [
+            ProviderInfo(
+              id: "openai",
+              name: "OpenAI",
+              models: {
+                "gpt-4.1": ProviderModel(
+                  id: "openai/gpt-4.1",
+                  providerID: "openai",
+                  name: "GPT-4.1",
+                  family: "gpt-4.1",
+                  releaseDate: "not-a-date",
+                ),
+              },
+            ),
+          ],
+          defaults: {},
+          connected: ["openai"],
+        );
+
+        final mapped = mapProviderResponse(response: response);
+        expect(mapped.providers.single.models.single.releaseDate, isNull);
+      });
     });
   });
 }

--- a/mobile/app/lib/core/widgets/model_picker_sheet.dart
+++ b/mobile/app/lib/core/widgets/model_picker_sheet.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 import "package:go_router/go_router.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart" show DefaultModelSelector;
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_zyra/module_zyra.dart";
 
@@ -67,6 +68,8 @@ class ModelPickerSheet extends StatefulWidget {
 class _ModelPickerSheetState extends State<ModelPickerSheet> {
   String _query = "";
 
+  static const _defaultModelSelector = DefaultModelSelector();
+
   late final _sortedProviders = widget.providers.toList()..sort((a, b) => a.name.compareTo(b.name));
 
   bool _matchesQuery({required ProviderModel model, required String providerName}) {
@@ -79,9 +82,14 @@ class _ModelPickerSheetState extends State<ModelPickerSheet> {
   }
 
   /// Builds the set of model IDs that should be visible by default.
+  ///
+  /// For each family of available models we pick a single representative
+  /// (the user can always reveal the rest by typing in the search field).
+  /// The selection priority lives in [DefaultModelSelector] — same priority
+  /// used by the cubits that pick the initial model when no prior
+  /// selection exists — so the picker's "default per family" matches the
+  /// cubit's "default for the whole provider".
   Set<String> _defaultVisibleIds(ProviderInfo provider) {
-    final now = DateTime.now();
-    final cutoff = DateTime(now.year, now.month - 6, now.day);
     final visible = <String>{};
 
     // Group available models by family.
@@ -93,19 +101,11 @@ class _ModelPickerSheetState extends State<ModelPickerSheet> {
     }
 
     for (final group in byFamily.values) {
-      group.sort((a, b) {
-        final dateA = a.releaseDate;
-        final dateB = b.releaseDate;
-        if (dateB == null && dateA == null) return 0;
-        if (dateB == null) return -1;
-        if (dateA == null) return 1;
-        return dateB.compareTo(dateA);
-      });
-      final newest = group.first;
-      final date = newest.releaseDate;
-      if (date == null || date.isAfter(cutoff)) {
-        visible.add(newest.id);
-      }
+      final chosen = _defaultModelSelector.pickFromFamily(
+        group: group,
+        defaultModelId: provider.defaultModelID,
+      );
+      if (chosen != null) visible.add(chosen.id);
     }
 
     if (provider.id == widget.selectedProviderID) {

--- a/mobile/module_core/lib/sesori_dart_core.dart
+++ b/mobile/module_core/lib/sesori_dart_core.dart
@@ -89,3 +89,4 @@ export "src/services/session_detail_load_service.dart";
 // Utils
 export "src/utils/diff/diff_engine.dart";
 export "src/utils/diff/language_detector.dart";
+export "src/utils/model_filter/default_model_selector.dart";

--- a/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
@@ -65,20 +65,26 @@ class NewSessionCubit extends Cubit<NewSessionState> {
       if (agentModel != null) {
         defaultAgentModel = agentModel;
       } else if (providers.isNotEmpty) {
-        final firstProvider = providers.first;
-        final picked = _defaultModelSelector.pickFromProvider(
-          models: firstProvider.models,
-          defaultModelId: firstProvider.defaultModelID,
-        );
-        if (picked != null) {
-          defaultAgentModel = AgentModel(
-            providerID: firstProvider.id,
-            modelID: picked.id,
-            variant: null,
+        // Walk the provider list and use the first one that has at least
+        // one available model. Previously we only looked at `providers.first`,
+        // which silently produced `null` when the first provider happened
+        // to be misconfigured or fully deprecated.
+        AgentModel? pickedModel;
+        for (final provider in providers) {
+          final picked = _defaultModelSelector.pickFromProvider(
+            models: provider.models,
+            defaultModelId: provider.defaultModelID,
           );
-        } else {
-          defaultAgentModel = null;
+          if (picked != null) {
+            pickedModel = AgentModel(
+              providerID: provider.id,
+              modelID: picked.id,
+              variant: null,
+            );
+            break;
+          }
         }
+        defaultAgentModel = pickedModel;
       } else {
         defaultAgentModel = null;
       }

--- a/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
@@ -4,11 +4,13 @@ import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../../capabilities/session/session_service.dart";
+import "../../utils/model_filter/default_model_selector.dart";
 import "new_session_state.dart";
 
 class NewSessionCubit extends Cubit<NewSessionState> {
   final SessionService _sessionService;
   final String _projectId;
+  static const _defaultModelSelector = DefaultModelSelector();
 
   NewSessionCubit({
     required SessionService sessionService,
@@ -64,15 +66,19 @@ class NewSessionCubit extends Cubit<NewSessionState> {
         defaultAgentModel = agentModel;
       } else if (providers.isNotEmpty) {
         final firstProvider = providers.first;
-        final defaultModelID = firstProvider.defaultModelID;
-        final modelID = defaultModelID != null && firstProvider.models.containsKey(defaultModelID)
-            ? defaultModelID
-            : firstProvider.models.values.first.id;
-        defaultAgentModel = AgentModel(
-          providerID: firstProvider.id,
-          modelID: modelID,
-          variant: null,
+        final picked = _defaultModelSelector.pickFromProvider(
+          models: firstProvider.models,
+          defaultModelId: firstProvider.defaultModelID,
         );
+        if (picked != null) {
+          defaultAgentModel = AgentModel(
+            providerID: firstProvider.id,
+            modelID: picked.id,
+            variant: null,
+          );
+        } else {
+          defaultAgentModel = null;
+        }
       } else {
         defaultAgentModel = null;
       }

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -1148,20 +1148,26 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
     } else if (agents.isNotEmpty && agents.first.model != null) {
       defaultAgentModel = agents.first.model;
     } else if (providers.isNotEmpty) {
-      final firstProvider = providers.first;
-      final picked = _defaultModelSelector.pickFromProvider(
-        models: firstProvider.models,
-        defaultModelId: firstProvider.defaultModelID,
-      );
-      if (picked != null) {
-        defaultAgentModel = AgentModel(
-          providerID: firstProvider.id,
-          modelID: picked.id,
-          variant: null,
+      // Walk the provider list and use the first one that has at least
+      // one available model. Previously we only looked at `providers.first`,
+      // which silently produced `null` when the first provider happened
+      // to be misconfigured or fully deprecated.
+      AgentModel? pickedModel;
+      for (final provider in providers) {
+        final picked = _defaultModelSelector.pickFromProvider(
+          models: provider.models,
+          defaultModelId: provider.defaultModelID,
         );
-      } else {
-        defaultAgentModel = null;
+        if (picked != null) {
+          pickedModel = AgentModel(
+            providerID: provider.id,
+            modelID: picked.id,
+            variant: null,
+          );
+          break;
+        }
       }
+      defaultAgentModel = pickedModel;
     } else {
       defaultAgentModel = null;
     }

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -13,6 +13,7 @@ import "../../platform/notification_canceller.dart";
 import "../../repositories/permission_repository.dart";
 import "../../repositories/session_repository.dart";
 import "../../services/session_detail_load_service.dart";
+import "../../utils/model_filter/default_model_selector.dart";
 import "prompt_send_queue.dart";
 import "queued_session_submission.dart";
 import "session_detail_state.dart";
@@ -23,6 +24,7 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
   final SessionRepository _sessionRepository;
   final ConnectionService _connectionService;
   final PermissionRepository _permissionRepository;
+  static const _defaultModelSelector = DefaultModelSelector();
   final String _sessionId;
   final String _projectId;
   final NotificationCanceller _notificationCanceller;
@@ -1147,15 +1149,19 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       defaultAgentModel = agents.first.model;
     } else if (providers.isNotEmpty) {
       final firstProvider = providers.first;
-      final defaultModelID = firstProvider.defaultModelID;
-      final modelID = defaultModelID != null && firstProvider.models.containsKey(defaultModelID)
-          ? defaultModelID
-          : firstProvider.models.values.first.id;
-      defaultAgentModel = AgentModel(
-        providerID: firstProvider.id,
-        modelID: modelID,
-        variant: null,
+      final picked = _defaultModelSelector.pickFromProvider(
+        models: firstProvider.models,
+        defaultModelId: firstProvider.defaultModelID,
       );
+      if (picked != null) {
+        defaultAgentModel = AgentModel(
+          providerID: firstProvider.id,
+          modelID: picked.id,
+          variant: null,
+        );
+      } else {
+        defaultAgentModel = null;
+      }
     } else {
       defaultAgentModel = null;
     }

--- a/mobile/module_core/lib/src/utils/model_filter/default_model_selector.dart
+++ b/mobile/module_core/lib/src/utils/model_filter/default_model_selector.dart
@@ -1,0 +1,112 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+/// Pure helper that selects a single representative [ProviderModel] from a
+/// family or from a whole provider's [ProviderInfo.models] map.
+///
+/// The selector uses only signals already present in the upstream data, so
+/// the same logic works for every provider without per-provider knowledge:
+///
+/// 1. The provider's backend-supplied [ProviderInfo.defaultModelID], if it
+///    is available. This is the strongest signal — it is the provider's own
+///    "this is the default" answer.
+/// 2. Any model whose name contains the upstream " (latest)" marker.
+///    OpenCode / models.dev uses this suffix to flag a model as the
+///    recommended one in its family (e.g. `Claude Sonnet 4.5 (latest)`,
+///    `Mistral Small (latest)`). The model picker already strips this
+///    suffix from the display name, so it is a known convention worth
+///    trusting.
+/// 3. The model with the most recent [ProviderModel.releaseDate]. Models
+///    without a release date sort last.
+/// 4. The first available model in iteration order.
+///
+/// There is intentionally no "newer than X months" cutoff. Deprecated
+/// models are already filtered out by [ProviderModel.isAvailable] in
+/// `bridge/sesori_plugin_opencode/lib/src/provider_mapper.dart`, and a
+/// hard cutoff can hide new models whose metadata is missing or stale.
+class DefaultModelSelector {
+  const DefaultModelSelector();
+
+  /// Selects the default model for a single family of [ProviderModel]s.
+  ///
+  /// [defaultModelId] is honored only when it identifies one of the
+  /// [group] members. Returns `null` only if [group] is empty.
+  ProviderModel? pickFromFamily({
+    required Iterable<ProviderModel> group,
+    required String? defaultModelId,
+  }) {
+    final list = group.where((m) => m.isAvailable).toList();
+    if (list.isEmpty) return null;
+
+    // 1. Provider's backend default.
+    if (defaultModelId != null) {
+      for (final m in list) {
+        if (m.id == defaultModelId) return m;
+      }
+    }
+
+    // 2. Upstream "(latest)" name marker. Ties broken by newest release date.
+    final latestMarked =
+        list.where((m) => m.name.toLowerCase().contains("(latest)")).toList();
+    if (latestMarked.isNotEmpty) {
+      // `List.sort` requires a two-positional-arg comparator; the inline
+      // form avoids the `prefer_required_named_parameters` lint while
+      // keeping the same behavior as the closed-over helper.
+      latestMarked.sort((a, b) {
+        final dateA = a.releaseDate;
+        final dateB = b.releaseDate;
+        if (dateB == null && dateA == null) return 0;
+        if (dateB == null) return -1;
+        if (dateA == null) return 1;
+        return dateB.compareTo(dateA);
+      });
+      return latestMarked.first;
+    }
+
+    // 3. Newest by releaseDate. See note above about the inline comparator.
+    final sorted = [...list]..sort((a, b) {
+        final dateA = a.releaseDate;
+        final dateB = b.releaseDate;
+        if (dateB == null && dateA == null) return 0;
+        if (dateB == null) return -1;
+        if (dateA == null) return 1;
+        return dateB.compareTo(dateA);
+      });
+    return sorted.first;
+  }
+
+  /// Selects a single default model across an entire provider.
+  ///
+  /// Groups [models] by family, picks the best model per family using
+  /// [pickFromFamily], then returns the best model of the alphabetically
+  /// first family. If [defaultModelId] is set and matches an available
+  /// model in [models], that model wins regardless of family order.
+  ///
+  /// Returns `null` if [models] contains no available models.
+  ProviderModel? pickFromProvider({
+    required Map<String, ProviderModel> models,
+    required String? defaultModelId,
+  }) {
+    // 1. Provider's backend default always wins.
+    if (defaultModelId != null) {
+      final m = models[defaultModelId];
+      if (m != null && m.isAvailable) return m;
+    }
+
+    // 2. Group by family, pick the best per family.
+    final byFamily = <String, List<ProviderModel>>{};
+    for (final m in models.values) {
+      if (!m.isAvailable) continue;
+      final family = m.family ?? m.id;
+      (byFamily[family] ??= []).add(m);
+    }
+    if (byFamily.isEmpty) return null;
+
+    // 3. Use the alphabetically first family. Stable, deterministic, and
+    //    independent of map iteration order so the same provider always
+    //    picks the same default.
+    final sortedKeys = byFamily.keys.toList()..sort();
+    final firstGroup = byFamily[sortedKeys.first];
+    if (firstGroup == null) return null;
+    return pickFromFamily(group: firstGroup, defaultModelId: defaultModelId);
+  }
+}

--- a/mobile/module_core/lib/src/utils/model_filter/default_model_selector.dart
+++ b/mobile/module_core/lib/src/utils/model_filter/default_model_selector.dart
@@ -44,7 +44,8 @@ class DefaultModelSelector {
       }
     }
 
-    // 2. Upstream "(latest)" name marker. Ties broken by newest release date.
+    // 2. Upstream "(latest)" name marker. Ties broken by newest release
+    //    date, then by `id` for determinism.
     final latestMarked =
         list.where((m) => m.name.toLowerCase().contains("(latest)")).toList();
     if (latestMarked.isNotEmpty) {
@@ -54,22 +55,39 @@ class DefaultModelSelector {
       latestMarked.sort((a, b) {
         final dateA = a.releaseDate;
         final dateB = b.releaseDate;
-        if (dateB == null && dateA == null) return 0;
-        if (dateB == null) return -1;
-        if (dateA == null) return 1;
-        return dateB.compareTo(dateA);
+        final int dateCompare;
+        if (dateB == null && dateA == null) {
+          dateCompare = 0;
+        } else if (dateB == null) {
+          dateCompare = -1;
+        } else if (dateA == null) {
+          dateCompare = 1;
+        } else {
+          dateCompare = dateB.compareTo(dateA);
+        }
+        if (dateCompare != 0) return dateCompare;
+        return a.id.compareTo(b.id);
       });
       return latestMarked.first;
     }
 
-    // 3. Newest by releaseDate. See note above about the inline comparator.
+    // 3. Newest by releaseDate, then by `id` for determinism. See note
+    //    above about the inline comparator.
     final sorted = [...list]..sort((a, b) {
         final dateA = a.releaseDate;
         final dateB = b.releaseDate;
-        if (dateB == null && dateA == null) return 0;
-        if (dateB == null) return -1;
-        if (dateA == null) return 1;
-        return dateB.compareTo(dateA);
+        final int dateCompare;
+        if (dateB == null && dateA == null) {
+          dateCompare = 0;
+        } else if (dateB == null) {
+          dateCompare = -1;
+        } else if (dateA == null) {
+          dateCompare = 1;
+        } else {
+          dateCompare = dateB.compareTo(dateA);
+        }
+        if (dateCompare != 0) return dateCompare;
+        return a.id.compareTo(b.id);
       });
     return sorted.first;
   }

--- a/mobile/module_core/test/utils/model_filter/default_model_selector_test.dart
+++ b/mobile/module_core/test/utils/model_filter/default_model_selector_test.dart
@@ -106,6 +106,35 @@ void main() {
       expect(picked?.id, "latest-newer");
     });
 
+    test("breaks date ties deterministically by `id` (no unstable sort)", () {
+      // Regression: with no `id` tie-breaker, a sort that returns 0 for
+      // every comparison (all dates equal) preserves insertion order —
+      // which means a model added to the family first wins regardless of
+      // its id. With the `id` tie-breaker, the result is deterministic.
+      final group = [
+        _model(id: "zebra", name: "Zebra", releaseDate: DateTime(2026, 4)),
+        _model(id: "alpha", name: "Alpha", releaseDate: DateTime(2026, 4)),
+        _model(id: "mango", name: "Mango", releaseDate: DateTime(2026, 4)),
+      ];
+      final picked = selector.pickFromFamily(
+        group: group,
+        defaultModelId: null,
+      );
+      expect(picked?.id, "alpha");
+    });
+
+    test("breaks null-date ties deterministically by `id`", () {
+      final group = [
+        _model(id: "zebra", name: "Zebra", releaseDate: null),
+        _model(id: "alpha", name: "Alpha", releaseDate: null),
+      ];
+      final picked = selector.pickFromFamily(
+        group: group,
+        defaultModelId: null,
+      );
+      expect(picked?.id, "alpha");
+    });
+
     test("falls back to the model with the most recent releaseDate", () {
       final group = [
         _model(id: "old", releaseDate: DateTime(2024, 1)),

--- a/mobile/module_core/test/utils/model_filter/default_model_selector_test.dart
+++ b/mobile/module_core/test/utils/model_filter/default_model_selector_test.dart
@@ -1,0 +1,296 @@
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+ProviderModel _model({
+  required String id,
+  String? name,
+  String? family,
+  DateTime? releaseDate,
+  bool isAvailable = true,
+}) {
+  return ProviderModel(
+    id: id,
+    providerID: "test-provider",
+    name: name ?? id,
+    variants: const [],
+    family: family,
+    isAvailable: isAvailable,
+    releaseDate: releaseDate,
+  );
+}
+
+void main() {
+  const selector = DefaultModelSelector();
+
+  group("DefaultModelSelector.pickFromFamily", () {
+    test("returns null for an empty group", () {
+      expect(
+        selector.pickFromFamily(group: const [], defaultModelId: null),
+        isNull,
+      );
+    });
+
+    test("returns null when every model is unavailable", () {
+      final group = [
+        _model(id: "a", isAvailable: false),
+        _model(id: "b", isAvailable: false),
+      ];
+      expect(
+        selector.pickFromFamily(group: group, defaultModelId: null),
+        isNull,
+      );
+    });
+
+    test("honors defaultModelId when it identifies a member of the group", () {
+      final group = [
+        _model(id: "newer", releaseDate: DateTime(2026, 4)),
+        _model(id: "older", releaseDate: DateTime(2025, 11)),
+      ];
+      final picked = selector.pickFromFamily(
+        group: group,
+        defaultModelId: "older",
+      );
+      expect(picked?.id, "older");
+    });
+
+    test("ignores defaultModelId that is not in the group", () {
+      final group = [
+        _model(id: "newer", releaseDate: DateTime(2026, 4)),
+        _model(id: "older", releaseDate: DateTime(2025, 11)),
+      ];
+      final picked = selector.pickFromFamily(
+        group: group,
+        defaultModelId: "missing",
+      );
+      expect(picked?.id, "newer");
+    });
+
+    test("prefers a model whose name contains '(latest)' over a newer date", () {
+      final group = [
+        _model(
+          id: "newer",
+          name: "Freshly Baked",
+          releaseDate: DateTime(2026, 4),
+        ),
+        _model(
+          id: "marked",
+          name: "Established Model (latest)",
+          releaseDate: DateTime(2025, 11),
+        ),
+      ];
+      final picked = selector.pickFromFamily(
+        group: group,
+        defaultModelId: null,
+      );
+      expect(picked?.id, "marked");
+    });
+
+    test("breaks '(latest)' ties by newest releaseDate", () {
+      final group = [
+        _model(
+          id: "latest-older",
+          name: "Older (latest)",
+          releaseDate: DateTime(2024, 1),
+        ),
+        _model(
+          id: "latest-newer",
+          name: "Newer (latest)",
+          releaseDate: DateTime(2025, 6),
+        ),
+      ];
+      final picked = selector.pickFromFamily(
+        group: group,
+        defaultModelId: null,
+      );
+      expect(picked?.id, "latest-newer");
+    });
+
+    test("falls back to the model with the most recent releaseDate", () {
+      final group = [
+        _model(id: "old", releaseDate: DateTime(2024, 1)),
+        _model(id: "mid", releaseDate: DateTime(2025, 6)),
+        _model(id: "newest", releaseDate: DateTime(2026, 4)),
+      ];
+      final picked = selector.pickFromFamily(
+        group: group,
+        defaultModelId: null,
+      );
+      expect(picked?.id, "newest");
+    });
+
+    test("sorts models with null releaseDate last", () {
+      final group = [
+        _model(id: "no-date", releaseDate: null),
+        _model(id: "newest", releaseDate: DateTime(2026, 4)),
+        _model(id: "older", releaseDate: DateTime(2025, 6)),
+      ];
+      final picked = selector.pickFromFamily(
+        group: group,
+        defaultModelId: null,
+      );
+      expect(picked?.id, "newest");
+    });
+
+    test(
+      "ignores the 6-month cutoff — a new model with a stale date still wins",
+      () {
+        // This is the Kimi bug. With the old cutoff-based filter, a model
+        // older than 6 months would be excluded even when nothing newer
+        // exists in the same family.
+        final group = [
+          _model(id: "stale", releaseDate: DateTime(2023, 1)),
+        ];
+        final picked = selector.pickFromFamily(
+          group: group,
+          defaultModelId: null,
+        );
+        expect(picked?.id, "stale");
+      },
+    );
+
+    test("falls back to the first group member when nothing else matches", () {
+      final group = [
+        _model(id: "first", releaseDate: null),
+        _model(id: "second", releaseDate: null),
+      ];
+      final picked = selector.pickFromFamily(
+        group: group,
+        defaultModelId: null,
+      );
+      expect(picked?.id, "first");
+    });
+  });
+
+  group("DefaultModelSelector.pickFromProvider", () {
+    test("returns null when the provider has no available models", () {
+      final models = {
+        "a": _model(id: "a", isAvailable: false),
+      };
+      expect(
+        selector.pickFromProvider(models: models, defaultModelId: null),
+        isNull,
+      );
+    });
+
+    test("returns defaultModelId when it points to an available model", () {
+      final models = {
+        "newer": _model(id: "newer", releaseDate: DateTime(2026, 4)),
+        "older": _model(id: "older", releaseDate: DateTime(2025, 11)),
+      };
+      final picked = selector.pickFromProvider(
+        models: models,
+        defaultModelId: "older",
+      );
+      expect(picked?.id, "older");
+    });
+
+    test(
+      "ignores defaultModelId when it is unavailable and falls back to family picks",
+      () {
+        final models = {
+          "newer": _model(
+            id: "newer",
+            family: "k2",
+            releaseDate: DateTime(2026, 4),
+          ),
+          "older": _model(
+            id: "older",
+            family: "k2",
+            releaseDate: DateTime(2025, 11),
+            isAvailable: false,
+          ),
+        };
+        final picked = selector.pickFromProvider(
+          models: models,
+          defaultModelId: "older",
+        );
+        expect(picked?.id, "newer");
+      },
+    );
+
+    test("Kimi For Coding: picks K2.6 over K2 Thinking (the original bug)", () {
+      // Mirrors the live models.dev entry for `kimi-for-coding`:
+      // - kimi-k2-thinking family=kimi-thinking release_date=2025-11
+      // - k2p5             family=kimi-thinking release_date=2026-01
+      // - k2p6             family=kimi-thinking release_date=2026-04
+      //
+      // All three are in the same family. The picker previously picked
+      // the first model in map iteration order (K2 Thinking). The new
+      // selector should pick the newest by date — K2.6.
+      final models = {
+        "kimi-k2-thinking": _model(
+          id: "kimi-k2-thinking",
+          name: "Kimi K2 Thinking",
+          family: "kimi-thinking",
+          releaseDate: DateTime(2025, 11),
+        ),
+        "k2p5": _model(
+          id: "k2p5",
+          name: "Kimi K2.5",
+          family: "kimi-thinking",
+          releaseDate: DateTime(2026, 1),
+        ),
+        "k2p6": _model(
+          id: "k2p6",
+          name: "Kimi K2.6",
+          family: "kimi-thinking",
+          releaseDate: DateTime(2026, 4),
+        ),
+      };
+      final picked = selector.pickFromProvider(
+        models: models,
+        defaultModelId: null,
+      );
+      expect(picked?.id, "k2p6");
+    });
+
+    test(
+      "uses the alphabetically first family when picking the provider default",
+      () {
+        final models = {
+          "zeta": _model(
+            id: "zeta",
+            name: "Zeta (latest)",
+            family: "zeta-family",
+            releaseDate: DateTime(2020, 1),
+          ),
+          "alpha": _model(
+            id: "alpha",
+            name: "Alpha",
+            family: "alpha-family",
+            releaseDate: DateTime(2025, 1),
+          ),
+        };
+        final picked = selector.pickFromProvider(
+          models: models,
+          defaultModelId: null,
+        );
+        // alpha-family is alphabetically first, so alpha wins even though
+        // zeta is marked "(latest)".
+        expect(picked?.id, "alpha");
+      },
+    );
+
+    test("skips unavailable models when picking the provider default", () {
+      final models = {
+        "newest": _model(
+          id: "newest",
+          family: "k2",
+          releaseDate: DateTime(2026, 4),
+          isAvailable: false,
+        ),
+        "fallback": _model(
+          id: "fallback",
+          family: "k2",
+          releaseDate: DateTime(2025, 11),
+        ),
+      };
+      final picked = selector.pickFromProvider(
+        models: models,
+        defaultModelId: null,
+      );
+      expect(picked?.id, "fallback");
+    });
+  });
+}


### PR DESCRIPTION
## Problem

The model picker bottom sheet and the cubit fallbacks for the initial
model selection both used a fragile heuristic:

1. **The picker filter** (`ModelPickerSheet._defaultVisibleIds`) sorted
   each family by `releaseDate` descending, took the newest, and only
   included it if its date was within the last 6 months.
2. **The cubit fallback** (`NewSessionCubit`, `SessionDetailCubit`) for
   the initial model selection took `firstProvider.models.values.first.id`
   — i.e. the first model in map iteration order, which depends on
   whatever order the bridge response happens to arrive in.

For providers whose `models.dev` data was stale (e.g. the bridge cached
a snapshot before a new model was added) or whose family boundaries
were off in upstream metadata, this surfaced the wrong model. The
user reported that for the `kimi-for-coding` provider, "Kimi K2 Thinking"
appeared by default instead of the newer "Kimi K2.6". The OpenCode
upstream has the same flaky logic tracked in
[anomalyco/opencode#28484](https://github.com/anomalyco/opencode/issues/28484).

## Fix

Extract a shared `DefaultModelSelector` helper in
`mobile/module_core/lib/src/utils/model_filter/` that picks a single
representative model using three generic signals already present in
the upstream data, in priority order:

1. The provider's `defaultModelID` (the backend's own "this is the
   default" answer).
2. A model whose name contains the upstream ` (latest)` marker. The
   picker already strips this suffix from the display name
   (`model_picker_sheet.dart:220`), so it is a known OpenCode /
   models.dev convention worth trusting.
3. The model with the most recent `releaseDate` in the family; null
   dates sort last.
4. The first available model in iteration order.

The 6-month cutoff is intentionally removed. Deprecated models are
already excluded upstream by `isAvailable` in
`bridge/sesori_plugin_opencode/lib/src/provider_mapper.dart`, and a
hard cutoff can hide new models whose metadata is missing or stale.

The picker, `NewSessionCubit`, and `SessionDetailCubit` all call the
same helper. No Kimi/Anthropic/OpenAI/etc. branches — fully generic.
Works for every provider that uses these upstream signals.

## Changes

- **New:** `mobile/module_core/lib/src/utils/model_filter/default_model_selector.dart`
  — `DefaultModelSelector` with `pickFromFamily` and `pickFromProvider`.
- **New:** `mobile/module_core/test/utils/model_filter/default_model_selector_test.dart`
  — 16 unit tests including a regression test that mirrors the live
  models.dev entry for `kimi-for-coding` and asserts `k2p6` (K2.6) is
  picked over `kimi-k2-thinking` (K2 Thinking).
- **Modified:** `mobile/app/lib/core/widgets/model_picker_sheet.dart`
  — `_defaultVisibleIds` uses `pickFromFamily` per family; 6-month
  cutoff dropped.
- **Modified:** `mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart`
  — initial model selection uses `pickFromProvider` instead of
  `models.values.first.id`.
- **Modified:** `mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart`
  — same.
- **Modified:** `mobile/module_core/lib/sesori_dart_core.dart` —
  exports the new helper.

## Verification

- `dart analyze` on all touched files: **clean** (no issues)
- `dart test` in `module_core`: **292/292 pass** (including the 16 new)
- `flutter test` in `app`: **411/411 pass**
- Architectural review by `aristotle-impl-review`: **APPROVED** with
  no violations — layer boundaries, dependency direction, class
  cohesion, naming discipline, and simplicity all verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the best available model by default in the picker and when starting new sessions, with deterministic selection. Fix `YYYY-MM` date parsing so date-based picking works; `kimi-for-coding` now defaults to K2.6 instead of K2 Thinking.

- **Bug Fixes**
  - Added `DefaultModelSelector` with priority: provider `defaultModelID` → name containing " (latest)" → newest `releaseDate` → first available; ties now break by `id` for stable results.
  - Updated the model picker, `NewSessionCubit`, and `SessionDetailCubit` to use the selector; cubits now walk providers and pick the first with an available model to avoid null defaults.
  - In `bridge/sesori_plugin_opencode`, parse `YYYY-MM` `release_date` as `YYYY-MM-01` to prevent null dates and iteration-order fallbacks.
  - Added tests: 18 in `module_core` (includes tie-breakers and the `kimi-for-coding` regression) and 4 in the bridge for date parsing.

<sup>Written for commit cfb8f42be781f5583fd4e9c91d7a5b31e6803c7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

