### PR TITLE
chore(mobile): upgrade Flutter to 3.44.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-flutter 3.41.9-stable
+flutter 3.44.1-stable

--- a/mobile/Makefile
+++ b/mobile/Makefile
@@ -3,6 +3,10 @@ FLUTTER_VERSION := $(shell grep '^flutter' $(TOOL_VERSIONS) | awk '{print $$2}')
 DART := $(HOME)/.asdf/installs/flutter/$(FLUTTER_VERSION)/bin/cache/dart-sdk/bin/dart
 FLUTTER := $(HOME)/.asdf/installs/flutter/$(FLUTTER_VERSION)/bin/flutter
 
+# Pin FLUTTER_ROOT to the version-locked SDK so the bundled `dart` resolves the
+# right Flutter even when the shell exports a stale FLUTTER_ROOT (e.g. asdf global).
+export FLUTTER_ROOT := $(HOME)/.asdf/installs/flutter/$(FLUTTER_VERSION)
+
 # Dependency order: module_auth -> module_core -> module_zyra -> app
 MODULES := module_auth module_core module_zyra app
 
@@ -11,7 +15,7 @@ MODULES := module_auth module_core module_zyra app
 codegen:
 	@for mod in $(MODULES); do \
 		echo "=== codegen: $$mod ==="; \
-		(cd $$mod && $(DART) run build_runner build --delete-conflicting-outputs); \
+		(cd $$mod && $(DART) run build_runner build) || exit 1; \
 	done
 
 pub-get:

--- a/mobile/module_auth/lib/src/auth_manager.dart
+++ b/mobile/module_auth/lib/src/auth_manager.dart
@@ -49,6 +49,20 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
        _delay = delay ?? Future<void>.delayed,
        _authState = BehaviorSubject.seeded(const AuthState.initial());
 
+  /// Builds the singleton with only its production dependencies.
+  ///
+  /// injectable uses this factory instead of the default constructor so the
+  /// `@visibleForTesting` seams (`pollInterval`, `pollTimeout`, `delay`) keep
+  /// their defaults. Without it, injectable_generator 3.0.2 under analyzer 10.x
+  /// tries to inject those optional params from get_it — and can't resolve the
+  /// inline `delay` function type at all.
+  @factoryMethod
+  factory AuthManager.create(
+    http.Client client,
+    TokenStorageService tokenStorage,
+    OAuthStorageService oAuthStorage,
+  ) => AuthManager(client, tokenStorage, oAuthStorage);
+
   @override
   ValueStream<AuthState> get authStateStream => _authState.stream;
 

--- a/mobile/module_auth/lib/src/di/injection.config.dart
+++ b/mobile/module_auth/lib/src/di/injection.config.dart
@@ -39,7 +39,7 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i164.TokenStorageService(gh<_i892.SecureStorage>()),
     );
     gh.lazySingleton<_i655.AuthManager>(
-      () => _i655.AuthManager(
+      () => _i655.AuthManager.create(
         gh<_i519.Client>(),
         gh<_i164.TokenStorageService>(),
         gh<_i765.OAuthStorageService>(),

--- a/mobile/module_zyra/lib/components/buttons/zyra_buttons_icon_glass.dart
+++ b/mobile/module_zyra/lib/components/buttons/zyra_buttons_icon_glass.dart
@@ -25,9 +25,6 @@ const double _kGlassFrostIntensity = 5.5;
 /// Light reflection intensity along the glass edge.
 const double _kGlassLightIntensity = 0.5;
 
-/// Alpha applied to the glass colour overlay tint.
-const double _kGlassColorAlpha = 0.3;
-
 /// Saturation boost applied to whatever is refracted behind the glass.
 const double _kGlassSaturation = 1.8;
 

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -873,10 +873,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1332,26 +1332,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   timezone:
     dependency: transitive
     description:
@@ -1594,4 +1594,4 @@ packages:
     version: "2.2.4"
 sdks:
   dart: ">=3.11.5 <4.0.0"
-  flutter: ">=3.41.7 <3.42.0"
+  flutter: ">=3.44.1 <3.45.0"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 environment:
   sdk: ^3.11.5
-  flutter: ">=3.41.7 <3.42.0"
+  flutter: ">=3.44.1 <3.45.0"
 
 workspace:
   - app


### PR DESCRIPTION
## Summary

Bumps the pinned Flutter SDK from **3.41.9 → 3.44.1** and cleans up the fallout from the newer toolchain.

## Changes

- **SDK pin** — `.tool-versions`, `pubspec.yaml`, and `pubspec.lock` updated to Flutter 3.44.1 (`>=3.44.1 <3.45.0`). Transitive bumps: `meta` 1.17.0→1.18.0, `test` 1.30.0→1.31.0, `test_api`/`test_core`.
- **auth (injectable / analyzer 10.x fix)** — added an `@factoryMethod` factory `AuthManager.create` that exposes only the production dependencies. The newer toolchain ships `analyzer` 10.x, under which `injectable_generator` 3.0.2 otherwise tries to inject the `@visibleForTesting` optional params (`pollInterval`, `pollTimeout`, `delay`) from `get_it` — and can't resolve the inline `delay` function type at all. Regenerated `injection.config.dart` to call the factory.
- **Makefile** — export `FLUTTER_ROOT` pinned to the version-locked SDK so the bundled `dart` resolves the right Flutter even when the shell exports a stale `FLUTTER_ROOT` (e.g. asdf global). Codegen now runs without `--delete-conflicting-outputs` and fails fast (`|| exit 1`) instead of silently continuing.
- **zyra** — dropped the now-unused `_kGlassColorAlpha` constant.

## Test plan

- [ ] `make codegen` succeeds on Flutter 3.44.1
- [ ] `make pub-get` / build passes
- [ ] Auth DI resolves `AuthManager` at runtime (login flow works)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the mobile Flutter SDK to 3.44.1 and adjust DI/codegen for the new toolchain to keep builds stable and deterministic.

- **Dependencies**
  - Pin Flutter 3.44.1 in `.tool-versions` and `pubspec.yaml` (`>=3.44.1 <3.45.0`).
  - Update `pubspec.lock`: `meta` 1.18.0, `test` 1.31.0, `test_api`/`test_core` minor bumps.

- **Refactors**
  - Add `@factoryMethod` `AuthManager.create` to avoid `injectable_generator` 3.0.2 injecting `@visibleForTesting` params under `analyzer` 10.x; regenerate DI to use the factory and fix the inline `delay` type issue with `get_it`.
  - Makefile: export `FLUTTER_ROOT` to the pinned SDK; run codegen without `--delete-conflicting-outputs` and fail fast on errors.
  - Remove unused `_kGlassColorAlpha` from `module_zyra`.

<sup>Written for commit a65dbe813eebc9ea24bb45e1547b19f797963d80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

