### PR TITLE
docs: refresh root README for current structure and versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ cd ../mobile && flutter pub get
 
 ## Common Tasks
 
-Each directory (bridge/, mobile/, or shared/) ships a Makefile with the same core targets — run them from that directory. They invoke the Flutter-bundled Dart SDK pinned in .tool-versions, so they work regardless of what's on your PATH.
+Each directory (bridge/, mobile/, or shared/) ships a Makefile with the same core targets — run them from that directory. They resolve the Flutter-bundled Dart SDK via the version pinned in .tool-versions and the default asdf install path (`~/.asdf/installs/flutter/<version>`), so they bypass whatever is on your PATH — provided you've run `asdf install`.
 
 | Target | What it does |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -26,15 +26,17 @@ bridge/                     # Dart workspace — Bridge CLI + plugin system
   app/                      # CLI relay server
   sesori_plugin_interface/  # Abstract plugin contract
   sesori_plugin_opencode/   # OpenCode backend plugin
-mobile/                     # Dart workspace — Flutter mobile client
+mobile/                     # Flutter workspace — mobile client
   app/                      # Flutter UI shell
   module_core/              # Pure Dart business logic
   module_auth/              # Auth & token lifecycle
+  module_zyra/              # Zyra design system — theme, fonts, icons, UI components
 shared/
   sesori_shared/            # Shared crypto & protocol types
+  no_slop_linter/           # Custom Dart lint rules (dev tooling)
 ```
 
-`bridge/` and `mobile/` are independent Dart workspaces with separate dependency resolution. `shared/sesori_shared` is referenced via path by both workspaces.
+`bridge/` and `mobile/` are independent Dart pub workspaces with separate dependency resolution. The packages under `shared/` are referenced via path by both: `sesori_shared` carries the crypto and protocol types, while `no_slop_linter` is a custom analyzer plugin pulled in as a dev dependency to enforce the repo's lint rules.
 
 ## Dependency Graph
 
@@ -47,11 +49,14 @@ graph TD
   sesori_plugin_opencode --> sesori_shared
   mobile_app[mobile/app] --> module_core[mobile/module_core]
   mobile_app --> module_auth[mobile/module_auth]
+  mobile_app --> module_zyra[mobile/module_zyra]
   mobile_app --> sesori_shared
   module_core --> module_auth
   module_core --> sesori_shared
   module_auth --> sesori_shared
 ```
+
+`shared/no_slop_linter` is omitted above — it is a dev-only analyzer plugin, not a runtime dependency.
 
 ## Data Flow
 
@@ -99,9 +104,9 @@ When a phone connects, it performs an **X25519 Diffie-Hellman key exchange** wit
 
 ## Prerequisites
 
-- **Dart 3.11.2** — bridge workspace
-- **Flutter 3.41.4-stable** — mobile workspace
-- **asdf** — recommended for version management
+- **Flutter** — mobile workspace; the exact version is pinned in [`.tool-versions`](.tool-versions)
+- **Dart SDK** — bridge workspace (a pure Dart workspace); ships with the pinned Flutter version, so no separate install is needed
+- **asdf** — recommended for version management; reads [`.tool-versions`](.tool-versions) automatically
 
 ## Getting Started
 
@@ -113,8 +118,33 @@ cd sesori_apps_monorepo
 cd bridge && dart pub get
 
 # Install mobile dependencies
-cd ../mobile && dart pub get
+cd ../mobile && flutter pub get
 ```
+
+## Common Tasks
+
+Each workspace ships a `Makefile` with the same core targets — run them from that workspace's directory (`bridge/`, `mobile/`, or `shared/`). They invoke the Flutter-bundled Dart SDK pinned in `.tool-versions`, so they work regardless of what's on your `PATH`.
+
+| Target | What it does |
+|---|---|
+| `make pub-get` | Resolve dependencies for the workspace |
+| `make codegen` | Run `build_runner` across modules (freezed, json_serializable, …) |
+| `make analyze` | Static analysis across modules |
+| `make test` | Run unit tests across modules |
+
+`mobile/` adds design-system helpers for the Zyra module:
+
+| Target | What it does |
+|---|---|
+| `make generate-assets` | Regenerate the Tabler/VESPR icon-font Dart bindings |
+| `make generate-tokens` | Sync Figma design tokens into `module_zyra` |
+
+The root `Makefile` manages cross-workspace versioning:
+
+| Target | What it does |
+|---|---|
+| `make bump-version TYPE=patch\|minor\|major` | Bump bridge + mobile versions in lockstep (or pass `VERSION=X.Y.Z`) |
+| `make bump-version-check` | Preview the version bump without writing changes |
 
 ## Bridge Install
 
@@ -158,7 +188,9 @@ If you used the npm bootstrap path, `npm uninstall @sesori/bridge` only removes 
 ## Workspace Docs
 
 - [bridge/README.md](bridge/README.md) — bridge CLI, plugin system, codegen, and testing
+- [bridge/ARCHITECTURE.md](bridge/ARCHITECTURE.md) — bridge layered architecture (Foundation → API → Repository → Service)
 - [mobile/README.md](mobile/README.md) — Flutter client, module structure, and testing
+- [shared/no_slop_linter/README.md](shared/no_slop_linter/README.md) — custom lint rules and how they're wired in
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ cd ../mobile && flutter pub get
 
 ## Common Tasks
 
-Each workspace ships a `Makefile` with the same core targets — run them from that workspace's directory (`bridge/`, `mobile/`, or `shared/`). They invoke the Flutter-bundled Dart SDK pinned in `.tool-versions`, so they work regardless of what's on your `PATH`.
+Each directory (bridge/, mobile/, or shared/) ships a Makefile with the same core targets — run them from that directory. They invoke the Flutter-bundled Dart SDK pinned in .tool-versions, so they work regardless of what's on your PATH.
 
 | Target | What it does |
 |---|---|


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Refresh root README for current repo structure and tooling
<code>📝 Documentation</code> <code>🕐 Less than 10 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

## What & why

The root `README.md` was last updated 75 commits ago and had drifted from `main`. The architecture, data-flow, and security sections were still accurate, so this PR touches only what was stale.

## Changes

- **Repository structure** — add the two new packages: `mobile/module_zyra` (Zyra design system: theme, fonts, icons, UI components) and `shared/no_slop_linter` (custom Dart lint rules); relabel `mobile/` as a Flutter workspace.
- **Dependency graph** — add the `mobile/app → module_zyra` edge, with a note that `no_slop_linter` is a dev-only analyzer plugin (not a runtime dep).
- **Prerequisites** — drop hardcoded Flutter/Dart versions; link to [`.tool-versions`](../blob/main/.tool-versions) as the single source of truth instead.
- **Getting Started** — use `flutter pub get` for the mobile workspace install step.
- **Common Tasks (new)** — document the Makefile targets: per-workspace `pub-get` / `codegen` / `analyze` / `test`, mobile's `generate-assets` / `generate-tokens`, and the root `bump-version` / `bump-version-check`.
- **Workspace docs** — link `bridge/ARCHITECTURE.md` and `shared/no_slop_linter/README.md`.

## Notes

- Verified versions against `.tool-versions` + pubspecs, the inter-package `path:` deps for the graph, and that the bridge still ships only the OpenCode plugin (multi-harness work is still a plan, not in the tree).
- Out of scope: `mobile/README.md` is itself slightly stale (its module table omits `module_zyra`) — happy to follow up separately.

Docs-only; no code changes.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Update README repo structure and dependency graph for Zyra and no_slop_linter.
• Point prerequisites to .tool-versions and use flutter pub get for mobile.
• Add common Makefile task docs and link additional workspace documentation.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  R["README.md"] --> TV[".tool-versions"] --> MF["Makefiles"]
  R --> MWS("mobile workspace") --> Z["module_zyra"]
  R --> SWS("shared packages") --> NS["no_slop_linter"]
  R --> BWS("bridge workspace")
  MF --> BWS --> SWS
  MF --> MWS
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Auto-generate README sections from repo metadata</b></summary>

- ➕ Reduces documentation drift (structure, dependency edges, versions).
- ➕ Can be validated in CI (fail when README is stale).
- ➖ Adds build/CI complexity and a generator to maintain.
- ➖ Generated output can be less readable unless carefully curated.

</details>

<details>
<summary><b>2. Move operational docs to a docs site (e.g., Docusaurus)</b></summary>

- ➕ Better navigation/search for setup + workflows.
- ➕ Easier to keep per-workspace docs modular and versioned.
- ➖ More overhead than needed for a small docs update.
- ➖ Requires additional hosting/build steps.

</details>

**Recommendation:** The PR’s approach (manual refresh of the root README) is appropriate and low-risk for a docs-only correction. If drift becomes frequent, consider adding a lightweight generator/CI check for the repo-structure, dependency-graph, and pinned-version sections to keep the README aligned with .tool-versions and pubspec path dependencies.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Documentation</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>README.md</strong> <code>Update repo structure, dependency graph, prerequisites, and common tasks</code> <code>+38/-6</code></summary>

<br/>

>Update repo structure, dependency graph, prerequisites, and common tasks
>
><pre>
>• Refreshes the repository structure to include mobile/module_zyra and shared/no_slop_linter and clarifies that mobile is a Flutter workspace. Updates the dependency graph and adds a note that no_slop_linter is dev-only, switches prerequisites to reference .tool-versions, changes mobile install to flutter pub get, adds a Common Tasks section documenting Makefile targets, and links additional workspace docs.
></pre>
>
><a href='https://github.com/sesori-ai/sesori_apps_monorepo/pull/205/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5'>README.md</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>