### PR TITLE
feat(ci): gate store-metadata publish on the private repo's own v* tags

### DIFF
--- a/.github/workflows/submit-release.yml
+++ b/.github/workflows/submit-release.yml
@@ -34,11 +34,6 @@ on:
         description: "Build number to submit (must match an existing build-<N> tag)"
         type: string
         required: true
-      upload_metadata:
-        description: "Pull and upload all App Store / Play listing metadata (text, changelogs, screenshots, images) from the private metadata repo"
-        type: boolean
-        required: false
-        default: false
 
 run-name: "submit · ${{ inputs.track }} · ${{ inputs.platforms }} · build ${{ inputs.build_number }}"
 
@@ -93,9 +88,11 @@ jobs:
             exit 1
           fi
 
-          echo "build_number=${N}"  >> "$GITHUB_OUTPUT"
-          echo "commit_sha=${SHA}"  >> "$GITHUB_OUTPUT"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          {
+            echo "build_number=${N}"
+            echo "commit_sha=${SHA}"
+            echo "version=${VERSION}"
+          } >> "$GITHUB_OUTPUT"
           {
             echo "### Resolved"
             echo "- **Build number**: \`${N}\`"
@@ -109,6 +106,11 @@ jobs:
     needs: resolve
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Surface the metadata-publish decision so the `tag` job knows whether (and
+    # which private-repo commit) to tag v<VERSION> after a successful submit.
+    outputs:
+      meta_publish: ${{ steps.gate.outputs.publish }}
+      meta_head:    ${{ steps.gate.outputs.head }}
     # `store-production` environment requires reviewer approval before this job
     # starts; `store-beta` has no protection rules. Both must exist as repo
     # environments (Settings → Environments).
@@ -121,24 +123,48 @@ jobs:
         with:
           ref: ${{ needs.resolve.outputs.commit_sha }}
 
-      # Pull App Store listing metadata from the private metadata repo. Only
-      # when this is a production submit dispatched with upload_metadata=true
-      # (and STORE_METADATA_REPO is configured). Lands at
-      # $GITHUB_WORKSPACE/store-metadata — the `path` is workspace-relative,
-      # independent of the job's working-directory (mobile/app/ios).
-      # persist-credentials:false so the read-only token is not left in git
-      # config for later steps (fastlane reads files, not git). When skipped,
-      # the lane no-ops (promote/submit only), so a routine submission never
-      # rewrites the live listing.
+      # Clone the private metadata repo so we can both read its listing and decide
+      # whether it needs publishing. Only for production submits with
+      # STORE_METADATA_REPO configured. fetch-depth:0 so HEAD's tags are present
+      # for the gate below. Lands at $GITHUB_WORKSPACE/store-metadata — the `path`
+      # is workspace-relative, independent of the job's working-directory
+      # (mobile/app/ios). persist-credentials:false so the token is not left in
+      # git config for the fastlane steps (fastlane reads files, not git).
       - name: Checkout store metadata
-        if: ${{ inputs.track == 'production' && inputs.upload_metadata && vars.STORE_METADATA_REPO != '' }}
+        id: cometa
+        if: ${{ inputs.track == 'production' && vars.STORE_METADATA_REPO != '' }}
         uses: actions/checkout@v6
         with:
           repository: ${{ vars.STORE_METADATA_REPO }}
           ref: ${{ vars.STORE_METADATA_REF || 'main' }}
           path: store-metadata
+          fetch-depth: 0
           persist-credentials: false
           token: ${{ secrets.METADATA_REPO_TOKEN }}
+
+      # Tag-driven gate: publish the listing only when the metadata repo's latest
+      # commit is NOT yet tagged `v*`. An untagged HEAD means there are listing
+      # changes that haven't shipped; a `v*` tag means this exact listing was
+      # already published in an earlier release, so we skip it (binary only). The
+      # `tag` job stamps v<VERSION> onto this commit on success (see below).
+      - name: Decide metadata publish
+        id: gate
+        if: ${{ steps.cometa.outcome == 'success' }}
+        working-directory: ${{ github.workspace }}/store-metadata
+        run: |
+          set -euo pipefail
+          head="$(git rev-parse HEAD)"
+          if git tag --points-at HEAD | grep -q '^v'; then
+            publish=false
+            echo "Metadata HEAD ${head} is already tagged $(git tag --points-at HEAD | grep '^v' | paste -sd, -) — already published; skipping listing."
+          else
+            publish=true
+            echo "Metadata HEAD ${head} has no v* tag — listing changed since last release; will publish + tag."
+          fi
+          {
+            echo "head=${head}"
+            echo "publish=${publish}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -157,10 +183,11 @@ jobs:
           BUILD_NUMBER:                      ${{ needs.resolve.outputs.build_number }}
           TRACK:                             ${{ inputs.track }}
           # Absolute paths: fastlane runs from mobile/app/ios but the metadata
-          # clone lives at the workspace root. Resolve to non-existent dirs when
-          # the checkout above was skipped, so the lane uploads no metadata.
-          IOS_METADATA_PATH:                 ${{ github.workspace }}/store-metadata/ios/metadata
-          IOS_SCREENSHOTS_PATH:              ${{ github.workspace }}/store-metadata/ios/screenshots
+          # clone lives at the workspace root. Set ONLY when the gate decided to
+          # publish; otherwise empty, so the lane sees no metadata dir and uploads
+          # nothing (binary submit only). Empty also when the checkout was skipped.
+          IOS_METADATA_PATH:                 ${{ steps.gate.outputs.publish == 'true' && format('{0}/store-metadata/ios/metadata', github.workspace) || '' }}
+          IOS_SCREENSHOTS_PATH:              ${{ steps.gate.outputs.publish == 'true' && format('{0}/store-metadata/ios/screenshots', github.workspace) || '' }}
         run: bundle exec fastlane submit_ios
 
       - name: Summary
@@ -185,6 +212,10 @@ jobs:
     needs: resolve
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # See submit-ios: surface the gate decision for the `tag` job.
+    outputs:
+      meta_publish: ${{ steps.gate.outputs.publish }}
+      meta_head:    ${{ steps.gate.outputs.head }}
     environment: ${{ inputs.track == 'production' && 'store-production' || 'store-beta' }}
     defaults:
       run:
@@ -194,20 +225,41 @@ jobs:
         with:
           ref: ${{ needs.resolve.outputs.commit_sha }}
 
-      # Pull Play Store listing metadata from the private metadata repo. Only
-      # when this is a production submit dispatched with upload_metadata=true
-      # (and STORE_METADATA_REPO is configured). See the iOS job for the
-      # rationale on path, auth, and persist-credentials. When skipped, the
-      # lane falls back to promotion-only.
+      # Clone the private metadata repo (production + STORE_METADATA_REPO only) to
+      # read the listing and run the same tag-driven gate as iOS. See the iOS job
+      # for the rationale on path, auth, fetch-depth, and persist-credentials.
       - name: Checkout store metadata
-        if: ${{ inputs.track == 'production' && inputs.upload_metadata && vars.STORE_METADATA_REPO != '' }}
+        id: cometa
+        if: ${{ inputs.track == 'production' && vars.STORE_METADATA_REPO != '' }}
         uses: actions/checkout@v6
         with:
           repository: ${{ vars.STORE_METADATA_REPO }}
           ref: ${{ vars.STORE_METADATA_REF || 'main' }}
           path: store-metadata
+          fetch-depth: 0
           persist-credentials: false
           token: ${{ secrets.METADATA_REPO_TOKEN }}
+
+      # Publish the listing only when the metadata repo's latest commit is not yet
+      # tagged `v*` (see submit-ios for the full rationale).
+      - name: Decide metadata publish
+        id: gate
+        if: ${{ steps.cometa.outcome == 'success' }}
+        working-directory: ${{ github.workspace }}/store-metadata
+        run: |
+          set -euo pipefail
+          head="$(git rev-parse HEAD)"
+          if git tag --points-at HEAD | grep -q '^v'; then
+            publish=false
+            echo "Metadata HEAD ${head} is already tagged $(git tag --points-at HEAD | grep '^v' | paste -sd, -) — already published; skipping listing."
+          else
+            publish=true
+            echo "Metadata HEAD ${head} has no v* tag — listing changed since last release; will publish + tag."
+          fi
+          {
+            echo "head=${head}"
+            echo "publish=${publish}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -221,10 +273,11 @@ jobs:
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           VERSION_CODE:                     ${{ needs.resolve.outputs.build_number }}
           TRACK:                            ${{ inputs.track }}
-          # Absolute path to the cloned metadata repo's Android listing dir
-          # (locale folders live directly under it). Resolves to a non-existent
-          # dir when the checkout above was skipped, so the lane promotes only.
-          ANDROID_METADATA_PATH:            ${{ github.workspace }}/store-metadata/android
+          # Absolute path to the cloned metadata repo's Android listing dir (locale
+          # folders live directly under it). Set ONLY when the gate decided to
+          # publish; otherwise empty, so the lane promotes only. Empty also when
+          # the checkout was skipped.
+          ANDROID_METADATA_PATH:            ${{ steps.gate.outputs.publish == 'true' && format('{0}/store-metadata/android', github.workspace) || '' }}
         run: bundle exec fastlane submit_android
 
       - name: Cleanup credentials
@@ -312,3 +365,64 @@ jobs:
           name: "v${{ needs.resolve.outputs.version }} (build ${{ needs.resolve.outputs.build_number }})"
           generate_release_notes: true
           make_latest: "true"
+
+      # Stamp the SAME v<VERSION> onto the metadata repo's published commit, so its
+      # HEAD is marked "published" and the next release's gate skips re-pushing an
+      # unchanged listing. Runs only when a platform actually published this run,
+      # tagging the exact commit that was published (meta_head). iOS and Android
+      # evaluate the same remote, so their decisions agree; the head is taken from
+      # whichever platform published (iOS preferred). Kept LAST so a tag-push
+      # failure can't suppress the GitHub Release above (the binary already
+      # shipped). METADATA_REPO_TOKEN must be a REPOSITORY secret with Contents:
+      # Write — this job declares no environment, so an environment-scoped secret
+      # would read as empty here.
+      - name: Tag store metadata repo
+        if: ${{ needs.submit-ios.outputs.meta_publish == 'true' || needs.submit-android.outputs.meta_publish == 'true' }}
+        env:
+          REPO:            ${{ vars.STORE_METADATA_REPO }}
+          VERSION:         ${{ needs.resolve.outputs.version }}
+          PUBLISH_IOS:     ${{ needs.submit-ios.outputs.meta_publish }}
+          PUBLISH_ANDROID: ${{ needs.submit-android.outputs.meta_publish }}
+          HEAD_IOS:        ${{ needs.submit-ios.outputs.meta_head }}
+          HEAD_ANDROID:    ${{ needs.submit-android.outputs.meta_head }}
+          TOKEN:           ${{ secrets.METADATA_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Tag the commit a publishing platform actually shipped (both evaluate
+          # the same remote, so when both publish their heads match).
+          HEAD=""
+          if [[ "$PUBLISH_IOS" == "true" ]]; then
+            HEAD="$HEAD_IOS"
+          elif [[ "$PUBLISH_ANDROID" == "true" ]]; then
+            HEAD="$HEAD_ANDROID"
+          fi
+          TAG="v${VERSION}"
+          if [[ -z "$HEAD" ]]; then
+            echo "::error::Metadata publish flagged but no published commit was reported by either platform."
+            exit 1
+          fi
+          if [[ -z "$TOKEN" ]]; then
+            echo "::error::Metadata was published but METADATA_REPO_TOKEN is empty in this job. It must be a REPOSITORY secret (not environment-scoped) with Contents: Write, so the tag job can push ${TAG} to ${REPO}."
+            exit 1
+          fi
+          work="$(mktemp -d)"
+          git clone --quiet "https://x-access-token:${TOKEN}@github.com/${REPO}.git" "$work"
+          cd "$work"
+          # Idempotent: if the tag already exists on the published commit, done;
+          # on a DIFFERENT commit, fail loudly (the listing for this version was
+          # already published from elsewhere).
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            existing="$(git rev-list -n1 "refs/tags/${TAG}")"
+            if [[ "$existing" == "$HEAD" ]]; then
+              echo "Metadata repo already tagged ${TAG} → ${HEAD} — nothing to do."
+              echo "- **Metadata repo**: \`${TAG}\` already → \`${HEAD}\`" >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            echo "::error::Metadata repo tag ${TAG} exists on ${existing}, expected ${HEAD}."
+            exit 1
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" "${HEAD}" -m "Published store metadata with ${TAG}"
+          git push --quiet origin "refs/tags/${TAG}"
+          echo "- **Metadata repo tagged**: \`${TAG}\` → \`${HEAD}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/docs/STORE_METADATA.md
+++ b/docs/STORE_METADATA.md
@@ -6,26 +6,47 @@ git repository and upload it as part of the submission. This keeps store copy
 (titles, descriptions, keywords, review notes, "What's new") versioned and
 editable by people who don't have access to the app source.
 
-The feature is **opt-in and non-breaking**. It activates only when a production
-submission is dispatched with the **`upload_metadata`** input ticked (default
-off) *and* the repository variable `STORE_METADATA_REPO` is set. Otherwise the
-metadata checkout is skipped and the fastlane lanes behave exactly as before
-(iOS: attach build + submit; Android: promote internal → production).
+Publishing is **driven by the metadata repo's own `v*` tags**, not a dispatch
+checkbox. On a **production** submit (and only when `STORE_METADATA_REPO` is set),
+CI inspects the **latest commit** of the private repo and:
 
-When activated, **everything in the cloned repo is uploaded** — listing text,
-"What's new" changelogs, screenshots, and images — so the repo is the single
-source of truth for the store listing.
+- **HEAD has no `v*` tag** → there are listing changes that haven't shipped →
+  **publish** the listing, then, on success, tag that exact commit with the
+  release's `v<VERSION>` (the same tag the monorepo gets). So `v1.0.8` ends up in
+  **both** repos.
+- **HEAD already has a `v*` tag** → this listing was already published in an
+  earlier release → **skip** it. The submit still ships the binary
+  (attach/promote), it just doesn't touch the live listing.
+- **Beta submit** → never publishes and never tags the metadata repo.
+
+In other words, the private repo's `v*` tag means "this commit's listing has been
+published." **To publish a listing edit, commit it to the private repo** — its
+HEAD becomes untagged again, and the next production release publishes and
+re-tags it. Unchanged metadata is never re-pushed.
+
+When it does publish, **everything in the cloned repo is uploaded** — listing
+text, "What's new" changelogs, screenshots, and images — so the repo is the
+single source of truth for the store listing. When it doesn't, the fastlane lanes
+behave exactly as before (iOS: attach build + submit; Android: promote
+internal → production).
+
+> **Token:** because CI now tags the private repo on publish, `METADATA_REPO_TOKEN`
+> must have **Contents: Write** (it was previously read-only) and be a
+> **repository** secret — the `tag` job that pushes the tag declares no
+> environment, so an environment-scoped secret would be empty there. The
+> production *submission* is still approval-gated; only the token's storage moves.
+> See [One-time setup](#2-configure-this-repo).
 
 ## Two ways metadata reaches the stores
 
 Both paths use the same tools (`deliver` for iOS, `supply` for Android) and the
 same private repo; they differ only in *when* and *what*:
 
-1. **With a release — `submit-release.yml`** in THIS repo (tick `upload_metadata`).
-   Pushes the full listing **alongside** a production binary submit/promote. This
-   is the only way to ship the per-release "What's new" changelog and the
-   new-version iOS screenshots/copy that must ride with the version under review.
-   Documented below.
+1. **With a release — `submit-release.yml`** in THIS repo (automatic when the
+   private repo's HEAD is untagged). Pushes the full listing **alongside** a
+   production binary submit/promote. This is the only way to ship the per-release
+   "What's new" changelog and the new-version iOS screenshots/copy that must ride
+   with the version under review. Documented below.
 2. **Standalone — `Sync Store Metadata` lives in the private metadata repo**
    (`app-stores-metadata`), not here. It pushes the listing (all languages +
    assets) **without** building or submitting a binary, runs on its own checkout
@@ -43,21 +64,28 @@ present.
 ## How it works
 
 1. `submit-release.yml` runs on `ubuntu-latest` (no rebuild — submission is pure
-   App Store Connect / Play API work).
-2. For a **production** run dispatched with `upload_metadata: true`, after
-   checking out the monorepo it also checks out the private metadata repo into
-   `$GITHUB_WORKSPACE/store-metadata` (`persist-credentials: false`, so the
-   read-only token isn't left behind). With `upload_metadata: false` (the
-   default) this step is skipped entirely.
-3. It passes **absolute** paths to the fastlane lanes via env vars
-   (`IOS_METADATA_PATH`, `IOS_SCREENSHOTS_PATH`, `ANDROID_METADATA_PATH`).
-   Absolute because fastlane runs from `mobile/app/<platform>` while the clone
-   lives at the workspace root.
+   App Store Connect / Play API work). The `resolve` job maps the dispatched
+   `build_number` → commit → version.
+2. Each submit job (`submit-ios`, `submit-android`) — on a **production** submit
+   with `STORE_METADATA_REPO` set — checks out the private metadata repo at
+   `STORE_METADATA_REF` (default `main`, `fetch-depth: 0` so its tags come too)
+   into `$GITHUB_WORKSPACE/store-metadata` (`persist-credentials: false`, so the
+   token isn't left in git config for the fastlane steps).
+3. A **gate** step then runs `git tag --points-at HEAD`: if the latest commit has
+   any `v*` tag the listing was already published, so the metadata env vars
+   (`IOS_METADATA_PATH`, `IOS_SCREENSHOTS_PATH`, `ANDROID_METADATA_PATH`) are left
+   **empty**; otherwise they point at the cloned tree. (Absolute paths, because
+   fastlane runs from `mobile/app/<platform>` while the clone lives at the
+   workspace root.)
 4. The lanes (`submit_ios`, `submit_android`) upload each part of the metadata
    **only when its directory exists and is non-empty** (`metadata_dir_from_env`
-   in each `Fastfile`). When the checkout was skipped the dirs are absent, so
-   the lanes no-op. A text-only repo uploads only text; add screenshots/images
-   to the repo and they upload too.
+   in each `Fastfile`). Empty paths → the lanes no-op (binary only). A text-only
+   repo uploads only text; add screenshots/images to the repo and they upload too.
+5. After the requested platforms submit successfully, the `tag` job stamps the
+   release's **`v<VERSION>`** onto the private repo's published commit (the same
+   value as the monorepo's release tag) using `METADATA_REPO_TOKEN` (write). This
+   marks that commit "published" so step 3 skips it next time. Idempotent: an
+   existing tag on the same commit is a no-op; on a different commit it fails loud.
 
 ### iOS — two passes (`submit_ios`)
 
@@ -106,7 +134,7 @@ Two distinct sources, by intent:
 
 ### Screenshots & images
 
-When `upload_metadata` is on, screenshots and images are uploaded too — but only
+When metadata publishes, screenshots and images are uploaded too — but only
 if you actually put them in the repo (an absent/empty `ios/screenshots` or
 Android `<locale>/images` tree is skipped). If you keep the repo text-only,
 nothing image-related is touched.
@@ -194,15 +222,17 @@ fastlane run download_from_play_store \
 # rm -rf android/*/images ios/screenshots
 
 # Optional: seed iOS screenshots (download_metadata does NOT fetch them).
-# Only needed if you want screenshots managed here (uploaded when you run a
-# production submit with upload_metadata=true).
+# Only needed if you want screenshots managed here (uploaded on the next
+# production release after they're committed — i.e. while HEAD is untagged).
 # fastlane deliver download_screenshots \
 #   --api_key_path "/abs/path/asc_api_key.json" \
 #   --app_identifier "com.sesori.app" \
 #   --screenshots_path "./ios/screenshots"
 
 git add -A && git commit -m "Seed store listing metadata"
-# create a PRIVATE remote, then push
+# create a PRIVATE remote, then push.
+# Leave this seed commit UNTAGGED — the first production release publishes it and
+# stamps v<VERSION> on it.
 ```
 
 ### 2. Configure this repo
@@ -210,37 +240,64 @@ git add -A && git commit -m "Seed store listing metadata"
 - **Repository variable** `STORE_METADATA_REPO` = `owner/store-metadata`
   (Settings → Secrets and variables → Actions → Variables). Optional:
   `STORE_METADATA_REF` (defaults to `main`).
-- **Secret** `METADATA_REPO_TOKEN` — read-only access to the private repo. Use a
-  fine-grained PAT scoped to just that repo with **Contents: Read**, or a
-  read-only deploy key (switch the checkout to `ssh-key:`). Add it to the
-  `store-production` environment.
+- **Secret** `METADATA_REPO_TOKEN` — **write** access to the private repo
+  (Contents: Write), because CI both clones the listing and pushes the
+  `v<VERSION>` tag back on publish. Use a fine-grained PAT scoped to just that
+  repo. Add it as a **repository** secret (Settings → Secrets and variables →
+  Actions → *Repository secrets*), **not** an environment secret: the `tag` job
+  that pushes the tag declares no environment, so an environment-scoped token
+  would resolve to empty and the tag push would fail. The submit jobs keep their
+  `store-production` approval gate on the actual submission regardless of where
+  the token lives.
 
-That's it. To push the listing, run **Submit Release** with `track: production`
-and tick **`upload_metadata`** — the run clones the private repo and uploads
-everything in it. Leaving `upload_metadata` unticked promotes/submits the binary
-only and never touches the listing. Edit copy by opening a PR against the private
-repo; no app-source access required.
+That's it. On a `track: production` **Submit Release**, the listing publishes
+**automatically whenever the private repo's latest commit is untagged** — the run
+clones the repo, uploads everything in it, ships the binary, and then stamps the
+release's `v<VERSION>` onto that commit (so `v1.0.8` exists in both repos). If the
+latest commit is already `v*`-tagged, the listing is left untouched and only the
+binary is submitted.
+
+**To publish a listing change**, commit it to the private repo (open a PR; no
+app-source access required). That moves HEAD to a new, untagged commit, and the
+next production release publishes and re-tags it. There's nothing to toggle at
+submit time.
+
+**Already-released, want to re-push the same commit?** Use the standalone **Sync
+Store Metadata** workflow in the private repo — it pushes the listing without a
+binary. (Deleting the `v<VERSION>` tag in the private repo and re-submitting would
+also re-trigger publish, but the standalone sync is cleaner.)
+
+**Split-platform releases:** the first platform to publish tags the private repo's
+HEAD, so a *separate* later single-platform submit sees the tag and skips the
+listing. Submit `platforms: both` in one run (both jobs see the untagged HEAD and
+publish; the tag is stamped once afterward), or push the lagging platform's
+listing via the standalone Sync workflow.
 
 ## Operational notes
 
-- **When you run with `upload_metadata: true`, a working `METADATA_REPO_TOKEN`
-  is required.** The metadata checkout runs before the submit step, so a
-  missing/expired/under-scoped token (or a deleted repo/ref) fails the job
-  *before* anything is promoted or submitted — a clean fail-fast with no
-  half-published state, but it does block the binary for that run. If the token
-  rotates, update the secret and re-run (the build is already on TestFlight /
-  the internal track, so re-running the submission is safe). A run with
-  `upload_metadata: false` never touches the private repo, so it's unaffected.
-  To degrade instead of fail — promotion-only when metadata can't be fetched —
-  add `continue-on-error: true` to the `Checkout store metadata` steps; note
-  that this trades loud failures for *silently* not updating the listing.
-- **Metadata tracks the latest `main` of the private repo, not the build's
-  commit.** The app is checked out at the historical `build-<N>` commit, but
-  metadata uses `STORE_METADATA_REF` (default `main`). This is intentional —
-  you normally want current store copy. To reproduce a past submission exactly,
-  set `STORE_METADATA_REF` to a tag/SHA in the private repo.
+- **A publishing production run needs a working write `METADATA_REPO_TOKEN`.**
+  The metadata checkout runs *before* the submit step, so a missing/expired/
+  under-scoped token (or a deleted repo/ref) fails the job *before* anything is
+  promoted or submitted — a clean fail-fast with no half-published state, but it
+  blocks the binary for that run. To degrade instead — promote/submit the binary
+  even when metadata can't be fetched — add `continue-on-error: true` to the
+  `Checkout store metadata` steps; that trades loud failure for *silently* not
+  updating the listing. A beta run, or a production run where HEAD is already
+  `v*`-tagged, never touches the private repo, so it's unaffected.
+- **If the final tag-push to the private repo fails** (e.g. the token lacks
+  write) *after* a successful submit, the listing is published but its commit
+  stays untagged. This is self-healing: fix the token and re-run — HEAD is still
+  untagged, so the gate republishes (idempotent) and re-attempts the tag. The
+  build is already on TestFlight / the internal track, so re-running the submit
+  is safe.
+- **Metadata tracks the latest `STORE_METADATA_REF` of the private repo, not the
+  build's commit.** The app is checked out at the historical `build-<N>` commit,
+  but the listing comes from `STORE_METADATA_REF` (default `main`). This is
+  intentional — you normally want current store copy. Note the gate keys off
+  *that* commit's tags, so pinning `STORE_METADATA_REF` to an already-`v*`-tagged
+  commit will skip publishing.
 - **The private repo is the source of truth for any field it contains.**
   `deliver`/`supply` only push fields whose file exists, so missing files leave
   the console value untouched — but for fields you *do* manage here, stop
-  editing them directly in App Store Connect / Play Console (every
-  `upload_metadata: true` submission re-pushes them).
+  editing them directly in App Store Connect / Play Console (every publishing
+  submission — and every standalone Sync run — re-pushes them).

--- a/mobile/app/android/fastlane/Fastfile
+++ b/mobile/app/android/fastlane/Fastfile
@@ -248,13 +248,13 @@ platform :android do
       UI.message("Promoting Android version code #{version_code} (v#{version_name}) " \
                  "from internal → #{target_track}")
 
-      # Optional Play Store listing metadata, cloned from the private metadata
-      # repo by CI only when the submission was dispatched with
-      # upload_metadata=true. Unlike iOS, supply runs the promotion and the
-      # metadata upload inside a SINGLE Play Edit, so a metadata error aborts
-      # the whole edit and the promotion does not half-land — no two-pass split
-      # needed. nil when the repo wasn't cloned, making this a pure promotion
-      # (pre-feature behavior).
+      # Optional Play Store listing metadata from the private metadata repo. CI
+      # populates this path only when that repo's latest commit has no `v*` tag
+      # (unpublished listing changes — see submit-release.yml). Unlike iOS, supply
+      # runs the promotion and the metadata upload inside a SINGLE Play Edit, so a
+      # metadata error aborts the whole edit and the promotion does not half-land
+      # — no two-pass split needed. nil when the path is unset, making this a
+      # pure promotion (pre-feature behavior).
       metadata_dir = metadata_dir_from_env("ANDROID_METADATA_PATH")
       have_meta = !metadata_dir.nil?
       UI.message(

--- a/mobile/app/ios/fastlane/Fastfile
+++ b/mobile/app/ios/fastlane/Fastfile
@@ -218,12 +218,13 @@ platform :ios do
     UI.message("Submitting iOS build #{build_number} (v#{version}) to #{track}")
 
     if track == "production"
-      # Optional App Store listing metadata, cloned from the private metadata
-      # repo by CI only when the submission was dispatched with
-      # upload_metadata=true. Everything present in the cloned tree is uploaded:
-      # text from IOS_METADATA_PATH, plus screenshots from IOS_SCREENSHOTS_PATH
-      # when that tree exists. Both resolve to nil when the repo wasn't cloned,
-      # making the upload a no-op (preserving pre-feature behavior). NOTE:
+      # Optional App Store listing metadata from the private metadata repo. CI
+      # populates these paths only when that repo's latest commit has no `v*` tag
+      # (unpublished listing changes — see submit-release.yml). Everything present
+      # in the cloned tree is uploaded: text from IOS_METADATA_PATH, plus
+      # screenshots from IOS_SCREENSHOTS_PATH when that tree exists. Both resolve
+      # to nil when the paths are unset, making the upload a no-op (preserving
+      # pre-feature behavior). NOTE:
       # uploading screenshots can hard-fail on a screen size deliver doesn't yet
       # recognize — but that happens in pass 1 below, before submission, so the
       # already-uploaded build is never affected.


### PR DESCRIPTION
## Summary

Auto-publishes App Store / Play **listing metadata** when submitting a release, driven by the **private metadata repo's own `v*` tags** instead of the manual `upload_metadata` dispatch checkbox.

The private repo's `v*` tag means *"this commit's listing has been published."* So the rule is simply: **if the metadata repo's latest commit is untagged, publish the listing; if it's already `v*`-tagged, skip it.**

## Flow (production submits, when `STORE_METADATA_REPO` is set)

1. Each submit job clones the private metadata repo at `STORE_METADATA_REF` (default `main`).
2. A **gate** step checks the latest commit for a `v*` tag (`git tag --points-at HEAD`):
   - **untagged** → listing changed since last release → **publish**
   - **`v*`-tagged** → already published → **skip listing, ship binary only**
3. On success, the `tag` job stamps the **same `v<VERSION>`** as the monorepo's release tag onto the private repo's published commit — so `v1.0.8` ends up in **both** repos, and the next release skips an unchanged listing.

**To publish a listing edit:** commit it to the private repo. HEAD becomes untagged → the next production release publishes and re-tags it. No checkbox to remember. Beta submits never touch the private repo.

## Changes

- **`submit-release.yml`**
  - Removed the `upload_metadata` input.
  - `submit-ios` / `submit-android`: clone the private repo (`fetch-depth: 0`) + a tag-gate step; metadata env paths are populated only when the gate decides to publish; jobs expose `meta_publish` / `meta_head` outputs.
  - `tag` job: monorepo tagging restored to original behavior; **new step** clones the private repo and tags the published commit `v<VERSION>`, ordered **after** the GitHub Release so a tag-push failure can't suppress the release.
- **iOS/Android `Fastfile`** — comments only; lane logic unchanged (lanes key off whether the metadata dir is present).
- **`docs/STORE_METADATA.md`** — activation narrative rewritten for the private-repo-tag gate.

## ⚠️ Setup change required

`METADATA_REPO_TOKEN` must now be a **repository** secret with **Contents: Write** (it was a read-only `store-production` *environment* secret). Two reasons:
- **Write** — the `tag` job pushes the `v<VERSION>` tag back to the private repo.
- **Repository-level** — the `tag` job declares no environment, so an environment-scoped secret would read as empty there and the tag push would fail. Making the tag job environment-gated would instead add a *second* approval prompt per release.

The production *submission* keeps its `store-production` approval gate regardless of where the token lives.

## Validation

- `actionlint` (+ shellcheck) clean; both `Fastfile`s pass `ruby -c`.
- Two rounds of adversarial multi-agent review (control-flow, bash, security, docs). The second round caught the env-secret-scoping blocker (token would be empty in the env-less `tag` job) — fixed by moving to a repository secret. All findings resolved; remaining were a nit (gate log) and the token fix.