### PR TITLE
feat: hash and set Firebase Analytics user ID for cross-device tracking

### DIFF
--- a/mobile/app/lib/core/analytics/analytics_user_id_tracker.dart
+++ b/mobile/app/lib/core/analytics/analytics_user_id_tracker.dart
@@ -3,7 +3,7 @@ import "dart:convert";
 
 import "package:crypto/crypto.dart";
 import "package:firebase_analytics/firebase_analytics.dart";
-import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
 
 /// Hashes the current user's ID and forwards it to Firebase Analytics so
 /// events from the same account are grouped across devices.
@@ -13,28 +13,35 @@ import "package:sesori_auth/sesori_auth.dart";
 class AnalyticsUserIdTracker {
   final AuthSession _authSession;
   final FirebaseAnalytics _analytics;
-  StreamSubscription<AuthState>? _subscription;
+  StreamSubscription<void>? _subscription;
 
   AnalyticsUserIdTracker({
     required AuthSession authSession,
     required FirebaseAnalytics analytics,
   }) : _authSession = authSession,
        _analytics = analytics {
-    _subscription = _authSession.authStateStream.listen(_onAuthStateChanged);
+    _subscription = _authSession.authStateStream
+        .asyncMap(_onAuthStateChanged)
+        .listen(null);
   }
 
   Future<void> _onAuthStateChanged(AuthState state) async {
-    switch (state) {
-      case AuthAuthenticated(:final user):
-        final hashedId = sha256.convert(utf8.encode(user.id)).toString();
-        await _analytics.setUserId(id: hashedId);
-      case AuthUnauthenticated():
-        await _analytics.setUserId(id: null);
-      case AuthInitial():
-      case AuthAuthenticating():
-      case AuthFailed():
-        // No clear user identity in these states — leave the ID unchanged.
-        break;
+    try {
+      switch (state) {
+        case AuthAuthenticated(:final user):
+          final hashedId = sha256.convert(utf8.encode(user.id)).toString();
+          await _analytics.setUserId(id: hashedId);
+        case AuthUnauthenticated():
+        case AuthFailed():
+          await _analytics.setUserId(id: null);
+        case AuthInitial():
+        case AuthAuthenticating():
+          // No clear user identity in these states — leave the ID unchanged.
+          break;
+      }
+    } on Object catch (_) {
+      // Best-effort: analytics failures must not crash the app or propagate
+      // as unhandled async errors.
     }
   }
 

--- a/mobile/app/lib/core/analytics/analytics_user_id_tracker.dart
+++ b/mobile/app/lib/core/analytics/analytics_user_id_tracker.dart
@@ -1,0 +1,45 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:crypto/crypto.dart";
+import "package:firebase_analytics/firebase_analytics.dart";
+import "package:sesori_auth/sesori_auth.dart";
+
+/// Hashes the current user's ID and forwards it to Firebase Analytics so
+/// events from the same account are grouped across devices.
+///
+/// The raw user ID is never sent to Firebase — only a SHA-256 hash of the
+/// internal [AuthUser.id], making the identifier anonymous yet deterministic.
+class AnalyticsUserIdTracker {
+  final AuthSession _authSession;
+  final FirebaseAnalytics _analytics;
+  StreamSubscription<AuthState>? _subscription;
+
+  AnalyticsUserIdTracker({
+    required AuthSession authSession,
+    required FirebaseAnalytics analytics,
+  }) : _authSession = authSession,
+       _analytics = analytics {
+    _subscription = _authSession.authStateStream.listen(_onAuthStateChanged);
+  }
+
+  Future<void> _onAuthStateChanged(AuthState state) async {
+    switch (state) {
+      case AuthAuthenticated(:final user):
+        final hashedId = sha256.convert(utf8.encode(user.id)).toString();
+        await _analytics.setUserId(id: hashedId);
+      case AuthUnauthenticated():
+        await _analytics.setUserId(id: null);
+      case AuthInitial():
+      case AuthAuthenticating():
+      case AuthFailed():
+        // No clear user identity in these states — leave the ID unchanged.
+        break;
+    }
+  }
+
+  Future<void> dispose() async {
+    await _subscription?.cancel();
+    _subscription = null;
+  }
+}

--- a/mobile/app/lib/features/project_list/project_list_screen.dart
+++ b/mobile/app/lib/features/project_list/project_list_screen.dart
@@ -6,7 +6,6 @@ import "package:flutter/services.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_svg/flutter_svg.dart";
 import "package:go_router/go_router.dart";
-import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_zyra/module_zyra.dart";

--- a/mobile/app/lib/main.dart
+++ b/mobile/app/lib/main.dart
@@ -10,6 +10,7 @@ import "package:flutter/services.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:theme_zyra/module_zyra.dart";
 
+import "core/analytics/analytics_user_id_tracker.dart";
 import "core/di/injection.dart";
 import "core/extensions/build_context_x.dart";
 import "core/routing/app_router.dart";
@@ -66,6 +67,7 @@ void main() async {
   if (_shouldInitializeFirebase) {
     await bootstrapSesoriApp(
       shouldInitializeFirebase: true,
+      supportsFirebaseAnalytics: _supportsFirebaseAnalytics,
       configureDependenciesFn: configureDependencies,
       initializeDeepLinks: () => getIt<DeepLinkService>().init(),
       startNotificationStartupFn: () => startNotificationStartup(
@@ -82,6 +84,7 @@ void main() async {
 
   await bootstrapSesoriApp(
     shouldInitializeFirebase: false,
+    supportsFirebaseAnalytics: false,
     configureDependenciesFn: configureDependencies,
     initializeDeepLinks: () => getIt<DeepLinkService>().init(),
     startNotificationStartupFn: () async {},
@@ -91,6 +94,7 @@ void main() async {
 
 Future<void> bootstrapSesoriApp({
   required bool shouldInitializeFirebase,
+  required bool supportsFirebaseAnalytics,
   required void Function() configureDependenciesFn,
   required void Function() initializeDeepLinks,
   required Future<void> Function() startNotificationStartupFn,
@@ -99,6 +103,12 @@ Future<void> bootstrapSesoriApp({
   configureDependenciesFn();
   initializeDeepLinks();
   if (shouldInitializeFirebase) {
+    if (supportsFirebaseAnalytics) {
+      AnalyticsUserIdTracker(
+        authSession: getIt<AuthSession>(),
+        analytics: FirebaseAnalytics.instance,
+      );
+    }
     unawaited(
       startNotificationStartupFn().catchError((Object error, StackTrace stackTrace) {
         loge("Error bootstrapping notification startup", error, stackTrace);

--- a/mobile/app/lib/main.dart
+++ b/mobile/app/lib/main.dart
@@ -104,6 +104,8 @@ Future<void> bootstrapSesoriApp({
   initializeDeepLinks();
   if (shouldInitializeFirebase) {
     if (supportsFirebaseAnalytics) {
+      // Side effect: the tracker auto-subscribes to auth state changes and
+      // syncs the hashed user ID with Firebase Analytics. Do not remove.
       AnalyticsUserIdTracker(
         authSession: getIt<AuthSession>(),
         analytics: FirebaseAnalytics.instance,

--- a/mobile/app/test/core/analytics/analytics_user_id_tracker_test.dart
+++ b/mobile/app/test/core/analytics/analytics_user_id_tracker_test.dart
@@ -4,8 +4,9 @@ import "package:crypto/crypto.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:mocktail/mocktail.dart";
 import "package:rxdart/rxdart.dart";
-import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/core/analytics/analytics_user_id_tracker.dart";
+import "package:sesori_shared/sesori_shared.dart";
 
 import "../../helpers/test_helpers.dart";
 
@@ -72,15 +73,12 @@ void main() {
       await tracker.dispose();
     });
 
-    test("does nothing for initial, authenticating, or failed states", () async {
+    test("clears user ID for failed state, does nothing for initial and authenticating", () async {
       final tracker = AnalyticsUserIdTracker(
         authSession: mockAuthSession,
         analytics: mockAnalytics,
       );
 
-      await Future<void>.delayed(Duration.zero);
-
-      authStateSubject.add(const AuthState.initial());
       await Future<void>.delayed(Duration.zero);
 
       authStateSubject.add(const AuthState.authenticating());
@@ -89,7 +87,8 @@ void main() {
       authStateSubject.add(const AuthState.failed(error: "oops"));
       await Future<void>.delayed(Duration.zero);
 
-      verifyNever(() => mockAnalytics.setUserId(id: any(named: "id")));
+      // Called once for the failed state; initial and authenticating are no-ops.
+      verify(() => mockAnalytics.setUserId(id: null)).called(1);
       await tracker.dispose();
     });
 
@@ -155,6 +154,58 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       verifyNever(() => mockAnalytics.setUserId(id: any(named: "id")));
+    });
+
+    test("swallows analytics errors without crashing", () async {
+      when(() => mockAnalytics.setUserId(id: any(named: "id"))).thenThrow(Exception("analytics crashed"));
+
+      authStateSubject.add(const AuthState.authenticated(user: AuthUser(
+        id: "user-1",
+        provider: AuthProvider.github,
+        providerUserId: "gh-1",
+        providerUsername: "test",
+      )));
+
+      AnalyticsUserIdTracker(
+        authSession: mockAuthSession,
+        analytics: mockAnalytics,
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      // Test passes if no exception is thrown.
+      verify(() => mockAnalytics.setUserId(id: any(named: "id"))).called(1);
+    });
+
+    test("processes auth events sequentially with asyncMap", () async {
+      final events = <String>[];
+
+      when(() => mockAnalytics.setUserId(id: any(named: "id"))).thenAnswer((invocation) async {
+        final id = invocation.namedArguments[#id] as String?;
+        events.add(id ?? "null");
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      });
+
+      authStateSubject.add(const AuthState.authenticated(user: AuthUser(
+        id: "user-1",
+        provider: AuthProvider.github,
+        providerUserId: "gh-1",
+        providerUsername: "test",
+      )));
+
+      final tracker = AnalyticsUserIdTracker(
+        authSession: mockAuthSession,
+        analytics: mockAnalytics,
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      authStateSubject.add(const AuthState.unauthenticated());
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // Events should be processed in order: set hash first, then clear.
+      expect(events, [hasLength(greaterThan(0)), "null"]);
+      await tracker.dispose();
     });
   });
 }

--- a/mobile/app/test/core/analytics/analytics_user_id_tracker_test.dart
+++ b/mobile/app/test/core/analytics/analytics_user_id_tracker_test.dart
@@ -1,0 +1,160 @@
+import "dart:convert";
+
+import "package:crypto/crypto.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:mocktail/mocktail.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_mobile/core/analytics/analytics_user_id_tracker.dart";
+
+import "../../helpers/test_helpers.dart";
+
+void main() {
+  late MockAuthSession mockAuthSession;
+  late MockFirebaseAnalytics mockAnalytics;
+  late BehaviorSubject<AuthState> authStateSubject;
+
+  setUpAll(registerAllFallbackValues);
+
+  setUp(() {
+    mockAuthSession = MockAuthSession();
+    mockAnalytics = MockFirebaseAnalytics();
+    authStateSubject = BehaviorSubject<AuthState>.seeded(const AuthState.initial());
+
+    when(() => mockAuthSession.authStateStream).thenAnswer((_) => authStateSubject.stream);
+    when(() => mockAnalytics.setUserId(id: any(named: "id"))).thenAnswer((_) async {});
+  });
+
+  tearDown(() async {
+    await authStateSubject.close();
+  });
+
+  group("AnalyticsUserIdTracker", () {
+    test("sets hashed user ID when auth state is authenticated", () async {
+      const user = AuthUser(
+        id: "user-abc-123",
+        provider: AuthProvider.github,
+        providerUserId: "gh-123",
+        providerUsername: "testuser",
+      );
+      authStateSubject.add(const AuthState.authenticated(user: user));
+
+      AnalyticsUserIdTracker(
+        authSession: mockAuthSession,
+        analytics: mockAnalytics,
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      final expectedHash = sha256.convert(utf8.encode(user.id)).toString();
+      verify(() => mockAnalytics.setUserId(id: expectedHash)).called(1);
+    });
+
+    test("clears user ID when auth state becomes unauthenticated", () async {
+      authStateSubject.add(const AuthState.authenticated(user: AuthUser(
+        id: "user-1",
+        provider: AuthProvider.github,
+        providerUserId: "gh-1",
+        providerUsername: "test",
+      )));
+
+      final tracker = AnalyticsUserIdTracker(
+        authSession: mockAuthSession,
+        analytics: mockAnalytics,
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      authStateSubject.add(const AuthState.unauthenticated());
+      await Future<void>.delayed(Duration.zero);
+
+      verify(() => mockAnalytics.setUserId(id: null)).called(1);
+      await tracker.dispose();
+    });
+
+    test("does nothing for initial, authenticating, or failed states", () async {
+      final tracker = AnalyticsUserIdTracker(
+        authSession: mockAuthSession,
+        analytics: mockAnalytics,
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      authStateSubject.add(const AuthState.initial());
+      await Future<void>.delayed(Duration.zero);
+
+      authStateSubject.add(const AuthState.authenticating());
+      await Future<void>.delayed(Duration.zero);
+
+      authStateSubject.add(const AuthState.failed(error: "oops"));
+      await Future<void>.delayed(Duration.zero);
+
+      verifyNever(() => mockAnalytics.setUserId(id: any(named: "id")));
+      await tracker.dispose();
+    });
+
+    test("reacts to initial stream value on creation", () async {
+      const user = AuthUser(
+        id: "initial-user",
+        provider: AuthProvider.google,
+        providerUserId: "google-1",
+        providerUsername: "initial",
+      );
+      await authStateSubject.close();
+      authStateSubject = BehaviorSubject<AuthState>.seeded(const AuthState.authenticated(user: user));
+      when(() => mockAuthSession.authStateStream).thenAnswer((_) => authStateSubject.stream);
+
+      AnalyticsUserIdTracker(
+        authSession: mockAuthSession,
+        analytics: mockAnalytics,
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      final expectedHash = sha256.convert(utf8.encode(user.id)).toString();
+      verify(() => mockAnalytics.setUserId(id: expectedHash)).called(1);
+    });
+
+    test("produces same hash for same user ID across multiple devices", () async {
+      const userId = "cross-device-user-42";
+      const user = AuthUser(
+        id: userId,
+        provider: AuthProvider.github,
+        providerUserId: "gh-42",
+        providerUsername: "cross",
+      );
+      authStateSubject.add(const AuthState.authenticated(user: user));
+
+      AnalyticsUserIdTracker(
+        authSession: mockAuthSession,
+        analytics: mockAnalytics,
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      final captured = verify(() => mockAnalytics.setUserId(id: captureAny(named: "id"))).captured.single as String;
+      final expectedHash = sha256.convert(utf8.encode(userId)).toString();
+
+      expect(captured, expectedHash);
+    });
+
+    test("dispose cancels subscription", () async {
+      final tracker = AnalyticsUserIdTracker(
+        authSession: mockAuthSession,
+        analytics: mockAnalytics,
+      );
+
+      await tracker.dispose();
+
+      authStateSubject.add(const AuthState.authenticated(user: AuthUser(
+        id: "after-dispose",
+        provider: AuthProvider.github,
+        providerUserId: "gh-99",
+        providerUsername: "late",
+      )));
+      await Future<void>.delayed(Duration.zero);
+
+      verifyNever(() => mockAnalytics.setUserId(id: any(named: "id")));
+    });
+  });
+}

--- a/mobile/app/test/helpers/test_helpers.dart
+++ b/mobile/app/test/helpers/test_helpers.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:firebase_analytics/firebase_analytics.dart";
 import "package:firebase_crashlytics/firebase_crashlytics.dart";
 import "package:flutter_secure_storage/flutter_secure_storage.dart";
 import "package:http/http.dart" as http;
@@ -140,6 +141,8 @@ class MockSseEventRepository extends Mock implements SseEventRepository {
 class MockFailureReporter extends Mock implements FailureReporter {}
 
 class MockFirebaseCrashlytics extends Mock implements FirebaseCrashlytics {}
+
+class MockFirebaseAnalytics extends Mock implements FirebaseAnalytics {}
 
 // ---------------------------------------------------------------------------
 // Fake classes — for registerFallbackValue

--- a/mobile/app/test/main_startup_notification_wiring_test.dart
+++ b/mobile/app/test/main_startup_notification_wiring_test.dart
@@ -36,6 +36,7 @@ void main() {
 
     await bootstrapSesoriApp(
       shouldInitializeFirebase: true,
+      supportsFirebaseAnalytics: false,
       configureDependenciesFn: configureDependencies,
       initializeDeepLinks: initializeDeepLinks,
       startNotificationStartupFn: startNotificationStartup,

--- a/mobile/module_core/lib/sesori_dart_core.dart
+++ b/mobile/module_core/lib/sesori_dart_core.dart
@@ -2,7 +2,17 @@
 library;
 
 // Re-exports from sesori_auth (move + re-export pattern)
-export "package:sesori_auth/sesori_auth.dart" show AuthSession, OAuthFlowProvider, SecureStorage;
+export "package:sesori_auth/sesori_auth.dart"
+    show
+        AuthSession,
+        AuthState,
+        AuthInitial,
+        AuthUnauthenticated,
+        AuthAuthenticating,
+        AuthAuthenticated,
+        AuthFailed,
+        OAuthFlowProvider,
+        SecureStorage;
 export "package:sesori_auth/sesori_auth.dart"
     show
         ApiError,

--- a/mobile/module_core/lib/sesori_dart_core.dart
+++ b/mobile/module_core/lib/sesori_dart_core.dart
@@ -4,13 +4,13 @@ library;
 // Re-exports from sesori_auth (move + re-export pattern)
 export "package:sesori_auth/sesori_auth.dart"
     show
+        AuthAuthenticated,
+        AuthAuthenticating,
+        AuthFailed,
+        AuthInitial,
         AuthSession,
         AuthState,
-        AuthInitial,
         AuthUnauthenticated,
-        AuthAuthenticating,
-        AuthAuthenticated,
-        AuthFailed,
         OAuthFlowProvider,
         SecureStorage;
 export "package:sesori_auth/sesori_auth.dart"


### PR DESCRIPTION
This PR implements privacy-preserving Firebase Analytics user identification using SHA-256 hashed user IDs.

## Changes

- **AnalyticsUserIdTracker**: New class in `app/lib/core/analytics/` that listens to auth state changes and syncs a hashed user ID to Firebase Analytics
- **main.dart**: Wires the tracker into app bootstrap when Firebase Analytics is supported
- **Tests**: 6 unit tests covering authentication, logout, no-op states, initial state, hash determinism, and disposal

## How it works

1. Listens to `AuthSession.authStateStream` (covers all login methods: OAuth, email, Apple Sign-In, session restore)
2. On authenticated: computes `SHA-256(AuthUser.id)` and calls `FirebaseAnalytics.instance.setUserId()`
3. On logout: calls `setUserId(id: null)` to disassociate future events
4. Other states (initial, authenticating, failed): no-op

## Privacy

- Raw `AuthUser.id` (a UUID) is never sent to Firebase
- SHA-256 is one-way and deterministic — same user gets same hash on every device
- No salt needed because UUIDs are already high-entropy (122 bits of randomness)
- Compliant with Firebase Analytics Terms of Service (no PII transmitted)

## Cross-device behavior

Same account on multiple devices → same hashed ID → Firebase Analytics treats them as one user in GA4 reports.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a privacy-preserving Analytics user ID by hashing `AuthUser.id` with SHA-256 and setting it in `firebase_analytics`. This groups the same account across devices without sending raw IDs.

- **New Features**
  - `AnalyticsUserIdTracker` listens to `authStateStream` and sets `FirebaseAnalytics.instance.setUserId(id: sha256(AuthUser.id))`; clears on logout and failed login; no-ops for initial/authenticating.
  - Integrated at startup behind `supportsFirebaseAnalytics`; `sesori_dart_core` now re-exports `AuthState` variants to avoid app→auth coupling.

- **Bug Fixes**
  - Process auth events sequentially with `asyncMap` and swallow analytics errors to prevent races and crashes; also removed a redundant `sesori_auth` import and sorted `sesori_dart_core` export combinators.

<sup>Written for commit 74f6b9779fb2c846f6f4d6bd29b23c96b3f011fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

