### PR TITLE
fix: fully delete worktree directories after git worktree remove

### DIFF
--- a/bridge/app/lib/src/bridge/api/git_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/git_cli_api.dart
@@ -195,26 +195,29 @@ class GitCliApi {
     final removed = result.exitCode == 0;
 
     // Git worktree remove may leave the directory behind if it contains
-    // untracked files or build artifacts. Ensure the directory is fully
-    // deleted so .worktrees/ does not accumulate stale directories.
-    final worktreeDir = Directory(worktreePath);
-    if (worktreeDir.existsSync()) {
-      try {
-        worktreeDir.deleteSync(recursive: true);
-      } on FileSystemException catch (e) {
-        Log.w("[GitCli] failed to delete worktree directory $worktreePath: $e");
-      }
-    }
-
-    // If the parent .worktrees/ directory is now empty, clean it up too.
-    final parentDir = worktreeDir.parent;
-    if (parentDir.existsSync() && parentDir.path.endsWith("/.worktrees")) {
-      try {
-        if (parentDir.listSync().isEmpty) {
-          parentDir.deleteSync();
+    // untracked files or build artifacts. Only clean up when the git command
+    // succeeded, to avoid bypassing Git's safety checks (e.g. dirty worktree).
+    if (removed) {
+      final worktreeDir = Directory(worktreePath);
+      if (worktreeDir.existsSync()) {
+        try {
+          worktreeDir.deleteSync(recursive: true);
+        } on FileSystemException catch (e) {
+          Log.w("[GitCli] failed to delete worktree directory $worktreePath: $e");
         }
-      } on FileSystemException catch (e) {
-        Log.w("[GitCli] failed to delete empty .worktrees directory ${parentDir.path}: $e");
+      }
+
+      // If the parent .worktrees/ directory is now empty, clean it up too.
+      final parentDir = worktreeDir.parent;
+      if (parentDir.existsSync() &&
+          parentDir.path.split(Platform.pathSeparator).last == ".worktrees") {
+        try {
+          if (parentDir.listSync().isEmpty) {
+            parentDir.deleteSync();
+          }
+        } on FileSystemException catch (e) {
+          Log.w("[GitCli] failed to delete empty .worktrees directory ${parentDir.path}: $e");
+        }
       }
     }
 

--- a/bridge/app/lib/src/bridge/api/git_cli_api.dart
+++ b/bridge/app/lib/src/bridge/api/git_cli_api.dart
@@ -192,7 +192,33 @@ class GitCliApi {
       projectPath: projectPath,
       arguments: ["worktree", "remove", if (force) "--force", "--", worktreePath],
     );
-    return result.exitCode == 0;
+    final removed = result.exitCode == 0;
+
+    // Git worktree remove may leave the directory behind if it contains
+    // untracked files or build artifacts. Ensure the directory is fully
+    // deleted so .worktrees/ does not accumulate stale directories.
+    final worktreeDir = Directory(worktreePath);
+    if (worktreeDir.existsSync()) {
+      try {
+        worktreeDir.deleteSync(recursive: true);
+      } on FileSystemException catch (e) {
+        Log.w("[GitCli] failed to delete worktree directory $worktreePath: $e");
+      }
+    }
+
+    // If the parent .worktrees/ directory is now empty, clean it up too.
+    final parentDir = worktreeDir.parent;
+    if (parentDir.existsSync() && parentDir.path.endsWith("/.worktrees")) {
+      try {
+        if (parentDir.listSync().isEmpty) {
+          parentDir.deleteSync();
+        }
+      } on FileSystemException catch (e) {
+        Log.w("[GitCli] failed to delete empty .worktrees directory ${parentDir.path}: $e");
+      }
+    }
+
+    return removed;
   }
 
   Future<bool> deleteBranch({


### PR DESCRIPTION
Git worktree remove may leave the directory behind if it contains untracked files or build artifacts. After running git worktree remove, explicitly delete the worktree directory and clean up empty .worktrees/ parent directories to prevent stale directory accumulation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure worktree directories are fully deleted after `git worktree remove`, and clean up empty `.worktrees` parents to prevent stale folder buildup.

- **Bug Fixes**
  - Only delete the worktree directory when `git worktree remove` succeeds (preserves Git safety checks).
  - Remove the parent `.worktrees` directory when it becomes empty, with cross‑platform path handling.
  - Log warnings on filesystem errors without failing the operation.

<sup>Written for commit 7720087d50d2a38623122d8de1e7e06d898032d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

