### PR TITLE
chore: add VS Code launch configs for the mobile app

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "Dart-Code.dart-code",
+    "Dart-Code.flutter"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+  // Launch configurations for the Sesori mobile app (mobile/app, package: sesori_mobile).
+  // Requires the Dart & Flutter VS Code extensions. There are no build flavors,
+  // so each entry differs only by Flutter build mode.
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Mobile (debug)",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main.dart",
+      "cwd": "${workspaceFolder}/mobile/app",
+      "flutterMode": "debug"
+    },
+    {
+      "name": "Mobile (profile)",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main.dart",
+      "cwd": "${workspaceFolder}/mobile/app",
+      "flutterMode": "profile"
+    },
+    {
+      "name": "Mobile (release)",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main.dart",
+      "cwd": "${workspaceFolder}/mobile/app",
+      "flutterMode": "release"
+    },
+    {
+      "name": "Mobile (attach)",
+      "request": "attach",
+      "type": "dart",
+      "cwd": "${workspaceFolder}/mobile/app"
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "name": "Mobile (debug)",
       "request": "launch",
       "type": "dart",
-      "program": "lib/main.dart",
+      "program": "${workspaceFolder}/mobile/app/lib/main.dart",
       "cwd": "${workspaceFolder}/mobile/app",
       "flutterMode": "debug"
     },
@@ -16,7 +16,7 @@
       "name": "Mobile (profile)",
       "request": "launch",
       "type": "dart",
-      "program": "lib/main.dart",
+      "program": "${workspaceFolder}/mobile/app/lib/main.dart",
       "cwd": "${workspaceFolder}/mobile/app",
       "flutterMode": "profile"
     },
@@ -24,7 +24,7 @@
       "name": "Mobile (release)",
       "request": "launch",
       "type": "dart",
-      "program": "lib/main.dart",
+      "program": "${workspaceFolder}/mobile/app/lib/main.dart",
       "cwd": "${workspaceFolder}/mobile/app",
       "flutterMode": "release"
     },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,9 @@
 {
-  // Launch configurations for the Sesori mobile app (mobile/app, package: sesori_mobile).
+  // Launch configurations for the Sesori app (mobile/app, package: sesori_mobile).
   // Requires the Dart & Flutter VS Code extensions. There are no build flavors,
-  // so each entry differs only by Flutter build mode.
+  // so entries differ only by Flutter build mode and target device. Desktop
+  // configs pin a host deviceId; pick the one matching your OS (only the macOS,
+  // Windows, and Linux desktop targets are enabled in mobile/app).
   "version": "0.2.0",
   "configurations": [
     {
@@ -33,6 +35,51 @@
       "request": "attach",
       "type": "dart",
       "cwd": "${workspaceFolder}/mobile/app"
+    },
+    {
+      "name": "Desktop macOS (debug)",
+      "request": "launch",
+      "type": "dart",
+      "program": "${workspaceFolder}/mobile/app/lib/main.dart",
+      "cwd": "${workspaceFolder}/mobile/app",
+      "deviceId": "macos",
+      "flutterMode": "debug"
+    },
+    {
+      "name": "Desktop macOS (profile)",
+      "request": "launch",
+      "type": "dart",
+      "program": "${workspaceFolder}/mobile/app/lib/main.dart",
+      "cwd": "${workspaceFolder}/mobile/app",
+      "deviceId": "macos",
+      "flutterMode": "profile"
+    },
+    {
+      "name": "Desktop macOS (release)",
+      "request": "launch",
+      "type": "dart",
+      "program": "${workspaceFolder}/mobile/app/lib/main.dart",
+      "cwd": "${workspaceFolder}/mobile/app",
+      "deviceId": "macos",
+      "flutterMode": "release"
+    },
+    {
+      "name": "Desktop Windows (debug)",
+      "request": "launch",
+      "type": "dart",
+      "program": "${workspaceFolder}/mobile/app/lib/main.dart",
+      "cwd": "${workspaceFolder}/mobile/app",
+      "deviceId": "windows",
+      "flutterMode": "debug"
+    },
+    {
+      "name": "Desktop Linux (debug)",
+      "request": "launch",
+      "type": "dart",
+      "program": "${workspaceFolder}/mobile/app/lib/main.dart",
+      "cwd": "${workspaceFolder}/mobile/app",
+      "deviceId": "linux",
+      "flutterMode": "debug"
     }
   ]
 }


### PR DESCRIPTION
## What

Adds a committed `.vscode/` configuration so the Sesori mobile app (`mobile/app`, package `sesori_mobile`) can be launched from VS Code's Run & Debug panel.

- **`launch.json`** — `debug` / `profile` / `release` / `attach` configs. Each sets `cwd` to `${workspaceFolder}/mobile/app` so the Dart extension resolves the package within the monorepo (it can't from the repo root).
- **`extensions.json`** — recommends the Dart & Flutter extensions the configs depend on.

These filenames are already whitelisted in the repo's `.gitignore`, so committing them follows the existing convention.

## Notes / deliberate omissions

- **No flavor or `--dart-define` entries** — the app has a single `lib/main.dart` entry point and no build flavors; the only env switch (`dart.vm.product`) is set automatically by the toolchain per build mode. Configs differ only by Flutter build mode.
- **No hardcoded SDK path** — Flutter is asdf-managed (`3.44.1-stable`); pinning `dart.flutterSdkPath` to a `$HOME/.asdf/...` path would break for differing local setups, so SDK resolution is left to `PATH`/asdf.

## Test plan

- Open the repo root in VS Code, pick a config from Run & Debug, select a device, and run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds VS Code launch configs for the mobile and desktop apps so you can run and debug `sesori_mobile` from the Run & Debug panel. Uses an absolute `program` path for reliable launches in the monorepo.

- New Features
  - Added `.vscode/launch.json` with mobile `debug`/`profile`/`release`/`attach` and desktop targets (macOS `debug`/`profile`/`release`, Windows `debug`, Linux `debug`). Each sets `cwd` to `${workspaceFolder}/mobile/app`.
  - Added `.vscode/extensions.json` recommending `Dart-Code.dart-code` and `Dart-Code.flutter`.

- Bug Fixes
  - Use absolute `program` path `${workspaceFolder}/mobile/app/lib/main.dart` to ensure VS Code resolves the entrypoint correctly.

<sup>Written for commit d0c64603e457a06290abacf67b34ba06221e917f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

