### PR TITLE
feat(ci): unify bridge releases into the mobile release pipeline

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -1,6 +1,12 @@
 name: 'Setup Flutter'
 description: 'Cache and install asdf tools + Flutter pub dependencies'
 
+inputs:
+  workspace:
+    description: 'Workspace directory to run `dart pub get` in ("none" skips it — toolchain install only)'
+    required: false
+    default: 'mobile'
+
 runs:
   using: 'composite'
   steps:
@@ -33,6 +39,7 @@ runs:
           ${{ runner.os }}-pub-${{ hashFiles('.tool-versions') }}-
 
     - name: Get dependencies (workspace)
+      if: inputs.workspace != 'none'
       shell: bash
       run: dart pub get
-      working-directory: mobile
+      working-directory: ${{ inputs.workspace }}

--- a/.github/workflows/_reusable-bridge-build.yml
+++ b/.github/workflows/_reusable-bridge-build.yml
@@ -64,13 +64,25 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      # Local `uses: ./...` actions resolve from the CHECKED-OUT tree, which
+      # for submit-release rebuilds can be an older commit whose copy of the
+      # action predates the `workspace` input (it would silently run pub get
+      # in mobile/). Pull the action from the workflow's own revision into a
+      # side directory and run it from there.
+      - name: Checkout CI actions at workflow revision
+        if: runner.os != 'Windows'
+        uses: actions/checkout@v6
+        with:
+          path: .ci-workflow
+          sparse-checkout: .github/actions
+
       # Same pinned toolchain as the mobile builds: asdf installs the Flutter
       # version from .tool-versions and dart comes from that installation. On
       # macOS the iOS deploy job usually warmed the same asdf cache already.
       # asdf has no Windows support, so Windows keeps dart-lang/setup-dart.
       - name: Setup Flutter (asdf)
         if: runner.os != 'Windows'
-        uses: ./.github/actions/setup-flutter
+        uses: ./.ci-workflow/.github/actions/setup-flutter
         with:
           workspace: bridge
 

--- a/.github/workflows/_reusable-bridge-build.yml
+++ b/.github/workflows/_reusable-bridge-build.yml
@@ -1,0 +1,171 @@
+name: Bridge Build (reusable)
+
+# Builds the 5-platform sesori-bridge archives and uploads them as workflow
+# artifacts (sesori-bridge-<os>-<arch>.<ext>). Used by:
+#   - release-all-platforms.yml — per main merge, baking an X.Y.Z-internal.<N>
+#     version so internal binaries self-report exactly their release tag.
+#   - submit-release.yml — at production submit, building from the resolved
+#     commit whose committed pubspec already holds the clean version.
+#
+# Version contract: the binaries MUST report `inputs.version`.
+#   - pubspec already matches  → build as-is.
+#   - pre-release requested    → bake it at build time via bump_version.dart
+#                                (never committed).
+#   - clean version mismatch   → fail loudly: the committed tree is out of
+#                                sync (run tool/sync_versions.dart), and
+#                                silently rewriting would mask it.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Commit/ref to build (defaults to the triggering sha)"
+        required: false
+        default: ""
+        type: string
+      version:
+        description: "Version the binaries must report (X.Y.Z or X.Y.Z-internal.N)"
+        required: true
+        type: string
+    secrets:
+      MACOS_CERT_P12_BASE64:
+        required: true
+      MACOS_CERT_PASSWORD:
+        required: true
+      MACOS_KEYCHAIN_PASSWORD:
+        required: true
+
+jobs:
+  build:
+    name: Build (${{ matrix.asset_name }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    env:
+      PUB_CACHE: ${{ github.workspace }}/.pub-cache
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-latest
+            asset_name: sesori-bridge-macos-arm64
+            archive_ext: tar.gz
+          - runner: macos-26-intel
+            asset_name: sesori-bridge-macos-x64
+            archive_ext: tar.gz
+          - runner: ubuntu-latest
+            asset_name: sesori-bridge-linux-x64
+            archive_ext: tar.gz
+          - runner: ubuntu-24.04-arm
+            asset_name: sesori-bridge-linux-arm64
+            archive_ext: tar.gz
+          - runner: windows-latest
+            asset_name: sesori-bridge-windows-x64
+            archive_ext: zip
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - uses: dart-lang/setup-dart@v1
+
+      - uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/.pub-cache
+          key: ${{ runner.os }}-${{ runner.arch }}-pub-${{ hashFiles('bridge/pubspec.lock') }}
+
+      - name: Get dependencies
+        run: dart pub get
+        working-directory: bridge
+
+      - name: Apply build version
+        shell: bash
+        working-directory: bridge/app
+        env:
+          TARGET_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          CURRENT_VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}')
+          if [[ "$CURRENT_VERSION" == "$TARGET_VERSION" ]]; then
+            echo "Version already set to $CURRENT_VERSION; nothing to bake."
+          elif [[ "$TARGET_VERSION" == *-* ]]; then
+            echo "Baking pre-release version $TARGET_VERSION (pubspec has $CURRENT_VERSION)."
+            dart run tool/bump_version.dart "$TARGET_VERSION"
+          else
+            echo "::error::Committed bridge version ($CURRENT_VERSION) does not match the requested release version ($TARGET_VERSION). Run tool/sync_versions.dart and merge the bump before releasing."
+            exit 1
+          fi
+
+      - name: Build binary
+        run: dart build cli -o build/cli
+        working-directory: bridge/app
+
+      - name: Rename binary (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: mv build/cli/bundle/bin/bridge build/cli/bundle/bin/sesori-bridge
+        working-directory: bridge/app
+
+      - name: Rename binary (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Rename-Item -Path "bridge/app/build/cli/bundle/bin/bridge.exe" -NewName "sesori-bridge.exe"
+
+      - name: Import signing certificate
+        if: runner.os == 'macOS'
+        env:
+          MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+        run: |
+          echo -n "$MACOS_CERT_P12_BASE64" | base64 --decode -o certificate.p12
+          security create-keychain -p "$MACOS_KEYCHAIN_PASSWORD" build.keychain
+          security unlock-keychain -p "$MACOS_KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -lut 1200 build.keychain
+          security import certificate.p12 -k build.keychain -P "$MACOS_CERT_PASSWORD" -A -t cert -f pkcs12
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$MACOS_KEYCHAIN_PASSWORD" build.keychain
+          security list-keychains -s build.keychain login.keychain
+          security default-keychain -s build.keychain
+          rm -f certificate.p12
+        working-directory: bridge/app
+
+      - name: Verify signing prerequisites
+        if: runner.os == 'macOS'
+        env:
+          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+        run: |
+          if [ -z "$APPLE_TEAM_ID" ]; then
+            echo "Error: APPLE_TEAM_ID repository variable is not set." >&2
+            echo "Set it in Settings > Secrets and variables > Variables." >&2
+            exit 1
+          fi
+        working-directory: bridge/app
+
+      - name: Sign binary
+        if: runner.os == 'macOS'
+        env:
+          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
+        run: |
+          codesign -s "Developer ID Application: DigitalBlock Labs LTD ($APPLE_TEAM_ID)" \
+            --timestamp \
+            --force \
+            --verbose \
+            build/cli/bundle/bin/sesori-bridge
+          codesign -dv --verbose=4 build/cli/bundle/bin/sesori-bridge
+        working-directory: bridge/app
+
+      - name: Create archive (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: tar -czf ${{ matrix.asset_name }}.tar.gz -C build/cli/bundle .
+        working-directory: bridge/app
+
+      - name: Create archive (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Compress-Archive -Path "bridge/app/build/cli/bundle/*" -DestinationPath "bridge/app/${{ matrix.asset_name }}.zip"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset_name }}
+          path: bridge/app/${{ matrix.asset_name }}.${{ matrix.archive_ext }}

--- a/.github/workflows/_reusable-bridge-build.yml
+++ b/.github/workflows/_reusable-bridge-build.yml
@@ -40,8 +40,6 @@ jobs:
     name: Build (${{ matrix.asset_name }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
-    env:
-      PUB_CACHE: ${{ github.workspace }}/.pub-cache
     strategy:
       fail-fast: false
       matrix:
@@ -66,14 +64,29 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - uses: dart-lang/setup-dart@v1
-
-      - uses: actions/cache@v5
+      # Same pinned toolchain as the mobile builds: asdf installs the Flutter
+      # version from .tool-versions and dart comes from that installation. On
+      # macOS the iOS deploy job usually warmed the same asdf cache already.
+      # asdf has no Windows support, so Windows keeps dart-lang/setup-dart.
+      - name: Setup Flutter (asdf)
+        if: runner.os != 'Windows'
+        uses: ./.github/actions/setup-flutter
         with:
-          path: ${{ github.workspace }}/.pub-cache
+          workspace: bridge
+
+      - name: Setup Dart (Windows)
+        if: runner.os == 'Windows'
+        uses: dart-lang/setup-dart@v1
+
+      - name: Cache pub dependencies (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/cache@v5
+        with:
+          path: ~\AppData\Local\Pub\Cache
           key: ${{ runner.os }}-${{ runner.arch }}-pub-${{ hashFiles('bridge/pubspec.lock') }}
 
-      - name: Get dependencies
+      - name: Get dependencies (Windows)
+        if: runner.os == 'Windows'
         run: dart pub get
         working-directory: bridge
 

--- a/.github/workflows/bridge-npm-publish.yml
+++ b/.github/workflows/bridge-npm-publish.yml
@@ -1,18 +1,31 @@
 name: Bridge npm Publish
 
 # Publishes the bridge npm packages (5 platform packages + the @sesori/bridge
-# wrapper) when a stable v<X.Y.Z> GitHub release goes LIVE.
+# wrapper) when a stable v<X.Y.Z> GitHub release goes LIVE, via two triggers:
 #
-# The `released` event type fires both when submit-release.yml publishes the
-# release immediately (publish_bridge ticked) and when an operator manually
-# promotes a pre-release to a full release in the GitHub UI — so npm
-# availability always coincides exactly with the moment the bridge
-# auto-updater starts seeing the release. It never fires for the rolling
-# v*-internal.* pre-releases.
+#   - workflow_dispatch: invoked directly by submit-release.yml when
+#     publish_bridge is ticked. Necessary because releases created with the
+#     default GITHUB_TOKEN do not emit workflow-triggering events.
+#   - release [released]: fires when an operator manually promotes a
+#     pre-release to a full release in the GitHub UI (a user action, so the
+#     event triggers normally). Never fires for the rolling v*-internal.*
+#     pre-releases.
+#
+# Either way, npm availability coincides with the moment the bridge
+# auto-updater starts seeing the release; the gate verifies the release is
+# actually live (published, not draft, not pre-release) before publishing.
 
 on:
   release:
     types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Stable release tag to publish (e.g. v1.0.9)"
+        required: true
+        type: string
+
+run-name: "npm publish · ${{ inputs.tag || github.event.release.tag_name }}"
 
 jobs:
   gate:
@@ -22,25 +35,37 @@ jobs:
     outputs:
       proceed: ${{ steps.check.outputs.proceed }}
       version: ${{ steps.check.outputs.version }}
+      tag: ${{ steps.check.outputs.tag }}
     permissions:
       contents: write
     env:
       GH_TOKEN: ${{ github.token }}
-      RELEASE_TAG: ${{ github.event.release.tag_name }}
+      RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
     steps:
-      - name: Check tag format
+      - name: Check tag format and release state
         id: check
         run: |
           set -euo pipefail
-          if [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "proceed=true" >> "$GITHUB_OUTPUT"
-            echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
-            echo "Release ${RELEASE_TAG} is a stable bridge release — publishing npm packages."
-          else
+          echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "proceed=false" >> "$GITHUB_OUTPUT"
             echo "version=" >> "$GITHUB_OUTPUT"
             echo "Release ${RELEASE_TAG} is not a stable v<X.Y.Z> release — skipping npm publish."
+            exit 0
           fi
+
+          # Publish only from a LIVE release — guards manual dispatches against
+          # drafts, pre-releases pending promotion, or typo'd tags.
+          STATE=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" \
+            --jq '{draft: .draft, prerelease: .prerelease}' 2>/dev/null || echo "missing")
+          if [[ "$STATE" != '{"draft":false,"prerelease":false}' ]]; then
+            echo "::error::Release ${RELEASE_TAG} is not a published stable release (state: ${STATE}). Promote/publish it first."
+            exit 1
+          fi
+
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+          echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "Release ${RELEASE_TAG} is a live stable bridge release — publishing npm packages."
 
       # The rolling internal pre-release for this version (v<X.Y.Z>-internal.<N>)
       # is now superseded by the stable release — drop the release object (its
@@ -71,13 +96,13 @@ jobs:
       contents: read
       id-token: write
     env:
-      RELEASE_TAG: ${{ github.event.release.tag_name }}
+      RELEASE_TAG: ${{ needs.gate.outputs.tag }}
     steps:
       # Check out the TAGGED commit (not main) so the package.json manifests
       # match the version actually being published.
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ needs.gate.outputs.tag }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -257,11 +282,11 @@ jobs:
       contents: read
       id-token: write
     env:
-      RELEASE_TAG: ${{ github.event.release.tag_name }}
+      RELEASE_TAG: ${{ needs.gate.outputs.tag }}
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ needs.gate.outputs.tag }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/bridge-npm-publish.yml
+++ b/.github/workflows/bridge-npm-publish.yml
@@ -1,222 +1,89 @@
-name: Bridge Release
+name: Bridge npm Publish
+
+# Publishes the bridge npm packages (5 platform packages + the @sesori/bridge
+# wrapper) when a stable v<X.Y.Z> GitHub release goes LIVE.
+#
+# The `released` event type fires both when submit-release.yml publishes the
+# release immediately (publish_bridge ticked) and when an operator manually
+# promotes a pre-release to a full release in the GitHub UI — so npm
+# availability always coincides exactly with the moment the bridge
+# auto-updater starts seeing the release. It never fires for the rolling
+# v*-internal.* pre-releases.
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: "Release tag (e.g., v1.0.0)"
-        required: true
-        type: string
-      dry_run:
-        description: "Dry run (build only, no publish)"
-        required: false
-        default: false
-        type: boolean
+  release:
+    types: [released]
 
 jobs:
-  build:
-    name: Build (${{ matrix.asset_name }})
-    runs-on: ${{ matrix.runner }}
-    env:
-      PUB_CACHE: ${{ github.workspace }}/.pub-cache
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: macos-latest
-            target_os: macos
-            target_arch: arm64
-            asset_name: sesori-bridge-macos-arm64
-            archive_ext: tar.gz
-          - runner: macos-26-intel
-            target_os: macos
-            target_arch: x64
-            asset_name: sesori-bridge-macos-x64
-            archive_ext: tar.gz
-          - runner: ubuntu-latest
-            target_os: linux
-            target_arch: x64
-            asset_name: sesori-bridge-linux-x64
-            archive_ext: tar.gz
-          - runner: ubuntu-24.04-arm
-            target_os: linux
-            target_arch: arm64
-            asset_name: sesori-bridge-linux-arm64
-            archive_ext: tar.gz
-          - runner: windows-latest
-            target_os: windows
-            target_arch: x64
-            asset_name: sesori-bridge-windows-x64
-            archive_ext: zip
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dart-lang/setup-dart@v1
-
-      - uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}/.pub-cache
-          key: ${{ runner.os }}-${{ runner.arch }}-pub-${{ hashFiles('bridge/pubspec.lock') }}
-
-      - name: Extract version
-        id: version
-        shell: bash
-        run: |
-          RELEASE_TAG="${{ github.event.inputs.tag }}"
-          VERSION="${RELEASE_TAG#v}"
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Get dependencies
-        run: dart pub get
-        working-directory: bridge
-
-      - name: Bump version
-        if: github.event.inputs.tag != ''
-        shell: bash
-        run: |
-          CURRENT_VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}')
-          if [[ "$CURRENT_VERSION" == "${{ steps.version.outputs.VERSION }}" ]]; then
-            echo "Version already set to $CURRENT_VERSION; skipping bump."
-            exit 0
-          fi
-
-          dart run tool/bump_version.dart ${{ steps.version.outputs.VERSION }}
-        working-directory: bridge/app
-
-      - name: Build binary
-        run: dart build cli -o build/cli
-        working-directory: bridge/app
-
-      - name: Rename binary (Unix)
-        if: runner.os != 'Windows'
-        shell: bash
-        run: mv build/cli/bundle/bin/bridge build/cli/bundle/bin/sesori-bridge
-        working-directory: bridge/app
-
-      - name: Rename binary (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: Rename-Item -Path "bridge/app/build/cli/bundle/bin/bridge.exe" -NewName "sesori-bridge.exe"
-
-      - name: Import signing certificate
-        if: runner.os == 'macOS'
-        env:
-          MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
-          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
-          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
-        run: |
-          echo -n "$MACOS_CERT_P12_BASE64" | base64 --decode -o certificate.p12
-          security create-keychain -p "$MACOS_KEYCHAIN_PASSWORD" build.keychain
-          security unlock-keychain -p "$MACOS_KEYCHAIN_PASSWORD" build.keychain
-          security set-keychain-settings -lut 1200 build.keychain
-          security import certificate.p12 -k build.keychain -P "$MACOS_CERT_PASSWORD" -A -t cert -f pkcs12
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$MACOS_KEYCHAIN_PASSWORD" build.keychain
-          security list-keychains -s build.keychain login.keychain
-          security default-keychain -s build.keychain
-          rm -f certificate.p12
-        working-directory: bridge/app
-
-      - name: Verify signing prerequisites
-        if: runner.os == 'macOS'
-        env:
-          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
-        run: |
-          if [ -z "$APPLE_TEAM_ID" ]; then
-            echo "Error: APPLE_TEAM_ID repository variable is not set." >&2
-            echo "Set it in Settings > Secrets and variables > Variables." >&2
-            exit 1
-          fi
-        working-directory: bridge/app
-
-      - name: Sign binary
-        if: runner.os == 'macOS'
-        env:
-          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
-        run: |
-          codesign -s "Developer ID Application: DigitalBlock Labs LTD ($APPLE_TEAM_ID)" \
-            --timestamp \
-            --force \
-            --verbose \
-            build/cli/bundle/bin/sesori-bridge
-          codesign -dv --verbose=4 build/cli/bundle/bin/sesori-bridge
-        working-directory: bridge/app
-
-      - name: Create archive (Unix)
-        if: runner.os != 'Windows'
-        shell: bash
-        run: tar -czf ${{ matrix.asset_name }}.tar.gz -C build/cli/bundle .
-        working-directory: bridge/app
-
-      - name: Create archive (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: Compress-Archive -Path "bridge/app/build/cli/bundle/*" -DestinationPath "bridge/app/${{ matrix.asset_name }}.zip"
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.asset_name }}
-          path: bridge/app/${{ matrix.asset_name }}.${{ matrix.archive_ext }}
-
-  release:
-    name: Create GitHub Release
-    needs: build
+  gate:
+    name: Validate release tag
     runs-on: ubuntu-latest
-    if: github.event.inputs.dry_run != 'true' && github.event.inputs.tag != ''
+    timeout-minutes: 5
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+      version: ${{ steps.check.outputs.version }}
     permissions:
       contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
     steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: Generate checksums
-        working-directory: artifacts
+      - name: Check tag format
+        id: check
         run: |
-          find . -type f \( -name '*.tar.gz' -o -name '*.zip' \) -print0 | sort -z | while IFS= read -r -d '' file; do
-            sha256sum "$file" | awk -v name="$(basename "$file")" '{print $1 "  " name}'
-          done > checksums.txt
-          cat checksums.txt
+          set -euo pipefail
+          if [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
+            echo "Release ${RELEASE_TAG} is a stable bridge release — publishing npm packages."
+          else
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            echo "version=" >> "$GITHUB_OUTPUT"
+            echo "Release ${RELEASE_TAG} is not a stable v<X.Y.Z> release — skipping npm publish."
+          fi
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.event.inputs.tag }}
-          name: Bridge ${{ github.event.inputs.tag }}
-          make_latest: "true"
-          generate_release_notes: true
-          files: |
-            artifacts/**/*.tar.gz
-            artifacts/**/*.zip
-            artifacts/checksums.txt
+      # The rolling internal pre-release for this version (v<X.Y.Z>-internal.<N>)
+      # is now superseded by the stable release — drop the release object (its
+      # tag is kept: submit-release.yml uses it to map build numbers to
+      # commits). Internal pre-releases for OTHER versions (e.g. the next bump
+      # already merged on main) are left alone.
+      - name: Delete superseded internal pre-release
+        if: steps.check.outputs.proceed == 'true'
+        env:
+          VERSION: ${{ steps.check.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName,isPrerelease \
+            --jq '.[] | select(.isPrerelease) | .tagName' \
+            | { grep -E "^v${VERSION//./\\.}-internal\.[0-9]+$" || true; } \
+            | while read -r stale; do
+                echo "Deleting superseded internal pre-release $stale (tag kept)"
+                gh release delete "$stale" --repo "$GITHUB_REPOSITORY" --yes
+              done
 
   publish-platform:
     name: Publish platform npm packages
-    needs: release
+    needs: gate
+    if: needs.gate.outputs.proceed == 'true'
     runs-on: ubuntu-latest
-    if: github.event.inputs.dry_run != 'true' && github.event.inputs.tag != ''
+    timeout-minutes: 15
     permissions:
       contents: read
       id-token: write
     env:
-      RELEASE_TAG: ${{ github.event.inputs.tag }}
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
     steps:
-
-      - uses: actions/checkout@v4
+      # Check out the TAGGED commit (not main) so the package.json manifests
+      # match the version actually being published.
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Extract version
-        id: version
-        shell: bash
-        run: |
-          VERSION="${RELEASE_TAG#v}"
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Download release assets
         env:
@@ -263,6 +130,8 @@ jobs:
 
       - name: Extract archives and copy runtime bundles
         shell: bash
+        env:
+          VERSION: ${{ needs.gate.outputs.version }}
         run: |
           mkdir -p /tmp/bridges/macos-arm64 /tmp/bridges/macos-x64 \
                    /tmp/bridges/linux-x64 /tmp/bridges/linux-arm64 \
@@ -317,7 +186,7 @@ jobs:
                   bootstrapOnly: metadata.bootstrapOnly,
                 }, null, 2) + "\n"
               );
-            ' "$package_root/package.json" "$RELEASE_TAG" "${{ steps.version.outputs.VERSION }}" "$asset_name" "$package_name"
+            ' "$package_root/package.json" "$RELEASE_TAG" "$VERSION" "$asset_name" "$package_name"
 
             diff -r "$source_root/bin" "$package_root/lib/runtime/bin"
             diff -r "$source_root/lib" "$package_root/lib/runtime/lib"
@@ -380,16 +249,19 @@ jobs:
 
   publish-wrapper:
     name: Publish wrapper npm package
-    needs: publish-platform
+    needs: [gate, publish-platform]
+    if: needs.gate.outputs.proceed == 'true'
     runs-on: ubuntu-latest
-    if: github.event.inputs.dry_run != 'true' && github.event.inputs.tag != ''
+    timeout-minutes: 10
     permissions:
       contents: read
       id-token: write
     env:
-      RELEASE_TAG: ${{ github.event.inputs.tag }}
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -397,15 +269,10 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Extract version
-        id: version
-        shell: bash
-        run: |
-          VERSION="${RELEASE_TAG#v}"
-          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
-
       - name: Validate wrapper package metadata
         shell: bash
+        env:
+          VERSION: ${{ needs.gate.outputs.version }}
         run: |
           node -e '
             const fs = require("fs");
@@ -433,7 +300,7 @@ jobs:
             if (metadata.releaseTag !== releaseTag) {
               throw new Error("releaseTag drift in " + packageJsonPath + ": expected " + releaseTag + ", got " + metadata.releaseTag);
             }
-          ' bridge/app/npm/sesori-bridge/package.json "$RELEASE_TAG" "${{ steps.version.outputs.VERSION }}"
+          ' bridge/app/npm/sesori-bridge/package.json "$RELEASE_TAG" "$VERSION"
 
       - name: Publish wrapper package
         run: npm publish --access public

--- a/.github/workflows/bridge-npm-publish.yml
+++ b/.github/workflows/bridge-npm-publish.yml
@@ -31,7 +31,7 @@ jobs:
   gate:
     name: Validate release tag
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     outputs:
       proceed: ${{ steps.check.outputs.proceed }}
       version: ${{ steps.check.outputs.version }}
@@ -91,7 +91,7 @@ jobs:
     needs: gate
     if: needs.gate.outputs.proceed == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write
@@ -277,7 +277,7 @@ jobs:
     needs: [gate, publish-platform]
     if: needs.gate.outputs.proceed == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -136,7 +136,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dart-lang/setup-dart@v1
+      # Pinned toolchain from .tool-versions; the notes script is
+      # dependency-free, so no workspace pub get is needed.
+      - name: Setup Flutter (asdf)
+        uses: ./.github/actions/setup-flutter
+        with:
+          workspace: none
 
       - name: Download bridge artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -2,6 +2,17 @@ name: Release All Platforms
 
 run-name: "release · build ${{ github.sha }}"
 
+# Per-merge internal release: uploads iOS to TestFlight and Android to the
+# Play internal track, builds the 5-platform bridge archives, and — only when
+# EVERYTHING succeeded (all-or-nothing) — pushes a `v<X>-internal.<N>` tag and
+# rolls the single internal GitHub pre-release onto it (previous pre-release
+# objects are deleted; their tags are kept forever as the build-number→commit
+# map used by submit-release.yml).
+#
+# The bridge auto-updater ignores pre-releases, so the rolling internal
+# pre-release never reaches end users — it serves internal testers and the
+# future pre-release update channel.
+
 on:
   workflow_dispatch:
   push:
@@ -16,8 +27,50 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  preflight:
+    name: Version guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      # Fail the WHOLE run (mobile and bridge) when the committed version was
+      # already released/submitted: a `v<version>` tag is pushed by every beta
+      # or production submit, so its existence means this version is taken and
+      # a `tool/sync_versions.dart` bump PR must land before main can produce
+      # new internal builds. Never auto-increment.
+      - name: Verify versions are in sync and unreleased
+        id: check
+        run: |
+          set -euo pipefail
+          MOBILE_VERSION=$(awk '/^version:/{split($2,a,"+"); print a[1]; exit}' mobile/app/pubspec.yaml)
+          BRIDGE_VERSION=$(awk '/^version:/{print $2; exit}' bridge/app/pubspec.yaml)
+          if [[ -z "$MOBILE_VERSION" || -z "$BRIDGE_VERSION" ]]; then
+            echo "::error::Could not parse versions (mobile: '$MOBILE_VERSION', bridge: '$BRIDGE_VERSION')."
+            exit 1
+          fi
+          if [[ "$MOBILE_VERSION" != "$BRIDGE_VERSION" ]]; then
+            echo "::error::Mobile ($MOBILE_VERSION) and bridge ($BRIDGE_VERSION) versions differ. Run tool/sync_versions.dart."
+            exit 1
+          fi
+
+          TAG="v${MOBILE_VERSION}"
+          PEELED=$(git ls-remote origin "refs/tags/${TAG}^{}" | awk '{print $1}')
+          PLAIN=$(git ls-remote origin "refs/tags/${TAG}" | awk '{print $1}')
+          EXISTING="${PEELED:-$PLAIN}"
+          if [[ -n "$EXISTING" && "$EXISTING" != "$GITHUB_SHA" ]]; then
+            echo "::error::Tag ${TAG} already exists — version ${MOBILE_VERSION} was already submitted/released. Bump the version with tool/sync_versions.dart before merging further changes."
+            exit 1
+          fi
+
+          echo "version=${MOBILE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Version ${MOBILE_VERSION} is in sync and unreleased."
+
   next-build-number:
     name: Resolve aligned build number
+    needs: preflight
     uses: ./.github/workflows/_reusable-next-build-number.yml
     secrets:
       APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
@@ -54,67 +107,120 @@ jobs:
       ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
       ANDROID_PROPERTIES: ${{ secrets.ANDROID_PROPERTIES }}
 
-  summary:
-    name: Release Summary
+  bridge:
+    name: Build bridge (internal)
+    needs: [preflight, next-build-number]
+    uses: ./.github/workflows/_reusable-bridge-build.yml
+    with:
+      version: ${{ needs.preflight.outputs.version }}-internal.${{ needs.next-build-number.outputs.build_number }}
+    secrets:
+      MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+      MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+      MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+
+  # All-or-nothing: runs only when iOS, Android AND all five bridge targets
+  # succeeded, so every internal tag maps to a complete set (both store builds
+  # + all bridge binaries). On any failure nothing is tagged or published and
+  # the rolling pre-release keeps pointing at the previous good build.
+  finalize:
+    name: Tag and roll internal pre-release
     runs-on: ubuntu-latest
-    needs: [next-build-number, ios, android]
-    if: always()
+    needs: [preflight, next-build-number, ios, android, bridge]
+    timeout-minutes: 10
     permissions:
       contents: write
-
+    env:
+      GH_TOKEN: ${{ github.token }}
+      VERSION: ${{ needs.preflight.outputs.version }}
+      BUILD_NUMBER: ${{ needs.next-build-number.outputs.build_number }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-      - name: Generate Summary
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Download bridge artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: sesori-bridge-*
+          merge-multiple: true
+
+      - name: Generate checksums
+        working-directory: artifacts
         run: |
-          echo "## Release Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Platform Status" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          find . -type f \( -name '*.tar.gz' -o -name '*.zip' \) -print0 | sort -z | while IFS= read -r -d '' file; do
+            sha256sum "$file" | awk -v name="$(basename "$file")" '{print $1 "  " name}'
+          done > checksums.txt
+          cat checksums.txt
 
-          if [ "${{ needs.next-build-number.result }}" == "success" ]; then
-            echo "- **Aligned build number**: ${{ needs.next-build-number.outputs.build_number }} (iOS next: ${{ needs.next-build-number.outputs.ios_next }}, Android next: ${{ needs.next-build-number.outputs.android_next }})" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "- **Aligned build number**: ${{ needs.next-build-number.result }}" >> $GITHUB_STEP_SUMMARY
-          fi
-
-          if [ "${{ needs.ios.result }}" == "success" ]; then
-            echo "- **iOS (artifact)**: Built" >> $GITHUB_STEP_SUMMARY
-          elif [ "${{ needs.ios.result }}" == "failure" ]; then
-            echo "- **iOS (artifact)**: Failed" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "- **iOS (artifact)**: ${{ needs.ios.result }}" >> $GITHUB_STEP_SUMMARY
-          fi
-
-          if [ "${{ needs.android.result }}" == "success" ]; then
-            echo "- **Android Internal**: Deployed" >> $GITHUB_STEP_SUMMARY
-          elif [ "${{ needs.android.result }}" == "failure" ]; then
-            echo "- **Android Internal**: Failed" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "- **Android Internal**: ${{ needs.android.result }}" >> $GITHUB_STEP_SUMMARY
-          fi
-
-      # Push a single `build-<N>` tag on the released commit. iOS and Android
-      # share the same aligned build number, so one tag is enough — the manual
-      # submit-release.yml workflow uses it to map a build number back to its
-      # commit. Tagged only when the build number resolved and at least one
-      # platform uploaded successfully (i.e. a build actually exists in a store).
-      - name: Tag commit with build number
-        if: >-
-          needs.next-build-number.result == 'success' &&
-          (needs.ios.result == 'success' || needs.android.result == 'success')
-        env:
-          BUILD_NUMBER: ${{ needs.next-build-number.outputs.build_number }}
+      - name: Push internal tag
+        id: tag
         run: |
           set -euo pipefail
-          TAG="build-${BUILD_NUMBER}"
+          TAG="v${VERSION}-internal.${BUILD_NUMBER}"
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if [ -n "$(git ls-remote --tags origin "refs/tags/${TAG}")" ]; then
             echo "Tag ${TAG} already exists on origin — skipping"
           else
-            git tag -a "$TAG" -m "Build ${BUILD_NUMBER} sha=${GITHUB_SHA}"
+            git tag -a "$TAG" -m "Internal build ${BUILD_NUMBER} (v${VERSION}) sha=${GITHUB_SHA}"
             git push origin "refs/tags/${TAG}"
           fi
-          echo "- **Tag**: \`${TAG}\`" >> $GITHUB_STEP_SUMMARY
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate release notes
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          dart tool/generate_release_notes.dart \
+            --repo "$GITHUB_REPOSITORY" \
+            --to "$TAG" \
+            --version "${VERSION}-internal.${BUILD_NUMBER}" \
+            --output notes.md
+          cat notes.md
+
+      # Keep exactly ONE internal pre-release: delete previous internal
+      # pre-release OBJECTS (their tags stay — submit-release.yml resolves
+      # build numbers through them) before publishing the new one.
+      - name: Roll internal pre-release
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release list --limit 100 --json tagName,isPrerelease \
+            --jq '.[] | select(.isPrerelease) | .tagName' \
+            | { grep -E '^v.+-internal\.[0-9]+$' || true; } \
+            | while read -r stale; do
+                if [ "$stale" != "$TAG" ]; then
+                  echo "Deleting previous internal pre-release $stale (tag kept)"
+                  gh release delete "$stale" --yes
+                fi
+              done
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release for ${TAG} already exists — uploading assets idempotently"
+            gh release upload "$TAG" artifacts/*.tar.gz artifacts/*.zip artifacts/checksums.txt --clobber
+            gh release edit "$TAG" --prerelease --notes-file notes.md
+          else
+            gh release create "$TAG" \
+              --prerelease \
+              --verify-tag \
+              --title "Internal v${VERSION}-internal.${BUILD_NUMBER}" \
+              --notes-file notes.md \
+              artifacts/*.tar.gz artifacts/*.zip artifacts/checksums.txt
+          fi
+
+      - name: Summary
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          {
+            echo "## Internal Release"
+            echo ""
+            echo "- **Version**: \`${VERSION}-internal.${BUILD_NUMBER}\`"
+            echo "- **Tag**: \`${TAG}\`"
+            echo "- **iOS (TestFlight)** / **Android (internal track)**: build ${BUILD_NUMBER} (iOS next: ${{ needs.next-build-number.outputs.ios_next }}, Android next: ${{ needs.next-build-number.outputs.android_next }})"
+            echo "- **Bridge pre-release**: rolled to \`${TAG}\` (5 platform archives + checksums)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/submit-release.yml
+++ b/.github/workflows/submit-release.yml
@@ -516,9 +516,12 @@ jobs:
     # unprotected store-beta environment to avoid a second approval pause.
     environment: ${{ inputs.platforms == 'bridge-only' && 'store-production' || 'store-beta' }}
     steps:
+      # Deliberately NOT the resolved commit: this job needs nothing from the
+      # release's tree (notes are API-driven, checksums come from artifacts,
+      # the tag is already pushed) — only tool/generate_release_notes.dart,
+      # which must come from the workflow's own revision. Resolved commits can
+      # predate the script entirely (legacy build-<N> tags).
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.resolve.outputs.commit_sha }}
 
       - uses: dart-lang/setup-dart@v1
 

--- a/.github/workflows/submit-release.yml
+++ b/.github/workflows/submit-release.yml
@@ -1,14 +1,25 @@
 name: Submit Release
 
 # Manually-triggered workflow that promotes an already-uploaded mobile build
-# from staging (TestFlight / Play Store internal) to beta or production.
+# from staging (TestFlight / Play Store internal) to beta or production, and —
+# for production — rebuilds the bridge from the same commit and attaches its
+# binaries to the v<VERSION> GitHub release (which is what the bridge
+# auto-updater consumes).
 #
-# DOES NOT rebuild — every job runs on ubuntu-latest because submission is
-# pure HTTPS API work against App Store Connect and Google Play.
+# Store submission jobs run on ubuntu-latest because submission is pure HTTPS
+# API work; only the bridge binaries are (re)built, on their own matrix.
 #
 # Required prerequisite: the build must have been uploaded by
-# release-all-platforms.yml, which pushes a single annotated tag
-# `build-<N>` we use to map a build number → commit.
+# release-all-platforms.yml, which pushes an annotated `v<X>-internal.<N>` tag
+# (legacy: `build-<N>`) used to map a build number → commit.
+#
+# Bridge publish modes (production):
+#   - publish_bridge ticked (default): the GitHub release is published
+#     immediately — bridge auto-update goes live for all users right away.
+#   - unticked: the release is created as a PRE-RELEASE (invisible to the
+#     auto-updater); promote it manually in the GitHub UI when ready. Either
+#     path fires the `release: released` event that publishes npm packages
+#     (bridge-npm-publish.yml).
 
 on:
   workflow_dispatch:
@@ -22,7 +33,7 @@ on:
           - production
           - beta
       platforms:
-        description: "Platforms to submit"
+        description: "Platforms to submit (bridge-only skips both stores; production only)"
         type: choice
         required: true
         default: both
@@ -30,10 +41,16 @@ on:
           - both
           - ios
           - android
+          - bridge-only
       build_number:
-        description: "Build number to submit (must match an existing build-<N> tag)"
+        description: "Build number to submit (must match an existing v*-internal.<N> or build-<N> tag)"
         type: string
         required: true
+      publish_bridge:
+        description: "Publish bridge GitHub release immediately (untick = create as pre-release for manual promotion)"
+        type: boolean
+        required: false
+        default: true
 
 run-name: "submit · ${{ inputs.track }} · ${{ inputs.platforms }} · build ${{ inputs.build_number }}"
 
@@ -63,28 +80,53 @@ jobs:
       - id: pick
         env:
           N: ${{ inputs.build_number }}
+          TRACK: ${{ inputs.track }}
+          PLATFORMS: ${{ inputs.platforms }}
         run: |
           set -euo pipefail
+          # 0) bridge-only only makes sense for production: beta submits never
+          # create a GitHub release, so there would be nothing to ship.
+          if [[ "$PLATFORMS" == "bridge-only" && "$TRACK" != "production" ]]; then
+            echo "::error::platforms=bridge-only requires track=production."
+            exit 1
+          fi
+
           # 1) Validate build number.
           if ! [[ "$N" =~ ^[0-9]+$ ]]; then
             echo "::error::build_number must be a positive integer (got: $N)"
             exit 1
           fi
 
-          # 2) Resolve the originating commit from the build-<N> tag pushed by
-          # release-all-platforms.yml.
-          SHA=$(git rev-list -n1 "build-${N}" 2>/dev/null || true)
-          if [[ -z "$SHA" ]]; then
-            echo "::error::No tag build-${N} found. Build ${N} was either never created by release-all-platforms.yml or its tag was deleted."
+          # 2) Resolve the originating commit from the internal tag pushed by
+          # release-all-platforms.yml (legacy fallback: build-<N>).
+          mapfile -t MATCHES < <(git tag -l "v*-internal.${N}")
+          if [[ ${#MATCHES[@]} -gt 1 ]]; then
+            echo "::error::Multiple internal tags match build ${N}: ${MATCHES[*]}"
             exit 1
           fi
+          TAG_NAME="${MATCHES[0]:-}"
+          if [[ -z "$TAG_NAME" ]] && git rev-parse -q --verify "refs/tags/build-${N}" >/dev/null; then
+            TAG_NAME="build-${N}"
+          fi
+          if [[ -z "$TAG_NAME" ]]; then
+            echo "::error::No tag v*-internal.${N} (or legacy build-${N}) found. Build ${N} was either never created by release-all-platforms.yml or its tag was deleted."
+            exit 1
+          fi
+          SHA=$(git rev-list -n1 "$TAG_NAME")
 
           # 3) Read marketing version from pubspec.yaml on the resolved commit
-          # (NOT current main) so the submit tag matches the binary's version.
+          # (NOT current main) so the submit tag matches the binary's version,
+          # and assert mobile/bridge are in sync at that commit.
           VERSION=$(git show "${SHA}:mobile/app/pubspec.yaml" \
             | awk '/^version:/{split($2,a,"+"); print a[1]; exit}')
           if [[ -z "$VERSION" ]]; then
-            echo "::error::Could not parse version from pubspec.yaml at ${SHA}"
+            echo "::error::Could not parse version from mobile pubspec.yaml at ${SHA}"
+            exit 1
+          fi
+          BRIDGE_VERSION=$(git show "${SHA}:bridge/app/pubspec.yaml" \
+            | awk '/^version:/{print $2; exit}')
+          if [[ "$VERSION" != "$BRIDGE_VERSION" ]]; then
+            echo "::error::Mobile ($VERSION) and bridge ($BRIDGE_VERSION) versions differ at ${SHA}. This commit predates a version sync — pick a newer build."
             exit 1
           fi
 
@@ -95,7 +137,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           {
             echo "### Resolved"
-            echo "- **Build number**: \`${N}\`"
+            echo "- **Build number**: \`${N}\` (tag \`${TAG_NAME}\`)"
             echo "- **Commit**: \`${SHA}\`"
             echo "- **Version**: \`${VERSION}\`"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -301,16 +343,37 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # Rebuild the bridge from the RESOLVED commit with its committed (clean)
+  # version. The per-merge internal binaries cannot be promoted — they have
+  # `X.Y.Z-internal.<N>` baked in, while the production release must
+  # self-report plain X.Y.Z. Beta submits skip this: they never create a
+  # GitHub release, so there is nothing to attach binaries to.
+  build-bridge:
+    name: Build bridge (release)
+    if: ${{ inputs.track == 'production' }}
+    needs: resolve
+    uses: ./.github/workflows/_reusable-bridge-build.yml
+    with:
+      ref: ${{ needs.resolve.outputs.commit_sha }}
+      version: ${{ needs.resolve.outputs.version }}
+    secrets:
+      MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+      MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+      MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+
   tag:
-    name: Tag commit and create release
-    needs: [resolve, submit-ios, submit-android]
-    # Run only if every REQUESTED platform succeeded. A skipped platform
-    # (because the operator picked one-platform-only) counts as OK.
+    name: Tag commit
+    needs: [resolve, submit-ios, submit-android, build-bridge]
+    # Run only if every REQUESTED job succeeded. A skipped store platform
+    # (one-platform-only or bridge-only submits) counts as OK; build-bridge is
+    # skipped on beta. For non-bridge-only submits at least one store platform
+    # must actually have run.
     if: |
       always() && needs.resolve.result == 'success' &&
       (needs.submit-ios.result    == 'success' || needs.submit-ios.result    == 'skipped') &&
       (needs.submit-android.result == 'success' || needs.submit-android.result == 'skipped') &&
-      !(needs.submit-ios.result == 'skipped' && needs.submit-android.result == 'skipped')
+      (needs.build-bridge.result  == 'success' || needs.build-bridge.result  == 'skipped') &&
+      (inputs.platforms == 'bridge-only' || !(needs.submit-ios.result == 'skipped' && needs.submit-android.result == 'skipped'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -356,26 +419,14 @@ jobs:
           echo "## Tagged" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Tag**: \`${TAG}\` → \`${SHA}\`" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Create GitHub Release (production only)
-        if: ${{ inputs.track == 'production' }}
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.tag.outputs.tag }}
-          target_commitish: ${{ needs.resolve.outputs.commit_sha }}
-          name: "v${{ needs.resolve.outputs.version }} (build ${{ needs.resolve.outputs.build_number }})"
-          generate_release_notes: true
-          make_latest: "true"
-
       # Stamp the SAME v<VERSION> onto the metadata repo's published commit, so its
       # HEAD is marked "published" and the next release's gate skips re-pushing an
       # unchanged listing. Runs only when a platform actually published this run,
       # tagging the exact commit that was published (meta_head). iOS and Android
       # evaluate the same remote, so their decisions agree; the head is taken from
-      # whichever platform published (iOS preferred). Kept LAST so a tag-push
-      # failure can't suppress the GitHub Release above (the binary already
-      # shipped). METADATA_REPO_TOKEN must be a REPOSITORY secret with Contents:
-      # Write — this job declares no environment, so an environment-scoped secret
-      # would read as empty here.
+      # whichever platform published (iOS preferred). METADATA_REPO_TOKEN must be a
+      # REPOSITORY secret with Contents: Write — this job declares no environment,
+      # so an environment-scoped secret would read as empty here.
       - name: Tag store metadata repo
         if: ${{ needs.submit-ios.outputs.meta_publish == 'true' || needs.submit-android.outputs.meta_publish == 'true' }}
         env:
@@ -426,3 +477,90 @@ jobs:
           git tag -a "${TAG}" "${HEAD}" -m "Published store metadata with ${TAG}"
           git push --quiet origin "refs/tags/${TAG}"
           echo "- **Metadata repo tagged**: \`${TAG}\` → \`${HEAD}\`" >> "$GITHUB_STEP_SUMMARY"
+
+  # Create the v<VERSION> GitHub release with the bridge binaries attached
+  # (production only). When publish_bridge is ticked the release goes live
+  # immediately — the bridge auto-updater picks it up within minutes.
+  # Otherwise it is created as a pre-release: invisible to the updater until
+  # manually promoted in the GitHub UI. npm publishing happens in
+  # bridge-npm-publish.yml, driven by the `release: released` event, so it
+  # fires at the right moment in both modes.
+  release:
+    name: Create GitHub release
+    needs: [resolve, submit-ios, submit-android, build-bridge, tag]
+    if: |
+      always() && inputs.track == 'production' &&
+      needs.tag.result == 'success' &&
+      needs.build-bridge.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    # bridge-only submits skip both store jobs and with them the
+    # store-production reviewer gate, so this job carries the gate instead.
+    # Regular submits already passed it at the store jobs and go through the
+    # unprotected store-beta environment to avoid a second approval pause.
+    environment: ${{ inputs.platforms == 'bridge-only' && 'store-production' || 'store-beta' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.resolve.outputs.commit_sha }}
+
+      - uses: dart-lang/setup-dart@v1
+
+      - name: Download bridge artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: sesori-bridge-*
+          merge-multiple: true
+
+      - name: Generate checksums
+        working-directory: artifacts
+        run: |
+          find . -type f \( -name '*.tar.gz' -o -name '*.zip' \) -print0 | sort -z | while IFS= read -r -d '' file; do
+            sha256sum "$file" | awk -v name="$(basename "$file")" '{print $1 "  " name}'
+          done > checksums.txt
+          cat checksums.txt
+
+      - name: Generate release notes
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          dart tool/generate_release_notes.dart \
+            --repo "$GITHUB_REPOSITORY" \
+            --to "v${VERSION}" \
+            --version "${VERSION}" \
+            --output notes.md
+          cat notes.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.resolve.outputs.version }}
+          target_commitish: ${{ needs.resolve.outputs.commit_sha }}
+          name: "v${{ needs.resolve.outputs.version }} (build ${{ needs.resolve.outputs.build_number }})"
+          body_path: notes.md
+          prerelease: ${{ !inputs.publish_bridge }}
+          make_latest: ${{ inputs.publish_bridge && 'true' || 'false' }}
+          files: |
+            artifacts/*.tar.gz
+            artifacts/*.zip
+            artifacts/checksums.txt
+
+      - name: Summary
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+          PUBLISH: ${{ inputs.publish_bridge }}
+        run: |
+          {
+            echo "## GitHub release"
+            echo "- **Tag**: \`v${VERSION}\`"
+            if [[ "$PUBLISH" == "true" ]]; then
+              echo "- **Mode**: published — bridge auto-update is LIVE; npm publish runs via bridge-npm-publish.yml."
+            else
+              echo "- **Mode**: pre-release — promote it in the GitHub UI to arm bridge auto-update and trigger npm publish."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/submit-release.yml
+++ b/.github/workflows/submit-release.yml
@@ -362,18 +362,35 @@ jobs:
       MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
       MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
 
+  # bridge-only submits skip both store jobs and with them the
+  # store-production reviewer gate. This no-op job holds that gate BEFORE the
+  # tag job, so a rejected approval leaves no v* tag behind (a stray stable
+  # tag would mark the version as consumed and trip the preflight guard on
+  # main). Regular submits never run it — they pass the gate at the store jobs.
+  approve-bridge-only:
+    name: Approve bridge-only release
+    if: ${{ inputs.platforms == 'bridge-only' }}
+    needs: resolve
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: store-production
+    steps:
+      - name: Approved
+        run: echo "bridge-only release of v${{ needs.resolve.outputs.version }} approved by a store-production reviewer."
+
   tag:
     name: Tag commit
-    needs: [resolve, submit-ios, submit-android, build-bridge]
+    needs: [resolve, submit-ios, submit-android, build-bridge, approve-bridge-only]
     # Run only if every REQUESTED job succeeded. A skipped store platform
     # (one-platform-only or bridge-only submits) counts as OK; build-bridge is
-    # skipped on beta. For non-bridge-only submits at least one store platform
-    # must actually have run.
+    # skipped on beta; approve-bridge-only is skipped unless bridge-only. For
+    # non-bridge-only submits at least one store platform must actually have run.
     if: |
       always() && needs.resolve.result == 'success' &&
       (needs.submit-ios.result    == 'success' || needs.submit-ios.result    == 'skipped') &&
       (needs.submit-android.result == 'success' || needs.submit-android.result == 'skipped') &&
       (needs.build-bridge.result  == 'success' || needs.build-bridge.result  == 'skipped') &&
+      (needs.approve-bridge-only.result == 'success' || needs.approve-bridge-only.result == 'skipped') &&
       (inputs.platforms == 'bridge-only' || !(needs.submit-ios.result == 'skipped' && needs.submit-android.result == 'skipped'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -510,11 +527,9 @@ jobs:
     permissions:
       contents: write
       actions: write
-    # bridge-only submits skip both store jobs and with them the
-    # store-production reviewer gate, so this job carries the gate instead.
-    # Regular submits already passed it at the store jobs and go through the
-    # unprotected store-beta environment to avoid a second approval pause.
-    environment: ${{ inputs.platforms == 'bridge-only' && 'store-production' || 'store-beta' }}
+    # No environment gate here: every path already passed store-production
+    # approval upstream (store jobs for regular submits, approve-bridge-only
+    # for bridge-only) — re-declaring it would pause the run a second time.
     steps:
       # Deliberately NOT the resolved commit: this job needs nothing from the
       # release's tree (notes are API-driven, checksums come from artifacts,

--- a/.github/workflows/submit-release.yml
+++ b/.github/workflows/submit-release.yml
@@ -15,11 +15,12 @@ name: Submit Release
 #
 # Bridge publish modes (production):
 #   - publish_bridge ticked (default): the GitHub release is published
-#     immediately — bridge auto-update goes live for all users right away.
+#     immediately — bridge auto-update goes live for all users right away —
+#     and this workflow dispatches bridge-npm-publish.yml to publish npm
+#     (GITHUB_TOKEN-created releases don't fire workflow-triggering events).
 #   - unticked: the release is created as a PRE-RELEASE (invisible to the
-#     auto-updater); promote it manually in the GitHub UI when ready. Either
-#     path fires the `release: released` event that publishes npm packages
-#     (bridge-npm-publish.yml).
+#     auto-updater); promote it manually in the GitHub UI when ready — that
+#     user action fires `release: released`, which runs bridge-npm-publish.yml.
 
 on:
   workflow_dispatch:
@@ -419,16 +420,26 @@ jobs:
           echo "## Tagged" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Tag**: \`${TAG}\` → \`${SHA}\`" >> "$GITHUB_STEP_SUMMARY"
 
-      # Stamp the SAME v<VERSION> onto the metadata repo's published commit, so its
-      # HEAD is marked "published" and the next release's gate skips re-pushing an
-      # unchanged listing. Runs only when a platform actually published this run,
-      # tagging the exact commit that was published (meta_head). iOS and Android
-      # evaluate the same remote, so their decisions agree; the head is taken from
-      # whichever platform published (iOS preferred). METADATA_REPO_TOKEN must be a
-      # REPOSITORY secret with Contents: Write — this job declares no environment,
-      # so an environment-scoped secret would read as empty here.
+  # Stamp the SAME v<VERSION> onto the metadata repo's published commit, so its
+  # HEAD is marked "published" and the next release's gate skips re-pushing an
+  # unchanged listing. Runs only when a platform actually published this run,
+  # tagging the exact commit that was published (meta_head). iOS and Android
+  # evaluate the same remote, so their decisions agree; the head is taken from
+  # whichever platform published (iOS preferred). A SEPARATE job (not a step in
+  # `tag`) so a metadata tagging failure can never block the GitHub release
+  # below — the binary already shipped. METADATA_REPO_TOKEN must be a
+  # REPOSITORY secret with Contents: Write — this job declares no environment,
+  # so an environment-scoped secret would read as empty here.
+  tag-metadata:
+    name: Tag store metadata repo
+    needs: [resolve, submit-ios, submit-android, tag]
+    if: |
+      always() && needs.tag.result == 'success' &&
+      (needs.submit-ios.outputs.meta_publish == 'true' || needs.submit-android.outputs.meta_publish == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
       - name: Tag store metadata repo
-        if: ${{ needs.submit-ios.outputs.meta_publish == 'true' || needs.submit-android.outputs.meta_publish == 'true' }}
         env:
           REPO:            ${{ vars.STORE_METADATA_REPO }}
           VERSION:         ${{ needs.resolve.outputs.version }}
@@ -480,11 +491,13 @@ jobs:
 
   # Create the v<VERSION> GitHub release with the bridge binaries attached
   # (production only). When publish_bridge is ticked the release goes live
-  # immediately — the bridge auto-updater picks it up within minutes.
-  # Otherwise it is created as a pre-release: invisible to the updater until
-  # manually promoted in the GitHub UI. npm publishing happens in
-  # bridge-npm-publish.yml, driven by the `release: released` event, so it
-  # fires at the right moment in both modes.
+  # immediately — the bridge auto-updater picks it up within minutes — and
+  # this job DISPATCHES bridge-npm-publish.yml explicitly: releases created
+  # with the default GITHUB_TOKEN do not emit workflow-triggering events
+  # (workflow_dispatch is the documented exception). When unticked, the
+  # release is created as a pre-release, invisible to the updater until
+  # manually promoted in the GitHub UI — that promotion is a user action, so
+  # the `release: released` trigger on bridge-npm-publish.yml fires normally.
   release:
     name: Create GitHub release
     needs: [resolve, submit-ios, submit-android, build-bridge, tag]
@@ -496,6 +509,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      actions: write
     # bridge-only submits skip both store jobs and with them the
     # store-production reviewer gate, so this job carries the gate instead.
     # Regular submits already passed it at the store jobs and go through the
@@ -549,6 +563,15 @@ jobs:
             artifacts/*.tar.gz
             artifacts/*.zip
             artifacts/checksums.txt
+
+      # Releases created with GITHUB_TOKEN don't fire the `release: released`
+      # event, so kick off npm publishing directly when the release went live.
+      - name: Trigger npm publish
+        if: ${{ inputs.publish_bridge }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: gh workflow run bridge-npm-publish.yml --repo "$GITHUB_REPOSITORY" -f tag="v${VERSION}"
 
       - name: Summary
         env:

--- a/.github/workflows/submit-release.yml
+++ b/.github/workflows/submit-release.yml
@@ -538,7 +538,12 @@ jobs:
       # predate the script entirely (legacy build-<N> tags).
       - uses: actions/checkout@v6
 
-      - uses: dart-lang/setup-dart@v1
+      # Pinned toolchain from .tool-versions; the notes script is
+      # dependency-free, so no workspace pub get is needed.
+      - name: Setup Flutter (asdf)
+        uses: ./.github/actions/setup-flutter
+        with:
+          workspace: none
 
       - name: Download bridge artifacts
         uses: actions/download-artifact@v4

--- a/bridge/RELEASING.md
+++ b/bridge/RELEASING.md
@@ -105,7 +105,7 @@ Run the `Submit Release` workflow (`submit-release.yml`) with the build number t
 
 ### 4. npm publish (automatic)
 
-When the stable `v<X.Y.Z>` release goes live (immediately, or at manual promotion), `bridge-npm-publish.yml` fires on the `release: released` event and publishes the npm packages.
+When the stable `v<X.Y.Z>` release goes live, `bridge-npm-publish.yml` publishes the npm packages: dispatched directly by `submit-release.yml` when publishing immediately, or fired by the `release: released` event when you promote a pre-release manually in the GitHub UI.
 
 ## What the release pipeline does
 

--- a/bridge/RELEASING.md
+++ b/bridge/RELEASING.md
@@ -80,48 +80,42 @@ And the following repository variable:
 
 ## Release steps
 
+The bridge releases together with the mobile apps under the shared `vX.Y.Z`
+version. There is no manual tagging — tags and GitHub releases are created by
+the workflows.
+
 ### 1. Bump version
 
 ```bash
 make bump-version TYPE=patch
 ```
 
-That bump step is the source of truth for the release version. It must keep `bridge/app/pubspec.yaml`, `bridge/app/lib/src/version.dart`, all six npm package manifests in `bridge/app/npm/`, and `mobile/app/pubspec.yaml` aligned to the same `X.Y.Z` semantic release before you tag. For an explicit version, run `make bump-version VERSION=X.Y.Z`.
+That bump step is the source of truth for the release version. It must keep `bridge/app/pubspec.yaml`, `bridge/app/lib/src/version.dart`, all six npm package manifests in `bridge/app/npm/`, and `mobile/app/pubspec.yaml` aligned to the same `X.Y.Z` semantic release. For an explicit version, run `make bump-version VERSION=X.Y.Z`. The bump is REQUIRED after every production release: `release-all-platforms.yml` fails its preflight guard for any main push whose version already has a `v<version>` tag.
 
-### 2. Commit and push
+### 2. Merge to main
 
-```bash
-git add .
-git commit -m "feat(bridge): release 0.3.1"
-git push
-```
+Every main merge runs `release-all-platforms.yml`: it uploads the mobile apps to TestFlight / Play internal, builds all five bridge platform archives with `X.Y.Z-internal.<N>` baked in, and — only when everything succeeded — pushes a `v<X.Y.Z>-internal.<N>` tag and rolls the single internal GitHub pre-release onto it (binaries + `checksums.txt` + regenerated notes). The auto-updater ignores pre-releases.
 
-### 3. Tag and push
+### 3. Submit to production
 
-```bash
-git tag v0.3.1
-git push origin v0.3.1
-```
+Run the `Submit Release` workflow (`submit-release.yml`) with the build number to promote. For production it rebuilds the bridge from the resolved commit with the clean version, tags `v<X.Y.Z>`, and creates the GitHub release with the five archives plus `checksums.txt`. Use `platforms: bridge-only` for a bridge hotfix that skips the app stores.
 
-## What the workflow does on manual dispatch
+- `publish_bridge` ticked (default): the release is published immediately — bridge auto-update goes live for all users right away.
+- `publish_bridge` unticked: the release is created as a pre-release, invisible to the auto-updater until you promote it in the GitHub UI.
 
-1. builds binaries for macOS arm64/x64, Linux x64/arm64, Windows x64
-2. renames `bridge` to `sesori-bridge`
+### 4. npm publish (automatic)
+
+When the stable `v<X.Y.Z>` release goes live (immediately, or at manual promotion), `bridge-npm-publish.yml` fires on the `release: released` event and publishes the npm packages.
+
+## What the release pipeline does
+
+1. builds binaries for macOS arm64/x64, Linux x64/arm64, Windows x64 (`_reusable-bridge-build.yml`)
+2. renames `bridge` to `sesori-bridge` and signs the macOS binaries
 3. creates release archives
 4. generates basename-based `checksums.txt`
-5. creates a GitHub Release and uploads all assets
+5. creates the `v<X.Y.Z>` GitHub Release and uploads all assets (`submit-release.yml`)
 6. publishes the five platform npm bootstrap packages from those tagged release assets
 7. publishes the `@sesori/bridge` wrapper package through npm trusted publishing
-
-## Dry run
-
-### GitHub CLI
-
-```bash
-gh workflow run bridge-release.yml -f dry_run=true
-```
-
-Expected: build jobs run, release/publish jobs do not.
 
 ## Manual test release and install
 
@@ -130,15 +124,9 @@ Use this sequence when you want to test the real packaged distribution flow end 
 ### A. Test a GitHub Release for the shell installers
 
 1. Bump the shared App + Bridge version with `make bump-version TYPE=<type>` or `make bump-version VERSION=X.Y.Z`.
-2. Commit and push the branch.
-3. Create and push a stable release tag:
-
-```bash
-git tag vX.Y.Z
-git push origin vX.Y.Z
-```
-
-4. Wait for `bridge-release.yml` to publish the GitHub Release assets and `checksums.txt`.
+2. Merge to main and wait for `release-all-platforms.yml` to roll the internal pre-release.
+3. Run `Submit Release` for production (use `platforms: bridge-only` to skip the app stores).
+4. Wait for the `v<X.Y.Z>` GitHub Release to be published with its assets and `checksums.txt`.
 5. Verify the release contains all five platform archives plus `checksums.txt`.
 6. Test the shell installer against that release:
 
@@ -225,7 +213,7 @@ Managed installs from these installers are the supported long-lived runtime and 
 
 ## npm trusted publishing prerequisites
 
-Configure npm trusted publishing for all six packages in this repo against the exact workflow file `.github/workflows/bridge-release.yml`:
+Configure npm trusted publishing for all six packages in this repo against the exact workflow file `.github/workflows/bridge-npm-publish.yml`:
 
 - `@sesori/bridge`
 - `@sesori/bridge-darwin-arm64`

--- a/bridge/app/test/tool/bump_version_test.dart
+++ b/bridge/app/test/tool/bump_version_test.dart
@@ -192,6 +192,25 @@ void main() {
       }
     });
 
+    test('accepts a pre-release version and updates all manifests', () async {
+      const internalVersion = '9.8.7-internal.53';
+      final result = await _runTool(fixture: fixture, args: [internalVersion]);
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+
+      final pubspec = await File(fixture.pubspecPath).readAsString();
+      final versionDart = await File(fixture.versionDartPath).readAsString();
+      final wrapperPackage = await _readJson(path: fixture.wrapperPackagePath);
+
+      expect(pubspec, contains('version: $internalVersion'));
+      expect(versionDart, equals("const String appVersion = '$internalVersion';\n"));
+      expect(wrapperPackage['version'], equals(internalVersion));
+      expect(
+        (wrapperPackage['sesoriBridge'] as Map<String, dynamic>)['releaseTag'],
+        equals('v$internalVersion'),
+      );
+    });
+
     test('rejects invalid semver and keeps fixture files unchanged', () async {
       final beforePubspec = await File(fixture.pubspecPath).readAsString();
       final beforeVersionDart = await File(fixture.versionDartPath).readAsString();

--- a/bridge/app/test/tool/bump_version_test.dart
+++ b/bridge/app/test/tool/bump_version_test.dart
@@ -209,6 +209,23 @@ void main() {
         (wrapperPackage['sesoriBridge'] as Map<String, dynamic>)['releaseTag'],
         equals('v$internalVersion'),
       );
+
+      final optionalDependencies = wrapperPackage['optionalDependencies'] as Map<String, dynamic>;
+      for (final package in _FixtureApp.platformPackages) {
+        final dependencyName = '@sesori/${package.replaceFirst('sesori-bridge-', 'bridge-')}';
+        expect(optionalDependencies[dependencyName], equals(internalVersion), reason: 'failed for $package');
+
+        final packageJson = await _readJson(
+          path: p.join(fixture.rootPath, 'npm', package, 'package.json'),
+        );
+        expect(packageJson['version'], equals(internalVersion), reason: 'failed for $package');
+        expect(
+          (packageJson['sesoriBridge'] as Map<String, dynamic>)['releaseTag'],
+          equals('v$internalVersion'),
+          reason: 'failed releaseTag update for $package',
+        );
+      }
+      expect(optionalDependencies['@sesori/not-bridge'], equals('4.5.6'));
     });
 
     test('rejects invalid semver and keeps fixture files unchanged', () async {

--- a/bridge/app/test/updater/release_contract_test.dart
+++ b/bridge/app/test/updater/release_contract_test.dart
@@ -177,35 +177,45 @@ void main() {
       expect(script, contains(r'''if ($filePart -eq $ArchiveName) {'''));
     });
 
-    test('workflow and docs lock basename checksums and automatic trusted publishing', () async {
-      final workflow = await _readRepoFile(relativePath: '.github/workflows/bridge-release.yml');
+    test('workflows and docs lock basename checksums and automatic trusted publishing', () async {
+      final npmWorkflow = await _readRepoFile(relativePath: '.github/workflows/bridge-npm-publish.yml');
+      final submitWorkflow = await _readRepoFile(relativePath: '.github/workflows/submit-release.yml');
+      final internalWorkflow = await _readRepoFile(relativePath: '.github/workflows/release-all-platforms.yml');
       final docs = await _readRepoFile(relativePath: 'bridge/RELEASING.md');
 
-      expect(workflow, contains('workflow_dispatch:'));
-      expect(workflow, contains('dry_run:'));
-      expect(workflow, contains('tag:'));
-      expect(workflow, contains('needs: release'));
-      expect(workflow, contains('id-token: write'));
-      expect(workflow, contains('registry-url: "https://registry.npmjs.org"'));
-      expect(workflow, contains(r'gh release download "$RELEASE_TAG"'));
-      expect(workflow, contains('--pattern "*.tar.gz" --pattern "*.zip" --pattern "checksums.txt"'));
-      expect(workflow, contains('Verify release archive checksums'));
-      expect(workflow, contains('checksum_for()'));
-      expect(workflow, contains('verify_archive_checksum()'));
-      expect(workflow, contains('copy_runtime_bundle()'));
-      expect(workflow, contains(r'cp -R "$source_root/bin" "$package_root/lib/runtime/bin"'));
-      expect(workflow, contains(r'cp -R "$source_root/lib" "$package_root/lib/runtime/lib"'));
-      expect(workflow, contains('.bridge-release-provenance.json'));
-      expect(workflow, contains(r'diff -r "$source_root/bin" "$package_root/lib/runtime/bin"'));
-      expect(workflow, contains(r'diff -r "$source_root/lib" "$package_root/lib/runtime/lib"'));
-      expect(workflow, contains(r'sha256sum "$file" | awk -v name="$(basename "$file")"'));
-      expect(workflow, contains('Validate wrapper package metadata'));
-      expect(workflow, isNot(contains('NPM_TOKEN')));
+      // npm publishing fires when a stable release goes LIVE (immediate
+      // publish or manual pre-release promotion), via trusted publishing.
+      expect(npmWorkflow, contains('release:'));
+      expect(npmWorkflow, contains('types: [released]'));
+      expect(npmWorkflow, contains('needs: gate'));
+      expect(npmWorkflow, contains('needs: [gate, publish-platform]'));
+      expect(npmWorkflow, contains('id-token: write'));
+      expect(npmWorkflow, contains('registry-url: "https://registry.npmjs.org"'));
+      expect(npmWorkflow, contains(r'gh release download "$RELEASE_TAG"'));
+      expect(npmWorkflow, contains('--pattern "*.tar.gz" --pattern "*.zip" --pattern "checksums.txt"'));
+      expect(npmWorkflow, contains('Verify release archive checksums'));
+      expect(npmWorkflow, contains('checksum_for()'));
+      expect(npmWorkflow, contains('verify_archive_checksum()'));
+      expect(npmWorkflow, contains('copy_runtime_bundle()'));
+      expect(npmWorkflow, contains(r'cp -R "$source_root/bin" "$package_root/lib/runtime/bin"'));
+      expect(npmWorkflow, contains(r'cp -R "$source_root/lib" "$package_root/lib/runtime/lib"'));
+      expect(npmWorkflow, contains('.bridge-release-provenance.json'));
+      expect(npmWorkflow, contains(r'diff -r "$source_root/bin" "$package_root/lib/runtime/bin"'));
+      expect(npmWorkflow, contains(r'diff -r "$source_root/lib" "$package_root/lib/runtime/lib"'));
+      expect(npmWorkflow, contains('Validate wrapper package metadata'));
+      expect(npmWorkflow, isNot(contains('NPM_TOKEN')));
 
-      expect(docs, contains('## What the workflow does on manual dispatch'));
+      // Both release-producing workflows generate basename-keyed checksums
+      // exactly as the updater and installers expect.
+      const checksumLine = r'sha256sum "$file" | awk -v name="$(basename "$file")"';
+      expect(submitWorkflow, contains(checksumLine));
+      expect(internalWorkflow, contains(checksumLine));
+      expect(submitWorkflow, contains('artifacts/checksums.txt'));
+      expect(internalWorkflow, contains('artifacts/checksums.txt'));
+
+      expect(docs, contains('## What the release pipeline does'));
       expect(docs, contains('6. publishes the five platform npm bootstrap packages from those tagged release assets'));
       expect(docs, contains('7. publishes the `@sesori/bridge` wrapper package through npm trusted publishing'));
-      expect(docs, contains('gh workflow run bridge-release.yml -f dry_run=true'));
       expect(
         docs,
         contains(
@@ -216,19 +226,14 @@ void main() {
       expect(
         docs,
         contains(
-          'Configure npm trusted publishing for all six packages in this repo against the exact workflow file `.github/workflows/bridge-release.yml`',
-        ),
-      );
-      expect(
-        docs,
-        contains(
-          'The workflow verifies the archived GitHub Release assets against `checksums.txt`, derives each platform npm payload from those exact release artifacts, and then publishes through npm trusted publishing on `ubuntu-latest`.',
+          'Configure npm trusted publishing for all six packages in this repo against the exact workflow file `.github/workflows/bridge-npm-publish.yml`',
         ),
       );
     });
 
     test('workflow asset names and npm package manifests stay aligned', () async {
-      final workflow = await _readRepoFile(relativePath: '.github/workflows/bridge-release.yml');
+      final buildWorkflow = await _readRepoFile(relativePath: '.github/workflows/_reusable-bridge-build.yml');
+      final npmWorkflow = await _readRepoFile(relativePath: '.github/workflows/bridge-npm-publish.yml');
       final wrapperPackage = await _readRepoJson(
         relativePath: 'bridge/app/npm/sesori-bridge/package.json',
       );
@@ -243,8 +248,12 @@ void main() {
       };
 
       for (final entry in workflowAssets.entries) {
-        expect(workflow, contains(entry.value));
-        expect(workflow, contains(entry.key.replaceFirst('@sesori/', 'sesori-')));
+        // The reusable build matrix produces each archive name...
+        expect(buildWorkflow, contains(entry.value.replaceAll(RegExp(r'\.(tar\.gz|zip)$'), '')));
+        // ...and the npm publish workflow consumes each archive into the
+        // matching platform package directory.
+        expect(npmWorkflow, contains(entry.value));
+        expect(npmWorkflow, contains(entry.key.replaceFirst('@sesori/', 'sesori-')));
       }
 
       final optionalDependencies = wrapperPackage['optionalDependencies'] as Map<String, dynamic>;

--- a/bridge/app/test/updater/release_repository_test.dart
+++ b/bridge/app/test/updater/release_repository_test.dart
@@ -672,6 +672,35 @@ void main() {
       );
     });
 
+    test('stable is higher precedence than internal build with same base', () {
+      expect(
+        BridgeVersion.parse(value: '9.8.7').compareTo(BridgeVersion.parse(value: '9.8.7-internal.53')),
+        isPositive,
+      );
+      expect(
+        BridgeVersion.parse(value: '9.8.7-internal.53').compareTo(BridgeVersion.parse(value: '9.8.7')),
+        isNegative,
+      );
+    });
+
+    test('internal builds with same base compare numerically by build number', () {
+      expect(
+        BridgeVersion.parse(value: '1.0.9-internal.9').compareTo(BridgeVersion.parse(value: '1.0.9-internal.53')),
+        isNegative,
+      );
+      expect(
+        BridgeVersion.parse(value: '1.0.9-internal.54').compareTo(BridgeVersion.parse(value: '1.0.9-internal.53')),
+        isPositive,
+      );
+    });
+
+    test('internal build of a newer base is higher than an older stable', () {
+      expect(
+        BridgeVersion.parse(value: '1.0.9-internal.53').compareTo(BridgeVersion.parse(value: '1.0.8')),
+        isPositive,
+      );
+    });
+
     test('prerelease with newer numeric base still compares positive', () {
       expect(
         BridgeVersion.parse(value: '2.0.0-beta').compareTo(BridgeVersion.parse(value: '1.9.9')),

--- a/bridge/app/tool/bump_version.dart
+++ b/bridge/app/tool/bump_version.dart
@@ -3,25 +3,15 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
-/// Validates that a version string is valid semver (X.Y.Z).
-/// Returns true if valid, false otherwise.
+/// Validates that a version string is valid semver: X.Y.Z with an optional
+/// pre-release suffix (e.g. 1.0.9 or 1.0.9-internal.53). Pre-release versions
+/// are baked into CI builds of internal (per-merge) releases and are never
+/// committed.
 bool isValidSemver({required String version}) {
-  final parts = version.split('.');
-  if (parts.length != 3) {
-    return false;
-  }
-
-  for (final part in parts) {
-    if (part.isEmpty) {
-      return false;
-    }
-    final num = int.tryParse(part);
-    if (num == null || num < 0) {
-      return false;
-    }
-  }
-
-  return true;
+  final pattern = RegExp(
+    r'^\d+\.\d+\.\d+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$',
+  );
+  return pattern.hasMatch(version);
 }
 
 /// Reads a file and returns its content as a string.
@@ -111,7 +101,7 @@ Future<void> main(final List<String> args) async {
   // Validate semver
   if (!isValidSemver(version: newVersion)) {
     stderr.writeln('Error: Invalid version format "$newVersion"');
-    stderr.writeln('Expected format: X.Y.Z (e.g., 0.3.0)');
+    stderr.writeln('Expected format: X.Y.Z with optional pre-release suffix (e.g., 0.3.0 or 0.3.0-internal.42)');
     exit(1);
   }
 

--- a/tool/generate_release_notes.dart
+++ b/tool/generate_release_notes.dart
@@ -1,0 +1,413 @@
+// Generates release notes with an App/Bridge split for GitHub releases.
+//
+// Lists the PRs merged between a previous stable release tag and a target
+// ref, classifies each PR by the paths it touched (mobile/** -> App,
+// bridge/** -> Bridge, shared/** -> both), buckets entries into
+// Added/Fixed/Changed from the conventional-commit PR title prefix, and
+// appends the flat "All PRs merged" list plus a Full Changelog compare link.
+//
+// Used by both the per-merge rolling internal pre-release and the production
+// release created by submit-release.yml, so it must stay deterministic and
+// dependency-free (run it with plain `dart tool/generate_release_notes.dart`,
+// no pub get required).
+//
+// Usage:
+//   GITHUB_TOKEN=... dart tool/generate_release_notes.dart \
+//     --repo owner/name \
+//     --to <sha-or-tag> \
+//     --version <X.Y.Z or X.Y.Z-internal.N> \
+//     [--from <tag>] \
+//     [--output <file>]
+//
+// When --from is omitted, the previous stable tag is auto-resolved: the
+// highest-semver published (non-draft, non-prerelease) release whose tag is a
+// plain vX.Y.Z, excluding the version being released; if no such release
+// exists yet (first release on the unified v* scheme), it falls back to the
+// highest plain vX.Y.Z git tag strictly below the version being released.
+
+import 'dart:convert';
+import 'dart:io';
+
+const String _ignoreLabel = 'ignore-for-release';
+const Set<String> _excludedAuthors = {'dependabot', 'dependabot[bot]'};
+
+void main(final List<String> args) async {
+  final options = _parseArgs(args: args);
+  final token = Platform.environment['GITHUB_TOKEN'] ?? Platform.environment['GH_TOKEN'];
+  if (token == null || token.isEmpty) {
+    stderr.writeln('Error: GITHUB_TOKEN (or GH_TOKEN) must be set.');
+    exit(1);
+  }
+
+  final api = _GitHubApi(repo: options.repo, token: token);
+
+  try {
+    final fromTag = options.from ?? await _resolvePreviousStableTag(api: api, version: options.version);
+    stderr.writeln('Comparing $fromTag...${options.to}');
+
+    final prNumbers = await _listMergedPrNumbers(api: api, from: fromTag, to: options.to);
+    final entries = <_PrEntry>[];
+    for (final number in prNumbers) {
+      final entry = await _loadPr(api: api, number: number);
+      if (entry != null) {
+        entries.add(entry);
+      }
+    }
+
+    final notes = _render(
+      repo: options.repo,
+      from: fromTag,
+      to: options.to,
+      entries: entries,
+    );
+
+    if (options.output != null) {
+      await File(options.output!).writeAsString(notes);
+      stderr.writeln('Wrote release notes to ${options.output}');
+    } else {
+      stdout.write(notes);
+    }
+  } finally {
+    api.close();
+  }
+}
+
+class _Options {
+  const _Options({
+    required this.repo,
+    required this.to,
+    required this.version,
+    required this.from,
+    required this.output,
+  });
+
+  final String repo;
+  final String to;
+  final String version;
+  final String? from;
+  final String? output;
+}
+
+_Options _parseArgs({required List<String> args}) {
+  final values = <String, String>{};
+  for (var i = 0; i < args.length; i += 2) {
+    final flag = args[i];
+    if (!flag.startsWith('--') || i + 1 >= args.length) {
+      stderr.writeln('Error: malformed arguments near "$flag".');
+      exit(1);
+    }
+    values[flag.substring(2)] = args[i + 1];
+  }
+
+  final repo = values['repo'];
+  final to = values['to'];
+  final version = values['version'];
+  if (repo == null || to == null || version == null) {
+    stderr.writeln('Usage: dart tool/generate_release_notes.dart '
+        '--repo owner/name --to <ref> --version <X.Y.Z[-pre]> [--from <tag>] [--output <file>]');
+    exit(1);
+  }
+
+  return _Options(
+    repo: repo,
+    to: to,
+    version: version,
+    from: values['from'],
+    output: values['output'],
+  );
+}
+
+class _GitHubApi {
+  _GitHubApi({required this.repo, required String token})
+    : _client = HttpClient(),
+      _token = token;
+
+  final String repo;
+  final HttpClient _client;
+  final String _token;
+
+  Future<dynamic> getJson({required String path}) async {
+    final uri = Uri.parse('https://api.github.com$path');
+    final request = await _client.getUrl(uri);
+    request.headers.set('Authorization', 'Bearer $_token');
+    request.headers.set('Accept', 'application/vnd.github+json');
+    request.headers.set('X-GitHub-Api-Version', '2022-11-28');
+    request.headers.set('User-Agent', 'sesori-release-notes');
+    final response = await request.close();
+    final body = await response.transform(utf8.decoder).join();
+    if (response.statusCode != 200) {
+      throw StateError('GET $path returned ${response.statusCode}: $body');
+    }
+    return jsonDecode(body);
+  }
+
+  void close() {
+    _client.close(force: true);
+  }
+}
+
+final RegExp _stableTagPattern = RegExp(r'^v(\d+)\.(\d+)\.(\d+)$');
+
+List<int>? _parseStableTag({required String tag}) {
+  final match = _stableTagPattern.firstMatch(tag);
+  if (match == null) {
+    return null;
+  }
+  return [
+    int.parse(match.group(1)!),
+    int.parse(match.group(2)!),
+    int.parse(match.group(3)!),
+  ];
+}
+
+int _compareSemver(final List<int> a, final List<int> b) {
+  for (var i = 0; i < 3; i++) {
+    final diff = a[i].compareTo(b[i]);
+    if (diff != 0) {
+      return diff;
+    }
+  }
+  return 0;
+}
+
+Future<String> _resolvePreviousStableTag({
+  required _GitHubApi api,
+  required String version,
+}) async {
+  // Base version being released (strip any pre-release suffix) so the
+  // previous-stable lookup never picks the release we are creating notes for.
+  final baseVersion = version.split('-').first;
+  final excludedTag = 'v$baseVersion';
+
+  String? best;
+  List<int>? bestParts;
+
+  void consider({required String tag}) {
+    if (tag == excludedTag) {
+      return;
+    }
+    final parts = _parseStableTag(tag: tag);
+    if (parts == null) {
+      return;
+    }
+    if (bestParts == null || _compareSemver(parts, bestParts!) > 0) {
+      best = tag;
+      bestParts = parts;
+    }
+  }
+
+  // Preferred source: published stable releases (what the bridge updater and
+  // end users actually received last).
+  for (var page = 1; page <= 3; page++) {
+    final releases = await api.getJson(path: '/repos/${api.repo}/releases?per_page=100&page=$page') as List<dynamic>;
+    for (final release in releases.cast<Map<String, dynamic>>()) {
+      if (release['draft'] == true || release['prerelease'] == true) {
+        continue;
+      }
+      consider(tag: release['tag_name'] as String);
+    }
+    if (releases.length < 100) {
+      break;
+    }
+  }
+  if (best != null) {
+    return best!;
+  }
+
+  // Fallback for the first release on the unified v* scheme: plain stable
+  // tags (beta submits tag without creating a release).
+  final currentParts = _parseStableTag(tag: excludedTag);
+  for (var page = 1; page <= 5; page++) {
+    final tags = await api.getJson(path: '/repos/${api.repo}/tags?per_page=100&page=$page') as List<dynamic>;
+    for (final tag in tags.cast<Map<String, dynamic>>()) {
+      final name = tag['name'] as String;
+      final parts = _parseStableTag(tag: name);
+      if (parts == null) {
+        continue;
+      }
+      if (currentParts != null && _compareSemver(parts, currentParts) >= 0) {
+        continue;
+      }
+      consider(tag: name);
+    }
+    if (tags.length < 100) {
+      break;
+    }
+  }
+  if (best != null) {
+    return best!;
+  }
+
+  throw StateError('Could not resolve a previous stable v* release or tag to diff against. '
+      'Pass --from explicitly.');
+}
+
+final RegExp _squashPrPattern = RegExp(r'\(#(\d+)\)');
+final RegExp _mergePrPattern = RegExp(r'^Merge pull request #(\d+)');
+
+Future<List<int>> _listMergedPrNumbers({
+  required _GitHubApi api,
+  required String from,
+  required String to,
+}) async {
+  final numbers = <int>[];
+  final seen = <int>{};
+
+  for (var page = 1; page <= 10; page++) {
+    final comparison =
+        await api.getJson(path: '/repos/${api.repo}/compare/$from...$to?per_page=100&page=$page')
+            as Map<String, dynamic>;
+    final commits = (comparison['commits'] as List<dynamic>).cast<Map<String, dynamic>>();
+    for (final commit in commits) {
+      final message = (commit['commit'] as Map<String, dynamic>)['message'] as String;
+      final subject = message.split('\n').first;
+      final match = _mergePrPattern.firstMatch(subject) ?? _squashPrPattern.firstMatch(subject);
+      if (match == null) {
+        continue;
+      }
+      final number = int.parse(match.group(1)!);
+      if (seen.add(number)) {
+        numbers.add(number);
+      }
+    }
+    if (commits.length < 100) {
+      break;
+    }
+  }
+
+  return numbers;
+}
+
+class _PrEntry {
+  const _PrEntry({
+    required this.number,
+    required this.title,
+    required this.author,
+    required this.url,
+    required this.touchesApp,
+    required this.touchesBridge,
+    required this.touchesShared,
+  });
+
+  final int number;
+  final String title;
+  final String author;
+  final String url;
+  final bool touchesApp;
+  final bool touchesBridge;
+  final bool touchesShared;
+}
+
+Future<_PrEntry?> _loadPr({required _GitHubApi api, required int number}) async {
+  final pr = await api.getJson(path: '/repos/${api.repo}/pulls/$number') as Map<String, dynamic>;
+
+  final author = ((pr['user'] as Map<String, dynamic>?)?['login'] as String?) ?? 'unknown';
+  if (_excludedAuthors.contains(author)) {
+    return null;
+  }
+  final labels = (pr['labels'] as List<dynamic>? ?? [])
+      .cast<Map<String, dynamic>>()
+      .map((label) => label['name'] as String);
+  if (labels.contains(_ignoreLabel)) {
+    return null;
+  }
+
+  var touchesApp = false;
+  var touchesBridge = false;
+  var touchesShared = false;
+  for (var page = 1; page <= 10; page++) {
+    final files = await api.getJson(path: '/repos/${api.repo}/pulls/$number/files?per_page=100&page=$page')
+        as List<dynamic>;
+    for (final file in files.cast<Map<String, dynamic>>()) {
+      final path = file['filename'] as String;
+      touchesApp = touchesApp || path.startsWith('mobile/');
+      touchesBridge = touchesBridge || path.startsWith('bridge/');
+      touchesShared = touchesShared || path.startsWith('shared/');
+    }
+    if (files.length < 100 || (touchesApp && touchesBridge && touchesShared)) {
+      break;
+    }
+  }
+
+  return _PrEntry(
+    number: number,
+    title: (pr['title'] as String).trim(),
+    author: author,
+    url: pr['html_url'] as String,
+    touchesApp: touchesApp,
+    touchesBridge: touchesBridge,
+    touchesShared: touchesShared,
+  );
+}
+
+final RegExp _conventionalPrefixPattern = RegExp(r'^(\w+)(\([^)]*\))?!?:\s*');
+
+String _bucketFor({required String title}) {
+  final match = _conventionalPrefixPattern.firstMatch(title);
+  final type = match?.group(1)?.toLowerCase();
+  switch (type) {
+    case 'feat':
+      return 'Added';
+    case 'fix':
+    case 'bug':
+      return 'Fixed';
+    default:
+      return 'Changed';
+  }
+}
+
+String _displayTitle({required _PrEntry entry}) {
+  var title = entry.title.replaceFirst(_conventionalPrefixPattern, '');
+  if (title.isNotEmpty) {
+    title = title[0].toUpperCase() + title.substring(1);
+  }
+  final sharedMarker = entry.touchesShared ? ' *(shared)*' : '';
+  return '$title (#${entry.number})$sharedMarker';
+}
+
+String _render({
+  required String repo,
+  required String from,
+  required String to,
+  required List<_PrEntry> entries,
+}) {
+  final buffer = StringBuffer('## What\'s Changed\n');
+
+  void writeSection({
+    required String section,
+    required bool Function(_PrEntry entry) selector,
+  }) {
+    final selected = entries.where(selector).toList();
+    if (selected.isEmpty) {
+      return;
+    }
+    buffer.write('\n### $section\n');
+    for (final bucket in const ['Added', 'Fixed', 'Changed']) {
+      final bucketEntries = selected.where((entry) => _bucketFor(title: entry.title) == bucket).toList();
+      if (bucketEntries.isEmpty) {
+        continue;
+      }
+      buffer.write('\n#### $bucket\n');
+      for (final entry in bucketEntries) {
+        buffer.writeln('- ${_displayTitle(entry: entry)}');
+      }
+    }
+  }
+
+  // shared/** is consumed by both sides, so shared-touching PRs are listed
+  // under both App and Bridge (marked "(shared)").
+  writeSection(section: 'App', selector: (entry) => entry.touchesApp || entry.touchesShared);
+  writeSection(section: 'Bridge', selector: (entry) => entry.touchesBridge || entry.touchesShared);
+
+  if (entries.isNotEmpty) {
+    buffer.write('\n### All PRs merged\n');
+    for (final entry in entries) {
+      buffer.writeln('* ${entry.title} by @${entry.author} in ${entry.url}');
+    }
+  } else {
+    buffer.write('\nNo pull requests merged in this range.\n');
+  }
+
+  buffer.write('\n**Full Changelog**: https://github.com/$repo/compare/$from...$to\n');
+  return buffer.toString();
+}

--- a/tool/generate_release_notes.dart
+++ b/tool/generate_release_notes.dart
@@ -252,27 +252,55 @@ Future<List<int>> _listMergedPrNumbers({
 }) async {
   final numbers = <int>[];
   final seen = <int>{};
+  var scannedCommits = 0;
+  var totalCommits = 0;
 
-  for (var page = 1; page <= 10; page++) {
+  var page = 1;
+  while (true) {
     final comparison =
         await api.getJson(path: '/repos/${api.repo}/compare/$from...$to?per_page=100&page=$page')
             as Map<String, dynamic>;
+    totalCommits = comparison['total_commits'] as int? ?? totalCommits;
     final commits = (comparison['commits'] as List<dynamic>).cast<Map<String, dynamic>>();
+    scannedCommits += commits.length;
     for (final commit in commits) {
       final message = (commit['commit'] as Map<String, dynamic>)['message'] as String;
       final subject = message.split('\n').first;
       final match = _mergePrPattern.firstMatch(subject) ?? _squashPrPattern.firstMatch(subject);
-      if (match == null) {
+      if (match != null) {
+        final number = int.parse(match.group(1)!);
+        if (seen.add(number)) {
+          numbers.add(number);
+        }
         continue;
       }
-      final number = int.parse(match.group(1)!);
-      if (seen.add(number)) {
-        numbers.add(number);
+      // Commits without a (#N) / merge-commit subject (rebase merges, edited
+      // squash titles, direct pushes): resolve through GitHub's commit -> PR
+      // association instead of silently dropping them.
+      final sha = commit['sha'] as String;
+      final associated =
+          await api.getJson(path: '/repos/${api.repo}/commits/$sha/pulls?per_page=10') as List<dynamic>;
+      for (final pull in associated.cast<Map<String, dynamic>>()) {
+        if (pull['merged_at'] == null) {
+          continue;
+        }
+        final number = pull['number'] as int;
+        if (seen.add(number)) {
+          numbers.add(number);
+        }
       }
     }
     if (commits.length < 100) {
       break;
     }
+    page++;
+  }
+
+  // Never truncate silently: incomplete notes on a release are worse than a
+  // failed workflow run (pass --from for a shorter range if this ever trips).
+  if (scannedCommits < totalCommits) {
+    throw StateError('Compare $from...$to reports $totalCommits commits but only '
+        '$scannedCommits were returned; refusing to publish truncated release notes.');
   }
 
   return numbers;
@@ -315,9 +343,13 @@ Future<_PrEntry?> _loadPr({required _GitHubApi api, required int number}) async 
   var touchesApp = false;
   var touchesBridge = false;
   var touchesShared = false;
-  for (var page = 1; page <= 10; page++) {
+  final changedFiles = pr['changed_files'] as int? ?? 0;
+  var listedFiles = 0;
+  var page = 1;
+  while (true) {
     final files = await api.getJson(path: '/repos/${api.repo}/pulls/$number/files?per_page=100&page=$page')
         as List<dynamic>;
+    listedFiles += files.length;
     for (final file in files.cast<Map<String, dynamic>>()) {
       final path = file['filename'] as String;
       touchesApp = touchesApp || path.startsWith('mobile/');
@@ -327,6 +359,16 @@ Future<_PrEntry?> _loadPr({required _GitHubApi api, required int number}) async 
     if (files.length < 100 || (touchesApp && touchesBridge && touchesShared)) {
       break;
     }
+    page++;
+  }
+  // The files API stops listing at 3000 files. If a PR is so large we could
+  // not see every file, degrade conservatively: list it under both sections
+  // rather than silently misclassifying it.
+  if (listedFiles < changedFiles && !(touchesApp && touchesBridge)) {
+    stderr.writeln('PR #$number lists only $listedFiles of $changedFiles changed files; '
+        'classifying it under both App and Bridge.');
+    touchesApp = true;
+    touchesBridge = true;
   }
 
   return _PrEntry(


### PR DESCRIPTION
## Summary

Merges the outdated standalone `bridge-release.yml` into the two mobile release workflows so every release ships app + bridge together under the synced `v*` version scheme, with GitHub releases carrying the bridge binaries the auto-updater consumes. Design agreed in an interactive planning session.

### `release-all-platforms.yml` — every main merge
- **Preflight version guard**: the whole run (mobile *and* bridge) fails loudly when mobile/bridge pubspec versions drift, or when the committed version already has a `v<version>` tag (created by any beta/production submit). The fix is always a `tool/sync_versions.dart` bump PR — never auto-increment.
- **Bridge matrix on every merge**: full 5-platform build (macos-arm64/x64, linux-x64/arm64, windows-x64, macOS codesigned) via the new reusable `_reusable-bridge-build.yml`, baking `X.Y.Z-internal.<N>` into the binary at build time (uncommitted) so internal builds self-report their tag and semver-order *below* the eventual stable release.
- **`v<X>-internal.<N>` tags replace `build-<N>`**: tags are kept forever as the build-number→commit map; the build number keeps incrementing per merge as before.
- **Rolling internal pre-release**: exactly one internal pre-release exists at any time — previous pre-release *objects* are deleted (tags kept), the new one gets the 5 archives + `checksums.txt` + regenerated notes spanning everything since the last stable release. The auto-updater ignores pre-releases, so nothing reaches end users; this serves internal testers and the future pre-release update channel.
- **All-or-nothing**: tag + pre-release only when iOS, Android AND all 5 bridge targets succeeded.

### `submit-release.yml` — manual promotion
- `platforms` gains **`bridge-only`** (production-only bridge hotfix path). It skips both store jobs, so the release job itself carries the `store-production` reviewer gate; regular submits pass through `store-beta` there to avoid a second approval pause.
- **Production rebuilds the bridge** from the resolved commit (internal binaries can't be promoted — they have `-internal.<N>` baked in) and attaches binaries + checksums + scripted notes to the `v<VERSION>` GitHub release.
- New **`publish_bridge` checkbox (default: on)**: unticked creates the release as a *pre-release* — invisible to the bridge auto-updater until manually promoted in the GitHub UI (one click).
- `resolve` maps build numbers via `v*-internal.<N>` with a legacy `build-<N>` fallback, and now also asserts mobile/bridge version sync at the resolved commit.
- Beta track behavior unchanged: tags `v<VERSION>`, no GitHub release, no bridge build.

### `bridge-npm-publish.yml` — new, `on: release: [released]`
- Publishes the 5 platform npm packages + `@sesori/bridge` wrapper when a stable `v<X.Y.Z>` release goes **live** — the `released` event fires both for immediate publishes and for manual pre-release promotions, so npm availability always coincides with the auto-updater seeing the release.
- Fixes a latent bug from the old workflow: manifests are now checked out at the **tagged commit**, not `main`.
- Deletes the superseded same-version internal pre-release (tag kept); internal pre-releases for newer versions are left alone.

### Tooling
- **`tool/generate_release_notes.dart`** (new, dependency-free): deterministic App/Bridge split notes — `mobile/**` → App, `bridge/**` → Bridge, `shared/**` → both (marked *(shared)*) — bucketed Added/Fixed/Changed from conventional PR title prefixes, plus the "All PRs merged" list and Full Changelog link. Respects `.github/release.yml` exclusions (`ignore-for-release`, dependabot). Smoke-tested against the real repo (`v1.0.7...main`).
- **`bridge/app/tool/bump_version.dart`** now accepts semver pre-release suffixes (e.g. `1.0.9-internal.53`) for the build-time bake; test added.

## Notes for reviewers
- Legacy `bridge-v*` releases are untouched — the updater only matches stable `v*` releases that carry its platform asset + `checksums.txt`, so they're already invisible to it.
- The updater (`release_repository.dart`) needs **zero changes**: the production release shape is exactly what it already expects. Auto-update goes from dormant to live with the first published `v*` release from this pipeline.
- After a production release, main is blocked by the preflight guard until a version-bump PR lands — this is intentional (forces bump hygiene; was chosen over auto-derive).

## Validation
- actionlint: clean on all four new/changed workflows (pre-existing findings in untouched files remain).
- `dart analyze --fatal-infos` clean on changed tools; `bump_version` tests pass (3/3).
- Notes generator run live against this repo produced the expected App/Bridge split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies bridge releases into the mobile pipeline so app and bridge ship together under synced `v*` versions. Adds a rolling internal pre-release on each merge, rebuilds bridge for production, aligns npm publish with when the GitHub release goes live, and hardens CI by resolving local actions from the workflow revision.

- **New Features**
  - Internal releases: version guard; 5-target bridge build via reusable workflow; `v<X.Y.Z>-internal.<N>` tags; single rolling GitHub pre-release with checksums + generated notes; all-or-nothing after iOS, Android, and bridge succeed.
  - Production submits: rebuilds bridge from the resolved commit and attaches binaries + checksums + generated notes to `v<VERSION>`; `publish_bridge` toggle (publish now vs pre-release) and a `bridge-only` path; store-production approval is held before tagging on bridge-only runs; store-metadata tagging moved to its own job.
  - npm publish: `bridge-npm-publish.yml` runs on two paths — `workflow_dispatch` from immediate publishes and `release: released` on manual promotion; gates on a live stable `v<X.Y.Z>` release, checks out the tagged commit, deletes the superseded same-version internal pre-release, and publishes 5 platform packages + `@sesori/bridge`.
  - Tooling/CI: asdf-pinned toolchain via shared `setup-flutter` (`workspace` input; Windows stays on `dart-lang/setup-dart`); notes generator is deterministic and fails on truncated compares, resolves PRs via commit associations, and classifies too-large PRs under both; reusable bridge-build now checks out `.github/actions` from the workflow revision to avoid stale local actions on legacy tags; increased npm publish timeouts.

- **Migration**
  - Keep mobile/bridge versions in sync and unreleased; after a production release, bump before merging.
  - Internal tags are now `v<X.Y.Z>-internal.<N>` (submit still resolves legacy `build-<N>`). For bridge-only hotfixes, use `platforms=bridge-only` on the production track.

<sup>Written for commit 7df5540f6f64892f3b1fef6823e498bccad174ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

