### PR TITLE
fix(ci): linux-arm64 bridge build cannot use the Flutter asdf toolchain

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -38,8 +38,12 @@ runs:
         path: |
           ~/.pub-cache
         key: ${{ runner.os }}-${{ runner.arch }}-pub-${{ hashFiles('.tool-versions') }}-${{ hashFiles('**/pubspec.lock') }}
+        # Second restore key keeps the pub cache warm across .tool-versions
+        # bumps — pub packages are SDK-version independent, so seeding an SDK
+        # upgrade from the previous cache is safe (it re-saves under the new key).
         restore-keys: |
           ${{ runner.os }}-${{ runner.arch }}-pub-${{ hashFiles('.tool-versions') }}-
+          ${{ runner.os }}-${{ runner.arch }}-pub-
 
     - name: Get dependencies (workspace)
       if: inputs.workspace != 'none'

--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -18,7 +18,10 @@ runs:
       uses: actions/cache@v5
       with:
         path: ${{ env.HOME }}/.asdf
-        key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
+        # runner.arch is part of the key: macos-latest (arm64) and
+        # macos-26-intel (x64) would otherwise share and cross-poison a cache
+        # of architecture-specific binaries.
+        key: ${{ runner.os }}-${{ runner.arch }}-asdf-${{ hashFiles('.tool-versions') }}
 
     - name: Install asdf tools
       if: steps.asdf-cache.outputs.cache-hit != 'true'
@@ -34,9 +37,9 @@ runs:
       with:
         path: |
           ~/.pub-cache
-        key: ${{ runner.os }}-pub-${{ hashFiles('.tool-versions') }}-${{ hashFiles('**/pubspec.lock') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-pub-${{ hashFiles('.tool-versions') }}-${{ hashFiles('**/pubspec.lock') }}
         restore-keys: |
-          ${{ runner.os }}-pub-${{ hashFiles('.tool-versions') }}-
+          ${{ runner.os }}-${{ runner.arch }}-pub-${{ hashFiles('.tool-versions') }}-
 
     - name: Get dependencies (workspace)
       if: inputs.workspace != 'none'

--- a/.github/workflows/_reusable-bridge-build.yml
+++ b/.github/workflows/_reusable-bridge-build.yml
@@ -95,9 +95,44 @@ jobs:
         with:
           workspace: bridge
 
+      # Even without asdf the toolchain must match .tool-versions: resolve the
+      # Dart SDK bundled with the pinned Flutter release from Flutter's
+      # releases manifest (read from the CHECKED-OUT ref, so rebuilds of older
+      # commits keep their own pin) and install exactly that version.
+      - name: Resolve pinned Dart version
+        id: dart-version
+        if: ${{ !matrix.use_asdf }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TOOL_SPEC=$(awk '$1 == "flutter" {print $2}' .tool-versions)
+          if [[ -z "$TOOL_SPEC" ]]; then
+            echo "::error::No flutter entry found in .tool-versions"
+            exit 1
+          fi
+          if [[ "$TOOL_SPEC" == *-* ]]; then
+            FLUTTER_VERSION="${TOOL_SPEC%-*}"
+            CHANNEL="${TOOL_SPEC##*-}"
+          else
+            FLUTTER_VERSION="$TOOL_SPEC"
+            CHANNEL="stable"
+          fi
+          DART_VERSION=$(curl -fsSL https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json \
+            | jq -r --arg v "$FLUTTER_VERSION" --arg c "$CHANNEL" \
+                '[.releases[] | select(.version == $v and .channel == $c)][0].dart_sdk_version // empty' \
+            | awk '{print $1}')
+          if [[ -z "$DART_VERSION" ]]; then
+            echo "::error::Could not resolve the Dart SDK bundled with Flutter ${TOOL_SPEC} from the Flutter releases manifest."
+            exit 1
+          fi
+          echo "Flutter ${TOOL_SPEC} bundles Dart ${DART_VERSION}"
+          echo "version=${DART_VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Setup Dart (setup-dart fallback)
         if: ${{ !matrix.use_asdf }}
         uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ steps.dart-version.outputs.version }}
 
       - name: Cache pub dependencies (setup-dart fallback)
         if: ${{ !matrix.use_asdf }}

--- a/.github/workflows/_reusable-bridge-build.yml
+++ b/.github/workflows/_reusable-bridge-build.yml
@@ -43,22 +43,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # use_asdf: the asdf/.tool-versions Flutter toolchain only works where
+        # Flutter publishes a host SDK and asdf runs — NOT on Windows (no asdf)
+        # and NOT on linux-arm64 (no Flutter host SDK; asdf would install the
+        # x64 tarball and dart dies with an Exec format error). Those legs use
+        # dart-lang/setup-dart instead, which ships all four host targets.
         include:
           - runner: macos-latest
             asset_name: sesori-bridge-macos-arm64
             archive_ext: tar.gz
+            use_asdf: true
           - runner: macos-26-intel
             asset_name: sesori-bridge-macos-x64
             archive_ext: tar.gz
+            use_asdf: true
           - runner: ubuntu-latest
             asset_name: sesori-bridge-linux-x64
             archive_ext: tar.gz
+            use_asdf: true
           - runner: ubuntu-24.04-arm
             asset_name: sesori-bridge-linux-arm64
             archive_ext: tar.gz
+            use_asdf: false
           - runner: windows-latest
             asset_name: sesori-bridge-windows-x64
             archive_ext: zip
+            use_asdf: false
     steps:
       - uses: actions/checkout@v6
         with:
@@ -70,7 +80,7 @@ jobs:
       # in mobile/). Pull the action from the workflow's own revision into a
       # side directory and run it from there.
       - name: Checkout CI actions at workflow revision
-        if: runner.os != 'Windows'
+        if: matrix.use_asdf
         uses: actions/checkout@v6
         with:
           path: .ci-workflow
@@ -79,26 +89,28 @@ jobs:
       # Same pinned toolchain as the mobile builds: asdf installs the Flutter
       # version from .tool-versions and dart comes from that installation. On
       # macOS the iOS deploy job usually warmed the same asdf cache already.
-      # asdf has no Windows support, so Windows keeps dart-lang/setup-dart.
       - name: Setup Flutter (asdf)
-        if: runner.os != 'Windows'
+        if: matrix.use_asdf
         uses: ./.ci-workflow/.github/actions/setup-flutter
         with:
           workspace: bridge
 
-      - name: Setup Dart (Windows)
-        if: runner.os == 'Windows'
+      - name: Setup Dart (setup-dart fallback)
+        if: ${{ !matrix.use_asdf }}
         uses: dart-lang/setup-dart@v1
 
-      - name: Cache pub dependencies (Windows)
-        if: runner.os == 'Windows'
+      - name: Cache pub dependencies (setup-dart fallback)
+        if: ${{ !matrix.use_asdf }}
         uses: actions/cache@v5
         with:
-          path: ~\AppData\Local\Pub\Cache
+          # Default pub cache locations; only the one for the current OS exists.
+          path: |
+            ~/.pub-cache
+            ~\AppData\Local\Pub\Cache
           key: ${{ runner.os }}-${{ runner.arch }}-pub-${{ hashFiles('bridge/pubspec.lock') }}
 
-      - name: Get dependencies (Windows)
-        if: runner.os == 'Windows'
+      - name: Get dependencies (setup-dart fallback)
+        if: ${{ !matrix.use_asdf }}
         run: dart pub get
         working-directory: bridge
 


### PR DESCRIPTION
## Summary

The first live run of the new bridge matrix ([run #64](https://github.com/sesori-ai/sesori_apps_monorepo/actions/runs/27281244415)) failed on `ubuntu-24.04-arm` with `cannot execute binary file: Exec format error` — **Flutter publishes no linux-arm64 host SDK**, so the asdf flutter plugin installs the x64 tarball and its bundled `dart` can't run.

### Changes
- The bridge build matrix drives the toolchain per leg via `use_asdf`: linux-arm64 joins Windows on `dart-lang/setup-dart` (which ships all four host targets); macOS arm64/x64 and linux-x64 keep the asdf/.tool-versions toolchain as requested in #213 review.
- `setup-flutter` cache keys now include `runner.arch`: `macos-latest` (arm64) and `macos-26-intel` (x64) previously shared a `macOS-…` key and would cross-poison a cache of architecture-specific binaries. (Mobile workflows never hit this — single arch per OS — they'll just rebuild their cache once under the new key.)

### Note
This run's failure means no `v1.0.8-internal.<N>` tag / internal pre-release was produced (all-or-nothing, as designed). Since `.github/**` changes don't trigger `release-all-platforms.yml`, after merging either dispatch it manually or let the next mobile/bridge/shared merge produce the first internal release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the linux-arm64 bridge CI by using `dart-lang/setup-dart` where Flutter lacks a host SDK, pins fallback Dart to the `.tool-versions` Flutter bundle, and adds arch-scoped cache keys. This stabilizes the bridge build across macOS, Linux, and Windows.

- **Bug Fixes**
  - Drive toolchain per matrix leg via `use_asdf`: enabled on macOS (arm64/x64) and Linux x64; disabled on Windows and Linux arm64.
  - Use `dart-lang/setup-dart` on Windows and Linux arm64, pinned to the Dart version bundled with the `.tool-versions` Flutter release.
  - Scope `setup-flutter` and pub cache keys by `runner.arch`, and add an arch-only restore key to warm caches across SDK bumps.

- **Migration**
  - After merge, manually dispatch `release-all-platforms.yml` or wait for the next qualifying merge to create the next internal release.

<sup>Written for commit 09dcd664d40e2227326b4ce7170ca04d8fd5c797. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

