### PR TITLE
feat(bridge): register bridge instances with auth and send bridgeId to relay

### DIFF
--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -2,10 +2,16 @@ import 'dart:io';
 
 import 'package:args/args.dart' show ArgParserException;
 import 'package:args/command_runner.dart' as cli;
+import 'package:http/http.dart' as http;
 import 'package:opencode_plugin/opencode_plugin.dart';
 import 'package:sesori_bridge/src/api/bridge_settings_api.dart';
 import 'package:sesori_bridge/src/api/default_editor_api.dart';
 import 'package:sesori_bridge/src/api/wake_lock_client.dart';
+import 'package:sesori_bridge/src/auth/bridge_registration_api.dart';
+import 'package:sesori_bridge/src/auth/bridge_registration_repository.dart';
+import 'package:sesori_bridge/src/auth/bridge_registration_service.dart';
+import 'package:sesori_bridge/src/auth/token.dart';
+import 'package:sesori_bridge/src/auth/token_manager.dart';
 import 'package:sesori_bridge/src/bridge/foundation/device_type_detector.dart';
 import 'package:sesori_bridge/src/bridge/foundation/process_runner.dart';
 import 'package:sesori_bridge/src/bridge/runtime/bridge_cli_dispatch.dart';
@@ -143,8 +149,17 @@ class LogoutCommand extends cli.Command<void> {
   @override
   final description = 'Clear stored authentication tokens';
 
+  LogoutCommand() {
+    argParser.addOption('auth-backend', defaultsTo: '', help: 'Auth backend URL');
+  }
+
   @override
   Future<void> run() async {
+    final authBackendUrl = BridgeCliOptions.resolveAuthBackendUrl(
+      authBackendFlag: argResults!['auth-backend'] as String,
+      environment: Platform.environment,
+      defaultAuthUrl: _defaultAuthURL,
+    );
     final systemProcessApi = SystemProcessApi(
       processRunner: ProcessRunner(),
       clock: const ServerClock(),
@@ -173,6 +188,7 @@ class LogoutCommand extends cli.Command<void> {
         clock: const ServerClock(),
       ),
       terminalPromptRepository: terminalPromptRepository,
+      unregisterBridge: () => _unregisterBridgeRegistration(authBackendUrl: authBackendUrl),
     );
 
     final result = await logoutRunner.logout(currentPid: pid);
@@ -192,6 +208,47 @@ class LogoutCommand extends cli.Command<void> {
         stderr.writeln('Error: Failed to clear authentication tokens: ${result.error}');
         exitCode = 1;
     }
+  }
+}
+
+/// Removes this bridge's registration on the auth server before the token
+/// file is deleted. Callers treat any failure as non-fatal.
+Future<void> _unregisterBridgeRegistration({required String authBackendUrl}) async {
+  final TokenData tokens;
+  try {
+    tokens = await loadTokens();
+  } on Object catch (e) {
+    // No stored tokens — nothing registered to remove. A corrupt token file
+    // also lands here; logout still proceeds, but leave a trace.
+    Log.w('Skipping bridge unregistration; could not load tokens: $e');
+    return;
+  }
+  if (tokens.bridgeId == null) {
+    return;
+  }
+
+  final httpClient = http.Client();
+  final tokenManager = TokenManager(
+    initialToken: tokens.accessToken,
+    authBackendUrl: authBackendUrl,
+    loadTokens: loadTokens,
+    saveTokens: saveTokens,
+  );
+  try {
+    final registrationService = BridgeRegistrationService(
+      repository: BridgeRegistrationRepository(
+        api: BridgeRegistrationApi(authBackendUrl: authBackendUrl, client: httpClient),
+      ),
+      tokenRefresher: tokenManager,
+      loadTokens: loadTokens,
+      saveTokens: saveTokens,
+      hostName: Platform.localHostname,
+      platform: BridgeRegistrationService.currentPlatformName(),
+    );
+    await registrationService.unregister().timeout(const Duration(seconds: 10));
+  } finally {
+    tokenManager.dispose();
+    httpClient.close();
   }
 }
 

--- a/bridge/app/lib/src/auth/bridge_id_provider.dart
+++ b/bridge/app/lib/src/auth/bridge_id_provider.dart
@@ -1,0 +1,5 @@
+/// Provides read access to the bridge id assigned by the auth server.
+abstract interface class BridgeIdProvider {
+  /// The current bridge id, or null when this bridge has not registered yet.
+  String? get bridgeId;
+}

--- a/bridge/app/lib/src/auth/bridge_registration_api.dart
+++ b/bridge/app/lib/src/auth/bridge_registration_api.dart
@@ -1,0 +1,89 @@
+import "dart:convert";
+
+import "package:http/http.dart" as http;
+import "package:sesori_shared/sesori_shared.dart";
+
+const Duration _requestTimeout = Duration(seconds: 15);
+
+/// Raised when an `/auth/bridges` request returns a non-success status.
+class BridgeRegistrationException implements Exception {
+  final int statusCode;
+  final String message;
+
+  BridgeRegistrationException({required this.statusCode, required String body})
+    : message = "BridgeRegistrationException: status $statusCode | body $body";
+
+  @override
+  String toString() => message;
+}
+
+class BridgeRegistrationApi {
+  final String _authBackendUrl;
+  final http.Client _client;
+
+  BridgeRegistrationApi({
+    required String authBackendUrl,
+    required http.Client client,
+  }) : _authBackendUrl = authBackendUrl.endsWith("/")
+           ? authBackendUrl.substring(0, authBackendUrl.length - 1)
+           : authBackendUrl,
+       _client = client;
+
+  /// Registers (or re-registers) this bridge via `POST /auth/bridges`.
+  ///
+  /// When [bridgeId] identifies an existing bridge owned by the calling user
+  /// the server updates and returns it (200); otherwise the server mints a
+  /// fresh bridge id (201). Throws [BridgeRegistrationException] on any other
+  /// status.
+  Future<BridgeSummary> registerBridge({
+    required String name,
+    required String platform,
+    required String? bridgeId,
+    required String accessToken,
+  }) async {
+    final body = <String, dynamic>{
+      "name": name,
+      "platform": platform,
+    };
+    if (bridgeId != null) {
+      body["bridgeId"] = bridgeId;
+    }
+
+    final response = await _client
+        .post(
+          Uri.parse("$_authBackendUrl/auth/bridges"),
+          headers: {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer $accessToken",
+          },
+          body: jsonEncode(body),
+        )
+        .timeout(_requestTimeout);
+
+    if (response.statusCode != 200 && response.statusCode != 201) {
+      throw BridgeRegistrationException(statusCode: response.statusCode, body: response.body);
+    }
+
+    return BridgeSummary.fromJson(jsonDecodeMap(response.body));
+  }
+
+  /// Removes this bridge's registration via `DELETE /auth/bridges/:bridgeId`.
+  ///
+  /// Throws [BridgeRegistrationException] on any non-200 status (including
+  /// 404 when the bridge is unknown or already revoked).
+  Future<void> deleteBridge({
+    required String bridgeId,
+    required String accessToken,
+  }) async {
+    final response = await _client
+        .delete(
+          Uri.parse("$_authBackendUrl/auth/bridges/$bridgeId"),
+          headers: {"Authorization": "Bearer $accessToken"},
+        )
+        .timeout(_requestTimeout);
+
+    if (response.statusCode != 200) {
+      throw BridgeRegistrationException(statusCode: response.statusCode, body: response.body);
+    }
+  }
+}

--- a/bridge/app/lib/src/auth/bridge_registration_api.dart
+++ b/bridge/app/lib/src/auth/bridge_registration_api.dart
@@ -41,13 +41,7 @@ class BridgeRegistrationApi {
     required String? bridgeId,
     required String accessToken,
   }) async {
-    final body = <String, dynamic>{
-      "name": name,
-      "platform": platform,
-    };
-    if (bridgeId != null) {
-      body["bridgeId"] = bridgeId;
-    }
+    final request = RegisterBridgeRequest(name: name, platform: platform, bridgeId: bridgeId);
 
     final response = await _client
         .post(
@@ -56,7 +50,7 @@ class BridgeRegistrationApi {
             "Content-Type": "application/json",
             "Authorization": "Bearer $accessToken",
           },
-          body: jsonEncode(body),
+          body: jsonEncode(request.toJson()),
         )
         .timeout(_requestTimeout);
 
@@ -77,7 +71,7 @@ class BridgeRegistrationApi {
   }) async {
     final response = await _client
         .delete(
-          Uri.parse("$_authBackendUrl/auth/bridges/$bridgeId"),
+          Uri.parse("$_authBackendUrl/auth/bridges/${Uri.encodeComponent(bridgeId)}"),
           headers: {"Authorization": "Bearer $accessToken"},
         )
         .timeout(_requestTimeout);

--- a/bridge/app/lib/src/auth/bridge_registration_repository.dart
+++ b/bridge/app/lib/src/auth/bridge_registration_repository.dart
@@ -1,0 +1,33 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+import "bridge_registration_api.dart";
+
+/// Repository over the auth server's `/auth/bridges` endpoints.
+class BridgeRegistrationRepository {
+  final BridgeRegistrationApi _api;
+
+  BridgeRegistrationRepository({required BridgeRegistrationApi api}) : _api = api;
+
+  /// Registers (or re-registers) this bridge and returns its [BridgeSummary].
+  Future<BridgeSummary> register({
+    required String name,
+    required String platform,
+    required String? bridgeId,
+    required String accessToken,
+  }) {
+    return _api.registerBridge(
+      name: name,
+      platform: platform,
+      bridgeId: bridgeId,
+      accessToken: accessToken,
+    );
+  }
+
+  /// Removes the registration identified by [bridgeId].
+  Future<void> unregister({
+    required String bridgeId,
+    required String accessToken,
+  }) {
+    return _api.deleteBridge(bridgeId: bridgeId, accessToken: accessToken);
+  }
+}

--- a/bridge/app/lib/src/auth/bridge_registration_service.dart
+++ b/bridge/app/lib/src/auth/bridge_registration_service.dart
@@ -81,7 +81,7 @@ class BridgeRegistrationService implements BridgeIdProvider {
 
     _bridgeId = summary.id;
     if (tokens.bridgeId != summary.id) {
-      await _persistBridgeId(summary.id);
+      await _persistBridgeId(summary.id, tokens);
     }
     _registered = true;
   }
@@ -139,8 +139,8 @@ class BridgeRegistrationService implements BridgeIdProvider {
     }
   }
 
-  Future<void> _persistBridgeId(String? bridgeId) async {
-    final tokens = await _loadTokens();
+  Future<void> _persistBridgeId(String? bridgeId, [TokenData? currentTokens]) async {
+    final tokens = currentTokens ?? await _loadTokens();
     await _saveTokens(
       TokenData(
         accessToken: tokens.accessToken,

--- a/bridge/app/lib/src/auth/bridge_registration_service.dart
+++ b/bridge/app/lib/src/auth/bridge_registration_service.dart
@@ -81,7 +81,7 @@ class BridgeRegistrationService implements BridgeIdProvider {
 
     _bridgeId = summary.id;
     if (tokens.bridgeId != summary.id) {
-      await _persistBridgeId(summary.id, tokens);
+      await _persistBridgeId(summary.id);
     }
     _registered = true;
   }
@@ -139,8 +139,12 @@ class BridgeRegistrationService implements BridgeIdProvider {
     }
   }
 
-  Future<void> _persistBridgeId(String? bridgeId, [TokenData? currentTokens]) async {
-    final tokens = currentTokens ?? await _loadTokens();
+  // Always re-reads the token file: the token refresher persists a rotated
+  // access/refresh pair mid-registration (e.g. on the 401-retry path), so a
+  // snapshot from before the register call would write stale credentials
+  // back to disk.
+  Future<void> _persistBridgeId(String? bridgeId) async {
+    final tokens = await _loadTokens();
     await _saveTokens(
       TokenData(
         accessToken: tokens.accessToken,

--- a/bridge/app/lib/src/auth/bridge_registration_service.dart
+++ b/bridge/app/lib/src/auth/bridge_registration_service.dart
@@ -1,0 +1,153 @@
+import "dart:io";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
+import "bridge_id_provider.dart";
+import "bridge_registration_api.dart";
+import "bridge_registration_repository.dart";
+import "token.dart";
+import "token_refresher.dart";
+
+/// Registers this bridge with the auth server and tracks the assigned
+/// bridge id across reconnects.
+///
+/// Registration is memoized per process: once [ensureRegistered] succeeds it
+/// returns immediately on subsequent calls until [handleBridgeRevoked]
+/// resets it (relay close code 4006 — bridge revoked).
+class BridgeRegistrationService implements BridgeIdProvider {
+  final BridgeRegistrationRepository _repository;
+  final TokenRefresher _tokenRefresher;
+  final Future<TokenData> Function() _loadTokens;
+  final Future<void> Function(TokenData) _saveTokens;
+  final String _hostName;
+  final String _platform;
+
+  bool _registered = false;
+  String? _bridgeId;
+
+  BridgeRegistrationService({
+    required BridgeRegistrationRepository repository,
+    required TokenRefresher tokenRefresher,
+    required Future<TokenData> Function() loadTokens,
+    required Future<void> Function(TokenData) saveTokens,
+    required String hostName,
+    required String platform,
+  }) : _repository = repository,
+       _tokenRefresher = tokenRefresher,
+       _loadTokens = loadTokens,
+       _saveTokens = saveTokens,
+       _hostName = sanitizeBridgeName(hostName),
+       _platform = platform;
+
+  /// The bridge platform name reported to the auth server.
+  static String currentPlatformName() {
+    if (Platform.isMacOS) return "macos";
+    if (Platform.isWindows) return "windows";
+    if (Platform.isLinux) return "linux";
+    throw UnsupportedError("Unsupported platform: ${Platform.operatingSystem}");
+  }
+
+  /// Clamps a bridge name to the auth server's 1-120 character contract so an
+  /// exotic hostname can never fail registration with a 400.
+  static String sanitizeBridgeName(String name) {
+    final trimmed = name.trim();
+    if (trimmed.isEmpty) return "sesori-bridge";
+    return trimmed.length <= 120 ? trimmed : trimmed.substring(0, 120);
+  }
+
+  @override
+  String? get bridgeId => _bridgeId;
+
+  /// Ensures this bridge is registered with the auth server.
+  ///
+  /// Posts the persisted bridge id (if any) so the server updates the
+  /// existing registration; the returned id is persisted to the token file.
+  /// Throws on failure so the caller can fail the connect attempt and retry
+  /// on its existing backoff.
+  Future<void> ensureRegistered() async {
+    if (_registered) {
+      return;
+    }
+
+    final tokens = await _loadTokens();
+    final summary = await _withAccessTokenRetry(
+      (accessToken) => _repository.register(
+        name: _hostName,
+        platform: _platform,
+        bridgeId: tokens.bridgeId,
+        accessToken: accessToken,
+      ),
+    );
+
+    _bridgeId = summary.id;
+    if (tokens.bridgeId != summary.id) {
+      await _persistBridgeId(summary.id);
+    }
+    _registered = true;
+  }
+
+  /// Clears the in-memory and persisted bridge id and resets the
+  /// registration memoization after the relay reported this bridge as
+  /// revoked (close code 4006).
+  ///
+  /// The next [ensureRegistered] call re-registers from scratch and receives
+  /// a fresh server-minted bridge id.
+  Future<void> handleBridgeRevoked() async {
+    _registered = false;
+    _bridgeId = null;
+    try {
+      await _persistBridgeId(null);
+    } on Object catch (e) {
+      // A stale persisted id self-heals: re-registering with a revoked id
+      // makes the server mint a fresh one.
+      Log.w("[bridge-registration] failed to clear persisted bridge id: $e");
+    }
+  }
+
+  /// Removes this bridge's registration on the auth server.
+  ///
+  /// Does nothing when no bridge id is persisted. A 404 (already revoked)
+  /// counts as success; any other failure is rethrown.
+  Future<void> unregister() async {
+    final tokens = await _loadTokens();
+    final bridgeId = tokens.bridgeId;
+    if (bridgeId == null) {
+      return;
+    }
+
+    try {
+      await _withAccessTokenRetry(
+        (accessToken) => _repository.unregister(bridgeId: bridgeId, accessToken: accessToken),
+      );
+    } on BridgeRegistrationException catch (e) {
+      if (e.statusCode != 404) {
+        rethrow;
+      }
+    }
+  }
+
+  Future<T> _withAccessTokenRetry<T>(Future<T> Function(String accessToken) action) async {
+    final accessToken = await _tokenRefresher.getAccessToken();
+    try {
+      return await action(accessToken);
+    } on BridgeRegistrationException catch (e) {
+      if (e.statusCode != 401) {
+        rethrow;
+      }
+      final refreshedToken = await _tokenRefresher.getAccessToken(forceRefresh: true);
+      return action(refreshedToken);
+    }
+  }
+
+  Future<void> _persistBridgeId(String? bridgeId) async {
+    final tokens = await _loadTokens();
+    await _saveTokens(
+      TokenData(
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
+        bridgeId: bridgeId,
+        lastProvider: tokens.lastProvider,
+      ),
+    );
+  }
+}

--- a/bridge/app/lib/src/auth/login_email_repository.dart
+++ b/bridge/app/lib/src/auth/login_email_repository.dart
@@ -62,6 +62,7 @@ class LoginEmailRepository {
       TokenData(
         accessToken: authResponse.accessToken,
         refreshToken: authResponse.refreshToken,
+        bridgeId: null,
         lastProvider: AuthProvider.email,
       ),
       authResponse.user.providerUsername ?? "",

--- a/bridge/app/lib/src/auth/login_oauth_service.dart
+++ b/bridge/app/lib/src/auth/login_oauth_service.dart
@@ -11,7 +11,7 @@ import "login_oauth_api.dart";
 import "token.dart";
 
 const int _totalLoginTimeoutSeconds = 300; // 5 minutes, matching server session expiry
-const int _perRequestTimeoutSeconds = 35;  // Slightly longer than server's 30s long poll
+const int _perRequestTimeoutSeconds = 35; // Slightly longer than server's 30s long poll
 const Duration _defaultPollInterval = Duration(milliseconds: 250);
 const Duration _defaultPollTimeout = Duration(seconds: _totalLoginTimeoutSeconds);
 const Duration _defaultPerRequestTimeout = Duration(seconds: _perRequestTimeoutSeconds);
@@ -117,6 +117,7 @@ class LoginOAuthService {
             return TokenData(
               accessToken: accessToken,
               refreshToken: refreshToken,
+              bridgeId: null,
               lastProvider: provider,
             );
           case AuthSessionStatusResponseDenied():
@@ -145,7 +146,8 @@ class LoginOAuthService {
 
     const confirmText = "Confirm this code on the web page";
     final confirmPadding = " " * ((contentWidth - confirmText.length) ~/ 2);
-    final confirmLine = "│$confirmPadding$confirmText${" " * (contentWidth - confirmPadding.length - confirmText.length)}│";
+    final confirmLine =
+        "│$confirmPadding$confirmText${" " * (contentWidth - confirmPadding.length - confirmText.length)}│";
 
     const beforeText = "before approving the login request.";
     final beforePadding = " " * ((contentWidth - beforeText.length) ~/ 2);

--- a/bridge/app/lib/src/auth/token.dart
+++ b/bridge/app/lib/src/auth/token.dart
@@ -7,17 +7,23 @@ import 'package:sesori_shared/sesori_shared.dart';
 class TokenData {
   final String accessToken;
   final String refreshToken;
-  final String? bridgeToken;
+
+  /// The bridge id assigned by the auth server's `/auth/bridges` endpoint,
+  /// or null when this bridge has not registered yet.
+  final String? bridgeId;
   final AuthProvider lastProvider;
 
   TokenData({
     required this.accessToken,
     required this.refreshToken,
-    this.bridgeToken,
+    this.bridgeId,
     required this.lastProvider,
   });
 
   /// Creates a TokenData instance from a JSON map.
+  ///
+  /// Unknown keys (e.g. the legacy `bridgeToken` key from old token files)
+  /// are ignored.
   factory TokenData.fromJson(Map<String, dynamic> json) {
     final providerName = json['lastProvider'] as String?;
     if (providerName == null) {
@@ -31,7 +37,7 @@ class TokenData {
     return TokenData(
       accessToken: json['accessToken'] as String,
       refreshToken: json['refreshToken'] as String,
-      bridgeToken: json['bridgeToken'] as String?,
+      bridgeId: json['bridgeId'] as String?,
       lastProvider: provider,
     );
   }
@@ -42,8 +48,8 @@ class TokenData {
       'accessToken': accessToken,
       'refreshToken': refreshToken,
     };
-    if (bridgeToken != null) {
-      json['bridgeToken'] = bridgeToken;
+    if (bridgeId != null) {
+      json['bridgeId'] = bridgeId;
     }
     json['lastProvider'] = lastProvider.key;
     return json;

--- a/bridge/app/lib/src/auth/token.dart
+++ b/bridge/app/lib/src/auth/token.dart
@@ -16,14 +16,11 @@ class TokenData {
   TokenData({
     required this.accessToken,
     required this.refreshToken,
-    this.bridgeId,
+    required this.bridgeId,
     required this.lastProvider,
   });
 
   /// Creates a TokenData instance from a JSON map.
-  ///
-  /// Unknown keys (e.g. the legacy `bridgeToken` key from old token files)
-  /// are ignored.
   factory TokenData.fromJson(Map<String, dynamic> json) {
     final providerName = json['lastProvider'] as String?;
     if (providerName == null) {

--- a/bridge/app/lib/src/auth/token_manager.dart
+++ b/bridge/app/lib/src/auth/token_manager.dart
@@ -114,11 +114,16 @@ class TokenManager implements AccessTokenProvider, AccessTokenUpdater, TokenRefr
 
     _tokenSubject.add(authResponse.accessToken);
 
+    // Re-read the token file before persisting: bridge registration can write
+    // a freshly minted bridgeId while this refresh is in flight (the
+    // background refresh at startup races registration), and persisting the
+    // pre-refresh snapshot would wipe it.
+    final latestTokens = await _loadTokens() ?? tokens;
     final persistedTokens = TokenData(
       accessToken: authResponse.accessToken,
       refreshToken: authResponse.refreshToken,
-      bridgeId: tokens.bridgeId,
-      lastProvider: tokens.lastProvider,
+      bridgeId: latestTokens.bridgeId,
+      lastProvider: latestTokens.lastProvider,
     );
     await _saveTokens(persistedTokens);
 

--- a/bridge/app/lib/src/auth/token_manager.dart
+++ b/bridge/app/lib/src/auth/token_manager.dart
@@ -117,7 +117,7 @@ class TokenManager implements AccessTokenProvider, AccessTokenUpdater, TokenRefr
     final persistedTokens = TokenData(
       accessToken: authResponse.accessToken,
       refreshToken: authResponse.refreshToken,
-      bridgeToken: tokens.bridgeToken,
+      bridgeId: tokens.bridgeId,
       lastProvider: tokens.lastProvider,
     );
     await _saveTokens(persistedTokens);

--- a/bridge/app/lib/src/auth/token_manager.dart
+++ b/bridge/app/lib/src/auth/token_manager.dart
@@ -117,8 +117,15 @@ class TokenManager implements AccessTokenProvider, AccessTokenUpdater, TokenRefr
     // Re-read the token file before persisting: bridge registration can write
     // a freshly minted bridgeId while this refresh is in flight (the
     // background refresh at startup races registration), and persisting the
-    // pre-refresh snapshot would wipe it.
-    final latestTokens = await _loadTokens() ?? tokens;
+    // pre-refresh snapshot would wipe it. A corrupt file falls back to the
+    // snapshot (the save below repairs it); a missing file propagates so a
+    // logout that deleted the file mid-refresh is not resurrected.
+    TokenData latestTokens;
+    try {
+      latestTokens = await _loadTokens() ?? tokens;
+    } on FormatException {
+      latestTokens = tokens;
+    }
     final persistedTokens = TokenData(
       accessToken: authResponse.accessToken,
       refreshToken: authResponse.refreshToken,

--- a/bridge/app/lib/src/auth/validate.dart
+++ b/bridge/app/lib/src/auth/validate.dart
@@ -3,20 +3,32 @@ import "dart:convert";
 import "package:http/http.dart" as http;
 import "package:sesori_shared/sesori_shared.dart";
 
-import "token.dart";
+/// Validated (and possibly refreshed) credentials.
+///
+/// Deliberately not a TokenData: validation never knows the bridge id, so
+/// this type cannot be persisted raw — callers merge it with persisted state.
+class TokenValidationResult {
+  final String accessToken;
+  final String refreshToken;
+
+  /// True if the credentials are valid (either original or refreshed);
+  /// false if both access and refresh failed (credentials may be revoked).
+  final bool isValid;
+
+  TokenValidationResult({
+    required this.accessToken,
+    required this.refreshToken,
+    required this.isValid,
+  });
+}
 
 /// Validates an access token and attempts refresh if expired.
 ///
-/// Returns `(TokenData, bool)` where:
-/// - bool is `true` if tokens are valid (either original or refreshed)
-/// - bool is `false` if both access and refresh failed (credentials may be revoked)
-///
 /// Throws on network/parsing errors.
-Future<(TokenData, bool)> validateToken({
+Future<TokenValidationResult> validateToken({
   required String authBackendURL,
   required String accessToken,
   required String refreshToken,
-  required AuthProvider lastProvider,
 }) async {
   // Build /auth/me URL
   final base = authBackendURL.endsWith("/") ? authBackendURL.substring(0, authBackendURL.length - 1) : authBackendURL;
@@ -35,27 +47,19 @@ Future<(TokenData, bool)> validateToken({
 
   // If 200 OK, tokens are valid
   if (meResponse.statusCode == 200) {
-    return (
-      TokenData(
-        accessToken: accessToken,
-        refreshToken: refreshToken,
-        bridgeId: null,
-        lastProvider: lastProvider,
-      ),
-      true,
+    return TokenValidationResult(
+      accessToken: accessToken,
+      refreshToken: refreshToken,
+      isValid: true,
     );
   }
 
-  // If not 401, return false (invalid but no error)
+  // If not 401, return invalid (but no error)
   if (meResponse.statusCode != 401) {
-    return (
-      TokenData(
-        accessToken: accessToken,
-        refreshToken: refreshToken,
-        bridgeId: null,
-        lastProvider: lastProvider,
-      ),
-      false,
+    return TokenValidationResult(
+      accessToken: accessToken,
+      refreshToken: refreshToken,
+      isValid: false,
     );
   }
 
@@ -74,16 +78,12 @@ Future<(TokenData, bool)> validateToken({
     throw Exception("refresh token: $e");
   }
 
-  // If refresh failed, return original tokens with false
+  // If refresh failed, return original tokens as invalid
   if (refreshResponse.statusCode != 200) {
-    return (
-      TokenData(
-        accessToken: accessToken,
-        refreshToken: refreshToken,
-        bridgeId: null,
-        lastProvider: lastProvider,
-      ),
-      false,
+    return TokenValidationResult(
+      accessToken: accessToken,
+      refreshToken: refreshToken,
+      isValid: false,
     );
   }
 
@@ -100,14 +100,10 @@ Future<(TokenData, bool)> validateToken({
     throw Exception("refresh response missing tokens");
   }
 
-  // Return new tokens with true
-  return (
-    TokenData(
-      accessToken: refreshed.accessToken,
-      refreshToken: refreshed.refreshToken,
-      bridgeId: null,
-      lastProvider: lastProvider,
-    ),
-    true,
+  // Return new tokens as valid
+  return TokenValidationResult(
+    accessToken: refreshed.accessToken,
+    refreshToken: refreshed.refreshToken,
+    isValid: true,
   );
 }

--- a/bridge/app/lib/src/auth/validate.dart
+++ b/bridge/app/lib/src/auth/validate.dart
@@ -39,6 +39,7 @@ Future<(TokenData, bool)> validateToken({
       TokenData(
         accessToken: accessToken,
         refreshToken: refreshToken,
+        bridgeId: null,
         lastProvider: lastProvider,
       ),
       true,
@@ -51,6 +52,7 @@ Future<(TokenData, bool)> validateToken({
       TokenData(
         accessToken: accessToken,
         refreshToken: refreshToken,
+        bridgeId: null,
         lastProvider: lastProvider,
       ),
       false,
@@ -78,6 +80,7 @@ Future<(TokenData, bool)> validateToken({
       TokenData(
         accessToken: accessToken,
         refreshToken: refreshToken,
+        bridgeId: null,
         lastProvider: lastProvider,
       ),
       false,
@@ -102,6 +105,7 @@ Future<(TokenData, bool)> validateToken({
     TokenData(
       accessToken: refreshed.accessToken,
       refreshToken: refreshed.refreshToken,
+      bridgeId: null,
       lastProvider: lastProvider,
     ),
     true,

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -8,6 +8,7 @@ import "package:rxdart/rxdart.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../auth/bridge_registration_service.dart";
 import "../auth/token_refresher.dart";
 import "../push/completion_push_listener.dart";
 import "../push/maintenance_push_listener.dart";
@@ -50,6 +51,7 @@ class Orchestrator {
   final CompletionPushListener _completionListener;
   final MaintenancePushListener _maintenanceListener;
   final TokenRefresher _tokenRefresher;
+  final BridgeRegistrationService _bridgeRegistrationService;
   final FailureReporter _failureReporter;
   final PrSyncService _prSyncService;
   final SessionRepository _sessionRepository;
@@ -68,6 +70,7 @@ class Orchestrator {
     required CompletionPushListener completionListener,
     required MaintenancePushListener maintenanceListener,
     required TokenRefresher tokenRefresher,
+    required BridgeRegistrationService bridgeRegistrationService,
     required FailureReporter failureReporter,
     required PrSyncService prSyncService,
     required SessionRepository sessionRepository,
@@ -83,6 +86,7 @@ class Orchestrator {
        _completionListener = completionListener,
        _maintenanceListener = maintenanceListener,
        _tokenRefresher = tokenRefresher,
+       _bridgeRegistrationService = bridgeRegistrationService,
        _failureReporter = failureReporter,
        _sessionRepository = sessionRepository,
        _prSyncService = prSyncService,
@@ -122,6 +126,7 @@ class Orchestrator {
       completionListener: _completionListener,
       maintenanceListener: _maintenanceListener,
       tokenRefresher: _tokenRefresher,
+      bridgeRegistrationService: _bridgeRegistrationService,
       roomKey: roomKey,
       sseManager: sseManager,
       bytesSentController: bytesSentController,
@@ -163,6 +168,7 @@ class OrchestratorSession {
   final CompletionPushListener _completionListener;
   final MaintenancePushListener _maintenanceListener;
   final TokenRefresher _tokenRefresher;
+  final BridgeRegistrationService _bridgeRegistrationService;
   final StreamController<int> _bytesSentController;
   final FailureReporter _failureReporter;
   final PrSyncService _prSyncService;
@@ -180,6 +186,7 @@ class OrchestratorSession {
     required CompletionPushListener completionListener,
     required MaintenancePushListener maintenanceListener,
     required TokenRefresher tokenRefresher,
+    required BridgeRegistrationService bridgeRegistrationService,
     required List<int> roomKey,
     required SSEManager sseManager,
     required StreamController<int> bytesSentController,
@@ -200,6 +207,7 @@ class OrchestratorSession {
        _completionListener = completionListener,
        _maintenanceListener = maintenanceListener,
        _tokenRefresher = tokenRefresher,
+       _bridgeRegistrationService = bridgeRegistrationService,
        _roomKey = roomKey,
        _sseManager = sseManager,
        _bytesSentController = bytesSentController,
@@ -215,12 +223,12 @@ class OrchestratorSession {
          abortSessionHandler: AbortSessionHandler(sessionAbortService: sessionAbortService),
          sessionCreationService: sessionCreationService,
          sessionArchiveService: sessionArchiveService,
-          sendPromptHandler: SendPromptHandler(
-            sessionPromptService: SessionPromptService(
-              sessionRepository: sessionRepository,
-              sseManager: sseManager,
-            ),
-          ),
+         sendPromptHandler: SendPromptHandler(
+           sessionPromptService: SessionPromptService(
+             sessionRepository: sessionRepository,
+             sseManager: sseManager,
+           ),
+         ),
          prSyncService: prSyncService,
          projectRepository: projectRepository,
          providerRepository: ProviderRepository(plugin: plugin),
@@ -251,6 +259,10 @@ class OrchestratorSession {
   Future<void> run() async {
     final kxManager = KeyExchangeManager(_roomKey);
     final activePhones = <int, bool>{};
+
+    Log.d("registering bridge with auth server...");
+    await _bridgeRegistrationService.ensureRegistered();
+    Log.d("bridge registered");
 
     try {
       Log.d("connecting to relay...");
@@ -326,6 +338,11 @@ class OrchestratorSession {
         _sseManager.orphanAll();
         activePhones.clear();
 
+        if (_client.closeCode == RelayCloseCodes.bridgeRevoked) {
+          Log.w("Relay reports this bridge as revoked — re-registering with a fresh bridge id");
+          await _bridgeRegistrationService.handleBridgeRevoked();
+        }
+
         var backoff = const Duration(seconds: 1);
         while (!_cancelled) {
           await Future<void>.delayed(backoff);
@@ -336,6 +353,7 @@ class OrchestratorSession {
           await _refreshAccessToken();
 
           try {
+            await _bridgeRegistrationService.ensureRegistered();
             await _client.reconnect();
           } catch (e) {
             Log.w("Reconnect failed: $e (retrying in $backoff)");

--- a/bridge/app/lib/src/bridge/relay_client.dart
+++ b/bridge/app/lib/src/bridge/relay_client.dart
@@ -7,6 +7,7 @@ import "package:sesori_shared/sesori_shared.dart";
 import "package:web_socket_channel/io.dart";
 
 import "../auth/access_token_provider.dart";
+import "../auth/bridge_id_provider.dart";
 
 const String _bridgeRole = "bridge";
 
@@ -20,6 +21,7 @@ class RelayClientMessage {
 class RelayClient {
   final String _relayURL;
   final AccessTokenProvider _accessTokenProvider;
+  final BridgeIdProvider _bridgeIdProvider;
   final Duration _pingInterval;
   final Duration _connectTimeout;
   IOWebSocketChannel? _channel;
@@ -27,12 +29,18 @@ class RelayClient {
   RelayClient({
     required String relayURL,
     required AccessTokenProvider accessTokenProvider,
+    required BridgeIdProvider bridgeIdProvider,
     Duration pingInterval = const Duration(seconds: 15),
     Duration connectTimeout = const Duration(seconds: 15),
   }) : _relayURL = relayURL,
        _accessTokenProvider = accessTokenProvider,
+       _bridgeIdProvider = bridgeIdProvider,
        _pingInterval = pingInterval,
        _connectTimeout = connectTimeout;
+
+  /// The WebSocket close code of the current connection, available once the
+  /// connection has closed and until [close] or [reconnect] discards it.
+  int? get closeCode => _channel?.closeCode;
 
   Future<void> connect() async {
     final wsURL = _buildWebSocketURL(_relayURL);
@@ -60,6 +68,7 @@ class RelayClient {
       final authMessage = RelayMessage.auth(
         token: token,
         role: _bridgeRole,
+        bridgeId: _bridgeIdProvider.bridgeId,
       );
       channel.sink.add(jsonEncode(authMessage.toJson()));
     }

--- a/bridge/app/lib/src/bridge/runtime/bridge_cli_options.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_cli_options.dart
@@ -30,7 +30,7 @@ class BridgeCliOptions {
     required String defaultAuthUrl,
   }) {
     final authBackendFlag = results["auth-backend"] as String;
-    final authBackendUrl = _resolveAuthBackendUrl(
+    final authBackendUrl = resolveAuthBackendUrl(
       authBackendFlag: authBackendFlag,
       environment: environment,
       defaultAuthUrl: defaultAuthUrl,
@@ -58,7 +58,9 @@ class BridgeCliOptions {
     );
   }
 
-  static String _resolveAuthBackendUrl({
+  /// Resolves the auth backend URL from the CLI flag, the
+  /// `AUTH_BACKEND_URL` environment variable, or the default, in that order.
+  static String resolveAuthBackendUrl({
     required String authBackendFlag,
     required Map<String, String> environment,
     required String defaultAuthUrl,

--- a/bridge/app/lib/src/bridge/runtime/bridge_logout_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_logout_runner.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Log;
+
 import '../../auth/token.dart' as token_store;
 import '../../server/foundation/terminal_prompt_decision.dart';
 import '../../server/repositories/bridge_instance_repository.dart';
@@ -38,15 +40,18 @@ class BridgeLogoutRunner {
     required BridgeInstanceRepository bridgeInstanceRepository,
     required BridgeInstanceService bridgeInstanceService,
     required TerminalPromptRepository terminalPromptRepository,
+    required Future<void> Function() unregisterBridge,
     Future<void> Function() clearTokens = token_store.clearTokens,
   }) : _bridgeInstanceRepository = bridgeInstanceRepository,
        _bridgeInstanceService = bridgeInstanceService,
        _terminalPromptRepository = terminalPromptRepository,
+       _unregisterBridge = unregisterBridge,
        _clearTokens = clearTokens;
 
   final BridgeInstanceRepository _bridgeInstanceRepository;
   final BridgeInstanceService _bridgeInstanceService;
   final TerminalPromptRepository _terminalPromptRepository;
+  final Future<void> Function() _unregisterBridge;
   final Future<void> Function() _clearTokens;
 
   Future<BridgeLogoutResult> logout({required int currentPid}) async {
@@ -74,6 +79,14 @@ class BridgeLogoutRunner {
       }
     }
 
+    // Best-effort: remove this bridge's registration on the auth server while
+    // we still have tokens. Logout must never block or fail because of this.
+    try {
+      await _unregisterBridge();
+    } on Object catch (error) {
+      Log.w('Failed to remove bridge registration on auth server (ignored): $error');
+    }
+
     try {
       await _clearTokens();
     } on FileSystemException catch (error) {
@@ -85,9 +98,7 @@ class BridgeLogoutRunner {
     }
 
     return BridgeLogoutResult(
-      status: runningBridgeCount > 0
-          ? BridgeLogoutStatus.loggedOutWithRunningBridges
-          : BridgeLogoutStatus.loggedOut,
+      status: runningBridgeCount > 0 ? BridgeLogoutStatus.loggedOutWithRunningBridges : BridgeLogoutStatus.loggedOut,
       runningBridgeCount: runningBridgeCount,
     );
   }

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
@@ -7,6 +7,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Bridg
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../../auth/access_token_provider.dart";
+import "../../auth/bridge_registration_service.dart";
 import "../../auth/token_refresher.dart";
 import "../../push/completion_notifier.dart";
 import "../../push/completion_push_listener.dart";
@@ -63,6 +64,7 @@ class BridgeRuntime {
     required http.Client httpClient,
     required AccessTokenProvider accessTokenProvider,
     required TokenRefresher tokenRefresher,
+    required BridgeRegistrationService bridgeRegistrationService,
     required AppDatabase database,
     required ProcessRunner processRunner,
     required FailureReporter failureReporter,
@@ -110,7 +112,11 @@ class BridgeRuntime {
       sessionEventEnrichmentService: sessionEventEnrichmentService,
       session: Orchestrator(
         config: config,
-        client: RelayClient(relayURL: config.relayURL, accessTokenProvider: accessTokenProvider),
+        client: RelayClient(
+          relayURL: config.relayURL,
+          accessTokenProvider: accessTokenProvider,
+          bridgeIdProvider: bridgeRegistrationService,
+        ),
         plugin: plugin,
         metadataService: MetadataService(
           client: httpClient,
@@ -131,6 +137,7 @@ class BridgeRuntime {
           telemetryBuilder: telemetryBuilder,
         ),
         tokenRefresher: tokenRefresher,
+        bridgeRegistrationService: bridgeRegistrationService,
         failureReporter: failureReporter,
         prSyncService: PrSyncService(
           prSource: PrSourceRepository(

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart
@@ -49,16 +49,15 @@ class BridgeRuntimeAuthService {
     try {
       final storedTokens = await loadTokens();
       try {
-        final (validatedTokens, ok) = await validateToken(
+        final validation = await validateToken(
           authBackendURL: options.authBackendUrl,
           accessToken: storedTokens.accessToken,
           refreshToken: storedTokens.refreshToken,
-          lastProvider: storedTokens.lastProvider,
         );
-        if (ok) {
+        if (validation.isValid) {
           final tokensToSave = TokenData(
-            accessToken: validatedTokens.accessToken,
-            refreshToken: validatedTokens.refreshToken,
+            accessToken: validation.accessToken,
+            refreshToken: validation.refreshToken,
             bridgeId: storedTokens.bridgeId,
             lastProvider: storedTokens.lastProvider,
           );

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart
@@ -129,8 +129,14 @@ class BridgeRuntimeAuthService {
     try {
       final existingTokens = await loadTokens();
       existingBridgeId = existingTokens.bridgeId;
-    } on Object {
-      // Token file missing or corrupt — no previous bridge id to carry over.
+    } on FileSystemException catch (error) {
+      if (error.osError?.errorCode != 2) {
+        rethrow;
+      }
+      // Token file missing — no previous bridge id to carry over.
+      existingBridgeId = null;
+    } on FormatException {
+      // Token file corrupt — no previous bridge id to carry over.
       existingBridgeId = null;
     }
 

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart
@@ -119,10 +119,25 @@ class BridgeRuntimeAuthService {
       EmailAuthProvider() => _loginEmailRepository.performEmailLogin(),
     };
 
+    // A fresh login response never carries a bridge id, so carry over the one
+    // persisted by a previous registration. Otherwise an interactive re-login
+    // (e.g. expired refresh token) would wipe it and the next registration
+    // would mint a duplicate bridge entry. Carrying it across an account
+    // switch is safe: registration is idempotent on (userId, bridgeId), and a
+    // bridge id not owned by the new account just gets a fresh mint.
+    String? existingBridgeId;
+    try {
+      final existingTokens = await loadTokens();
+      existingBridgeId = existingTokens.bridgeId;
+    } on Object {
+      // Token file missing or corrupt — no previous bridge id to carry over.
+      existingBridgeId = null;
+    }
+
     final tokensToSave = TokenData(
       accessToken: tokens.accessToken,
       refreshToken: tokens.refreshToken,
-      bridgeId: tokens.bridgeId,
+      bridgeId: tokens.bridgeId ?? existingBridgeId,
       lastProvider: provider,
     );
     await saveTokens(tokensToSave);

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart
@@ -59,7 +59,7 @@ class BridgeRuntimeAuthService {
           final tokensToSave = TokenData(
             accessToken: validatedTokens.accessToken,
             refreshToken: validatedTokens.refreshToken,
-            bridgeToken: storedTokens.bridgeToken,
+            bridgeId: storedTokens.bridgeId,
             lastProvider: storedTokens.lastProvider,
           );
           await saveTokens(tokensToSave);
@@ -122,7 +122,7 @@ class BridgeRuntimeAuthService {
     final tokensToSave = TokenData(
       accessToken: tokens.accessToken,
       refreshToken: tokens.refreshToken,
-      bridgeToken: tokens.bridgeToken,
+      bridgeId: tokens.bridgeId,
       lastProvider: provider,
     );
     await saveTokens(tokensToSave);

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -6,6 +6,9 @@ import "package:path/path.dart" as path;
 import "package:rxdart/rxdart.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginApi, Log;
 
+import "../../auth/bridge_registration_api.dart";
+import "../../auth/bridge_registration_repository.dart";
+import "../../auth/bridge_registration_service.dart";
 import "../../auth/login_email_api.dart";
 import "../../auth/login_email_repository.dart";
 import "../../auth/login_oauth_api.dart";
@@ -230,6 +233,20 @@ class BridgeRuntimeRunner {
       );
       shutdownCoordinator.add(disposable: tokenManager.dispose);
 
+      final bridgeRegistrationService = BridgeRegistrationService(
+        repository: BridgeRegistrationRepository(
+          api: BridgeRegistrationApi(
+            authBackendUrl: options.authBackendUrl,
+            client: httpClient,
+          ),
+        ),
+        tokenRefresher: tokenManager,
+        loadTokens: loadTokens,
+        saveTokens: saveTokens,
+        hostName: io.Platform.localHostname,
+        platform: BridgeRegistrationService.currentPlatformName(),
+      );
+
       final runtime = BridgeRuntime.create(
         config: BridgeConfig(
           relayURL: options.relayUrl,
@@ -245,6 +262,7 @@ class BridgeRuntimeRunner {
         httpClient: httpClient,
         accessTokenProvider: tokenManager,
         tokenRefresher: tokenManager,
+        bridgeRegistrationService: bridgeRegistrationService,
         database: AppDatabase.create(),
         processRunner: processRunner,
         failureReporter: LogFailureReporter(),

--- a/bridge/app/test/auth/bridge_registration_api_test.dart
+++ b/bridge/app/test/auth/bridge_registration_api_test.dart
@@ -75,6 +75,18 @@ void main() {
       expect(request.authorization, equals("Bearer access-token"));
     });
 
+    test("URL-encodes a bridgeId that is not URL-safe (corrupt token file)", () async {
+      final server = await _BridgesTestServer.start(statusCode: 200);
+      addTearDown(server.close);
+
+      final api = _createApi(server);
+      await api.deleteBridge(bridgeId: "br weird/../id?x=1", accessToken: "access-token");
+
+      final request = server.requests.single;
+      expect(request.method, equals("DELETE"));
+      expect(request.path, equals("/auth/bridges/br%20weird%2F..%2Fid%3Fx%3D1"));
+    });
+
     test("throws BridgeRegistrationException with status 404 for unknown bridges", () async {
       final server = await _BridgesTestServer.start(statusCode: 404);
       addTearDown(server.close);

--- a/bridge/app/test/auth/bridge_registration_api_test.dart
+++ b/bridge/app/test/auth/bridge_registration_api_test.dart
@@ -1,0 +1,164 @@
+import "dart:convert";
+import "dart:io";
+
+import "package:http/http.dart" as http;
+import "package:sesori_bridge/src/auth/bridge_registration_api.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("BridgeRegistrationApi.registerBridge", () {
+    test("posts name, platform and bridgeId with bearer token and parses a 200 response", () async {
+      final server = await _BridgesTestServer.start(statusCode: 200);
+      addTearDown(server.close);
+
+      final api = _createApi(server);
+      final summary = await api.registerBridge(
+        name: "dev-laptop",
+        platform: "macos",
+        bridgeId: "br_existing01",
+        accessToken: "access-token",
+      );
+
+      expect(summary.id, equals("br_server001"));
+      expect(summary.name, equals("dev-laptop"));
+      expect(summary.platform, equals("macos"));
+      final request = server.requests.single;
+      expect(request.method, equals("POST"));
+      expect(request.path, equals("/auth/bridges"));
+      expect(request.authorization, equals("Bearer access-token"));
+      expect(
+        jsonDecode(request.body),
+        equals({"name": "dev-laptop", "platform": "macos", "bridgeId": "br_existing01"}),
+      );
+    });
+
+    test("omits bridgeId from the body when null and accepts a 201 response", () async {
+      final server = await _BridgesTestServer.start(statusCode: 201);
+      addTearDown(server.close);
+
+      final api = _createApi(server);
+      final summary = await api.registerBridge(
+        name: "dev-laptop",
+        platform: "linux",
+        bridgeId: null,
+        accessToken: "access-token",
+      );
+
+      expect(summary.id, equals("br_server001"));
+      expect(jsonDecode(server.requests.single.body), equals({"name": "dev-laptop", "platform": "linux"}));
+    });
+
+    test("throws BridgeRegistrationException carrying the status code on failure", () async {
+      final server = await _BridgesTestServer.start(statusCode: 500);
+      addTearDown(server.close);
+
+      final api = _createApi(server);
+
+      await expectLater(
+        api.registerBridge(name: "dev-laptop", platform: "macos", bridgeId: null, accessToken: "access-token"),
+        throwsA(isA<BridgeRegistrationException>().having((e) => e.statusCode, "statusCode", 500)),
+      );
+    });
+  });
+
+  group("BridgeRegistrationApi.deleteBridge", () {
+    test("deletes /auth/bridges/:bridgeId with bearer token", () async {
+      final server = await _BridgesTestServer.start(statusCode: 200);
+      addTearDown(server.close);
+
+      final api = _createApi(server);
+      await api.deleteBridge(bridgeId: "br_existing01", accessToken: "access-token");
+
+      final request = server.requests.single;
+      expect(request.method, equals("DELETE"));
+      expect(request.path, equals("/auth/bridges/br_existing01"));
+      expect(request.authorization, equals("Bearer access-token"));
+    });
+
+    test("throws BridgeRegistrationException with status 404 for unknown bridges", () async {
+      final server = await _BridgesTestServer.start(statusCode: 404);
+      addTearDown(server.close);
+
+      final api = _createApi(server);
+
+      await expectLater(
+        api.deleteBridge(bridgeId: "br_unknown01", accessToken: "access-token"),
+        throwsA(isA<BridgeRegistrationException>().having((e) => e.statusCode, "statusCode", 404)),
+      );
+    });
+  });
+}
+
+BridgeRegistrationApi _createApi(_BridgesTestServer server) {
+  final client = http.Client();
+  addTearDown(client.close);
+  return BridgeRegistrationApi(authBackendUrl: server.baseUrl, client: client);
+}
+
+class _RecordedRequest {
+  final String method;
+  final String path;
+  final String? authorization;
+  final String body;
+
+  const _RecordedRequest({
+    required this.method,
+    required this.path,
+    required this.authorization,
+    required this.body,
+  });
+}
+
+class _BridgesTestServer {
+  final HttpServer _server;
+  final int _statusCode;
+
+  final List<_RecordedRequest> requests = [];
+
+  _BridgesTestServer._(this._server, this._statusCode);
+
+  static Future<_BridgesTestServer> start({required int statusCode}) async {
+    final server = await HttpServer.bind("127.0.0.1", 0);
+    final testServer = _BridgesTestServer._(server, statusCode);
+    server.listen(testServer._handle);
+    return testServer;
+  }
+
+  String get baseUrl => "http://${_server.address.host}:${_server.port}";
+
+  Future<void> close() async {
+    await _server.close(force: true);
+  }
+
+  Future<void> _handle(HttpRequest request) async {
+    final body = await utf8.decoder.bind(request).join();
+    requests.add(
+      _RecordedRequest(
+        method: request.method,
+        path: request.uri.path,
+        authorization: request.headers.value(HttpHeaders.authorizationHeader),
+        body: body,
+      ),
+    );
+
+    request.response.statusCode = _statusCode;
+    request.response.headers.contentType = ContentType.json;
+    if (_statusCode != 200 && _statusCode != 201) {
+      request.response.write(jsonEncode({"error": "request failed"}));
+    } else if (request.method == "DELETE") {
+      request.response.write(jsonEncode({"ok": true}));
+    } else {
+      final requested = jsonDecode(body) as Map<String, dynamic>;
+      request.response.write(
+        jsonEncode({
+          "id": "br_server001",
+          "name": requested["name"],
+          "platform": requested["platform"],
+          "addedAt": "2026-06-01T00:00:00.000Z",
+          "lastSeenAt": null,
+        }),
+      );
+    }
+    await request.response.close();
+  }
+}

--- a/bridge/app/test/auth/bridge_registration_service_test.dart
+++ b/bridge/app/test/auth/bridge_registration_service_test.dart
@@ -1,0 +1,236 @@
+import "package:sesori_bridge/src/auth/bridge_registration_api.dart";
+import "package:sesori_bridge/src/auth/bridge_registration_repository.dart";
+import "package:sesori_bridge/src/auth/bridge_registration_service.dart";
+import "package:sesori_bridge/src/auth/token.dart";
+import "package:sesori_bridge/src/auth/token_refresher.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "../helpers/test_helpers.dart";
+
+void main() {
+  late FakeBridgeRegistrationRepository repository;
+  late InMemoryTokenStore tokenStore;
+  late _RecordingTokenRefresher tokenRefresher;
+  late BridgeRegistrationService service;
+
+  setUp(() {
+    repository = FakeBridgeRegistrationRepository();
+    tokenStore = InMemoryTokenStore(
+      TokenData(accessToken: "access", refreshToken: "refresh", lastProvider: AuthProvider.github),
+    );
+    tokenRefresher = _RecordingTokenRefresher();
+    service = BridgeRegistrationService(
+      repository: repository,
+      tokenRefresher: tokenRefresher,
+      loadTokens: tokenStore.load,
+      saveTokens: tokenStore.save,
+      hostName: "dev-laptop",
+      platform: "macos",
+    );
+  });
+
+  group("BridgeRegistrationService.ensureRegistered", () {
+    test("registers without a bridge id and persists the server-minted id", () async {
+      await service.ensureRegistered();
+
+      expect(repository.registeredBridgeIds, equals([null]));
+      expect(service.bridgeId, equals("br_test1234"));
+      expect(tokenStore.tokens!.bridgeId, equals("br_test1234"));
+      expect(tokenStore.tokens!.accessToken, equals("access"));
+      expect(tokenStore.tokens!.refreshToken, equals("refresh"));
+      expect(tokenStore.tokens!.lastProvider, equals(AuthProvider.github));
+    });
+
+    test("posts the persisted bridge id when one exists", () async {
+      tokenStore.tokens = TokenData(
+        accessToken: "access",
+        refreshToken: "refresh",
+        bridgeId: "br_persisted1",
+        lastProvider: AuthProvider.github,
+      );
+      repository.nextBridgeId = "br_persisted1";
+
+      await service.ensureRegistered();
+
+      expect(repository.registeredBridgeIds, equals(["br_persisted1"]));
+      expect(service.bridgeId, equals("br_persisted1"));
+      expect(tokenStore.tokens!.bridgeId, equals("br_persisted1"));
+    });
+
+    test("is memoized per process — a second call does not re-register", () async {
+      await service.ensureRegistered();
+      await service.ensureRegistered();
+
+      expect(repository.registeredBridgeIds, hasLength(1));
+    });
+
+    test("failure propagates and the next call retries the registration", () async {
+      repository.registerError = BridgeRegistrationException(statusCode: 500, body: "boom");
+
+      await expectLater(service.ensureRegistered(), throwsA(isA<BridgeRegistrationException>()));
+      expect(service.bridgeId, isNull);
+
+      repository.registerError = null;
+      await service.ensureRegistered();
+
+      expect(repository.registeredBridgeIds, hasLength(2));
+      expect(service.bridgeId, equals("br_test1234"));
+    });
+
+    test("retries once with a force-refreshed token on 401", () async {
+      repository.registerError = BridgeRegistrationException(statusCode: 401, body: "expired");
+      tokenRefresher.onForceRefresh = () {
+        repository.registerError = null;
+      };
+
+      await service.ensureRegistered();
+
+      expect(repository.registeredBridgeIds, hasLength(2));
+      expect(tokenRefresher.forceRefreshCalls, equals(1));
+      expect(service.bridgeId, equals("br_test1234"));
+    });
+  });
+
+  group("BridgeRegistrationService.sanitizeBridgeName", () {
+    test("passes a normal hostname through unchanged", () {
+      expect(BridgeRegistrationService.sanitizeBridgeName("Alexs-MacBook"), equals("Alexs-MacBook"));
+    });
+
+    test("truncates names longer than the server's 120-char limit", () {
+      final long = "h" * 200;
+      expect(BridgeRegistrationService.sanitizeBridgeName(long).length, equals(120));
+    });
+
+    test("falls back to a default for empty or whitespace-only names", () {
+      expect(BridgeRegistrationService.sanitizeBridgeName("   "), equals("sesori-bridge"));
+    });
+  });
+
+  group("BridgeRegistrationService.handleBridgeRevoked", () {
+    test("clears the persisted bridge id and re-registers fresh on the next attempt", () async {
+      await service.ensureRegistered();
+      repository.nextBridgeId = "br_fresh5678";
+
+      await service.handleBridgeRevoked();
+
+      expect(service.bridgeId, isNull);
+      expect(tokenStore.tokens!.bridgeId, isNull);
+
+      await service.ensureRegistered();
+
+      expect(repository.registeredBridgeIds, equals([null, null]));
+      expect(service.bridgeId, equals("br_fresh5678"));
+      expect(tokenStore.tokens!.bridgeId, equals("br_fresh5678"));
+    });
+
+    test("still resets the memoization when the token file cannot be updated", () async {
+      await service.ensureRegistered();
+      tokenStore.tokens = null; // Loading now throws FileSystemException.
+
+      await service.handleBridgeRevoked();
+
+      expect(service.bridgeId, isNull);
+    });
+  });
+
+  group("BridgeRegistrationService.unregister", () {
+    test("does nothing when no bridge id is persisted", () async {
+      await service.unregister();
+
+      expect(repository.unregisteredBridgeIds, isEmpty);
+    });
+
+    test("deletes the persisted bridge id on the auth server", () async {
+      tokenStore.tokens = TokenData(
+        accessToken: "access",
+        refreshToken: "refresh",
+        bridgeId: "br_persisted1",
+        lastProvider: AuthProvider.github,
+      );
+
+      await service.unregister();
+
+      expect(repository.unregisteredBridgeIds, equals(["br_persisted1"]));
+    });
+
+    test("treats a 404 (already revoked) as success", () async {
+      tokenStore.tokens = TokenData(
+        accessToken: "access",
+        refreshToken: "refresh",
+        bridgeId: "br_persisted1",
+        lastProvider: AuthProvider.github,
+      );
+      final failingRepository = _UnregisterFailingRepository(statusCode: 404);
+      final failingService = BridgeRegistrationService(
+        repository: failingRepository,
+        tokenRefresher: tokenRefresher,
+        loadTokens: tokenStore.load,
+        saveTokens: tokenStore.save,
+        hostName: "dev-laptop",
+        platform: "macos",
+      );
+
+      await failingService.unregister();
+    });
+
+    test("rethrows non-404 failures", () async {
+      tokenStore.tokens = TokenData(
+        accessToken: "access",
+        refreshToken: "refresh",
+        bridgeId: "br_persisted1",
+        lastProvider: AuthProvider.github,
+      );
+      final failingRepository = _UnregisterFailingRepository(statusCode: 500);
+      final failingService = BridgeRegistrationService(
+        repository: failingRepository,
+        tokenRefresher: tokenRefresher,
+        loadTokens: tokenStore.load,
+        saveTokens: tokenStore.save,
+        hostName: "dev-laptop",
+        platform: "macos",
+      );
+
+      await expectLater(
+        failingService.unregister(),
+        throwsA(isA<BridgeRegistrationException>().having((e) => e.statusCode, "statusCode", 500)),
+      );
+    });
+  });
+}
+
+class _RecordingTokenRefresher implements TokenRefresher {
+  int forceRefreshCalls = 0;
+  void Function()? onForceRefresh;
+
+  @override
+  Future<String> getAccessToken({bool forceRefresh = false}) async {
+    if (forceRefresh) {
+      forceRefreshCalls += 1;
+      onForceRefresh?.call();
+      return "refreshed-token";
+    }
+    return "access-token";
+  }
+}
+
+class _UnregisterFailingRepository implements BridgeRegistrationRepository {
+  final int statusCode;
+
+  _UnregisterFailingRepository({required this.statusCode});
+
+  @override
+  Future<BridgeSummary> register({
+    required String name,
+    required String platform,
+    required String? bridgeId,
+    required String accessToken,
+  }) {
+    throw UnimplementedError("not used by unregister tests");
+  }
+
+  @override
+  Future<void> unregister({required String bridgeId, required String accessToken}) async {
+    throw BridgeRegistrationException(statusCode: statusCode, body: "unregister failed");
+  }
+}

--- a/bridge/app/test/auth/bridge_registration_service_test.dart
+++ b/bridge/app/test/auth/bridge_registration_service_test.dart
@@ -58,24 +58,25 @@ void main() {
       expect(tokenStore.tokens!.bridgeId, equals("br_persisted1"));
     });
 
-    test("reads the token file only once when persisting the server-minted id", () async {
-      var loadCount = 0;
-      final countingService = BridgeRegistrationService(
-        repository: repository,
-        tokenRefresher: tokenRefresher,
-        loadTokens: () {
-          loadCount += 1;
-          return tokenStore.load();
-        },
-        saveTokens: tokenStore.save,
-        hostName: "dev-laptop",
-        platform: "macos",
-      );
+    test("does not clobber tokens rotated and persisted mid-registration (401-retry path)", () async {
+      // TokenManager persists a rotated access/refresh pair to the token file
+      // when it force-refreshes; persisting the bridge id afterwards must keep
+      // those rotated credentials, not a snapshot from before the refresh.
+      repository.registerError = BridgeRegistrationException(statusCode: 401, body: "expired");
+      tokenRefresher.onForceRefresh = () {
+        repository.registerError = null;
+        tokenStore.tokens = TokenData(
+          accessToken: "rotated-access",
+          refreshToken: "rotated-refresh",
+          lastProvider: AuthProvider.github,
+        );
+      };
 
-      await countingService.ensureRegistered();
+      await service.ensureRegistered();
 
-      expect(loadCount, equals(1));
       expect(tokenStore.tokens!.bridgeId, equals("br_test1234"));
+      expect(tokenStore.tokens!.accessToken, equals("rotated-access"));
+      expect(tokenStore.tokens!.refreshToken, equals("rotated-refresh"));
     });
 
     test("is memoized per process — a second call does not re-register", () async {

--- a/bridge/app/test/auth/bridge_registration_service_test.dart
+++ b/bridge/app/test/auth/bridge_registration_service_test.dart
@@ -17,7 +17,7 @@ void main() {
   setUp(() {
     repository = FakeBridgeRegistrationRepository();
     tokenStore = InMemoryTokenStore(
-      TokenData(accessToken: "access", refreshToken: "refresh", lastProvider: AuthProvider.github),
+      TokenData(accessToken: "access", refreshToken: "refresh", bridgeId: null, lastProvider: AuthProvider.github),
     );
     tokenRefresher = _RecordingTokenRefresher();
     service = BridgeRegistrationService(
@@ -68,6 +68,7 @@ void main() {
         tokenStore.tokens = TokenData(
           accessToken: "rotated-access",
           refreshToken: "rotated-refresh",
+          bridgeId: null,
           lastProvider: AuthProvider.github,
         );
       };

--- a/bridge/app/test/auth/bridge_registration_service_test.dart
+++ b/bridge/app/test/auth/bridge_registration_service_test.dart
@@ -58,6 +58,26 @@ void main() {
       expect(tokenStore.tokens!.bridgeId, equals("br_persisted1"));
     });
 
+    test("reads the token file only once when persisting the server-minted id", () async {
+      var loadCount = 0;
+      final countingService = BridgeRegistrationService(
+        repository: repository,
+        tokenRefresher: tokenRefresher,
+        loadTokens: () {
+          loadCount += 1;
+          return tokenStore.load();
+        },
+        saveTokens: tokenStore.save,
+        hostName: "dev-laptop",
+        platform: "macos",
+      );
+
+      await countingService.ensureRegistered();
+
+      expect(loadCount, equals(1));
+      expect(tokenStore.tokens!.bridgeId, equals("br_test1234"));
+    });
+
     test("is memoized per process — a second call does not re-register", () async {
       await service.ensureRegistered();
       await service.ensureRegistered();

--- a/bridge/app/test/auth/profile_test.dart
+++ b/bridge/app/test/auth/profile_test.dart
@@ -30,6 +30,7 @@ void main() {
                 'providerUserId': '1',
                 'providerUsername': 'testuser',
               },
+              'bridges': <Object>[],
             }),
           );
         } else {
@@ -54,6 +55,7 @@ void main() {
                 'providerUserId': '1',
                 'providerUsername': null,
               },
+              'bridges': <Object>[],
             }),
           );
         } else {

--- a/bridge/app/test/auth/token_manager_test.dart
+++ b/bridge/app/test/auth/token_manager_test.dart
@@ -19,7 +19,8 @@ void main() {
       final manager = TokenManager(
         initialToken: currentToken,
         authBackendUrl: server.baseUrl,
-        loadTokens: () async => TokenData(accessToken: "a", refreshToken: "r", lastProvider: AuthProvider.github),
+        loadTokens: () async =>
+            TokenData(accessToken: "a", refreshToken: "r", bridgeId: null, lastProvider: AuthProvider.github),
         saveTokens: (_) async {},
       );
 
@@ -48,7 +49,12 @@ void main() {
         authBackendUrl: server.baseUrl,
         loadTokens: () async {
           await Future<void>.delayed(const Duration(milliseconds: 120));
-          return TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github);
+          return TokenData(
+            accessToken: "old-access",
+            refreshToken: "refresh-token",
+            bridgeId: null,
+            lastProvider: AuthProvider.github,
+          );
         },
         saveTokens: (_) async {
           if (!refreshCompleted.isCompleted) {
@@ -76,8 +82,12 @@ void main() {
       final manager = TokenManager(
         initialToken: _makeJwtFromNow(10),
         authBackendUrl: server.baseUrl,
-        loadTokens: () async =>
-            TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
+        loadTokens: () async => TokenData(
+          accessToken: "old-access",
+          refreshToken: "refresh-token",
+          bridgeId: null,
+          lastProvider: AuthProvider.github,
+        ),
         saveTokens: (_) async {},
       );
 
@@ -94,8 +104,12 @@ void main() {
       final manager = TokenManager(
         initialToken: _makeJwtFromNow(300),
         authBackendUrl: server.baseUrl,
-        loadTokens: () async =>
-            TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
+        loadTokens: () async => TokenData(
+          accessToken: "old-access",
+          refreshToken: "refresh-token",
+          bridgeId: null,
+          lastProvider: AuthProvider.github,
+        ),
         saveTokens: (_) async {},
       );
 
@@ -112,8 +126,12 @@ void main() {
       final manager = TokenManager(
         initialToken: _makeJwtFromNow(300),
         authBackendUrl: server.baseUrl,
-        loadTokens: () async =>
-            TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
+        loadTokens: () async => TokenData(
+          accessToken: "old-access",
+          refreshToken: "refresh-token",
+          bridgeId: null,
+          lastProvider: AuthProvider.github,
+        ),
         saveTokens: (_) async {},
       );
 
@@ -169,6 +187,7 @@ void main() {
       var stored = TokenData(
         accessToken: "old-access",
         refreshToken: "refresh-token",
+        bridgeId: null,
         lastProvider: AuthProvider.github,
       );
       final manager = TokenManager(
@@ -247,7 +266,12 @@ void main() {
           if (loadCalls > 1) {
             throw const FileSystemException("token file deleted", "token.json", OSError("No such file", 2));
           }
-          return TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github);
+          return TokenData(
+            accessToken: "old-access",
+            refreshToken: "refresh-token",
+            bridgeId: null,
+            lastProvider: AuthProvider.github,
+          );
         },
         saveTokens: (tokens) async {
           savedTokens = tokens;
@@ -265,8 +289,12 @@ void main() {
       final manager = TokenManager(
         initialToken: _makeJwtFromNow(10),
         authBackendUrl: server.baseUrl,
-        loadTokens: () async =>
-            TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
+        loadTokens: () async => TokenData(
+          accessToken: "old-access",
+          refreshToken: "refresh-token",
+          bridgeId: null,
+          lastProvider: AuthProvider.github,
+        ),
         saveTokens: (_) async {},
       );
 
@@ -282,8 +310,12 @@ void main() {
       final manager = TokenManager(
         initialToken: _makeJwtFromNow(10),
         authBackendUrl: server.baseUrl,
-        loadTokens: () async =>
-            TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
+        loadTokens: () async => TokenData(
+          accessToken: "old-access",
+          refreshToken: "refresh-token",
+          bridgeId: null,
+          lastProvider: AuthProvider.github,
+        ),
         saveTokens: (_) async {},
       );
 
@@ -294,8 +326,12 @@ void main() {
       final manager = TokenManager(
         initialToken: _makeJwtFromNow(10),
         authBackendUrl: "http://127.0.0.1:1",
-        loadTokens: () async =>
-            TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
+        loadTokens: () async => TokenData(
+          accessToken: "old-access",
+          refreshToken: "refresh-token",
+          bridgeId: null,
+          lastProvider: AuthProvider.github,
+        ),
         saveTokens: (_) async {},
         client: _ThrowingClient(),
       );
@@ -325,7 +361,7 @@ void main() {
         initialToken: _makeJwtFromNow(10),
         authBackendUrl: server.baseUrl,
         loadTokens: () async =>
-            TokenData(accessToken: "old-access", refreshToken: "", lastProvider: AuthProvider.github),
+            TokenData(accessToken: "old-access", refreshToken: "", bridgeId: null, lastProvider: AuthProvider.github),
         saveTokens: (_) async {},
       );
 
@@ -340,8 +376,12 @@ void main() {
       final manager = TokenManager(
         initialToken: malformedJwt,
         authBackendUrl: server.baseUrl,
-        loadTokens: () async =>
-            TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
+        loadTokens: () async => TokenData(
+          accessToken: "old-access",
+          refreshToken: "refresh-token",
+          bridgeId: null,
+          lastProvider: AuthProvider.github,
+        ),
         saveTokens: (_) async {},
       );
 

--- a/bridge/app/test/auth/token_manager_test.dart
+++ b/bridge/app/test/auth/token_manager_test.dart
@@ -198,6 +198,66 @@ void main() {
       expect(stored.refreshToken, "new-refresh-token");
     });
 
+    test("refresh repairs a corrupt token file by persisting the snapshot's merge fields", () async {
+      final server = await _RefreshTestServer.start();
+      addTearDown(server.close);
+
+      var loadCalls = 0;
+      TokenData? savedTokens;
+      final manager = TokenManager(
+        initialToken: _makeJwtFromNow(10),
+        authBackendUrl: server.baseUrl,
+        loadTokens: () async {
+          loadCalls += 1;
+          if (loadCalls > 1) {
+            throw const FormatException("corrupt token file");
+          }
+          return TokenData(
+            accessToken: "old-access",
+            refreshToken: "refresh-token",
+            bridgeId: "br_abc12345",
+            lastProvider: AuthProvider.github,
+          );
+        },
+        saveTokens: (tokens) async {
+          savedTokens = tokens;
+        },
+      );
+
+      final token = await manager.getAccessToken();
+
+      expect(token, "new-access-token");
+      expect(savedTokens, isNotNull);
+      expect(savedTokens!.accessToken, "new-access-token");
+      expect(savedTokens!.refreshToken, "new-refresh-token");
+      expect(savedTokens!.bridgeId, "br_abc12345");
+    });
+
+    test("refresh does not recreate a token file deleted mid-refresh", () async {
+      final server = await _RefreshTestServer.start();
+      addTearDown(server.close);
+
+      var loadCalls = 0;
+      TokenData? savedTokens;
+      final manager = TokenManager(
+        initialToken: _makeJwtFromNow(10),
+        authBackendUrl: server.baseUrl,
+        loadTokens: () async {
+          loadCalls += 1;
+          if (loadCalls > 1) {
+            throw const FileSystemException("token file deleted", "token.json", OSError("No such file", 2));
+          }
+          return TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github);
+        },
+        saveTokens: (tokens) async {
+          savedTokens = tokens;
+        },
+      );
+
+      await expectLater(manager.getAccessToken(), throwsA(isA<FileSystemException>()));
+      expect(savedTokens, isNull);
+    });
+
     test("successful refresh updates current access token", () async {
       final server = await _RefreshTestServer.start();
       addTearDown(server.close);

--- a/bridge/app/test/auth/token_manager_test.dart
+++ b/bridge/app/test/auth/token_manager_test.dart
@@ -76,7 +76,8 @@ void main() {
       final manager = TokenManager(
         initialToken: _makeJwtFromNow(10),
         authBackendUrl: server.baseUrl,
-        loadTokens: () async => TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
+        loadTokens: () async =>
+            TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
         saveTokens: (_) async {},
       );
 
@@ -93,7 +94,8 @@ void main() {
       final manager = TokenManager(
         initialToken: _makeJwtFromNow(300),
         authBackendUrl: server.baseUrl,
-        loadTokens: () async => TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
+        loadTokens: () async =>
+            TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
         saveTokens: (_) async {},
       );
 
@@ -110,7 +112,8 @@ void main() {
       final manager = TokenManager(
         initialToken: _makeJwtFromNow(300),
         authBackendUrl: server.baseUrl,
-        loadTokens: () async => TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
+        loadTokens: () async =>
+            TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
         saveTokens: (_) async {},
       );
 
@@ -124,7 +127,7 @@ void main() {
       expect(server.requestCount, 1);
     });
 
-    test("successful refresh persists new tokens while preserving bridgeToken", () async {
+    test("successful refresh persists new tokens while preserving bridgeId", () async {
       final server = await _RefreshTestServer.start();
       addTearDown(server.close);
 
@@ -135,7 +138,7 @@ void main() {
         loadTokens: () async => TokenData(
           accessToken: "old-access",
           refreshToken: "refresh-token",
-          bridgeToken: "bridge-token-value",
+          bridgeId: "br_abc12345",
           lastProvider: AuthProvider.github,
         ),
         saveTokens: (tokens) async {
@@ -148,7 +151,7 @@ void main() {
       expect(savedTokens, isNotNull);
       expect(savedTokens!.accessToken, "new-access-token");
       expect(savedTokens!.refreshToken, "new-refresh-token");
-      expect(savedTokens!.bridgeToken, "bridge-token-value");
+      expect(savedTokens!.bridgeId, "br_abc12345");
     });
 
     test("successful refresh updates current access token", () async {
@@ -158,7 +161,8 @@ void main() {
       final manager = TokenManager(
         initialToken: _makeJwtFromNow(10),
         authBackendUrl: server.baseUrl,
-        loadTokens: () async => TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
+        loadTokens: () async =>
+            TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
         saveTokens: (_) async {},
       );
 
@@ -174,7 +178,8 @@ void main() {
       final manager = TokenManager(
         initialToken: _makeJwtFromNow(10),
         authBackendUrl: server.baseUrl,
-        loadTokens: () async => TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
+        loadTokens: () async =>
+            TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
         saveTokens: (_) async {},
       );
 
@@ -185,7 +190,8 @@ void main() {
       final manager = TokenManager(
         initialToken: _makeJwtFromNow(10),
         authBackendUrl: "http://127.0.0.1:1",
-        loadTokens: () async => TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
+        loadTokens: () async =>
+            TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
         saveTokens: (_) async {},
         client: _ThrowingClient(),
       );
@@ -214,7 +220,8 @@ void main() {
       final manager = TokenManager(
         initialToken: _makeJwtFromNow(10),
         authBackendUrl: server.baseUrl,
-        loadTokens: () async => TokenData(accessToken: "old-access", refreshToken: "", lastProvider: AuthProvider.github),
+        loadTokens: () async =>
+            TokenData(accessToken: "old-access", refreshToken: "", lastProvider: AuthProvider.github),
         saveTokens: (_) async {},
       );
 
@@ -229,7 +236,8 @@ void main() {
       final manager = TokenManager(
         initialToken: malformedJwt,
         authBackendUrl: server.baseUrl,
-        loadTokens: () async => TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
+        loadTokens: () async =>
+            TokenData(accessToken: "old-access", refreshToken: "refresh-token", lastProvider: AuthProvider.github),
         saveTokens: (_) async {},
       );
 

--- a/bridge/app/test/auth/token_manager_test.dart
+++ b/bridge/app/test/auth/token_manager_test.dart
@@ -154,6 +154,50 @@ void main() {
       expect(savedTokens!.bridgeId, "br_abc12345");
     });
 
+    test("refresh keeps a bridgeId persisted while the refresh was in flight", () async {
+      final requestReceived = Completer<void>();
+      final server = await _RefreshTestServer.start(
+        responseDelay: const Duration(milliseconds: 60),
+        onRequest: (_, __) {
+          if (!requestReceived.isCompleted) {
+            requestReceived.complete();
+          }
+        },
+      );
+      addTearDown(server.close);
+
+      var stored = TokenData(
+        accessToken: "old-access",
+        refreshToken: "refresh-token",
+        lastProvider: AuthProvider.github,
+      );
+      final manager = TokenManager(
+        initialToken: _makeJwtFromNow(300),
+        authBackendUrl: server.baseUrl,
+        loadTokens: () async => stored,
+        saveTokens: (tokens) async {
+          stored = tokens;
+        },
+      );
+
+      final refreshFuture = manager.getAccessToken(forceRefresh: true);
+      // The refresh has loaded its pre-registration snapshot and is awaiting
+      // the HTTP response; registration now persists a freshly minted id.
+      await requestReceived.future.timeout(const Duration(seconds: 2));
+      stored = TokenData(
+        accessToken: stored.accessToken,
+        refreshToken: stored.refreshToken,
+        bridgeId: "br_minted123",
+        lastProvider: stored.lastProvider,
+      );
+
+      await refreshFuture;
+
+      expect(stored.bridgeId, "br_minted123");
+      expect(stored.accessToken, "new-access-token");
+      expect(stored.refreshToken, "new-refresh-token");
+    });
+
     test("successful refresh updates current access token", () async {
       final server = await _RefreshTestServer.start();
       addTearDown(server.close);

--- a/bridge/app/test/auth/token_test.dart
+++ b/bridge/app/test/auth/token_test.dart
@@ -24,6 +24,7 @@ void main() {
       final data = TokenData(
         accessToken: "access-token",
         refreshToken: "refresh-token",
+        bridgeId: null,
         lastProvider: AuthProvider.github,
       );
 

--- a/bridge/app/test/auth/token_test.dart
+++ b/bridge/app/test/auth/token_test.dart
@@ -8,7 +8,7 @@ void main() {
       final original = TokenData(
         accessToken: "access-token",
         refreshToken: "refresh-token",
-        bridgeToken: "bridge-token",
+        bridgeId: "br_abc12345",
         lastProvider: AuthProvider.github,
       );
 
@@ -16,11 +16,11 @@ void main() {
 
       expect(restored.accessToken, equals(original.accessToken));
       expect(restored.refreshToken, equals(original.refreshToken));
-      expect(restored.bridgeToken, equals(original.bridgeToken));
+      expect(restored.bridgeId, equals(original.bridgeId));
       expect(restored.lastProvider, equals(original.lastProvider));
     });
 
-    test("toJson omits bridgeToken when it is null", () {
+    test("toJson omits bridgeId when it is null", () {
       final data = TokenData(
         accessToken: "access-token",
         refreshToken: "refresh-token",
@@ -29,11 +29,11 @@ void main() {
 
       final json = data.toJson();
 
-      expect(json.containsKey("bridgeToken"), isFalse);
+      expect(json.containsKey("bridgeId"), isFalse);
       expect(json["lastProvider"], equals("github"));
     });
 
-    test("fromJson sets bridgeToken to null when missing", () {
+    test("fromJson sets bridgeId to null when missing", () {
       final restored = TokenData.fromJson(<String, dynamic>{
         "accessToken": "access-token",
         "refreshToken": "refresh-token",
@@ -42,8 +42,23 @@ void main() {
 
       expect(restored.accessToken, equals("access-token"));
       expect(restored.refreshToken, equals("refresh-token"));
-      expect(restored.bridgeToken, isNull);
+      expect(restored.bridgeId, isNull);
       expect(restored.lastProvider, equals(AuthProvider.google));
+    });
+
+    test("fromJson ignores the legacy bridgeToken key from old token files", () {
+      final restored = TokenData.fromJson(<String, dynamic>{
+        "accessToken": "access-token",
+        "refreshToken": "refresh-token",
+        "bridgeToken": "legacy-bridge-token",
+        "lastProvider": "github",
+      });
+
+      expect(restored.accessToken, equals("access-token"));
+      expect(restored.refreshToken, equals("refresh-token"));
+      expect(restored.bridgeId, isNull);
+      expect(restored.lastProvider, equals(AuthProvider.github));
+      expect(restored.toJson().containsKey("bridgeToken"), isFalse);
     });
 
     test("fromJson throws when lastProvider is missing", () {

--- a/bridge/app/test/auth/validate_test.dart
+++ b/bridge/app/test/auth/validate_test.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:sesori_bridge/src/auth/validate.dart';
-import 'package:sesori_shared/sesori_shared.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -35,17 +34,15 @@ void main() {
         ),
       ]);
 
-      final (tokens, valid) = await validateToken(
+      final result = await validateToken(
         authBackendURL: baseUrl,
         accessToken: 'valid-token',
         refreshToken: 'refresh-token',
-        lastProvider: AuthProvider.github,
       );
 
-      expect(valid, isTrue);
-      expect(tokens.accessToken, equals('valid-token'));
-      expect(tokens.refreshToken, equals('refresh-token'));
-      expect(tokens.lastProvider, equals(AuthProvider.github));
+      expect(result.isValid, isTrue);
+      expect(result.accessToken, equals('valid-token'));
+      expect(result.refreshToken, equals('refresh-token'));
     });
 
     test('returns false when /auth/me returns 403', () async {
@@ -57,15 +54,14 @@ void main() {
         ),
       ]);
 
-      final (tokens, valid) = await validateToken(
+      final result = await validateToken(
         authBackendURL: baseUrl,
         accessToken: 'valid-token',
         refreshToken: 'refresh-token',
-        lastProvider: AuthProvider.github,
       );
 
-      expect(valid, isFalse);
-      expect(tokens.accessToken, equals('valid-token'));
+      expect(result.isValid, isFalse);
+      expect(result.accessToken, equals('valid-token'));
     });
 
     test('refreshes token on 401 and returns new tokens', () async {
@@ -91,16 +87,15 @@ void main() {
         ),
       ]);
 
-      final (tokens, valid) = await validateToken(
+      final result = await validateToken(
         authBackendURL: baseUrl,
         accessToken: 'expired-token',
         refreshToken: 'refresh-token',
-        lastProvider: AuthProvider.github,
       );
 
-      expect(valid, isTrue);
-      expect(tokens.accessToken, equals('new-access-token'));
-      expect(tokens.refreshToken, equals('new-refresh-token'));
+      expect(result.isValid, isTrue);
+      expect(result.accessToken, equals('new-access-token'));
+      expect(result.refreshToken, equals('new-refresh-token'));
     });
 
     test('returns false when refresh fails', () async {
@@ -117,15 +112,14 @@ void main() {
         ),
       ]);
 
-      final (tokens, valid) = await validateToken(
+      final result = await validateToken(
         authBackendURL: baseUrl,
         accessToken: 'expired-token',
         refreshToken: 'invalid-refresh',
-        lastProvider: AuthProvider.github,
       );
 
-      expect(valid, isFalse);
-      expect(tokens.accessToken, equals('expired-token'));
+      expect(result.isValid, isFalse);
+      expect(result.accessToken, equals('expired-token'));
     });
 
     test('throws on network error', () async {
@@ -136,7 +130,6 @@ void main() {
           authBackendURL: 'http://127.0.0.1:1',
           accessToken: 'token',
           refreshToken: 'refresh',
-          lastProvider: AuthProvider.github,
         ),
         throwsA(isA<Exception>()),
       );

--- a/bridge/app/test/bridge/client_test.dart
+++ b/bridge/app/test/bridge/client_test.dart
@@ -3,6 +3,7 @@ import "dart:io";
 import "dart:typed_data";
 
 import "package:sesori_bridge/src/bridge/relay_client.dart";
+import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
 import "../helpers/test_helpers.dart";
@@ -47,12 +48,87 @@ void main() {
       final client = RelayClient(
         relayURL: "ws://localhost:9999",
         accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
       );
 
       expect(
         () => client.send(0, "hello".codeUnits),
         throwsA(isA<StateError>()),
       );
+    });
+  });
+
+  group("RelayClient auth message", () {
+    test("includes bridgeId when the provider has one", () async {
+      final server = await TestRelayServer.start();
+      addTearDown(server.close);
+
+      final client = RelayClient(
+        relayURL: "ws://127.0.0.1:${server.port}",
+        accessTokenProvider: FakeAccessTokenProvider("jwt-token"),
+        bridgeIdProvider: FakeBridgeIdProvider("br_abc12345"),
+      );
+      await client.connect();
+      addTearDown(client.close);
+
+      final serverWs = await server.nextClient();
+      final authJson = await _firstTextFrame(serverWs);
+
+      expect(
+        authJson,
+        equals({
+          "type": "auth",
+          "token": "jwt-token",
+          "role": "bridge",
+          "bridgeId": "br_abc12345",
+        }),
+      );
+    });
+
+    test("omits bridgeId when the provider has none", () async {
+      final server = await TestRelayServer.start();
+      addTearDown(server.close);
+
+      final client = RelayClient(
+        relayURL: "ws://127.0.0.1:${server.port}",
+        accessTokenProvider: FakeAccessTokenProvider("jwt-token"),
+        bridgeIdProvider: FakeBridgeIdProvider(),
+      );
+      await client.connect();
+      addTearDown(client.close);
+
+      final serverWs = await server.nextClient();
+      final authJson = await _firstTextFrame(serverWs);
+
+      expect(
+        authJson,
+        equals({"type": "auth", "token": "jwt-token", "role": "bridge"}),
+      );
+    });
+  });
+
+  group("RelayClient close code", () {
+    test("exposes the server's close code after the stream ends", () async {
+      final server = await TestRelayServer.start();
+      addTearDown(server.close);
+
+      final client = RelayClient(
+        relayURL: "ws://127.0.0.1:${server.port}",
+        accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
+      );
+      await client.connect();
+      addTearDown(client.close);
+
+      final serverWs = await server.nextClient();
+      expect(client.closeCode, isNull);
+
+      final streamDone = Completer<void>();
+      client.read().listen((_) {}, onDone: streamDone.complete);
+      await serverWs.close(RelayCloseCodes.bridgeRevoked);
+      await streamDone.future.timeout(const Duration(seconds: 5));
+
+      expect(client.closeCode, equals(RelayCloseCodes.bridgeRevoked));
     });
   });
 
@@ -64,6 +140,7 @@ void main() {
       final client = RelayClient(
         relayURL: "ws://127.0.0.1:${server.port}",
         accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
       );
       await client.connect();
       addTearDown(client.close);
@@ -103,6 +180,7 @@ void main() {
       final client = RelayClient(
         relayURL: "ws://127.0.0.1:${server.port}",
         accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
       );
       await client.connect();
       addTearDown(client.close);
@@ -146,6 +224,7 @@ void main() {
       final client = RelayClient(
         relayURL: "ws://127.0.0.1:${server.port}",
         accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
       );
       await client.connect();
       addTearDown(client.close);
@@ -187,6 +266,7 @@ void main() {
       final client = RelayClient(
         relayURL: "ws://127.0.0.1:${server.port}",
         accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
       );
       await client.connect();
       addTearDown(client.close);
@@ -241,10 +321,16 @@ void main() {
       final client = RelayClient(
         relayURL: "ws://127.0.0.1:${rawServer.port}",
         accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
         connectTimeout: const Duration(milliseconds: 500),
       );
 
       await expectLater(client.connect(), throwsA(isA<TimeoutException>()));
     });
   });
+}
+
+Future<Map<String, dynamic>> _firstTextFrame(WebSocket socket) async {
+  final message = await socket.firstWhere((dynamic data) => data is String).timeout(const Duration(seconds: 5));
+  return jsonDecodeMap(message as String);
 }

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -35,6 +35,7 @@ _DebugServerHarness _createDebugServerHarness({
     httpClient: httpClient,
     accessTokenProvider: FakeAccessTokenProvider(),
     tokenRefresher: _FakeTokenRefresher(),
+    bridgeRegistrationService: createFakeBridgeRegistrationService(),
     database: db,
     processRunner: ProcessRunner(),
     failureReporter: FakeFailureReporter(),

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -82,6 +82,7 @@ void main() {
     final relayClient = RelayClient(
       relayURL: "ws://127.0.0.1:${relayServer.port}",
       accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
     );
     final sessionEventEnrichmentService = SessionEventEnrichmentService(
       sessionRepository: sessionRepository,
@@ -103,6 +104,7 @@ void main() {
       completionListener: pushSubsystem.completionListener,
       maintenanceListener: pushSubsystem.maintenanceListener,
       tokenRefresher: _FakeTokenRefresher(),
+      bridgeRegistrationService: createFakeBridgeRegistrationService(),
       failureReporter: FakeFailureReporter(),
       prSyncService: fakePrSyncService,
       sessionRepository: sessionRepository,
@@ -189,6 +191,7 @@ void main() {
     final relayClient = RelayClient(
       relayURL: "ws://127.0.0.1:${relayServer.port}",
       accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
     );
     final sessionEventEnrichmentService = SessionEventEnrichmentService(
       sessionRepository: sessionRepository,
@@ -228,6 +231,7 @@ void main() {
       completionListener: pushListeners.completionListener,
       maintenanceListener: pushListeners.maintenanceListener,
       tokenRefresher: _FakeTokenRefresher(),
+      bridgeRegistrationService: createFakeBridgeRegistrationService(),
       failureReporter: FakeFailureReporter(),
       prSyncService: fakePrSyncService,
       sessionRepository: sessionRepository,
@@ -329,6 +333,7 @@ void main() {
     final relayClient = RelayClient(
       relayURL: "ws://127.0.0.1:${relayServer.port}",
       accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
     );
 
     await database.projectsDao.insertProjectsIfMissing(projectIds: ["p1"]);
@@ -381,6 +386,7 @@ void main() {
       completionListener: pushListeners.completionListener,
       maintenanceListener: pushListeners.maintenanceListener,
       tokenRefresher: _FakeTokenRefresher(),
+      bridgeRegistrationService: createFakeBridgeRegistrationService(),
       failureReporter: FakeFailureReporter(),
       prSyncService: _FakePrSyncService(),
       sessionRepository: sessionRepository,
@@ -484,6 +490,7 @@ void main() {
     final relayClient = RelayClient(
       relayURL: "ws://127.0.0.1:${relayServer.port}",
       accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
     );
     final sessionEventEnrichmentService = SessionEventEnrichmentService(
       sessionRepository: sessionRepository,
@@ -505,6 +512,7 @@ void main() {
       completionListener: pushListeners.completionListener,
       maintenanceListener: pushListeners.maintenanceListener,
       tokenRefresher: _FakeTokenRefresher(),
+      bridgeRegistrationService: createFakeBridgeRegistrationService(),
       failureReporter: FakeFailureReporter(),
       prSyncService: _FakePrSyncService(),
       sessionRepository: sessionRepository,
@@ -579,6 +587,7 @@ void main() {
     final relayClient = RelayClient(
       relayURL: "ws://127.0.0.1:${relayServer.port}",
       accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
     );
     final sessionEventEnrichmentService = SessionEventEnrichmentService(
       sessionRepository: sessionRepository,
@@ -600,6 +609,7 @@ void main() {
       completionListener: pushSubsystem.completionListener,
       maintenanceListener: pushSubsystem.maintenanceListener,
       tokenRefresher: _FakeTokenRefresher(),
+      bridgeRegistrationService: createFakeBridgeRegistrationService(),
       failureReporter: FakeFailureReporter(),
       prSyncService: _FakePrSyncService(),
       sessionRepository: sessionRepository,
@@ -699,6 +709,7 @@ void main() {
     final relayClient = RelayClient(
       relayURL: "ws://127.0.0.1:${relayServer.port}",
       accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
     );
     final sessionEventEnrichmentService = SessionEventEnrichmentService(
       sessionRepository: sessionRepository,
@@ -720,6 +731,7 @@ void main() {
       completionListener: pushSubsystem.completionListener,
       maintenanceListener: pushSubsystem.maintenanceListener,
       tokenRefresher: _FakeTokenRefresher(),
+      bridgeRegistrationService: createFakeBridgeRegistrationService(),
       failureReporter: FakeFailureReporter(),
       prSyncService: _FakePrSyncService(),
       sessionRepository: sessionRepository,

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -66,6 +66,7 @@ void main() {
         completionListener: pushSubsystem.completionListener,
         maintenanceListener: pushSubsystem.maintenanceListener,
         tokenRefresher: _FakeTokenRefresher(),
+        bridgeRegistrationService: createFakeBridgeRegistrationService(),
         failureReporter: FakeFailureReporter(),
         prSyncService: PrSyncService(
           prSource: _NoopPrSource(),
@@ -191,6 +192,7 @@ class _TestHarness {
     final relayClient = RelayClient(
       relayURL: "ws://127.0.0.1:${relayServer.port}",
       accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
     );
 
     final metadataService = FakeMetadataService();
@@ -255,6 +257,7 @@ class _TestHarness {
       completionListener: pushSubsystem.completionListener,
       maintenanceListener: pushSubsystem.maintenanceListener,
       tokenRefresher: tokenRefresher,
+      bridgeRegistrationService: createFakeBridgeRegistrationService(),
       failureReporter: failureReporter,
       prSyncService: prSyncService,
       sessionRepository: sessionRepository,
@@ -536,6 +539,7 @@ class _ThrowingConnectRelayClient extends RelayClient {
     : super(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
       );
 
   @override

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -1,0 +1,352 @@
+import "dart:async";
+import "dart:io";
+
+import "package:http/http.dart" as http;
+import "package:sesori_bridge/src/auth/bridge_registration_api.dart";
+import "package:sesori_bridge/src/auth/bridge_registration_service.dart";
+import "package:sesori_bridge/src/auth/token.dart";
+import "package:sesori_bridge/src/bridge/api/git_cli_api.dart";
+import "package:sesori_bridge/src/bridge/models/bridge_config.dart";
+import "package:sesori_bridge/src/bridge/orchestrator.dart";
+import "package:sesori_bridge/src/bridge/persistence/database.dart";
+import "package:sesori_bridge/src/bridge/relay_client.dart";
+import "package:sesori_bridge/src/bridge/repositories/permission_repository.dart";
+import "package:sesori_bridge/src/bridge/repositories/project_repository.dart";
+import "package:sesori_bridge/src/bridge/repositories/pull_request_repository.dart";
+import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
+import "package:sesori_bridge/src/bridge/repositories/worktree_repository.dart";
+import "package:sesori_bridge/src/bridge/services/session_event_enrichment_service.dart";
+import "package:sesori_bridge/src/bridge/services/session_persistence_service.dart";
+import "package:sesori_bridge/src/bridge/services/worktree_service.dart";
+import "package:sesori_bridge/src/push/completion_notifier.dart";
+import "package:sesori_bridge/src/push/completion_push_listener.dart";
+import "package:sesori_bridge/src/push/maintenance_push_listener.dart";
+import "package:sesori_bridge/src/push/push_dispatcher.dart";
+import "package:sesori_bridge/src/push/push_maintenance_telemetry.dart";
+import "package:sesori_bridge/src/push/push_notification_client.dart";
+import "package:sesori_bridge/src/push/push_notification_content_builder.dart";
+import "package:sesori_bridge/src/push/push_rate_limiter.dart";
+import "package:sesori_bridge/src/push/push_session_state_tracker.dart";
+import "package:sesori_shared/sesori_shared.dart" hide PermissionReply;
+import "package:test/test.dart";
+
+import "../helpers/test_database.dart";
+import "../helpers/test_helpers.dart";
+import "api/git_remote_api_test.dart";
+import "routing/routing_test_helpers.dart";
+
+void main() {
+  group("OrchestratorSession bridge registration", () {
+    test("startup registration failure fails the run without connecting to the relay", () async {
+      final repository = FakeBridgeRegistrationRepository()
+        ..registerError = BridgeRegistrationException(statusCode: 500, body: "boom");
+      final harness = await _RegistrationHarness.start(repository: repository);
+      addTearDown(harness.close);
+
+      await expectLater(harness.runFuture, throwsA(isA<BridgeRegistrationException>()));
+
+      expect(repository.registeredBridgeIds, equals([null]));
+      expect(harness.relayServer.connectedClientCount, equals(0));
+    });
+
+    test("registers before the initial connect and sends the bridge id in the auth message", () async {
+      final repository = FakeBridgeRegistrationRepository()..nextBridgeId = "br_first001";
+      final harness = await _RegistrationHarness.start(repository: repository);
+      addTearDown(harness.close);
+
+      final bridgeSocket = await harness.relayServer.nextClient();
+      final authMessage = await _firstTextMessage(bridgeSocket);
+
+      expect(repository.registeredBridgeIds, equals([null]));
+      expect(harness.tokenStore.tokens!.bridgeId, equals("br_first001"));
+      expect(authMessage["type"], equals("auth"));
+      expect(authMessage["role"], equals("bridge"));
+      expect(authMessage["bridgeId"], equals("br_first001"));
+    });
+
+    test("normal disconnect reconnects without re-registering", () async {
+      final repository = FakeBridgeRegistrationRepository()..nextBridgeId = "br_first001";
+      final harness = await _RegistrationHarness.start(repository: repository);
+      addTearDown(harness.close);
+
+      final firstSocket = await harness.relayServer.nextClient();
+      await _firstTextMessage(firstSocket);
+      await firstSocket.close();
+
+      final secondSocket = await harness.relayServer.nextClient();
+      final authMessage = await _firstTextMessage(secondSocket);
+
+      expect(repository.registeredBridgeIds, equals([null]), reason: "registration is memoized per process");
+      expect(authMessage["bridgeId"], equals("br_first001"));
+    });
+
+    test("close code 4006 clears the bridge id and re-registers fresh", () async {
+      final repository = FakeBridgeRegistrationRepository()..nextBridgeId = "br_first001";
+      final harness = await _RegistrationHarness.start(repository: repository);
+      addTearDown(harness.close);
+
+      final firstSocket = await harness.relayServer.nextClient();
+      await _firstTextMessage(firstSocket);
+
+      repository.nextBridgeId = "br_second002";
+      await firstSocket.close(RelayCloseCodes.bridgeRevoked);
+
+      final secondSocket = await harness.relayServer.nextClient();
+      final authMessage = await _firstTextMessage(secondSocket);
+
+      expect(
+        repository.registeredBridgeIds,
+        equals([null, null]),
+        reason: "the revoked bridge id must not be re-posted",
+      );
+      expect(harness.tokenStore.tokens!.bridgeId, equals("br_second002"));
+      expect(authMessage["bridgeId"], equals("br_second002"));
+    });
+
+    test("registration failure after 4006 retries the connect attempt on the existing backoff", () async {
+      final repository = FakeBridgeRegistrationRepository()..nextBridgeId = "br_first001";
+      final harness = await _RegistrationHarness.start(repository: repository);
+      addTearDown(harness.close);
+
+      final firstSocket = await harness.relayServer.nextClient();
+      await _firstTextMessage(firstSocket);
+
+      repository
+        ..nextBridgeId = "br_second002"
+        ..registerError = BridgeRegistrationException(statusCode: 500, body: "boom");
+      await firstSocket.close(RelayCloseCodes.bridgeRevoked);
+
+      // First reconnect attempt fails on registration without touching the relay.
+      await _waitFor(
+        () => repository.registeredBridgeIds.length >= 2,
+        reason: "first re-registration attempt",
+      );
+      expect(harness.relayServer.connectedClientCount, equals(1));
+
+      // Once registration succeeds the next backoff attempt reconnects.
+      repository.registerError = null;
+      final secondSocket = await harness.relayServer.nextClient(timeout: const Duration(seconds: 10));
+      final authMessage = await _firstTextMessage(secondSocket);
+
+      expect(repository.registeredBridgeIds.length, greaterThanOrEqualTo(3));
+      expect(authMessage["bridgeId"], equals("br_second002"));
+    });
+  });
+}
+
+Future<Map<String, dynamic>> _firstTextMessage(WebSocket socket) async {
+  final message = await socket.firstWhere((dynamic data) => data is String).timeout(const Duration(seconds: 5));
+  return jsonDecodeMap(message as String);
+}
+
+Future<void> _waitFor(bool Function() condition, {required String reason}) async {
+  final timeoutAt = DateTime.now().add(const Duration(seconds: 10));
+  while (!condition()) {
+    if (DateTime.now().isAfter(timeoutAt)) {
+      fail("Timed out waiting for: $reason");
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  }
+}
+
+class _RegistrationHarness {
+  final FakeBridgePlugin plugin;
+  final InMemoryTokenStore tokenStore;
+  final OrchestratorSession session;
+  final Future<void> runFuture;
+  final _CountingRelayServer relayServer;
+  final AppDatabase database;
+
+  _RegistrationHarness._({
+    required this.plugin,
+    required this.tokenStore,
+    required this.session,
+    required this.runFuture,
+    required this.relayServer,
+    required this.database,
+  });
+
+  static Future<_RegistrationHarness> start({
+    required FakeBridgeRegistrationRepository repository,
+  }) async {
+    final relayServer = await _CountingRelayServer.start();
+    final database = createTestDatabase();
+    final plugin = FakeBridgePlugin();
+    final tokenStore = InMemoryTokenStore(
+      TokenData(accessToken: "access", refreshToken: "refresh", lastProvider: AuthProvider.github),
+    );
+    final registrationService = BridgeRegistrationService(
+      repository: repository,
+      tokenRefresher: FakeTokenRefresher(),
+      loadTokens: tokenStore.load,
+      saveTokens: tokenStore.save,
+      hostName: "test-host",
+      platform: "macos",
+    );
+
+    final pullRequestRepository = PullRequestRepository(
+      pullRequestDao: database.pullRequestDao,
+      projectsDao: database.projectsDao,
+    );
+    final sessionRepository = SessionRepository(
+      plugin: plugin,
+      sessionDao: database.sessionDao,
+      pullRequestRepository: pullRequestRepository,
+    );
+    final pushSubsystem = _createPushSubsystem();
+
+    final orchestrator = Orchestrator(
+      config: BridgeConfig(
+        relayURL: "ws://127.0.0.1:${relayServer.port}",
+        serverURL: "http://127.0.0.1:4096",
+        serverPassword: null,
+        authBackendURL: "http://127.0.0.1:8080",
+        sseReplayWindow: const Duration(minutes: 1),
+      ),
+      client: RelayClient(
+        relayURL: "ws://127.0.0.1:${relayServer.port}",
+        accessTokenProvider: FakeAccessTokenProvider(),
+        bridgeIdProvider: registrationService,
+      ),
+      plugin: plugin,
+      metadataService: FakeMetadataService(),
+      pushDispatcher: pushSubsystem.dispatcher,
+      completionListener: pushSubsystem.completionListener,
+      maintenanceListener: pushSubsystem.maintenanceListener,
+      tokenRefresher: FakeTokenRefresher(),
+      bridgeRegistrationService: registrationService,
+      failureReporter: FakeFailureReporter(),
+      prSyncService: FakePrSyncService(),
+      sessionRepository: sessionRepository,
+      projectRepository: ProjectRepository(plugin: plugin, projectsDao: database.projectsDao),
+      permissionRepository: PermissionRepository(plugin: plugin),
+      sessionPersistenceService: SessionPersistenceService(
+        projectsDao: database.projectsDao,
+        sessionDao: database.sessionDao,
+        db: database,
+      ),
+      worktreeService: WorktreeService(
+        worktreeRepository: WorktreeRepository(
+          projectsDao: database.projectsDao,
+          sessionDao: database.sessionDao,
+          gitApi: GitCliApi(
+            processRunner: FakeProcessRunner((
+              String executable,
+              List<String> arguments, {
+              Map<String, String>? environment,
+              String? workingDirectory,
+              Duration timeout = const Duration(seconds: 15),
+            }) async {
+              return ProcessResult(0, 127, "", "command not found");
+            }),
+            gitPathExists: ({required String gitPath}) => true,
+          ),
+          plugin: plugin,
+        ),
+      ),
+      sessionEventEnrichmentService: SessionEventEnrichmentService(
+        sessionRepository: sessionRepository,
+        failureReporter: FakeFailureReporter(),
+      ),
+    );
+
+    final session = orchestrator.create();
+    // Surface run() failures through [runFuture] without triggering an
+    // unhandled async error when a test only awaits it via expectLater later.
+    final runFuture = session.run();
+    unawaited(runFuture.catchError((_) {}));
+
+    return _RegistrationHarness._(
+      plugin: plugin,
+      tokenStore: tokenStore,
+      session: session,
+      runFuture: runFuture,
+      relayServer: relayServer,
+      database: database,
+    );
+  }
+
+  Future<void> close() async {
+    await session.cancel();
+    try {
+      await runFuture.timeout(const Duration(seconds: 10));
+    } on Object {
+      // run() may have already completed with the error under test.
+    }
+    await database.close();
+    await relayServer.close();
+  }
+}
+
+/// A [TestRelayServer] that also counts how many clients ever connected.
+class _CountingRelayServer {
+  final TestRelayServer _inner;
+  int connectedClientCount = 0;
+
+  _CountingRelayServer._(this._inner);
+
+  static Future<_CountingRelayServer> start() async {
+    return _CountingRelayServer._(await TestRelayServer.start());
+  }
+
+  int get port => _inner.port;
+
+  Future<WebSocket> nextClient({Duration timeout = const Duration(seconds: 5)}) async {
+    final socket = await _inner.nextClient().timeout(timeout);
+    connectedClientCount += 1;
+    return socket;
+  }
+
+  Future<void> close() => _inner.close();
+}
+
+typedef _TestPushSubsystem = ({
+  PushDispatcher dispatcher,
+  CompletionPushListener completionListener,
+  MaintenancePushListener maintenanceListener,
+});
+
+_TestPushSubsystem _createPushSubsystem() {
+  final tracker = PushSessionStateTracker(now: DateTime.now);
+  final completionNotifier = CompletionNotifier(tracker: tracker);
+  final rateLimiter = PushRateLimiter();
+  final telemetryBuilder = PushMaintenanceTelemetryBuilder(
+    completionNotifier: completionNotifier,
+    rateLimiter: rateLimiter,
+    rssBytesReader: () => null,
+  );
+  final dispatcher = PushDispatcher(
+    client: _NoopPushNotificationClient(),
+    rateLimiter: rateLimiter,
+    tracker: tracker,
+    contentBuilder: const PushNotificationContentBuilder(),
+  );
+  return (
+    dispatcher: dispatcher,
+    completionListener: CompletionPushListener(
+      tracker: tracker,
+      completionNotifier: completionNotifier,
+      contentBuilder: const PushNotificationContentBuilder(),
+      dispatcher: dispatcher,
+    ),
+    maintenanceListener: MaintenancePushListener(
+      tracker: tracker,
+      completionNotifier: completionNotifier,
+      rateLimiter: rateLimiter,
+      telemetryBuilder: telemetryBuilder,
+      maintenanceInterval: const Duration(minutes: 10),
+    ),
+  );
+}
+
+class _NoopPushNotificationClient extends PushNotificationClient {
+  _NoopPushNotificationClient()
+    : super(
+        authBackendURL: "http://127.0.0.1:8080",
+        tokenRefreshManager: FakeTokenRefresher(),
+        client: http.Client(),
+      );
+
+  @override
+  Future<void> sendNotification(SendNotificationPayload payload) async {}
+}

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -173,7 +173,7 @@ class _RegistrationHarness {
     final database = createTestDatabase();
     final plugin = FakeBridgePlugin();
     final tokenStore = InMemoryTokenStore(
-      TokenData(accessToken: "access", refreshToken: "refresh", lastProvider: AuthProvider.github),
+      TokenData(accessToken: "access", refreshToken: "refresh", bridgeId: null, lastProvider: AuthProvider.github),
     );
     final registrationService = BridgeRegistrationService(
       repository: repository,

--- a/bridge/app/test/bridge/runtime/bridge_logout_runner_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_logout_runner_test.dart
@@ -14,7 +14,10 @@ void main() {
     late _FakeBridgeInstanceRepository bridgeInstanceRepository;
     late _FakeBridgeInstanceService bridgeInstanceService;
     late _FakeTerminalPromptRepository terminalPromptRepository;
+    late int unregisterBridgeCalls;
+    late Object? unregisterBridgeError;
     late int clearTokensCalls;
+    late int clearTokensCallsAtLastUnregister;
     late Object? clearTokensError;
     late BridgeLogoutRunner service;
 
@@ -22,12 +25,22 @@ void main() {
       bridgeInstanceRepository = _FakeBridgeInstanceRepository();
       bridgeInstanceService = _FakeBridgeInstanceService();
       terminalPromptRepository = _FakeTerminalPromptRepository();
+      unregisterBridgeCalls = 0;
+      unregisterBridgeError = null;
       clearTokensCalls = 0;
+      clearTokensCallsAtLastUnregister = -1;
       clearTokensError = null;
       service = BridgeLogoutRunner(
         bridgeInstanceRepository: bridgeInstanceRepository,
         bridgeInstanceService: bridgeInstanceService,
         terminalPromptRepository: terminalPromptRepository,
+        unregisterBridge: () async {
+          unregisterBridgeCalls += 1;
+          clearTokensCallsAtLastUnregister = clearTokensCalls;
+          if (unregisterBridgeError != null) {
+            throw unregisterBridgeError!;
+          }
+        },
         clearTokens: () async {
           clearTokensCalls += 1;
           if (clearTokensError != null) {
@@ -110,6 +123,36 @@ void main() {
 
       expect(result.status, equals(BridgeLogoutStatus.failed));
       expect(result.error, equals(clearTokensError));
+    });
+
+    test('unregisters the bridge before clearing tokens', () async {
+      final result = await service.logout(currentPid: 100);
+
+      expect(result.status, equals(BridgeLogoutStatus.loggedOut));
+      expect(unregisterBridgeCalls, equals(1));
+      expect(clearTokensCallsAtLastUnregister, equals(0));
+      expect(clearTokensCalls, equals(1));
+    });
+
+    test('still clears tokens when unregistering the bridge fails', () async {
+      unregisterBridgeError = Exception('auth server unreachable');
+
+      final result = await service.logout(currentPid: 100);
+
+      expect(result.status, equals(BridgeLogoutStatus.loggedOut));
+      expect(unregisterBridgeCalls, equals(1));
+      expect(clearTokensCalls, equals(1));
+    });
+
+    test('does not unregister the bridge when logout is declined', () async {
+      bridgeInstanceRepository.liveBridges = <ProcessIdentity>[_candidate(pid: 200)];
+      terminalPromptRepository.decision = TerminalPromptDecision.decline;
+
+      final result = await service.logout(currentPid: 100);
+
+      expect(result.status, equals(BridgeLogoutStatus.cancelled));
+      expect(unregisterBridgeCalls, equals(0));
+      expect(clearTokensCalls, equals(0));
     });
   });
 }

--- a/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
@@ -52,6 +52,7 @@ void main() {
       httpClient: httpClient,
       accessTokenProvider: FakeAccessTokenProvider(),
       tokenRefresher: _FakeTokenRefresher(),
+      bridgeRegistrationService: createFakeBridgeRegistrationService(),
       database: database,
       processRunner: ProcessRunner(),
       failureReporter: FakeFailureReporter(),

--- a/bridge/app/test/bridge/sse_manager_test.dart
+++ b/bridge/app/test/bridge/sse_manager_test.dart
@@ -21,6 +21,7 @@ void main() {
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
       );
 
       manager.subscribePath(1, "/global/event", relayClient);
@@ -113,6 +114,7 @@ void main() {
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
       );
       addTearDown(manager.stop);
 
@@ -133,6 +135,7 @@ void main() {
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
       );
       addTearDown(manager.stop);
 
@@ -286,6 +289,7 @@ void main() {
       final relayClient = RelayClient(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
       );
 
       manager.subscribePath(1, "/global/event", relayClient);
@@ -372,6 +376,7 @@ class _RecordingRelayClient extends RelayClient {
     : super(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
       );
 
   @override
@@ -386,6 +391,7 @@ class _ThrowingRelayClient extends RelayClient {
     : super(
         relayURL: "ws://127.0.0.1:1",
         accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
       );
 
   @override

--- a/bridge/app/test/helpers/test_helpers.dart
+++ b/bridge/app/test/helpers/test_helpers.dart
@@ -5,6 +5,11 @@ import "dart:math";
 
 import "package:rxdart/rxdart.dart";
 import "package:sesori_bridge/src/auth/access_token_provider.dart";
+import "package:sesori_bridge/src/auth/bridge_id_provider.dart";
+import "package:sesori_bridge/src/auth/bridge_registration_repository.dart";
+import "package:sesori_bridge/src/auth/bridge_registration_service.dart";
+import "package:sesori_bridge/src/auth/token.dart";
+import "package:sesori_bridge/src/auth/token_refresher.dart";
 import "package:sesori_bridge/src/bridge/relay_client.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
@@ -18,6 +23,101 @@ class FakeAccessTokenProvider implements AccessTokenProvider {
 
   @override
   ValueStream<String> get tokenStream => _subject.stream;
+}
+
+class FakeBridgeIdProvider implements BridgeIdProvider {
+  String? id;
+
+  FakeBridgeIdProvider([this.id]);
+
+  @override
+  String? get bridgeId => id;
+}
+
+class FakeTokenRefresher implements TokenRefresher {
+  @override
+  Future<String> getAccessToken({bool forceRefresh = false}) async => "test-token";
+}
+
+/// In-memory token file substitute for [BridgeRegistrationService] tests.
+class InMemoryTokenStore {
+  TokenData? tokens;
+
+  InMemoryTokenStore([this.tokens]);
+
+  Future<TokenData> load() async {
+    final stored = tokens;
+    if (stored == null) {
+      throw const FileSystemException("no tokens stored");
+    }
+    return stored;
+  }
+
+  Future<void> save(TokenData data) async {
+    tokens = data;
+  }
+}
+
+/// A [BridgeRegistrationRepository] fake that records calls and returns
+/// configurable results without touching the network.
+class FakeBridgeRegistrationRepository implements BridgeRegistrationRepository {
+  /// The bridge ids that [register] was called with, in order.
+  final List<String?> registeredBridgeIds = [];
+
+  /// The bridge ids that [unregister] was called with, in order.
+  final List<String> unregisteredBridgeIds = [];
+
+  /// When non-null, [register] throws this error instead of succeeding.
+  Object? registerError;
+
+  /// The id returned from successful [register] calls.
+  String nextBridgeId = "br_test1234";
+
+  @override
+  Future<BridgeSummary> register({
+    required String name,
+    required String platform,
+    required String? bridgeId,
+    required String accessToken,
+  }) async {
+    registeredBridgeIds.add(bridgeId);
+    if (registerError != null) {
+      throw registerError!;
+    }
+    return BridgeSummary(
+      id: nextBridgeId,
+      name: name,
+      platform: platform,
+      addedAt: DateTime.utc(2026, 6, 1),
+      lastSeenAt: null,
+    );
+  }
+
+  @override
+  Future<void> unregister({required String bridgeId, required String accessToken}) async {
+    unregisteredBridgeIds.add(bridgeId);
+  }
+}
+
+/// Builds a [BridgeRegistrationService] backed by in-memory fakes, suitable
+/// for orchestrator and runtime tests.
+BridgeRegistrationService createFakeBridgeRegistrationService({
+  BridgeRegistrationRepository? repository,
+  InMemoryTokenStore? tokenStore,
+}) {
+  final store =
+      tokenStore ??
+      InMemoryTokenStore(
+        TokenData(accessToken: "access", refreshToken: "refresh", lastProvider: AuthProvider.github),
+      );
+  return BridgeRegistrationService(
+    repository: repository ?? FakeBridgeRegistrationRepository(),
+    tokenRefresher: FakeTokenRefresher(),
+    loadTokens: store.load,
+    saveTokens: store.save,
+    hostName: "test-host",
+    platform: "macos",
+  );
 }
 
 class FakeFailureReporter implements FailureReporter {
@@ -94,6 +194,7 @@ Future<RelayClient> connectTestRelayClient(HttpServer server) async {
   final client = RelayClient(
     relayURL: "ws://127.0.0.1:${server.port}",
     accessTokenProvider: FakeAccessTokenProvider(),
+    bridgeIdProvider: FakeBridgeIdProvider(),
   );
   await client.connect();
   return client;

--- a/bridge/app/test/helpers/test_helpers.dart
+++ b/bridge/app/test/helpers/test_helpers.dart
@@ -108,7 +108,7 @@ BridgeRegistrationService createFakeBridgeRegistrationService({
   final store =
       tokenStore ??
       InMemoryTokenStore(
-        TokenData(accessToken: "access", refreshToken: "refresh", lastProvider: AuthProvider.github),
+        TokenData(accessToken: "access", refreshToken: "refresh", bridgeId: null, lastProvider: AuthProvider.github),
       );
   return BridgeRegistrationService(
     repository: repository ?? FakeBridgeRegistrationRepository(),

--- a/mobile/app/test/capabilities/relay/protocol/relay_messages_test.dart
+++ b/mobile/app/test/capabilities/relay/protocol/relay_messages_test.dart
@@ -91,7 +91,7 @@ void main() {
     });
 
     test("auth message serialization includes type, token, and role fields", () {
-      const msg = RelayMessage.auth(token: "jwt_bearer_token", role: "phone");
+      const msg = RelayMessage.auth(token: "jwt_bearer_token", role: "phone", bridgeId: null);
       final json = msg.toJson();
 
       expect(json["type"], equals("auth"));

--- a/mobile/module_auth/test/auth_manager_test.dart
+++ b/mobile/module_auth/test/auth_manager_test.dart
@@ -21,7 +21,9 @@ void main() {
   setUpAll(() {
     registerFallbackValue(Uri.parse("https://example.com"));
     registerFallbackValue(AuthProvider.github);
-    registerFallbackValue(const AuthUser(id: "", provider: AuthProvider.github, providerUserId: "", providerUsername: null));
+    registerFallbackValue(
+      const AuthUser(id: "", provider: AuthProvider.github, providerUserId: "", providerUsername: null),
+    );
   });
 
   late MockHttpClient mockHttpClient;
@@ -625,6 +627,7 @@ void main() {
               "providerUserId": user.providerUserId,
               "providerUsername": user.providerUsername,
             },
+            "bridges": <Object>[],
           }),
           200,
         ),
@@ -912,6 +915,7 @@ void main() {
               "providerUserId": user.providerUserId,
               "providerUsername": user.providerUsername,
             },
+            "bridges": <Object>[],
           }),
           200,
         ),
@@ -942,6 +946,7 @@ void main() {
               "providerUserId": user.providerUserId,
               "providerUsername": user.providerUsername,
             },
+            "bridges": <Object>[],
           }),
           200,
         ),

--- a/mobile/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/mobile/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -103,7 +103,9 @@ class RelayClient {
       // is provided by WSS (TLS). The relay cannot read E2EE application data.
       final token = authToken;
       if (token != null && token.isNotEmpty) {
-        final authMessage = RelayMessage.auth(token: token, role: RelayProtocol.rolePhone);
+        // Phones never register as bridges, so the bridgeId is always null
+        // for role "phone".
+        final authMessage = RelayMessage.auth(token: token, role: RelayProtocol.rolePhone, bridgeId: null);
         channel.sink.add(jsonEncode(authMessage.toJson()));
         logd("Relay auth message sent");
       }

--- a/shared/sesori_shared/lib/sesori_shared.dart
+++ b/shared/sesori_shared/lib/sesori_shared.dart
@@ -17,6 +17,7 @@ export "src/models/auth/auth_provider.dart";
 export "src/models/auth/auth_response.dart";
 export "src/models/auth/auth_url_response.dart";
 export "src/models/auth/auth_user.dart";
+export "src/models/auth/bridge_summary.dart";
 export "src/models/auth/logout_response.dart";
 export "src/models/auth/session_status_response.dart";
 export "src/models/sesori/active_session.dart";

--- a/shared/sesori_shared/lib/sesori_shared.dart
+++ b/shared/sesori_shared/lib/sesori_shared.dart
@@ -19,6 +19,7 @@ export "src/models/auth/auth_url_response.dart";
 export "src/models/auth/auth_user.dart";
 export "src/models/auth/bridge_summary.dart";
 export "src/models/auth/logout_response.dart";
+export "src/models/auth/register_bridge_request.dart";
 export "src/models/auth/session_status_response.dart";
 export "src/models/sesori/active_session.dart";
 export "src/models/sesori/agent_info.dart";

--- a/shared/sesori_shared/lib/src/models/auth/auth_me_response.dart
+++ b/shared/sesori_shared/lib/src/models/auth/auth_me_response.dart
@@ -10,7 +10,7 @@ part "auth_me_response.g.dart";
 sealed class AuthMeResponse with _$AuthMeResponse {
   const factory AuthMeResponse({
     required AuthUser user,
-    @Default(<BridgeSummary>[]) List<BridgeSummary> bridges,
+    required List<BridgeSummary> bridges,
   }) = _AuthMeResponse;
 
   factory AuthMeResponse.fromJson(Map<String, dynamic> json) => _$AuthMeResponseFromJson(json);

--- a/shared/sesori_shared/lib/src/models/auth/auth_me_response.dart
+++ b/shared/sesori_shared/lib/src/models/auth/auth_me_response.dart
@@ -1,6 +1,7 @@
 import "package:freezed_annotation/freezed_annotation.dart";
 
 import "auth_user.dart";
+import "bridge_summary.dart";
 
 part "auth_me_response.freezed.dart";
 part "auth_me_response.g.dart";
@@ -9,6 +10,7 @@ part "auth_me_response.g.dart";
 sealed class AuthMeResponse with _$AuthMeResponse {
   const factory AuthMeResponse({
     required AuthUser user,
+    @Default(<BridgeSummary>[]) List<BridgeSummary> bridges,
   }) = _AuthMeResponse;
 
   factory AuthMeResponse.fromJson(Map<String, dynamic> json) => _$AuthMeResponseFromJson(json);

--- a/shared/sesori_shared/lib/src/models/auth/auth_me_response.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/auth/auth_me_response.freezed.dart
@@ -88,12 +88,12 @@ $AuthUserCopyWith<$Res> get user {
 @JsonSerializable(createToJson: false)
 
 class _AuthMeResponse implements AuthMeResponse {
-  const _AuthMeResponse({required this.user, final  List<BridgeSummary> bridges = const <BridgeSummary>[]}): _bridges = bridges;
+  const _AuthMeResponse({required this.user, required final  List<BridgeSummary> bridges}): _bridges = bridges;
   factory _AuthMeResponse.fromJson(Map<String, dynamic> json) => _$AuthMeResponseFromJson(json);
 
 @override final  AuthUser user;
  final  List<BridgeSummary> _bridges;
-@override@JsonKey() List<BridgeSummary> get bridges {
+@override List<BridgeSummary> get bridges {
   if (_bridges is EqualUnmodifiableListView) return _bridges;
   // ignore: implicit_dynamic_type
   return EqualUnmodifiableListView(_bridges);

--- a/shared/sesori_shared/lib/src/models/auth/auth_me_response.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/auth/auth_me_response.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$AuthMeResponse {
 
- AuthUser get user;
+ AuthUser get user; List<BridgeSummary> get bridges;
 /// Create a copy of AuthMeResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $AuthMeResponseCopyWith<AuthMeResponse> get copyWith => _$AuthMeResponseCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AuthMeResponse&&(identical(other.user, user) || other.user == user));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AuthMeResponse&&(identical(other.user, user) || other.user == user)&&const DeepCollectionEquality().equals(other.bridges, bridges));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,user);
+int get hashCode => Object.hash(runtimeType,user,const DeepCollectionEquality().hash(bridges));
 
 @override
 String toString() {
-  return 'AuthMeResponse(user: $user)';
+  return 'AuthMeResponse(user: $user, bridges: $bridges)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $AuthMeResponseCopyWith<$Res>  {
   factory $AuthMeResponseCopyWith(AuthMeResponse value, $Res Function(AuthMeResponse) _then) = _$AuthMeResponseCopyWithImpl;
 @useResult
 $Res call({
- AuthUser user
+ AuthUser user, List<BridgeSummary> bridges
 });
 
 
@@ -63,10 +63,11 @@ class _$AuthMeResponseCopyWithImpl<$Res>
 
 /// Create a copy of AuthMeResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? user = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? user = null,Object? bridges = null,}) {
   return _then(_self.copyWith(
 user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
-as AuthUser,
+as AuthUser,bridges: null == bridges ? _self.bridges : bridges // ignore: cast_nullable_to_non_nullable
+as List<BridgeSummary>,
   ));
 }
 /// Create a copy of AuthMeResponse
@@ -87,10 +88,17 @@ $AuthUserCopyWith<$Res> get user {
 @JsonSerializable(createToJson: false)
 
 class _AuthMeResponse implements AuthMeResponse {
-  const _AuthMeResponse({required this.user});
+  const _AuthMeResponse({required this.user, final  List<BridgeSummary> bridges = const <BridgeSummary>[]}): _bridges = bridges;
   factory _AuthMeResponse.fromJson(Map<String, dynamic> json) => _$AuthMeResponseFromJson(json);
 
 @override final  AuthUser user;
+ final  List<BridgeSummary> _bridges;
+@override@JsonKey() List<BridgeSummary> get bridges {
+  if (_bridges is EqualUnmodifiableListView) return _bridges;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_bridges);
+}
+
 
 /// Create a copy of AuthMeResponse
 /// with the given fields replaced by the non-null parameter values.
@@ -102,16 +110,16 @@ _$AuthMeResponseCopyWith<_AuthMeResponse> get copyWith => __$AuthMeResponseCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AuthMeResponse&&(identical(other.user, user) || other.user == user));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AuthMeResponse&&(identical(other.user, user) || other.user == user)&&const DeepCollectionEquality().equals(other._bridges, _bridges));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,user);
+int get hashCode => Object.hash(runtimeType,user,const DeepCollectionEquality().hash(_bridges));
 
 @override
 String toString() {
-  return 'AuthMeResponse(user: $user)';
+  return 'AuthMeResponse(user: $user, bridges: $bridges)';
 }
 
 
@@ -122,7 +130,7 @@ abstract mixin class _$AuthMeResponseCopyWith<$Res> implements $AuthMeResponseCo
   factory _$AuthMeResponseCopyWith(_AuthMeResponse value, $Res Function(_AuthMeResponse) _then) = __$AuthMeResponseCopyWithImpl;
 @override @useResult
 $Res call({
- AuthUser user
+ AuthUser user, List<BridgeSummary> bridges
 });
 
 
@@ -139,10 +147,11 @@ class __$AuthMeResponseCopyWithImpl<$Res>
 
 /// Create a copy of AuthMeResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? user = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? user = null,Object? bridges = null,}) {
   return _then(_AuthMeResponse(
 user: null == user ? _self.user : user // ignore: cast_nullable_to_non_nullable
-as AuthUser,
+as AuthUser,bridges: null == bridges ? _self._bridges : bridges // ignore: cast_nullable_to_non_nullable
+as List<BridgeSummary>,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/auth/auth_me_response.g.dart
+++ b/shared/sesori_shared/lib/src/models/auth/auth_me_response.g.dart
@@ -8,4 +8,11 @@ part of 'auth_me_response.dart';
 
 _AuthMeResponse _$AuthMeResponseFromJson(Map json) => _AuthMeResponse(
   user: AuthUser.fromJson(Map<String, dynamic>.from(json['user'] as Map)),
+  bridges:
+      (json['bridges'] as List<dynamic>?)
+          ?.map(
+            (e) => BridgeSummary.fromJson(Map<String, dynamic>.from(e as Map)),
+          )
+          .toList() ??
+      const <BridgeSummary>[],
 );

--- a/shared/sesori_shared/lib/src/models/auth/auth_me_response.g.dart
+++ b/shared/sesori_shared/lib/src/models/auth/auth_me_response.g.dart
@@ -8,11 +8,7 @@ part of 'auth_me_response.dart';
 
 _AuthMeResponse _$AuthMeResponseFromJson(Map json) => _AuthMeResponse(
   user: AuthUser.fromJson(Map<String, dynamic>.from(json['user'] as Map)),
-  bridges:
-      (json['bridges'] as List<dynamic>?)
-          ?.map(
-            (e) => BridgeSummary.fromJson(Map<String, dynamic>.from(e as Map)),
-          )
-          .toList() ??
-      const <BridgeSummary>[],
+  bridges: (json['bridges'] as List<dynamic>)
+      .map((e) => BridgeSummary.fromJson(Map<String, dynamic>.from(e as Map)))
+      .toList(),
 );

--- a/shared/sesori_shared/lib/src/models/auth/bridge_summary.dart
+++ b/shared/sesori_shared/lib/src/models/auth/bridge_summary.dart
@@ -1,0 +1,19 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "bridge_summary.freezed.dart";
+part "bridge_summary.g.dart";
+
+/// A bridge registered with the auth server, as returned by the
+/// `/auth/bridges` endpoints and the `bridges` field of `/auth/me`.
+@Freezed(fromJson: true, toJson: true)
+sealed class BridgeSummary with _$BridgeSummary {
+  const factory BridgeSummary({
+    required String id,
+    required String name,
+    required String platform,
+    required DateTime addedAt,
+    required DateTime? lastSeenAt,
+  }) = _BridgeSummary;
+
+  factory BridgeSummary.fromJson(Map<String, dynamic> json) => _$BridgeSummaryFromJson(json);
+}

--- a/shared/sesori_shared/lib/src/models/auth/bridge_summary.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/auth/bridge_summary.freezed.dart
@@ -1,0 +1,160 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'bridge_summary.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$BridgeSummary {
+
+ String get id; String get name; String get platform; DateTime get addedAt; DateTime? get lastSeenAt;
+/// Create a copy of BridgeSummary
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$BridgeSummaryCopyWith<BridgeSummary> get copyWith => _$BridgeSummaryCopyWithImpl<BridgeSummary>(this as BridgeSummary, _$identity);
+
+  /// Serializes this BridgeSummary to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is BridgeSummary&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.platform, platform) || other.platform == platform)&&(identical(other.addedAt, addedAt) || other.addedAt == addedAt)&&(identical(other.lastSeenAt, lastSeenAt) || other.lastSeenAt == lastSeenAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,platform,addedAt,lastSeenAt);
+
+@override
+String toString() {
+  return 'BridgeSummary(id: $id, name: $name, platform: $platform, addedAt: $addedAt, lastSeenAt: $lastSeenAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $BridgeSummaryCopyWith<$Res>  {
+  factory $BridgeSummaryCopyWith(BridgeSummary value, $Res Function(BridgeSummary) _then) = _$BridgeSummaryCopyWithImpl;
+@useResult
+$Res call({
+ String id, String name, String platform, DateTime addedAt, DateTime? lastSeenAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$BridgeSummaryCopyWithImpl<$Res>
+    implements $BridgeSummaryCopyWith<$Res> {
+  _$BridgeSummaryCopyWithImpl(this._self, this._then);
+
+  final BridgeSummary _self;
+  final $Res Function(BridgeSummary) _then;
+
+/// Create a copy of BridgeSummary
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? platform = null,Object? addedAt = null,Object? lastSeenAt = freezed,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,platform: null == platform ? _self.platform : platform // ignore: cast_nullable_to_non_nullable
+as String,addedAt: null == addedAt ? _self.addedAt : addedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,lastSeenAt: freezed == lastSeenAt ? _self.lastSeenAt : lastSeenAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _BridgeSummary implements BridgeSummary {
+  const _BridgeSummary({required this.id, required this.name, required this.platform, required this.addedAt, required this.lastSeenAt});
+  factory _BridgeSummary.fromJson(Map<String, dynamic> json) => _$BridgeSummaryFromJson(json);
+
+@override final  String id;
+@override final  String name;
+@override final  String platform;
+@override final  DateTime addedAt;
+@override final  DateTime? lastSeenAt;
+
+/// Create a copy of BridgeSummary
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$BridgeSummaryCopyWith<_BridgeSummary> get copyWith => __$BridgeSummaryCopyWithImpl<_BridgeSummary>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$BridgeSummaryToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _BridgeSummary&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.platform, platform) || other.platform == platform)&&(identical(other.addedAt, addedAt) || other.addedAt == addedAt)&&(identical(other.lastSeenAt, lastSeenAt) || other.lastSeenAt == lastSeenAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,platform,addedAt,lastSeenAt);
+
+@override
+String toString() {
+  return 'BridgeSummary(id: $id, name: $name, platform: $platform, addedAt: $addedAt, lastSeenAt: $lastSeenAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$BridgeSummaryCopyWith<$Res> implements $BridgeSummaryCopyWith<$Res> {
+  factory _$BridgeSummaryCopyWith(_BridgeSummary value, $Res Function(_BridgeSummary) _then) = __$BridgeSummaryCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String name, String platform, DateTime addedAt, DateTime? lastSeenAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$BridgeSummaryCopyWithImpl<$Res>
+    implements _$BridgeSummaryCopyWith<$Res> {
+  __$BridgeSummaryCopyWithImpl(this._self, this._then);
+
+  final _BridgeSummary _self;
+  final $Res Function(_BridgeSummary) _then;
+
+/// Create a copy of BridgeSummary
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? platform = null,Object? addedAt = null,Object? lastSeenAt = freezed,}) {
+  return _then(_BridgeSummary(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,platform: null == platform ? _self.platform : platform // ignore: cast_nullable_to_non_nullable
+as String,addedAt: null == addedAt ? _self.addedAt : addedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,lastSeenAt: freezed == lastSeenAt ? _self.lastSeenAt : lastSeenAt // ignore: cast_nullable_to_non_nullable
+as DateTime?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/shared/sesori_shared/lib/src/models/auth/bridge_summary.g.dart
+++ b/shared/sesori_shared/lib/src/models/auth/bridge_summary.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'bridge_summary.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_BridgeSummary _$BridgeSummaryFromJson(Map json) => _BridgeSummary(
+  id: json['id'] as String,
+  name: json['name'] as String,
+  platform: json['platform'] as String,
+  addedAt: DateTime.parse(json['addedAt'] as String),
+  lastSeenAt: json['lastSeenAt'] == null
+      ? null
+      : DateTime.parse(json['lastSeenAt'] as String),
+);
+
+Map<String, dynamic> _$BridgeSummaryToJson(_BridgeSummary instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'platform': instance.platform,
+      'addedAt': instance.addedAt.toIso8601String(),
+      'lastSeenAt': instance.lastSeenAt?.toIso8601String(),
+    };

--- a/shared/sesori_shared/lib/src/models/auth/register_bridge_request.dart
+++ b/shared/sesori_shared/lib/src/models/auth/register_bridge_request.dart
@@ -1,0 +1,20 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "register_bridge_request.freezed.dart";
+part "register_bridge_request.g.dart";
+
+/// Request body for `POST /auth/bridges`.
+///
+/// When [bridgeId] is null the key is omitted from the JSON body and the
+/// server mints a fresh bridge id; when set, the server updates the existing
+/// registration with that id.
+@Freezed(fromJson: true, toJson: true)
+sealed class RegisterBridgeRequest with _$RegisterBridgeRequest {
+  const factory RegisterBridgeRequest({
+    required String name,
+    required String platform,
+    @JsonKey(includeIfNull: false) required String? bridgeId,
+  }) = _RegisterBridgeRequest;
+
+  factory RegisterBridgeRequest.fromJson(Map<String, dynamic> json) => _$RegisterBridgeRequestFromJson(json);
+}

--- a/shared/sesori_shared/lib/src/models/auth/register_bridge_request.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/auth/register_bridge_request.freezed.dart
@@ -1,0 +1,154 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'register_bridge_request.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$RegisterBridgeRequest {
+
+ String get name; String get platform;@JsonKey(includeIfNull: false) String? get bridgeId;
+/// Create a copy of RegisterBridgeRequest
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RegisterBridgeRequestCopyWith<RegisterBridgeRequest> get copyWith => _$RegisterBridgeRequestCopyWithImpl<RegisterBridgeRequest>(this as RegisterBridgeRequest, _$identity);
+
+  /// Serializes this RegisterBridgeRequest to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RegisterBridgeRequest&&(identical(other.name, name) || other.name == name)&&(identical(other.platform, platform) || other.platform == platform)&&(identical(other.bridgeId, bridgeId) || other.bridgeId == bridgeId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,platform,bridgeId);
+
+@override
+String toString() {
+  return 'RegisterBridgeRequest(name: $name, platform: $platform, bridgeId: $bridgeId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RegisterBridgeRequestCopyWith<$Res>  {
+  factory $RegisterBridgeRequestCopyWith(RegisterBridgeRequest value, $Res Function(RegisterBridgeRequest) _then) = _$RegisterBridgeRequestCopyWithImpl;
+@useResult
+$Res call({
+ String name, String platform,@JsonKey(includeIfNull: false) String? bridgeId
+});
+
+
+
+
+}
+/// @nodoc
+class _$RegisterBridgeRequestCopyWithImpl<$Res>
+    implements $RegisterBridgeRequestCopyWith<$Res> {
+  _$RegisterBridgeRequestCopyWithImpl(this._self, this._then);
+
+  final RegisterBridgeRequest _self;
+  final $Res Function(RegisterBridgeRequest) _then;
+
+/// Create a copy of RegisterBridgeRequest
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? platform = null,Object? bridgeId = freezed,}) {
+  return _then(_self.copyWith(
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,platform: null == platform ? _self.platform : platform // ignore: cast_nullable_to_non_nullable
+as String,bridgeId: freezed == bridgeId ? _self.bridgeId : bridgeId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _RegisterBridgeRequest implements RegisterBridgeRequest {
+  const _RegisterBridgeRequest({required this.name, required this.platform, @JsonKey(includeIfNull: false) required this.bridgeId});
+  factory _RegisterBridgeRequest.fromJson(Map<String, dynamic> json) => _$RegisterBridgeRequestFromJson(json);
+
+@override final  String name;
+@override final  String platform;
+@override@JsonKey(includeIfNull: false) final  String? bridgeId;
+
+/// Create a copy of RegisterBridgeRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RegisterBridgeRequestCopyWith<_RegisterBridgeRequest> get copyWith => __$RegisterBridgeRequestCopyWithImpl<_RegisterBridgeRequest>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$RegisterBridgeRequestToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RegisterBridgeRequest&&(identical(other.name, name) || other.name == name)&&(identical(other.platform, platform) || other.platform == platform)&&(identical(other.bridgeId, bridgeId) || other.bridgeId == bridgeId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,platform,bridgeId);
+
+@override
+String toString() {
+  return 'RegisterBridgeRequest(name: $name, platform: $platform, bridgeId: $bridgeId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RegisterBridgeRequestCopyWith<$Res> implements $RegisterBridgeRequestCopyWith<$Res> {
+  factory _$RegisterBridgeRequestCopyWith(_RegisterBridgeRequest value, $Res Function(_RegisterBridgeRequest) _then) = __$RegisterBridgeRequestCopyWithImpl;
+@override @useResult
+$Res call({
+ String name, String platform,@JsonKey(includeIfNull: false) String? bridgeId
+});
+
+
+
+
+}
+/// @nodoc
+class __$RegisterBridgeRequestCopyWithImpl<$Res>
+    implements _$RegisterBridgeRequestCopyWith<$Res> {
+  __$RegisterBridgeRequestCopyWithImpl(this._self, this._then);
+
+  final _RegisterBridgeRequest _self;
+  final $Res Function(_RegisterBridgeRequest) _then;
+
+/// Create a copy of RegisterBridgeRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? platform = null,Object? bridgeId = freezed,}) {
+  return _then(_RegisterBridgeRequest(
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,platform: null == platform ? _self.platform : platform // ignore: cast_nullable_to_non_nullable
+as String,bridgeId: freezed == bridgeId ? _self.bridgeId : bridgeId // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/shared/sesori_shared/lib/src/models/auth/register_bridge_request.g.dart
+++ b/shared/sesori_shared/lib/src/models/auth/register_bridge_request.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'register_bridge_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_RegisterBridgeRequest _$RegisterBridgeRequestFromJson(Map json) =>
+    _RegisterBridgeRequest(
+      name: json['name'] as String,
+      platform: json['platform'] as String,
+      bridgeId: json['bridgeId'] as String?,
+    );
+
+Map<String, dynamic> _$RegisterBridgeRequestToJson(
+  _RegisterBridgeRequest instance,
+) => <String, dynamic>{
+  'name': instance.name,
+  'platform': instance.platform,
+  'bridgeId': ?instance.bridgeId,
+};

--- a/shared/sesori_shared/lib/src/protocol/close_codes.dart
+++ b/shared/sesori_shared/lib/src/protocol/close_codes.dart
@@ -15,16 +15,23 @@ abstract final class RelayCloseCodes {
   /// Account full — too many devices connected (>5) — do NOT reconnect.
   static const accountFull = 4005;
 
+  /// Bridge revoked — the bridge's registration was deleted on the auth
+  /// server. The bridge must re-register before connecting again — do NOT
+  /// reconnect with the same bridge id.
+  static const bridgeRevoked = 4006;
+
   static const noReconnectCodes = {
     authFailure,
     authRequired,
     roomFull,
     roomNotFound,
     accountFull,
+    bridgeRevoked,
   };
 
   /// Returns true if the close code indicates the client should attempt reconnection.
-  /// Returns false for terminal errors (auth failure, auth required, room full, room not found, account full).
+  /// Returns false for terminal errors (auth failure, auth required, room full, room not found, account full,
+  /// bridge revoked).
   static bool shouldReconnect(int? closeCode) {
     if (closeCode == null) return true;
     return !noReconnectCodes.contains(closeCode);

--- a/shared/sesori_shared/lib/src/protocol/messages.dart
+++ b/shared/sesori_shared/lib/src/protocol/messages.dart
@@ -50,11 +50,10 @@ sealed class RelayMessage with _$RelayMessage {
   const factory RelayMessage.rekeyRequired() = RelayRekeyRequired;
 
   @FreezedUnionValue("auth")
-  // ignore: no_slop_linter/prefer_required_named_parameters, optional bridgeId keeps existing phone/bridge callers compiling; absent means a legacy unregistered bridge.
   const factory RelayMessage.auth({
     required String token,
     required String role,
-    @JsonKey(includeIfNull: false) String? bridgeId,
+    @JsonKey(includeIfNull: false) required String? bridgeId,
   }) = AuthRelayMessage;
 
   factory RelayMessage.fromJson(Map<String, dynamic> json) => _$RelayMessageFromJson(json);

--- a/shared/sesori_shared/lib/src/protocol/messages.dart
+++ b/shared/sesori_shared/lib/src/protocol/messages.dart
@@ -50,9 +50,11 @@ sealed class RelayMessage with _$RelayMessage {
   const factory RelayMessage.rekeyRequired() = RelayRekeyRequired;
 
   @FreezedUnionValue("auth")
+  // ignore: no_slop_linter/prefer_required_named_parameters, optional bridgeId keeps existing phone/bridge callers compiling; absent means a legacy unregistered bridge.
   const factory RelayMessage.auth({
     required String token,
     required String role,
+    @JsonKey(includeIfNull: false) String? bridgeId,
   }) = AuthRelayMessage;
 
   factory RelayMessage.fromJson(Map<String, dynamic> json) => _$RelayMessageFromJson(json);

--- a/shared/sesori_shared/lib/src/protocol/messages.freezed.dart
+++ b/shared/sesori_shared/lib/src/protocol/messages.freezed.dart
@@ -730,11 +730,12 @@ String toString() {
 @JsonSerializable()
 
 class AuthRelayMessage implements RelayMessage {
-  const AuthRelayMessage({required this.token, required this.role, final  String? $type}): $type = $type ?? 'auth';
+  const AuthRelayMessage({required this.token, required this.role, @JsonKey(includeIfNull: false) this.bridgeId, final  String? $type}): $type = $type ?? 'auth';
   factory AuthRelayMessage.fromJson(Map<String, dynamic> json) => _$AuthRelayMessageFromJson(json);
 
  final  String token;
  final  String role;
+@JsonKey(includeIfNull: false) final  String? bridgeId;
 
 @JsonKey(name: 'type')
 final String $type;
@@ -753,16 +754,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AuthRelayMessage&&(identical(other.token, token) || other.token == token)&&(identical(other.role, role) || other.role == role));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AuthRelayMessage&&(identical(other.token, token) || other.token == token)&&(identical(other.role, role) || other.role == role)&&(identical(other.bridgeId, bridgeId) || other.bridgeId == bridgeId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,token,role);
+int get hashCode => Object.hash(runtimeType,token,role,bridgeId);
 
 @override
 String toString() {
-  return 'RelayMessage.auth(token: $token, role: $role)';
+  return 'RelayMessage.auth(token: $token, role: $role, bridgeId: $bridgeId)';
 }
 
 
@@ -773,7 +774,7 @@ abstract mixin class $AuthRelayMessageCopyWith<$Res> implements $RelayMessageCop
   factory $AuthRelayMessageCopyWith(AuthRelayMessage value, $Res Function(AuthRelayMessage) _then) = _$AuthRelayMessageCopyWithImpl;
 @useResult
 $Res call({
- String token, String role
+ String token, String role,@JsonKey(includeIfNull: false) String? bridgeId
 });
 
 
@@ -790,11 +791,12 @@ class _$AuthRelayMessageCopyWithImpl<$Res>
 
 /// Create a copy of RelayMessage
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? token = null,Object? role = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? token = null,Object? role = null,Object? bridgeId = freezed,}) {
   return _then(AuthRelayMessage(
 token: null == token ? _self.token : token // ignore: cast_nullable_to_non_nullable
 as String,role: null == role ? _self.role : role // ignore: cast_nullable_to_non_nullable
-as String,
+as String,bridgeId: freezed == bridgeId ? _self.bridgeId : bridgeId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/protocol/messages.freezed.dart
+++ b/shared/sesori_shared/lib/src/protocol/messages.freezed.dart
@@ -730,7 +730,7 @@ String toString() {
 @JsonSerializable()
 
 class AuthRelayMessage implements RelayMessage {
-  const AuthRelayMessage({required this.token, required this.role, @JsonKey(includeIfNull: false) this.bridgeId, final  String? $type}): $type = $type ?? 'auth';
+  const AuthRelayMessage({required this.token, required this.role, @JsonKey(includeIfNull: false) required this.bridgeId, final  String? $type}): $type = $type ?? 'auth';
   factory AuthRelayMessage.fromJson(Map<String, dynamic> json) => _$AuthRelayMessageFromJson(json);
 
  final  String token;

--- a/shared/sesori_shared/lib/src/protocol/messages.g.dart
+++ b/shared/sesori_shared/lib/src/protocol/messages.g.dart
@@ -105,6 +105,7 @@ Map<String, dynamic> _$RelayRekeyRequiredToJson(RelayRekeyRequired instance) =>
 AuthRelayMessage _$AuthRelayMessageFromJson(Map json) => AuthRelayMessage(
   token: json['token'] as String,
   role: json['role'] as String,
+  bridgeId: json['bridgeId'] as String?,
   $type: json['type'] as String?,
 );
 
@@ -112,5 +113,6 @@ Map<String, dynamic> _$AuthRelayMessageToJson(AuthRelayMessage instance) =>
     <String, dynamic>{
       'token': instance.token,
       'role': instance.role,
+      'bridgeId': ?instance.bridgeId,
       'type': instance.$type,
     };

--- a/shared/sesori_shared/test/models/bridge_summary_test.dart
+++ b/shared/sesori_shared/test/models/bridge_summary_test.dart
@@ -34,17 +34,21 @@ void main() {
   });
 
   group("AuthMeResponse bridges", () {
-    test("defaults to an empty list when the key is absent", () {
-      final response = AuthMeResponse.fromJson({
-        "user": {
-          "id": "user-1",
-          "provider": "github",
-          "providerUserId": "12345",
-          "providerUsername": "octocat",
-        },
-      });
-
-      expect(response.bridges, isEmpty);
+    test("throws when the key is absent", () {
+      // The deployed auth server always returns bridges, so a missing key
+      // means a broken or incompatible server — fail fast instead of
+      // silently treating it as "no bridges".
+      expect(
+        () => AuthMeResponse.fromJson({
+          "user": {
+            "id": "user-1",
+            "provider": "github",
+            "providerUserId": "12345",
+            "providerUsername": "octocat",
+          },
+        }),
+        throwsA(isA<TypeError>()),
+      );
     });
 
     test("parses the bridges list when present", () {

--- a/shared/sesori_shared/test/models/bridge_summary_test.dart
+++ b/shared/sesori_shared/test/models/bridge_summary_test.dart
@@ -1,0 +1,73 @@
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("BridgeSummary", () {
+    test("round-trips through JSON", () {
+      final original = BridgeSummary(
+        id: "br_abc12345",
+        name: "alex-macbook",
+        platform: "macos",
+        addedAt: DateTime.utc(2026, 6, 1, 12),
+        lastSeenAt: DateTime.utc(2026, 6, 10, 9, 30),
+      );
+
+      final json = original.toJson();
+      final restored = BridgeSummary.fromJson(json);
+
+      expect(restored, equals(original));
+    });
+
+    test("parses null lastSeenAt", () {
+      final restored = BridgeSummary.fromJson({
+        "id": "br_abc12345",
+        "name": "alex-macbook",
+        "platform": "linux",
+        "addedAt": "2026-06-01T12:00:00.000Z",
+        "lastSeenAt": null,
+      });
+
+      expect(restored.id, equals("br_abc12345"));
+      expect(restored.platform, equals("linux"));
+      expect(restored.lastSeenAt, isNull);
+    });
+  });
+
+  group("AuthMeResponse bridges", () {
+    test("defaults to an empty list when the key is absent", () {
+      final response = AuthMeResponse.fromJson({
+        "user": {
+          "id": "user-1",
+          "provider": "github",
+          "providerUserId": "12345",
+          "providerUsername": "octocat",
+        },
+      });
+
+      expect(response.bridges, isEmpty);
+    });
+
+    test("parses the bridges list when present", () {
+      final response = AuthMeResponse.fromJson({
+        "user": {
+          "id": "user-1",
+          "provider": "github",
+          "providerUserId": "12345",
+          "providerUsername": "octocat",
+        },
+        "bridges": [
+          {
+            "id": "br_abc12345",
+            "name": "alex-macbook",
+            "platform": "macos",
+            "addedAt": "2026-06-01T12:00:00.000Z",
+            "lastSeenAt": null,
+          },
+        ],
+      });
+
+      expect(response.bridges, hasLength(1));
+      expect(response.bridges.single.id, equals("br_abc12345"));
+    });
+  });
+}

--- a/shared/sesori_shared/test/models/register_bridge_request_test.dart
+++ b/shared/sesori_shared/test/models/register_bridge_request_test.dart
@@ -1,0 +1,66 @@
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("RegisterBridgeRequest", () {
+    test("omits bridgeId from JSON when null", () {
+      const request = RegisterBridgeRequest(name: "alex-macbook", platform: "macos", bridgeId: null);
+
+      final json = request.toJson();
+
+      expect(json, equals({"name": "alex-macbook", "platform": "macos"}));
+    });
+
+    test("includes bridgeId in JSON when set", () {
+      const request = RegisterBridgeRequest(
+        name: "alex-macbook",
+        platform: "macos",
+        bridgeId: "br_abc12345",
+      );
+
+      final json = request.toJson();
+
+      expect(
+        json,
+        equals({
+          "name": "alex-macbook",
+          "platform": "macos",
+          "bridgeId": "br_abc12345",
+        }),
+      );
+    });
+
+    test("parses a body without bridgeId", () {
+      final request = RegisterBridgeRequest.fromJson({
+        "name": "alex-macbook",
+        "platform": "linux",
+      });
+
+      expect(request.name, equals("alex-macbook"));
+      expect(request.platform, equals("linux"));
+      expect(request.bridgeId, isNull);
+    });
+
+    test("parses a body with bridgeId", () {
+      final request = RegisterBridgeRequest.fromJson({
+        "name": "alex-macbook",
+        "platform": "linux",
+        "bridgeId": "br_abc12345",
+      });
+
+      expect(request.bridgeId, equals("br_abc12345"));
+    });
+
+    test("round-trips through JSON", () {
+      const original = RegisterBridgeRequest(
+        name: "alex-macbook",
+        platform: "windows",
+        bridgeId: "br_abc12345",
+      );
+
+      final restored = RegisterBridgeRequest.fromJson(original.toJson());
+
+      expect(restored, equals(original));
+    });
+  });
+}

--- a/shared/sesori_shared/test/protocol/close_codes_test.dart
+++ b/shared/sesori_shared/test/protocol/close_codes_test.dart
@@ -1,0 +1,21 @@
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("RelayCloseCodes", () {
+    test("bridgeRevoked is 4006", () {
+      expect(RelayCloseCodes.bridgeRevoked, equals(4006));
+    });
+
+    test("bridgeRevoked does not reconnect", () {
+      expect(RelayCloseCodes.noReconnectCodes, contains(RelayCloseCodes.bridgeRevoked));
+      expect(RelayCloseCodes.shouldReconnect(RelayCloseCodes.bridgeRevoked), isFalse);
+    });
+
+    test("normal and unknown codes reconnect", () {
+      expect(RelayCloseCodes.shouldReconnect(null), isTrue);
+      expect(RelayCloseCodes.shouldReconnect(1000), isTrue);
+      expect(RelayCloseCodes.shouldReconnect(1006), isTrue);
+    });
+  });
+}

--- a/shared/sesori_shared/test/protocol/relay_auth_message_test.dart
+++ b/shared/sesori_shared/test/protocol/relay_auth_message_test.dart
@@ -1,0 +1,57 @@
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("RelayMessage.auth bridgeId", () {
+    test("omits bridgeId from JSON when null", () {
+      const msg = RelayMessage.auth(token: "jwt-token", role: "bridge");
+
+      final json = msg.toJson();
+
+      expect(json, equals({"type": "auth", "token": "jwt-token", "role": "bridge"}));
+    });
+
+    test("includes bridgeId in JSON when set", () {
+      const msg = RelayMessage.auth(
+        token: "jwt-token",
+        role: "bridge",
+        bridgeId: "br_abc12345",
+      );
+
+      final json = msg.toJson();
+
+      expect(
+        json,
+        equals({
+          "type": "auth",
+          "token": "jwt-token",
+          "role": "bridge",
+          "bridgeId": "br_abc12345",
+        }),
+      );
+    });
+
+    test("parses auth message without bridgeId", () {
+      final msg = RelayMessage.fromJson({
+        "type": "auth",
+        "token": "jwt-token",
+        "role": "phone",
+      });
+
+      expect(msg, isA<AuthRelayMessage>());
+      expect((msg as AuthRelayMessage).bridgeId, isNull);
+    });
+
+    test("parses auth message with bridgeId", () {
+      final msg = RelayMessage.fromJson({
+        "type": "auth",
+        "token": "jwt-token",
+        "role": "bridge",
+        "bridgeId": "br_abc12345",
+      });
+
+      expect(msg, isA<AuthRelayMessage>());
+      expect((msg as AuthRelayMessage).bridgeId, equals("br_abc12345"));
+    });
+  });
+}

--- a/shared/sesori_shared/test/protocol/relay_auth_message_test.dart
+++ b/shared/sesori_shared/test/protocol/relay_auth_message_test.dart
@@ -4,7 +4,7 @@ import "package:test/test.dart";
 void main() {
   group("RelayMessage.auth bridgeId", () {
     test("omits bridgeId from JSON when null", () {
-      const msg = RelayMessage.auth(token: "jwt-token", role: "bridge");
+      const msg = RelayMessage.auth(token: "jwt-token", role: "bridge", bridgeId: null);
 
       final json = msg.toJson();
 


### PR DESCRIPTION
## Summary

Bridge side of per-bridge-instance tracking, so the mobile app can tell from `GET /auth/me` whether the user ever set up a bridge, how many exist, and identify them by name/platform. Companion PRs: sesori-ai/sesori_auth_server#28 (registry + `/auth/me bridges[]`), sesori-ai/sesori_relay_server#6 (bridgeId passthrough + 4006 close).

There is **no second credential**: the bridge keeps authenticating everywhere with the user access token. Identity travels as a server-minted `bridgeId`.

## Shared package

- New `BridgeSummary` model: `{ id, name, platform, addedAt, lastSeenAt }`.
- New `RegisterBridgeRequest` model — typed body for `POST /auth/bridges` (`bridgeId` omitted from JSON when null).
- `AuthMeResponse` gains a **required** `bridges: List<BridgeSummary>` — a `/auth/me` response missing the key fails fast at parse time (deliberate: the auth server releases before this PR merges, so a missing key means a broken/incompatible server).
- `RelayMessage.auth` gains a `required String? bridgeId` (phones pass an explicit `null`), omitted from the JSON when null — the legacy wire format is byte-identical.
- `RelayCloseCodes.bridgeRevoked = 4006`, added to `noReconnectCodes`.

## Bridge

- `token.json` persists `bridgeId`. The dormant `bridgeToken` field is removed; old files containing it still parse (key ignored, dropped on next save). An interactive re-login carries the persisted `bridgeId` over (a fresh login response never has one), so re-login can't mint a duplicate bridge.
- Registration (`POST /auth/bridges` with hostname + platform, resending the persisted `bridgeId` so the server updates instead of duplicating) is a **memoized blocking step in the existing refresh→connect loop**: failures fail the attempt and retry on the existing backoff — no new retry machinery, no legacy fallback path.
- The relay WS auth message carries `bridgeId`.
- On a `4006` close (bridge revoked server-side), the bridge clears its stored id and re-registers fresh on the next attempt.
- Logout best-effort `DELETE /auth/bridges/:id` (10s timeout, failures logged and ignored — logout never blocks) before clearing tokens.
- Hostnames are clamped to the server's 1–120 char contract.

## Mobile

No behavior change — only the shared `/auth/me` model. Consuming `bridges[]` (onboarding vs offline distinction) is follow-up work.

## Backward compatibility

- Old bridges (no bridgeId) keep connecting and keep user-level push notifications while `RELAY_REQUIRE_BRIDGE_ID=false`.
- Old token.json files parse unchanged.
- **Release-order requirement**: the updated app/bridge requires the new auth server — `/auth/me` without `bridges[]` fails fast by design (review decision: fail fast over silent tolerance).

## Tests

- shared: 230 passed (`dart analyze --fatal-infos` clean)
- bridge/app: 1198 passed, incl. new suites for registration API/service (memoization, 401-retry, 4006 reset, unregister-404, name clamping, DELETE URL-encoding, no clobbering of tokens rotated mid-registration), TokenManager refresh re-read (bridgeId kept when written mid-refresh, corrupt-file repair, no file resurrection after logout), orchestrator registration (startup failure, backoff retry, 4006 re-register), RelayClient auth message + closeCode, logout runner
- mobile: `flutter analyze` clean; module_auth 72 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-bridge instance registration and tracking. Bridges register with auth, persist a server‑minted bridgeId, include it in relay auth, and `/auth/me` lists a user’s bridges; bridges auto‑register on next connect. Also require `bridgeId` params in code (phones pass null); wire format unchanged.

- **New Features**
  - Shared: added `BridgeSummary`; `AuthMeResponse.bridges` (defaults to []); `RegisterBridgeRequest`; `RelayMessage.auth` accepts `bridgeId` (omitted from JSON when null); `RelayCloseCodes.bridgeRevoked = 4006`.
  - Bridge: registers via `POST /auth/bridges` (hostname + platform, resends stored id), persists `bridgeId` in token.json, includes it in relay auth, re-login carries the persisted id, clears id and re-registers on 4006, best‑effort `DELETE /auth/bridges/:id` on logout, clamps hostnames to 1–120 chars.
  - Compatibility: no mobile behavior change; old bridges still connect while `RELAY_REQUIRE_BRIDGE_ID=false`; old token files parse; legacy wire format unchanged when `bridgeId` is absent.

- **Bug Fixes**
  - Re-read the token file before persisting both registration and refresh updates to avoid clobbering rotated tokens or wiping a newly minted `bridgeId`; on the post-refresh re-read, tolerate a corrupt token file (fallback to the pre-refresh snapshot) but let a missing file propagate to avoid resurrecting a logout.
  - Narrow login carry-over for `bridgeId`: only ignore missing/corrupt token files; rethrow other filesystem errors.
  - Safer token validation: `validateToken` now returns `TokenValidationResult` (access/refresh/isValid) instead of a partial `TokenData` + bool to avoid accidentally persisting state without `bridgeId`; the unused `lastProvider` param was removed.

<sup>Written for commit f4026a896896bad55cf790603ab29546cf8ad7dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


