### PR TITLE
fix: restore agent & model pickers by scoping GET /agent to a directory

### DIFF
--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -26,6 +26,7 @@ import "routing/abort_session_handler.dart";
 import "routing/get_agents_handler.dart";
 import "routing/get_commands_handler.dart";
 import "routing/get_session_diffs_handler.dart";
+import "routing/post_agents_handler.dart";
 import "routing/request_router.dart";
 import "routing/send_prompt_handler.dart";
 import "services/pr_sync_service.dart";
@@ -225,6 +226,9 @@ class OrchestratorSession {
          projectRepository: projectRepository,
          providerRepository: ProviderRepository(plugin: plugin),
          getAgentsHandler: GetAgentsHandler(
+           AgentRepository(plugin: plugin),
+         ),
+         postAgentsHandler: PostAgentsHandler(
            AgentRepository(plugin: plugin),
          ),
          permissionRepository: permissionRepository,

--- a/bridge/app/lib/src/bridge/repositories/agent_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/agent_repository.dart
@@ -1,5 +1,7 @@
+import "dart:io" as io;
+
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginApi;
-import "package:sesori_shared/sesori_shared.dart" show Agents;
+import "package:sesori_shared/sesori_shared.dart" show Agents, StringExtensions;
 
 import "mappers/plugin_agent_mapper.dart";
 
@@ -8,8 +10,12 @@ class AgentRepository {
 
   AgentRepository({required BridgePluginApi plugin}) : _plugin = plugin;
 
-  Future<Agents> getAgents({String? projectId}) async {
-    final pluginAgents = await _plugin.getAgents(projectId: projectId);
+  Future<Agents> getAgents({required String? projectId}) async {
+    // A null/blank projectId comes from the deprecated GET /agent route,
+    // which carries no project context. Fall back to the bridge CWD, which
+    // plugins treat as the active project.
+    final resolvedProjectId = projectId?.normalize() ?? io.Directory.current.path;
+    final pluginAgents = await _plugin.getAgents(projectId: resolvedProjectId);
     final agents = pluginAgents.map((a) => a.toAgentInfo()).toList();
     return Agents(agents: agents);
   }

--- a/bridge/app/lib/src/bridge/repositories/agent_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/agent_repository.dart
@@ -8,8 +8,8 @@ class AgentRepository {
 
   AgentRepository({required BridgePluginApi plugin}) : _plugin = plugin;
 
-  Future<Agents> getAgents() async {
-    final pluginAgents = await _plugin.getAgents();
+  Future<Agents> getAgents({String? projectId}) async {
+    final pluginAgents = await _plugin.getAgents(projectId: projectId);
     final agents = pluginAgents.map((a) => a.toAgentInfo()).toList();
     return Agents(agents: agents);
   }

--- a/bridge/app/lib/src/bridge/routing/get_agents_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_agents_handler.dart
@@ -4,6 +4,10 @@ import "../repositories/agent_repository.dart";
 import "request_handler.dart";
 
 /// Handles `GET /agent` — returns all available agents from the plugin.
+///
+/// Accepts an optional `projectId` query parameter (the project worktree
+/// directory) so the plugin can resolve project-scoped agents. Older clients
+/// that omit it get the plugin's fallback behaviour.
 class GetAgentsHandler extends GetRequestHandler<Agents> {
   final AgentRepository _repository;
 
@@ -16,6 +20,6 @@ class GetAgentsHandler extends GetRequestHandler<Agents> {
     required Map<String, String> queryParams,
     required String? fragment,
   }) async {
-    return _repository.getAgents();
+    return _repository.getAgents(projectId: queryParams["projectId"]);
   }
 }

--- a/bridge/app/lib/src/bridge/routing/get_agents_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_agents_handler.dart
@@ -5,12 +5,13 @@ import "request_handler.dart";
 
 /// Handles `GET /agent` — returns all available agents from the plugin.
 ///
-/// Accepts an optional `projectId` query parameter (the project worktree
-/// directory) so the plugin can resolve project-scoped agents. Older clients
-/// that omit it get the plugin's fallback behaviour.
+/// Carries no project context, so the repository falls back to the bridge
+/// CWD as the active project.
+@Deprecated("Use POST /agent with a ProjectIdRequest body (PostAgentsHandler)")
 class GetAgentsHandler extends GetRequestHandler<Agents> {
   final AgentRepository _repository;
 
+  @Deprecated("Use POST /agent with a ProjectIdRequest body (PostAgentsHandler)")
   GetAgentsHandler(this._repository) : super("/agent");
 
   @override
@@ -20,6 +21,6 @@ class GetAgentsHandler extends GetRequestHandler<Agents> {
     required Map<String, String> queryParams,
     required String? fragment,
   }) async {
-    return _repository.getAgents(projectId: queryParams["projectId"]);
+    return _repository.getAgents(projectId: null);
   }
 }

--- a/bridge/app/lib/src/bridge/routing/post_agents_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/post_agents_handler.dart
@@ -1,0 +1,27 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../repositories/agent_repository.dart";
+import "request_handler.dart";
+
+/// Handles `POST /agent` — returns the agents available for the project.
+class PostAgentsHandler extends BodyRequestHandler<ProjectIdRequest, Agents> {
+  final AgentRepository _repository;
+
+  PostAgentsHandler(this._repository)
+    : super(
+        HttpMethod.post,
+        "/agent",
+        fromJson: ProjectIdRequest.fromJson,
+      );
+
+  @override
+  Future<Agents> handle(
+    RelayRequest request, {
+    required ProjectIdRequest body,
+    required Map<String, String> pathParams,
+    required Map<String, String> queryParams,
+    required String? fragment,
+  }) {
+    return _repository.getAgents(projectId: body.projectId);
+  }
+}

--- a/bridge/app/lib/src/bridge/routing/request_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/request_handler.dart
@@ -51,6 +51,7 @@ abstract class GetRequestHandler<RES extends Object> extends RequestHandlerBase 
 
       return buildOkJsonResponse(request, result);
     } on PluginApiException catch (err) {
+      Log.w("${request.method} ${request.path}: upstream failure: $err");
       return buildErrorResponse(request, err.statusCode, err.toString());
     } on RelayResponse catch (err) {
       if (err.status >= 200 && err.status < 300) {
@@ -61,7 +62,8 @@ abstract class GetRequestHandler<RES extends Object> extends RequestHandlerBase 
         // just return the error response
         return err;
       }
-    } catch (err) {
+    } catch (err, stackTrace) {
+      Log.w("${request.method} ${request.path}: handler failed: $err\n$stackTrace");
       return buildErrorResponse(request, 500, "Internal Server Error: $err");
     }
   }
@@ -110,6 +112,7 @@ abstract class BodyRequestHandler<REQ, RES extends Object> extends RequestHandle
 
       return buildOkJsonResponse(request, result);
     } on PluginApiException catch (err) {
+      Log.w("${request.method} ${request.path}: upstream failure: $err");
       return buildErrorResponse(request, err.statusCode, err.toString());
     } on RelayResponse catch (err) {
       if (err.status >= 200 && err.status < 300) {
@@ -120,7 +123,8 @@ abstract class BodyRequestHandler<REQ, RES extends Object> extends RequestHandle
         // just return the error response
         return err;
       }
-    } catch (err) {
+    } catch (err, stackTrace) {
+      Log.w("${request.method} ${request.path}: handler failed: $err\n$stackTrace");
       return buildErrorResponse(request, 500, "Internal Server Error: $err");
     }
   }

--- a/bridge/app/lib/src/bridge/routing/request_router.dart
+++ b/bridge/app/lib/src/bridge/routing/request_router.dart
@@ -32,6 +32,7 @@ import "get_sessions_handler.dart";
 import "health_check_handler.dart";
 import "hide_project_handler.dart";
 import "open_project_handler.dart";
+import "post_agents_handler.dart";
 import "reject_question_handler.dart";
 import "rename_project_handler.dart";
 import "rename_session_handler.dart";
@@ -68,6 +69,7 @@ class RequestRouter {
     required WorktreeService worktreeService,
     required GetSessionDiffsHandler sessionDiffsHandler,
     required GetAgentsHandler getAgentsHandler,
+    required PostAgentsHandler postAgentsHandler,
   }) : _handlers = _buildHandlers(
          plugin: plugin,
          getCommandsHandler: getCommandsHandler,
@@ -84,6 +86,7 @@ class RequestRouter {
          worktreeService: worktreeService,
          sessionDiffsHandler: sessionDiffsHandler,
          getAgentsHandler: getAgentsHandler,
+         postAgentsHandler: postAgentsHandler,
        );
 
   static List<RequestHandlerBase> _buildHandlers({
@@ -102,6 +105,7 @@ class RequestRouter {
     required WorktreeService worktreeService,
     required GetSessionDiffsHandler sessionDiffsHandler,
     required GetAgentsHandler getAgentsHandler,
+    required PostAgentsHandler postAgentsHandler,
   }) {
     return [
       HealthCheckHandler(plugin),
@@ -130,6 +134,7 @@ class RequestRouter {
       abortSessionHandler,
       GetProvidersHandler(providerRepository),
       getAgentsHandler,
+      postAgentsHandler,
       GetSessionQuestionsHandler(plugin),
       GetProjectQuestionsHandler(plugin),
       ReplyToQuestionHandler(plugin),

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -445,7 +445,7 @@ class _FakeBridgePlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) async {}
 
   @override
-  Future<List<PluginAgent>> getAgents({String? projectId}) async => [];
+  Future<List<PluginAgent>> getAgents({required String projectId}) async => [];
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async => [];
@@ -607,7 +607,7 @@ class _TrackingBridgePlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) async {}
 
   @override
-  Future<List<PluginAgent>> getAgents({String? projectId}) async => [];
+  Future<List<PluginAgent>> getAgents({required String projectId}) async => [];
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async => [];

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -445,7 +445,7 @@ class _FakeBridgePlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) async {}
 
   @override
-  Future<List<PluginAgent>> getAgents() async => [];
+  Future<List<PluginAgent>> getAgents({String? projectId}) async => [];
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async => [];
@@ -607,7 +607,7 @@ class _TrackingBridgePlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) async {}
 
   @override
-  Future<List<PluginAgent>> getAgents() async => [];
+  Future<List<PluginAgent>> getAgents({String? projectId}) async => [];
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async => [];

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -1087,7 +1087,7 @@ class _SummaryPlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) async {}
 
   @override
-  Future<List<PluginAgent>> getAgents() async => <PluginAgent>[];
+  Future<List<PluginAgent>> getAgents({String? projectId}) async => <PluginAgent>[];
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async {
@@ -1235,7 +1235,7 @@ class _NoopPlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) async {}
 
   @override
-  Future<List<PluginAgent>> getAgents() async => <PluginAgent>[];
+  Future<List<PluginAgent>> getAgents({String? projectId}) async => <PluginAgent>[];
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async {

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -1087,7 +1087,7 @@ class _SummaryPlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) async {}
 
   @override
-  Future<List<PluginAgent>> getAgents({String? projectId}) async => <PluginAgent>[];
+  Future<List<PluginAgent>> getAgents({required String projectId}) async => <PluginAgent>[];
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async {
@@ -1235,7 +1235,7 @@ class _NoopPlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) async {}
 
   @override
-  Future<List<PluginAgent>> getAgents({String? projectId}) async => <PluginAgent>[];
+  Future<List<PluginAgent>> getAgents({required String projectId}) async => <PluginAgent>[];
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async {

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -457,7 +457,7 @@ class _ThrowingSummaryPlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) async {}
 
   @override
-  Future<List<PluginAgent>> getAgents({String? projectId}) async => [];
+  Future<List<PluginAgent>> getAgents({required String projectId}) async => [];
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -457,7 +457,7 @@ class _ThrowingSummaryPlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) async {}
 
   @override
-  Future<List<PluginAgent>> getAgents() async => [];
+  Future<List<PluginAgent>> getAgents({String? projectId}) async => [];
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -211,7 +211,7 @@ class _FakeBridgePlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) => throw UnimplementedError();
 
   @override
-  Future<List<PluginAgent>> getAgents() => throw UnimplementedError();
+  Future<List<PluginAgent>> getAgents({String? projectId}) => throw UnimplementedError();
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) => throw UnimplementedError();

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -211,7 +211,7 @@ class _FakeBridgePlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) => throw UnimplementedError();
 
   @override
-  Future<List<PluginAgent>> getAgents({String? projectId}) => throw UnimplementedError();
+  Future<List<PluginAgent>> getAgents({required String projectId}) => throw UnimplementedError();
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) => throw UnimplementedError();

--- a/bridge/app/test/bridge/routing/get_agents_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_agents_handler_test.dart
@@ -24,6 +24,28 @@ void main() {
       expect(handler.canHandle(makeRequest("GET", "/agent")), isTrue);
     });
 
+    test("forwards the projectId query parameter to the plugin", () async {
+      await handler.handle(
+        makeRequest("GET", "/agent?projectId=/repo"),
+        pathParams: {},
+        queryParams: {"projectId": "/repo"},
+        fragment: null,
+      );
+
+      expect(plugin.lastAgentsProjectId, equals("/repo"));
+    });
+
+    test("passes a null projectId when the query parameter is absent", () async {
+      await handler.handle(
+        makeRequest("GET", "/agent"),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(plugin.lastAgentsProjectId, isNull);
+    });
+
     test("returns typed list", () async {
       final response = await handler.handle(
         makeRequest("GET", "/agent"),

--- a/bridge/app/test/bridge/routing/get_agents_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_agents_handler_test.dart
@@ -1,3 +1,5 @@
+import "dart:io" as io;
+
 import "package:sesori_bridge/src/bridge/repositories/agent_repository.dart";
 import "package:sesori_bridge/src/bridge/routing/get_agents_handler.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
@@ -24,18 +26,7 @@ void main() {
       expect(handler.canHandle(makeRequest("GET", "/agent")), isTrue);
     });
 
-    test("forwards the projectId query parameter to the plugin", () async {
-      await handler.handle(
-        makeRequest("GET", "/agent?projectId=/repo"),
-        pathParams: {},
-        queryParams: {"projectId": "/repo"},
-        fragment: null,
-      );
-
-      expect(plugin.lastAgentsProjectId, equals("/repo"));
-    });
-
-    test("passes a null projectId when the query parameter is absent", () async {
+    test("falls back to the bridge CWD because the route carries no project", () async {
       await handler.handle(
         makeRequest("GET", "/agent"),
         pathParams: {},
@@ -43,7 +34,7 @@ void main() {
         fragment: null,
       );
 
-      expect(plugin.lastAgentsProjectId, isNull);
+      expect(plugin.lastAgentsProjectId, equals(io.Directory.current.path));
     });
 
     test("returns typed list", () async {

--- a/bridge/app/test/bridge/routing/post_agents_handler_test.dart
+++ b/bridge/app/test/bridge/routing/post_agents_handler_test.dart
@@ -1,0 +1,51 @@
+import "package:sesori_bridge/src/bridge/repositories/agent_repository.dart";
+import "package:sesori_bridge/src/bridge/routing/post_agents_handler.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "routing_test_helpers.dart";
+
+void main() {
+  group("PostAgentsHandler", () {
+    late FakeBridgePlugin plugin;
+    late AgentRepository repository;
+    late PostAgentsHandler handler;
+
+    setUp(() {
+      plugin = FakeBridgePlugin();
+      repository = AgentRepository(plugin: plugin);
+      handler = PostAgentsHandler(repository);
+    });
+
+    tearDown(() => plugin.close());
+
+    test("canHandle POST /agent", () {
+      expect(handler.canHandle(makeRequest("POST", "/agent")), isTrue);
+      expect(handler.canHandle(makeRequest("GET", "/agent")), isFalse);
+    });
+
+    test("forwards the projectId from the request body to the plugin", () async {
+      plugin.agentsResult = [
+        const PluginAgent(
+          name: "planner",
+          description: "Plans tasks",
+          model: PluginAgentModel(modelID: "gpt-4o", providerID: "openai", variant: "high"),
+          mode: PluginAgentMode.primary,
+          hidden: false,
+        ),
+      ];
+
+      final response = await handler.handle(
+        makeRequest("POST", "/agent"),
+        body: const ProjectIdRequest(projectId: "/repo"),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(plugin.lastAgentsProjectId, equals("/repo"));
+      expect(response.agents.single.name, equals("planner"));
+    });
+  });
+}

--- a/bridge/app/test/bridge/routing/request_router_test.dart
+++ b/bridge/app/test/bridge/routing/request_router_test.dart
@@ -280,6 +280,19 @@ void main() {
       expect(response.status, equals(200));
     });
 
+    test("routes POST /agent to PostAgentsHandler and forwards the project body", () async {
+      final response = await router.route(
+        makeRequest(
+          "POST",
+          "/agent",
+          body: jsonEncode({"projectId": "/repo"}),
+        ),
+      );
+
+      expect(response.status, equals(200));
+      expect(plugin.lastAgentsProjectId, equals("/repo"));
+    });
+
     test("routes POST /session/questions to GetSessionQuestionsHandler", () async {
       final response = await router.route(
         makeRequest(

--- a/bridge/app/test/bridge/routing/request_router_test.dart
+++ b/bridge/app/test/bridge/routing/request_router_test.dart
@@ -14,6 +14,7 @@ import "package:sesori_bridge/src/bridge/routing/abort_session_handler.dart";
 import "package:sesori_bridge/src/bridge/routing/get_agents_handler.dart";
 import "package:sesori_bridge/src/bridge/routing/get_commands_handler.dart";
 import "package:sesori_bridge/src/bridge/routing/get_session_diffs_handler.dart";
+import "package:sesori_bridge/src/bridge/routing/post_agents_handler.dart";
 import "package:sesori_bridge/src/bridge/routing/request_router.dart";
 import "package:sesori_bridge/src/bridge/routing/send_prompt_handler.dart";
 import "package:sesori_bridge/src/bridge/services/session_abort_service.dart";
@@ -100,6 +101,7 @@ void main() {
         projectRepository: projectRepository,
         providerRepository: providerRepository,
         getAgentsHandler: GetAgentsHandler(AgentRepository(plugin: plugin)),
+        postAgentsHandler: PostAgentsHandler(AgentRepository(plugin: plugin)),
         permissionRepository: permissionRepository,
         sessionPersistenceService: sessionPersistenceService,
         worktreeService: worktreeService,
@@ -419,6 +421,7 @@ void main() {
         projectRepository: projectRepository,
         providerRepository: providerRepository,
         getAgentsHandler: GetAgentsHandler(AgentRepository(plugin: plugin)),
+        postAgentsHandler: PostAgentsHandler(AgentRepository(plugin: plugin)),
         permissionRepository: permissionRepository,
         sessionPersistenceService: sessionPersistenceService,
         worktreeService: worktreeService,

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -55,6 +55,7 @@ class FakeBridgePlugin implements BridgePluginApi {
   List<PluginSession> childSessionsResult = [];
   Map<String, PluginSessionStatus> sessionStatusesResult = {};
   List<PluginAgent> agentsResult = [];
+  String? lastAgentsProjectId;
   List<PluginPendingQuestion> pendingQuestionsResult = [];
   PluginProject? currentProjectResult;
 
@@ -302,7 +303,10 @@ class FakeBridgePlugin implements BridgePluginApi {
   }
 
   @override
-  Future<List<PluginAgent>> getAgents() async => agentsResult;
+  Future<List<PluginAgent>> getAgents({String? projectId}) async {
+    lastAgentsProjectId = projectId;
+    return agentsResult;
+  }
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async => pendingQuestionsResult;

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -303,7 +303,7 @@ class FakeBridgePlugin implements BridgePluginApi {
   }
 
   @override
-  Future<List<PluginAgent>> getAgents({String? projectId}) async {
+  Future<List<PluginAgent>> getAgents({required String projectId}) async {
     lastAgentsProjectId = projectId;
     return agentsResult;
   }

--- a/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
+++ b/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
@@ -1191,7 +1191,7 @@ class _FakeBridgePlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) async {}
 
   @override
-  Future<List<PluginAgent>> getAgents() async => [];
+  Future<List<PluginAgent>> getAgents({String? projectId}) async => [];
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async => [];

--- a/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
+++ b/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
@@ -1191,7 +1191,7 @@ class _FakeBridgePlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) async {}
 
   @override
-  Future<List<PluginAgent>> getAgents({String? projectId}) async => [];
+  Future<List<PluginAgent>> getAgents({required String projectId}) async => [];
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async => [];

--- a/bridge/app/test/bridge/routing/worktree_cleanup_test.dart
+++ b/bridge/app/test/bridge/routing/worktree_cleanup_test.dart
@@ -408,7 +408,7 @@ class _FakeBridgePlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) async {}
 
   @override
-  Future<List<PluginAgent>> getAgents() async => [];
+  Future<List<PluginAgent>> getAgents({String? projectId}) async => [];
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async => [];

--- a/bridge/app/test/bridge/routing/worktree_cleanup_test.dart
+++ b/bridge/app/test/bridge/routing/worktree_cleanup_test.dart
@@ -408,7 +408,7 @@ class _FakeBridgePlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) async {}
 
   @override
-  Future<List<PluginAgent>> getAgents({String? projectId}) async => [];
+  Future<List<PluginAgent>> getAgents({required String projectId}) async => [];
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) async => [];

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -1094,7 +1094,7 @@ class _FakeBridgePluginApi implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) async {}
 
   @override
-  Future<List<PluginAgent>> getAgents() async => [];
+  Future<List<PluginAgent>> getAgents({String? projectId}) async => [];
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -1094,7 +1094,7 @@ class _FakeBridgePluginApi implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) async {}
 
   @override
-  Future<List<PluginAgent>> getAgents({String? projectId}) async => [];
+  Future<List<PluginAgent>> getAgents({required String projectId}) async => [];
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({

--- a/bridge/app/test/integration/pr_sync_fk_regression_test.dart
+++ b/bridge/app/test/integration/pr_sync_fk_regression_test.dart
@@ -319,7 +319,7 @@ class _FakeBridgePlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) => throw UnimplementedError();
 
   @override
-  Future<List<PluginAgent>> getAgents({String? projectId}) => throw UnimplementedError();
+  Future<List<PluginAgent>> getAgents({required String projectId}) => throw UnimplementedError();
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) => throw UnimplementedError();

--- a/bridge/app/test/integration/pr_sync_fk_regression_test.dart
+++ b/bridge/app/test/integration/pr_sync_fk_regression_test.dart
@@ -319,7 +319,7 @@ class _FakeBridgePlugin implements BridgePluginApi {
   Future<void> abortSession({required String sessionId}) => throw UnimplementedError();
 
   @override
-  Future<List<PluginAgent>> getAgents() => throw UnimplementedError();
+  Future<List<PluginAgent>> getAgents({String? projectId}) => throw UnimplementedError();
 
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId}) => throw UnimplementedError();

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -97,7 +97,12 @@ abstract class BridgePluginApi {
 
   Future<void> abortSession({required String sessionId});
 
-  Future<List<PluginAgent>> getAgents();
+  /// Returns the agents available for the given project.
+  ///
+  /// [projectId] is the project worktree directory. When `null`, the plugin
+  /// falls back to a directory it considers reasonable (e.g. its own CWD) —
+  /// kept for callers that predate project-scoped agent listing.
+  Future<List<PluginAgent>> getAgents({String? projectId});
 
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId});
 

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -99,10 +99,8 @@ abstract class BridgePluginApi {
 
   /// Returns the agents available for the given project.
   ///
-  /// [projectId] is the project worktree directory. When `null`, the plugin
-  /// falls back to a directory it considers reasonable (e.g. its own CWD) —
-  /// kept for callers that predate project-scoped agent listing.
-  Future<List<PluginAgent>> getAgents({String? projectId});
+  /// [projectId] identifies the project; its format is plugin-defined.
+  Future<List<PluginAgent>> getAgents({required String projectId});
 
   Future<List<PluginPendingQuestion>> getPendingQuestions({required String sessionId});
 

--- a/bridge/sesori_plugin_interface/lib/src/plugin_api_exception.dart
+++ b/bridge/sesori_plugin_interface/lib/src/plugin_api_exception.dart
@@ -6,8 +6,15 @@ class PluginApiException implements Exception {
   final int statusCode;
   final String endpoint;
 
-  PluginApiException(this.endpoint, this.statusCode);
+  /// Optional upstream failure detail (e.g. the upstream response body) so
+  /// logs surface the actual reason instead of just a status code.
+  final String? detail;
+
+  PluginApiException(this.endpoint, this.statusCode, {this.detail});
 
   @override
-  String toString() => "PluginApiException: $endpoint failed with status $statusCode";
+  String toString() {
+    final detailSuffix = detail == null || detail!.isEmpty ? "" : ": $detail";
+    return "PluginApiException: $endpoint failed with status $statusCode$detailSuffix";
+  }
 }

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -327,12 +327,12 @@ class OpenCodeApi {
     _ensureSuccess(response, "POST /session/$sessionId/abort");
   }
 
-  Future<List<AgentInfo>> listAgents({required String? directory}) async {
+  Future<List<AgentInfo>> listAgents({required String directory}) async {
     // OpenCode resolves agents per project; newer releases reject requests
     // that carry no directory context with a 500.
     final headers = <String, String>{
       ..._authHeaders,
-      _directoryOpenCodeHeader: ?directory,
+      _directoryOpenCodeHeader: directory,
     };
     final response = await _client.get(Uri.parse("$serverURL/agent"), headers: headers);
     _ensureSuccess(response, "GET /agent");

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -327,8 +327,14 @@ class OpenCodeApi {
     _ensureSuccess(response, "POST /session/$sessionId/abort");
   }
 
-  Future<List<AgentInfo>> listAgents() async {
-    final response = await _client.get(Uri.parse("$serverURL/agent"), headers: _authHeaders);
+  Future<List<AgentInfo>> listAgents({required String? directory}) async {
+    // OpenCode resolves agents per project; newer releases reject requests
+    // that carry no directory context with a 500.
+    final headers = <String, String>{
+      ..._authHeaders,
+      _directoryOpenCodeHeader: ?directory,
+    };
+    final response = await _client.get(Uri.parse("$serverURL/agent"), headers: headers);
     _ensureSuccess(response, "GET /agent");
 
     final decoded = jsonDecodeListMap(response.body);
@@ -514,17 +520,33 @@ class OpenCodeApi {
 
   static void _ensureSuccess(http.Response response, String endpoint) {
     if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw OpenCodeApiException(endpoint, response.statusCode);
+      throw OpenCodeApiException(endpoint, response.statusCode, responseBody: response.body);
     }
   }
 }
 
 class OpenCodeApiException implements Exception {
+  static const _maxBodyLength = 500;
+
   final String endpoint;
   final int statusCode;
 
-  OpenCodeApiException(this.endpoint, this.statusCode);
+  /// Upstream response body, truncated to [_maxBodyLength] characters.
+  /// OpenCode error bodies carry the actual failure reason (e.g.
+  /// `{"name":"UnknownError","data":{...}}`), which is essential for
+  /// diagnosing failures from logs.
+  final String? responseBody;
+
+  OpenCodeApiException(this.endpoint, this.statusCode, {String? responseBody})
+    : responseBody = switch (responseBody) {
+        null => null,
+        final body when body.length > _maxBodyLength => "${body.substring(0, _maxBodyLength)}…",
+        final body => body,
+      };
 
   @override
-  String toString() => "OpenCodeApiException: $endpoint failed with status $statusCode";
+  String toString() {
+    final bodySuffix = responseBody == null || responseBody!.isEmpty ? "" : " body=$responseBody";
+    return "OpenCodeApiException: $endpoint failed with status $statusCode$bodySuffix";
+  }
 }

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -90,7 +90,7 @@ class OpenCodePlugin implements BridgePluginApi {
     try {
       return await fn();
     } on OpenCodeApiException catch (e) {
-      throw PluginApiException(e.endpoint, e.statusCode);
+      throw PluginApiException(e.endpoint, e.statusCode, detail: e.responseBody);
     }
   }
 
@@ -308,9 +308,8 @@ class OpenCodePlugin implements BridgePluginApi {
   }
 
   @override
-  Future<List<PluginAgent>> getAgents() async {
-    final agents = await _call(_service.repository.api.listAgents);
-    return agents.map((agent) => agent.toPlugin()).toList();
+  Future<List<PluginAgent>> getAgents({String? projectId}) {
+    return _call(() => _service.getAgents(projectId: projectId));
   }
 
   @override

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -308,7 +308,7 @@ class OpenCodePlugin implements BridgePluginApi {
   }
 
   @override
-  Future<List<PluginAgent>> getAgents({String? projectId}) {
+  Future<List<PluginAgent>> getAgents({required String projectId}) {
     return _call(() => _service.getAgents(projectId: projectId));
   }
 

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
@@ -1,5 +1,6 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
     show
+        PluginAgent,
         PluginCommand,
         PluginCommandSource,
         PluginPermissionReply,
@@ -9,6 +10,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
         PluginSessionVariant;
 import "package:sesori_shared/sesori_shared.dart" show StringExtensions, wait2;
 
+import "models/agent_info.dart";
 import "models/command.dart";
 import "models/pending_permission.dart";
 import "models/pending_question.dart";
@@ -62,6 +64,11 @@ class OpenCodeRepository {
   Future<List<PluginCommand>> getCommands({required String? projectId}) async {
     final commands = await _api.listCommands(directory: projectId?.normalize());
     return commands.map<PluginCommand>(_mapCommand).toList();
+  }
+
+  Future<List<PluginAgent>> getAgents({required String? directory}) async {
+    final agents = await _api.listAgents(directory: directory?.normalize());
+    return agents.map((agent) => agent.toPlugin()).toList();
   }
 
   Future<PluginSession> createSession({

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
@@ -66,8 +66,8 @@ class OpenCodeRepository {
     return commands.map<PluginCommand>(_mapCommand).toList();
   }
 
-  Future<List<PluginAgent>> getAgents({required String? directory}) async {
-    final agents = await _api.listAgents(directory: directory?.normalize());
+  Future<List<PluginAgent>> getAgents({required String directory}) async {
+    final agents = await _api.listAgents(directory: directory);
     return agents.map((agent) => agent.toPlugin()).toList();
   }
 

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -1,7 +1,10 @@
+import "dart:io" as io;
+
 import "package:json_annotation/json_annotation.dart" show CheckedFromJsonException;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
     show
         Log,
+        PluginAgent,
         PluginApiException,
         PluginCommand,
         PluginPermissionReply,
@@ -31,6 +34,21 @@ class OpenCodeService {
 
   Future<List<PluginCommand>> getCommands({required String? projectId}) {
     return repository.getCommands(projectId: projectId);
+  }
+
+  /// Returns the agents available for [projectId] (a worktree directory).
+  ///
+  /// OpenCode resolves agents per project, so a directory is always sent.
+  /// When [projectId] is `null` (callers that predate project-scoped agent
+  /// listing) we fall back to the bridge's own CWD, which yields the global
+  /// agent set.
+  Future<List<PluginAgent>> getAgents({required String? projectId}) {
+    var directory = projectId;
+    if (directory == null) {
+      directory = io.Directory.current.path;
+      Log.d("getAgents: no projectId given, falling back to bridge CWD: $directory");
+    }
+    return repository.getAgents(directory: directory);
   }
 
   Future<List<Session>> getSessions({

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -12,7 +12,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
         PluginProvidersResult,
         PluginSession,
         PluginSessionVariant;
-import "package:sesori_shared/sesori_shared.dart" show ProjectActivitySummary;
+import "package:sesori_shared/sesori_shared.dart" show ProjectActivitySummary, StringExtensions;
 
 import "../opencode_plugin.dart";
 
@@ -39,14 +39,16 @@ class OpenCodeService {
   /// Returns the agents available for [projectId] (a worktree directory).
   ///
   /// OpenCode resolves agents per project, so a directory is always sent.
-  /// When [projectId] is `null` (callers that predate project-scoped agent
-  /// listing) we fall back to the bridge's own CWD, which yields the global
-  /// agent set.
+  /// When [projectId] is `null` or blank we fall back to the bridge's own
+  /// CWD, which yields the global agent set.
   Future<List<PluginAgent>> getAgents({required String? projectId}) {
-    var directory = projectId;
-    if (directory == null) {
+    final String directory;
+    final normalized = projectId?.normalize();
+    if (normalized == null) {
       directory = io.Directory.current.path;
       Log.d("getAgents: no projectId given, falling back to bridge CWD: $directory");
+    } else {
+      directory = normalized;
     }
     return repository.getAgents(directory: directory);
   }

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -1155,7 +1155,7 @@ class _FakeApi implements OpenCodeApi {
   Future<void> abortSession({required String sessionId, required String? directory}) async {}
 
   @override
-  Future<List<AgentInfo>> listAgents() async => [];
+  Future<List<AgentInfo>> listAgents({required String? directory}) async => [];
 
   @override
   Future<List<PendingQuestion>> getPendingQuestions({required String? directory}) async => [];

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -1155,7 +1155,7 @@ class _FakeApi implements OpenCodeApi {
   Future<void> abortSession({required String sessionId, required String? directory}) async {}
 
   @override
-  Future<List<AgentInfo>> listAgents({required String? directory}) async => [];
+  Future<List<AgentInfo>> listAgents({required String directory}) async => [];
 
   @override
   Future<List<PendingQuestion>> getPendingQuestions({required String? directory}) async => [];

--- a/bridge/sesori_plugin_opencode/test/opencode_api_http_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_api_http_test.dart
@@ -86,25 +86,6 @@ void main() {
       expect(agents.single.name, equals("build"));
     });
 
-    test("omits the directory header when no directory is given", () async {
-      late http.BaseRequest capturedRequest;
-
-      final mockClient = MockClient((request) async {
-        capturedRequest = request;
-        return http.Response(jsonEncode(<Map<String, dynamic>>[]), 200);
-      });
-
-      final api = OpenCodeApi(
-        serverURL: "http://localhost:1234",
-        password: "test-pass",
-        client: mockClient,
-      );
-
-      await api.listAgents(directory: null);
-
-      expect(capturedRequest.headers.containsKey("x-opencode-directory"), isFalse);
-    });
-
     test("includes the upstream response body in the thrown exception", () async {
       final mockClient = MockClient((request) async {
         return http.Response('{"name":"UnknownError","data":{"message":"boom"}}', 500);

--- a/bridge/sesori_plugin_opencode/test/opencode_api_http_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_api_http_test.dart
@@ -53,6 +53,80 @@ void main() {
     });
   });
 
+  group("OpenCodeApi.listAgents", () {
+    test("uses GET /agent and forwards the directory header", () async {
+      late http.BaseRequest capturedRequest;
+
+      final mockClient = MockClient((request) async {
+        capturedRequest = request;
+        return http.Response(
+          jsonEncode([
+            {
+              "name": "build",
+              "description": "The default agent.",
+              "mode": "primary",
+              "model": {"modelID": "gpt-4.1", "providerID": "openai"},
+            },
+          ]),
+          200,
+        );
+      });
+
+      final api = OpenCodeApi(
+        serverURL: "http://localhost:1234",
+        password: "test-pass",
+        client: mockClient,
+      );
+
+      final agents = await api.listAgents(directory: "/repo");
+
+      expect(capturedRequest.method, equals("GET"));
+      expect(capturedRequest.url.toString(), equals("http://localhost:1234/agent"));
+      expect(capturedRequest.headers["x-opencode-directory"], equals("/repo"));
+      expect(agents.single.name, equals("build"));
+    });
+
+    test("omits the directory header when no directory is given", () async {
+      late http.BaseRequest capturedRequest;
+
+      final mockClient = MockClient((request) async {
+        capturedRequest = request;
+        return http.Response(jsonEncode(<Map<String, dynamic>>[]), 200);
+      });
+
+      final api = OpenCodeApi(
+        serverURL: "http://localhost:1234",
+        password: "test-pass",
+        client: mockClient,
+      );
+
+      await api.listAgents(directory: null);
+
+      expect(capturedRequest.headers.containsKey("x-opencode-directory"), isFalse);
+    });
+
+    test("includes the upstream response body in the thrown exception", () async {
+      final mockClient = MockClient((request) async {
+        return http.Response('{"name":"UnknownError","data":{"message":"boom"}}', 500);
+      });
+
+      final api = OpenCodeApi(
+        serverURL: "http://localhost:1234",
+        password: "test-pass",
+        client: mockClient,
+      );
+
+      await expectLater(
+        api.listAgents(directory: "/repo"),
+        throwsA(
+          isA<OpenCodeApiException>()
+              .having((e) => e.statusCode, "statusCode", 500)
+              .having((e) => e.responseBody, "responseBody", contains("UnknownError")),
+        ),
+      );
+    });
+  });
+
   group("OpenCodeApi.sendCommand", () {
     test("uses the injected client for POST /session/{id}/command", () async {
       var calls = 0;

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -628,7 +628,7 @@ class _FakeApi implements OpenCodeApi {
   Future<void> abortSession({required String sessionId, required String? directory}) async {}
 
   @override
-  Future<List<AgentInfo>> listAgents() async => [];
+  Future<List<AgentInfo>> listAgents({required String? directory}) async => [];
 
   @override
   Future<List<PendingQuestion>> getPendingQuestions({required String? directory}) async => [];

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -628,7 +628,7 @@ class _FakeApi implements OpenCodeApi {
   Future<void> abortSession({required String sessionId, required String? directory}) async {}
 
   @override
-  Future<List<AgentInfo>> listAgents({required String? directory}) async => [];
+  Future<List<AgentInfo>> listAgents({required String directory}) async => [];
 
   @override
   Future<List<PendingQuestion>> getPendingQuestions({required String? directory}) async => [];

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -1,3 +1,5 @@
+import "dart:io" as io;
+
 import "package:opencode_plugin/opencode_plugin.dart" hide Message, MessageError, MessageErrorData, MessageWithParts;
 import "package:opencode_plugin/src/models/message.dart" as plugin_msg;
 import "package:opencode_plugin/src/models/message_with_parts.dart" as plugin;
@@ -37,6 +39,26 @@ void main() {
       expect(repository.lastCommandsProjectId, equals("/repo"));
       expect(commands, hasLength(1));
       expect(commands.single.name, equals("/review-work"));
+    });
+  });
+
+  group("OpenCodeService.getAgents", () {
+    test("passes the projectId through as the directory", () async {
+      final repository = FakeOpenCodeRepository();
+      final service = OpenCodeService(repository, FakeActiveSessionTracker());
+
+      await service.getAgents(projectId: "/repo");
+
+      expect(repository.lastAgentsDirectory, equals("/repo"));
+    });
+
+    test("falls back to the current working directory when projectId is null", () async {
+      final repository = FakeOpenCodeRepository();
+      final service = OpenCodeService(repository, FakeActiveSessionTracker());
+
+      await service.getAgents(projectId: null);
+
+      expect(repository.lastAgentsDirectory, equals(io.Directory.current.path));
     });
   });
 
@@ -585,7 +607,7 @@ class FakeOpenCodeApi implements OpenCodeApi {
   Future<void> abortSession({required String sessionId, required String? directory}) async {}
 
   @override
-  Future<List<AgentInfo>> listAgents() async => [];
+  Future<List<AgentInfo>> listAgents({required String? directory}) async => [];
 
   @override
   Future<List<PendingQuestion>> getPendingQuestions({required String? directory}) async => [];
@@ -662,6 +684,7 @@ class FakeOpenCodeRepository extends OpenCodeRepository {
   int getSessionsCalls = 0;
   String? lastWorktree;
   String? lastCommandsProjectId;
+  String? lastAgentsDirectory;
   String? lastCreateDirectory;
   String? lastCreateParentSessionId;
   String? lastPromptSessionId;
@@ -706,6 +729,12 @@ class FakeOpenCodeRepository extends OpenCodeRepository {
     getSessionsCalls += 1;
     lastWorktree = worktree;
     return _sessions;
+  }
+
+  @override
+  Future<List<PluginAgent>> getAgents({required String? directory}) async {
+    lastAgentsDirectory = directory;
+    return const [];
   }
 
   @override

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -607,7 +607,7 @@ class FakeOpenCodeApi implements OpenCodeApi {
   Future<void> abortSession({required String sessionId, required String? directory}) async {}
 
   @override
-  Future<List<AgentInfo>> listAgents({required String? directory}) async => [];
+  Future<List<AgentInfo>> listAgents({required String directory}) async => [];
 
   @override
   Future<List<PendingQuestion>> getPendingQuestions({required String? directory}) async => [];
@@ -732,7 +732,7 @@ class FakeOpenCodeRepository extends OpenCodeRepository {
   }
 
   @override
-  Future<List<PluginAgent>> getAgents({required String? directory}) async {
+  Future<List<PluginAgent>> getAgents({required String directory}) async {
     lastAgentsDirectory = directory;
     return const [];
   }

--- a/mobile/app/test/features/new_session/new_session_screen_test.dart
+++ b/mobile/app/test/features/new_session/new_session_screen_test.dart
@@ -70,7 +70,7 @@ void main() {
     sessionService = MockSessionService();
     voiceTranscriptionService = MockVoiceTranscriptionService();
 
-    when(() => sessionService.listAgents()).thenAnswer(
+    when(() => sessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
       (_) async => ApiResponse.success(
         Agents(
           agents: [

--- a/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/mobile/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -124,7 +124,7 @@ void main() {
         verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(1);
         verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
         verify(() => mockSessionService.getSessionStatuses()).called(1);
-        verify(() => mockSessionService.listAgents()).called(1);
+        verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).called(1);
         verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).called(1);
         verify(() => mockSessionService.listCommands(projectId: "project-1")).called(1);
         verify(() => mockSessionRepository.getSession(sessionId: sessionId)).called(1);
@@ -182,7 +182,7 @@ void main() {
         verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(2);
         verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(2);
         verify(() => mockSessionService.getSessionStatuses()).called(2);
-        verify(() => mockSessionService.listAgents()).called(2);
+        verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).called(2);
         verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).called(2);
         verify(() => mockSessionService.listCommands(projectId: "project-1")).called(2);
         verify(() => mockSessionRepository.getSession(sessionId: sessionId)).called(2);
@@ -1776,7 +1776,7 @@ void _stubAllDefaults(
     ),
   );
   when(
-    () => service.listAgents(),
+    () => service.listAgents(projectId: any(named: "projectId")),
   ).thenAnswer(
     (_) => Future<ApiResponse<Agents>>.value(
       ApiResponse.success(Agents(agents: [testAgentInfo()])),

--- a/mobile/app/test/helpers/test_helpers.dart
+++ b/mobile/app/test/helpers/test_helpers.dart
@@ -195,7 +195,7 @@ void delegateSessionRepositoryToService({
   );
   when(() => repository.getSessionStatuses()).thenAnswer((_) => service.getSessionStatuses());
   when(() => repository.listAgents(projectId: any(named: "projectId"))).thenAnswer(
-    (invocation) => service.listAgents(projectId: invocation.namedArguments[#projectId] as String?),
+    (invocation) => service.listAgents(projectId: invocation.namedArguments[#projectId] as String),
   );
   when(() => repository.listProviders(projectId: any(named: "projectId"))).thenAnswer(
     (invocation) => service.listProviders(projectId: invocation.namedArguments[#projectId] as String),

--- a/mobile/app/test/helpers/test_helpers.dart
+++ b/mobile/app/test/helpers/test_helpers.dart
@@ -194,7 +194,9 @@ void delegateSessionRepositoryToService({
     (invocation) => service.getChildren(sessionId: invocation.namedArguments[#sessionId]! as String),
   );
   when(() => repository.getSessionStatuses()).thenAnswer((_) => service.getSessionStatuses());
-  when(() => repository.listAgents(projectId: any(named: "projectId"))).thenAnswer((_) => service.listAgents());
+  when(() => repository.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+    (invocation) => service.listAgents(projectId: invocation.namedArguments[#projectId] as String?),
+  );
   when(() => repository.listProviders(projectId: any(named: "projectId"))).thenAnswer(
     (invocation) => service.listProviders(projectId: invocation.namedArguments[#projectId] as String),
   );

--- a/mobile/app/test/helpers/test_helpers.dart
+++ b/mobile/app/test/helpers/test_helpers.dart
@@ -194,7 +194,7 @@ void delegateSessionRepositoryToService({
     (invocation) => service.getChildren(sessionId: invocation.namedArguments[#sessionId]! as String),
   );
   when(() => repository.getSessionStatuses()).thenAnswer((_) => service.getSessionStatuses());
-  when(() => repository.listAgents()).thenAnswer((_) => service.listAgents());
+  when(() => repository.listAgents(projectId: any(named: "projectId"))).thenAnswer((_) => service.listAgents());
   when(() => repository.listProviders(projectId: any(named: "projectId"))).thenAnswer(
     (invocation) => service.listProviders(projectId: invocation.namedArguments[#projectId] as String),
   );

--- a/mobile/module_core/lib/src/api/session_api.dart
+++ b/mobile/module_core/lib/src/api/session_api.dart
@@ -17,11 +17,19 @@ class SessionApi {
 
   SessionApi({required RelayHttpApiClient client}) : _client = client;
 
-  Future<ApiResponse<Agents>> listAgents({String? projectId}) {
-    return _client.get(
+  Future<ApiResponse<Agents>> listAgents({required String? projectId}) {
+    if (projectId == null) {
+      // Deprecated bridge route for callers with no project context; the
+      // bridge resolves a fallback project (its CWD) itself.
+      return _client.get(
+        "/agent",
+        fromJson: Agents.fromJson,
+      );
+    }
+    return _client.post(
       "/agent",
       fromJson: Agents.fromJson,
-      queryParameters: projectId == null ? null : {"projectId": projectId},
+      body: ProjectIdRequest(projectId: projectId),
     );
   }
 

--- a/mobile/module_core/lib/src/api/session_api.dart
+++ b/mobile/module_core/lib/src/api/session_api.dart
@@ -17,10 +17,11 @@ class SessionApi {
 
   SessionApi({required RelayHttpApiClient client}) : _client = client;
 
-  Future<ApiResponse<Agents>> listAgents() {
+  Future<ApiResponse<Agents>> listAgents({String? projectId}) {
     return _client.get(
       "/agent",
       fromJson: Agents.fromJson,
+      queryParameters: projectId == null ? null : {"projectId": projectId},
     );
   }
 

--- a/mobile/module_core/lib/src/api/session_api.dart
+++ b/mobile/module_core/lib/src/api/session_api.dart
@@ -17,15 +17,7 @@ class SessionApi {
 
   SessionApi({required RelayHttpApiClient client}) : _client = client;
 
-  Future<ApiResponse<Agents>> listAgents({required String? projectId}) {
-    if (projectId == null) {
-      // Deprecated bridge route for callers with no project context; the
-      // bridge resolves a fallback project (its CWD) itself.
-      return _client.get(
-        "/agent",
-        fromJson: Agents.fromJson,
-      );
-    }
+  Future<ApiResponse<Agents>> listAgents({required String projectId}) {
     return _client.post(
       "/agent",
       fromJson: Agents.fromJson,

--- a/mobile/module_core/lib/src/capabilities/session/session_service.dart
+++ b/mobile/module_core/lib/src/capabilities/session/session_service.dart
@@ -83,7 +83,12 @@ class SessionService {
   }
 
   Future<ApiResponse<Agents>> listAgents({required String? projectId}) {
-    return _repository.listAgents(projectId: projectId?.normalize());
+    final normalizedProjectId = projectId?.normalize();
+    if (normalizedProjectId == null) {
+      return Future.value(ApiResponse.success(const Agents(agents: <AgentInfo>[])));
+    }
+
+    return _repository.listAgents(projectId: normalizedProjectId);
   }
 
   Future<ApiResponse<ProviderListResponse>> listProviders({required String projectId}) {

--- a/mobile/module_core/lib/src/capabilities/session/session_service.dart
+++ b/mobile/module_core/lib/src/capabilities/session/session_service.dart
@@ -82,7 +82,7 @@ class SessionService {
     return _repository.getSessionStatuses();
   }
 
-  Future<ApiResponse<Agents>> listAgents({String? projectId}) {
+  Future<ApiResponse<Agents>> listAgents({required String? projectId}) {
     return _repository.listAgents(projectId: projectId?.normalize());
   }
 

--- a/mobile/module_core/lib/src/capabilities/session/session_service.dart
+++ b/mobile/module_core/lib/src/capabilities/session/session_service.dart
@@ -82,8 +82,8 @@ class SessionService {
     return _repository.getSessionStatuses();
   }
 
-  Future<ApiResponse<Agents>> listAgents() {
-    return _repository.listAgents();
+  Future<ApiResponse<Agents>> listAgents({String? projectId}) {
+    return _repository.listAgents(projectId: projectId?.normalize());
   }
 
   Future<ApiResponse<ProviderListResponse>> listProviders({required String projectId}) {

--- a/mobile/module_core/lib/src/capabilities/session/session_service.dart
+++ b/mobile/module_core/lib/src/capabilities/session/session_service.dart
@@ -82,13 +82,8 @@ class SessionService {
     return _repository.getSessionStatuses();
   }
 
-  Future<ApiResponse<Agents>> listAgents({required String? projectId}) {
-    final normalizedProjectId = projectId?.normalize();
-    if (normalizedProjectId == null) {
-      return Future.value(ApiResponse.success(const Agents(agents: <AgentInfo>[])));
-    }
-
-    return _repository.listAgents(projectId: normalizedProjectId);
+  Future<ApiResponse<Agents>> listAgents({required String projectId}) {
+    return _repository.listAgents(projectId: projectId);
   }
 
   Future<ApiResponse<ProviderListResponse>> listProviders({required String projectId}) {

--- a/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
@@ -40,12 +40,16 @@ class NewSessionCubit extends Cubit<NewSessionState> {
         ApiResponse<ProviderListResponse> providersResponse,
         ApiResponse<CommandListResponse> commandsResponse,
       ) = await wait3(
-        _sessionService.listAgents(),
+        _sessionService.listAgents(projectId: _projectId),
         _sessionService.listProviders(projectId: _projectId),
         _sessionService.listCommands(projectId: _projectId),
       );
 
       if (isClosed) return;
+
+      _logComposerDataError(resource: "agents", response: agentsResponse);
+      _logComposerDataError(resource: "providers", response: providersResponse);
+      _logComposerDataError(resource: "commands", response: commandsResponse);
 
       final agents = switch (agentsResponse) {
         SuccessResponse(:final data) => data.agents.where((a) => !a.hidden && a.mode != AgentMode.subagent).toList(),
@@ -98,8 +102,18 @@ class NewSessionCubit extends Cubit<NewSessionState> {
         selectedAgent: defaultAgent,
         selectedAgentModel: defaultAgentModel,
       );
-    } catch (_) {
+    } catch (e, stackTrace) {
+      loge("New session: failed to load composer data for project $_projectId", e, stackTrace);
       return;
+    }
+  }
+
+  /// The composer degrades gracefully on partial failures (empty pickers),
+  /// which previously made these errors invisible. Log them so missing
+  /// agent/model pickers can be traced back to the failing request.
+  void _logComposerDataError<T>({required String resource, required ApiResponse<T> response}) {
+    if (response case ErrorResponse(:final error)) {
+      loge("New session: failed to load $resource for project $_projectId", error);
     }
   }
 

--- a/mobile/module_core/lib/src/repositories/session_repository.dart
+++ b/mobile/module_core/lib/src/repositories/session_repository.dart
@@ -93,8 +93,8 @@ class SessionRepository {
     return _api.getSession(sessionId: sessionId);
   }
 
-  Future<ApiResponse<Agents>> listAgents() {
-    return _api.listAgents();
+  Future<ApiResponse<Agents>> listAgents({String? projectId}) {
+    return _api.listAgents(projectId: projectId);
   }
 
   Future<ApiResponse<ProviderListResponse>> listProviders({required String projectId}) async {

--- a/mobile/module_core/lib/src/repositories/session_repository.dart
+++ b/mobile/module_core/lib/src/repositories/session_repository.dart
@@ -93,7 +93,7 @@ class SessionRepository {
     return _api.getSession(sessionId: sessionId);
   }
 
-  Future<ApiResponse<Agents>> listAgents({String? projectId}) {
+  Future<ApiResponse<Agents>> listAgents({required String? projectId}) {
     return _api.listAgents(projectId: projectId);
   }
 

--- a/mobile/module_core/lib/src/repositories/session_repository.dart
+++ b/mobile/module_core/lib/src/repositories/session_repository.dart
@@ -93,7 +93,7 @@ class SessionRepository {
     return _api.getSession(sessionId: sessionId);
   }
 
-  Future<ApiResponse<Agents>> listAgents({required String? projectId}) {
+  Future<ApiResponse<Agents>> listAgents({required String projectId}) {
     return _api.listAgents(projectId: projectId);
   }
 

--- a/mobile/module_core/lib/src/services/session_detail_load_service.dart
+++ b/mobile/module_core/lib/src/services/session_detail_load_service.dart
@@ -57,7 +57,7 @@ class SessionDetailLoadService {
         _repository.getPendingPermissions(),
         _repository.getChildren(sessionId: sessionId),
         _repository.getSessionStatuses(),
-        _repository.listAgents(),
+        _repository.listAgents(projectId: routeProjectId),
         _repository.listProviders(projectId: projectId),
         _repository.getSession(sessionId: sessionId),
       ).wait;

--- a/mobile/module_core/lib/src/services/session_detail_load_service.dart
+++ b/mobile/module_core/lib/src/services/session_detail_load_service.dart
@@ -42,13 +42,13 @@ class SessionDetailLoadService {
       final routeProjectId = projectId.normalize();
       final projectContextFuture = _loadProjectSessionContext(sessionId: sessionId);
       final commandsFuture = routeProjectId == null ? null : _listCommands(projectId: routeProjectId);
+      final agentsFuture = routeProjectId == null ? null : _repository.listAgents(projectId: routeProjectId);
       final (
         messagesResponse,
         questionsResponse,
         permissionsResponse,
         childrenResponse,
         statusesResponse,
-        agentsResponse,
         providersResponse,
         sessionResponse,
       ) = await (
@@ -57,13 +57,15 @@ class SessionDetailLoadService {
         _repository.getPendingPermissions(),
         _repository.getChildren(sessionId: sessionId),
         _repository.getSessionStatuses(),
-        _repository.listAgents(projectId: routeProjectId),
         _repository.listProviders(projectId: projectId),
         _repository.getSession(sessionId: sessionId),
       ).wait;
       final projectContext = await projectContextFuture;
       final effectiveProjectId = routeProjectId ?? projectContext?.projectId;
+      // When the route carries no project id, resolve it from the session
+      // context so agents and commands are still project-scoped.
       final commandsResponse = await (commandsFuture ?? _listCommands(projectId: effectiveProjectId));
+      final agentsResponse = await (agentsFuture ?? _repository.listAgents(projectId: effectiveProjectId));
       final session = switch (sessionResponse) {
         SuccessResponse(:final data) => data,
         ErrorResponse(:final error) => () {

--- a/mobile/module_core/lib/src/services/session_detail_load_service.dart
+++ b/mobile/module_core/lib/src/services/session_detail_load_service.dart
@@ -42,7 +42,7 @@ class SessionDetailLoadService {
       final routeProjectId = projectId.normalize();
       final projectContextFuture = _loadProjectSessionContext(sessionId: sessionId);
       final commandsFuture = routeProjectId == null ? null : _listCommands(projectId: routeProjectId);
-      final agentsFuture = routeProjectId == null ? null : _repository.listAgents(projectId: routeProjectId);
+      final agentsFuture = routeProjectId == null ? null : _listAgents(projectId: routeProjectId);
       final (
         messagesResponse,
         questionsResponse,
@@ -65,7 +65,7 @@ class SessionDetailLoadService {
       // When the route carries no project id, resolve it from the session
       // context so agents and commands are still project-scoped.
       final commandsResponse = await (commandsFuture ?? _listCommands(projectId: effectiveProjectId));
-      final agentsResponse = await (agentsFuture ?? _repository.listAgents(projectId: effectiveProjectId));
+      final agentsResponse = await (agentsFuture ?? _listAgents(projectId: effectiveProjectId));
       final session = switch (sessionResponse) {
         SuccessResponse(:final data) => data,
         ErrorResponse(:final error) => () {
@@ -138,6 +138,19 @@ class SessionDetailLoadService {
     } on Object catch (error, stackTrace) {
       return SessionDetailLoadResult.failed(error: error, stackTrace: stackTrace);
     }
+  }
+
+  Future<ApiResponse<Agents>> _listAgents({required String? projectId}) {
+    final normalizedProjectId = projectId?.normalize();
+    if (normalizedProjectId == null) {
+      // Without any project context there is no way to scope the agent list;
+      // an empty list keeps the UI consistent instead of guessing a project.
+      return Future<ApiResponse<Agents>>.value(
+        ApiResponse.success(const Agents(agents: <AgentInfo>[])),
+      );
+    }
+
+    return _repository.listAgents(projectId: normalizedProjectId);
   }
 
   Future<ApiResponse<CommandListResponse>> _listCommands({required String? projectId}) {

--- a/mobile/module_core/test/cubits/new_session/new_session_cubit_test.dart
+++ b/mobile/module_core/test/cubits/new_session/new_session_cubit_test.dart
@@ -16,7 +16,7 @@ void main() {
       mockSessionService = MockSessionService();
 
       when(
-        () => mockSessionService.listAgents(),
+        () => mockSessionService.listAgents(projectId: any(named: "projectId")),
       ).thenAnswer((_) async => ApiResponse<Agents>.success(const Agents(agents: <AgentInfo>[])));
       when(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).thenAnswer(
         (_) async => ApiResponse<ProviderListResponse>.success(
@@ -170,7 +170,7 @@ void main() {
     blocTest<NewSessionCubit, NewSessionState>(
       "selectVariant updates state and createSession forwards variant",
       build: () {
-        when(() => mockSessionService.listAgents()).thenAnswer(
+        when(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
           (_) async => ApiResponse.success(
             const Agents(
               agents: [
@@ -244,7 +244,7 @@ void main() {
     blocTest<NewSessionCubit, NewSessionState>(
       "selectAgent changes agent without affecting selected model variant",
       build: () {
-        when(() => mockSessionService.listAgents()).thenAnswer(
+        when(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
           (_) async => ApiResponse.success(
             const Agents(
               agents: [
@@ -291,7 +291,7 @@ void main() {
     blocTest<NewSessionCubit, NewSessionState>(
       "selectModel updates selectedAgentModel to the chosen model variant",
       build: () {
-        when(() => mockSessionService.listAgents()).thenAnswer(
+        when(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
           (_) async => ApiResponse.success(
             const Agents(
               agents: [
@@ -334,7 +334,7 @@ void main() {
     blocTest<NewSessionCubit, NewSessionState>(
       "selectVariant updates selectedAgentModel variant",
       build: () {
-        when(() => mockSessionService.listAgents()).thenAnswer(
+        when(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
           (_) async => ApiResponse.success(
             const Agents(
               agents: [
@@ -395,7 +395,7 @@ void main() {
     blocTest<NewSessionCubit, NewSessionState>(
       "selectVariant to null clears selectedAgentModel variant",
       build: () {
-        when(() => mockSessionService.listAgents()).thenAnswer(
+        when(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
           (_) async => ApiResponse.success(
             const Agents(
               agents: [

--- a/mobile/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
+++ b/mobile/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
@@ -278,7 +278,7 @@ void main() {
       verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getSessionStatuses()).called(1);
-      verify(() => mockSessionService.listAgents()).called(1);
+      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).called(1);
       verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).called(1);
     });
 
@@ -376,7 +376,7 @@ void _stubLoadApis(MockSessionService service, {required String sessionId}) {
       ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
     ),
   );
-  when(() => service.listAgents()).thenAnswer(
+  when(() => service.listAgents(projectId: any(named: "projectId"))).thenAnswer(
     (_) => Future<ApiResponse<Agents>>.value(ApiResponse.success(Agents(agents: _agents()))),
   );
   when(() => service.listProviders(projectId: any(named: "projectId"))).thenAnswer(

--- a/mobile/module_core/test/cubits/session_detail/session_detail_reconnect_test.dart
+++ b/mobile/module_core/test/cubits/session_detail/session_detail_reconnect_test.dart
@@ -301,7 +301,7 @@ void _stubLoadApis(MockSessionService service) {
   when(() => service.getSessionStatuses()).thenAnswer(
     (_) async => ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
   );
-  when(() => service.listAgents()).thenAnswer(
+  when(() => service.listAgents(projectId: any(named: "projectId"))).thenAnswer(
     (_) async => ApiResponse.success(
       const Agents(
         agents: [

--- a/mobile/module_core/test/cubits/session_detail/session_detail_stale_test.dart
+++ b/mobile/module_core/test/cubits/session_detail/session_detail_stale_test.dart
@@ -140,7 +140,7 @@ void main() {
         verifyNever(() => mockSessionService.getPendingQuestions(sessionId: sessionId));
         verifyNever(() => mockSessionService.getChildren(sessionId: sessionId));
         verifyNever(() => mockSessionService.getSessionStatuses());
-        verifyNever(() => mockSessionService.listAgents());
+        verifyNever(() => mockSessionService.listAgents(projectId: any(named: "projectId")));
         verifyNever(() => mockSessionService.listProviders(projectId: any(named: "projectId")));
 
         connectionStatus.add(connectedStatus);
@@ -189,7 +189,7 @@ void main() {
       verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getSessionStatuses()).called(1);
-      verify(() => mockSessionService.listAgents()).called(1);
+      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).called(1);
       verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).called(1);
 
       expect(emitted.first, isA<SessionDetailLoaded>().having((s) => s.isRefreshing, "isRefreshing", isTrue));
@@ -219,7 +219,7 @@ void main() {
       cubit.selectModel(providerID: "openai", modelID: "gpt-4.1");
       cubit.selectVariant(const SessionVariant(id: "xhigh"));
 
-      when(() => mockSessionService.listAgents()).thenAnswer(
+      when(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
         (_) async => ApiResponse.success(
           const Agents(
             agents: [
@@ -336,7 +336,7 @@ void main() {
         (_) async => ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
       );
       when(
-        () => mockSessionService.listAgents(),
+        () => mockSessionService.listAgents(projectId: any(named: "projectId")),
       ).thenAnswer((_) async => ApiResponse.success(Agents(agents: _agents())));
       when(
         () => mockSessionService.listProviders(projectId: any(named: "projectId")),
@@ -427,7 +427,7 @@ void main() {
       verify(() => mockSessionService.getPendingPermissions()).called(1);
       verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getSessionStatuses()).called(1);
-      verify(() => mockSessionService.listAgents()).called(1);
+      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).called(1);
       verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).called(1);
 
       messagesCompleter.complete(ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()])));
@@ -532,7 +532,7 @@ void main() {
         (_) async => ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
       );
       when(
-        () => mockSessionService.listAgents(),
+        () => mockSessionService.listAgents(projectId: any(named: "projectId")),
       ).thenAnswer((_) async => ApiResponse.success(Agents(agents: _agents())));
       when(
         () => mockSessionService.listProviders(projectId: any(named: "projectId")),
@@ -555,7 +555,7 @@ void main() {
       verify(() => mockSessionService.getPendingPermissions()).called(1);
       verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getSessionStatuses()).called(1);
-      verify(() => mockSessionService.listAgents()).called(1);
+      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).called(1);
       verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).called(1);
     });
   });
@@ -597,7 +597,7 @@ void _stubLoadApis(MockSessionService service, {required String sessionId}) {
       ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
     ),
   );
-  when(() => service.listAgents()).thenAnswer(
+  when(() => service.listAgents(projectId: any(named: "projectId"))).thenAnswer(
     (_) => Future<ApiResponse<Agents>>.value(ApiResponse.success(Agents(agents: _agents()))),
   );
   when(() => service.listProviders(projectId: any(named: "projectId"))).thenAnswer(

--- a/mobile/module_core/test/helpers/test_helpers.dart
+++ b/mobile/module_core/test/helpers/test_helpers.dart
@@ -122,7 +122,7 @@ void delegateSessionRepositoryToService({
     (invocation) => service.getChildren(sessionId: invocation.namedArguments[#sessionId]! as String),
   );
   when(() => repository.getSessionStatuses()).thenAnswer((_) => service.getSessionStatuses());
-  when(() => repository.listAgents()).thenAnswer((_) => service.listAgents());
+  when(() => repository.listAgents(projectId: any(named: "projectId"))).thenAnswer((_) => service.listAgents());
   when(() => repository.listProviders(projectId: any(named: "projectId"))).thenAnswer(
     (invocation) => service.listProviders(projectId: invocation.namedArguments[#projectId] as String),
   );

--- a/mobile/module_core/test/helpers/test_helpers.dart
+++ b/mobile/module_core/test/helpers/test_helpers.dart
@@ -122,7 +122,9 @@ void delegateSessionRepositoryToService({
     (invocation) => service.getChildren(sessionId: invocation.namedArguments[#sessionId]! as String),
   );
   when(() => repository.getSessionStatuses()).thenAnswer((_) => service.getSessionStatuses());
-  when(() => repository.listAgents(projectId: any(named: "projectId"))).thenAnswer((_) => service.listAgents());
+  when(() => repository.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+    (invocation) => service.listAgents(projectId: invocation.namedArguments[#projectId] as String?),
+  );
   when(() => repository.listProviders(projectId: any(named: "projectId"))).thenAnswer(
     (invocation) => service.listProviders(projectId: invocation.namedArguments[#projectId] as String),
   );

--- a/mobile/module_core/test/helpers/test_helpers.dart
+++ b/mobile/module_core/test/helpers/test_helpers.dart
@@ -123,7 +123,7 @@ void delegateSessionRepositoryToService({
   );
   when(() => repository.getSessionStatuses()).thenAnswer((_) => service.getSessionStatuses());
   when(() => repository.listAgents(projectId: any(named: "projectId"))).thenAnswer(
-    (invocation) => service.listAgents(projectId: invocation.namedArguments[#projectId] as String?),
+    (invocation) => service.listAgents(projectId: invocation.namedArguments[#projectId] as String),
   );
   when(() => repository.listProviders(projectId: any(named: "projectId"))).thenAnswer(
     (invocation) => service.listProviders(projectId: invocation.namedArguments[#projectId] as String),

--- a/mobile/module_core/test/repositories/session_repository_test.dart
+++ b/mobile/module_core/test/repositories/session_repository_test.dart
@@ -28,7 +28,9 @@ void main() {
     when(api.getSessionStatuses).thenAnswer(
       (_) async => ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
     );
-    when(api.listAgents).thenAnswer((_) async => ApiResponse.success(const Agents(agents: <AgentInfo>[])));
+    when(
+      () => api.listAgents(projectId: any(named: "projectId")),
+    ).thenAnswer((_) async => ApiResponse.success(const Agents(agents: <AgentInfo>[])));
     when(() => api.listProviders(projectId: any(named: "projectId"))).thenAnswer(
       (_) async => ApiResponse.success(const ProviderListResponse(connectedOnly: false, items: <ProviderInfo>[])),
     );
@@ -63,7 +65,7 @@ void main() {
     await repository.getPendingPermissions();
     await repository.getChildren(sessionId: "session-1");
     await repository.getSessionStatuses();
-    await repository.listAgents();
+    await repository.listAgents(projectId: "project-1");
     await repository.listProviders(projectId: "project-1");
     await repository.listCommands(projectId: "project-1");
     await repository.sendMessage(
@@ -88,7 +90,7 @@ void main() {
     verify(api.getPendingPermissions).called(1);
     verify(() => api.getChildren(sessionId: "session-1")).called(1);
     verify(api.getSessionStatuses).called(1);
-    verify(api.listAgents).called(1);
+    verify(() => api.listAgents(projectId: "project-1")).called(1);
     verify(() => api.listProviders(projectId: "project-1")).called(1);
     verify(() => api.listCommands(projectId: "project-1")).called(1);
     verify(

--- a/mobile/module_core/test/services/session_detail_load_service_test.dart
+++ b/mobile/module_core/test/services/session_detail_load_service_test.dart
@@ -100,7 +100,7 @@ void main() {
         (_) async => ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
       );
       when(
-        () => repository.listAgents(),
+        () => repository.listAgents(projectId: any(named: "projectId")),
       ).thenAnswer((_) async => ApiResponse.success(const Agents(agents: <AgentInfo>[])));
       when(() => repository.listProviders(projectId: any(named: "projectId"))).thenAnswer(
         (_) async => ApiResponse.success(const ProviderListResponse(connectedOnly: false, items: <ProviderInfo>[])),
@@ -168,7 +168,7 @@ void _stubRepositorySnapshot({
   when(() => repository.getSessionStatuses()).thenAnswer(
     (_) async => ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
   );
-  when(() => repository.listAgents()).thenAnswer(
+  when(() => repository.listAgents(projectId: any(named: "projectId"))).thenAnswer(
     (_) async => ApiResponse.success(
       const Agents(
         agents: [


### PR DESCRIPTION
## Problem

On the mobile new-session screen, the agent and model pickers stopped showing up entirely.

Root cause chain:

1. Newer OpenCode releases (verified on 1.17.1) resolve agents per project and return `500 UnknownError` when `GET /agent` carries no directory context (header or query param). Older releases tolerated the bare call.
2. The bridge's `OpenCodeApi.listAgents()` called `GET /agent` with no directory at all, so every agent fetch failed with a 500.
3. The failure was invisible: the bridge request handlers convert `PluginApiException` to an error response without logging, and the mobile `NewSessionCubit` maps the error to an empty agent list (plus a `catch (_) {}`).
4. The new-session screen hides the whole `AgentModelButtons` header when the agent list is empty (`new_session_screen.dart`), so **both** the agent and the model picker disappeared even though `POST /provider` still worked.

## Fix

**Bridge**
- `OpenCodeApi.listAgents` now sends the `x-opencode-directory` header (verified against a live OpenCode 1.17.1: bare call 500s, with header returns the agent list).
- Agent listing is threaded through `OpenCodeRepository` → `OpenCodeService` → plugin impl per the layering rules. The service falls back to the bridge CWD when no `projectId` is given, so older mobile clients keep working.
- `GetAgentsHandler` accepts an optional `projectId` query parameter (the project worktree directory), mirroring how providers/commands are already project-scoped.

**Mobile**
- `listAgents` passes the project id end to end (new-session composer and session-detail load), so project-scoped agents (`.opencode/agent`) resolve correctly per project.

**Logging** (the failure produced zero log lines before)
- `OpenCodeApiException` / `PluginApiException` now carry the upstream response body, so the OpenCode error payload (e.g. `{"name":"UnknownError",...}`) shows up in bridge logs.
- Bridge request handlers log upstream and unexpected failures before converting them to error responses.
- The new-session composer logs agent/provider/command load failures instead of silently emitting empty lists.

## Testing

- New unit tests: `listAgents` forwards the directory header / omits it when absent / surfaces the upstream body; `OpenCodeService.getAgents` projectId pass-through and CWD fallback; `GetAgentsHandler` forwards the `projectId` query param.
- All suites pass: bridge app (1168), opencode plugin (169), mobile module_core (311), mobile app (419). `dart analyze` clean across bridge and mobile.
- Live-verified the new API→repository→service path against the running OpenCode 1.17.1 instance: returns all 20 agents both project-scoped and via the CWD fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the mobile agent and model pickers by scoping agent listing to a project. Adds POST /agent (ProjectIdRequest), deprecates GET /agent (CWD fallback), always sends the x-opencode-directory header, and updates mobile to query agents per project.

- **Bug Fixes**
  - Bridge: Implemented POST /agent (project-scoped); deprecated GET /agent with CWD fallback. AgentRepository forwards projectId or CWD; `OpenCodeApi.listAgents(directory)` always sets `x-opencode-directory`. Plugin `getAgents({projectId})` is required. Request handlers log upstream/unexpected errors; exceptions include upstream response bodies.
  - Mobile: `SessionApi.listAgents({projectId})` now POSTs and requires a project id. `SessionService.listAgents` is a non-null pass-through. `SessionDetailLoadService` resolves project from route/session and returns an empty list when unknown. New-session and session-detail pass projectId; the composer logs agent/provider/command load failures.

<sup>Written for commit 7ac6ce75b19752f72b1cc1521887f701ffb73873. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

