### PR TITLE
fix: ignore new upstream OpenCode SSE event types in bridge parser

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/sse_event_parser.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse_event_parser.dart
@@ -193,6 +193,19 @@ const Set<String> _knownEventTypes = {
 
 const Set<String> _ignoredEventTypes = {
   "sync",
+  // plugin lifecycle — internal to the OpenCode server, not useful for mobile UI
+  "plugin.added",
+  // server-internal bookkeeping — not useful for mobile UI
+  "reference.updated",
+  "models-dev.refreshed",
+  "catalog.model.updated",
+  "project.directories.updated",
+  // local account/auth lifecycle on the dev machine — not useful for mobile UI
+  "account.added",
+  "account.removed",
+  "account.switched",
+  // desktop IDE integration — not useful for mobile UI
+  "ide.installed",
   // session.next.* — internal lifecycle events, not useful for mobile UI
   "session.next.agent.switched",
   "session.next.model.switched",

--- a/bridge/sesori_plugin_opencode/test/sse_event_parser_test.dart
+++ b/bridge/sesori_plugin_opencode/test/sse_event_parser_test.dart
@@ -201,6 +201,27 @@ void main() {
       expect(result.rawData, equals(rawData));
     });
 
+    test("plugin.added event is recognized and ignored with preserved metadata", () {
+      final parser = SseEventParser();
+      final rawData = jsonEncode({
+        "directory": "/repo",
+        "payload": {
+          "type": "plugin.added",
+          "properties": {
+            "name": "some-plugin",
+          },
+        },
+      });
+
+      final result = parser.parse(rawData);
+
+      expect(result.outcome, equals(SseParseOutcome.ignoredKnownEvent));
+      expect(result.event, isNull);
+      expect(result.directory, equals("/repo"));
+      expect(result.eventType, equals("plugin.added"));
+      expect(result.rawData, equals(rawData));
+    });
+
     test("malformed JSON returns null event and preserved rawData", () {
       final parser = SseEventParser();
       const rawData = "{not-json";


### PR DESCRIPTION
The bridge was logging `[opencode][sse][unknown-event-type] ... eventType=plugin.added ... Ignoring SSE frame with unknown event type.` warnings from newer OpenCode releases.

Newly ignored upstream event types:
- `plugin.added`, `reference.updated` — https://github.com/sst/opencode/blob/936363e7a8e91c1e7c17f54dcbd53c3c92883dbf/packages/core/src/reference.ts#L30-L32
- `models-dev.refreshed` — https://github.com/sst/opencode/blob/936363e7a8e91c1e7c17f54dcbd53c3c92883dbf/packages/core/src/models-dev.ts#L111-L115
- `catalog.model.updated` — https://github.com/sst/opencode/blob/936363e7a8e91c1e7c17f54dcbd53c3c92883dbf/packages/core/src/catalog.ts#L35-L41
- `account.added`, `account.removed`, `account.switched` — https://github.com/sst/opencode/blob/936363e7a8e91c1e7c17f54dcbd53c3c92883dbf/packages/core/src/auth.ts#L61-L81
- `project.directories.updated` — https://github.com/sst/opencode/blob/936363e7a8e91c1e7c17f54dcbd53c3c92883dbf/packages/core/src/project/copy.ts#L95-L99
- `ide.installed` — https://github.com/sst/opencode/blob/936363e7a8e91c1e7c17f54dcbd53c3c92883dbf/packages/opencode/src/ide/index.ts#L14-L20

These are intentionally ignored because they are server-internal / desktop-only and not useful for the mobile UI, matching the existing treatment for sync and `session.next.*` events.

Verification:
- `make analyze` ✅
- `make test` ✅ (1206 tests)
- `aristotle-impl-review` approved ✅

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore new upstream OpenCode SSE event types in the bridge parser to stop noisy unknown-event-type logs. These are server-internal or desktop-only and not needed for mobile.

- **Bug Fixes**
  - Treat as ignored: plugin.added, reference.updated, models-dev.refreshed, catalog.model.updated, project.directories.updated, account.added/removed/switched, ide.installed.
  - Preserve metadata (directory, eventType, rawData) and mark as ignoredKnownEvent; added a unit test for plugin.added.

<sup>Written for commit af3d7404c1809402ffe5b6f7014b6dd9cd2665e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

