### PR TITLE
fix(ci): metadata-repo tagging secret scope + faster release-notes toolchain

### DIFF
--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -136,12 +136,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Pinned toolchain from .tool-versions; the notes script is
-      # dependency-free, so no workspace pub get is needed.
-      - name: Setup Flutter (asdf)
-        uses: ./.github/actions/setup-flutter
+      # The notes script is dependency-free pure Dart — a bare Dart SDK
+      # installs in seconds, vs minutes for the asdf Flutter toolchain.
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
         with:
-          workspace: none
+          sdk: stable
 
       - name: Download bridge artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/submit-release.yml
+++ b/.github/workflows/submit-release.yml
@@ -444,9 +444,11 @@ jobs:
   # evaluate the same remote, so their decisions agree; the head is taken from
   # whichever platform published (iOS preferred). A SEPARATE job (not a step in
   # `tag`) so a metadata tagging failure can never block the GitHub release
-  # below — the binary already shipped. METADATA_REPO_TOKEN must be a
-  # REPOSITORY secret with Contents: Write — this job declares no environment,
-  # so an environment-scoped secret would read as empty here.
+  # below — the binary already shipped. METADATA_REPO_TOKEN is scoped to the
+  # store-production environment, so this job must declare that environment to
+  # read it. That means a SECOND reviewer approval for runs that published a
+  # listing — the job is skipped (no approval prompt) when nothing was
+  # published, and metadata-publishing releases are the rare case.
   tag-metadata:
     name: Tag store metadata repo
     needs: [resolve, submit-ios, submit-android, tag]
@@ -455,6 +457,7 @@ jobs:
       (needs.submit-ios.outputs.meta_publish == 'true' || needs.submit-android.outputs.meta_publish == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    environment: store-production
     steps:
       - name: Tag store metadata repo
         env:
@@ -481,7 +484,7 @@ jobs:
             exit 1
           fi
           if [[ -z "$TOKEN" ]]; then
-            echo "::error::Metadata was published but METADATA_REPO_TOKEN is empty in this job. It must be a REPOSITORY secret (not environment-scoped) with Contents: Write, so the tag job can push ${TAG} to ${REPO}."
+            echo "::error::Metadata was published but METADATA_REPO_TOKEN is empty in this job. It must exist in the store-production environment with Contents: Write on ${REPO}."
             exit 1
           fi
           work="$(mktemp -d)"

--- a/.github/workflows/submit-release.yml
+++ b/.github/workflows/submit-release.yml
@@ -541,12 +541,12 @@ jobs:
       # predate the script entirely (legacy build-<N> tags).
       - uses: actions/checkout@v6
 
-      # Pinned toolchain from .tool-versions; the notes script is
-      # dependency-free, so no workspace pub get is needed.
-      - name: Setup Flutter (asdf)
-        uses: ./.github/actions/setup-flutter
+      # The notes script is dependency-free pure Dart — a bare Dart SDK
+      # installs in seconds, vs minutes for the asdf Flutter toolchain.
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
         with:
-          workspace: none
+          sdk: stable
 
       - name: Download bridge artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## What

Two CI fixes around the release pipeline:

### 1. `tag-metadata` failure — empty `METADATA_REPO_TOKEN` ([failed run](https://github.com/sesori-ai/sesori_apps_monorepo/actions/runs/27300252770/job/80644511778))

`METADATA_REPO_TOKEN` is scoped to the **store-production** environment, but the `tag-metadata` job declared no environment. GitHub injects environment secrets per **job**, not per run, so the token read as empty and the job failed on every metadata-publishing production release.

Fix: declare `environment: store-production` on the job (and update the stale comment + error message that claimed the secret had to be repository-level).

Trade-off: a second reviewer approval prompt — but only on runs that actually published a store listing; the job is skipped otherwise, and skipped jobs never request approval.

**Manual remediation already done for the failed run:** `v1.0.8` tag pushed to `sesori-ai/app-stores-metadata` @ `63ca11a` (what the job would have done), so the next release's gate correctly skips re-publishing the unchanged listing.

### 2. `dart-lang/setup-dart` for release-notes jobs

The `finalize` (release-all-platforms) and `release` (submit-release) jobs only need a Dart SDK to run the dependency-free `tool/generate_release_notes.dart`. The asdf Flutter toolchain takes minutes (uncached) for that; `setup-dart` installs in seconds.

## Verification

- YAML parses clean on both workflows
- `store-production` environment confirmed (via API) to hold `METADATA_REPO_TOKEN`; repo-level secrets do not
- Metadata repo tag verified: `v1.0.8` → `63ca11a9d238d8924ef73b4bb73db8d36ef92c95`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI release tagging and speeds up release-notes generation. The `tag-metadata` job now reads the correct secret, and release jobs run faster with a lighter toolchain.

- **Bug Fixes**
  - `tag-metadata`: declare `environment: store-production` so `METADATA_REPO_TOKEN` is injected; updated error text. Job stays non-blocking and only asks for a second approval when a store listing was published.

- **Dependencies**
  - Use `dart-lang/setup-dart@v1` for `tool/generate_release_notes.dart` in `release-all-platforms` and `submit-release`. Installs in seconds vs minutes for the asdf Flutter toolchain.

<sup>Written for commit 34421c0b09ae77ff60bc44b8778df2918921145f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

