### PR TITLE
fix: accept the auth server's "password" provider key for email login

### DIFF
--- a/mobile/module_auth/test/auth_config_test.dart
+++ b/mobile/module_auth/test/auth_config_test.dart
@@ -15,6 +15,18 @@ void main() {
       expect(result, equals(AuthProvider.google));
     });
 
+    test("returns email provider for email key", () {
+      final result = AuthProvider.fromKey("email");
+
+      expect(result, equals(AuthProvider.email));
+    });
+
+    test("returns email provider for server password key", () {
+      final result = AuthProvider.fromKey("password");
+
+      expect(result, equals(AuthProvider.email));
+    });
+
     test("returns null for unknown key", () {
       final result = AuthProvider.fromKey("unknown");
 

--- a/mobile/module_auth/test/auth_manager_test.dart
+++ b/mobile/module_auth/test/auth_manager_test.dart
@@ -845,7 +845,8 @@ void main() {
             "refreshToken": "email-refresh-token",
             "user": {
               "id": user.id,
-              "provider": "email",
+              // The auth server reports email/password accounts as "password".
+              "provider": "password",
               "providerUserId": user.providerUserId,
               "providerUsername": user.providerUsername,
             },
@@ -878,6 +879,7 @@ void main() {
       ).called(1);
       final savedEmailUser = verify(() => mockTokenStorage.saveUser(captureAny())).captured.single as AuthUser;
       expect(savedEmailUser.providerUsername, "testuser");
+      expect(savedEmailUser.provider, AuthProvider.email);
     });
 
     test("throws on 401 invalid credentials", () async {

--- a/shared/sesori_shared/lib/src/models/auth/auth_provider.dart
+++ b/shared/sesori_shared/lib/src/models/auth/auth_provider.dart
@@ -8,11 +8,15 @@ sealed class AuthProvider {
 
   const AuthProvider._();
 
+  /// The key the auth server uses for email/password accounts.
+  static const _serverPasswordKey = "password";
+
   static AuthProvider? fromKey(String? key) => switch (true) {
     _ when github.key == key => github,
     _ when google.key == key => google,
     _ when apple.key == key => apple,
     _ when email.key == key => email,
+    _ when _serverPasswordKey == key => email,
     _ => null,
   };
 

--- a/shared/sesori_shared/test/models/auth_flow_models_test.dart
+++ b/shared/sesori_shared/test/models/auth_flow_models_test.dart
@@ -39,6 +39,21 @@ void main() {
     });
   });
 
+  group("AuthUser", () {
+    test("parses the server's password provider key as the email provider", () {
+      final user = AuthUser.fromJson({
+        "id": "user-1",
+        "provider": "password",
+        "providerUserId": "test@example.com",
+        "providerUsername": null,
+      });
+
+      expect(user.provider, equals(AuthProvider.email));
+      // Serialization keeps the canonical client-side key.
+      expect(user.toJson()["provider"], equals("email"));
+    });
+  });
+
   group("AuthSessionStatusResponse", () {
     test("round-trips pending status", () {
       const original = AuthSessionStatusResponse.pending();


### PR DESCRIPTION
## Problem

Email login on mobile fails with:

```
Email login failed: Exception: Failed to parse auth response: FormatException: Unknown AuthProvider key: password
```

The auth server reports email/password accounts with the provider key `"password"` (`AUTH_PROVIDER_PASSWORD = "password"` in `sesori_auth_server/src/types/oauth.ts`), used in the `/auth/email` login response, token refresh, and `/auth/me`. The client's `AuthProvider.fromKey` in `sesori_shared` only recognized `github` / `google` / `apple` / `email`, so `AuthUser.fromJson` threw and the login failed after the server had already accepted the credentials.

The bridge's `LoginEmailApi` parses the same `AuthResponse` model, so it had the same latent failure.

## Fix

- `sesori_shared`: `AuthProvider.fromKey` now maps the server key `"password"` to `AuthProvider.email`. The canonical client-side `key` getter still returns `"email"`, so local persistence round-trips unchanged. Both mobile and bridge consumers are fixed by the shared model change.

## Tests

- `sesori_shared`: `AuthUser.fromJson` with `"provider": "password"` parses to `AuthProvider.email` and serializes back as `"email"`.
- `module_auth`: `fromKey` cases for `"email"` and `"password"`; the `loginWithEmail` success test now mocks the real server response (`"provider": "password"` — the previous mock used `"email"`, which is why this slipped through) and asserts the saved user's provider.

## Verification

- `dart analyze` + `dart test` clean in `shared/sesori_shared`, `mobile/module_auth`, `mobile/module_core`
- `flutter test` clean in `mobile/app` (419 tests)
- `make analyze` + `make test` clean in `bridge/` (1206 tests)
- aristotle-plan-review and aristotle-impl-review: APPROVED

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes email login failures on mobile by accepting the auth server’s `"password"` provider key and mapping it to the email provider in `sesori_shared`. Restores email/password login, token refresh, and `/auth/me` parsing across mobile and `bridge`.

- **Bug Fixes**
  - Map `"password"` to `AuthProvider.email` in `AuthProvider.fromKey`; keep serialized key as `"email"` for persistence.
  - Updated tests in `sesori_shared` and `module_auth` to cover the server’s `"password"` provider response.

<sup>Written for commit 5688e401bebfd76ea37b9c1f2a65ae94f7d8af51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

