### PR TITLE
docs: explain how to update sesori-bridge and opencode on headless VMs

### DIFF
--- a/bridge/INSTALL.md
+++ b/bridge/INSTALL.md
@@ -87,6 +87,7 @@ sesori-bridge
 - Release checksum manifests use archive basenames such as `sesori-bridge-macos-arm64.tar.gz`; installers match that basename instead of a temp download path
 - Startup auto-update only applies to managed installs under the Sesori install root (`~/.local/share/sesori/bin` on macOS/Linux, `%LOCALAPPDATA%\sesori\bin` on Windows)
 - Runtime auto-update also performs periodic polling every 4 hours while the managed bridge is running, and it is skipped in CI and when `SESORI_NO_UPDATE=1` is set
+- Periodic polling only notifies that an update is available — the update is applied at the next startup. For a bridge running under a service manager (e.g. systemd), restart the service to apply updates (see `docs/SETUP_HEADLESS_VM.md`)
 - Direct execution of package binaries from npm-owned `node_modules` locations is unsupported
 
 ## Uninstall

--- a/bridge/INSTALL.md
+++ b/bridge/INSTALL.md
@@ -87,7 +87,7 @@ sesori-bridge
 - Release checksum manifests use archive basenames such as `sesori-bridge-macos-arm64.tar.gz`; installers match that basename instead of a temp download path
 - Startup auto-update only applies to managed installs under the Sesori install root (`~/.local/share/sesori/bin` on macOS/Linux, `%LOCALAPPDATA%\sesori\bin` on Windows)
 - Runtime auto-update also performs periodic polling every 4 hours while the managed bridge is running, and it is skipped in CI and when `SESORI_NO_UPDATE=1` is set
-- Periodic polling only notifies that an update is available — the update is applied at the next startup. For a bridge running under a service manager (e.g. systemd), restart the service to apply updates (see `docs/SETUP_HEADLESS_VM.md`)
+- Periodic polling only notifies that an update is available — the update is applied at the next startup. For a bridge running under a service manager (e.g. systemd), restart the service to apply updates (see [`docs/SETUP_HEADLESS_VM.md`](../docs/SETUP_HEADLESS_VM.md))
 - Direct execution of package binaries from npm-owned `node_modules` locations is unsupported
 
 ## Uninstall

--- a/docs/SETUP_HEADLESS_VM.md
+++ b/docs/SETUP_HEADLESS_VM.md
@@ -184,6 +184,46 @@ systemctl status sesori-bridge --no-pager
 
 ---
 
+## Updating
+
+### Sesori Bridge
+
+The bridge auto-updates, but only **at process startup**. While running it polls for new releases every 4 hours and logs `A new bridge version (vX.Y.Z) is available. Restart to update.` — it never swaps the binary mid-run. A long-running systemd service therefore stays on its current version until it restarts.
+
+To force an update, restart the service:
+
+```bash
+systemctl restart sesori-bridge
+```
+
+On startup the bridge checks GitHub releases, downloads and installs the newest version into `~/.local/share/sesori/bin/`, and relaunches. With `Restart=always` in the unit, the service ends up running the new binary.
+
+If the startup check is not picking up the update, re-run the installer and restart:
+
+```bash
+curl -fsSL https://sesori.com/install | bash
+systemctl restart sesori-bridge
+```
+
+Verify via the logs — you should see `Updating to vX.Y.Z...`, or a clean start on the current version:
+
+```bash
+journalctl -u sesori-bridge -n 50
+```
+
+Note: the startup update check is skipped when `SESORI_NO_UPDATE` is set or a CI environment variable (`CI`, `GITHUB_ACTIONS`, ...) is present in the service environment. The stock unit above has neither, so updates apply by default.
+
+### OpenCode
+
+OpenCode does not auto-update in this setup. Update it manually, then restart its service:
+
+```bash
+opencode upgrade
+systemctl restart opencode
+```
+
+---
+
 ## Logs and Debugging
 
 ### Follow OpenCode logs
@@ -238,5 +278,6 @@ dmesg -T | grep -i oom
 - OpenCode runs as a systemd service on port 9921
 - Sesori Bridge depends on it and connects to that port
 - Both auto-start on boot
+- Bridge updates apply on service restart; OpenCode updates via `opencode upgrade`
 - Logs are accessible via `journalctl`
 - Swap prevents crashes on low-memory instances


### PR DESCRIPTION
## Summary
- Add an **Updating** section to `docs/SETUP_HEADLESS_VM.md` covering both services:
  - **Sesori Bridge**: auto-update is only applied at process startup — the 4-hour runtime poll just logs that a new version is available. Under systemd, `systemctl restart sesori-bridge` is enough to force an update; re-running the installer is the fallback refresh path.
  - **OpenCode**: no auto-update in this setup — `opencode upgrade && systemctl restart opencode`.
- Note in `bridge/INSTALL.md` that periodic polling only notifies, and service-managed installs need a restart to apply updates.

## Why
The VM setup guide left the impression the bridge would never self-update. It does, but only on restart — this documents the force-update path and the relevant skip conditions (`SESORI_NO_UPDATE`, CI env vars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Updating section to the headless VM guide showing how to update `sesori-bridge` and `opencode`. Clarifies that bridge updates apply only on startup (runtime poll is notify-only), how to verify via logs, and that CI/`SESORI_NO_UPDATE` skip the startup check; adds a restart note to `bridge/INSTALL.md`.

- **Migration**
  - Update `sesori-bridge`: `systemctl restart sesori-bridge` (or `curl -fsSL https://sesori.com/install | bash`, then restart).
  - Update `opencode`: `opencode upgrade && systemctl restart opencode`.

<sup>Written for commit 46d0dd35645dfa3347d14900cb45e3383700567b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

