### PR TITLE
fix(mobile): stop picker bottom sheets from blocking the UI thread on open

### DIFF
--- a/mobile/app/lib/core/widgets/command_picker_sheet.dart
+++ b/mobile/app/lib/core/widgets/command_picker_sheet.dart
@@ -1,5 +1,9 @@
+import "dart:async";
+
+import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:go_router/go_router.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart" show CommandPickerEntry, CommandPickerEntryBuilder, loge;
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_zyra/module_zyra.dart";
 
@@ -26,13 +30,16 @@ class CommandPickerSheet extends StatefulWidget {
       builder: (sheetContext) {
         final height = MediaQuery.sizeOf(sheetContext).height * 0.7;
         final zyra = sheetContext.zyra;
-        return Container(
-          height: height,
-          decoration: BoxDecoration(
-            color: zyra.colors.bgPrimary,
-            borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+        // Material (not a decorated Container) so the ListTiles inside can
+        // paint their ink effects on the sheet surface.
+        return Material(
+          color: zyra.colors.bgPrimary,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+          clipBehavior: Clip.antiAlias,
+          child: SizedBox(
+            height: height,
+            child: CommandPickerSheet(commands: commands),
           ),
-          child: CommandPickerSheet(commands: commands),
         );
       },
     );
@@ -45,16 +52,49 @@ class CommandPickerSheet extends StatefulWidget {
 class _CommandPickerSheetState extends State<CommandPickerSheet> {
   String _query = "";
 
-  List<CommandInfo> get _filteredCommands {
-    final sorted = [...widget.commands]..sort((a, b) => a.name.compareTo(b.name));
+  /// Precomputed picker entries; `null` while the background isolate is
+  /// still preparing them.
+  List<CommandPickerEntry>? _entries;
+
+  /// Entries matching [_query]. Cached so unrelated rebuilds don't re-run
+  /// the filter pass; only recomputed when the entries arrive or the query
+  /// changes. `null` while the entries are still loading.
+  List<CommandPickerEntry>? _filtered;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_loadEntries());
+  }
+
+  Future<void> _loadEntries() async {
+    List<CommandPickerEntry> entries;
+    try {
+      entries = await compute(_buildEntries, widget.commands);
+    } catch (error, stackTrace) {
+      // Fail soft: show the empty state rather than leaving the sheet stuck
+      // on the spinner with an uncaught async error.
+      loge("Command picker entry build failed", error, stackTrace);
+      entries = const [];
+    }
+    if (!mounted) return;
+    setState(() {
+      _entries = entries;
+      _filtered = _filteredEntries(entries);
+    });
+  }
+
+  /// Entry point for compute() — must be top-level or static.
+  static List<CommandPickerEntry> _buildEntries(List<CommandInfo> commands) =>
+      const CommandPickerEntryBuilder().build(commands: commands);
+
+  /// Cheap single `contains` pass over precomputed lowercase haystacks —
+  /// the sorting and display-string preparation already happened in the
+  /// background isolate.
+  List<CommandPickerEntry> _filteredEntries(List<CommandPickerEntry> entries) {
     final query = _query.trim().toLowerCase();
-    if (query.isEmpty) return sorted;
-    return sorted.where((command) {
-      final hintsText = (command.hints ?? []).join(" ").toLowerCase();
-      return command.name.toLowerCase().contains(query) ||
-          (command.description?.toLowerCase().contains(query) ?? false) ||
-          hintsText.contains(query);
-    }).toList();
+    if (query.isEmpty) return entries;
+    return entries.where((entry) => entry.searchText.contains(query)).toList();
   }
 
   String _sourceLabel(CommandSource? source, {required AppLocalizations loc}) => switch (source) {
@@ -68,7 +108,6 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
   Widget build(BuildContext context) {
     final zyra = context.zyra;
     final loc = context.loc;
-    final commands = _filteredCommands;
 
     return Column(
       children: [
@@ -105,13 +144,18 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
               filled: true,
               fillColor: zyra.colors.bgPrimary,
             ),
-            onChanged: (value) => setState(() => _query = value),
+            onChanged: (value) => setState(() {
+              _query = value;
+              final entries = _entries;
+              if (entries != null) _filtered = _filteredEntries(entries);
+            }),
           ),
         ),
         const SizedBox(height: 8),
         Expanded(
-          child: switch (commands.isEmpty) {
-            true => Center(
+          child: switch (_filtered) {
+            null => const Center(child: CircularProgressIndicator()),
+            final filtered when filtered.isEmpty => Center(
               child: Padding(
                 padding: const EdgeInsets.all(24),
                 child: Text(
@@ -123,30 +167,30 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
                 ),
               ),
             ),
-            false => ListView.separated(
+            final filtered => ListView.separated(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              itemCount: commands.length,
+              itemCount: filtered.length,
               separatorBuilder: (_, _) => Divider(
                 height: 1,
                 color: zyra.colors.borderPrimary,
               ),
               itemBuilder: (context, index) {
-                final command = commands[index];
-                final description = command.description?.trim();
-                final hints = (command.hints ?? []).where((hint) => hint.trim().isNotEmpty).join("  •  ");
+                final entry = filtered[index];
+                final description = entry.displayDescription;
+                final hints = entry.displayHints;
                 return ListTile(
-                  title: Text("/${command.name}"),
+                  title: Text("/${entry.command.name}"),
                   subtitle: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      if (description != null && description.isNotEmpty)
+                      if (description != null)
                         Text(
                           description,
                           maxLines: 2,
                           overflow: TextOverflow.ellipsis,
                         ),
-                      if (hints.isNotEmpty)
+                      if (hints != null)
                         Padding(
                           padding: const EdgeInsetsDirectional.only(top: 4),
                           child: Text(
@@ -167,14 +211,14 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
                       borderRadius: BorderRadius.circular(12),
                     ),
                     child: Text(
-                      _sourceLabel(command.source, loc: loc),
+                      _sourceLabel(entry.command.source, loc: loc),
                       style: zyra.textTheme.textXs.medium.copyWith(
                         color: zyra.colors.textBrandPrimary,
                         fontWeight: FontWeight.w600,
                       ),
                     ),
                   ),
-                  onTap: () => context.pop(command),
+                  onTap: () => context.pop(entry.command),
                 );
               },
             ),

--- a/mobile/app/lib/core/widgets/model_picker_list_items.dart
+++ b/mobile/app/lib/core/widgets/model_picker_list_items.dart
@@ -1,0 +1,58 @@
+import "package:flutter/material.dart";
+import "package:theme_zyra/module_zyra.dart";
+
+/// Provider name header above a group of models in the model picker list.
+class ModelPickerProviderHeader extends StatelessWidget {
+  final String name;
+
+  const ModelPickerProviderHeader({super.key, required this.name});
+
+  @override
+  Widget build(BuildContext context) {
+    final zyra = context.zyra;
+    return Padding(
+      padding: const EdgeInsetsDirectional.fromSTEB(16, 16, 16, 4),
+      child: Text(
+        name,
+        style: zyra.textTheme.textXs.medium.copyWith(
+          color: zyra.colors.bgBrandSolid,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+/// A single selectable model row in the model picker list.
+class ModelPickerModelTile extends StatelessWidget {
+  final String name;
+  final String? subtitle;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const ModelPickerModelTile({
+    super.key,
+    required this.name,
+    required this.subtitle,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final zyra = context.zyra;
+
+    return ListTile(
+      dense: true,
+      title: Text(name),
+      subtitle: switch (subtitle) {
+        final text? => Text(text),
+        null => null,
+      },
+      leading: isSelected
+          ? Icon(Icons.radio_button_checked, color: zyra.colors.bgBrandSolid)
+          : Icon(Icons.radio_button_unchecked, color: zyra.colors.borderPrimary),
+      onTap: onTap,
+    );
+  }
+}

--- a/mobile/app/lib/core/widgets/model_picker_list_items.dart
+++ b/mobile/app/lib/core/widgets/model_picker_list_items.dart
@@ -44,6 +44,9 @@ class ModelPickerModelTile extends StatelessWidget {
 
     return ListTile(
       dense: true,
+      // Exposes the selection state to assistive technology (TalkBack /
+      // VoiceOver); the radio icon below only communicates it visually.
+      selected: isSelected,
       title: Text(name),
       subtitle: switch (subtitle) {
         final text? => Text(text),

--- a/mobile/app/lib/core/widgets/model_picker_sheet.dart
+++ b/mobile/app/lib/core/widgets/model_picker_sheet.dart
@@ -1,14 +1,23 @@
+import "dart:async";
+
+import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:go_router/go_router.dart";
-import "package:sesori_dart_core/sesori_dart_core.dart" show DefaultModelSelector;
+import "package:sesori_dart_core/sesori_dart_core.dart"
+    show ModelPickerModelEntry, ModelPickerSection, ModelPickerSectionBuilder;
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_zyra/module_zyra.dart";
 
 import "../extensions/build_context_x.dart";
 import "app_modal_bottom_sheet.dart";
+import "model_picker_list_items.dart";
 
 /// Bottom sheet for selecting a model, grouped by provider.
 /// Includes a search field for filtering. Unavailable models are excluded.
+///
+/// The sheet opens immediately with a progress indicator: the provider and
+/// model grouping/sorting runs in a background isolate once the sheet is up,
+/// so opening never blocks the UI thread on the size of the model catalog.
 class ModelPickerSheet extends StatefulWidget {
   final List<ProviderInfo> providers;
   final String selectedProviderID;
@@ -41,20 +50,23 @@ class ModelPickerSheet extends StatefulWidget {
       builder: (sheetContext) {
         final height = MediaQuery.sizeOf(sheetContext).height * 0.7;
         final zyra = sheetContext.zyra;
-        return Container(
-          height: height,
-          decoration: BoxDecoration(
-            color: zyra.colors.bgPrimary,
-            borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
-          ),
-          child: ModelPickerSheet(
-            providers: providers,
-            selectedProviderID: selectedProviderID,
-            selectedModelID: selectedModelID,
-            onModelChanged: ({required String providerID, required String modelID}) {
-              onModelChanged(providerID: providerID, modelID: modelID);
-              context.pop();
-            },
+        // Material (not a decorated Container) so the ListTiles inside can
+        // paint their ink and selection effects on the sheet surface.
+        return Material(
+          color: zyra.colors.bgPrimary,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+          clipBehavior: Clip.antiAlias,
+          child: SizedBox(
+            height: height,
+            child: ModelPickerSheet(
+              providers: providers,
+              selectedProviderID: selectedProviderID,
+              selectedModelID: selectedModelID,
+              onModelChanged: ({required String providerID, required String modelID}) {
+                onModelChanged(providerID: providerID, modelID: modelID);
+                context.pop();
+              },
+            ),
           ),
         );
       },
@@ -68,51 +80,54 @@ class ModelPickerSheet extends StatefulWidget {
 class _ModelPickerSheetState extends State<ModelPickerSheet> {
   String _query = "";
 
-  static const _defaultModelSelector = DefaultModelSelector();
+  /// Precomputed provider sections; `null` while the background isolate is
+  /// still preparing them.
+  List<ModelPickerSection>? _sections;
 
-  late final _sortedProviders = widget.providers.toList()..sort((a, b) => a.name.compareTo(b.name));
-
-  bool _matchesQuery({required ProviderModel model, required String providerName}) {
-    if (_query.isEmpty) return true;
-    final q = _query.toLowerCase();
-    return model.name.toLowerCase().contains(q) ||
-        (model.family?.toLowerCase().contains(q) ?? false) ||
-        model.id.toLowerCase().contains(q) ||
-        providerName.toLowerCase().contains(q);
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_loadSections());
   }
 
-  /// Builds the set of model IDs that should be visible by default.
-  ///
-  /// For each family of available models we pick a single representative
-  /// (the user can always reveal the rest by typing in the search field).
-  /// The selection priority lives in [DefaultModelSelector] — same priority
-  /// used by the cubits that pick the initial model when no prior
-  /// selection exists — so the picker's "default per family" matches the
-  /// cubit's "default for the whole provider".
-  Set<String> _defaultVisibleIds(ProviderInfo provider) {
-    final visible = <String>{};
+  Future<void> _loadSections() async {
+    final sections = await compute(_buildSections, (
+      providers: widget.providers,
+      selectedProviderID: widget.selectedProviderID,
+      selectedModelID: widget.selectedModelID,
+    ));
+    if (!mounted) return;
+    setState(() => _sections = sections);
+  }
 
-    // Group available models by family.
-    final byFamily = <String, List<ProviderModel>>{};
-    for (final m in provider.models.values) {
-      if (!m.isAvailable) continue;
-      final family = m.family ?? m.id;
-      (byFamily[family] ??= []).add(m);
+  /// Entry point for compute() — must be top-level or static.
+  static List<ModelPickerSection> _buildSections(
+    ({List<ProviderInfo> providers, String selectedProviderID, String selectedModelID}) args,
+  ) {
+    return const ModelPickerSectionBuilder().build(
+      providers: args.providers,
+      selectedProviderID: args.selectedProviderID,
+      selectedModelID: args.selectedModelID,
+    );
+  }
+
+  /// Flattens the precomputed sections into the rows currently visible,
+  /// applying the search query. Cheap: a single `contains` pass over
+  /// precomputed lowercase haystacks — no sorting or grouping.
+  List<_PickerRow> _visibleRows(List<ModelPickerSection> sections) {
+    final query = _query.toLowerCase();
+    final rows = <_PickerRow>[];
+    for (final section in sections) {
+      final models = section.models
+          .where((m) => query.isEmpty ? m.visibleByDefault : m.searchText.contains(query))
+          .toList();
+      if (models.isEmpty) continue;
+      rows.add(_ProviderHeaderRow(providerName: section.providerName));
+      for (final model in models) {
+        rows.add(_ModelRow(providerID: section.providerID, entry: model));
+      }
     }
-
-    for (final group in byFamily.values) {
-      final chosen = _defaultModelSelector.pickFromFamily(
-        group: group,
-        defaultModelId: provider.defaultModelID,
-      );
-      if (chosen != null) visible.add(chosen.id);
-    }
-
-    if (provider.id == widget.selectedProviderID) {
-      visible.add(widget.selectedModelID);
-    }
-
-    return visible;
+    return rows;
   }
 
   @override
@@ -161,99 +176,48 @@ class _ModelPickerSheetState extends State<ModelPickerSheet> {
         ),
         const SizedBox(height: 4),
         Expanded(
-          child: ListView(
-            // Extend the scrollable area underneath the home indicator: the
-            // bottom inset is added as scroll padding so the last model can
-            // scroll clear of the indicator instead of being clipped above it.
-            padding: EdgeInsetsDirectional.only(bottom: MediaQuery.paddingOf(context).bottom),
-            children: [
-              for (final provider in _sortedProviders) ..._buildProviderSection(provider: provider, context: context),
-            ],
-          ),
+          child: switch (_sections) {
+            null => const Center(child: CircularProgressIndicator()),
+            final sections => _buildModelList(context: context, sections: sections),
+          },
         ),
       ],
     );
   }
 
-  List<Widget> _buildProviderSection({required ProviderInfo provider, required BuildContext context}) {
-    final zyra = context.zyra;
-    final isSearching = _query.isNotEmpty;
-    final visibleIds = isSearching ? null : _defaultVisibleIds(provider);
-
-    final models =
-        provider.models.values
-            .where((m) => m.isAvailable)
-            .where((m) => _matchesQuery(model: m, providerName: provider.name))
-            .where((m) {
-              if (isSearching) {
-                return true;
-              }
-              return visibleIds?.contains(m.id) ?? false;
-            })
-            .toList()
-          ..sort((a, b) {
-            final aDate = a.releaseDate;
-            final bDate = b.releaseDate;
-            if (aDate != bDate) {
-              if (bDate == null) return -1;
-              if (aDate == null) return 1;
-              return bDate.compareTo(aDate);
-            }
-            return a.name.compareTo(b.name);
-          });
-
-    if (models.isEmpty) return const [];
-
-    return [
-      Padding(
-        padding: const EdgeInsetsDirectional.fromSTEB(16, 16, 16, 4),
-        child: Text(
-          provider.name,
-          style: zyra.textTheme.textXs.medium.copyWith(
-            color: zyra.colors.bgBrandSolid,
-            fontWeight: FontWeight.w600,
-          ),
+  Widget _buildModelList({required BuildContext context, required List<ModelPickerSection> sections}) {
+    final rows = _visibleRows(sections);
+    return ListView.builder(
+      // Extend the scrollable area underneath the home indicator: the
+      // bottom inset is added as scroll padding so the last model can
+      // scroll clear of the indicator instead of being clipped above it.
+      padding: EdgeInsetsDirectional.only(bottom: MediaQuery.paddingOf(context).bottom),
+      itemCount: rows.length,
+      itemBuilder: (context, index) => switch (rows[index]) {
+        _ProviderHeaderRow(:final providerName) => ModelPickerProviderHeader(name: providerName),
+        _ModelRow(:final providerID, :final entry) => ModelPickerModelTile(
+          name: entry.displayName,
+          subtitle: entry.family,
+          isSelected: widget.selectedProviderID == providerID && widget.selectedModelID == entry.modelID,
+          onTap: () => widget.onModelChanged(providerID: providerID, modelID: entry.modelID),
         ),
-      ),
-      for (final model in models)
-        _ModelTile(
-          name: model.name.replaceAll("(latest)", "").trim(),
-          subtitle: model.family,
-          isSelected: widget.selectedProviderID == provider.id && widget.selectedModelID == model.id,
-          onTap: () => widget.onModelChanged(providerID: provider.id, modelID: model.id),
-        ),
-    ];
+      },
+    );
   }
 }
 
-class _ModelTile extends StatelessWidget {
-  final String name;
-  final String? subtitle;
-  final bool isSelected;
-  final VoidCallback onTap;
+/// A row in the flattened picker list: either a provider header or a model.
+sealed class _PickerRow {
+  const _PickerRow();
+}
 
-  const _ModelTile({
-    required this.name,
-    required this.subtitle,
-    required this.isSelected,
-    required this.onTap,
-  });
+class _ProviderHeaderRow extends _PickerRow {
+  final String providerName;
+  const _ProviderHeaderRow({required this.providerName});
+}
 
-  @override
-  Widget build(BuildContext context) {
-    final zyra = context.zyra;
-
-    return ListTile(
-      dense: true,
-      title: Text(name),
-      subtitle: switch (subtitle) {
-        final text? => Text(text),
-        null => null,
-      },
-      leading: isSelected
-          ? Icon(Icons.radio_button_checked, color: zyra.colors.bgBrandSolid)
-          : Icon(Icons.radio_button_unchecked, color: zyra.colors.borderPrimary),
-      onTap: onTap,
-    );
-  }
+class _ModelRow extends _PickerRow {
+  final String providerID;
+  final ModelPickerModelEntry entry;
+  const _ModelRow({required this.providerID, required this.entry});
 }

--- a/mobile/app/lib/core/widgets/model_picker_sheet.dart
+++ b/mobile/app/lib/core/widgets/model_picker_sheet.dart
@@ -4,7 +4,7 @@ import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:go_router/go_router.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart"
-    show ModelPickerModelEntry, ModelPickerSection, ModelPickerSectionBuilder;
+    show ModelPickerModelEntry, ModelPickerSection, ModelPickerSectionBuilder, loge;
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_zyra/module_zyra.dart";
 
@@ -84,6 +84,12 @@ class _ModelPickerSheetState extends State<ModelPickerSheet> {
   /// still preparing them.
   List<ModelPickerSection>? _sections;
 
+  /// Rows currently visible for [_query]. Cached so unrelated rebuilds
+  /// (keyboard animation, focus changes) don't re-run the filter pass; only
+  /// recomputed when the sections arrive or the query changes. `null` while
+  /// the sections are still loading.
+  List<_PickerRow>? _rows;
+
   @override
   void initState() {
     super.initState();
@@ -91,13 +97,24 @@ class _ModelPickerSheetState extends State<ModelPickerSheet> {
   }
 
   Future<void> _loadSections() async {
-    final sections = await compute(_buildSections, (
-      providers: widget.providers,
-      selectedProviderID: widget.selectedProviderID,
-      selectedModelID: widget.selectedModelID,
-    ));
+    List<ModelPickerSection> sections;
+    try {
+      sections = await compute(_buildSections, (
+        providers: widget.providers,
+        selectedProviderID: widget.selectedProviderID,
+        selectedModelID: widget.selectedModelID,
+      ));
+    } catch (error, stackTrace) {
+      // Fail soft: show an empty list rather than leaving the sheet stuck
+      // on the spinner with an uncaught async error.
+      loge("Model picker section build failed", error, stackTrace);
+      sections = const [];
+    }
     if (!mounted) return;
-    setState(() => _sections = sections);
+    setState(() {
+      _sections = sections;
+      _rows = _visibleRows(sections);
+    });
   }
 
   /// Entry point for compute() — must be top-level or static.
@@ -171,22 +188,25 @@ class _ModelPickerSheetState extends State<ModelPickerSheet> {
               filled: true,
               fillColor: zyra.colors.bgPrimary,
             ),
-            onChanged: (value) => setState(() => _query = value.trim()),
+            onChanged: (value) => setState(() {
+              _query = value.trim();
+              final sections = _sections;
+              if (sections != null) _rows = _visibleRows(sections);
+            }),
           ),
         ),
         const SizedBox(height: 4),
         Expanded(
-          child: switch (_sections) {
+          child: switch (_rows) {
             null => const Center(child: CircularProgressIndicator()),
-            final sections => _buildModelList(context: context, sections: sections),
+            final rows => _buildModelList(context: context, rows: rows),
           },
         ),
       ],
     );
   }
 
-  Widget _buildModelList({required BuildContext context, required List<ModelPickerSection> sections}) {
-    final rows = _visibleRows(sections);
+  Widget _buildModelList({required BuildContext context, required List<_PickerRow> rows}) {
     return ListView.builder(
       // Extend the scrollable area underneath the home indicator: the
       // bottom inset is added as scroll padding so the last model can

--- a/mobile/app/test/core/widgets/command_picker_sheet_test.dart
+++ b/mobile/app/test/core/widgets/command_picker_sheet_test.dart
@@ -1,0 +1,147 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:go_router/go_router.dart";
+import "package:sesori_mobile/core/widgets/command_picker_sheet.dart";
+import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
+
+CommandInfo _command({
+  required String name,
+  String? description,
+  List<String>? hints,
+}) {
+  return CommandInfo(
+    name: name,
+    template: null,
+    hints: hints,
+    description: description,
+    agent: null,
+    model: null,
+    provider: null,
+    source: CommandSource.command,
+    subtask: null,
+  );
+}
+
+List<CommandInfo> _commands() {
+  return [
+    _command(name: "release", description: "Cut a release", hints: ["version"]),
+    _command(name: "deploy", description: "Ship the app"),
+  ];
+}
+
+Widget _buildApp({
+  required List<CommandInfo> commands,
+  required ValueChanged<CommandInfo?> onClosed,
+}) {
+  final router = GoRouter(
+    routes: [
+      GoRoute(
+        path: "/",
+        builder: (context, state) => Scaffold(
+          body: FilledButton(
+            onPressed: () async {
+              final selected = await CommandPickerSheet.show(context, commands: commands);
+              onClosed(selected);
+            },
+            child: const Text("Open picker"),
+          ),
+        ),
+      ),
+    ],
+  );
+
+  return MaterialApp.router(
+    routerConfig: router,
+    theme: ThemeData(
+      extensions: [ZyraDesignSystem.light],
+    ),
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+  );
+}
+
+/// Opens the picker. The entry computation runs in a real isolate via
+/// compute(), which the fake-async test clock cannot settle on its own, so
+/// the sheet deterministically shows its loading state at this point.
+Future<void> _openPicker(WidgetTester tester) async {
+  await tester.tap(find.text("Open picker"));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 50));
+}
+
+/// Lets the compute() isolate finish and the sheet rebuild with its result.
+/// Alternates [WidgetTester.runAsync] and [WidgetTester.pump]; pumpAndSettle
+/// cannot be used with compute's real isolates.
+Future<void> _waitForEntries(WidgetTester tester, {required Finder until}) async {
+  for (var i = 0; i < 40 && until.evaluate().isEmpty; i++) {
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pump();
+  }
+  expect(until, findsWidgets, reason: "command picker content did not finish loading");
+}
+
+void main() {
+  testWidgets("opens with a loading indicator, then shows the sorted commands", (tester) async {
+    await tester.pumpWidget(_buildApp(commands: _commands(), onClosed: (_) {}));
+
+    await _openPicker(tester);
+
+    expect(find.text("Slash commands"), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text("/deploy"), findsNothing);
+
+    await _waitForEntries(tester, until: find.text("/deploy"));
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text("/release"), findsOneWidget);
+    expect(find.text("Ship the app"), findsOneWidget);
+    expect(find.text("version"), findsOneWidget);
+  });
+
+  testWidgets("search filters commands by name, description, and hints", (tester) async {
+    await tester.pumpWidget(_buildApp(commands: _commands(), onClosed: (_) {}));
+
+    await _openPicker(tester);
+    await _waitForEntries(tester, until: find.text("/deploy"));
+
+    await tester.enterText(find.byType(TextField), "Ship");
+    await tester.pump();
+
+    expect(find.text("/deploy"), findsOneWidget);
+    expect(find.text("/release"), findsNothing);
+  });
+
+  testWidgets("tapping a command returns it through the show() future and closes the sheet", (tester) async {
+    CommandInfo? selected;
+    await tester.pumpWidget(_buildApp(commands: _commands(), onClosed: (command) => selected = command));
+
+    await _openPicker(tester);
+    await _waitForEntries(tester, until: find.text("/deploy"));
+    // Let the sheet's entrance animation finish: while the route is still
+    // animating, the navigator ignores pointer events on its content.
+    await tester.pump(const Duration(milliseconds: 400));
+
+    await tester.tap(find.text("/deploy"));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(selected?.name, "deploy");
+    expect(find.text("Slash commands"), findsNothing);
+  });
+
+  testWidgets("shows the empty message when no commands are available", (tester) async {
+    await tester.pumpWidget(_buildApp(commands: const [], onClosed: (_) {}));
+
+    await _openPicker(tester);
+    await _waitForEntries(
+      tester,
+      until: find.text("No slash commands are available for this project."),
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+}

--- a/mobile/app/test/core/widgets/model_picker_sheet_test.dart
+++ b/mobile/app/test/core/widgets/model_picker_sheet_test.dart
@@ -1,0 +1,179 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:go_router/go_router.dart";
+import "package:sesori_mobile/core/widgets/model_picker_sheet.dart";
+import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_zyra/module_zyra.dart";
+
+ProviderModel _model({
+  required String id,
+  required String name,
+  String? family,
+  DateTime? releaseDate,
+}) {
+  return ProviderModel(
+    id: id,
+    providerID: "test-provider",
+    name: name,
+    variants: const [],
+    family: family,
+    releaseDate: releaseDate,
+  );
+}
+
+List<ProviderInfo> _providers() {
+  return [
+    ProviderInfo(
+      id: "anthropic",
+      name: "Anthropic",
+      models: {
+        "claude-new": _model(
+          id: "claude-new",
+          name: "Claude Sonnet (latest)",
+          family: "claude",
+          releaseDate: DateTime(2026),
+        ),
+        "claude-old": _model(
+          id: "claude-old",
+          name: "Claude Opus Classic",
+          family: "claude",
+          releaseDate: DateTime(2024),
+        ),
+      },
+      defaultModelID: null,
+    ),
+    ProviderInfo(
+      id: "zeta",
+      name: "Zeta AI",
+      models: {
+        "z-1": _model(id: "z-1", name: "Zeta One", releaseDate: DateTime(2025)),
+      },
+      defaultModelID: null,
+    ),
+  ];
+}
+
+Widget _buildApp({
+  required void Function({required String providerID, required String modelID}) onModelChanged,
+}) {
+  final router = GoRouter(
+    routes: [
+      GoRoute(
+        path: "/",
+        builder: (context, state) => Scaffold(
+          body: FilledButton(
+            onPressed: () => ModelPickerSheet.show(
+              context,
+              providers: _providers(),
+              selectedProviderID: "anthropic",
+              selectedModelID: "claude-new",
+              onModelChanged: onModelChanged,
+            ),
+            child: const Text("Open picker"),
+          ),
+        ),
+      ),
+    ],
+  );
+
+  return MaterialApp.router(
+    routerConfig: router,
+    theme: ThemeData(
+      extensions: [ZyraDesignSystem.light],
+    ),
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+  );
+}
+
+/// Opens the picker. The section computation runs in a real isolate via
+/// compute(), which the fake-async test clock cannot settle on its own, so
+/// the sheet deterministically shows its loading state at this point.
+Future<void> _openPicker(WidgetTester tester) async {
+  await tester.tap(find.text("Open picker"));
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 50));
+}
+
+/// Lets the compute() isolate finish and the sheet rebuild with its result.
+///
+/// Alternates between [WidgetTester.runAsync] (so the isolate's real-time
+/// message round-trip can happen) and [WidgetTester.pump] (so the fake-async
+/// clock processes the resulting setState rebuild). pumpAndSettle cannot be
+/// used: the isolate communication leaves pending work the fake-async clock
+/// never resolves on its own.
+Future<void> _waitForModels(WidgetTester tester, {required Finder until}) async {
+  for (var i = 0; i < 40 && until.evaluate().isEmpty; i++) {
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    });
+    await tester.pump();
+  }
+  expect(until, findsWidgets, reason: "model picker content did not finish loading");
+}
+
+void main() {
+  testWidgets("opens with a loading indicator, then shows default models per family", (tester) async {
+    await tester.pumpWidget(_buildApp(onModelChanged: ({required providerID, required modelID}) {}));
+
+    await _openPicker(tester);
+
+    // The sheet is open (title visible) but the model list is still being
+    // computed in the background isolate: loading indicator, no models yet.
+    expect(find.text("Select Model"), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text("Claude Sonnet"), findsNothing);
+
+    await _waitForModels(tester, until: find.text("Claude Sonnet"));
+
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text("Anthropic"), findsOneWidget);
+    expect(find.text("Zeta AI"), findsOneWidget);
+    expect(find.text("Zeta One"), findsOneWidget);
+    // Only the family representative is visible by default; the "(latest)"
+    // marker is stripped from the display name.
+    expect(find.text("Claude Opus Classic"), findsNothing);
+  });
+
+  testWidgets("search reveals non-default family members and filters providers", (tester) async {
+    await tester.pumpWidget(_buildApp(onModelChanged: ({required providerID, required modelID}) {}));
+
+    await _openPicker(tester);
+    await _waitForModels(tester, until: find.text("Claude Sonnet"));
+
+    await tester.enterText(find.byType(TextField), "Opus");
+    await tester.pump();
+
+    expect(find.text("Claude Opus Classic"), findsOneWidget);
+    expect(find.text("Claude Sonnet"), findsNothing);
+    expect(find.text("Zeta One"), findsNothing);
+  });
+
+  testWidgets("tapping a model returns the selection and closes the sheet", (tester) async {
+    String? selectedProviderID;
+    String? selectedModelID;
+    await tester.pumpWidget(
+      _buildApp(
+        onModelChanged: ({required providerID, required modelID}) {
+          selectedProviderID = providerID;
+          selectedModelID = modelID;
+        },
+      ),
+    );
+
+    await _openPicker(tester);
+    await _waitForModels(tester, until: find.text("Zeta One"));
+    // Let the sheet's entrance animation finish: while the route is still
+    // animating, the navigator ignores pointer events on its content.
+    await tester.pump(const Duration(milliseconds: 400));
+
+    await tester.tap(find.text("Zeta One"));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(selectedProviderID, "zeta");
+    expect(selectedModelID, "z-1");
+    expect(find.text("Select Model"), findsNothing);
+  });
+}

--- a/mobile/module_core/lib/sesori_dart_core.dart
+++ b/mobile/module_core/lib/sesori_dart_core.dart
@@ -99,6 +99,7 @@ export "src/services/foreground_notification_dispatcher.dart";
 export "src/services/notification_registration_service.dart";
 export "src/services/session_detail_load_service.dart";
 // Utils
+export "src/utils/command_filter/command_picker_entry_builder.dart";
 export "src/utils/diff/diff_engine.dart";
 export "src/utils/diff/language_detector.dart";
 export "src/utils/model_filter/default_model_selector.dart";

--- a/mobile/module_core/lib/sesori_dart_core.dart
+++ b/mobile/module_core/lib/sesori_dart_core.dart
@@ -102,3 +102,4 @@ export "src/services/session_detail_load_service.dart";
 export "src/utils/diff/diff_engine.dart";
 export "src/utils/diff/language_detector.dart";
 export "src/utils/model_filter/default_model_selector.dart";
+export "src/utils/model_filter/model_picker_section_builder.dart";

--- a/mobile/module_core/lib/src/utils/command_filter/command_picker_entry_builder.dart
+++ b/mobile/module_core/lib/src/utils/command_filter/command_picker_entry_builder.dart
@@ -1,0 +1,76 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+/// A command row in the command picker, pre-shaped for display.
+class CommandPickerEntry {
+  /// The command reported back when the entry is selected.
+  final CommandInfo command;
+
+  /// Trimmed description, `null` when absent or blank. Capped in length so
+  /// pathological multi-kilobyte strings never reach text layout.
+  final String? displayDescription;
+
+  /// Non-blank hints joined for display, `null` when there are none.
+  final String? displayHints;
+
+  /// Lowercase search haystack (command name, description, hints) matched
+  /// against the lowercased search query with a plain `contains`.
+  final String searchText;
+
+  const CommandPickerEntry({
+    required this.command,
+    required this.displayDescription,
+    required this.displayHints,
+    required this.searchText,
+  });
+}
+
+/// Shapes raw [CommandInfo] catalogs into the entries displayed by the
+/// command picker sheet.
+///
+/// Pure transformation with no side effects, extracted from the picker
+/// widget so it can run in a background isolate: sorting and display-string
+/// preparation for large command/skill catalogs would otherwise run during
+/// the sheet's opening frame (and again on every rebuild).
+class CommandPickerEntryBuilder {
+  const CommandPickerEntryBuilder();
+
+  /// Caps precomputed display strings. The tiles show at most two ellipsized
+  /// lines, which can never render this many characters — but without a cap
+  /// the text engine lays out the full string before truncating, and some
+  /// skill/MCP descriptions are multiple kilobytes long.
+  static const _maxDisplayLength = 1000;
+
+  /// Builds the picker entries, sorted by command name.
+  List<CommandPickerEntry> build({required List<CommandInfo> commands}) {
+    final sorted = commands.toList()..sort((a, b) => a.name.compareTo(b.name));
+    return [
+      for (final command in sorted)
+        CommandPickerEntry(
+          command: command,
+          displayDescription: _displayDescription(command: command),
+          displayHints: _displayHints(command: command),
+          searchText: _searchText(command: command),
+        ),
+    ];
+  }
+
+  String? _displayDescription({required CommandInfo command}) {
+    final description = command.description?.trim();
+    if (description == null || description.isEmpty) return null;
+    return _truncate(value: description);
+  }
+
+  String? _displayHints({required CommandInfo command}) {
+    final hints = (command.hints ?? []).where((hint) => hint.trim().isNotEmpty).join("  •  ");
+    if (hints.isEmpty) return null;
+    return _truncate(value: hints);
+  }
+
+  String _searchText({required CommandInfo command}) {
+    final hintsText = (command.hints ?? []).join(" ");
+    return "${command.name} ${command.description ?? ""} $hintsText".toLowerCase();
+  }
+
+  String _truncate({required String value}) =>
+      value.length <= _maxDisplayLength ? value : value.substring(0, _maxDisplayLength);
+}

--- a/mobile/module_core/lib/src/utils/model_filter/model_picker_section_builder.dart
+++ b/mobile/module_core/lib/src/utils/model_filter/model_picker_section_builder.dart
@@ -1,0 +1,157 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+import "default_model_selector.dart";
+
+/// A single selectable model row in the model picker, precomputed so the
+/// sheet can render without any per-frame sorting or grouping.
+class ModelPickerModelEntry {
+  /// Model identifier reported back when the entry is selected.
+  final String modelID;
+
+  /// Display name with the upstream "(latest)" marker stripped.
+  final String displayName;
+
+  /// Model family, shown as the tile subtitle when present.
+  final String? family;
+
+  /// Lowercase haystack (model name, family, id, provider name) matched
+  /// against the lowercased search query with a plain `contains`.
+  final String searchText;
+
+  /// Whether the entry is shown when the search query is empty — true for
+  /// each family's representative and for the currently selected model.
+  final bool visibleByDefault;
+
+  const ModelPickerModelEntry({
+    required this.modelID,
+    required this.displayName,
+    required this.family,
+    required this.searchText,
+    required this.visibleByDefault,
+  });
+}
+
+/// One provider's section in the model picker.
+class ModelPickerSection {
+  final String providerID;
+  final String providerName;
+
+  /// Available models sorted by release date (newest first, undated last),
+  /// ties broken by name.
+  final List<ModelPickerModelEntry> models;
+
+  const ModelPickerSection({
+    required this.providerID,
+    required this.providerName,
+    required this.models,
+  });
+}
+
+/// Shapes raw [ProviderInfo] catalogs into the sections displayed by the
+/// model picker sheet.
+///
+/// This is a pure transformation extracted from the picker widget so it can
+/// run inside a background isolate: large catalogs (hundreds to thousands of
+/// models) made the synchronous in-build sorting/grouping block the sheet's
+/// opening animation.
+///
+/// For each family of available models a single representative is visible by
+/// default; the user reveals the rest by typing in the search field. The
+/// selection priority lives in [DefaultModelSelector] — the same priority
+/// used by the cubits that pick the initial model when no prior selection
+/// exists — so the picker's "default per family" matches the cubit's
+/// "default for the whole provider".
+class ModelPickerSectionBuilder {
+  const ModelPickerSectionBuilder();
+
+  static const _defaultModelSelector = DefaultModelSelector();
+
+  /// Builds the provider sections for the given catalog.
+  ///
+  /// Providers are sorted by name and providers without available models are
+  /// omitted. [selectedProviderID]/[selectedModelID] mark the corresponding
+  /// entry as visible by default so the current selection never disappears
+  /// from the unfiltered list.
+  List<ModelPickerSection> build({
+    required List<ProviderInfo> providers,
+    required String selectedProviderID,
+    required String selectedModelID,
+  }) {
+    final sortedProviders = providers.toList()..sort((a, b) => a.name.compareTo(b.name));
+
+    final sections = <ModelPickerSection>[];
+    for (final provider in sortedProviders) {
+      final models = provider.models.values.where((m) => m.isAvailable).toList()
+        ..sort((a, b) {
+          final aDate = a.releaseDate;
+          final bDate = b.releaseDate;
+          if (aDate != bDate) {
+            if (bDate == null) return -1;
+            if (aDate == null) return 1;
+            return bDate.compareTo(aDate);
+          }
+          return a.name.compareTo(b.name);
+        });
+      if (models.isEmpty) continue;
+
+      final visibleIds = _defaultVisibleIds(
+        provider: provider,
+        availableModels: models,
+        selectedProviderID: selectedProviderID,
+        selectedModelID: selectedModelID,
+      );
+
+      sections.add(
+        ModelPickerSection(
+          providerID: provider.id,
+          providerName: provider.name,
+          models: [
+            for (final model in models)
+              ModelPickerModelEntry(
+                modelID: model.id,
+                displayName: model.name.replaceAll("(latest)", "").trim(),
+                family: model.family,
+                searchText: "${model.name} ${model.family ?? ""} ${model.id} ${provider.name}".toLowerCase(),
+                visibleByDefault: visibleIds.contains(model.id),
+              ),
+          ],
+        ),
+      );
+    }
+    return sections;
+  }
+
+  /// Builds the set of model IDs that should be visible by default.
+  ///
+  /// For each family of available models we pick a single representative via
+  /// [DefaultModelSelector.pickFromFamily]; the currently selected model of
+  /// the selected provider is always included.
+  Set<String> _defaultVisibleIds({
+    required ProviderInfo provider,
+    required List<ProviderModel> availableModels,
+    required String selectedProviderID,
+    required String selectedModelID,
+  }) {
+    final visible = <String>{};
+
+    final byFamily = <String, List<ProviderModel>>{};
+    for (final m in availableModels) {
+      final family = m.family ?? m.id;
+      (byFamily[family] ??= []).add(m);
+    }
+
+    for (final group in byFamily.values) {
+      final chosen = _defaultModelSelector.pickFromFamily(
+        group: group,
+        defaultModelId: provider.defaultModelID,
+      );
+      if (chosen != null) visible.add(chosen.id);
+    }
+
+    if (provider.id == selectedProviderID) {
+      visible.add(selectedModelID);
+    }
+
+    return visible;
+  }
+}

--- a/mobile/module_core/test/utils/command_filter/command_picker_entry_builder_test.dart
+++ b/mobile/module_core/test/utils/command_filter/command_picker_entry_builder_test.dart
@@ -1,0 +1,105 @@
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+CommandInfo _command({
+  required String name,
+  String? description,
+  List<String>? hints,
+}) {
+  return CommandInfo(
+    name: name,
+    template: null,
+    hints: hints,
+    description: description,
+    agent: null,
+    model: null,
+    provider: null,
+    source: CommandSource.command,
+    subtask: null,
+  );
+}
+
+void main() {
+  const builder = CommandPickerEntryBuilder();
+
+  group("CommandPickerEntryBuilder.build", () {
+    test("sorts commands by name", () {
+      final entries = builder.build(
+        commands: [
+          _command(name: "zeta"),
+          _command(name: "alpha"),
+          _command(name: "mid"),
+        ],
+      );
+      expect(entries.map((e) => e.command.name), ["alpha", "mid", "zeta"]);
+    });
+
+    test("keeps the original command on each entry", () {
+      final command = _command(name: "deploy", description: "Ship it");
+      final entries = builder.build(commands: [command]);
+      expect(entries.single.command, command);
+    });
+
+    test("trims the description and nulls it out when blank or absent", () {
+      final entries = builder.build(
+        commands: [
+          _command(name: "a", description: "  padded  "),
+          _command(name: "b", description: "   "),
+          _command(name: "c"),
+        ],
+      );
+      expect(entries[0].displayDescription, "padded");
+      expect(entries[1].displayDescription, isNull);
+      expect(entries[2].displayDescription, isNull);
+    });
+
+    test("joins non-blank hints and nulls out when there are none", () {
+      final entries = builder.build(
+        commands: [
+          _command(name: "a", hints: ["first", "  ", "second"]),
+          _command(name: "b", hints: ["   "]),
+          _command(name: "c"),
+        ],
+      );
+      expect(entries[0].displayHints, "first  •  second");
+      expect(entries[1].displayHints, isNull);
+      expect(entries[2].displayHints, isNull);
+    });
+
+    test("caps display strings so huge descriptions never reach text layout", () {
+      final entries = builder.build(
+        commands: [
+          _command(name: "a", description: "x" * 5000, hints: ["y" * 5000]),
+        ],
+      );
+      expect(entries.single.displayDescription, hasLength(1000));
+      expect(entries.single.displayHints, hasLength(1000));
+    });
+
+    test("builds a lowercase search haystack from name, description, and hints", () {
+      final entries = builder.build(
+        commands: [
+          _command(name: "Deploy", description: "Ships the App", hints: ["Target ENV"]),
+        ],
+      );
+      final searchText = entries.single.searchText;
+      expect(searchText, contains("deploy"));
+      expect(searchText, contains("ships the app"));
+      expect(searchText, contains("target env"));
+      expect(searchText, equals(searchText.toLowerCase()));
+    });
+
+    test("search haystack keeps the full description even when display is capped", () {
+      final longTail = "${"x" * 2000} needle";
+      final entries = builder.build(
+        commands: [_command(name: "a", description: longTail)],
+      );
+      expect(entries.single.searchText, contains("needle"));
+    });
+
+    test("returns an empty list for no commands", () {
+      expect(builder.build(commands: const []), isEmpty);
+    });
+  });
+}

--- a/mobile/module_core/test/utils/model_filter/model_picker_section_builder_test.dart
+++ b/mobile/module_core/test/utils/model_filter/model_picker_section_builder_test.dart
@@ -1,0 +1,208 @@
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+ProviderModel _model({
+  required String id,
+  String? name,
+  String? family,
+  DateTime? releaseDate,
+  bool isAvailable = true,
+}) {
+  return ProviderModel(
+    id: id,
+    providerID: "test-provider",
+    name: name ?? id,
+    variants: const [],
+    family: family,
+    isAvailable: isAvailable,
+    releaseDate: releaseDate,
+  );
+}
+
+ProviderInfo _provider({
+  required String id,
+  required List<ProviderModel> models,
+  String? name,
+  String? defaultModelID,
+}) {
+  return ProviderInfo(
+    id: id,
+    name: name ?? id,
+    models: {for (final m in models) m.id: m},
+    defaultModelID: defaultModelID,
+  );
+}
+
+void main() {
+  const builder = ModelPickerSectionBuilder();
+
+  List<ModelPickerSection> build({
+    required List<ProviderInfo> providers,
+    String selectedProviderID = "",
+    String selectedModelID = "",
+  }) {
+    return builder.build(
+      providers: providers,
+      selectedProviderID: selectedProviderID,
+      selectedModelID: selectedModelID,
+    );
+  }
+
+  group("ModelPickerSectionBuilder.build", () {
+    test("sorts providers by name", () {
+      final sections = build(
+        providers: [
+          _provider(id: "z", name: "Zeta", models: [_model(id: "z-1")]),
+          _provider(id: "a", name: "Alpha", models: [_model(id: "a-1")]),
+        ],
+      );
+      expect(sections.map((s) => s.providerName), ["Alpha", "Zeta"]);
+    });
+
+    test("omits providers without available models", () {
+      final sections = build(
+        providers: [
+          _provider(id: "empty", models: const []),
+          _provider(id: "dead", models: [_model(id: "d-1", isAvailable: false)]),
+          _provider(id: "alive", models: [_model(id: "a-1")]),
+        ],
+      );
+      expect(sections.map((s) => s.providerID), ["alive"]);
+    });
+
+    test("excludes unavailable models", () {
+      final sections = build(
+        providers: [
+          _provider(id: "p", models: [
+            _model(id: "kept"),
+            _model(id: "dropped", isAvailable: false),
+          ]),
+        ],
+      );
+      expect(sections.single.models.map((m) => m.modelID), ["kept"]);
+    });
+
+    test("sorts models by release date descending, undated last, ties by name", () {
+      final sections = build(
+        providers: [
+          _provider(id: "p", models: [
+            _model(id: "undated-b", name: "B undated"),
+            _model(id: "old", name: "Old", releaseDate: DateTime(2024)),
+            _model(id: "undated-a", name: "A undated"),
+            _model(id: "new", name: "New", releaseDate: DateTime(2026)),
+          ]),
+        ],
+      );
+      expect(
+        sections.single.models.map((m) => m.modelID),
+        ["new", "old", "undated-a", "undated-b"],
+      );
+    });
+
+    test("marks one representative per family as visible by default", () {
+      final sections = build(
+        providers: [
+          _provider(id: "p", models: [
+            _model(id: "sonnet-new", family: "sonnet", releaseDate: DateTime(2026)),
+            _model(id: "sonnet-old", family: "sonnet", releaseDate: DateTime(2024)),
+            _model(id: "haiku-only", family: "haiku", releaseDate: DateTime(2025)),
+          ]),
+        ],
+      );
+      final visible = sections.single.models.where((m) => m.visibleByDefault).map((m) => m.modelID);
+      expect(visible, containsAll(["sonnet-new", "haiku-only"]));
+      expect(visible, isNot(contains("sonnet-old")));
+    });
+
+    test("honors the provider defaultModelID when picking the family representative", () {
+      final sections = build(
+        providers: [
+          _provider(
+            id: "p",
+            defaultModelID: "sonnet-old",
+            models: [
+              _model(id: "sonnet-new", family: "sonnet", releaseDate: DateTime(2026)),
+              _model(id: "sonnet-old", family: "sonnet", releaseDate: DateTime(2024)),
+            ],
+          ),
+        ],
+      );
+      final visible = sections.single.models.where((m) => m.visibleByDefault).map((m) => m.modelID);
+      expect(visible, contains("sonnet-old"));
+      expect(visible, isNot(contains("sonnet-new")));
+    });
+
+    test("treats models without a family as their own family", () {
+      final sections = build(
+        providers: [
+          _provider(id: "p", models: [
+            _model(id: "lone-a", releaseDate: DateTime(2024)),
+            _model(id: "lone-b", releaseDate: DateTime(2026)),
+          ]),
+        ],
+      );
+      expect(sections.single.models.every((m) => m.visibleByDefault), isTrue);
+    });
+
+    test("keeps the selected model visible by default in the selected provider only", () {
+      final providers = [
+        _provider(id: "p1", models: [
+          _model(id: "shared-new", family: "fam", releaseDate: DateTime(2026)),
+          _model(id: "shared-old", family: "fam", releaseDate: DateTime(2024)),
+        ]),
+        _provider(id: "p2", models: [
+          _model(id: "shared-new", family: "fam", releaseDate: DateTime(2026)),
+          _model(id: "shared-old", family: "fam", releaseDate: DateTime(2024)),
+        ]),
+      ];
+      final sections = build(
+        providers: providers,
+        selectedProviderID: "p1",
+        selectedModelID: "shared-old",
+      );
+      final p1 = sections.firstWhere((s) => s.providerID == "p1");
+      final p2 = sections.firstWhere((s) => s.providerID == "p2");
+      expect(p1.models.firstWhere((m) => m.modelID == "shared-old").visibleByDefault, isTrue);
+      expect(p2.models.firstWhere((m) => m.modelID == "shared-old").visibleByDefault, isFalse);
+    });
+
+    test("strips the (latest) marker from the display name", () {
+      final sections = build(
+        providers: [
+          _provider(id: "p", models: [
+            _model(id: "m", name: "Claude Sonnet (latest)"),
+          ]),
+        ],
+      );
+      expect(sections.single.models.single.displayName, "Claude Sonnet");
+    });
+
+    test("builds a lowercase search haystack from name, family, id, and provider name", () {
+      final sections = build(
+        providers: [
+          _provider(id: "anthropic", name: "Anthropic", models: [
+            _model(id: "claude-4", name: "Claude Sonnet", family: "Sonnet"),
+          ]),
+        ],
+      );
+      final searchText = sections.single.models.single.searchText;
+      expect(searchText, contains("claude sonnet"));
+      expect(searchText, contains("sonnet"));
+      expect(searchText, contains("claude-4"));
+      expect(searchText, contains("anthropic"));
+      expect(searchText, equals(searchText.toLowerCase()));
+    });
+
+    test("exposes the family as the entry subtitle", () {
+      final sections = build(
+        providers: [
+          _provider(id: "p", models: [
+            _model(id: "with", family: "fam"),
+          ]),
+        ],
+      );
+      expect(sections.single.models.single.family, "fam");
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Opening the **model picker** and the **command/skill picker** bottom sheets is visibly slow (reported on macOS): there is a noticeable delay between tapping the trigger button and the sheet appearing, growing with the size of the catalog.

## Root causes

Both sheets did their content preparation **synchronously inside their first build**, which runs while the bottom-sheet route is being pushed (blocking the entrance animation's first frame):

**Model picker** (`ModelPickerSheet`):
1. Provider sorting + per-provider family grouping (`DefaultModelSelector.pickFromFamily` per family)
2. Per-provider availability filtering + release-date sorting
3. **Eager construction of every model tile** via non-lazy `ListView(children:)` — the dominant cost with catalogs of hundreds–thousands of models

**Command picker** (`CommandPickerSheet`):
1. Copied + sorted the whole command/skill catalog on **every** build (first build, every keystroke, every unrelated rebuild)
2. Laid out full multi-kilobyte skill/MCP `description` strings — `Text(maxLines: 2, ellipsis)` lays out the entire string before truncating

Both repeated the work on every search keystroke.

## Fix

Both sheets now open **instantly with a loading indicator** and prepare their content **off the main thread**, starting only once the sheet is up:

- **New pure builders in `module_core`** (mirroring the existing `DiffEngine`/`DiffViewModelBuilder` split):
  - `ModelPickerSectionBuilder` (`utils/model_filter/`) — provider/model sorting, family-representative default visibility, "(latest)" stripping, lowercase search haystacks
  - `CommandPickerEntryBuilder` (`utils/command_filter/`) — name sorting, trimmed display strings **capped at 1000 chars** (so pathological multi-KB descriptions never reach text layout), lowercase search haystacks
- **Both sheets** kick off `compute()` in `initState` (precedent: `DiffViewModelBuilder`), show `CircularProgressIndicator` until results arrive, and fail soft (log via `loge` + empty list) if the isolate errors
- **Lazy rendering**: model picker switched to `ListView.builder`; command picker keeps its lazy `ListView.separated`
- **Memoized filtering**: filtered rows/entries are cached and recomputed only when data arrives or the query changes — search keystrokes are now a single `contains` pass over precomputed haystacks
- **A11y**: model tiles expose selection state via `ListTile.selected`
- **Material surfaces**: both sheets switched from color-decorated `Container`s to `Material` so `ListTile`s can paint ink/selection effects (previously triggered Flutter's debug assertion, surfaced by the new widget tests)

Public APIs (`ModelPickerSheet.show`, `CommandPickerSheet.show`) are unchanged; all call sites untouched.

## Tests

- 11 unit tests for `ModelPickerSectionBuilder` + 8 for `CommandPickerEntryBuilder` (sorting, grouping/defaults, capping, search haystacks)
- 3 widget tests for `ModelPickerSheet` + 4 for `CommandPickerSheet` (loading state until the isolate completes, rendering, search filtering, tap-returns-selection, empty state)

## Verification

- `dart analyze`: clean in `module_core` and `app`
- `dart test` (module_core): 330 passed
- `flutter test` (app): 426 passed
- Plan + implementation approved by aristotle-plan-review / aristotle-impl-review (both pickers)