### PR TITLE
feat(mobile): animate splash-to-login with logo hero flight and fade

### DIFF
--- a/mobile/app/android/gradle.properties
+++ b/mobile/app/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/mobile/app/lib/core/extensions/build_context_x.dart
+++ b/mobile/app/lib/core/extensions/build_context_x.dart
@@ -16,6 +16,14 @@ extension BuildContextLocalization on BuildContext {
     return Theme.of(this).brightness;
   }
 
+  /// True when OS accessibility settings ask to minimize motion; used to
+  /// skip decorative animations.
+  bool get isReducedMotion {
+    final disableAnimations = MediaQuery.maybeDisableAnimationsOf(this) ?? false;
+    final accessibleNavigation = MediaQuery.maybeAccessibleNavigationOf(this) ?? false;
+    return disableAnimations || accessibleNavigation;
+  }
+
   AppLocalizations get loc {
     final localizations = AppLocalizations.of(this);
     if (localizations == null) {

--- a/mobile/app/lib/core/extensions/build_context_x.dart
+++ b/mobile/app/lib/core/extensions/build_context_x.dart
@@ -18,10 +18,14 @@ extension BuildContextLocalization on BuildContext {
 
   /// True when OS accessibility settings ask to minimize motion; used to
   /// skip decorative animations.
+  ///
+  /// Backed solely by the OS reduce-motion preference
+  /// (`MediaQuery.disableAnimations`). Screen-reader presence
+  /// (`accessibleNavigation`) is intentionally excluded: it is a separate
+  /// preference, and screen-reader users may rely on motion for spatial
+  /// orientation.
   bool get isReducedMotion {
-    final disableAnimations = MediaQuery.maybeDisableAnimationsOf(this) ?? false;
-    final accessibleNavigation = MediaQuery.maybeAccessibleNavigationOf(this) ?? false;
-    return disableAnimations || accessibleNavigation;
+    return MediaQuery.maybeDisableAnimationsOf(this) ?? false;
   }
 
   AppLocalizations get loc {

--- a/mobile/app/lib/core/routing/app_router.dart
+++ b/mobile/app/lib/core/routing/app_router.dart
@@ -10,47 +10,94 @@ import "../../features/session_diffs/session_diffs_screen.dart";
 import "../../features/session_list/session_list_screen.dart";
 import "../../features/settings/settings_screen.dart";
 import "../../features/splash/splash_screen.dart";
+import "../extensions/build_context_x.dart";
+import "../widgets/sesori_logo.dart";
 
 extension AppRouteToGoRoute on AppRouteDef {
   /// Returns the [GoRoute] for this route definition with an exhaustive
   /// builder switch over decoded [AppRoute] values.
   GoRoute toGoRoute() {
+    // The login screen gets a fade-in page instead of the platform slide so
+    // the splash → login hand-off reads as one continuous motion — see
+    // _loginTransitionPage.
+    if (this == AppRouteDef.login) {
+      return GoRoute(
+        path: path,
+        pageBuilder: (context, state) => _loginTransitionPage(
+          context: context,
+          state: state,
+          child: _buildScreen(context: context, state: state),
+        ),
+      );
+    }
     return GoRoute(
       path: path,
-      builder: (context, state) {
-        final route = AppRoute.fromDef(
-          def: this,
-          pathParams: state.pathParameters,
-          queryParams: state.uri.queryParameters,
-        );
-
-        return switch (route) {
-          AppRouteSplash() => const SplashScreen(),
-          AppRouteLogin() => const LoginScreen(),
-          AppRouteProjects() => const ProjectListScreen(),
-          AppRouteSettings() => const SettingsScreen(),
-          AppRouteSessions(:final projectId, :final projectName) => SessionListScreen(
-            projectId: projectId,
-            projectName: projectName,
-          ),
-          AppRouteNewSession(:final projectId) => NewSessionScreen(
-            projectId: projectId,
-          ),
-          AppRouteSessionDetail(:final projectId, :final sessionId, :final sessionTitle, :final readOnly) =>
-            SessionDetailScreen(
-              projectId: projectId,
-              sessionId: sessionId,
-              sessionTitle: sessionTitle,
-              readOnly: readOnly,
-            ),
-          AppRouteSessionDiffs(:final projectId, :final sessionId) => SessionDiffsScreen(
-            projectId: projectId,
-            sessionId: sessionId,
-          ),
-        };
-      },
+      builder: (context, state) => _buildScreen(context: context, state: state),
     );
   }
+
+  Widget _buildScreen({required BuildContext context, required GoRouterState state}) {
+    final route = AppRoute.fromDef(
+      def: this,
+      pathParams: state.pathParameters,
+      queryParams: state.uri.queryParameters,
+    );
+
+    return switch (route) {
+      AppRouteSplash() => const SplashScreen(),
+      AppRouteLogin() => const LoginScreen(),
+      AppRouteProjects() => const ProjectListScreen(),
+      AppRouteSettings() => const SettingsScreen(),
+      AppRouteSessions(:final projectId, :final projectName) => SessionListScreen(
+        projectId: projectId,
+        projectName: projectName,
+      ),
+      AppRouteNewSession(:final projectId) => NewSessionScreen(
+        projectId: projectId,
+      ),
+      AppRouteSessionDetail(:final projectId, :final sessionId, :final sessionTitle, :final readOnly) =>
+        SessionDetailScreen(
+          projectId: projectId,
+          sessionId: sessionId,
+          sessionTitle: sessionTitle,
+          readOnly: readOnly,
+        ),
+      AppRouteSessionDiffs(:final projectId, :final sessionId) => SessionDiffsScreen(
+        projectId: projectId,
+        sessionId: sessionId,
+      ),
+    };
+  }
+}
+
+/// Fade-only page transition for every navigation into the login screen.
+///
+/// When coming from the splash screen, the splash stays visible underneath
+/// while the login screen — which shares the same background — fades in on
+/// top. The splash title appears to dissolve, the login text and buttons
+/// fade in, and the [SesoriLogo] hero glides from the screen center to its
+/// login position. Other entry points (logout, session expiry) get the same
+/// fade without a hero flight.
+Page<void> _loginTransitionPage({
+  required BuildContext context,
+  required GoRouterState state,
+  required Widget child,
+}) {
+  // Reduced motion only zeroes the duration: returning a different Page
+  // subclass here would fail Page.canUpdate and recreate the login route —
+  // dropping in-flight login state — if the OS setting flips while the
+  // screen is shown.
+  final duration = context.isReducedMotion ? Duration.zero : const Duration(milliseconds: 500);
+  return CustomTransitionPage<void>(
+    key: state.pageKey,
+    transitionDuration: duration,
+    reverseTransitionDuration: duration,
+    transitionsBuilder: (context, animation, secondaryAnimation, child) => FadeTransition(
+      opacity: CurveTween(curve: Curves.easeInOut).animate(animation),
+      child: child,
+    ),
+    child: child,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/mobile/app/lib/core/widgets/sesori_logo.dart
+++ b/mobile/app/lib/core/widgets/sesori_logo.dart
@@ -15,9 +15,17 @@ import "package:vector_graphics/vector_graphics.dart";
 class SesoriLogo extends StatelessWidget {
   const SesoriLogo({super.key, this.squareSize = _svgSquare});
 
+  /// Shared [Hero] tag so the logo flies between screens that show it
+  /// (splash → login) during route transitions.
+  static const String heroTag = "sesori-logo";
+
   /// Edge length of the rounded square, in logical pixels. Everything else
   /// (frame, shadow, bevel) scales relative to this.
   final double squareSize;
+
+  /// Rendered frame height for this [squareSize], including the shadow
+  /// space the SVG frame reserves below the squircle.
+  double get frameHeight => _svgHeight * (squareSize / _svgSquare);
 
   static const double _svgSquare = 120;
   static const double _svgWidth = 151;

--- a/mobile/app/lib/features/login/login_screen.dart
+++ b/mobile/app/lib/features/login/login_screen.dart
@@ -139,7 +139,7 @@ class _LoginScreenBodyState extends State<_LoginScreenBody> {
                             child: Column(
                               mainAxisSize: .min,
                               children: [
-                                const SesoriLogo(),
+                                const Hero(tag: SesoriLogo.heroTag, child: SesoriLogo()),
                                 Text(
                                   loc.loginTitle,
                                   style: zyra.textTheme.textSm.regular,

--- a/mobile/app/lib/features/new_session/new_session_loading_overlay.dart
+++ b/mobile/app/lib/features/new_session/new_session_loading_overlay.dart
@@ -4,6 +4,8 @@ import "package:cue/cue.dart";
 import "package:flutter/material.dart";
 import "package:theme_zyra/module_zyra.dart";
 
+import "../../core/extensions/build_context_x.dart";
+
 /// A full-screen loading overlay shown while a new session is being created.
 ///
 /// Fills its parent and visually dims underlying content. Displays a centered
@@ -29,11 +31,7 @@ class _NewSessionLoadingOverlayState extends State<NewSessionLoadingOverlay> {
   int _messageIndex = 0;
   Timer? _timer;
 
-  bool get _isReducedMotion {
-    final disableAnimations = MediaQuery.disableAnimationsOf(context);
-    final accessibleNav = MediaQuery.maybeAccessibleNavigationOf(context) ?? false;
-    return disableAnimations || accessibleNav;
-  }
+  bool get _isReducedMotion => context.isReducedMotion;
 
   void _startTimer() {
     if (_timer?.isActive ?? false) return;

--- a/mobile/app/lib/features/splash/splash_screen.dart
+++ b/mobile/app/lib/features/splash/splash_screen.dart
@@ -1,10 +1,10 @@
+import "dart:async";
+
 import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
-import "package:theme_zyra/module_zyra.dart";
 
 import "../../core/di/injection.dart";
-import "../../core/extensions/build_context_x.dart";
 import "../../core/routing/app_router.dart";
 import "../../core/widgets/sesori_background_widget.dart";
 import "../../core/widgets/sesori_logo.dart";
@@ -24,14 +24,35 @@ class SplashScreen extends StatelessWidget {
 class _SplashScreenBody extends StatelessWidget {
   const _SplashScreenBody();
 
+  /// Completes once [animation] settles. Used to hold navigation until the
+  /// splash entrance transition finishes (after logout, splash is pushed
+  /// with the platform transition and the cubit resolves within a few
+  /// frames), so the login cross-fade and logo hero flight start from a
+  /// screen at rest instead of mid-slide.
+  Future<void> _settled(Animation<double> animation) {
+    final completer = Completer<void>();
+    void onStatus(AnimationStatus status) {
+      if (status == .completed || status == .dismissed) {
+        animation.removeStatusListener(onStatus);
+        completer.complete();
+      }
+    }
+
+    animation.addStatusListener(onStatus);
+    return completer.future;
+  }
+
   @override
   Widget build(BuildContext context) {
     return BlocListener<SplashCubit, SplashState>(
-      listener: (context, state) {
-        // return;
-        if (state is SplashReady) {
-          context.goRoute(state.route);
+      listener: (context, state) async {
+        if (state is! SplashReady) return;
+        final animation = ModalRoute.of(context)?.animation;
+        if (animation != null && !animation.isCompleted) {
+          await _settled(animation);
+          if (!context.mounted) return;
         }
+        context.goRoute(state.route);
       },
       child: const _SplashView(),
     );
@@ -43,29 +64,12 @@ class _SplashView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final zyra = context.zyra;
-    return Stack(
-      clipBehavior: .none,
+    return const Stack(
       children: [
-        const Positioned.fill(child: SesoriBackgroundWidget()),
+        Positioned.fill(child: SesoriBackgroundWidget()),
         Align(
           alignment: .center,
-          child: Material(
-            type: MaterialType.transparency,
-            child: Column(
-              mainAxisSize: .min,
-              children: [
-                const SesoriLogo(),
-                // Image has some embedded "bottom padding"
-                // caused by the shadow
-                const SizedBox(height: 13),
-                Text(
-                  context.loc.splashTitle,
-                  style: zyra.textTheme.textMd.bold,
-                ),
-              ],
-            ),
-          ),
+          child: Hero(tag: SesoriLogo.heroTag, child: SesoriLogo()),
         ),
       ],
     );

--- a/mobile/app/lib/features/splash/splash_screen.dart
+++ b/mobile/app/lib/features/splash/splash_screen.dart
@@ -48,7 +48,10 @@ class _SplashScreenBody extends StatelessWidget {
       listener: (context, state) async {
         if (state is! SplashReady) return;
         final animation = ModalRoute.of(context)?.animation;
-        if (animation != null && !animation.isCompleted) {
+        // Only wait when the entrance transition is actively running forward.
+        // A static `dismissed` animation (disabled transitions, test fakes)
+        // never fires a status change, so `_settled` would hang.
+        if (animation != null && animation.status == AnimationStatus.forward) {
           await _settled(animation);
           if (!context.mounted) return;
         }

--- a/mobile/app/lib/l10n/app_en.arb
+++ b/mobile/app/lib/l10n/app_en.arb
@@ -380,7 +380,6 @@
     }
   },
   "diffRetry": "Retry",
-  "splashTitle": "Sesori",
   "newSessionLoadingSemantics": "Creating session",
   "newSessionLoadingMessage1": "Warming up the engines…",
   "newSessionLoadingMessage2": "Generating session telemetry…",

--- a/mobile/app/lib/l10n/app_localizations.dart
+++ b/mobile/app/lib/l10n/app_localizations.dart
@@ -1525,12 +1525,6 @@ abstract class AppLocalizations {
   /// **'Retry'**
   String get diffRetry;
 
-  /// No description provided for @splashTitle.
-  ///
-  /// In en, this message translates to:
-  /// **'Sesori'**
-  String get splashTitle;
-
   /// No description provided for @newSessionLoadingSemantics.
   ///
   /// In en, this message translates to:

--- a/mobile/app/lib/l10n/app_localizations_en.dart
+++ b/mobile/app/lib/l10n/app_localizations_en.dart
@@ -794,9 +794,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get diffRetry => 'Retry';
 
   @override
-  String get splashTitle => 'Sesori';
-
-  @override
   String get newSessionLoadingSemantics => 'Creating session';
 
   @override

--- a/mobile/app/test/core/routing/app_route_test.dart
+++ b/mobile/app/test/core/routing/app_route_test.dart
@@ -109,13 +109,14 @@ void main() {
       }
     });
 
-    test("login route builds LoginScreen", () {
+    test("login route builds LoginScreen behind a fade transition page", () {
       final goRoute = AppRouteDef.login.toGoRoute();
-      final widget = goRoute.builder!(
+      final page = goRoute.pageBuilder!(
         _FakeBuildContext(),
         _FakeGoRouterState(),
       );
-      expect(widget, isA<LoginScreen>());
+      expect(page, isA<CustomTransitionPage<void>>());
+      expect((page as CustomTransitionPage<void>).child, isA<LoginScreen>());
     });
 
     test("projects route builds ProjectListScreen", () {
@@ -260,7 +261,12 @@ void main() {
 // Test helpers
 // ---------------------------------------------------------------------------
 
-class _FakeBuildContext extends Fake implements BuildContext {}
+class _FakeBuildContext extends Fake implements BuildContext {
+  // No inherited widgets in this synthetic context: MediaQuery lookups in
+  // page builders (reduced-motion checks) resolve to null → defaults.
+  @override
+  InheritedElement? getElementForInheritedWidgetOfExactType<T extends InheritedWidget>() => null;
+}
 
 // ignore: avoid_implementing_value_types
 class _FakeGoRouterState extends Fake implements GoRouterState {
@@ -274,4 +280,7 @@ class _FakeGoRouterState extends Fake implements GoRouterState {
 
   @override
   final Uri uri;
+
+  @override
+  ValueKey<String> get pageKey => const ValueKey<String>("/login");
 }

--- a/mobile/app/test/core/routing/app_route_test.dart
+++ b/mobile/app/test/core/routing/app_route_test.dart
@@ -264,6 +264,9 @@ void main() {
 class _FakeBuildContext extends Fake implements BuildContext {
   // No inherited widgets in this synthetic context: MediaQuery lookups in
   // page builders (reduced-motion checks) resolve to null → defaults.
+  // MediaQuery is an InheritedModel, so InheritedModel.inheritFrom resolves
+  // it via getElementForInheritedWidgetOfExactType (not the plain
+  // dependOnInheritedWidgetOfExactType), so that is the method to stub.
   @override
   InheritedElement? getElementForInheritedWidgetOfExactType<T extends InheritedWidget>() => null;
 }


### PR DESCRIPTION
## Summary

Reworks the splash-to-login transition into a single coordinated animation and applies a minor Android Gradle config update.

### Splash-to-login animation
- The splash screen now shows only the Sesori logo, exactly centered.
- On navigation to login, the logo flies via `Hero` from the screen center to its login position while the login text and buttons fade in over the shared background, replacing the platform slide transition.
- The login route uses a 500ms fade `CustomTransitionPage`. Duration drops to zero under reduced motion while keeping the page type stable, so the route (and in-flight login state) survives OS setting toggles.
- Splash navigation waits for the route entrance animation to settle, so the post-logout path gets the same clean cross-fade and flight.
- Adds a new `context.isReducedMotion` extension, reused by the new-session loading overlay.
- Removes the now-unused `splashTitle` l10n key.

### Android config
- Adds `android.builtInKotlin=false` and `android.newDsl=false` to `gradle.properties` (added automatically by the Flutter migrator).

## Testing
- Updated `app_route_test.dart` for the new transition behavior.