### PR TITLE
fix(bridge): stop holding the phone's request open while a slash command runs

### DIFF
--- a/bridge/AGENTS.md
+++ b/bridge/AGENTS.md
@@ -102,6 +102,10 @@ Do not extract a bridge collaborator only to make a file shorter. The extracted 
 
 In the push subsystem, `PushDispatcher` owns only outbound push sends. `CompletionPushListener` owns SSE-driven tracker/notifier bookkeeping plus abort suppression, and `MaintenancePushListener` owns the timer lifecycle, maintenance-step sequencing, and maintenance telemetry/logging.
 
+### Backend Quirks Live In The Plugin
+
+Backend-specific endpoint semantics and the workarounds they require (synchronous vs async endpoints, dispatch timeouts compensating for upstream API shape, retry quirks) belong inside the plugin that implements `BridgePluginApi` — never in bridge `app/` services or handlers. Bridge `app/` code must stay plugin-agnostic: it programs against the `BridgePluginApi` contract, and the contract's doc comments define the semantics (e.g., `sendCommand` completes on acceptance, not on run completion). If a fix requires knowing how a specific backend behaves, it goes in that backend's plugin.
+
 ### Orchestrator Owns SSE Decisions
 
 No component below the Orchestrator may emit SSE events directly. The Orchestrator subscribes to streams (`plugin.events`, `prSyncService.prChanges`) and decides what to emit to phones. No `emitBridgeEvent()` or similar public methods on the Orchestrator.

--- a/bridge/app/lib/src/bridge/services/session_prompt_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_prompt_service.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart";
 
@@ -7,12 +9,15 @@ import "../sse/sse_manager.dart";
 class SessionPromptService {
   final SessionRepository _sessionRepository;
   final SSEManager _sseManager;
+  final Duration _commandDispatchFastFailWindow;
 
   SessionPromptService({
     required SessionRepository sessionRepository,
     required SSEManager sseManager,
+    Duration commandDispatchFastFailWindow = const Duration(seconds: 3),
   })  : _sessionRepository = sessionRepository,
-        _sseManager = sseManager;
+        _sseManager = sseManager,
+        _commandDispatchFastFailWindow = commandDispatchFastFailWindow;
 
   Future<void> sendPrompt({
     required String sessionId,
@@ -41,7 +46,7 @@ class SessionPromptService {
     }
 
     final textPart = parts.whereType<PromptPartText>().firstOrNull;
-    await _sessionRepository.sendCommand(
+    final sendFuture = _sessionRepository.sendCommand(
       sessionId: sessionId,
       command: normalizedCommand,
       arguments: textPart?.text ?? '',
@@ -49,6 +54,24 @@ class SessionPromptService {
       agent: agent,
       model: model,
     );
+    try {
+      await sendFuture.timeout(_commandDispatchFastFailWindow);
+    } on TimeoutException {
+      // OpenCode's /command endpoint is synchronous — it responds only after
+      // the full agent run completes, and no async variant exists upstream.
+      // Surviving the fast-fail window means OpenCode accepted the command and
+      // the run is in progress (progress streams over SSE). Detach instead of
+      // holding the phone's relay request open until its client-side timeout
+      // misreports an in-flight command as a failed send.
+      unawaited(
+        sendFuture.catchError((Object e) {
+          Log.w(
+            "command '$normalizedCommand' for session $sessionId "
+            "failed after dispatch: $e",
+          );
+        }),
+      );
+    }
     await _updatePromptDefaults(
       sessionId: sessionId,
       variant: variant,

--- a/bridge/app/lib/src/bridge/services/session_prompt_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_prompt_service.dart
@@ -64,10 +64,12 @@ class SessionPromptService {
       // holding the phone's relay request open until its client-side timeout
       // misreports an in-flight command as a failed send.
       unawaited(
-        sendFuture.catchError((Object e) {
+        sendFuture.catchError((Object e, StackTrace s) {
           Log.w(
             "command '$normalizedCommand' for session $sessionId "
             "failed after dispatch: $e",
+            e,
+            s,
           );
         }),
       );

--- a/bridge/app/lib/src/bridge/services/session_prompt_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_prompt_service.dart
@@ -54,26 +54,31 @@ class SessionPromptService {
       agent: agent,
       model: model,
     );
-    try {
-      await sendFuture.timeout(_commandDispatchFastFailWindow);
-    } on TimeoutException {
-      // OpenCode's /command endpoint is synchronous — it responds only after
-      // the full agent run completes, and no async variant exists upstream.
-      // Surviving the fast-fail window means OpenCode accepted the command and
-      // the run is in progress (progress streams over SSE). Detach instead of
-      // holding the phone's relay request open until its client-side timeout
-      // misreports an in-flight command as a failed send.
-      unawaited(
-        sendFuture.catchError((Object e, StackTrace s) {
-          Log.w(
-            "command '$normalizedCommand' for session $sessionId "
-            "failed after dispatch: $e",
-            e,
-            s,
-          );
-        }),
-      );
-    }
+    // OpenCode's /command endpoint is synchronous — it responds only after
+    // the full agent run completes, and no async variant exists upstream.
+    // Surviving the fast-fail window means OpenCode accepted the command and
+    // the run is in progress (progress streams over SSE). Detach instead of
+    // holding the phone's relay request open until its client-side timeout
+    // misreports an in-flight command as a failed send.
+    //
+    // `onTimeout` (rather than catching [TimeoutException]) fires only when
+    // the window itself elapses, so a genuine TimeoutException raised by the
+    // send chain within the window still propagates as a dispatch failure.
+    await sendFuture.timeout(
+      _commandDispatchFastFailWindow,
+      onTimeout: () {
+        unawaited(
+          sendFuture.catchError((Object e, StackTrace s) {
+            Log.w(
+              "command '$normalizedCommand' for session $sessionId "
+              "failed after dispatch: $e",
+              e,
+              s,
+            );
+          }),
+        );
+      },
+    );
     await _updatePromptDefaults(
       sessionId: sessionId,
       variant: variant,

--- a/bridge/app/lib/src/bridge/services/session_prompt_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_prompt_service.dart
@@ -1,5 +1,3 @@
-import "dart:async";
-
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart";
 
@@ -9,15 +7,12 @@ import "../sse/sse_manager.dart";
 class SessionPromptService {
   final SessionRepository _sessionRepository;
   final SSEManager _sseManager;
-  final Duration _commandDispatchFastFailWindow;
 
   SessionPromptService({
     required SessionRepository sessionRepository,
     required SSEManager sseManager,
-    Duration commandDispatchFastFailWindow = const Duration(seconds: 3),
   })  : _sessionRepository = sessionRepository,
-        _sseManager = sseManager,
-        _commandDispatchFastFailWindow = commandDispatchFastFailWindow;
+        _sseManager = sseManager;
 
   Future<void> sendPrompt({
     required String sessionId,
@@ -46,38 +41,17 @@ class SessionPromptService {
     }
 
     final textPart = parts.whereType<PromptPartText>().firstOrNull;
-    final sendFuture = _sessionRepository.sendCommand(
+    // Per the BridgePluginApi contract, sendCommand completes once the
+    // backend has accepted the command — not when its run finishes — so
+    // awaiting it here never holds the phone's relay request open for the
+    // duration of the command's agent run.
+    await _sessionRepository.sendCommand(
       sessionId: sessionId,
       command: normalizedCommand,
       arguments: textPart?.text ?? '',
       variant: variant,
       agent: agent,
       model: model,
-    );
-    // OpenCode's /command endpoint is synchronous — it responds only after
-    // the full agent run completes, and no async variant exists upstream.
-    // Surviving the fast-fail window means OpenCode accepted the command and
-    // the run is in progress (progress streams over SSE). Detach instead of
-    // holding the phone's relay request open until its client-side timeout
-    // misreports an in-flight command as a failed send.
-    //
-    // `onTimeout` (rather than catching [TimeoutException]) fires only when
-    // the window itself elapses, so a genuine TimeoutException raised by the
-    // send chain within the window still propagates as a dispatch failure.
-    await sendFuture.timeout(
-      _commandDispatchFastFailWindow,
-      onTimeout: () {
-        unawaited(
-          sendFuture.catchError((Object e, StackTrace s) {
-            Log.w(
-              "command '$normalizedCommand' for session $sessionId "
-              "failed after dispatch: $e",
-              e,
-              s,
-            );
-          }),
-        );
-      },
     );
     await _updatePromptDefaults(
       sessionId: sessionId,

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -117,6 +117,7 @@ class FakeBridgePlugin implements BridgePluginApi {
   Object? throwOnDeleteSessionError;
   Object? throwOnArchiveSessionError;
   Completer<void>? archiveSessionCompleter;
+  Completer<void>? sendCommandCompleter;
 
   // ── BridgePlugin implementation ──────────────────────────────────────────
 
@@ -295,6 +296,9 @@ class FakeBridgePlugin implements BridgePluginApi {
     lastSendCommandVariant = variant?.id;
     lastSendCommandAgent = agent;
     lastSendCommandModel = model;
+    if (sendCommandCompleter case final completer?) {
+      await completer.future;
+    }
   }
 
   @override

--- a/bridge/app/test/bridge/services/session_prompt_service_test.dart
+++ b/bridge/app/test/bridge/services/session_prompt_service_test.dart
@@ -69,6 +69,16 @@ void main() {
       await expectLater(sendCommand(), throwsA(isA<StateError>()));
     });
 
+    test("propagates a TimeoutException raised by the send chain within the window", () async {
+      // Must not be conflated with the fast-fail window elapsing: a timeout
+      // thrown by the send chain itself is a genuine dispatch failure.
+      final completer = Completer<void>();
+      plugin.sendCommandCompleter = completer;
+      completer.completeError(TimeoutException("inner send timeout"));
+
+      await expectLater(sendCommand(), throwsA(isA<TimeoutException>()));
+    });
+
     test("completes after the window when the command run keeps going", () async {
       // Simulates OpenCode's synchronous /command endpoint: the HTTP response
       // only arrives after the full agent run. The service must not hold the

--- a/bridge/app/test/bridge/services/session_prompt_service_test.dart
+++ b/bridge/app/test/bridge/services/session_prompt_service_test.dart
@@ -12,8 +12,6 @@ import "../routing/routing_test_helpers.dart";
 
 void main() {
   group("SessionPromptService command dispatch", () {
-    const fastFailWindow = Duration(milliseconds: 50);
-
     late FakeBridgePlugin plugin;
     late AppDatabase db;
     late SessionRepository sessionRepository;
@@ -33,7 +31,6 @@ void main() {
       service = SessionPromptService(
         sessionRepository: sessionRepository,
         sseManager: FakeSSEManager(),
-        commandDispatchFastFailWindow: fastFailWindow,
       );
     });
 
@@ -53,7 +50,7 @@ void main() {
       );
     }
 
-    test("completes when the command finishes within the window", () async {
+    test("sends the command and records normalized arguments", () async {
       await sendCommand();
 
       expect(plugin.lastSendCommandSessionId, equals("s1"));
@@ -61,7 +58,10 @@ void main() {
       expect(plugin.lastSendCommandArguments, equals("extra args"));
     });
 
-    test("propagates a failure raised within the window", () async {
+    test("propagates a command dispatch failure", () async {
+      // The fast-fail dispatch window lives inside the OpenCode plugin (see
+      // OpenCodeService) — the bridge stays plugin-agnostic and simply
+      // surfaces whatever the plugin throws.
       final completer = Completer<void>();
       plugin.sendCommandCompleter = completer;
       completer.completeError(StateError("unknown command"));
@@ -69,49 +69,7 @@ void main() {
       await expectLater(sendCommand(), throwsA(isA<StateError>()));
     });
 
-    test("propagates a TimeoutException raised by the send chain within the window", () async {
-      // Must not be conflated with the fast-fail window elapsing: a timeout
-      // thrown by the send chain itself is a genuine dispatch failure.
-      final completer = Completer<void>();
-      plugin.sendCommandCompleter = completer;
-      completer.completeError(TimeoutException("inner send timeout"));
-
-      await expectLater(sendCommand(), throwsA(isA<TimeoutException>()));
-    });
-
-    test("completes after the window when the command run keeps going", () async {
-      // Simulates OpenCode's synchronous /command endpoint: the HTTP response
-      // only arrives after the full agent run. The service must not hold the
-      // phone's request open that long.
-      final completer = Completer<void>();
-      plugin.sendCommandCompleter = completer;
-
-      final stopwatch = Stopwatch()..start();
-      await sendCommand();
-      stopwatch.stop();
-
-      expect(plugin.lastSendCommand, equals("review"));
-      expect(
-        stopwatch.elapsed,
-        lessThan(const Duration(seconds: 5)),
-        reason: "dispatch must detach instead of awaiting the full run",
-      );
-
-      completer.complete();
-    });
-
-    test("swallows and logs a failure raised after the window", () async {
-      final completer = Completer<void>();
-      plugin.sendCommandCompleter = completer;
-
-      await sendCommand();
-
-      completer.completeError(StateError("run failed mid-flight"));
-      // Flush microtasks — an unhandled async error would fail the test zone.
-      await Future<void>.delayed(Duration.zero);
-    });
-
-    test("still updates prompt defaults when the command run outlives the window", () async {
+    test("updates prompt defaults after the command is dispatched", () async {
       await sessionRepository.insertStoredSession(
         sessionId: "s-defaults-command",
         projectId: "/repo",
@@ -124,9 +82,6 @@ void main() {
         agent: "old-agent",
         agentModel: null,
       );
-      final completer = Completer<void>();
-      plugin.sendCommandCompleter = completer;
-
       await service.sendPrompt(
         sessionId: "s-defaults-command",
         parts: const [PromptPart.text(text: "")],
@@ -142,8 +97,6 @@ void main() {
       expect(dbSession.lastAgentModel?.providerID, equals("openai"));
       expect(dbSession.lastAgentModel?.modelID, equals("gpt-4o"));
       expect(dbSession.lastAgentModel?.variant, equals("low"));
-
-      completer.complete();
     });
 
     test("plain prompts are unaffected and delegate to sendPrompt", () async {

--- a/bridge/app/test/bridge/services/session_prompt_service_test.dart
+++ b/bridge/app/test/bridge/services/session_prompt_service_test.dart
@@ -1,0 +1,153 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/bridge/persistence/database.dart";
+import "package:sesori_bridge/src/bridge/repositories/pull_request_repository.dart";
+import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
+import "package:sesori_bridge/src/bridge/services/session_prompt_service.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+import "../../helpers/test_database.dart";
+import "../routing/routing_test_helpers.dart";
+
+void main() {
+  group("SessionPromptService command dispatch", () {
+    const fastFailWindow = Duration(milliseconds: 50);
+
+    late FakeBridgePlugin plugin;
+    late AppDatabase db;
+    late SessionRepository sessionRepository;
+    late SessionPromptService service;
+
+    setUp(() {
+      db = createTestDatabase();
+      plugin = FakeBridgePlugin();
+      sessionRepository = SessionRepository(
+        plugin: plugin,
+        sessionDao: db.sessionDao,
+        pullRequestRepository: PullRequestRepository(
+          pullRequestDao: db.pullRequestDao,
+          projectsDao: db.projectsDao,
+        ),
+      );
+      service = SessionPromptService(
+        sessionRepository: sessionRepository,
+        sseManager: FakeSSEManager(),
+        commandDispatchFastFailWindow: fastFailWindow,
+      );
+    });
+
+    tearDown(() async {
+      await plugin.close();
+      await db.close();
+    });
+
+    Future<void> sendCommand({String command = "review"}) {
+      return service.sendPrompt(
+        sessionId: "s1",
+        parts: const [PromptPart.text(text: "extra args")],
+        variant: null,
+        agent: null,
+        model: null,
+        command: command,
+      );
+    }
+
+    test("completes when the command finishes within the window", () async {
+      await sendCommand();
+
+      expect(plugin.lastSendCommandSessionId, equals("s1"));
+      expect(plugin.lastSendCommand, equals("review"));
+      expect(plugin.lastSendCommandArguments, equals("extra args"));
+    });
+
+    test("propagates a failure raised within the window", () async {
+      final completer = Completer<void>();
+      plugin.sendCommandCompleter = completer;
+      completer.completeError(StateError("unknown command"));
+
+      await expectLater(sendCommand(), throwsA(isA<StateError>()));
+    });
+
+    test("completes after the window when the command run keeps going", () async {
+      // Simulates OpenCode's synchronous /command endpoint: the HTTP response
+      // only arrives after the full agent run. The service must not hold the
+      // phone's request open that long.
+      final completer = Completer<void>();
+      plugin.sendCommandCompleter = completer;
+
+      final stopwatch = Stopwatch()..start();
+      await sendCommand();
+      stopwatch.stop();
+
+      expect(plugin.lastSendCommand, equals("review"));
+      expect(
+        stopwatch.elapsed,
+        lessThan(const Duration(seconds: 5)),
+        reason: "dispatch must detach instead of awaiting the full run",
+      );
+
+      completer.complete();
+    });
+
+    test("swallows and logs a failure raised after the window", () async {
+      final completer = Completer<void>();
+      plugin.sendCommandCompleter = completer;
+
+      await sendCommand();
+
+      completer.completeError(StateError("run failed mid-flight"));
+      // Flush microtasks — an unhandled async error would fail the test zone.
+      await Future<void>.delayed(Duration.zero);
+    });
+
+    test("still updates prompt defaults when the command run outlives the window", () async {
+      await sessionRepository.insertStoredSession(
+        sessionId: "s-defaults-command",
+        projectId: "/repo",
+        isDedicated: false,
+        createdAt: 1,
+        worktreePath: null,
+        branchName: null,
+        baseBranch: null,
+        baseCommit: null,
+        agent: "old-agent",
+        agentModel: null,
+      );
+      final completer = Completer<void>();
+      plugin.sendCommandCompleter = completer;
+
+      await service.sendPrompt(
+        sessionId: "s-defaults-command",
+        parts: const [PromptPart.text(text: "")],
+        variant: const SessionVariant(id: "low"),
+        agent: "planner",
+        model: const PromptModel(providerID: "openai", modelID: "gpt-4o"),
+        command: "review",
+      );
+
+      final dbSession = await db.sessionDao.getSession(sessionId: "s-defaults-command");
+      expect(dbSession, isNotNull);
+      expect(dbSession!.lastAgent, equals("planner"));
+      expect(dbSession.lastAgentModel?.providerID, equals("openai"));
+      expect(dbSession.lastAgentModel?.modelID, equals("gpt-4o"));
+      expect(dbSession.lastAgentModel?.variant, equals("low"));
+
+      completer.complete();
+    });
+
+    test("plain prompts are unaffected and delegate to sendPrompt", () async {
+      await service.sendPrompt(
+        sessionId: "s1",
+        parts: const [PromptPart.text(text: "Hello")],
+        variant: null,
+        agent: null,
+        model: null,
+        command: null,
+      );
+
+      expect(plugin.lastSendPromptSessionId, equals("s1"));
+      expect(plugin.lastSendCommand, isNull);
+    });
+  });
+}

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -86,6 +86,18 @@ abstract class BridgePluginApi {
     required ({String providerID, String modelID})? model,
   });
 
+  /// Sends a slash command to a session.
+  ///
+  /// The returned future MUST complete once the backend has **accepted** the
+  /// command for execution — not when the command's run finishes. Callers
+  /// (bridge request handlers serving phones) await this future while holding
+  /// a client request open, so an implementation must never block for the
+  /// duration of the command's agent run. If the backend only exposes a
+  /// synchronous endpoint, the implementation is responsible for detaching
+  /// (and surfacing later failures through its [events] stream / logs).
+  ///
+  /// Dispatch failures (unknown command, missing session, backend down) MUST
+  /// be thrown so callers can report the send as failed.
   Future<void> sendCommand({
     required String sessionId,
     required String command,

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -294,6 +294,14 @@ class OpenCodeApi {
     _ensureSuccess(response, "POST /session/$sessionId/prompt_async");
   }
 
+  /// Sends a slash command to a session via `POST /session/:id/command`.
+  ///
+  /// WARNING: this OpenCode endpoint is **synchronous** — the HTTP response
+  /// (and therefore the returned future) does not complete until the
+  /// command's full agent run has finished, which can take minutes. No async
+  /// variant exists upstream (unlike prompts, which have `prompt_async`).
+  /// Callers that must not block on the run (see [OpenCodeService]) are
+  /// responsible for detaching; this Layer 1 method stays a dumb HTTP call.
   Future<void> sendCommand({
     required String sessionId,
     required SendCommandBody body,

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:io" as io;
 
 import "package:json_annotation/json_annotation.dart" show CheckedFromJsonException;
@@ -19,8 +20,13 @@ import "../opencode_plugin.dart";
 class OpenCodeService {
   final OpenCodeRepository repository;
   final ActiveSessionTracker tracker;
+  final Duration _commandDispatchFastFailWindow;
 
-  OpenCodeService(this.repository, this.tracker);
+  OpenCodeService(
+    this.repository,
+    this.tracker, {
+    Duration commandDispatchFastFailWindow = const Duration(seconds: 3),
+  }) : _commandDispatchFastFailWindow = commandDispatchFastFailWindow;
 
   Future<List<Project>> getProjects() {
     return repository.getProjects();
@@ -141,9 +147,9 @@ class OpenCodeService {
     required String? agent,
     required PluginSessionVariant? variant,
     required ({String providerID, String modelID})? model,
-  }) {
+  }) async {
     final directory = _getTrackedDirectory(sessionId: sessionId);
-    return repository.sendCommand(
+    final sendFuture = repository.sendCommand(
       sessionId: sessionId,
       directory: directory,
       command: command,
@@ -151,6 +157,34 @@ class OpenCodeService {
       agent: agent,
       variant: variant,
       model: model,
+    );
+    // OpenCode's POST /session/:id/command endpoint is synchronous — it
+    // responds only after the command's full agent run completes, and no
+    // async variant exists upstream (see OpenCodeApi.sendCommand). The
+    // BridgePluginApi contract requires sendCommand to complete once the
+    // command is accepted, so dispatch with a fast-fail window: failures
+    // raised within the window (unknown command/agent, missing session,
+    // server down) propagate to the caller, while a run that outlives the
+    // window is treated as accepted and detached — its progress and errors
+    // stream over SSE.
+    //
+    // `onTimeout` (rather than catching [TimeoutException]) fires only when
+    // the window itself elapses, so a genuine TimeoutException raised by the
+    // send chain within the window still propagates as a dispatch failure.
+    await sendFuture.timeout(
+      _commandDispatchFastFailWindow,
+      onTimeout: () {
+        unawaited(
+          sendFuture.catchError((Object e, StackTrace s) {
+            Log.w(
+              "command '$command' for session $sessionId "
+              "failed after dispatch: $e",
+              e,
+              s,
+            );
+          }),
+        );
+      },
     );
   }
 

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:io" as io;
 
 import "package:opencode_plugin/opencode_plugin.dart" hide Message, MessageError, MessageErrorData, MessageWithParts;
@@ -362,6 +363,83 @@ void main() {
       expect(repository.lastCommandVariant, equals("xhigh"));
       expect(repository.lastCommandModel, equals((providerID: "openai", modelID: "gpt-4.1")));
     });
+
+    group("dispatch fast-fail window", () {
+      const fastFailWindow = Duration(milliseconds: 50);
+
+      late FakeOpenCodeRepository repository;
+      late OpenCodeService service;
+
+      setUp(() {
+        repository = FakeOpenCodeRepository();
+        service = OpenCodeService(
+          repository,
+          FakeActiveSessionTracker(sessionDirectories: const {"ses-1": "/repo"}),
+          commandDispatchFastFailWindow: fastFailWindow,
+        );
+      });
+
+      Future<void> sendCommand() {
+        return service.sendCommand(
+          sessionId: "ses-1",
+          command: "/review-work",
+          arguments: "",
+          agent: null,
+          variant: null,
+          model: null,
+        );
+      }
+
+      test("propagates a failure raised within the window", () async {
+        final completer = Completer<void>();
+        repository.sendCommandCompleter = completer;
+        completer.completeError(StateError("unknown command"));
+
+        await expectLater(sendCommand(), throwsA(isA<StateError>()));
+      });
+
+      test("propagates a TimeoutException raised by the send chain within the window", () async {
+        // Must not be conflated with the fast-fail window elapsing: a timeout
+        // thrown by the send chain itself is a genuine dispatch failure.
+        final completer = Completer<void>();
+        repository.sendCommandCompleter = completer;
+        completer.completeError(TimeoutException("inner send timeout"));
+
+        await expectLater(sendCommand(), throwsA(isA<TimeoutException>()));
+      });
+
+      test("completes after the window when the command run keeps going", () async {
+        // Simulates OpenCode's synchronous /command endpoint: the HTTP
+        // response only arrives after the full agent run. The plugin must
+        // complete sendCommand once the command is considered accepted.
+        final completer = Completer<void>();
+        repository.sendCommandCompleter = completer;
+
+        final stopwatch = Stopwatch()..start();
+        await sendCommand();
+        stopwatch.stop();
+
+        expect(repository.lastCommandName, equals("/review-work"));
+        expect(
+          stopwatch.elapsed,
+          lessThan(const Duration(seconds: 5)),
+          reason: "dispatch must detach instead of awaiting the full run",
+        );
+
+        completer.complete();
+      });
+
+      test("swallows and logs a failure raised after the window", () async {
+        final completer = Completer<void>();
+        repository.sendCommandCompleter = completer;
+
+        await sendCommand();
+
+        completer.completeError(StateError("run failed mid-flight"));
+        // Flush microtasks — an unhandled async error would fail the test zone.
+        await Future<void>.delayed(Duration.zero);
+      });
+    });
   });
 
   group("OpenCodeService.handleSseEvent", () {
@@ -701,6 +779,7 @@ class FakeOpenCodeRepository extends OpenCodeRepository {
   String? lastCommandAgent;
   String? lastCommandVariant;
   ({String providerID, String modelID})? lastCommandModel;
+  Completer<void>? sendCommandCompleter;
   String? lastDeletedSessionId;
   String? lastDeletedDirectory;
 
@@ -796,6 +875,9 @@ class FakeOpenCodeRepository extends OpenCodeRepository {
     lastCommandAgent = agent;
     lastCommandVariant = variant?.id;
     lastCommandModel = model;
+    if (sendCommandCompleter case final completer?) {
+      await completer.future;
+    }
   }
 
   @override


### PR DESCRIPTION
## Problem

Sending a slash command (skill) from the mobile app executes correctly, but the command re-appears as **"queued"** in the UI shortly after — and can later be re-sent from the queue, causing duplicate execution.

## Root cause

- OpenCode's `POST /session/:id/command` endpoint is **synchronous**: it responds only after the full agent run completes. No `command_async` variant exists upstream (verified in sst/opencode source). Plain prompts use `POST /session/:id/prompt_async`, which forks and returns 204 immediately.
- The bridge's `SessionPromptService.sendPrompt` awaited that call, holding the phone's relay request open for the entire skill run.
- The mobile `RelayClient` times out pending requests after 30s → mapped to `ErrorResponse` → `SessionDetailCubit.sendMessage` requeued the already-running command (`_promptQueue.requeue`) → ghost "queued" bubble + duplicate execution risk when the queue drains.

This explains why it happens only for commands (prompts use the async endpoint), virtually every time (skills run longer than 30s), and why the command genuinely keeps running while showing as queued.

## Fix

Dispatch commands with a bounded **fast-fail window** (default 3s, constructor-injectable for tests — same pattern as `GetSessionsHandler.prRefreshTimeout`):

- Failures raised **within** the window (unknown command, missing session, OpenCode down) still propagate to the phone as genuine error responses → mobile requeue/retry behavior stays correct for real dispatch failures.
- A run that **outlives** the window is treated as dispatched: the future is detached with an error-logging handler, mirroring the fire-and-forget semantics plain prompts already get via `prompt_async` (failures logged + surfaced through session error SSE events).
- `_updatePromptDefaults` still runs after dispatch; plain-prompt branch unchanged.

## Tests

New `session_prompt_service_test.dart` (6 tests): in-window success, in-window failure propagation, detach after window (completes promptly), late failure swallowed + logged (no unhandled async error), prompt defaults persisted when run outlives window, plain prompts unaffected. `FakeBridgePlugin` gained a `sendCommandCompleter` hook (matches existing `archiveSessionCompleter` pattern).

## Verification

- `make analyze` — clean across all 3 bridge modules
- `make test` — 1204 tests pass
- `aristotle-plan-review` and `aristotle-impl-review` — both APPROVED

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops holding the mobile relay request open for slash commands by moving the fast‑fail dispatch window into the OpenCode plugin and detaching long runs. Fixes ghost “queued” bubbles and prevents duplicate command execution.

- **Bug Fixes**
  - `OpenCodeService.sendCommand` uses a 3s fast‑fail window with `onTimeout`; detaches long runs and logs late failures with error and stack, matching `prompt_async`.
  - Bridge service now simply awaits `sendCommand`; dispatch failures (including inner `TimeoutException`s) still propagate, so requeue behavior stays correct.
  - Prompt defaults updates and plain prompts unchanged.

- **Refactors**
  - Documented `BridgePluginApi.sendCommand` contract: complete on acceptance, never block on the full run.
  - Documented OpenCode’s sync `POST /session/:id/command`; moved window tests into the plugin and clarified in `AGENTS.md` that backend quirks live in the plugin.

<sup>Written for commit 21c427599c111476243694f1509c4c818828efee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

