### PR TITLE
feat(bridge): PluginHost implementation in the bridge (migration PR 3/15)

### DIFF
--- a/bridge/app/lib/src/server/api/runtime_file_api.dart
+++ b/bridge/app/lib/src/server/api/runtime_file_api.dart
@@ -1,18 +1,49 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
+/// Raw file persistence inside [runtimeDirectory].
+///
+/// Keep a single instance per directory per process: [updateFile]'s mutual
+/// exclusion combines an OS advisory lock (cross-process) with an in-process
+/// per-name queue, and the in-process half lives on this instance. POSIX
+/// advisory locks neither exclude lockers within one process nor survive
+/// another file descriptor to the lock file being closed, so a second
+/// instance over the same directory would silently break the guarantee.
 class RuntimeFileApi {
   final String runtimeDirectory;
 
   RuntimeFileApi({required this.runtimeDirectory});
 
-  String get ownershipFilePath => p.join(runtimeDirectory, 'opencode-processes.json');
+  static const String _ownershipFileName = 'opencode-processes.json';
+
+  /// Suffix of the sidecar files [updateFile] takes its advisory lock on.
+  ///
+  /// Sidecars are created next to the data file and deliberately never
+  /// deleted: the data file itself is replaced by rename on every write, so a
+  /// lock taken on it could outlive the inode it guards, and deleting the
+  /// sidecar would reopen the same race.
+  static const String updateLockSuffix = '.update-lock';
+
+  final Map<String, Future<void>> _updateChains = <String, Future<void>>{};
+
+  String get ownershipFilePath => p.join(runtimeDirectory, _ownershipFileName);
 
   String get startupLockFilePath => p.join(runtimeDirectory, 'bridge-startup.lock');
 
-  Future<String?> readOwnershipFile() async {
-    final file = File(ownershipFilePath);
+  Future<String?> readOwnershipFile() => readFile(name: _ownershipFileName);
+
+  Future<void> writeOwnershipFile({required String contents}) =>
+      writeFile(name: _ownershipFileName, contents: contents);
+
+  Future<void> deleteOwnershipFile() => deleteFile(name: _ownershipFileName);
+
+  Future<void> renameOwnershipFile({required String fileName}) =>
+      renameFile(fromName: _ownershipFileName, toName: fileName);
+
+  Future<String?> readFile({required String name}) async {
+    final file = File(p.join(runtimeDirectory, name));
     if (!file.existsSync()) {
       return null;
     }
@@ -27,11 +58,12 @@ class RuntimeFileApi {
     }
   }
 
-  Future<void> writeOwnershipFile({required String contents}) async {
+  Future<void> writeFile({required String name, required String contents}) async {
     await _ensureRuntimeDirectory();
 
-    final targetFile = File(ownershipFilePath);
-    final tmpFile = File('$ownershipFilePath.tmp');
+    final targetPath = p.join(runtimeDirectory, name);
+    final targetFile = File(targetPath);
+    final tmpFile = File('$targetPath.tmp');
     await tmpFile.writeAsString(contents, flush: true);
 
     try {
@@ -47,8 +79,8 @@ class RuntimeFileApi {
     }
   }
 
-  Future<void> deleteOwnershipFile() async {
-    final file = File(ownershipFilePath);
+  Future<void> deleteFile({required String name}) async {
+    final file = File(p.join(runtimeDirectory, name));
     try {
       await file.delete();
     } on FileSystemException catch (error) {
@@ -59,14 +91,71 @@ class RuntimeFileApi {
     }
   }
 
-  Future<void> renameOwnershipFile({required String fileName}) async {
-    final sourceFile = File(ownershipFilePath);
+  Future<void> renameFile({required String fromName, required String toName}) async {
+    final sourceFile = File(p.join(runtimeDirectory, fromName));
     if (!sourceFile.existsSync()) {
       return;
     }
 
-    final targetFile = File(p.join(runtimeDirectory, fileName));
+    final targetFile = File(p.join(runtimeDirectory, toName));
     await sourceFile.rename(targetFile.path);
+  }
+
+  /// Reads [name], applies [transform], and writes the result back atomically
+  /// while holding an exclusive OS advisory lock on the file's sidecar, so
+  /// mutators in other bridge processes cannot drop each other's changes.
+  ///
+  /// [transform] receives the current contents (`null` when the file does not
+  /// exist) and returns the new contents; returning `null` deletes the file.
+  /// Returns what was written (or `null` when deleted). [transform] must not
+  /// call [updateFile] for the same [name] — calls for one name are queued on
+  /// this instance and a reentrant call would deadlock behind itself.
+  Future<String?> updateFile({
+    required String name,
+    required FutureOr<String?> Function(String? current) transform,
+  }) {
+    final previous = _updateChains[name] ?? Future<void>.value();
+    final completer = Completer<void>();
+    _updateChains[name] = completer.future;
+    return previous.then((_) async {
+      try {
+        return await _lockedUpdate(name: name, transform: transform);
+      } finally {
+        completer.complete();
+        if (identical(_updateChains[name], completer.future)) {
+          unawaited(_updateChains.remove(name));
+        }
+      }
+    });
+  }
+
+  Future<String?> _lockedUpdate({
+    required String name,
+    required FutureOr<String?> Function(String? current) transform,
+  }) async {
+    await _ensureRuntimeDirectory();
+
+    final lockFile = await File(p.join(runtimeDirectory, '$name$updateLockSuffix')).open(mode: FileMode.append);
+    try {
+      // An explicit one-byte range: locking an empty file's default (whole)
+      // range is platform-dependent, and the lock must also be acquirable by
+      // other processes computing the same range.
+      await lockFile.lock(FileLock.blockingExclusive, 0, 1);
+      try {
+        final current = await readFile(name: name);
+        final next = await transform(current);
+        if (next == null) {
+          await deleteFile(name: name);
+        } else {
+          await writeFile(name: name, contents: next);
+        }
+        return next;
+      } finally {
+        await lockFile.unlock(0, 1);
+      }
+    } finally {
+      await lockFile.close();
+    }
   }
 
   Future<bool> acquireStartupLock({required String contents}) async {

--- a/bridge/app/lib/src/server/host/bridge_host_info_impl.dart
+++ b/bridge/app/lib/src/server/host/bridge_host_info_impl.dart
@@ -1,0 +1,41 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgeHostInfo, ProcessIdentity;
+
+import "../foundation/process_match.dart";
+import "../repositories/process_repository.dart";
+
+class BridgeHostInfoImpl implements BridgeHostInfo {
+  BridgeHostInfoImpl({
+    required this.identity,
+    required this.ownerSessionId,
+    required ProcessRepository processRepository,
+  }) : _processRepository = processRepository;
+
+  @override
+  final ProcessIdentity identity;
+
+  @override
+  final String ownerSessionId;
+
+  final ProcessRepository _processRepository;
+
+  /// Mirrors the stale-kill authorization predicate
+  /// (`OpenCodeServerService._isStaleKillAuthorized`): classification plus
+  /// marker matching, deliberately without a same-user check — returning
+  /// `true` spares the pid's runtimes, and sparing another user's live bridge
+  /// is the conservative direction.
+  @override
+  Future<bool> isLiveBridgeProcess({required int pid, required String? startMarker}) async {
+    final match = await _processRepository.inspectProcessMatch(pid: pid);
+    if (match == null || match.kind != ProcessMatchKind.sesoriBridge) {
+      return false;
+    }
+
+    if (startMarker != null || match.identity.startMarker != null) {
+      return match.identity.startMarker == startMarker;
+    }
+
+    // Both markers are null (e.g. Windows). The decision rests on the
+    // bridge-process classification alone.
+    return true;
+  }
+}

--- a/bridge/app/lib/src/server/host/bridge_host_json_store.dart
+++ b/bridge/app/lib/src/server/host/bridge_host_json_store.dart
@@ -1,0 +1,64 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show HostJsonStore;
+
+import "../api/runtime_file_api.dart";
+
+class BridgeHostJsonStore implements HostJsonStore {
+  BridgeHostJsonStore({
+    required RuntimeFileApi fileApi,
+  }) : _fileApi = fileApi;
+
+  final RuntimeFileApi _fileApi;
+
+  @override
+  Future<String?> read({required String name}) {
+    _validateName(name);
+    return _fileApi.readFile(name: name);
+  }
+
+  @override
+  Future<void> write({required String name, required String contents}) {
+    _validateName(name);
+    return _fileApi.writeFile(name: name, contents: contents);
+  }
+
+  @override
+  Future<void> delete({required String name}) {
+    _validateName(name);
+    return _fileApi.deleteFile(name: name);
+  }
+
+  @override
+  Future<void> quarantine({required String name, required String quarantinedName}) {
+    _validateName(name);
+    _validateName(quarantinedName);
+    return _fileApi.renameFile(fromName: name, toName: quarantinedName);
+  }
+
+  @override
+  Future<String?> update({
+    required String name,
+    required FutureOr<String?> Function(String? current) transform,
+  }) {
+    _validateName(name);
+    return _fileApi.updateFile(name: name, transform: transform);
+  }
+
+  /// A bad name is plugin code reaching outside its store, not user input —
+  /// hence [ArgumentError], not a recoverable exception.
+  static void _validateName(String name) {
+    if (name.isEmpty || name == "." || name == "..") {
+      throw ArgumentError.value(name, "name", "must be a plain file name");
+    }
+    if (name.contains("/") || name.contains(r"\")) {
+      throw ArgumentError.value(name, "name", "must not contain path separators");
+    }
+    if (name.startsWith("bridge-startup")) {
+      throw ArgumentError.value(name, "name", "the 'bridge-startup.*' prefix is reserved for the bridge");
+    }
+    if (name.endsWith(".tmp") || name.endsWith(RuntimeFileApi.updateLockSuffix)) {
+      throw ArgumentError.value(name, "name", "the '.tmp' and '${RuntimeFileApi.updateLockSuffix}' suffixes are reserved for the store's own machinery");
+    }
+  }
+}

--- a/bridge/app/lib/src/server/host/bridge_host_port_service.dart
+++ b/bridge/app/lib/src/server/host/bridge_host_port_service.dart
@@ -1,0 +1,16 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show HostPortService;
+
+import "../api/loopback_port_api.dart";
+
+class BridgeHostPortService implements HostPortService {
+  const BridgeHostPortService({
+    required LoopbackPortApi loopbackPortApi,
+  }) : _loopbackPortApi = loopbackPortApi;
+
+  final LoopbackPortApi _loopbackPortApi;
+
+  @override
+  Future<bool> isBindable({required String host, required int port}) {
+    return _loopbackPortApi.isBindable(host: host, port: port);
+  }
+}

--- a/bridge/app/lib/src/server/host/bridge_host_process_service.dart
+++ b/bridge/app/lib/src/server/host/bridge_host_process_service.dart
@@ -95,10 +95,11 @@ class BridgeHostProcessService implements HostProcessService {
     final ProcessIdentity? inspectedIdentity;
     try {
       inspectedIdentity = await _processRepository.inspectProcess(pid: spawnIdentity.pid);
-    } on Exception catch (error) {
+    } on Object catch (error) {
       // The child is already running and only the returned handle lets the
-      // caller stop it, so a failed process-table read must not fail the
-      // spawn — fall back to the partial spawn-time identity.
+      // caller stop it, so nothing thrown by the process-table read — Errors
+      // included — may fail the spawn. Fall back to the partial spawn-time
+      // identity.
       Log.w("Post-spawn identity inspection failed for pid ${spawnIdentity.pid}\n$error");
       return spawnIdentity;
     }

--- a/bridge/app/lib/src/server/host/bridge_host_process_service.dart
+++ b/bridge/app/lib/src/server/host/bridge_host_process_service.dart
@@ -1,0 +1,189 @@
+import "dart:io" as io;
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
+    show HostProcessService, Log, ProcessIdentity, ProcessUser, ServerClock, SignalResult, SpawnedProcess;
+
+import "../repositories/process_repository.dart";
+
+/// Spawn seam for [BridgeHostProcessService]; production passes
+/// `io.Process.start`. Unlike `OpenCodeProcessStarter` it carries
+/// [workingDirectory], which the host contract requires.
+typedef HostProcessStarter =
+    Future<io.Process> Function(
+      String executable,
+      List<String> arguments, {
+      Map<String, String>? environment,
+      String? workingDirectory,
+      bool runInShell,
+    });
+
+class BridgeHostProcessService implements HostProcessService {
+  BridgeHostProcessService({
+    required HostProcessStarter processStarter,
+    required ProcessRepository processRepository,
+    required ServerClock clock,
+    required ProcessUser? currentUser,
+    required bool isWindows,
+    required String platform,
+  }) : _processStarter = processStarter,
+       _processRepository = processRepository,
+       _clock = clock,
+       _currentUser = currentUser,
+       _isWindows = isWindows,
+       _platform = platform;
+
+  final HostProcessStarter _processStarter;
+  final ProcessRepository _processRepository;
+  final ServerClock _clock;
+  final ProcessUser? _currentUser;
+  final bool _isWindows;
+  final String _platform;
+
+  @override
+  Future<SpawnedProcess> spawn({
+    required String executable,
+    required List<String> arguments,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+    required bool runInShell,
+  }) async {
+    final process = await _processStarter(
+      executable,
+      arguments,
+      environment: environment,
+      workingDirectory: workingDirectory,
+      runInShell: runInShell,
+    );
+
+    final spawnIdentity = ProcessIdentity(
+      pid: process.pid,
+      startMarker: null,
+      executablePath: executable,
+      commandLine: [executable, ...arguments].join(" "),
+      ownerUser: _currentUser,
+      platform: _platform,
+      capturedAt: _clock.now(),
+    );
+
+    return _HostSpawnedProcess(
+      process: process,
+      identity: await _resolveSpawnedIdentity(spawnIdentity: spawnIdentity),
+    );
+  }
+
+  @override
+  Future<ProcessIdentity?> inspect({required int pid}) {
+    return _processRepository.inspectProcess(pid: pid);
+  }
+
+  @override
+  Future<List<ProcessIdentity>> list({required int? excludePid}) {
+    return _processRepository.listProcessIdentities(excludePid: excludePid);
+  }
+
+  @override
+  Future<SignalResult> signalGraceful({required int pid}) {
+    return _processRepository.sendGracefulSignal(pid: pid);
+  }
+
+  @override
+  Future<SignalResult> signalForce({required int pid}) {
+    return _processRepository.sendForceSignal(pid: pid);
+  }
+
+  Future<ProcessIdentity> _resolveSpawnedIdentity({required ProcessIdentity spawnIdentity}) async {
+    final ProcessIdentity? inspectedIdentity;
+    try {
+      inspectedIdentity = await _processRepository.inspectProcess(pid: spawnIdentity.pid);
+    } on Exception catch (error) {
+      // The child is already running and only the returned handle lets the
+      // caller stop it, so a failed process-table read must not fail the
+      // spawn — fall back to the partial spawn-time identity.
+      Log.w("Post-spawn identity inspection failed for pid ${spawnIdentity.pid}\n$error");
+      return spawnIdentity;
+    }
+
+    if (inspectedIdentity != null &&
+        _matchesSpawnedIdentity(spawnIdentity: spawnIdentity, inspectedIdentity: inspectedIdentity)) {
+      return inspectedIdentity;
+    }
+    return spawnIdentity;
+  }
+
+  bool _matchesSpawnedIdentity({
+    required ProcessIdentity spawnIdentity,
+    required ProcessIdentity inspectedIdentity,
+  }) {
+    if (inspectedIdentity.pid != spawnIdentity.pid) {
+      return false;
+    }
+
+    if (_isWindows && _isWindowsImageNameOnlyCommandLine(inspectedIdentity.commandLine)) {
+      return _samePath(inspectedIdentity.executablePath, spawnIdentity.executablePath ?? "");
+    }
+
+    return inspectedIdentity.commandLine == spawnIdentity.commandLine;
+  }
+
+  bool _samePath(String? actual, String expected) {
+    if (actual == null) {
+      return false;
+    }
+
+    if (_isWindows) {
+      final normalizedActual = _normalizeWindowsPath(actual);
+      final normalizedExpected = _normalizeWindowsPath(expected);
+      if (normalizedActual == normalizedExpected) {
+        return true;
+      }
+
+      return _windowsPathBasename(normalizedActual) == _windowsPathBasename(normalizedExpected);
+    }
+
+    return actual == expected;
+  }
+
+  bool _isWindowsImageNameOnlyCommandLine(String commandLine) {
+    return commandLine.isNotEmpty && !commandLine.contains(" ") && !commandLine.contains("\t");
+  }
+
+  String _normalizeWindowsPath(String path) {
+    var normalized = path.replaceAll("/", String.fromCharCode(92));
+    if (normalized.toLowerCase().endsWith(".exe")) {
+      normalized = normalized.substring(0, normalized.length - 4);
+    }
+    return normalized.toLowerCase();
+  }
+
+  String _windowsPathBasename(String path) {
+    final segments = path.split(RegExp(r"[\\/]+"));
+    return segments.isEmpty ? path : segments.last;
+  }
+}
+
+class _HostSpawnedProcess implements SpawnedProcess {
+  _HostSpawnedProcess({
+    required io.Process process,
+    required this.identity,
+  }) : _process = process;
+
+  final io.Process _process;
+
+  @override
+  final ProcessIdentity identity;
+
+  @override
+  int get pid => _process.pid;
+
+  @override
+  io.IOSink get stdin => _process.stdin;
+
+  @override
+  Stream<List<int>> get stdout => _process.stdout;
+
+  @override
+  Stream<List<int>> get stderr => _process.stderr;
+
+  @override
+  Future<int> get exitCode => _process.exitCode;
+}

--- a/bridge/app/lib/src/server/host/bridge_plugin_host_impl.dart
+++ b/bridge/app/lib/src/server/host/bridge_plugin_host_impl.dart
@@ -1,0 +1,122 @@
+import "dart:io";
+
+import "package:path/path.dart" as p;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
+    show
+        BridgeHostInfo,
+        HostJsonStore,
+        HostPortService,
+        HostProcessService,
+        PluginConfig,
+        PluginHost,
+        ProcessIdentity,
+        ProcessUser,
+        ServerClock,
+        StartAbortSignal;
+
+import "../api/loopback_port_api.dart";
+import "../api/runtime_file_api.dart";
+import "../repositories/process_repository.dart";
+import "bridge_host_info_impl.dart";
+import "bridge_host_json_store.dart";
+import "bridge_host_port_service.dart";
+import "bridge_host_process_service.dart";
+
+/// The bridge's production [PluginHost].
+///
+/// The constructor is pure wiring (tests may inject fakes per service);
+/// [create] assembles the production services from the bridge's existing
+/// seams and creates [stateDirectory] — the contract promises it exists
+/// before the plugin's `start()` runs.
+///
+/// [create] builds a fresh [RuntimeFileApi] over [stateDirectory]. When the
+/// bridge already holds a [RuntimeFileApi] over that directory (OpenCode's
+/// `<cacheDir>/runtime`), wire through the plain constructor with a store
+/// over the shared instance instead — `RuntimeFileApi.updateFile`'s mutual
+/// exclusion is only guaranteed within one instance per directory.
+class BridgePluginHostImpl implements PluginHost {
+  BridgePluginHostImpl({
+    required this.config,
+    required this.stateDirectory,
+    required this.environment,
+    required this.clock,
+    required this.startAborted,
+    required this.bridge,
+    required this.processes,
+    required this.ports,
+    required this.store,
+  });
+
+  static Future<BridgePluginHostImpl> create({
+    required PluginConfig config,
+    required String stateDirectory,
+    required Map<String, String> environment,
+    required ServerClock clock,
+    required StartAbortSignal startAborted,
+    required ProcessIdentity bridgeIdentity,
+    required String ownerSessionId,
+    required ProcessRepository processRepository,
+    required LoopbackPortApi loopbackPortApi,
+    required HostProcessStarter processStarter,
+    required ProcessUser? currentUser,
+    required bool isWindows,
+    required String platform,
+  }) async {
+    if (!p.isAbsolute(stateDirectory)) {
+      throw ArgumentError.value(stateDirectory, "stateDirectory", "must be an absolute path");
+    }
+    await Directory(stateDirectory).create(recursive: true);
+
+    return BridgePluginHostImpl(
+      config: config,
+      stateDirectory: stateDirectory,
+      environment: Map<String, String>.unmodifiable(environment),
+      clock: clock,
+      startAborted: startAborted,
+      bridge: BridgeHostInfoImpl(
+        identity: bridgeIdentity,
+        ownerSessionId: ownerSessionId,
+        processRepository: processRepository,
+      ),
+      processes: BridgeHostProcessService(
+        processStarter: processStarter,
+        processRepository: processRepository,
+        clock: clock,
+        currentUser: currentUser,
+        isWindows: isWindows,
+        platform: platform,
+      ),
+      ports: BridgeHostPortService(loopbackPortApi: loopbackPortApi),
+      store: BridgeHostJsonStore(
+        fileApi: RuntimeFileApi(runtimeDirectory: stateDirectory),
+      ),
+    );
+  }
+
+  @override
+  final PluginConfig config;
+
+  @override
+  final String stateDirectory;
+
+  @override
+  final Map<String, String> environment;
+
+  @override
+  final ServerClock clock;
+
+  @override
+  final StartAbortSignal startAborted;
+
+  @override
+  final BridgeHostInfo bridge;
+
+  @override
+  final HostProcessService processes;
+
+  @override
+  final HostPortService ports;
+
+  @override
+  final HostJsonStore store;
+}

--- a/bridge/app/lib/src/server/host/plugin_state_directory.dart
+++ b/bridge/app/lib/src/server/host/plugin_state_directory.dart
@@ -1,0 +1,32 @@
+import "package:path/path.dart" as p;
+
+import "../../updater/models/managed_runtime_paths.dart";
+
+/// Descriptor id of the OpenCode plugin.
+const String openCodePluginId = "opencode";
+
+/// The private state directory handed to plugin [pluginId] as
+/// `PluginHost.stateDirectory`.
+///
+/// Plugins live under `<installRoot>/plugins/<id>/` — except OpenCode, which
+/// is handed `<cacheDirectory>/runtime`: its ownership file
+/// `opencode-processes.json` lives there under a frozen cross-version
+/// contract and can never move.
+String pluginStateDirectoryPath({
+  required ManagedRuntimePaths paths,
+  required String pluginId,
+}) {
+  if (pluginId.isEmpty ||
+      pluginId == "." ||
+      pluginId == ".." ||
+      pluginId.contains("/") ||
+      pluginId.contains(r"\")) {
+    throw ArgumentError.value(pluginId, "pluginId", "must be a plain directory name");
+  }
+
+  if (pluginId == openCodePluginId) {
+    return p.join(paths.cacheDirectory, "runtime");
+  }
+
+  return p.join(paths.installRoot, "plugins", pluginId);
+}

--- a/bridge/app/test/server/fixtures/update_lock_holder.dart
+++ b/bridge/app/test/server/fixtures/update_lock_holder.dart
@@ -1,0 +1,17 @@
+import 'dart:convert';
+import 'dart:io';
+
+/// Test fixture: holds the exclusive advisory lock `RuntimeFileApi.updateFile`
+/// uses (byte 0–1 of the sidecar passed as the only argument) until a line
+/// arrives on stdin. Prints "locked" once the lock is held.
+Future<void> main(List<String> args) async {
+  final lockFile = await File(args.single).open(mode: FileMode.append);
+  await lockFile.lock(FileLock.blockingExclusive, 0, 1);
+  stdout.writeln('locked');
+  await stdout.flush();
+
+  await stdin.transform(utf8.decoder).transform(const LineSplitter()).first;
+
+  await lockFile.unlock(0, 1);
+  await lockFile.close();
+}

--- a/bridge/app/test/server/host/bridge_host_info_impl_test.dart
+++ b/bridge/app/test/server/host/bridge_host_info_impl_test.dart
@@ -1,0 +1,155 @@
+import 'package:sesori_bridge/src/server/foundation/process_match.dart';
+import 'package:sesori_bridge/src/server/host/bridge_host_info_impl.dart';
+import 'package:sesori_bridge/src/server/repositories/process_repository.dart';
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BridgeHostInfoImpl', () {
+    late _FakeProcessRepository processRepository;
+    late BridgeHostInfoImpl hostInfo;
+
+    final bridgeIdentity = _identity(
+      pid: 100,
+      startMarker: 'bridge-start-marker',
+      executablePath: '/usr/local/bin/sesori-bridge',
+      commandLine: '/usr/local/bin/sesori-bridge --port 4096',
+    );
+
+    setUp(() {
+      processRepository = _FakeProcessRepository();
+      hostInfo = BridgeHostInfoImpl(
+        identity: bridgeIdentity,
+        ownerSessionId: '100:bridge-start-marker',
+        processRepository: processRepository,
+      );
+    });
+
+    test('exposes the bridge identity and owner session id', () {
+      expect(hostInfo.identity, same(bridgeIdentity));
+      expect(hostInfo.ownerSessionId, '100:bridge-start-marker');
+    });
+
+    test('isLiveBridgeProcess is false when the pid is not running', () async {
+      expect(
+        await hostInfo.isLiveBridgeProcess(pid: 211, startMarker: 'other-marker'),
+        isFalse,
+      );
+    });
+
+    test('isLiveBridgeProcess is false when the pid is not a sesori bridge', () async {
+      processRepository.matchResults[211] = ProcessMatch(
+        identity: _identity(
+          pid: 211,
+          startMarker: 'other-marker',
+          executablePath: '/usr/bin/vim',
+          commandLine: '/usr/bin/vim notes.txt',
+        ),
+        kind: ProcessMatchKind.unknown,
+        isCurrentUserProcess: true,
+      );
+
+      expect(
+        await hostInfo.isLiveBridgeProcess(pid: 211, startMarker: 'other-marker'),
+        isFalse,
+      );
+    });
+
+    test('isLiveBridgeProcess requires matching markers when either side has one', () async {
+      processRepository.matchResults[211] = _bridgeMatch(pid: 211, startMarker: 'marker-a');
+
+      expect(await hostInfo.isLiveBridgeProcess(pid: 211, startMarker: 'marker-a'), isTrue);
+      processRepository.matchResults[211] = _bridgeMatch(pid: 211, startMarker: 'marker-a');
+      expect(await hostInfo.isLiveBridgeProcess(pid: 211, startMarker: 'marker-b'), isFalse);
+      processRepository.matchResults[211] = _bridgeMatch(pid: 211, startMarker: 'marker-a');
+      expect(await hostInfo.isLiveBridgeProcess(pid: 211, startMarker: null), isFalse);
+      processRepository.matchResults[211] = _bridgeMatch(pid: 211, startMarker: null);
+      expect(await hostInfo.isLiveBridgeProcess(pid: 211, startMarker: 'marker-a'), isFalse);
+    });
+
+    test('isLiveBridgeProcess accepts marker-less records for a marker-less live bridge', () async {
+      processRepository.matchResults[211] = _bridgeMatch(pid: 211, startMarker: null);
+
+      expect(await hostInfo.isLiveBridgeProcess(pid: 211, startMarker: null), isTrue);
+    });
+
+    test('isLiveBridgeProcess spares live bridges owned by another user', () async {
+      processRepository.matchResults[211] = ProcessMatch(
+        identity: _identity(
+          pid: 211,
+          startMarker: 'marker-a',
+          executablePath: '/usr/local/bin/sesori-bridge',
+          commandLine: '/usr/local/bin/sesori-bridge',
+        ),
+        kind: ProcessMatchKind.sesoriBridge,
+        isCurrentUserProcess: false,
+      );
+
+      expect(await hostInfo.isLiveBridgeProcess(pid: 211, startMarker: 'marker-a'), isTrue);
+    });
+  });
+}
+
+ProcessMatch _bridgeMatch({required int pid, required String? startMarker}) {
+  return ProcessMatch(
+    identity: _identity(
+      pid: pid,
+      startMarker: startMarker,
+      executablePath: '/usr/local/bin/sesori-bridge',
+      commandLine: '/usr/local/bin/sesori-bridge --port 4097',
+    ),
+    kind: ProcessMatchKind.sesoriBridge,
+    isCurrentUserProcess: true,
+  );
+}
+
+ProcessIdentity _identity({
+  required int pid,
+  required String? startMarker,
+  required String executablePath,
+  required String commandLine,
+}) {
+  return ProcessIdentity(
+    pid: pid,
+    startMarker: startMarker,
+    executablePath: executablePath,
+    commandLine: commandLine,
+    ownerUser: ProcessUser.fromRawUser('alex'),
+    platform: 'macos',
+    capturedAt: DateTime.utc(2026, 5, 15, 12),
+  );
+}
+
+class _FakeProcessRepository implements ProcessRepository {
+  final Map<int, ProcessMatch?> matchResults = <int, ProcessMatch?>{};
+
+  @override
+  Future<ProcessMatch?> inspectProcessMatch({required int pid}) async {
+    return matchResults[pid];
+  }
+
+  @override
+  Future<ProcessIdentity?> inspectProcess({required int pid}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<ProcessIdentity>> listProcessIdentities({required int? excludePid}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<ProcessMatch>> listProcesses({required int? excludePid}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<SignalResult> sendGracefulSignal({required int pid}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<SignalResult> sendForceSignal({required int pid}) {
+    throw UnimplementedError();
+  }
+}

--- a/bridge/app/test/server/host/bridge_host_json_store_test.dart
+++ b/bridge/app/test/server/host/bridge_host_json_store_test.dart
@@ -1,0 +1,158 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:sesori_bridge/src/server/api/runtime_file_api.dart';
+import 'package:sesori_bridge/src/server/host/bridge_host_json_store.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BridgeHostJsonStore', () {
+    late Directory tempDir;
+    late BridgeHostJsonStore store;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('bridge-host-json-store-test-');
+      store = BridgeHostJsonStore(
+        fileApi: RuntimeFileApi(runtimeDirectory: tempDir.path),
+      );
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('read returns null for a missing file', () async {
+      expect(await store.read(name: 'absent.json'), isNull);
+    });
+
+    test('write then read round-trips contents without leaving a temp file', () async {
+      await store.write(name: 'state.json', contents: '{"a":1}');
+
+      expect(await store.read(name: 'state.json'), '{"a":1}');
+      expect(File(p.join(tempDir.path, 'state.json.tmp')).existsSync(), isFalse);
+    });
+
+    test('delete removes the file and ignores missing files', () async {
+      await store.write(name: 'state.json', contents: '{}');
+
+      await store.delete(name: 'state.json');
+      await store.delete(name: 'state.json');
+
+      expect(File(p.join(tempDir.path, 'state.json')).existsSync(), isFalse);
+    });
+
+    test('quarantine moves contents aside', () async {
+      await store.write(name: 'state.json', contents: '{ corrupt');
+
+      await store.quarantine(name: 'state.json', quarantinedName: 'state.invalid.json');
+
+      expect(await store.read(name: 'state.json'), isNull);
+      expect(await store.read(name: 'state.invalid.json'), '{ corrupt');
+    });
+
+    test('quarantine is a no-op when the file does not exist', () async {
+      await store.quarantine(name: 'absent.json', quarantinedName: 'absent.invalid.json');
+
+      expect(File(p.join(tempDir.path, 'absent.invalid.json')).existsSync(), isFalse);
+    });
+
+    test('update creates the file when absent and returns what was written', () async {
+      final written = await store.update(
+        name: 'state.json',
+        transform: (current) {
+          expect(current, isNull);
+          return '{"generation":1}';
+        },
+      );
+
+      expect(written, '{"generation":1}');
+      expect(await store.read(name: 'state.json'), '{"generation":1}');
+    });
+
+    test('update deletes the file when transform returns null', () async {
+      await store.write(name: 'state.json', contents: '{}');
+
+      expect(await store.update(name: 'state.json', transform: (current) => null), isNull);
+      expect(File(p.join(tempDir.path, 'state.json')).existsSync(), isFalse);
+    });
+
+    test('update serializes concurrent mutators for the same name', () async {
+      await store.write(name: 'state.json', contents: '[]');
+
+      final firstEntered = Completer<void>();
+      final releaseFirst = Completer<void>();
+      final transformCalls = <String>[];
+
+      final first = store.update(
+        name: 'state.json',
+        transform: (current) async {
+          transformCalls.add('first:$current');
+          firstEntered.complete();
+          await releaseFirst.future;
+          return '["first"]';
+        },
+      );
+      await firstEntered.future;
+
+      final second = store.update(
+        name: 'state.json',
+        transform: (current) {
+          transformCalls.add('second:$current');
+          return '["first","second"]';
+        },
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      expect(transformCalls, equals(<String>['first:[]']));
+
+      releaseFirst.complete();
+      expect(await first, '["first"]');
+      expect(await second, '["first","second"]');
+      expect(transformCalls, equals(<String>['first:[]', 'second:["first"]']));
+    });
+
+    test('accepts the frozen ownership file name', () async {
+      await store.write(name: 'opencode-processes.json', contents: '{}');
+
+      expect(await store.read(name: 'opencode-processes.json'), '{}');
+    });
+
+    test('rejects reserved and non-plain names on every operation', () {
+      const invalidNames = <String>[
+        '',
+        '.',
+        '..',
+        'nested/state.json',
+        r'nested\state.json',
+        'bridge-startup.lock',
+        'bridge-startup.intent.json',
+        'state.json.tmp',
+        'state.json.update-lock',
+      ];
+
+      for (final name in invalidNames) {
+        expect(() => store.read(name: name), throwsArgumentError, reason: name);
+        expect(() => store.write(name: name, contents: '{}'), throwsArgumentError, reason: name);
+        expect(() => store.delete(name: name), throwsArgumentError, reason: name);
+        expect(
+          () => store.update(name: name, transform: (current) => current),
+          throwsArgumentError,
+          reason: name,
+        );
+        expect(
+          () => store.quarantine(name: name, quarantinedName: 'aside.json'),
+          throwsArgumentError,
+          reason: name,
+        );
+        expect(
+          () => store.quarantine(name: 'state.json', quarantinedName: name),
+          throwsArgumentError,
+          reason: name,
+        );
+      }
+    });
+  });
+}

--- a/bridge/app/test/server/host/bridge_host_port_service_test.dart
+++ b/bridge/app/test/server/host/bridge_host_port_service_test.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+
+import 'package:sesori_bridge/src/server/api/loopback_port_api.dart';
+import 'package:sesori_bridge/src/server/host/bridge_host_port_service.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BridgeHostPortService', () {
+    test('delegates host and port to the loopback probe', () async {
+      final loopbackPortApi = _FakeLoopbackPortApi(availabilityByPort: {50123: true, 50124: false});
+      final service = BridgeHostPortService(loopbackPortApi: loopbackPortApi);
+
+      expect(await service.isBindable(host: '127.0.0.1', port: 50123), isTrue);
+      expect(await service.isBindable(host: '::1', port: 50124), isFalse);
+      expect(
+        loopbackPortApi.invocations,
+        equals(<String>['127.0.0.1:50123', '::1:50124']),
+      );
+    });
+
+    test('reports a held loopback port as not bindable', () async {
+      final occupiedSocket = await ServerSocket.bind('127.0.0.1', 0);
+      addTearDown(occupiedSocket.close);
+      const service = BridgeHostPortService(loopbackPortApi: LoopbackPortApi());
+
+      expect(await service.isBindable(host: '127.0.0.1', port: occupiedSocket.port), isFalse);
+    });
+  });
+}
+
+class _FakeLoopbackPortApi implements LoopbackPortApi {
+  _FakeLoopbackPortApi({required Map<int, bool> availabilityByPort}) : _availabilityByPort = availabilityByPort;
+
+  final Map<int, bool> _availabilityByPort;
+  final List<String> invocations = <String>[];
+
+  @override
+  Future<bool> isBindable({required String host, required int port}) async {
+    invocations.add('$host:$port');
+    final available = _availabilityByPort[port];
+    if (available == null) {
+      throw StateError('Unexpected port probe: $port');
+    }
+    return available;
+  }
+}

--- a/bridge/app/test/server/host/bridge_host_process_service_test.dart
+++ b/bridge/app/test/server/host/bridge_host_process_service_test.dart
@@ -109,6 +109,16 @@ void main() {
       expect(spawned.identity.startMarker, isNull);
     });
 
+    test('spawn falls back when inspection throws an Error — the child must never be orphaned', () async {
+      starter.process = _FakeProcess(pidValue: 7001);
+      processRepository.inspectError = ArgumentError('broken process-table parse');
+
+      final spawned = await spawnAgent();
+
+      expect(spawned.identity.pid, 7001);
+      expect(spawned.identity.startMarker, isNull);
+    });
+
     test('spawn matches Windows image-name-only command lines by executable path', () async {
       starter.process = _FakeProcess(pidValue: 7001);
       final inspected = _identity(
@@ -363,7 +373,7 @@ class _FakeServerClock implements ServerClock {
 
 class _FakeProcessRepository implements ProcessRepository {
   final Map<int, List<ProcessIdentity?>> inspectResults = <int, List<ProcessIdentity?>>{};
-  Exception? inspectError;
+  Object? inspectError;
   List<ProcessIdentity> identities = <ProcessIdentity>[];
   int? lastExcludePid;
   SignalResult? gracefulResult;

--- a/bridge/app/test/server/host/bridge_host_process_service_test.dart
+++ b/bridge/app/test/server/host/bridge_host_process_service_test.dart
@@ -1,0 +1,413 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:sesori_bridge/src/bridge/foundation/process_runner.dart';
+import 'package:sesori_bridge/src/server/api/system_process_api.dart';
+import 'package:sesori_bridge/src/server/foundation/process_match.dart';
+import 'package:sesori_bridge/src/server/host/bridge_host_process_service.dart';
+import 'package:sesori_bridge/src/server/repositories/process_repository.dart';
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BridgeHostProcessService', () {
+    late _RecordingStarter starter;
+    late _FakeProcessRepository processRepository;
+
+    setUp(() {
+      starter = _RecordingStarter();
+      processRepository = _FakeProcessRepository();
+    });
+
+    BridgeHostProcessService service({bool isWindows = false}) {
+      return BridgeHostProcessService(
+        processStarter: starter.call,
+        processRepository: processRepository,
+        clock: _FakeServerClock(),
+        currentUser: ProcessUser.fromRawUser('alex'),
+        isWindows: isWindows,
+        platform: 'macos',
+      );
+    }
+
+    Future<SpawnedProcess> spawnAgent({bool isWindows = false, String executable = '/usr/local/bin/agent'}) {
+      return service(isWindows: isWindows).spawn(
+        executable: executable,
+        arguments: const ['--stdio'],
+        environment: const {'AGENT_MODE': 'acp'},
+        workingDirectory: '/tmp/workdir',
+        runInShell: false,
+      );
+    }
+
+    test('spawn forwards executable, arguments, environment, workingDirectory, and runInShell', () async {
+      starter.process = _FakeProcess(pidValue: 7001);
+
+      await spawnAgent();
+
+      expect(starter.executable, '/usr/local/bin/agent');
+      expect(starter.arguments, equals(<String>['--stdio']));
+      expect(starter.environment, equals(<String, String>{'AGENT_MODE': 'acp'}));
+      expect(starter.workingDirectory, '/tmp/workdir');
+      expect(starter.runInShell, isFalse);
+    });
+
+    test('spawn upgrades the identity from post-spawn inspection when the command line matches', () async {
+      starter.process = _FakeProcess(pidValue: 7001);
+      final inspected = _identity(
+        pid: 7001,
+        startMarker: 'Mon Jun  1 09:00:00 2026',
+        executablePath: '/usr/local/bin/agent',
+        commandLine: '/usr/local/bin/agent --stdio',
+      );
+      processRepository.inspectResults[7001] = <ProcessIdentity?>[inspected];
+
+      final spawned = await spawnAgent();
+
+      expect(spawned.identity, same(inspected));
+      expect(spawned.identity.startMarker, 'Mon Jun  1 09:00:00 2026');
+    });
+
+    test('spawn falls back to the partial spawn-time identity when the child is already gone', () async {
+      starter.process = _FakeProcess(pidValue: 7001);
+
+      final spawned = await spawnAgent();
+
+      expect(spawned.identity.pid, 7001);
+      expect(spawned.identity.startMarker, isNull);
+      expect(spawned.identity.executablePath, '/usr/local/bin/agent');
+      expect(spawned.identity.commandLine, '/usr/local/bin/agent --stdio');
+      expect(spawned.identity.ownerUser, ProcessUser.fromRawUser('alex'));
+      expect(spawned.identity.platform, 'macos');
+    });
+
+    test('spawn falls back when the inspected command line does not match (pid reuse)', () async {
+      starter.process = _FakeProcess(pidValue: 7001);
+      processRepository.inspectResults[7001] = <ProcessIdentity?>[
+        _identity(
+          pid: 7001,
+          startMarker: 'Mon Jun  1 09:00:00 2026',
+          executablePath: '/usr/bin/vim',
+          commandLine: '/usr/bin/vim notes.txt',
+        ),
+      ];
+
+      final spawned = await spawnAgent();
+
+      expect(spawned.identity.startMarker, isNull);
+      expect(spawned.identity.commandLine, '/usr/local/bin/agent --stdio');
+    });
+
+    test('spawn falls back when inspection throws instead of failing the spawn', () async {
+      starter.process = _FakeProcess(pidValue: 7001);
+      processRepository.inspectError = const ProcessException('ps', <String>['-axwwo']);
+
+      final spawned = await spawnAgent();
+
+      expect(spawned.identity.pid, 7001);
+      expect(spawned.identity.startMarker, isNull);
+    });
+
+    test('spawn matches Windows image-name-only command lines by executable path', () async {
+      starter.process = _FakeProcess(pidValue: 7001);
+      final inspected = _identity(
+        pid: 7001,
+        startMarker: null,
+        executablePath: r'C:\TOOLS\AGENT.EXE',
+        commandLine: 'agent.exe',
+      );
+      processRepository.inspectResults[7001] = <ProcessIdentity?>[inspected];
+
+      final spawned = await spawnAgent(isWindows: true, executable: 'C:/tools/agent.exe');
+
+      expect(spawned.identity, same(inspected));
+    });
+
+    test('spawn matches a bare Windows image name against the resolved path by basename', () async {
+      starter.process = _FakeProcess(pidValue: 7001);
+      final inspected = _identity(
+        pid: 7001,
+        startMarker: null,
+        executablePath: r'C:\Program Files\agent\agent.exe',
+        commandLine: 'agent.exe',
+      );
+      processRepository.inspectResults[7001] = <ProcessIdentity?>[inspected];
+
+      final spawned = await spawnAgent(isWindows: true, executable: 'agent.exe');
+
+      expect(spawned.identity, same(inspected));
+    });
+
+    test('spawn rejects Windows image-name-only matches with a different executable', () async {
+      starter.process = _FakeProcess(pidValue: 7001);
+      processRepository.inspectResults[7001] = <ProcessIdentity?>[
+        _identity(
+          pid: 7001,
+          startMarker: null,
+          executablePath: r'C:\other\bogus.exe',
+          commandLine: 'bogus.exe',
+        ),
+      ];
+
+      final spawned = await spawnAgent(isWindows: true, executable: r'C:\tools\agent.exe');
+
+      expect(spawned.identity.executablePath, r'C:\tools\agent.exe');
+      expect(spawned.identity.startMarker, isNull);
+    });
+
+    test('spawn leaves stdout and stderr to the caller instead of draining them', () async {
+      final process = _FakeProcess(pidValue: 7001);
+      starter.process = process;
+
+      final spawned = await spawnAgent();
+
+      // Single-subscription streams: this listen would throw if the service
+      // had subscribed (drained) them itself.
+      final stdoutChunks = <List<int>>[];
+      final stderrChunks = <List<int>>[];
+      spawned.stdout.listen(stdoutChunks.add);
+      spawned.stderr.listen(stderrChunks.add);
+      process.stdoutController.add(utf8.encode('out'));
+      process.stderrController.add(utf8.encode('err'));
+      await pumpEventQueue();
+
+      expect(utf8.decode(stdoutChunks.single), 'out');
+      expect(utf8.decode(stderrChunks.single), 'err');
+    });
+
+    test('spawned process exposes pid and exitCode of the child', () async {
+      final process = _FakeProcess(pidValue: 7001);
+      starter.process = process;
+
+      final spawned = await spawnAgent();
+      process.exitCodeCompleter.complete(3);
+
+      expect(spawned.pid, 7001);
+      expect(await spawned.exitCode, 3);
+    });
+
+    test('inspect and list delegate to the process repository', () async {
+      final identity = _identity(
+        pid: 211,
+        startMarker: 'marker',
+        executablePath: '/usr/local/bin/opencode',
+        commandLine: '/usr/local/bin/opencode serve',
+      );
+      processRepository.inspectResults[211] = <ProcessIdentity?>[identity];
+      processRepository.identities = <ProcessIdentity>[identity];
+
+      expect(await service().inspect(pid: 211), same(identity));
+      expect(await service().list(excludePid: 100), equals(<ProcessIdentity>[identity]));
+      expect(processRepository.lastExcludePid, 100);
+    });
+
+    test('signalGraceful and signalForce delegate to the process repository', () async {
+      processRepository.gracefulResult = _signalResult(pid: 211, signal: ShutdownSignal.graceful);
+      processRepository.forceResult = _signalResult(pid: 211, signal: ShutdownSignal.force);
+
+      final graceful = await service().signalGraceful(pid: 211);
+      final force = await service().signalForce(pid: 211);
+
+      expect(graceful.requestedSignal, ShutdownSignal.graceful);
+      expect(force.requestedSignal, ShutdownSignal.force);
+      expect(processRepository.signalRequests, equals(<String>['graceful:211', 'force:211']));
+    });
+
+    group('against a real child process', () {
+      test('spawn exposes a working stdio surface and captures a real identity', () async {
+        if (Platform.isWindows) {
+          return;
+        }
+
+        final realService = BridgeHostProcessService(
+          processStarter: Process.start,
+          processRepository: ProcessRepository(
+            api: SystemProcessApi(
+              processRunner: ProcessRunner(),
+              clock: const ServerClock(),
+              isWindows: Platform.isWindows,
+              platform: Platform.operatingSystem,
+            ),
+            currentUser: null,
+          ),
+          clock: const ServerClock(),
+          currentUser: null,
+          isWindows: Platform.isWindows,
+          platform: Platform.operatingSystem,
+        );
+
+        final spawned = await realService.spawn(
+          executable: '/bin/cat',
+          arguments: const [],
+          environment: null,
+          workingDirectory: null,
+          runInShell: false,
+        );
+
+        final stdoutFuture = spawned.stdout.transform(utf8.decoder).join();
+        final stderrFuture = spawned.stderr.transform(utf8.decoder).join();
+
+        spawned.stdin.writeln('ping');
+        await spawned.stdin.flush();
+        await spawned.stdin.close();
+
+        expect(await spawned.exitCode, 0);
+        expect(await stdoutFuture, 'ping\n');
+        expect(await stderrFuture, isEmpty);
+        expect(spawned.pid, greaterThan(0));
+        expect(spawned.identity.pid, spawned.pid);
+        expect(
+          spawned.identity.startMarker,
+          isNotNull,
+          reason: 'a live POSIX child must get its ps start marker captured',
+        );
+      });
+    });
+  });
+}
+
+ProcessIdentity _identity({
+  required int pid,
+  required String? startMarker,
+  required String executablePath,
+  required String commandLine,
+}) {
+  return ProcessIdentity(
+    pid: pid,
+    startMarker: startMarker,
+    executablePath: executablePath,
+    commandLine: commandLine,
+    ownerUser: ProcessUser.fromRawUser('alex'),
+    platform: 'macos',
+    capturedAt: DateTime.utc(2026, 5, 15, 12),
+  );
+}
+
+SignalResult _signalResult({required int pid, required ShutdownSignal signal}) {
+  return SignalResult(
+    pid: pid,
+    requestedSignal: signal,
+    deliveredSignal: signal == ShutdownSignal.graceful ? ProcessSignal.sigterm : ProcessSignal.sigkill,
+    wasRequested: true,
+    attemptedAt: DateTime.utc(2026, 5, 15, 12),
+  );
+}
+
+class _RecordingStarter {
+  _FakeProcess? process;
+  String? executable;
+  List<String>? arguments;
+  Map<String, String>? environment;
+  String? workingDirectory;
+  bool? runInShell;
+
+  Future<Process> call(
+    String executable,
+    List<String> arguments, {
+    Map<String, String>? environment,
+    String? workingDirectory,
+    bool runInShell = false,
+  }) async {
+    this.executable = executable;
+    this.arguments = arguments;
+    this.environment = environment;
+    this.workingDirectory = workingDirectory;
+    this.runInShell = runInShell;
+    final process = this.process;
+    if (process == null) {
+      throw StateError('No fake process configured');
+    }
+    return process;
+  }
+}
+
+class _FakeProcess implements Process {
+  _FakeProcess({required int pidValue}) : _pidValue = pidValue;
+
+  final int _pidValue;
+  final StreamController<List<int>> stdoutController = StreamController<List<int>>();
+  final StreamController<List<int>> stderrController = StreamController<List<int>>();
+  final Completer<int> exitCodeCompleter = Completer<int>();
+
+  @override
+  int get pid => _pidValue;
+
+  @override
+  Stream<List<int>> get stdout => stdoutController.stream;
+
+  @override
+  Stream<List<int>> get stderr => stderrController.stream;
+
+  @override
+  Future<int> get exitCode => exitCodeCompleter.future;
+
+  @override
+  IOSink get stdin => throw UnimplementedError();
+
+  @override
+  bool kill([ProcessSignal signal = ProcessSignal.sigterm]) {
+    return true;
+  }
+}
+
+class _FakeServerClock implements ServerClock {
+  @override
+  DateTime now() {
+    return DateTime.utc(2026, 5, 15, 12, 30);
+  }
+
+  @override
+  Future<void> delay({required Duration duration}) async {}
+}
+
+class _FakeProcessRepository implements ProcessRepository {
+  final Map<int, List<ProcessIdentity?>> inspectResults = <int, List<ProcessIdentity?>>{};
+  Exception? inspectError;
+  List<ProcessIdentity> identities = <ProcessIdentity>[];
+  int? lastExcludePid;
+  SignalResult? gracefulResult;
+  SignalResult? forceResult;
+  final List<String> signalRequests = <String>[];
+
+  @override
+  Future<ProcessIdentity?> inspectProcess({required int pid}) async {
+    final error = inspectError;
+    if (error != null) {
+      throw error;
+    }
+    final queue = inspectResults[pid];
+    if (queue == null || queue.isEmpty) {
+      return null;
+    }
+    return queue.removeAt(0);
+  }
+
+  @override
+  Future<List<ProcessIdentity>> listProcessIdentities({required int? excludePid}) async {
+    lastExcludePid = excludePid;
+    return identities;
+  }
+
+  @override
+  Future<SignalResult> sendGracefulSignal({required int pid}) async {
+    signalRequests.add('graceful:$pid');
+    return gracefulResult!;
+  }
+
+  @override
+  Future<SignalResult> sendForceSignal({required int pid}) async {
+    signalRequests.add('force:$pid');
+    return forceResult!;
+  }
+
+  @override
+  Future<ProcessMatch?> inspectProcessMatch({required int pid}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<ProcessMatch>> listProcesses({required int? excludePid}) {
+    throw UnimplementedError();
+  }
+}

--- a/bridge/app/test/server/host/bridge_plugin_host_impl_test.dart
+++ b/bridge/app/test/server/host/bridge_plugin_host_impl_test.dart
@@ -1,0 +1,149 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:sesori_bridge/src/server/api/loopback_port_api.dart';
+import 'package:sesori_bridge/src/server/foundation/process_match.dart';
+import 'package:sesori_bridge/src/server/host/bridge_plugin_host_impl.dart';
+import 'package:sesori_bridge/src/server/repositories/process_repository.dart';
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BridgePluginHostImpl.create', () {
+    late Directory tempDir;
+
+    final bridgeIdentity = ProcessIdentity(
+      pid: 100,
+      startMarker: 'bridge-start-marker',
+      executablePath: '/usr/local/bin/sesori-bridge',
+      commandLine: '/usr/local/bin/sesori-bridge',
+      ownerUser: ProcessUser.fromRawUser('alex'),
+      platform: 'macos',
+      capturedAt: DateTime.utc(2026, 5, 15, 12),
+    );
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('bridge-plugin-host-impl-test-');
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    Future<BridgePluginHostImpl> createHost({required String stateDirectory}) {
+      return BridgePluginHostImpl.create(
+        config: const PluginConfig(values: {'port': '4096'}),
+        stateDirectory: stateDirectory,
+        environment: const {'HOME': '/home/alex'},
+        clock: const ServerClock(),
+        startAborted: StartAbortSignal.never,
+        bridgeIdentity: bridgeIdentity,
+        ownerSessionId: '100:bridge-start-marker',
+        processRepository: _UnusedProcessRepository(),
+        loopbackPortApi: const LoopbackPortApi(),
+        processStarter: _failingStarter,
+        currentUser: ProcessUser.fromRawUser('alex'),
+        isWindows: false,
+        platform: 'macos',
+      );
+    }
+
+    test('creates the state directory before the plugin starts', () async {
+      final stateDirectory = p.join(tempDir.path, 'plugins', 'acp');
+
+      final host = await createHost(stateDirectory: stateDirectory);
+
+      expect(Directory(stateDirectory).existsSync(), isTrue);
+      expect(host.stateDirectory, stateDirectory);
+    });
+
+    test('store persists files inside the state directory', () async {
+      final stateDirectory = p.join(tempDir.path, 'plugins', 'acp');
+      final host = await createHost(stateDirectory: stateDirectory);
+
+      await host.store.write(name: 'state.json', contents: '{"a":1}');
+
+      expect(File(p.join(stateDirectory, 'state.json')).existsSync(), isTrue);
+      expect(await host.store.read(name: 'state.json'), '{"a":1}');
+    });
+
+    test('wires config, environment, clock, abort signal, and bridge facts through', () async {
+      final host = await createHost(stateDirectory: p.join(tempDir.path, 'plugins', 'acp'));
+
+      expect(host.config.intValue('port'), 4096);
+      expect(host.environment, equals(<String, String>{'HOME': '/home/alex'}));
+      expect(host.clock, isA<ServerClock>());
+      expect(host.startAborted.isAborted, isFalse);
+      expect(host.bridge.identity, same(bridgeIdentity));
+      expect(host.bridge.ownerSessionId, '100:bridge-start-marker');
+    });
+
+    test('hands the plugin an unmodifiable view of the environment', () async {
+      final host = await createHost(stateDirectory: p.join(tempDir.path, 'plugins', 'acp'));
+
+      expect(() => host.environment['INJECTED'] = 'value', throwsUnsupportedError);
+    });
+
+    test('rejects a relative state directory', () async {
+      await expectLater(
+        createHost(stateDirectory: p.join('relative', 'plugins', 'acp')),
+        throwsArgumentError,
+      );
+    });
+
+    test('ports probe reports a held loopback port as not bindable', () async {
+      final occupiedSocket = await ServerSocket.bind('127.0.0.1', 0);
+      addTearDown(occupiedSocket.close);
+      final host = await createHost(stateDirectory: p.join(tempDir.path, 'plugins', 'acp'));
+
+      expect(
+        await host.ports.isBindable(host: '127.0.0.1', port: occupiedSocket.port),
+        isFalse,
+      );
+    });
+  });
+}
+
+Future<Process> _failingStarter(
+  String executable,
+  List<String> arguments, {
+  Map<String, String>? environment,
+  String? workingDirectory,
+  bool runInShell = false,
+}) {
+  throw StateError('This test never spawns');
+}
+
+class _UnusedProcessRepository implements ProcessRepository {
+  @override
+  Future<ProcessIdentity?> inspectProcess({required int pid}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<ProcessMatch?> inspectProcessMatch({required int pid}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<ProcessIdentity>> listProcessIdentities({required int? excludePid}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<List<ProcessMatch>> listProcesses({required int? excludePid}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<SignalResult> sendGracefulSignal({required int pid}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<SignalResult> sendForceSignal({required int pid}) {
+    throw UnimplementedError();
+  }
+}

--- a/bridge/app/test/server/host/plugin_state_directory_test.dart
+++ b/bridge/app/test/server/host/plugin_state_directory_test.dart
@@ -1,0 +1,42 @@
+import 'package:path/path.dart' as p;
+import 'package:sesori_bridge/src/server/host/plugin_state_directory.dart';
+import 'package:sesori_bridge/src/updater/models/managed_runtime_paths.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('pluginStateDirectoryPath', () {
+    // Distinct values on purpose: production sets these equal today, and an
+    // installRoot/cacheDirectory mix-up must not pass these tests.
+    const paths = ManagedRuntimePaths(
+      installRoot: '/home/alex/.local/share/sesori',
+      binaryPath: '/home/alex/.local/share/sesori/bin/sesori-bridge',
+      cacheDirectory: '/home/alex/.cache/sesori',
+    );
+
+    test('plugins live under <installRoot>/plugins/<id>', () {
+      expect(
+        pluginStateDirectoryPath(paths: paths, pluginId: 'acp'),
+        p.join('/home/alex/.local/share/sesori', 'plugins', 'acp'),
+      );
+    });
+
+    test('opencode is handed the frozen <cacheDirectory>/runtime directory', () {
+      expect(
+        pluginStateDirectoryPath(paths: paths, pluginId: openCodePluginId),
+        p.join('/home/alex/.cache/sesori', 'runtime'),
+      );
+    });
+
+    test('rejects plugin ids that are not plain directory names', () {
+      const invalidIds = <String>['', '.', '..', 'a/b', r'a\b'];
+
+      for (final pluginId in invalidIds) {
+        expect(
+          () => pluginStateDirectoryPath(paths: paths, pluginId: pluginId),
+          throwsArgumentError,
+          reason: pluginId,
+        );
+      }
+    });
+  });
+}

--- a/bridge/app/test/server/runtime_file_api_test.dart
+++ b/bridge/app/test/server/runtime_file_api_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -117,5 +119,147 @@ void main() {
         throwsA(isA<FileSystemException>()),
       );
     });
+
+    group('updateFile', () {
+      test('creates the file when absent and returns what was written', () async {
+        final api = RuntimeFileApi(runtimeDirectory: p.join(tempDir.path, 'runtime'));
+        final seenContents = <String?>[];
+
+        final written = await api.updateFile(
+          name: 'state.json',
+          transform: (current) {
+            seenContents.add(current);
+            return '{"generation":1}';
+          },
+        );
+
+        expect(written, '{"generation":1}');
+        expect(seenContents, equals(<String?>[null]));
+        expect(await api.readFile(name: 'state.json'), '{"generation":1}');
+      });
+
+      test('passes current contents to transform and replaces the file', () async {
+        final api = RuntimeFileApi(runtimeDirectory: p.join(tempDir.path, 'runtime'));
+        await api.writeFile(name: 'state.json', contents: '{"generation":1}');
+
+        final written = await api.updateFile(
+          name: 'state.json',
+          transform: (current) {
+            expect(current, '{"generation":1}');
+            return '{"generation":2}';
+          },
+        );
+
+        expect(written, '{"generation":2}');
+        expect(await api.readFile(name: 'state.json'), '{"generation":2}');
+      });
+
+      test('deletes the file when transform returns null', () async {
+        final runtimeDirectory = p.join(tempDir.path, 'runtime');
+        final api = RuntimeFileApi(runtimeDirectory: runtimeDirectory);
+        await api.writeFile(name: 'state.json', contents: '{}');
+
+        final written = await api.updateFile(name: 'state.json', transform: (current) => null);
+
+        expect(written, isNull);
+        expect(File(p.join(runtimeDirectory, 'state.json')).existsSync(), isFalse);
+      });
+
+      test('recovers the in-process update queue when transform throws', () async {
+        final api = RuntimeFileApi(runtimeDirectory: p.join(tempDir.path, 'runtime'));
+
+        await expectLater(
+          api.updateFile(name: 'state.json', transform: (current) => throw StateError('boom')),
+          throwsA(isA<StateError>()),
+        );
+
+        expect(
+          await api.updateFile(name: 'state.json', transform: (current) => '{"recovered":true}'),
+          '{"recovered":true}',
+        );
+      });
+
+      test('queues concurrent updates for the same name without losing either', () async {
+        final api = RuntimeFileApi(runtimeDirectory: p.join(tempDir.path, 'runtime'));
+        await api.writeFile(name: 'state.json', contents: '[]');
+
+        final firstEntered = Completer<void>();
+        final releaseFirst = Completer<void>();
+        final transformCalls = <String>[];
+
+        final first = api.updateFile(
+          name: 'state.json',
+          transform: (current) async {
+            transformCalls.add('first:$current');
+            firstEntered.complete();
+            await releaseFirst.future;
+            return '["first"]';
+          },
+        );
+        await firstEntered.future;
+
+        final second = api.updateFile(
+          name: 'state.json',
+          transform: (current) {
+            transformCalls.add('second:$current');
+            return '["first","second"]';
+          },
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(transformCalls, equals(<String>['first:[]']));
+
+        releaseFirst.complete();
+        expect(await first, '["first"]');
+        expect(await second, '["first","second"]');
+        expect(transformCalls, equals(<String>['first:[]', 'second:["first"]']));
+      });
+
+      test('blocks while another process holds the advisory lock', () async {
+        final runtimeDirectory = p.join(tempDir.path, 'runtime');
+        await Directory(runtimeDirectory).create(recursive: true);
+        final api = RuntimeFileApi(runtimeDirectory: runtimeDirectory);
+        final lockPath = p.join(runtimeDirectory, 'state.json${RuntimeFileApi.updateLockSuffix}');
+
+        final holder = await Process.start(
+          Platform.resolvedExecutable,
+          [_fixturePath('update_lock_holder.dart'), lockPath],
+        );
+        final holderStdout = holder.stdout.transform(utf8.decoder).transform(const LineSplitter());
+        holder.stderr.drain<void>().ignore();
+        addTearDown(() {
+          holder.kill(ProcessSignal.sigkill);
+        });
+        expect(await holderStdout.first, 'locked');
+
+        var updateCompleted = false;
+        final update = api
+            .updateFile(name: 'state.json', transform: (current) => '{"writer":"parent"}')
+            .whenComplete(() => updateCompleted = true);
+
+        await Future<void>.delayed(const Duration(milliseconds: 300));
+        expect(updateCompleted, isFalse, reason: 'updateFile must wait for the cross-process lock');
+
+        holder.stdin.writeln('release');
+        await holder.stdin.flush();
+
+        expect(await update, '{"writer":"parent"}');
+        expect(await holder.exitCode, 0);
+      });
+    });
   });
+}
+
+String _fixturePath(String name) {
+  final candidates = [
+    p.join('test', 'server', 'fixtures', name),
+    p.join('app', 'test', 'server', 'fixtures', name),
+    p.join('bridge', 'app', 'test', 'server', 'fixtures', name),
+  ];
+  for (final candidate in candidates) {
+    if (File(candidate).existsSync()) {
+      return p.absolute(candidate);
+    }
+  }
+  throw StateError('Fixture $name not found from ${Directory.current.path}');
 }

--- a/bridge/sesori_plugin_interface/lib/src/host/host_json_store.dart
+++ b/bridge/sesori_plugin_interface/lib/src/host/host_json_store.dart
@@ -34,6 +34,11 @@ abstract class HostJsonStore {
   /// [transform] receives the current contents (`null` when the file does
   /// not exist) and returns the new contents; returning `null` deletes the
   /// file. Returns what was written (or `null` when deleted).
+  ///
+  /// [transform] must not call [update] for the same [name], directly or
+  /// transitively: implementations queue same-name calls within the process
+  /// (the OS advisory lock alone cannot exclude them there), so a reentrant
+  /// call deadlocks behind its caller.
   Future<String?> update({
     required String name,
     required FutureOr<String?> Function(String? current) transform,


### PR DESCRIPTION
PR 3 of the [plugin lifecycle migration plan](docs/plans/plugin-lifecycle-migration.html): a production-quality `BridgePluginHostImpl` in `bridge/app`, fully tested, **still unused** — production wiring lands in PR 4.

## What's here

**`bridge/app/lib/src/server/host/` (new)**
- `BridgePluginHostImpl` — the `PluginHost` aggregate. Pure-wiring constructor (tests inject fakes per service) + `create()` factory that assembles the production services and creates the state directory before `start()` runs, per contract.
- `BridgeHostProcessService` — spawn over a new `HostProcessStarter` seam (carries `workingDirectory`, which the old `OpenCodeProcessStarter` lacked; production passes `io.Process.start`). The host's `spawn()` owns the best-effort post-spawn identity re-inspection (pinned during PR 2 review): POSIX `ps lstart` start-marker capture with fallback to the partial spawn-time identity when the child exits first, `ps` races, or the process-table read throws — once the child exists, `spawn()` must return its handle (only the caller can stop it), so it never fails on identity capture. Match/normalization logic mirrors the legacy `OpenCodeServerService` anchors verbatim, including the Windows image-name-only and basename fallbacks. `SpawnedProcess` exposes stdin/stdout/stderr/exitCode **undrained** — stdio belongs to the plugin (ACP).
- `BridgeHostInfoImpl` — `isLiveBridgeProcess` mirrors the stale-kill authorization predicate (`kind == sesoriBridge` + either-marker-must-match, both-null → rest on classification), deliberately without a same-user check: returning `true` spares, and sparing another user's live bridge is the conservative direction.
- `BridgeHostJsonStore` — name validation rejects path separators, the reserved `bridge-startup.*` prefix, and the store's own `.tmp` / `.update-lock` machinery suffixes.
- `BridgeHostPortService` — delegates to `LoopbackPortApi`.
- `plugin_state_directory.dart` — `<installRoot>/plugins/<id>/`, with OpenCode handed `<cacheDir>/runtime` to honor the frozen ownership-file location.

**`RuntimeFileApi` (modified)**
- Filenames parameterized: `readFile`/`writeFile`/`deleteFile`/`renameFile({name})`; the legacy ownership methods became one-line delegates. Byte-identical behavior is proven by the *unmodified* pre-existing test suites (RuntimeFileApi, OpenCodeOwnershipRepository, StartupMutexRepository). The startup-lock O_EXCL path is untouched.
- New `updateFile()` — the locked read-modify-write `HostJsonStore.update` needs: an exclusive OS advisory lock (`RandomAccessFile.lock`, explicit 1-byte range) taken on a **never-deleted sidecar** (`<name>.update-lock`) rather than the data file, because rename-based atomic writes would detach a lock from the inode it guards; layered under an in-process per-name queue, since POSIX `fcntl` locks neither exclude within one process nor survive another fd's close.

**Interface package (doc-comment only)**
- `HostJsonStore.update` now documents the no-reentrancy rule (transform must not call `update` for the same name) — surfaced by review; the restriction existed only on the implementation while the contract is what plugin authors read.

## Tests (new host suite + extensions)
- Real stdio **echo-child** spawn test (`/bin/cat`): write stdin → read stdout → exit 0, real `ps` identity capture asserted (start marker present on POSIX).
- **Cross-process advisory-lock test**: a fixture child VM holds the sidecar lock; `updateFile` is proven to block until release.
- In-process serialization (no lost update, ordered transforms), transform-throw recovery, delete-on-null, name-validation matrix, state-dir derivation with deliberately distinct `installRoot`/`cacheDirectory` fixture values (mutation-proof per review), Windows image-name + basename fallback acceptance/rejection, host wiring + unmodifiable environment.

## Review
Multi-agent adversarial pass (4 dimensions → per-finding refutation): 10 findings, 4 confirmed and fixed (interface doc gap, vacuous state-dir fixture, untested Windows basename-accept branch, over-claiming test name), 6 refuted — notably the "create() builds a second RuntimeFileApi over the runtime dir" family: no production caller exists in this PR, the pure constructor is the injection seam, and `create()` now documents the shared-instance rule for PR 4's OpenCode wiring.

## Checklist (per plan §5)
- ✅ `dart analyze --fatal-infos` clean in `app` + `interface`; full workspace tests green (1,244 app / 100 interface / 169 opencode)
- ✅ Diff ≤ 2,000 changed lines (1,704 per `git diff --stat`)
- ✅ No CLI flag changes; no change to steady-state `opencode-processes.json` bytes (existing write paths byte-identical; sidecar lock files are new, separate files inert to pre-migration readers)
- ✅ **Behavior delta: none** (no production wiring touched — `bin/bridge.dart`, runner, orchestrator all unchanged)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a production `BridgePluginHostImpl` with process, port, and JSON store services, plus a safer file update path. Fully tested and still unused; production wiring lands next. No behavior change.

- New Features
  - `BridgePluginHostImpl` factory creates and wires `processes`, `ports`, `store`, and `bridge` info, and ensures `stateDirectory` exists before `start()`.
  - Per-plugin state dirs under `<installRoot>/plugins/<id>`, with OpenCode using `<cacheDir>/runtime` to keep `opencode-processes.json` in its frozen location.
  - Host services: process spawning with best‑effort identity capture (POSIX start marker, Windows image-name/basename fallbacks), loopback port probing, and a validated JSON store.

- Refactors
  - `RuntimeFileApi` now uses named file operations and adds `updateFile()` with an exclusive OS advisory lock on a persistent sidecar plus an in‑process per‑name queue.
  - Interface doc: `HostJsonStore.update` clarifies no reentrancy for the same name to avoid deadlocks.
  - Legacy ownership helpers are thin delegates; existing behavior remains byte‑identical.
  - Post‑spawn identity inspection now catches all thrown objects so `spawn()` never fails once the child exists; covered by a new Error‑throwing test.

<sup>Written for commit e3289f7df05f7dec93356caf281376b5cf4798a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

