### PR TITLE
feat(bridge): seam flip via LegacyOpenCodeDescriptor (migration PR 4/15)

### DIFF
--- a/bridge/app/AGENTS.md
+++ b/bridge/app/AGENTS.md
@@ -53,7 +53,7 @@ modules/
 
 ## CONVENTIONS
 
-- **Plugin architecture** — all backend-specific code lives in plugin modules under `modules/`. The bridge `lib/src/` is plugin-agnostic — it only imports from `sesori_plugin_interface`, never from concrete plugins.
+- **Plugin architecture** — all backend-specific code lives in plugin modules under `modules/`. The bridge `lib/src/` is plugin-agnostic — it only imports from `sesori_plugin_interface`, never from concrete plugins. *Transitional exception (plugin-lifecycle migration, see `docs/plans/plugin-lifecycle-migration.html`): the legacy OpenCode lifecycle still lives under `lib/src/` (`server/services/open_code_*`, `bridge/runtime/legacy_opencode_descriptor.dart`, which imports `opencode_plugin`) until the real descriptor replaces it at the flip (PR 12) and the deletion sweep removes the rest (PR 13).*
 - **Intercept-first routing** — requests are intercepted by handlers by default. Proxy is the fallback for unhandled routes, not the default path.
 - **Crypto from `sesori_shared`** — all crypto primitives imported from shared package, not duplicated
 - **Linting**: `package:lints/recommended.yaml` (lighter than mobile's `all_lint_rules`)

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:args/args.dart' show ArgParserException;
 import 'package:args/command_runner.dart' as cli;
 import 'package:http/http.dart' as http;
-import 'package:opencode_plugin/opencode_plugin.dart';
 import 'package:sesori_bridge/src/api/bridge_settings_api.dart';
 import 'package:sesori_bridge/src/api/default_editor_api.dart';
 import 'package:sesori_bridge/src/api/wake_lock_client.dart';
@@ -18,6 +17,8 @@ import 'package:sesori_bridge/src/bridge/runtime/bridge_cli_dispatch.dart';
 import 'package:sesori_bridge/src/bridge/runtime/bridge_cli_options.dart';
 import 'package:sesori_bridge/src/bridge/runtime/bridge_logout_runner.dart';
 import 'package:sesori_bridge/src/bridge/runtime/bridge_runtime_runner.dart';
+import 'package:sesori_bridge/src/bridge/runtime/legacy_opencode_descriptor.dart';
+import 'package:sesori_bridge/src/bridge/runtime/plugin_cli_binding.dart';
 import 'package:sesori_bridge/src/repositories/bridge_settings_repository.dart';
 import 'package:sesori_bridge/src/repositories/default_editor_repository.dart';
 import 'package:sesori_bridge/src/repositories/wake_lock_repository.dart';
@@ -30,17 +31,11 @@ import 'package:sesori_bridge/src/server/services/bridge_instance_service.dart';
 import 'package:sesori_bridge/src/services/bridge_config_service.dart';
 import 'package:sesori_bridge/src/services/sleep_prevention_service.dart';
 import 'package:sesori_bridge/src/version.dart';
-import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Log, LogLevel, ProcessUser, ServerClock;
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart'
+    show Log, LogLevel, PluginConfig, PluginConfigException, ProcessUser, ServerClock;
 
 const String _defaultRelayURL = 'wss://relay.sesori.com';
 const String _defaultAuthURL = 'https://api.sesori.com';
-
-OpenCodePlugin _createOpenCodePlugin({
-  required String serverUrl,
-  required String? serverPassword,
-}) {
-  return OpenCodePlugin(serverUrl: serverUrl, password: serverPassword);
-}
 
 class RunCommand extends cli.Command<void> {
   @override
@@ -56,26 +51,11 @@ class RunCommand extends cli.Command<void> {
         negatable: false,
         help: 'Show version and exit',
       )
-      ..addOption('relay', defaultsTo: _defaultRelayURL, help: 'Relay server URL')
-      ..addOption(
-        'port',
-        help: 'Port for opencode server to listen on',
-      )
-      ..addFlag(
-        'no-auto-start',
-        defaultsTo: false,
-        help: 'Skip auto-starting opencode server (use existing localhost server)',
-      )
-      ..addOption(
-        'password',
-        defaultsTo: '',
-        help: 'Override server password (auto-generated if not set)',
-      )
-      ..addOption(
-        'opencode-bin',
-        defaultsTo: 'opencode',
-        help: 'Path to opencode binary',
-      )
+      ..addOption('relay', defaultsTo: _defaultRelayURL, help: 'Relay server URL');
+    // The selected plugin contributes its own CLI options (the four OpenCode
+    // flags, with their historical names, help text, and defaults).
+    registerPluginOptions(parser: argParser, options: LegacyOpenCodeDescriptor.cliOptions);
+    argParser
       ..addOption('auth-backend', defaultsTo: '', help: 'Auth backend URL')
       ..addOption(
         'debug-port',
@@ -100,7 +80,13 @@ class RunCommand extends cli.Command<void> {
     }
 
     final BridgeCliOptions options;
+    final PluginConfig pluginConfig;
     try {
+      // Plugin option validate hooks and config validation run at
+      // argument-parse time — strictly before the startup mutex, so a typo'd
+      // flag can never terminate a healthy resident bridge.
+      pluginConfig = parsePluginConfig(options: LegacyOpenCodeDescriptor.cliOptions, results: results);
+      LegacyOpenCodeDescriptor.validateConfigValues(pluginConfig);
       options = BridgeCliOptions.fromArgResults(
         cliArgs: globalResults!.arguments,
         results: results,
@@ -108,6 +94,8 @@ class RunCommand extends cli.Command<void> {
         defaultAuthUrl: _defaultAuthURL,
       );
     } on ArgParserException catch (e) {
+      usageException(e.message);
+    } on PluginConfigException catch (e) {
       usageException(e.message);
     }
     Log.level = LogLevel.values.byName(options.logLevelName);
@@ -133,7 +121,7 @@ class RunCommand extends cli.Command<void> {
 
     final exitCode = await runBridgeApp(
       options: options,
-      pluginFactory: _createOpenCodePlugin,
+      pluginConfig: pluginConfig,
     );
     await sleepPreventionService.dispose();
     exit(exitCode);

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:io" as io;
 
 import "package:clock/clock.dart";
@@ -5,7 +6,16 @@ import "package:http/http.dart" as http;
 import "package:path/path.dart" as path;
 import "package:rxdart/rxdart.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
-    show BridgePluginApi, Log, ProcessIdentity, ProcessUser, ServerClock;
+    show
+        Log,
+        PluginConfig,
+        PluginFailed,
+        PluginStartAbortedException,
+        ProcessIdentity,
+        ProcessUser,
+        ServerClock,
+        StartAbortController,
+        StartAbortSignal;
 
 import "../../auth/bridge_registration_api.dart";
 import "../../auth/bridge_registration_repository.dart";
@@ -21,6 +31,11 @@ import "../../server/api/open_code_process_api.dart";
 import "../../server/api/runtime_file_api.dart";
 import "../../server/api/system_process_api.dart";
 import "../../server/api/terminal_prompt_api.dart";
+import "../../server/host/bridge_host_info_impl.dart";
+import "../../server/host/bridge_host_json_store.dart";
+import "../../server/host/bridge_host_port_service.dart";
+import "../../server/host/bridge_host_process_service.dart";
+import "../../server/host/bridge_plugin_host_impl.dart";
 import "../../server/models/open_code_ownership_record.dart";
 import "../../server/repositories/bridge_instance_repository.dart";
 import "../../server/repositories/open_code_ownership_repository.dart";
@@ -64,27 +79,34 @@ import "bridge_runtime.dart";
 import "bridge_runtime_auth.dart";
 import "bridge_runtime_server.dart";
 import "bridge_shutdown_coordinator.dart";
-
-typedef BridgePluginFactory = BridgePluginApi Function({required String serverUrl, required String? serverPassword});
+import "legacy_opencode_descriptor.dart";
+import "plugin_failure_latch.dart";
 
 Future<int> runBridgeApp({
   required BridgeCliOptions options,
-  required BridgePluginFactory pluginFactory,
+  required PluginConfig pluginConfig,
 }) {
   return BridgeRuntimeRunner.run(
     options: options,
-    pluginFactory: pluginFactory,
+    pluginConfig: pluginConfig,
   );
 }
 
 class BridgeRuntimeRunner {
   const BridgeRuntimeRunner._();
 
+  /// Soft deadline granted to the plugin's ordered `shutdown()` step. The
+  /// shutdown coordinator's backstop is sized from it (budget + slack).
+  static const Duration _pluginShutdownBudget = Duration(seconds: 10);
+
   static Future<int> run({
     required BridgeCliOptions options,
-    required BridgePluginFactory pluginFactory,
+    required PluginConfig pluginConfig,
   }) async {
-    final shutdownCoordinator = BridgeShutdownCoordinator();
+    final failureLatch = PluginFailureLatch();
+    final shutdownCoordinator = BridgeShutdownCoordinator(
+      backstopExitCode: () => failureLatch.failure == null ? 0 : 1,
+    );
     final subscriptions = CompositeSubscription();
     shutdownCoordinator.add(disposable: subscriptions.cancel);
     final httpClient = http.Client();
@@ -99,9 +121,10 @@ class BridgeRuntimeRunner {
     final managedRuntimePaths = const ManagedRuntimePathService().currentPaths(
       environment: environment,
     );
-    final runtimeFileApi = RuntimeFileApi(
-      runtimeDirectory: path.join(managedRuntimePaths.cacheDirectory, "runtime"),
-    );
+    // Also the OpenCode plugin's state directory: its ownership file lives
+    // here under a frozen cross-version contract (see pluginStateDirectoryPath).
+    final runtimeDirectory = path.join(managedRuntimePaths.cacheDirectory, "runtime");
+    final runtimeFileApi = RuntimeFileApi(runtimeDirectory: runtimeDirectory);
     final systemProcessApi = SystemProcessApi(
       processRunner: processRunner,
       clock: serverClock,
@@ -206,22 +229,34 @@ class BridgeRuntimeRunner {
         random: null,
       );
 
-      final serverRuntime = await resolveServer(
-        options: options,
+      final startAbortController = StartAbortController();
+      final plugin = await startLegacyOpenCodePlugin(
+        pluginConfig: pluginConfig,
         currentBridgeIdentity: currentBridgeIdentity,
         ownerSessionId: ownerSessionId,
         startupMutexRepository: startupMutexRepository,
-        ownershipRepository: ownershipRepository,
         bridgeInstanceService: bridgeInstanceService,
+        ownershipRepository: ownershipRepository,
         openCodeServerService: openCodeServerService,
+        processRepository: processRepository,
+        runtimeFileApi: runtimeFileApi,
+        runtimeDirectory: runtimeDirectory,
+        serverClock: serverClock,
+        environment: environment,
+        currentUser: currentUser,
+        startAborted: startAbortController.signal,
       );
-      registerOwnedOpenCodeShutdown(
-        shutdownCoordinator: shutdownCoordinator,
-        serverRuntime: serverRuntime,
-        stopOwnedOpenCode: (record) {
-          return openCodeServerService.stopOwnedServer(record: record);
-        },
+      shutdownCoordinator.addOrdered(
+        action: () => plugin.shutdown(budget: _pluginShutdownBudget),
+        budget: _pluginShutdownBudget,
       );
+      plugin.status
+          .listen((status) {
+            if (status is PluginFailed) {
+              failureLatch.record(status);
+            }
+          })
+          .addTo(subscriptions);
 
       final tokenManager = TokenManager(
         initialToken: authTokens.accessToken,
@@ -248,15 +283,12 @@ class BridgeRuntimeRunner {
       final runtime = BridgeRuntime.create(
         config: BridgeConfig(
           relayURL: options.relayUrl,
-          serverURL: serverRuntime.serverUrl,
-          serverPassword: serverRuntime.serverPassword,
+          serverURL: plugin.serverUrl,
+          serverPassword: plugin.serverPassword,
           authBackendURL: options.authBackendUrl,
           sseReplayWindow: SSEManager.defaultReplayWindow,
         ),
-        plugin: pluginFactory(
-          serverUrl: serverRuntime.serverUrl,
-          serverPassword: serverRuntime.serverPassword,
-        ),
+        plugin: plugin.api,
         httpClient: httpClient,
         accessTokenProvider: tokenManager,
         tokenRefresher: tokenManager,
@@ -280,7 +312,20 @@ class BridgeRuntimeRunner {
           })
           .addTo(subscriptions);
 
+      final startupFailure = failureLatch.failure;
+      if (startupFailure != null) {
+        Log.e("Plugin failed before the session could start: ${startupFailure.reason}");
+        return 1;
+      }
+      failureLatch.bind((failure) {
+        Log.e("Plugin failed: ${failure.reason}. Cancelling the session.");
+        unawaited(runtime.session.cancel());
+      });
+
       await runtime.session.run();
+      return failureLatch.failure == null ? 0 : 1;
+    } on PluginStartAbortedException {
+      Log.i("Plugin start aborted as requested.");
       return 0;
     } catch (error) {
       Log.e("$error");
@@ -288,6 +333,100 @@ class BridgeRuntimeRunner {
     } finally {
       await shutdownCoordinator.shutdown();
     }
+  }
+
+  /// Runs the legacy OpenCode descriptor under the cross-instance startup
+  /// mutex: mutex → enforce-single-bridge → build host → descriptor.start.
+  ///
+  /// The mutex is held until `start()` settles; an abort would surface as
+  /// [PluginStartAbortedException] from `start()` and is handled by the
+  /// caller as "aborted as requested" (nothing triggers the abort signal
+  /// yet — the cooperative checks arrive with the supervisor).
+  ///
+  /// Public so tests can drive the live orchestration with fakes;
+  /// [buildPluginApi] is the test seam forwarded to the descriptor —
+  /// production omits it and gets a real `OpenCodePlugin`.
+  static Future<LegacyOpenCodeBridgePlugin> startLegacyOpenCodePlugin({
+    required PluginConfig pluginConfig,
+    required ProcessIdentity currentBridgeIdentity,
+    required String ownerSessionId,
+    required StartupMutexRepository startupMutexRepository,
+    required BridgeInstanceService bridgeInstanceService,
+    required OpenCodeOwnershipRepository ownershipRepository,
+    required OpenCodeServerService openCodeServerService,
+    required ProcessRepository processRepository,
+    required RuntimeFileApi runtimeFileApi,
+    required String runtimeDirectory,
+    required ServerClock serverClock,
+    required Map<String, String> environment,
+    required ProcessUser? currentUser,
+    required StartAbortSignal startAborted,
+    LegacyPluginApiBuilder? buildPluginApi,
+  }) {
+    return startupMutexRepository.withLock<LegacyOpenCodeBridgePlugin>(
+      bridgePid: currentBridgeIdentity.pid,
+      bridgeStartMarker: currentBridgeIdentity.startMarker,
+      onLockAcquired: () async {
+        Log.d("acquired startup lock");
+        final resolution = await bridgeInstanceService.enforceSingleLiveBridge(
+          currentPid: currentBridgeIdentity.pid,
+        );
+        switch (resolution.status) {
+          case BridgeInstanceResolutionStatus.allowed:
+            // The host contract promises the state directory exists before
+            // start() runs. The store shares the runner's RuntimeFileApi:
+            // its locked update() is only mutually exclusive within one
+            // instance per directory.
+            await io.Directory(runtimeDirectory).create(recursive: true);
+            final host = BridgePluginHostImpl(
+              config: pluginConfig,
+              stateDirectory: runtimeDirectory,
+              environment: Map<String, String>.unmodifiable(environment),
+              clock: serverClock,
+              startAborted: startAborted,
+              bridge: BridgeHostInfoImpl(
+                identity: currentBridgeIdentity,
+                ownerSessionId: ownerSessionId,
+                processRepository: processRepository,
+              ),
+              processes: BridgeHostProcessService(
+                processStarter: io.Process.start,
+                processRepository: processRepository,
+                clock: serverClock,
+                currentUser: currentUser,
+                isWindows: io.Platform.isWindows,
+                platform: io.Platform.operatingSystem,
+              ),
+              ports: const BridgeHostPortService(loopbackPortApi: LoopbackPortApi()),
+              store: BridgeHostJsonStore(fileApi: runtimeFileApi),
+            );
+            final descriptor = LegacyOpenCodeDescriptor(
+              openCodeServerService: openCodeServerService,
+              ownershipRepository: ownershipRepository,
+              ownerSessionId: ownerSessionId,
+              terminatedBridgeIdentities: resolution.terminatedBridges,
+              buildPluginApi: buildPluginApi,
+            );
+            return descriptor.start(host);
+          case BridgeInstanceResolutionStatus.declined:
+            throw const BridgeRuntimeServerException(
+              "Startup aborted because another Sesori bridge is already running and replacement was declined.",
+            );
+          case BridgeInstanceResolutionStatus.nonInteractive:
+            throw const BridgeRuntimeServerException(
+              "Startup aborted because another Sesori bridge is already running and this session is non-interactive.",
+            );
+        }
+      },
+      onLockRejected: (result) async {
+        switch (result) {
+          case StartupMutexAcquireResult.alreadyLocked:
+            throw const BridgeRuntimeServerException(
+              "Startup aborted because another Sesori bridge startup is already in progress.",
+            );
+        }
+      },
+    );
   }
 
   static UpdateService _createUpdateService({

--- a/bridge/app/lib/src/bridge/runtime/bridge_shutdown_coordinator.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_shutdown_coordinator.dart
@@ -76,8 +76,11 @@ class BridgeShutdownCoordinator {
           firstOrderedStackTrace ??= stackTrace;
         }
       }
+      // Future.sync (not Future.value(disposable())): a synchronously
+      // throwing disposable must become a failed future, not abort the lazy
+      // map iteration inside Future.wait and skip the disposables after it.
       await Future.wait(
-        _disposables.map((disposable) => Future.value(disposable())),
+        _disposables.map(Future.sync),
       );
       if (firstOrderedError != null) {
         Error.throwWithStackTrace(firstOrderedError, firstOrderedStackTrace!);

--- a/bridge/app/lib/src/bridge/runtime/bridge_shutdown_coordinator.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_shutdown_coordinator.dart
@@ -1,14 +1,56 @@
 import "dart:async";
-import "dart:io";
+import "dart:io" as io;
 
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
+/// Coordinates bridge shutdown in two phases under one process-wide backstop:
+///
+/// 1. **Ordered phase** — steps registered with [addOrdered] run
+///    sequentially, in registration order. The plugin's `shutdown(budget)`
+///    runs here so api teardown and the owned-runtime stop finish before
+///    anything else is torn down (previously they raced the parallel phase).
+/// 2. **Parallel phase** — disposables registered with [add] run
+///    concurrently, as before.
+///
+/// The backstop timer is armed *before* the ordered phase — there is no
+/// window with no timer running — and is sized as the sum of the ordered
+/// budgets plus [_backstopSlack] for the parallel phase. When it fires, the
+/// process exits with [backstopExitCode]: a hung shutdown after a terminal
+/// plugin failure must not exit 0.
+///
+/// A *throwing* ordered step does not block later steps or the parallel
+/// phase, but [shutdown] rethrows the first such error once both phases ran
+/// — a failed plugin stop must surface loudly (non-zero exit), exactly as it
+/// did when it was a parallel disposable.
 class BridgeShutdownCoordinator {
+  BridgeShutdownCoordinator({
+    int Function()? backstopExitCode,
+    void Function(int code)? exitProcess,
+  }) : _backstopExitCode = backstopExitCode ?? _alwaysZero,
+       _exitProcess = exitProcess ?? io.exit;
+
+  static int _alwaysZero() => 0;
+
+  static const Duration _backstopSlack = Duration(seconds: 10);
+
+  final int Function() _backstopExitCode;
+  final void Function(int code) _exitProcess;
   final List<FutureOr<void> Function()> _disposables = <FutureOr<void> Function()>[];
+  final List<({Future<void> Function() action, Duration budget})> _orderedSteps =
+      <({Future<void> Function() action, Duration budget})>[];
   Future<void>? _activeShutdown;
 
   void add({required FutureOr<void> Function() disposable}) {
     _disposables.add(disposable);
+  }
+
+  /// Registers an ordered shutdown step that runs before the parallel phase.
+  ///
+  /// [budget] is the step's soft deadline; it extends the backstop rather
+  /// than being enforced per-step (the step itself is expected to degrade to
+  /// forceful termination within its budget).
+  void addOrdered({required Future<void> Function() action, required Duration budget}) {
+    _orderedSteps.add((action: action, budget: budget));
   }
 
   Future<void> shutdown() {
@@ -16,17 +58,32 @@ class BridgeShutdownCoordinator {
   }
 
   Future<void> _shutdownInternal() async {
-    final safetyTimer = Timer(const Duration(seconds: 10), () {
+    final orderedBudget = _orderedSteps.fold(Duration.zero, (total, step) => total + step.budget);
+    final backstop = Timer(orderedBudget + _backstopSlack, () {
       Log.e("Failed to finish gracefully");
-      exit(0);
+      _exitProcess(_backstopExitCode());
     });
 
     try {
+      Object? firstOrderedError;
+      StackTrace? firstOrderedStackTrace;
+      for (final step in _orderedSteps) {
+        try {
+          await step.action();
+        } catch (error, stackTrace) {
+          Log.e("Ordered shutdown step failed: $error");
+          firstOrderedError ??= error;
+          firstOrderedStackTrace ??= stackTrace;
+        }
+      }
       await Future.wait(
         _disposables.map((disposable) => Future.value(disposable())),
-      ).timeout(const Duration(seconds: 15));
+      );
+      if (firstOrderedError != null) {
+        Error.throwWithStackTrace(firstOrderedError, firstOrderedStackTrace!);
+      }
     } finally {
-      safetyTimer.cancel();
+      backstop.cancel();
     }
   }
 }

--- a/bridge/app/lib/src/bridge/runtime/legacy_opencode_descriptor.dart
+++ b/bridge/app/lib/src/bridge/runtime/legacy_opencode_descriptor.dart
@@ -1,0 +1,285 @@
+import "package:opencode_plugin/opencode_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
+    show
+        BridgePlugin,
+        BridgePluginApi,
+        BridgePluginDescriptor,
+        Log,
+        PluginConfig,
+        PluginConfigException,
+        PluginDiagnostics,
+        PluginFlagOption,
+        PluginHost,
+        PluginOption,
+        PluginReady,
+        PluginStatus,
+        PluginStatusController,
+        PluginStopped,
+        PluginStopping,
+        PluginValueOption,
+        ProcessIdentity;
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../../server/models/open_code_ownership_record.dart";
+import "../../server/repositories/open_code_ownership_repository.dart";
+import "../../server/services/open_code_server_service.dart";
+import "bridge_runtime_server.dart" show defaultTargetHost;
+
+/// Builds the [BridgePluginApi] for a resolved server. The production
+/// default constructs an [OpenCodePlugin]; tests inject a fake.
+typedef LegacyPluginApiBuilder = BridgePluginApi Function({required String serverUrl, required String? serverPassword});
+
+OpenCodePlugin _createOpenCodePlugin({required String serverUrl, required String? serverPassword}) {
+  return OpenCodePlugin(serverUrl: serverUrl, password: serverPassword);
+}
+
+/// Migration-window descriptor that wraps today's exact OpenCode startup
+/// flow behind the [BridgePluginDescriptor] seam. No OpenCode lifecycle code
+/// moves: `start()` drives the same [OpenCodeServerService] calls the runner
+/// used to drive through `resolveServer`, and the returned plugin's
+/// `shutdown()` folds in what `registerOwnedOpenCodeShutdown` used to
+/// register with the shutdown coordinator.
+///
+/// Unlike the contract's ideal const descriptor, this one is constructed by
+/// the runner *inside* the startup mutex with the legacy services injected —
+/// the registration-time surface ([cliOptions], [validateConfigValues]) is
+/// exposed statically so `bin/bridge.dart` can declare and validate options
+/// at argument-parse time without constructing the heavy flow. A second
+/// deliberate divergence: `start()` propagates the legacy
+/// `OpenCodeServerStartException` for expected start failures instead of the
+/// contract's `PluginStartException` — wrapping would change the logged
+/// error text. Nothing may pattern-match `on PluginStartException` against
+/// this descriptor. Both divergences resolve with the real, const
+/// `OpenCodePluginDescriptor` at the flip (PR 12).
+class LegacyOpenCodeDescriptor extends BridgePluginDescriptor {
+  const LegacyOpenCodeDescriptor({
+    required OpenCodeServerService openCodeServerService,
+    required OpenCodeOwnershipRepository ownershipRepository,
+    required String ownerSessionId,
+    required List<ProcessIdentity> terminatedBridgeIdentities,
+    LegacyPluginApiBuilder? buildPluginApi,
+  }) : _openCodeServerService = openCodeServerService,
+       _ownershipRepository = ownershipRepository,
+       _ownerSessionId = ownerSessionId,
+       _terminatedBridgeIdentities = terminatedBridgeIdentities,
+       _buildPluginApi = buildPluginApi;
+
+  /// The four OpenCode CLI options, names/help/defaults identical to the
+  /// flags `bin/bridge.dart` has always declared.
+  static const List<PluginOption> cliOptions = [
+    PluginValueOption.integer(
+      name: "port",
+      help: "Port for opencode server to listen on",
+      defaultsTo: null,
+      valueHelp: null,
+    ),
+    PluginFlagOption(
+      name: "no-auto-start",
+      help: "Skip auto-starting opencode server (use existing localhost server)",
+      defaultsTo: false,
+      negatable: true,
+    ),
+    PluginValueOption(
+      name: "password",
+      help: "Override server password (auto-generated if not set)",
+      defaultsTo: "",
+      allowedValues: null,
+      valueHelp: null,
+      validate: null,
+    ),
+    PluginValueOption(
+      name: "opencode-bin",
+      help: "Path to opencode binary",
+      defaultsTo: "opencode",
+      allowedValues: null,
+      valueHelp: null,
+      validate: null,
+    ),
+  ];
+
+  /// Static counterpart of [validateConfig] so argument-parse-time callers
+  /// don't need a constructed descriptor (whose dependencies only exist
+  /// later, inside the runner).
+  static void validateConfigValues(PluginConfig config) {
+    if (config.flag("no-auto-start") && config.intValue("port") == null) {
+      throw const PluginConfigException("The --no-auto-start flag requires --port to be set.");
+    }
+  }
+
+  final OpenCodeServerService _openCodeServerService;
+  final OpenCodeOwnershipRepository _ownershipRepository;
+  final String _ownerSessionId;
+  final List<ProcessIdentity> _terminatedBridgeIdentities;
+  final LegacyPluginApiBuilder? _buildPluginApi;
+
+  @override
+  String get id => "opencode";
+
+  @override
+  String get displayName => "OpenCode";
+
+  @override
+  List<PluginOption> get options => cliOptions;
+
+  @override
+  void validateConfig(PluginConfig config) => validateConfigValues(config);
+
+  @override
+  Future<LegacyOpenCodeBridgePlugin> start(PluginHost host) async {
+    final config = host.config;
+    final requestedPort = config.intValue("port");
+    final password = config.value("password")?.normalize();
+
+    if (config.flag("no-auto-start")) {
+      try {
+        final runtime = await _openCodeServerService.validateExistingServer(
+          port: requestedPort!,
+          password: password,
+        );
+        Log.i("Using existing server at ${runtime.serverUri} (auto-start disabled)");
+        return _wrap(
+          serverUrl: runtime.serverUri.toString(),
+          serverPassword: runtime.serverPassword,
+          port: runtime.port,
+          ownedOpenCodeRecord: null,
+        );
+      } on OpenCodeServerStartException catch (error) {
+        Log.w(
+          "Cannot reach OpenCode at port $requestedPort (auto-start disabled): $error. Bridge will start anyway; start OpenCode manually to enable proxying.",
+        );
+        return _wrap(
+          serverUrl: "$defaultTargetHost:$requestedPort",
+          serverPassword: password,
+          port: requestedPort!,
+          ownedOpenCodeRecord: null,
+        );
+      }
+    }
+
+    Log.d("[OPENCODE] Starting new instance");
+    final runtime = await _openCodeServerService.start(
+      executablePath: config.value("opencode-bin")!,
+      requestedPort: requestedPort,
+      password: password,
+      terminatedBridgeIdentities: _terminatedBridgeIdentities,
+    );
+
+    Log.d("[OPENCODE] Started on port ${runtime.port}");
+    final ownedOpenCodeRecord = await _ownershipRepository.readByOwnerSessionId(
+      ownerSessionId: _ownerSessionId,
+    );
+
+    return _wrap(
+      serverUrl: runtime.serverUri.toString(),
+      serverPassword: runtime.serverPassword,
+      port: runtime.port,
+      ownedOpenCodeRecord: ownedOpenCodeRecord?.status == OpenCodeOwnershipStatus.ready ? ownedOpenCodeRecord : null,
+    );
+  }
+
+  LegacyOpenCodeBridgePlugin _wrap({
+    required String serverUrl,
+    required String? serverPassword,
+    required int port,
+    required OpenCodeOwnershipRecord? ownedOpenCodeRecord,
+  }) {
+    return LegacyOpenCodeBridgePlugin(
+      api: (_buildPluginApi ?? _createOpenCodePlugin)(serverUrl: serverUrl, serverPassword: serverPassword),
+      serverUrl: serverUrl,
+      serverPassword: serverPassword,
+      port: port,
+      ownedOpenCodeRecord: ownedOpenCodeRecord,
+      stopOwnedServer: (record) => _openCodeServerService.stopOwnedServer(record: record),
+    );
+  }
+}
+
+/// Live-plugin wrapper for the legacy OpenCode flow.
+///
+/// [serverUrl]/[serverPassword] feed `BridgeConfig` until PR 12 removes
+/// those fields; [shutdown] runs api teardown then the owned-server stop in
+/// order (previously two racing parallel disposables).
+class LegacyOpenCodeBridgePlugin implements BridgePlugin {
+  LegacyOpenCodeBridgePlugin({
+    required this.api,
+    required this.serverUrl,
+    required this.serverPassword,
+    required this.port,
+    required OpenCodeOwnershipRecord? ownedOpenCodeRecord,
+    required Future<void> Function(OpenCodeOwnershipRecord record) stopOwnedServer,
+  }) : _ownedOpenCodeRecord = ownedOpenCodeRecord,
+       _stopOwnedServer = stopOwnedServer;
+
+  @override
+  final BridgePluginApi api;
+
+  final String serverUrl;
+  final String? serverPassword;
+  final int port;
+  final OpenCodeOwnershipRecord? _ownedOpenCodeRecord;
+  final Future<void> Function(OpenCodeOwnershipRecord record) _stopOwnedServer;
+
+  // The legacy flow returns from start() only once the server answered a
+  // health probe (or attach mode accepted it degraded-but-addressable), so
+  // the wrapper is born Ready. Nothing monitors the runtime after start
+  // until PR 12 activates the supervisor's exit monitor, so no Failed /
+  // Degraded source exists here.
+  final PluginStatusController _status = PluginStatusController(initial: const PluginReady());
+
+  Future<void>? _shutdown;
+
+  @override
+  Stream<PluginStatus> get status => _status.stream;
+
+  @override
+  PluginStatus get currentStatus => _status.current;
+
+  @override
+  PluginDiagnostics describe() {
+    return PluginDiagnostics(
+      pluginId: "opencode",
+      endpoint: serverUrl,
+      details: {
+        "port": "$port",
+        "mode": _ownedOpenCodeRecord == null ? "attached" : "managed",
+      },
+    );
+  }
+
+  /// Stops the plugin: api teardown first, then the owned `opencode serve`
+  /// process (when this bridge owns one). Idempotent — repeated calls return
+  /// the same future — and safe before/after [BridgePluginApi.dispose],
+  /// which the orchestrator still calls directly until PR 12.
+  ///
+  /// [budget] is accepted but not subdivided: the legacy stop path keeps its
+  /// own internal pacing (graceful signal, wait, force). The shutdown
+  /// coordinator's backstop, sized from the same budget, bounds the total.
+  @override
+  Future<void> shutdown({required Duration? budget}) => _shutdown ??= _shutdownNow();
+
+  Future<void> _shutdownNow() async {
+    _status.set(const PluginStopping());
+    try {
+      Object? disposeError;
+      StackTrace? disposeStackTrace;
+      try {
+        await api.dispose();
+      } catch (error, stackTrace) {
+        // The owned server must still be stopped when api teardown fails —
+        // the old parallel registration guaranteed their independence.
+        disposeError = error;
+        disposeStackTrace = stackTrace;
+        Log.e("Plugin api dispose failed: $error");
+      }
+      final record = _ownedOpenCodeRecord;
+      if (record != null) {
+        await _stopOwnedServer(record);
+      }
+      if (disposeError != null) {
+        Error.throwWithStackTrace(disposeError, disposeStackTrace!);
+      }
+    } finally {
+      _status.set(const PluginStopped());
+    }
+  }
+}

--- a/bridge/app/lib/src/bridge/runtime/plugin_cli_binding.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_cli_binding.dart
@@ -1,0 +1,54 @@
+import "package:args/args.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
+    show PluginConfig, PluginFlagOption, PluginOption, PluginValueOption;
+
+/// Registers a plugin's declared [options] into the bridge's CLI [parser].
+///
+/// Pure declaration: no validation runs here. The bridge registers only the
+/// *selected* plugin's options, so flag names cannot collide across plugins.
+void registerPluginOptions({required ArgParser parser, required List<PluginOption> options}) {
+  for (final option in options) {
+    switch (option) {
+      case PluginFlagOption():
+        parser.addFlag(
+          option.name,
+          help: option.help,
+          defaultsTo: option.defaultsTo,
+          negatable: option.negatable,
+        );
+      case PluginValueOption():
+        parser.addOption(
+          option.name,
+          help: option.help,
+          defaultsTo: option.defaultsTo,
+          allowed: option.allowedValues,
+          valueHelp: option.valueHelp,
+        );
+    }
+  }
+}
+
+/// Builds the [PluginConfig] for [options] from parsed [results], running
+/// each value option's `validate` hook on present, non-empty values.
+///
+/// This is the argument-parse-time half of the plugin config contract: it
+/// runs strictly before the startup mutex, so a typed value the user got
+/// wrong (e.g. a non-numeric `--port`) surfaces as a usage error
+/// (`PluginConfigException`) before any irreversible step.
+PluginConfig parsePluginConfig({required List<PluginOption> options, required ArgResults results}) {
+  final values = <String, Object?>{};
+  for (final option in options) {
+    switch (option) {
+      case PluginFlagOption():
+        values[option.name] = results[option.name] as bool;
+      case PluginValueOption():
+        final raw = results[option.name] as String?;
+        values[option.name] = raw;
+        final validate = option.validate;
+        if (validate != null && raw != null && raw.isNotEmpty) {
+          validate(option.name, raw);
+        }
+    }
+  }
+  return PluginConfig(values: values);
+}

--- a/bridge/app/lib/src/bridge/runtime/plugin_failure_latch.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_failure_latch.dart
@@ -1,0 +1,41 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginFailed;
+
+/// Latches the first `PluginFailed` a plugin's status stream reports and
+/// drives the bridge's reaction to it.
+///
+/// The runner records failures here from the moment `start()` returns,
+/// checks [failure] right before entering the relay session, and late-binds
+/// [onFailure] to the session's `cancel()` once the session exists — so a
+/// terminal plugin failure always produces an orderly shutdown with exit
+/// code 1, never a zombie bridge serving requests against a dead plugin.
+///
+/// Until PR 12 activates the supervisor's exit monitor nothing can emit
+/// `PluginFailed` after a successful start; the latch is the (tested)
+/// machinery awaiting that signal.
+class PluginFailureLatch {
+  PluginFailed? _failure;
+  void Function(PluginFailed failure)? _onFailure;
+
+  /// The first failure recorded, if any.
+  PluginFailed? get failure => _failure;
+
+  /// Records [failure] if none is latched yet; later failures are ignored.
+  void record(PluginFailed failure) {
+    if (_failure != null) {
+      return;
+    }
+    _failure = failure;
+    _onFailure?.call(failure);
+  }
+
+  /// Binds the failure reaction, replacing any previous one. Fires
+  /// immediately when a failure is already latched, so binding after
+  /// [record] cannot miss it.
+  void bind(void Function(PluginFailed failure) onFailure) {
+    _onFailure = onFailure;
+    final failure = _failure;
+    if (failure != null) {
+      onFailure(failure);
+    }
+  }
+}

--- a/bridge/app/test/bridge/runtime/bridge_runtime_server_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_server_test.dart
@@ -1,50 +1,62 @@
-import "package:args/args.dart";
-import "package:sesori_bridge/src/bridge/runtime/bridge_cli_options.dart";
+import "dart:io";
+
+import "package:sesori_bridge/src/bridge/runtime/bridge_runtime_runner.dart";
 import "package:sesori_bridge/src/bridge/runtime/bridge_runtime_server.dart";
+import "package:sesori_bridge/src/bridge/runtime/legacy_opencode_descriptor.dart";
+import "package:sesori_bridge/src/server/api/runtime_file_api.dart";
 import "package:sesori_bridge/src/server/models/open_code_ownership_record.dart";
 import "package:sesori_bridge/src/server/repositories/open_code_ownership_repository.dart";
+import "package:sesori_bridge/src/server/repositories/process_repository.dart";
 import "package:sesori_bridge/src/server/repositories/startup_mutex_repository.dart";
 import "package:sesori_bridge/src/server/services/bridge_instance_service.dart";
 import "package:sesori_bridge/src/server/services/open_code_server_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
+// The "--no-auto-start requires --port" rule moved to argument-parse time:
+// LegacyOpenCodeDescriptor.validateConfigValues, covered in
+// legacy_opencode_descriptor_test.dart and plugin_cli_binding_test.dart.
 void main() {
-  group("resolveServer", () {
+  group("BridgeRuntimeRunner.startLegacyOpenCodePlugin", () {
     late _FakeStartupMutexRepository startupMutexRepository;
     late _FakeOwnershipRepository ownershipRepository;
     late _FakeBridgeInstanceService bridgeInstanceService;
     late _FakeOpenCodeServerService openCodeServerService;
     late ProcessIdentity currentBridgeIdentity;
+    late Directory runtimeDirectory;
 
-    setUp(() {
+    setUp(() async {
       startupMutexRepository = _FakeStartupMutexRepository();
       ownershipRepository = _FakeOwnershipRepository();
       bridgeInstanceService = _FakeBridgeInstanceService();
       openCodeServerService = _FakeOpenCodeServerService();
       currentBridgeIdentity = _identity(pid: 100, startMarker: "bridge-start");
+      runtimeDirectory = await Directory.systemTemp.createTemp("bridge-runtime-server-test");
     });
 
-    test("no-auto-start without port still fails clearly", () async {
-      await expectLater(
-        resolveServer(
-          options: _options(port: null, noAutoStart: true),
-          currentBridgeIdentity: currentBridgeIdentity,
-          ownerSessionId: "owner-session",
-          startupMutexRepository: startupMutexRepository,
-          ownershipRepository: ownershipRepository,
-          bridgeInstanceService: bridgeInstanceService,
-          openCodeServerService: openCodeServerService,
-        ),
-        throwsA(
-          isA<ArgParserException>().having(
-            (error) => error.message,
-            "message",
-            contains("--no-auto-start"),
-          ),
-        ),
-      );
+    tearDown(() async {
+      await runtimeDirectory.delete(recursive: true);
     });
+
+    Future<LegacyOpenCodeBridgePlugin> startPlugin({required PluginConfig pluginConfig}) {
+      return BridgeRuntimeRunner.startLegacyOpenCodePlugin(
+        pluginConfig: pluginConfig,
+        currentBridgeIdentity: currentBridgeIdentity,
+        ownerSessionId: "owner-session",
+        startupMutexRepository: startupMutexRepository,
+        bridgeInstanceService: bridgeInstanceService,
+        ownershipRepository: ownershipRepository,
+        openCodeServerService: openCodeServerService,
+        processRepository: _FakeProcessRepository(),
+        runtimeFileApi: RuntimeFileApi(runtimeDirectory: runtimeDirectory.path),
+        runtimeDirectory: runtimeDirectory.path,
+        serverClock: const ServerClock(),
+        environment: const <String, String>{},
+        currentUser: ProcessUser.fromRawUser("alex"),
+        startAborted: StartAbortSignal.never,
+        buildPluginApi: ({required String serverUrl, required String? serverPassword}) => _FakePluginApi(),
+      );
+    }
 
     test("auto-start without port uses mutex then singleton resolution then service start", () async {
       final terminatedBridge = _identity(pid: 200, startMarker: "old-bridge-start");
@@ -62,15 +74,7 @@ void main() {
       );
       ownershipRepository.recordByOwnerSessionId["owner-session"] = _ownedRecord();
 
-      final runtime = await resolveServer(
-        options: _options(port: null, noAutoStart: false),
-        currentBridgeIdentity: currentBridgeIdentity,
-        ownerSessionId: "owner-session",
-        startupMutexRepository: startupMutexRepository,
-        ownershipRepository: ownershipRepository,
-        bridgeInstanceService: bridgeInstanceService,
-        openCodeServerService: openCodeServerService,
-      );
+      final plugin = await startPlugin(pluginConfig: _config(port: null, noAutoStart: false));
 
       expect(startupMutexRepository.lockRequests, hasLength(1));
       expect(startupMutexRepository.lockRequests.single, equals((pid: 100, startMarker: "bridge-start")));
@@ -88,9 +92,9 @@ void main() {
         ],
         equals(<String>["mutex.acquire", "singleton.check", "opencode.start"]),
       );
-      expect(runtime.serverUrl, equals("http://127.0.0.1:50123"));
-      expect(runtime.port, equals(50123));
-      expect(runtime.ownedOpenCodeRecord, isNotNull);
+      expect(plugin.serverUrl, equals("http://127.0.0.1:50123"));
+      expect(plugin.port, equals(50123));
+      expect(plugin.describe().details["mode"], equals("managed"));
       expect(ownershipRepository.readOwnerSessionIds, equals(<String>["owner-session"]));
     });
 
@@ -102,15 +106,7 @@ void main() {
       );
 
       await expectLater(
-        resolveServer(
-          options: _options(port: 4096, noAutoStart: false),
-          currentBridgeIdentity: currentBridgeIdentity,
-          ownerSessionId: "owner-session",
-          startupMutexRepository: startupMutexRepository,
-          ownershipRepository: ownershipRepository,
-          bridgeInstanceService: bridgeInstanceService,
-          openCodeServerService: openCodeServerService,
-        ),
+        startPlugin(pluginConfig: _config(port: 4096, noAutoStart: false)),
         throwsA(
           isA<BridgeRuntimeServerException>().having(
             (error) => error.message,
@@ -132,15 +128,7 @@ void main() {
       );
 
       await expectLater(
-        resolveServer(
-          options: _options(port: 4096, noAutoStart: false),
-          currentBridgeIdentity: currentBridgeIdentity,
-          ownerSessionId: "owner-session",
-          startupMutexRepository: startupMutexRepository,
-          ownershipRepository: ownershipRepository,
-          bridgeInstanceService: bridgeInstanceService,
-          openCodeServerService: openCodeServerService,
-        ),
+        startPlugin(pluginConfig: _config(port: 4096, noAutoStart: false)),
         throwsA(
           isA<BridgeRuntimeServerException>().having(
             (error) => error.message,
@@ -158,15 +146,7 @@ void main() {
       startupMutexRepository.rejectLock = true;
 
       await expectLater(
-        resolveServer(
-          options: _options(port: null, noAutoStart: false),
-          currentBridgeIdentity: currentBridgeIdentity,
-          ownerSessionId: "owner-session",
-          startupMutexRepository: startupMutexRepository,
-          ownershipRepository: ownershipRepository,
-          bridgeInstanceService: bridgeInstanceService,
-          openCodeServerService: openCodeServerService,
-        ),
+        startPlugin(pluginConfig: _config(port: null, noAutoStart: false)),
         throwsA(
           isA<BridgeRuntimeServerException>().having(
             (error) => error.message,
@@ -195,39 +175,30 @@ void main() {
         identity: null,
       );
 
-      final runtime = await resolveServer(
-        options: _options(port: 4096, noAutoStart: true, password: "existing-password"),
-        currentBridgeIdentity: currentBridgeIdentity,
-        ownerSessionId: "owner-session",
-        startupMutexRepository: startupMutexRepository,
-        ownershipRepository: ownershipRepository,
-        bridgeInstanceService: bridgeInstanceService,
-        openCodeServerService: openCodeServerService,
+      final plugin = await startPlugin(
+        pluginConfig: _config(port: 4096, noAutoStart: true, password: "existing-password"),
       );
 
       expect(openCodeServerService.startCalls, isEmpty);
       expect(openCodeServerService.validateCalls.single, equals((port: 4096, password: "existing-password")));
-      expect(runtime.ownedOpenCodeRecord, isNull);
+      expect(plugin.describe().details["mode"], equals("attached"));
       expect(ownershipRepository.readOwnerSessionIds, isEmpty);
     });
   });
 }
 
-BridgeCliOptions _options({
+PluginConfig _config({
   required int? port,
   required bool noAutoStart,
   String password = "",
 }) {
-  return BridgeCliOptions(
-    cliArgs: const <String>["bridge"],
-    relayUrl: "wss://relay.sesori.com",
-    port: port,
-    noAutoStart: noAutoStart,
-    password: password,
-    opencodeBin: "opencode",
-    authBackendUrl: "https://api.sesori.com",
-    debugPort: null,
-    logLevelName: "info",
+  return PluginConfig(
+    values: <String, Object?>{
+      "port": port?.toString(),
+      "no-auto-start": noAutoStart,
+      "password": password,
+      "opencode-bin": "opencode",
+    },
   );
 }
 
@@ -257,6 +228,21 @@ OpenCodeOwnershipRecord _ownedRecord() {
     startedAt: DateTime.utc(2026, 5, 15, 12),
     status: OpenCodeOwnershipStatus.ready,
   );
+}
+
+/// Never invoked in these tests: the host's process service is constructed
+/// but the fake OpenCode service short-circuits before any process work.
+class _FakeProcessRepository implements ProcessRepository {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakePluginApi implements BridgePluginApi {
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _FakeStartupMutexRepository implements StartupMutexRepository {

--- a/bridge/app/test/bridge/runtime/bridge_shutdown_coordinator_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_shutdown_coordinator_test.dart
@@ -48,6 +48,17 @@ void main() {
       expect(operations, ["ordered.2", "parallel"]);
     });
 
+    test("a synchronously throwing disposable does not prevent the others from running", () async {
+      final coordinator = BridgeShutdownCoordinator(exitProcess: (_) {});
+      final operations = <String>[];
+
+      coordinator.add(disposable: () => throw StateError("sync disposable failure"));
+      coordinator.add(disposable: () => operations.add("parallel.b"));
+
+      await expectLater(coordinator.shutdown(), throwsA(isA<StateError>()));
+      expect(operations, ["parallel.b"]);
+    });
+
     test("repeated shutdown calls share one run", () async {
       final coordinator = BridgeShutdownCoordinator(exitProcess: (_) {});
       var disposals = 0;

--- a/bridge/app/test/bridge/runtime/bridge_shutdown_coordinator_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_shutdown_coordinator_test.dart
@@ -1,0 +1,113 @@
+import "dart:async";
+
+import "package:fake_async/fake_async.dart";
+import "package:sesori_bridge/src/bridge/runtime/bridge_shutdown_coordinator.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("BridgeShutdownCoordinator", () {
+    test("runs ordered steps in order, before the parallel phase", () async {
+      final coordinator = BridgeShutdownCoordinator(exitProcess: (_) {});
+      final operations = <String>[];
+
+      coordinator.add(disposable: () => operations.add("parallel.a"));
+      coordinator.addOrdered(
+        action: () async => operations.add("ordered.1"),
+        budget: const Duration(seconds: 5),
+      );
+      coordinator.addOrdered(
+        action: () async => operations.add("ordered.2"),
+        budget: const Duration(seconds: 5),
+      );
+      coordinator.add(disposable: () => operations.add("parallel.b"));
+
+      await coordinator.shutdown();
+
+      expect(operations, ["ordered.1", "ordered.2", "parallel.a", "parallel.b"]);
+    });
+
+    test("a failing ordered step does not block later steps or the parallel phase, then surfaces", () async {
+      final coordinator = BridgeShutdownCoordinator(exitProcess: (_) {});
+      final operations = <String>[];
+
+      coordinator.addOrdered(
+        action: () async => throw StateError("plugin shutdown failed"),
+        budget: const Duration(seconds: 5),
+      );
+      coordinator.addOrdered(
+        action: () async => operations.add("ordered.2"),
+        budget: const Duration(seconds: 5),
+      );
+      coordinator.add(disposable: () => operations.add("parallel"));
+
+      await expectLater(
+        coordinator.shutdown(),
+        throwsA(isA<StateError>()),
+        reason: "a failed plugin stop must stay loud (non-zero exit), as it was as a parallel disposable",
+      );
+      expect(operations, ["ordered.2", "parallel"]);
+    });
+
+    test("repeated shutdown calls share one run", () async {
+      final coordinator = BridgeShutdownCoordinator(exitProcess: (_) {});
+      var disposals = 0;
+      coordinator.add(disposable: () => disposals++);
+
+      final first = coordinator.shutdown();
+      final second = coordinator.shutdown();
+      await first;
+      await second;
+
+      expect(identical(first, second), isTrue);
+      expect(disposals, 1);
+    });
+
+    test("backstop fires at ordered budget plus slack with the latch-derived exit code", () {
+      fakeAsync((async) {
+        final exitCalls = <int>[];
+        final coordinator = BridgeShutdownCoordinator(
+          backstopExitCode: () => 1,
+          exitProcess: exitCalls.add,
+        );
+        coordinator.addOrdered(
+          action: () => Completer<void>().future,
+          budget: const Duration(seconds: 10),
+        );
+
+        unawaited(coordinator.shutdown());
+        async.elapse(const Duration(seconds: 19));
+        expect(exitCalls, isEmpty, reason: "backstop is sized budget (10s) + slack (10s)");
+
+        async.elapse(const Duration(seconds: 2));
+        expect(exitCalls, [1]);
+      });
+    });
+
+    test("backstop covers a hung parallel phase even with no ordered steps", () {
+      fakeAsync((async) {
+        final exitCalls = <int>[];
+        final coordinator = BridgeShutdownCoordinator(exitProcess: exitCalls.add);
+        coordinator.add(disposable: () => Completer<void>().future);
+
+        unawaited(coordinator.shutdown());
+        async.elapse(const Duration(seconds: 11));
+
+        expect(exitCalls, [0]);
+      });
+    });
+
+    test("backstop never fires when shutdown completes in time", () {
+      fakeAsync((async) {
+        final exitCalls = <int>[];
+        final coordinator = BridgeShutdownCoordinator(exitProcess: exitCalls.add);
+        coordinator.addOrdered(action: () async {}, budget: const Duration(seconds: 10));
+        coordinator.add(disposable: () {});
+
+        unawaited(coordinator.shutdown());
+        async.elapse(const Duration(minutes: 5));
+
+        expect(exitCalls, isEmpty);
+      });
+    });
+  });
+}

--- a/bridge/app/test/bridge/runtime/legacy_opencode_descriptor_test.dart
+++ b/bridge/app/test/bridge/runtime/legacy_opencode_descriptor_test.dart
@@ -1,0 +1,438 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/bridge/runtime/legacy_opencode_descriptor.dart";
+import "package:sesori_bridge/src/server/models/open_code_ownership_record.dart";
+import "package:sesori_bridge/src/server/repositories/open_code_ownership_repository.dart";
+import "package:sesori_bridge/src/server/services/open_code_server_service.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
+    show
+        BridgeHostInfo,
+        BridgePluginApi,
+        HostJsonStore,
+        HostPortService,
+        HostProcessService,
+        PluginConfig,
+        PluginConfigException,
+        PluginHost,
+        PluginReady,
+        PluginStatus,
+        PluginStopped,
+        PluginStopping,
+        ProcessIdentity,
+        ProcessUser,
+        ServerClock,
+        StartAbortSignal;
+import "package:test/test.dart";
+
+void main() {
+  group("LegacyOpenCodeDescriptor config surface", () {
+    test("rejects no-auto-start without a port as a usage error", () {
+      expect(
+        () => LegacyOpenCodeDescriptor.validateConfigValues(_config(port: null, noAutoStart: true)),
+        throwsA(
+          isA<PluginConfigException>().having((e) => e.message, "message", contains("--no-auto-start")),
+        ),
+      );
+    });
+
+    test("accepts no-auto-start with a port and plain auto-start", () {
+      LegacyOpenCodeDescriptor.validateConfigValues(_config(port: 4096, noAutoStart: true));
+      LegacyOpenCodeDescriptor.validateConfigValues(_config(port: null, noAutoStart: false));
+    });
+  });
+
+  group("LegacyOpenCodeDescriptor.start", () {
+    late _FakeOpenCodeServerService openCodeServerService;
+    late _FakeOwnershipRepository ownershipRepository;
+    late _FakePluginApi pluginApi;
+
+    setUp(() {
+      openCodeServerService = _FakeOpenCodeServerService();
+      ownershipRepository = _FakeOwnershipRepository();
+      pluginApi = _FakePluginApi();
+    });
+
+    LegacyOpenCodeDescriptor descriptor({List<ProcessIdentity> terminatedBridges = const []}) {
+      return LegacyOpenCodeDescriptor(
+        openCodeServerService: openCodeServerService,
+        ownershipRepository: ownershipRepository,
+        ownerSessionId: "owner-session",
+        terminatedBridgeIdentities: terminatedBridges,
+        buildPluginApi: ({required String serverUrl, required String? serverPassword}) {
+          pluginApi.builds.add((serverUrl: serverUrl, serverPassword: serverPassword));
+          return pluginApi;
+        },
+      );
+    }
+
+    test("auto-start starts OpenCode from config and keeps the ready ownership record", () async {
+      openCodeServerService.startRuntime = OpenCodeServerRuntime(
+        serverUri: Uri.parse("http://127.0.0.1:50123"),
+        serverPassword: "generated-password",
+        process: null,
+        port: 50123,
+        identity: null,
+      );
+      ownershipRepository.recordByOwnerSessionId["owner-session"] = _ownedRecord();
+      final terminated = [_identity(pid: 200, startMarker: "old-start")];
+
+      final plugin = await descriptor(terminatedBridges: terminated).start(_TestPluginHost(_config()));
+
+      final startCall = openCodeServerService.startCalls.single;
+      expect(startCall.executablePath, "opencode");
+      expect(startCall.requestedPort, isNull);
+      expect(startCall.password, isNull, reason: "empty --password normalizes to null");
+      expect(startCall.terminatedBridgeIdentities.map((identity) => identity.pid), [200]);
+
+      expect(plugin.serverUrl, "http://127.0.0.1:50123");
+      expect(plugin.serverPassword, "generated-password");
+      expect(plugin.port, 50123);
+      expect(plugin.api, same(pluginApi));
+      expect(
+        pluginApi.builds.single,
+        (serverUrl: "http://127.0.0.1:50123", serverPassword: "generated-password"),
+      );
+      expect(ownershipRepository.readOwnerSessionIds, ["owner-session"]);
+      expect(plugin.describe().endpoint, "http://127.0.0.1:50123");
+      expect(plugin.describe().details["mode"], "managed");
+      expect(plugin.currentStatus, const PluginReady());
+    });
+
+    test("discards an ownership record that never reached ready", () async {
+      ownershipRepository.recordByOwnerSessionId["owner-session"] = _ownedRecord(
+        status: OpenCodeOwnershipStatus.starting,
+      );
+
+      final plugin = await descriptor().start(_TestPluginHost(_config()));
+
+      expect(plugin.describe().details["mode"], "attached");
+      await plugin.shutdown(budget: null);
+      expect(openCodeServerService.stopRecords, isEmpty);
+    });
+
+    test("no-auto-start validates the existing server and owns nothing", () async {
+      openCodeServerService.validateRuntime = OpenCodeServerRuntime(
+        serverUri: Uri.parse("http://127.0.0.1:4096"),
+        serverPassword: "existing-password",
+        process: null,
+        port: 4096,
+        identity: null,
+      );
+
+      final plugin = await descriptor().start(
+        _TestPluginHost(_config(port: 4096, noAutoStart: true, password: "existing-password")),
+      );
+
+      expect(openCodeServerService.startCalls, isEmpty);
+      expect(openCodeServerService.validateCalls.single, (port: 4096, password: "existing-password"));
+      expect(plugin.describe().details["mode"], "attached");
+      expect(ownershipRepository.readOwnerSessionIds, isEmpty);
+    });
+
+    test("no-auto-start falls back to a degraded target when validation fails", () async {
+      openCodeServerService.validateError = const OpenCodeServerStartException(
+        "no server on port 4096",
+        cause: null,
+      );
+
+      final plugin = await descriptor().start(
+        _TestPluginHost(_config(port: 4096, noAutoStart: true, password: "existing-password")),
+      );
+
+      expect(plugin.serverUrl, "http://127.0.0.1:4096");
+      expect(plugin.serverPassword, "existing-password");
+      expect(plugin.port, 4096);
+      expect(plugin.describe().details["mode"], "attached");
+      await plugin.shutdown(budget: null);
+      expect(openCodeServerService.stopRecords, isEmpty);
+    });
+  });
+
+  group("LegacyOpenCodeBridgePlugin shutdown", () {
+    late _FakePluginApi api;
+    late List<OpenCodeOwnershipRecord> stopped;
+    late List<String> operations;
+
+    setUp(() {
+      operations = [];
+      api = _FakePluginApi(operations: () => operations);
+      stopped = [];
+    });
+
+    LegacyOpenCodeBridgePlugin plugin({OpenCodeOwnershipRecord? record}) {
+      return LegacyOpenCodeBridgePlugin(
+        api: api,
+        serverUrl: "http://127.0.0.1:50123",
+        serverPassword: "secret",
+        port: 50123,
+        ownedOpenCodeRecord: record,
+        stopOwnedServer: (record) async {
+          operations.add("server.stop");
+          stopped.add(record);
+        },
+      );
+    }
+
+    test("disposes the api before stopping the owned server", () async {
+      await plugin(record: _ownedRecord()).shutdown(budget: const Duration(seconds: 10));
+
+      expect(operations, ["api.dispose", "server.stop"]);
+      expect(stopped.single.ownerSessionId, "owner-session");
+    });
+
+    test("is idempotent: repeated calls return the same future and run once", () async {
+      final wrapper = plugin(record: _ownedRecord());
+
+      final first = wrapper.shutdown(budget: null);
+      final second = wrapper.shutdown(budget: null);
+      await first;
+      await second;
+
+      expect(identical(first, second), isTrue);
+      expect(operations, ["api.dispose", "server.stop"]);
+    });
+
+    test("stays safe when the orchestrator already disposed the api directly", () async {
+      final wrapper = plugin(record: _ownedRecord());
+
+      // Until PR 12 the orchestrator's finally calls dispose() on its own;
+      // the wrapper's shutdown must tolerate running after it.
+      await api.dispose();
+      await wrapper.shutdown(budget: null);
+
+      expect(operations, ["api.dispose", "api.dispose", "server.stop"]);
+      expect(stopped, hasLength(1));
+    });
+
+    test("skips the server stop when this bridge owns no record", () async {
+      await plugin().shutdown(budget: null);
+
+      expect(operations, ["api.dispose"]);
+    });
+
+    test("emits Stopping then Stopped and closes the status stream", () async {
+      final wrapper = plugin(record: _ownedRecord());
+      final statuses = <PluginStatus>[];
+      final done = Completer<void>();
+      wrapper.status.listen(statuses.add, onDone: done.complete);
+
+      await wrapper.shutdown(budget: null);
+      await done.future;
+
+      expect(statuses, const [PluginReady(), PluginStopping(), PluginStopped()]);
+    });
+
+    test("still stops the owned server when api dispose fails, then surfaces the error", () async {
+      final wrapper = LegacyOpenCodeBridgePlugin(
+        api: _ThrowingDisposeApi(),
+        serverUrl: "http://127.0.0.1:50123",
+        serverPassword: null,
+        port: 50123,
+        ownedOpenCodeRecord: _ownedRecord(),
+        stopOwnedServer: (record) async => stopped.add(record),
+      );
+
+      await expectLater(wrapper.shutdown(budget: null), throwsA(isA<StateError>()));
+
+      expect(stopped, hasLength(1), reason: "api teardown failure must not leak the owned opencode process");
+      expect(wrapper.currentStatus, const PluginStopped());
+    });
+
+    test("still reaches Stopped when the server stop fails", () async {
+      final wrapper = LegacyOpenCodeBridgePlugin(
+        api: api,
+        serverUrl: "http://127.0.0.1:50123",
+        serverPassword: null,
+        port: 50123,
+        ownedOpenCodeRecord: _ownedRecord(),
+        stopOwnedServer: (_) async => throw StateError("stop failed"),
+      );
+
+      await expectLater(wrapper.shutdown(budget: null), throwsA(isA<StateError>()));
+      expect(wrapper.currentStatus, const PluginStopped());
+    });
+  });
+}
+
+PluginConfig _config({int? port, bool noAutoStart = false, String password = ""}) {
+  return PluginConfig(
+    values: {
+      "port": port?.toString(),
+      "no-auto-start": noAutoStart,
+      "password": password,
+      "opencode-bin": "opencode",
+    },
+  );
+}
+
+ProcessIdentity _identity({required int pid, required String? startMarker}) {
+  return ProcessIdentity(
+    pid: pid,
+    startMarker: startMarker,
+    executablePath: "/usr/local/bin/sesori-bridge",
+    commandLine: "/usr/local/bin/sesori-bridge",
+    ownerUser: ProcessUser.fromRawUser("alex"),
+    platform: "macos",
+    capturedAt: DateTime.utc(2026, 5, 15, 12),
+  );
+}
+
+OpenCodeOwnershipRecord _ownedRecord({OpenCodeOwnershipStatus status = OpenCodeOwnershipStatus.ready}) {
+  return OpenCodeOwnershipRecord(
+    ownerSessionId: "owner-session",
+    openCodePid: 300,
+    openCodeStartMarker: "open-start",
+    openCodeExecutablePath: "/usr/local/bin/opencode",
+    openCodeCommand: "/usr/local/bin/opencode",
+    openCodeArgs: const ["serve", "--port", "50123", "--hostname", "127.0.0.1"],
+    port: 50123,
+    bridgePid: 100,
+    bridgeStartMarker: "bridge-start",
+    startedAt: DateTime.utc(2026, 5, 15, 12),
+    status: status,
+  );
+}
+
+/// Host double for the legacy descriptor, which only reads [config] (its
+/// collaborators are constructor-injected during the migration window).
+class _TestPluginHost implements PluginHost {
+  _TestPluginHost(this.config);
+
+  @override
+  final PluginConfig config;
+
+  @override
+  StartAbortSignal get startAborted => StartAbortSignal.never;
+
+  @override
+  String get stateDirectory => throw UnimplementedError();
+
+  @override
+  Map<String, String> get environment => throw UnimplementedError();
+
+  @override
+  ServerClock get clock => throw UnimplementedError();
+
+  @override
+  BridgeHostInfo get bridge => throw UnimplementedError();
+
+  @override
+  HostProcessService get processes => throw UnimplementedError();
+
+  @override
+  HostPortService get ports => throw UnimplementedError();
+
+  @override
+  HostJsonStore get store => throw UnimplementedError();
+}
+
+class _ThrowingDisposeApi implements BridgePluginApi {
+  @override
+  Future<void> dispose() async => throw StateError("dispose failed");
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakePluginApi implements BridgePluginApi {
+  _FakePluginApi({List<String> Function()? operations}) : _operations = operations;
+
+  final List<String> Function()? _operations;
+  final List<({String serverUrl, String? serverPassword})> builds = [];
+
+  @override
+  Future<void> dispose() async {
+    _operations?.call().add("api.dispose");
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeOpenCodeServerService implements OpenCodeServerService {
+  OpenCodeServerRuntime? startRuntime;
+  OpenCodeServerRuntime? validateRuntime;
+  OpenCodeServerStartException? validateError;
+
+  final List<
+    ({
+      String executablePath,
+      int? requestedPort,
+      String? password,
+      List<ProcessIdentity> terminatedBridgeIdentities,
+    })
+  >
+  startCalls = [];
+  final List<({int port, String? password})> validateCalls = [];
+  final List<OpenCodeOwnershipRecord> stopRecords = [];
+
+  @override
+  Future<void> cleanupStaleOwnedServers({required Iterable<ProcessIdentity> terminatedBridgeIdentities}) async {}
+
+  @override
+  Future<OpenCodeServerRuntime> start({
+    required String executablePath,
+    required int? requestedPort,
+    required String? password,
+    required Iterable<ProcessIdentity> terminatedBridgeIdentities,
+  }) async {
+    startCalls.add((
+      executablePath: executablePath,
+      requestedPort: requestedPort,
+      password: password,
+      terminatedBridgeIdentities: List<ProcessIdentity>.from(terminatedBridgeIdentities),
+    ));
+    return startRuntime ??
+        OpenCodeServerRuntime(
+          serverUri: Uri.parse("http://127.0.0.1:50123"),
+          serverPassword: password,
+          process: null,
+          port: requestedPort ?? 50123,
+          identity: null,
+        );
+  }
+
+  @override
+  Future<void> stopOwnedServer({required OpenCodeOwnershipRecord record}) async {
+    stopRecords.add(record);
+  }
+
+  @override
+  Future<OpenCodeServerRuntime> validateExistingServer({required int port, required String? password}) async {
+    validateCalls.add((port: port, password: password));
+    final error = validateError;
+    if (error != null) {
+      throw error;
+    }
+    return validateRuntime ??
+        OpenCodeServerRuntime(
+          serverUri: Uri.parse("http://127.0.0.1:$port"),
+          serverPassword: password,
+          process: null,
+          port: port,
+          identity: null,
+        );
+  }
+}
+
+class _FakeOwnershipRepository implements OpenCodeOwnershipRepository {
+  final Map<String, OpenCodeOwnershipRecord> recordByOwnerSessionId = {};
+  final List<String> readOwnerSessionIds = [];
+
+  @override
+  Future<void> deleteByOwnerSessionId({required String ownerSessionId}) async {}
+
+  @override
+  Future<List<OpenCodeOwnershipRecord>> readAll() async => recordByOwnerSessionId.values.toList();
+
+  @override
+  Future<OpenCodeOwnershipRecord?> readByOwnerSessionId({required String ownerSessionId}) async {
+    readOwnerSessionIds.add(ownerSessionId);
+    return recordByOwnerSessionId[ownerSessionId];
+  }
+
+  @override
+  Future<void> upsert({required OpenCodeOwnershipRecord record}) async {
+    recordByOwnerSessionId[record.ownerSessionId] = record;
+  }
+}

--- a/bridge/app/test/bridge/runtime/plugin_cli_binding_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_cli_binding_test.dart
@@ -1,0 +1,116 @@
+import "package:args/args.dart";
+import "package:sesori_bridge/src/bridge/runtime/plugin_cli_binding.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
+    show PluginConfigException, PluginFlagOption, PluginOption, PluginValueOption;
+import "package:test/test.dart";
+
+void main() {
+  group("registerPluginOptions", () {
+    test("registers flags and value options with declared defaults", () {
+      final parser = ArgParser();
+      registerPluginOptions(parser: parser, options: _options);
+
+      final results = parser.parse(const []);
+      expect(results["no-auto-start"], isFalse);
+      expect(results["port"], isNull);
+      expect(results["password"], "");
+      expect(results["opencode-bin"], "opencode");
+    });
+
+    test("keeps flags negatable when declared negatable", () {
+      final parser = ArgParser();
+      registerPluginOptions(parser: parser, options: _options);
+
+      final results = parser.parse(const ["--no-no-auto-start"]);
+      expect(results["no-auto-start"], isFalse);
+    });
+
+    test("rejects values outside allowedValues at parse time", () {
+      final parser = ArgParser();
+      registerPluginOptions(
+        parser: parser,
+        options: const [
+          PluginValueOption(
+            name: "mode",
+            help: "Mode",
+            defaultsTo: null,
+            allowedValues: ["fast", "safe"],
+            valueHelp: null,
+            validate: null,
+          ),
+        ],
+      );
+
+      expect(() => parser.parse(const ["--mode", "slow"]), throwsA(isA<ArgParserException>()));
+    });
+  });
+
+  group("parsePluginConfig", () {
+    test("captures parsed values for every declared option", () {
+      final parser = ArgParser();
+      registerPluginOptions(parser: parser, options: _options);
+      final results = parser.parse(const ["--port", "4096", "--no-auto-start"]);
+
+      final config = parsePluginConfig(options: _options, results: results);
+      expect(config.intValue("port"), 4096);
+      expect(config.flag("no-auto-start"), isTrue);
+      expect(config.value("password"), "");
+      expect(config.value("opencode-bin"), "opencode");
+    });
+
+    test("runs validate hooks on present, non-empty values", () {
+      final parser = ArgParser();
+      registerPluginOptions(parser: parser, options: _options);
+      final results = parser.parse(const ["--port", "not-a-number"]);
+
+      expect(
+        () => parsePluginConfig(options: _options, results: results),
+        throwsA(
+          isA<PluginConfigException>().having((e) => e.message, "message", contains("--port")),
+        ),
+      );
+    });
+
+    test("skips validate hooks for absent and empty values", () {
+      final parser = ArgParser();
+      registerPluginOptions(parser: parser, options: _options);
+
+      final absent = parsePluginConfig(options: _options, results: parser.parse(const []));
+      expect(absent.intValue("port"), isNull);
+
+      final empty = parsePluginConfig(options: _options, results: parser.parse(const ["--port", ""]));
+      expect(empty.intValue("port"), isNull);
+    });
+  });
+}
+
+const List<PluginOption> _options = [
+  PluginValueOption.integer(
+    name: "port",
+    help: "Port for opencode server to listen on",
+    defaultsTo: null,
+    valueHelp: null,
+  ),
+  PluginFlagOption(
+    name: "no-auto-start",
+    help: "Skip auto-starting opencode server (use existing localhost server)",
+    defaultsTo: false,
+    negatable: true,
+  ),
+  PluginValueOption(
+    name: "password",
+    help: "Override server password (auto-generated if not set)",
+    defaultsTo: "",
+    allowedValues: null,
+    valueHelp: null,
+    validate: null,
+  ),
+  PluginValueOption(
+    name: "opencode-bin",
+    help: "Path to opencode binary",
+    defaultsTo: "opencode",
+    allowedValues: null,
+    valueHelp: null,
+    validate: null,
+  ),
+];

--- a/bridge/app/test/bridge/runtime/plugin_failure_latch_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_failure_latch_test.dart
@@ -1,0 +1,47 @@
+import "package:sesori_bridge/src/bridge/runtime/plugin_failure_latch.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginFailed;
+import "package:test/test.dart";
+
+void main() {
+  group("PluginFailureLatch", () {
+    test("latches the first failure and ignores later ones", () {
+      final latch = PluginFailureLatch();
+
+      latch.record(const PluginFailed(reason: "runtime exited", cause: null));
+      latch.record(const PluginFailed(reason: "second failure", cause: null));
+
+      expect(latch.failure?.reason, "runtime exited");
+    });
+
+    test("fires the bound reaction when a failure arrives after binding", () {
+      final latch = PluginFailureLatch();
+      final reactions = <PluginFailed>[];
+      latch.bind(reactions.add);
+
+      latch.record(const PluginFailed(reason: "runtime exited", cause: null));
+
+      expect(reactions.map((failure) => failure.reason), ["runtime exited"]);
+    });
+
+    test("fires immediately when binding after the failure was latched", () {
+      final latch = PluginFailureLatch();
+      latch.record(const PluginFailed(reason: "runtime exited", cause: null));
+
+      final reactions = <PluginFailed>[];
+      latch.bind(reactions.add);
+
+      expect(reactions.map((failure) => failure.reason), ["runtime exited"]);
+    });
+
+    test("reacts at most once for a single latched failure", () {
+      final latch = PluginFailureLatch();
+      final reactions = <PluginFailed>[];
+      latch.bind(reactions.add);
+
+      latch.record(const PluginFailed(reason: "runtime exited", cause: null));
+      latch.record(const PluginFailed(reason: "noise", cause: null));
+
+      expect(reactions, hasLength(1));
+    });
+  });
+}


### PR DESCRIPTION
Part of the [plugin lifecycle migration plan](docs/plans/plugin-lifecycle-migration.html) — **PR 4/15, the seam flip** (flagged riskiest in the plan; kept surgical).

## What

The runner now consumes the `BridgePluginDescriptor → start(PluginHost) → BridgePlugin` contract while **zero OpenCode lifecycle code moves**:

- **`LegacyOpenCodeDescriptor`** (bridge-app-internal, deleted at the flip in PR 12) wraps today's exact flow: the four CLI options with historical names/help/defaults, `validateConfig` = the `--no-auto-start`-requires-`--port` rule, and `start(host)` = the `validateExistingServer`/`start` + ownership-record flow, constructing the `OpenCodePlugin` and returning a **`LegacyOpenCodeBridgePlugin`** wrapper.
- **Wrapper `shutdown()`** folds in what `registerOwnedOpenCodeShutdown` used to register: api dispose **then** owned-server stop, in order. Idempotent (memoized future), safe before/after the orchestrator's direct `_plugin.dispose()` (still called until PR 12 — covered by a dedicated double-dispose test), and a dispose failure cannot skip the owned-server stop.
- **Runner** (`bridge_runtime_runner.dart`): `BridgePluginFactory` typedef and `_createOpenCodePlugin` deleted. Sequence: mutex → `enforceSingleLiveBridge` → build `BridgePluginHostImpl` (store shares the runner's `RuntimeFileApi` over `<cacheDir>/runtime`) → `descriptor.start(host)`, mutex held until `start()` settles. `PluginStartAbortedException` → "aborted as requested" (exit 0, dormant until the supervisor adds abort checks).
- **Parse-time validation**: plugin option validate hooks (`PluginValueOption.integer` for `--port`) and `validateConfig` run at argument-parse time in `bin/bridge.dart`, strictly before the mutex and before `enforceSingleLiveBridge`; `PluginConfigException` maps to the usage-error flow. `--help` output verified byte-identical.
- **Shutdown coordinator**: ordered phase before the parallel phase; process-wide backstop armed before the ordered phase, sized budget + slack, exit code derived from the **terminal-failure latch** (exit 1 if `PluginFailed` was recorded). Ordered-step errors don't block later teardown but rethrow after both phases, so a failed owned-server stop still surfaces loudly (non-zero exit), exactly as it did as a parallel disposable.
- **Failure latch**: first `PluginFailed` recorded from the moment `start()` returns, checked right before `session.run()`, late-bound to `session.cancel()` after. Honest scope: nothing can emit `PluginFailed` after a successful start until the exit monitor activates in PR 12.

`resolveServer`, `BridgeServerRuntime`, and `registerOwnedOpenCodeShutdown` deliberately remain (now production-dead) for PR 13's deletion sweep. `BridgeConfig.serverURL/serverPassword` stay, fed from the wrapper, so the orchestrator is untouched.

## Behavior deltas (deliberate, per the plan card)

1. Plugin shutdown is **ordered** (was: parallel race between SSE teardown and OpenCode kill).
2. The shutdown backstop's exit code is **latch-aware** (was: always `exit(0)`).
3. A non-numeric `--port` is a clean usage error (was: unhandled `FormatException` crash).

Everything else byte-identical: flags, log lines, exception messages, ownership-file timing and bytes (frozen contract untouched — this PR adds no new writes to `<cacheDir>/runtime`).

## Tests

- `legacy_opencode_descriptor_test.dart` (new): config validation, all four start flows, shutdown ordering/idempotency, **double-dispose path**, dispose-failure-still-stops-server, status machine + stream close.
- `bridge_runtime_server_test.dart` repointed at the live `BridgeRuntimeRunner.startLegacyOpenCodePlugin` orchestration (mutex→singleton→start ordering, declined/non-interactive/locked aborts, attach flow). The parse-time rule moved with its code to the descriptor/binding tests.
- `bridge_shutdown_coordinator_test.dart`, `plugin_cli_binding_test.dart`, `plugin_failure_latch_test.dart` (new).
- `dart analyze --fatal-infos` clean; full bridge/app suite green (1,273 tests). Manual smoke: `--help` byte-identical; usage errors for `--port abc` and bare `--no-auto-start`; live run correctly aborted non-interactively against a resident bridge without touching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flip the runner to the BridgePluginDescriptor → BridgePlugin seam using a legacy OpenCode wrapper so behavior stays the same while enabling ordered shutdown and safer startup/shutdown handling.

- **New Features**
  - Runner starts via `LegacyOpenCodeDescriptor.start(host)` under the startup mutex, after single-bridge enforcement.
  - The plugin declares its four OpenCode CLI flags; validation runs at parse time; `--help` output unchanged.
  - Ordered shutdown: plugin `shutdown(budget)` runs before parallel disposables; process backstop exit code derives from a terminal-failure latch.
  - Failure latch records the first `PluginFailed`, cancels the session, and sets a non-zero exit code.
  - Start abort maps to exit 0 with a clear message (ready for future supervisor-driven aborts).
  - Orchestrator remains unchanged; `serverURL/serverPassword` come from the wrapper. No new writes to `<cacheDir>/runtime`.

- **Bug Fixes**
  - Non-numeric `--port` is now a clean usage error (previously crashed with `FormatException`).
  - Owned OpenCode server stop is guaranteed even if API dispose fails; shutdown is idempotent and double-dispose safe.
  - Parallel disposables run via `Future.sync`, so a synchronously throwing disposable can’t skip later disposables.

<sup>Written for commit e68310537d6032fa74aaff1b9665ba53d03158ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

