### PR TITLE
feat: surface retry state in session list

### DIFF
--- a/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
@@ -186,6 +186,7 @@ class BridgeEventMapper {
                         id: a.id,
                         mainAgentRunning: a.mainAgentRunning,
                         awaitingInput: a.awaitingInput,
+                        isRetrying: a.isRetrying,
                         childSessionIds: a.childSessionIds,
                       ),
                     )

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_active_session.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_active_session.dart
@@ -13,6 +13,7 @@ sealed class PluginActiveSession with _$PluginActiveSession {
     required String id,
     @Default(false) bool mainAgentRunning,
     @Default(false) bool awaitingInput,
+    @Default(false) bool isRetrying,
     @Default([]) List<String> childSessionIds,
   }) = _PluginActiveSession;
 }

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_active_session.freezed.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_active_session.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$PluginActiveSession {
 
- String get id; bool get mainAgentRunning; bool get awaitingInput; List<String> get childSessionIds;
+ String get id; bool get mainAgentRunning; bool get awaitingInput; bool get isRetrying; List<String> get childSessionIds;
 /// Create a copy of PluginActiveSession
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -27,16 +27,16 @@ $PluginActiveSessionCopyWith<PluginActiveSession> get copyWith => _$PluginActive
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&const DeepCollectionEquality().equals(other.childSessionIds, childSessionIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&(identical(other.isRetrying, isRetrying) || other.isRetrying == isRetrying)&&const DeepCollectionEquality().equals(other.childSessionIds, childSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,awaitingInput,const DeepCollectionEquality().hash(childSessionIds));
+int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,awaitingInput,isRetrying,const DeepCollectionEquality().hash(childSessionIds));
 
 @override
 String toString() {
-  return 'PluginActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, childSessionIds: $childSessionIds)';
+  return 'PluginActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, isRetrying: $isRetrying, childSessionIds: $childSessionIds)';
 }
 
 
@@ -47,7 +47,7 @@ abstract mixin class $PluginActiveSessionCopyWith<$Res>  {
   factory $PluginActiveSessionCopyWith(PluginActiveSession value, $Res Function(PluginActiveSession) _then) = _$PluginActiveSessionCopyWithImpl;
 @useResult
 $Res call({
- String id, bool mainAgentRunning, bool awaitingInput, List<String> childSessionIds
+ String id, bool mainAgentRunning, bool awaitingInput, bool isRetrying, List<String> childSessionIds
 });
 
 
@@ -64,11 +64,12 @@ class _$PluginActiveSessionCopyWithImpl<$Res>
 
 /// Create a copy of PluginActiveSession
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? mainAgentRunning = null,Object? awaitingInput = null,Object? childSessionIds = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? mainAgentRunning = null,Object? awaitingInput = null,Object? isRetrying = null,Object? childSessionIds = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
 as bool,awaitingInput: null == awaitingInput ? _self.awaitingInput : awaitingInput // ignore: cast_nullable_to_non_nullable
+as bool,isRetrying: null == isRetrying ? _self.isRetrying : isRetrying // ignore: cast_nullable_to_non_nullable
 as bool,childSessionIds: null == childSessionIds ? _self.childSessionIds : childSessionIds // ignore: cast_nullable_to_non_nullable
 as List<String>,
   ));
@@ -82,12 +83,13 @@ as List<String>,
 @JsonSerializable(createFactory: false)
 
 class _PluginActiveSession implements PluginActiveSession {
-  const _PluginActiveSession({required this.id, this.mainAgentRunning = false, this.awaitingInput = false, final  List<String> childSessionIds = const []}): _childSessionIds = childSessionIds;
+  const _PluginActiveSession({required this.id, this.mainAgentRunning = false, this.awaitingInput = false, this.isRetrying = false, final  List<String> childSessionIds = const []}): _childSessionIds = childSessionIds;
   
 
 @override final  String id;
 @override@JsonKey() final  bool mainAgentRunning;
 @override@JsonKey() final  bool awaitingInput;
+@override@JsonKey() final  bool isRetrying;
  final  List<String> _childSessionIds;
 @override@JsonKey() List<String> get childSessionIds {
   if (_childSessionIds is EqualUnmodifiableListView) return _childSessionIds;
@@ -109,16 +111,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&const DeepCollectionEquality().equals(other._childSessionIds, _childSessionIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&(identical(other.isRetrying, isRetrying) || other.isRetrying == isRetrying)&&const DeepCollectionEquality().equals(other._childSessionIds, _childSessionIds));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,awaitingInput,const DeepCollectionEquality().hash(_childSessionIds));
+int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,awaitingInput,isRetrying,const DeepCollectionEquality().hash(_childSessionIds));
 
 @override
 String toString() {
-  return 'PluginActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, childSessionIds: $childSessionIds)';
+  return 'PluginActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, isRetrying: $isRetrying, childSessionIds: $childSessionIds)';
 }
 
 
@@ -129,7 +131,7 @@ abstract mixin class _$PluginActiveSessionCopyWith<$Res> implements $PluginActiv
   factory _$PluginActiveSessionCopyWith(_PluginActiveSession value, $Res Function(_PluginActiveSession) _then) = __$PluginActiveSessionCopyWithImpl;
 @override @useResult
 $Res call({
- String id, bool mainAgentRunning, bool awaitingInput, List<String> childSessionIds
+ String id, bool mainAgentRunning, bool awaitingInput, bool isRetrying, List<String> childSessionIds
 });
 
 
@@ -146,11 +148,12 @@ class __$PluginActiveSessionCopyWithImpl<$Res>
 
 /// Create a copy of PluginActiveSession
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? mainAgentRunning = null,Object? awaitingInput = null,Object? childSessionIds = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? mainAgentRunning = null,Object? awaitingInput = null,Object? isRetrying = null,Object? childSessionIds = null,}) {
   return _then(_PluginActiveSession(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
 as bool,awaitingInput: null == awaitingInput ? _self.awaitingInput : awaitingInput // ignore: cast_nullable_to_non_nullable
+as bool,isRetrying: null == isRetrying ? _self.isRetrying : isRetrying // ignore: cast_nullable_to_non_nullable
 as bool,childSessionIds: null == childSessionIds ? _self._childSessionIds : childSessionIds // ignore: cast_nullable_to_non_nullable
 as List<String>,
   ));

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_active_session.g.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_active_session.g.dart
@@ -12,5 +12,6 @@ Map<String, dynamic> _$PluginActiveSessionToJson(
   'id': instance.id,
   'mainAgentRunning': instance.mainAgentRunning,
   'awaitingInput': instance.awaitingInput,
+  'isRetrying': instance.isRetrying,
   'childSessionIds': instance.childSessionIds,
 };

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -22,7 +22,7 @@ class ActiveSessionTracker {
   final Map<String, String?> _sessionParentIds = {};
 
   Map<String, int> _lastEmittedActiveSessions = {};
-  Map<String, int> _lastEmittedRetrySessions = {};
+  Set<String> _lastEmittedRetrySessions = {};
   Set<String> _lastEmittedPendingInputSessions = {};
 
   ActiveSessionTracker(this._repository);
@@ -94,7 +94,7 @@ class ActiveSessionTracker {
     }
 
     _lastEmittedActiveSessions = _activeSessionCounts;
-    _lastEmittedRetrySessions = _retrySessionCounts;
+    _lastEmittedRetrySessions = _retryingSessionIds;
     _lastEmittedPendingInputSessions = _pendingInputSessions;
   }
 
@@ -156,11 +156,11 @@ class ActiveSessionTracker {
     }
 
     final next = _activeSessionCounts;
-    final nextRetry = _retrySessionCounts;
+    final nextRetry = _retryingSessionIds;
     final nextPendingInputSessions = _pendingInputSessions;
     if (!forceReemit &&
         _mapsEqual(_lastEmittedActiveSessions, next) &&
-        _mapsEqual(_lastEmittedRetrySessions, nextRetry) &&
+        _setsEqual(_lastEmittedRetrySessions, nextRetry) &&
         _setsEqual(_lastEmittedPendingInputSessions, nextPendingInputSessions)) {
       return false;
     }
@@ -222,11 +222,11 @@ class ActiveSessionTracker {
     }
 
     final nextActive = _activeSessionCounts;
-    final nextRetry = _retrySessionCounts;
+    final nextRetry = _retryingSessionIds;
     final nextPending = _pendingInputSessions;
 
     if (_mapsEqual(_lastEmittedActiveSessions, nextActive) &&
-        _mapsEqual(_lastEmittedRetrySessions, nextRetry) &&
+        _setsEqual(_lastEmittedRetrySessions, nextRetry) &&
         _setsEqual(_lastEmittedPendingInputSessions, nextPending)) {
       return false;
     }
@@ -348,19 +348,17 @@ class ActiveSessionTracker {
     return counts;
   }
 
-  /// Count of retrying sessions per worktree.
+  /// Set of session IDs that are currently in retry state.
   ///
   /// Used for change detection so that a busy→retry transition (where the
   /// per-worktree active count does not change) still triggers a re-emit.
-  Map<String, int> get _retrySessionCounts {
-    final counts = <String, int>{};
-    for (final entry in _sessionStatuses.entries) {
-      if (entry.value is! SessionStatusRetry) continue;
-      final worktree = _sessionWorktrees[entry.key];
-      if (worktree == null) continue;
-      counts[worktree] = (counts[worktree] ?? 0) + 1;
-    }
-    return counts;
+  /// Tracking individual IDs rather than counts ensures session-level swaps
+  /// (A stops retrying while B starts) are also detected.
+  Set<String> get _retryingSessionIds {
+    return _sessionStatuses.entries
+        .where((e) => e.value is SessionStatusRetry)
+        .map((e) => e.key)
+        .toSet();
   }
 
   /// Exposed for testing: raw count of all busy/retry sessions per worktree.

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -22,6 +22,7 @@ class ActiveSessionTracker {
   final Map<String, String?> _sessionParentIds = {};
 
   Map<String, int> _lastEmittedActiveSessions = {};
+  Map<String, int> _lastEmittedRetrySessions = {};
   Set<String> _lastEmittedPendingInputSessions = {};
 
   ActiveSessionTracker(this._repository);
@@ -93,6 +94,7 @@ class ActiveSessionTracker {
     }
 
     _lastEmittedActiveSessions = _activeSessionCounts;
+    _lastEmittedRetrySessions = _retrySessionCounts;
     _lastEmittedPendingInputSessions = _pendingInputSessions;
   }
 
@@ -154,13 +156,16 @@ class ActiveSessionTracker {
     }
 
     final next = _activeSessionCounts;
+    final nextRetry = _retrySessionCounts;
     final nextPendingInputSessions = _pendingInputSessions;
     if (!forceReemit &&
         _mapsEqual(_lastEmittedActiveSessions, next) &&
+        _mapsEqual(_lastEmittedRetrySessions, nextRetry) &&
         _setsEqual(_lastEmittedPendingInputSessions, nextPendingInputSessions)) {
       return false;
     }
     _lastEmittedActiveSessions = next;
+    _lastEmittedRetrySessions = nextRetry;
     _lastEmittedPendingInputSessions = nextPendingInputSessions;
     return true;
   }
@@ -174,6 +179,7 @@ class ActiveSessionTracker {
     _pendingQuestions.clear();
     _pendingPermissions.clear();
     _lastEmittedActiveSessions = {};
+    _lastEmittedRetrySessions = {};
     _lastEmittedPendingInputSessions = {};
   }
 
@@ -216,14 +222,17 @@ class ActiveSessionTracker {
     }
 
     final nextActive = _activeSessionCounts;
+    final nextRetry = _retrySessionCounts;
     final nextPending = _pendingInputSessions;
 
     if (_mapsEqual(_lastEmittedActiveSessions, nextActive) &&
+        _mapsEqual(_lastEmittedRetrySessions, nextRetry) &&
         _setsEqual(_lastEmittedPendingInputSessions, nextPending)) {
       return false;
     }
 
     _lastEmittedActiveSessions = nextActive;
+    _lastEmittedRetrySessions = nextRetry;
     _lastEmittedPendingInputSessions = nextPending;
     return true;
   }
@@ -300,6 +309,8 @@ class ActiveSessionTracker {
         continue;
       }
       final children = activeChildrenByParent[rootId] ?? const <String>[];
+      final isRetrying = _sessionStatuses[rootId] is SessionStatusRetry ||
+          children.any((childId) => _sessionStatuses[childId] is SessionStatusRetry);
       byWorktree
           .putIfAbsent(worktree, () => [])
           .add(
@@ -307,6 +318,7 @@ class ActiveSessionTracker {
               id: rootId,
               mainAgentRunning: activeRoots.contains(rootId),
               awaitingInput: _rootHasPendingInput(rootId, children),
+              isRetrying: isRetrying,
               childSessionIds: children,
             ),
           );
@@ -329,6 +341,21 @@ class ActiveSessionTracker {
   Map<String, int> get _activeSessionCounts {
     final counts = <String, int>{};
     for (final entry in _sessionStatuses.entries) {
+      final worktree = _sessionWorktrees[entry.key];
+      if (worktree == null) continue;
+      counts[worktree] = (counts[worktree] ?? 0) + 1;
+    }
+    return counts;
+  }
+
+  /// Count of retrying sessions per worktree.
+  ///
+  /// Used for change detection so that a busy→retry transition (where the
+  /// per-worktree active count does not change) still triggers a re-emit.
+  Map<String, int> get _retrySessionCounts {
+    final counts = <String, int>{};
+    for (final entry in _sessionStatuses.entries) {
+      if (entry.value is! SessionStatusRetry) continue;
       final worktree = _sessionWorktrees[entry.key];
       if (worktree == null) continue;
       counts[worktree] = (counts[worktree] ?? 0) + 1;

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -580,6 +580,7 @@ class OpenCodePlugin implements BridgePluginApi {
                     id: a.id,
                     mainAgentRunning: a.mainAgentRunning,
                     awaitingInput: a.awaitingInput,
+                    isRetrying: a.isRetrying,
                     childSessionIds: a.childSessionIds,
                   ),
                 )

--- a/mobile/app/lib/features/session_list/session_list_screen.dart
+++ b/mobile/app/lib/features/session_list/session_list_screen.dart
@@ -199,6 +199,7 @@ class _SessionListBody extends StatelessWidget {
                             isArchived: isArchived,
                             isActive: activityInfo != null,
                             awaitingInput: activityInfo?.awaitingInput ?? false,
+                            isRetrying: activityInfo?.isRetrying ?? false,
                             backgroundTaskCount: activityInfo?.backgroundTaskCount ?? 0,
                             onLongPress: () => _showSessionActions(context: context, session: session),
                             onSwipe: () => isArchived

--- a/mobile/app/lib/features/session_list/session_list_widgets.dart
+++ b/mobile/app/lib/features/session_list/session_list_widgets.dart
@@ -116,7 +116,7 @@ Widget _buildActivityRow({
   };
   final label = switch ((awaitingInput, isRetrying)) {
     (true, _) => loc.sessionListAwaitingInput,
-    (_, true) => "${loc.sessionListRunning} (retrying)",
+    (_, true) => loc.sessionListRunningRetrying,
     _ => loc.sessionListRunning,
   };
 

--- a/mobile/app/lib/features/session_list/session_list_widgets.dart
+++ b/mobile/app/lib/features/session_list/session_list_widgets.dart
@@ -6,6 +6,7 @@ class _SessionTile extends StatelessWidget {
   final bool isArchived;
   final bool isActive;
   final bool awaitingInput;
+  final bool isRetrying;
   final int backgroundTaskCount;
   final VoidCallback onLongPress;
   final VoidCallback onSwipe;
@@ -16,6 +17,7 @@ class _SessionTile extends StatelessWidget {
     required this.isArchived,
     required this.isActive,
     this.awaitingInput = false,
+    this.isRetrying = false,
     this.backgroundTaskCount = 0,
     required this.onLongPress,
     required this.onSwipe,
@@ -77,6 +79,7 @@ class _SessionTile extends StatelessWidget {
                 context: context,
                 loc: loc,
                 awaitingInput: awaitingInput,
+                isRetrying: isRetrying,
                 backgroundTaskCount: backgroundTaskCount,
               ),
           ],
@@ -103,10 +106,19 @@ Widget _buildActivityRow({
   required BuildContext context,
   required AppLocalizations loc,
   required bool awaitingInput,
+  required bool isRetrying,
   required int backgroundTaskCount,
 }) {
-  final color = awaitingInput ? kStatusAmber : context.zyra.colors.bgBrandSolid;
-  final label = awaitingInput ? loc.sessionListAwaitingInput : loc.sessionListRunning;
+  final color = switch ((awaitingInput, isRetrying)) {
+    (true, _) => kStatusAmber,
+    (_, true) => context.zyra.colors.fgErrorPrimary,
+    _ => context.zyra.colors.bgBrandSolid,
+  };
+  final label = switch ((awaitingInput, isRetrying)) {
+    (true, _) => loc.sessionListAwaitingInput,
+    (_, true) => "${loc.sessionListRunning} (retrying)",
+    _ => loc.sessionListRunning,
+  };
 
   return Row(
     children: [

--- a/mobile/app/lib/l10n/app_en.arb
+++ b/mobile/app/lib/l10n/app_en.arb
@@ -237,6 +237,10 @@
   "@sessionListRunning": {
     "description": "Label shown next to the green dot for sessions that are currently active"
   },
+  "sessionListRunningRetrying": "Running (retrying)",
+  "@sessionListRunningRetrying": {
+    "description": "Label shown next to the red dot for sessions that are active but in a retry/error state"
+  },
   "sessionListAwaitingInput": "Awaiting input",
   "@sessionListAwaitingInput": {
     "description": "Label shown next to the amber dot for sessions that are waiting for user input (question or permission)"

--- a/mobile/app/lib/l10n/app_localizations.dart
+++ b/mobile/app/lib/l10n/app_localizations.dart
@@ -997,6 +997,12 @@ abstract class AppLocalizations {
   /// **'Running'**
   String get sessionListRunning;
 
+  /// Label shown next to the red dot for sessions that are active but in a retry/error state
+  ///
+  /// In en, this message translates to:
+  /// **'Running (retrying)'**
+  String get sessionListRunningRetrying;
+
   /// Label shown next to the amber dot for sessions that are waiting for user input (question or permission)
   ///
   /// In en, this message translates to:

--- a/mobile/app/lib/l10n/app_localizations_en.dart
+++ b/mobile/app/lib/l10n/app_localizations_en.dart
@@ -505,6 +505,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionListRunning => 'Running';
 
   @override
+  String get sessionListRunningRetrying => 'Running (retrying)';
+
+  @override
   String get sessionListAwaitingInput => 'Awaiting input';
 
   @override

--- a/mobile/module_core/lib/src/capabilities/sse/session_activity_info.dart
+++ b/mobile/module_core/lib/src/capabilities/sse/session_activity_info.dart
@@ -12,5 +12,6 @@ sealed class SessionActivityInfo with _$SessionActivityInfo {
     @Default(false) bool mainAgentRunning,
     @Default(false) bool awaitingInput,
     @Default(0) int backgroundTaskCount,
+    @Default(false) bool isRetrying,
   }) = _SessionActivityInfo;
 }

--- a/mobile/module_core/lib/src/capabilities/sse/session_activity_info.freezed.dart
+++ b/mobile/module_core/lib/src/capabilities/sse/session_activity_info.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$SessionActivityInfo {
 
- bool get mainAgentRunning; bool get awaitingInput; int get backgroundTaskCount;
+ bool get mainAgentRunning; bool get awaitingInput; int get backgroundTaskCount; bool get isRetrying;
 /// Create a copy of SessionActivityInfo
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $SessionActivityInfoCopyWith<SessionActivityInfo> get copyWith => _$SessionActiv
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionActivityInfo&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&(identical(other.backgroundTaskCount, backgroundTaskCount) || other.backgroundTaskCount == backgroundTaskCount));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionActivityInfo&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&(identical(other.backgroundTaskCount, backgroundTaskCount) || other.backgroundTaskCount == backgroundTaskCount)&&(identical(other.isRetrying, isRetrying) || other.isRetrying == isRetrying));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,mainAgentRunning,awaitingInput,backgroundTaskCount);
+int get hashCode => Object.hash(runtimeType,mainAgentRunning,awaitingInput,backgroundTaskCount,isRetrying);
 
 @override
 String toString() {
-  return 'SessionActivityInfo(mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, backgroundTaskCount: $backgroundTaskCount)';
+  return 'SessionActivityInfo(mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, backgroundTaskCount: $backgroundTaskCount, isRetrying: $isRetrying)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $SessionActivityInfoCopyWith<$Res>  {
   factory $SessionActivityInfoCopyWith(SessionActivityInfo value, $Res Function(SessionActivityInfo) _then) = _$SessionActivityInfoCopyWithImpl;
 @useResult
 $Res call({
- bool mainAgentRunning, bool awaitingInput, int backgroundTaskCount
+ bool mainAgentRunning, bool awaitingInput, int backgroundTaskCount, bool isRetrying
 });
 
 
@@ -62,12 +62,13 @@ class _$SessionActivityInfoCopyWithImpl<$Res>
 
 /// Create a copy of SessionActivityInfo
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? mainAgentRunning = null,Object? awaitingInput = null,Object? backgroundTaskCount = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? mainAgentRunning = null,Object? awaitingInput = null,Object? backgroundTaskCount = null,Object? isRetrying = null,}) {
   return _then(_self.copyWith(
 mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
 as bool,awaitingInput: null == awaitingInput ? _self.awaitingInput : awaitingInput // ignore: cast_nullable_to_non_nullable
 as bool,backgroundTaskCount: null == backgroundTaskCount ? _self.backgroundTaskCount : backgroundTaskCount // ignore: cast_nullable_to_non_nullable
-as int,
+as int,isRetrying: null == isRetrying ? _self.isRetrying : isRetrying // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 
@@ -79,12 +80,13 @@ as int,
 
 
 class _SessionActivityInfo implements SessionActivityInfo {
-  const _SessionActivityInfo({this.mainAgentRunning = false, this.awaitingInput = false, this.backgroundTaskCount = 0});
+  const _SessionActivityInfo({this.mainAgentRunning = false, this.awaitingInput = false, this.backgroundTaskCount = 0, this.isRetrying = false});
   
 
 @override@JsonKey() final  bool mainAgentRunning;
 @override@JsonKey() final  bool awaitingInput;
 @override@JsonKey() final  int backgroundTaskCount;
+@override@JsonKey() final  bool isRetrying;
 
 /// Create a copy of SessionActivityInfo
 /// with the given fields replaced by the non-null parameter values.
@@ -96,16 +98,16 @@ _$SessionActivityInfoCopyWith<_SessionActivityInfo> get copyWith => __$SessionAc
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionActivityInfo&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&(identical(other.backgroundTaskCount, backgroundTaskCount) || other.backgroundTaskCount == backgroundTaskCount));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionActivityInfo&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&(identical(other.backgroundTaskCount, backgroundTaskCount) || other.backgroundTaskCount == backgroundTaskCount)&&(identical(other.isRetrying, isRetrying) || other.isRetrying == isRetrying));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,mainAgentRunning,awaitingInput,backgroundTaskCount);
+int get hashCode => Object.hash(runtimeType,mainAgentRunning,awaitingInput,backgroundTaskCount,isRetrying);
 
 @override
 String toString() {
-  return 'SessionActivityInfo(mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, backgroundTaskCount: $backgroundTaskCount)';
+  return 'SessionActivityInfo(mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, backgroundTaskCount: $backgroundTaskCount, isRetrying: $isRetrying)';
 }
 
 
@@ -116,7 +118,7 @@ abstract mixin class _$SessionActivityInfoCopyWith<$Res> implements $SessionActi
   factory _$SessionActivityInfoCopyWith(_SessionActivityInfo value, $Res Function(_SessionActivityInfo) _then) = __$SessionActivityInfoCopyWithImpl;
 @override @useResult
 $Res call({
- bool mainAgentRunning, bool awaitingInput, int backgroundTaskCount
+ bool mainAgentRunning, bool awaitingInput, int backgroundTaskCount, bool isRetrying
 });
 
 
@@ -133,12 +135,13 @@ class __$SessionActivityInfoCopyWithImpl<$Res>
 
 /// Create a copy of SessionActivityInfo
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? mainAgentRunning = null,Object? awaitingInput = null,Object? backgroundTaskCount = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? mainAgentRunning = null,Object? awaitingInput = null,Object? backgroundTaskCount = null,Object? isRetrying = null,}) {
   return _then(_SessionActivityInfo(
 mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
 as bool,awaitingInput: null == awaitingInput ? _self.awaitingInput : awaitingInput // ignore: cast_nullable_to_non_nullable
 as bool,backgroundTaskCount: null == backgroundTaskCount ? _self.backgroundTaskCount : backgroundTaskCount // ignore: cast_nullable_to_non_nullable
-as int,
+as int,isRetrying: null == isRetrying ? _self.isRetrying : isRetrying // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart
+++ b/mobile/module_core/lib/src/capabilities/sse/sse_event_repository.dart
@@ -65,6 +65,7 @@ class SseEventRepository with Disposable {
                 mainAgentRunning: session.mainAgentRunning,
                 awaitingInput: session.awaitingInput,
                 backgroundTaskCount: session.childSessionIds.length,
+                isRetrying: session.isRetrying,
               );
             }
             sessionMap[summary.id] = infoMap;

--- a/shared/sesori_shared/lib/src/models/sesori/active_session.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/active_session.dart
@@ -16,6 +16,7 @@ sealed class ActiveSession with _$ActiveSession {
     @Default(false) bool mainAgentRunning,
     @Default(false) bool awaitingInput,
     @Default([]) List<String> childSessionIds,
+    @Default(false) bool isRetrying,
   }) = _ActiveSession;
 
   factory ActiveSession.fromJson(Map<String, dynamic> json) => _$ActiveSessionFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/active_session.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/active_session.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ActiveSession {
 
- String get id; bool get mainAgentRunning; bool get awaitingInput; List<String> get childSessionIds;
+ String get id; bool get mainAgentRunning; bool get awaitingInput; List<String> get childSessionIds; bool get isRetrying;
 /// Create a copy of ActiveSession
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $ActiveSessionCopyWith<ActiveSession> get copyWith => _$ActiveSessionCopyWithImp
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&const DeepCollectionEquality().equals(other.childSessionIds, childSessionIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&const DeepCollectionEquality().equals(other.childSessionIds, childSessionIds)&&(identical(other.isRetrying, isRetrying) || other.isRetrying == isRetrying));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,awaitingInput,const DeepCollectionEquality().hash(childSessionIds));
+int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,awaitingInput,const DeepCollectionEquality().hash(childSessionIds),isRetrying);
 
 @override
 String toString() {
-  return 'ActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, childSessionIds: $childSessionIds)';
+  return 'ActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, childSessionIds: $childSessionIds, isRetrying: $isRetrying)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $ActiveSessionCopyWith<$Res>  {
   factory $ActiveSessionCopyWith(ActiveSession value, $Res Function(ActiveSession) _then) = _$ActiveSessionCopyWithImpl;
 @useResult
 $Res call({
- String id, bool mainAgentRunning, bool awaitingInput, List<String> childSessionIds
+ String id, bool mainAgentRunning, bool awaitingInput, List<String> childSessionIds, bool isRetrying
 });
 
 
@@ -65,13 +65,14 @@ class _$ActiveSessionCopyWithImpl<$Res>
 
 /// Create a copy of ActiveSession
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? mainAgentRunning = null,Object? awaitingInput = null,Object? childSessionIds = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? mainAgentRunning = null,Object? awaitingInput = null,Object? childSessionIds = null,Object? isRetrying = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
 as bool,awaitingInput: null == awaitingInput ? _self.awaitingInput : awaitingInput // ignore: cast_nullable_to_non_nullable
 as bool,childSessionIds: null == childSessionIds ? _self.childSessionIds : childSessionIds // ignore: cast_nullable_to_non_nullable
-as List<String>,
+as List<String>,isRetrying: null == isRetrying ? _self.isRetrying : isRetrying // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 
@@ -83,7 +84,7 @@ as List<String>,
 @JsonSerializable()
 
 class _ActiveSession implements ActiveSession {
-  const _ActiveSession({required this.id, this.mainAgentRunning = false, this.awaitingInput = false, final  List<String> childSessionIds = const []}): _childSessionIds = childSessionIds;
+  const _ActiveSession({required this.id, this.mainAgentRunning = false, this.awaitingInput = false, final  List<String> childSessionIds = const [], this.isRetrying = false}): _childSessionIds = childSessionIds;
   factory _ActiveSession.fromJson(Map<String, dynamic> json) => _$ActiveSessionFromJson(json);
 
 @override final  String id;
@@ -96,6 +97,7 @@ class _ActiveSession implements ActiveSession {
   return EqualUnmodifiableListView(_childSessionIds);
 }
 
+@override@JsonKey() final  bool isRetrying;
 
 /// Create a copy of ActiveSession
 /// with the given fields replaced by the non-null parameter values.
@@ -110,16 +112,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&const DeepCollectionEquality().equals(other._childSessionIds, _childSessionIds));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ActiveSession&&(identical(other.id, id) || other.id == id)&&(identical(other.mainAgentRunning, mainAgentRunning) || other.mainAgentRunning == mainAgentRunning)&&(identical(other.awaitingInput, awaitingInput) || other.awaitingInput == awaitingInput)&&const DeepCollectionEquality().equals(other._childSessionIds, _childSessionIds)&&(identical(other.isRetrying, isRetrying) || other.isRetrying == isRetrying));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,awaitingInput,const DeepCollectionEquality().hash(_childSessionIds));
+int get hashCode => Object.hash(runtimeType,id,mainAgentRunning,awaitingInput,const DeepCollectionEquality().hash(_childSessionIds),isRetrying);
 
 @override
 String toString() {
-  return 'ActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, childSessionIds: $childSessionIds)';
+  return 'ActiveSession(id: $id, mainAgentRunning: $mainAgentRunning, awaitingInput: $awaitingInput, childSessionIds: $childSessionIds, isRetrying: $isRetrying)';
 }
 
 
@@ -130,7 +132,7 @@ abstract mixin class _$ActiveSessionCopyWith<$Res> implements $ActiveSessionCopy
   factory _$ActiveSessionCopyWith(_ActiveSession value, $Res Function(_ActiveSession) _then) = __$ActiveSessionCopyWithImpl;
 @override @useResult
 $Res call({
- String id, bool mainAgentRunning, bool awaitingInput, List<String> childSessionIds
+ String id, bool mainAgentRunning, bool awaitingInput, List<String> childSessionIds, bool isRetrying
 });
 
 
@@ -147,13 +149,14 @@ class __$ActiveSessionCopyWithImpl<$Res>
 
 /// Create a copy of ActiveSession
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? mainAgentRunning = null,Object? awaitingInput = null,Object? childSessionIds = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? mainAgentRunning = null,Object? awaitingInput = null,Object? childSessionIds = null,Object? isRetrying = null,}) {
   return _then(_ActiveSession(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,mainAgentRunning: null == mainAgentRunning ? _self.mainAgentRunning : mainAgentRunning // ignore: cast_nullable_to_non_nullable
 as bool,awaitingInput: null == awaitingInput ? _self.awaitingInput : awaitingInput // ignore: cast_nullable_to_non_nullable
 as bool,childSessionIds: null == childSessionIds ? _self._childSessionIds : childSessionIds // ignore: cast_nullable_to_non_nullable
-as List<String>,
+as List<String>,isRetrying: null == isRetrying ? _self.isRetrying : isRetrying // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/active_session.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/active_session.g.dart
@@ -15,6 +15,7 @@ _ActiveSession _$ActiveSessionFromJson(Map json) => _ActiveSession(
           ?.map((e) => e as String)
           .toList() ??
       const [],
+  isRetrying: json['isRetrying'] as bool? ?? false,
 );
 
 Map<String, dynamic> _$ActiveSessionToJson(_ActiveSession instance) =>
@@ -23,4 +24,5 @@ Map<String, dynamic> _$ActiveSessionToJson(_ActiveSession instance) =>
       'mainAgentRunning': instance.mainAgentRunning,
       'awaitingInput': instance.awaitingInput,
       'childSessionIds': instance.childSessionIds,
+      'isRetrying': instance.isRetrying,
     };

--- a/shared/sesori_shared/test/models/sesori_sse_event_test.dart
+++ b/shared/sesori_shared/test/models/sesori_sse_event_test.dart
@@ -234,8 +234,8 @@ void main() {
       final first = (json['projects'] as List)[0] as Map<String, dynamic>;
       expect(first['id'], '/foo');
       expect(first['activeSessions'], <Map<String, dynamic>>[
-        {'id': 's1', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
-        {'id': 's2', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
+        {'id': 's1', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
+        {'id': 's2', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
       ]);
       final second = (json['projects'] as List)[1] as Map<String, dynamic>;
       expect(second['id'], '/bar');
@@ -249,9 +249,9 @@ void main() {
           <String, dynamic>{
             'id': '/foo',
             'activeSessions': <Map<String, dynamic>>[
-              {'id': 's1', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
-              {'id': 's2', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
-              {'id': 's3', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
+              {'id': 's1', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
+              {'id': 's2', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
+              {'id': 's3', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
             ],
           },
         ],
@@ -444,10 +444,10 @@ void main() {
       final json = summary.toJson();
       expect(json['id'], '/my/path');
       expect(json['activeSessions'], <Map<String, dynamic>>[
-        {'id': 's1', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
-        {'id': 's2', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
-        {'id': 's3', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
-        {'id': 's4', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
+        {'id': 's1', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
+        {'id': 's2', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
+        {'id': 's3', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
+        {'id': 's4', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
       ]);
     });
 
@@ -455,15 +455,15 @@ void main() {
       final json = <String, dynamic>{
         'id': '/from/json',
         'activeSessions': <Map<String, dynamic>>[
-          {'id': 's1', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
-          {'id': 's2', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
-          {'id': 's3', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
-          {'id': 's4', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
-          {'id': 's5', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
-          {'id': 's6', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
-          {'id': 's7', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
-          {'id': 's8', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
-          {'id': 's9', 'mainAgentRunning': false, 'awaitingInput': false, 'childSessionIds': <String>[]},
+          {'id': 's1', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
+          {'id': 's2', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
+          {'id': 's3', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
+          {'id': 's4', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
+          {'id': 's5', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
+          {'id': 's6', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
+          {'id': 's7', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
+          {'id': 's8', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
+          {'id': 's9', 'mainAgentRunning': false, 'awaitingInput': false, 'isRetrying': false, 'childSessionIds': <String>[]},
         ],
       };
       final summary = ProjectActivitySummary.fromJson(json);


### PR DESCRIPTION
Show retry/temporary error state in the session list screen. When a session is in a retry state, the running indicator now shows 'Running (retrying)' in a reddish color instead of the standard primary blue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface the retry/temporary error state in the session list. The running badge now shows “Running (retrying)” in error red, and SSE re-emits when sessions enter/leave retry even if active counts don’t change.

- **New Features**
  - Added `isRetrying` to `ActiveSession`, `PluginActiveSession`, and `SessionActivityInfo`; propagated through `BridgeEventMapper`, `OpenCodePlugin`, and `SseEventRepository`.
  - Active session tracker computes `isRetrying` from root or children and tracks the set of retrying session IDs for change detection, ensuring re-emits on busy↔retry transitions and session swaps.
  - UI: `_SessionTile` accepts `isRetrying` and updates color/label; added `sessionListRunningRetrying` to l10n.

<sup>Written for commit 43bc0b76f0f850417ee352f3f9fff84ca2d04b5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

