### PR TITLE
fix(mobile): only scroll-compensate collapse when the diff header is pinned

### DIFF
--- a/mobile/app/lib/features/session_diffs/session_diffs_body.dart
+++ b/mobile/app/lib/features/session_diffs/session_diffs_body.dart
@@ -1,0 +1,213 @@
+import "package:flutter/material.dart";
+import "package:flutter_bloc/flutter_bloc.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../../core/extensions/build_context_x.dart";
+import "models/diff_file_view_model.dart";
+import "models/diff_view_model_builder.dart";
+import "widgets/diff_error_view.dart";
+import "widgets/diff_file_content_sliver.dart";
+import "widgets/diff_file_header_delegate.dart";
+
+/// Scrollable body of the diff viewer: one pinned sticky header per file
+/// with expandable diff content underneath. Owns the expand/collapse state
+/// and the post-collapse scroll compensation.
+class SessionDiffsBody extends StatefulWidget {
+  const SessionDiffsBody({super.key});
+
+  @override
+  State<SessionDiffsBody> createState() => _SessionDiffsBodyState();
+}
+
+class _SessionDiffsBodyState extends State<SessionDiffsBody> {
+  List<DiffFileViewModel>? _viewModels;
+  Set<int> _expandedFileIndices = <int>{};
+  bool _isComputing = false;
+  Object? _computeError;
+  List<FileDiff>? _lastFiles;
+  int _computeToken = 0;
+  Brightness? _lastBrightness;
+
+  /// Stable [GlobalKey]s attached to each file's header [SizedBox] so the
+  /// post-frame scroll adjustment can find the collapsed file's header.
+  /// Keys are created lazily as files are rendered.
+  final Map<int, GlobalKey> _headerKeys = <int, GlobalKey>{};
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<DiffCubit, DiffState>(
+      buildWhen: (prev, curr) =>
+          prev.runtimeType != curr.runtimeType ||
+          (prev is DiffStateLoaded && curr is DiffStateLoaded && !identical(prev.files, curr.files)),
+      builder: (context, state) => switch (state) {
+        DiffStateLoading() => const Center(child: CircularProgressIndicator()),
+        DiffStateFailed(:final error) => DiffErrorView(
+          error: error,
+          onRetry: () => context.read<DiffCubit>().refresh(),
+        ),
+        DiffStateLoaded(:final files) when files.isEmpty => Center(
+          child: Text(context.loc.diffNoFileChanges),
+        ),
+        DiffStateLoaded(:final files) => _buildLoadedState(context: context, files: files),
+      },
+    );
+  }
+
+  Widget _buildLoadedState({required BuildContext context, required List<FileDiff> files}) {
+    _maybeComputeViewModels(files: files);
+    if (_computeError case final computeError?) {
+      return DiffErrorView(
+        error: computeError,
+        onRetry: () => context.read<DiffCubit>().refresh(),
+      );
+    }
+
+    final viewModels = _viewModels;
+    if (_isComputing || viewModels == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return CustomScrollView(slivers: _buildSlivers(viewModels: viewModels));
+  }
+
+  List<Widget> _buildSlivers({required List<DiffFileViewModel> viewModels}) {
+    return [
+      for (var i = 0; i < viewModels.length; i++)
+        SliverMainAxisGroup(
+          slivers: [
+            SliverPersistentHeader(
+              pinned: true,
+              delegate: DiffFileHeaderDelegate(
+                viewModel: viewModels[i],
+                isExpanded: _expandedFileIndices.contains(i),
+                onToggle: () => _toggleFile(i),
+                headerKey: _headerKeys.putIfAbsent(i, GlobalKey.new),
+              ),
+            ),
+            if (_expandedFileIndices.contains(i))
+              DiffFileContentSliver(viewModel: viewModels[i])
+            else
+              const SliverToBoxAdapter(child: SizedBox.shrink()),
+          ],
+        ),
+    ];
+  }
+
+  void _maybeComputeViewModels({required List<FileDiff> files}) {
+    final brightness = Theme.of(context).brightness;
+    if (identical(files, _lastFiles) && brightness == _lastBrightness) return;
+    final preserveExpansion = identical(files, _lastFiles);
+    _lastFiles = files;
+    _lastBrightness = brightness;
+
+    // Defer computation to avoid setState() during build.
+    Future.microtask(() {
+      if (mounted) {
+        _computeViewModels(files: files, preserveExpansion: preserveExpansion);
+      }
+    });
+  }
+
+  Future<void> _computeViewModels({
+    required List<FileDiff> files,
+    required bool preserveExpansion,
+  }) async {
+    final token = ++_computeToken;
+    setState(() {
+      _isComputing = true;
+      _computeError = null;
+      _viewModels = null;
+      // Drop stale GlobalKeys from the previous file list so they don't
+      // accumulate when the user switches sessions or refreshes.
+      _headerKeys.clear();
+    });
+    try {
+      final viewModels = await DiffViewModelBuilder.build(
+        files,
+        brightness: Theme.of(context).brightness,
+      );
+      if (!mounted || token != _computeToken) return;
+      final expanded = preserveExpansion
+          ? Set<int>.from(_expandedFileIndices)
+          : <int>{
+              for (var i = 0; i < viewModels.length; i++) i,
+            };
+
+      setState(() {
+        _viewModels = viewModels;
+        _expandedFileIndices = expanded;
+        _isComputing = false;
+      });
+    } catch (error) {
+      if (!mounted || token != _computeToken) return;
+      setState(() {
+        _computeError = error;
+        _isComputing = false;
+      });
+    }
+  }
+
+  void _toggleFile(int fileIndex) {
+    final viewModels = _viewModels;
+    if (viewModels == null) return;
+    final expanded = Set<int>.from(_expandedFileIndices);
+    final wasExpanded = expanded.contains(fileIndex);
+    if (wasExpanded) {
+      expanded.remove(fileIndex);
+    } else {
+      expanded.add(fileIndex);
+    }
+    // Check whether the collapsed file's header is currently pinned at the
+    // top of the viewport BEFORE triggering the rebuild. After the body
+    // shrinks, the layout shifts and a later header can take over the
+    // pinned slot, so the post-collapse check would lie.
+    final headerKey = _headerKeys[fileIndex];
+    final wasPinnedAtTop = wasExpanded && headerKey != null && _isHeaderPinnedAtTop(headerKey);
+    setState(() => _expandedFileIndices = expanded);
+    if (wasExpanded && wasPinnedAtTop) {
+      // After the sliver rebuilds with file `fileIndex` collapsed (body
+      // shrunk to zero), realign the viewport so the collapsed header stays
+      // at the top and the next file becomes visible just below it.
+      _scheduleScrollCompensation(collapsedIndex: fileIndex);
+    }
+  }
+
+  /// Returns true if the header identified by [headerKey] is currently
+  /// painted at the top of its enclosing scroll viewport. This is true both
+  /// for headers at their natural position (e.g. the first file with no
+  /// scroll) and for headers held there by a pinned
+  /// [SliverPersistentHeader]. It is false for headers scrolled past the
+  /// top — even if those headers would be pinned in isolation, a later
+  /// pinned header has already taken over the pinned slot.
+  bool _isHeaderPinnedAtTop(GlobalKey headerKey) {
+    final headerContext = headerKey.currentContext;
+    if (headerContext == null) return false;
+    final headerBox = headerContext.findRenderObject();
+    if (headerBox is! RenderBox || !headerBox.attached) return false;
+    final scrollable = Scrollable.maybeOf(headerContext);
+    if (scrollable == null) return false;
+    final scrollableBox = scrollable.context.findRenderObject();
+    if (scrollableBox is! RenderBox || !scrollableBox.attached) return false;
+    // Offset of the header's top edge in the scrollable's coordinate space.
+    // The scrollable is a render ancestor of the header (it was found by
+    // walking up from the header's context), so the conversion is direct.
+    final headerTopInScrollable = headerBox.localToGlobal(Offset.zero, ancestor: scrollableBox).dy;
+    return headerTopInScrollable.abs() < 1.0;
+  }
+
+  /// Schedules a post-frame adjustment that realigns the viewport so the
+  /// collapsed file's own header stays at the top, with the next file
+  /// visible just below it. The caller must have already verified (before
+  /// the rebuild) that the header was pinned at the top — we cannot
+  /// re-check after the collapse because the layout has shifted.
+  void _scheduleScrollCompensation({required int collapsedIndex}) {
+    final currentKey = _headerKeys[collapsedIndex];
+    if (currentKey == null) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final context = currentKey.currentContext;
+      if (context == null) return;
+      Scrollable.ensureVisible(context, alignment: 0.0, duration: Duration.zero);
+    });
+  }
+}

--- a/mobile/app/lib/features/session_diffs/session_diffs_screen.dart
+++ b/mobile/app/lib/features/session_diffs/session_diffs_screen.dart
@@ -6,11 +6,7 @@ import "package:theme_zyra/module_zyra.dart";
 
 import "../../core/di/injection.dart";
 import "../../core/extensions/build_context_x.dart";
-import "models/diff_file_view_model.dart";
-import "models/diff_view_model_builder.dart";
-import "widgets/diff_file_header_delegate.dart";
-import "widgets/diff_hunk_widget.dart";
-import "widgets/diff_line_widget.dart";
+import "session_diffs_body.dart";
 
 class SessionDiffsScreen extends StatelessWidget {
   final String projectId;
@@ -29,71 +25,41 @@ class SessionDiffsScreen extends StatelessWidget {
         sessionRepository: getIt<SessionRepository>(),
         sessionId: sessionId,
       ),
-      child: const _SessionDiffsBody(),
+      child: Scaffold(
+        appBar: AppBar(title: const _DiffStatsTitle()),
+        body: const SessionDiffsBody(),
+      ),
     );
   }
 }
 
-class _SessionDiffsBody extends StatefulWidget {
-  const _SessionDiffsBody();
-
-  @override
-  State<_SessionDiffsBody> createState() => _SessionDiffsBodyState();
-}
-
-class _SessionDiffsBodyState extends State<_SessionDiffsBody> {
-  List<DiffFileViewModel>? _viewModels;
-  Set<int> _expandedFileIndices = <int>{};
-  bool _isComputing = false;
-  Object? _computeError;
-  List<FileDiff>? _lastFiles;
-  int _computeToken = 0;
-  Brightness? _lastBrightness;
-
-  /// Stable [GlobalKey]s attached to each file's header [SizedBox] so the
-  /// post-frame scroll adjustment can find the next file's header after a
-  /// collapse. Keys are created lazily as files are rendered.
-  final Map<int, GlobalKey> _headerKeys = <int, GlobalKey>{};
+/// App bar title showing "File changes" plus a files/additions/deletions
+/// summary line once the diff has loaded.
+class _DiffStatsTitle extends StatelessWidget {
+  const _DiffStatsTitle();
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: BlocBuilder<DiffCubit, DiffState>(
-          buildWhen: (prev, curr) => _getStats(prev) != _getStats(curr),
-          builder: (context, state) {
-            final (fileCount, additions, deletions) = _getStats(state);
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(context.loc.diffFileChangesTitle),
-                if (fileCount > 0)
-                  Text(
-                    context.loc.diffFilesChangedCount(
-                      fileCount,
-                      additions,
-                      deletions,
-                    ),
-                    style: context.zyra.textTheme.textXs.regular,
-                  ),
-              ],
-            );
-          },
-        ),
-      ),
-      body: BlocBuilder<DiffCubit, DiffState>(
-        buildWhen: (prev, curr) =>
-            prev.runtimeType != curr.runtimeType ||
-            (prev is DiffStateLoaded && curr is DiffStateLoaded && !identical(prev.files, curr.files)),
-        builder: (context, state) => switch (state) {
-          DiffStateLoading() => const Center(child: CircularProgressIndicator()),
-          DiffStateFailed(:final error) => _buildErrorState(context: context, error: error),
-          DiffStateLoaded(:final files) when files.isEmpty => Center(
-            child: Text(context.loc.diffNoFileChanges),
-          ),
-          DiffStateLoaded(:final files) => _buildLoadedState(context: context, files: files),
-        },
-      ),
+    return BlocBuilder<DiffCubit, DiffState>(
+      buildWhen: (prev, curr) => _getStats(prev) != _getStats(curr),
+      builder: (context, state) {
+        final (fileCount, additions, deletions) = _getStats(state);
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(context.loc.diffFileChangesTitle),
+            if (fileCount > 0)
+              Text(
+                context.loc.diffFilesChangedCount(
+                  fileCount,
+                  additions,
+                  deletions,
+                ),
+                style: context.zyra.textTheme.textXs.regular,
+              ),
+          ],
+        );
+      },
     );
   }
 
@@ -108,214 +74,5 @@ class _SessionDiffsBodyState extends State<_SessionDiffsBody> {
       }
     }
     return (state.files.length, adds, dels);
-  }
-
-  Widget _buildLoadedState({required BuildContext context, required List<FileDiff> files}) {
-    _maybeComputeViewModels(files: files);
-    if (_computeError case final computeError?) {
-      return _buildErrorState(context: context, error: computeError);
-    }
-
-    final viewModels = _viewModels;
-    if (_isComputing || viewModels == null) {
-      return const Center(child: CircularProgressIndicator());
-    }
-    return CustomScrollView(slivers: _buildSlivers(viewModels: viewModels));
-  }
-
-  List<Widget> _buildSlivers({required List<DiffFileViewModel> viewModels}) {
-    return [
-      for (var i = 0; i < viewModels.length; i++)
-        SliverMainAxisGroup(
-          slivers: [
-            SliverPersistentHeader(
-              pinned: true,
-              delegate: DiffFileHeaderDelegate(
-                viewModel: viewModels[i],
-                isExpanded: _expandedFileIndices.contains(i),
-                onToggle: () => _toggleFile(i),
-                headerKey: _headerKeys.putIfAbsent(i, GlobalKey.new),
-              ),
-            ),
-            if (_expandedFileIndices.contains(i))
-              _buildFileContentSliver(viewModels[i])
-            else
-              const SliverToBoxAdapter(child: SizedBox.shrink()),
-          ],
-        ),
-    ];
-  }
-
-  Widget _buildFileContentSliver(DiffFileViewModel vm) {
-    if (vm.skipReason case final skipReason?) {
-      return SliverToBoxAdapter(child: _buildSkippedPlaceholder(skipReason));
-    }
-    final childCount = vm.hunks.fold<int>(0, (sum, h) => sum + 1 + h.lines.length);
-    return SliverList.builder(
-      itemCount: childCount,
-      itemBuilder: (context, index) {
-        var remaining = index;
-        for (final hunk in vm.hunks) {
-          if (remaining == 0) return DiffHunkWidget(viewModel: hunk);
-          remaining--;
-          if (remaining < hunk.lines.length) {
-            return DiffLineWidget(viewModel: hunk.lines[remaining]);
-          }
-          remaining -= hunk.lines.length;
-        }
-        return const SizedBox.shrink();
-      },
-    );
-  }
-
-  void _maybeComputeViewModels({required List<FileDiff> files}) {
-    final brightness = Theme.of(context).brightness;
-    if (identical(files, _lastFiles) && brightness == _lastBrightness) return;
-    final preserveExpansion = identical(files, _lastFiles);
-    _lastFiles = files;
-    _lastBrightness = brightness;
-
-    // Defer computation to avoid setState() during build.
-    Future.microtask(() {
-      if (mounted) {
-        _computeViewModels(files: files, preserveExpansion: preserveExpansion);
-      }
-    });
-  }
-
-  Future<void> _computeViewModels({
-    required List<FileDiff> files,
-    required bool preserveExpansion,
-  }) async {
-    final token = ++_computeToken;
-    setState(() {
-      _isComputing = true;
-      _computeError = null;
-      _viewModels = null;
-      // Drop stale GlobalKeys from the previous file list so they don't
-      // accumulate when the user switches sessions or refreshes.
-      _headerKeys.clear();
-    });
-    try {
-      final viewModels = await DiffViewModelBuilder.build(
-        files,
-        brightness: Theme.of(context).brightness,
-      );
-      if (!mounted || token != _computeToken) return;
-      final expanded = preserveExpansion
-          ? Set<int>.from(_expandedFileIndices)
-          : <int>{
-              for (var i = 0; i < viewModels.length; i++) i,
-            };
-
-      setState(() {
-        _viewModels = viewModels;
-        _expandedFileIndices = expanded;
-        _isComputing = false;
-      });
-    } catch (error) {
-      if (!mounted || token != _computeToken) return;
-      setState(() {
-        _computeError = error;
-        _isComputing = false;
-      });
-    }
-  }
-
-  void _toggleFile(int fileIndex) {
-    final viewModels = _viewModels;
-    if (viewModels == null) return;
-    final expanded = Set<int>.from(_expandedFileIndices);
-    final wasExpanded = expanded.contains(fileIndex);
-    if (wasExpanded) {
-      expanded.remove(fileIndex);
-    } else {
-      expanded.add(fileIndex);
-    }
-    // Check whether the collapsed file's header is currently pinned at the
-    // top of the viewport BEFORE triggering the rebuild. After the body
-    // shrinks, the layout shifts and a later header can take over the
-    // pinned slot, so the post-collapse check would lie.
-    final headerKey = _headerKeys[fileIndex];
-    final wasPinnedAtTop = wasExpanded && headerKey != null && _isHeaderPinnedAtTop(headerKey);
-    setState(() => _expandedFileIndices = expanded);
-    if (wasExpanded && wasPinnedAtTop) {
-      // After the sliver rebuilds with file `fileIndex` collapsed (body
-      // shrunk to zero), realign the viewport so the collapsed header stays
-      // at the top and the next file becomes visible just below it.
-      _scheduleScrollCompensation(collapsedIndex: fileIndex);
-    }
-  }
-
-  /// Returns true if the header identified by [headerKey] is currently
-  /// painted at the top of its enclosing scroll viewport. This is true both
-  /// for headers at their natural position (e.g. the first file with no
-  /// scroll) and for headers held there by a pinned
-  /// [SliverPersistentHeader]. It is false for headers scrolled past the
-  /// top — even if those headers would be pinned in isolation, a later
-  /// pinned header has already taken over the pinned slot.
-  bool _isHeaderPinnedAtTop(GlobalKey headerKey) {
-    final headerContext = headerKey.currentContext;
-    if (headerContext == null) return false;
-    final headerBox = headerContext.findRenderObject();
-    if (headerBox is! RenderBox) return false;
-    final scrollable = Scrollable.maybeOf(headerContext);
-    if (scrollable == null) return false;
-    final scrollableBox = scrollable.context.findRenderObject();
-    if (scrollableBox is! RenderBox) return false;
-    final headerTop = headerBox.localToGlobal(Offset.zero).dy;
-    final scrollableTop = scrollableBox.localToGlobal(Offset.zero).dy;
-    return (headerTop - scrollableTop).abs() < 1.0;
-  }
-
-  /// Schedules a post-frame adjustment that realigns the viewport so the
-  /// collapsed file's own header stays at the top, with the next file
-  /// visible just below it. The caller must have already verified (before
-  /// the rebuild) that the header was pinned at the top — we cannot
-  /// re-check after the collapse because the layout has shifted.
-  void _scheduleScrollCompensation({required int collapsedIndex}) {
-    final currentKey = _headerKeys[collapsedIndex];
-    if (currentKey == null) return;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      final context = currentKey.currentContext;
-      if (context == null) return;
-      Scrollable.ensureVisible(context, alignment: 0.0, duration: Duration.zero);
-    });
-  }
-
-  Widget _buildSkippedPlaceholder(FileDiffSkipReason reason) {
-    final loc = context.loc;
-    final message = switch (reason) {
-      FileDiffSkipReason.binary => loc.diffBinaryFileChanged,
-      FileDiffSkipReason.tooLarge => loc.diffFileTooLarge,
-      FileDiffSkipReason.readError => loc.diffCouldNotReadFile,
-    };
-    return Padding(
-      padding: const EdgeInsets.all(16),
-      child: Text(
-        message,
-        style: const TextStyle(
-          color: Colors.grey,
-          fontStyle: FontStyle.italic,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildErrorState({required BuildContext context, required Object error}) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Text(context.loc.diffErrorPrefix(error.toString())),
-          const SizedBox(height: 16),
-          TextButton(
-            onPressed: () => context.read<DiffCubit>().refresh(),
-            child: Text(context.loc.diffRetry),
-          ),
-        ],
-      ),
-    );
   }
 }

--- a/mobile/app/lib/features/session_diffs/session_diffs_screen.dart
+++ b/mobile/app/lib/features/session_diffs/session_diffs_screen.dart
@@ -232,27 +232,53 @@ class _SessionDiffsBodyState extends State<_SessionDiffsBody> {
     } else {
       expanded.add(fileIndex);
     }
+    // Check whether the collapsed file's header is currently pinned at the
+    // top of the viewport BEFORE triggering the rebuild. After the body
+    // shrinks, the layout shifts and a later header can take over the
+    // pinned slot, so the post-collapse check would lie.
+    final headerKey = _headerKeys[fileIndex];
+    final wasPinnedAtTop = wasExpanded && headerKey != null && _isHeaderPinnedAtTop(headerKey);
     setState(() => _expandedFileIndices = expanded);
-    if (wasExpanded) {
+    if (wasExpanded && wasPinnedAtTop) {
       // After the sliver rebuilds with file `fileIndex` collapsed (body
-      // shrunk to zero), jump the viewport so the next file's header sits
-      // at the top — otherwise the user lands several files down for large
-      // collapsed files.
-      _scheduleScrollToNext(collapsedIndex: fileIndex, totalFiles: viewModels.length);
+      // shrunk to zero), realign the viewport so the collapsed header stays
+      // at the top and the next file becomes visible just below it.
+      _scheduleScrollCompensation(collapsedIndex: fileIndex);
     }
   }
 
-  /// Schedules a post-frame jump so the header at `collapsedIndex + 1` is
-  /// aligned to the top of the viewport. No-op if the collapsed file is the
-  /// last one (there is no "next file" to anchor to) or the key has not yet
-  /// been attached to a rendered widget.
-  void _scheduleScrollToNext({required int collapsedIndex, required int totalFiles}) {
-    if (collapsedIndex + 1 >= totalFiles) return;
-    final nextKey = _headerKeys[collapsedIndex + 1];
-    if (nextKey == null) return;
+  /// Returns true if the header identified by [headerKey] is currently
+  /// painted at the top of its enclosing scroll viewport. This is true both
+  /// for headers at their natural position (e.g. the first file with no
+  /// scroll) and for headers held there by a pinned
+  /// [SliverPersistentHeader]. It is false for headers scrolled past the
+  /// top — even if those headers would be pinned in isolation, a later
+  /// pinned header has already taken over the pinned slot.
+  bool _isHeaderPinnedAtTop(GlobalKey headerKey) {
+    final headerContext = headerKey.currentContext;
+    if (headerContext == null) return false;
+    final headerBox = headerContext.findRenderObject();
+    if (headerBox is! RenderBox) return false;
+    final scrollable = Scrollable.maybeOf(headerContext);
+    if (scrollable == null) return false;
+    final scrollableBox = scrollable.context.findRenderObject();
+    if (scrollableBox is! RenderBox) return false;
+    final headerTop = headerBox.localToGlobal(Offset.zero).dy;
+    final scrollableTop = scrollableBox.localToGlobal(Offset.zero).dy;
+    return (headerTop - scrollableTop).abs() < 1.0;
+  }
+
+  /// Schedules a post-frame adjustment that realigns the viewport so the
+  /// collapsed file's own header stays at the top, with the next file
+  /// visible just below it. The caller must have already verified (before
+  /// the rebuild) that the header was pinned at the top — we cannot
+  /// re-check after the collapse because the layout has shifted.
+  void _scheduleScrollCompensation({required int collapsedIndex}) {
+    final currentKey = _headerKeys[collapsedIndex];
+    if (currentKey == null) return;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      final context = nextKey.currentContext;
+      final context = currentKey.currentContext;
       if (context == null) return;
       Scrollable.ensureVisible(context, alignment: 0.0, duration: Duration.zero);
     });

--- a/mobile/app/lib/features/session_diffs/widgets/diff_error_view.dart
+++ b/mobile/app/lib/features/session_diffs/widgets/diff_error_view.dart
@@ -1,0 +1,29 @@
+import "package:flutter/material.dart";
+
+import "../../../core/extensions/build_context_x.dart";
+
+/// Centered error message with a retry button, shown when the diff fails
+/// to load or when diff view-model computation fails.
+class DiffErrorView extends StatelessWidget {
+  final Object error;
+  final VoidCallback onRetry;
+
+  const DiffErrorView({super.key, required this.error, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(context.loc.diffErrorPrefix(error.toString())),
+          const SizedBox(height: 16),
+          TextButton(
+            onPressed: onRetry,
+            child: Text(context.loc.diffRetry),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/app/lib/features/session_diffs/widgets/diff_file_content_sliver.dart
+++ b/mobile/app/lib/features/session_diffs/widgets/diff_file_content_sliver.dart
@@ -1,0 +1,65 @@
+import "package:flutter/material.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../../../core/extensions/build_context_x.dart";
+import "../models/diff_file_view_model.dart";
+import "diff_hunk_widget.dart";
+import "diff_line_widget.dart";
+
+/// Sliver that renders the body of one expanded file diff: a lazy list of
+/// its hunk headers and lines, or an italic placeholder when the diff was
+/// skipped (binary file, too large, or unreadable).
+class DiffFileContentSliver extends StatelessWidget {
+  final DiffFileViewModel viewModel;
+
+  const DiffFileContentSliver({super.key, required this.viewModel});
+
+  @override
+  Widget build(BuildContext context) {
+    if (viewModel.skipReason case final skipReason?) {
+      return SliverToBoxAdapter(child: _SkippedPlaceholder(reason: skipReason));
+    }
+    final childCount = viewModel.hunks.fold<int>(0, (sum, h) => sum + 1 + h.lines.length);
+    return SliverList.builder(
+      itemCount: childCount,
+      itemBuilder: (context, index) {
+        var remaining = index;
+        for (final hunk in viewModel.hunks) {
+          if (remaining == 0) return DiffHunkWidget(viewModel: hunk);
+          remaining--;
+          if (remaining < hunk.lines.length) {
+            return DiffLineWidget(viewModel: hunk.lines[remaining]);
+          }
+          remaining -= hunk.lines.length;
+        }
+        return const SizedBox.shrink();
+      },
+    );
+  }
+}
+
+class _SkippedPlaceholder extends StatelessWidget {
+  final FileDiffSkipReason reason;
+
+  const _SkippedPlaceholder({required this.reason});
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = context.loc;
+    final message = switch (reason) {
+      FileDiffSkipReason.binary => loc.diffBinaryFileChanged,
+      FileDiffSkipReason.tooLarge => loc.diffFileTooLarge,
+      FileDiffSkipReason.readError => loc.diffCouldNotReadFile,
+    };
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Text(
+        message,
+        style: const TextStyle(
+          color: Colors.grey,
+          fontStyle: FontStyle.italic,
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/app/test/features/session_diffs/session_diffs_collapse_scroll_test.dart
+++ b/mobile/app/test/features/session_diffs/session_diffs_collapse_scroll_test.dart
@@ -75,12 +75,13 @@ void main() {
   });
 
   testWidgets(
-    "collapsing an expanded file jumps the viewport so the next file's header sits at the top",
+    "collapsing an expanded file whose header is pinned at the top keeps that header pinned",
     (tester) async {
       // Three files: a large one (aaa) whose body we'll scroll into, a small
-      // one (bbb) that should become the new top after the collapse, and a
-      // trailing one (ccc) to ensure we don't accidentally land past the
-      // end of the list.
+      // one (bbb), and a trailing one (ccc) to ensure we don't accidentally
+      // land past the end of the list. After collapsing aaa while its header
+      // is pinned, aaa's header should stay at the top so both aaa and bbb
+      // remain visible.
       when(() => mockRepo.getSessionDiffs(sessionId: any(named: "sessionId"))).thenAnswer(
         (_) async => ApiResponse.success(
           SessionDiffsResponse(diffs: [
@@ -96,15 +97,24 @@ void main() {
       final scrollFinder = find.byType(CustomScrollView);
       expect(scrollFinder, findsOneWidget);
 
-      // Scroll a little into the first file's body so bbb's header is no
-      // longer at the very top of the viewport.
+      // Scroll a little into the first file's body so aaa's header is
+      // pinned at the top of the viewport (we've scrolled past its natural
+      // position) and bbb's header is below it.
       await tester.drag(scrollFinder, const Offset(0, -50));
       await tester.pumpAndSettle();
 
-      final bbbHeader = find.text("bbb.dart");
-      expect(bbbHeader, findsOneWidget);
+      final aaaHeader = find.text("aaa.dart");
+      expect(aaaHeader, findsOneWidget);
 
       final scrollRectBefore = tester.getRect(scrollFinder);
+      final aaaRectBefore = tester.getRect(aaaHeader);
+      expect(
+        aaaRectBefore.top,
+        closeTo(scrollRectBefore.top, 10.0),
+        reason: "precondition: aaa's header should be pinned at the top of the viewport before the collapse",
+      );
+
+      final bbbHeader = find.text("bbb.dart");
       final bbbRectBefore = tester.getRect(bbbHeader);
       expect(
         bbbRectBefore.top,
@@ -113,19 +123,64 @@ void main() {
       );
 
       // Collapse the first file by tapping its header.
-      await tester.tap(find.text("aaa.dart"));
+      await tester.tap(aaaHeader);
       await tester.pumpAndSettle();
 
       final scrollRectAfter = tester.getRect(scrollFinder);
-      final bbbRectAfter = tester.getRect(bbbHeader);
+      final aaaRectAfter = tester.getRect(aaaHeader);
       // The [DiffFileWidget] has `EdgeInsets.symmetric(vertical: 6)` so the
       // file-name text sits a few pixels below the header's top edge. The
       // 10px tolerance covers that padding plus any sub-pixel rounding from
       // the SliverPersistentHeader layout.
       expect(
-        bbbRectAfter.top,
+        aaaRectAfter.top,
         closeTo(scrollRectAfter.top, 10.0),
-        reason: "bbb's header should be aligned to the top of the scroll viewport after the collapse",
+        reason: "aaa's header should stay pinned at the top of the scroll viewport after the collapse",
+      );
+    },
+  );
+
+  testWidgets(
+    "collapsing a file whose header is NOT pinned at the top does not jump the viewport",
+    (tester) async {
+      // aaa is large enough that we can scroll past it; bbb is also large
+      // so that scrolling deep into the list pushes aaa's header off the
+      // pinned position and bbb's header takes over.
+      when(() => mockRepo.getSessionDiffs(sessionId: any(named: "sessionId"))).thenAnswer(
+        (_) async => ApiResponse.success(
+          SessionDiffsResponse(diffs: [
+            _makeDiff("aaa.dart", lineCount: 30),
+            _makeDiff("bbb.dart", lineCount: 30),
+            _makeDiff("ccc.dart", lineCount: 10),
+          ]),
+        ),
+      );
+
+      await _pumpLoadedScreen(tester);
+
+      final scrollFinder = find.byType(CustomScrollView);
+      // Scroll deep into the list so that aaa's header is above the
+      // viewport and bbb's header is pinned at the top instead.
+      await tester.drag(scrollFinder, const Offset(0, -700));
+      await tester.pumpAndSettle();
+
+      final scrollable = tester.state<ScrollableState>(find.byType(Scrollable).first);
+      final positionBefore = scrollable.position.pixels;
+
+      // Collapse aaa — its header is NOT pinned at the top, so the viewport
+      // should not jump to a new file's header.
+      await tester.tap(find.text("aaa.dart"));
+      await tester.pumpAndSettle();
+
+      final positionAfter = tester.state<ScrollableState>(find.byType(Scrollable).first).position.pixels;
+      // The viewport should not have scrolled forward to align with a new
+      // file's header. It may have clamped down (if collapsing aaa's body
+      // reduced the total content height and the old offset exceeded the
+      // new maxScrollExtent), but it should never have increased.
+      expect(
+        positionAfter,
+        lessThanOrEqualTo(positionBefore),
+        reason: "collapsing a non-pinned header must not scroll the viewport forward",
       );
     },
   );


### PR DESCRIPTION
## Summary

When a file header in the diff viewer is tapped to collapse, the viewport used to always jump to the next file's header. This was jarring in two situations:

1. **The user wanted to collapse the _current_ file.** The viewport yanked forward to the next file, hiding the file they just collapsed.
2. **The user was scrolled past the collapsed file's header** (e.g. into a later file's content). Any jump would be disorienting — they were not looking at the file they just collapsed.

## Changes

- **Only apply the post-collapse scroll adjustment when the collapsed file's header was pinned at the top of the viewport at the moment of the tap.** When the user is scrolled past it, do nothing and let Flutter's natural scroll clamping handle the layout shift.
- **When the adjustment does run, realign to the collapsed file's own header** instead of the next file's. The collapsed header stays visible and the next file appears just below it, which is what the user expects to see after a collapse.

The pinned check compares the header's painted position to the enclosing `Scrollable`'s top edge via `localToGlobal` — a direct paint-position test that correctly distinguishes "pinned at top" from "scrolled past" even after the body shrinks and a later header takes over the pinned slot.

The check is captured **before** the rebuild, because the post-collapse layout no longer reflects the pre-collapse viewport state.

## Tests

- Updated: "collapsing an expanded file whose header is pinned at the top keeps that header pinned" (previously expected the next file's header to jump to the top; now expects the current header to stay pinned).
- Added: "collapsing a file whose header is NOT pinned at the top does not jump the viewport" — covers the regression case where collapsing a non-pinned header would have yanked the viewport forward.
- Unchanged: "collapsing the last file leaves the viewport anchored to the end of the list".

All 427 app tests pass; `dart analyze` reports no issues.

## Review

- Plan reviewed by `aristotle-plan-review`: APPROVED.
- Implementation reviewed by `aristotle-impl-review`: APPROVED.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes jarring jumps when collapsing files in the mobile diff viewer. Scroll is now adjusted only when the tapped header is pinned, and the collapsed header stays at the top.

- **Bug Fixes**
  - Only adjust scroll when the tapped header was pinned at the top (checked before rebuild); when compensating, realign to the collapsed file’s own header so it remains at the top.
  - Tests updated/added for pinned header staying pinned and non‑pinned header not jumping; last‑file behavior unchanged.

- **Refactors**
  - Split UI into `SessionDiffsBody`, `DiffFileContentSliver`, and `DiffErrorView`; screen keeps provider/scaffold+stats title. Hardened pinned‑header check by guarding `RenderBox.attached` and computing the header offset in the scrollable’s space via `localToGlobal(ancestor: ...)`.

<sup>Written for commit f611e114d015d0ff2fb54dd7d01bf313c66aa3fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

