### PR TITLE
fix(bridge): recoverable startup-lock contention + safe post-update relaunch

### DIFF
--- a/bridge/AGENTS.md
+++ b/bridge/AGENTS.md
@@ -10,6 +10,8 @@ From `bridge/`:
 - `make test` — run tests in all modules that have a `test/` directory
 - `make analyze` — static analysis across all modules
 
+Bridge CI runs `dart analyze --fatal-infos`, which is stricter than `make analyze` — info-level lints (e.g. `directives_ordering` import sorting) fail CI. Before pushing, run `dart analyze --fatal-infos` from each changed module dir (e.g. `bridge/app/`).
+
 From `bridge/app/`:
 - `make build` — build all targets (host-native + Linux cross-compiled)
 - `make build-host` — native binary only

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -172,7 +172,11 @@ class LogoutCommand extends cli.Command<void> {
       currentUser: currentUser,
     );
     final terminalPromptRepository = TerminalPromptRepository(
-      api: TerminalPromptApi(stdin: stdin, stdout: stdout),
+      api: TerminalPromptApi(
+        stdin: stdin,
+        stdout: stdout,
+        environment: Platform.environment,
+      ),
     );
     final logoutRunner = BridgeLogoutRunner(
       bridgeInstanceRepository: bridgeInstanceRepository,

--- a/bridge/app/lib/src/bridge/foundation/post_update_restart_flag.dart
+++ b/bridge/app/lib/src/bridge/foundation/post_update_restart_flag.dart
@@ -1,0 +1,1 @@
+const String sesoriPostUpdateRestartEnvVar = 'SESORI_POST_UPDATE_RESTART';

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart
@@ -8,19 +8,29 @@ import '../../auth/login_oauth_service.dart';
 import '../../auth/profile.dart';
 import '../../auth/token.dart';
 import '../../auth/validate.dart';
+import '../foundation/post_update_restart_flag.dart';
 import 'bridge_cli_options.dart';
 
 class BridgeRuntimeAuthService {
   final LoginEmailRepository _loginEmailRepository;
   final LoginOAuthService _loginOAuthService;
+  final Map<String, String> _environment;
 
   const BridgeRuntimeAuthService({
     required LoginEmailRepository loginEmailRepository,
     required LoginOAuthService loginOAuthService,
+    required Map<String, String> environment,
   }) : _loginEmailRepository = loginEmailRepository,
-       _loginOAuthService = loginOAuthService;
+       _loginOAuthService = loginOAuthService,
+       _environment = environment;
 
   Future<AuthProvider> promptForProvider() async {
+    if (_environment[sesoriPostUpdateRestartEnvVar] == '1') {
+      throw Exception(
+        'Login required, but this bridge was relaunched non-interactively after an auto-update. Run sesori-bridge again from a terminal to log in.',
+      );
+    }
+
     while (true) {
       stdout.writeln('Select login method: [1] GitHub [2] Google [3] Apple [4] Email');
       stdout.write('Enter choice (1-4): ');

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -123,6 +123,7 @@ class BridgeRuntimeRunner {
     final terminalPromptApi = TerminalPromptApi(
       stdin: io.stdin,
       stdout: io.stdout,
+      environment: environment,
     );
     final terminalPromptRepository = TerminalPromptRepository(
       api: terminalPromptApi,
@@ -194,6 +195,7 @@ class BridgeRuntimeRunner {
             currentUser: currentUser,
             isWindows: io.Platform.isWindows,
             platform: io.Platform.operatingSystem,
+            probeTimeout: const Duration(seconds: 5),
           ),
         ),
         processRepository: processRepository,
@@ -320,7 +322,7 @@ class BridgeRuntimeRunner {
       ),
       installedFileRepository: installedFileRepository,
       updateLock: UpdateLock(currentPid: io.pid, processRunner: processRunner),
-      updateRelaunchClient: UpdateRelaunchClient(),
+      updateRelaunchClient: UpdateRelaunchClient(processStarter: io.Process.start),
       installRoot: managedRuntimePaths.installRoot,
       executablePath: io.Platform.resolvedExecutable,
       managedExecutablePath: managedRuntimePaths.binaryPath,

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -174,6 +174,7 @@ class BridgeRuntimeRunner {
         ),
         browserLauncher: openOAuthBrowser,
       ),
+      environment: environment,
     );
 
     try {

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_server.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_server.dart
@@ -27,79 +27,107 @@ Future<BridgeServerRuntime> resolveServer({
     throw ArgParserException('The --no-auto-start flag requires --port to be set.');
   }
 
-  return startupMutexRepository.withLock<BridgeServerRuntime>(
-    bridgePid: currentBridgeIdentity.pid,
-    bridgeStartMarker: currentBridgeIdentity.startMarker,
-    onLockAcquired: () async {
-      Log.d("acquired startup lock");
-      final resolution = await bridgeInstanceService.enforceSingleLiveBridge(
-        currentPid: currentBridgeIdentity.pid,
-      );
-      switch (resolution.status) {
-        case BridgeInstanceResolutionStatus.allowed:
-          if (options.noAutoStart) {
-            try {
-              final runtime = await openCodeServerService.validateExistingServer(
-                port: requestedPort!,
-                password: options.password.normalize(),
-              );
-              Log.i('Using existing server at ${runtime.serverUri} (auto-start disabled)');
-              return BridgeServerRuntime.fromOpenCodeRuntime(
-                runtime: runtime,
-                ownedOpenCodeRecord: null,
-              );
-            } on OpenCodeServerStartException catch (error) {
-              Log.w(
-                'Cannot reach OpenCode at port $requestedPort (auto-start disabled): $error. Bridge will start anyway; start OpenCode manually to enable proxying.',
-              );
-              return BridgeServerRuntime(
-                serverUrl: '$defaultTargetHost:$requestedPort',
-                serverPassword: options.password.normalize(),
-                process: null,
-                ownedOpenCodeRecord: null,
-                port: requestedPort!,
-              );
+  Future<BridgeServerRuntime> attemptResolve({required int attempt}) {
+    return startupMutexRepository.withLock<BridgeServerRuntime>(
+      bridgePid: currentBridgeIdentity.pid,
+      bridgeStartMarker: currentBridgeIdentity.startMarker,
+      onLockAcquired: () async {
+        Log.d("acquired startup lock");
+        final resolution = await bridgeInstanceService.enforceSingleLiveBridge(
+          currentPid: currentBridgeIdentity.pid,
+        );
+        switch (resolution.status) {
+          case BridgeInstanceResolutionStatus.allowed:
+            if (options.noAutoStart) {
+              try {
+                final runtime = await openCodeServerService.validateExistingServer(
+                  port: requestedPort!,
+                  password: options.password.normalize(),
+                );
+                Log.i('Using existing server at ${runtime.serverUri} (auto-start disabled)');
+                return BridgeServerRuntime.fromOpenCodeRuntime(
+                  runtime: runtime,
+                  ownedOpenCodeRecord: null,
+                );
+              } on OpenCodeServerStartException catch (error) {
+                Log.w(
+                  'Cannot reach OpenCode at port $requestedPort (auto-start disabled): $error. Bridge will start anyway; start OpenCode manually to enable proxying.',
+                );
+                return BridgeServerRuntime(
+                  serverUrl: '$defaultTargetHost:$requestedPort',
+                  serverPassword: options.password.normalize(),
+                  process: null,
+                  ownedOpenCodeRecord: null,
+                  port: requestedPort!,
+                );
+              }
             }
-          }
 
-          Log.d("[OPENCODE] Starting new instance");
-          final runtime = await openCodeServerService.start(
-            executablePath: options.opencodeBin,
-            requestedPort: requestedPort,
-            password: options.password.normalize(),
-            terminatedBridgeIdentities: resolution.terminatedBridges,
-          );
+            Log.d("[OPENCODE] Starting new instance");
+            final runtime = await openCodeServerService.start(
+              executablePath: options.opencodeBin,
+              requestedPort: requestedPort,
+              password: options.password.normalize(),
+              terminatedBridgeIdentities: resolution.terminatedBridges,
+            );
 
-          Log.d("[OPENCODE] Started on port ${runtime.port}");
-          final ownedOpenCodeRecord = await ownershipRepository.readByOwnerSessionId(
-            ownerSessionId: ownerSessionId,
-          );
+            Log.d("[OPENCODE] Started on port ${runtime.port}");
+            final ownedOpenCodeRecord = await ownershipRepository.readByOwnerSessionId(
+              ownerSessionId: ownerSessionId,
+            );
 
-          return BridgeServerRuntime.fromOpenCodeRuntime(
-            runtime: runtime,
-            ownedOpenCodeRecord: ownedOpenCodeRecord?.status == OpenCodeOwnershipStatus.ready
-                ? ownedOpenCodeRecord
-                : null,
+            return BridgeServerRuntime.fromOpenCodeRuntime(
+              runtime: runtime,
+              ownedOpenCodeRecord: ownedOpenCodeRecord?.status == OpenCodeOwnershipStatus.ready
+                  ? ownedOpenCodeRecord
+                  : null,
+            );
+          case BridgeInstanceResolutionStatus.declined:
+            throw const BridgeRuntimeServerException(
+              'Startup aborted because another Sesori bridge is already running and replacement was declined.',
+            );
+          case BridgeInstanceResolutionStatus.nonInteractive:
+            throw const BridgeRuntimeServerException(
+              'Startup aborted because another Sesori bridge is already running and this session is non-interactive.',
+            );
+        }
+      },
+      onLockRejected: (rejection) async {
+        final lock = rejection.lock;
+        final holderMatch = rejection.holderMatch;
+        if (lock == null || holderMatch == null) {
+          throw BridgeRuntimeServerException(
+            'Startup aborted because another Sesori bridge startup is already in progress. If this persists, delete ${rejection.lockFilePath} and retry.',
           );
-        case BridgeInstanceResolutionStatus.declined:
-          throw const BridgeRuntimeServerException(
-            'Startup aborted because another Sesori bridge is already running and replacement was declined.',
-          );
-        case BridgeInstanceResolutionStatus.nonInteractive:
-          throw const BridgeRuntimeServerException(
-            'Startup aborted because another Sesori bridge is already running and this session is non-interactive.',
-          );
-      }
-    },
-    onLockRejected: (result) async {
-      switch (result) {
-        case StartupMutexAcquireResult.alreadyLocked:
-          throw const BridgeRuntimeServerException(
-            'Startup aborted because another Sesori bridge startup is already in progress.',
-          );
-      }
-    },
-  );
+        }
+
+        final status = await bridgeInstanceService.resolveStartupLockContention(
+          lock: lock,
+          holder: holderMatch,
+          currentPid: currentBridgeIdentity.pid,
+        );
+        switch (status) {
+          case BridgeInstanceResolutionStatus.allowed:
+            if (attempt < 2) {
+              return attemptResolve(attempt: attempt + 1);
+            }
+            throw const BridgeRuntimeServerException(
+              'Startup aborted because another Sesori bridge startup is still in progress after attempting replacement.',
+            );
+          case BridgeInstanceResolutionStatus.declined:
+            throw const BridgeRuntimeServerException(
+              'Startup aborted because another Sesori bridge startup is already in progress and replacement was declined.',
+            );
+          case BridgeInstanceResolutionStatus.nonInteractive:
+            throw BridgeRuntimeServerException(
+              'Startup aborted because another Sesori bridge startup is already in progress and this session is non-interactive. Bridge pid ${holderMatch.identity.pid} holds ${rejection.lockFilePath}; kill that process or delete the file to recover.',
+            );
+        }
+      },
+    );
+  }
+
+  return attemptResolve(attempt: 1);
 }
 
 class BridgeServerRuntime {

--- a/bridge/app/lib/src/server/api/open_code_process_api.dart
+++ b/bridge/app/lib/src/server/api/open_code_process_api.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:convert";
 import "dart:io";
 import "dart:math";
@@ -22,13 +23,15 @@ class OpenCodeProcessApi {
     required ProcessUser? currentUser,
     required bool isWindows,
     required String platform,
+    required Duration probeTimeout,
   }) : _processStarter = processStarter,
        _httpClient = httpClient,
        _clock = clock,
        _environment = Map<String, String>.from(environment),
        _currentUser = currentUser,
        _isWindows = isWindows,
-       _platform = platform;
+       _platform = platform,
+       _probeTimeout = probeTimeout;
 
   static const int passwordLength = 32;
 
@@ -39,6 +42,7 @@ class OpenCodeProcessApi {
   final ProcessUser? _currentUser;
   final bool _isWindows;
   final String _platform;
+  final Duration _probeTimeout;
 
   String generatePassword() {
     final random = Random.secure();
@@ -86,8 +90,7 @@ class OpenCodeProcessApi {
     request.headers["Authorization"] = "Basic ${base64Encode(utf8.encode("opencode:$password"))}";
 
     try {
-      final response = await _httpClient.send(request);
-      await response.stream.drain<void>();
+      final response = await _sendAndDrain(request: request).timeout(_probeTimeout);
       return OpenCodeHealthProbeFact(
         uri: healthUri,
         statusCode: response.statusCode,
@@ -102,6 +105,12 @@ class OpenCodeProcessApi {
         checkedAt: _clock.now(),
       );
     }
+  }
+
+  Future<http.StreamedResponse> _sendAndDrain({required http.Request request}) async {
+    final response = await _httpClient.send(request);
+    await response.stream.drain<void>();
+    return response;
   }
 }
 

--- a/bridge/app/lib/src/server/api/terminal_prompt_api.dart
+++ b/bridge/app/lib/src/server/api/terminal_prompt_api.dart
@@ -1,16 +1,24 @@
 import 'dart:io';
 
+import '../../bridge/foundation/post_update_restart_flag.dart';
+
 class TerminalPromptApi {
   TerminalPromptApi({
     required Stdin stdin,
     required Stdout stdout,
+    required Map<String, String> environment,
   }) : _stdin = stdin,
-       _stdout = stdout;
+       _stdout = stdout,
+       _environment = environment;
 
   final Stdin _stdin;
   final Stdout _stdout;
+  final Map<String, String> _environment;
 
   bool get isInteractive {
+    if (_environment[sesoriPostUpdateRestartEnvVar] == '1') {
+      return false;
+    }
     return _stdin.hasTerminal && _stdout.hasTerminal;
   }
 
@@ -18,6 +26,10 @@ class TerminalPromptApi {
     required String message,
     bool disableEcho = false, // disable it for passwords
   }) {
+    if (_environment[sesoriPostUpdateRestartEnvVar] == '1') {
+      return null;
+    }
+
     _stdout.write(message);
 
     if (disableEcho) {

--- a/bridge/app/lib/src/server/models/bridge_startup_lock.dart
+++ b/bridge/app/lib/src/server/models/bridge_startup_lock.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
 
 part 'bridge_startup_lock.freezed.dart';
 part 'bridge_startup_lock.g.dart';
@@ -10,6 +11,17 @@ sealed class BridgeStartupLock with _$BridgeStartupLock {
     required String? bridgeStartMarker,
   }) = _BridgeStartupLock;
 
-  factory BridgeStartupLock.fromJson(Map<String, dynamic> json) =>
-      _$BridgeStartupLockFromJson(json);
+  const BridgeStartupLock._();
+
+  factory BridgeStartupLock.fromJson(Map<String, dynamic> json) => _$BridgeStartupLockFromJson(json);
+
+  bool matchesStartMarkerOf({required ProcessIdentity identity}) {
+    if (identity.startMarker != null || bridgeStartMarker != null) {
+      return identity.startMarker == bridgeStartMarker;
+    }
+    // Both markers are null (e.g. Windows). We cannot distinguish a recycled
+    // PID from the original owner without additional heuristics, so we
+    // conservatively treat the lock as active.
+    return true;
+  }
 }

--- a/bridge/app/lib/src/server/models/bridge_startup_lock.freezed.dart
+++ b/bridge/app/lib/src/server/models/bridge_startup_lock.freezed.dart
@@ -80,8 +80,8 @@ as String?,
 /// @nodoc
 @JsonSerializable()
 
-class _BridgeStartupLock implements BridgeStartupLock {
-  const _BridgeStartupLock({required this.bridgePid, required this.bridgeStartMarker});
+class _BridgeStartupLock extends BridgeStartupLock {
+  const _BridgeStartupLock({required this.bridgePid, required this.bridgeStartMarker}): super._();
   factory _BridgeStartupLock.fromJson(Map<String, dynamic> json) => _$BridgeStartupLockFromJson(json);
 
 @override final  int bridgePid;

--- a/bridge/app/lib/src/server/repositories/startup_mutex_repository.dart
+++ b/bridge/app/lib/src/server/repositories/startup_mutex_repository.dart
@@ -8,8 +8,26 @@ import '../foundation/process_match.dart';
 import '../models/bridge_startup_lock.dart';
 import 'process_repository.dart';
 
-enum StartupMutexAcquireResult {
-  alreadyLocked,
+class StartupLockRejection {
+  const StartupLockRejection({
+    required this.lock,
+    required this.holderMatch,
+    required this.lockFilePath,
+  });
+
+  final BridgeStartupLock? lock;
+  final ProcessMatch? holderMatch;
+  final String lockFilePath;
+}
+
+class _LiveStartupLockHolder {
+  const _LiveStartupLockHolder({
+    required this.lock,
+    required this.match,
+  });
+
+  final BridgeStartupLock lock;
+  final ProcessMatch match;
 }
 
 class StartupMutexRepository {
@@ -26,7 +44,7 @@ class StartupMutexRepository {
     required int bridgePid,
     required String? bridgeStartMarker,
     required Future<T> Function() onLockAcquired,
-    required Future<T> Function(StartupMutexAcquireResult result) onLockRejected,
+    required Future<T> Function(StartupLockRejection rejection) onLockRejected,
   }) async {
     final lock = BridgeStartupLock(
       bridgePid: bridgePid,
@@ -44,8 +62,8 @@ class StartupMutexRepository {
       }
     }
 
-    final staleLockCleared = await _clearStaleLockIfAny();
-    if (staleLockCleared) {
+    final holder = await _inspectLiveHolder();
+    if (holder == null) {
       final retryAcquired = await _runtimeFileApi.acquireStartupLock(
         contents: jsonEncode(lock.toJson()),
       );
@@ -56,20 +74,35 @@ class StartupMutexRepository {
           await _runtimeFileApi.releaseStartupLock();
         }
       }
+
+      final retryHolder = await _inspectLiveHolder();
+      return onLockRejected(
+        StartupLockRejection(
+          lock: retryHolder?.lock,
+          holderMatch: retryHolder?.match,
+          lockFilePath: _runtimeFileApi.startupLockFilePath,
+        ),
+      );
     }
 
-    return onLockRejected(StartupMutexAcquireResult.alreadyLocked);
+    return onLockRejected(
+      StartupLockRejection(
+        lock: holder.lock,
+        holderMatch: holder.match,
+        lockFilePath: _runtimeFileApi.startupLockFilePath,
+      ),
+    );
   }
 
-  Future<bool> _clearStaleLockIfAny() async {
+  Future<_LiveStartupLockHolder?> _inspectLiveHolder() async {
     final lockContents = await _runtimeFileApi.readStartupLock();
     if (lockContents == null) {
-      return true;
+      return null;
     }
 
     if (lockContents.isEmpty) {
       await _runtimeFileApi.releaseStartupLock();
-      return true;
+      return null;
     }
 
     final BridgeStartupLock lock;
@@ -80,7 +113,7 @@ class StartupMutexRepository {
     } catch (err, st) {
       Log.w("Failed to parse lockfile to `BridgeStartupLock`", err, st);
       await _runtimeFileApi.releaseStartupLock();
-      return true;
+      return null;
     }
 
     final match = await _processRepository.inspectProcessMatch(pid: lock.bridgePid);
@@ -89,10 +122,10 @@ class StartupMutexRepository {
         !match.isCurrentUserProcess ||
         !_lockMatchesProcess(lock: lock, match: match)) {
       await _runtimeFileApi.releaseStartupLock();
-      return true;
+      return null;
     }
 
-    return false;
+    return _LiveStartupLockHolder(lock: lock, match: match);
   }
 
   bool _lockMatchesProcess({

--- a/bridge/app/lib/src/server/repositories/startup_mutex_repository.dart
+++ b/bridge/app/lib/src/server/repositories/startup_mutex_repository.dart
@@ -62,7 +62,7 @@ class StartupMutexRepository {
       }
     }
 
-    final holder = await _inspectLiveHolder();
+    final holder = await _inspectLiveHolder(currentBridgePid: bridgePid);
     if (holder == null) {
       final retryAcquired = await _runtimeFileApi.acquireStartupLock(
         contents: jsonEncode(lock.toJson()),
@@ -75,7 +75,7 @@ class StartupMutexRepository {
         }
       }
 
-      final retryHolder = await _inspectLiveHolder();
+      final retryHolder = await _inspectLiveHolder(currentBridgePid: bridgePid);
       return onLockRejected(
         StartupLockRejection(
           lock: retryHolder?.lock,
@@ -94,7 +94,7 @@ class StartupMutexRepository {
     );
   }
 
-  Future<_LiveStartupLockHolder?> _inspectLiveHolder() async {
+  Future<_LiveStartupLockHolder?> _inspectLiveHolder({required int currentBridgePid}) async {
     final lockContents = await _runtimeFileApi.readStartupLock();
     if (lockContents == null) {
       return null;
@@ -116,29 +116,21 @@ class StartupMutexRepository {
       return null;
     }
 
+    if (lock.bridgePid == currentBridgePid) {
+      Log.w('Startup lock records this process pid $currentBridgePid; treating it as stale.');
+      await _runtimeFileApi.releaseStartupLock();
+      return null;
+    }
+
     final match = await _processRepository.inspectProcessMatch(pid: lock.bridgePid);
     if (match == null ||
         match.kind != ProcessMatchKind.sesoriBridge ||
         !match.isCurrentUserProcess ||
-        !_lockMatchesProcess(lock: lock, match: match)) {
+        !lock.matchesStartMarkerOf(identity: match.identity)) {
       await _runtimeFileApi.releaseStartupLock();
       return null;
     }
 
     return _LiveStartupLockHolder(lock: lock, match: match);
-  }
-
-  bool _lockMatchesProcess({
-    required BridgeStartupLock lock,
-    required ProcessMatch match,
-  }) {
-    final identity = match.identity;
-    if (identity.startMarker != null || lock.bridgeStartMarker != null) {
-      return identity.startMarker == lock.bridgeStartMarker;
-    }
-    // Both markers are null (e.g. Windows). We cannot distinguish a recycled
-    // PID from the original owner without additional heuristics, so we
-    // conservatively treat the lock as active.
-    return true;
   }
 }

--- a/bridge/app/lib/src/server/repositories/terminal_prompt_repository.dart
+++ b/bridge/app/lib/src/server/repositories/terminal_prompt_repository.dart
@@ -12,6 +12,12 @@ class TerminalPromptRepository {
     );
   }
 
+  Future<TerminalPromptDecision> askReplaceStartingBridge({required int holderPid}) async {
+    return _askYesNo(
+      message: 'Another Sesori bridge is still starting up (pid $holderPid). Kill it and start fresh? [y/N]',
+    );
+  }
+
   Future<TerminalPromptDecision> askStopBridgesBeforeLogout({required int bridgeCount}) async {
     return _askYesNo(
       message: '$bridgeCount bridge instance(s) are currently running. Stop them before logging out? [y/N]',

--- a/bridge/app/lib/src/server/services/bridge_instance_service.dart
+++ b/bridge/app/lib/src/server/services/bridge_instance_service.dart
@@ -81,6 +81,10 @@ class BridgeInstanceService {
     required ProcessMatch holder,
     required int currentPid,
   }) async {
+    if (lock.bridgePid == currentPid) {
+      return BridgeInstanceResolutionStatus.allowed;
+    }
+
     final decision = await _terminalPromptRepository.askReplaceStartingBridge(holderPid: holder.identity.pid);
     switch (decision) {
       case TerminalPromptDecision.nonInteractive:
@@ -99,7 +103,11 @@ class BridgeInstanceService {
           return BridgeInstanceResolutionStatus.declined;
         }
 
-        await _processRepository.sendGracefulSignal(pid: lock.bridgePid);
+        try {
+          await _processRepository.sendGracefulSignal(pid: lock.bridgePid);
+        } on Object catch (err, st) {
+          Log.w('Failed to send graceful signal to startup lock holder pid ${lock.bridgePid}', err, st);
+        }
         await _clock.delay(duration: _bridgeShutdownWait);
 
         final afterGraceful = await _processRepository.inspectProcessMatch(pid: lock.bridgePid);
@@ -107,7 +115,11 @@ class BridgeInstanceService {
           return BridgeInstanceResolutionStatus.allowed;
         }
 
-        await _processRepository.sendForceSignal(pid: lock.bridgePid);
+        try {
+          await _processRepository.sendForceSignal(pid: lock.bridgePid);
+        } on Object catch (err, st) {
+          Log.w('Failed to send force signal to startup lock holder pid ${lock.bridgePid}', err, st);
+        }
         await _clock.delay(duration: const Duration(seconds: 1));
 
         final afterForce = await _processRepository.inspectProcessMatch(pid: lock.bridgePid);
@@ -205,10 +217,6 @@ class BridgeInstanceService {
       return false;
     }
 
-    final identity = match.identity;
-    if (identity.startMarker != null || lock.bridgeStartMarker != null) {
-      return identity.startMarker == lock.bridgeStartMarker;
-    }
-    return true;
+    return lock.matchesStartMarkerOf(identity: match.identity);
   }
 }

--- a/bridge/app/lib/src/server/services/bridge_instance_service.dart
+++ b/bridge/app/lib/src/server/services/bridge_instance_service.dart
@@ -1,6 +1,8 @@
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
 
+import '../foundation/process_match.dart';
 import '../foundation/terminal_prompt_decision.dart';
+import '../models/bridge_startup_lock.dart';
 import '../repositories/bridge_instance_repository.dart';
 import '../repositories/process_repository.dart';
 import '../repositories/terminal_prompt_repository.dart';
@@ -71,6 +73,50 @@ class BridgeInstanceService {
           existingBridges: existingBridges,
           terminatedBridges: terminatedBridges,
         );
+    }
+  }
+
+  Future<BridgeInstanceResolutionStatus> resolveStartupLockContention({
+    required BridgeStartupLock lock,
+    required ProcessMatch holder,
+    required int currentPid,
+  }) async {
+    final decision = await _terminalPromptRepository.askReplaceStartingBridge(holderPid: holder.identity.pid);
+    switch (decision) {
+      case TerminalPromptDecision.nonInteractive:
+        return BridgeInstanceResolutionStatus.nonInteractive;
+      case TerminalPromptDecision.decline:
+        return BridgeInstanceResolutionStatus.declined;
+      case TerminalPromptDecision.replace:
+        final revalidated = await _processRepository.inspectProcessMatch(pid: lock.bridgePid);
+        if (revalidated == null) {
+          return BridgeInstanceResolutionStatus.allowed;
+        }
+        if (!_matchesLockedBridge(lock: lock, match: revalidated)) {
+          Log.w(
+            'Startup lock holder pid ${lock.bridgePid} no longer matches the recorded Sesori bridge; refusing to kill it.',
+          );
+          return BridgeInstanceResolutionStatus.declined;
+        }
+
+        await _processRepository.sendGracefulSignal(pid: lock.bridgePid);
+        await _clock.delay(duration: _bridgeShutdownWait);
+
+        final afterGraceful = await _processRepository.inspectProcessMatch(pid: lock.bridgePid);
+        if (afterGraceful == null || !_matchesLockedBridge(lock: lock, match: afterGraceful)) {
+          return BridgeInstanceResolutionStatus.allowed;
+        }
+
+        await _processRepository.sendForceSignal(pid: lock.bridgePid);
+        await _clock.delay(duration: const Duration(seconds: 1));
+
+        final afterForce = await _processRepository.inspectProcessMatch(pid: lock.bridgePid);
+        if (afterForce == null || !_matchesLockedBridge(lock: lock, match: afterForce)) {
+          return BridgeInstanceResolutionStatus.allowed;
+        }
+
+        Log.e('Failed to kill Sesori bridge startup lock holder pid ${lock.bridgePid}');
+        return BridgeInstanceResolutionStatus.declined;
     }
   }
 
@@ -149,5 +195,20 @@ class BridgeInstanceService {
     required int pid,
   }) {
     return candidates.any((candidate) => candidate.pid == pid);
+  }
+
+  bool _matchesLockedBridge({
+    required BridgeStartupLock lock,
+    required ProcessMatch match,
+  }) {
+    if (match.kind != ProcessMatchKind.sesoriBridge || !match.isCurrentUserProcess) {
+      return false;
+    }
+
+    final identity = match.identity;
+    if (identity.startMarker != null || lock.bridgeStartMarker != null) {
+      return identity.startMarker == lock.bridgeStartMarker;
+    }
+    return true;
   }
 }

--- a/bridge/app/lib/src/server/services/bridge_instance_service.dart
+++ b/bridge/app/lib/src/server/services/bridge_instance_service.dart
@@ -98,9 +98,9 @@ class BridgeInstanceService {
         }
         if (!_matchesLockedBridge(lock: lock, match: revalidated)) {
           Log.w(
-            'Startup lock holder pid ${lock.bridgePid} no longer matches the recorded Sesori bridge; refusing to kill it.',
+            'Startup lock holder pid ${lock.bridgePid} no longer matches the recorded Sesori bridge; treating the lock as stale without signaling.',
           );
-          return BridgeInstanceResolutionStatus.declined;
+          return BridgeInstanceResolutionStatus.allowed;
         }
 
         try {

--- a/bridge/app/lib/src/updater/api/file_replacement_api.dart
+++ b/bridge/app/lib/src/updater/api/file_replacement_api.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 
 import '../../bridge/foundation/process_runner.dart';
+import '../../bridge/foundation/post_update_restart_flag.dart';
 import '../models/file_replacement_result.dart';
 import '../models/pending_windows_update.dart';
 
@@ -183,6 +184,7 @@ class FileReplacementApi {
       '}',
       r'if (Test-Path $oldBinaryPath) { Remove-Item -Force $oldBinaryPath }',
       r'if (Test-Path $oldLibPath) { Remove-Item -Recurse -Force $oldLibPath }',
+      "\$env:$sesoriPostUpdateRestartEnvVar = '1'",
       r'Start-Process -FilePath $binaryPath -ArgumentList $args',
       r'if (Test-Path $archivePath) { Remove-Item -Force $archivePath }',
       r'if (Test-Path $stagingRoot) { Remove-Item -Recurse -Force $stagingRoot }',

--- a/bridge/app/lib/src/updater/api/file_replacement_api.dart
+++ b/bridge/app/lib/src/updater/api/file_replacement_api.dart
@@ -2,8 +2,8 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
-import '../../bridge/foundation/process_runner.dart';
 import '../../bridge/foundation/post_update_restart_flag.dart';
+import '../../bridge/foundation/process_runner.dart';
 import '../models/file_replacement_result.dart';
 import '../models/pending_windows_update.dart';
 

--- a/bridge/app/lib/src/updater/foundation/update_relaunch_client.dart
+++ b/bridge/app/lib/src/updater/foundation/update_relaunch_client.dart
@@ -1,10 +1,25 @@
 import 'dart:io';
 
+import '../../bridge/foundation/post_update_restart_flag.dart';
+
+typedef RelaunchProcessStarter =
+    Future<Process> Function(
+      String executable,
+      List<String> arguments, {
+      required Map<String, String>? environment,
+      required ProcessStartMode mode,
+    });
+
 class UpdateRelaunchClient {
+  UpdateRelaunchClient({required RelaunchProcessStarter processStarter}) : _processStarter = processStarter;
+
+  final RelaunchProcessStarter _processStarter;
+
   Future<Never> relaunchWindowsSwapScript({required String scriptPath}) async {
-    await Process.start(
+    await _processStarter(
       'powershell',
       ['-ExecutionPolicy', 'Bypass', '-File', scriptPath],
+      environment: const <String, String>{sesoriPostUpdateRestartEnvVar: '1'},
       mode: ProcessStartMode.detached,
     );
     exit(0);
@@ -14,9 +29,10 @@ class UpdateRelaunchClient {
     required String binaryPath,
     required List<String> args,
   }) async {
-    await Process.start(
+    await _processStarter(
       binaryPath,
       args,
+      environment: const <String, String>{sesoriPostUpdateRestartEnvVar: '1'},
       mode: ProcessStartMode.inheritStdio,
     );
     exit(0);

--- a/bridge/app/test/bridge/runtime/bridge_logout_runner_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_logout_runner_test.dart
@@ -1,7 +1,9 @@
 import 'dart:io';
 
 import 'package:sesori_bridge/src/bridge/runtime/bridge_logout_runner.dart';
+import 'package:sesori_bridge/src/server/foundation/process_match.dart';
 import 'package:sesori_bridge/src/server/foundation/terminal_prompt_decision.dart';
+import 'package:sesori_bridge/src/server/models/bridge_startup_lock.dart';
 import 'package:sesori_bridge/src/server/repositories/bridge_instance_repository.dart';
 import 'package:sesori_bridge/src/server/repositories/terminal_prompt_repository.dart';
 import 'package:sesori_bridge/src/server/services/bridge_instance_service.dart';
@@ -194,6 +196,15 @@ class _FakeBridgeInstanceService implements BridgeInstanceService {
     terminateRequests.add(existingBridges);
     return terminatedBridges;
   }
+
+  @override
+  Future<BridgeInstanceResolutionStatus> resolveStartupLockContention({
+    required BridgeStartupLock lock,
+    required ProcessMatch holder,
+    required int currentPid,
+  }) async {
+    throw UnimplementedError('not used by logout');
+  }
 }
 
 class _FakeTerminalPromptRepository implements TerminalPromptRepository {
@@ -203,6 +214,11 @@ class _FakeTerminalPromptRepository implements TerminalPromptRepository {
 
   @override
   Future<TerminalPromptDecision> askReplaceExistingBridge({required int bridgeCount}) async {
+    throw UnimplementedError('not used by logout');
+  }
+
+  @override
+  Future<TerminalPromptDecision> askReplaceStartingBridge({required int holderPid}) async {
     throw UnimplementedError('not used by logout');
   }
 

--- a/bridge/app/test/bridge/runtime/bridge_runtime_auth_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_auth_test.dart
@@ -1,0 +1,51 @@
+import 'package:sesori_bridge/src/auth/login_email_api.dart';
+import 'package:sesori_bridge/src/auth/login_email_repository.dart';
+import 'package:sesori_bridge/src/auth/login_oauth_service.dart';
+import 'package:sesori_bridge/src/auth/token.dart';
+import 'package:sesori_bridge/src/bridge/foundation/post_update_restart_flag.dart';
+import 'package:sesori_bridge/src/bridge/runtime/bridge_runtime_auth.dart';
+import 'package:sesori_shared/sesori_shared.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BridgeRuntimeAuthService', () {
+    test('promptForProvider throws post-update non-interactive login guidance without reading stdin', () async {
+      final service = BridgeRuntimeAuthService(
+        loginEmailRepository: _FakeLoginEmailRepository(),
+        loginOAuthService: _FakeLoginOAuthService(),
+        environment: const <String, String>{sesoriPostUpdateRestartEnvVar: '1'},
+      );
+
+      await expectLater(
+        service.promptForProvider(),
+        throwsA(
+          isA<Exception>().having(
+            (error) => error.toString(),
+            'message',
+            contains('Login required, but this bridge was relaunched non-interactively after an auto-update'),
+          ),
+        ),
+      );
+    });
+  });
+}
+
+class _FakeLoginEmailRepository implements LoginEmailRepository {
+  @override
+  LoginEmailApi get emailAuthApi => throw UnimplementedError();
+
+  @override
+  ({String email, String password}) Function() get promptForCredentials => throw UnimplementedError();
+
+  @override
+  Future<TokenData> performEmailLogin() {
+    throw UnimplementedError();
+  }
+}
+
+class _FakeLoginOAuthService implements LoginOAuthService {
+  @override
+  Future<TokenData> performOAuthLogin(OAuthProvider provider) {
+    throw UnimplementedError();
+  }
+}

--- a/bridge/app/test/bridge/runtime/bridge_runtime_server_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_server_test.dart
@@ -1,6 +1,8 @@
 import "package:args/args.dart";
 import "package:sesori_bridge/src/bridge/runtime/bridge_cli_options.dart";
 import "package:sesori_bridge/src/bridge/runtime/bridge_runtime_server.dart";
+import "package:sesori_bridge/src/server/foundation/process_match.dart";
+import "package:sesori_bridge/src/server/models/bridge_startup_lock.dart";
 import "package:sesori_bridge/src/server/models/open_code_ownership_record.dart";
 import "package:sesori_bridge/src/server/repositories/open_code_ownership_repository.dart";
 import "package:sesori_bridge/src/server/repositories/startup_mutex_repository.dart";
@@ -156,6 +158,8 @@ void main() {
 
     test("mutex rejection aborts before singleton or OpenCode work", () async {
       startupMutexRepository.rejectLock = true;
+      startupMutexRepository.rejection = _startupLockRejection();
+      bridgeInstanceService.startupLockStatus = BridgeInstanceResolutionStatus.declined;
 
       await expectLater(
         resolveServer(
@@ -179,6 +183,134 @@ void main() {
       expect(bridgeInstanceService.currentPids, isEmpty);
       expect(openCodeServerService.startCalls, isEmpty);
       expect(openCodeServerService.validateCalls, isEmpty);
+    });
+
+    test("mutex rejection with unidentifiable holder includes lock path recovery", () async {
+      startupMutexRepository.rejectLock = true;
+      startupMutexRepository.rejection = const StartupLockRejection(
+        lock: null,
+        holderMatch: null,
+        lockFilePath: "/tmp/bridge-startup.lock",
+      );
+
+      await expectLater(
+        resolveServer(
+          options: _options(port: null, noAutoStart: false),
+          currentBridgeIdentity: currentBridgeIdentity,
+          ownerSessionId: "owner-session",
+          startupMutexRepository: startupMutexRepository,
+          ownershipRepository: ownershipRepository,
+          bridgeInstanceService: bridgeInstanceService,
+          openCodeServerService: openCodeServerService,
+        ),
+        throwsA(
+          isA<BridgeRuntimeServerException>().having(
+            (error) => error.message,
+            "message",
+            allOf(contains("delete /tmp/bridge-startup.lock"), contains("already in progress")),
+          ),
+        ),
+      );
+
+      expect(bridgeInstanceService.startupLockContentionCalls, isEmpty);
+    });
+
+    test("startup lock takeover retries mutex and returns runtime", () async {
+      startupMutexRepository.rejectSequence = <bool>[true, false];
+      startupMutexRepository.rejection = _startupLockRejection();
+      bridgeInstanceService.startupLockStatus = BridgeInstanceResolutionStatus.allowed;
+
+      final runtime = await resolveServer(
+        options: _options(port: null, noAutoStart: false),
+        currentBridgeIdentity: currentBridgeIdentity,
+        ownerSessionId: "owner-session",
+        startupMutexRepository: startupMutexRepository,
+        ownershipRepository: ownershipRepository,
+        bridgeInstanceService: bridgeInstanceService,
+        openCodeServerService: openCodeServerService,
+      );
+
+      expect(runtime.port, equals(50123));
+      expect(startupMutexRepository.lockRequests, hasLength(2));
+      expect(bridgeInstanceService.startupLockContentionCalls.single.lock.bridgePid, equals(201));
+      expect(bridgeInstanceService.currentPids, equals(<int>[100]));
+    });
+
+    test("startup lock replacement decline aborts with declined message", () async {
+      startupMutexRepository.rejectLock = true;
+      startupMutexRepository.rejection = _startupLockRejection();
+      bridgeInstanceService.startupLockStatus = BridgeInstanceResolutionStatus.declined;
+
+      await expectLater(
+        resolveServer(
+          options: _options(port: null, noAutoStart: false),
+          currentBridgeIdentity: currentBridgeIdentity,
+          ownerSessionId: "owner-session",
+          startupMutexRepository: startupMutexRepository,
+          ownershipRepository: ownershipRepository,
+          bridgeInstanceService: bridgeInstanceService,
+          openCodeServerService: openCodeServerService,
+        ),
+        throwsA(
+          isA<BridgeRuntimeServerException>().having(
+            (error) => error.message,
+            "message",
+            contains("replacement was declined"),
+          ),
+        ),
+      );
+    });
+
+    test("startup lock nonInteractive message includes pid and lock path", () async {
+      startupMutexRepository.rejectLock = true;
+      startupMutexRepository.rejection = _startupLockRejection(lockFilePath: "/tmp/start.lock");
+      bridgeInstanceService.startupLockStatus = BridgeInstanceResolutionStatus.nonInteractive;
+
+      await expectLater(
+        resolveServer(
+          options: _options(port: null, noAutoStart: false),
+          currentBridgeIdentity: currentBridgeIdentity,
+          ownerSessionId: "owner-session",
+          startupMutexRepository: startupMutexRepository,
+          ownershipRepository: ownershipRepository,
+          bridgeInstanceService: bridgeInstanceService,
+          openCodeServerService: openCodeServerService,
+        ),
+        throwsA(
+          isA<BridgeRuntimeServerException>().having(
+            (error) => error.message,
+            "message",
+            allOf(contains("non-interactive"), contains("Bridge pid 201"), contains("/tmp/start.lock")),
+          ),
+        ),
+      );
+    });
+
+    test("startup lock allowed but still locked on retry aborts without infinite loop", () async {
+      startupMutexRepository.rejectSequence = <bool>[true, true];
+      startupMutexRepository.rejection = _startupLockRejection();
+      bridgeInstanceService.startupLockStatus = BridgeInstanceResolutionStatus.allowed;
+
+      await expectLater(
+        resolveServer(
+          options: _options(port: null, noAutoStart: false),
+          currentBridgeIdentity: currentBridgeIdentity,
+          ownerSessionId: "owner-session",
+          startupMutexRepository: startupMutexRepository,
+          ownershipRepository: ownershipRepository,
+          bridgeInstanceService: bridgeInstanceService,
+          openCodeServerService: openCodeServerService,
+        ),
+        throwsA(
+          isA<BridgeRuntimeServerException>().having(
+            (error) => error.message,
+            "message",
+            contains("still in progress after attempting replacement"),
+          ),
+        ),
+      );
+
+      expect(startupMutexRepository.lockRequests, hasLength(2));
     });
 
     test("no-auto-start explicit port validates existing server and creates no ownership", () async {
@@ -259,8 +391,23 @@ OpenCodeOwnershipRecord _ownedRecord() {
   );
 }
 
+StartupLockRejection _startupLockRejection({String lockFilePath = "/tmp/bridge-startup.lock"}) {
+  final holderIdentity = _identity(pid: 201, startMarker: "holder-start");
+  return StartupLockRejection(
+    lock: const BridgeStartupLock(bridgePid: 201, bridgeStartMarker: "holder-start"),
+    holderMatch: ProcessMatch(
+      identity: holderIdentity,
+      kind: ProcessMatchKind.sesoriBridge,
+      isCurrentUserProcess: true,
+    ),
+    lockFilePath: lockFilePath,
+  );
+}
+
 class _FakeStartupMutexRepository implements StartupMutexRepository {
   bool rejectLock = false;
+  List<bool>? rejectSequence;
+  StartupLockRejection? rejection;
   final List<({int pid, String? startMarker})> lockRequests = <({int pid, String? startMarker})>[];
   final List<String> operations = <String>[];
 
@@ -269,12 +416,20 @@ class _FakeStartupMutexRepository implements StartupMutexRepository {
     required int bridgePid,
     required String? bridgeStartMarker,
     required Future<T> Function() onLockAcquired,
-    required Future<T> Function(StartupMutexAcquireResult result) onLockRejected,
+    required Future<T> Function(StartupLockRejection rejection) onLockRejected,
   }) async {
     lockRequests.add((pid: bridgePid, startMarker: bridgeStartMarker));
     operations.add("mutex.acquire");
-    if (rejectLock) {
-      return onLockRejected(StartupMutexAcquireResult.alreadyLocked);
+    final shouldReject = rejectSequence?.removeAt(0) ?? rejectLock;
+    if (shouldReject) {
+      return onLockRejected(
+        rejection ??
+            const StartupLockRejection(
+              lock: null,
+              holderMatch: null,
+              lockFilePath: "/tmp/bridge-startup.lock",
+            ),
+      );
     }
     return onLockAcquired();
   }
@@ -312,6 +467,9 @@ class _FakeBridgeInstanceService implements BridgeInstanceService {
   );
   final List<int> currentPids = <int>[];
   final List<String> operations = <String>[];
+  BridgeInstanceResolutionStatus startupLockStatus = BridgeInstanceResolutionStatus.allowed;
+  final List<({BridgeStartupLock lock, ProcessMatch holder, int currentPid})> startupLockContentionCalls =
+      <({BridgeStartupLock lock, ProcessMatch holder, int currentPid})>[];
 
   @override
   Future<BridgeInstanceResolution> enforceSingleLiveBridge({required int currentPid}) async {
@@ -327,6 +485,16 @@ class _FakeBridgeInstanceService implements BridgeInstanceService {
   }) async {
     operations.add("singleton.terminate");
     return existingBridges;
+  }
+
+  @override
+  Future<BridgeInstanceResolutionStatus> resolveStartupLockContention({
+    required BridgeStartupLock lock,
+    required ProcessMatch holder,
+    required int currentPid,
+  }) async {
+    startupLockContentionCalls.add((lock: lock, holder: holder, currentPid: currentPid));
+    return startupLockStatus;
   }
 }
 

--- a/bridge/app/test/server/api/open_code_process_api_test.dart
+++ b/bridge/app/test/server/api/open_code_process_api_test.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:sesori_bridge/src/server/api/open_code_process_api.dart';
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OpenCodeProcessApi', () {
+    test('probeHealth returns unhealthy fact when send and drain exceed timeout', () async {
+      final api = OpenCodeProcessApi(
+        processStarter: _unusedProcessStarter,
+        httpClient: _NeverCompletingClient(),
+        clock: const ServerClock(),
+        environment: const <String, String>{},
+        currentUser: null,
+        isWindows: false,
+        platform: 'macos',
+        probeTimeout: const Duration(milliseconds: 10),
+      );
+
+      final fact = await api.probeHealth(
+        serverUri: Uri.parse('http://127.0.0.1:4096'),
+        password: 'password',
+      );
+
+      expect(fact.statusCode, isNull);
+      expect(fact.error, isA<TimeoutException>());
+    });
+  });
+}
+
+Future<Process> _unusedProcessStarter(
+  String executable,
+  List<String> arguments, {
+  Map<String, String>? environment,
+  bool runInShell = false,
+}) {
+  throw UnimplementedError();
+}
+
+class _NeverCompletingClient extends http.BaseClient {
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    return Completer<http.StreamedResponse>().future;
+  }
+}

--- a/bridge/app/test/server/api/terminal_prompt_api_test.dart
+++ b/bridge/app/test/server/api/terminal_prompt_api_test.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+
+import 'package:sesori_bridge/src/bridge/foundation/post_update_restart_flag.dart';
+import 'package:sesori_bridge/src/server/api/terminal_prompt_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TerminalPromptApi', () {
+    test('post-update restart env flag disables interactivity and readLine without reading', () {
+      final api = TerminalPromptApi(
+        stdin: stdin,
+        stdout: stdout,
+        environment: const <String, String>{sesoriPostUpdateRestartEnvVar: '1'},
+      );
+
+      expect(api.isInteractive, isFalse);
+      expect(api.readLine(message: 'should not be written'), isNull);
+    });
+
+    test('without post-update restart env flag interactivity uses terminal handles', () {
+      final api = TerminalPromptApi(
+        stdin: stdin,
+        stdout: stdout,
+        environment: const <String, String>{},
+      );
+
+      expect(api.isInteractive, equals(stdin.hasTerminal && stdout.hasTerminal));
+    });
+  });
+}

--- a/bridge/app/test/server/models/bridge_startup_lock_test.dart
+++ b/bridge/app/test/server/models/bridge_startup_lock_test.dart
@@ -1,0 +1,45 @@
+import 'package:sesori_bridge/src/server/models/bridge_startup_lock.dart';
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BridgeStartupLock', () {
+    test('matchesStartMarkerOf returns true for equal non-null markers', () {
+      const lock = BridgeStartupLock(bridgePid: 123, bridgeStartMarker: 'marker');
+
+      expect(lock.matchesStartMarkerOf(identity: _identity(startMarker: 'marker')), isTrue);
+    });
+
+    test('matchesStartMarkerOf returns false for mismatched non-null markers', () {
+      const lock = BridgeStartupLock(bridgePid: 123, bridgeStartMarker: 'marker');
+
+      expect(lock.matchesStartMarkerOf(identity: _identity(startMarker: 'other')), isFalse);
+    });
+
+    test('matchesStartMarkerOf returns false for one-sided null markers', () {
+      const lock = BridgeStartupLock(bridgePid: 123, bridgeStartMarker: 'marker');
+      const nullMarkerLock = BridgeStartupLock(bridgePid: 123, bridgeStartMarker: null);
+
+      expect(lock.matchesStartMarkerOf(identity: _identity(startMarker: null)), isFalse);
+      expect(nullMarkerLock.matchesStartMarkerOf(identity: _identity(startMarker: 'marker')), isFalse);
+    });
+
+    test('matchesStartMarkerOf returns true when both markers are null', () {
+      const lock = BridgeStartupLock(bridgePid: 123, bridgeStartMarker: null);
+
+      expect(lock.matchesStartMarkerOf(identity: _identity(startMarker: null)), isTrue);
+    });
+  });
+}
+
+ProcessIdentity _identity({required String? startMarker}) {
+  return ProcessIdentity(
+    pid: 123,
+    startMarker: startMarker,
+    executablePath: '/usr/local/bin/sesori-bridge',
+    commandLine: 'sesori-bridge',
+    ownerUser: ProcessUser.fromRawUser('alex'),
+    platform: 'macos',
+    capturedAt: DateTime.utc(2026, 5, 15),
+  );
+}

--- a/bridge/app/test/server/repositories/terminal_prompt_repository_test.dart
+++ b/bridge/app/test/server/repositories/terminal_prompt_repository_test.dart
@@ -39,6 +39,18 @@ void main() {
       expect(decision, equals(TerminalPromptDecision.decline));
       expect(api.messages.single, equals('Another Sesori bridge is already running. Kill it and start fresh? [y/N]'));
     });
+
+    test('askReplaceStartingBridge uses startup contention prompt message', () async {
+      api.answer = 'yes';
+
+      final decision = await repository.askReplaceStartingBridge(holderPid: 1234);
+
+      expect(decision, equals(TerminalPromptDecision.replace));
+      expect(
+        api.messages.single,
+        equals('Another Sesori bridge is still starting up (pid 1234). Kill it and start fresh? [y/N]'),
+      );
+    });
   });
 }
 

--- a/bridge/app/test/server/services/bridge_instance_service_test.dart
+++ b/bridge/app/test/server/services/bridge_instance_service_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:sesori_bridge/src/server/foundation/process_match.dart';
 import 'package:sesori_bridge/src/server/foundation/terminal_prompt_decision.dart';
+import 'package:sesori_bridge/src/server/models/bridge_startup_lock.dart';
 import 'package:sesori_bridge/src/server/repositories/bridge_instance_repository.dart';
 import 'package:sesori_bridge/src/server/repositories/process_repository.dart';
 import 'package:sesori_bridge/src/server/repositories/terminal_prompt_repository.dart';
@@ -146,6 +147,119 @@ void main() {
       expect(contents, isNot(contains('OpenCodeServerService')));
       expect(contents, isNot(contains("../api/")));
     });
+
+    test('startup lock replace graceful-kill verified holder returns allowed', () async {
+      const lock = BridgeStartupLock(bridgePid: 300, bridgeStartMarker: 'holder-start');
+      final holder = _match(pid: 300, startMarker: 'holder-start');
+      processRepository.matchSnapshots[300] = <ProcessMatch?>[holder, null];
+      terminalPromptRepository.decision = TerminalPromptDecision.replace;
+
+      final status = await service.resolveStartupLockContention(
+        lock: lock,
+        holder: holder,
+        currentPid: 100,
+      );
+
+      expect(status, equals(BridgeInstanceResolutionStatus.allowed));
+      expect(terminalPromptRepository.startingBridgePids, equals(<int>[300]));
+      expect(processRepository.signalRequests, equals(<String>['graceful:300']));
+      expect(clock.delays, equals(<Duration>[const Duration(seconds: 5)]));
+    });
+
+    test('startup lock holder already dead at revalidation returns allowed without signals', () async {
+      const lock = BridgeStartupLock(bridgePid: 301, bridgeStartMarker: 'holder-start');
+      final holder = _match(pid: 301, startMarker: 'holder-start');
+      processRepository.matchSnapshots[301] = <ProcessMatch?>[null];
+      terminalPromptRepository.decision = TerminalPromptDecision.replace;
+
+      final status = await service.resolveStartupLockContention(
+        lock: lock,
+        holder: holder,
+        currentPid: 100,
+      );
+
+      expect(status, equals(BridgeInstanceResolutionStatus.allowed));
+      expect(processRepository.signalRequests, isEmpty);
+    });
+
+    test('startup lock identity mismatch declines and sends no kill signals', () async {
+      const lock = BridgeStartupLock(bridgePid: 302, bridgeStartMarker: 'original-start');
+      final holder = _match(pid: 302, startMarker: 'original-start');
+      processRepository.matchSnapshots[302] = <ProcessMatch?>[_match(pid: 302, startMarker: 'reused-start')];
+      terminalPromptRepository.decision = TerminalPromptDecision.replace;
+
+      final status = await service.resolveStartupLockContention(
+        lock: lock,
+        holder: holder,
+        currentPid: 100,
+      );
+
+      expect(status, equals(BridgeInstanceResolutionStatus.declined));
+      expect(processRepository.signalRequests, isEmpty);
+    });
+
+    test('startup lock decline returns declined', () async {
+      const lock = BridgeStartupLock(bridgePid: 303, bridgeStartMarker: 'holder-start');
+      final holder = _match(pid: 303, startMarker: 'holder-start');
+      terminalPromptRepository.decision = TerminalPromptDecision.decline;
+
+      final status = await service.resolveStartupLockContention(
+        lock: lock,
+        holder: holder,
+        currentPid: 100,
+      );
+
+      expect(status, equals(BridgeInstanceResolutionStatus.declined));
+      expect(processRepository.signalRequests, isEmpty);
+    });
+
+    test('startup lock nonInteractive returns nonInteractive', () async {
+      const lock = BridgeStartupLock(bridgePid: 304, bridgeStartMarker: 'holder-start');
+      final holder = _match(pid: 304, startMarker: 'holder-start');
+      terminalPromptRepository.decision = TerminalPromptDecision.nonInteractive;
+
+      final status = await service.resolveStartupLockContention(
+        lock: lock,
+        holder: holder,
+        currentPid: 100,
+      );
+
+      expect(status, equals(BridgeInstanceResolutionStatus.nonInteractive));
+      expect(processRepository.signalRequests, isEmpty);
+    });
+
+    test('startup lock survives graceful then force-killed returns allowed', () async {
+      const lock = BridgeStartupLock(bridgePid: 305, bridgeStartMarker: 'holder-start');
+      final holder = _match(pid: 305, startMarker: 'holder-start');
+      processRepository.matchSnapshots[305] = <ProcessMatch?>[holder, holder, null];
+      terminalPromptRepository.decision = TerminalPromptDecision.replace;
+
+      final status = await service.resolveStartupLockContention(
+        lock: lock,
+        holder: holder,
+        currentPid: 100,
+      );
+
+      expect(status, equals(BridgeInstanceResolutionStatus.allowed));
+      expect(processRepository.signalRequests, equals(<String>['graceful:305', 'force:305']));
+      expect(clock.delays, equals(<Duration>[const Duration(seconds: 5), const Duration(seconds: 1)]));
+    });
+
+    test('startup lock survives force returns declined', () async {
+      const lock = BridgeStartupLock(bridgePid: 306, bridgeStartMarker: 'holder-start');
+      final holder = _match(pid: 306, startMarker: 'holder-start');
+      processRepository.matchSnapshots[306] = <ProcessMatch?>[holder, holder, holder];
+      terminalPromptRepository.decision = TerminalPromptDecision.replace;
+
+      final status = await service.resolveStartupLockContention(
+        lock: lock,
+        holder: holder,
+        currentPid: 100,
+      );
+
+      expect(status, equals(BridgeInstanceResolutionStatus.declined));
+      expect(processRepository.signalRequests, equals(<String>['graceful:306', 'force:306']));
+    });
   });
 }
 
@@ -161,6 +275,19 @@ ProcessIdentity _candidate({
     ownerUser: ProcessUser.fromRawUser("alex"),
     platform: 'macos',
     capturedAt: DateTime.utc(2026, 5, 15, 12),
+  );
+}
+
+ProcessMatch _match({
+  required int pid,
+  required String? startMarker,
+  ProcessMatchKind kind = ProcessMatchKind.sesoriBridge,
+  bool isCurrentUserProcess = true,
+}) {
+  return ProcessMatch(
+    identity: _candidate(pid: pid, startMarker: startMarker),
+    kind: kind,
+    isCurrentUserProcess: isCurrentUserProcess,
   );
 }
 
@@ -183,11 +310,19 @@ class _FakeTerminalPromptRepository implements TerminalPromptRepository {
   int askCount = 0;
   int emailPromptCount = 0;
   final List<int> bridgeCounts = <int>[];
+  final List<int> startingBridgePids = <int>[];
 
   @override
   Future<TerminalPromptDecision> askReplaceExistingBridge({required int bridgeCount}) async {
     askCount += 1;
     bridgeCounts.add(bridgeCount);
+    return decision;
+  }
+
+  @override
+  Future<TerminalPromptDecision> askReplaceStartingBridge({required int holderPid}) async {
+    askCount += 1;
+    startingBridgePids.add(holderPid);
     return decision;
   }
 
@@ -210,6 +345,7 @@ class _FakeTerminalPromptRepository implements TerminalPromptRepository {
 
 class _FakeProcessRepository implements ProcessRepository {
   final List<String> signalRequests = <String>[];
+  final Map<int, List<ProcessMatch?>> matchSnapshots = <int, List<ProcessMatch?>>{};
 
   @override
   Future<ProcessIdentity?> inspectProcess({required int pid}) async {
@@ -218,7 +354,11 @@ class _FakeProcessRepository implements ProcessRepository {
 
   @override
   Future<ProcessMatch?> inspectProcessMatch({required int pid}) async {
-    return null;
+    final snapshots = matchSnapshots[pid];
+    if (snapshots == null || snapshots.isEmpty) {
+      return null;
+    }
+    return snapshots.removeAt(0);
   }
 
   @override

--- a/bridge/app/test/server/services/bridge_instance_service_test.dart
+++ b/bridge/app/test/server/services/bridge_instance_service_test.dart
@@ -197,7 +197,7 @@ void main() {
       expect(processRepository.signalRequests, isEmpty);
     });
 
-    test('startup lock identity mismatch declines and sends no kill signals', () async {
+    test('startup lock identity mismatch treats lock as stale and sends no kill signals', () async {
       const lock = BridgeStartupLock(bridgePid: 302, bridgeStartMarker: 'original-start');
       final holder = _match(pid: 302, startMarker: 'original-start');
       processRepository.matchSnapshots[302] = <ProcessMatch?>[_match(pid: 302, startMarker: 'reused-start')];
@@ -209,7 +209,7 @@ void main() {
         currentPid: 100,
       );
 
-      expect(status, equals(BridgeInstanceResolutionStatus.declined));
+      expect(status, equals(BridgeInstanceResolutionStatus.allowed));
       expect(processRepository.signalRequests, isEmpty);
     });
 

--- a/bridge/app/test/server/services/bridge_instance_service_test.dart
+++ b/bridge/app/test/server/services/bridge_instance_service_test.dart
@@ -166,6 +166,21 @@ void main() {
       expect(clock.delays, equals(<Duration>[const Duration(seconds: 5)]));
     });
 
+    test('startup lock matching current pid returns allowed without prompt or signals', () async {
+      const lock = BridgeStartupLock(bridgePid: 300, bridgeStartMarker: 'holder-start');
+      final holder = _match(pid: 300, startMarker: 'holder-start');
+
+      final status = await service.resolveStartupLockContention(
+        lock: lock,
+        holder: holder,
+        currentPid: 300,
+      );
+
+      expect(status, equals(BridgeInstanceResolutionStatus.allowed));
+      expect(terminalPromptRepository.askCount, equals(0));
+      expect(processRepository.signalRequests, isEmpty);
+    });
+
     test('startup lock holder already dead at revalidation returns allowed without signals', () async {
       const lock = BridgeStartupLock(bridgePid: 301, bridgeStartMarker: 'holder-start');
       final holder = _match(pid: 301, startMarker: 'holder-start');
@@ -260,6 +275,40 @@ void main() {
       expect(status, equals(BridgeInstanceResolutionStatus.declined));
       expect(processRepository.signalRequests, equals(<String>['graceful:306', 'force:306']));
     });
+
+    test('startup lock graceful signal failure proceeds to force path without escaping', () async {
+      const lock = BridgeStartupLock(bridgePid: 307, bridgeStartMarker: 'holder-start');
+      final holder = _match(pid: 307, startMarker: 'holder-start');
+      processRepository.matchSnapshots[307] = <ProcessMatch?>[holder, holder, holder];
+      processRepository.throwGraceful = true;
+      terminalPromptRepository.decision = TerminalPromptDecision.replace;
+
+      final status = await service.resolveStartupLockContention(
+        lock: lock,
+        holder: holder,
+        currentPid: 100,
+      );
+
+      expect(status, equals(BridgeInstanceResolutionStatus.declined));
+      expect(processRepository.signalRequests, equals(<String>['graceful:307', 'force:307']));
+    });
+
+    test('startup lock force signal failure returns declined without escaping', () async {
+      const lock = BridgeStartupLock(bridgePid: 308, bridgeStartMarker: 'holder-start');
+      final holder = _match(pid: 308, startMarker: 'holder-start');
+      processRepository.matchSnapshots[308] = <ProcessMatch?>[holder, holder, holder];
+      processRepository.throwForce = true;
+      terminalPromptRepository.decision = TerminalPromptDecision.replace;
+
+      final status = await service.resolveStartupLockContention(
+        lock: lock,
+        holder: holder,
+        currentPid: 100,
+      );
+
+      expect(status, equals(BridgeInstanceResolutionStatus.declined));
+      expect(processRepository.signalRequests, equals(<String>['graceful:308', 'force:308']));
+    });
   });
 }
 
@@ -346,6 +395,8 @@ class _FakeTerminalPromptRepository implements TerminalPromptRepository {
 class _FakeProcessRepository implements ProcessRepository {
   final List<String> signalRequests = <String>[];
   final Map<int, List<ProcessMatch?>> matchSnapshots = <int, List<ProcessMatch?>>{};
+  bool throwGraceful = false;
+  bool throwForce = false;
 
   @override
   Future<ProcessIdentity?> inspectProcess({required int pid}) async {
@@ -374,6 +425,9 @@ class _FakeProcessRepository implements ProcessRepository {
   @override
   Future<SignalResult> sendGracefulSignal({required int pid}) async {
     signalRequests.add('graceful:$pid');
+    if (throwGraceful) {
+      throw StateError('graceful failed');
+    }
     return SignalResult(
       pid: pid,
       requestedSignal: ShutdownSignal.graceful,
@@ -386,6 +440,9 @@ class _FakeProcessRepository implements ProcessRepository {
   @override
   Future<SignalResult> sendForceSignal({required int pid}) async {
     signalRequests.add('force:$pid');
+    if (throwForce) {
+      throw StateError('force failed');
+    }
     return SignalResult(
       pid: pid,
       requestedSignal: ShutdownSignal.force,

--- a/bridge/app/test/server/startup_mutex_repository_test.dart
+++ b/bridge/app/test/server/startup_mutex_repository_test.dart
@@ -125,6 +125,39 @@ void main() {
       expect(File(runtimeFileApi.startupLockFilePath).existsSync(), isFalse);
     });
 
+    test('withLock clears stale lock recording caller pid and retry succeeds', () async {
+      await runtimeFileApi.acquireStartupLock(
+        contents: jsonEncode(<String, dynamic>{
+          'bridgePid': 123,
+          'bridgeStartMarker': null,
+        }),
+      );
+
+      processRepository.matchResults[123] = ProcessMatch(
+        identity: ProcessIdentity(
+          pid: 123,
+          startMarker: null,
+          executablePath: '/usr/local/bin/sesori-bridge',
+          commandLine: 'sesori-bridge',
+          ownerUser: ProcessUser.fromRawUser('user'),
+          platform: 'windows',
+          capturedAt: DateTime.utc(2026, 5, 15),
+        ),
+        kind: ProcessMatchKind.sesoriBridge,
+        isCurrentUserProcess: true,
+      );
+
+      final result = await repository.withLock<int>(
+        bridgePid: 123,
+        bridgeStartMarker: null,
+        onLockAcquired: () async => 42,
+        onLockRejected: (_) async => -1,
+      );
+
+      expect(result, equals(42));
+      expect(File(runtimeFileApi.startupLockFilePath).existsSync(), isFalse);
+    });
+
     test('withLock steals stale lock when recorded bridge process is not a bridge', () async {
       await runtimeFileApi.acquireStartupLock(
         contents: jsonEncode(<String, dynamic>{'bridgePid': 999}),

--- a/bridge/app/test/server/startup_mutex_repository_test.dart
+++ b/bridge/app/test/server/startup_mutex_repository_test.dart
@@ -93,7 +93,10 @@ void main() {
         bridgeStartMarker: 'other-bridge-start-marker',
         onLockAcquired: () async => 2,
         onLockRejected: (result) async {
-          expect(result, equals(StartupMutexAcquireResult.alreadyLocked));
+          expect(result.lock?.bridgePid, equals(123));
+          expect(result.lock?.bridgeStartMarker, equals('bridge-start-marker'));
+          expect(result.holderMatch?.identity.pid, equals(123));
+          expect(result.lockFilePath, equals(runtimeFileApi.startupLockFilePath));
           return -1;
         },
       );
@@ -209,7 +212,31 @@ void main() {
         bridgeStartMarker: 'bridge-start-marker',
         onLockAcquired: () async => 42,
         onLockRejected: (result) async {
-          expect(result, equals(StartupMutexAcquireResult.alreadyLocked));
+          expect(result.lock?.bridgePid, equals(456));
+          expect(result.holderMatch?.identity.pid, equals(456));
+          expect(result.lockFilePath, equals(runtimeFileApi.startupLockFilePath));
+          return -1;
+        },
+      );
+
+      expect(result, equals(-1));
+    });
+
+    test('withLock rejection carries nulls when vanished lock race cannot identify holder', () async {
+      final fakeRuntimeFileApi = _RacingRuntimeFileApi(runtimeDirectory: p.join(tempDir.path, 'racing-runtime'));
+      final racingRepository = StartupMutexRepository(
+        runtimeFileApi: fakeRuntimeFileApi,
+        processRepository: processRepository,
+      );
+
+      final result = await racingRepository.withLock<int>(
+        bridgePid: 123,
+        bridgeStartMarker: 'bridge-start-marker',
+        onLockAcquired: () async => 42,
+        onLockRejected: (rejection) async {
+          expect(rejection.lock, isNull);
+          expect(rejection.holderMatch, isNull);
+          expect(rejection.lockFilePath, equals(fakeRuntimeFileApi.startupLockFilePath));
           return -1;
         },
       );
@@ -283,5 +310,19 @@ class _FakeProcessRepository implements ProcessRepository {
   @override
   Future<SignalResult> sendForceSignal({required int pid}) {
     throw UnimplementedError();
+  }
+}
+
+class _RacingRuntimeFileApi extends RuntimeFileApi {
+  _RacingRuntimeFileApi({required super.runtimeDirectory});
+
+  @override
+  Future<bool> acquireStartupLock({required String contents}) async {
+    return false;
+  }
+
+  @override
+  Future<String?> readStartupLock() async {
+    return null;
   }
 }

--- a/bridge/app/test/updater/file_replacement_api_test.dart
+++ b/bridge/app/test/updater/file_replacement_api_test.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:sesori_bridge/src/bridge/foundation/process_runner.dart';
+import 'package:sesori_bridge/src/bridge/foundation/post_update_restart_flag.dart';
+import 'package:sesori_bridge/src/updater/api/file_replacement_api.dart';
+import 'package:sesori_bridge/src/updater/models/pending_windows_update.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('FileReplacementApi', () {
+    test('Windows swap script sets post-update env flag before Start-Process', () async {
+      final tempDir = await Directory.systemTemp.createTemp('file-replacement-api-test-');
+      addTearDown(() async {
+        if (tempDir.existsSync()) {
+          await tempDir.delete(recursive: true);
+        }
+      });
+
+      final api = FileReplacementApi(processRunner: _FakeProcessRunner());
+      final scriptPath = await api.createWindowsSwapScript(
+        pending: PendingWindowsUpdate(
+          installRoot: tempDir.path,
+          stagingPath: p.join(tempDir.path, 'staging'),
+          archivePath: p.join(tempDir.path, 'archive.zip'),
+          lockPath: p.join(tempDir.path, 'update.lock'),
+        ),
+        args: const <String>['run'],
+      );
+
+      final script = await File(scriptPath).readAsString();
+      const envLine = "${r'$env:'}$sesoriPostUpdateRestartEnvVar = '1'";
+      final envIndex = script.indexOf(envLine);
+      final startIndex = script.indexOf(r'Start-Process -FilePath $binaryPath -ArgumentList $args');
+
+      expect(envIndex, isNonNegative);
+      expect(startIndex, isNonNegative);
+      expect(envIndex, lessThan(startIndex));
+    });
+  });
+}
+
+class _FakeProcessRunner implements ProcessRunner {
+  @override
+  Future<ProcessResult> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    Duration timeout = const Duration(seconds: 15),
+  }) {
+    throw UnimplementedError();
+  }
+}

--- a/bridge/app/test/updater/file_replacement_api_test.dart
+++ b/bridge/app/test/updater/file_replacement_api_test.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
-import 'package:sesori_bridge/src/bridge/foundation/process_runner.dart';
 import 'package:sesori_bridge/src/bridge/foundation/post_update_restart_flag.dart';
+import 'package:sesori_bridge/src/bridge/foundation/process_runner.dart';
 import 'package:sesori_bridge/src/updater/api/file_replacement_api.dart';
 import 'package:sesori_bridge/src/updater/models/pending_windows_update.dart';
 import 'package:test/test.dart';

--- a/bridge/app/test/updater/update_relaunch_client_test.dart
+++ b/bridge/app/test/updater/update_relaunch_client_test.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:sesori_bridge/src/bridge/foundation/post_update_restart_flag.dart';
+import 'package:sesori_bridge/src/updater/foundation/update_relaunch_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('UpdateRelaunchClient', () {
+    test('relaunchBinary passes post-update env flag and inheritStdio mode', () async {
+      final calls =
+          <({String executable, List<String> arguments, Map<String, String>? environment, ProcessStartMode mode})>[];
+      final client = UpdateRelaunchClient(
+        processStarter:
+            (
+              executable,
+              arguments, {
+              required Map<String, String>? environment,
+              required ProcessStartMode mode,
+            }) {
+              calls.add((executable: executable, arguments: arguments, environment: environment, mode: mode));
+              throw _TestAbort();
+            },
+      );
+
+      await expectLater(
+        client.relaunchBinary(binaryPath: '/bin/sesori-bridge', args: const <String>['run']),
+        throwsA(isA<_TestAbort>()),
+      );
+
+      expect(calls, hasLength(1));
+      expect(calls.single.executable, equals('/bin/sesori-bridge'));
+      expect(calls.single.arguments, equals(<String>['run']));
+      expect(calls.single.environment, equals(const <String, String>{sesoriPostUpdateRestartEnvVar: '1'}));
+      expect(calls.single.mode, equals(ProcessStartMode.inheritStdio));
+    });
+  });
+}
+
+class _TestAbort implements Exception {}


### PR DESCRIPTION
## Problem

A user's bridge auto-updated to 1.0.8 on startup and then could never start again: every attempt aborted with **"Startup aborted because another Sesori bridge startup is already in progress."** — with no recovery option. The user was not aware of any other bridge running. Per the original product spec, the bridge must **always** offer to kill whatever instance is blocking startup; the startup-lock path violated that.

Related symptom seen by multiple users: after closing the bridge and starting again, it reports another running bridge and asks to kill it.

## Root cause

1. **The post-update relaunch orphans the new bridge.** `UpdateRelaunchClient.relaunchBinary` is spawn + `exit(0)` (`inheritStdio`). The relaunched process inherits the TTY file descriptors — so `stdin.hasTerminal` claims it is interactive — but the user's shell has already reclaimed the terminal, so nobody can answer its prompts and Ctrl+C never reaches it. On Windows it's worse: the swap script's `Start-Process` detaches the new bridge into a console the user never sees.
2. **Unbounded blocking inside the lock window.** While holding `bridge-startup.lock`, startup can block forever on `stdin.readLineSync()` (the "kill existing bridge?" prompt) and on the OpenCode health probe (`http send` with no timeout).
3. **The rejection path had no recovery.** A bridge stuck in that window is a live, same-user, marker-matching `sesori-bridge` process, so the staleness check correctly reports it as live — and the mutex-rejected path hard-aborted with no kill option. Permanent brick; the stuck holder is invisible to the user.

The orphaning also explains the second symptom: auto-updated bridges aren't part of any terminal job, survive "closing" the terminal, and trigger the kill prompt on the next start.

## Fix

**A. Recoverable lock contention (spec compliance)**
- `StartupMutexRepository.withLock` rejection now carries facts (`StartupLockRejection`: parsed lock, live holder `ProcessMatch`, lock file path) instead of a bare enum. Stale-clear semantics unchanged.
- New Layer-3 decision: `BridgeInstanceService.resolveStartupLockContention` — prompts `Another Sesori bridge is still starting up (pid N). Kill it and start fresh? [y/N]`, then **revalidates the exact holder** (same PID + sesori-bridge classification + same user + start-marker match against the lock) immediately before killing — graceful → 5s → force → recheck. Never kills an unverified PID (PID-reuse safety); no broad process-scan kills in this path.
- `resolveServer` retries lock acquisition once after a successful takeover (the retry's stale-clear removes the dead holder's lock). Decline / non-interactive aborts now include the holder PID and lock file path so headless users can recover manually.

**B. Bounded lock window**
- `OpenCodeProcessApi.probeHealth` gains an injected `probeTimeout` (wired to 5s) — a half-dead OpenCode can no longer hang startup indefinitely while the lock is held.

**C. Deterministic non-interactive relaunch**
- The relaunched process gets `SESORI_POST_UPDATE_RESTART=1` (Unix relaunch env + Windows swap script). `TerminalPromptApi` treats that flag as non-interactive, so a post-update bridge can never block on stdin it cannot read; at worst it aborts cleanly with the lock released and a clear message.

The stuck 1.0.8 user recovers automatically once this ships: the update check runs *before* the startup mutex, so simply rerunning the bridge fetches the fixed release and relaunches into it; the fixed binary then offers the kill prompt for the stuck holder. Immediate manual unblock (no update needed): kill the stuck `sesori-bridge` process and/or delete `bridge-startup.lock` under the managed runtime cache dir.

## Coordination with #227 (plugin lifecycle migration 4/15)

#227 rewires the runner to call `StartupMutexRepository` + `BridgeInstanceService` directly (and `resolveServer` later becomes dead code). All recovery logic here lives in those shared components; only the thin retry loop sits in `resolveServer`, so the migration can lift it verbatim when rebasing. `bridge_shutdown_coordinator.dart`, orchestrator, and plugin/descriptor files are deliberately untouched.

## Out of scope (follow-up)

The "shutdown leaves a running bridge/OpenCode behind" report is a distinct bug (interacts with #227's shutdown-coordinator rewrite) and needs its own investigation.

## Verification

- `make analyze` — clean across all bridge modules
- `make test` — 1268 tests pass (new coverage: rejection facts, exact-holder revalidation/kill paths, bounded retry + new abort messages, env-flag non-interactivity, relaunch env/mode injection, swap-script env line, probe timeout)
- Plan approved by `aristotle-plan-review`; implementation approved by `aristotle-impl-review`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unrecoverable startup-lock bricks and prevents orphaned post-update bridges by making lock contention recoverable with a kill‑and‑retry flow and relaunching non‑interactively. Also adds a 5s OpenCode health‑probe timeout and treats PID‑reuse/mismatched lock holders as stale so startup can proceed safely.

- **Bug Fixes**
  - Recoverable startup‑lock contention: `StartupMutexRepository` now returns a `StartupLockRejection` with lock facts, exact holder match, and lock file path. The runner/server prompt “still starting up (pid N)”, revalidate the exact holder, send graceful → wait 5s → force, then retry the lock once. If the holder identity no longer matches (PID reused), the lock is treated as stale and startup continues; non‑interactive or declined paths include the holder PID and lock path, and if the holder can’t be identified we show the lock path to delete.
  - Bounded lock window: `OpenCodeProcessApi.probeHealth` now times out and drains in 5s to avoid hanging while the lock is held.
  - Safe post‑update relaunch: set `SESORI_POST_UPDATE_RESTART=1` on Unix and in the Windows swap script; `TerminalPromptApi` reads `environment`, treats restarts as non‑interactive, and skips `readLine`; `BridgeRuntimeAuthService` (now env‑aware) throws a clear “rerun from a terminal to log in” error; `UpdateRelaunchClient` injects `processStarter` and passes the flag; entry points now pass `environment` to the prompt API. Docs note CI uses `dart analyze --fatal-infos`.

- **Migration**
  - Recovery: rerun the bridge; the updater runs before the mutex, and the relaunched binary offers to kill the stuck holder.
  - Headless: kill the reported PID or delete the shown `bridge-startup.lock` path.

<sup>Written for commit 9c58cffe6020765a51396165d186e2eafafad8ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

