### PR TITLE
feat(bridge): plugin selection, enablement & PluginManager (migration PR 5/15)

### DIFF
--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -294,7 +294,9 @@ class ConfigCommand extends cli.Command<void> {
 /// stderr: stdout of `--version`/`--help` must stay machine-consumable.
 Future<List<String>?> _loadEnabledPluginsFromSettings() async {
   try {
-    final settings = await BridgeSettingsRepository(api: BridgeSettingsApi()).peekSettings();
+    final settings = await BridgeSettingsRepository(
+      api: BridgeSettingsApi(),
+    ).peekSettings(onInvalidConfig: stderr.writeln);
     return settings.enabledPlugins;
   } on Object catch (error) {
     stderr.writeln('Could not read bridge settings for plugin selection: $error');

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -290,16 +290,15 @@ class ConfigCommand extends cli.Command<void> {
 
 /// Best-effort `enabledPlugins` read for plugin selection. Selection also
 /// runs for `--help` and `logout`, so it must never crash on (or create)
-/// a missing/broken config — failures resolve to "unset". Diagnostics go to
-/// stderr: stdout of `--version`/`--help` must stay machine-consumable.
+/// a missing/broken config — failures resolve to "unset". Diagnostics go
+/// through [Log.e] (the stderr level): stdout of `--version`/`--help` must
+/// stay machine-consumable.
 Future<List<String>?> _loadEnabledPluginsFromSettings() async {
   try {
-    final settings = await BridgeSettingsRepository(
-      api: BridgeSettingsApi(),
-    ).peekSettings(onInvalidConfig: stderr.writeln);
+    final settings = await BridgeSettingsRepository(api: BridgeSettingsApi()).peekSettings();
     return settings.enabledPlugins;
   } on Object catch (error) {
-    stderr.writeln('Could not read bridge settings for plugin selection: $error');
+    Log.e('Could not read bridge settings for plugin selection: $error');
     return null;
   }
 }

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -17,8 +17,8 @@ import 'package:sesori_bridge/src/bridge/runtime/bridge_cli_dispatch.dart';
 import 'package:sesori_bridge/src/bridge/runtime/bridge_cli_options.dart';
 import 'package:sesori_bridge/src/bridge/runtime/bridge_logout_runner.dart';
 import 'package:sesori_bridge/src/bridge/runtime/bridge_runtime_runner.dart';
-import 'package:sesori_bridge/src/bridge/runtime/legacy_opencode_descriptor.dart';
 import 'package:sesori_bridge/src/bridge/runtime/plugin_cli_binding.dart';
+import 'package:sesori_bridge/src/bridge/runtime/plugin_registry.dart';
 import 'package:sesori_bridge/src/repositories/bridge_settings_repository.dart';
 import 'package:sesori_bridge/src/repositories/default_editor_repository.dart';
 import 'package:sesori_bridge/src/repositories/wake_lock_repository.dart';
@@ -44,17 +44,35 @@ class RunCommand extends cli.Command<void> {
   @override
   final description = 'Run the Sesori bridge (default)';
 
-  RunCommand() {
+  final PluginCliSurface _selectedPlugin;
+
+  /// Deferred plugin-selection failure (bad `enabledPlugins`): only running
+  /// the bridge needs a valid selection, so the error surfaces here instead
+  /// of blocking informational commands like `--help`, logout, or config.
+  final String? _selectionError;
+
+  RunCommand({required PluginCliSurface selectedPlugin, required String? selectionError})
+    : _selectedPlugin = selectedPlugin,
+      _selectionError = selectionError {
     argParser
       ..addFlag(
         'version',
         negatable: false,
         help: 'Show version and exit',
       )
-      ..addOption('relay', defaultsTo: _defaultRelayURL, help: 'Relay server URL');
-    // The selected plugin contributes its own CLI options (the four OpenCode
-    // flags, with their historical names, help text, and defaults).
-    registerPluginOptions(parser: argParser, options: LegacyOpenCodeDescriptor.cliOptions);
+      ..addOption('relay', defaultsTo: _defaultRelayURL, help: 'Relay server URL')
+      // The selection was already scanned out of the raw argv to build this
+      // parser (see PluginSelector); registering the option here makes the
+      // full parse accept it and reject unknown ids via the allowed list.
+      // --help therefore documents the *selected* plugin's options.
+      ..addOption(
+        'plugin',
+        help: 'Plugin backend to run. Defaults to "enabledPlugins" in the bridge settings, then opencode',
+        allowed: [for (final plugin in knownPlugins) plugin.id],
+      );
+    // The selected plugin contributes its own CLI options (for OpenCode: the
+    // four flags with their historical names, help text, and defaults).
+    registerPluginOptions(parser: argParser, options: _selectedPlugin.options);
     argParser
       ..addOption('auth-backend', defaultsTo: '', help: 'Auth backend URL')
       ..addOption(
@@ -79,14 +97,19 @@ class RunCommand extends cli.Command<void> {
       return;
     }
 
+    final selectionError = _selectionError;
+    if (selectionError != null) {
+      usageException(selectionError);
+    }
+
     final BridgeCliOptions options;
     final PluginConfig pluginConfig;
     try {
       // Plugin option validate hooks and config validation run at
       // argument-parse time — strictly before the startup mutex, so a typo'd
       // flag can never terminate a healthy resident bridge.
-      pluginConfig = parsePluginConfig(options: LegacyOpenCodeDescriptor.cliOptions, results: results);
-      LegacyOpenCodeDescriptor.validateConfigValues(pluginConfig);
+      pluginConfig = parsePluginConfig(options: _selectedPlugin.options, results: results);
+      _selectedPlugin.validateConfig(pluginConfig);
       options = BridgeCliOptions.fromArgResults(
         cliArgs: globalResults!.arguments,
         results: results,
@@ -122,6 +145,7 @@ class RunCommand extends cli.Command<void> {
     final exitCode = await runBridgeApp(
       options: options,
       pluginConfig: pluginConfig,
+      pluginId: _selectedPlugin.id,
     );
     await sleepPreventionService.dispose();
     exit(exitCode);
@@ -264,14 +288,46 @@ class ConfigCommand extends cli.Command<void> {
   }
 }
 
+/// Best-effort `enabledPlugins` read for plugin selection. Selection also
+/// runs for `--help` and `logout`, so it must never crash on (or create)
+/// a missing/broken config — failures resolve to "unset". Diagnostics go to
+/// stderr: stdout of `--version`/`--help` must stay machine-consumable.
+Future<List<String>?> _loadEnabledPluginsFromSettings() async {
+  try {
+    final settings = await BridgeSettingsRepository(api: BridgeSettingsApi()).peekSettings();
+    return settings.enabledPlugins;
+  } on Object catch (error) {
+    stderr.writeln('Could not read bridge settings for plugin selection: $error');
+    return null;
+  }
+}
+
 Future<void> main(List<String> args) async {
   if (!(Platform.isWindows || Platform.isMacOS || Platform.isLinux)) {
     Log.e('Unsupported platform ${Platform.operatingSystem}');
     exit(1);
   }
 
+  // First pass of the two-pass parse: the selected plugin determines which
+  // options the run command's parser is built with.
+  PluginCliSurface selectedPlugin;
+  String? pluginSelectionError;
+  try {
+    selectedPlugin = await const PluginSelector(
+      knownPlugins: knownPlugins,
+      defaultPluginId: defaultPluginId,
+      loadEnabledPlugins: _loadEnabledPluginsFromSettings,
+    ).resolve(args: args);
+  } on PluginSelectionException catch (e) {
+    // Bad settings must not brick --help, logout, or config — config being
+    // the recovery command the message recommends. Build the parser from the
+    // default surface and defer the error to the run command itself.
+    selectedPlugin = knownPlugins.firstWhere((plugin) => plugin.id == defaultPluginId);
+    pluginSelectionError = e.message;
+  }
+
   final runner = cli.CommandRunner<void>('sesori-bridge', 'Sesori Bridge CLI')
-    ..addCommand(RunCommand())
+    ..addCommand(RunCommand(selectedPlugin: selectedPlugin, selectionError: pluginSelectionError))
     ..addCommand(LogoutCommand())
     ..addCommand(ConfigCommand());
 

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -36,6 +36,7 @@ import "../../server/host/bridge_host_json_store.dart";
 import "../../server/host/bridge_host_port_service.dart";
 import "../../server/host/bridge_host_process_service.dart";
 import "../../server/host/bridge_plugin_host_impl.dart";
+import "../../server/host/plugin_state_directory.dart" show openCodePluginId;
 import "../../server/models/open_code_ownership_record.dart";
 import "../../server/repositories/bridge_instance_repository.dart";
 import "../../server/repositories/open_code_ownership_repository.dart";
@@ -81,14 +82,17 @@ import "bridge_runtime_server.dart";
 import "bridge_shutdown_coordinator.dart";
 import "legacy_opencode_descriptor.dart";
 import "plugin_failure_latch.dart";
+import "plugin_manager.dart";
 
 Future<int> runBridgeApp({
   required BridgeCliOptions options,
   required PluginConfig pluginConfig,
+  required String pluginId,
 }) {
   return BridgeRuntimeRunner.run(
     options: options,
     pluginConfig: pluginConfig,
+    pluginId: pluginId,
   );
 }
 
@@ -102,6 +106,7 @@ class BridgeRuntimeRunner {
   static Future<int> run({
     required BridgeCliOptions options,
     required PluginConfig pluginConfig,
+    required String pluginId,
   }) async {
     final failureLatch = PluginFailureLatch();
     final shutdownCoordinator = BridgeShutdownCoordinator(
@@ -230,24 +235,33 @@ class BridgeRuntimeRunner {
       );
 
       final startAbortController = StartAbortController();
-      final plugin = await startLegacyOpenCodePlugin(
-        pluginConfig: pluginConfig,
-        currentBridgeIdentity: currentBridgeIdentity,
-        ownerSessionId: ownerSessionId,
-        startupMutexRepository: startupMutexRepository,
-        bridgeInstanceService: bridgeInstanceService,
-        ownershipRepository: ownershipRepository,
-        openCodeServerService: openCodeServerService,
-        processRepository: processRepository,
-        runtimeFileApi: runtimeFileApi,
-        runtimeDirectory: runtimeDirectory,
-        serverClock: serverClock,
-        environment: environment,
-        currentUser: currentUser,
-        startAborted: startAbortController.signal,
+      final pluginManager = PluginManager();
+      pluginManager.register(
+        id: openCodePluginId,
+        shutdownBudget: _pluginShutdownBudget,
+        starter: () => startLegacyOpenCodePlugin(
+          pluginConfig: pluginConfig,
+          currentBridgeIdentity: currentBridgeIdentity,
+          ownerSessionId: ownerSessionId,
+          startupMutexRepository: startupMutexRepository,
+          bridgeInstanceService: bridgeInstanceService,
+          ownershipRepository: ownershipRepository,
+          openCodeServerService: openCodeServerService,
+          processRepository: processRepository,
+          runtimeFileApi: runtimeFileApi,
+          runtimeDirectory: runtimeDirectory,
+          serverClock: serverClock,
+          environment: environment,
+          currentUser: currentUser,
+          startAborted: startAbortController.signal,
+        ),
       );
+      // The registry holds only the legacy OpenCode starter until the real
+      // descriptor lands (PR 12), and BridgeConfig below still needs the
+      // legacy-only serverUrl/serverPassword — hence the downcast.
+      final plugin = await pluginManager.startPlugin(id: pluginId) as LegacyOpenCodeBridgePlugin;
       shutdownCoordinator.addOrdered(
-        action: () => plugin.shutdown(budget: _pluginShutdownBudget),
+        action: () => pluginManager.stopPlugin(id: pluginId),
         budget: _pluginShutdownBudget,
       );
       plugin.status
@@ -298,6 +312,11 @@ class BridgeRuntimeRunner {
         failureReporter: LogFailureReporter(),
       );
       shutdownCoordinator.add(disposable: runtime.close);
+      // Defined stop semantics: stopping the active plugin cancels the
+      // session first, so the bridge never keeps serving requests against a
+      // stopped plugin. cancel() is idempotent and safe after run() returns,
+      // which covers the ordinary post-session stop during shutdown.
+      pluginManager.bindActiveSession(cancel: runtime.session.cancel);
 
       await BridgeDiagnostics().runAll();
       await startDebugServerIfRequested(

--- a/bridge/app/lib/src/bridge/runtime/plugin_manager.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_manager.dart
@@ -1,0 +1,206 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePlugin, Log;
+
+/// Builds and starts a registered plugin instance.
+///
+/// Transitional seam (plugin-lifecycle migration, PR 5): the contract's
+/// descriptors are meant to be const and registered directly, but
+/// `LegacyOpenCodeDescriptor` can only be constructed inside the startup
+/// mutex with the legacy services injected, so the runner registers a bound
+/// start delegate instead. Collapses to `descriptor.start(host)` when the
+/// real descriptor lands at the flip (PR 12).
+typedef PluginStarter = Future<BridgePlugin> Function();
+
+/// Owns which plugins are running: registered plugins are *not* auto-started;
+/// each is independently startable and stoppable by id.
+///
+/// - [startPlugin] / [stopPlugin] are idempotent per id: a repeated start
+///   shares the in-flight (or completed) start, a repeated stop shares the
+///   one stop. After a stop completes the id may be started fresh.
+/// - Stopping the active plugin first cancels the bridge session (when one
+///   is bound via [bindActiveSession]), then runs the plugin's
+///   `shutdown(budget)` — a stopped plugin must never be left behind a live
+///   session still routing requests to it.
+/// - The manager API is N-ready, but the bridge currently supports exactly
+///   one active plugin (a single `BridgePluginApi` is constructor-baked into
+///   the orchestrator's components); starting a second id while another is
+///   active fails with a clear error.
+class PluginManager {
+  PluginManager();
+
+  final Map<String, _PluginRegistration> _registrations = {};
+  final Map<String, _RunningPlugin> _running = {};
+  Future<void> Function()? _cancelActiveSession;
+
+  /// Registers [starter] under [id] without starting it.
+  ///
+  /// [shutdownBudget] is the soft deadline granted to this plugin's
+  /// `shutdown()` when [stopPlugin] runs it.
+  void register({
+    required String id,
+    required PluginStarter starter,
+    required Duration shutdownBudget,
+  }) {
+    if (_registrations.containsKey(id)) {
+      throw StateError('Plugin "$id" is already registered.');
+    }
+    _registrations[id] = _PluginRegistration(starter: starter, shutdownBudget: shutdownBudget);
+  }
+
+  /// Binds how [stopPlugin] cancels the bridge session before tearing the
+  /// active plugin down, replacing any previous binding.
+  ///
+  /// The runner binds `session.cancel()` once the session exists; the cancel
+  /// is also invoked on stops that happen after the session already ended,
+  /// so the bound callback must tolerate that (`OrchestratorSession.cancel`
+  /// does — it is idempotent and never throws).
+  void bindActiveSession({required Future<void> Function() cancel}) {
+    _cancelActiveSession = cancel;
+  }
+
+  /// The successfully started, not yet stopping plugins, keyed by id.
+  Map<String, BridgePlugin> get activePlugins {
+    return Map<String, BridgePlugin>.unmodifiable(<String, BridgePlugin>{
+      for (final MapEntry(key: id, value: running) in _running.entries)
+        if (running.instance != null && running.stop == null) id: running.instance!,
+    });
+  }
+
+  /// Starts the plugin registered under [id], or returns the already
+  /// started/starting instance.
+  ///
+  /// A start over an in-flight [stopPlugin] of the same id waits for the
+  /// stop to settle — even a *failed* stop frees the slot, and its error
+  /// belongs to the stop caller — then starts fresh. Starting while a
+  /// *different* id is active throws: the bridge supports exactly one
+  /// active plugin until the orchestrator can rebind plugin APIs
+  /// mid-session. A failed start
+  /// untracks the id, so a later retry invokes the starter again.
+  Future<BridgePlugin> startPlugin({required String id}) async {
+    final registration = _registrations[id];
+    if (registration == null) {
+      throw StateError(
+        'Unknown plugin "$id". Registered plugins: ${_registrations.keys.join(", ")}.',
+      );
+    }
+
+    while (true) {
+      for (final runningId in _running.keys) {
+        if (runningId != id) {
+          throw StateError(
+            'Cannot start plugin "$id" while "$runningId" is active: '
+            "the bridge supports exactly one active plugin.",
+          );
+        }
+      }
+      final existing = _running[id];
+      if (existing == null) {
+        break;
+      }
+      final stop = existing.stop;
+      if (stop == null) {
+        return existing.start;
+      }
+      // Wait the in-flight stop out, then re-check: another caller may have
+      // restarted (or a different id may have started) in the meantime.
+      try {
+        await stop;
+      } catch (error) {
+        // The failed stop surfaces through the stopPlugin caller (the
+        // runner's ordered shutdown step keeps it loud); the restart only
+        // needs the slot free, which the stop guarantees on every path.
+        Log.w('The previous stop of plugin "$id" failed: $error');
+      }
+    }
+
+    // Track before invoking the starter: _startTracked runs synchronously up
+    // to its first await, so a synchronously throwing starter would untrack
+    // *before* a track placed after this call — wedging the id forever. No
+    // await separates these statements, so no caller can observe the entry
+    // without its start future.
+    final running = _RunningPlugin();
+    _running[id] = running;
+    return running.start = _startTracked(id: id, running: running, starter: registration.starter);
+  }
+
+  /// Stops the plugin running under [id]; a no-op when nothing runs there.
+  ///
+  /// Order: cancel the bound session first (see [bindActiveSession]), then
+  /// `shutdown(budget)` with the budget given at [register] time. A stop
+  /// over an in-flight start waits for the start to settle first; if that
+  /// start failed there is nothing to stop.
+  Future<void> stopPlugin({required String id}) {
+    final running = _running[id];
+    if (running == null) {
+      return Future.value();
+    }
+    return running.stop ??= _stopTracked(id: id, running: running);
+  }
+
+  Future<BridgePlugin> _startTracked({
+    required String id,
+    required _RunningPlugin running,
+    required PluginStarter starter,
+  }) async {
+    try {
+      final plugin = await starter();
+      running.instance = plugin;
+      return plugin;
+    } catch (_) {
+      _untrack(id: id, running: running);
+      rethrow;
+    }
+  }
+
+  Future<void> _stopTracked({required String id, required _RunningPlugin running}) async {
+    final BridgePlugin plugin;
+    try {
+      plugin = await running.start;
+    } catch (_) {
+      // The start failed and untracked the id; its caller surfaces the
+      // error. Nothing is running, so this stop trivially succeeded. The
+      // untrack here is defense in depth (idempotent via the identical
+      // guard) so a tracking bug can never wedge the id.
+      _untrack(id: id, running: running);
+      return;
+    }
+
+    final cancelActiveSession = _cancelActiveSession;
+    if (cancelActiveSession != null) {
+      try {
+        await cancelActiveSession();
+      } catch (error) {
+        // A failed cancel must not leave the plugin running: proceed to
+        // shutdown — the zombie to avoid is a live session over a stopped
+        // plugin, not the reverse.
+        Log.w('Cancelling the session before stopping plugin "$id" failed: $error');
+      }
+    }
+
+    try {
+      await plugin.shutdown(budget: _registrations[id]?.shutdownBudget);
+    } finally {
+      _untrack(id: id, running: running);
+    }
+  }
+
+  void _untrack({required String id, required _RunningPlugin running}) {
+    if (identical(_running[id], running)) {
+      _running.remove(id);
+    }
+  }
+}
+
+class _PluginRegistration {
+  const _PluginRegistration({required this.starter, required this.shutdownBudget});
+
+  final PluginStarter starter;
+  final Duration shutdownBudget;
+}
+
+class _RunningPlugin {
+  late final Future<BridgePlugin> start;
+  BridgePlugin? instance;
+  Future<void>? stop;
+}

--- a/bridge/app/lib/src/bridge/runtime/plugin_registry.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_registry.dart
@@ -1,0 +1,161 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginConfig, PluginOption;
+
+import "../../server/host/plugin_state_directory.dart" show openCodePluginId;
+import "legacy_opencode_descriptor.dart";
+
+/// The parse-time CLI surface of a registered plugin: everything
+/// `bin/bridge.dart` needs *before* any service exists — the id selected via
+/// `--plugin`, the options to register into the argument parser, and the
+/// config rule to run at argument-parse time.
+///
+/// Transitional shape (plugin-lifecycle migration, PR 5): the contract reads
+/// this surface off the descriptor itself, but `LegacyOpenCodeDescriptor`
+/// can only be constructed inside the startup mutex, so its static surface
+/// is registered here instead. Collapses into a registry of const
+/// descriptors at the flip (PR 12).
+class PluginCliSurface {
+  const PluginCliSurface({
+    required this.id,
+    required this.options,
+    required this.validateConfig,
+  });
+
+  /// Descriptor id, as typed after `--plugin`.
+  final String id;
+
+  /// CLI options this plugin contributes to the parser when selected.
+  final List<PluginOption> options;
+
+  /// Cross-option config rule, run at argument-parse time — strictly before
+  /// the startup mutex, so a misconfigured invocation can never terminate a
+  /// healthy resident bridge.
+  final void Function(PluginConfig config) validateConfig;
+}
+
+/// Every plugin this bridge build knows how to run.
+const List<PluginCliSurface> knownPlugins = [
+  PluginCliSurface(
+    id: openCodePluginId,
+    options: LegacyOpenCodeDescriptor.cliOptions,
+    validateConfig: LegacyOpenCodeDescriptor.validateConfigValues,
+  ),
+];
+
+/// The plugin used when neither `--plugin` nor `enabledPlugins` selects one,
+/// so existing installs see zero change.
+const String defaultPluginId = openCodePluginId;
+
+/// Selection cannot be resolved from the bridge settings — the user must fix
+/// `enabledPlugins`. Command-line problems are never reported through this:
+/// they surface as the parser's own usage errors on the full parse.
+class PluginSelectionException implements Exception {
+  const PluginSelectionException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+/// Resolves which plugin's CLI surface the bridge registers into its
+/// argument parser — the first pass of the two-pass parse: `--plugin` is
+/// scanned out of the raw argv, the full parser is then built from the
+/// winning surface and parses everything (including `--plugin` itself, whose
+/// `allowed:` list produces the usage error for unknown ids).
+///
+/// Precedence: `--plugin` on the command line, then `enabledPlugins` from
+/// the bridge settings, then the injected default id.
+class PluginSelector {
+  const PluginSelector({
+    required List<PluginCliSurface> knownPlugins,
+    required String defaultPluginId,
+    required Future<List<String>?> Function() loadEnabledPlugins,
+  }) : _knownPlugins = knownPlugins,
+       _defaultPluginId = defaultPluginId,
+       _loadEnabledPlugins = loadEnabledPlugins;
+
+  final List<PluginCliSurface> _knownPlugins;
+  final String _defaultPluginId;
+
+  /// Reads `enabledPlugins` from the bridge settings; null means unset.
+  /// Only invoked when the command line selects nothing. Must not throw and
+  /// must not create files — selection also runs for `--help` and `logout`.
+  final Future<List<String>?> Function() _loadEnabledPlugins;
+
+  /// Resolves the surface for raw process [args] (pre `run`-insertion; the
+  /// scan is insensitive to the implicit-command rewrite, which only ever
+  /// prepends a token).
+  ///
+  /// The scan itself never raises a user-facing error: an unknown or missing
+  /// `--plugin` value resolves to a fallback surface so the parser still
+  /// gets built, and the full parse then reports it (`allowed:` violation or
+  /// missing argument).
+  Future<PluginCliSurface> resolve({required List<String> args}) async {
+    final cliSelection = _scanPluginFlag(args);
+    if (cliSelection != null) {
+      return _surfaceById(cliSelection) ?? _fallback;
+    }
+
+    final enabledPlugins = await _loadEnabledPlugins();
+    if (enabledPlugins == null || enabledPlugins.isEmpty) {
+      return _fallback;
+    }
+    if (enabledPlugins.length > 1) {
+      throw PluginSelectionException(
+        "Bridge settings enable ${enabledPlugins.length} plugins "
+        '(${enabledPlugins.join(", ")}), but the bridge supports exactly one '
+        'active plugin. Set "enabledPlugins" to a single entry.',
+      );
+    }
+    final enabled = enabledPlugins.single;
+    final surface = _surfaceById(enabled);
+    if (surface == null) {
+      throw PluginSelectionException(
+        'Bridge settings enable unknown plugin "$enabled". Known plugins: '
+        '${_knownPlugins.map((plugin) => plugin.id).join(", ")}. Update '
+        '"enabledPlugins" in the bridge config (sesori-bridge config).',
+      );
+    }
+    return surface;
+  }
+
+  PluginCliSurface get _fallback => _surfaceById(_defaultPluginId)!;
+
+  PluginCliSurface? _surfaceById(String id) {
+    for (final plugin in _knownPlugins) {
+      if (plugin.id == id) {
+        return plugin;
+      }
+    }
+    return null;
+  }
+
+  /// The value of the last `--plugin` occurrence before a standalone `--`
+  /// terminator, or null when the command line selects nothing.
+  ///
+  /// Mirrors `package:args` long-option mechanics so both passes agree:
+  /// `--plugin=<id>` and `--plugin <id>` forms, exact name match (args never
+  /// abbreviates long names), last occurrence wins, and the space form
+  /// consumes the next token unconditionally. Not mirrored: a `--plugin`
+  /// token that the parser would swallow as a *preceding* value option's
+  /// argument (e.g. `--password --plugin`) is read as a selection here —
+  /// pathological input; the full parse still has the last word on errors.
+  static String? _scanPluginFlag(List<String> args) {
+    String? value;
+    for (var i = 0; i < args.length; i++) {
+      final token = args[i];
+      if (token == "--") {
+        break;
+      }
+      if (token == "--plugin") {
+        if (i + 1 < args.length) {
+          value = args[i + 1];
+          i++;
+        }
+      } else if (token.startsWith("--plugin=")) {
+        value = token.substring("--plugin=".length);
+      }
+    }
+    return value;
+  }
+}

--- a/bridge/app/lib/src/bridge/runtime/plugin_registry.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_registry.dart
@@ -119,7 +119,18 @@ class PluginSelector {
     return surface;
   }
 
-  PluginCliSurface get _fallback => _surfaceById(_defaultPluginId)!;
+  PluginCliSurface get _fallback {
+    final fallback = _surfaceById(_defaultPluginId);
+    if (fallback == null) {
+      // Only reachable by miswiring the selector itself — fail with a
+      // diagnosis rather than a bare null-check error.
+      throw StateError(
+        'Default plugin "$_defaultPluginId" is not among the known plugins: '
+        '${_knownPlugins.map((plugin) => plugin.id).join(", ")}.',
+      );
+    }
+    return fallback;
+  }
 
   PluginCliSurface? _surfaceById(String id) {
     for (final plugin in _knownPlugins) {

--- a/bridge/app/lib/src/repositories/bridge_settings.dart
+++ b/bridge/app/lib/src/repositories/bridge_settings.dart
@@ -6,13 +6,21 @@ enum SleepPreventionMode {
 class BridgeSettings {
   final SleepPreventionMode sleepPrevention;
 
+  /// Plugin ids enabled to run (the `--plugin <id>` namespace). Null means
+  /// unset — the bridge then defaults to opencode, so existing installs see
+  /// zero change. Until the orchestrator supports multiple concurrently
+  /// active plugins, more than one entry is rejected at startup.
+  final List<String>? enabledPlugins;
+
   const BridgeSettings({
     this.sleepPrevention = SleepPreventionMode.always,
+    this.enabledPlugins,
   });
 
   factory BridgeSettings.fromJson(Map<String, dynamic> json) {
     return BridgeSettings(
       sleepPrevention: _parseSleepPrevention(json['sleepPrevention']),
+      enabledPlugins: _parseEnabledPlugins(json['enabledPlugins']),
     );
   }
 
@@ -22,6 +30,9 @@ class BridgeSettings {
         SleepPreventionMode.off => 'off',
         SleepPreventionMode.always => 'always',
       },
+      // Only written when set: the defaults file must keep its exact
+      // pre-existing shape for installs that never touched the key.
+      if (enabledPlugins != null) 'enabledPlugins': enabledPlugins,
     };
   }
 
@@ -31,5 +42,12 @@ class BridgeSettings {
       'always' => SleepPreventionMode.always,
       _ => SleepPreventionMode.always,
     };
+  }
+
+  static List<String>? _parseEnabledPlugins(Object? rawValue) {
+    if (rawValue is! List) {
+      return null;
+    }
+    return rawValue.whereType<String>().toList();
   }
 }

--- a/bridge/app/lib/src/repositories/bridge_settings_repository.dart
+++ b/bridge/app/lib/src/repositories/bridge_settings_repository.dart
@@ -42,15 +42,13 @@ class BridgeSettingsRepository {
   /// even built, where `--help` or `logout` must not create the config file.
   ///
   /// Only *content* problems are absorbed here; an invalid config is
-  /// reported through [onInvalidConfig] rather than [Log] because `Log.w`
-  /// writes to *stdout*, which must stay machine-clean for
-  /// `--version`/`--help` (the parse-time caller routes the warning to
-  /// stderr). An I/O failure from the read itself propagates, like it does
-  /// from [loadSettings]: whether that is fatal is the caller's policy (the
-  /// parse-time caller maps it to "unset" with a stderr diagnostic).
-  Future<BridgeSettings> peekSettings({
-    void Function(String message)? onInvalidConfig,
-  }) async {
+  /// reported via [Log.e] — the one level that writes to stderr — because
+  /// selection also runs for `--version`/`--help`, whose stdout must stay
+  /// machine-clean ([Log.w] writes to stdout). An I/O failure from the
+  /// read itself propagates, like it does from [loadSettings]: whether that
+  /// is fatal is the caller's policy (the parse-time caller maps it to
+  /// "unset" with a stderr diagnostic).
+  Future<BridgeSettings> peekSettings() async {
     final storedConfig = await _api.readConfig();
     if (storedConfig == null) {
       return const BridgeSettings();
@@ -59,7 +57,7 @@ class BridgeSettingsRepository {
     try {
       return BridgeSettings.fromJson(jsonDecodeMap(storedConfig));
     } catch (error) {
-      onInvalidConfig?.call('[bridge-settings] invalid config at $configFilePath: $error');
+      Log.e('[bridge-settings] invalid config at $configFilePath: $error');
       return const BridgeSettings();
     }
   }

--- a/bridge/app/lib/src/repositories/bridge_settings_repository.dart
+++ b/bridge/app/lib/src/repositories/bridge_settings_repository.dart
@@ -43,6 +43,11 @@ class BridgeSettingsRepository {
   /// Deliberately silent for the same reason: a corruption warning here
   /// would land on stdout of `--version`/`--help` before any `--log-level`
   /// is parsed; the run path reports corruption through [loadSettings].
+  ///
+  /// Only *content* problems are absorbed here. An I/O failure from the
+  /// read itself propagates, like it does from [loadSettings]: whether that
+  /// is fatal is the caller's policy (the parse-time caller maps it to
+  /// "unset" with a stderr diagnostic).
   Future<BridgeSettings> peekSettings() async {
     final storedConfig = await _api.readConfig();
     if (storedConfig == null) {

--- a/bridge/app/lib/src/repositories/bridge_settings_repository.dart
+++ b/bridge/app/lib/src/repositories/bridge_settings_repository.dart
@@ -34,6 +34,28 @@ class BridgeSettingsRepository {
     }
   }
 
+  /// Reads settings without [loadSettings]'s create-with-defaults side
+  /// effect: a missing or invalid config yields in-memory defaults and the
+  /// file is left untouched.
+  ///
+  /// For parse-time reads — plugin selection runs before the CLI parser is
+  /// even built, where `--help` or `logout` must not create the config file.
+  /// Deliberately silent for the same reason: a corruption warning here
+  /// would land on stdout of `--version`/`--help` before any `--log-level`
+  /// is parsed; the run path reports corruption through [loadSettings].
+  Future<BridgeSettings> peekSettings() async {
+    final storedConfig = await _api.readConfig();
+    if (storedConfig == null) {
+      return const BridgeSettings();
+    }
+
+    try {
+      return BridgeSettings.fromJson(jsonDecodeMap(storedConfig));
+    } catch (_) {
+      return const BridgeSettings();
+    }
+  }
+
   Future<void> saveSettings({required BridgeSettings settings}) {
     return _api.writeConfig(_jsonEncoder.convert(settings.toJson()));
   }

--- a/bridge/app/lib/src/repositories/bridge_settings_repository.dart
+++ b/bridge/app/lib/src/repositories/bridge_settings_repository.dart
@@ -40,15 +40,17 @@ class BridgeSettingsRepository {
   ///
   /// For parse-time reads — plugin selection runs before the CLI parser is
   /// even built, where `--help` or `logout` must not create the config file.
-  /// Deliberately silent for the same reason: a corruption warning here
-  /// would land on stdout of `--version`/`--help` before any `--log-level`
-  /// is parsed; the run path reports corruption through [loadSettings].
   ///
-  /// Only *content* problems are absorbed here. An I/O failure from the
-  /// read itself propagates, like it does from [loadSettings]: whether that
-  /// is fatal is the caller's policy (the parse-time caller maps it to
-  /// "unset" with a stderr diagnostic).
-  Future<BridgeSettings> peekSettings() async {
+  /// Only *content* problems are absorbed here; an invalid config is
+  /// reported through [onInvalidConfig] rather than [Log] because `Log.w`
+  /// writes to *stdout*, which must stay machine-clean for
+  /// `--version`/`--help` (the parse-time caller routes the warning to
+  /// stderr). An I/O failure from the read itself propagates, like it does
+  /// from [loadSettings]: whether that is fatal is the caller's policy (the
+  /// parse-time caller maps it to "unset" with a stderr diagnostic).
+  Future<BridgeSettings> peekSettings({
+    void Function(String message)? onInvalidConfig,
+  }) async {
     final storedConfig = await _api.readConfig();
     if (storedConfig == null) {
       return const BridgeSettings();
@@ -56,7 +58,8 @@ class BridgeSettingsRepository {
 
     try {
       return BridgeSettings.fromJson(jsonDecodeMap(storedConfig));
-    } catch (_) {
+    } catch (error) {
+      onInvalidConfig?.call('[bridge-settings] invalid config at $configFilePath: $error');
       return const BridgeSettings();
     }
   }

--- a/bridge/app/test/bridge/runtime/plugin_manager_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_manager_test.dart
@@ -1,0 +1,422 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/bridge/runtime/plugin_manager.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePlugin;
+import "package:test/test.dart";
+
+void main() {
+  group("PluginManager", () {
+    const budget = Duration(seconds: 7);
+
+    test("startPlugin starts the registered plugin and tracks it as active", () async {
+      final manager = PluginManager();
+      final plugin = _FakeBridgePlugin();
+      manager.register(id: "opencode", starter: () async => plugin, shutdownBudget: budget);
+
+      final started = await manager.startPlugin(id: "opencode");
+
+      expect(started, same(plugin));
+      expect(manager.activePlugins, {"opencode": plugin});
+    });
+
+    test("startPlugin throws for an unknown id, naming the registered ones", () async {
+      final manager = PluginManager();
+      manager.register(id: "opencode", starter: () async => _FakeBridgePlugin(), shutdownBudget: budget);
+
+      await expectLater(
+        manager.startPlugin(id: "cursor"),
+        throwsA(
+          isA<StateError>().having((e) => e.message, "message", allOf(contains('"cursor"'), contains("opencode"))),
+        ),
+      );
+    });
+
+    test("repeated startPlugin shares one start", () async {
+      final manager = PluginManager();
+      var starts = 0;
+      manager.register(
+        id: "opencode",
+        starter: () async {
+          starts++;
+          return _FakeBridgePlugin();
+        },
+        shutdownBudget: budget,
+      );
+
+      final first = await manager.startPlugin(id: "opencode");
+      final second = await manager.startPlugin(id: "opencode");
+
+      expect(starts, 1);
+      expect(second, same(first));
+    });
+
+    test("startPlugin for a second id while one is active throws", () async {
+      final manager = PluginManager();
+      manager.register(id: "opencode", starter: () async => _FakeBridgePlugin(), shutdownBudget: budget);
+      manager.register(id: "cursor", starter: () async => _FakeBridgePlugin(), shutdownBudget: budget);
+      await manager.startPlugin(id: "opencode");
+
+      await expectLater(
+        manager.startPlugin(id: "cursor"),
+        throwsA(isA<StateError>().having((e) => e.message, "message", contains("exactly one active plugin"))),
+      );
+    });
+
+    test("startPlugin for a second id while the first is still stopping throws", () async {
+      final manager = PluginManager();
+      final shutdownGate = Completer<void>();
+      manager.register(
+        id: "opencode",
+        starter: () async => _FakeBridgePlugin(shutdownGate: shutdownGate),
+        shutdownBudget: budget,
+      );
+      manager.register(id: "cursor", starter: () async => _FakeBridgePlugin(), shutdownBudget: budget);
+      await manager.startPlugin(id: "opencode");
+      final stop = manager.stopPlugin(id: "opencode");
+
+      await expectLater(
+        manager.startPlugin(id: "cursor"),
+        throwsA(isA<StateError>().having((e) => e.message, "message", contains("exactly one active plugin"))),
+      );
+
+      shutdownGate.complete();
+      await stop;
+    });
+
+    test("a failed start untracks the id so a retry starts fresh", () async {
+      final manager = PluginManager();
+      var starts = 0;
+      manager.register(
+        id: "opencode",
+        starter: () async {
+          starts++;
+          if (starts == 1) {
+            throw StateError("boom");
+          }
+          return _FakeBridgePlugin();
+        },
+        shutdownBudget: budget,
+      );
+
+      await expectLater(manager.startPlugin(id: "opencode"), throwsA(isA<StateError>()));
+      expect(manager.activePlugins, isEmpty);
+
+      await manager.startPlugin(id: "opencode");
+
+      expect(starts, 2);
+      expect(manager.activePlugins.keys, ["opencode"]);
+    });
+
+    test("stopPlugin is a no-op when nothing runs under the id", () async {
+      final manager = PluginManager();
+      manager.register(id: "opencode", starter: () async => _FakeBridgePlugin(), shutdownBudget: budget);
+
+      await manager.stopPlugin(id: "opencode");
+      await manager.stopPlugin(id: "never-registered");
+    });
+
+    test("stopPlugin cancels the session before shutting the plugin down, honoring the budget", () async {
+      final manager = PluginManager();
+      final operations = <String>[];
+      final plugin = _FakeBridgePlugin(operations: operations);
+      manager.register(id: "opencode", starter: () async => plugin, shutdownBudget: budget);
+      manager.bindActiveSession(
+        cancel: () async {
+          operations.add("session.cancel");
+        },
+      );
+      await manager.startPlugin(id: "opencode");
+
+      await manager.stopPlugin(id: "opencode");
+
+      expect(operations, ["session.cancel", "shutdown"]);
+      expect(plugin.shutdownBudgets, [budget]);
+      expect(manager.activePlugins, isEmpty);
+    });
+
+    test("stopPlugin without a bound session goes straight to shutdown", () async {
+      final manager = PluginManager();
+      final plugin = _FakeBridgePlugin();
+      manager.register(id: "opencode", starter: () async => plugin, shutdownBudget: budget);
+      await manager.startPlugin(id: "opencode");
+
+      await manager.stopPlugin(id: "opencode");
+
+      expect(plugin.shutdownCalls, 1);
+    });
+
+    test("concurrent stopPlugin calls share one stop", () async {
+      final manager = PluginManager();
+      final plugin = _FakeBridgePlugin();
+      manager.register(id: "opencode", starter: () async => plugin, shutdownBudget: budget);
+      await manager.startPlugin(id: "opencode");
+
+      final first = manager.stopPlugin(id: "opencode");
+      final second = manager.stopPlugin(id: "opencode");
+      await first;
+      await second;
+
+      expect(identical(first, second), isTrue);
+      expect(plugin.shutdownCalls, 1);
+
+      await manager.stopPlugin(id: "opencode");
+      expect(plugin.shutdownCalls, 1, reason: "a stop after completion is a no-op, not a second shutdown");
+    });
+
+    test("stopPlugin proceeds to shutdown when the session cancel throws", () async {
+      final manager = PluginManager();
+      final plugin = _FakeBridgePlugin();
+      manager.register(id: "opencode", starter: () async => plugin, shutdownBudget: budget);
+      manager.bindActiveSession(cancel: () async => throw StateError("cancel failed"));
+      await manager.startPlugin(id: "opencode");
+
+      await manager.stopPlugin(id: "opencode");
+
+      expect(plugin.shutdownCalls, 1);
+    });
+
+    test("stopPlugin over an in-flight start waits for the start, then stops", () async {
+      final manager = PluginManager();
+      final startGate = Completer<BridgePlugin>();
+      final plugin = _FakeBridgePlugin();
+      manager.register(id: "opencode", starter: () => startGate.future, shutdownBudget: budget);
+
+      final start = manager.startPlugin(id: "opencode");
+      final stop = manager.stopPlugin(id: "opencode");
+      expect(plugin.shutdownCalls, 0);
+
+      startGate.complete(plugin);
+      await start;
+      await stop;
+
+      expect(plugin.shutdownCalls, 1);
+      expect(manager.activePlugins, isEmpty);
+    });
+
+    test("stopPlugin over a failed in-flight start completes without stopping anything", () async {
+      final manager = PluginManager();
+      final startGate = Completer<BridgePlugin>();
+      manager.register(id: "opencode", starter: () => startGate.future, shutdownBudget: budget);
+
+      final start = manager.startPlugin(id: "opencode");
+      final stop = manager.stopPlugin(id: "opencode");
+      startGate.completeError(StateError("start failed"));
+
+      await expectLater(start, throwsA(isA<StateError>()));
+      await stop;
+      expect(manager.activePlugins, isEmpty);
+    });
+
+    test("after a stop the id can be started fresh", () async {
+      final manager = PluginManager();
+      var starts = 0;
+      manager.register(
+        id: "opencode",
+        starter: () async {
+          starts++;
+          return _FakeBridgePlugin();
+        },
+        shutdownBudget: budget,
+      );
+
+      await manager.startPlugin(id: "opencode");
+      await manager.stopPlugin(id: "opencode");
+      await manager.startPlugin(id: "opencode");
+
+      expect(starts, 2);
+      expect(manager.activePlugins.keys, ["opencode"]);
+    });
+
+    test("startPlugin during an in-flight stop waits for the stop, then restarts", () async {
+      final manager = PluginManager();
+      final shutdownGate = Completer<void>();
+      var starts = 0;
+      manager.register(
+        id: "opencode",
+        starter: () async {
+          starts++;
+          return starts == 1 ? _FakeBridgePlugin(shutdownGate: shutdownGate) : _FakeBridgePlugin();
+        },
+        shutdownBudget: budget,
+      );
+      await manager.startPlugin(id: "opencode");
+      final stop = manager.stopPlugin(id: "opencode");
+
+      final restart = manager.startPlugin(id: "opencode");
+      expect(starts, 1, reason: "the restart must wait for the in-flight stop");
+
+      shutdownGate.complete();
+      await stop;
+      await restart;
+
+      expect(starts, 2);
+      expect(manager.activePlugins.keys, ["opencode"]);
+    });
+
+    test("activePlugins excludes starting and stopping plugins", () async {
+      final manager = PluginManager();
+      final startGate = Completer<BridgePlugin>();
+      final shutdownGate = Completer<void>();
+      final plugin = _FakeBridgePlugin(shutdownGate: shutdownGate);
+      manager.register(id: "opencode", starter: () => startGate.future, shutdownBudget: budget);
+
+      final start = manager.startPlugin(id: "opencode");
+      expect(manager.activePlugins, isEmpty, reason: "still starting");
+
+      startGate.complete(plugin);
+      await start;
+      expect(manager.activePlugins.keys, ["opencode"]);
+
+      final stop = manager.stopPlugin(id: "opencode");
+      await Future<void>.delayed(Duration.zero);
+      expect(manager.activePlugins, isEmpty, reason: "already stopping");
+
+      shutdownGate.complete();
+      await stop;
+      expect(manager.activePlugins, isEmpty);
+    });
+
+    test("a synchronously throwing starter is untracked like an async failure", () async {
+      final manager = PluginManager();
+      var starts = 0;
+      manager.register(
+        id: "opencode",
+        starter: () {
+          starts++;
+          if (starts == 1) {
+            throw StateError("sync boom");
+          }
+          return Future.value(_FakeBridgePlugin());
+        },
+        shutdownBudget: budget,
+      );
+      manager.register(id: "cursor", starter: () async => _FakeBridgePlugin(), shutdownBudget: budget);
+
+      await expectLater(manager.startPlugin(id: "opencode"), throwsA(isA<StateError>()));
+      expect(manager.activePlugins, isEmpty);
+
+      await manager.stopPlugin(id: "opencode");
+      await manager.startPlugin(id: "opencode");
+      expect(starts, 2, reason: "the failed sync start must not wedge the id");
+
+      await manager.stopPlugin(id: "opencode");
+      await manager.startPlugin(id: "cursor");
+      expect(manager.activePlugins.keys, ["cursor"], reason: "other ids must not see a phantom active plugin");
+    });
+
+    test("stopPlugin rethrows a failing shutdown — the runner's loud-exit guarantee depends on it", () async {
+      final manager = PluginManager();
+      final plugin = _FakeBridgePlugin(shutdownError: StateError("shutdown failed"));
+      manager.register(id: "opencode", starter: () async => plugin, shutdownBudget: budget);
+      await manager.startPlugin(id: "opencode");
+
+      await expectLater(manager.stopPlugin(id: "opencode"), throwsA(isA<StateError>()));
+    });
+
+    test("a failing shutdown still untracks the id: repeat stop is a no-op and a restart starts fresh", () async {
+      final manager = PluginManager();
+      var starts = 0;
+      manager.register(
+        id: "opencode",
+        starter: () async {
+          starts++;
+          return starts == 1 ? _FakeBridgePlugin(shutdownError: StateError("shutdown failed")) : _FakeBridgePlugin();
+        },
+        shutdownBudget: budget,
+      );
+      await manager.startPlugin(id: "opencode");
+
+      await expectLater(manager.stopPlugin(id: "opencode"), throwsA(isA<StateError>()));
+      expect(manager.activePlugins, isEmpty);
+
+      await manager.stopPlugin(id: "opencode");
+
+      await manager.startPlugin(id: "opencode");
+      expect(starts, 2);
+      expect(manager.activePlugins.keys, ["opencode"]);
+    });
+
+    test("startPlugin over an in-flight stop whose shutdown fails still starts fresh", () async {
+      final manager = PluginManager();
+      final shutdownGate = Completer<void>();
+      var starts = 0;
+      manager.register(
+        id: "opencode",
+        starter: () async {
+          starts++;
+          return starts == 1
+              ? _FakeBridgePlugin(shutdownGate: shutdownGate, shutdownError: StateError("shutdown failed"))
+              : _FakeBridgePlugin();
+        },
+        shutdownBudget: budget,
+      );
+      await manager.startPlugin(id: "opencode");
+      final stop = manager.stopPlugin(id: "opencode");
+
+      final restart = manager.startPlugin(id: "opencode");
+      shutdownGate.complete();
+
+      await expectLater(stop, throwsA(isA<StateError>()), reason: "the stop caller owns the shutdown error");
+      await restart;
+      expect(starts, 2, reason: "the failed stop must not leak its error into the restart");
+      expect(manager.activePlugins.keys, ["opencode"]);
+    });
+
+    test("bindActiveSession replaces the previous binding", () async {
+      final manager = PluginManager();
+      final operations = <String>[];
+      final plugin = _FakeBridgePlugin(operations: operations);
+      manager.register(id: "opencode", starter: () async => plugin, shutdownBudget: budget);
+      manager.bindActiveSession(
+        cancel: () async {
+          operations.add("cancel.replaced");
+        },
+      );
+      manager.bindActiveSession(
+        cancel: () async {
+          operations.add("cancel.latest");
+        },
+      );
+      await manager.startPlugin(id: "opencode");
+
+      await manager.stopPlugin(id: "opencode");
+
+      expect(operations, ["cancel.latest", "shutdown"]);
+    });
+
+    test("register throws for a duplicate id", () {
+      final manager = PluginManager();
+      manager.register(id: "opencode", starter: () async => _FakeBridgePlugin(), shutdownBudget: budget);
+
+      expect(
+        () => manager.register(id: "opencode", starter: () async => _FakeBridgePlugin(), shutdownBudget: budget),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+}
+
+class _FakeBridgePlugin implements BridgePlugin {
+  _FakeBridgePlugin({List<String>? operations, this.shutdownGate, this.shutdownError})
+    : operations = operations ?? <String>[];
+
+  final List<String> operations;
+  final Completer<void>? shutdownGate;
+  final Object? shutdownError;
+  final List<Duration?> shutdownBudgets = [];
+  int shutdownCalls = 0;
+
+  @override
+  Future<void> shutdown({required Duration? budget}) async {
+    shutdownCalls++;
+    shutdownBudgets.add(budget);
+    operations.add("shutdown");
+    await (shutdownGate?.future ?? Future<void>.value());
+    if (shutdownError != null) {
+      throw shutdownError!;
+    }
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/bridge/runtime/plugin_registry_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_registry_test.dart
@@ -1,0 +1,189 @@
+import "package:sesori_bridge/src/bridge/runtime/legacy_opencode_descriptor.dart";
+import "package:sesori_bridge/src/bridge/runtime/plugin_registry.dart";
+import "package:sesori_bridge/src/server/host/plugin_state_directory.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginConfig;
+import "package:test/test.dart";
+
+void main() {
+  group("knownPlugins", () {
+    test("registers the OpenCode surface off the legacy descriptor statics", () {
+      expect(knownPlugins, hasLength(1));
+      expect(knownPlugins.single.id, openCodePluginId);
+      expect(identical(knownPlugins.single.options, LegacyOpenCodeDescriptor.cliOptions), isTrue);
+      expect(knownPlugins.single.validateConfig, LegacyOpenCodeDescriptor.validateConfigValues);
+      expect(defaultPluginId, openCodePluginId);
+    });
+  });
+
+  group("PluginSelector", () {
+    test("defaults to the fallback when nothing selects a plugin", () async {
+      final selector = _selector(enabledPlugins: null);
+
+      final surface = await selector.resolve(args: ["run", "--port", "4096"]);
+
+      expect(surface.id, "opencode");
+    });
+
+    test("a --plugin value on the command line wins over settings", () async {
+      var loads = 0;
+      final selector = PluginSelector(
+        knownPlugins: _surfaces,
+        defaultPluginId: "opencode",
+        loadEnabledPlugins: () async {
+          loads++;
+          return ["cursor"];
+        },
+      );
+
+      final surface = await selector.resolve(args: ["--plugin", "opencode"]);
+
+      expect(surface.id, "opencode");
+      expect(loads, 0, reason: "settings are only read when the command line selects nothing");
+    });
+
+    test("the --plugin=id form is recognized", () async {
+      final selector = _selector(enabledPlugins: null);
+
+      final surface = await selector.resolve(args: ["--plugin=cursor"]);
+
+      expect(surface.id, "cursor");
+    });
+
+    test("the last --plugin occurrence wins, like the parser's last-wins rule", () async {
+      final selector = _selector(enabledPlugins: null);
+
+      final surface = await selector.resolve(args: ["--plugin", "cursor", "--plugin=opencode"]);
+
+      expect(surface.id, "opencode");
+    });
+
+    test("the scan stops at a standalone -- terminator", () async {
+      final selector = _selector(enabledPlugins: ["cursor"]);
+
+      final surface = await selector.resolve(args: ["run", "--", "--plugin", "opencode"]);
+
+      expect(surface.id, "cursor", reason: "tokens after -- are rest arguments, not options");
+    });
+
+    test("the space form consumes the next token unconditionally, like the parser", () async {
+      final selector = _selector(enabledPlugins: null);
+
+      final surface = await selector.resolve(args: ["--plugin", "cursor", "--", "--plugin=opencode"]);
+
+      expect(surface.id, "cursor");
+    });
+
+    test("the space form swallows even a -- token as the value, exactly like the parser", () async {
+      final selector = _selector(enabledPlugins: ["cursor"]);
+
+      final surface = await selector.resolve(args: ["--plugin", "--", "x"]);
+
+      expect(
+        surface.id,
+        "opencode",
+        reason: 'the parser reads "--" as the value (unknown id -> fallback); settings must not win',
+      );
+    });
+
+    test("the space form swallows a following option token as the value, exactly like the parser", () async {
+      final selector = _selector(enabledPlugins: ["cursor"]);
+
+      final surface = await selector.resolve(args: ["--plugin", "--port", "4096"]);
+
+      expect(
+        surface.id,
+        "opencode",
+        reason: 'the parser reads "--port" as the value (unknown id -> fallback); the full parse reports it',
+      );
+    });
+
+    test("an empty --plugin= value resolves to the fallback, not settings", () async {
+      final selector = _selector(enabledPlugins: ["cursor"]);
+
+      final surface = await selector.resolve(args: ["--plugin="]);
+
+      expect(surface.id, "opencode");
+    });
+
+    test("an unknown --plugin value resolves to the fallback surface", () async {
+      final selector = _selector(enabledPlugins: ["cursor"]);
+
+      final surface = await selector.resolve(args: ["--plugin", "bogus"]);
+
+      expect(
+        surface.id,
+        "opencode",
+        reason: "the parser still gets built; its allowed: list reports the unknown id on the full parse",
+      );
+    });
+
+    test("a trailing --plugin with no value falls through to settings", () async {
+      final selector = _selector(enabledPlugins: ["cursor"]);
+
+      final surface = await selector.resolve(args: ["--port", "4096", "--plugin"]);
+
+      expect(surface.id, "cursor", reason: "the full parse reports the missing argument");
+    });
+
+    test("settings select the plugin when the command line does not", () async {
+      final selector = _selector(enabledPlugins: ["cursor"]);
+
+      final surface = await selector.resolve(args: ["run"]);
+
+      expect(surface.id, "cursor");
+    });
+
+    test("an empty enabledPlugins list falls back to the default", () async {
+      final selector = _selector(enabledPlugins: []);
+
+      final surface = await selector.resolve(args: []);
+
+      expect(surface.id, "opencode");
+    });
+
+    test("multiple enabledPlugins entries throw a selection error", () async {
+      final selector = _selector(enabledPlugins: ["opencode", "cursor"]);
+
+      await expectLater(
+        selector.resolve(args: []),
+        throwsA(
+          isA<PluginSelectionException>().having(
+            (e) => e.message,
+            "message",
+            allOf(contains("opencode, cursor"), contains("exactly one")),
+          ),
+        ),
+      );
+    });
+
+    test("an unknown enabledPlugins id throws a selection error naming the known plugins", () async {
+      final selector = _selector(enabledPlugins: ["bogus"]);
+
+      await expectLater(
+        selector.resolve(args: []),
+        throwsA(
+          isA<PluginSelectionException>().having(
+            (e) => e.message,
+            "message",
+            allOf(contains('"bogus"'), contains("opencode, cursor")),
+          ),
+        ),
+      );
+    });
+  });
+}
+
+void _noValidation(PluginConfig config) {}
+
+const _surfaces = [
+  PluginCliSurface(id: "opencode", options: [], validateConfig: _noValidation),
+  PluginCliSurface(id: "cursor", options: [], validateConfig: _noValidation),
+];
+
+PluginSelector _selector({required List<String>? enabledPlugins}) {
+  return PluginSelector(
+    knownPlugins: _surfaces,
+    defaultPluginId: "opencode",
+    loadEnabledPlugins: () async => enabledPlugins,
+  );
+}

--- a/bridge/app/test/bridge/runtime/plugin_registry_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_registry_test.dart
@@ -156,6 +156,25 @@ void main() {
       );
     });
 
+    test("a default id missing from the known plugins is a descriptive wiring error", () async {
+      final selector = PluginSelector(
+        knownPlugins: _surfaces,
+        defaultPluginId: "miswired",
+        loadEnabledPlugins: () async => null,
+      );
+
+      await expectLater(
+        selector.resolve(args: []),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            "message",
+            allOf(contains('"miswired"'), contains("opencode, cursor")),
+          ),
+        ),
+      );
+    });
+
     test("an unknown enabledPlugins id throws a selection error naming the known plugins", () async {
       final selector = _selector(enabledPlugins: ["bogus"]);
 

--- a/bridge/app/test/bridge_config_service_test.dart
+++ b/bridge/app/test/bridge_config_service_test.dart
@@ -40,9 +40,7 @@ class _FakeBridgeSettingsRepository implements BridgeSettingsRepository {
   }
 
   @override
-  Future<BridgeSettings> peekSettings({
-    void Function(String message)? onInvalidConfig,
-  }) async => const BridgeSettings();
+  Future<BridgeSettings> peekSettings() async => const BridgeSettings();
 
   @override
   Future<void> saveSettings({required BridgeSettings settings}) async {}

--- a/bridge/app/test/bridge_config_service_test.dart
+++ b/bridge/app/test/bridge_config_service_test.dart
@@ -40,7 +40,9 @@ class _FakeBridgeSettingsRepository implements BridgeSettingsRepository {
   }
 
   @override
-  Future<BridgeSettings> peekSettings() async => const BridgeSettings();
+  Future<BridgeSettings> peekSettings({
+    void Function(String message)? onInvalidConfig,
+  }) async => const BridgeSettings();
 
   @override
   Future<void> saveSettings({required BridgeSettings settings}) async {}

--- a/bridge/app/test/bridge_config_service_test.dart
+++ b/bridge/app/test/bridge_config_service_test.dart
@@ -40,6 +40,9 @@ class _FakeBridgeSettingsRepository implements BridgeSettingsRepository {
   }
 
   @override
+  Future<BridgeSettings> peekSettings() async => const BridgeSettings();
+
+  @override
   Future<void> saveSettings({required BridgeSettings settings}) async {}
 }
 

--- a/bridge/app/test/bridge_settings_repository_test.dart
+++ b/bridge/app/test/bridge_settings_repository_test.dart
@@ -99,6 +99,30 @@ void main() {
       expect(api.writeCount, equals(0));
     });
 
+    test('peekSettings reports a corrupted config through onInvalidConfig', () async {
+      final api = FakeBridgeSettingsApi(readResult: '{');
+      final repository = BridgeSettingsRepository(api: api);
+      final warnings = <String>[];
+
+      await repository.peekSettings(onInvalidConfig: warnings.add);
+
+      expect(warnings, hasLength(1));
+      expect(warnings.single, contains('invalid config at /tmp/config.json'));
+    });
+
+    test('peekSettings does not invoke onInvalidConfig for a valid or missing config', () async {
+      final warnings = <String>[];
+
+      await BridgeSettingsRepository(
+        api: FakeBridgeSettingsApi(readResult: null),
+      ).peekSettings(onInvalidConfig: warnings.add);
+      await BridgeSettingsRepository(
+        api: FakeBridgeSettingsApi(readResult: '{"sleepPrevention":"off"}'),
+      ).peekSettings(onInvalidConfig: warnings.add);
+
+      expect(warnings, isEmpty);
+    });
+
     test('saveSettings pretty prints JSON through the api', () async {
       final api = FakeBridgeSettingsApi(readResult: null);
       final repository = BridgeSettingsRepository(api: api);

--- a/bridge/app/test/bridge_settings_repository_test.dart
+++ b/bridge/app/test/bridge_settings_repository_test.dart
@@ -65,6 +65,40 @@ void main() {
       expect(api.lastWrittenConfig, equals(_defaultJson));
     });
 
+    test('peekSettings returns defaults without writing when config is missing', () async {
+      final api = FakeBridgeSettingsApi(readResult: null);
+      final repository = BridgeSettingsRepository(api: api);
+
+      final settings = await repository.peekSettings();
+
+      expect(settings.sleepPrevention, SleepPreventionMode.always);
+      expect(settings.enabledPlugins, isNull);
+      expect(api.writeCount, equals(0));
+    });
+
+    test('peekSettings parses a valid config', () async {
+      final api = FakeBridgeSettingsApi(
+        readResult: '{"sleepPrevention":"off","enabledPlugins":["opencode"]}',
+      );
+      final repository = BridgeSettingsRepository(api: api);
+
+      final settings = await repository.peekSettings();
+
+      expect(settings.sleepPrevention, SleepPreventionMode.off);
+      expect(settings.enabledPlugins, equals(['opencode']));
+      expect(api.writeCount, equals(0));
+    });
+
+    test('peekSettings returns defaults without rewriting a corrupted config', () async {
+      final api = FakeBridgeSettingsApi(readResult: '{');
+      final repository = BridgeSettingsRepository(api: api);
+
+      final settings = await repository.peekSettings();
+
+      expect(settings.sleepPrevention, SleepPreventionMode.always);
+      expect(api.writeCount, equals(0));
+    });
+
     test('saveSettings pretty prints JSON through the api', () async {
       final api = FakeBridgeSettingsApi(readResult: null);
       final repository = BridgeSettingsRepository(api: api);

--- a/bridge/app/test/bridge_settings_repository_test.dart
+++ b/bridge/app/test/bridge_settings_repository_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:sesori_bridge/src/api/bridge_settings_api.dart';
 import 'package:sesori_bridge/src/repositories/bridge_settings.dart';
 import 'package:sesori_bridge/src/repositories/bridge_settings_repository.dart';
@@ -99,28 +101,42 @@ void main() {
       expect(api.writeCount, equals(0));
     });
 
-    test('peekSettings reports a corrupted config through onInvalidConfig', () async {
+    test('peekSettings reports a corrupted config on stderr, never stdout', () async {
       final api = FakeBridgeSettingsApi(readResult: '{');
       final repository = BridgeSettingsRepository(api: api);
-      final warnings = <String>[];
+      final stderrLines = <String>[];
+      final stdoutLines = <String>[];
 
-      await repository.peekSettings(onInvalidConfig: warnings.add);
+      await IOOverrides.runZoned(
+        repository.peekSettings,
+        stderr: () => _CapturingStdout(stderrLines),
+        stdout: () => _CapturingStdout(stdoutLines),
+      );
 
-      expect(warnings, hasLength(1));
-      expect(warnings.single, contains('invalid config at /tmp/config.json'));
+      expect(stderrLines, hasLength(1));
+      expect(stderrLines.single, contains('invalid config at /tmp/config.json'));
+      expect(stdoutLines, isEmpty, reason: 'stdout must stay machine-clean for --version/--help');
     });
 
-    test('peekSettings does not invoke onInvalidConfig for a valid or missing config', () async {
-      final warnings = <String>[];
+    test('peekSettings logs nothing for a valid or missing config', () async {
+      final stderrLines = <String>[];
+      final stdoutLines = <String>[];
 
-      await BridgeSettingsRepository(
-        api: FakeBridgeSettingsApi(readResult: null),
-      ).peekSettings(onInvalidConfig: warnings.add);
-      await BridgeSettingsRepository(
-        api: FakeBridgeSettingsApi(readResult: '{"sleepPrevention":"off"}'),
-      ).peekSettings(onInvalidConfig: warnings.add);
+      await IOOverrides.runZoned(
+        () async {
+          await BridgeSettingsRepository(
+            api: FakeBridgeSettingsApi(readResult: null),
+          ).peekSettings();
+          await BridgeSettingsRepository(
+            api: FakeBridgeSettingsApi(readResult: '{"sleepPrevention":"off"}'),
+          ).peekSettings();
+        },
+        stderr: () => _CapturingStdout(stderrLines),
+        stdout: () => _CapturingStdout(stdoutLines),
+      );
 
-      expect(warnings, isEmpty);
+      expect(stderrLines, isEmpty);
+      expect(stdoutLines, isEmpty);
     });
 
     test('saveSettings pretty prints JSON through the api', () async {
@@ -150,6 +166,21 @@ void main() {
 }
 
 const _defaultJson = '{\n  "sleepPrevention": "always"\n}';
+
+/// Captures [writeln] calls; [IOOverrides] swaps it in for stdout/stderr.
+class _CapturingStdout implements Stdout {
+  _CapturingStdout(this.lines);
+
+  final List<String> lines;
+
+  @override
+  void writeln([Object? object = '']) {
+    lines.add(object.toString());
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
 
 class FakeBridgeSettingsApi implements BridgeSettingsApi {
   @override

--- a/bridge/app/test/bridge_settings_test.dart
+++ b/bridge/app/test/bridge_settings_test.dart
@@ -46,5 +46,57 @@ void main() {
 
       expect(settings.toJson(), equals({'sleepPrevention': 'off'}));
     });
+
+    test('enabledPlugins defaults to unset', () {
+      const settings = BridgeSettings();
+
+      expect(settings.enabledPlugins, isNull);
+    });
+
+    test('fromJson parses enabledPlugins entries', () {
+      final settings = BridgeSettings.fromJson({
+        'enabledPlugins': ['opencode'],
+      });
+
+      expect(settings.enabledPlugins, equals(['opencode']));
+    });
+
+    test('fromJson treats a missing enabledPlugins key as unset', () {
+      final settings = BridgeSettings.fromJson({'sleepPrevention': 'always'});
+
+      expect(settings.enabledPlugins, isNull);
+    });
+
+    test('fromJson treats a non-list enabledPlugins as unset', () {
+      final settings = BridgeSettings.fromJson({'enabledPlugins': 'opencode'});
+
+      expect(settings.enabledPlugins, isNull);
+    });
+
+    test('fromJson keeps only string entries of enabledPlugins', () {
+      final settings = BridgeSettings.fromJson({
+        'enabledPlugins': ['opencode', 42, null],
+      });
+
+      expect(settings.enabledPlugins, equals(['opencode']));
+    });
+
+    test('toJson omits enabledPlugins when unset, keeping the defaults file shape', () {
+      const settings = BridgeSettings();
+
+      expect(settings.toJson(), equals({'sleepPrevention': 'always'}));
+    });
+
+    test('toJson includes enabledPlugins when set', () {
+      const settings = BridgeSettings(enabledPlugins: ['opencode']);
+
+      expect(
+        settings.toJson(),
+        equals({
+          'sleepPrevention': 'always',
+          'enabledPlugins': ['opencode'],
+        }),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

PR 5 of the [plugin-lifecycle migration plan](../blob/main/docs/plans/plugin-lifecycle-migration.html) (stacked on #227 — only the last commit is new). Registered plugins are no longer implicitly the started set:

- **`PluginManager`** (`plugin_manager.dart`): per-id `startPlugin`/`stopPlugin` (idempotent, memoized; a failed start untracks the id; restart over an in-flight stop is sequenced), `activePlugins` view, exactly-one-active enforced with a clear error. **Defined stop semantics:** stopping the active plugin first cancels the bridge session (bound via `bindActiveSession`; `OrchestratorSession.cancel` is idempotent and safe after `run()` returns), then runs the plugin's `shutdown(budget)` — never a live session over a stopped plugin.
- **Two-pass `--plugin` parse** (`plugin_registry.dart`): pass 1 scans the raw argv (mirroring `package:args` long-option mechanics: `=` and space forms, last-wins, `--` terminator, unconditional value consumption) to pick which plugin's CLI surface builds the parser; pass 2 is the normal full parse, where the registered `--plugin` option's `allowed:` list produces the usage errors. `--help` documents the selected plugin's options.
- **`enabledPlugins` in bridge settings** as the no-flag fallback, default `opencode` — existing installs see zero change (`run --help` differs only by the additive `--plugin` lines; verified by diff). New side-effect-free `BridgeSettingsRepository.peekSettings()` so selection never creates the config file for `--help`/`logout`; a bad `enabledPlugins` value defers its error to the `run` command instead of bricking `--help`/`logout`/`config` (the recovery command).
- **Runner** routes startup and the ordered shutdown step through the manager; the failure-latch wiring, mutex flow, and `startLegacyOpenCodePlugin` are unchanged from PR 4.

### Transitional deviations (resolve at PR 12)
- The manager registry holds runner-bound **starter closures**, not descriptors: `LegacyOpenCodeDescriptor` can only be constructed inside the startup mutex. Documented on `PluginStarter`.
- One downcast to `LegacyOpenCodeBridgePlugin` in the runner (BridgeConfig still needs `serverUrl`/`serverPassword`).

## Test plan
- 25 new `PluginManager` tests (idempotency, exactly-one, stop-cancels-session ordering + budget, sync-throwing starter untracking, failing-shutdown propagation/untracking, restart over failed stop, binding replacement) and 16 selector/registry tests (precedence, scanner⇄parser agreement edges, settings errors).
- `dart analyze --fatal-infos` clean; full suite 1,322 green; `dart format` clean on touched files.
- Smoke: `--help`/`run`/`--version` against sandboxed configs with unknown/multiple `enabledPlugins` and corrupt JSON (`--version` stdout stays machine-pure); `--plugin bogus` and missing-value usage errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PluginManager and a two-pass --plugin selection so the bridge explicitly starts/stops exactly one plugin, with stop cancelling the session first. Existing installs behave the same; `opencode` stays default, and settings reads are side‑effect‑free and now report invalid configs to stderr via `Log.e`.

- **New Features**
  - `PluginManager`: per-id start/stop (idempotent, memoized), `activePlugins` view, exactly one active enforced.
  - Stop semantics: stop cancels the bound session first, then calls the plugin’s `shutdown(budget)`.
  - Two-pass `--plugin` selection: scan raw argv to pick the plugin surface, then full parse; unknown ids error via `allowed:`; `--help` shows the selected plugin’s flags.
  - Settings fallback: `enabledPlugins` selects when the CLI doesn’t; defaults to `opencode`. `BridgeSettingsRepository.peekSettings()` is side‑effect‑free and logs invalid-config parse failures via `Log.e` to stderr; I/O errors propagate. Bad settings defer to `run` (parser built from the default surface).

- **Bug Fixes**
  - Fallback surface wiring: when the default plugin id isn’t in `knownPlugins`, selection now throws a clear error instead of a null assert.

<sup>Written for commit bbd812a4430a001ecfb64763ece77749cf26fd08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

