### PR TITLE
chore: mark generated files and test dirs as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Generated code — collapse diffs on GitHub and exclude from language stats
+*.g.dart linguist-generated=true
+*.freezed.dart linguist-generated=true
+*.gr.dart linguist-generated=true
+*.config.dart linguist-generated=true
+*.steps.dart linguist-generated=true
+*.mocks.dart linguist-generated=true
+**/drift_schemas/** linguist-generated=true
+
+# Lockfiles
+pubspec.lock linguist-generated=true
+Gemfile.lock linguist-generated=true
+Podfile.lock linguist-generated=true
+
+# Flutter platform-specific generated files
+**/GeneratedPluginRegistrant.* linguist-generated=true
+**/generated_plugin_registrant.* linguist-generated=true
+**/generated_plugins.cmake linguist-generated=true
+
+# Test directories — don't render diffs by default
+**/test/** linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,11 +7,6 @@
 *.mocks.dart linguist-generated=true
 **/drift_schemas/** linguist-generated=true
 
-# Lockfiles
-pubspec.lock linguist-generated=true
-Gemfile.lock linguist-generated=true
-Podfile.lock linguist-generated=true
-
 # Flutter platform-specific generated files
 **/GeneratedPluginRegistrant.* linguist-generated=true
 **/generated_plugin_registrant.* linguist-generated=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,6 +353,8 @@ The bridge uses Drift (SQLite) for local persistence. Schema changes require a s
 
 Conventional commits: `fix:`, `feat:`, `ci:`, `docs:`, `chore:`.
 
+`.gitattributes` marks generated code and test directories as `linguist-generated` so GitHub collapses their diffs. Lockfiles (`pubspec.lock`, `Gemfile.lock`, `Podfile.lock`) must NEVER be marked as generated — the user always reviews lockfile diffs.
+
 ## Testing
 
 | Location                 | Command        |


### PR DESCRIPTION
## What

Adds a root `.gitattributes` marking generated artifacts and test directories as `linguist-generated=true`, so GitHub collapses their diffs by default in PRs and excludes them from language stats.

Lockfiles (`pubspec.lock`, `Gemfile.lock`, `Podfile.lock`) are intentionally **not** marked — those should stay rendered for review.

## Covered patterns

- **Dart codegen**: `*.g.dart`, `*.freezed.dart`, `*.gr.dart`, `*.config.dart`, `*.steps.dart`, `*.mocks.dart`
- **Drift schema snapshots**: `**/drift_schemas/**`
- **Test directories**: `**/test/**` (any depth — note `*/test/*` would only match one level below root)
- **Flutter platform codegen**: `GeneratedPluginRegistrant.*`, `generated_plugin_registrant.*`, `generated_plugins.cmake`

## Verification

Verified with `git check-attr linguist-generated` against real tracked paths (nested test files, drift schemas, injection configs, platform registrants) — all resolve to `true`; regular source files and lockfiles remain `unspecified`.