### PR TITLE
fix(mobile): return split detail pane to empty state after deleting the open session

### DIFF
--- a/mobile/app/lib/core/routing/app_router.dart
+++ b/mobile/app/lib/core/routing/app_router.dart
@@ -23,8 +23,8 @@ final _rootNavigatorKey = GlobalKey<NavigatorState>();
 final _sessionShellNavigatorKey = GlobalKey<NavigatorState>();
 
 const _newSessionRouteSegment = "new";
-const _sessionsRouteSegment = ":projectId/sessions";
-const _sessionDetailRouteSegment = ":sessionId";
+const _sessionsRouteSegment = ":$projectIdPathParam/sessions";
+const _sessionDetailRouteSegment = ":$sessionIdPathParam";
 const _sessionDiffsRouteSegment = "diffs";
 
 extension AppRouteToGoRoute on AppRouteDef {
@@ -210,9 +210,9 @@ List<RouteBase> _buildAppRoutes({
         ShellRoute(
           navigatorKey: sessionShellNavigatorKey,
           builder: (context, state, child) {
-            final projectId = state.pathParameters["projectId"] ?? "";
+            final projectId = state.pathParameters[projectIdPathParam] ?? "";
             final projectName = state.uri.queryParameters[projectNameQueryParam];
-            final selectedSessionId = state.pathParameters["sessionId"];
+            final selectedSessionId = state.pathParameters[sessionIdPathParam];
 
             return SessionListCubitProvider(
               key: ValueKey("session-list-cubit-$projectId"),

--- a/mobile/app/lib/features/session_list/session_list_actions.dart
+++ b/mobile/app/lib/features/session_list/session_list_actions.dart
@@ -217,9 +217,9 @@ Future<void> _deleteSession({
 /// already current when deleting from the list, so this is a no-op there.
 void _closeDeletedSessionRoute({required BuildContext context, required String sessionId}) {
   final routeState = GoRouterState.of(context);
-  if (routeState.pathParameters["sessionId"] != sessionId) return;
+  if (routeState.pathParameters[sessionIdPathParam] != sessionId) return;
 
-  final projectId = routeState.pathParameters["projectId"];
+  final projectId = routeState.pathParameters[projectIdPathParam];
   if (projectId == null) return;
 
   context.goRoute(

--- a/mobile/app/lib/features/session_list/session_list_actions.dart
+++ b/mobile/app/lib/features/session_list/session_list_actions.dart
@@ -185,6 +185,7 @@ Future<void> _deleteSession({
     ScaffoldMessenger.of(context)
       ..clearSnackBars()
       ..showSnackBar(SnackBar(content: Text(loc.sessionListDeleted)));
+    _closeDeletedSessionRoute(context: context, sessionId: sessionId);
     return;
   }
 
@@ -205,4 +206,26 @@ Future<void> _deleteSession({
       ..clearSnackBars()
       ..showSnackBar(SnackBar(content: Text(loc.sessionListDeleteFailed)));
   }
+}
+
+/// Leaves the deleted session's detail (or diffs) route when it is still the
+/// current location.
+///
+/// In the split layout the detail pane would otherwise keep rendering the
+/// deleted session; returning to the sessions route swaps it for the empty
+/// "select a session" panel. In the narrow layout the sessions route is
+/// already current when deleting from the list, so this is a no-op there.
+void _closeDeletedSessionRoute({required BuildContext context, required String sessionId}) {
+  final routeState = GoRouterState.of(context);
+  if (routeState.pathParameters["sessionId"] != sessionId) return;
+
+  final projectId = routeState.pathParameters["projectId"];
+  if (projectId == null) return;
+
+  context.goRoute(
+    AppRoute.sessions(
+      projectId: projectId,
+      projectName: routeState.uri.queryParameters[projectNameQueryParam],
+    ),
+  );
 }

--- a/mobile/app/test/features/session_list/adaptive_session_list_navigation_test.dart
+++ b/mobile/app/test/features/session_list/adaptive_session_list_navigation_test.dart
@@ -320,6 +320,109 @@ void main() {
     );
   });
 
+  testWidgets("deleting the selected session returns the wide detail pane to the empty state", (tester) async {
+    const location = "/projects/p1/sessions?name=Project+One";
+    final harness = AdaptiveSessionRouterTestHarness();
+    await tester.binding.setSurfaceSize(const Size(1024, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    addTearDown(harness.tearDown);
+    await harness.setUp(
+      initialLocation: location,
+      currentRouteDef: AppRouteDef.sessions,
+      sessionsByProject: {
+        "p1": [adaptiveTestSession(projectId: "p1", id: "session-1", title: "Session One")],
+      },
+    );
+    when(
+      () => harness.sessionRepository.deleteSession(
+        sessionId: any(named: "sessionId"),
+        deleteWorktree: any(named: "deleteWorktree"),
+        deleteBranch: any(named: "deleteBranch"),
+        force: any(named: "force"),
+      ),
+    ).thenAnswer((_) async => ApiResponse<void>.success(null));
+
+    await tester.pumpWidget(harness.buildApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text("Session One"));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey("session-detail-session-1")), findsOneWidget);
+
+    await tester.longPress(
+      find.descendant(
+        of: find.byKey(const Key("session-split-left-pane")),
+        matching: find.text("Session One"),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text("Delete"));
+    await tester.pumpAndSettle();
+
+    final uri = Uri.parse(harness.currentLocation);
+    expect(uri.path, "/projects/p1/sessions");
+    expect(uri.queryParameters["name"], "Project One");
+    expect(find.byKey(const Key("empty-session-detail-panel")), findsOneWidget);
+    expect(find.byKey(const ValueKey("session-detail-session-1")), findsNothing);
+
+    // Let the deletion snackbar expire so no timers outlive the test.
+    await tester.pump(const Duration(seconds: 5));
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets("deleting an unselected session keeps the open wide detail pane", (tester) async {
+    const location = "/projects/p1/sessions?name=Project+One";
+    final harness = AdaptiveSessionRouterTestHarness();
+    await tester.binding.setSurfaceSize(const Size(1024, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    addTearDown(harness.tearDown);
+    await harness.setUp(
+      initialLocation: location,
+      currentRouteDef: AppRouteDef.sessions,
+      sessionsByProject: {
+        "p1": [
+          adaptiveTestSession(projectId: "p1", id: "session-1", title: "Session One"),
+          adaptiveTestSession(projectId: "p1", id: "session-2", title: "Session Two"),
+        ],
+      },
+    );
+    when(
+      () => harness.sessionRepository.deleteSession(
+        sessionId: any(named: "sessionId"),
+        deleteWorktree: any(named: "deleteWorktree"),
+        deleteBranch: any(named: "deleteBranch"),
+        force: any(named: "force"),
+      ),
+    ).thenAnswer((_) async => ApiResponse<void>.success(null));
+
+    await tester.pumpWidget(harness.buildApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text("Session One"));
+    await tester.pumpAndSettle();
+
+    await tester.longPress(
+      find.descendant(
+        of: find.byKey(const Key("session-split-left-pane")),
+        matching: find.text("Session Two"),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text("Delete"));
+    await tester.pumpAndSettle();
+
+    expect(Uri.parse(harness.currentLocation).path, "/projects/p1/sessions/session-1");
+    expect(find.byKey(const ValueKey("session-detail-session-1")), findsOneWidget);
+    expect(find.byKey(const Key("empty-session-detail-panel")), findsNothing);
+
+    // Let the deletion snackbar expire so no timers outlive the test.
+    await tester.pump(const Duration(seconds: 5));
+    await tester.pumpAndSettle();
+  });
+
   testWidgets("wide shell preserves the left-list cubit for same-project routes and resets it for a new project", (
     tester,
   ) async {

--- a/mobile/module_core/lib/src/routing/app_routes.dart
+++ b/mobile/module_core/lib/src/routing/app_routes.dart
@@ -1,6 +1,8 @@
 const bundleId = "com.sesori.app";
 const redirectUri = "$bundleId://auth/callback";
 const projectNameQueryParam = "name";
+const projectIdPathParam = "projectId";
+const sessionIdPathParam = "sessionId";
 
 String _appendQuery({required String path, required Map<String, String> queryParameters}) {
   if (queryParameters.isEmpty) return path;
@@ -16,10 +18,10 @@ enum AppRouteDef {
   login("/login"),
   projects("/projects"),
   settings("/settings"),
-  sessions("/projects/:projectId/sessions"),
-  newSession("/projects/:projectId/sessions/new"),
-  sessionDetail("/projects/:projectId/sessions/:sessionId"),
-  sessionDiffs("/projects/:projectId/sessions/:sessionId/diffs"),
+  sessions("/projects/:$projectIdPathParam/sessions"),
+  newSession("/projects/:$projectIdPathParam/sessions/new"),
+  sessionDetail("/projects/:$projectIdPathParam/sessions/:$sessionIdPathParam"),
+  sessionDiffs("/projects/:$projectIdPathParam/sessions/:$sessionIdPathParam/diffs"),
   ;
 
   const AppRouteDef(this.path);
@@ -147,7 +149,7 @@ class AppRouteSettings extends AppRoute {
 }
 
 class AppRouteSessions extends AppRoute {
-  static const _projectIdPathParam = "projectId";
+  static const _projectIdPathParam = projectIdPathParam;
   static const _nameQueryParam = projectNameQueryParam;
 
   final String projectId;
@@ -180,7 +182,7 @@ class AppRouteSessions extends AppRoute {
 }
 
 class AppRouteNewSession extends AppRoute {
-  static const _projectIdPathParam = "projectId";
+  static const _projectIdPathParam = projectIdPathParam;
   static const _nameQueryParam = projectNameQueryParam;
 
   final String projectId;
@@ -213,8 +215,8 @@ class AppRouteNewSession extends AppRoute {
 }
 
 class AppRouteSessionDetail extends AppRoute {
-  static const _projectIdPathParam = "projectId";
-  static const _sessionIdPathParam = "sessionId";
+  static const _projectIdPathParam = projectIdPathParam;
+  static const _sessionIdPathParam = sessionIdPathParam;
   static const _nameQueryParam = projectNameQueryParam;
   static const _titleQueryParam = "title";
   static const _readOnlyQueryParam = "readOnly";
@@ -263,8 +265,8 @@ class AppRouteSessionDetail extends AppRoute {
 }
 
 class AppRouteSessionDiffs extends AppRoute {
-  static const _projectIdPathParam = "projectId";
-  static const _sessionIdPathParam = "sessionId";
+  static const _projectIdPathParam = projectIdPathParam;
+  static const _sessionIdPathParam = sessionIdPathParam;
   static const _nameQueryParam = projectNameQueryParam;
 
   final String projectId;


### PR DESCRIPTION
## Problem

In the tablet/desktop split view, long-pressing the currently open session in the left list pane and deleting it left the right detail pane rendering the just-deleted session. The pane is driven purely by the route, and the delete flow never updated it.

## Fix

After a successful delete, `_deleteSession` now calls a new `_closeDeletedSessionRoute` helper: if the current location's `sessionId` path param matches the deleted session, it navigates back to the sessions route, which the split shell renders as the empty "select a session" panel.

- Also covers the diffs subroute (right pane showing diffs of the deleted session)
- Covers the force-delete (409 → retry) path, which re-enters `_deleteSession`
- No-op in narrow layouts (sessions route has no `sessionId` param) and when deleting a session that isn't the one open
- Preserves the `?name=` query param so the left pane header keeps the project name

## Tests

Two regression tests added to `adaptive_session_list_navigation_test.dart` using the existing `AdaptiveSessionRouterTestHarness`:
- deleting the selected session returns the wide detail pane to the empty state
- deleting an unselected session keeps the open detail pane

Full `flutter test` suite in `mobile/app`: 481/481 passing. `dart analyze` clean on changed files. Architectural review (aristotle-impl-review): approved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the split view so deleting the open session returns the right pane to the empty “select a session” state. Also standardizes route path-param names via shared constants.

- **Bug Fixes**
  - Close the deleted session route after a successful delete.
  - If the current route’s `sessionId` matches, navigate back to the sessions route and preserve the `?name=` query; covers detail and diffs, including force-delete retries; no-op on narrow layouts or when deleting a different session.
  - Added two widget tests for wide mode to verify clearing the detail pane vs. keeping it when deleting another session.

- **Refactors**
  - Extracted `projectId` and `sessionId` path-param names into shared consts and updated route definitions and lookups to use them.

<sup>Written for commit 1ebb7203c4959e018571fa61a1afa4426298d75b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

