### PR TITLE
feat(bridge): sesori_plugin_runtime — ownership repository, stale cleanup, stop (migration PR 7/15)

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -38,6 +38,10 @@ jobs:
         run: dart analyze --fatal-infos
         working-directory: bridge/sesori_plugin_interface
 
+      - name: Analyze sesori_plugin_runtime
+        run: dart analyze --fatal-infos
+        working-directory: bridge/sesori_plugin_runtime
+
       - name: Analyze sesori_plugin_opencode
         run: dart analyze --fatal-infos
         working-directory: bridge/sesori_plugin_opencode
@@ -49,6 +53,10 @@ jobs:
       - name: Run tests for sesori_plugin_interface
         run: dart test
         working-directory: bridge/sesori_plugin_interface
+
+      - name: Run tests for sesori_plugin_runtime
+        run: dart test
+        working-directory: bridge/sesori_plugin_runtime
 
       - name: Run tests for sesori_plugin_opencode
         run: dart test

--- a/bridge/Makefile
+++ b/bridge/Makefile
@@ -8,8 +8,12 @@ MODULES := sesori_plugin_interface sesori_plugin_runtime sesori_plugin_opencode 
 
 codegen:
 	@for mod in $(MODULES); do \
-		echo "=== codegen: $$mod ==="; \
-		(cd $$mod && $(DART) run build_runner build --delete-conflicting-outputs); \
+		if grep -q build_runner $$mod/pubspec.yaml; then \
+			echo "=== codegen: $$mod ==="; \
+			(cd $$mod && $(DART) run build_runner build --delete-conflicting-outputs); \
+		else \
+			echo "=== codegen: $$mod (skipped: no build_runner dependency) ==="; \
+		fi; \
 	done
 
 pub-get:

--- a/bridge/Makefile
+++ b/bridge/Makefile
@@ -2,7 +2,7 @@ TOOL_VERSIONS := $(shell git rev-parse --show-toplevel)/.tool-versions
 FLUTTER_VERSION := $(shell grep '^flutter' $(TOOL_VERSIONS) | awk '{print $$2}')
 DART := $(HOME)/.asdf/installs/flutter/$(FLUTTER_VERSION)/bin/cache/dart-sdk/bin/dart
 
-MODULES := sesori_plugin_interface sesori_plugin_opencode app
+MODULES := sesori_plugin_interface sesori_plugin_runtime sesori_plugin_opencode app
 
 .PHONY: codegen pub-get test analyze
 

--- a/bridge/pubspec.yaml
+++ b/bridge/pubspec.yaml
@@ -7,4 +7,5 @@ environment:
 workspace:
   - app
   - sesori_plugin_opencode
+  - sesori_plugin_runtime
   - sesori_plugin_interface

--- a/bridge/sesori_plugin_runtime/analysis_options.yaml
+++ b/bridge/sesori_plugin_runtime/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../app/analysis_options.yaml

--- a/bridge/sesori_plugin_runtime/lib/sesori_plugin_runtime.dart
+++ b/bridge/sesori_plugin_runtime/lib/sesori_plugin_runtime.dart
@@ -1,0 +1,4 @@
+export "src/host_json_runtime_ownership_repository.dart";
+export "src/managed_process_service.dart";
+export "src/runtime_ownership_repository.dart";
+export "src/runtime_record_mapper.dart";

--- a/bridge/sesori_plugin_runtime/lib/src/host_json_runtime_ownership_repository.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/host_json_runtime_ownership_repository.dart
@@ -38,9 +38,9 @@ class HostJsonRuntimeOwnershipRepository<R> implements RuntimeOwnershipRepositor
     await _store.update(
       name: _fileName,
       transform: (current) async {
-        final records = await _loadRecordsFromContents(contents: current);
-        records[_mapper.ownerSessionIdOf(record: record)] = record;
-        return jsonEncode(_recordsToJson(records: records));
+        final loaded = await _loadRecordsFromContents(contents: current);
+        loaded.records[_mapper.ownerSessionIdOf(record: record)] = record;
+        return jsonEncode(_recordsToJson(records: loaded.records));
       },
     );
   }
@@ -50,12 +50,19 @@ class HostJsonRuntimeOwnershipRepository<R> implements RuntimeOwnershipRepositor
     await _store.update(
       name: _fileName,
       transform: (current) async {
-        final records = await _loadRecordsFromContents(contents: current);
-        records.remove(ownerSessionId);
-        if (records.isEmpty) {
+        final loaded = await _loadRecordsFromContents(contents: current);
+        final removedRecord = loaded.records.remove(ownerSessionId);
+        if (removedRecord == null) {
+          // Nothing to delete: leave a valid file byte-for-byte untouched
+          // (legacy early-returns without writing). If the contents were just
+          // quarantined, returning null keeps the original name absent instead
+          // of resurrecting the corrupt bytes.
+          return loaded.wasInvalid ? null : current;
+        }
+        if (loaded.records.isEmpty) {
           return null;
         }
-        return jsonEncode(_recordsToJson(records: records));
+        return jsonEncode(_recordsToJson(records: loaded.records));
       },
     );
   }
@@ -68,12 +75,13 @@ class HostJsonRuntimeOwnershipRepository<R> implements RuntimeOwnershipRepositor
       await _handleInvalidRuntimeFile(reason: "unreadable runtime ownership file", error: error);
       return <String, R>{};
     }
-    return _loadRecordsFromContents(contents: contents);
+    final loaded = await _loadRecordsFromContents(contents: contents);
+    return loaded.records;
   }
 
-  Future<Map<String, R>> _loadRecordsFromContents({required String? contents}) async {
+  Future<({Map<String, R> records, bool wasInvalid})> _loadRecordsFromContents({required String? contents}) async {
     if (contents == null || contents.trim().isEmpty) {
-      return <String, R>{};
+      return (records: <String, R>{}, wasInvalid: false);
     }
 
     try {
@@ -82,13 +90,16 @@ class HostJsonRuntimeOwnershipRepository<R> implements RuntimeOwnershipRepositor
         throw const FormatException("Runtime ownership root must be an object");
       }
       final rootJson = Map<String, dynamic>.from(decoded);
-      return <String, R>{
-        for (final MapEntry<String, dynamic> entry in rootJson.entries)
-          entry.key: _mapper.fromJson(json: Map<String, dynamic>.from(entry.value as Map)),
-      };
+      return (
+        records: <String, R>{
+          for (final MapEntry<String, dynamic> entry in rootJson.entries)
+            entry.key: _mapper.fromJson(json: Map<String, dynamic>.from(entry.value as Map)),
+        },
+        wasInvalid: false,
+      );
     } on Object catch (error) {
       await _handleInvalidRuntimeFile(reason: "invalid runtime ownership file", error: error);
-      return <String, R>{};
+      return (records: <String, R>{}, wasInvalid: true);
     }
   }
 

--- a/bridge/sesori_plugin_runtime/lib/src/host_json_runtime_ownership_repository.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/host_json_runtime_ownership_repository.dart
@@ -38,9 +38,12 @@ class HostJsonRuntimeOwnershipRepository<R> implements RuntimeOwnershipRepositor
     await _store.update(
       name: _fileName,
       transform: (current) async {
-        final loaded = await _loadRecordsFromContents(contents: current);
-        loaded.records[_mapper.ownerSessionIdOf(record: record)] = record;
-        return jsonEncode(_recordsToJson(records: loaded.records));
+        final parsed = _parseRecords(contents: current);
+        if (parsed.invalidError != null) {
+          await _handleInvalidRuntimeFile(reason: "invalid runtime ownership file", error: parsed.invalidError!);
+        }
+        parsed.records[_mapper.ownerSessionIdOf(record: record)] = record;
+        return jsonEncode(_recordsToJson(records: parsed.records));
       },
     );
   }
@@ -50,19 +53,22 @@ class HostJsonRuntimeOwnershipRepository<R> implements RuntimeOwnershipRepositor
     await _store.update(
       name: _fileName,
       transform: (current) async {
-        final loaded = await _loadRecordsFromContents(contents: current);
-        final removedRecord = loaded.records.remove(ownerSessionId);
+        final parsed = _parseRecords(contents: current);
+        if (parsed.invalidError != null) {
+          await _handleInvalidRuntimeFile(reason: "invalid runtime ownership file", error: parsed.invalidError!);
+        }
+        final removedRecord = parsed.records.remove(ownerSessionId);
         if (removedRecord == null) {
           // Nothing to delete: leave a valid file byte-for-byte untouched
           // (legacy early-returns without writing). If the contents were just
           // quarantined, returning null keeps the original name absent instead
           // of resurrecting the corrupt bytes.
-          return loaded.wasInvalid ? null : current;
+          return parsed.invalidError != null ? null : current;
         }
-        if (loaded.records.isEmpty) {
+        if (parsed.records.isEmpty) {
           return null;
         }
-        return jsonEncode(_recordsToJson(records: loaded.records));
+        return jsonEncode(_recordsToJson(records: parsed.records));
       },
     );
   }
@@ -72,16 +78,20 @@ class HostJsonRuntimeOwnershipRepository<R> implements RuntimeOwnershipRepositor
     try {
       contents = await _store.read(name: _fileName);
     } on Object catch (error) {
-      await _handleInvalidRuntimeFile(reason: "unreadable runtime ownership file", error: error);
+      await _quarantineIfStillInvalid(reason: "unreadable runtime ownership file", error: error);
       return <String, R>{};
     }
-    final loaded = await _loadRecordsFromContents(contents: contents);
-    return loaded.records;
+    final parsed = _parseRecords(contents: contents);
+    if (parsed.invalidError != null) {
+      await _quarantineIfStillInvalid(reason: "invalid runtime ownership file", error: parsed.invalidError!);
+      return <String, R>{};
+    }
+    return parsed.records;
   }
 
-  Future<({Map<String, R> records, bool wasInvalid})> _loadRecordsFromContents({required String? contents}) async {
+  ({Map<String, R> records, Object? invalidError}) _parseRecords({required String? contents}) {
     if (contents == null || contents.trim().isEmpty) {
-      return (records: <String, R>{}, wasInvalid: false);
+      return (records: <String, R>{}, invalidError: null);
     }
 
     try {
@@ -95,11 +105,39 @@ class HostJsonRuntimeOwnershipRepository<R> implements RuntimeOwnershipRepositor
           for (final MapEntry<String, dynamic> entry in rootJson.entries)
             entry.key: _mapper.fromJson(json: Map<String, dynamic>.from(entry.value as Map)),
         },
-        wasInvalid: false,
+        invalidError: null,
       );
     } on Object catch (error) {
-      await _handleInvalidRuntimeFile(reason: "invalid runtime ownership file", error: error);
-      return (records: <String, R>{}, wasInvalid: true);
+      return (records: <String, R>{}, invalidError: error);
+    }
+  }
+
+  /// Quarantines the ownership file only if it is still invalid when observed
+  /// under the store's update lock. A snapshot that failed to parse on the
+  /// unlocked read path must not rename the file directly: a concurrent
+  /// locked mutation may have repaired it in between, and renaming then would
+  /// quarantine a freshly written valid file.
+  Future<void> _quarantineIfStillInvalid({required String reason, required Object error}) async {
+    try {
+      await _store.update(
+        name: _fileName,
+        transform: (current) async {
+          if (current == null || current.trim().isEmpty) {
+            return current;
+          }
+          final recheck = _parseRecords(contents: current);
+          if (recheck.invalidError == null) {
+            return current;
+          }
+          await _handleInvalidRuntimeFile(reason: reason, error: recheck.invalidError!);
+          return null;
+        },
+      );
+    } on Object catch (updateError) {
+      Log.w(
+        "Could not revalidate runtime ownership file at $_fileName before quarantine; "
+        "continuing fresh without persisted ownership state. Error: $updateError (original: $error)",
+      );
     }
   }
 

--- a/bridge/sesori_plugin_runtime/lib/src/host_json_runtime_ownership_repository.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/host_json_runtime_ownership_repository.dart
@@ -1,0 +1,122 @@
+import "dart:convert";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "runtime_ownership_repository.dart";
+import "runtime_record_mapper.dart";
+
+class HostJsonRuntimeOwnershipRepository<R> implements RuntimeOwnershipRepository<R> {
+  HostJsonRuntimeOwnershipRepository({
+    required HostJsonStore store,
+    required RuntimeRecordMapper<R> mapper,
+    required String fileName,
+    required ServerClock clock,
+  }) : _store = store,
+       _mapper = mapper,
+       _fileName = fileName,
+       _clock = clock;
+
+  final HostJsonStore _store;
+  final RuntimeRecordMapper<R> _mapper;
+  final String _fileName;
+  final ServerClock _clock;
+
+  @override
+  Future<List<R>> readAll() async {
+    final records = await _loadRecordsFromRead();
+    return records.values.toList(growable: false);
+  }
+
+  @override
+  Future<R?> readByOwnerSessionId({required String ownerSessionId}) async {
+    final records = await _loadRecordsFromRead();
+    return records[ownerSessionId];
+  }
+
+  @override
+  Future<void> upsert({required R record}) async {
+    await _store.update(
+      name: _fileName,
+      transform: (current) async {
+        final records = await _loadRecordsFromContents(contents: current);
+        records[_mapper.ownerSessionIdOf(record: record)] = record;
+        return jsonEncode(_recordsToJson(records: records));
+      },
+    );
+  }
+
+  @override
+  Future<void> deleteByOwnerSessionId({required String ownerSessionId}) async {
+    await _store.update(
+      name: _fileName,
+      transform: (current) async {
+        final records = await _loadRecordsFromContents(contents: current);
+        records.remove(ownerSessionId);
+        if (records.isEmpty) {
+          return null;
+        }
+        return jsonEncode(_recordsToJson(records: records));
+      },
+    );
+  }
+
+  Future<Map<String, R>> _loadRecordsFromRead() async {
+    final String? contents;
+    try {
+      contents = await _store.read(name: _fileName);
+    } on Object catch (error) {
+      await _handleInvalidRuntimeFile(reason: "unreadable runtime ownership file", error: error);
+      return <String, R>{};
+    }
+    return _loadRecordsFromContents(contents: contents);
+  }
+
+  Future<Map<String, R>> _loadRecordsFromContents({required String? contents}) async {
+    if (contents == null || contents.trim().isEmpty) {
+      return <String, R>{};
+    }
+
+    try {
+      final decoded = jsonDecode(contents);
+      if (decoded is! Map) {
+        throw const FormatException("Runtime ownership root must be an object");
+      }
+      final rootJson = Map<String, dynamic>.from(decoded);
+      return <String, R>{
+        for (final MapEntry<String, dynamic> entry in rootJson.entries)
+          entry.key: _mapper.fromJson(json: Map<String, dynamic>.from(entry.value as Map)),
+      };
+    } on Object catch (error) {
+      await _handleInvalidRuntimeFile(reason: "invalid runtime ownership file", error: error);
+      return <String, R>{};
+    }
+  }
+
+  Map<String, dynamic> _recordsToJson({required Map<String, R> records}) {
+    return <String, dynamic>{
+      for (final MapEntry<String, R> entry in records.entries) entry.key: _mapper.toJson(record: entry.value),
+    };
+  }
+
+  Future<void> _handleInvalidRuntimeFile({required String reason, required Object error}) async {
+    Log.w("$reason at $_fileName; ignoring persisted ownership state and continuing fresh. Error: $error");
+
+    final timestamp = _clock.now().toUtc().toIso8601String().replaceAll(":", "-").replaceAll(".", "-");
+    final quarantinedName = "${_fileNameBase()}.invalid.$timestamp.json";
+
+    try {
+      await _store.quarantine(name: _fileName, quarantinedName: quarantinedName);
+    } on Object catch (renameError) {
+      Log.w(
+        "Failed to rename invalid runtime ownership file at $_fileName; continuing fresh without persisted ownership state. Error: $renameError",
+      );
+    }
+  }
+
+  String _fileNameBase() {
+    if (_fileName.endsWith(".json")) {
+      return _fileName.substring(0, _fileName.length - ".json".length);
+    }
+    return _fileName;
+  }
+}

--- a/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
@@ -62,7 +62,9 @@ class ManagedProcessService<R> {
 
     try {
       await Future.wait(
-        recordsToTerminate.map((record) => _processes.signalGraceful(pid: _runtimePidOf(record: record))),
+        recordsToTerminate.map(
+          (record) => Future.sync(() => _processes.signalGraceful(pid: _runtimePidOf(record: record))),
+        ),
       ).timeout(_gracefulShutdownWait);
     } catch (error, stackTrace) {
       Log.w("[$_runtimeId] Failed to gracefully stop some runtime instance(s)", error, stackTrace);
@@ -88,7 +90,9 @@ class ManagedProcessService<R> {
 
     try {
       await Future.wait(
-        survivors.map((record) => _processes.signalForce(pid: _runtimePidOf(record: record))),
+        survivors.map(
+          (record) => Future.sync(() => _processes.signalForce(pid: _runtimePidOf(record: record))),
+        ),
       ).timeout(_gracefulShutdownWait);
     } catch (error, stackTrace) {
       Log.w("[$_runtimeId] Failed to force kill some runtime instance(s)", error, stackTrace);

--- a/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
@@ -1,0 +1,336 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "runtime_ownership_repository.dart";
+import "runtime_record_mapper.dart";
+
+class ManagedProcessService<R> {
+  ManagedProcessService({
+    required RuntimeOwnershipRepository<R> ownershipRepository,
+    required RuntimeRecordMapper<R> mapper,
+    required HostProcessService processes,
+    required BridgeHostInfo bridge,
+    required ServerClock clock,
+    required String runtimeId,
+    required Duration gracefulShutdownWait,
+  }) : _ownershipRepository = ownershipRepository,
+       _mapper = mapper,
+       _processes = processes,
+       _bridge = bridge,
+       _clock = clock,
+       _runtimeId = runtimeId,
+       _gracefulShutdownWait = gracefulShutdownWait;
+
+  final RuntimeOwnershipRepository<R> _ownershipRepository;
+  final RuntimeRecordMapper<R> _mapper;
+  final HostProcessService _processes;
+  final BridgeHostInfo _bridge;
+  final ServerClock _clock;
+  final String _runtimeId;
+  final Duration _gracefulShutdownWait;
+  final Map<String, _CurrentOwnedRuntimeProcess> _currentOwnedProcessesBySessionId =
+      <String, _CurrentOwnedRuntimeProcess>{};
+
+  void trackOwnedRuntime({required String ownerSessionId, required SpawnedProcess process}) {
+    _currentOwnedProcessesBySessionId[ownerSessionId] = _CurrentOwnedRuntimeProcess(
+      process: process,
+      identity: process.identity,
+    );
+  }
+
+  bool isTrackingOwnedRuntime({required String ownerSessionId}) {
+    return _currentOwnedProcessesBySessionId.containsKey(ownerSessionId);
+  }
+
+  Future<void> cleanupStaleOwnedRuntimes({required List<ProcessIdentity> terminatedBridgeIdentities}) async {
+    final records = await _ownershipRepository.readAll();
+
+    final recordsToTerminate = <R>[];
+    for (final record in records) {
+      if (!await _isStaleKillAuthorized(record: record, terminatedBridgeIdentities: terminatedBridgeIdentities)) {
+        continue;
+      }
+
+      final shouldTerminate = await _shouldTerminateRecord(record: record);
+      if (shouldTerminate) {
+        recordsToTerminate.add(record);
+      }
+    }
+
+    if (recordsToTerminate.isEmpty) {
+      return;
+    }
+
+    try {
+      await Future.wait(
+        recordsToTerminate.map((record) => _processes.signalGraceful(pid: _runtimePidOf(record: record))),
+      ).timeout(_gracefulShutdownWait);
+    } catch (error, stackTrace) {
+      Log.w("[$_runtimeId] Failed to gracefully stop some runtime instance(s)", error, stackTrace);
+    }
+
+    await _clock.delay(duration: _gracefulShutdownWait);
+
+    final survivors = <R>[];
+    for (final record in recordsToTerminate) {
+      final currentOwned = _currentOwnedProcessFor(record: record);
+      final currentOwnedStillRunning =
+          currentOwned != null && await _isCurrentOwnedProcessRunning(process: currentOwned);
+      final remainingIdentity = await _processes.inspect(pid: _runtimePidOf(record: record));
+      final matchesRemaining =
+          remainingIdentity != null && _matchesRuntimeRecord(identity: remainingIdentity, record: record);
+
+      if (currentOwnedStillRunning || matchesRemaining) {
+        survivors.add(record);
+      } else {
+        _currentOwnedProcessesBySessionId.remove(_ownerSessionIdOf(record: record));
+      }
+    }
+
+    try {
+      await Future.wait(
+        survivors.map((record) => _processes.signalForce(pid: _runtimePidOf(record: record))),
+      ).timeout(_gracefulShutdownWait);
+    } catch (error, stackTrace) {
+      Log.w("[$_runtimeId] Failed to force kill some runtime instance(s)", error, stackTrace);
+    }
+
+    for (final record in recordsToTerminate) {
+      final currentOwned = _currentOwnedProcessFor(record: record);
+      final currentOwnedStillRunning =
+          currentOwned != null && await _isCurrentOwnedProcessRunning(process: currentOwned);
+
+      if (!currentOwnedStillRunning) {
+        _currentOwnedProcessesBySessionId.remove(_ownerSessionIdOf(record: record));
+      }
+
+      if (currentOwnedStillRunning) {
+        continue;
+      }
+
+      final finalIdentity = await _processes.inspect(pid: _runtimePidOf(record: record));
+      if (finalIdentity == null || !_matchesRuntimeRecord(identity: finalIdentity, record: record)) {
+        await _ownershipRepository.deleteByOwnerSessionId(ownerSessionId: _ownerSessionIdOf(record: record));
+      }
+    }
+  }
+
+  Future<void> stopOwnedRuntime({required R record}) async {
+    await _ownershipRepository.upsert(record: _mapper.markStopping(record: record));
+    await _stopRecord(record: record, removeOwnership: true);
+  }
+
+  Future<void> _stopRecord({required R record, required bool removeOwnership}) async {
+    final currentOwnedProcess = _currentOwnedProcessFor(record: record);
+    final initialIdentity = await _processes.inspect(pid: _runtimePidOf(record: record));
+    final matchesInitialIdentity =
+        initialIdentity != null && _matchesRuntimeRecord(identity: initialIdentity, record: record);
+    if (!matchesInitialIdentity && currentOwnedProcess == null) {
+      if (removeOwnership) {
+        await _ownershipRepository.deleteByOwnerSessionId(ownerSessionId: _ownerSessionIdOf(record: record));
+      }
+      return;
+    }
+
+    if (!matchesInitialIdentity && currentOwnedProcess != null) {
+      final currentOwnedStillRunningBeforeGraceful = await _isCurrentOwnedProcessRunning(process: currentOwnedProcess);
+      if (!currentOwnedStillRunningBeforeGraceful) {
+        _currentOwnedProcessesBySessionId.remove(_ownerSessionIdOf(record: record));
+        if (removeOwnership) {
+          await _ownershipRepository.deleteByOwnerSessionId(ownerSessionId: _ownerSessionIdOf(record: record));
+        }
+        return;
+      }
+    }
+
+    await _processes.signalGraceful(pid: _runtimePidOf(record: record));
+    await _clock.delay(duration: _gracefulShutdownWait);
+
+    final currentOwnedStillRunningAfterGraceful =
+        currentOwnedProcess != null && await _isCurrentOwnedProcessRunning(process: currentOwnedProcess);
+    final remainingIdentity = await _processes.inspect(pid: _runtimePidOf(record: record));
+    final matchesRemainingIdentity =
+        remainingIdentity != null && _matchesRuntimeRecord(identity: remainingIdentity, record: record);
+    if (currentOwnedStillRunningAfterGraceful || matchesRemainingIdentity) {
+      await _processes.signalForce(pid: _runtimePidOf(record: record));
+    }
+
+    final finalIdentity = await _processes.inspect(pid: _runtimePidOf(record: record));
+    final currentOwnedStillRunningAfterForce =
+        currentOwnedProcess != null && await _isCurrentOwnedProcessRunning(process: currentOwnedProcess);
+    if (!currentOwnedStillRunningAfterForce) {
+      _currentOwnedProcessesBySessionId.remove(_ownerSessionIdOf(record: record));
+    }
+    if (currentOwnedStillRunningAfterForce) {
+      return;
+    }
+
+    if (finalIdentity == null || !_matchesRuntimeRecord(identity: finalIdentity, record: record)) {
+      if (removeOwnership) {
+        await _ownershipRepository.deleteByOwnerSessionId(ownerSessionId: _ownerSessionIdOf(record: record));
+      }
+    }
+  }
+
+  Future<bool> _shouldTerminateRecord({required R record}) async {
+    final currentOwnedProcess = _currentOwnedProcessFor(record: record);
+    final initialIdentity = await _processes.inspect(pid: _runtimePidOf(record: record));
+    final matchesInitialIdentity =
+        initialIdentity != null && _matchesRuntimeRecord(identity: initialIdentity, record: record);
+
+    if (!matchesInitialIdentity && currentOwnedProcess == null) {
+      await _ownershipRepository.deleteByOwnerSessionId(ownerSessionId: _ownerSessionIdOf(record: record));
+      return false;
+    }
+
+    if (!matchesInitialIdentity && currentOwnedProcess != null) {
+      final currentOwnedStillRunningBeforeGraceful = await _isCurrentOwnedProcessRunning(process: currentOwnedProcess);
+      if (!currentOwnedStillRunningBeforeGraceful) {
+        _currentOwnedProcessesBySessionId.remove(_ownerSessionIdOf(record: record));
+        await _ownershipRepository.deleteByOwnerSessionId(ownerSessionId: _ownerSessionIdOf(record: record));
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  _CurrentOwnedRuntimeProcess? _currentOwnedProcessFor({required R record}) {
+    final currentOwnedProcess = _currentOwnedProcessesBySessionId[_ownerSessionIdOf(record: record)];
+    if (currentOwnedProcess == null || !_matchesCurrentOwnedRecord(process: currentOwnedProcess, record: record)) {
+      return null;
+    }
+    return currentOwnedProcess;
+  }
+
+  bool _matchesCurrentOwnedRecord({required _CurrentOwnedRuntimeProcess process, required R record}) {
+    return process.identity.pid == _runtimePidOf(record: record) &&
+        (_runtimeStartMarkerOf(record: record) == null ||
+            process.identity.startMarker == _runtimeStartMarkerOf(record: record)) &&
+        _samePath(
+          process.identity.executablePath,
+          _runtimeExecutablePathOf(record: record),
+          platform: process.identity.platform,
+        ) &&
+        _matchesRuntimeCommandLine(identity: process.identity, record: record);
+  }
+
+  Future<bool> _isCurrentOwnedProcessRunning({required _CurrentOwnedRuntimeProcess process}) async {
+    final exitCode = await process.process.exitCode
+        .then<int?>((code) => code)
+        .timeout(Duration.zero, onTimeout: () => null);
+    return exitCode == null;
+  }
+
+  Future<bool> _isStaleKillAuthorized({
+    required R record,
+    required Iterable<ProcessIdentity> terminatedBridgeIdentities,
+  }) async {
+    final runtimeIdentity = await _processes.inspect(pid: _runtimePidOf(record: record));
+    if (runtimeIdentity == null || !_matchesRuntimeRecord(identity: runtimeIdentity, record: record)) {
+      await _ownershipRepository.deleteByOwnerSessionId(ownerSessionId: _ownerSessionIdOf(record: record));
+      return false;
+    }
+
+    if (_matchesBridgeRecord(identity: _bridge.identity, record: record)) {
+      return true;
+    }
+
+    for (final identity in terminatedBridgeIdentities) {
+      if (_matchesBridgeRecord(identity: identity, record: record)) {
+        return true;
+      }
+    }
+
+    final ownerBridgeIsLive = await _bridge.isLiveBridgeProcess(
+      pid: _bridgePidOf(record: record),
+      startMarker: _bridgeStartMarkerOf(record: record),
+    );
+    if (ownerBridgeIsLive) {
+      return false;
+    }
+
+    return true;
+  }
+
+  bool _matchesRuntimeRecord({required ProcessIdentity identity, required R record}) {
+    if (identity.pid != _runtimePidOf(record: record)) {
+      return false;
+    }
+    if (_runtimeStartMarkerOf(record: record) != null || identity.startMarker != null) {
+      return identity.startMarker == _runtimeStartMarkerOf(record: record) &&
+          _samePath(identity.executablePath, _runtimeExecutablePathOf(record: record), platform: identity.platform) &&
+          _matchesRuntimeCommandLine(identity: identity, record: record);
+    }
+    return _samePath(identity.executablePath, _runtimeExecutablePathOf(record: record), platform: identity.platform);
+  }
+
+  bool _matchesBridgeRecord({required ProcessIdentity identity, required R record}) {
+    if (identity.pid != _bridgePidOf(record: record)) {
+      return false;
+    }
+    if (_bridgeStartMarkerOf(record: record) != null || identity.startMarker != null) {
+      return identity.startMarker == _bridgeStartMarkerOf(record: record);
+    }
+    return true;
+  }
+
+  bool _samePath(String? actual, String? expected, {required String platform}) {
+    if (actual == null || expected == null) {
+      return false;
+    }
+
+    if (!_isWindowsPlatform(platform: platform)) {
+      return actual == expected;
+    }
+
+    final normalizedActual = _normalizeWindowsPath(actual);
+    final normalizedExpected = _normalizeWindowsPath(expected);
+    if (normalizedActual == normalizedExpected) {
+      return true;
+    }
+
+    return _windowsPathBasename(normalizedActual) == _windowsPathBasename(normalizedExpected);
+  }
+
+  bool _isWindowsPlatform({required String platform}) {
+    final normalizedPlatform = platform.toLowerCase();
+    return normalizedPlatform == "windows" || normalizedPlatform == "win32";
+  }
+
+  String _normalizeWindowsPath(String path) {
+    var normalized = path.replaceAll("/", String.fromCharCode(92));
+    if (normalized.toLowerCase().endsWith(".exe")) {
+      normalized = normalized.substring(0, normalized.length - 4);
+    }
+    return normalized.toLowerCase();
+  }
+
+  String _windowsPathBasename(String path) {
+    final segments = path.split(RegExp(r"[\\/]+"));
+    return segments.isEmpty ? path : segments.last;
+  }
+
+  bool _matchesRuntimeCommandLine({required ProcessIdentity identity, required R record}) {
+    final runtimeCommandLine = _mapper.runtimeCommandLineOf(record: record);
+    return runtimeCommandLine != null && identity.commandLine == runtimeCommandLine;
+  }
+
+  String _ownerSessionIdOf({required R record}) => _mapper.ownerSessionIdOf(record: record);
+
+  int _runtimePidOf({required R record}) => _mapper.runtimePidOf(record: record);
+
+  String? _runtimeStartMarkerOf({required R record}) => _mapper.runtimeStartMarkerOf(record: record);
+
+  String? _runtimeExecutablePathOf({required R record}) => _mapper.runtimeExecutablePathOf(record: record);
+
+  int _bridgePidOf({required R record}) => _mapper.bridgePidOf(record: record);
+
+  String? _bridgeStartMarkerOf({required R record}) => _mapper.bridgeStartMarkerOf(record: record);
+}
+
+class _CurrentOwnedRuntimeProcess {
+  const _CurrentOwnedRuntimeProcess({required this.process, required this.identity});
+
+  final SpawnedProcess process;
+  final ProcessIdentity identity;
+}

--- a/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
@@ -315,8 +315,7 @@ class ManagedProcessService<R> {
   }
 
   bool _matchesRuntimeCommandLine({required ProcessIdentity identity, required R record}) {
-    final runtimeCommandLine = _mapper.runtimeCommandLineOf(record: record);
-    return runtimeCommandLine != null && identity.commandLine == runtimeCommandLine;
+    return identity.commandLine == _mapper.runtimeCommandLineOf(record: record);
   }
 
   String _ownerSessionIdOf({required R record}) => _mapper.ownerSessionIdOf(record: record);

--- a/bridge/sesori_plugin_runtime/lib/src/runtime_ownership_repository.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/runtime_ownership_repository.dart
@@ -1,0 +1,9 @@
+abstract class RuntimeOwnershipRepository<R> {
+  Future<List<R>> readAll();
+
+  Future<R?> readByOwnerSessionId({required String ownerSessionId});
+
+  Future<void> upsert({required R record});
+
+  Future<void> deleteByOwnerSessionId({required String ownerSessionId});
+}

--- a/bridge/sesori_plugin_runtime/lib/src/runtime_record_mapper.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/runtime_record_mapper.dart
@@ -19,7 +19,13 @@ abstract class RuntimeRecordMapper<R> {
   /// Full command line the runtime was spawned with, for example command plus
   /// args joined with single spaces. Used for identity matching when process
   /// start markers are present.
-  String? runtimeCommandLineOf({required R record});
+  ///
+  /// Non-null by contract: a managed-runtime record must persist enough to
+  /// reconstruct its spawn command line (the frozen OpenCode schema requires
+  /// command and args). A nullable surface here would force the matcher to
+  /// choose between leaking a live child (null never matches) or killing a
+  /// recycled pid (null always matches).
+  String runtimeCommandLineOf({required R record});
 
   int bridgePidOf({required R record});
 

--- a/bridge/sesori_plugin_runtime/lib/src/runtime_record_mapper.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/runtime_record_mapper.dart
@@ -1,0 +1,29 @@
+/// Maps a plugin-owned runtime record to and from its frozen persistence contract.
+///
+/// This is the byte-compatibility seam for managed plugin runtimes. At PR 11 the
+/// OpenCode plugin supplies its existing Freezed ownership model verbatim through
+/// this seam, writing byte-compatible JSON to the frozen legacy path.
+abstract class RuntimeRecordMapper<R> {
+  Map<String, dynamic> toJson({required R record});
+
+  R fromJson({required Map<String, dynamic> json});
+
+  String ownerSessionIdOf({required R record});
+
+  int runtimePidOf({required R record});
+
+  String? runtimeStartMarkerOf({required R record});
+
+  String? runtimeExecutablePathOf({required R record});
+
+  /// Full command line the runtime was spawned with, for example command plus
+  /// args joined with single spaces. Used for identity matching when process
+  /// start markers are present.
+  String? runtimeCommandLineOf({required R record});
+
+  int bridgePidOf({required R record});
+
+  String? bridgeStartMarkerOf({required R record});
+
+  R markStopping({required R record});
+}

--- a/bridge/sesori_plugin_runtime/pubspec.yaml
+++ b/bridge/sesori_plugin_runtime/pubspec.yaml
@@ -1,0 +1,14 @@
+name: sesori_plugin_runtime
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.11.5
+
+dependencies:
+  sesori_plugin_interface:
+    path: ../sesori_plugin_interface
+
+dev_dependencies:
+  lints: ^6.1.0
+  test: ^1.25.0

--- a/bridge/sesori_plugin_runtime/test/host_json_runtime_ownership_repository_test.dart
+++ b/bridge/sesori_plugin_runtime/test/host_json_runtime_ownership_repository_test.dart
@@ -66,6 +66,18 @@ void main() {
       expect(store.files["opencode-processes.json"], equals(contents));
     });
 
+    test("deleteByOwnerSessionId preserves non-canonical bytes when record is absent", () async {
+      final record = _record(ownerSessionId: "owner-a", pid: 401, status: _TestStatus.ready);
+      final prettyContents = const JsonEncoder.withIndent(
+        "  ",
+      ).convert(<String, dynamic>{"owner-a": record.toJson()});
+      store.files["opencode-processes.json"] = prettyContents;
+
+      await repository.deleteByOwnerSessionId(ownerSessionId: "missing");
+
+      expect(store.files["opencode-processes.json"], equals(prettyContents));
+    });
+
     test("corrupt file is quarantined with legacy-compatible name and treated as empty", () async {
       store.files["opencode-processes.json"] = "{";
 
@@ -240,7 +252,7 @@ class _TestRecordMapper implements RuntimeRecordMapper<_TestRecord> {
   String? runtimeExecutablePathOf({required _TestRecord record}) => record.openCodeExecutablePath;
 
   @override
-  String? runtimeCommandLineOf({required _TestRecord record}) {
+  String runtimeCommandLineOf({required _TestRecord record}) {
     return <String>[record.openCodeCommand, ...record.openCodeArgs].join(" ");
   }
 

--- a/bridge/sesori_plugin_runtime/test/host_json_runtime_ownership_repository_test.dart
+++ b/bridge/sesori_plugin_runtime/test/host_json_runtime_ownership_repository_test.dart
@@ -1,0 +1,320 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("HostJsonRuntimeOwnershipRepository", () {
+    late _FakeHostJsonStore store;
+    late HostJsonRuntimeOwnershipRepository<_TestRecord> repository;
+
+    setUp(() {
+      store = _FakeHostJsonStore();
+      repository = HostJsonRuntimeOwnershipRepository<_TestRecord>(
+        store: store,
+        mapper: const _TestRecordMapper(),
+        fileName: "opencode-processes.json",
+        clock: const _FixedClock(),
+      );
+    });
+
+    test("readAll and readByOwnerSessionId return decoded records", () async {
+      final record = _record(ownerSessionId: "owner-a", pid: 401, status: _TestStatus.ready);
+      store.files["opencode-processes.json"] = jsonEncode(<String, dynamic>{"owner-a": record.toJson()});
+
+      expect(
+        (await repository.readAll()).map((entry) => entry.toJson()),
+        equals(<Map<String, dynamic>>[record.toJson()]),
+      );
+      expect((await repository.readByOwnerSessionId(ownerSessionId: "owner-a"))?.toJson(), equals(record.toJson()));
+      expect(store.calls, equals(<String>["read:opencode-processes.json", "read:opencode-processes.json"]));
+    });
+
+    test("upsert writes root map keyed by ownerSessionId through update", () async {
+      final first = _record(ownerSessionId: "owner-a", pid: 401, status: _TestStatus.ready);
+      final second = _record(ownerSessionId: "owner-b", pid: 402, status: _TestStatus.starting);
+
+      await repository.upsert(record: first);
+      await repository.upsert(record: second);
+
+      expect(store.calls, equals(<String>["update:opencode-processes.json", "update:opencode-processes.json"]));
+      expect(
+        store.files["opencode-processes.json"],
+        equals(jsonEncode(<String, dynamic>{"owner-a": first.toJson(), "owner-b": second.toJson()})),
+      );
+    });
+
+    test("deleteByOwnerSessionId deletes file when last record removed", () async {
+      final record = _record(ownerSessionId: "owner-a", pid: 401, status: _TestStatus.ready);
+      store.files["opencode-processes.json"] = jsonEncode(<String, dynamic>{"owner-a": record.toJson()});
+
+      await repository.deleteByOwnerSessionId(ownerSessionId: "owner-a");
+
+      expect(store.calls, equals(<String>["update:opencode-processes.json"]));
+      expect(store.files.containsKey("opencode-processes.json"), isFalse);
+    });
+
+    test("deleteByOwnerSessionId leaves file unchanged when record is absent", () async {
+      final record = _record(ownerSessionId: "owner-a", pid: 401, status: _TestStatus.ready);
+      final contents = jsonEncode(<String, dynamic>{"owner-a": record.toJson()});
+      store.files["opencode-processes.json"] = contents;
+
+      await repository.deleteByOwnerSessionId(ownerSessionId: "missing");
+
+      expect(store.files["opencode-processes.json"], equals(contents));
+    });
+
+    test("corrupt file is quarantined with legacy-compatible name and treated as empty", () async {
+      store.files["opencode-processes.json"] = "{";
+
+      expect(await repository.readAll(), isEmpty);
+
+      expect(
+        store.calls,
+        equals(<String>[
+          "read:opencode-processes.json",
+          "quarantine:opencode-processes.json:opencode-processes.invalid.2026-05-15T12-30-01-234Z.json",
+        ]),
+      );
+      expect(store.files.containsKey("opencode-processes.json"), isFalse);
+      expect(store.files["opencode-processes.invalid.2026-05-15T12-30-01-234Z.json"], equals("{"));
+    });
+
+    test("non-map file is quarantined with legacy-compatible name and treated as empty", () async {
+      store.files["opencode-processes.json"] = jsonEncode(<String>["not", "a", "map"]);
+
+      expect(await repository.readByOwnerSessionId(ownerSessionId: "owner-a"), isNull);
+
+      expect(
+        store.calls.last,
+        equals("quarantine:opencode-processes.json:opencode-processes.invalid.2026-05-15T12-30-01-234Z.json"),
+      );
+    });
+
+    test("upsert over corrupt file quarantines then writes the new record", () async {
+      final record = _record(ownerSessionId: "owner-a", pid: 401, status: _TestStatus.ready);
+      store.files["opencode-processes.json"] = "{";
+
+      await repository.upsert(record: record);
+
+      expect(
+        store.calls,
+        equals(<String>[
+          "update:opencode-processes.json",
+          "quarantine:opencode-processes.json:opencode-processes.invalid.2026-05-15T12-30-01-234Z.json",
+        ]),
+      );
+      expect(store.files["opencode-processes.invalid.2026-05-15T12-30-01-234Z.json"], equals("{"));
+      expect(store.files["opencode-processes.json"], equals(jsonEncode(<String, dynamic>{"owner-a": record.toJson()})));
+    });
+
+    test("deleteByOwnerSessionId over corrupt file quarantines without resurrecting corrupt bytes", () async {
+      store.files["opencode-processes.json"] = "{";
+
+      await repository.deleteByOwnerSessionId(ownerSessionId: "owner-a");
+
+      expect(
+        store.calls,
+        equals(<String>[
+          "update:opencode-processes.json",
+          "quarantine:opencode-processes.json:opencode-processes.invalid.2026-05-15T12-30-01-234Z.json",
+        ]),
+      );
+      expect(store.files["opencode-processes.invalid.2026-05-15T12-30-01-234Z.json"], equals("{"));
+      expect(store.files.containsKey("opencode-processes.json"), isFalse);
+    });
+
+    test("byte-compatible legacy-shaped records round-trip and write golden bytes", () async {
+      final first = _record(ownerSessionId: "owner-a", pid: 401, status: _TestStatus.ready);
+      final second = _record(ownerSessionId: "owner-b", pid: 402, status: _TestStatus.stopping);
+
+      await repository.upsert(record: first);
+      await repository.upsert(record: second);
+
+      final golden = jsonEncode(<String, dynamic>{"owner-a": first.toJson(), "owner-b": second.toJson()});
+      expect(store.files["opencode-processes.json"], equals(golden));
+
+      final roundTrip = await repository.readAll();
+      expect(roundTrip.map((entry) => entry.toJson()), equals(<Map<String, dynamic>>[first.toJson(), second.toJson()]));
+    });
+  });
+}
+
+_TestRecord _record({required String ownerSessionId, required int pid, required _TestStatus status}) {
+  return _TestRecord(
+    ownerSessionId: ownerSessionId,
+    openCodePid: pid,
+    openCodeStartMarker: "open-start-$pid",
+    openCodeExecutablePath: "/usr/local/bin/opencode",
+    openCodeCommand: "/usr/local/bin/opencode",
+    openCodeArgs: const <String>["serve", "--port", "50123", "--hostname", "127.0.0.1"],
+    port: 50123,
+    bridgePid: 900,
+    bridgeStartMarker: "bridge-start",
+    startedAt: DateTime.utc(2026, 5, 15, 12),
+    status: status,
+  );
+}
+
+enum _TestStatus { starting, ready, stopping }
+
+class _TestRecord {
+  const _TestRecord({
+    required this.ownerSessionId,
+    required this.openCodePid,
+    required this.openCodeStartMarker,
+    required this.openCodeExecutablePath,
+    required this.openCodeCommand,
+    required this.openCodeArgs,
+    required this.port,
+    required this.bridgePid,
+    required this.bridgeStartMarker,
+    required this.startedAt,
+    required this.status,
+  });
+
+  final String ownerSessionId;
+  final int openCodePid;
+  final String? openCodeStartMarker;
+  final String openCodeExecutablePath;
+  final String openCodeCommand;
+  final List<String> openCodeArgs;
+  final int port;
+  final int bridgePid;
+  final String? bridgeStartMarker;
+  final DateTime startedAt;
+  final _TestStatus status;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      "ownerSessionId": ownerSessionId,
+      "openCodePid": openCodePid,
+      "openCodeStartMarker": openCodeStartMarker,
+      "openCodeExecutablePath": openCodeExecutablePath,
+      "openCodeCommand": openCodeCommand,
+      "openCodeArgs": openCodeArgs,
+      "port": port,
+      "bridgePid": bridgePid,
+      "bridgeStartMarker": bridgeStartMarker,
+      "startedAt": startedAt.toIso8601String(),
+      "status": status.name,
+    };
+  }
+}
+
+class _TestRecordMapper implements RuntimeRecordMapper<_TestRecord> {
+  const _TestRecordMapper();
+
+  @override
+  Map<String, dynamic> toJson({required _TestRecord record}) => record.toJson();
+
+  @override
+  _TestRecord fromJson({required Map<String, dynamic> json}) {
+    return _TestRecord(
+      ownerSessionId: json["ownerSessionId"] as String,
+      openCodePid: (json["openCodePid"] as num).toInt(),
+      openCodeStartMarker: json["openCodeStartMarker"] as String?,
+      openCodeExecutablePath: json["openCodeExecutablePath"] as String,
+      openCodeCommand: json["openCodeCommand"] as String,
+      openCodeArgs: (json["openCodeArgs"] as List<dynamic>).map((entry) => entry as String).toList(),
+      port: (json["port"] as num).toInt(),
+      bridgePid: (json["bridgePid"] as num).toInt(),
+      bridgeStartMarker: json["bridgeStartMarker"] as String?,
+      startedAt: DateTime.parse(json["startedAt"] as String),
+      status: _TestStatus.values.byName(json["status"] as String),
+    );
+  }
+
+  @override
+  String ownerSessionIdOf({required _TestRecord record}) => record.ownerSessionId;
+
+  @override
+  int runtimePidOf({required _TestRecord record}) => record.openCodePid;
+
+  @override
+  String? runtimeStartMarkerOf({required _TestRecord record}) => record.openCodeStartMarker;
+
+  @override
+  String? runtimeExecutablePathOf({required _TestRecord record}) => record.openCodeExecutablePath;
+
+  @override
+  String? runtimeCommandLineOf({required _TestRecord record}) {
+    return <String>[record.openCodeCommand, ...record.openCodeArgs].join(" ");
+  }
+
+  @override
+  int bridgePidOf({required _TestRecord record}) => record.bridgePid;
+
+  @override
+  String? bridgeStartMarkerOf({required _TestRecord record}) => record.bridgeStartMarker;
+
+  @override
+  _TestRecord markStopping({required _TestRecord record}) {
+    return _TestRecord(
+      ownerSessionId: record.ownerSessionId,
+      openCodePid: record.openCodePid,
+      openCodeStartMarker: record.openCodeStartMarker,
+      openCodeExecutablePath: record.openCodeExecutablePath,
+      openCodeCommand: record.openCodeCommand,
+      openCodeArgs: record.openCodeArgs,
+      port: record.port,
+      bridgePid: record.bridgePid,
+      bridgeStartMarker: record.bridgeStartMarker,
+      startedAt: record.startedAt,
+      status: _TestStatus.stopping,
+    );
+  }
+}
+
+class _FakeHostJsonStore implements HostJsonStore {
+  final Map<String, String> files = <String, String>{};
+  final List<String> calls = <String>[];
+
+  @override
+  Future<void> delete({required String name}) async {
+    calls.add("delete:$name");
+    files.remove(name);
+  }
+
+  @override
+  Future<String?> read({required String name}) async {
+    calls.add("read:$name");
+    return files[name];
+  }
+
+  @override
+  Future<void> quarantine({required String name, required String quarantinedName}) async {
+    calls.add("quarantine:$name:$quarantinedName");
+    final contents = files.remove(name);
+    if (contents != null) {
+      files[quarantinedName] = contents;
+    }
+  }
+
+  @override
+  Future<String?> update({required String name, required FutureOr<String?> Function(String? current) transform}) async {
+    calls.add("update:$name");
+    final updated = await transform(files[name]);
+    if (updated == null) {
+      files.remove(name);
+    } else {
+      files[name] = updated;
+    }
+    return updated;
+  }
+
+  @override
+  Future<void> write({required String name, required String contents}) async {
+    calls.add("write:$name");
+    files[name] = contents;
+  }
+}
+
+class _FixedClock extends ServerClock {
+  const _FixedClock();
+
+  @override
+  DateTime now() => DateTime.utc(2026, 5, 15, 12, 30, 1, 234);
+}

--- a/bridge/sesori_plugin_runtime/test/host_json_runtime_ownership_repository_test.dart
+++ b/bridge/sesori_plugin_runtime/test/host_json_runtime_ownership_repository_test.dart
@@ -87,11 +87,26 @@ void main() {
         store.calls,
         equals(<String>[
           "read:opencode-processes.json",
+          "update:opencode-processes.json",
           "quarantine:opencode-processes.json:opencode-processes.invalid.2026-05-15T12-30-01-234Z.json",
         ]),
       );
       expect(store.files.containsKey("opencode-processes.json"), isFalse);
       expect(store.files["opencode-processes.invalid.2026-05-15T12-30-01-234Z.json"], equals("{"));
+    });
+
+    test("stale corrupt read does not quarantine a concurrently repaired file", () async {
+      final record = _record(ownerSessionId: "owner-a", pid: 401, status: _TestStatus.ready);
+      final repairedContents = jsonEncode(<String, dynamic>{"owner-a": record.toJson()});
+      store.files["opencode-processes.json"] = "{";
+      store.onBeforeUpdate = () {
+        store.files["opencode-processes.json"] = repairedContents;
+      };
+
+      expect(await repository.readAll(), isEmpty);
+
+      expect(store.calls, equals(<String>["read:opencode-processes.json", "update:opencode-processes.json"]));
+      expect(store.files["opencode-processes.json"], equals(repairedContents));
     });
 
     test("non-map file is quarantined with legacy-compatible name and treated as empty", () async {
@@ -283,6 +298,7 @@ class _TestRecordMapper implements RuntimeRecordMapper<_TestRecord> {
 class _FakeHostJsonStore implements HostJsonStore {
   final Map<String, String> files = <String, String>{};
   final List<String> calls = <String>[];
+  void Function()? onBeforeUpdate;
 
   @override
   Future<void> delete({required String name}) async {
@@ -307,6 +323,7 @@ class _FakeHostJsonStore implements HostJsonStore {
 
   @override
   Future<String?> update({required String name, required FutureOr<String?> Function(String? current) transform}) async {
+    onBeforeUpdate?.call();
     calls.add("update:$name");
     final updated = await transform(files[name]);
     if (updated == null) {

--- a/bridge/sesori_plugin_runtime/test/managed_process_service_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_process_service_test.dart
@@ -469,7 +469,7 @@ class _TestRecordMapper implements RuntimeRecordMapper<_TestRecord> {
   String? runtimeExecutablePathOf({required _TestRecord record}) => record.openCodeExecutablePath;
 
   @override
-  String? runtimeCommandLineOf({required _TestRecord record}) {
+  String runtimeCommandLineOf({required _TestRecord record}) {
     return <String>[record.openCodeCommand, ...record.openCodeArgs].join(" ");
   }
 

--- a/bridge/sesori_plugin_runtime/test/managed_process_service_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_process_service_test.dart
@@ -1,0 +1,644 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
+import "package:test/test.dart";
+
+const _gracefulShutdownWait = Duration(seconds: 5);
+
+void main() {
+  group("ManagedProcessService", () {
+    late _FakeOwnershipRepository ownershipRepository;
+    late _FakeHostProcessService processService;
+    late _FakeBridgeHostInfo bridge;
+    late _FakeServerClock clock;
+
+    setUp(() {
+      ownershipRepository = _FakeOwnershipRepository();
+      processService = _FakeHostProcessService();
+      bridge = _FakeBridgeHostInfo(
+        identity: _identity(
+          pid: 900,
+          startMarker: "bridge-start",
+          executablePath: "/usr/local/bin/sesori-bridge",
+          commandLine: "sesori-bridge",
+        ),
+      );
+      clock = _FakeServerClock();
+    });
+
+    test("stale cleanup kills matching OpenCode only when owner bridge is dead", () async {
+      final staleRecord = _record(
+        ownerSessionId: "stale-owner",
+        openCodePid: 401,
+        openCodeStartMarker: "open-start",
+        bridgePid: 901,
+        bridgeStartMarker: "dead-bridge-start",
+      );
+      ownershipRepository.records[staleRecord.ownerSessionId] = staleRecord;
+      processService.inspectResults[401] = <ProcessIdentity?>[
+        _opencodeIdentity(pid: 401, startMarker: "open-start"),
+        _opencodeIdentity(pid: 401, startMarker: "open-start"),
+        _opencodeIdentity(pid: 401, startMarker: "open-start"),
+        null,
+      ];
+      bridge.liveBridgeResults[901] = <bool>[false];
+
+      await _service(
+        ownershipRepository: ownershipRepository,
+        processService: processService,
+        bridge: bridge,
+        clock: clock,
+      ).cleanupStaleOwnedRuntimes(terminatedBridgeIdentities: const <ProcessIdentity>[]);
+
+      expect(processService.signalRequests, equals(<String>["graceful:401", "force:401"]));
+      expect(ownershipRepository.records, isEmpty);
+      expect(clock.delays, equals(<Duration>[_gracefulShutdownWait]));
+    });
+
+    test("stale cleanup does not signal when pre-signal identity no longer matches", () async {
+      final staleRecord = _record(
+        ownerSessionId: "stale-owner",
+        openCodePid: 402,
+        openCodeStartMarker: "open-start",
+        bridgePid: 901,
+        bridgeStartMarker: "dead-bridge-start",
+      );
+      ownershipRepository.records[staleRecord.ownerSessionId] = staleRecord;
+      processService.inspectResults[402] = <ProcessIdentity?>[
+        _opencodeIdentity(pid: 402, startMarker: "open-start"),
+        _opencodeIdentity(pid: 402, startMarker: "different-start"),
+      ];
+      bridge.liveBridgeResults[901] = <bool>[false];
+
+      await _service(
+        ownershipRepository: ownershipRepository,
+        processService: processService,
+        bridge: bridge,
+        clock: clock,
+      ).cleanupStaleOwnedRuntimes(terminatedBridgeIdentities: const <ProcessIdentity>[]);
+
+      expect(processService.signalRequests, isEmpty);
+      expect(clock.delays, isEmpty);
+      expect(ownershipRepository.records, isEmpty);
+    });
+
+    test("stale cleanup preserves live owner and missing marker records", () async {
+      final liveRecord = _record(
+        ownerSessionId: "live-owner",
+        openCodePid: 501,
+        openCodeStartMarker: "open-live",
+        bridgePid: 902,
+        bridgeStartMarker: "live-bridge-start",
+      );
+      final missingMarkerRecord = _record(
+        ownerSessionId: "missing-marker",
+        openCodePid: 502,
+        openCodeStartMarker: null,
+        bridgePid: 903,
+        bridgeStartMarker: "dead-bridge-start",
+      );
+      ownershipRepository.records[liveRecord.ownerSessionId] = liveRecord;
+      ownershipRepository.records[missingMarkerRecord.ownerSessionId] = missingMarkerRecord;
+      processService.inspectResults[501] = <ProcessIdentity?>[_opencodeIdentity(pid: 501, startMarker: "open-live")];
+      bridge.liveBridgeResults[902] = <bool>[true];
+
+      await _service(
+        ownershipRepository: ownershipRepository,
+        processService: processService,
+        bridge: bridge,
+        clock: clock,
+      ).cleanupStaleOwnedRuntimes(terminatedBridgeIdentities: const <ProcessIdentity>[]);
+
+      expect(processService.signalRequests, isEmpty);
+      expect(ownershipRepository.records.keys, contains("live-owner"));
+    });
+
+    test("stale cleanup kill-authorizes persisted records missing a start marker when bridge is dead", () async {
+      final missingMarkerRecord = _record(
+        ownerSessionId: "missing-marker",
+        openCodePid: 503,
+        openCodeStartMarker: null,
+        bridgePid: 903,
+        bridgeStartMarker: "dead-bridge-start",
+      );
+      ownershipRepository.records[missingMarkerRecord.ownerSessionId] = missingMarkerRecord;
+      processService.inspectResults[503] = <ProcessIdentity?>[
+        _opencodeIdentity(pid: 503, startMarker: null),
+        _opencodeIdentity(pid: 503, startMarker: null),
+        null,
+      ];
+      bridge.liveBridgeResults[903] = <bool>[false];
+
+      await _service(
+        ownershipRepository: ownershipRepository,
+        processService: processService,
+        bridge: bridge,
+        clock: clock,
+      ).cleanupStaleOwnedRuntimes(terminatedBridgeIdentities: const <ProcessIdentity>[]);
+
+      expect(processService.signalRequests, equals(<String>["graceful:503"]));
+      expect(ownershipRepository.records, isEmpty);
+    });
+
+    test("replacement bridge identity authorizes stale OpenCode cleanup", () async {
+      final record = _record(
+        ownerSessionId: "replaced-owner",
+        openCodePid: 601,
+        openCodeStartMarker: "open-replaced",
+        bridgePid: 904,
+        bridgeStartMarker: "replaced-bridge-start",
+      );
+      ownershipRepository.records[record.ownerSessionId] = record;
+      processService.inspectResults[601] = <ProcessIdentity?>[
+        _opencodeIdentity(pid: 601, startMarker: "open-replaced"),
+        _opencodeIdentity(pid: 601, startMarker: "open-replaced"),
+        null,
+        null,
+      ];
+
+      await _service(
+        ownershipRepository: ownershipRepository,
+        processService: processService,
+        bridge: bridge,
+        clock: clock,
+      ).cleanupStaleOwnedRuntimes(
+        terminatedBridgeIdentities: <ProcessIdentity>[
+          _identity(
+            pid: 904,
+            startMarker: "replaced-bridge-start",
+            executablePath: "/usr/local/bin/sesori-bridge",
+            commandLine: "sesori-bridge",
+          ),
+        ],
+      );
+
+      expect(processService.signalRequests, equals(<String>["graceful:601"]));
+      expect(ownershipRepository.records, isEmpty);
+    });
+
+    test("shutdown revalidates identity before force kill", () async {
+      final record = _record(
+        ownerSessionId: "current-owner",
+        openCodePid: 701,
+        openCodeStartMarker: "open-current",
+        bridgePid: 900,
+        bridgeStartMarker: "bridge-start",
+      );
+      ownershipRepository.records[record.ownerSessionId] = record;
+      processService.inspectResults[701] = <ProcessIdentity?>[
+        _opencodeIdentity(pid: 701, startMarker: "open-current"),
+        _opencodeIdentity(pid: 701, startMarker: "open-current"),
+        null,
+      ];
+
+      await _service(
+        ownershipRepository: ownershipRepository,
+        processService: processService,
+        bridge: bridge,
+        clock: clock,
+      ).stopOwnedRuntime(record: record);
+
+      expect(processService.signalRequests, equals(<String>["graceful:701", "force:701"]));
+      expect(ownershipRepository.upsertedStatuses.last, equals(_TestStatus.stopping));
+      expect(ownershipRepository.records, isEmpty);
+    });
+
+    test("shutdown keeps ownership when current-owned missing-marker child survives force", () async {
+      final spawnedProcess = _FakeSpawnedProcess(
+        identity: _opencodeIdentity(pid: 702, startMarker: null, port: 50131),
+        exitImmediately: false,
+      );
+      final record = _record(
+        ownerSessionId: "current-owner",
+        openCodePid: 702,
+        openCodeStartMarker: null,
+        bridgePid: 900,
+        bridgeStartMarker: "bridge-start",
+        port: 50131,
+      );
+      ownershipRepository.records[record.ownerSessionId] = record;
+      processService.inspectResults[702] = <ProcessIdentity?>[null, null, null];
+      final service = _service(
+        ownershipRepository: ownershipRepository,
+        processService: processService,
+        bridge: bridge,
+        clock: clock,
+      );
+      service.trackOwnedRuntime(ownerSessionId: record.ownerSessionId, process: spawnedProcess);
+
+      await service.stopOwnedRuntime(record: record);
+
+      expect(processService.signalRequests, equals(<String>["graceful:702", "force:702"]));
+      expect(ownershipRepository.records.keys, contains("current-owner"));
+      expect(ownershipRepository.records.values.single.status, equals(_TestStatus.stopping));
+      expect(clock.delays, equals(<Duration>[_gracefulShutdownWait]));
+      expect(service.isTrackingOwnedRuntime(ownerSessionId: record.ownerSessionId), isTrue);
+    });
+
+    test("shutdown does not signal an exited current-owned missing-marker child", () async {
+      final spawnedProcess = _FakeSpawnedProcess(
+        identity: _opencodeIdentity(pid: 703, startMarker: null, port: 50132),
+        exitImmediately: false,
+      );
+      final record = _record(
+        ownerSessionId: "current-owner",
+        openCodePid: 703,
+        openCodeStartMarker: null,
+        bridgePid: 900,
+        bridgeStartMarker: "bridge-start",
+        port: 50132,
+      );
+      ownershipRepository.records[record.ownerSessionId] = record;
+      processService.inspectResults[703] = <ProcessIdentity?>[null];
+      final service = _service(
+        ownershipRepository: ownershipRepository,
+        processService: processService,
+        bridge: bridge,
+        clock: clock,
+      );
+      service.trackOwnedRuntime(ownerSessionId: record.ownerSessionId, process: spawnedProcess);
+      spawnedProcess.completeExit();
+
+      await service.stopOwnedRuntime(record: record);
+
+      expect(processService.signalRequests, isEmpty);
+      expect(ownershipRepository.records, isEmpty);
+      expect(clock.delays, isEmpty);
+      expect(service.isTrackingOwnedRuntime(ownerSessionId: record.ownerSessionId), isFalse);
+    });
+
+    test("stop path never calls child process kill directly", () async {
+      final spawnedProcess = _FakeSpawnedProcess(
+        identity: _opencodeIdentity(pid: 211, startMarker: "open-start-211", port: 50129),
+        exitImmediately: true,
+      );
+      final record = _record(
+        ownerSessionId: "current-owner",
+        openCodePid: 211,
+        openCodeStartMarker: "open-start-211",
+        bridgePid: 900,
+        bridgeStartMarker: "bridge-start",
+        port: 50129,
+      );
+      ownershipRepository.records[record.ownerSessionId] = record;
+      processService.inspectResults[211] = <ProcessIdentity?>[
+        _opencodeIdentity(pid: 211, startMarker: "open-start-211", port: 50129),
+        null,
+        null,
+      ];
+      final service = _service(
+        ownershipRepository: ownershipRepository,
+        processService: processService,
+        bridge: bridge,
+        clock: clock,
+      );
+      service.trackOwnedRuntime(ownerSessionId: record.ownerSessionId, process: spawnedProcess);
+
+      await service.stopOwnedRuntime(record: record);
+
+      expect(processService.signalRequests, equals(<String>["graceful:211"]));
+      expect(spawnedProcess.killSignals, isEmpty);
+    });
+
+    test("stop path force stops current-owned child without a start marker", () async {
+      final spawnedProcess = _FakeSpawnedProcess(
+        identity: _opencodeIdentity(pid: 212, startMarker: null, port: 50130),
+        exitImmediately: false,
+      );
+      final record = _record(
+        ownerSessionId: "current-owner",
+        openCodePid: 212,
+        openCodeStartMarker: null,
+        bridgePid: 900,
+        bridgeStartMarker: "bridge-start",
+        port: 50130,
+      );
+      ownershipRepository.records[record.ownerSessionId] = record;
+      processService.inspectResults[212] = <ProcessIdentity?>[null, null, null];
+      processService.forceHooks[212] = spawnedProcess.completeExit;
+      final service = _service(
+        ownershipRepository: ownershipRepository,
+        processService: processService,
+        bridge: bridge,
+        clock: clock,
+      );
+      service.trackOwnedRuntime(ownerSessionId: record.ownerSessionId, process: spawnedProcess);
+
+      await service.stopOwnedRuntime(record: record);
+
+      expect(processService.signalRequests, equals(<String>["graceful:212", "force:212"]));
+      expect(clock.delays, equals(<Duration>[_gracefulShutdownWait]));
+      expect(ownershipRepository.records, isEmpty);
+      expect(spawnedProcess.killSignals, isEmpty);
+    });
+  });
+}
+
+ManagedProcessService<_TestRecord> _service({
+  required _FakeOwnershipRepository ownershipRepository,
+  required _FakeHostProcessService processService,
+  required _FakeBridgeHostInfo bridge,
+  required _FakeServerClock clock,
+}) {
+  return ManagedProcessService<_TestRecord>(
+    ownershipRepository: ownershipRepository,
+    mapper: const _TestRecordMapper(),
+    processes: processService,
+    bridge: bridge,
+    clock: clock,
+    runtimeId: "OPENCODE",
+    gracefulShutdownWait: _gracefulShutdownWait,
+  );
+}
+
+_TestRecord _record({
+  required String ownerSessionId,
+  required int openCodePid,
+  required String? openCodeStartMarker,
+  required int bridgePid,
+  required String? bridgeStartMarker,
+  int port = 50123,
+}) {
+  return _TestRecord(
+    ownerSessionId: ownerSessionId,
+    openCodePid: openCodePid,
+    openCodeStartMarker: openCodeStartMarker,
+    openCodeExecutablePath: "/usr/local/bin/opencode",
+    openCodeCommand: "/usr/local/bin/opencode",
+    openCodeArgs: <String>["serve", "--port", "$port", "--hostname", "127.0.0.1"],
+    port: port,
+    bridgePid: bridgePid,
+    bridgeStartMarker: bridgeStartMarker,
+    startedAt: DateTime.utc(2026, 5, 15, 12),
+    status: _TestStatus.ready,
+  );
+}
+
+ProcessIdentity _opencodeIdentity({required int pid, required String? startMarker, int port = 50123}) {
+  return _identity(
+    pid: pid,
+    startMarker: startMarker,
+    executablePath: "/usr/local/bin/opencode",
+    commandLine: "/usr/local/bin/opencode serve --port $port --hostname 127.0.0.1",
+  );
+}
+
+ProcessIdentity _identity({
+  required int pid,
+  required String? startMarker,
+  required String executablePath,
+  required String commandLine,
+}) {
+  return ProcessIdentity(
+    pid: pid,
+    startMarker: startMarker,
+    executablePath: executablePath,
+    commandLine: commandLine,
+    ownerUser: ProcessUser.fromRawUser("alex"),
+    platform: "macos",
+    capturedAt: DateTime.utc(2026, 5, 15, 12),
+  );
+}
+
+enum _TestStatus { ready, stopping }
+
+class _TestRecord {
+  const _TestRecord({
+    required this.ownerSessionId,
+    required this.openCodePid,
+    required this.openCodeStartMarker,
+    required this.openCodeExecutablePath,
+    required this.openCodeCommand,
+    required this.openCodeArgs,
+    required this.port,
+    required this.bridgePid,
+    required this.bridgeStartMarker,
+    required this.startedAt,
+    required this.status,
+  });
+
+  final String ownerSessionId;
+  final int openCodePid;
+  final String? openCodeStartMarker;
+  final String openCodeExecutablePath;
+  final String openCodeCommand;
+  final List<String> openCodeArgs;
+  final int port;
+  final int bridgePid;
+  final String? bridgeStartMarker;
+  final DateTime startedAt;
+  final _TestStatus status;
+}
+
+class _TestRecordMapper implements RuntimeRecordMapper<_TestRecord> {
+  const _TestRecordMapper();
+
+  @override
+  Map<String, dynamic> toJson({required _TestRecord record}) {
+    return <String, dynamic>{
+      "ownerSessionId": record.ownerSessionId,
+      "openCodePid": record.openCodePid,
+      "openCodeStartMarker": record.openCodeStartMarker,
+      "openCodeExecutablePath": record.openCodeExecutablePath,
+      "openCodeCommand": record.openCodeCommand,
+      "openCodeArgs": record.openCodeArgs,
+      "port": record.port,
+      "bridgePid": record.bridgePid,
+      "bridgeStartMarker": record.bridgeStartMarker,
+      "startedAt": record.startedAt.toIso8601String(),
+      "status": record.status.name,
+    };
+  }
+
+  @override
+  _TestRecord fromJson({required Map<String, dynamic> json}) => throw UnimplementedError();
+
+  @override
+  String ownerSessionIdOf({required _TestRecord record}) => record.ownerSessionId;
+
+  @override
+  int runtimePidOf({required _TestRecord record}) => record.openCodePid;
+
+  @override
+  String? runtimeStartMarkerOf({required _TestRecord record}) => record.openCodeStartMarker;
+
+  @override
+  String? runtimeExecutablePathOf({required _TestRecord record}) => record.openCodeExecutablePath;
+
+  @override
+  String? runtimeCommandLineOf({required _TestRecord record}) {
+    return <String>[record.openCodeCommand, ...record.openCodeArgs].join(" ");
+  }
+
+  @override
+  int bridgePidOf({required _TestRecord record}) => record.bridgePid;
+
+  @override
+  String? bridgeStartMarkerOf({required _TestRecord record}) => record.bridgeStartMarker;
+
+  @override
+  _TestRecord markStopping({required _TestRecord record}) {
+    return _TestRecord(
+      ownerSessionId: record.ownerSessionId,
+      openCodePid: record.openCodePid,
+      openCodeStartMarker: record.openCodeStartMarker,
+      openCodeExecutablePath: record.openCodeExecutablePath,
+      openCodeCommand: record.openCodeCommand,
+      openCodeArgs: record.openCodeArgs,
+      port: record.port,
+      bridgePid: record.bridgePid,
+      bridgeStartMarker: record.bridgeStartMarker,
+      startedAt: record.startedAt,
+      status: _TestStatus.stopping,
+    );
+  }
+}
+
+class _FakeOwnershipRepository implements RuntimeOwnershipRepository<_TestRecord> {
+  final Map<String, _TestRecord> records = <String, _TestRecord>{};
+  final List<_TestStatus> upsertedStatuses = <_TestStatus>[];
+
+  @override
+  Future<void> deleteByOwnerSessionId({required String ownerSessionId}) async {
+    records.remove(ownerSessionId);
+  }
+
+  @override
+  Future<List<_TestRecord>> readAll() async => records.values.toList(growable: false);
+
+  @override
+  Future<_TestRecord?> readByOwnerSessionId({required String ownerSessionId}) async => records[ownerSessionId];
+
+  @override
+  Future<void> upsert({required _TestRecord record}) async {
+    records[record.ownerSessionId] = record;
+    upsertedStatuses.add(record.status);
+  }
+}
+
+class _FakeHostProcessService implements HostProcessService {
+  final Map<int, List<ProcessIdentity?>> inspectResults = <int, List<ProcessIdentity?>>{};
+  final Map<int, void Function()> gracefulHooks = <int, void Function()>{};
+  final Map<int, void Function()> forceHooks = <int, void Function()>{};
+  final List<String> signalRequests = <String>[];
+
+  @override
+  Future<ProcessIdentity?> inspect({required int pid}) async {
+    final results = inspectResults[pid];
+    if (results == null || results.isEmpty) {
+      return null;
+    }
+    return results.removeAt(0);
+  }
+
+  @override
+  Future<List<ProcessIdentity>> list({required int? excludePid}) async => const <ProcessIdentity>[];
+
+  @override
+  Future<SignalResult> signalForce({required int pid}) async {
+    signalRequests.add("force:$pid");
+    forceHooks[pid]?.call();
+    return _shutdown(pid: pid, signal: ShutdownSignal.force);
+  }
+
+  @override
+  Future<SignalResult> signalGraceful({required int pid}) async {
+    signalRequests.add("graceful:$pid");
+    gracefulHooks[pid]?.call();
+    return _shutdown(pid: pid, signal: ShutdownSignal.graceful);
+  }
+
+  @override
+  Future<SpawnedProcess> spawn({
+    required String executable,
+    required List<String> arguments,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+    required bool runInShell,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  SignalResult _shutdown({required int pid, required ShutdownSignal signal}) {
+    return SignalResult(
+      pid: pid,
+      requestedSignal: signal,
+      deliveredSignal: signal == ShutdownSignal.graceful ? ProcessSignal.sigterm : ProcessSignal.sigkill,
+      wasRequested: true,
+      attemptedAt: DateTime.utc(2026, 5, 15, 12),
+    );
+  }
+}
+
+class _FakeBridgeHostInfo implements BridgeHostInfo {
+  _FakeBridgeHostInfo({required ProcessIdentity identity}) : _identity = identity;
+
+  final ProcessIdentity _identity;
+  final Map<int, List<bool>> liveBridgeResults = <int, List<bool>>{};
+
+  @override
+  ProcessIdentity get identity => _identity;
+
+  @override
+  String get ownerSessionId => "current-owner";
+
+  @override
+  Future<bool> isLiveBridgeProcess({required int pid, required String? startMarker}) async {
+    final results = liveBridgeResults[pid];
+    if (results == null || results.isEmpty) {
+      return false;
+    }
+    return results.removeAt(0);
+  }
+}
+
+class _FakeServerClock implements ServerClock {
+  final List<Duration> delays = <Duration>[];
+
+  @override
+  Future<void> delay({required Duration duration}) async {
+    delays.add(duration);
+  }
+
+  @override
+  DateTime now() => DateTime.utc(2026, 5, 15, 12, 30);
+}
+
+class _FakeSpawnedProcess implements SpawnedProcess {
+  _FakeSpawnedProcess({required ProcessIdentity identity, required bool exitImmediately}) : _identity = identity {
+    if (exitImmediately) {
+      _exitCodeCompleter.complete(0);
+    }
+  }
+
+  final ProcessIdentity _identity;
+  final Completer<int> _exitCodeCompleter = Completer<int>();
+  final List<ProcessSignal> killSignals = <ProcessSignal>[];
+
+  @override
+  Future<int> get exitCode => _exitCodeCompleter.future;
+
+  @override
+  ProcessIdentity get identity => _identity;
+
+  @override
+  int get pid => _identity.pid;
+
+  @override
+  IOSink get stdin => throw UnimplementedError();
+
+  @override
+  Stream<List<int>> get stderr => Stream<List<int>>.value(utf8.encode(""));
+
+  @override
+  Stream<List<int>> get stdout => Stream<List<int>>.value(utf8.encode(""));
+
+  void completeExit([int code = 0]) {
+    if (!_exitCodeCompleter.isCompleted) {
+      _exitCodeCompleter.complete(code);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

PR 7 of the [plugin-lifecycle migration plan](../blob/main/docs/plans/plugin-lifecycle-migration.html): the new package `bridge/sesori_plugin_runtime` — the first half of the reusable managed-runtime lifecycle skeleton, extracted from the generic parts of the legacy `OpenCodeServerService`. **No production consumer yet** (always-green: new package + tests only; `bridge/app` is untouched apart from workspace/Makefile/CI scaffolding). Depends only on `sesori_plugin_interface`.

- **`RuntimeRecordMapper<R>`** — plugin-supplied codec seam: `toJson`/`fromJson`, identity-field accessors (owner session id, runtime pid/marker/executable/command line, bridge pid/marker), and `markStopping`. At PR 11 the OpenCode plugin supplies its existing freezed ownership model verbatim through this seam, keeping the frozen `opencode-processes.json` schema and steady-state bytes.
- **`RuntimeOwnershipRepository<R>`** — record-level persistence seam mirroring the legacy repository surface (`readAll`/`readByOwnerSessionId`/`upsert`/`deleteByOwnerSessionId`). This is the seam PR 10 adapts the legacy `OpenCodeOwnershipRepository` onto, so the 1,224-line legacy suite can hold unmodified at the fidelity gate.
- **`HostJsonRuntimeOwnershipRepository<R>`** — production default over `HostJsonStore`: mutations routed through the OS-advisory-locked `update()` (closes the concurrent-write risk from the plan's risk register), legacy-compatible corrupt-file quarantine (`<base>.invalid.<ts>.json`, **also during mutations** — corrupt bytes are quarantined, never silently overwritten or resurrected), delete-file-when-empty.
- **`ManagedProcessService<R>`** — owns the in-memory owned-runtime registry plus the two lifecycle pipelines ported faithfully from the legacy service: the **5-phase stale-owned-runtime cleanup** (per-record identity recheck; kill authorization via current-bridge match, terminated-bridge identities, or owner-bridge liveness through `BridgeHostInfo.isLiveBridgeProcess` — live other-owner bridges are spared; parallel graceful with timeout; mandatory wait; survivor detection incl. owned-child exit probe; parallel force; delete records only once the pid is gone or mismatched) and **`stopOwnedRuntime`** (upsert `stopping` → identity check → graceful → wait → identity recheck before force → record delete). Missing-start-marker conservative matching and the Windows executable-basename fallback are preserved exactly.

Naming note: the plan document calls these `ManagedProcessSupervisor`/`RuntimeOwnershipStore`; they ship as `ManagedProcessService`/`RuntimeOwnershipRepository` per the repo's class-suffix rules (architecture review). Later plan cards (PRs 8–12) should read the vocabulary accordingly.

## Test plan
- 10 cleanup/stop/authorization scenarios ported from `open_code_server_service_test.dart` (the behavioral spec) against new seam fakes: owner-dead kill authorization, pre-signal identity mismatch (no signals), live-owner spared + missing-marker purge, missing-marker kill authorization, replacement-bridge authorization, stop identity-recheck-before-force, missing-marker child surviving force keeps ownership, exited child gets no signals, signal-discipline (graceful→force ordering, waits via injected clock, signals only through `HostProcessService`).
- Repository tests: CRUD semantics, delete-when-empty, corrupt/non-map quarantine with legacy-compatible names (incl. during `upsert`/delete), locked-update routing, byte-compat golden tests for the legacy record JSON contract (round-trip + exact bytes, root map keyed by owner session id).
- `dart analyze --fatal-infos` clean in all four packages; full suites green post-rebase on main: app 1,344 / runtime 19 / opencode 186 / interface 100. CI gains analyze+test steps for the new module.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `bridge/sesori_plugin_runtime`, a reusable managed-runtime lifecycle package (ownership repository, stale cleanup, stop). No production consumer yet; includes tests and CI steps only.

- New Features
  - `RuntimeRecordMapper<R>`: codec seam with identity accessors and `markStopping`.
  - `RuntimeOwnershipRepository<R>`: CRUD for ownership records.
  - `HostJsonRuntimeOwnershipRepository<R>`: `HostJsonStore`-backed with locked `update()`, corrupt-file quarantine (`<base>.invalid.<ts>.json`, incl. during mutations), and delete-when-empty.
  - `ManagedProcessService<R>`: tracks owned processes; 5-phase stale cleanup with authorization via `BridgeHostInfo`; stop flow (graceful → wait → identity recheck → force → delete). Preserves missing-start-marker matching and Windows basename fallback.

- Bug Fixes
  - Wrapped signal fan-outs in `Future.sync` to guard against synchronous mapper throws during cleanup/stop.
  - Makefile codegen: skip modules without `build_runner` to avoid no-op failures in the workspace.
  - `HostJsonRuntimeOwnershipRepository.deleteByOwnerSessionId`: when the record is absent, do not rewrite bytes; if the file was just quarantined, keep it absent (no corrupt-byte resurrection).
  - `RuntimeRecordMapper.runtimeCommandLineOf` is non-null by contract, matching legacy behavior and removing null-match ambiguity in identity checks.
  - Read-path quarantine now revalidates under the `HostJsonStore.update()` lock to avoid quarantining a concurrently repaired valid file.

<sup>Written for commit 03a7dac463b2e1fb6ba0d1e932fc9365c55023ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

