### PR TITLE
chore: add git repository references to local opencode config

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -12,6 +12,20 @@
       "enabled": true
     }
   },
+  "references": {
+    "sesori-auth": {
+      "repository": "sesori-ai/sesori_auth_server",
+      "description": "Sesori auth server — OAuth flows, token issuance, and auth API endpoints used by the bridge and mobile app"
+    },
+    "sesori-relay": {
+      "repository": "sesori-ai/sesori_relay_server",
+      "description": "Sesori relay server — WebSocket routing of encrypted frames between bridge and mobile app"
+    },
+    "opencode": {
+      "repository": "anomalyco/opencode",
+      "description": "OpenCode AI assistant — REST/SSE API the bridge plugin integrates with"
+    }
+  },
   "permission": {
     "skill": {
       "pr-inline-comments": "deny"


### PR DESCRIPTION
Adds OpenCode [references](https://opencode.ai/docs/references/) to `opencode.json` using the Git repository style:

- `sesori-auth` → `sesori-ai/sesori_auth_server`
- `sesori-relay` → `sesori-ai/sesori_relay_server`
- `opencode` → `anomalyco/opencode`

Each has a description so agents get them in context; default branches are used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add OpenCode references in `opencode.json` to map project aliases to GitHub repos so agents have repository context.

- **New Features**
  - `sesori-auth` → `sesori-ai/sesori_auth_server`
  - `sesori-relay` → `sesori-ai/sesori_relay_server`
  - `opencode` → `anomalyco/opencode`

<sup>Written for commit aaa09a0b64048e9071a7681f358be294850bd7b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

