### PR TITLE
feat(bridge): sesori_plugin_runtime — supervisor start/attach with legacy-default policy knobs (migration PR 8/15)

### DIFF
--- a/bridge/sesori_plugin_runtime/lib/sesori_plugin_runtime.dart
+++ b/bridge/sesori_plugin_runtime/lib/sesori_plugin_runtime.dart
@@ -1,4 +1,5 @@
 export "src/host_json_runtime_ownership_repository.dart";
 export "src/managed_process_service.dart";
+export "src/managed_runtime_spec.dart";
 export "src/runtime_ownership_repository.dart";
 export "src/runtime_record_mapper.dart";

--- a/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
@@ -73,6 +73,9 @@ class ManagedProcessService<R> {
     _throwIfAborted(abort);
 
     final probe = await _probeTolerant(spec: spec, port: port);
+    // Honor an abort that fired while the probe was in flight: even a healthy
+    // result must not produce a live handle once the bridge has aborted.
+    _throwIfAborted(abort);
     if (!probe.healthy) {
       throw PluginStartException(
         "[$_runtimeId] existing runtime health check failed on port $port",
@@ -115,11 +118,18 @@ class ManagedProcessService<R> {
     Object? lastError;
     var attempts = 0;
 
-    for (final port in _dynamicCandidates(policy: policy)) {
+    // The cap counts every raw candidate examined — not just the in-range
+    // ones — so a lazy source that keeps yielding the reserved or out-of-range
+    // port can never spin past maxAttempts while the startup mutex is held.
+    for (final port in policy.candidates) {
       if (attempts >= policy.maxAttempts) {
         break;
       }
       attempts += 1;
+
+      if (port == policy.reservedPort || port < policy.minPort || port > policy.maxPort) {
+        continue;
+      }
 
       _throwIfAborted(abort);
 
@@ -151,14 +161,6 @@ class ManagedProcessService<R> {
       "[$_runtimeId] unable to start runtime on an available dynamic port after $attempts attempt(s)",
       cause: lastError,
     );
-  }
-
-  Iterable<int> _dynamicCandidates({required DynamicPortPolicy policy}) sync* {
-    for (final port in policy.candidates) {
-      if (port != policy.reservedPort && port >= policy.minPort && port <= policy.maxPort) {
-        yield port;
-      }
-    }
   }
 
   Future<ManagedRuntimeHandle<R>> _startAndConfirmHealthy({
@@ -218,7 +220,12 @@ class ManagedProcessService<R> {
         health: health,
       );
     } on Object {
-      await _cleanupFailedStart(record: record);
+      // Never let a cleanup failure mask the error that triggered it.
+      try {
+        await _cleanupFailedStart(record: record);
+      } on Object catch (cleanupError, cleanupStackTrace) {
+        Log.w("[$_runtimeId] Failed to clean up after a failed start on port $port", cleanupError, cleanupStackTrace);
+      }
       rethrow;
     }
   }

--- a/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
@@ -135,11 +135,14 @@ class ManagedProcessService<R> {
       }
       attempts += 1;
 
+      // Honor cancellation on every iteration boundary, including the ones
+      // that only skip an invalid candidate, so an abort during an all-invalid
+      // tail settles as an abort rather than a generic exhaustion failure.
+      _throwIfAborted(abort);
+
       if (port == policy.reservedPort || port < policy.minPort || port > policy.maxPort) {
         continue;
       }
-
-      _throwIfAborted(abort);
 
       final bindable = await spec.probePortBindable(port: port);
       if (!bindable) {

--- a/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
@@ -1,5 +1,6 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
+import "managed_runtime_spec.dart";
 import "runtime_ownership_repository.dart";
 import "runtime_record_mapper.dart";
 
@@ -29,6 +30,285 @@ class ManagedProcessService<R> {
   final Duration _gracefulShutdownWait;
   final Map<String, _CurrentOwnedRuntimeProcess> _currentOwnedProcessesBySessionId =
       <String, _CurrentOwnedRuntimeProcess>{};
+
+  /// Starts a freshly owned runtime per [spec], after first cleaning up any
+  /// stale runtimes this bridge is authorized to reclaim.
+  ///
+  /// Honors the cooperative abort [startAborted] at every phase boundary: an
+  /// aborted start rolls back everything it acquired (kills the child, deletes
+  /// the record) and settles by throwing [PluginStartAbortedException] — never
+  /// by abandonment, because the bridge holds its startup mutex until this
+  /// settles. A spawn that cannot even launch propagates from the explicit
+  /// path and is retried on the dynamic path; any other start failure rolls
+  /// back and throws [PluginStartException].
+  Future<ManagedRuntimeHandle<R>> start({
+    required ManagedRuntimeSpec<R> spec,
+    required List<ProcessIdentity> terminatedBridgeIdentities,
+    StartAbortSignal? startAborted,
+  }) async {
+    final abort = startAborted ?? StartAbortSignal.never;
+
+    await cleanupStaleOwnedRuntimes(terminatedBridgeIdentities: terminatedBridgeIdentities);
+    _throwIfAborted(abort);
+
+    final portPolicy = spec.portPolicy;
+    switch (portPolicy) {
+      case ExplicitPortPolicy():
+        return _startOnExplicitPort(spec: spec, policy: portPolicy, abort: abort);
+      case DynamicPortPolicy():
+        return _startOnDynamicPort(spec: spec, policy: portPolicy, abort: abort);
+    }
+  }
+
+  /// Attaches to a runtime already listening on [port] (the `--no-auto-start`
+  /// path): a single health probe, no ownership, no process to kill. Returns
+  /// an un-owned handle on success; throws [PluginStartException] when the
+  /// existing server is unreachable.
+  Future<ManagedRuntimeHandle<R>> attach({
+    required ManagedRuntimeSpec<R> spec,
+    required int port,
+    StartAbortSignal? startAborted,
+  }) async {
+    final abort = startAborted ?? StartAbortSignal.never;
+    _throwIfAborted(abort);
+
+    final probe = await _probeTolerant(spec: spec, port: port);
+    if (!probe.healthy) {
+      throw PluginStartException(
+        "[$_runtimeId] existing runtime health check failed on port $port",
+        cause: probe.error,
+      );
+    }
+
+    return ManagedRuntimeHandle<R>(
+      port: port,
+      record: null,
+      process: null,
+      identity: null,
+      health: probe,
+    );
+  }
+
+  Future<ManagedRuntimeHandle<R>> _startOnExplicitPort({
+    required ManagedRuntimeSpec<R> spec,
+    required ExplicitPortPolicy policy,
+    required StartAbortSignal abort,
+  }) async {
+    if (policy.preProbeBindable) {
+      final bindable = await spec.probePortBindable(port: policy.port);
+      if (!bindable) {
+        throw PluginStartException(
+          "[$_runtimeId] explicit port ${policy.port} is already in use",
+          cause: null,
+        );
+      }
+      _throwIfAborted(abort);
+    }
+    return _startAndConfirmHealthy(spec: spec, port: policy.port, abort: abort);
+  }
+
+  Future<ManagedRuntimeHandle<R>> _startOnDynamicPort({
+    required ManagedRuntimeSpec<R> spec,
+    required DynamicPortPolicy policy,
+    required StartAbortSignal abort,
+  }) async {
+    Object? lastError;
+    var attempts = 0;
+
+    for (final port in _dynamicCandidates(policy: policy)) {
+      if (attempts >= policy.maxAttempts) {
+        break;
+      }
+      attempts += 1;
+
+      _throwIfAborted(abort);
+
+      final bindable = await spec.probePortBindable(port: port);
+      if (!bindable) {
+        continue;
+      }
+
+      try {
+        return await _startAndConfirmHealthy(spec: spec, port: port, abort: abort);
+      } on PluginStartAbortedException {
+        rethrow;
+      } on PluginStartException catch (error) {
+        // A failure after a successful spawn (health/validation): try the
+        // next candidate, as the legacy path does.
+        lastError = error;
+      } on Object catch (error) {
+        // A spawn that could not launch: retry the next candidate unless the
+        // policy opts into failing fast.
+        if (policy.failFastOnSpawnError) {
+          rethrow;
+        }
+        Log.w("[$_runtimeId] Failed to start runtime on port $port", error);
+        lastError = error;
+      }
+    }
+
+    throw PluginStartException(
+      "[$_runtimeId] unable to start runtime on an available dynamic port after $attempts attempt(s)",
+      cause: lastError,
+    );
+  }
+
+  Iterable<int> _dynamicCandidates({required DynamicPortPolicy policy}) sync* {
+    for (final port in policy.candidates) {
+      if (port != policy.reservedPort && port >= policy.minPort && port <= policy.maxPort) {
+        yield port;
+      }
+    }
+  }
+
+  Future<ManagedRuntimeHandle<R>> _startAndConfirmHealthy({
+    required ManagedRuntimeSpec<R> spec,
+    required int port,
+    required StartAbortSignal abort,
+  }) async {
+    if (spec.recordTiming == RuntimeRecordTiming.intentSideFile) {
+      // The bridge-private intent side file is introduced in a later step;
+      // until then only the legacy after-spawn timing is representable.
+      throw UnsupportedError("[$_runtimeId] intent side-file record timing is not available yet");
+    }
+
+    // Spawn errors propagate before any ownership state is acquired: the
+    // explicit-port caller surfaces them raw, the dynamic caller retries.
+    final spawned = await spec.spawn(port: port);
+
+    final record = spec.buildRecord(
+      RuntimeRecordDraft(
+        ownerSessionId: _bridge.ownerSessionId,
+        runtimeIdentity: spawned.identity,
+        port: port,
+        bridgeIdentity: _bridge.identity,
+        startedAt: _clock.now(),
+      ),
+    );
+    trackOwnedRuntime(ownerSessionId: _ownerSessionIdOf(record: record), process: spawned);
+
+    try {
+      await _ownershipRepository.upsert(record: record);
+      _throwIfAborted(abort);
+
+      final health = await _confirmHealthy(spec: spec, port: port, spawned: spawned, abort: abort);
+
+      final validate = spec.validateRuntime;
+      if (validate != null) {
+        try {
+          await validate(port: port);
+        } on PluginStartAbortedException {
+          rethrow;
+        } on Object catch (error) {
+          // Surface validation failures as a (retryable) start failure rather
+          // than a raw error the dynamic path would mistake for a spawn error.
+          throw PluginStartException("[$_runtimeId] runtime validation failed on port $port", cause: error);
+        }
+      }
+      _throwIfAborted(abort);
+
+      final readyRecord = _mapper.markReady(record: record);
+      await _ownershipRepository.upsert(record: readyRecord);
+
+      return ManagedRuntimeHandle<R>(
+        port: port,
+        record: readyRecord,
+        process: spawned,
+        identity: spawned.identity,
+        health: health,
+      );
+    } on Object {
+      await _cleanupFailedStart(record: record);
+      rethrow;
+    }
+  }
+
+  Future<RuntimeHealthProbe> _confirmHealthy({
+    required ManagedRuntimeSpec<R> spec,
+    required int port,
+    required SpawnedProcess spawned,
+    required StartAbortSignal abort,
+  }) async {
+    final policy = spec.healthPolicy;
+    switch (policy) {
+      case HealthAttemptCountPolicy():
+        RuntimeHealthProbe? last;
+        for (var attempt = 1; attempt <= policy.attempts; attempt += 1) {
+          await _clock.delay(duration: policy.delay);
+          final probe = await _probeOnce(spec: spec, port: port, spawned: spawned, abort: abort);
+          last = probe;
+          if (probe.healthy) {
+            return probe;
+          }
+        }
+        throw PluginStartException(
+          "[$_runtimeId] health check failed on port $port after ${policy.attempts} attempt(s)",
+          cause: last?.error,
+        );
+      case HealthDeadlinePolicy():
+        final deadline = _clock.now().add(policy.deadline);
+        RuntimeHealthProbe? last;
+        while (true) {
+          await _clock.delay(duration: policy.pollInterval);
+          final probe = await _probeOnce(spec: spec, port: port, spawned: spawned, abort: abort);
+          last = probe;
+          if (probe.healthy) {
+            return probe;
+          }
+          if (!_clock.now().isBefore(deadline)) {
+            throw PluginStartException(
+              "[$_runtimeId] health check failed on port $port within ${policy.deadline.inMilliseconds}ms",
+              cause: last.error,
+            );
+          }
+        }
+    }
+  }
+
+  Future<RuntimeHealthProbe> _probeOnce({
+    required ManagedRuntimeSpec<R> spec,
+    required int port,
+    required SpawnedProcess spawned,
+    required StartAbortSignal abort,
+  }) async {
+    _throwIfAborted(abort);
+
+    if (spec.failOnEarlyChildExit && await _spawnedProcessExited(process: spawned)) {
+      // The child we launched is gone; a healthy probe now would be answered
+      // by an unrelated process holding the port. Fail authoritatively.
+      throw PluginStartException(
+        "[$_runtimeId] runtime exited before becoming healthy on port $port",
+        cause: null,
+      );
+    }
+
+    return _probeTolerant(spec: spec, port: port);
+  }
+
+  /// Probes health, treating a thrown probe as unhealthy — the [ManagedRuntimeSpec.probeHealth]
+  /// contract lets a transient connection error simply read as "not ready yet".
+  Future<RuntimeHealthProbe> _probeTolerant({required ManagedRuntimeSpec<R> spec, required int port}) async {
+    try {
+      return await spec.probeHealth(port: port);
+    } on Object catch (error) {
+      return RuntimeHealthProbe.unhealthy(error: error);
+    }
+  }
+
+  Future<bool> _spawnedProcessExited({required SpawnedProcess process}) async {
+    final exitCode = await process.exitCode.then<int?>((code) => code).timeout(Duration.zero, onTimeout: () => null);
+    return exitCode != null;
+  }
+
+  Future<void> _cleanupFailedStart({required R record}) async {
+    await _stopRecord(record: record, removeOwnership: true);
+  }
+
+  void _throwIfAborted(StartAbortSignal abort) {
+    if (abort.isAborted) {
+      throw const PluginStartAbortedException();
+    }
+  }
 
   void trackOwnedRuntime({required String ownerSessionId, required SpawnedProcess process}) {
     _currentOwnedProcessesBySessionId[ownerSessionId] = _CurrentOwnedRuntimeProcess(

--- a/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
@@ -48,6 +48,14 @@ class ManagedProcessService<R> {
   }) async {
     final abort = startAborted ?? StartAbortSignal.never;
 
+    // A deterministic configuration error: reject it once, up front, so the
+    // dynamic path never retries it candidate by candidate.
+    if (spec.recordTiming == RuntimeRecordTiming.intentSideFile) {
+      // The bridge-private intent side file is introduced in a later step;
+      // until then only the legacy after-spawn timing is representable.
+      throw UnsupportedError("[$_runtimeId] intent side-file record timing is not available yet");
+    }
+
     await cleanupStaleOwnedRuntimes(terminatedBridgeIdentities: terminatedBridgeIdentities);
     _throwIfAborted(abort);
 
@@ -168,25 +176,31 @@ class ManagedProcessService<R> {
     required int port,
     required StartAbortSignal abort,
   }) async {
-    if (spec.recordTiming == RuntimeRecordTiming.intentSideFile) {
-      // The bridge-private intent side file is introduced in a later step;
-      // until then only the legacy after-spawn timing is representable.
-      throw UnsupportedError("[$_runtimeId] intent side-file record timing is not available yet");
-    }
-
     // Spawn errors propagate before any ownership state is acquired: the
     // explicit-port caller surfaces them raw, the dynamic caller retries.
     final spawned = await spec.spawn(port: port);
 
-    final record = spec.buildRecord(
-      RuntimeRecordDraft(
-        ownerSessionId: _bridge.ownerSessionId,
-        runtimeIdentity: spawned.identity,
-        port: port,
-        bridgeIdentity: _bridge.identity,
-        startedAt: _clock.now(),
-      ),
-    );
+    final R record;
+    try {
+      record = spec.buildRecord(
+        RuntimeRecordDraft(
+          ownerSessionId: _bridge.ownerSessionId,
+          runtimeIdentity: spawned.identity,
+          port: port,
+          bridgeIdentity: _bridge.identity,
+          startedAt: _clock.now(),
+        ),
+      );
+    } on Object {
+      // The child is already running but not yet tracked or recorded — stop it
+      // directly so a record-factory failure cannot leak a started runtime.
+      try {
+        await _stopUntrackedSpawn(process: spawned);
+      } on Object catch (cleanupError, cleanupStackTrace) {
+        Log.w("[$_runtimeId] Failed to stop an orphaned child after a record build error on port $port", cleanupError, cleanupStackTrace);
+      }
+      rethrow;
+    }
     trackOwnedRuntime(ownerSessionId: _ownerSessionIdOf(record: record), process: spawned);
 
     try {
@@ -309,6 +323,20 @@ class ManagedProcessService<R> {
 
   Future<void> _cleanupFailedStart({required R record}) async {
     await _stopRecord(record: record, removeOwnership: true);
+  }
+
+  /// Stops a freshly spawned child that has no ownership record yet (the record
+  /// factory threw before one could be built). Graceful, then force if it
+  /// outlives the grace period — there is nothing tracked or persisted to undo.
+  Future<void> _stopUntrackedSpawn({required SpawnedProcess process}) async {
+    if (await _spawnedProcessExited(process: process)) {
+      return;
+    }
+    await _processes.signalGraceful(pid: process.pid);
+    await _clock.delay(duration: _gracefulShutdownWait);
+    if (!await _spawnedProcessExited(process: process)) {
+      await _processes.signalForce(pid: process.pid);
+    }
   }
 
   void _throwIfAborted(StartAbortSignal abort) {

--- a/bridge/sesori_plugin_runtime/lib/src/managed_runtime_spec.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_runtime_spec.dart
@@ -70,7 +70,7 @@ sealed class RuntimeHealthPolicy {
 
   /// Deadline pacing: probe every [pollInterval] until healthy or until
   /// [deadline] elapses (host clock).
-  const factory RuntimeHealthPolicy.deadline({
+  factory RuntimeHealthPolicy.deadline({
     required Duration deadline,
     required Duration pollInterval,
   }) = HealthDeadlinePolicy;
@@ -86,7 +86,12 @@ class HealthAttemptCountPolicy extends RuntimeHealthPolicy {
 }
 
 class HealthDeadlinePolicy extends RuntimeHealthPolicy {
-  const HealthDeadlinePolicy({required this.deadline, required this.pollInterval}) : super();
+  // Not const: the parameter guards below compare Durations, which is not a
+  // constant-evaluable operation. The policy is built at runtime anyway.
+  HealthDeadlinePolicy({required this.deadline, required this.pollInterval})
+    : assert(!deadline.isNegative, "deadline must be non-negative"),
+      assert(pollInterval > Duration.zero, "pollInterval must be positive"),
+      super();
 
   final Duration deadline;
   final Duration pollInterval;

--- a/bridge/sesori_plugin_runtime/lib/src/managed_runtime_spec.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_runtime_spec.dart
@@ -154,13 +154,17 @@ class DynamicPortPolicy extends RuntimePortPolicy {
   }) : assert(maxAttempts > 0, "maxAttempts must be positive"),
        super();
 
-  /// Candidate ports to consider, in order. May be a lazy generator (e.g. a
-  /// random source). Candidates equal to [reservedPort] or outside
-  /// [[minPort], [maxPort]] are skipped.
+  /// Candidate ports to consider, in order. May be a lazy or unbounded
+  /// generator (e.g. a random source): the supervisor pulls at most
+  /// [maxAttempts] values from it and counts every value examined against that
+  /// cap — including ones skipped for being [reservedPort] or outside
+  /// [[minPort], [maxPort]] — so even an all-invalid infinite source still
+  /// terminates rather than spinning under the startup mutex.
   final Iterable<int> candidates;
 
-  /// Maximum number of candidates examined (whether bindable or not) before
-  /// giving up — bounds discovery the way the legacy five-candidate cap does.
+  /// Maximum number of candidates examined (whether skipped, unbindable, or
+  /// attempted) before giving up — bounds discovery the way the legacy
+  /// five-candidate cap does, and guarantees termination for lazy [candidates].
   final int maxAttempts;
 
   /// The reserved default port, excluded from dynamic discovery.

--- a/bridge/sesori_plugin_runtime/lib/src/managed_runtime_spec.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_runtime_spec.dart
@@ -1,0 +1,251 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+/// Structured outcome of a single runtime health probe.
+///
+/// Plugins return this from [ManagedRuntimeSpec.probeHealth]. The supervisor
+/// only looks at [healthy] to decide whether the runtime is up; [version] and
+/// [detail] are surfaced through the resulting [ManagedRuntimeHandle] for
+/// diagnostics, and [error] carries the failure cause when a probe reports
+/// unhealthy (so a start failure can name why).
+class RuntimeHealthProbe {
+  const RuntimeHealthProbe({required this.healthy, this.version, this.detail, this.error});
+
+  /// A probe that failed, carrying its [error] cause.
+  const RuntimeHealthProbe.unhealthy({Object? error}) : this(healthy: false, error: error);
+
+  final bool healthy;
+  final String? version;
+  final String? detail;
+  final Object? error;
+}
+
+/// Facts the supervisor hands a plugin's record factory after a successful
+/// spawn, so it can build its concrete (byte-frozen) ownership record.
+///
+/// The supervisor stays generic over the record type `R`; the plugin's
+/// [ManagedRuntimeSpec.buildRecord] maps these facts — plus its own knowledge
+/// of the command line it spawned — into `R` at the "starting" status.
+class RuntimeRecordDraft {
+  const RuntimeRecordDraft({
+    required this.ownerSessionId,
+    required this.runtimeIdentity,
+    required this.port,
+    required this.bridgeIdentity,
+    required this.startedAt,
+  });
+
+  /// Stable identifier of the bridge run that owns the runtime.
+  final String ownerSessionId;
+
+  /// Identity of the freshly spawned runtime process, as captured by the
+  /// spawn seam. May be partial (no start marker) on Windows or when the
+  /// child raced the post-spawn inspection.
+  final ProcessIdentity runtimeIdentity;
+
+  /// The port the runtime was started on.
+  final int port;
+
+  /// Identity of the hosting bridge process.
+  final ProcessIdentity bridgeIdentity;
+
+  /// When the runtime was started (host clock).
+  final DateTime startedAt;
+}
+
+/// How the supervisor paces health confirmation after a spawn.
+///
+/// The legacy spec is [RuntimeHealthPolicy.attemptCount]; the hardened
+/// deadline-based pacing ([RuntimeHealthPolicy.deadline]) becomes the default
+/// only when the real descriptor opts in at the flip. The legacy test suite
+/// hard-asserts exact delay sequences, so pacing must be configurable rather
+/// than replaced.
+sealed class RuntimeHealthPolicy {
+  const RuntimeHealthPolicy();
+
+  /// Legacy pacing: up to [attempts] probes, each preceded by [delay].
+  const factory RuntimeHealthPolicy.attemptCount({
+    required int attempts,
+    required Duration delay,
+  }) = HealthAttemptCountPolicy;
+
+  /// Deadline pacing: probe every [pollInterval] until healthy or until
+  /// [deadline] elapses (host clock).
+  const factory RuntimeHealthPolicy.deadline({
+    required Duration deadline,
+    required Duration pollInterval,
+  }) = HealthDeadlinePolicy;
+}
+
+class HealthAttemptCountPolicy extends RuntimeHealthPolicy {
+  const HealthAttemptCountPolicy({required this.attempts, required this.delay})
+    : assert(attempts > 0, "attempts must be positive"),
+      super();
+
+  final int attempts;
+  final Duration delay;
+}
+
+class HealthDeadlinePolicy extends RuntimeHealthPolicy {
+  const HealthDeadlinePolicy({required this.deadline, required this.pollInterval}) : super();
+
+  final Duration deadline;
+  final Duration pollInterval;
+}
+
+/// When the supervisor writes the ownership record relative to spawn.
+enum RuntimeRecordTiming {
+  /// Legacy: the record is written only after spawn, once a real pid exists.
+  /// The frozen schema's runtime pid is required non-null, so there is no
+  /// representable pre-spawn state in the ownership file itself.
+  afterSpawn,
+
+  /// Hardened: an intent record is written to a bridge-private side file
+  /// before spawn and resolved after. Activated in a later migration step;
+  /// the supervisor rejects it until then.
+  intentSideFile,
+}
+
+/// Where the supervisor obtains the listening port for a start.
+sealed class RuntimePortPolicy {
+  const RuntimePortPolicy();
+
+  /// A single, caller-chosen port.
+  const factory RuntimePortPolicy.explicit({
+    required int port,
+    bool preProbeBindable,
+  }) = ExplicitPortPolicy;
+
+  /// Dynamic discovery across [candidates]: probe each for bindability and
+  /// start on the first that works, up to [maxAttempts] examined candidates.
+  const factory RuntimePortPolicy.dynamic({
+    required Iterable<int> candidates,
+    required int maxAttempts,
+    required int reservedPort,
+    required int minPort,
+    required int maxPort,
+    bool failFastOnSpawnError,
+  }) = DynamicPortPolicy;
+}
+
+class ExplicitPortPolicy extends RuntimePortPolicy {
+  const ExplicitPortPolicy({required this.port, this.preProbeBindable = false}) : super();
+
+  final int port;
+
+  /// Hardened (default off): probe bindability before spawning and fail with
+  /// a diagnosed error when the port is already held. Off reproduces the
+  /// legacy behavior of spawning straight onto the explicit port.
+  final bool preProbeBindable;
+}
+
+class DynamicPortPolicy extends RuntimePortPolicy {
+  const DynamicPortPolicy({
+    required this.candidates,
+    required this.maxAttempts,
+    required this.reservedPort,
+    required this.minPort,
+    required this.maxPort,
+    this.failFastOnSpawnError = false,
+  }) : assert(maxAttempts > 0, "maxAttempts must be positive"),
+       super();
+
+  /// Candidate ports to consider, in order. May be a lazy generator (e.g. a
+  /// random source). Candidates equal to [reservedPort] or outside
+  /// [[minPort], [maxPort]] are skipped.
+  final Iterable<int> candidates;
+
+  /// Maximum number of candidates examined (whether bindable or not) before
+  /// giving up — bounds discovery the way the legacy five-candidate cap does.
+  final int maxAttempts;
+
+  /// The reserved default port, excluded from dynamic discovery.
+  final int reservedPort;
+
+  /// Inclusive bounds of the dynamic range.
+  final int minPort;
+  final int maxPort;
+
+  /// Hardened (default off): treat a spawn error as fatal and stop instead of
+  /// retrying the next candidate. Off reproduces the legacy behavior of
+  /// retrying on any start error (e.g. a bind race).
+  final bool failFastOnSpawnError;
+}
+
+/// Everything a [ManagedProcessService] needs to start (or attach to) one
+/// managed runtime, expressed as seams so the same supervisor serves the
+/// legacy in-place wrapper, the eventual host-backed plugin, and tests.
+///
+/// The seams ([spawn], [probeHealth], [probePortBindable]) are supplied as
+/// functions rather than service objects so a plugin (or a legacy adapter)
+/// owns exactly how a runtime is launched and inspected. The supervisor
+/// trusts the identity its [spawn] seam returns and never re-inspects it.
+class ManagedRuntimeSpec<R> {
+  const ManagedRuntimeSpec({
+    required this.spawn,
+    required this.probeHealth,
+    required this.probePortBindable,
+    required this.buildRecord,
+    required this.portPolicy,
+    required this.healthPolicy,
+    this.recordTiming = RuntimeRecordTiming.afterSpawn,
+    this.validateRuntime,
+    this.failOnEarlyChildExit = false,
+  });
+
+  /// Launches the runtime on [port] and returns the spawned process with its
+  /// captured identity. Contract: the returned [SpawnedProcess.identity] is
+  /// authoritative — the supervisor does not re-inspect it.
+  final Future<SpawnedProcess> Function({required int port}) spawn;
+
+  /// Probes the runtime's health on [port]. Should report unhealthy rather
+  /// than throw, but the supervisor tolerates a thrown probe (treated as
+  /// unhealthy) so a transient connection error simply retries.
+  final Future<RuntimeHealthProbe> Function({required int port}) probeHealth;
+
+  /// Whether [port] can currently be bound (used for dynamic discovery and
+  /// the optional explicit pre-probe).
+  final Future<bool> Function({required int port}) probePortBindable;
+
+  /// Maps the post-spawn facts into the plugin's concrete ownership record at
+  /// the "starting" status.
+  final R Function(RuntimeRecordDraft draft) buildRecord;
+
+  final RuntimePortPolicy portPolicy;
+  final RuntimeHealthPolicy healthPolicy;
+  final RuntimeRecordTiming recordTiming;
+
+  /// Optional post-health validation, run after the first healthy probe and
+  /// before the record flips to "ready". A throw fails the start (with
+  /// rollback). Null reproduces the legacy behavior of no extra validation.
+  final Future<void> Function({required int port})? validateRuntime;
+
+  /// Hardened (default off): if the spawned child exits before the first
+  /// healthy probe, fail the start regardless of probe success — a healthy
+  /// response after our child died means an unrelated process holds the port.
+  final bool failOnEarlyChildExit;
+}
+
+/// The outcome of a successful [ManagedProcessService.start] or
+/// [ManagedProcessService.attach].
+///
+/// A started runtime is owned ([process], [identity] and [record] are
+/// populated); an attached runtime is not ([isOwned] is false and those
+/// fields are null — the bridge never kills or records a server it merely
+/// connected to).
+class ManagedRuntimeHandle<R> {
+  const ManagedRuntimeHandle({
+    required this.port,
+    required this.record,
+    required this.process,
+    required this.identity,
+    required this.health,
+  });
+
+  final int port;
+  final R? record;
+  final SpawnedProcess? process;
+  final ProcessIdentity? identity;
+  final RuntimeHealthProbe health;
+
+  bool get isOwned => process != null;
+}

--- a/bridge/sesori_plugin_runtime/lib/src/runtime_record_mapper.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/runtime_record_mapper.dart
@@ -31,5 +31,11 @@ abstract class RuntimeRecordMapper<R> {
 
   String? bridgeStartMarkerOf({required R record});
 
+  /// Returns a copy of [record] whose persisted lifecycle status is "ready".
+  ///
+  /// Written by the supervisor once a freshly spawned runtime has passed its
+  /// first health probe. Symmetric with [markStopping].
+  R markReady({required R record});
+
   R markStopping({required R record});
 }

--- a/bridge/sesori_plugin_runtime/test/host_json_runtime_ownership_repository_test.dart
+++ b/bridge/sesori_plugin_runtime/test/host_json_runtime_ownership_repository_test.dart
@@ -278,6 +278,23 @@ class _TestRecordMapper implements RuntimeRecordMapper<_TestRecord> {
   String? bridgeStartMarkerOf({required _TestRecord record}) => record.bridgeStartMarker;
 
   @override
+  _TestRecord markReady({required _TestRecord record}) {
+    return _TestRecord(
+      ownerSessionId: record.ownerSessionId,
+      openCodePid: record.openCodePid,
+      openCodeStartMarker: record.openCodeStartMarker,
+      openCodeExecutablePath: record.openCodeExecutablePath,
+      openCodeCommand: record.openCodeCommand,
+      openCodeArgs: record.openCodeArgs,
+      port: record.port,
+      bridgePid: record.bridgePid,
+      bridgeStartMarker: record.bridgeStartMarker,
+      startedAt: record.startedAt,
+      status: _TestStatus.ready,
+    );
+  }
+
+  @override
   _TestRecord markStopping({required _TestRecord record}) {
     return _TestRecord(
       ownerSessionId: record.ownerSessionId,

--- a/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
@@ -120,6 +120,29 @@ void main() {
       expect(fakes.processes.signalRequests, isEmpty);
     });
 
+    test("caps an unbounded source that only ever yields the reserved port", () async {
+      // A lazy candidate generator that never yields an in-range port must
+      // still terminate at maxAttempts — the cap counts raw candidates.
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(
+            portPolicy: RuntimePortPolicy.dynamic(
+              candidates: _endless(4096),
+              maxAttempts: 5,
+              reservedPort: 4096,
+              minPort: 49152,
+              maxPort: 65535,
+            ),
+          ),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+        ),
+        throwsA(isA<PluginStartException>()),
+      );
+
+      expect(fakes.bindable.probedPorts, isEmpty);
+      expect(fakes.spawn.spawnedPorts, isEmpty);
+    });
+
     test("fail-fast policy stops on a spawn error instead of retrying", () async {
       fakes.bindable.byPort.addAll(<int, bool>{49152: true, 49153: true});
       fakes.spawn.results.add(const ProcessException("opencode", <String>["serve"]));
@@ -235,6 +258,25 @@ void main() {
           for (var i = 0; i < 5; i += 1) const Duration(milliseconds: 500),
           _gracefulShutdownWait,
         ]),
+      );
+    });
+
+    test("a cleanup failure does not mask the original start failure", () async {
+      fakes.spawn.results.add(_spawned(pid: 220, port: 50133, exitImmediately: true));
+      fakes.probe.results.addAll(<RuntimeHealthProbe>[
+        for (var i = 0; i < 5; i += 1) const RuntimeHealthProbe(healthy: false, error: "not ready"),
+      ]);
+      fakes.processes.inspectResults[220] = <ProcessIdentity?>[null];
+      // The record delete during rollback fails; the health-check failure that
+      // triggered the rollback must still be what surfaces.
+      fakes.ownership.deleteError = StateError("ownership store offline");
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 50133)),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+        ),
+        throwsA(isA<PluginStartException>()),
       );
     });
 
@@ -359,9 +401,9 @@ void main() {
       final handle = await fakes.service().start(
         spec: fakes.spec(
           portPolicy: const ExplicitPortPolicy(port: 50150),
-          healthPolicy: const RuntimeHealthPolicy.deadline(
-            deadline: Duration(seconds: 5),
-            pollInterval: Duration(seconds: 1),
+          healthPolicy: RuntimeHealthPolicy.deadline(
+            deadline: const Duration(seconds:5),
+            pollInterval: const Duration(seconds: 1),
           ),
         ),
         terminatedBridgeIdentities: const <ProcessIdentity>[],
@@ -384,9 +426,9 @@ void main() {
         fakes.service().start(
           spec: fakes.spec(
             portPolicy: const ExplicitPortPolicy(port: 50151),
-            healthPolicy: const RuntimeHealthPolicy.deadline(
-              deadline: Duration(seconds: 2),
-              pollInterval: Duration(seconds: 1),
+            healthPolicy: RuntimeHealthPolicy.deadline(
+              deadline: const Duration(seconds:2),
+              pollInterval: const Duration(seconds: 1),
             ),
           ),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
@@ -396,6 +438,20 @@ void main() {
 
       expect(fakes.probe.probedPorts, equals(<int>[50151, 50151]));
       expect(fakes.ownership.records, isEmpty);
+    });
+
+    test("rejects a non-positive poll interval or negative deadline", () {
+      expect(
+        () => RuntimeHealthPolicy.deadline(deadline: const Duration(seconds: 5), pollInterval: Duration.zero),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => RuntimeHealthPolicy.deadline(
+          deadline: const Duration(seconds: -1),
+          pollInterval: const Duration(seconds: 1),
+        ),
+        throwsA(isA<AssertionError>()),
+      );
     });
   });
 
@@ -535,6 +591,23 @@ void main() {
       expect(fakes.processes.signalRequests, isEmpty);
     });
 
+    test("honors an abort that fires while the health probe is in flight", () async {
+      final controller = StartAbortController();
+      fakes.probe.results.add(const RuntimeHealthProbe(healthy: true));
+      fakes.probe.onProbe = controller.abort;
+
+      await expectLater(
+        fakes.service().attach(
+          spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 50128)),
+          port: 50128,
+          startAborted: controller.signal,
+        ),
+        throwsA(isA<PluginStartAbortedException>()),
+      );
+
+      expect(fakes.probe.probedPorts, equals(<int>[50128]));
+    });
+
     test("treats a thrown probe as an unreachable server", () async {
       fakes.probe.throwError = Exception("connection refused");
 
@@ -551,6 +624,14 @@ void main() {
       expect(fakes.processes.signalRequests, isEmpty);
     });
   });
+}
+
+/// An unbounded source that keeps yielding [value] — used to prove the
+/// dynamic-start cap terminates even when every candidate is filtered out.
+Iterable<int> _endless(int value) sync* {
+  while (true) {
+    yield value;
+  }
 }
 
 RuntimePortPolicy _dynamic(List<int> candidates, {bool failFastOnSpawnError = false}) {
@@ -798,10 +879,15 @@ class _FakeOwnershipRepository implements RuntimeOwnershipRepository<_TestRecord
   final List<_TestStatus> upsertedStatuses = <_TestStatus>[];
   int writeCallCount = 0;
   int deleteCallCount = 0;
+  Object? deleteError;
 
   @override
   Future<void> deleteByOwnerSessionId({required String ownerSessionId}) async {
     deleteCallCount += 1;
+    final error = deleteError;
+    if (error != null) {
+      throw error;
+    }
     records.remove(ownerSessionId);
   }
 

--- a/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
@@ -382,6 +382,48 @@ void main() {
       expect(fakes.spawn.spawnedPorts, isEmpty);
       expect(fakes.ownership.records, isEmpty);
     });
+
+    test("rejects intent side-file timing once, never retrying across dynamic candidates", () async {
+      fakes.bindable.byPort.addAll(<int, bool>{49152: true, 49153: true});
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(
+            portPolicy: _dynamic(<int>[49152, 49153]),
+            recordTiming: RuntimeRecordTiming.intentSideFile,
+          ),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+        ),
+        throwsA(isA<UnsupportedError>()),
+      );
+
+      // Rejected before the candidate loop: nothing probed or spawned.
+      expect(fakes.bindable.probedPorts, isEmpty);
+      expect(fakes.spawn.spawnedPorts, isEmpty);
+    });
+
+    test("stops the spawned child when the record factory throws", () async {
+      final spawned = _spawned(pid: 230, port: 50143, exitImmediately: false);
+      fakes.spawn.results.add(spawned);
+      fakes.processes.forceHooks[230] = spawned.completeExit;
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(
+            portPolicy: const ExplicitPortPolicy(port: 50143),
+            buildRecord: (draft) => throw StateError("malformed record"),
+          ),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+        ),
+        throwsA(isA<StateError>()),
+      );
+
+      // The orphaned child is stopped via host signals; no record is ever written.
+      expect(fakes.spawn.spawnedPorts, equals(<int>[50143]));
+      expect(fakes.processes.signalRequests, equals(<String>["graceful:230", "force:230"]));
+      expect(fakes.ownership.writeCallCount, equals(0));
+      expect(fakes.ownership.records, isEmpty);
+    });
   });
 
   group("ManagedProcessService.start (deadline health policy)", () {
@@ -724,12 +766,13 @@ class _Fakes {
     RuntimeRecordTiming recordTiming = RuntimeRecordTiming.afterSpawn,
     Future<void> Function({required int port})? validateRuntime,
     bool failOnEarlyChildExit = false,
+    _TestRecord Function(RuntimeRecordDraft draft)? buildRecord,
   }) {
     return ManagedRuntimeSpec<_TestRecord>(
       spawn: spawn.spawn,
       probeHealth: probe.probe,
       probePortBindable: bindable.bindable,
-      buildRecord: _buildRecord,
+      buildRecord: buildRecord ?? _buildRecord,
       portPolicy: portPolicy,
       healthPolicy: healthPolicy,
       recordTiming: recordTiming,

--- a/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
@@ -1,0 +1,966 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
+import "package:test/test.dart";
+
+const _gracefulShutdownWait = Duration(seconds: 5);
+const _legacyHealthPolicy = RuntimeHealthPolicy.attemptCount(
+  attempts: 5,
+  delay: Duration(milliseconds: 500),
+);
+
+void main() {
+  group("ManagedProcessService.start (dynamic port)", () {
+    late _Fakes fakes;
+
+    setUp(() {
+      fakes = _Fakes();
+    });
+
+    test("retries dynamic candidates after a start race and skips the reserved port", () async {
+      fakes.bindable.byPort.addAll(<int, bool>{49152: true, 49153: true});
+      fakes.spawn.results.addAll(<Object>[
+        StateError("bind race"),
+        _spawned(pid: 101, port: 49153),
+      ]);
+      fakes.probe.results.add(const RuntimeHealthProbe(healthy: true));
+
+      final handle = await fakes.service().start(
+        spec: fakes.spec(portPolicy: _dynamic(<int>[4096, 49152, 49153])),
+        terminatedBridgeIdentities: const <ProcessIdentity>[],
+      );
+
+      expect(handle.port, equals(49153));
+      expect(handle.isOwned, isTrue);
+      expect(fakes.bindable.probedPorts, equals(<int>[49152, 49153]));
+      expect(fakes.spawn.spawnedPorts, equals(<int>[49152, 49153]));
+      expect(fakes.ownership.records.values.single.status, equals(_TestStatus.ready));
+      expect(fakes.ownership.records.values.single.port, equals(49153));
+    });
+
+    test("retries the health probe and succeeds on a later attempt", () async {
+      fakes.bindable.byPort[49152] = true;
+      fakes.spawn.results.add(_spawned(pid: 101, port: 49152));
+      fakes.probe.results.addAll(<RuntimeHealthProbe>[
+        const RuntimeHealthProbe(healthy: false, error: "not ready"),
+        const RuntimeHealthProbe(healthy: false, error: "not ready"),
+        const RuntimeHealthProbe(healthy: true),
+      ]);
+
+      final handle = await fakes.service().start(
+        spec: fakes.spec(portPolicy: _dynamic(<int>[49152])),
+        terminatedBridgeIdentities: const <ProcessIdentity>[],
+      );
+
+      expect(handle.port, equals(49152));
+      expect(fakes.probe.probedPorts, equals(<int>[49152, 49152, 49152]));
+      expect(
+        fakes.clock.delays,
+        equals(<Duration>[
+          const Duration(milliseconds: 500),
+          const Duration(milliseconds: 500),
+          const Duration(milliseconds: 500),
+        ]),
+      );
+      expect(fakes.ownership.upsertedStatuses.last, equals(_TestStatus.ready));
+    });
+
+    test("exhausts all health retries on one port and moves to the next", () async {
+      fakes.bindable.byPort.addAll(<int, bool>{49152: true, 49153: true});
+      fakes.spawn.results.addAll(<Object>[
+        _spawned(pid: 101, port: 49152),
+        _spawned(pid: 102, port: 49153),
+      ]);
+      fakes.probe.results.addAll(<RuntimeHealthProbe>[
+        for (var i = 0; i < 5; i += 1) const RuntimeHealthProbe(healthy: false, error: "not ready"),
+        const RuntimeHealthProbe(healthy: true),
+      ]);
+      // The first port's failed-start cleanup finds the child already gone.
+      fakes.processes.inspectResults[101] = <ProcessIdentity?>[null];
+
+      final handle = await fakes.service().start(
+        spec: fakes.spec(portPolicy: _dynamic(<int>[49152, 49153])),
+        terminatedBridgeIdentities: const <ProcessIdentity>[],
+      );
+
+      expect(handle.port, equals(49153));
+      expect(fakes.spawn.spawnedPorts, equals(<int>[49152, 49153]));
+      expect(
+        fakes.probe.probedPorts,
+        equals(<int>[49152, 49152, 49152, 49152, 49152, 49153]),
+      );
+      expect(
+        fakes.clock.delays,
+        equals(<Duration>[for (var i = 0; i < 6; i += 1) const Duration(milliseconds: 500)]),
+      );
+      expect(fakes.ownership.records.values.single.status, equals(_TestStatus.ready));
+      expect(fakes.ownership.records.values.single.port, equals(49153));
+    });
+
+    test("stops dynamic discovery after the configured candidate cap", () async {
+      for (var port = 49152; port < 49162; port += 1) {
+        fakes.bindable.byPort[port] = false;
+      }
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(
+            portPolicy: _dynamic(List<int>.generate(10, (index) => 49152 + index)),
+          ),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+        ),
+        throwsA(isA<PluginStartException>()),
+      );
+
+      expect(fakes.bindable.probedPorts, hasLength(5));
+      expect(fakes.spawn.spawnedPorts, isEmpty);
+      expect(fakes.processes.signalRequests, isEmpty);
+    });
+
+    test("fail-fast policy stops on a spawn error instead of retrying", () async {
+      fakes.bindable.byPort.addAll(<int, bool>{49152: true, 49153: true});
+      fakes.spawn.results.add(const ProcessException("opencode", <String>["serve"]));
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(
+            portPolicy: _dynamic(<int>[49152, 49153], failFastOnSpawnError: true),
+          ),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+        ),
+        throwsA(isA<ProcessException>()),
+      );
+
+      expect(fakes.spawn.spawnedPorts, equals(<int>[49152]));
+      expect(fakes.ownership.records, isEmpty);
+    });
+  });
+
+  group("ManagedProcessService.start (explicit port)", () {
+    late _Fakes fakes;
+
+    setUp(() {
+      fakes = _Fakes();
+    });
+
+    test("bypasses discovery but still retries health on the single port", () async {
+      fakes.spawn.results.add(_spawned(pid: 201, port: 4096));
+      fakes.probe.results.addAll(<RuntimeHealthProbe>[
+        for (var i = 0; i < 5; i += 1) const RuntimeHealthProbe(healthy: false, error: "not ready"),
+      ]);
+      fakes.processes.inspectResults[201] = <ProcessIdentity?>[
+        _runtimeIdentity(pid: 201, port: 4096),
+        null,
+        null,
+      ];
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 4096)),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+        ),
+        throwsA(isA<PluginStartException>()),
+      );
+
+      expect(fakes.bindable.probedPorts, isEmpty);
+      expect(fakes.spawn.spawnedPorts, equals(<int>[4096]));
+      expect(fakes.probe.probedPorts, equals(<int>[4096, 4096, 4096, 4096, 4096]));
+      expect(fakes.processes.signalRequests, equals(<String>["graceful:201"]));
+      expect(fakes.ownership.records, isEmpty);
+    });
+
+    test("propagates a raw spawn error without writing or signaling", () async {
+      fakes.spawn.results.add(StateError("bind failed"));
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 50128)),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+        ),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(fakes.bindable.probedPorts, isEmpty);
+      expect(fakes.spawn.spawnedPorts, equals(<int>[50128]));
+      expect(fakes.probe.probedPorts, isEmpty);
+      expect(fakes.processes.signalRequests, isEmpty);
+      expect(fakes.ownership.writeCallCount, equals(0));
+      expect(fakes.ownership.deleteCallCount, equals(0));
+      expect(fakes.ownership.records, isEmpty);
+    });
+
+    test("records starting then ready in order", () async {
+      fakes.spawn.results.add(_spawned(pid: 301, port: 50123));
+      fakes.probe.results.add(const RuntimeHealthProbe(healthy: true, version: "1.2.3"));
+
+      final handle = await fakes.service().start(
+        spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 50123)),
+        terminatedBridgeIdentities: const <ProcessIdentity>[],
+      );
+
+      expect(
+        fakes.ownership.upsertedStatuses,
+        equals(<_TestStatus>[_TestStatus.starting, _TestStatus.ready]),
+      );
+      expect(fakes.ownership.records.values.single.openCodePid, equals(301));
+      expect(handle.health.version, equals("1.2.3"));
+      expect(handle.identity!.pid, equals(301));
+    });
+
+    test("failed-start cleanup force-stops a surviving markerless child via host signals", () async {
+      final spawned = _spawned(pid: 212, port: 50130, startMarker: null, exitImmediately: false);
+      fakes.spawn.results.add(spawned);
+      fakes.probe.results.addAll(<RuntimeHealthProbe>[
+        for (var i = 0; i < 5; i += 1) const RuntimeHealthProbe(healthy: false, error: "not ready"),
+      ]);
+      fakes.processes.inspectResults[212] = <ProcessIdentity?>[null, null, null];
+      fakes.processes.forceHooks[212] = spawned.completeExit;
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 50130)),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+        ),
+        throwsA(isA<PluginStartException>()),
+      );
+
+      expect(fakes.processes.signalRequests, equals(<String>["graceful:212", "force:212"]));
+      expect(fakes.ownership.records, isEmpty);
+      expect(
+        fakes.clock.delays,
+        equals(<Duration>[
+          for (var i = 0; i < 5; i += 1) const Duration(milliseconds: 500),
+          _gracefulShutdownWait,
+        ]),
+      );
+    });
+
+    test("optional pre-probe rejects an unbindable explicit port without spawning", () async {
+      fakes.bindable.byPort[4096] = false;
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(
+            portPolicy: const ExplicitPortPolicy(port: 4096, preProbeBindable: true),
+          ),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+        ),
+        throwsA(isA<PluginStartException>()),
+      );
+
+      expect(fakes.bindable.probedPorts, equals(<int>[4096]));
+      expect(fakes.spawn.spawnedPorts, isEmpty);
+      expect(fakes.ownership.records, isEmpty);
+    });
+
+    test("optional pre-probe proceeds when the explicit port is bindable", () async {
+      fakes.bindable.byPort[4096] = true;
+      fakes.spawn.results.add(_spawned(pid: 501, port: 4096));
+      fakes.probe.results.add(const RuntimeHealthProbe(healthy: true));
+
+      final handle = await fakes.service().start(
+        spec: fakes.spec(
+          portPolicy: const ExplicitPortPolicy(port: 4096, preProbeBindable: true),
+        ),
+        terminatedBridgeIdentities: const <ProcessIdentity>[],
+      );
+
+      expect(fakes.bindable.probedPorts, equals(<int>[4096]));
+      expect(handle.port, equals(4096));
+      expect(fakes.ownership.records.values.single.status, equals(_TestStatus.ready));
+    });
+  });
+
+  group("ManagedProcessService.start (squatter defense & validation)", () {
+    late _Fakes fakes;
+
+    setUp(() {
+      fakes = _Fakes();
+    });
+
+    test("treats a child exit before the first healthy probe as authoritative failure", () async {
+      // Child exits immediately; the probe would report healthy, but it can
+      // only be an unrelated process holding the port.
+      fakes.spawn.results.add(_spawned(pid: 601, port: 50140, exitImmediately: true));
+      fakes.probe.results.add(const RuntimeHealthProbe(healthy: true));
+      fakes.processes.inspectResults[601] = <ProcessIdentity?>[null];
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(
+            portPolicy: const ExplicitPortPolicy(port: 50140),
+            failOnEarlyChildExit: true,
+          ),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+        ),
+        throwsA(isA<PluginStartException>()),
+      );
+
+      expect(fakes.probe.probedPorts, isEmpty);
+      expect(fakes.ownership.records, isEmpty);
+    });
+
+    test("a failing validateRuntime rolls back the start", () async {
+      fakes.spawn.results.add(_spawned(pid: 701, port: 50141));
+      fakes.probe.results.add(const RuntimeHealthProbe(healthy: true));
+      fakes.processes.inspectResults[701] = <ProcessIdentity?>[null];
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(
+            portPolicy: const ExplicitPortPolicy(port: 50141),
+            validateRuntime: ({required int port}) => Future<void>.error(StateError("bad version")),
+          ),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+        ),
+        throwsA(isA<PluginStartException>()),
+      );
+
+      expect(fakes.ownership.records, isEmpty);
+      expect(fakes.ownership.upsertedStatuses, equals(<_TestStatus>[_TestStatus.starting]));
+    });
+
+    test("rejects the not-yet-available intent side-file record timing", () async {
+      fakes.spawn.results.add(_spawned(pid: 801, port: 50142));
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(
+            portPolicy: const ExplicitPortPolicy(port: 50142),
+            recordTiming: RuntimeRecordTiming.intentSideFile,
+          ),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+        ),
+        throwsA(isA<UnsupportedError>()),
+      );
+
+      expect(fakes.spawn.spawnedPorts, isEmpty);
+      expect(fakes.ownership.records, isEmpty);
+    });
+  });
+
+  group("ManagedProcessService.start (deadline health policy)", () {
+    late _Fakes fakes;
+
+    setUp(() {
+      fakes = _Fakes(clock: _AdvancingServerClock());
+    });
+
+    test("polls until healthy before the deadline", () async {
+      fakes.spawn.results.add(_spawned(pid: 901, port: 50150));
+      fakes.probe.results.addAll(<RuntimeHealthProbe>[
+        const RuntimeHealthProbe(healthy: false, error: "warming up"),
+        const RuntimeHealthProbe(healthy: true),
+      ]);
+
+      final handle = await fakes.service().start(
+        spec: fakes.spec(
+          portPolicy: const ExplicitPortPolicy(port: 50150),
+          healthPolicy: const RuntimeHealthPolicy.deadline(
+            deadline: Duration(seconds: 5),
+            pollInterval: Duration(seconds: 1),
+          ),
+        ),
+        terminatedBridgeIdentities: const <ProcessIdentity>[],
+      );
+
+      expect(handle.port, equals(50150));
+      expect(fakes.probe.probedPorts, equals(<int>[50150, 50150]));
+      expect(fakes.ownership.records.values.single.status, equals(_TestStatus.ready));
+    });
+
+    test("fails once the deadline elapses", () async {
+      fakes.spawn.results.add(_spawned(pid: 902, port: 50151));
+      fakes.probe.results.addAll(<RuntimeHealthProbe>[
+        const RuntimeHealthProbe(healthy: false, error: "still down"),
+        const RuntimeHealthProbe(healthy: false, error: "still down"),
+      ]);
+      fakes.processes.inspectResults[902] = <ProcessIdentity?>[null];
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(
+            portPolicy: const ExplicitPortPolicy(port: 50151),
+            healthPolicy: const RuntimeHealthPolicy.deadline(
+              deadline: Duration(seconds: 2),
+              pollInterval: Duration(seconds: 1),
+            ),
+          ),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+        ),
+        throwsA(isA<PluginStartException>()),
+      );
+
+      expect(fakes.probe.probedPorts, equals(<int>[50151, 50151]));
+      expect(fakes.ownership.records, isEmpty);
+    });
+  });
+
+  group("ManagedProcessService.start (cooperative abort)", () {
+    late _Fakes fakes;
+
+    setUp(() {
+      fakes = _Fakes();
+    });
+
+    test("aborting before port selection throws without spawning", () async {
+      final controller = StartAbortController()..abort();
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(portPolicy: _dynamic(<int>[49152])),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+          startAborted: controller.signal,
+        ),
+        throwsA(isA<PluginStartAbortedException>()),
+      );
+
+      expect(fakes.spawn.spawnedPorts, isEmpty);
+      expect(fakes.bindable.probedPorts, isEmpty);
+    });
+
+    test("aborting after spawn rolls back the record and child", () async {
+      final controller = StartAbortController();
+      final spawned = _spawned(pid: 401, port: 50160, exitImmediately: true);
+      fakes.spawn.results.add(spawned);
+      fakes.spawn.onSpawn = controller.abort;
+      fakes.processes.inspectResults[401] = <ProcessIdentity?>[null];
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 50160)),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+          startAborted: controller.signal,
+        ),
+        throwsA(isA<PluginStartAbortedException>()),
+      );
+
+      expect(fakes.spawn.spawnedPorts, equals(<int>[50160]));
+      expect(fakes.ownership.upsertedStatuses, equals(<_TestStatus>[_TestStatus.starting]));
+      expect(fakes.ownership.records, isEmpty);
+    });
+
+    test("aborting during the health loop rolls back and never retries the next port", () async {
+      final controller = StartAbortController();
+      fakes.bindable.byPort.addAll(<int, bool>{49152: true, 49153: true});
+      final spawned = _spawned(pid: 111, port: 49152, exitImmediately: true);
+      fakes.spawn.results.add(spawned);
+      fakes.probe.results.add(const RuntimeHealthProbe(healthy: false, error: "warming up"));
+      fakes.probe.onProbe = controller.abort;
+      fakes.processes.inspectResults[111] = <ProcessIdentity?>[null];
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(portPolicy: _dynamic(<int>[49152, 49153])),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+          startAborted: controller.signal,
+        ),
+        throwsA(isA<PluginStartAbortedException>()),
+      );
+
+      expect(fakes.spawn.spawnedPorts, equals(<int>[49152]));
+      expect(fakes.probe.probedPorts, equals(<int>[49152]));
+      expect(fakes.ownership.records, isEmpty);
+    });
+
+    test("aborting after validation rolls back before marking ready", () async {
+      final controller = StartAbortController();
+      fakes.spawn.results.add(_spawned(pid: 121, port: 50161, exitImmediately: true));
+      fakes.probe.results.add(const RuntimeHealthProbe(healthy: true));
+      fakes.processes.inspectResults[121] = <ProcessIdentity?>[null];
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(
+            portPolicy: const ExplicitPortPolicy(port: 50161),
+            validateRuntime: ({required int port}) async => controller.abort(),
+          ),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+          startAborted: controller.signal,
+        ),
+        throwsA(isA<PluginStartAbortedException>()),
+      );
+
+      // The ready record is never written; the starting record is rolled back.
+      expect(fakes.ownership.upsertedStatuses, equals(<_TestStatus>[_TestStatus.starting]));
+      expect(fakes.ownership.records, isEmpty);
+    });
+  });
+
+  group("ManagedProcessService.attach", () {
+    late _Fakes fakes;
+
+    setUp(() {
+      fakes = _Fakes();
+    });
+
+    test("returns an un-owned handle when the existing server is healthy", () async {
+      fakes.probe.results.add(const RuntimeHealthProbe(healthy: true));
+
+      final handle = await fakes.service().attach(
+        spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 50125)),
+        port: 50125,
+      );
+
+      expect(handle.port, equals(50125));
+      expect(handle.isOwned, isFalse);
+      expect(handle.record, isNull);
+      expect(handle.process, isNull);
+      expect(handle.identity, isNull);
+      expect(fakes.probe.probedPorts, equals(<int>[50125]));
+      expect(fakes.spawn.spawnedPorts, isEmpty);
+      expect(fakes.ownership.writeCallCount, equals(0));
+      expect(fakes.ownership.deleteCallCount, equals(0));
+      expect(fakes.processes.signalRequests, isEmpty);
+    });
+
+    test("fails without ownership or signals when the existing server is unreachable", () async {
+      fakes.probe.results.add(const RuntimeHealthProbe(healthy: false, error: "connection refused"));
+
+      await expectLater(
+        fakes.service().attach(
+          spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 50126)),
+          port: 50126,
+        ),
+        throwsA(isA<PluginStartException>()),
+      );
+
+      expect(fakes.probe.probedPorts, equals(<int>[50126]));
+      expect(fakes.spawn.spawnedPorts, isEmpty);
+      expect(fakes.ownership.writeCallCount, equals(0));
+      expect(fakes.ownership.deleteCallCount, equals(0));
+      expect(fakes.processes.signalRequests, isEmpty);
+    });
+
+    test("treats a thrown probe as an unreachable server", () async {
+      fakes.probe.throwError = Exception("connection refused");
+
+      await expectLater(
+        fakes.service().attach(
+          spec: fakes.spec(portPolicy: const ExplicitPortPolicy(port: 50127)),
+          port: 50127,
+        ),
+        throwsA(isA<PluginStartException>()),
+      );
+
+      expect(fakes.probe.probedPorts, equals(<int>[50127]));
+      expect(fakes.ownership.writeCallCount, equals(0));
+      expect(fakes.processes.signalRequests, isEmpty);
+    });
+  });
+}
+
+RuntimePortPolicy _dynamic(List<int> candidates, {bool failFastOnSpawnError = false}) {
+  return RuntimePortPolicy.dynamic(
+    candidates: candidates,
+    maxAttempts: 5,
+    reservedPort: 4096,
+    minPort: 49152,
+    maxPort: 65535,
+    failFastOnSpawnError: failFastOnSpawnError,
+  );
+}
+
+_FakeSpawnedProcess _spawned({
+  required int pid,
+  required int port,
+  String? startMarker = "open-start",
+  bool exitImmediately = true,
+}) {
+  return _FakeSpawnedProcess(
+    identity: _runtimeIdentity(pid: pid, port: port, startMarker: startMarker),
+    exitImmediately: exitImmediately,
+  );
+}
+
+ProcessIdentity _runtimeIdentity({required int pid, required int port, String? startMarker = "open-start"}) {
+  return ProcessIdentity(
+    pid: pid,
+    startMarker: startMarker,
+    executablePath: "/usr/local/bin/opencode",
+    commandLine: "/usr/local/bin/opencode serve --port $port --hostname 127.0.0.1",
+    ownerUser: ProcessUser.fromRawUser("alex"),
+    platform: "macos",
+    capturedAt: DateTime.utc(2026, 5, 15, 12),
+  );
+}
+
+_TestRecord _buildRecord(RuntimeRecordDraft draft) {
+  return _TestRecord(
+    ownerSessionId: draft.ownerSessionId,
+    openCodePid: draft.runtimeIdentity.pid,
+    openCodeStartMarker: draft.runtimeIdentity.startMarker,
+    openCodeExecutablePath: draft.runtimeIdentity.executablePath ?? "",
+    openCodeCommand: draft.runtimeIdentity.executablePath ?? "opencode",
+    openCodeArgs: <String>["serve", "--port", "${draft.port}", "--hostname", "127.0.0.1"],
+    port: draft.port,
+    bridgePid: draft.bridgeIdentity.pid,
+    bridgeStartMarker: draft.bridgeIdentity.startMarker,
+    startedAt: draft.startedAt,
+    status: _TestStatus.starting,
+  );
+}
+
+class _Fakes {
+  _Fakes({_RecordingClock? clock}) : clock = clock ?? _FakeServerClock();
+
+  final _FakeOwnershipRepository ownership = _FakeOwnershipRepository();
+  final _FakeHostProcessService processes = _FakeHostProcessService();
+  final _FakeBridgeHostInfo bridge = _FakeBridgeHostInfo(
+    identity: ProcessIdentity(
+      pid: 900,
+      startMarker: "bridge-start",
+      executablePath: "/usr/local/bin/sesori-bridge",
+      commandLine: "sesori-bridge",
+      ownerUser: ProcessUser.fromRawUser("alex"),
+      platform: "macos",
+      capturedAt: DateTime.utc(2026, 5, 15, 12),
+    ),
+  );
+  final _RecordingClock clock;
+  final _SpawnPlan spawn = _SpawnPlan();
+  final _ProbePlan probe = _ProbePlan();
+  final _BindablePlan bindable = _BindablePlan();
+
+  ManagedProcessService<_TestRecord> service() {
+    return ManagedProcessService<_TestRecord>(
+      ownershipRepository: ownership,
+      mapper: const _TestRecordMapper(),
+      processes: processes,
+      bridge: bridge,
+      clock: clock,
+      runtimeId: "OPENCODE",
+      gracefulShutdownWait: _gracefulShutdownWait,
+    );
+  }
+
+  ManagedRuntimeSpec<_TestRecord> spec({
+    required RuntimePortPolicy portPolicy,
+    RuntimeHealthPolicy healthPolicy = _legacyHealthPolicy,
+    RuntimeRecordTiming recordTiming = RuntimeRecordTiming.afterSpawn,
+    Future<void> Function({required int port})? validateRuntime,
+    bool failOnEarlyChildExit = false,
+  }) {
+    return ManagedRuntimeSpec<_TestRecord>(
+      spawn: spawn.spawn,
+      probeHealth: probe.probe,
+      probePortBindable: bindable.bindable,
+      buildRecord: _buildRecord,
+      portPolicy: portPolicy,
+      healthPolicy: healthPolicy,
+      recordTiming: recordTiming,
+      validateRuntime: validateRuntime,
+      failOnEarlyChildExit: failOnEarlyChildExit,
+    );
+  }
+}
+
+class _SpawnPlan {
+  final List<Object> results = <Object>[];
+  final List<int> spawnedPorts = <int>[];
+  void Function()? onSpawn;
+
+  Future<SpawnedProcess> spawn({required int port}) async {
+    spawnedPorts.add(port);
+    onSpawn?.call();
+    final result = results.removeAt(0);
+    if (result is SpawnedProcess) {
+      return result;
+    }
+    throw result;
+  }
+}
+
+class _ProbePlan {
+  final List<RuntimeHealthProbe> results = <RuntimeHealthProbe>[];
+  final List<int> probedPorts = <int>[];
+  void Function()? onProbe;
+  Object? throwError;
+
+  Future<RuntimeHealthProbe> probe({required int port}) async {
+    probedPorts.add(port);
+    onProbe?.call();
+    final error = throwError;
+    if (error != null) {
+      throw error;
+    }
+    if (results.isEmpty) {
+      return const RuntimeHealthProbe(healthy: false, error: "no probe configured");
+    }
+    return results.removeAt(0);
+  }
+}
+
+class _BindablePlan {
+  final Map<int, bool> byPort = <int, bool>{};
+  final List<int> probedPorts = <int>[];
+
+  Future<bool> bindable({required int port}) async {
+    probedPorts.add(port);
+    final value = byPort[port];
+    if (value == null) {
+      throw StateError("No bindability configured for $port");
+    }
+    return value;
+  }
+}
+
+enum _TestStatus { starting, ready, stopping }
+
+class _TestRecord {
+  const _TestRecord({
+    required this.ownerSessionId,
+    required this.openCodePid,
+    required this.openCodeStartMarker,
+    required this.openCodeExecutablePath,
+    required this.openCodeCommand,
+    required this.openCodeArgs,
+    required this.port,
+    required this.bridgePid,
+    required this.bridgeStartMarker,
+    required this.startedAt,
+    required this.status,
+  });
+
+  final String ownerSessionId;
+  final int openCodePid;
+  final String? openCodeStartMarker;
+  final String openCodeExecutablePath;
+  final String openCodeCommand;
+  final List<String> openCodeArgs;
+  final int port;
+  final int bridgePid;
+  final String? bridgeStartMarker;
+  final DateTime startedAt;
+  final _TestStatus status;
+
+  _TestRecord copyWith({required _TestStatus status}) {
+    return _TestRecord(
+      ownerSessionId: ownerSessionId,
+      openCodePid: openCodePid,
+      openCodeStartMarker: openCodeStartMarker,
+      openCodeExecutablePath: openCodeExecutablePath,
+      openCodeCommand: openCodeCommand,
+      openCodeArgs: openCodeArgs,
+      port: port,
+      bridgePid: bridgePid,
+      bridgeStartMarker: bridgeStartMarker,
+      startedAt: startedAt,
+      status: status,
+    );
+  }
+}
+
+class _TestRecordMapper implements RuntimeRecordMapper<_TestRecord> {
+  const _TestRecordMapper();
+
+  @override
+  Map<String, dynamic> toJson({required _TestRecord record}) => throw UnimplementedError();
+
+  @override
+  _TestRecord fromJson({required Map<String, dynamic> json}) => throw UnimplementedError();
+
+  @override
+  String ownerSessionIdOf({required _TestRecord record}) => record.ownerSessionId;
+
+  @override
+  int runtimePidOf({required _TestRecord record}) => record.openCodePid;
+
+  @override
+  String? runtimeStartMarkerOf({required _TestRecord record}) => record.openCodeStartMarker;
+
+  @override
+  String? runtimeExecutablePathOf({required _TestRecord record}) => record.openCodeExecutablePath;
+
+  @override
+  String runtimeCommandLineOf({required _TestRecord record}) {
+    return <String>[record.openCodeCommand, ...record.openCodeArgs].join(" ");
+  }
+
+  @override
+  int bridgePidOf({required _TestRecord record}) => record.bridgePid;
+
+  @override
+  String? bridgeStartMarkerOf({required _TestRecord record}) => record.bridgeStartMarker;
+
+  @override
+  _TestRecord markReady({required _TestRecord record}) => record.copyWith(status: _TestStatus.ready);
+
+  @override
+  _TestRecord markStopping({required _TestRecord record}) => record.copyWith(status: _TestStatus.stopping);
+}
+
+class _FakeOwnershipRepository implements RuntimeOwnershipRepository<_TestRecord> {
+  final Map<String, _TestRecord> records = <String, _TestRecord>{};
+  final List<_TestStatus> upsertedStatuses = <_TestStatus>[];
+  int writeCallCount = 0;
+  int deleteCallCount = 0;
+
+  @override
+  Future<void> deleteByOwnerSessionId({required String ownerSessionId}) async {
+    deleteCallCount += 1;
+    records.remove(ownerSessionId);
+  }
+
+  @override
+  Future<List<_TestRecord>> readAll() async => records.values.toList(growable: false);
+
+  @override
+  Future<_TestRecord?> readByOwnerSessionId({required String ownerSessionId}) async => records[ownerSessionId];
+
+  @override
+  Future<void> upsert({required _TestRecord record}) async {
+    writeCallCount += 1;
+    records[record.ownerSessionId] = record;
+    upsertedStatuses.add(record.status);
+  }
+}
+
+class _FakeHostProcessService implements HostProcessService {
+  final Map<int, List<ProcessIdentity?>> inspectResults = <int, List<ProcessIdentity?>>{};
+  final Map<int, void Function()> gracefulHooks = <int, void Function()>{};
+  final Map<int, void Function()> forceHooks = <int, void Function()>{};
+  final List<String> signalRequests = <String>[];
+
+  @override
+  Future<ProcessIdentity?> inspect({required int pid}) async {
+    final results = inspectResults[pid];
+    if (results == null || results.isEmpty) {
+      return null;
+    }
+    return results.removeAt(0);
+  }
+
+  @override
+  Future<List<ProcessIdentity>> list({required int? excludePid}) async => const <ProcessIdentity>[];
+
+  @override
+  Future<SignalResult> signalForce({required int pid}) async {
+    signalRequests.add("force:$pid");
+    forceHooks[pid]?.call();
+    return _signal(pid: pid, signal: ShutdownSignal.force);
+  }
+
+  @override
+  Future<SignalResult> signalGraceful({required int pid}) async {
+    signalRequests.add("graceful:$pid");
+    gracefulHooks[pid]?.call();
+    return _signal(pid: pid, signal: ShutdownSignal.graceful);
+  }
+
+  @override
+  Future<SpawnedProcess> spawn({
+    required String executable,
+    required List<String> arguments,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+    required bool runInShell,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  SignalResult _signal({required int pid, required ShutdownSignal signal}) {
+    return SignalResult(
+      pid: pid,
+      requestedSignal: signal,
+      deliveredSignal: signal == ShutdownSignal.graceful ? ProcessSignal.sigterm : ProcessSignal.sigkill,
+      wasRequested: true,
+      attemptedAt: DateTime.utc(2026, 5, 15, 12),
+    );
+  }
+}
+
+class _FakeBridgeHostInfo implements BridgeHostInfo {
+  _FakeBridgeHostInfo({required ProcessIdentity identity}) : _identity = identity;
+
+  final ProcessIdentity _identity;
+  final Map<int, List<bool>> liveBridgeResults = <int, List<bool>>{};
+
+  @override
+  ProcessIdentity get identity => _identity;
+
+  @override
+  String get ownerSessionId => "current-owner";
+
+  @override
+  Future<bool> isLiveBridgeProcess({required int pid, required String? startMarker}) async {
+    final results = liveBridgeResults[pid];
+    if (results == null || results.isEmpty) {
+      return false;
+    }
+    return results.removeAt(0);
+  }
+}
+
+abstract interface class _RecordingClock implements ServerClock {
+  List<Duration> get delays;
+}
+
+class _FakeServerClock implements _RecordingClock {
+  @override
+  final List<Duration> delays = <Duration>[];
+
+  @override
+  Future<void> delay({required Duration duration}) async {
+    delays.add(duration);
+  }
+
+  @override
+  DateTime now() => DateTime.utc(2026, 5, 15, 12, 30);
+}
+
+class _AdvancingServerClock implements _RecordingClock {
+  _AdvancingServerClock({DateTime? start}) : _now = start ?? DateTime.utc(2026, 5, 15, 12);
+
+  DateTime _now;
+
+  @override
+  final List<Duration> delays = <Duration>[];
+
+  @override
+  Future<void> delay({required Duration duration}) async {
+    delays.add(duration);
+    _now = _now.add(duration);
+  }
+
+  @override
+  DateTime now() => _now;
+}
+
+class _FakeSpawnedProcess implements SpawnedProcess {
+  _FakeSpawnedProcess({required ProcessIdentity identity, required bool exitImmediately}) : _identity = identity {
+    if (exitImmediately) {
+      _exitCodeCompleter.complete(0);
+    }
+  }
+
+  final ProcessIdentity _identity;
+  final Completer<int> _exitCodeCompleter = Completer<int>();
+
+  @override
+  Future<int> get exitCode => _exitCodeCompleter.future;
+
+  @override
+  ProcessIdentity get identity => _identity;
+
+  @override
+  int get pid => _identity.pid;
+
+  @override
+  IOSink get stdin => throw UnimplementedError();
+
+  @override
+  Stream<List<int>> get stderr => Stream<List<int>>.value(utf8.encode(""));
+
+  @override
+  Stream<List<int>> get stdout => Stream<List<int>>.value(utf8.encode(""));
+
+  void completeExit([int code = 0]) {
+    if (!_exitCodeCompleter.isCompleted) {
+      _exitCodeCompleter.complete(code);
+    }
+  }
+}

--- a/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
@@ -564,6 +564,27 @@ void main() {
       expect(fakes.ownership.records, isEmpty);
     });
 
+    test("aborting settles as an abort even when the remaining candidates are all invalid", () async {
+      // The first candidate's spawn aborts the start and fails; every later
+      // candidate is the reserved port, so the loop would otherwise skip them
+      // all and end as a generic exhaustion failure instead of an abort.
+      final controller = StartAbortController();
+      fakes.bindable.byPort[49152] = true;
+      fakes.spawn.results.add(StateError("bind race"));
+      fakes.spawn.onSpawn = controller.abort;
+
+      await expectLater(
+        fakes.service().start(
+          spec: fakes.spec(portPolicy: _dynamic(<int>[49152, 4096, 4096, 4096])),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+          startAborted: controller.signal,
+        ),
+        throwsA(isA<PluginStartAbortedException>()),
+      );
+
+      expect(fakes.spawn.spawnedPorts, equals(<int>[49152]));
+    });
+
     test("aborting after validation rolls back before marking ready", () async {
       final controller = StartAbortController();
       fakes.spawn.results.add(_spawned(pid: 121, port: 50161, exitImmediately: true));

--- a/bridge/sesori_plugin_runtime/test/managed_process_service_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_process_service_test.dart
@@ -480,6 +480,23 @@ class _TestRecordMapper implements RuntimeRecordMapper<_TestRecord> {
   String? bridgeStartMarkerOf({required _TestRecord record}) => record.bridgeStartMarker;
 
   @override
+  _TestRecord markReady({required _TestRecord record}) {
+    return _TestRecord(
+      ownerSessionId: record.ownerSessionId,
+      openCodePid: record.openCodePid,
+      openCodeStartMarker: record.openCodeStartMarker,
+      openCodeExecutablePath: record.openCodeExecutablePath,
+      openCodeCommand: record.openCodeCommand,
+      openCodeArgs: record.openCodeArgs,
+      port: record.port,
+      bridgePid: record.bridgePid,
+      bridgeStartMarker: record.bridgeStartMarker,
+      startedAt: record.startedAt,
+      status: _TestStatus.ready,
+    );
+  }
+
+  @override
   _TestRecord markStopping({required _TestRecord record}) {
     return _TestRecord(
       ownerSessionId: record.ownerSessionId,


### PR DESCRIPTION
## Migration PR 8/15 — Supervisor start / attach with legacy-default policy knobs

Part of the [plugin lifecycle migration](docs/plans/plugin-lifecycle-migration.html). Builds directly on PR 7 (#236). **Package code only — no production consumer is wired up yet.**

PR 7 extracted the *stale cleanup* and *stop* halves of the managed-runtime skeleton into `sesori_plugin_runtime`. PR 8 adds the **start path**: `ManagedProcessService<R>` now owns `start()` and `attach()`, driven by a new `ManagedRuntimeSpec` contract. Everything defaults to the exact legacy `OpenCodeServerService` behavior so PR 10's fidelity gate (running the unmodified 1.2k-line legacy suite against this code) can hold.

### What's here

**New contract — `managed_runtime_spec.dart`**
- `ManagedRuntimeSpec<R>`: the start seams as closures (`spawn` / `probeHealth` / `probePortBindable`), a `buildRecord` factory, and the policy knobs.
- **Two named knobs, both defaulting to legacy:**
  - `healthPolicy`: `attemptCount(n, delay)` (legacy: 5 × 500 ms) **or** `deadline(d, pollInterval)` (the new default at the flip).
  - `recordTiming`: `afterSpawn` (legacy) **or** `intentSideFile` (reserved for PR 9 — rejected with a clear error until then).
- `ManagedRuntimeHandle<R>` (owned-vs-attached), `RuntimeHealthProbe` (`{healthy, version, detail, error}`), `RuntimeRecordDraft`, sealed `RuntimePortPolicy` / `RuntimeHealthPolicy`.

**`start()` / `attach()` on `ManagedProcessService<R>`** (reuses PR 7's `_stopRecord`, the tracking map, and `cleanupStaleOwnedRuntimes`)
- Explicit + dynamic port paths reproducing the legacy observables: reserved-port filtering, the candidate-attempt cap, retry-on-spawn-race, raw spawn-error propagation on the explicit path vs wrapped on the dynamic path, and the `starting` → `ready` upsert ordering.
- The supervisor **never re-inspects** the spawn identity — the spawn seam owns identity capture (a legacy adapter does it in PR 10, the host does it in PR 11).
- **Cooperative abort** honored at every phase boundary (after cleanup, after spawn, before each health probe, after validation): rolls back everything acquired via host signals and settles with `PluginStartAbortedException`; the dynamic loop never retries on abort.
- Rollback always goes through host signals (`signalGraceful` / `signalForce`), never a child kill.
- Hardened behaviors, all **default-off** so legacy fidelity holds: explicit port pre-probe, `failFastOnSpawnError`, and `failOnEarlyChildExit` (squatter defense — a healthy probe after our child died means an unrelated process holds the port).
- `attach()` (the `--no-auto-start` path): a single tolerant probe, no ownership, no kill.
- `markReady` added to `RuntimeRecordMapper`, symmetric with `markStopping`.

**Deliberately deferred to PR 9:** restart, exit monitoring, port pinning, and the intent side file.

### Verification
- `dart analyze --fatal-infos`: clean across `sesori_plugin_runtime`, `app`, `opencode`.
- `dart test` (runtime): all green, including the ported start/attach/port/health scenarios plus new tests for abort, the deadline policy, validation failure, the squatter defense, and the intent-side-file guard.
- No production consumer; the frozen `opencode-processes.json` contract is untouched.
- Diff: ~1,540 lines, within the plan's ~1,200–1,600 budget for this rung.
- An adversarial multi-lens review (legacy fidelity / contract design / correctness / budget) surfaced two contract-consistency gaps — a missing abort check between `validateRuntime` and `markReady`, and `attach()` not tolerating a thrown probe — both fixed and covered by tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds supervisor start and attach flows to `sesori_plugin_runtime` via `ManagedProcessService<R>` and a new `ManagedRuntimeSpec`, preserving legacy defaults while enabling policy-driven behavior. Package code only; no production wiring yet.

- **New Features**
  - `ManagedRuntimeSpec<R>`: spawn/probe closures, `buildRecord`, and policy knobs — `healthPolicy` (attemptCount 5×500ms or deadline) and `recordTiming` (afterSpawn; intentSideFile rejected upfront for now).
  - `start()`: explicit/dynamic ports with reserved-port filtering, attempt cap, retry-on-spawn-race, and starting → ready upsert; identity is trusted from spawn.
  - Cooperative abort at phase boundaries with rollback via host signals; no retries after abort.
  - Hardened opts (default off): explicit pre-probe, `failFastOnSpawnError`, `failOnEarlyChildExit` (squatter defense).
  - `attach()`: single tolerant health probe; returns unowned handle.
  - `RuntimeRecordMapper.markReady` to finalize the record after the first healthy probe.

- **Bug Fixes**
  - `start()`: if `buildRecord` throws after spawn, stop the orphaned child via host signals so a started runtime never leaks.
  - `attach()`: if aborted while the probe is in flight, do not return a handle.
  - Dynamic start: count every candidate toward `maxAttempts`, skip reserved/out-of-range inside the loop, and honor abort on every iteration (including invalid candidates) so cancellation surfaces as `PluginStartAbortedException`.
  - Failed start: cleanup errors are logged and never mask the original failure.
  - `HealthDeadlinePolicy`: validates non-negative `deadline` and positive `pollInterval`.

<sup>Written for commit fb8d65ed3e3961c68a38a1aa95132a64cb9dd97f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

