### PR TITLE
fix(mobile): present split-view snackbars across both panes and stop stale-context breakage

### DIFF
--- a/mobile/app/lib/core/widgets/session_split/session_split_shell.dart
+++ b/mobile/app/lib/core/widgets/session_split/session_split_shell.dart
@@ -30,30 +30,38 @@ class SessionSplitShell extends StatelessWidget {
 
         final listWidth = (constraints.maxWidth * maxListPanelRatio).clamp(minListPanelWidth, maxListPanelWidth);
 
-        return Row(
-          children: [
-            SizedBox(
-              key: const Key("session-split-left-pane"),
-              width: listWidth,
-              child: Material(
-                color: Theme.of(context).scaffoldBackgroundColor,
-                child: SafeArea(
-                  child: list,
+        // The shell-level Scaffold is the single root Scaffold registered
+        // with the root ScaffoldMessenger in split mode. Snackbars therefore
+        // present once, spanning both panes, instead of attaching to the
+        // right pane's transient route Scaffolds (which also breaks when a
+        // snackbar is shown mid pane-transition).
+        return Scaffold(
+          key: const Key("session-split-scaffold"),
+          body: Row(
+            children: [
+              SizedBox(
+                key: const Key("session-split-left-pane"),
+                width: listWidth,
+                child: Material(
+                  color: Theme.of(context).scaffoldBackgroundColor,
+                  child: SafeArea(
+                    child: list,
+                  ),
                 ),
               ),
-            ),
-            const VerticalDivider(
-              key: Key("session-split-divider"),
-              width: 1,
-            ),
-            Expanded(
-              key: const Key("session-split-right-pane"),
-              child: SessionSplitScope(
-                isSplit: true,
-                child: child,
+              const VerticalDivider(
+                key: Key("session-split-divider"),
+                width: 1,
               ),
-            ),
-          ],
+              Expanded(
+                key: const Key("session-split-right-pane"),
+                child: SessionSplitScope(
+                  isSplit: true,
+                  child: child,
+                ),
+              ),
+            ],
+          ),
         );
       },
     );

--- a/mobile/app/lib/features/new_session/new_session_screen.dart
+++ b/mobile/app/lib/features/new_session/new_session_screen.dart
@@ -147,11 +147,22 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
     final loc = context.loc;
     final zyra = context.zyra;
     final isSending = state is NewSessionSending;
+    // Captured at build time: the pop callback below runs while this route is
+    // being torn down, where an ancestor lookup on a deactivated context
+    // throws. The root messenger outlives this route, so the reference stays
+    // valid.
+    final scaffoldMessenger = ScaffoldMessenger.of(context);
 
     return BlocListener<NewSessionCubit, NewSessionState>(
       listenWhen: (_, current) => current is NewSessionCreated,
       listener: (context, state) {
         if (state case NewSessionCreated(:final session)) {
+          // The user may have navigated elsewhere (e.g. opened another
+          // session from the split-view list) while creation was in flight.
+          // Replacing the route then would hijack their navigation — the
+          // pop-time snackbar already told them the session continues.
+          final modalRoute = ModalRoute.of(context);
+          if (modalRoute != null && !modalRoute.isCurrent) return;
           _navigatingToCreatedSession = true;
           context.replaceRoute(
             AppRoute.sessionDetail(
@@ -168,7 +179,7 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
         canPop: true,
         onPopInvokedWithResult: (didPop, result) {
           if (didPop && isSending && !_navigatingToCreatedSession) {
-            ScaffoldMessenger.of(context).showSnackBar(
+            scaffoldMessenger.showSnackBar(
               SnackBar(
                 content: Text(loc.newSessionLaunchingInBackground),
                 duration: const Duration(seconds: 3),

--- a/mobile/app/lib/features/new_session/new_session_screen.dart
+++ b/mobile/app/lib/features/new_session/new_session_screen.dart
@@ -147,11 +147,13 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
     final loc = context.loc;
     final zyra = context.zyra;
     final isSending = state is NewSessionSending;
-    // Captured at build time: the pop callback below runs while this route is
+    // Captured at build time: the callbacks below can run while this route is
     // being torn down, where an ancestor lookup on a deactivated context
-    // throws. The root messenger outlives this route, so the reference stays
-    // valid.
+    // throws. Both references stay valid — the root messenger outlives this
+    // route, and the route object is stable (`isCurrent` is still read at
+    // event time).
     final scaffoldMessenger = ScaffoldMessenger.of(context);
+    final modalRoute = ModalRoute.of(context);
 
     return BlocListener<NewSessionCubit, NewSessionState>(
       listenWhen: (_, current) => current is NewSessionCreated,
@@ -161,7 +163,6 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
           // session from the split-view list) while creation was in flight.
           // Replacing the route then would hijack their navigation — the
           // pop-time snackbar already told them the session continues.
-          final modalRoute = ModalRoute.of(context);
           if (modalRoute != null && !modalRoute.isCurrent) return;
           _navigatingToCreatedSession = true;
           context.replaceRoute(

--- a/mobile/app/test/core/widgets/session_split/session_split_shell_test.dart
+++ b/mobile/app/test/core/widgets/session_split/session_split_shell_test.dart
@@ -103,6 +103,43 @@ void main() {
       expect(leftPane.width, lessThanOrEqualTo(maxListPanelWidth));
     });
 
+    testWidgets("wide mode presents snackbars on the shell scaffold spanning both panes", (tester) async {
+      final harness = AdaptiveSessionRouterTestHarness();
+      await tester.binding.setSurfaceSize(const Size(1024, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      addTearDown(harness.tearDown);
+      await harness.setUp(
+        initialLocation: "/projects/p1/sessions",
+        currentRouteDef: AppRouteDef.sessions,
+        sessionsByProject: {
+          "p1": [adaptiveTestSession(projectId: "p1", id: "s1", title: "Session One")],
+        },
+      );
+
+      await tester.pumpWidget(harness.buildApp());
+      await tester.pumpAndSettle();
+
+      // Trigger a snackbar from a left-pane context, like the "session
+      // deleted" snackbar shown after deleting a session from the list.
+      final leftPaneContext = tester.element(find.text("Session One"));
+      ScaffoldMessenger.of(leftPaneContext).showSnackBar(
+        const SnackBar(content: Text("Session deleted")),
+      );
+      await tester.pumpAndSettle();
+
+      // Exactly one snackbar, attached to the shell scaffold — spanning the
+      // full shell width instead of being confined to the right pane.
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(
+        find.ancestor(
+          of: find.byType(SnackBar),
+          matching: find.byKey(const Key("session-split-scaffold")),
+        ),
+        findsOneWidget,
+      );
+      expect(tester.getSize(find.byType(SnackBar)).width, 1024);
+    });
+
     testWidgets("wide to narrow resize preserves the same SessionListCubit instance", (tester) async {
       final harness = AdaptiveSessionRouterTestHarness();
       await tester.binding.setSurfaceSize(const Size(1024, 800));

--- a/mobile/app/test/features/new_session/new_session_screen_test.dart
+++ b/mobile/app/test/features/new_session/new_session_screen_test.dart
@@ -349,6 +349,48 @@ void main() {
     expect(find.byType(NewSessionScreen), findsNothing);
   });
 
+  testWidgets("does not hijack navigation when creation completes after the user navigated away", (tester) async {
+    final createCompleter = Completer<ApiResponse<Session>>();
+    when(
+      () => sessionService.createSessionWithMessage(
+        projectId: any(named: "projectId"),
+        text: any(named: "text"),
+        agent: any(named: "agent"),
+        providerID: any(named: "providerID"),
+        modelID: any(named: "modelID"),
+        variant: any(named: "variant"),
+        command: any(named: "command"),
+        dedicatedWorktree: any(named: "dedicatedWorktree"),
+      ),
+    ).thenAnswer((_) => createCompleter.future);
+
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+
+    final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
+
+    await tester.enterText(find.byType(TextField), "test message");
+    await tester.tap(find.byIcon(Icons.send), warnIfMissed: false);
+    await tester.pump();
+
+    expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
+
+    // User leaves while the creation request is still in flight.
+    await tester.pageBack();
+    await tester.pump();
+    expect(find.text(loc.newSessionLaunchingInBackground), findsOneWidget);
+
+    // Creation completes while the screen is still animating out.
+    createCompleter.complete(ApiResponse.success(testSession(id: "session-1", title: "Created session")));
+    await tester.pumpAndSettle();
+
+    // The user's chosen location must be preserved — no redirect to the
+    // created session's detail route.
+    expect(find.text("session-detail:session-1"), findsNothing);
+    expect(find.byType(NewSessionScreen), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets("still navigates to session detail after creating a session", (tester) async {
     final createCompleter = Completer<ApiResponse<Session>>();
     when(


### PR DESCRIPTION
## Problem

Two split-view snackbar bugs:

1. **Snackbars always appeared inside the right panel.** In wide split mode only the right-pane route screens carry `Scaffold`s — the left list pane renders without one — so the root `ScaffoldMessenger` presented every snackbar in the right pane. Deleting a session from the **left** panel showed "session deleted" in the **right** panel.
2. **Big UI error when switching sessions during new-session creation.** Switching to an active session while a creation was in flight tears down the new-session pane route. Its `PopScope` callback looked up `ScaffoldMessenger.of(context)` on the dying route while two transitioning pane scaffolds were registered, breaking the snackbar presentation — and if creation completed during the transition, the `BlocListener` `replaceRoute()`d to the created session, hijacking the navigation the user had just chosen.

## Fix

- **`SessionSplitShell`**: the wide layout is now wrapped in a shell-level `Scaffold`. Flutter's `ScaffoldMessenger` only presents snackbars on *root* scaffolds (scaffolds without a registered ancestor), so the shell scaffold becomes the single presentation target in split mode: snackbars show once, **spanning both panes**, and no longer attach to transient pane scaffolds mid-transition. Narrow layout unchanged.
- **`NewSessionScreen`**:
  - captures the `ScaffoldMessenger` at build time and uses the captured reference in the `PopScope` pop callback (no ancestor lookup on a route being torn down);
  - guards the post-creation `replaceRoute()` with `ModalRoute.isCurrent` — if the user already navigated elsewhere, creation completion no longer hijacks their navigation (the pop-time "launching in background" snackbar already informs them).

## Tests

- `session_split_shell_test.dart`: snackbar triggered from a left-pane context renders exactly once, attached to the shell scaffold, spanning the full 1024px shell width.
- `new_session_screen_test.dart`: completing creation after the user popped away shows the snackbar, throws no exception, and does **not** redirect to the created session.

## Verification

- `dart analyze --fatal-infos` clean on all 4 mobile modules
- `flutter test` in `mobile/app`: 483 tests green
- aristotle-plan-review: APPROVED · aristotle-impl-review: APPROVED

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes split-view snackbars so they appear once across both panes and prevents errors or unwanted redirects when leaving the New Session screen during creation.

- **Bug Fixes**
  - SessionSplitShell: added a shell-level Scaffold in wide mode so the root ScaffoldMessenger shows snackbars once across both panes and not on transient pane scaffolds during transitions.
  - NewSessionScreen: captured the ScaffoldMessenger and ModalRoute at build for PopScope and isCurrent checks to avoid stale-context lookups; guarded post-creation navigation with isCurrent so it won’t hijack if the user navigated away.

<sup>Written for commit cfdb13a2617a9af07d0cd8d0bc39b6a11d5c7e45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

