### PR TITLE
fix(mobile): ignore API defaultModelID and pick newest model by date

### DIFF
--- a/.opencode/skills/address-pr-comments/SKILL.md
+++ b/.opencode/skills/address-pr-comments/SKILL.md
@@ -17,7 +17,9 @@ Addresses unresolved inline PR review comments by assessing their validity, impl
 6. **Extra scrutiny for AI/bot comments**: Comments from AI reviewers or bots require more careful assessment. They are more likely to be incorrect, irrelevant, or based on stale context.
 7. **Human comments are trusted by default**: Comments from actual humans should be assumed valid unless you have a strong reason to believe they are wrong, detrimental, or cause likely unintended side effects.
 8. **Single commit**: All fixes can be committed together in a single commit. The user squash-merges at the end.
-9. **Outdated comments**: If `is_outdated == true`, assess whether the comment is still relevant. If the issue still exists in the current code, address it. If not, reply explaining why it is no longer applicable.
+9. **Never amend**: Always create new commits when addressing feedback. Do not use `git commit --amend`, `git rebase` to rewrite published history, or any other history-rewriting operation. If you make a mistake in a commit, fix it with a follow-up commit rather than rewriting.
+10. **Never force push**: Do not use force push under any circumstances. If the remote branch has moved ahead of your local branch, pull/merge and continue with normal commits. History rewriting on a shared branch is forbidden.
+11. **Outdated comments**: If `is_outdated == true`, assess whether the comment is still relevant. If the issue still exists in the current code, address it. If not, reply explaining why it is no longer applicable.
 
 ## Workflow
 
@@ -122,7 +124,7 @@ git push origin <branch-name>
 
 **Important:** Always commit and push BEFORE posting replies. If you post "Addressed" before pushing, the fixes won't be visible to reviewers, making the replies misleading.
 
-**Important:** DO NOT use force push without explicit per-instance consent. Do not assume that you can use force push again just because the user allowed it previously.
+**Important:** Never rewrite history when addressing PR feedback. Do not amend commits and do not force push. If the remote branch has diverged, pull/merge normally and add new commits on top. The user squash-merges at the end, so a linear chain of fix commits is expected.
 
 **No changes to commit:** If all fetched comments were invalid, outdated, or questions requiring no code change, skip the commit and push steps. Proceed directly to posting replies.
 

--- a/.opencode/skills/address-pr-comments/SKILL.md
+++ b/.opencode/skills/address-pr-comments/SKILL.md
@@ -238,6 +238,10 @@ If the user explicitly asks you to look at resolved comments, omit the `--unreso
 - `pr-inline-comments` skill (for fetching comments)
 - Access to the repository working tree (to read and edit files)
 
+## Determining the PR Number
+
+If the user invokes this skill without an explicit PR number (e.g. "address the PR comments" or "review feedback"), assume they are referring to the most recently raised PR in the current session. Look at the recent conversation for the latest PR URL or number; if in doubt, ask the user to confirm before fetching comments.
+
 ## Example Session
 
 User: "Address the comments on PR 42"

--- a/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/new_session/new_session_cubit.dart
@@ -79,7 +79,6 @@ class NewSessionCubit extends Cubit<NewSessionState> {
         for (final provider in providers) {
           final picked = _defaultModelSelector.pickFromProvider(
             models: provider.models,
-            defaultModelId: provider.defaultModelID,
           );
           if (picked != null) {
             pickedModel = AgentModel(

--- a/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -1162,7 +1162,6 @@ class SessionDetailCubit extends Cubit<SessionDetailState> {
       for (final provider in providers) {
         final picked = _defaultModelSelector.pickFromProvider(
           models: provider.models,
-          defaultModelId: provider.defaultModelID,
         );
         if (picked != null) {
           pickedModel = AgentModel(

--- a/mobile/module_core/lib/src/utils/model_filter/default_model_selector.dart
+++ b/mobile/module_core/lib/src/utils/model_filter/default_model_selector.dart
@@ -34,16 +34,6 @@ class DefaultModelSelector {
   ProviderModel? pickFromFamily({required Iterable<ProviderModel> group}) {
     final list = group.where((m) => m.isAvailable).toList();
     if (list.isEmpty) return null;
-
-    // 1. Upstream "(latest)" name marker. Ties broken by newest release
-    //    date, then by `id` for determinism.
-    final latestMarked =
-        list.where((m) => m.name.toLowerCase().contains("(latest)")).toList();
-    if (latestMarked.isNotEmpty) {
-      return _bestModel(latestMarked);
-    }
-
-    // 2. Newest by releaseDate, then by `id` for determinism.
     return _bestModel(list);
   }
 

--- a/mobile/module_core/lib/src/utils/model_filter/default_model_selector.dart
+++ b/mobile/module_core/lib/src/utils/model_filter/default_model_selector.dart
@@ -6,18 +6,20 @@ import "package:sesori_shared/sesori_shared.dart";
 /// The selector uses only signals already present in the upstream data, so
 /// the same logic works for every provider without per-provider knowledge:
 ///
-/// 1. The provider's backend-supplied [ProviderInfo.defaultModelID], if it
-///    is available. This is the strongest signal — it is the provider's own
-///    "this is the default" answer.
-/// 2. Any model whose name contains the upstream " (latest)" marker.
+/// 1. Any model whose name contains the upstream " (latest)" marker.
 ///    OpenCode / models.dev uses this suffix to flag a model as the
 ///    recommended one in its family (e.g. `Claude Sonnet 4.5 (latest)`,
 ///    `Mistral Small (latest)`). The model picker already strips this
 ///    suffix from the display name, so it is a known convention worth
 ///    trusting.
-/// 3. The model with the most recent [ProviderModel.releaseDate]. Models
+/// 2. The model with the most recent [ProviderModel.releaseDate]. Models
 ///    without a release date sort last.
-/// 4. The first available model in iteration order.
+/// 3. The first available model in iteration order.
+///
+/// The provider's backend-supplied [ProviderInfo.defaultModelID] is
+/// intentionally ignored. It is a provider-wide default that is frequently
+/// stale (e.g. Kimi), and the family-level newest-by-date signal is a more
+/// reliable default for the picker.
 ///
 /// There is intentionally no "newer than X months" cutoff. Deprecated
 /// models are already filtered out by [ProviderModel.isAvailable] in
@@ -28,23 +30,12 @@ class DefaultModelSelector {
 
   /// Selects the default model for a single family of [ProviderModel]s.
   ///
-  /// [defaultModelId] is honored only when it identifies one of the
-  /// [group] members. Returns `null` only if [group] is empty.
-  ProviderModel? pickFromFamily({
-    required Iterable<ProviderModel> group,
-    required String? defaultModelId,
-  }) {
+  /// Returns `null` only if [group] is empty.
+  ProviderModel? pickFromFamily({required Iterable<ProviderModel> group}) {
     final list = group.where((m) => m.isAvailable).toList();
     if (list.isEmpty) return null;
 
-    // 1. Provider's backend default.
-    if (defaultModelId != null) {
-      for (final m in list) {
-        if (m.id == defaultModelId) return m;
-      }
-    }
-
-    // 2. Upstream "(latest)" name marker. Ties broken by newest release
+    // 1. Upstream "(latest)" name marker. Ties broken by newest release
     //    date, then by `id` for determinism.
     final latestMarked =
         list.where((m) => m.name.toLowerCase().contains("(latest)")).toList();
@@ -71,7 +62,7 @@ class DefaultModelSelector {
       return latestMarked.first;
     }
 
-    // 3. Newest by releaseDate, then by `id` for determinism. See note
+    // 2. Newest by releaseDate, then by `id` for determinism. See note
     //    above about the inline comparator.
     final sorted = [...list]..sort((a, b) {
         final dateA = a.releaseDate;
@@ -96,21 +87,11 @@ class DefaultModelSelector {
   ///
   /// Groups [models] by family, picks the best model per family using
   /// [pickFromFamily], then returns the best model of the alphabetically
-  /// first family. If [defaultModelId] is set and matches an available
-  /// model in [models], that model wins regardless of family order.
+  /// first family.
   ///
   /// Returns `null` if [models] contains no available models.
-  ProviderModel? pickFromProvider({
-    required Map<String, ProviderModel> models,
-    required String? defaultModelId,
-  }) {
-    // 1. Provider's backend default always wins.
-    if (defaultModelId != null) {
-      final m = models[defaultModelId];
-      if (m != null && m.isAvailable) return m;
-    }
-
-    // 2. Group by family, pick the best per family.
+  ProviderModel? pickFromProvider({required Map<String, ProviderModel> models}) {
+    // 1. Group by family, pick the best per family.
     final byFamily = <String, List<ProviderModel>>{};
     for (final m in models.values) {
       if (!m.isAvailable) continue;
@@ -119,12 +100,12 @@ class DefaultModelSelector {
     }
     if (byFamily.isEmpty) return null;
 
-    // 3. Use the alphabetically first family. Stable, deterministic, and
+    // 2. Use the alphabetically first family. Stable, deterministic, and
     //    independent of map iteration order so the same provider always
     //    picks the same default.
     final sortedKeys = byFamily.keys.toList()..sort();
     final firstGroup = byFamily[sortedKeys.first];
     if (firstGroup == null) return null;
-    return pickFromFamily(group: firstGroup, defaultModelId: defaultModelId);
+    return pickFromFamily(group: firstGroup);
   }
 }

--- a/mobile/module_core/lib/src/utils/model_filter/default_model_selector.dart
+++ b/mobile/module_core/lib/src/utils/model_filter/default_model_selector.dart
@@ -40,31 +40,56 @@ class DefaultModelSelector {
     final latestMarked =
         list.where((m) => m.name.toLowerCase().contains("(latest)")).toList();
     if (latestMarked.isNotEmpty) {
-      // `List.sort` requires a two-positional-arg comparator; the inline
-      // form avoids the `prefer_required_named_parameters` lint while
-      // keeping the same behavior as the closed-over helper.
-      latestMarked.sort((a, b) {
-        final dateA = a.releaseDate;
-        final dateB = b.releaseDate;
-        final int dateCompare;
-        if (dateB == null && dateA == null) {
-          dateCompare = 0;
-        } else if (dateB == null) {
-          dateCompare = -1;
-        } else if (dateA == null) {
-          dateCompare = 1;
-        } else {
-          dateCompare = dateB.compareTo(dateA);
-        }
-        if (dateCompare != 0) return dateCompare;
-        return a.id.compareTo(b.id);
-      });
-      return latestMarked.first;
+      return _bestModel(latestMarked);
     }
 
-    // 2. Newest by releaseDate, then by `id` for determinism. See note
-    //    above about the inline comparator.
-    final sorted = [...list]..sort((a, b) {
+    // 2. Newest by releaseDate, then by `id` for determinism.
+    return _bestModel(list);
+  }
+
+  /// Selects a single default model across an entire provider.
+  ///
+  /// Groups [models] by family, picks the best model per family using
+  /// [pickFromFamily], then returns the best of those representatives
+  /// using the same ranking ("(latest)" marker, then newest release date,
+  /// then `id`).
+  ///
+  /// Returns `null` if [models] contains no available models.
+  ProviderModel? pickFromProvider({required Map<String, ProviderModel> models}) {
+    // 1. Group by family, pick the best per family.
+    final byFamily = <String, List<ProviderModel>>{};
+    for (final m in models.values) {
+      if (!m.isAvailable) continue;
+      final family = m.family ?? m.id;
+      (byFamily[family] ??= []).add(m);
+    }
+    if (byFamily.isEmpty) return null;
+
+    // 2. Pick the best representative across all families using the same
+    //    ranking as `pickFromFamily`. This avoids defaulting to an
+    //    arbitrary alphabetically-first family when a newer model exists
+    //    in another family.
+    final representatives = byFamily.values
+        .map((group) => pickFromFamily(group: group))
+        .whereType<ProviderModel>()
+        .toList();
+    if (representatives.isEmpty) return null;
+    return _bestModel(representatives);
+  }
+
+  /// Returns the best model from [candidates] using the standard ranking:
+  /// "(latest)" marker wins, then newest release date, then id.
+  ///
+  /// [candidates] must be non-empty and contain only available models.
+  ProviderModel _bestModel(List<ProviderModel> candidates) {
+    assert(candidates.isNotEmpty, "_bestModel requires non-empty candidates");
+
+    // Prefer any model whose name contains the "(latest)" marker.
+    final latestMarked =
+        candidates.where((m) => m.name.toLowerCase().contains("(latest)")).toList();
+    final toSort = latestMarked.isNotEmpty ? latestMarked : candidates;
+
+    final sorted = [...toSort]..sort((a, b) {
         final dateA = a.releaseDate;
         final dateB = b.releaseDate;
         final int dateCompare;
@@ -81,31 +106,5 @@ class DefaultModelSelector {
         return a.id.compareTo(b.id);
       });
     return sorted.first;
-  }
-
-  /// Selects a single default model across an entire provider.
-  ///
-  /// Groups [models] by family, picks the best model per family using
-  /// [pickFromFamily], then returns the best model of the alphabetically
-  /// first family.
-  ///
-  /// Returns `null` if [models] contains no available models.
-  ProviderModel? pickFromProvider({required Map<String, ProviderModel> models}) {
-    // 1. Group by family, pick the best per family.
-    final byFamily = <String, List<ProviderModel>>{};
-    for (final m in models.values) {
-      if (!m.isAvailable) continue;
-      final family = m.family ?? m.id;
-      (byFamily[family] ??= []).add(m);
-    }
-    if (byFamily.isEmpty) return null;
-
-    // 2. Use the alphabetically first family. Stable, deterministic, and
-    //    independent of map iteration order so the same provider always
-    //    picks the same default.
-    final sortedKeys = byFamily.keys.toList()..sort();
-    final firstGroup = byFamily[sortedKeys.first];
-    if (firstGroup == null) return null;
-    return pickFromFamily(group: firstGroup);
   }
 }

--- a/mobile/module_core/lib/src/utils/model_filter/model_picker_section_builder.dart
+++ b/mobile/module_core/lib/src/utils/model_filter/model_picker_section_builder.dart
@@ -141,10 +141,7 @@ class ModelPickerSectionBuilder {
     }
 
     for (final group in byFamily.values) {
-      final chosen = _defaultModelSelector.pickFromFamily(
-        group: group,
-        defaultModelId: provider.defaultModelID,
-      );
+      final chosen = _defaultModelSelector.pickFromFamily(group: group);
       if (chosen != null) visible.add(chosen.id);
     }
 

--- a/mobile/module_core/test/utils/model_filter/default_model_selector_test.dart
+++ b/mobile/module_core/test/utils/model_filter/default_model_selector_test.dart
@@ -219,25 +219,68 @@ void main() {
     );
 
     test(
-      "uses the alphabetically first family when picking the provider default",
+      "picks the best representative across all families, not just the alphabetically first",
       () {
         final models = {
-          "zeta": _model(
-            id: "zeta",
-            name: "Zeta (latest)",
-            family: "zeta-family",
-            releaseDate: DateTime(2020, 1),
-          ),
           "alpha": _model(
             id: "alpha",
             name: "Alpha",
             family: "alpha-family",
             releaseDate: DateTime(2025, 1),
           ),
+          "zeta-newer": _model(
+            id: "zeta-newer",
+            name: "Zeta Newer",
+            family: "zeta-family",
+            releaseDate: DateTime(2026, 4),
+          ),
         };
         final picked = selector.pickFromProvider(models: models);
-        // alpha-family is alphabetically first, so alpha wins even though
-        // zeta is marked "(latest)".
+        // zeta-family is alphabetically later but has the newer model.
+        expect(picked?.id, "zeta-newer");
+      },
+    );
+
+    test(
+      "prefers a '(latest)' marker in any family over a newer date in another family",
+      () {
+        final models = {
+          "newer-plain": _model(
+            id: "newer-plain",
+            name: "Newer Plain",
+            family: "plain-family",
+            releaseDate: DateTime(2026, 4),
+          ),
+          "marked-older": _model(
+            id: "marked-older",
+            name: "Marked Older (latest)",
+            family: "marked-family",
+            releaseDate: DateTime(2025, 1),
+          ),
+        };
+        final picked = selector.pickFromProvider(models: models);
+        expect(picked?.id, "marked-older");
+      },
+    );
+
+    test(
+      "breaks cross-family ties deterministically by id when dates are equal",
+      () {
+        final models = {
+          "zebra": _model(
+            id: "zebra",
+            name: "Zeta",
+            family: "zeta-family",
+            releaseDate: DateTime(2026, 4),
+          ),
+          "alpha": _model(
+            id: "alpha",
+            name: "Alpha",
+            family: "alpha-family",
+            releaseDate: DateTime(2026, 4),
+          ),
+        };
+        final picked = selector.pickFromProvider(models: models);
         expect(picked?.id, "alpha");
       },
     );

--- a/mobile/module_core/test/utils/model_filter/default_model_selector_test.dart
+++ b/mobile/module_core/test/utils/model_filter/default_model_selector_test.dart
@@ -26,7 +26,7 @@ void main() {
   group("DefaultModelSelector.pickFromFamily", () {
     test("returns null for an empty group", () {
       expect(
-        selector.pickFromFamily(group: const [], defaultModelId: null),
+        selector.pickFromFamily(group: const []),
         isNull,
       );
     });
@@ -37,33 +37,9 @@ void main() {
         _model(id: "b", isAvailable: false),
       ];
       expect(
-        selector.pickFromFamily(group: group, defaultModelId: null),
+        selector.pickFromFamily(group: group),
         isNull,
       );
-    });
-
-    test("honors defaultModelId when it identifies a member of the group", () {
-      final group = [
-        _model(id: "newer", releaseDate: DateTime(2026, 4)),
-        _model(id: "older", releaseDate: DateTime(2025, 11)),
-      ];
-      final picked = selector.pickFromFamily(
-        group: group,
-        defaultModelId: "older",
-      );
-      expect(picked?.id, "older");
-    });
-
-    test("ignores defaultModelId that is not in the group", () {
-      final group = [
-        _model(id: "newer", releaseDate: DateTime(2026, 4)),
-        _model(id: "older", releaseDate: DateTime(2025, 11)),
-      ];
-      final picked = selector.pickFromFamily(
-        group: group,
-        defaultModelId: "missing",
-      );
-      expect(picked?.id, "newer");
     });
 
     test("prefers a model whose name contains '(latest)' over a newer date", () {
@@ -79,10 +55,7 @@ void main() {
           releaseDate: DateTime(2025, 11),
         ),
       ];
-      final picked = selector.pickFromFamily(
-        group: group,
-        defaultModelId: null,
-      );
+      final picked = selector.pickFromFamily(group: group);
       expect(picked?.id, "marked");
     });
 
@@ -99,10 +72,7 @@ void main() {
           releaseDate: DateTime(2025, 6),
         ),
       ];
-      final picked = selector.pickFromFamily(
-        group: group,
-        defaultModelId: null,
-      );
+      final picked = selector.pickFromFamily(group: group);
       expect(picked?.id, "latest-newer");
     });
 
@@ -116,10 +86,7 @@ void main() {
         _model(id: "alpha", name: "Alpha", releaseDate: DateTime(2026, 4)),
         _model(id: "mango", name: "Mango", releaseDate: DateTime(2026, 4)),
       ];
-      final picked = selector.pickFromFamily(
-        group: group,
-        defaultModelId: null,
-      );
+      final picked = selector.pickFromFamily(group: group);
       expect(picked?.id, "alpha");
     });
 
@@ -128,10 +95,7 @@ void main() {
         _model(id: "zebra", name: "Zebra", releaseDate: null),
         _model(id: "alpha", name: "Alpha", releaseDate: null),
       ];
-      final picked = selector.pickFromFamily(
-        group: group,
-        defaultModelId: null,
-      );
+      final picked = selector.pickFromFamily(group: group);
       expect(picked?.id, "alpha");
     });
 
@@ -141,10 +105,7 @@ void main() {
         _model(id: "mid", releaseDate: DateTime(2025, 6)),
         _model(id: "newest", releaseDate: DateTime(2026, 4)),
       ];
-      final picked = selector.pickFromFamily(
-        group: group,
-        defaultModelId: null,
-      );
+      final picked = selector.pickFromFamily(group: group);
       expect(picked?.id, "newest");
     });
 
@@ -154,10 +115,7 @@ void main() {
         _model(id: "newest", releaseDate: DateTime(2026, 4)),
         _model(id: "older", releaseDate: DateTime(2025, 6)),
       ];
-      final picked = selector.pickFromFamily(
-        group: group,
-        defaultModelId: null,
-      );
+      final picked = selector.pickFromFamily(group: group);
       expect(picked?.id, "newest");
     });
 
@@ -170,23 +128,28 @@ void main() {
         final group = [
           _model(id: "stale", releaseDate: DateTime(2023, 1)),
         ];
-        final picked = selector.pickFromFamily(
-          group: group,
-          defaultModelId: null,
-        );
+        final picked = selector.pickFromFamily(group: group);
         expect(picked?.id, "stale");
       },
     );
+
+    test("ignores an API defaultModelID pointing to an older model", () {
+      // Regression: the upstream provider default is frequently stale.
+      // The selector should prefer the newest-by-date model instead.
+      final group = [
+        _model(id: "newer", releaseDate: DateTime(2026, 4)),
+        _model(id: "api-default", releaseDate: DateTime(2025, 6)),
+      ];
+      final picked = selector.pickFromFamily(group: group);
+      expect(picked?.id, "newer");
+    });
 
     test("falls back to the first group member when nothing else matches", () {
       final group = [
         _model(id: "first", releaseDate: null),
         _model(id: "second", releaseDate: null),
       ];
-      final picked = selector.pickFromFamily(
-        group: group,
-        defaultModelId: null,
-      );
+      final picked = selector.pickFromFamily(group: group);
       expect(picked?.id, "first");
     });
   });
@@ -197,46 +160,10 @@ void main() {
         "a": _model(id: "a", isAvailable: false),
       };
       expect(
-        selector.pickFromProvider(models: models, defaultModelId: null),
+        selector.pickFromProvider(models: models),
         isNull,
       );
     });
-
-    test("returns defaultModelId when it points to an available model", () {
-      final models = {
-        "newer": _model(id: "newer", releaseDate: DateTime(2026, 4)),
-        "older": _model(id: "older", releaseDate: DateTime(2025, 11)),
-      };
-      final picked = selector.pickFromProvider(
-        models: models,
-        defaultModelId: "older",
-      );
-      expect(picked?.id, "older");
-    });
-
-    test(
-      "ignores defaultModelId when it is unavailable and falls back to family picks",
-      () {
-        final models = {
-          "newer": _model(
-            id: "newer",
-            family: "k2",
-            releaseDate: DateTime(2026, 4),
-          ),
-          "older": _model(
-            id: "older",
-            family: "k2",
-            releaseDate: DateTime(2025, 11),
-            isAvailable: false,
-          ),
-        };
-        final picked = selector.pickFromProvider(
-          models: models,
-          defaultModelId: "older",
-        );
-        expect(picked?.id, "newer");
-      },
-    );
 
     test("Kimi For Coding: picks K2.6 over K2 Thinking (the original bug)", () {
       // Mirrors the live models.dev entry for `kimi-for-coding`:
@@ -267,12 +194,29 @@ void main() {
           releaseDate: DateTime(2026, 4),
         ),
       };
-      final picked = selector.pickFromProvider(
-        models: models,
-        defaultModelId: null,
-      );
+      final picked = selector.pickFromProvider(models: models);
       expect(picked?.id, "k2p6");
     });
+
+    test(
+      "ignores the provider's API defaultModelID and still picks newest by date",
+      () {
+        final models = {
+          "newer": _model(
+            id: "newer",
+            family: "k2",
+            releaseDate: DateTime(2026, 4),
+          ),
+          "api-default": _model(
+            id: "api-default",
+            family: "k2",
+            releaseDate: DateTime(2025, 11),
+          ),
+        };
+        final picked = selector.pickFromProvider(models: models);
+        expect(picked?.id, "newer");
+      },
+    );
 
     test(
       "uses the alphabetically first family when picking the provider default",
@@ -291,10 +235,7 @@ void main() {
             releaseDate: DateTime(2025, 1),
           ),
         };
-        final picked = selector.pickFromProvider(
-          models: models,
-          defaultModelId: null,
-        );
+        final picked = selector.pickFromProvider(models: models);
         // alpha-family is alphabetically first, so alpha wins even though
         // zeta is marked "(latest)".
         expect(picked?.id, "alpha");
@@ -315,10 +256,7 @@ void main() {
           releaseDate: DateTime(2025, 11),
         ),
       };
-      final picked = selector.pickFromProvider(
-        models: models,
-        defaultModelId: null,
-      );
+      final picked = selector.pickFromProvider(models: models);
       expect(picked?.id, "fallback");
     });
   });

--- a/mobile/module_core/test/utils/model_filter/model_picker_section_builder_test.dart
+++ b/mobile/module_core/test/utils/model_filter/model_picker_section_builder_test.dart
@@ -24,13 +24,12 @@ ProviderInfo _provider({
   required String id,
   required List<ProviderModel> models,
   String? name,
-  String? defaultModelID,
 }) {
   return ProviderInfo(
     id: id,
     name: name ?? id,
     models: {for (final m in models) m.id: m},
-    defaultModelID: defaultModelID,
+    defaultModelID: null,
   );
 }
 
@@ -115,12 +114,11 @@ void main() {
       expect(visible, isNot(contains("sonnet-old")));
     });
 
-    test("honors the provider defaultModelID when picking the family representative", () {
+    test("ignores the provider defaultModelID and picks the newest by date", () {
       final sections = build(
         providers: [
           _provider(
             id: "p",
-            defaultModelID: "sonnet-old",
             models: [
               _model(id: "sonnet-new", family: "sonnet", releaseDate: DateTime(2026)),
               _model(id: "sonnet-old", family: "sonnet", releaseDate: DateTime(2024)),
@@ -129,8 +127,8 @@ void main() {
         ],
       );
       final visible = sections.single.models.where((m) => m.visibleByDefault).map((m) => m.modelID);
-      expect(visible, contains("sonnet-old"));
-      expect(visible, isNot(contains("sonnet-new")));
+      expect(visible, contains("sonnet-new"));
+      expect(visible, isNot(contains("sonnet-old")));
     });
 
     test("treats models without a family as their own family", () {


### PR DESCRIPTION
Removes the provider-level defaultModelID signal from model picker selection because OpenCode/models.dev defaults are frequently stale (e.g. Kimi). The selector now relies on newest-by-date per family.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix default model selection by ignoring the provider API `defaultModelID` and picking the best across families — "(latest)" first, then newest by date — to avoid stale defaults (e.g., Kimi). Update `address-pr-comments` docs to forbid amend/force-push and clarify default PR selection when unspecified.

- **Bug Fixes**
  - Ranking: "(latest)" > newest `releaseDate` > `id` (deterministic).
  - `pickFromProvider`: pick best across families (not alphabetically first).
  - Tests: regression coverage (Kimi, cross-family, stale API default).

- **Refactors**
  - Removed `defaultModelId` from `DefaultModelSelector`; updated `NewSessionCubit`, `SessionDetailCubit`, `ModelPickerSectionBuilder`.
  - Docs: `address-pr-comments` — never amend or force push; clarify how to pick the PR number when omitted.

<sup>Written for commit 0bb420e2922488e3a23dbff4b77bd76bba3909e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

