### PR TITLE
feat: add pr_monitor opencode plugin and monitor-pr skill

### DIFF
--- a/.opencode/plugins/pr-monitor.ts
+++ b/.opencode/plugins/pr-monitor.ts
@@ -369,6 +369,8 @@ class PrWatch {
   private holdStartedAt: number | undefined
   private consecutiveFailures = 0
   private deliveryFailures = 0
+  private fetchStartedAt: number | undefined
+  private snapshotAt: number | undefined
   private stopped = false
   private ticking = false
 
@@ -401,12 +403,14 @@ class PrWatch {
     try {
       let next: PrSnapshot
       try {
+        this.fetchStartedAt = this.deps.now()
         next = await this.deps.fetchSnapshot()
       } catch (error) {
         this.handlePollFailure(error)
         return
       }
       this.consecutiveFailures = 0
+      this.snapshotAt = this.fetchStartedAt
       if (this.snapshot !== undefined && detectActivity(this.snapshot, next)) {
         this.dirty = true
         this.lastActivityAt = this.deps.now()
@@ -424,8 +428,10 @@ class PrWatch {
   /** Manual flush: always re-fetches and always returns a full report. */
   async manualFlush(): Promise<string> {
     try {
+      this.fetchStartedAt = this.deps.now()
       this.snapshot = await this.deps.fetchSnapshot()
       this.consecutiveFailures = 0
+      this.snapshotAt = this.fetchStartedAt
     } catch (error) {
       if (this.snapshot === undefined) return `${targetKey(this.target)}: flush failed — ${(error as Error).message}`
       // Refresh failed: report from the stale snapshot WITHOUT advancing the
@@ -509,7 +515,7 @@ class PrWatch {
   private flush(forcedHoldMinutes: number | undefined): string {
     const snapshot = this.snapshot!
     const report = buildReport(this.target, snapshot, { baselineMs: this.lastFlushAt, forcedHoldMinutes })
-    this.lastFlushAt = this.deps.now()
+    this.lastFlushAt = this.snapshotAt ?? this.deps.now()
     this.dirty = false
     this.holdStartedAt = undefined
     return report

--- a/.opencode/plugins/pr-monitor.ts
+++ b/.opencode/plugins/pr-monitor.ts
@@ -518,6 +518,16 @@ class PrWatch {
 export const PrMonitorPlugin: Plugin = async ({ client, directory, worktree, $ }) => {
   type Entry = { watch: PrWatch; timer: ReturnType<typeof setInterval> }
   const watches = new Map<string, Entry>() // key: `${sessionID} ${owner/repo#n}`
+
+  // Plugin reloads can re-instantiate this plugin without finalizing the
+  // previous instance, leaving its setInterval timers polling as invisible
+  // zombies that deliver duplicate reports (observed live). Each instance
+  // registers a killer on globalThis; the next instance invokes it on init.
+  const globalState = globalThis as { __sesoriPrMonitorTakeover?: () => void }
+  globalState.__sesoriPrMonitorTakeover?.()
+  globalState.__sesoriPrMonitorTakeover = () => {
+    for (const entry of [...watches.values()]) entry.watch.stop()
+  }
   let selfLogin: string | undefined
 
   const log = (message: string): void => {
@@ -554,8 +564,17 @@ export const PrMonitorPlugin: Plugin = async ({ client, directory, worktree, $ }
   // `agent` must be sent explicitly: agent-less prompts resolve to the server's
   // default agent, which fails when that default is configured as a subagent
   // (observed live: 'default agent "build" is a subagent').
+  // The SDK client defaults to responseStyle "fields" / throwOnError false:
+  // promptAsync resolves { data, error } and NEVER rejects on server errors,
+  // so delivery failure must be detected via the error field explicitly.
   const deliver = (sessionID: string, agent: string) => async (report: string): Promise<void> => {
-    await client.session.promptAsync({ path: { id: sessionID }, body: { agent, parts: [{ type: "text", text: report }] } })
+    const result = await client.session.promptAsync({
+      path: { id: sessionID },
+      body: { agent, parts: [{ type: "text", text: report }] },
+    })
+    if (result.error !== undefined) {
+      throw new Error(`prompt_async rejected: ${JSON.stringify(result.error)}`)
+    }
   }
 
   const sessionWatches = (sessionID: string): PrWatch[] =>

--- a/.opencode/plugins/pr-monitor.ts
+++ b/.opencode/plugins/pr-monitor.ts
@@ -1,0 +1,652 @@
+import { tool, type Plugin } from "@opencode-ai/plugin"
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+
+// ============================================================================
+// pr-monitor — opencode plugin that watches GitHub PRs and reports changes.
+//
+// Design (settled via user interview; see .sisyphus/plans/pr-monitor-plugin.md):
+// - One watch per PR, owned by the session that started it. Explicit
+//   `owner/repo#123` or PR URL targets only — no cwd inference.
+// - Polls GitHub via `gh api graphql` (one query per watch per tick).
+// - Rolling debounce (no cap): any activity resets the quiet timer. When the
+//   quiet window elapses, a report is generated fresh from the latest
+//   snapshot and delivered to the owning session via promptAsync.
+// - CI hold: a due report is held while the check suite is running, bounded
+//   by maxCiWaitMinutes, then force-flushed naming unfinished checks.
+// - Reports are facts only: no advice, no comment bodies — counts + authors.
+//   "New" = created after this watch's lastFlushAt baseline.
+// - Comments authored by the authenticated gh user containing the configured
+//   ignore tag are invisible to the plugin entirely.
+// - In-memory only: opencode restarts drop all watches by design.
+// ============================================================================
+
+// The opencode plugin loader invokes EVERY export of files in
+// .opencode/plugins/ as a plugin, so `PrMonitorPlugin` must stay the sole export.
+
+type Target = { owner: string; repo: string; number: number }
+
+type MonitorConfig = {
+  debounceMinutes: number
+  maxCiWaitMinutes: number
+  pollIntervalSeconds: number
+  ignoreCommentTag: string | undefined
+}
+
+type CommentMeta = { author: string; isBot: boolean; createdAt: string }
+
+type CheckInfo = { name: string; outcome: "pending" | "success" | "failure" }
+
+type ReviewInfo = { login: string; state: string }
+
+type PrSnapshot = {
+  title: string
+  url: string
+  state: "OPEN" | "MERGED" | "CLOSED"
+  mergeable: "MERGEABLE" | "CONFLICTING" | "UNKNOWN"
+  headSha: string
+  checks: CheckInfo[] // empty = PR has no CI checks
+  reviews: ReviewInfo[] // latest review per reviewer (submitted only)
+  pendingReviewers: string[] // requested, not yet reviewed
+  unresolvedThreads: number
+  inlineComments: CommentMeta[] // ignore-filtered
+  issueCommentsTotal: number // totalCount minus ignored among fetched window
+  issueComments: CommentMeta[] // ignore-filtered (last 100 fetched)
+}
+
+class PollError extends Error {
+  readonly notFound: boolean
+  constructor(message: string, opts?: { notFound?: boolean }) {
+    super(message)
+    this.notFound = opts?.notFound ?? false
+  }
+}
+
+
+const SHORT_RE = /^([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)\/([A-Za-z0-9._-]+)#(\d+)$/
+const URL_RE = /^https:\/\/github\.com\/([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)\/([A-Za-z0-9._-]+)\/pull\/(\d+)(?:[/?#].*)?$/
+
+function parseTarget(input: string): Target | { error: string } {
+  const trimmed = input.trim()
+  const match = SHORT_RE.exec(trimmed) ?? URL_RE.exec(trimmed)
+  if (!match) {
+    return {
+      error:
+        `Invalid PR identifier: "${input}". Use "owner/repo#123" or a full PR URL ` +
+        `(https://github.com/owner/repo/pull/123). The repo must always be explicit.`,
+    }
+  }
+  return { owner: match[1]!, repo: match[2]!, number: Number(match[3]!) }
+}
+
+function targetKey(target: Target): string {
+  return `${target.owner}/${target.repo}#${target.number}`
+}
+
+
+const CONFIG_FILE = "pr-monitor.json"
+
+const DEFAULT_CONFIG: MonitorConfig = {
+  debounceMinutes: 5,
+  maxCiWaitMinutes: 30,
+  pollIntervalSeconds: 60,
+  ignoreCommentTag: undefined,
+}
+
+const MIN_POLL_INTERVAL_SECONDS = 30
+
+function resolveConfig(raw: unknown): MonitorConfig {
+  const cfg = { ...DEFAULT_CONFIG }
+  if (typeof raw !== "object" || raw === null) return cfg
+  const record = raw as Record<string, unknown>
+  const num = (key: string): number | undefined => {
+    const value = record[key]
+    return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined
+  }
+  cfg.debounceMinutes = num("debounceMinutes") ?? cfg.debounceMinutes
+  cfg.maxCiWaitMinutes = num("maxCiWaitMinutes") ?? cfg.maxCiWaitMinutes
+  const poll = num("pollIntervalSeconds") ?? cfg.pollIntervalSeconds
+  cfg.pollIntervalSeconds = Math.max(poll, MIN_POLL_INTERVAL_SECONDS)
+  const tag = record["ignoreCommentTag"]
+  cfg.ignoreCommentTag = typeof tag === "string" && tag.length > 0 ? tag : undefined
+  return cfg
+}
+
+async function loadConfig(dirs: string[]): Promise<MonitorConfig> {
+  for (const dir of dirs) {
+    try {
+      const text = await readFile(join(dir, ".opencode", CONFIG_FILE), "utf8")
+      return resolveConfig(JSON.parse(text))
+    } catch {
+      // missing/unreadable/invalid file in this dir -> try next, else defaults
+    }
+  }
+  return resolveConfig(undefined)
+}
+
+
+const PR_QUERY = `
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      title url state mergeable headRefOid
+      commits(last: 1) { nodes { commit { statusCheckRollup {
+        contexts(first: 100) { nodes {
+          __typename
+          ... on CheckRun { name status conclusion }
+          ... on StatusContext { context state }
+        } }
+      } } } }
+      reviewRequests(first: 50) { nodes { requestedReviewer {
+        __typename
+        ... on User { login }
+        ... on Team { slug }
+        ... on Bot { login }
+      } } }
+      latestReviews(first: 50) { nodes { author { login __typename } state } }
+      reviewThreads(first: 100) { nodes {
+        isResolved
+        comments(first: 100) { nodes { author { login __typename } body createdAt } }
+      } }
+      comments(last: 100) { totalCount nodes { author { login __typename } body createdAt } }
+    }
+  }
+}`
+
+type RawComment = { author: { login: string; __typename: string } | null; body: string; createdAt: string }
+
+function toMeta(raw: RawComment): CommentMeta {
+  return {
+    author: raw.author?.login ?? "ghost",
+    isBot: raw.author?.__typename === "Bot",
+    createdAt: raw.createdAt,
+  }
+}
+
+function normalizeSnapshot(
+  payload: unknown,
+  opts: { ignoreTag: string | undefined; selfLogin: string | undefined },
+): PrSnapshot {
+  const pr = (payload as any)?.data?.repository?.pullRequest
+  if (!pr) throw new PollError("PR not found in GraphQL response", { notFound: true })
+
+  const ignored = (raw: RawComment): boolean =>
+    opts.ignoreTag !== undefined &&
+    opts.selfLogin !== undefined &&
+    raw.author?.login === opts.selfLogin &&
+    raw.body.includes(opts.ignoreTag)
+
+  const checks: CheckInfo[] = []
+  const contexts = pr.commits?.nodes?.[0]?.commit?.statusCheckRollup?.contexts?.nodes ?? []
+  for (const ctx of contexts) {
+    if (ctx.__typename === "CheckRun") {
+      const outcome =
+        ctx.status !== "COMPLETED"
+          ? "pending"
+          : ["SUCCESS", "NEUTRAL", "SKIPPED"].includes(ctx.conclusion)
+            ? "success"
+            : "failure"
+      checks.push({ name: ctx.name, outcome })
+    } else if (ctx.__typename === "StatusContext") {
+      const outcome = ctx.state === "SUCCESS" ? "success" : ["PENDING", "EXPECTED"].includes(ctx.state) ? "pending" : "failure"
+      checks.push({ name: ctx.context, outcome })
+    }
+  }
+
+  const reviews: ReviewInfo[] = (pr.latestReviews?.nodes ?? [])
+    .filter((node: any) => node.author?.login && node.state !== "PENDING")
+    .map((node: any) => ({ login: node.author.login, state: node.state }))
+
+  const pendingReviewers: string[] = (pr.reviewRequests?.nodes ?? [])
+    .map((node: any) => node.requestedReviewer?.login ?? node.requestedReviewer?.slug)
+    .filter((name: unknown): name is string => typeof name === "string")
+
+  const threads = pr.reviewThreads?.nodes ?? []
+  const inlineComments: CommentMeta[] = []
+  for (const thread of threads) {
+    for (const comment of thread.comments?.nodes ?? []) {
+      if (!ignored(comment)) inlineComments.push(toMeta(comment))
+    }
+  }
+
+  const issueNodes: RawComment[] = pr.comments?.nodes ?? []
+  const issueVisible = issueNodes.filter((node) => !ignored(node))
+  const ignoredCount = issueNodes.length - issueVisible.length
+
+  return {
+    title: pr.title,
+    url: pr.url,
+    state: pr.state,
+    mergeable: pr.mergeable ?? "UNKNOWN",
+    headSha: pr.headRefOid,
+    checks,
+    reviews,
+    pendingReviewers,
+    unresolvedThreads: threads.filter((thread: any) => !thread.isResolved).length,
+    inlineComments,
+    issueCommentsTotal: Math.max((pr.comments?.totalCount ?? issueNodes.length) - ignoredCount, 0),
+    issueComments: issueVisible.map(toMeta),
+  }
+}
+
+type CiPhase = "none" | "running" | "concluded"
+
+function ciPhase(snapshot: PrSnapshot): CiPhase {
+  if (snapshot.checks.length === 0) return "none"
+  return snapshot.checks.some((check) => check.outcome === "pending") ? "running" : "concluded"
+}
+
+
+function commentSig(comments: CommentMeta[]): string {
+  const last = comments[comments.length - 1]
+  return `${comments.length}:${last?.createdAt ?? ""}`
+}
+
+function reviewSig(snapshot: PrSnapshot): string {
+  const states = snapshot.reviews.map((review) => `${review.login}=${review.state}`).sort()
+  const pending = [...snapshot.pendingReviewers].sort()
+  return `${states.join(",")}|${pending.join(",")}`
+}
+
+function ciConcludedSig(snapshot: PrSnapshot): string {
+  const failed = snapshot.checks
+    .filter((check) => check.outcome === "failure")
+    .map((check) => check.name)
+    .sort()
+  return `${snapshot.headSha}:${failed.join(",")}`
+}
+
+/** True when something report-worthy changed between consecutive polls. */
+function detectActivity(prev: PrSnapshot, next: PrSnapshot): boolean {
+  if (prev.state !== next.state) return true
+  if (prev.mergeable !== next.mergeable) return true
+  if (reviewSig(prev) !== reviewSig(next)) return true
+  if (prev.unresolvedThreads !== next.unresolvedThreads) return true
+  if (commentSig(prev.inlineComments) !== commentSig(next.inlineComments)) return true
+  if (prev.issueCommentsTotal !== next.issueCommentsTotal || commentSig(prev.issueComments) !== commentSig(next.issueComments)) return true
+  // CI: only suite conclusion counts. Transitions into "running" (new push)
+  // and per-check progress are intentionally NOT activity.
+  if (ciPhase(next) === "concluded" && (ciPhase(prev) !== "concluded" || ciConcludedSig(prev) !== ciConcludedSig(next))) return true
+  return false
+}
+
+
+function authorBreakdown(comments: CommentMeta[]): string {
+  const counts = new Map<string, number>()
+  for (const comment of comments) {
+    const name = comment.isBot ? `${comment.author}[bot]` : comment.author
+    counts.set(name, (counts.get(name) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([name, count]) => `${count} ${name}`)
+    .join(", ")
+}
+
+function newSince(comments: CommentMeta[], baselineMs: number): CommentMeta[] {
+  return comments.filter((comment) => Date.parse(comment.createdAt) > baselineMs)
+}
+
+function ciLine(snapshot: PrSnapshot, forcedHoldMinutes: number | undefined): string {
+  const phase = ciPhase(snapshot)
+  if (phase === "none") return "- CI: none"
+  const total = snapshot.checks.length
+  const failed = snapshot.checks.filter((check) => check.outcome === "failure")
+  const pending = snapshot.checks.filter((check) => check.outcome === "pending")
+  if (phase === "concluded") {
+    if (failed.length === 0) return `- CI: passing (${total}/${total})`
+    return `- CI: failing (${failed.length}/${total} failed: ${failed.map((check) => check.name).join(", ")})`
+  }
+  if (forcedHoldMinutes !== undefined) {
+    return `- CI: running for ${forcedHoldMinutes}m+ (in_progress: ${pending.map((check) => check.name).join(", ")})`
+  }
+  const done = total - pending.length
+  const failedPart = failed.length > 0 ? `, ${failed.length} failed so far: ${failed.map((check) => check.name).join(", ")}` : ""
+  return `- CI: running (${done}/${total} done${failedPart})`
+}
+
+function reviewLine(snapshot: PrSnapshot): string {
+  const MARKS: Record<string, string> = {
+    APPROVED: "✓ approved",
+    CHANGES_REQUESTED: "✗ changes_requested",
+    COMMENTED: "✦ commented",
+    DISMISSED: "⊘ dismissed",
+  }
+  const parts = snapshot.reviews.map((review) => `${review.login} ${MARKS[review.state] ?? review.state.toLowerCase()}`)
+  for (const login of snapshot.pendingReviewers) parts.push(`${login} ⏳ pending`)
+  return `- Reviews: ${parts.length > 0 ? parts.join(" · ") : "none"}`
+}
+
+function buildReport(
+  target: Target,
+  snapshot: PrSnapshot,
+  opts: { baselineMs: number; forcedHoldMinutes?: number },
+): string {
+  const stateSuffix = snapshot.state !== "OPEN" ? ` — ${snapshot.state}` : ""
+  const newInline = newSince(snapshot.inlineComments, opts.baselineMs)
+  const newIssue = newSince(snapshot.issueComments, opts.baselineMs)
+  const newPart = (fresh: CommentMeta[]): string =>
+    fresh.length > 0 ? `${fresh.length} new since last flush: ${authorBreakdown(fresh)}` : "0 new since last flush"
+  return [
+    `[PR Monitor] ${targetKey(target)} — "${snapshot.title}"${stateSuffix} (${snapshot.url})`,
+    ciLine(snapshot, opts.forcedHoldMinutes),
+    `- Mergeable: ${snapshot.mergeable}`,
+    reviewLine(snapshot),
+    `- [comment:inline] ${snapshot.unresolvedThreads} unresolved threads (${newPart(newInline)})`,
+    `- [comment:issue] ${snapshot.issueCommentsTotal} total (${newPart(newIssue)})`,
+  ].join("\n")
+}
+
+
+type WatchDeps = {
+  now: () => number
+  fetchSnapshot: () => Promise<PrSnapshot>
+  deliver: (report: string) => void
+  log: (message: string) => void
+  onStopped: () => void
+}
+
+const MAX_CONSECUTIVE_FAILURES = 10
+
+class PrWatch {
+  readonly target: Target
+  readonly sessionID: string
+  readonly config: MonitorConfig
+  private readonly deps: WatchDeps
+  private readonly startedAt: number
+
+  private snapshot: PrSnapshot | undefined
+  private dirty = false
+  private lastActivityAt = 0
+  private lastFlushAt: number
+  private holdStartedAt: number | undefined
+  private consecutiveFailures = 0
+  private stopped = false
+  private ticking = false
+
+  constructor(input: { target: Target; sessionID: string; config: MonitorConfig; deps: WatchDeps; initial: PrSnapshot }) {
+    this.target = input.target
+    this.sessionID = input.sessionID
+    this.config = input.config
+    this.deps = input.deps
+    this.startedAt = input.deps.now()
+    this.lastFlushAt = this.startedAt
+    this.snapshot = input.initial
+  }
+
+  get isStopped(): boolean {
+    return this.stopped
+  }
+
+  statusLine(): string {
+    const now = this.deps.now()
+    const phase = this.holdStartedAt !== undefined ? "ci-hold" : "watching"
+    const baselineAge = Math.round((now - this.lastFlushAt) / 60_000)
+    const failures = this.consecutiveFailures > 0 ? `, ${this.consecutiveFailures} consecutive poll failures` : ""
+    return `${targetKey(this.target)} — ${phase}, ${this.dirty ? "activity buffered" : "quiet"}, baseline ${baselineAge}m ago${failures}`
+  }
+
+  /** Periodic poll; never throws. */
+  async tick(): Promise<void> {
+    if (this.stopped || this.ticking) return
+    this.ticking = true
+    try {
+      let next: PrSnapshot
+      try {
+        next = await this.deps.fetchSnapshot()
+      } catch (error) {
+        this.handlePollFailure(error)
+        return
+      }
+      this.consecutiveFailures = 0
+      if (this.snapshot !== undefined && detectActivity(this.snapshot, next)) {
+        this.dirty = true
+        this.lastActivityAt = this.deps.now()
+        this.holdStartedAt = undefined
+      }
+      this.snapshot = next
+      this.maybeAutoFlush()
+    } finally {
+      this.ticking = false
+    }
+  }
+
+  /** Manual flush: always re-fetches and always returns a full report. */
+  async manualFlush(): Promise<string> {
+    try {
+      this.snapshot = await this.deps.fetchSnapshot()
+      this.consecutiveFailures = 0
+    } catch (error) {
+      if (this.snapshot === undefined) return `${targetKey(this.target)}: flush failed — ${(error as Error).message}`
+      // fall through with last known snapshot, stated factually
+      const report = this.flush(undefined)
+      return `${report}\n(note: refresh failed — ${(error as Error).message}; data is from the previous poll)`
+    }
+    const report = this.flush(undefined)
+    this.stopIfTerminal()
+    return report
+  }
+
+  stop(): void {
+    if (this.stopped) return
+    this.stopped = true
+    this.deps.onStopped()
+  }
+
+  private handlePollFailure(error: unknown): void {
+    const message = error instanceof Error ? error.message : String(error)
+    if (error instanceof PollError && error.notFound) {
+      this.deps.deliver(`[PR Monitor] ${targetKey(this.target)} — monitor stopped: PR not found (deleted or inaccessible). Last error: ${message}`)
+      this.stop()
+      return
+    }
+    this.consecutiveFailures += 1
+    this.deps.log(`poll failed for ${targetKey(this.target)} (${this.consecutiveFailures}/${MAX_CONSECUTIVE_FAILURES}): ${message}`)
+    if (this.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+      this.deps.deliver(`[PR Monitor] ${targetKey(this.target)} — monitor stopped: ${MAX_CONSECUTIVE_FAILURES} consecutive poll failures. Last error: ${message}`)
+      this.stop()
+    }
+  }
+
+  private maybeAutoFlush(): void {
+    if (!this.dirty || this.snapshot === undefined) return
+    const now = this.deps.now()
+    if (now - this.lastActivityAt < this.config.debounceMinutes * 60_000) return
+
+    let forcedHoldMinutes: number | undefined
+    if (ciPhase(this.snapshot) === "running") {
+      if (this.holdStartedAt === undefined) this.holdStartedAt = now
+      const heldMs = now - this.holdStartedAt
+      if (heldMs < this.config.maxCiWaitMinutes * 60_000) return
+      forcedHoldMinutes = Math.round(heldMs / 60_000)
+    }
+    this.deps.deliver(this.flush(forcedHoldMinutes))
+    this.stopIfTerminal()
+  }
+
+  private flush(forcedHoldMinutes: number | undefined): string {
+    const snapshot = this.snapshot!
+    const report = buildReport(this.target, snapshot, { baselineMs: this.lastFlushAt, forcedHoldMinutes })
+    this.lastFlushAt = this.deps.now()
+    this.dirty = false
+    this.holdStartedAt = undefined
+    return report
+  }
+
+  private stopIfTerminal(): void {
+    if (this.snapshot !== undefined && this.snapshot.state !== "OPEN") this.stop()
+  }
+}
+
+
+export const PrMonitorPlugin: Plugin = async ({ client, directory, worktree, $ }) => {
+  type Entry = { watch: PrWatch; timer: ReturnType<typeof setInterval> }
+  const watches = new Map<string, Entry>() // key: `${sessionID} ${owner/repo#n}`
+  let selfLogin: string | undefined
+
+  const log = (message: string): void => {
+    void client.app.log({ body: { service: "pr-monitor", level: "info", message } }).catch(() => {})
+  }
+
+  const runGh = async (args: string[]): Promise<string> => {
+    const result = await $`gh ${args}`.quiet().nothrow()
+    if (result.exitCode !== 0) {
+      const stderr = result.stderr.toString().trim()
+      const notFound = /could not resolve|not found|404/i.test(stderr)
+      throw new PollError(stderr || `gh exited with code ${result.exitCode}`, { notFound })
+    }
+    return result.stdout.toString()
+  }
+
+  const fetchSnapshot = async (target: Target, config: MonitorConfig): Promise<PrSnapshot> => {
+    const stdout = await runGh([
+      "api", "graphql",
+      "-f", `query=${PR_QUERY}`,
+      "-F", `owner=${target.owner}`,
+      "-F", `repo=${target.repo}`,
+      "-F", `number=${target.number}`,
+    ])
+    let payload: unknown
+    try {
+      payload = JSON.parse(stdout)
+    } catch {
+      throw new PollError("gh returned non-JSON output")
+    }
+    return normalizeSnapshot(payload, { ignoreTag: config.ignoreCommentTag, selfLogin })
+  }
+
+  const deliver = (sessionID: string) => (report: string) => {
+    void client.session
+      .promptAsync({ path: { id: sessionID }, body: { parts: [{ type: "text", text: report }] } })
+      .catch((error: unknown) => log(`failed to deliver report to session ${sessionID}: ${error}`))
+  }
+
+  const sessionWatches = (sessionID: string): PrWatch[] =>
+    [...watches.values()].filter((entry) => entry.watch.sessionID === sessionID).map((entry) => entry.watch)
+
+  const selectWatches = (sessionID: string, pr: string): PrWatch[] | { error: string } => {
+    if (pr === "all") return sessionWatches(sessionID)
+    const target = parseTarget(pr)
+    if ("error" in target) return target
+    const entry = watches.get(`${sessionID} ${targetKey(target)}`)
+    if (!entry) return { error: `No monitor for ${targetKey(target)} in this session. Use action "status" to list active monitors.` }
+    return [entry.watch]
+  }
+
+  const startWatch = async (sessionID: string, pr: string): Promise<string> => {
+    const target = parseTarget(pr)
+    if ("error" in target) return target.error
+    const key = `${sessionID} ${targetKey(target)}`
+    const existing = watches.get(key)
+    if (existing) return `Already monitoring ${targetKey(target)} in this session.\n${existing.watch.statusLine()}`
+
+    const config = await loadConfig([directory, worktree])
+    if (config.ignoreCommentTag !== undefined && selfLogin === undefined) {
+      try {
+        selfLogin = (await runGh(["api", "user", "--jq", ".login"])).trim()
+      } catch (error) {
+        return `Cannot start monitor: ignoreCommentTag is configured but resolving the authenticated gh user failed (${(error as Error).message}). Run \`gh auth status\` to check.`
+      }
+    }
+
+    let initial: PrSnapshot
+    try {
+      initial = await fetchSnapshot(target, config)
+    } catch (error) {
+      return `Cannot start monitor for ${targetKey(target)}: ${(error as Error).message}`
+    }
+    if (initial.state !== "OPEN") return `Cannot start monitor: ${targetKey(target)} is already ${initial.state}.`
+
+    const watch = new PrWatch({
+      target,
+      sessionID,
+      config,
+      initial,
+      deps: {
+        now: Date.now,
+        fetchSnapshot: () => fetchSnapshot(target, config),
+        deliver: deliver(sessionID),
+        log,
+        onStopped: () => {
+          const entry = watches.get(key)
+          if (entry) clearInterval(entry.timer)
+          watches.delete(key)
+        },
+      },
+    })
+    const timer = setInterval(() => void watch.tick(), config.pollIntervalSeconds * 1000)
+    watches.set(key, { watch, timer })
+    log(`started monitoring ${targetKey(target)} for session ${sessionID}`)
+    return (
+      `Started monitoring ${targetKey(target)} — "${initial.title}".\n` +
+      `Polling every ${config.pollIntervalSeconds}s; reports arrive in this session as [PR Monitor] messages after ` +
+      `${config.debounceMinutes} quiet minutes following detected activity. The monitor stops automatically when the PR ` +
+      `is merged or closed, and does not survive an opencode restart.`
+    )
+  }
+
+  return {
+    tool: {
+      pr_monitor: tool({
+        description:
+          "Monitor a GitHub PR in the background. Detects CI suite conclusions, new reviews, new inline/issue comments, " +
+          "mergeability changes, and merge/close. Changes are aggregated (rolling debounce) and delivered to THIS session " +
+          "as a '[PR Monitor]' message stating facts only. Actions: start (begin watching a PR), stop (end watching), " +
+          "flush (immediately return a full status report and reset the 'new since' baseline — do this after handling a " +
+          "report), status (list this session's monitors). The pr argument must be explicit 'owner/repo#123' or a full " +
+          "PR URL; 'all' is allowed for stop/flush. Tuning lives in .opencode/pr-monitor.json. Monitors are per-session " +
+          "and do not survive opencode restarts.",
+        args: {
+          action: tool.schema.enum(["start", "stop", "flush", "status"]).describe("What to do"),
+          pr: tool.schema
+            .string()
+            .optional()
+            .describe("PR identifier: 'owner/repo#123' or PR URL. Required for start/stop/flush; 'all' allowed for stop/flush."),
+        },
+        async execute(args, context) {
+          const sessionID = context.sessionID
+          switch (args.action) {
+            case "start": {
+              if (!args.pr || args.pr === "all") return "action 'start' requires a single explicit pr: 'owner/repo#123' or a PR URL."
+              return await startWatch(sessionID, args.pr)
+            }
+            case "stop": {
+              if (!args.pr) return "action 'stop' requires pr: 'owner/repo#123', a PR URL, or 'all'."
+              const selected = selectWatches(sessionID, args.pr)
+              if ("error" in selected) return selected.error
+              if (selected.length === 0) return "No active monitors in this session."
+              for (const watch of selected) watch.stop()
+              return `Stopped ${selected.length} monitor(s): ${selected.map((watch) => targetKey(watch.target)).join(", ")}.`
+            }
+            case "flush": {
+              if (!args.pr) return "action 'flush' requires pr: 'owner/repo#123', a PR URL, or 'all'."
+              const selected = selectWatches(sessionID, args.pr)
+              if ("error" in selected) return selected.error
+              if (selected.length === 0) return "No active monitors in this session."
+              const reports = await Promise.all(selected.map((watch) => watch.manualFlush()))
+              return reports.join("\n\n")
+            }
+            case "status": {
+              const active = sessionWatches(sessionID)
+              if (active.length === 0) return "No active monitors in this session."
+              return active.map((watch) => watch.statusLine()).join("\n")
+            }
+          }
+        },
+      }),
+    },
+
+    event: async ({ event }) => {
+      if (event.type !== "session.deleted") return
+      const sessionID = (event.properties as { info?: { id?: string } })?.info?.id
+      if (!sessionID) return
+      for (const entry of [...watches.values()]) {
+        if (entry.watch.sessionID === sessionID) entry.watch.stop()
+      }
+    },
+
+    dispose: async () => {
+      for (const entry of [...watches.values()]) entry.watch.stop()
+    },
+  }
+}

--- a/.opencode/plugins/pr-monitor.ts
+++ b/.opencode/plugins/pr-monitor.ts
@@ -368,6 +368,7 @@ class PrWatch {
   private lastFlushAt: number
   private holdStartedAt: number | undefined
   private consecutiveFailures = 0
+  private deliveryFailures = 0
   private stopped = false
   private ticking = false
 
@@ -471,15 +472,26 @@ class PrWatch {
       forcedHoldMinutes = Math.round(heldMs / 60_000)
     }
     const previousFlushAt = this.lastFlushAt
+    const previousHoldStartedAt = this.holdStartedAt
     const report = this.flush(forcedHoldMinutes)
     void this.deps.deliver(report).then(
-      () => this.stopIfTerminal(),
+      () => {
+        this.deliveryFailures = 0
+        this.stopIfTerminal()
+      },
       (error: unknown) => {
-        // Delivery failed: restore the baseline and dirty flag so the same
-        // activity is re-reported on a later tick instead of silently lost.
+        // Delivery failed: restore the baseline, dirty flag, and CI-hold
+        // timer so the same activity is re-reported on a later tick without
+        // restarting the maxCiWaitMinutes window.
         this.lastFlushAt = previousFlushAt
         this.dirty = true
-        this.deps.log(`report delivery failed for ${targetKey(this.target)}, will retry: ${error}`)
+        this.holdStartedAt = previousHoldStartedAt
+        this.deliveryFailures += 1
+        this.deps.log(`report delivery failed for ${targetKey(this.target)} (${this.deliveryFailures}/${MAX_CONSECUTIVE_FAILURES}), will retry: ${error}`)
+        if (this.deliveryFailures >= MAX_CONSECUTIVE_FAILURES) {
+          this.deps.log(`monitor stopped for ${targetKey(this.target)}: ${MAX_CONSECUTIVE_FAILURES} consecutive delivery failures`)
+          this.stop()
+        }
       },
     )
   }

--- a/.opencode/plugins/pr-monitor.ts
+++ b/.opencode/plugins/pr-monitor.ts
@@ -463,7 +463,7 @@ class PrWatch {
     if (now - this.lastActivityAt < this.config.debounceMinutes * 60_000) return
 
     let forcedHoldMinutes: number | undefined
-    if (ciPhase(this.snapshot) === "running") {
+    if (ciPhase(this.snapshot) === "running" && this.snapshot.state === "OPEN") {
       if (this.holdStartedAt === undefined) this.holdStartedAt = now
       const heldMs = now - this.holdStartedAt
       if (heldMs < this.config.maxCiWaitMinutes * 60_000) return

--- a/.opencode/plugins/pr-monitor.ts
+++ b/.opencode/plugins/pr-monitor.ts
@@ -444,6 +444,12 @@ class PrWatch {
     this.deps.onStopped()
   }
 
+  stopWithNotice(reason: string): void {
+    if (this.stopped) return
+    this.deliverOrLog(`[PR Monitor] ${targetKey(this.target)} — ${reason}`)
+    this.stop()
+  }
+
   private handlePollFailure(error: unknown): void {
     const message = error instanceof Error ? error.message : String(error)
     if (error instanceof PollError && error.notFound) {
@@ -522,12 +528,20 @@ export const PrMonitorPlugin: Plugin = async ({ client, directory, worktree, $ }
   // Plugin reloads can re-instantiate this plugin without finalizing the
   // previous instance, leaving its setInterval timers polling as invisible
   // zombies that deliver duplicate reports (observed live). Each instance
-  // registers a killer on globalThis; the next instance invokes it on init.
-  const globalState = globalThis as { __sesoriPrMonitorTakeover?: () => void }
-  globalState.__sesoriPrMonitorTakeover?.()
-  globalState.__sesoriPrMonitorTakeover = () => {
-    for (const entry of [...watches.values()]) entry.watch.stop()
-  }
+  // registers a killer on globalThis, keyed by project directory (instances
+  // are per-directory; a process can host several projects); the next
+  // same-directory instance invokes it on init. Killed watches send one
+  // factual stop notice so owning sessions can re-start monitoring.
+  const globalState = globalThis as { __sesoriPrMonitorTakeovers?: Map<string, () => void> }
+  const takeovers = (globalState.__sesoriPrMonitorTakeovers ??= new Map())
+  takeovers.get(directory)?.()
+  takeovers.set(directory, () => {
+    for (const entry of [...watches.values()]) {
+      entry.watch.stopWithNotice(
+        "monitor stopped: the pr-monitor plugin was reloaded. Re-start monitoring if still needed.",
+      )
+    }
+  })
   let selfLogin: string | undefined
 
   const log = (message: string): void => {

--- a/.opencode/plugins/pr-monitor.ts
+++ b/.opencode/plugins/pr-monitor.ts
@@ -37,7 +37,7 @@ type CommentMeta = { author: string; isBot: boolean; createdAt: string }
 
 type CheckInfo = { name: string; outcome: "pending" | "success" | "failure" }
 
-type ReviewInfo = { login: string; state: string }
+type ReviewInfo = { login: string; state: string; submittedAt: string }
 
 type PrSnapshot = {
   title: string
@@ -149,10 +149,10 @@ query($owner: String!, $repo: String!, $number: Int!) {
         ... on Team { slug }
         ... on Bot { login }
       } } }
-      latestReviews(first: 50) { nodes { author { login __typename } state } }
+      latestReviews(first: 50) { nodes { author { login __typename } state submittedAt } }
       reviewThreads(first: 100) { nodes {
         isResolved
-        comments(first: 100) { nodes { author { login __typename } body createdAt } }
+        comments(last: 100) { nodes { author { login __typename } body createdAt } }
       } }
       comments(last: 100) { totalCount nodes { author { login __typename } body createdAt } }
     }
@@ -201,7 +201,7 @@ function normalizeSnapshot(
 
   const reviews: ReviewInfo[] = (pr.latestReviews?.nodes ?? [])
     .filter((node: any) => node.author?.login && node.state !== "PENDING")
-    .map((node: any) => ({ login: node.author.login, state: node.state }))
+    .map((node: any) => ({ login: node.author.login, state: node.state, submittedAt: node.submittedAt ?? "" }))
 
   const pendingReviewers: string[] = (pr.reviewRequests?.nodes ?? [])
     .map((node: any) => node.requestedReviewer?.login ?? node.requestedReviewer?.slug)
@@ -249,7 +249,7 @@ function commentSig(comments: CommentMeta[]): string {
 }
 
 function reviewSig(snapshot: PrSnapshot): string {
-  const states = snapshot.reviews.map((review) => `${review.login}=${review.state}`).sort()
+  const states = snapshot.reviews.map((review) => `${review.login}=${review.state}@${review.submittedAt}`).sort()
   const pending = [...snapshot.pendingReviewers].sort()
   return `${states.join(",")}|${pending.join(",")}`
 }
@@ -329,12 +329,13 @@ function buildReport(
   opts: { baselineMs: number; forcedHoldMinutes?: number },
 ): string {
   const stateSuffix = snapshot.state !== "OPEN" ? ` — ${snapshot.state}` : ""
+  const title = snapshot.title.replace(/\s+/g, " ").trim()
   const newInline = newSince(snapshot.inlineComments, opts.baselineMs)
   const newIssue = newSince(snapshot.issueComments, opts.baselineMs)
   const newPart = (fresh: CommentMeta[]): string =>
     fresh.length > 0 ? `${fresh.length} new since last flush: ${authorBreakdown(fresh)}` : "0 new since last flush"
   return [
-    `[PR Monitor] ${targetKey(target)} — "${snapshot.title}"${stateSuffix} (${snapshot.url})`,
+    `[PR Monitor] ${targetKey(target)} — "${title}"${stateSuffix} (${snapshot.url})`,
     ciLine(snapshot, opts.forcedHoldMinutes),
     `- Mergeable: ${snapshot.mergeable}`,
     reviewLine(snapshot),
@@ -347,7 +348,7 @@ function buildReport(
 type WatchDeps = {
   now: () => number
   fetchSnapshot: () => Promise<PrSnapshot>
-  deliver: (report: string) => void
+  deliver: (report: string) => Promise<void>
   log: (message: string) => void
   onStopped: () => void
 }
@@ -445,14 +446,14 @@ class PrWatch {
   private handlePollFailure(error: unknown): void {
     const message = error instanceof Error ? error.message : String(error)
     if (error instanceof PollError && error.notFound) {
-      this.deps.deliver(`[PR Monitor] ${targetKey(this.target)} — monitor stopped: PR not found (deleted or inaccessible). Last error: ${message}`)
+      this.deliverOrLog(`[PR Monitor] ${targetKey(this.target)} — monitor stopped: PR not found (deleted or inaccessible). Last error: ${message}`)
       this.stop()
       return
     }
     this.consecutiveFailures += 1
     this.deps.log(`poll failed for ${targetKey(this.target)} (${this.consecutiveFailures}/${MAX_CONSECUTIVE_FAILURES}): ${message}`)
     if (this.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
-      this.deps.deliver(`[PR Monitor] ${targetKey(this.target)} — monitor stopped: ${MAX_CONSECUTIVE_FAILURES} consecutive poll failures. Last error: ${message}`)
+      this.deliverOrLog(`[PR Monitor] ${targetKey(this.target)} — monitor stopped: ${MAX_CONSECUTIVE_FAILURES} consecutive poll failures. Last error: ${message}`)
       this.stop()
     }
   }
@@ -469,8 +470,22 @@ class PrWatch {
       if (heldMs < this.config.maxCiWaitMinutes * 60_000) return
       forcedHoldMinutes = Math.round(heldMs / 60_000)
     }
-    this.deps.deliver(this.flush(forcedHoldMinutes))
-    this.stopIfTerminal()
+    const previousFlushAt = this.lastFlushAt
+    const report = this.flush(forcedHoldMinutes)
+    void this.deps.deliver(report).then(
+      () => this.stopIfTerminal(),
+      (error: unknown) => {
+        // Delivery failed: restore the baseline and dirty flag so the same
+        // activity is re-reported on a later tick instead of silently lost.
+        this.lastFlushAt = previousFlushAt
+        this.dirty = true
+        this.deps.log(`report delivery failed for ${targetKey(this.target)}, will retry: ${error}`)
+      },
+    )
+  }
+
+  private deliverOrLog(message: string): void {
+    void this.deps.deliver(message).catch((error: unknown) => this.deps.log(`report delivery failed for ${targetKey(this.target)}: ${error}`))
   }
 
   private flush(forcedHoldMinutes: number | undefined): string {
@@ -501,7 +516,7 @@ export const PrMonitorPlugin: Plugin = async ({ client, directory, worktree, $ }
     const result = await $`gh ${args}`.quiet().nothrow()
     if (result.exitCode !== 0) {
       const stderr = result.stderr.toString().trim()
-      const notFound = /could not resolve|not found|404/i.test(stderr)
+      const notFound = /could not resolve to|not found|404/i.test(stderr) && !/could not resolve host/i.test(stderr)
       throw new PollError(stderr || `gh exited with code ${result.exitCode}`, { notFound })
     }
     return result.stdout.toString()
@@ -527,10 +542,8 @@ export const PrMonitorPlugin: Plugin = async ({ client, directory, worktree, $ }
   // `agent` must be sent explicitly: agent-less prompts resolve to the server's
   // default agent, which fails when that default is configured as a subagent
   // (observed live: 'default agent "build" is a subagent').
-  const deliver = (sessionID: string, agent: string) => (report: string) => {
-    void client.session
-      .promptAsync({ path: { id: sessionID }, body: { agent, parts: [{ type: "text", text: report }] } })
-      .catch((error: unknown) => log(`failed to deliver report to session ${sessionID}: ${error}`))
+  const deliver = (sessionID: string, agent: string) => async (report: string): Promise<void> => {
+    await client.session.promptAsync({ path: { id: sessionID }, body: { agent, parts: [{ type: "text", text: report }] } })
   }
 
   const sessionWatches = (sessionID: string): PrWatch[] =>

--- a/.opencode/plugins/pr-monitor.ts
+++ b/.opencode/plugins/pr-monitor.ts
@@ -112,13 +112,19 @@ function resolveConfig(raw: unknown): MonitorConfig {
   return cfg
 }
 
-async function loadConfig(dirs: string[]): Promise<MonitorConfig> {
+async function loadConfig(dirs: string[], log: (message: string) => void): Promise<MonitorConfig> {
   for (const dir of dirs) {
+    const path = join(dir, ".opencode", CONFIG_FILE)
+    let text: string
     try {
-      const text = await readFile(join(dir, ".opencode", CONFIG_FILE), "utf8")
-      return resolveConfig(JSON.parse(text))
+      text = await readFile(path, "utf8")
     } catch {
-      // missing/unreadable/invalid file in this dir -> try next, else defaults
+      continue // missing/unreadable file in this dir -> try next, else defaults
+    }
+    try {
+      return resolveConfig(JSON.parse(text))
+    } catch (error) {
+      log(`config file ${path} is not valid JSON, ignoring it: ${(error as Error).message}`)
     }
   }
   return resolveConfig(undefined)
@@ -406,6 +412,8 @@ class PrWatch {
       }
       this.snapshot = next
       this.maybeAutoFlush()
+    } catch (error) {
+      this.deps.log(`unexpected tick error for ${targetKey(this.target)}: ${error}`)
     } finally {
       this.ticking = false
     }
@@ -418,9 +426,10 @@ class PrWatch {
       this.consecutiveFailures = 0
     } catch (error) {
       if (this.snapshot === undefined) return `${targetKey(this.target)}: flush failed — ${(error as Error).message}`
-      // fall through with last known snapshot, stated factually
-      const report = this.flush(undefined)
-      return `${report}\n(note: refresh failed — ${(error as Error).message}; data is from the previous poll)`
+      // Refresh failed: report from the stale snapshot WITHOUT advancing the
+      // baseline, so activity newer than that snapshot is not silently skipped.
+      const report = buildReport(this.target, this.snapshot, { baselineMs: this.lastFlushAt })
+      return `${report}\n(note: refresh failed — ${(error as Error).message}; data is from the previous poll; baseline NOT reset)`
     }
     const report = this.flush(undefined)
     this.stopIfTerminal()
@@ -540,7 +549,7 @@ export const PrMonitorPlugin: Plugin = async ({ client, directory, worktree, $ }
     const existing = watches.get(key)
     if (existing) return `Already monitoring ${targetKey(target)} in this session.\n${existing.watch.statusLine()}`
 
-    const config = await loadConfig([directory, worktree])
+    const config = await loadConfig([directory, worktree], log)
     if (config.ignoreCommentTag !== undefined && selfLogin === undefined) {
       try {
         selfLogin = (await runGh(["api", "user", "--jq", ".login"])).trim()

--- a/.opencode/plugins/pr-monitor.ts
+++ b/.opencode/plugins/pr-monitor.ts
@@ -524,9 +524,12 @@ export const PrMonitorPlugin: Plugin = async ({ client, directory, worktree, $ }
     return normalizeSnapshot(payload, { ignoreTag: config.ignoreCommentTag, selfLogin })
   }
 
-  const deliver = (sessionID: string) => (report: string) => {
+  // `agent` must be sent explicitly: agent-less prompts resolve to the server's
+  // default agent, which fails when that default is configured as a subagent
+  // (observed live: 'default agent "build" is a subagent').
+  const deliver = (sessionID: string, agent: string) => (report: string) => {
     void client.session
-      .promptAsync({ path: { id: sessionID }, body: { parts: [{ type: "text", text: report }] } })
+      .promptAsync({ path: { id: sessionID }, body: { agent, parts: [{ type: "text", text: report }] } })
       .catch((error: unknown) => log(`failed to deliver report to session ${sessionID}: ${error}`))
   }
 
@@ -542,7 +545,7 @@ export const PrMonitorPlugin: Plugin = async ({ client, directory, worktree, $ }
     return [entry.watch]
   }
 
-  const startWatch = async (sessionID: string, pr: string): Promise<string> => {
+  const startWatch = async (sessionID: string, agent: string, pr: string): Promise<string> => {
     const target = parseTarget(pr)
     if ("error" in target) return target.error
     const key = `${sessionID} ${targetKey(target)}`
@@ -574,7 +577,7 @@ export const PrMonitorPlugin: Plugin = async ({ client, directory, worktree, $ }
       deps: {
         now: Date.now,
         fetchSnapshot: () => fetchSnapshot(target, config),
-        deliver: deliver(sessionID),
+        deliver: deliver(sessionID, agent),
         log,
         onStopped: () => {
           const entry = watches.get(key)
@@ -617,7 +620,7 @@ export const PrMonitorPlugin: Plugin = async ({ client, directory, worktree, $ }
           switch (args.action) {
             case "start": {
               if (!args.pr || args.pr === "all") return "action 'start' requires a single explicit pr: 'owner/repo#123' or a PR URL."
-              return await startWatch(sessionID, args.pr)
+              return await startWatch(sessionID, context.agent, args.pr)
             }
             case "stop": {
               if (!args.pr) return "action 'stop' requires pr: 'owner/repo#123', a PR URL, or 'all'."

--- a/.opencode/pr-monitor.json
+++ b/.opencode/pr-monitor.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommentTag": "[Sesori reply]"
+}

--- a/.opencode/skills/monitor-pr/SKILL.md
+++ b/.opencode/skills/monitor-pr/SKILL.md
@@ -32,7 +32,7 @@ act as follows, addressing everything in the report in one batch:
 | Report says | Do this |
 | --- | --- |
 | `CI: failing (…)` | Inspect the failures (`gh pr checks <pr> --repo owner/repo`, `gh run view <run-id> --log-failed --repo owner/repo`), fix the root cause, commit and push. Never delete or weaken tests to go green. |
-| `Mergeable: CONFLICTING` | Merge the latest base branch INTO the PR branch: `git fetch origin && git merge origin/main`. **NEVER rebase.** Resolve conflicts conservatively so functionality from both sides is preserved — when unsure, read the full context of both changes before choosing. Run the relevant tests, then push the merge commit. |
+| `Mergeable: CONFLICTING` | Merge the latest base branch INTO the PR branch. First resolve the PR's actual base ref: `gh pr view <number> --repo owner/repo --json baseRefName -q .baseRefName`, then `git fetch origin && git merge origin/<baseRefName>`. **NEVER rebase.** Resolve conflicts conservatively so functionality from both sides is preserved — when unsure, read the full context of both changes before choosing. Run the relevant tests, then push the merge commit. |
 | New inline comments / `changes_requested` | Follow the `address-pr-comments` skill: fetch unresolved threads, assess validity, implement fixes, reply to every thread. |
 | New issue comments | Read them (`gh pr view <number> --repo owner/repo --comments`) and act only if they request something. |
 | Approved + CI passing + 0 unresolved threads | Nothing to fix — summarize the PR state to the user. |

--- a/.opencode/skills/monitor-pr/SKILL.md
+++ b/.opencode/skills/monitor-pr/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: monitor-pr
+description: Monitor GitHub PRs with the pr_monitor tool and handle incoming "[PR Monitor]" reports. Use immediately after raising a PR, when the user asks to monitor/watch a PR, and whenever a "[PR Monitor]" message arrives in the session (CI results, new review comments, merge conflicts, approvals). Requires gh.
+---
+
+# monitor-pr
+
+Watch a GitHub PR in the background via the `pr_monitor` tool and act on the
+factual reports it delivers to this session.
+
+## Starting a monitor
+
+**Proactively start a monitor right after raising a PR** (e.g. after `gh pr create`):
+
+```
+pr_monitor(action: "start", pr: "owner/repo#123")
+```
+
+- The `pr` argument is always explicit — `owner/repo#123` or a full PR URL. Never a bare number.
+- One monitor per PR; start several monitors for several PRs.
+- Monitors belong to this session and **do not survive an opencode restart**. When
+  resuming PR work in a fresh opencode instance, check `pr_monitor(action: "status")`
+  and re-start monitors as needed.
+- Tuning (debounce, poll interval, CI wait, ignored comment tag) lives in
+  `.opencode/pr-monitor.json` — not in tool arguments.
+
+## Handling a `[PR Monitor]` report
+
+Reports state facts only (CI status, mergeability, reviews, comment counts). Decide and
+act as follows, addressing everything in the report in one batch:
+
+| Report says | Do this |
+| --- | --- |
+| `CI: failing (…)` | Inspect the failures (`gh pr checks <pr> --repo owner/repo`, `gh run view <run-id> --log-failed --repo owner/repo`), fix the root cause, commit and push. Never delete or weaken tests to go green. |
+| `Mergeable: CONFLICTING` | Merge the latest base branch INTO the PR branch: `git fetch origin && git merge origin/main`. **NEVER rebase.** Resolve conflicts conservatively so functionality from both sides is preserved — when unsure, read the full context of both changes before choosing. Run the relevant tests, then push the merge commit. |
+| New inline comments / `changes_requested` | Follow the `address-pr-comments` skill: fetch unresolved threads, assess validity, implement fixes, reply to every thread. |
+| New issue comments | Read them (`gh pr view <number> --repo owner/repo --comments`) and act only if they request something. |
+| Approved + CI passing + 0 unresolved threads | Nothing to fix — summarize the PR state to the user. |
+| `— MERGED` / `— CLOSED` | The monitor already stopped itself. Nothing to do. |
+
+## After handling a report — ALWAYS flush
+
+Finish every handled cycle with:
+
+```
+pr_monitor(action: "flush", pr: "owner/repo#123")
+```
+
+This returns the current full status and advances the "new since last flush" baseline
+past your own pushes and replies, so they are not echoed back as new activity. Skipping
+this step causes a redundant wake-up report about your own follow-up comments.
+
+## Other actions
+
+- `pr_monitor(action: "status")` — list this session's monitors (also useful before ending a work session).
+- `pr_monitor(action: "stop", pr: "owner/repo#123" | "all")` — stop watching without waiting for merge.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,6 +355,10 @@ Conventional commits: `fix:`, `feat:`, `ci:`, `docs:`, `chore:`.
 
 `.gitattributes` marks generated code and test directories as `linguist-generated` so GitHub collapses their diffs. Lockfiles (`pubspec.lock`, `Gemfile.lock`, `Podfile.lock`) must NEVER be marked as generated — the user always reviews lockfile diffs.
 
+## PR Monitoring
+
+A `pr_monitor` tool (provided by `.opencode/plugins/pr-monitor.ts`) watches GitHub PRs in the background and delivers factual `[PR Monitor]` reports into the owning session. Usage and report-handling policy live in the `monitor-pr` skill — load it after raising a PR and whenever a `[PR Monitor]` message arrives. Monitors are per-session, configured via `.opencode/pr-monitor.json`, and do not survive opencode restarts.
+
 ## Testing
 
 | Location                 | Command        |


### PR DESCRIPTION
## What

A project-level opencode plugin (`.opencode/plugins/pr-monitor.ts`) exposing a `pr_monitor` tool (`start` / `stop` / `flush` / `status`) that watches GitHub PRs in the background and wakes the owning session with factual `[PR Monitor]` reports, plus a `monitor-pr` skill carrying the repo's report-handling policy and an AGENTS.md pointer.

## Design highlights

- **Explicit targets only**: `owner/repo#123` or PR URL — no cwd inference; cross-repo supported; one watch per PR, multiple watches per session.
- **Session-scoped**: watches belong to the session that started them (`context.sessionID`); stop/flush/status never see other sessions' watches; reports are delivered to the owning session via `client.session.promptAsync` (fire-and-forget).
- **Polling**: one `gh api graphql` query per watch per 60s (config floor 30s) fetching CI rollup, reviews, review threads, issue comments, mergeability.
- **Rolling debounce (5m default, no cap)**: any activity resets the quiet timer; everything buffered flushes as one aggregated report. Suite-level CI conclusion is activity; per-check progress and conclusion→running (new push) are not.
- **Bounded CI hold**: a due report holds while the suite runs, force-flushing after `maxCiWaitMinutes` (30m default) naming in-progress checks.
- **Facts only**: snapshot (CI / mergeable / reviewer states) + counts of new comments since the last flush, author-attributed, bot-tagged. No comment bodies, no advice — the `monitor-pr` skill owns handling policy (e.g. merge `origin/main`, never rebase).
- **Ignore tag**: comments by the authenticated `gh` user containing `ignoreCommentTag` (`[Sesori reply]` here) are invisible to the monitor — keeps the agent's own reply cycle from echoing back.
- **Lifecycle**: auto-stop on merge/close (final report), session deletion, 10 consecutive poll failures (one death notice), immediate on 404. In-memory by design — opencode restarts drop watches.

## Verification

- Temporary `bun test` suite (26 tests: parsing, config clamping, ignore-tag matrix, activity rules, debounce/CI-hold/failure state machine, report golden cases) was green, then deleted per plan — ships test-free.
- `tsc --noEmit` clean; plugin file's sole export is the plugin function (the loader invokes every export — verified against opencode v1.17.4 source).
- Dogfood checklist on this very PR follows as a comment once the plugin is loaded (requires opencode restart in the worktree).

## Notes

- `.opencode/package.json` / `tsconfig.json` stay local-only per the existing `.opencode/.gitignore` convention.
- Aristotle plan/impl reviews intentionally skipped (user-approved): this is TS opencode tooling outside the Dart layer-architecture domain; plan was Momus-reviewed instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opencode plugin `pr_monitor` to watch GitHub PRs and post concise “[PR Monitor]” updates to the owning session, plus the `monitor-pr` skill and `.opencode/pr-monitor.json`. Reliability is improved with explicit agent delivery, prompt failure detection, project-scoped reload takeover with stop notices, tighter activity detection, zombie-timer cleanup, and CI-hold–aware retries.

- **New Features**
  - `pr_monitor` tool with start/stop/flush/status; explicit targets (`owner/repo#123` or PR URL); per-session, in-memory watches.
  - Polls via `gh api graphql` every 60s (min 30s), aggregates with a 5m rolling debounce, holds during CI up to 30m.
  - Reports facts only: CI, mergeability, latest reviews, unresolved threads, and comment counts; ignores `[Sesori reply]`; auto-stops on merge/close, session deletion, 404.

- **Bug Fixes**
  - Delivery: pass owning agent; detect `prompt_async` errors; restore baseline and CI-hold on failure; stop after 10 consecutive delivery failures.
  - Reload safety: kill zombie timers; scope takeover by project directory; killed watches send a one-time stop notice.
  - Robustness: input validation and clearer errors; status shows consecutive poll failures; log delivery/poll errors.
  - Behavior: skip CI hold once PR is merged/closed and flush final report; flush fallback returns previous snapshot without advancing the baseline; stop on `session.deleted` and plugin dispose; anchor “new since” baseline to the snapshot fetch start to avoid missing comments between fetch and flush (may double-count instead of miss).

<sup>Written for commit 780009e40b0c1d0820e67c0f9d9488926fa2d4cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

