### PR TITLE
feat(bridge): sesori_plugin_runtime — supervisor restart, exit monitoring, port pinning, intent side-file (migration PR 9/15)

### DIFF
--- a/bridge/sesori_plugin_runtime/lib/sesori_plugin_runtime.dart
+++ b/bridge/sesori_plugin_runtime/lib/sesori_plugin_runtime.dart
@@ -1,5 +1,8 @@
 export "src/host_json_runtime_ownership_repository.dart";
 export "src/managed_process_service.dart";
+export "src/managed_runtime_monitor.dart";
 export "src/managed_runtime_spec.dart";
 export "src/runtime_ownership_repository.dart";
 export "src/runtime_record_mapper.dart";
+export "src/runtime_restart_policy.dart";
+export "src/runtime_start_intent.dart";

--- a/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
@@ -58,9 +58,7 @@ class ManagedProcessService<R> {
 
     // A deterministic configuration error: reject it once, up front, before
     // cleanup and before the dynamic path can retry it candidate by candidate.
-    if (spec.recordTiming == RuntimeRecordTiming.intentSideFile && _intentStore == null) {
-      throw ArgumentError("[$_runtimeId] intent side-file record timing requires an intent store");
-    }
+    _requireIntentStoreFor(spec);
 
     await cleanupStaleOwnedRuntimes(terminatedBridgeIdentities: terminatedBridgeIdentities);
     _throwIfAborted(abort);
@@ -124,6 +122,10 @@ class ManagedProcessService<R> {
     required Duration portReleasePollInterval,
     StartAbortSignal? startAborted,
   }) async {
+    // Reject a misconfigured intent timing up front, before waiting on the port,
+    // so a direct caller fails fast and clearly instead of crashing on a null
+    // intent store deep inside the spawn path.
+    _requireIntentStoreFor(spec);
     final abort = startAborted ?? StartAbortSignal.never;
     _throwIfAborted(abort);
     await _waitForPortRelease(
@@ -134,6 +136,15 @@ class ManagedProcessService<R> {
       abort: abort,
     );
     return _startAndConfirmHealthy(spec: spec, port: port, abort: abort);
+  }
+
+  /// A managed runtime that opts into intent side-file timing must be given an
+  /// intent store; selecting the timing without one is a deterministic
+  /// configuration error, surfaced before any side effects.
+  void _requireIntentStoreFor(ManagedRuntimeSpec<R> spec) {
+    if (spec.recordTiming == RuntimeRecordTiming.intentSideFile && _intentStore == null) {
+      throw ArgumentError("[$_runtimeId] intent side-file record timing requires an intent store");
+    }
   }
 
   Future<void> _waitForPortRelease({

--- a/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_process_service.dart
@@ -3,6 +3,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "managed_runtime_spec.dart";
 import "runtime_ownership_repository.dart";
 import "runtime_record_mapper.dart";
+import "runtime_start_intent.dart";
 
 class ManagedProcessService<R> {
   ManagedProcessService({
@@ -13,13 +14,15 @@ class ManagedProcessService<R> {
     required ServerClock clock,
     required String runtimeId,
     required Duration gracefulShutdownWait,
+    RuntimeStartIntentStore? intentStore,
   }) : _ownershipRepository = ownershipRepository,
        _mapper = mapper,
        _processes = processes,
        _bridge = bridge,
        _clock = clock,
        _runtimeId = runtimeId,
-       _gracefulShutdownWait = gracefulShutdownWait;
+       _gracefulShutdownWait = gracefulShutdownWait,
+       _intentStore = intentStore;
 
   final RuntimeOwnershipRepository<R> _ownershipRepository;
   final RuntimeRecordMapper<R> _mapper;
@@ -28,6 +31,11 @@ class ManagedProcessService<R> {
   final ServerClock _clock;
   final String _runtimeId;
   final Duration _gracefulShutdownWait;
+
+  /// Optional bridge-private side-file store for [RuntimeRecordTiming.intentSideFile].
+  /// Required when that timing is selected; unused for the legacy after-spawn
+  /// timing, so it defaults to null and the legacy path never touches it.
+  final RuntimeStartIntentStore? _intentStore;
   final Map<String, _CurrentOwnedRuntimeProcess> _currentOwnedProcessesBySessionId =
       <String, _CurrentOwnedRuntimeProcess>{};
 
@@ -48,12 +56,10 @@ class ManagedProcessService<R> {
   }) async {
     final abort = startAborted ?? StartAbortSignal.never;
 
-    // A deterministic configuration error: reject it once, up front, so the
-    // dynamic path never retries it candidate by candidate.
-    if (spec.recordTiming == RuntimeRecordTiming.intentSideFile) {
-      // The bridge-private intent side file is introduced in a later step;
-      // until then only the legacy after-spawn timing is representable.
-      throw UnsupportedError("[$_runtimeId] intent side-file record timing is not available yet");
+    // A deterministic configuration error: reject it once, up front, before
+    // cleanup and before the dynamic path can retry it candidate by candidate.
+    if (spec.recordTiming == RuntimeRecordTiming.intentSideFile && _intentStore == null) {
+      throw ArgumentError("[$_runtimeId] intent side-file record timing requires an intent store");
     }
 
     await cleanupStaleOwnedRuntimes(terminatedBridgeIdentities: terminatedBridgeIdentities);
@@ -98,6 +104,71 @@ class ManagedProcessService<R> {
       identity: null,
       health: probe,
     );
+  }
+
+  /// Re-spawns the runtime on its original, address-frozen [port] after an
+  /// unexpected exit.
+  ///
+  /// Unlike [start] this runs no stale cleanup and never moves to another port:
+  /// the runtime's HTTP/SSE stack is pinned to [port], so a restart must reclaim
+  /// that exact address. The previous child has already exited; this waits for
+  /// the address to free (bounded by [portReleaseTimeout]) — if it never frees
+  /// it throws [PluginStartException], which the caller treats as terminal.
+  /// Otherwise it spawns a fresh child and writes the new ownership record and
+  /// confirms health on exactly the cold-start path (including intent side-file
+  /// handling and rollback).
+  Future<ManagedRuntimeHandle<R>> restartOnPort({
+    required ManagedRuntimeSpec<R> spec,
+    required int port,
+    required Duration portReleaseTimeout,
+    required Duration portReleasePollInterval,
+    StartAbortSignal? startAborted,
+  }) async {
+    final abort = startAborted ?? StartAbortSignal.never;
+    _throwIfAborted(abort);
+    await _waitForPortRelease(
+      spec: spec,
+      port: port,
+      timeout: portReleaseTimeout,
+      pollInterval: portReleasePollInterval,
+      abort: abort,
+    );
+    return _startAndConfirmHealthy(spec: spec, port: port, abort: abort);
+  }
+
+  Future<void> _waitForPortRelease({
+    required ManagedRuntimeSpec<R> spec,
+    required int port,
+    required Duration timeout,
+    required Duration pollInterval,
+    required StartAbortSignal abort,
+  }) async {
+    final deadline = _clock.now().add(timeout);
+    // A hard backstop independent of the clock: a misconfigured (e.g.
+    // non-advancing) clock must fail loud, never hang the supervisor.
+    final maxPolls = _portReleaseMaxPolls(timeout: timeout, pollInterval: pollInterval);
+    var polls = 0;
+    while (true) {
+      _throwIfAborted(abort);
+      if (await spec.probePortBindable(port: port)) {
+        return;
+      }
+      polls += 1;
+      if (polls >= maxPolls || !_clock.now().isBefore(deadline)) {
+        throw PluginStartException(
+          "[$_runtimeId] port $port did not free for restart within ${timeout.inMilliseconds}ms",
+          cause: null,
+        );
+      }
+      await _clock.delay(duration: pollInterval);
+    }
+  }
+
+  int _portReleaseMaxPolls({required Duration timeout, required Duration pollInterval}) {
+    if (pollInterval <= Duration.zero) {
+      return 1;
+    }
+    return (timeout.inMicroseconds / pollInterval.inMicroseconds).ceil() + 2;
   }
 
   Future<ManagedRuntimeHandle<R>> _startOnExplicitPort({
@@ -179,9 +250,44 @@ class ManagedProcessService<R> {
     required int port,
     required StartAbortSignal abort,
   }) async {
+    final usesIntent = spec.recordTiming == RuntimeRecordTiming.intentSideFile;
+    if (usesIntent) {
+      // Record the spawn intent before the child exists, so a crash between
+      // spawn and the ownership write still names the bridge run and the port.
+      await _intentStore!.write(
+        RuntimeStartIntent(
+          ownerSessionId: _bridge.ownerSessionId,
+          port: port,
+          bridgePid: _bridge.identity.pid,
+          bridgeStartMarker: _bridge.identity.startMarker,
+          recordedAt: _clock.now(),
+        ),
+      );
+    }
+
     // Spawn errors propagate before any ownership state is acquired: the
     // explicit-port caller surfaces them raw, the dynamic caller retries.
-    final spawned = await spec.spawn(port: port);
+    final SpawnedProcess spawned;
+    try {
+      spawned = await spec.spawn(port: port);
+    } on Object {
+      if (usesIntent) {
+        await _clearIntentQuietly();
+      }
+      rethrow;
+    }
+
+    // The documented post-spawn abort checkpoint: settle here, before any
+    // ownership state is created, so an abort that fired during the spawn does
+    // not first write a starting record only to roll it straight back. The
+    // freshly spawned child is still untracked, so stop it directly.
+    if (abort.isAborted) {
+      await _stopUntrackedSpawnQuietly(process: spawned, port: port, reason: "after a post-spawn abort");
+      if (usesIntent) {
+        await _clearIntentQuietly();
+      }
+      throw const PluginStartAbortedException();
+    }
 
     final R record;
     try {
@@ -197,10 +303,9 @@ class ManagedProcessService<R> {
     } on Object {
       // The child is already running but not yet tracked or recorded — stop it
       // directly so a record-factory failure cannot leak a started runtime.
-      try {
-        await _stopUntrackedSpawn(process: spawned);
-      } on Object catch (cleanupError, cleanupStackTrace) {
-        Log.w("[$_runtimeId] Failed to stop an orphaned child after a record build error on port $port", cleanupError, cleanupStackTrace);
+      await _stopUntrackedSpawnQuietly(process: spawned, port: port, reason: "after a record build error");
+      if (usesIntent) {
+        await _clearIntentQuietly();
       }
       rethrow;
     }
@@ -208,6 +313,11 @@ class ManagedProcessService<R> {
 
     try {
       await _ownershipRepository.upsert(record: record);
+      if (usesIntent) {
+        // The starting record is now in the frozen ownership file; an orphan is
+        // trackable from there, so the intent has done its job.
+        await _clearIntentQuietly();
+      }
       _throwIfAborted(abort);
 
       final health = await _confirmHealthy(spec: spec, port: port, spawned: spawned, abort: abort);
@@ -243,7 +353,24 @@ class ManagedProcessService<R> {
       } on Object catch (cleanupError, cleanupStackTrace) {
         Log.w("[$_runtimeId] Failed to clean up after a failed start on port $port", cleanupError, cleanupStackTrace);
       }
+      if (usesIntent) {
+        await _clearIntentQuietly();
+      }
       rethrow;
+    }
+  }
+
+  /// Best-effort removal of the intent side file. An intent-clear failure must
+  /// never mask the start error that prompted it, so this only logs.
+  Future<void> _clearIntentQuietly() async {
+    final store = _intentStore;
+    if (store == null) {
+      return;
+    }
+    try {
+      await store.clear();
+    } on Object catch (error, stackTrace) {
+      Log.w("[$_runtimeId] Failed to clear the runtime start-intent side file", error, stackTrace);
     }
   }
 
@@ -326,6 +453,21 @@ class ManagedProcessService<R> {
 
   Future<void> _cleanupFailedStart({required R record}) async {
     await _stopRecord(record: record, removeOwnership: true);
+  }
+
+  /// Stops an untracked, unrecorded child without letting the stop failure mask
+  /// the start outcome that triggered it (an abort, a record-build error). Only
+  /// logs on failure.
+  Future<void> _stopUntrackedSpawnQuietly({
+    required SpawnedProcess process,
+    required int port,
+    required String reason,
+  }) async {
+    try {
+      await _stopUntrackedSpawn(process: process);
+    } on Object catch (cleanupError, cleanupStackTrace) {
+      Log.w("[$_runtimeId] Failed to stop an orphaned child $reason on port $port", cleanupError, cleanupStackTrace);
+    }
   }
 
   /// Stops a freshly spawned child that has no ownership record yet (the record

--- a/bridge/sesori_plugin_runtime/lib/src/managed_runtime_monitor.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_runtime_monitor.dart
@@ -161,7 +161,12 @@ class ManagedRuntimeMonitor<R> {
         if (_disarmed) {
           return;
         }
-        _status.trySet(PluginRestarting(attempt: attempt, reason: reason));
+        if (!_status.trySet(PluginRestarting(attempt: attempt, reason: reason))) {
+          // The status machine rejected the transition — the plugin is stopping,
+          // stopped, or already failed — so stand down instead of spawning a
+          // child into a terminal/shutdown state.
+          return;
+        }
         await _clock.delay(duration: policy.backoffFor(attempt));
         if (_disarmed) {
           return;

--- a/bridge/sesori_plugin_runtime/lib/src/managed_runtime_monitor.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_runtime_monitor.dart
@@ -1,0 +1,237 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "managed_process_service.dart";
+import "managed_runtime_spec.dart";
+import "runtime_restart_policy.dart";
+
+/// Supervises an already-started managed runtime: drains its stdio (logging
+/// stderr with a `[runtimeId]` prefix), watches for an unexpected exit, and —
+/// when a bounded restart policy is configured — relaunches it on its original,
+/// address-frozen port with backoff, publishing lifecycle transitions through
+/// the plugin's [PluginStatusController].
+///
+/// The monitor is a **separate** component that composes [ManagedProcessService]
+/// rather than living inside it. The legacy in-place wrapper (and its fidelity
+/// gate) drives the service directly and never constructs a monitor, so
+/// "exit monitoring / restart / stderr logging" are simply absent there — the
+/// way the migration keeps these hardened behaviors off until the flip.
+///
+/// Concurrency contract:
+/// - Every exit-driven action runs only for the *current* child
+///   (`identical(firedProcess, currentHandle.process)`) and only while not
+///   disarmed — an exit future for a superseded child is dropped. Bare
+///   `Future<int> exitCode` cannot be cancelled, so this identity check, not a
+///   subscription cancel, is what makes a stale exit inert.
+/// - All status writes go through [PluginStatusController.trySet]; a `Failed`
+///   that races a deliberate `Stopping` is silently dropped by the state
+///   machine, belt-and-suspenders with [disarm].
+/// - [disarm] (called by the owner's shutdown *before* it signals the child)
+///   aborts any in-flight restart so the relaunched child is rolled back rather
+///   than leaked, and cancels the stdio subscriptions. It is idempotent.
+class ManagedRuntimeMonitor<R> {
+  ManagedRuntimeMonitor({
+    required ManagedProcessService<R> service,
+    required ManagedRuntimeSpec<R> spec,
+    required PluginStatusController status,
+    required ServerClock clock,
+    required String runtimeId,
+    required RuntimeRestartPolicy restartPolicy,
+  }) : _service = service,
+       _spec = spec,
+       _status = status,
+       _clock = clock,
+       _runtimeId = runtimeId,
+       _restartPolicy = restartPolicy;
+
+  final ManagedProcessService<R> _service;
+  final ManagedRuntimeSpec<R> _spec;
+  final PluginStatusController _status;
+  final ServerClock _clock;
+  final String _runtimeId;
+  final RuntimeRestartPolicy _restartPolicy;
+
+  ManagedRuntimeHandle<R>? _currentHandle;
+  int? _pinnedPort;
+  bool _disarmed = false;
+  // Long-lived stdio drains, cancelled in _cancelStdioSubscriptions (on restart)
+  // and disarm (on stop) rather than where they are created.
+  // ignore: cancel_subscriptions
+  StreamSubscription<void>? _stdoutSubscription;
+  // ignore: cancel_subscriptions
+  StreamSubscription<String>? _stderrSubscription;
+  StartAbortController? _restartAbort;
+
+  /// The handle for the runtime currently being supervised — updated to the
+  /// fresh handle after each successful restart so callers (and the eventual
+  /// `stop()`) target the live child.
+  ManagedRuntimeHandle<R>? get currentHandle => _currentHandle;
+
+  /// Begins supervising [handle].
+  ///
+  /// For an attached (un-owned) handle there is no child to watch, so this only
+  /// records the handle. For an owned handle it pins the port, wires the stdout
+  /// drain and stderr logging in a single synchronous turn (both are
+  /// single-subscription and a full pipe would block the child), and watches
+  /// the child's exit. Safe to call once; a no-op once disarmed.
+  void arm(ManagedRuntimeHandle<R> handle) {
+    if (_disarmed) {
+      return;
+    }
+    _currentHandle = handle;
+
+    final process = handle.process;
+    if (process == null) {
+      // Attach mode: the bridge connected to a runtime it does not own, so
+      // there is no child to drain, watch, or restart.
+      return;
+    }
+
+    _pinnedPort = handle.port;
+    _watchProcess(process);
+  }
+
+  /// Stops supervising: aborts any in-flight restart (so its freshly spawned
+  /// child is rolled back, not leaked), and cancels the stdio subscriptions.
+  ///
+  /// The owner calls this *before* signaling the child during shutdown, so the
+  /// child's deliberate exit is never mistaken for a crash. Idempotent.
+  Future<void> disarm() async {
+    if (_disarmed) {
+      return;
+    }
+    _disarmed = true;
+    _restartAbort?.abort();
+    await _cancelStdioSubscriptions();
+  }
+
+  void _watchProcess(SpawnedProcess process) {
+    // Wire both stdio drains synchronously: both streams are single
+    // subscription and the child blocks on a full pipe, so neither may wait on
+    // an await before being consumed. Both subscriptions are long-lived and
+    // cancelled in _cancelStdioSubscriptions (on restart) and disarm (on stop).
+    _stdoutSubscription = process.stdout.listen((_) {}, onError: (Object _) {}, cancelOnError: false);
+    final stderrLines = process.stderr.transform(utf8.decoder).transform(const LineSplitter());
+    _stderrSubscription = stderrLines.listen(
+      (line) => Log.d("[$_runtimeId] $line"),
+      onError: (Object _) {},
+      cancelOnError: false,
+    );
+
+    // exitCode is a bare Future with no cancel; _onUnexpectedExit re-checks the
+    // current-child identity and the disarm flag, so a stale completion is inert.
+    unawaited(process.exitCode.then((code) => _onUnexpectedExit(process, code)).catchError((Object _) {}));
+  }
+
+  Future<void> _onUnexpectedExit(SpawnedProcess process, int exitCode) async {
+    if (_disarmed || !identical(process, _currentHandle?.process)) {
+      return;
+    }
+    Log.e("[$_runtimeId] runtime exited unexpectedly with code $exitCode");
+
+    final policy = _restartPolicy;
+    switch (policy) {
+      case DisabledRestartPolicy():
+        _status.trySet(
+          PluginFailed(reason: "[$_runtimeId] runtime exited unexpectedly with code $exitCode", cause: null),
+        );
+      case BoundedRestartPolicy():
+        await _runRestartEpisode(policy: policy, exitCode: exitCode);
+    }
+  }
+
+  Future<void> _runRestartEpisode({required BoundedRestartPolicy policy, required int exitCode}) async {
+    final port = _pinnedPort;
+    if (port == null) {
+      return;
+    }
+    final reason = "runtime exited with code $exitCode";
+    final abort = StartAbortController();
+    _restartAbort = abort;
+
+    Object? lastError;
+    try {
+      for (var attempt = 1; attempt <= policy.maxAttempts; attempt += 1) {
+        if (_disarmed) {
+          return;
+        }
+        _status.trySet(PluginRestarting(attempt: attempt, reason: reason));
+        await _clock.delay(duration: policy.backoffFor(attempt));
+        if (_disarmed) {
+          return;
+        }
+
+        try {
+          final handle = await _service.restartOnPort(
+            spec: _spec,
+            port: port,
+            portReleaseTimeout: policy.portReleaseTimeout,
+            portReleasePollInterval: policy.portReleasePollInterval,
+            startAborted: abort.signal,
+          );
+          // Adopt the freshly started child *before* any stand-down check: if a
+          // disarm raced the final ownership write, restartOnPort still committed
+          // (and is tracking) this child, so it must become the current handle
+          // or the owner's shutdown would stop the wrong (dead) child and leak
+          // it. _adoptRestartedHandle leaves the new child unwatched when disarmed.
+          _adoptRestartedHandle(handle);
+          if (_disarmed) {
+            return;
+          }
+          // A concurrent recovery (e.g. the SSE layer flipping back to Ready)
+          // means this episode is stale, so announce nothing further.
+          if (_status.current is! PluginRestarting) {
+            return;
+          }
+          _status.trySet(const PluginReady());
+          return;
+        } on PluginStartAbortedException {
+          // Disarmed mid-restart: restartOnPort already rolled back the child
+          // and record. Nothing to fail; the shutdown owns the outcome.
+          return;
+        } on Object catch (error) {
+          lastError = error;
+        }
+      }
+
+      _status.trySet(
+        PluginFailed(
+          reason: "[$_runtimeId] runtime could not be restarted after ${policy.maxAttempts} attempt(s)",
+          cause: lastError,
+        ),
+      );
+    } finally {
+      // Only clear the controller this episode owns: if a later episode has
+      // already taken over _restartAbort, nulling it here would leave that
+      // episode's in-flight restart unabortable by disarm().
+      if (identical(_restartAbort, abort)) {
+        _restartAbort = null;
+      }
+    }
+  }
+
+  void _adoptRestartedHandle(ManagedRuntimeHandle<R> handle) {
+    // Cancel the exited child's stdio drains before wiring the new child's.
+    unawaited(_cancelStdioSubscriptions());
+    _currentHandle = handle;
+    final process = handle.process;
+    // When disarmed (a shutdown raced this restart), the child is now tracked
+    // and reachable via _currentHandle for the owner's stop, but it must not be
+    // re-watched: a fresh exit watch could only fire after disarm and would be
+    // dropped anyway, and leaving stdio subscriptions would be a needless leak.
+    if (process != null && !_disarmed) {
+      _watchProcess(process);
+    }
+  }
+
+  Future<void> _cancelStdioSubscriptions() async {
+    final stdoutSubscription = _stdoutSubscription;
+    final stderrSubscription = _stderrSubscription;
+    _stdoutSubscription = null;
+    _stderrSubscription = null;
+    await stdoutSubscription?.cancel();
+    await stderrSubscription?.cancel();
+  }
+}

--- a/bridge/sesori_plugin_runtime/lib/src/managed_runtime_monitor.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_runtime_monitor.dart
@@ -113,7 +113,11 @@ class ManagedRuntimeMonitor<R> {
     // an await before being consumed. Both subscriptions are long-lived and
     // cancelled in _cancelStdioSubscriptions (on restart) and disarm (on stop).
     _stdoutSubscription = process.stdout.listen((_) {}, onError: (Object _) {}, cancelOnError: false);
-    final stderrLines = process.stderr.transform(utf8.decoder).transform(const LineSplitter());
+    // allowMalformed: a crashing runtime can emit non-UTF-8 bytes on stderr; a
+    // strict decoder would throw and tear down the drain, so substitute instead.
+    final stderrLines = process.stderr
+        .transform(const Utf8Decoder(allowMalformed: true))
+        .transform(const LineSplitter());
     _stderrSubscription = stderrLines.listen(
       (line) => Log.d("[$_runtimeId] $line"),
       onError: (Object _) {},
@@ -191,7 +195,10 @@ class ManagedRuntimeMonitor<R> {
           // Disarmed mid-restart: restartOnPort already rolled back the child
           // and record. Nothing to fail; the shutdown owns the outcome.
           return;
-        } on Object catch (error) {
+        } on Object catch (error, stackTrace) {
+          // Log every failed attempt: PluginFailed only carries the last error,
+          // so without this an early failure in a multi-attempt episode is silent.
+          Log.w("[$_runtimeId] restart attempt $attempt failed", error, stackTrace);
           lastError = error;
         }
       }
@@ -231,7 +238,17 @@ class ManagedRuntimeMonitor<R> {
     final stderrSubscription = _stderrSubscription;
     _stdoutSubscription = null;
     _stderrSubscription = null;
-    await stdoutSubscription?.cancel();
-    await stderrSubscription?.cancel();
+    // This runs unawaited from _adoptRestartedHandle, so a throwing cancel would
+    // surface as an unhandled async error; swallow (logged) to keep teardown safe.
+    try {
+      await stdoutSubscription?.cancel();
+    } on Object catch (error, stackTrace) {
+      Log.w("[$_runtimeId] Failed to cancel the runtime stdout drain", error, stackTrace);
+    }
+    try {
+      await stderrSubscription?.cancel();
+    } on Object catch (error, stackTrace) {
+      Log.w("[$_runtimeId] Failed to cancel the runtime stderr drain", error, stackTrace);
+    }
   }
 }

--- a/bridge/sesori_plugin_runtime/lib/src/runtime_restart_policy.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/runtime_restart_policy.dart
@@ -1,0 +1,82 @@
+/// How the supervisor responds when a managed runtime exits unexpectedly
+/// while it is meant to be running.
+///
+/// The legacy behavior is [RuntimeRestartPolicy.disabled] — an unexpected exit
+/// is terminal. The hardened bounded-restart pacing
+/// ([RuntimeRestartPolicy.bounded]) becomes available only when the real
+/// descriptor opts in at the flip; until then the monitor is simply never
+/// armed, so production behavior is unchanged.
+sealed class RuntimeRestartPolicy {
+  const RuntimeRestartPolicy();
+
+  /// Legacy: an unexpected exit is terminal and surfaces as `PluginFailed`.
+  const factory RuntimeRestartPolicy.disabled() = DisabledRestartPolicy;
+
+  /// Hardened: up to [maxAttempts] restarts within a single failure episode,
+  /// each preceded by an exponential backoff and a bounded wait for the
+  /// address-frozen port to free. Exhausting the attempts surfaces as
+  /// `PluginFailed`.
+  factory RuntimeRestartPolicy.bounded({
+    required int maxAttempts,
+    required Duration initialBackoff,
+    required Duration maxBackoff,
+    required Duration portReleaseTimeout,
+    required Duration portReleasePollInterval,
+    double backoffMultiplier,
+  }) = BoundedRestartPolicy;
+}
+
+/// Restarts are off: the supervisor never relaunches a runtime that exits.
+class DisabledRestartPolicy extends RuntimeRestartPolicy {
+  const DisabledRestartPolicy();
+}
+
+/// Bounded restart-with-backoff, pinned to the runtime's original port.
+class BoundedRestartPolicy extends RuntimeRestartPolicy {
+  // Not const: the parameter guards compare Durations, which is not a
+  // constant-evaluable operation. Built at runtime anyway (at the flip).
+  BoundedRestartPolicy({
+    required this.maxAttempts,
+    required this.initialBackoff,
+    required this.maxBackoff,
+    required this.portReleaseTimeout,
+    required this.portReleasePollInterval,
+    this.backoffMultiplier = 2.0,
+  }) : assert(maxAttempts > 0, "maxAttempts must be positive"),
+       assert(!initialBackoff.isNegative, "initialBackoff must be non-negative"),
+       assert(backoffMultiplier >= 1.0, "backoffMultiplier must be at least 1.0"),
+       assert(maxBackoff >= initialBackoff, "maxBackoff must be at least initialBackoff"),
+       assert(!portReleaseTimeout.isNegative, "portReleaseTimeout must be non-negative"),
+       assert(portReleasePollInterval > Duration.zero, "portReleasePollInterval must be positive");
+
+  /// Maximum restarts attempted within one failure episode. A restart that
+  /// reaches `Ready` ends the episode; a later exit starts a fresh one.
+  final int maxAttempts;
+
+  /// Backoff before the first restart attempt.
+  final Duration initialBackoff;
+
+  /// Upper bound on the (geometrically growing) backoff.
+  final Duration maxBackoff;
+
+  /// How long to wait for the pinned port to become bindable again before a
+  /// restart attempt gives up (the previous child is releasing the address).
+  final Duration portReleaseTimeout;
+
+  /// How often to re-probe the pinned port while waiting for it to free.
+  final Duration portReleasePollInterval;
+
+  /// Multiplier applied to the backoff between successive attempts.
+  final double backoffMultiplier;
+
+  /// Backoff before the 1-based [attempt] restart, capped at [maxBackoff].
+  Duration backoffFor(int attempt) {
+    assert(attempt >= 1, "attempt is 1-based: the first restart is attempt 1");
+    var value = initialBackoff;
+    for (var i = 1; i < attempt && value < maxBackoff; i += 1) {
+      final next = value * backoffMultiplier;
+      value = next < maxBackoff ? next : maxBackoff;
+    }
+    return value < maxBackoff ? value : maxBackoff;
+  }
+}

--- a/bridge/sesori_plugin_runtime/lib/src/runtime_start_intent.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/runtime_start_intent.dart
@@ -1,0 +1,121 @@
+import "dart:convert";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+/// A record that a managed-runtime spawn is *about to happen*, persisted to a
+/// bridge-private side file before the child is launched and removed once the
+/// real ownership record exists.
+///
+/// This closes the gap between "child spawned" and "ownership record written":
+/// a bridge that crashes inside that window leaves no entry in the frozen
+/// ownership file, but the intent side file still names the bridge run and the
+/// port the spawn targeted. It deliberately carries **no child pid** — it is
+/// written before the pid exists — and it is **never** merged into the frozen
+/// `opencode-processes.json` (whose schema requires a non-null runtime pid and
+/// is read verbatim by older bridge versions). Its shape is bridge-private and
+/// may evolve freely.
+class RuntimeStartIntent {
+  const RuntimeStartIntent({
+    required this.ownerSessionId,
+    required this.port,
+    required this.bridgePid,
+    required this.bridgeStartMarker,
+    required this.recordedAt,
+  });
+
+  /// Stable identifier of the bridge run that is about to spawn the runtime.
+  final String ownerSessionId;
+
+  /// The port the spawn is targeting.
+  final int port;
+
+  /// Pid of the hosting bridge process.
+  final int bridgePid;
+
+  /// Start marker of the hosting bridge process (absent on Windows).
+  final String? bridgeStartMarker;
+
+  /// When the intent was recorded (host clock).
+  final DateTime recordedAt;
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      "ownerSessionId": ownerSessionId,
+      "port": port,
+      "bridgePid": bridgePid,
+      "bridgeStartMarker": bridgeStartMarker,
+      "recordedAt": recordedAt.toUtc().toIso8601String(),
+    };
+  }
+
+  static RuntimeStartIntent fromJson(Map<String, dynamic> json) {
+    return RuntimeStartIntent(
+      ownerSessionId: json["ownerSessionId"] as String,
+      port: json["port"] as int,
+      bridgePid: json["bridgePid"] as int,
+      bridgeStartMarker: json["bridgeStartMarker"] as String?,
+      recordedAt: DateTime.parse(json["recordedAt"] as String),
+    );
+  }
+
+  @override
+  String toString() {
+    return "RuntimeStartIntent(ownerSessionId: $ownerSessionId, port: $port, bridgePid: $bridgePid)";
+  }
+}
+
+/// Reads and writes the single in-flight [RuntimeStartIntent] to a bridge-private
+/// side file (typically `<runtimeId>-start-intent.json`) inside the runtime's
+/// state directory.
+///
+/// The file is a sibling of the frozen ownership file but is **never** read by
+/// older bridge versions: writing or removing it leaves the ownership file
+/// byte-for-byte untouched. Writes and removals use the plain [HostJsonStore]
+/// operations (atomic write / no-op delete) rather than the locked `update()` —
+/// the intent targets its own file, so there is nothing to serialize against,
+/// and nesting an `update()` inside the ownership store's locked critical
+/// section would deadlock.
+class RuntimeStartIntentStore {
+  RuntimeStartIntentStore({required HostJsonStore store, required String fileName})
+    : _store = store,
+      _fileName = fileName;
+
+  final HostJsonStore _store;
+  final String _fileName;
+
+  /// Atomically writes [intent], replacing any previous in-flight intent.
+  Future<void> write(RuntimeStartIntent intent) async {
+    await _store.write(name: _fileName, contents: jsonEncode(intent.toJson()));
+  }
+
+  /// Reads the current intent, or `null` when none is recorded or the file is
+  /// unreadable/corrupt (a leftover intent must never block a fresh start).
+  Future<RuntimeStartIntent?> read() async {
+    final String? contents;
+    try {
+      contents = await _store.read(name: _fileName);
+    } on Object catch (error) {
+      Log.w("Failed to read runtime start-intent side file at $_fileName; ignoring. Error: $error");
+      return null;
+    }
+    if (contents == null || contents.trim().isEmpty) {
+      return null;
+    }
+    try {
+      final decoded = jsonDecode(contents);
+      if (decoded is! Map) {
+        return null;
+      }
+      return RuntimeStartIntent.fromJson(Map<String, dynamic>.from(decoded));
+    } on Object catch (error) {
+      Log.w("Failed to parse runtime start-intent side file at $_fileName; ignoring. Error: $error");
+      return null;
+    }
+  }
+
+  /// Removes the intent side file. A no-op when no intent is recorded, so it is
+  /// safe to call on every start outcome (success, failure, abort).
+  Future<void> clear() async {
+    await _store.delete(name: _fileName);
+  }
+}

--- a/bridge/sesori_plugin_runtime/lib/src/runtime_start_intent.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/runtime_start_intent.dart
@@ -1,6 +1,10 @@
 import "dart:convert";
 
+import "package:freezed_annotation/freezed_annotation.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+part "runtime_start_intent.freezed.dart";
+part "runtime_start_intent.g.dart";
 
 /// A record that a managed-runtime spawn is *about to happen*, persisted to a
 /// bridge-private side file before the child is launched and removed once the
@@ -14,54 +18,26 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 /// `opencode-processes.json` (whose schema requires a non-null runtime pid and
 /// is read verbatim by older bridge versions). Its shape is bridge-private and
 /// may evolve freely.
-class RuntimeStartIntent {
-  const RuntimeStartIntent({
-    required this.ownerSessionId,
-    required this.port,
-    required this.bridgePid,
-    required this.bridgeStartMarker,
-    required this.recordedAt,
-  });
+@freezed
+sealed class RuntimeStartIntent with _$RuntimeStartIntent {
+  const factory RuntimeStartIntent({
+    /// Stable identifier of the bridge run that is about to spawn the runtime.
+    required String ownerSessionId,
 
-  /// Stable identifier of the bridge run that is about to spawn the runtime.
-  final String ownerSessionId;
+    /// The port the spawn is targeting.
+    required int port,
 
-  /// The port the spawn is targeting.
-  final int port;
+    /// Pid of the hosting bridge process.
+    required int bridgePid,
 
-  /// Pid of the hosting bridge process.
-  final int bridgePid;
+    /// Start marker of the hosting bridge process (absent on Windows).
+    required String? bridgeStartMarker,
 
-  /// Start marker of the hosting bridge process (absent on Windows).
-  final String? bridgeStartMarker;
+    /// When the intent was recorded (host clock).
+    required DateTime recordedAt,
+  }) = _RuntimeStartIntent;
 
-  /// When the intent was recorded (host clock).
-  final DateTime recordedAt;
-
-  Map<String, dynamic> toJson() {
-    return <String, dynamic>{
-      "ownerSessionId": ownerSessionId,
-      "port": port,
-      "bridgePid": bridgePid,
-      "bridgeStartMarker": bridgeStartMarker,
-      "recordedAt": recordedAt.toUtc().toIso8601String(),
-    };
-  }
-
-  static RuntimeStartIntent fromJson(Map<String, dynamic> json) {
-    return RuntimeStartIntent(
-      ownerSessionId: json["ownerSessionId"] as String,
-      port: json["port"] as int,
-      bridgePid: json["bridgePid"] as int,
-      bridgeStartMarker: json["bridgeStartMarker"] as String?,
-      recordedAt: DateTime.parse(json["recordedAt"] as String),
-    );
-  }
-
-  @override
-  String toString() {
-    return "RuntimeStartIntent(ownerSessionId: $ownerSessionId, port: $port, bridgePid: $bridgePid)";
-  }
+  factory RuntimeStartIntent.fromJson(Map<String, dynamic> json) => _$RuntimeStartIntentFromJson(json);
 }
 
 /// Reads and writes the single in-flight [RuntimeStartIntent] to a bridge-private

--- a/bridge/sesori_plugin_runtime/lib/src/runtime_start_intent.freezed.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/runtime_start_intent.freezed.dart
@@ -1,0 +1,293 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'runtime_start_intent.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$RuntimeStartIntent {
+
+/// Stable identifier of the bridge run that is about to spawn the runtime.
+ String get ownerSessionId;/// The port the spawn is targeting.
+ int get port;/// Pid of the hosting bridge process.
+ int get bridgePid;/// Start marker of the hosting bridge process (absent on Windows).
+ String? get bridgeStartMarker;/// When the intent was recorded (host clock).
+ DateTime get recordedAt;
+/// Create a copy of RuntimeStartIntent
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RuntimeStartIntentCopyWith<RuntimeStartIntent> get copyWith => _$RuntimeStartIntentCopyWithImpl<RuntimeStartIntent>(this as RuntimeStartIntent, _$identity);
+
+  /// Serializes this RuntimeStartIntent to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RuntimeStartIntent&&(identical(other.ownerSessionId, ownerSessionId) || other.ownerSessionId == ownerSessionId)&&(identical(other.port, port) || other.port == port)&&(identical(other.bridgePid, bridgePid) || other.bridgePid == bridgePid)&&(identical(other.bridgeStartMarker, bridgeStartMarker) || other.bridgeStartMarker == bridgeStartMarker)&&(identical(other.recordedAt, recordedAt) || other.recordedAt == recordedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,ownerSessionId,port,bridgePid,bridgeStartMarker,recordedAt);
+
+@override
+String toString() {
+  return 'RuntimeStartIntent(ownerSessionId: $ownerSessionId, port: $port, bridgePid: $bridgePid, bridgeStartMarker: $bridgeStartMarker, recordedAt: $recordedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RuntimeStartIntentCopyWith<$Res>  {
+  factory $RuntimeStartIntentCopyWith(RuntimeStartIntent value, $Res Function(RuntimeStartIntent) _then) = _$RuntimeStartIntentCopyWithImpl;
+@useResult
+$Res call({
+ String ownerSessionId, int port, int bridgePid, String? bridgeStartMarker, DateTime recordedAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$RuntimeStartIntentCopyWithImpl<$Res>
+    implements $RuntimeStartIntentCopyWith<$Res> {
+  _$RuntimeStartIntentCopyWithImpl(this._self, this._then);
+
+  final RuntimeStartIntent _self;
+  final $Res Function(RuntimeStartIntent) _then;
+
+/// Create a copy of RuntimeStartIntent
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? ownerSessionId = null,Object? port = null,Object? bridgePid = null,Object? bridgeStartMarker = freezed,Object? recordedAt = null,}) {
+  return _then(_self.copyWith(
+ownerSessionId: null == ownerSessionId ? _self.ownerSessionId : ownerSessionId // ignore: cast_nullable_to_non_nullable
+as String,port: null == port ? _self.port : port // ignore: cast_nullable_to_non_nullable
+as int,bridgePid: null == bridgePid ? _self.bridgePid : bridgePid // ignore: cast_nullable_to_non_nullable
+as int,bridgeStartMarker: freezed == bridgeStartMarker ? _self.bridgeStartMarker : bridgeStartMarker // ignore: cast_nullable_to_non_nullable
+as String?,recordedAt: null == recordedAt ? _self.recordedAt : recordedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [RuntimeStartIntent].
+extension RuntimeStartIntentPatterns on RuntimeStartIntent {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RuntimeStartIntent value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RuntimeStartIntent() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RuntimeStartIntent value)  $default,){
+final _that = this;
+switch (_that) {
+case _RuntimeStartIntent():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RuntimeStartIntent value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RuntimeStartIntent() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String ownerSessionId,  int port,  int bridgePid,  String? bridgeStartMarker,  DateTime recordedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RuntimeStartIntent() when $default != null:
+return $default(_that.ownerSessionId,_that.port,_that.bridgePid,_that.bridgeStartMarker,_that.recordedAt);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String ownerSessionId,  int port,  int bridgePid,  String? bridgeStartMarker,  DateTime recordedAt)  $default,) {final _that = this;
+switch (_that) {
+case _RuntimeStartIntent():
+return $default(_that.ownerSessionId,_that.port,_that.bridgePid,_that.bridgeStartMarker,_that.recordedAt);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String ownerSessionId,  int port,  int bridgePid,  String? bridgeStartMarker,  DateTime recordedAt)?  $default,) {final _that = this;
+switch (_that) {
+case _RuntimeStartIntent() when $default != null:
+return $default(_that.ownerSessionId,_that.port,_that.bridgePid,_that.bridgeStartMarker,_that.recordedAt);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _RuntimeStartIntent implements RuntimeStartIntent {
+  const _RuntimeStartIntent({required this.ownerSessionId, required this.port, required this.bridgePid, required this.bridgeStartMarker, required this.recordedAt});
+  factory _RuntimeStartIntent.fromJson(Map<String, dynamic> json) => _$RuntimeStartIntentFromJson(json);
+
+/// Stable identifier of the bridge run that is about to spawn the runtime.
+@override final  String ownerSessionId;
+/// The port the spawn is targeting.
+@override final  int port;
+/// Pid of the hosting bridge process.
+@override final  int bridgePid;
+/// Start marker of the hosting bridge process (absent on Windows).
+@override final  String? bridgeStartMarker;
+/// When the intent was recorded (host clock).
+@override final  DateTime recordedAt;
+
+/// Create a copy of RuntimeStartIntent
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RuntimeStartIntentCopyWith<_RuntimeStartIntent> get copyWith => __$RuntimeStartIntentCopyWithImpl<_RuntimeStartIntent>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$RuntimeStartIntentToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RuntimeStartIntent&&(identical(other.ownerSessionId, ownerSessionId) || other.ownerSessionId == ownerSessionId)&&(identical(other.port, port) || other.port == port)&&(identical(other.bridgePid, bridgePid) || other.bridgePid == bridgePid)&&(identical(other.bridgeStartMarker, bridgeStartMarker) || other.bridgeStartMarker == bridgeStartMarker)&&(identical(other.recordedAt, recordedAt) || other.recordedAt == recordedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,ownerSessionId,port,bridgePid,bridgeStartMarker,recordedAt);
+
+@override
+String toString() {
+  return 'RuntimeStartIntent(ownerSessionId: $ownerSessionId, port: $port, bridgePid: $bridgePid, bridgeStartMarker: $bridgeStartMarker, recordedAt: $recordedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RuntimeStartIntentCopyWith<$Res> implements $RuntimeStartIntentCopyWith<$Res> {
+  factory _$RuntimeStartIntentCopyWith(_RuntimeStartIntent value, $Res Function(_RuntimeStartIntent) _then) = __$RuntimeStartIntentCopyWithImpl;
+@override @useResult
+$Res call({
+ String ownerSessionId, int port, int bridgePid, String? bridgeStartMarker, DateTime recordedAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$RuntimeStartIntentCopyWithImpl<$Res>
+    implements _$RuntimeStartIntentCopyWith<$Res> {
+  __$RuntimeStartIntentCopyWithImpl(this._self, this._then);
+
+  final _RuntimeStartIntent _self;
+  final $Res Function(_RuntimeStartIntent) _then;
+
+/// Create a copy of RuntimeStartIntent
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? ownerSessionId = null,Object? port = null,Object? bridgePid = null,Object? bridgeStartMarker = freezed,Object? recordedAt = null,}) {
+  return _then(_RuntimeStartIntent(
+ownerSessionId: null == ownerSessionId ? _self.ownerSessionId : ownerSessionId // ignore: cast_nullable_to_non_nullable
+as String,port: null == port ? _self.port : port // ignore: cast_nullable_to_non_nullable
+as int,bridgePid: null == bridgePid ? _self.bridgePid : bridgePid // ignore: cast_nullable_to_non_nullable
+as int,bridgeStartMarker: freezed == bridgeStartMarker ? _self.bridgeStartMarker : bridgeStartMarker // ignore: cast_nullable_to_non_nullable
+as String?,recordedAt: null == recordedAt ? _self.recordedAt : recordedAt // ignore: cast_nullable_to_non_nullable
+as DateTime,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/sesori_plugin_runtime/lib/src/runtime_start_intent.g.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/runtime_start_intent.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'runtime_start_intent.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_RuntimeStartIntent _$RuntimeStartIntentFromJson(Map<String, dynamic> json) =>
+    _RuntimeStartIntent(
+      ownerSessionId: json['ownerSessionId'] as String,
+      port: (json['port'] as num).toInt(),
+      bridgePid: (json['bridgePid'] as num).toInt(),
+      bridgeStartMarker: json['bridgeStartMarker'] as String?,
+      recordedAt: DateTime.parse(json['recordedAt'] as String),
+    );
+
+Map<String, dynamic> _$RuntimeStartIntentToJson(_RuntimeStartIntent instance) =>
+    <String, dynamic>{
+      'ownerSessionId': instance.ownerSessionId,
+      'port': instance.port,
+      'bridgePid': instance.bridgePid,
+      'bridgeStartMarker': instance.bridgeStartMarker,
+      'recordedAt': instance.recordedAt.toIso8601String(),
+    };

--- a/bridge/sesori_plugin_runtime/pubspec.yaml
+++ b/bridge/sesori_plugin_runtime/pubspec.yaml
@@ -3,12 +3,17 @@ publish_to: none
 resolution: workspace
 
 environment:
-  sdk: ^3.11.5
+  sdk: ^3.12.2
 
 dependencies:
+  freezed_annotation: ^3.1.0
+  json_annotation: ^4.12.0
   sesori_plugin_interface:
     path: ../sesori_plugin_interface
 
 dev_dependencies:
   lints: ^6.1.0
+  freezed: ^3.2.5
+  json_serializable: ^6.14.0
+  build_runner: any
   test: ^1.25.0

--- a/bridge/sesori_plugin_runtime/test/managed_process_service_intent_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_process_service_intent_test.dart
@@ -1,0 +1,474 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
+import "package:test/test.dart";
+
+const _ownershipFile = "opencode-processes.json";
+const _intentFile = "OPENCODE-start-intent.json";
+const _gracefulShutdownWait = Duration(seconds: 5);
+const _legacyHealthPolicy = RuntimeHealthPolicy.attemptCount(attempts: 5, delay: Duration(milliseconds: 500));
+
+void main() {
+  group("ManagedProcessService intent side-file timing", () {
+    late _Harness harness;
+
+    setUp(() {
+      harness = _Harness();
+    });
+
+    test("writes the intent before spawn and resolves it after the starting record", () async {
+      harness.spawn.results.add(_spawned(pid: 301, port: 50123, exitImmediately: false));
+      harness.probe.results.add(const RuntimeHealthProbe(healthy: true));
+
+      final handle = await harness.service().start(
+        spec: harness.spec(port: 50123),
+        terminatedBridgeIdentities: const <ProcessIdentity>[],
+      );
+
+      // The intent existed on disk at the moment the child was spawned...
+      expect(harness.intentPresentAtSpawn, isTrue);
+      final spawnTimeIntent = harness.intentAtSpawn;
+      expect(spawnTimeIntent, isNotNull);
+      expect(spawnTimeIntent!["port"], equals(50123));
+      expect(spawnTimeIntent["ownerSessionId"], equals("current-owner"));
+      expect(spawnTimeIntent["bridgePid"], equals(900));
+      // ...and it is gone once the ownership record exists.
+      expect(harness.store.files.containsKey(_intentFile), isFalse);
+
+      // The frozen ownership file holds exactly the ready record.
+      final ownership = harness.decodeOwnership();
+      expect(ownership.keys, equals(<String>["current-owner"]));
+      expect(ownership["current-owner"]!["status"], equals("ready"));
+      expect(handle.port, equals(50123));
+    });
+
+    test("clears the intent when the spawn itself fails", () async {
+      harness.spawn.results.add(const ProcessException("opencode", <String>["serve"]));
+
+      await expectLater(
+        harness.service().start(
+          spec: harness.spec(port: 50124),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+        ),
+        throwsA(isA<ProcessException>()),
+      );
+
+      expect(harness.intentPresentAtSpawn, isTrue);
+      expect(harness.store.files.containsKey(_intentFile), isFalse);
+      // The frozen ownership file was never created by the failed attempt.
+      expect(harness.store.files.containsKey(_ownershipFile), isFalse);
+    });
+
+    test("clears the intent and the record when the start rolls back after spawn", () async {
+      harness.spawn.results.add(_spawned(pid: 302, port: 50125, exitImmediately: true));
+      harness.probe.results.addAll(<RuntimeHealthProbe>[
+        for (var i = 0; i < 5; i += 1) const RuntimeHealthProbe(healthy: false, error: "not ready"),
+      ]);
+      harness.processes.inspectResults[302] = <ProcessIdentity?>[null];
+
+      await expectLater(
+        harness.service().start(
+          spec: harness.spec(port: 50125),
+          terminatedBridgeIdentities: const <ProcessIdentity>[],
+        ),
+        throwsA(isA<PluginStartException>()),
+      );
+
+      expect(harness.intentPresentAtSpawn, isTrue);
+      expect(harness.store.files.containsKey(_intentFile), isFalse);
+      // The rolled-back record leaves the ownership file empty/absent.
+      expect(harness.decodeOwnership(), isEmpty);
+    });
+
+    test("an intent write leaves the frozen ownership file untouched (mixed-version inertness)", () async {
+      // A pre-migration bridge only ever reads the ownership file. Writing the
+      // bridge-private intent side file must be invisible to it.
+      final intentStore = RuntimeStartIntentStore(store: harness.store, fileName: _intentFile);
+      await intentStore.write(
+        RuntimeStartIntent(
+          ownerSessionId: "current-owner",
+          port: 4096,
+          bridgePid: 900,
+          bridgeStartMarker: "bridge-start",
+          recordedAt: DateTime.utc(2026, 5, 15, 12, 30),
+        ),
+      );
+
+      // The side file is its own, separately named file...
+      expect(harness.store.files.containsKey(_intentFile), isTrue);
+      // ...and the ownership file an old bridge reads is still absent.
+      expect(await harness.store.read(name: _ownershipFile), isNull);
+
+      // The round-trip preserves the intent for a future bridge that resolves it.
+      final readBack = await intentStore.read();
+      expect(readBack, isNotNull);
+      expect(readBack!.port, equals(4096));
+      expect(readBack.ownerSessionId, equals("current-owner"));
+
+      await intentStore.clear();
+      expect(harness.store.files.containsKey(_intentFile), isFalse);
+      // clear() is idempotent.
+      await intentStore.clear();
+    });
+  });
+}
+
+_FakeSpawnedProcess _spawned({required int pid, required int port, required bool exitImmediately}) {
+  return _FakeSpawnedProcess(
+    identity: ProcessIdentity(
+      pid: pid,
+      startMarker: "open-start",
+      executablePath: "/usr/local/bin/opencode",
+      commandLine: "/usr/local/bin/opencode serve --port $port --hostname 127.0.0.1",
+      ownerUser: ProcessUser.fromRawUser("alex"),
+      platform: "macos",
+      capturedAt: DateTime.utc(2026, 5, 15, 12),
+    ),
+    exitImmediately: exitImmediately,
+  );
+}
+
+class _Harness {
+  _Harness() {
+    intentStore = RuntimeStartIntentStore(store: store, fileName: _intentFile);
+    spawn.onSpawn = () {
+      final contents = store.files[_intentFile];
+      intentPresentAtSpawn = contents != null;
+      intentAtSpawn = contents == null ? null : Map<String, dynamic>.from(jsonDecode(contents) as Map);
+    };
+  }
+
+  final _InMemoryHostJsonStore store = _InMemoryHostJsonStore();
+  final _SpawnPlan spawn = _SpawnPlan();
+  final _ProbePlan probe = _ProbePlan();
+  final _FakeHostProcessService processes = _FakeHostProcessService();
+  final _FakeServerClock clock = _FakeServerClock();
+  final _FakeBridgeHostInfo bridge = _FakeBridgeHostInfo();
+  late final RuntimeStartIntentStore intentStore;
+
+  bool intentPresentAtSpawn = false;
+  Map<String, dynamic>? intentAtSpawn;
+
+  ManagedProcessService<_IntentRecord> service() {
+    return ManagedProcessService<_IntentRecord>(
+      ownershipRepository: HostJsonRuntimeOwnershipRepository<_IntentRecord>(
+        store: store,
+        mapper: const _IntentRecordMapper(),
+        fileName: _ownershipFile,
+        clock: clock,
+      ),
+      mapper: const _IntentRecordMapper(),
+      processes: processes,
+      bridge: bridge,
+      clock: clock,
+      runtimeId: "OPENCODE",
+      gracefulShutdownWait: _gracefulShutdownWait,
+      intentStore: intentStore,
+    );
+  }
+
+  ManagedRuntimeSpec<_IntentRecord> spec({required int port}) {
+    return ManagedRuntimeSpec<_IntentRecord>(
+      spawn: spawn.spawn,
+      probeHealth: probe.probe,
+      probePortBindable: ({required int port}) async => true,
+      buildRecord: (draft) => _IntentRecord(
+        ownerSessionId: draft.ownerSessionId,
+        openCodePid: draft.runtimeIdentity.pid,
+        openCodeStartMarker: draft.runtimeIdentity.startMarker,
+        openCodeExecutablePath: draft.runtimeIdentity.executablePath ?? "",
+        commandLine: draft.runtimeIdentity.commandLine,
+        port: draft.port,
+        bridgePid: draft.bridgeIdentity.pid,
+        bridgeStartMarker: draft.bridgeIdentity.startMarker,
+        status: "starting",
+      ),
+      portPolicy: ExplicitPortPolicy(port: port),
+      healthPolicy: _legacyHealthPolicy,
+      recordTiming: RuntimeRecordTiming.intentSideFile,
+    );
+  }
+
+  Map<String, Map<String, dynamic>> decodeOwnership() {
+    final contents = store.files[_ownershipFile];
+    if (contents == null) {
+      return <String, Map<String, dynamic>>{};
+    }
+    final decoded = Map<String, dynamic>.from(jsonDecode(contents) as Map);
+    return decoded.map((key, value) => MapEntry(key, Map<String, dynamic>.from(value as Map)));
+  }
+}
+
+class _InMemoryHostJsonStore implements HostJsonStore {
+  final Map<String, String> files = <String, String>{};
+
+  @override
+  Future<String?> read({required String name}) async => files[name];
+
+  @override
+  Future<void> write({required String name, required String contents}) async {
+    files[name] = contents;
+  }
+
+  @override
+  Future<void> delete({required String name}) async {
+    files.remove(name);
+  }
+
+  @override
+  Future<void> quarantine({required String name, required String quarantinedName}) async {
+    final contents = files.remove(name);
+    if (contents != null) {
+      files[quarantinedName] = contents;
+    }
+  }
+
+  @override
+  Future<String?> update({
+    required String name,
+    required FutureOr<String?> Function(String? current) transform,
+  }) async {
+    final next = await transform(files[name]);
+    if (next == null) {
+      files.remove(name);
+    } else {
+      files[name] = next;
+    }
+    return next;
+  }
+}
+
+class _SpawnPlan {
+  final List<Object> results = <Object>[];
+  final List<int> spawnedPorts = <int>[];
+  void Function()? onSpawn;
+
+  Future<SpawnedProcess> spawn({required int port}) async {
+    spawnedPorts.add(port);
+    onSpawn?.call();
+    final result = results.removeAt(0);
+    if (result is SpawnedProcess) {
+      return result;
+    }
+    throw result;
+  }
+}
+
+class _ProbePlan {
+  final List<RuntimeHealthProbe> results = <RuntimeHealthProbe>[];
+
+  Future<RuntimeHealthProbe> probe({required int port}) async {
+    if (results.isEmpty) {
+      return const RuntimeHealthProbe(healthy: false, error: "no probe configured");
+    }
+    return results.removeAt(0);
+  }
+}
+
+class _IntentRecord {
+  const _IntentRecord({
+    required this.ownerSessionId,
+    required this.openCodePid,
+    required this.openCodeStartMarker,
+    required this.openCodeExecutablePath,
+    required this.commandLine,
+    required this.port,
+    required this.bridgePid,
+    required this.bridgeStartMarker,
+    required this.status,
+  });
+
+  final String ownerSessionId;
+  final int openCodePid;
+  final String? openCodeStartMarker;
+  final String openCodeExecutablePath;
+  final String commandLine;
+  final int port;
+  final int bridgePid;
+  final String? bridgeStartMarker;
+  final String status;
+
+  _IntentRecord withStatus(String status) {
+    return _IntentRecord(
+      ownerSessionId: ownerSessionId,
+      openCodePid: openCodePid,
+      openCodeStartMarker: openCodeStartMarker,
+      openCodeExecutablePath: openCodeExecutablePath,
+      commandLine: commandLine,
+      port: port,
+      bridgePid: bridgePid,
+      bridgeStartMarker: bridgeStartMarker,
+      status: status,
+    );
+  }
+}
+
+class _IntentRecordMapper implements RuntimeRecordMapper<_IntentRecord> {
+  const _IntentRecordMapper();
+
+  @override
+  Map<String, dynamic> toJson({required _IntentRecord record}) {
+    return <String, dynamic>{
+      "ownerSessionId": record.ownerSessionId,
+      "openCodePid": record.openCodePid,
+      "openCodeStartMarker": record.openCodeStartMarker,
+      "openCodeExecutablePath": record.openCodeExecutablePath,
+      "commandLine": record.commandLine,
+      "port": record.port,
+      "bridgePid": record.bridgePid,
+      "bridgeStartMarker": record.bridgeStartMarker,
+      "status": record.status,
+    };
+  }
+
+  @override
+  _IntentRecord fromJson({required Map<String, dynamic> json}) {
+    return _IntentRecord(
+      ownerSessionId: json["ownerSessionId"] as String,
+      openCodePid: json["openCodePid"] as int,
+      openCodeStartMarker: json["openCodeStartMarker"] as String?,
+      openCodeExecutablePath: json["openCodeExecutablePath"] as String,
+      commandLine: json["commandLine"] as String,
+      port: json["port"] as int,
+      bridgePid: json["bridgePid"] as int,
+      bridgeStartMarker: json["bridgeStartMarker"] as String?,
+      status: json["status"] as String,
+    );
+  }
+
+  @override
+  String ownerSessionIdOf({required _IntentRecord record}) => record.ownerSessionId;
+
+  @override
+  int runtimePidOf({required _IntentRecord record}) => record.openCodePid;
+
+  @override
+  String? runtimeStartMarkerOf({required _IntentRecord record}) => record.openCodeStartMarker;
+
+  @override
+  String? runtimeExecutablePathOf({required _IntentRecord record}) => record.openCodeExecutablePath;
+
+  @override
+  String runtimeCommandLineOf({required _IntentRecord record}) => record.commandLine;
+
+  @override
+  int bridgePidOf({required _IntentRecord record}) => record.bridgePid;
+
+  @override
+  String? bridgeStartMarkerOf({required _IntentRecord record}) => record.bridgeStartMarker;
+
+  @override
+  _IntentRecord markReady({required _IntentRecord record}) => record.withStatus("ready");
+
+  @override
+  _IntentRecord markStopping({required _IntentRecord record}) => record.withStatus("stopping");
+}
+
+class _FakeHostProcessService implements HostProcessService {
+  final Map<int, List<ProcessIdentity?>> inspectResults = <int, List<ProcessIdentity?>>{};
+  final List<String> signalRequests = <String>[];
+
+  @override
+  Future<ProcessIdentity?> inspect({required int pid}) async {
+    final results = inspectResults[pid];
+    if (results == null || results.isEmpty) {
+      return null;
+    }
+    return results.removeAt(0);
+  }
+
+  @override
+  Future<List<ProcessIdentity>> list({required int? excludePid}) async => const <ProcessIdentity>[];
+
+  @override
+  Future<SignalResult> signalForce({required int pid}) async {
+    signalRequests.add("force:$pid");
+    return _signal(pid: pid, signal: ShutdownSignal.force);
+  }
+
+  @override
+  Future<SignalResult> signalGraceful({required int pid}) async {
+    signalRequests.add("graceful:$pid");
+    return _signal(pid: pid, signal: ShutdownSignal.graceful);
+  }
+
+  @override
+  Future<SpawnedProcess> spawn({
+    required String executable,
+    required List<String> arguments,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+    required bool runInShell,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  SignalResult _signal({required int pid, required ShutdownSignal signal}) {
+    return SignalResult(
+      pid: pid,
+      requestedSignal: signal,
+      deliveredSignal: signal == ShutdownSignal.graceful ? ProcessSignal.sigterm : ProcessSignal.sigkill,
+      wasRequested: true,
+      attemptedAt: DateTime.utc(2026, 5, 15, 12),
+    );
+  }
+}
+
+class _FakeBridgeHostInfo implements BridgeHostInfo {
+  @override
+  ProcessIdentity get identity => ProcessIdentity(
+    pid: 900,
+    startMarker: "bridge-start",
+    executablePath: "/usr/local/bin/sesori-bridge",
+    commandLine: "sesori-bridge",
+    ownerUser: ProcessUser.fromRawUser("alex"),
+    platform: "macos",
+    capturedAt: DateTime.utc(2026, 5, 15, 12),
+  );
+
+  @override
+  String get ownerSessionId => "current-owner";
+
+  @override
+  Future<bool> isLiveBridgeProcess({required int pid, required String? startMarker}) async => false;
+}
+
+class _FakeServerClock implements ServerClock {
+  @override
+  Future<void> delay({required Duration duration}) async {}
+
+  @override
+  DateTime now() => DateTime.utc(2026, 5, 15, 12, 30);
+}
+
+class _FakeSpawnedProcess implements SpawnedProcess {
+  _FakeSpawnedProcess({required ProcessIdentity identity, required bool exitImmediately}) : _identity = identity {
+    if (exitImmediately) {
+      _exitCodeCompleter.complete(0);
+    }
+  }
+
+  final ProcessIdentity _identity;
+  final Completer<int> _exitCodeCompleter = Completer<int>();
+
+  @override
+  Future<int> get exitCode => _exitCodeCompleter.future;
+
+  @override
+  ProcessIdentity get identity => _identity;
+
+  @override
+  int get pid => _identity.pid;
+
+  @override
+  IOSink get stdin => throw UnimplementedError();
+
+  @override
+  Stream<List<int>> get stderr => Stream<List<int>>.value(utf8.encode(""));
+
+  @override
+  Stream<List<int>> get stdout => Stream<List<int>>.value(utf8.encode(""));
+}

--- a/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
@@ -403,6 +403,25 @@ void main() {
       expect(fakes.spawn.spawnedPorts, isEmpty);
     });
 
+    test("restartOnPort rejects a storeless intent timing before waiting on the port", () async {
+      await expectLater(
+        fakes.service().restartOnPort(
+          spec: fakes.spec(
+            portPolicy: const ExplicitPortPolicy(port: 4096),
+            recordTiming: RuntimeRecordTiming.intentSideFile,
+          ),
+          port: 4096,
+          portReleaseTimeout: const Duration(seconds: 2),
+          portReleasePollInterval: const Duration(milliseconds: 250),
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+
+      // Fails fast: the port-release wait never runs and nothing is spawned.
+      expect(fakes.bindable.probedPorts, isEmpty);
+      expect(fakes.spawn.spawnedPorts, isEmpty);
+    });
+
     test("stops the spawned child when the record factory throws", () async {
       final spawned = _spawned(pid: 230, port: 50143, exitImmediately: false);
       fakes.spawn.results.add(spawned);

--- a/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
@@ -365,7 +365,7 @@ void main() {
       expect(fakes.ownership.upsertedStatuses, equals(<_TestStatus>[_TestStatus.starting]));
     });
 
-    test("rejects the not-yet-available intent side-file record timing", () async {
+    test("rejects intent side-file record timing when no intent store is wired", () async {
       fakes.spawn.results.add(_spawned(pid: 801, port: 50142));
 
       await expectLater(
@@ -376,14 +376,14 @@ void main() {
           ),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
         ),
-        throwsA(isA<UnsupportedError>()),
+        throwsA(isA<ArgumentError>()),
       );
 
       expect(fakes.spawn.spawnedPorts, isEmpty);
       expect(fakes.ownership.records, isEmpty);
     });
 
-    test("rejects intent side-file timing once, never retrying across dynamic candidates", () async {
+    test("rejects a storeless intent timing once, never retrying across dynamic candidates", () async {
       fakes.bindable.byPort.addAll(<int, bool>{49152: true, 49153: true});
 
       await expectLater(
@@ -394,10 +394,11 @@ void main() {
           ),
           terminatedBridgeIdentities: const <ProcessIdentity>[],
         ),
-        throwsA(isA<UnsupportedError>()),
+        throwsA(isA<ArgumentError>()),
       );
 
-      // Rejected before the candidate loop: nothing probed or spawned.
+      // Rejected up front, before cleanup and the candidate loop: nothing
+      // probed or spawned.
       expect(fakes.bindable.probedPorts, isEmpty);
       expect(fakes.spawn.spawnedPorts, isEmpty);
     });
@@ -520,12 +521,12 @@ void main() {
       expect(fakes.bindable.probedPorts, isEmpty);
     });
 
-    test("aborting after spawn rolls back the record and child", () async {
+    test("aborting at the post-spawn checkpoint stops the child before any record is written", () async {
       final controller = StartAbortController();
-      final spawned = _spawned(pid: 401, port: 50160, exitImmediately: true);
+      final spawned = _spawned(pid: 401, port: 50160, exitImmediately: false);
       fakes.spawn.results.add(spawned);
       fakes.spawn.onSpawn = controller.abort;
-      fakes.processes.inspectResults[401] = <ProcessIdentity?>[null];
+      fakes.processes.forceHooks[401] = spawned.completeExit;
 
       await expectLater(
         fakes.service().start(
@@ -537,7 +538,10 @@ void main() {
       );
 
       expect(fakes.spawn.spawnedPorts, equals(<int>[50160]));
-      expect(fakes.ownership.upsertedStatuses, equals(<_TestStatus>[_TestStatus.starting]));
+      // The abort is honored immediately after spawn (the documented checkpoint):
+      // the untracked child is stopped and no ownership record is ever written.
+      expect(fakes.processes.signalRequests, equals(<String>["graceful:401", "force:401"]));
+      expect(fakes.ownership.upsertedStatuses, isEmpty);
       expect(fakes.ownership.records, isEmpty);
     });
 

--- a/bridge/sesori_plugin_runtime/test/managed_runtime_monitor_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_runtime_monitor_test.dart
@@ -1,0 +1,667 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
+import "package:test/test.dart";
+
+const _gracefulShutdownWait = Duration(seconds: 5);
+const _legacyHealthPolicy = RuntimeHealthPolicy.attemptCount(attempts: 5, delay: Duration(milliseconds: 500));
+
+void main() {
+  group("ManagedRuntimeMonitor", () {
+    late _Fakes fakes;
+
+    setUp(() {
+      fakes = _Fakes();
+    });
+
+    test("arming an attached (un-owned) handle never watches or restarts", () async {
+      final status = PluginStatusController(initial: const PluginReady());
+      final tags = _collect(status);
+      final monitor = fakes.monitor(status: status, restartPolicy: _bounded());
+
+      monitor.arm(
+        const ManagedRuntimeHandle<_TestRecord>(
+          port: 50100,
+          record: null,
+          process: null,
+          identity: null,
+          health: RuntimeHealthProbe(healthy: true),
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(monitor.currentHandle, isNotNull);
+      expect(fakes.spawn.spawnedPorts, isEmpty);
+      expect(tags, equals(<String>["ready"]));
+    });
+
+    test("a disabled restart policy fails terminally on an unexpected exit", () async {
+      final status = PluginStatusController(initial: const PluginReady());
+      final tags = _collect(status);
+      final monitor = fakes.monitor(status: status, restartPolicy: const RuntimeRestartPolicy.disabled());
+      final child = _child(pid: 101);
+
+      monitor.arm(_handle(port: 4096, process: child));
+      child.completeExit(1);
+      await pumpEventQueue();
+
+      expect(tags, equals(<String>["ready", "failed"]));
+      expect(fakes.spawn.spawnedPorts, isEmpty);
+    });
+
+    test("an unexpected exit restarts on the pinned port and returns to ready", () async {
+      final status = PluginStatusController(initial: const PluginReady());
+      final tags = _collect(status);
+      final monitor = fakes.monitor(status: status, restartPolicy: _bounded());
+      final child = _child(pid: 101);
+      final restarted = _child(pid: 102);
+
+      fakes.bindable.byPort[4096] = true;
+      fakes.spawn.results.add(restarted);
+      fakes.probe.results.add(const RuntimeHealthProbe(healthy: true));
+
+      monitor.arm(_handle(port: 4096, process: child));
+      child.completeExit(1);
+      await pumpEventQueue();
+
+      expect(tags, equals(<String>["ready", "restarting(1)", "ready"]));
+      // Pinned: the restart spawned on the same port it started on.
+      expect(fakes.spawn.spawnedPorts, equals(<int>[4096]));
+      expect(monitor.currentHandle!.process, same(restarted));
+      expect(fakes.ownership.records.values.single.status, equals(_TestStatus.ready));
+    });
+
+    test("a restarted child that exits again starts a fresh episode at attempt 1", () async {
+      final status = PluginStatusController(initial: const PluginReady());
+      final tags = _collect(status);
+      final monitor = fakes.monitor(status: status, restartPolicy: _bounded());
+      final child = _child(pid: 101);
+      final restarted = _child(pid: 102);
+      final restartedAgain = _child(pid: 103);
+
+      fakes.bindable.byPort[4096] = true;
+      fakes.spawn.results.addAll(<SpawnedProcess>[restarted, restartedAgain]);
+      fakes.probe.results.addAll(<RuntimeHealthProbe>[
+        const RuntimeHealthProbe(healthy: true),
+        const RuntimeHealthProbe(healthy: true),
+      ]);
+
+      monitor.arm(_handle(port: 4096, process: child));
+      child.completeExit(1);
+      await pumpEventQueue();
+      restarted.completeExit(1);
+      await pumpEventQueue();
+
+      expect(tags, equals(<String>["ready", "restarting(1)", "ready", "restarting(1)", "ready"]));
+      expect(monitor.currentHandle!.process, same(restartedAgain));
+    });
+
+    test("exhausting the restart attempts fails terminally", () async {
+      final status = PluginStatusController(initial: const PluginReady());
+      final tags = _collect(status);
+      final monitor = fakes.monitor(status: status, restartPolicy: _bounded(maxAttempts: 2));
+      final child = _child(pid: 101);
+
+      fakes.bindable.byPort[4096] = true;
+      // Both restart attempts fail to spawn.
+      fakes.spawn.results.addAll(<Object>[
+        const ProcessException("opencode", <String>["serve"]),
+        const ProcessException("opencode", <String>["serve"]),
+      ]);
+
+      monitor.arm(_handle(port: 4096, process: child));
+      child.completeExit(1);
+      await pumpEventQueue();
+
+      expect(tags, equals(<String>["ready", "restarting(1)", "restarting(2)", "failed"]));
+      expect(fakes.spawn.spawnedPorts, equals(<int>[4096, 4096]));
+    });
+
+    test("a port that never frees fails the restart", () async {
+      final status = PluginStatusController(initial: const PluginReady());
+      final tags = _collect(status);
+      final monitor = fakes.monitor(status: status, restartPolicy: _bounded(maxAttempts: 1));
+      final child = _child(pid: 101);
+
+      // The address-frozen port is held by the dying child and never frees.
+      fakes.bindable.byPort[4096] = false;
+
+      monitor.arm(_handle(port: 4096, process: child));
+      child.completeExit(1);
+      await pumpEventQueue();
+
+      expect(tags, equals(<String>["ready", "restarting(1)", "failed"]));
+      // It never got far enough to spawn — the address was never reclaimable.
+      expect(fakes.spawn.spawnedPorts, isEmpty);
+    });
+
+    test("the port-release wait terminates on its maxPolls backstop under a stuck clock", () async {
+      final clock = _StuckServerClock();
+      final stuckFakes = _Fakes(clock: clock);
+      final status = PluginStatusController(initial: const PluginReady());
+      final tags = _collect(status);
+      final monitor = stuckFakes.monitor(status: status, restartPolicy: _bounded(maxAttempts: 1));
+      final child = _child(pid: 101);
+
+      // The port never frees AND the clock never advances, so the deadline can
+      // never be reached: only the maxPolls backstop can terminate the wait.
+      stuckFakes.bindable.byPort[4096] = false;
+
+      monitor.arm(_handle(port: 4096, process: child));
+      child.completeExit(1);
+      await pumpEventQueue();
+
+      expect(tags, equals(<String>["ready", "restarting(1)", "failed"]));
+      expect(stuckFakes.spawn.spawnedPorts, isEmpty);
+      // It actually polled (and was bounded) rather than hanging or bailing early.
+      expect(clock.delays, greaterThan(0));
+    });
+
+    test("disarming before the exit suppresses any restart or failure", () async {
+      final status = PluginStatusController(initial: const PluginReady());
+      final tags = _collect(status);
+      final monitor = fakes.monitor(status: status, restartPolicy: _bounded());
+      final child = _child(pid: 101);
+
+      monitor.arm(_handle(port: 4096, process: child));
+      await monitor.disarm();
+      child.completeExit(137);
+      await pumpEventQueue();
+
+      // A deliberate shutdown is never mistaken for a crash.
+      expect(tags, equals(<String>["ready"]));
+      expect(fakes.spawn.spawnedPorts, isEmpty);
+    });
+
+    test("disarming during an in-flight restart stops the new child instead of failing", () async {
+      final status = PluginStatusController(initial: const PluginReady());
+      final tags = _collect(status);
+      final monitor = fakes.monitor(status: status, restartPolicy: _bounded());
+      final child = _child(pid: 101);
+      final restarted = _child(pid: 102);
+
+      fakes.bindable.byPort[4096] = true;
+      fakes.spawn.results.add(restarted);
+      // The restart spawn blocks until the test releases the gate.
+      final gate = Completer<void>();
+      final reached = Completer<void>();
+      fakes.spawn.gate = gate;
+      fakes.spawn.reached = reached;
+      fakes.probe.results.add(const RuntimeHealthProbe(healthy: true));
+      fakes.processes.forceHooks[102] = restarted.completeExit;
+
+      monitor.arm(_handle(port: 4096, process: child));
+      child.completeExit(1);
+      await reached.future; // the restart has reached the (blocked) spawn
+      await monitor.disarm(); // disarm mid-restart -> aborts the in-flight start
+      gate.complete();
+      await pumpEventQueue();
+
+      // No terminal failure surfaced; the aborted restart stopped its freshly
+      // spawned child (the post-spawn abort checkpoint) and wrote no record.
+      expect(tags, isNot(contains("failed")));
+      expect(fakes.processes.signalRequests, equals(<String>["graceful:102", "force:102"]));
+      expect(fakes.ownership.records, isEmpty);
+    });
+
+    test("a disarm racing the committing restart still adopts the live child", () async {
+      final status = PluginStatusController(initial: const PluginReady());
+      final tags = _collect(status);
+      final monitor = fakes.monitor(status: status, restartPolicy: _bounded());
+      final child = _child(pid: 101);
+      final restarted = _child(pid: 102);
+
+      fakes.bindable.byPort[4096] = true;
+      fakes.spawn.results.add(restarted);
+      fakes.probe.results.add(const RuntimeHealthProbe(healthy: true));
+      // Block the final "ready" ownership write so a disarm can land in the
+      // window after the restart commits but before it is announced.
+      final gate = Completer<void>();
+      final reached = Completer<void>();
+      fakes.ownership.readyUpsertGate = gate;
+      fakes.ownership.readyUpsertReached = reached;
+
+      monitor.arm(_handle(port: 4096, process: child));
+      child.completeExit(1);
+      await reached.future; // the restart has passed health and is committing
+      await monitor.disarm(); // disarm races the commit (after the last abort checkpoint)
+      gate.complete();
+      await pumpEventQueue();
+
+      // The committed child is adopted so the owner stops the *live* child, not
+      // the dead one — and no terminal failure surfaced.
+      expect(monitor.currentHandle!.process, same(restarted));
+      expect(tags, isNot(contains("failed")));
+    });
+
+    test("consumes the child's stderr so a full pipe cannot block it", () async {
+      final status = PluginStatusController(initial: const PluginReady());
+      final monitor = fakes.monitor(status: status, restartPolicy: const RuntimeRestartPolicy.disabled());
+      final stderr = StreamController<List<int>>();
+      final child = _child(pid: 101, stderr: stderr.stream);
+
+      monitor.arm(_handle(port: 4096, process: child));
+      await pumpEventQueue();
+
+      expect(stderr.hasListener, isTrue);
+      stderr.add(utf8.encode("opencode: warming up\n"));
+      await pumpEventQueue();
+      await stderr.close();
+    });
+  });
+}
+
+String _tag(PluginStatus status) {
+  return switch (status) {
+    PluginStarting() => "starting",
+    PluginReady() => "ready",
+    PluginDegraded() => "degraded",
+    PluginRestarting(:final attempt) => "restarting($attempt)",
+    PluginFailed() => "failed",
+    PluginStopping() => "stopping",
+    PluginStopped() => "stopped",
+  };
+}
+
+List<String> _collect(PluginStatusController controller) {
+  final tags = <String>[];
+  controller.stream.listen((status) => tags.add(_tag(status)));
+  return tags;
+}
+
+RuntimeRestartPolicy _bounded({int maxAttempts = 3}) {
+  return RuntimeRestartPolicy.bounded(
+    maxAttempts: maxAttempts,
+    initialBackoff: const Duration(milliseconds: 100),
+    maxBackoff: const Duration(seconds: 1),
+    portReleaseTimeout: const Duration(seconds: 2),
+    portReleasePollInterval: const Duration(milliseconds: 250),
+  );
+}
+
+ManagedRuntimeHandle<_TestRecord> _handle({required int port, required SpawnedProcess process}) {
+  return ManagedRuntimeHandle<_TestRecord>(
+    port: port,
+    record: _record(pid: process.pid, port: port),
+    process: process,
+    identity: process.identity,
+    health: const RuntimeHealthProbe(healthy: true),
+  );
+}
+
+_MonitorSpawnedProcess _child({
+  required int pid,
+  bool exitImmediately = false,
+  Stream<List<int>>? stderr,
+}) {
+  return _MonitorSpawnedProcess(
+    identity: _identity(pid: pid),
+    exitImmediately: exitImmediately,
+    stderr: stderr,
+  );
+}
+
+ProcessIdentity _identity({required int pid}) {
+  return ProcessIdentity(
+    pid: pid,
+    startMarker: "open-start-$pid",
+    executablePath: "/usr/local/bin/opencode",
+    commandLine: "/usr/local/bin/opencode serve --port 4096 --hostname 127.0.0.1",
+    ownerUser: ProcessUser.fromRawUser("alex"),
+    platform: "macos",
+    capturedAt: DateTime.utc(2026, 5, 15, 12),
+  );
+}
+
+_TestRecord _record({required int pid, required int port}) {
+  return _TestRecord(
+    ownerSessionId: "current-owner",
+    openCodePid: pid,
+    openCodeStartMarker: "open-start-$pid",
+    openCodeExecutablePath: "/usr/local/bin/opencode",
+    commandLine: "/usr/local/bin/opencode serve --port $port --hostname 127.0.0.1",
+    port: port,
+    bridgePid: 900,
+    bridgeStartMarker: "bridge-start",
+    status: _TestStatus.starting,
+  );
+}
+
+class _Fakes {
+  _Fakes({ServerClock? clock}) : clock = clock ?? _AdvancingServerClock();
+
+  final _FakeOwnershipRepository ownership = _FakeOwnershipRepository();
+  final _FakeHostProcessService processes = _FakeHostProcessService();
+  final _FakeBridgeHostInfo bridge = _FakeBridgeHostInfo();
+  final ServerClock clock;
+  final _SpawnPlan spawn = _SpawnPlan();
+  final _ProbePlan probe = _ProbePlan();
+  final _BindablePlan bindable = _BindablePlan();
+
+  ManagedProcessService<_TestRecord> service() {
+    return ManagedProcessService<_TestRecord>(
+      ownershipRepository: ownership,
+      mapper: const _TestRecordMapper(),
+      processes: processes,
+      bridge: bridge,
+      clock: clock,
+      runtimeId: "OPENCODE",
+      gracefulShutdownWait: _gracefulShutdownWait,
+    );
+  }
+
+  ManagedRuntimeSpec<_TestRecord> spec() {
+    return ManagedRuntimeSpec<_TestRecord>(
+      spawn: spawn.spawn,
+      probeHealth: probe.probe,
+      probePortBindable: bindable.bindable,
+      buildRecord: (draft) => _record(pid: draft.runtimeIdentity.pid, port: draft.port),
+      portPolicy: const ExplicitPortPolicy(port: 4096),
+      healthPolicy: _legacyHealthPolicy,
+    );
+  }
+
+  ManagedRuntimeMonitor<_TestRecord> monitor({
+    required PluginStatusController status,
+    required RuntimeRestartPolicy restartPolicy,
+  }) {
+    return ManagedRuntimeMonitor<_TestRecord>(
+      service: service(),
+      spec: spec(),
+      status: status,
+      clock: clock,
+      runtimeId: "OPENCODE",
+      restartPolicy: restartPolicy,
+    );
+  }
+}
+
+class _SpawnPlan {
+  final List<Object> results = <Object>[];
+  final List<int> spawnedPorts = <int>[];
+  Completer<void>? gate;
+  Completer<void>? reached;
+
+  Future<SpawnedProcess> spawn({required int port}) async {
+    spawnedPorts.add(port);
+    reached?.complete();
+    reached = null;
+    final gate = this.gate;
+    if (gate != null) {
+      this.gate = null;
+      await gate.future;
+    }
+    final result = results.removeAt(0);
+    if (result is SpawnedProcess) {
+      return result;
+    }
+    throw result;
+  }
+}
+
+class _ProbePlan {
+  final List<RuntimeHealthProbe> results = <RuntimeHealthProbe>[];
+
+  Future<RuntimeHealthProbe> probe({required int port}) async {
+    if (results.isEmpty) {
+      return const RuntimeHealthProbe(healthy: false, error: "no probe configured");
+    }
+    return results.removeAt(0);
+  }
+}
+
+class _BindablePlan {
+  final Map<int, bool> byPort = <int, bool>{};
+
+  Future<bool> bindable({required int port}) async {
+    return byPort[port] ?? false;
+  }
+}
+
+enum _TestStatus { starting, ready, stopping }
+
+class _TestRecord {
+  const _TestRecord({
+    required this.ownerSessionId,
+    required this.openCodePid,
+    required this.openCodeStartMarker,
+    required this.openCodeExecutablePath,
+    required this.commandLine,
+    required this.port,
+    required this.bridgePid,
+    required this.bridgeStartMarker,
+    required this.status,
+  });
+
+  final String ownerSessionId;
+  final int openCodePid;
+  final String? openCodeStartMarker;
+  final String openCodeExecutablePath;
+  final String commandLine;
+  final int port;
+  final int bridgePid;
+  final String? bridgeStartMarker;
+  final _TestStatus status;
+
+  _TestRecord withStatus(_TestStatus status) {
+    return _TestRecord(
+      ownerSessionId: ownerSessionId,
+      openCodePid: openCodePid,
+      openCodeStartMarker: openCodeStartMarker,
+      openCodeExecutablePath: openCodeExecutablePath,
+      commandLine: commandLine,
+      port: port,
+      bridgePid: bridgePid,
+      bridgeStartMarker: bridgeStartMarker,
+      status: status,
+    );
+  }
+}
+
+class _TestRecordMapper implements RuntimeRecordMapper<_TestRecord> {
+  const _TestRecordMapper();
+
+  @override
+  Map<String, dynamic> toJson({required _TestRecord record}) => throw UnimplementedError();
+
+  @override
+  _TestRecord fromJson({required Map<String, dynamic> json}) => throw UnimplementedError();
+
+  @override
+  String ownerSessionIdOf({required _TestRecord record}) => record.ownerSessionId;
+
+  @override
+  int runtimePidOf({required _TestRecord record}) => record.openCodePid;
+
+  @override
+  String? runtimeStartMarkerOf({required _TestRecord record}) => record.openCodeStartMarker;
+
+  @override
+  String? runtimeExecutablePathOf({required _TestRecord record}) => record.openCodeExecutablePath;
+
+  @override
+  String runtimeCommandLineOf({required _TestRecord record}) => record.commandLine;
+
+  @override
+  int bridgePidOf({required _TestRecord record}) => record.bridgePid;
+
+  @override
+  String? bridgeStartMarkerOf({required _TestRecord record}) => record.bridgeStartMarker;
+
+  @override
+  _TestRecord markReady({required _TestRecord record}) => record.withStatus(_TestStatus.ready);
+
+  @override
+  _TestRecord markStopping({required _TestRecord record}) => record.withStatus(_TestStatus.stopping);
+}
+
+class _FakeOwnershipRepository implements RuntimeOwnershipRepository<_TestRecord> {
+  final Map<String, _TestRecord> records = <String, _TestRecord>{};
+  Completer<void>? readyUpsertGate;
+  Completer<void>? readyUpsertReached;
+
+  @override
+  Future<void> deleteByOwnerSessionId({required String ownerSessionId}) async {
+    records.remove(ownerSessionId);
+  }
+
+  @override
+  Future<List<_TestRecord>> readAll() async => records.values.toList(growable: false);
+
+  @override
+  Future<_TestRecord?> readByOwnerSessionId({required String ownerSessionId}) async => records[ownerSessionId];
+
+  @override
+  Future<void> upsert({required _TestRecord record}) async {
+    if (record.status == _TestStatus.ready && readyUpsertGate != null) {
+      readyUpsertReached?.complete();
+      readyUpsertReached = null;
+      final gate = readyUpsertGate!;
+      readyUpsertGate = null;
+      await gate.future;
+    }
+    records[record.ownerSessionId] = record;
+  }
+}
+
+class _FakeHostProcessService implements HostProcessService {
+  final Map<int, List<ProcessIdentity?>> inspectResults = <int, List<ProcessIdentity?>>{};
+  final Map<int, void Function()> forceHooks = <int, void Function()>{};
+  final List<String> signalRequests = <String>[];
+
+  @override
+  Future<ProcessIdentity?> inspect({required int pid}) async {
+    final results = inspectResults[pid];
+    if (results == null || results.isEmpty) {
+      return null;
+    }
+    return results.removeAt(0);
+  }
+
+  @override
+  Future<List<ProcessIdentity>> list({required int? excludePid}) async => const <ProcessIdentity>[];
+
+  @override
+  Future<SignalResult> signalForce({required int pid}) async {
+    signalRequests.add("force:$pid");
+    forceHooks[pid]?.call();
+    return _signal(pid: pid, signal: ShutdownSignal.force);
+  }
+
+  @override
+  Future<SignalResult> signalGraceful({required int pid}) async {
+    signalRequests.add("graceful:$pid");
+    return _signal(pid: pid, signal: ShutdownSignal.graceful);
+  }
+
+  @override
+  Future<SpawnedProcess> spawn({
+    required String executable,
+    required List<String> arguments,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+    required bool runInShell,
+  }) async {
+    throw UnimplementedError();
+  }
+
+  SignalResult _signal({required int pid, required ShutdownSignal signal}) {
+    return SignalResult(
+      pid: pid,
+      requestedSignal: signal,
+      deliveredSignal: signal == ShutdownSignal.graceful ? ProcessSignal.sigterm : ProcessSignal.sigkill,
+      wasRequested: true,
+      attemptedAt: DateTime.utc(2026, 5, 15, 12),
+    );
+  }
+}
+
+class _FakeBridgeHostInfo implements BridgeHostInfo {
+  @override
+  ProcessIdentity get identity => ProcessIdentity(
+    pid: 900,
+    startMarker: "bridge-start",
+    executablePath: "/usr/local/bin/sesori-bridge",
+    commandLine: "sesori-bridge",
+    ownerUser: ProcessUser.fromRawUser("alex"),
+    platform: "macos",
+    capturedAt: DateTime.utc(2026, 5, 15, 12),
+  );
+
+  @override
+  String get ownerSessionId => "current-owner";
+
+  @override
+  Future<bool> isLiveBridgeProcess({required int pid, required String? startMarker}) async => false;
+}
+
+class _AdvancingServerClock implements ServerClock {
+  DateTime _now = DateTime.utc(2026, 5, 15, 12);
+
+  @override
+  Future<void> delay({required Duration duration}) async {
+    _now = _now.add(duration);
+  }
+
+  @override
+  DateTime now() => _now;
+}
+
+/// A clock whose `now()` never moves, even across `delay()` calls — used to
+/// prove the port-release wait terminates on its `maxPolls` backstop rather
+/// than the (never-reached) deadline.
+class _StuckServerClock implements ServerClock {
+  int delays = 0;
+
+  @override
+  Future<void> delay({required Duration duration}) async {
+    delays += 1;
+  }
+
+  @override
+  DateTime now() => DateTime.utc(2026, 5, 15, 12, 30);
+}
+
+class _MonitorSpawnedProcess implements SpawnedProcess {
+  _MonitorSpawnedProcess({
+    required ProcessIdentity identity,
+    required bool exitImmediately,
+    Stream<List<int>>? stderr,
+  }) : _identity = identity,
+       _stderr = stderr ?? const Stream<List<int>>.empty() {
+    if (exitImmediately) {
+      _exitCodeCompleter.complete(0);
+    }
+  }
+
+  final ProcessIdentity _identity;
+  final Stream<List<int>> _stderr;
+  final Completer<int> _exitCodeCompleter = Completer<int>();
+
+  @override
+  Future<int> get exitCode => _exitCodeCompleter.future;
+
+  @override
+  ProcessIdentity get identity => _identity;
+
+  @override
+  int get pid => _identity.pid;
+
+  @override
+  IOSink get stdin => throw UnimplementedError();
+
+  @override
+  Stream<List<int>> get stderr => _stderr;
+
+  @override
+  Stream<List<int>> get stdout => const Stream<List<int>>.empty();
+
+  void completeExit([int code = 0]) {
+    if (!_exitCodeCompleter.isCompleted) {
+      _exitCodeCompleter.complete(code);
+    }
+  }
+}

--- a/bridge/sesori_plugin_runtime/test/managed_runtime_monitor_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_runtime_monitor_test.dart
@@ -160,6 +160,24 @@ void main() {
       expect(clock.delays, greaterThan(0));
     });
 
+    test("a restart stands down when the status machine has already moved to a terminal state", () async {
+      final status = PluginStatusController(initial: const PluginReady());
+      final tags = _collect(status);
+      final monitor = fakes.monitor(status: status, restartPolicy: _bounded());
+      final child = _child(pid: 101);
+
+      monitor.arm(_handle(port: 4096, process: child));
+      // The owner moved the plugin to Stopping without disarming the monitor:
+      // the rejected PluginRestarting transition must stop the episode.
+      status.set(const PluginStopping());
+      child.completeExit(1);
+      await pumpEventQueue();
+
+      expect(fakes.spawn.spawnedPorts, isEmpty);
+      expect(tags, isNot(contains("restarting(1)")));
+      expect(tags, isNot(contains("failed")));
+    });
+
     test("disarming before the exit suppresses any restart or failure", () async {
       final status = PluginStatusController(initial: const PluginReady());
       final tags = _collect(status);

--- a/bridge/sesori_plugin_runtime/test/runtime_restart_policy_test.dart
+++ b/bridge/sesori_plugin_runtime/test/runtime_restart_policy_test.dart
@@ -1,0 +1,71 @@
+import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("RuntimeRestartPolicy", () {
+    test("disabled() is const and is the disabled variant", () {
+      const policy = RuntimeRestartPolicy.disabled();
+      expect(policy, isA<DisabledRestartPolicy>());
+      expect(identical(const RuntimeRestartPolicy.disabled(), const RuntimeRestartPolicy.disabled()), isTrue);
+    });
+
+    BoundedRestartPolicy bounded({
+      int maxAttempts = 3,
+      Duration initialBackoff = const Duration(milliseconds: 200),
+      Duration maxBackoff = const Duration(seconds: 2),
+      double backoffMultiplier = 2.0,
+    }) {
+      return RuntimeRestartPolicy.bounded(
+        maxAttempts: maxAttempts,
+        initialBackoff: initialBackoff,
+        maxBackoff: maxBackoff,
+        backoffMultiplier: backoffMultiplier,
+        portReleaseTimeout: const Duration(seconds: 5),
+        portReleasePollInterval: const Duration(milliseconds: 250),
+      ) as BoundedRestartPolicy;
+    }
+
+    test("backoffFor grows geometrically from the first attempt", () {
+      final policy = bounded();
+      expect(policy.backoffFor(1), equals(const Duration(milliseconds: 200)));
+      expect(policy.backoffFor(2), equals(const Duration(milliseconds: 400)));
+      expect(policy.backoffFor(3), equals(const Duration(milliseconds: 800)));
+    });
+
+    test("backoffFor is capped at maxBackoff", () {
+      final policy = bounded(maxBackoff: const Duration(milliseconds: 500));
+      expect(policy.backoffFor(3), equals(const Duration(milliseconds: 500)));
+      expect(policy.backoffFor(50), equals(const Duration(milliseconds: 500)));
+    });
+
+    test("a multiplier of 1.0 keeps the backoff flat", () {
+      final policy = bounded(backoffMultiplier: 1.0);
+      expect(policy.backoffFor(1), equals(const Duration(milliseconds: 200)));
+      expect(policy.backoffFor(5), equals(const Duration(milliseconds: 200)));
+    });
+
+    test("rejects invalid parameters", () {
+      expect(() => bounded(maxAttempts: 0), throwsA(isA<AssertionError>()));
+      expect(
+        () => RuntimeRestartPolicy.bounded(
+          maxAttempts: 1,
+          initialBackoff: const Duration(seconds: 1),
+          maxBackoff: const Duration(milliseconds: 500),
+          portReleaseTimeout: const Duration(seconds: 5),
+          portReleasePollInterval: const Duration(milliseconds: 250),
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => RuntimeRestartPolicy.bounded(
+          maxAttempts: 1,
+          initialBackoff: const Duration(milliseconds: 200),
+          maxBackoff: const Duration(seconds: 2),
+          portReleaseTimeout: const Duration(seconds: 5),
+          portReleasePollInterval: Duration.zero,
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+}

--- a/docs/plans/plugin-lifecycle-migration.html
+++ b/docs/plans/plugin-lifecycle-migration.html
@@ -87,10 +87,10 @@
   <h1>Plugin Lifecycle Migration Plan</h1>
   <div class="sub">Move all OpenCode runtime ownership (spawn, ports, health, ownership records, DB maintenance) out of <code>bridge/app</code> and into the OpenCode plugin, behind a plugin interface that supports managed-runtime, direct-CLI, and remote-server plugins — with per-plugin enable/start/stop. Delivered as a ladder of small, always-green PRs.</div>
   <div class="meta">
-    <span><b>Status:</b> in progress (rev 4 — PRs 1–8 merged (PR 8 = #239), PR 9 shipped #243; shipped cards carry delta callouts binding on later PRs)</span>
-    <span><b>Date:</b> 2026-06-10 (rev 3: 2026-06-11; rev 4: 2026-06-12)</span>
+    <span><b>Status:</b> in progress (rev 5 — PRs 1–8 merged (PR 8 = #239), PR 9 shipped #243; codegen / line-budget rule revised per maintainer review; shipped cards carry delta callouts binding on later PRs)</span>
+    <span><b>Date:</b> 2026-06-10 (rev 3: 2026-06-11; rev 4–5: 2026-06-12)</span>
     <span><b>PRs:</b> 15, strictly sequential</span>
-    <span><b>Max PR size:</b> ~2,000 changed lines (hard)</span>
+    <span><b>Max PR size:</b> ~2,000 hand-written changed lines (soft target; generated code excluded)</span>
     <span><b>Branch base:</b> main</span>
   </div>
 </header>
@@ -100,8 +100,8 @@
   <ul>
     <li><b>Always green.</b> After every PR: <code>dart analyze --fatal-infos</code> clean in every touched package (this is what <code>bridge-ci.yml</code> runs — note: a cross-package <code>@Deprecated</code> fails it, see PR 2), all tests pass, and the bridge runs end-to-end exactly as before (start, login, OpenCode spawn, mobile session flow, <code>--no-auto-start</code> attach mode, clean shutdown). No PR depends on a future PR to compile or behave.</li>
     <li><b>No breaking changes.</b> CLI flags (<code>--port</code>, <code>--no-auto-start</code>, <code>--password</code>, <code>--opencode-bin</code>) keep their exact names and semantics throughout — headless/systemd units (<code>docs/SETUP_HEADLESS_VM.md</code>) must never need editing. The on-disk ownership file <code>&lt;cacheDir&gt;/runtime/opencode-processes.json</code> keeps its exact schema and steady-state bytes <i>forever</i> (frozen contract — self-updating fleets mix bridge versions). Anything new the supervisor needs to persist goes in <b>separate, new files</b> that old bridges never read.</li>
-    <li><b>≤ ~2,000 changed lines per PR, as <code>git diff --stat</code> counts them</b> — moves count on both sides, generated files count, deletions count. Pure-deletion PRs get their own rungs rather than a leniency clause.</li>
-    <li><b>No codegen in new contract types.</b> All new interface/runtime types are hand-written Dart 3 sealed classes and records — no freezed, no json_serializable. (The interface package's freezed convention has a measured ~10× generated-line multiplier that would blow PR budgets.)</li>
+    <li><b>~2,000 changed lines per PR — a soft target, not a hard cap.</b> Counted as <code>git diff --stat</code> does, <i>except generated code (<code>.freezed.dart</code>/<code>.g.dart</code>) is excluded</i>; hand-written source, moves (both sides), and deletions count. Pure-deletion PRs still get their own rungs rather than a leniency clause.</li>
+    <li><b>Generated code is fine for data models.</b> New serialized data types use <b>freezed + json_serializable</b> like the rest of the bridge (generated <code>.freezed.dart</code>/<code>.g.dart</code>, committed, excluded from the line target) — the budget never drives a hand-rolled-JSON decision. Behavioral types (policy/strategy sealed classes with logic, e.g. <code>RuntimeRestartPolicy</code>) may stay hand-written where freezed adds no value. <i>(Revised in PR 9 per maintainer review; supersedes the earlier no-codegen rule, which the now-removed ~2,000-line hard cap had motivated. Already-merged hand-written types are not retrofitted; this applies going forward — e.g. PR 9's <code>RuntimeStartIntent</code> is freezed.)</i></li>
     <li><b>Duplication between phases is fine.</b> Old and new implementations may coexist; the old path keeps running production until a single, small "flip" PR switches it.</li>
     <li><b>Fidelity gate.</b> The 1,224-line <code>open_code_server_service_test.dart</code> is the behavioral spec for process lifecycle. The extraction is proven by those scenarios passing against the new code (PR 10) — not by review alone. To make that possible, all behavioral changes (health pacing, record timing, restart) are <b>explicit policy knobs</b> that default to legacy behavior until the flip (PR 12).</li>
   </ul>

--- a/docs/plans/plugin-lifecycle-migration.html
+++ b/docs/plans/plugin-lifecycle-migration.html
@@ -87,8 +87,8 @@
   <h1>Plugin Lifecycle Migration Plan</h1>
   <div class="sub">Move all OpenCode runtime ownership (spawn, ports, health, ownership records, DB maintenance) out of <code>bridge/app</code> and into the OpenCode plugin, behind a plugin interface that supports managed-runtime, direct-CLI, and remote-server plugins — with per-plugin enable/start/stop. Delivered as a ladder of small, always-green PRs.</div>
   <div class="meta">
-    <span><b>Status:</b> in progress (rev 3 — PR 1 merged #210, PR 2 shipped #223; their cards carry shipped-delta callouts binding on later PRs)</span>
-    <span><b>Date:</b> 2026-06-10 (rev 3: 2026-06-11)</span>
+    <span><b>Status:</b> in progress (rev 4 — PRs 1–8 merged (PR 8 = #239), PR 9 shipped #243; shipped cards carry delta callouts binding on later PRs)</span>
+    <span><b>Date:</b> 2026-06-10 (rev 3: 2026-06-11; rev 4: 2026-06-12)</span>
     <span><b>PRs:</b> 15, strictly sequential</span>
     <span><b>Max PR size:</b> ~2,000 changed lines (hard)</span>
     <span><b>Branch base:</b> main</span>
@@ -296,6 +296,15 @@
   <li>All features here are <b>off by default</b> and activate only when the real descriptor opts in at PR 12 — PR 10's wrapper keeps them off.</li>
 </ul>
 <div class="safe"><b>Why always-green:</b> no production consumer; everything default-off.</div>
+<div class="callout green">
+  <b>Shipped as #243 (2026-06-12).</b> Deltas vs this card, <b>binding on later PRs</b>:
+  <ul>
+    <li><b>The monitor is a separate class, not folded into the service.</b> <code>ManagedRuntimeMonitor&lt;R&gt;</code> composes <code>ManagedProcessService</code> and is the unit that drains stdio, watches exit, restarts, and publishes status via an injected <code>PluginStatusController</code>. <b>PR 10 keeps exit-monitoring/restart "off" by simply not constructing a monitor</b> (the service alone has no exit watch, so the fidelity suite is untouched); <b>PR 11 constructs the monitor, arms it with the started handle, and owns its status controller</b>; <b>PR 12 switches its <code>RuntimeRestartPolicy</code> from <code>disabled()</code> to <code>bounded(...)</code></b>. The restart policy is a <i>monitor constructor argument</i>, not a <code>ManagedRuntimeSpec</code> field.</li>
+    <li><b><code>restartOnPort()</code> lives on the service.</b> It waits (bounded by an advancing-clock deadline <i>and</i> a <code>maxPolls</code> backstop) for the address-frozen port to free, then reuses the cold-start spawn/record/health/rollback path — <i>no</i> stale cleanup. The monitor adopts its returned handle (adopt-before-stand-down, so a disarm racing the commit can't orphan the new child); restart pins the port and emits <code>PluginFailed</code> if it never frees.</li>
+    <li><b>Tightened abort contract (start-path behavior delta).</b> <code>start()</code> now honors the documented post-spawn abort checkpoint: an abort observed right after spawn stops the untracked child and throws <code>PluginStartAbortedException</code> <i>before</i> any starting record is written (previously the starting record was written then rolled back). <b>Inert on the legacy/PR-10 path</b> (<code>afterSpawn</code> + the never-abort signal ⇒ no-op), so the 1,224-line suite is unaffected; PR 11/12 emitters should expect no pre-record write on an aborted spawn.</li>
+    <li><b>Intent side-file.</b> <code>RuntimeRecordTiming.intentSideFile</code> is implemented via an injected <code>RuntimeStartIntentStore</code> (<code>ManagedProcessService(intentStore: …)</code>); the bridge-private <code>RuntimeStartIntent</code> carries <i>no child pid</i> and never touches <code>opencode-processes.json</code> (mixed-version inertness test). Selecting the timing with no store is an <code>ArgumentError</code> raised before stale cleanup (was <code>UnsupportedError</code>). <b>PR 11</b> supplies the store at <code>&lt;cacheDir&gt;/runtime/&lt;runtimeId&gt;-start-intent.json</code>; <b>PR 12's "crashed-mid-intent" case resolves implicitly</b> — a fresh spawning start overwrites+clears a leftover intent. PR 9 ships <b>no</b> cross-bridge reclamation path (deferred, as scoped).</li>
+  </ul>
+</div>
 </div>
 
 <div class="card pr">


### PR DESCRIPTION
Part of the **Plugin Lifecycle Migration** (`docs/plans/plugin-lifecycle-migration.html`) — PR **9/15**. Builds on the supervisor start/attach (#239, PR 8). Adds the hardened managed-runtime behaviors to `sesori_plugin_runtime`, **all default-off with no production consumer** (`bridge/app` untouched). They activate only when the real descriptor opts in at the flip (PR 12).

## What's in this PR

- **`ManagedRuntimeMonitor<R>`** (new) — composes `ManagedProcessService`. Drains stdout, pipes stderr to `Log.d` with a `[runtimeId]` prefix, watches `exitCode`. On an unexpected exit it runs a **bounded restart-with-backoff** (`PluginRestarting`) **pinned to the original port**, surfacing `PluginFailed` on exhaust. `disarm()` aborts any in-flight restart so a clean shutdown can't be mistaken for a crash; all status writes go through `trySet` (no `Failed` after `Stopping`).
- **`ManagedProcessService.restartOnPort()`** — bounded wait for the address-frozen port to free (advancing-clock deadline **+ `maxPolls` backstop**), then reuses the cold-start spawn/record/health/rollback path (no stale cleanup). The monitor adopts its returned handle.
- **`RuntimeRestartPolicy`** — `disabled()` (default) / `bounded(...)`; a **monitor constructor argument**, not a spec field.
- **Intent side-file** — `RuntimeRecordTiming.intentSideFile` implemented via an injected `RuntimeStartIntentStore`. A bridge-private `RuntimeStartIntent` (ownerSessionId, port, bridge pid/marker, recordedAt — **no child pid**) is written **before spawn** and cleared **after the starting record is persisted** (and on every failure path). It **never** touches the frozen `opencode-processes.json` (mixed-version inertness test). Selecting the timing without a store is an `ArgumentError` raised before stale cleanup.
- **Tightened abort contract** — `start()` now honors the documented post-spawn abort checkpoint: an abort observed right after spawn stops the untracked child **before any record is written**. **Inert on the legacy/PR-10 path** (afterSpawn + never-abort ⇒ no-op), so the 1,224-line fidelity suite is unaffected.

## Always-green / scope

- `dart analyze --fatal-infos` clean across all four bridge packages; **71/71** `sesori_plugin_runtime` tests pass.
- No `bridge/app` changes, no CLI/flag changes, frozen `opencode-processes.json` schema untouched.
- Diff ~1,843 changed lines (production ~609, within the production budget; under the 2,000 hard cap).

## Process

Architecture validated by a design panel (GO-with-changes), then an adversarial review (15 raw → 8 confirmed). Confirmed findings fixed in this branch: post-spawn abort checkpoint (M2), `_restartAbort` ownership guard (M1), a self-found disarm-vs-commit adopt-first leak fix, plus the disarm-rollback-signals and `maxPolls`-backstop tests. Cross-bridge intent reclamation is deliberately deferred (a fresh spawn overwrites+resolves a leftover intent), consistent with the plan's scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hardened runtime supervision to `sesori_plugin_runtime`: exit monitoring, bounded restarts with backoff on the same port, and a start intent side-file. All features are default-off; production behavior is unchanged. The intent model is now a `@freezed` type with generated JSON.

- **New Features**
  - `ManagedRuntimeMonitor<R>`: drains stdout, logs stderr with `[runtimeId]`, watches exits, and on unexpected exit can restart with backoff on the same port. `disarm()` aborts in-flight restarts; status updates use `trySet`.
  - `ManagedProcessService.restartOnPort(...)`: waits for the pinned port to free (deadline + `maxPolls` backstop) and reuses the cold-start spawn/record/health/rollback path.
  - `RuntimeRestartPolicy`: `disabled()` (default) or `bounded(...)`; passed to the monitor (not a spec field).
  - Intent side-file: implements `RuntimeRecordTiming.intentSideFile` via `RuntimeStartIntentStore`. `RuntimeStartIntent` is a `freezed` model with `json_serializable` JSON; written before spawn and cleared after the starting record is persisted or on any failure. Selecting this timing without a store throws `ArgumentError`.
  - Start abort checkpoint: if an abort fires right after spawn, the untracked child is stopped before any record is written (legacy path unaffected).
  - Scope/Docs: no `bridge/app` or CLI changes; ownership schema unchanged; tests are green. Plan docs updated with PR 9 shipped-delta callouts and the codegen/line-budget rule. `pubspec.yaml` adds `freezed_annotation`/`json_annotation` (dev: `freezed`, `json_serializable`, `build_runner`) and bumps Dart SDK to `^3.12.2`.

- **Bug Fixes**
  - Stderr decoding is UTF-8 with `allowMalformed: true` to avoid tearing down on bad bytes.
  - Each failed restart attempt is logged; final failure still surfaces via `PluginFailed`.
  - Stdio subscription cancellation is guarded and logged to prevent unhandled errors.
  - `restartOnPort` validates intent timing up front for fail-fast errors.
  - A restart now stands down when the status machine rejects `PluginRestarting` (e.g., stopping state).

<sup>Written for commit adf564023150cd8dbc4faf365fa1706dbd428c19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

