### PR TITLE
fix(mobile): show back button on narrow session list screen

### DIFF
--- a/mobile/app/lib/features/session_list/session_list_scaffold.dart
+++ b/mobile/app/lib/features/session_list/session_list_scaffold.dart
@@ -15,6 +15,7 @@ class SessionListScaffold extends StatelessWidget {
   final ValueChanged<Session> onSessionLongPress;
   final ValueChanged<Session> onSessionSwipe;
   final VoidCallback onNewSession;
+  final VoidCallback? onBack;
 
   const SessionListScaffold({
     super.key,
@@ -24,6 +25,7 @@ class SessionListScaffold extends StatelessWidget {
     required this.onSessionLongPress,
     required this.onSessionSwipe,
     required this.onNewSession,
+    required this.onBack,
   });
 
   @override
@@ -35,6 +37,10 @@ class SessionListScaffold extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(
+        // The sessions route sits at the base of the nested pane navigator,
+        // so AppBar cannot imply a back button — the poppable route lives on
+        // the root navigator. Render it explicitly from the injected callback.
+        leading: onBack != null ? BackButton(onPressed: onBack) : null,
         title: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/mobile/app/lib/features/session_list/session_list_screen.dart
+++ b/mobile/app/lib/features/session_list/session_list_screen.dart
@@ -46,9 +46,16 @@ class _SessionListBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const actionDispatcher = SessionListActionDispatcher();
+    // The sessions route is the base of the nested pane navigator, so the
+    // pane navigator can never pop it; the poppable session shell route (with
+    // /projects underneath) lives on the root navigator.
+    // ignore: no_slop_linter/avoid_navigator_of, root navigator pop is required so back exits the session shell to the projects list instead of targeting the nested pane navigator
+    final rootNavigator = Navigator.of(context, rootNavigator: true);
 
     return SessionListScaffold(
       projectName: projectName,
+      // ignore: unnecessary_lambdas, Navigator.pop is generic and does not match VoidCallback as a tear-off
+      onBack: rootNavigator.canPop() ? () => rootNavigator.pop() : null,
       onNewSession: () {
         context.pushRoute(AppRoute.newSession(projectId: projectId, projectName: projectName));
       },

--- a/mobile/app/test/features/session_list/adaptive_session_list_navigation_test.dart
+++ b/mobile/app/test/features/session_list/adaptive_session_list_navigation_test.dart
@@ -45,6 +45,76 @@ void main() {
     expect(find.byKey(const Key("session-split-left-pane")), findsNothing);
   });
 
+  testWidgets("narrow /projects/p1/sessions entry shows BackButton to projects", (tester) async {
+    const location = "/projects/p1/sessions?name=Project+One";
+    final harness = AdaptiveSessionRouterTestHarness();
+    await tester.binding.setSurfaceSize(const Size(390, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    addTearDown(harness.tearDown);
+    await harness.setUp(
+      initialLocation: location,
+      currentRouteDef: AppRouteDef.sessions,
+      sessionsByProject: {
+        "p1": [adaptiveTestSession(projectId: "p1", id: "session-1", title: "Session One")],
+      },
+    );
+
+    await tester.pumpWidget(harness.buildApp());
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key("session-split-left-pane")), findsNothing);
+    expect(find.byType(BackButton), findsOneWidget);
+    expect(harness.router.canPop(), isTrue);
+
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+
+    expect(Uri.parse(harness.currentLocation).path, "/projects");
+  });
+
+  testWidgets("narrow sessions pushed from /projects pops back to the project list", (tester) async {
+    final harness = AdaptiveSessionRouterTestHarness();
+    await tester.binding.setSurfaceSize(const Size(390, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    addTearDown(harness.tearDown);
+    await harness.setUp(
+      initialLocation: "/projects",
+      currentRouteDef: AppRouteDef.projects,
+      sessionsByProject: {
+        "p1": [adaptiveTestSession(projectId: "p1", id: "session-1", title: "Session One")],
+      },
+    );
+
+    when(() => harness.projectService.listProjects()).thenAnswer(
+      (_) async => ApiResponse.success(
+        const Projects(
+          data: [
+            Project(
+              id: "p1",
+              name: "Project One",
+              time: ProjectTime(created: 1700000000000, updated: 1700000000000, initialized: null),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(harness.buildApp());
+    await tester.pumpAndSettle();
+
+    unawaited(harness.router.push("/projects/p1/sessions?name=Project+One"));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BackButton), findsOneWidget);
+
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+
+    expect(harness.router.canPop(), isFalse);
+    expect(Uri.parse(harness.currentLocation).path, "/projects");
+    expect(find.text("Project One"), findsOneWidget);
+  });
+
   testWidgets("list tile tap opens detail in the wide split shell", (tester) async {
     const location = "/projects/p1/sessions?name=Project+One";
     final harness = AdaptiveSessionRouterTestHarness();


### PR DESCRIPTION
## Problem

On phones (narrow layout) there was no way back from a project's session list to the projects list. The sessions route sits at the **base of the nested pane navigator**, so its `AppBar` never implies a back button — the poppable session-shell route (with `/projects` underneath) lives on the **root** navigator, which the pane navigator knows nothing about.

## Fix

`SessionListScreen` now wires an explicit `BackButton` through `SessionListScaffold` that pops the root navigator, rendered only when `rootNavigator.canPop()` — mirroring the existing split-mode left-pane exit behavior. Split layout is untouched: in wide mode the list renders via `_SessionListPane`/`SessionSplitShell`, not `SessionListScreen`, so the new leading button never appears there.

## Tests

Two new widget tests in `adaptive_session_list_navigation_test.dart`:
- narrow deep-link entry at `/projects/p1/sessions` shows a `BackButton` and popping lands on `/projects`
- sessions pushed from `/projects` pops back to the project list (router stack fully unwound)

## Verification

- `dart analyze --fatal-infos` clean on `mobile/app`; `flutter test` on the adaptive navigation suite: 13/13 green
- **Manual E2E on iPhone 17 Pro Max simulator (iOS 26.5), real bridge + relay data:**
  - projects → `sesori_apps_monorepo` → session list shows the back chevron; tapping it returns to projects
  - pushing a session detail and popping back leaves the back button intact and working
  - iOS edge-swipe from the session list pops to the same place as the button (system-back parity)
  - rotating to landscape engages the split layout (no narrow back button, as designed); rotating back restores it and it still pops correctly

![session list with back button on narrow layout](https://gist.githubusercontent.com/daniil-shumko/d7d6e31c774e0cbae810a32ed4b186b8/raw/sesori_session_list_back_button.png)

**Noticed during verification (pre-existing, out of scope):** phone-landscape split mode overflows the left pane header (`RenderFlex overflowed by 44px`, `session_list_panel.dart:46`, dates to #196) — title renders vertically with overflow stripes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes back navigation on phones by showing a Back button on the sessions list. It pops the root navigator back to the projects list; split view is unchanged.

- **Bug Fixes**
  - Added an explicit BackButton in SessionListScreen via SessionListScaffold’s new onBack, shown only when the root navigator can pop.
  - Narrow layout only; split (wide) layout remains using panes with no leading button.
  - Added two widget tests for deep-link entry and push-from-projects flows.

<sup>Written for commit cd5dd6b40cc3f33ae8b0c3204e2be58840a9d666. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

