### PR TITLE
fix(bridge): detect dartvm and dartaotruntime source runs for conflict detection

### DIFF
--- a/bridge/app/lib/src/server/repositories/bridge_instance_repository.dart
+++ b/bridge/app/lib/src/server/repositories/bridge_instance_repository.dart
@@ -10,6 +10,16 @@ class BridgeInstanceRepository {
   }) : _api = api,
        _currentUser = currentUser;
 
+  static const Set<String> _dartExecutableNames = <String>{
+    'dart',
+    'dart.exe',
+    'dartvm',
+    'dartvm.exe',
+    'dartaotruntime',
+    'dartaotruntime.exe',
+    'bridge.dart',
+  };
+
   final SystemProcessApi _api;
   final ProcessUser? _currentUser;
 
@@ -37,6 +47,6 @@ class BridgeInstanceRepository {
       return false;
     }
 
-    return executableBasename == 'dart' || executableBasename == 'dart.exe' || executableBasename == 'bridge.dart';
+    return executableBasename != null && _dartExecutableNames.contains(executableBasename);
   }
 }

--- a/bridge/app/test/server/repositories/bridge_instance_repository_test.dart
+++ b/bridge/app/test/server/repositories/bridge_instance_repository_test.dart
@@ -52,6 +52,38 @@ void main() {
       expect(candidates.single.pid, equals(20));
     });
 
+    test('accepts source-run dartvm bridge command (Flutter-bundled Dart SDK)', () async {
+      api.facts = <ProcessIdentity>[
+        _fact(
+          pid: 21,
+          executablePath: '/Users/alex/.asdf/installs/flutter/3.44.2-stable/bin/cache/dart-sdk/bin/dartvm',
+          commandLine: '/Users/alex/.asdf/installs/flutter/3.44.2-stable/bin/cache/dart-sdk/bin/dartvm '
+              '--resolved_executable_name=/Users/alex/.asdf/installs/flutter/3.44.2-stable/bin/cache/dart-sdk/bin/dart '
+              '--executable_name=/Users/alex/.asdf/installs/flutter/3.44.2-stable/bin/cache/dart-sdk/bin/dart '
+              'bridge/app/bin/bridge.dart --debug-port=7829 --log-level=debug --no-auto-start --port 4096',
+        ),
+      ];
+
+      final candidates = await repository.listLiveBridgeCandidates(currentPid: 999);
+
+      expect(candidates.single.pid, equals(21));
+    });
+
+    test('accepts source-run dartaotruntime bridge command', () async {
+      api.facts = <ProcessIdentity>[
+        _fact(
+          pid: 22,
+          executablePath: '/Users/alex/.asdf/installs/flutter/3.44.2-stable/bin/cache/dart-sdk/bin/dartaotruntime',
+          commandLine: '/Users/alex/.asdf/installs/flutter/3.44.2-stable/bin/cache/dart-sdk/bin/dartaotruntime '
+              'bridge/app/bin/bridge.dart --relay wss://relay.sesori.com',
+        ),
+      ];
+
+      final candidates = await repository.listLiveBridgeCandidates(currentPid: 999);
+
+      expect(candidates.single.pid, equals(22));
+    });
+
     test('filters false positives and other-user bridge commands', () async {
       api.facts = <ProcessIdentity>[
         _fact(


### PR DESCRIPTION
## Problem

Multiple bridge instances launched from source with the Flutter-bundled Dart SDK were not detected as conflicting.

`dart run bridge/app/bin/bridge.dart` is actually executed by the `dartvm` binary, e.g.:

```
.../dart-sdk/bin/dartvm --resolved_executable_name=.../dart --executable_name=.../dart bridge/app/bin/bridge.dart ...
```

The existing conflict detector in `BridgeInstanceRepository` only recognized executables named `dart`, `dart.exe`, or `bridge.dart`, so it ignored these processes and allowed two bridges to run simultaneously.

## Change

- Adds `dartvm`, `dartvm.exe`, `dartaotruntime`, and `dartaotruntime.exe` to the recognized source-run executable names in `BridgeInstanceRepository`.
- Adds unit tests covering the `dartvm` and `dartaotruntime` source-run command lines observed in the wild.

## Verification

- `dart analyze --fatal-infos` clean in `bridge/app`.
- Targeted tests pass:
  - `bridge/app/test/server/repositories/bridge_instance_repository_test.dart`
  - `bridge/app/test/server/repositories/process_repository_test.dart`

## Scope note

This is a minimal fix in the existing process-matching logic. Broader path normalization is intentionally avoided to minimize rebase risk with the plugin-lifecycle migration (PR 12).