### PR TITLE
docs(bridge): plugin-agnostic docs sweep and shared doc-comment cleanup (migration PR 14+15)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ app/lib/src/
 │   ├── push_session_state_tracker.dart
 │   └── completion_notifier.dart
 │
-└── server/                  # Subsystem (minimal — process lifecycle)
+└── server/                  # Subsystem (bridge instance / host services: single-live-bridge, startup mutex, plugin host abstractions)
 ```
 
 - BridgePlugin is semantically a Layer 1 data source (it exposes a public API for projects/sessions/messages)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,7 +271,7 @@ module_auth/lib/src/
 
 - **Bridge plugin system:** `BridgePluginApi` abstract class in `sesori_plugin_interface` defines the backend contract (projects, sessions, messages, events, health). THIS BELONGS TO Layer 1 (API layer). `sesori_plugin_opencode` implements it for OpenCode. New backends implement this interface.
 - **Relay protocol:** `RelayMessage` sealed class in `sesori_shared` defines all message types (auth, key_exchange, ready, request, response, sse_event, etc.). Binary wire format: `[version_byte][nonce (24B)][ciphertext + auth tag]`.
-- **Request routing (bridge):** Intercept-first handler chain. `RequestRouter` tries each registered handler in order; first match wins. `ProxyHandler` is the catch-all fallback.
+- **Request routing (bridge):** Explicit handler chain. `RequestRouter` tries each registered handler in order; first match wins. Unmatched routes return 404 — there is no catch-all proxy.
 - **SSE pipeline (bridge):** `SseConnection` → `SseEventParser` → plugin event stream → `Orchestrator` → `SSEManager` → per-phone encrypted delivery with event buffering.
 - **Mobile state management:** BLoC/Cubit pattern. Cubits live in `module_core` (pure Dart, testable). UI widgets in `app/` consume cubit state.
 - **Mobile DI:** 3-phase injection: platform adapters → auth → core services.

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -116,7 +116,7 @@ A plugin is a Dart package that implements the contract defined in `sesori_plugi
 3. Implement the contract:
    - A `BridgePluginDescriptor` that declares the plugin's CLI options, validates configuration, and starts the plugin against a `PluginHost`.
    - A `BridgePlugin` that exposes a `BridgePluginApi`, reports status via a `PluginStatus` stream, and implements ordered `shutdown()`.
-4. Register the descriptor in `app/bin/bridge.dart` (`plugin_registry.dart`).
+4. Register the descriptor in `app/lib/src/bridge/runtime/plugin_registry.dart` (referenced from `app/bin/bridge.dart`).
 
 For a concrete example, see `sesori_plugin_opencode`.
 

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -1,26 +1,20 @@
 # Sesori Bridge
 
-Dart workspace containing the Sesori Bridge CLI and its plugin system. The bridge connects a local OpenCode server to mobile devices over an encrypted WebSocket relay.
+Dart workspace containing the Sesori Bridge CLI and its plugin system. The bridge connects a local AI assistant server to mobile devices over an encrypted WebSocket relay.
 
-## Architecture
-
-Plugin-based design with three modules:
-
-- **`sesori_plugin_interface`** defines the plugin contract: the `BridgePluginApi` request surface (sessions, prompts, questions, permissions, projects, providers, events) and the lifecycle contract (`BridgePluginDescriptor` → `start(PluginHost)` → `BridgePlugin`). See its [README](sesori_plugin_interface/README.md).
-- **`sesori_plugin_opencode`** implements that contract for the OpenCode backend.
-- **`app`** orchestrates everything: auth (OAuth PKCE), relay connection, encryption, and request routing. It depends only on the plugin interface, not on any specific implementation.
+The bridge itself is plugin-agnostic: it knows how to authenticate, relay, encrypt, and route traffic, but all backend-specific logic (how to spawn the assistant, what its health endpoint looks like, how to parse its events) lives in plugins.
 
 ```
-Phone <--(E2E encrypted)--> Relay Server <--(E2E encrypted)--> Bridge CLI -> [Plugin] -> opencode serve
+Phone <--(E2E encrypted)--> Relay Server <--(E2E encrypted)--> Bridge CLI -> [Plugin] -> AI assistant server
 ```
 
 ## Modules
 
 | Module | Description |
 |--------|-------------|
-| `sesori_plugin_interface` | Plugin contract (`BridgePluginApi`, lifecycle types) and shared model types |
+| `sesori_plugin_interface` | Plugin contract (`BridgePluginApi`, `BridgePluginDescriptor`, lifecycle types) and shared model types |
 | `sesori_plugin_opencode` | OpenCode backend implementation of the plugin contract |
-| `app` | CLI entry point: auth, relay, encryption, request routing |
+| `app` | CLI entry point: auth, relay, encryption, request routing, plugin loading |
 
 ## Quick Start
 
@@ -115,7 +109,23 @@ See `app/README.md` for the full security and protocol details.
 
 ## Adding a New Plugin
 
+A plugin is a Dart package that implements the contract defined in `sesori_plugin_interface`.
+
 1. Create a new Dart package in `bridge/`.
 2. Add `sesori_plugin_interface` as a dependency.
-3. Implement the contract — see the [plugin interface README](sesori_plugin_interface/README.md) for the full guide.
-4. Register the plugin in the `app` orchestrator (`bin/bridge.dart`).
+3. Implement the contract:
+   - A `BridgePluginDescriptor` that declares the plugin's CLI options, validates configuration, and starts the plugin against a `PluginHost`.
+   - A `BridgePlugin` that exposes a `BridgePluginApi`, reports status via a `PluginStatus` stream, and implements ordered `shutdown()`.
+4. Register the descriptor in `app/bin/bridge.dart` (`plugin_registry.dart`).
+
+For a concrete example, see `sesori_plugin_opencode`.
+
+### Plugin lifecycle at a glance
+
+The bridge selects one plugin at startup, runs its `validateConfig()` strictly before acquiring the startup mutex, then calls `start(PluginHost)` under the mutex. The plugin is responsible for:
+
+- Starting (or attaching to) its backend server.
+- Publishing `Ready` / `Degraded` / `Failed` / `Restarting` status transitions.
+- Gracefully shutting down when the bridge exits.
+
+The bridge handles relay connection, encryption, request routing, and SSE multiplexing; it never knows the backend's command line, health endpoint, or event format.

--- a/bridge/app/AGENTS.md
+++ b/bridge/app/AGENTS.md
@@ -1,6 +1,6 @@
 # Sesori Bridge (Dart)
 
-Dart CLI compiled to native binary. Runs on laptop, authenticates via OAuth PKCE, connects to relay, routes E2E-encrypted traffic between phones and local server. Plugin-based architecture supports multiple backends (OpenCode, Codex, etc.). Manages process lifecycle (SIGTERM on shutdown).
+Dart CLI compiled to native binary. Runs on laptop, authenticates via OAuth PKCE, connects to relay, routes E2E-encrypted traffic between phones and a local AI assistant server. Plugin-based architecture supports multiple backends (OpenCode, Codex, etc.).
 
 ## STRUCTURE
 
@@ -24,11 +24,12 @@ lib/src/
 │   │   ├── sse_manager.dart   SSE stream multiplexing to connected phones
 │   │   └── event_queue.dart   Per-subscriber event buffer with replay
 │   └── debug_server.dart      Debug HTTP server for local testing
-├── server/                    OpenCode process management (start/stop/health check)
-modules/
-├── sesori_plugin_interface/   Plugin contract — BridgePlugin, RequestHandler, SseConfig
-└── opencode_plugin/           OpenCode implementation
-    ├── handlers/              Request handlers (project list, session list, messages)
+├── server/                    Bridge instance / host services (single-live-bridge enforcement, startup mutex, plugin host abstractions)
+
+bridge/ workspace modules (siblings of app/):
+├── sesori_plugin_interface/   Plugin contract — BridgePlugin, BridgePluginDescriptor, PluginHost
+└── sesori_plugin_opencode/    OpenCode implementation
+    ├── runtime/               OpenCode lifecycle: descriptor, spawn, health, ownership, DB maintenance
     ├── models/                Freezed models (project, session, message, SSE events, etc.)
     ├── opencode_plugin_impl.dart  BridgePlugin implementation
     ├── opencode_service.dart      Business logic coordinator
@@ -42,14 +43,14 @@ modules/
 
 | Task             | Location                           | Notes                                                   |
 | ---------------- | ---------------------------------- | ------------------------------------------------------- |
-| CLI flags        | `bin/bridge.dart`                  | `--relay`, `--port`, `--no-auto-start`, etc. |
+| CLI flags        | `bin/bridge.dart`                  | Bridge flags (`--relay`, `--port`, etc.); selected plugin contributes its own options |
 | Auth flow        | `lib/src/auth/`                    | OAuth PKCE with token persistence to disk               |
 | Relay connection | `lib/src/bridge/relay_client.dart` | WebSocket + auth handshake + reconnection               |
 | Key exchange     | `lib/src/bridge/key_exchange.dart` | X25519 → HKDF → room key delivery                       |
 | Request routing  | `lib/src/bridge/routing/`          | Intercept-first handlers with proxy fallback            |
 | Plugin interface | `modules/sesori_plugin_interface/` | BridgePlugin contract for all backends                  |
-| OpenCode plugin  | `modules/opencode_plugin/`         | OpenCode backend implementation + models + tests        |
-| Process mgmt     | `lib/src/server/`                  | Spawns OpenCode, health poll, SIGTERM cleanup         |
+| OpenCode plugin  | `modules/sesori_plugin_opencode/`  | OpenCode backend implementation + models + tests        |
+| Bridge instances | `lib/src/server/`                  | Single-live-bridge enforcement, startup mutex, plugin host abstractions |
 
 ## CONVENTIONS
 
@@ -95,12 +96,12 @@ For push code specifically, `PushDispatcher` owns only outbound push sends (imme
 ## TESTING
 
 ```bash
-dart test                                    # Bridge tests
-dart test modules/opencode_plugin/           # Plugin tests
-dart analyze                                 # Bridge analysis
-dart analyze modules/sesori_plugin_interface/ # Interface analysis
-dart analyze modules/opencode_plugin/        # Plugin analysis
-make build                                   # Compile native binary
+dart test                                    # Bridge tests (run from bridge/app/)
+cd bridge/sesori_plugin_opencode && dart test # Plugin tests
+make analyze                                 # Bridge analysis (run from bridge/)
+cd bridge/sesori_plugin_interface && dart analyze # Interface analysis
+cd bridge/sesori_plugin_opencode && dart analyze  # Plugin analysis
+make build                                   # Compile native binary (run from bridge/app/)
 ```
 
 Test helpers in `test/helpers/test_helpers.dart`: `makeRoomKey()`, `startTestRelayServer()`, `connectTestRelayClient()`

--- a/bridge/app/AGENTS.md
+++ b/bridge/app/AGENTS.md
@@ -29,7 +29,7 @@ lib/src/
 bridge/ workspace modules (siblings of app/):
 ├── sesori_plugin_interface/   Plugin contract — BridgePlugin, BridgePluginDescriptor, PluginHost
 └── sesori_plugin_opencode/    OpenCode implementation
-    ├── runtime/               OpenCode lifecycle: descriptor, spawn, health, ownership, DB maintenance
+    ├── runtime/               OpenCode lifecycle: descriptor, managed runtime (spawn, health, restart), ownership records
     ├── models/                Freezed models (project, session, message, SSE events, etc.)
     ├── opencode_plugin_impl.dart  BridgePlugin implementation
     ├── opencode_service.dart      Business logic coordinator
@@ -43,18 +43,18 @@ bridge/ workspace modules (siblings of app/):
 
 | Task             | Location                           | Notes                                                   |
 | ---------------- | ---------------------------------- | ------------------------------------------------------- |
-| CLI flags        | `bin/bridge.dart`                  | Bridge flags (`--relay`, `--port`, etc.); selected plugin contributes its own options |
+| CLI flags        | `bin/bridge.dart`                  | Bridge core flags (`--relay`, `--plugin`, etc.); the selected plugin contributes its own (OpenCode adds `--port`, `--no-auto-start`) |
 | Auth flow        | `lib/src/auth/`                    | OAuth PKCE with token persistence to disk               |
 | Relay connection | `lib/src/bridge/relay_client.dart` | WebSocket + auth handshake + reconnection               |
 | Key exchange     | `lib/src/bridge/key_exchange.dart` | X25519 → HKDF → room key delivery                       |
 | Request routing  | `lib/src/bridge/routing/`          | Intercept-first handlers with proxy fallback            |
-| Plugin interface | `modules/sesori_plugin_interface/` | BridgePlugin contract for all backends                  |
-| OpenCode plugin  | `modules/sesori_plugin_opencode/`  | OpenCode backend implementation + models + tests        |
+| Plugin interface | `../sesori_plugin_interface/`       | BridgePlugin contract for all backends                  |
+| OpenCode plugin  | `../sesori_plugin_opencode/`        | OpenCode backend implementation + models + tests        |
 | Bridge instances | `lib/src/server/`                  | Single-live-bridge enforcement, startup mutex, plugin host abstractions |
 
 ## CONVENTIONS
 
-- **Plugin architecture** — all backend-specific code lives in plugin modules under `modules/`. The bridge `lib/src/` is plugin-agnostic — it only imports from `sesori_plugin_interface`, never from concrete plugins. `bin/bridge.dart`'s registry (`plugin_registry.dart`) imports `opencode_plugin` for the const descriptor — that is the supported descriptor registration point.
+- **Plugin architecture** — all backend-specific code lives in sibling plugin packages under `bridge/` (e.g. `sesori_plugin_opencode`). The bridge `lib/src/` is plugin-agnostic — it only imports from `sesori_plugin_interface`, never from concrete plugins. `bin/bridge.dart`'s registry (`plugin_registry.dart`) imports `opencode_plugin` for the const descriptor — that is the supported descriptor registration point.
 - **Intercept-first routing** — requests are intercepted by handlers by default. Proxy is the fallback for unhandled routes, not the default path.
 - **Crypto from `sesori_shared`** — all crypto primitives imported from shared package, not duplicated
 - **Linting**: `package:lints/recommended.yaml` (lighter than mobile's `all_lint_rules`)
@@ -96,12 +96,16 @@ For push code specifically, `PushDispatcher` owns only outbound push sends (imme
 ## TESTING
 
 ```bash
-dart test                                    # Bridge tests (run from bridge/app/)
-cd bridge/sesori_plugin_opencode && dart test # Plugin tests
-make analyze                                 # Bridge analysis (run from bridge/)
-cd bridge/sesori_plugin_interface && dart analyze # Interface analysis
-cd bridge/sesori_plugin_opencode && dart analyze  # Plugin analysis
-make build                                   # Compile native binary (run from bridge/app/)
+# Run all commands from the bridge/ workspace root.
+make analyze                                   # Analyze all bridge modules
+make test                                      # Test all bridge modules
+(cd app && make build)                         # Compile the native binary
+
+# Target a single module (the subshell keeps your shell at bridge/):
+(cd app && dart test)                          # Bridge app tests only
+(cd sesori_plugin_opencode && dart test)       # OpenCode plugin tests only
+(cd sesori_plugin_interface && dart analyze)   # Interface analysis only
+(cd sesori_plugin_opencode && dart analyze)    # Plugin analysis only
 ```
 
 Test helpers in `test/helpers/test_helpers.dart`: `makeRoomKey()`, `startTestRelayServer()`, `connectTestRelayClient()`

--- a/bridge/app/AGENTS.md
+++ b/bridge/app/AGENTS.md
@@ -14,12 +14,11 @@ lib/src/
 │   ├── key_exchange.dart      X25519 DH key exchange with phones, room key delivery
 │   ├── routing/               Request handler chain (one class per API route)
 │   │   ├── request_handler.dart  Abstract base — declares method + path pattern, implements canHandle/extractParams
-│   │   ├── request_router.dart   Iterates handler list, extracts params, delegates to first match
+│   │   ├── request_router.dart   Iterates handlers, delegates to first match; returns 404 when none match
 │   │   ├── health_check_handler.dart        GET /global/health
 │   │   ├── get_projects_handler.dart        GET /project
 │   │   ├── get_sessions_handler.dart        GET /session
-│   │   ├── get_session_messages_handler.dart GET /session/:id/message
-│   │   └── proxy_handler.dart               Catch-all fallback — proxies unmatched routes to plugin backend
+│   │   └── get_session_messages_handler.dart GET /session/:id/message
 │   ├── sse/                   SSE stream management (backend-agnostic)
 │   │   ├── sse_manager.dart   SSE stream multiplexing to connected phones
 │   │   └── event_queue.dart   Per-subscriber event buffer with replay
@@ -47,7 +46,7 @@ bridge/ workspace modules (siblings of app/):
 | Auth flow        | `lib/src/auth/`                    | OAuth PKCE with token persistence to disk               |
 | Relay connection | `lib/src/bridge/relay_client.dart` | WebSocket + auth handshake + reconnection               |
 | Key exchange     | `lib/src/bridge/key_exchange.dart` | X25519 → HKDF → room key delivery                       |
-| Request routing  | `lib/src/bridge/routing/`          | Intercept-first handlers with proxy fallback            |
+| Request routing  | `lib/src/bridge/routing/`          | Explicit handlers; unmatched routes return 404          |
 | Plugin interface | `../sesori_plugin_interface/`       | BridgePlugin contract for all backends                  |
 | OpenCode plugin  | `../sesori_plugin_opencode/`        | OpenCode backend implementation + models + tests        |
 | Bridge instances | `lib/src/server/`                  | Single-live-bridge enforcement, startup mutex, plugin host abstractions |
@@ -55,7 +54,7 @@ bridge/ workspace modules (siblings of app/):
 ## CONVENTIONS
 
 - **Plugin architecture** — all backend-specific code lives in sibling plugin packages under `bridge/` (e.g. `sesori_plugin_opencode`). The bridge `lib/src/` is plugin-agnostic — it only imports from `sesori_plugin_interface`, never from concrete plugins. `bin/bridge.dart`'s registry (`plugin_registry.dart`) imports `opencode_plugin` for the const descriptor — that is the supported descriptor registration point.
-- **Intercept-first routing** — requests are intercepted by handlers by default. Proxy is the fallback for unhandled routes, not the default path.
+- **Explicit routing** — every supported route has a dedicated handler; `RequestRouter` returns 404 for unmatched routes (no catch-all proxy).
 - **Crypto from `sesori_shared`** — all crypto primitives imported from shared package, not duplicated
 - **Linting**: `package:lints/recommended.yaml` (lighter than mobile's `all_lint_rules`)
 - **Binary distribution**: npm wrapper package with platform-specific optional deps (darwin/linux/windows × arm64/x64)

--- a/bridge/app/README.md
+++ b/bridge/app/README.md
@@ -1,8 +1,8 @@
 # Sesori Bridge CLI
 
-Native CLI tool written in Dart, compiled to a platform binary, that bridges a local OpenCode server to mobile devices over the internet via an encrypted WebSocket relay.
+Native CLI tool written in Dart, compiled to a platform binary, that bridges a local AI assistant server to mobile devices over the internet via an encrypted WebSocket relay.
 
-It authenticates with OAuth PKCE, spawns `opencode serve`, connects to the relay, performs an X25519 key exchange with each connecting phone, and routes encrypted requests and responses between them. All traffic is end-to-end encrypted; the relay server only ever sees ciphertext.
+The bridge authenticates with OAuth PKCE, loads the selected plugin, connects to the relay, performs an X25519 key exchange with each connecting phone, and routes encrypted requests and responses between them. All traffic is end-to-end encrypted; the relay server only ever sees ciphertext. The plugin (e.g. `sesori_plugin_opencode`) owns all backend-specific logic: spawning the assistant, health checks, SSE event parsing, and graceful shutdown.
 
 ## Quick Start
 
@@ -14,7 +14,7 @@ make build
 ./dist/bridge-macos-arm64
 ```
 
-Press `Ctrl+C` to stop. This shuts down both the bridge and the OpenCode server it started.
+Press `Ctrl+C` to stop. This shuts down the bridge and triggers the selected plugin's ordered shutdown, which in turn stops any backend server it started.
 
 No Dart SDK? You can bootstrap the managed install with npm:
 
@@ -96,33 +96,37 @@ If you used the npm bootstrap path, `npm uninstall @sesori/bridge` does not remo
 ## How It Works
 
 ```
-Phone <--(E2E encrypted)--> Relay Server <--(E2E encrypted)--> Bridge CLI -> [OpenCode Plugin] -> opencode serve
+Phone <--(E2E encrypted)--> Relay Server <--(E2E encrypted)--> Bridge CLI -> [Plugin] -> AI assistant server
 ```
 
-1. Bridge starts `opencode serve` on `127.0.0.1:4096` with a generated password.
-2. Bridge authenticates with the auth backend (OAuth PKCE).
-3. Bridge connects to the relay WebSocket with role `"bridge"`.
-4. Phone connects to the same relay, grouped by user ID.
-5. Key exchange: phone sends its X25519 public key; bridge derives a shared secret via HKDF-SHA256 and sends an encrypted ready message containing the room key.
-6. All subsequent traffic is end-to-end encrypted. The relay cannot read any data.
-7. Up to 5 phones can connect simultaneously.
-8. Phone HTTP requests are decrypted by the bridge and forwarded to the local OpenCode server.
-9. Responses flow back encrypted through the relay to the phone.
+1. The bridge loads the selected plugin descriptor and runs its `start(PluginHost)`.
+2. The plugin starts (or attaches to) its backend server on a local port and reports `Ready`.
+3. The bridge authenticates with the auth backend (OAuth PKCE).
+4. The bridge connects to the relay WebSocket with role `"bridge"`.
+5. The phone connects to the same relay, grouped by user ID.
+6. Key exchange: phone sends its X25519 public key; bridge derives a shared secret via HKDF-SHA256 and sends an encrypted ready message containing the room key.
+7. All subsequent traffic is end-to-end encrypted. The relay cannot read any data.
+8. Up to 5 phones can connect simultaneously.
+9. Phone HTTP requests are decrypted by the bridge and forwarded to the local assistant server through the plugin.
+10. Responses flow back encrypted through the relay to the phone.
 
 ## CLI Flags (for `run` command)
 
 These flags apply when running the bridge. The `run` command is the default, so you can use these flags directly without specifying `run`.
 
+Bridge core flags:
+
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--relay` | `wss://relay.sesori.com` | Relay server URL |
-| `--port` | `4096` | Port for the OpenCode server (applies to both auto-start and `--no-auto-start`) |
-| `--password` | *(auto-generated)* | Override the server password |
-| `--opencode-bin` | `opencode` | Path to the OpenCode binary |
-| `--no-auto-start` | `false` | Skip spawning OpenCode; connect to an existing server on localhost instead |
+| `--port` | plugin-defined | Port the plugin should use for its backend server (when supported) |
+| `--password` | *(auto-generated)* | Override the backend server password |
+| `--plugin` | `opencode` | Plugin backend to run |
 | `--auth-backend` | `https://api.sesori.com` | Auth backend URL (also reads `AUTH_BACKEND_URL` env var) |
 | `--debug-port` | *(disabled)* | Start a debug HTTP server on this port for Postman/curl testing |
 | `--log-level` | `info` | Minimum log level: `verbose`, `debug`, `info`, `warning`, `error` |
+
+Each plugin contributes its own options. For example, the OpenCode plugin adds `--no-auto-start` and `--opencode-bin`. Run `--help` to see the options for the selected plugin.
 
 ## Commands
 
@@ -140,20 +144,24 @@ In addition to flags, the bridge supports subcommands:
 # Use a custom relay server
 ./dist/bridge-macos-arm64 --relay wss://my-relay.example.com
 
-# Connect to an already-running OpenCode server on port 4096
-./dist/bridge-macos-arm64 --no-auto-start --port 4096
-
-# Connect to an already-running OpenCode server on a custom port
-./dist/bridge-macos-arm64 --no-auto-start --port 8080
-
-# Use a custom OpenCode binary path
-./dist/bridge-macos-arm64 --opencode-bin /usr/local/bin/opencode
-
 # Use a custom auth backend
 ./dist/bridge-macos-arm64 --auth-backend https://my-auth.example.com
 
+# Select a different plugin (when available)
+./dist/bridge-macos-arm64 --plugin opencode
+
 # Log out (clear stored tokens)
 ./dist/bridge-macos-arm64 logout
+```
+
+Plugin-specific examples (OpenCode):
+
+```bash
+# Connect to an already-running OpenCode server on port 4096
+./dist/bridge-macos-arm64 --no-auto-start --port 4096
+
+# Use a custom OpenCode binary path
+./dist/bridge-macos-arm64 --opencode-bin /usr/local/bin/opencode
 ```
 
 ## Security
@@ -170,17 +178,19 @@ The bridge generates a 32-byte room key on startup. Each phone receives this key
 
 ### Password authentication
 
-The bridge generates a 64-character hex password (32 random bytes) and passes it to `opencode serve` via the `OPENCODE_SERVER_PASSWORD` environment variable. All proxied requests include an `Authorization: Basic` header injected by the bridge. The password never leaves the local machine.
+The bridge generates a 64-character hex password (32 random bytes) and passes it to the backend server via the plugin. All proxied requests include an `Authorization: Basic` header injected by the bridge. The password never leaves the local machine; the exact mechanism is plugin-defined.
 
-## Process Management
+## Plugin Process Management
 
-The bridge manages the OpenCode server process lifecycle:
+Backend process lifecycle is owned by the plugin, not the bridge core:
 
-- On startup, it spawns `opencode serve` and polls the health endpoint until it responds.
-- On `Ctrl+C` (SIGINT) or SIGTERM, it sends SIGTERM to the child process and waits for a clean exit.
-- On Windows, SIGTERM is unavailable; the bridge sends SIGKILL directly.
-- If the child process exits unexpectedly, the bridge shuts down as well.
+- On startup, the plugin starts (or attaches to) its backend server.
+- On `Ctrl+C` (SIGINT) or SIGTERM, the bridge calls the plugin's ordered `shutdown()`, which sends the appropriate signals and waits for a clean exit.
+- On Windows, SIGTERM is unavailable; the plugin typically sends SIGKILL directly.
+- If the backend process exits unexpectedly, the plugin publishes `Failed`/`Degraded` status and the bridge shuts down the session.
 - A 10-second safety timer forces process exit if graceful shutdown stalls.
+
+See the plugin package (e.g. `sesori_plugin_opencode`) for backend-specific details.
 
 ## Build
 
@@ -221,12 +231,24 @@ sesori-bridge
 
 ```
 bin/bridge.dart       CLI entry point: flag parsing, auth, plugin loading, signal handling
-lib/src/auth/         OAuth PKCE login, token persistence, validation
-lib/src/bridge/       Core bridge (plugin-agnostic): relay client, orchestrator, SSE delivery, debug server
-lib/src/server/       OpenCode process management: start, stop, health polling
+lib/src/
+├── api/              Dumb data-access classes (HTTP, DB, shell, plugins)
+├── auth/             OAuth PKCE login, token persistence, validation
+├── bridge/           Core bridge (plugin-agnostic)
+│   ├── relay_client.dart      WebSocket connection to relay, message routing
+│   ├── orchestrator.dart      Coordinates relay + plugin lifecycle + key exchange
+│   ├── key_exchange.dart      X25519 DH key exchange with phones, room key delivery
+│   ├── routing/               Request handler chain (one class per API route) + proxy fallback
+│   ├── sse/                   SSE stream multiplexing and per-subscriber event buffers
+│   └── debug_server.dart      Debug HTTP server for local testing
+├── push/             Outgoing push notification subsystem
+├── repositories/     Aggregators + mappers over APIs
+├── server/           Bridge instance / host services: single-live-bridge enforcement, startup mutex, plugin host abstractions
+├── services/         Business logic and coordination
+└── updater/          Packaged-install auto-update logic
 ```
 
-The crypto and protocol types live in `sesori_shared`, shared with the Flutter mobile app.
+The crypto and protocol types live in `sesori_shared`, shared with the Flutter mobile app. Backend-specific logic lives in plugin packages (e.g. `bridge/sesori_plugin_opencode`).
 
 ## Testing
 

--- a/bridge/app/README.md
+++ b/bridge/app/README.md
@@ -193,7 +193,7 @@ Backend process lifecycle is owned by the plugin, not the bridge core:
 - On startup, the plugin starts (or attaches to) its backend server.
 - On `Ctrl+C` (SIGINT) or SIGTERM, the bridge calls the plugin's ordered `shutdown()`, which sends the appropriate signals and waits for a clean exit.
 - On Windows, SIGTERM is unavailable; the plugin typically sends SIGKILL directly.
-- If the backend process exits unexpectedly, the plugin publishes `Failed`/`Degraded` status and the bridge shuts down the session.
+- If the backend process exits unexpectedly, the plugin attempts a bounded restart (status `Restarting`, on the same pinned port). Only a terminal `Failed` — restarts exhausted or the port never frees — cancels the relay session and shuts the bridge down (exit 1). Transient problems surface as recoverable `Degraded` and do not stop the bridge.
 - A 10-second safety timer forces process exit if graceful shutdown stalls.
 
 See the plugin package (e.g. `sesori_plugin_opencode`) for backend-specific details.
@@ -244,7 +244,7 @@ lib/src/
 │   ├── relay_client.dart      WebSocket connection to relay, message routing
 │   ├── orchestrator.dart      Coordinates relay + plugin lifecycle + key exchange
 │   ├── key_exchange.dart      X25519 DH key exchange with phones, room key delivery
-│   ├── routing/               Request handler chain (one class per API route) + proxy fallback
+│   ├── routing/               Explicit request handler chain (one class per API route); unmatched routes return 404
 │   ├── sse/                   SSE stream multiplexing and per-subscriber event buffers
 │   └── debug_server.dart      Debug HTTP server for local testing
 ├── push/             Outgoing push notification subsystem

--- a/bridge/app/README.md
+++ b/bridge/app/README.md
@@ -119,14 +119,20 @@ Bridge core flags:
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--relay` | `wss://relay.sesori.com` | Relay server URL |
-| `--port` | plugin-defined | Port the plugin should use for its backend server (when supported) |
-| `--password` | *(auto-generated)* | Override the backend server password |
 | `--plugin` | `opencode` | Plugin backend to run |
 | `--auth-backend` | `https://api.sesori.com` | Auth backend URL (also reads `AUTH_BACKEND_URL` env var) |
 | `--debug-port` | *(disabled)* | Start a debug HTTP server on this port for Postman/curl testing |
 | `--log-level` | `info` | Minimum log level: `verbose`, `debug`, `info`, `warning`, `error` |
+| `--version` | — | Print the bridge version and exit |
 
-Each plugin contributes its own options. For example, the OpenCode plugin adds `--no-auto-start` and `--opencode-bin`. Run `--help` to see the options for the selected plugin.
+The selected plugin contributes its own options, parsed after `--plugin` resolves the backend. Run `--help` to see the options for the selected plugin. The OpenCode plugin adds:
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--port` | *(auto)* | Port for the OpenCode server. Required with `--no-auto-start`; otherwise a free port is chosen automatically. |
+| `--password` | *(auto-generated)* | Override the OpenCode server password |
+| `--no-auto-start` | `false` | Skip spawning OpenCode; attach to an existing server on `--port` |
+| `--opencode-bin` | `opencode` | Path to the OpenCode binary |
 
 ## Commands
 

--- a/docs/SETUP_HEADLESS_VM.md
+++ b/docs/SETUP_HEADLESS_VM.md
@@ -173,7 +173,9 @@ systemctl daemon-reload
 systemctl enable --now sesori-bridge
 ```
 
-> **Process ownership note:** because this unit passes `--no-auto-start`, the OpenCode plugin does **not** spawn or manage the OpenCode process. Systemd owns OpenCode via the `opencode.service` unit above. If you omitted `--no-auto-start`, the plugin would spawn OpenCode itself, write the ownership file under `~/.local/share/sesori/runtime/`, and handle restarts/cleanup.
+> **Process ownership note:** because this unit passes `--no-auto-start`, the OpenCode plugin does **not** spawn or manage the OpenCode process. Systemd owns OpenCode via the `opencode.service` unit above, and the bridge attaches to it on `--port 9921`.
+>
+> **Switching to plugin-owned OpenCode:** dropping `--no-auto-start` alone is **not** enough in this setup. With an explicit `--port`, the plugin runs in managed mode and pre-probes that port as bindable, so it will fail to start because `opencode.service` is already listening on `9921`. To hand OpenCode ownership to the plugin: (1) stop and disable the standalone server with `systemctl disable --now opencode`, (2) remove the `After=opencode.service` and `Requires=opencode.service` lines from `sesori-bridge.service`, and (3) remove `--no-auto-start` from `ExecStart` (keep `--port 9921` for a fixed port, or drop it to let the plugin pick a free one). The plugin then spawns OpenCode itself, writes the ownership file under `~/.local/share/sesori/runtime/`, and handles restarts/cleanup.
 
 ---
 

--- a/docs/SETUP_HEADLESS_VM.md
+++ b/docs/SETUP_HEADLESS_VM.md
@@ -173,6 +173,8 @@ systemctl daemon-reload
 systemctl enable --now sesori-bridge
 ```
 
+> **Process ownership note:** because this unit passes `--no-auto-start`, the OpenCode plugin does **not** spawn or manage the OpenCode process. Systemd owns OpenCode via the `opencode.service` unit above. If you omitted `--no-auto-start`, the plugin would spawn OpenCode itself, write the ownership file under `~/.local/share/sesori/runtime/`, and handle restarts/cleanup.
+
 ---
 
 ## 10. Verify services
@@ -276,7 +278,7 @@ dmesg -T | grep -i oom
 ## Summary
 
 - OpenCode runs as a systemd service on port 9921
-- Sesori Bridge depends on it and connects to that port
+- Sesori Bridge depends on it and connects to that port (`--no-auto-start` means the plugin does not manage the OpenCode process)
 - Both auto-start on boot
 - Bridge updates apply on service restart; OpenCode updates via `opencode upgrade`
 - Logs are accessible via `journalctl`

--- a/docs/plans/plugin-lifecycle-migration.html
+++ b/docs/plans/plugin-lifecycle-migration.html
@@ -87,7 +87,7 @@
   <h1>Plugin Lifecycle Migration Plan</h1>
   <div class="sub">Move all OpenCode runtime ownership (spawn, ports, health, ownership records, DB maintenance) out of <code>bridge/app</code> and into the OpenCode plugin, behind a plugin interface that supports managed-runtime, direct-CLI, and remote-server plugins — with per-plugin enable/start/stop. Delivered as a ladder of small, always-green PRs.</div>
   <div class="meta">
-    <span><b>Status:</b> in progress (rev 6 — PRs 1–11 merged (PR 9 #243, PR 10 #244, PR 11 #245 + follow-up #248), PR 12 shipped #249; codegen / line-budget rule revised per maintainer review; shipped cards carry delta callouts binding on later PRs)</span>
+    <span><b>Status:</b> in progress (rev 7 — PRs 1–11 merged, PR 12 shipped #249, PR 13 shipped #251; PR 14 had no remaining deletions and was folded into PR 15 docs sweep; codegen / line-budget rule revised per maintainer review; shipped cards carry delta callouts binding on later PRs)</span>
     <span><b>Date:</b> 2026-06-10 (rev 3: 2026-06-11; rev 4–6: 2026-06-12)</span>
     <span><b>PRs:</b> 15, strictly sequential</span>
     <span><b>Max PR size:</b> ~2,000 hand-written changed lines (soft target; generated code excluded)</span>
@@ -155,8 +155,7 @@
   <tr><td>11</td><td>OpenCode plugin absorbs its lifecycle (dormant)</td><td><span class="pill pkg">opencode</span></td><td>~1,400–1,900</td><td><span class="pill s">low</span></td></tr>
   <tr><td>12</td><td>Flip to the real descriptor; new policies activate</td><td><span class="pill pkg">app</span> <span class="pill pkg">opencode</span></td><td>~700–1,000</td><td><span class="pill l">high</span></td></tr>
   <tr><td>13</td><td>Deletion sweep 1: legacy source files and their direct tests</td><td><span class="pill pkg">app</span></td><td>~2,000 (pure del)</td><td><span class="pill s">low</span></td></tr>
-  <tr><td>14</td><td>Deletion sweep 2: remaining legacy tests (if any)</td><td><span class="pill pkg">app</span></td><td>~small / 0</td><td><span class="pill s">low</span></td></tr>
-  <tr><td>15</td><td>Docs sweep</td><td><span class="pill pkg">docs</span></td><td>~400–700</td><td><span class="pill s">low</span></td></tr>
+  <tr><td>14+15</td><td>Final sweep: remaining tests (none) + docs update</td><td><span class="pill pkg">docs</span></td><td>~400–700</td><td><span class="pill s">low</span></td></tr>
 </table>
 <p class="meta" style="margin-top:4px">Packages: <b>interface</b> = <code>bridge/sesori_plugin_interface</code> · <b>app</b> = <code>bridge/app</code> · <b>opencode</b> = <code>bridge/sesori_plugin_opencode</code> (pub name <code>opencode_plugin</code>) · <b>runtime</b> = new <code>bridge/sesori_plugin_runtime</code></p>
 
@@ -374,22 +373,25 @@
   <li>Clean up the stale transitional exception note in <code>bridge/app/AGENTS.md</code> that claimed legacy OpenCode sources still lived in <code>lib/src/server/services/open_code_*</code>.</li>
 </ul>
 <div class="safe"><b>Why always-green:</b> nothing references the deleted sources after PR 12; the directly-dependent tests are removed with them so <code>dart analyze</code> stays clean. ~2,000 lines, all deletions.</div>
+<div class="callout green"><b>Shipped as #251 (2026-06-13).</b> No deltas vs this card.</div>
 </div>
 
 <div class="card pr">
-<h3><span class="prnum">PR 14</span> Deletion sweep 2 — remaining legacy tests</h3>
+<h3><span class="prnum">PR 14+15</span> Final sweep — remaining tests (none) + docs update</h3>
 <ul>
-  <li>Delete any leftover legacy tests not already removed in PR 13. (The PR 1 re-export shims were removed in PR 1 itself, per review — nothing left to sweep here.)</li>
+  <li><b>PR 14 scope:</b> no remaining legacy tests to delete. The only test still referencing deleted classes is <code>bridge_instance_service_test.dart</code>, which asserts the source does <i>not</i> contain <code>OpenCodeServerService</code> — a regression guard, not a legacy test. PR 14 is therefore empty and folded into this final sweep.</li>
+  <li><b>PR 15 docs sweep:</b>
+    <ul>
+      <li><code>bridge/README.md</code>: rewrite intro and architecture diagram to be plugin-agnostic; expand "Adding a New Plugin" guide with descriptor-based steps and lifecycle overview.</li>
+      <li><code>bridge/app/README.md</code>: make intro, how-it-works, CLI flags, examples, process-management, and project-structure sections plugin-agnostic; move OpenCode specifics to plugin-specific examples.</li>
+      <li><code>bridge/app/AGENTS.md</code>: update STRUCTURE/WHERE TO LOOK for <code>server/</code> (bridge instance / host services), update modules diagram, remove stale transitional exception.</li>
+      <li>Root <code>AGENTS.md</code>: update <code>server/</code> subsystem description from "process lifecycle" to "bridge instance / host services".</li>
+      <li><code>docs/SETUP_HEADLESS_VM.md</code>: flags unchanged; add process-ownership note explaining that <code>--no-auto-start</code> leaves OpenCode managed by systemd, not the plugin.</li>
+      <li><code>shared/sesori_shared</code>: generalize OpenCode-specific doc comments in <code>session.dart</code> and <code>message.dart</code>.</li>
+    </ul>
+  </li>
 </ul>
-<div class="safe"><b>Why always-green:</b> test-only deletions. Small/zero-risk by construction.</div>
-</div>
-
-<div class="card pr">
-<h3><span class="prnum">PR 15</span> Docs sweep</h3>
-<ul>
-  <li><code>bridge/README.md</code> plugin-authoring guide (descriptor-based), <code>bridge/app/README.md</code> process-management sections → plugin docs, both <code>AGENTS.md</code>, root <code>AGENTS.md</code> server-subsystem description, <code>docs/SETUP_HEADLESS_VM.md</code> (flags unchanged; ownership story updated), scrub OpenCode references from <code>sesori_shared</code> doc comments.</li>
-</ul>
-<div class="safe"><b>Why always-green:</b> docs only.</div>
+<div class="safe"><b>Why always-green:</b> docs only; no production code changes.</div>
 </div>
 
 <h2><span class="num">4</span>Risk register → where each is retired</h2>
@@ -418,8 +420,8 @@
 <div class="card">
 <ul class="check">
   <li><code>dart analyze --fatal-infos</code> clean in every touched package; <code>dart test</code> green across the bridge workspace.</li>
-  <li>Bridge smoke test: start → OpenCode spawns → mobile can create a session and stream a reply → Ctrl-C → clean exit, no orphaned <code>opencode serve</code> (check <code>ps</code>), ownership file consistent.</li>
-  <li><code>--no-auto-start --port &lt;p&gt;</code> attach mode works against a manually started server.</li>
+  <li>Bridge smoke test: start → plugin backend spawns → mobile can create a session and stream a reply → Ctrl-C → clean exit, no orphaned backend process, ownership file consistent.</li>
+  <li><code>--no-auto-start --port &lt;p&gt;</code> attach mode works against a manually started server (plugin-provided flag).</li>
   <li>Diff ≤ ~2,000 changed lines as <code>git diff --stat</code> counts them (split the PR if a test suite or codegen pushes it over).</li>
   <li>No change to CLI flag names/semantics. No change to <i>steady-state</i> <code>opencode-processes.json</code> bytes (PRs 7–12: verify explicitly); any new persisted state lives in separate files proven inert to pre-migration bridges (mixed-version test).</li>
   <li>PR description states its behavior delta (expected: "none", except the deliberate deltas in PRs 4, 6, and 12).</li>

--- a/shared/sesori_shared/lib/src/models/sesori/message.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message.dart
@@ -18,7 +18,7 @@ part "message.g.dart";
 /// - `MessageError`: `"error"`
 ///
 /// The bridge layer is responsible for normalizing backend-specific error
-/// shapes (e.g., OpenCode's nested `error.data.message`) into the flat
+/// shapes (e.g., a nested `error.data.message`) into the flat
 /// `errorName` and `errorMessage` fields before constructing a
 /// [MessageError].
 @Freezed(unionKey: "role", fromJson: true, toJson: true)

--- a/shared/sesori_shared/lib/src/models/sesori/session.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.dart
@@ -83,7 +83,7 @@ sealed class SessionSummary with _$SessionSummary {
 
 /// Session with embedded project info, returned by `/experimental/session`.
 ///
-/// This is the `GlobalInfo` type from the OpenCode server — a [Session] extended
+/// This is the `GlobalInfo` type from the backend server — a [Session] extended
 /// with a nullable [SessionProject] that identifies which project the session
 /// belongs to.
 @Freezed(fromJson: true, toJson: true)
@@ -104,7 +104,7 @@ sealed class GlobalSession with _$GlobalSession {
 
 /// Lightweight project reference embedded in [GlobalSession].
 ///
-/// This is the `ProjectInfo` / `ProjectSummary` type from the OpenCode server —
+/// This is the `ProjectInfo` / `ProjectSummary` type from the backend server —
 /// a subset of [Project] with only `id`, `name`, and `worktree`.
 @Freezed(fromJson: true, toJson: true)
 sealed class SessionProject with _$SessionProject {


### PR DESCRIPTION
Final documentation sweep of the plugin-lifecycle migration.

## What changed
- Rewrote `bridge/README.md` and `bridge/app/README.md` to be plugin-agnostic, with OpenCode specifics moved to plugin-specific examples.
- Updated `bridge/app/AGENTS.md` and the repo-root `AGENTS.md` to describe `server/` as bridge-instance / host services instead of OpenCode process management.
- Added a process-ownership note to `docs/SETUP_HEADLESS_VM.md` explaining how `--no-auto-start` shifts OpenCode lifecycle ownership to systemd.
- Updated `docs/plans/plugin-lifecycle-migration.html` to mark PR 13 shipped, fold the empty PR 14 into PR 15, and refresh the final sweep checklist.
- Generalized OpenCode-specific doc comments in `shared/sesori_shared/lib/src/models/sesori/message.dart` and `session.dart`.

## Verification
- `dart analyze --fatal-infos` clean in `shared/sesori_shared` and all bridge packages.
- `make test` from `bridge/` passes (1304 bridge tests + plugin/runtime tests).

Closes the plugin-lifecycle migration ladder.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the bridge docs plugin-agnostic and complete the plugin‑lifecycle migration (PR 14+15), correcting the routing model and plugin failure semantics. Fix the plugin registry path, clarify flag ownership (core vs plugin), add `--version`, and expand the headless process-ownership note; docs only.

- **Migration**
  - `bridge/README.md` and `bridge/app/README.md`: made plugin-agnostic; added plugin lifecycle overview; plugin registration now points to `app/lib/src/bridge/runtime/plugin_registry.dart`; clarified that routing is explicit (404 for unmatched routes, no proxy fallback) and that only terminal plugin failure shuts the bridge down (unexpected exits trigger bounded restarts; `Degraded` is recoverable).
  - `bridge/app/AGENTS.md` and root `AGENTS.md`: updated `server/` to “bridge instance / host services”; removed `proxy_handler.dart` and “proxy fallback” claims; corrected sibling plugin paths (`../sesori_plugin_*`) and CLI-flags row; made testing commands runnable from `bridge/`.
  - CLI flags: bridge core includes `--plugin`, `--relay`, and `--version`; moved `--port`, `--password`, `--no-auto-start`, and `--opencode-bin` to the `sesori_plugin_opencode` options table.
  - `docs/SETUP_HEADLESS_VM.md`: clarified process ownership—`--no-auto-start` leaves OpenCode to systemd; switching to plugin-owned requires disabling `opencode.service`, removing `Requires=`/`After=`, and dropping `--no-auto-start`.
  - `docs/plans/plugin-lifecycle-migration.html`: marked PR 13 shipped and folded PR 14 into this docs sweep; generalized OpenCode-specific doc comments in `shared/sesori_shared` (`message.dart`, `session.dart`).

<sup>Written for commit 80fa698220f6666d85c2037978aacbac784c17ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

