### PR TITLE
fix: ignore (latest) marker when picking default model

### DIFF
--- a/mobile/module_core/lib/src/utils/model_filter/default_model_selector.dart
+++ b/mobile/module_core/lib/src/utils/model_filter/default_model_selector.dart
@@ -6,15 +6,14 @@ import "package:sesori_shared/sesori_shared.dart";
 /// The selector uses only signals already present in the upstream data, so
 /// the same logic works for every provider without per-provider knowledge:
 ///
-/// 1. Any model whose name contains the upstream " (latest)" marker.
-///    OpenCode / models.dev uses this suffix to flag a model as the
-///    recommended one in its family (e.g. `Claude Sonnet 4.5 (latest)`,
-///    `Mistral Small (latest)`). The model picker already strips this
-///    suffix from the display name, so it is a known convention worth
-///    trusting.
-/// 2. The model with the most recent [ProviderModel.releaseDate]. Models
+/// 1. The model with the most recent [ProviderModel.releaseDate]. Models
 ///    without a release date sort last.
-/// 3. The first available model in iteration order.
+/// 2. The first available model in iteration order.
+///
+/// The "(latest)" marker in a model name is intentionally ignored as a
+/// ranking signal. Providers may label an older model as "latest" (e.g.
+/// `Claude Sonnet 4.5 (latest)` vs. a newer `Claude Sonnet 4.8`), so the
+/// release date is a more reliable signal for picking the current default.
 ///
 /// The provider's backend-supplied [ProviderInfo.defaultModelID] is
 /// intentionally ignored. It is a provider-wide default that is frequently
@@ -41,8 +40,7 @@ class DefaultModelSelector {
   ///
   /// Groups [models] by family, picks the best model per family using
   /// [pickFromFamily], then returns the best of those representatives
-  /// using the same ranking ("(latest)" marker, then newest release date,
-  /// then `id`).
+  /// using the same ranking (newest release date, then `id`).
   ///
   /// Returns `null` if [models] contains no available models.
   ProviderModel? pickFromProvider({required Map<String, ProviderModel> models}) {
@@ -68,18 +66,13 @@ class DefaultModelSelector {
   }
 
   /// Returns the best model from [candidates] using the standard ranking:
-  /// "(latest)" marker wins, then newest release date, then id.
+  /// newest release date, then id.
   ///
   /// [candidates] must be non-empty and contain only available models.
   ProviderModel _bestModel(List<ProviderModel> candidates) {
     assert(candidates.isNotEmpty, "_bestModel requires non-empty candidates");
 
-    // Prefer any model whose name contains the "(latest)" marker.
-    final latestMarked =
-        candidates.where((m) => m.name.toLowerCase().contains("(latest)")).toList();
-    final toSort = latestMarked.isNotEmpty ? latestMarked : candidates;
-
-    final sorted = [...toSort]..sort((a, b) {
+    final sorted = [...candidates]..sort((a, b) {
         final dateA = a.releaseDate;
         final dateB = b.releaseDate;
         final int dateCompare;

--- a/mobile/module_core/test/utils/model_filter/default_model_selector_test.dart
+++ b/mobile/module_core/test/utils/model_filter/default_model_selector_test.dart
@@ -42,7 +42,7 @@ void main() {
       );
     });
 
-    test("prefers a model whose name contains '(latest)' over a newer date", () {
+    test("ignores a model whose name contains '(latest)' in favor of a newer date", () {
       final group = [
         _model(
           id: "newer",
@@ -56,10 +56,10 @@ void main() {
         ),
       ];
       final picked = selector.pickFromFamily(group: group);
-      expect(picked?.id, "marked");
+      expect(picked?.id, "newer");
     });
 
-    test("breaks '(latest)' ties by newest releaseDate", () {
+    test("breaks ties by newest releaseDate", () {
       final group = [
         _model(
           id: "latest-older",
@@ -242,7 +242,7 @@ void main() {
     );
 
     test(
-      "prefers a '(latest)' marker in any family over a newer date in another family",
+      "ignores a '(latest)' marker in another family in favor of a newer date",
       () {
         final models = {
           "newer-plain": _model(
@@ -259,7 +259,7 @@ void main() {
           ),
         };
         final picked = selector.pickFromProvider(models: models);
-        expect(picked?.id, "marked-older");
+        expect(picked?.id, "newer-plain");
       },
     );
 


### PR DESCRIPTION
Previously, `DefaultModelSelector` treated a model name containing `(latest)` as a higher-priority signal than the release date. Providers can label an older model as latest (e.g. Claude Sonnet 4.5 (latest) vs. a newer Claude Sonnet 4.8 in the same family), which led to stale defaults being selected.

This change removes the `(latest)` keyword check and ranks models by release date only, then by `id` for deterministic tie-breaking. The corresponding tests now assert that newer release dates win over the `(latest)` marker.

## Verification
- `dart test test/utils/model_filter/default_model_selector_test.dart test/utils/model_filter/model_picker_section_builder_test.dart` passes
- `dart analyze` in `mobile/module_core` reports no issues

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore the "(latest)" marker when picking the default model. Choose by newest release date, then break ties by id for deterministic results.

- **Bug Fixes**
  - Prevents stale defaults when providers label older models as "(latest)" (e.g., 4.5 vs 4.8).

<sup>Written for commit aac64fb6068ce4a4f2b41a318b9ed691a8fe8ab4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

