### PR TITLE
feat(bridge): surface OpenCode compaction as an injectable /compact command

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/opencode_plugin.dart
+++ b/bridge/sesori_plugin_opencode/lib/opencode_plugin.dart
@@ -19,6 +19,7 @@ export "src/models/send_prompt_body.dart";
 export "src/models/session.dart";
 export "src/models/session_status.dart";
 export "src/models/sse_event_data.dart";
+export "src/models/summarize_body.dart";
 export "src/opencode_api.dart";
 export "src/opencode_db_api.dart";
 export "src/opencode_db_maintenance_service.dart";

--- a/bridge/sesori_plugin_opencode/lib/src/models/summarize_body.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/summarize_body.dart
@@ -1,0 +1,27 @@
+/// Request body for OpenCode's `POST /session/:id/summarize` endpoint, which
+/// triggers AI compaction of a session.
+///
+/// Unlike [SendCommandBody], which encodes the model as a single
+/// `"providerID/modelID"` string, summarize requires the provider and model as
+/// **separate** fields. `auto` distinguishes automatic (context-overflow)
+/// compaction from a manual, user-initiated one; the bridge only ever triggers
+/// the manual variant, so it defaults to `false`.
+class SummarizeBody {
+  final String providerID;
+  final String modelID;
+  final bool auto;
+
+  const SummarizeBody({
+    required this.providerID,
+    required this.modelID,
+    this.auto = false,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      "providerID": providerID,
+      "modelID": modelID,
+      "auto": auto,
+    };
+  }
+}

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -15,6 +15,7 @@ import "models/send_command_body.dart";
 import "models/send_prompt_body.dart";
 import "models/session.dart";
 import "models/session_status.dart";
+import "models/summarize_body.dart";
 
 const _directoryOpenCodeHeader = "x-opencode-directory";
 
@@ -317,6 +318,30 @@ class OpenCodeApi {
       body: jsonEncode(body.toJson()),
     );
     _ensureSuccess(response, "POST /session/$sessionId/command");
+  }
+
+  /// Triggers AI compaction of a session via `POST /session/:id/summarize`.
+  ///
+  /// WARNING: like [sendCommand], this OpenCode endpoint is **synchronous** —
+  /// the HTTP response does not complete until the compaction agent run has
+  /// finished, which can take minutes. Callers that must not block on the run
+  /// (see [OpenCodeService]) are responsible for detaching; this Layer 1 method
+  /// stays a dumb HTTP call.
+  Future<void> summarize({
+    required String sessionId,
+    required SummarizeBody body,
+    required String? directory,
+  }) async {
+    final response = await _client.post(
+      Uri.parse("$serverURL/session/$sessionId/summarize"),
+      headers: {
+        ..._authHeaders,
+        "content-type": "application/json",
+        _directoryOpenCodeHeader: ?directory,
+      },
+      body: jsonEncode(body.toJson()),
+    );
+    _ensureSuccess(response, "POST /session/$sessionId/summarize");
   }
 
   Future<void> abortSession({

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
@@ -18,6 +18,7 @@ import "models/project.dart";
 import "models/send_command_body.dart";
 import "models/send_prompt_body.dart";
 import "models/session.dart";
+import "models/summarize_body.dart";
 import "opencode_api.dart";
 import "provider_mapper.dart";
 
@@ -121,6 +122,25 @@ class OpenCodeRepository {
         agent: agent,
         variant: variant?.id,
         model: model,
+      ),
+    );
+  }
+
+  /// Triggers manual compaction of [sessionId] via the summarize endpoint.
+  ///
+  /// Unlike [sendCommand], OpenCode's summarize payload needs the provider and
+  /// model as separate, non-optional fields, so [model] is required here.
+  Future<void> summarize({
+    required String sessionId,
+    required String? directory,
+    required ({String providerID, String modelID}) model,
+  }) {
+    return _api.summarize(
+      sessionId: sessionId,
+      directory: directory?.normalize(),
+      body: SummarizeBody(
+        providerID: model.providerID,
+        modelID: model.modelID,
       ),
     );
   }

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -39,10 +39,16 @@ class OpenCodeService {
   final ActiveSessionTracker tracker;
   final Duration _commandDispatchFastFailWindow;
 
+  /// [commandDispatchFastFailWindow] bounds how long [sendCommand] waits on
+  /// OpenCode's synchronous command/summarize endpoints before treating the run
+  /// as accepted and detaching (see [sendCommand]). Genuine dispatch rejections
+  /// (unknown command/session, missing model, server down) surface from
+  /// localhost within milliseconds, so 1s is enough to catch them while keeping
+  /// the phone's "accepted" feedback snappy.
   OpenCodeService(
     this.repository,
     this.tracker, {
-    Duration commandDispatchFastFailWindow = const Duration(seconds: 3),
+    Duration commandDispatchFastFailWindow = const Duration(seconds: 1),
   }) : _commandDispatchFastFailWindow = commandDispatchFastFailWindow;
 
   Future<List<Project>> getProjects() {

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -8,6 +8,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
         PluginAgent,
         PluginApiException,
         PluginCommand,
+        PluginCommandSource,
         PluginPermissionReply,
         PluginPromptPart,
         PluginProvidersResult,
@@ -18,6 +19,22 @@ import "package:sesori_shared/sesori_shared.dart" show ProjectActivitySummary, S
 import "../opencode_plugin.dart";
 
 class OpenCodeService {
+  /// Name of the artificial slash command injected into [getCommands] so the
+  /// mobile app can trigger OpenCode's manual compaction.
+  ///
+  /// OpenCode does not list `/compact` in `GET /command` — it is a client-side
+  /// built-in in OpenCode's own TUI/web — so the plugin synthesizes it here and
+  /// routes its invocation to the summarize endpoint in [sendCommand].
+  static const String compactionCommandName = "compact";
+
+  static const PluginCommand _compactionCommand = PluginCommand(
+    name: compactionCommandName,
+    description: "Summarize the conversation so far to free up the context window",
+    provider: null,
+    source: PluginCommandSource.command,
+    subtask: null,
+  );
+
   final OpenCodeRepository repository;
   final ActiveSessionTracker tracker;
   final Duration _commandDispatchFastFailWindow;
@@ -38,8 +55,14 @@ class OpenCodeService {
     );
   }
 
-  Future<List<PluginCommand>> getCommands({required String? projectId}) {
-    return repository.getCommands(projectId: projectId);
+  Future<List<PluginCommand>> getCommands({required String? projectId}) async {
+    final commands = await repository.getCommands(projectId: projectId);
+    // Synthesize the compaction command unless the project already defines one
+    // with the same name (e.g. a user-authored `compact` config command).
+    if (commands.any((command) => command.name == compactionCommandName)) {
+      return commands;
+    }
+    return [...commands, _compactionCommand];
   }
 
   /// Returns the agents available for [projectId] (a worktree directory).
@@ -149,19 +172,28 @@ class OpenCodeService {
     required ({String providerID, String modelID})? model,
   }) async {
     final directory = _getTrackedDirectory(sessionId: sessionId);
-    final sendFuture = repository.sendCommand(
-      sessionId: sessionId,
-      directory: directory,
-      command: command,
-      arguments: arguments,
-      agent: agent,
-      variant: variant,
-      model: model,
-    );
-    // OpenCode's POST /session/:id/command endpoint is synchronous — it
-    // responds only after the command's full agent run completes, and no
-    // async variant exists upstream (see OpenCodeApi.sendCommand). The
-    // BridgePluginApi contract requires sendCommand to complete once the
+    // The artificial "compact" command (see [compactionCommandName]) has no
+    // OpenCode command counterpart — route it to the summarize endpoint, which
+    // performs manual compaction. Everything else is a real slash command.
+    final sendFuture = command == compactionCommandName
+        ? repository.summarize(
+            sessionId: sessionId,
+            directory: directory,
+            model: _requireCompactionModel(model: model, sessionId: sessionId),
+          )
+        : repository.sendCommand(
+            sessionId: sessionId,
+            directory: directory,
+            command: command,
+            arguments: arguments,
+            agent: agent,
+            variant: variant,
+            model: model,
+          );
+    // OpenCode's POST /session/:id/command and /summarize endpoints are both
+    // synchronous — they respond only after the agent run completes, and no
+    // async variant exists upstream (see OpenCodeApi.sendCommand/summarize).
+    // The BridgePluginApi contract requires sendCommand to complete once the
     // command is accepted, so dispatch with a fast-fail window: failures
     // raised within the window (unknown command/agent, missing session,
     // server down) propagate to the caller, while a run that outlives the
@@ -186,6 +218,24 @@ class OpenCodeService {
         );
       },
     );
+  }
+
+  /// Compaction needs an explicit provider/model (OpenCode's summarize payload
+  /// has no server-side default). The session model is normally threaded in
+  /// from the mobile prompt request; if it is absent we fail loudly rather than
+  /// silently dropping the compaction.
+  ({String providerID, String modelID}) _requireCompactionModel({
+    required ({String providerID, String modelID})? model,
+    required String sessionId,
+  }) {
+    if (model == null) {
+      throw PluginApiException(
+        "POST /session/$sessionId/summarize",
+        400,
+        message: "compaction requires a model selection",
+      );
+    }
+    return model;
   }
 
   Future<void> replyToPermission({

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -1114,6 +1114,13 @@ class _FakeApi implements OpenCodeApi {
   Future<List<Command>> listCommands({required String? directory}) async => const [];
 
   @override
+  Future<void> summarize({
+    required String sessionId,
+    required SummarizeBody body,
+    required String? directory,
+  }) async {}
+
+  @override
   Future<Session> createSession({required String directory, String? parentSessionId}) async =>
       throw UnimplementedError();
 

--- a/bridge/sesori_plugin_opencode/test/opencode_api_http_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_api_http_test.dart
@@ -159,6 +159,49 @@ void main() {
     });
   });
 
+  group("OpenCodeApi.summarize", () {
+    test("uses the injected client for POST /session/{id}/summarize", () async {
+      var calls = 0;
+      late http.BaseRequest capturedRequest;
+      late String capturedBody;
+
+      final mockClient = MockClient((request) async {
+        calls += 1;
+        capturedRequest = request;
+        capturedBody = request.body;
+        return http.Response("true", 200);
+      });
+
+      final api = OpenCodeApi(
+        serverURL: "http://localhost:1234",
+        password: "test-pass",
+        client: mockClient,
+      );
+
+      await api.summarize(
+        sessionId: "ses-123",
+        body: const SummarizeBody(providerID: "openai", modelID: "gpt-4.1"),
+        directory: "/repo",
+      );
+
+      expect(calls, equals(1));
+      expect(capturedRequest.method, equals("POST"));
+      expect(
+        capturedRequest.url.toString(),
+        equals("http://localhost:1234/session/ses-123/summarize"),
+      );
+      expect(capturedRequest.headers["x-opencode-directory"], equals("/repo"));
+      expect(
+        jsonDecode(capturedBody),
+        equals({
+          "providerID": "openai",
+          "modelID": "gpt-4.1",
+          "auto": false,
+        }),
+      );
+    });
+  });
+
   group("Send body serialization", () {
     test("SendPromptBody omits variant when null", () {
       const body = SendPromptBody(

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -80,14 +80,15 @@ void main() {
       expect(child.parentID, isNull);
     });
 
-    test("getCommands delegates through service and returns plugin commands", () async {
+    test("getCommands delegates through service and includes the synthetic compact command", () async {
       final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
 
       final commands = await plugin.getCommands(projectId: "/repo");
 
-      expect(commands, hasLength(1));
-      expect(commands.single.name, equals("/review-work"));
-      expect(commands.single.source, equals(PluginCommandSource.skill));
+      expect(
+        commands.map((command) => command.name),
+        containsAll(["/review-work", OpenCodeService.compactionCommandName]),
+      );
     });
 
     test("createSession creates the session then sends the first prompt", () async {

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -478,6 +478,26 @@ void main() {
     });
   });
 
+  group("OpenCodeRepository.summarize", () {
+    test("builds the summarize payload and normalizes the directory", () async {
+      final api = _FakeApi();
+      final repository = OpenCodeRepository(api);
+
+      await repository.summarize(
+        sessionId: "ses-1",
+        directory: " /repo ",
+        model: (providerID: "openai", modelID: "gpt-4.1"),
+      );
+
+      expect(api.lastSummarizeSessionId, equals("ses-1"));
+      expect(api.lastSummarizeDirectory, equals("/repo"));
+      expect(
+        api.lastSummarizeBody?.toJson(),
+        equals({"providerID": "openai", "modelID": "gpt-4.1", "auto": false}),
+      );
+    });
+  });
+
   group("Send*Body toJson", () {
     test("SendPromptBody emits variant only when provided", () {
       final withVariant = const SendPromptBody(
@@ -534,6 +554,9 @@ class _FakeApi implements OpenCodeApi {
   String? lastCommandSessionId;
   String? lastCommandDirectory;
   SendCommandBody? lastCommandBody;
+  String? lastSummarizeSessionId;
+  String? lastSummarizeDirectory;
+  SummarizeBody? lastSummarizeBody;
 
   _FakeApi({
     List<Session>? sessions,
@@ -622,6 +645,17 @@ class _FakeApi implements OpenCodeApi {
     lastCommandSessionId = sessionId;
     lastCommandDirectory = directory;
     lastCommandBody = body;
+  }
+
+  @override
+  Future<void> summarize({
+    required String sessionId,
+    required SummarizeBody body,
+    required String? directory,
+  }) async {
+    lastSummarizeSessionId = sessionId;
+    lastSummarizeDirectory = directory;
+    lastSummarizeBody = body;
   }
 
   @override

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -27,10 +27,10 @@ void main() {
   });
 
   group("OpenCodeService.getCommands", () {
-    test("delegates to repository and returns plugin commands", () async {
+    test("returns upstream commands alongside the synthetic compact command", () async {
       final repository = FakeOpenCodeRepository(
         commands: const [
-          PluginCommand(name: "/review-work", provider: "openai", source: PluginCommandSource.skill),
+          PluginCommand(name: "review-work", provider: "openai", source: PluginCommandSource.skill),
         ],
       );
       final service = OpenCodeService(repository, FakeActiveSessionTracker());
@@ -38,8 +38,38 @@ void main() {
       final commands = await service.getCommands(projectId: "/repo");
 
       expect(repository.lastCommandsProjectId, equals("/repo"));
-      expect(commands, hasLength(1));
-      expect(commands.single.name, equals("/review-work"));
+      expect(
+        commands.map((command) => command.name),
+        containsAll(["review-work", OpenCodeService.compactionCommandName]),
+      );
+    });
+
+    test("appends a compact command carrying display metadata", () async {
+      final service = OpenCodeService(FakeOpenCodeRepository(), FakeActiveSessionTracker());
+
+      final commands = await service.getCommands(projectId: "/repo");
+
+      final compact = commands.singleWhere(
+        (command) => command.name == OpenCodeService.compactionCommandName,
+      );
+      expect(compact.description, isNotNull);
+      expect(compact.source, equals(PluginCommandSource.command));
+    });
+
+    test("does not duplicate compact when the project already defines one", () async {
+      final repository = FakeOpenCodeRepository(
+        commands: const [
+          PluginCommand(name: "compact", provider: null, source: PluginCommandSource.command),
+        ],
+      );
+      final service = OpenCodeService(repository, FakeActiveSessionTracker());
+
+      final commands = await service.getCommands(projectId: "/repo");
+
+      expect(
+        commands.where((command) => command.name == OpenCodeService.compactionCommandName),
+        hasLength(1),
+      );
     });
   });
 
@@ -364,6 +394,47 @@ void main() {
       expect(repository.lastCommandModel, equals((providerID: "openai", modelID: "gpt-4.1")));
     });
 
+    test("routes the artificial compact command to the summarize endpoint", () async {
+      final tracker = FakeActiveSessionTracker(sessionDirectories: const {"ses-1": "/repo"});
+      final repository = FakeOpenCodeRepository();
+      final service = OpenCodeService(repository, tracker);
+
+      await service.sendCommand(
+        sessionId: "ses-1",
+        command: OpenCodeService.compactionCommandName,
+        arguments: "",
+        agent: null,
+        variant: null,
+        model: (providerID: "openai", modelID: "gpt-4.1"),
+      );
+
+      expect(repository.summarizeCalls, equals(1));
+      expect(repository.lastSummarizeSessionId, equals("ses-1"));
+      expect(repository.lastSummarizeDirectory, equals("/repo"));
+      expect(repository.lastSummarizeModel, equals((providerID: "openai", modelID: "gpt-4.1")));
+      // The real command endpoint must never be hit for compaction.
+      expect(repository.lastCommandName, isNull);
+    });
+
+    test("throws and skips summarize when compact is invoked without a model", () async {
+      final tracker = FakeActiveSessionTracker(sessionDirectories: const {"ses-1": "/repo"});
+      final repository = FakeOpenCodeRepository();
+      final service = OpenCodeService(repository, tracker);
+
+      await expectLater(
+        service.sendCommand(
+          sessionId: "ses-1",
+          command: OpenCodeService.compactionCommandName,
+          arguments: "",
+          agent: null,
+          variant: null,
+          model: null,
+        ),
+        throwsA(isA<PluginApiException>()),
+      );
+      expect(repository.summarizeCalls, equals(0));
+    });
+
     group("dispatch fast-fail window", () {
       const fastFailWindow = Duration(milliseconds: 50);
 
@@ -682,6 +753,13 @@ class FakeOpenCodeApi implements OpenCodeApi {
   }) async {}
 
   @override
+  Future<void> summarize({
+    required String sessionId,
+    required SummarizeBody body,
+    required String? directory,
+  }) async {}
+
+  @override
   Future<void> abortSession({required String sessionId, required String? directory}) async {}
 
   @override
@@ -780,6 +858,10 @@ class FakeOpenCodeRepository extends OpenCodeRepository {
   String? lastCommandVariant;
   ({String providerID, String modelID})? lastCommandModel;
   Completer<void>? sendCommandCompleter;
+  int summarizeCalls = 0;
+  String? lastSummarizeSessionId;
+  String? lastSummarizeDirectory;
+  ({String providerID, String modelID})? lastSummarizeModel;
   String? lastDeletedSessionId;
   String? lastDeletedDirectory;
 
@@ -878,6 +960,18 @@ class FakeOpenCodeRepository extends OpenCodeRepository {
     if (sendCommandCompleter case final completer?) {
       await completer.future;
     }
+  }
+
+  @override
+  Future<void> summarize({
+    required String sessionId,
+    required String? directory,
+    required ({String providerID, String modelID}) model,
+  }) async {
+    summarizeCalls += 1;
+    lastSummarizeSessionId = sessionId;
+    lastSummarizeDirectory = directory;
+    lastSummarizeModel = model;
   }
 
   @override


### PR DESCRIPTION
## What & why

The mobile app's slash-command picker never surfaced compaction. OpenCode does **not** list `/compact` in `GET /command` — it is a client-side built-in in OpenCode's own TUI/web, which call `POST /session/:id/summarize` directly. So nothing flowed through to our picker.

This injects an **artificial `compact` command** in the OpenCode bridge plugin so the mobile app can display and invoke it with **zero mobile / shared / interface / bridge-app changes**.

## How it works

- **List:** `OpenCodeService.getCommands` appends a synthetic `compact` `PluginCommand` (deduped against any user-authored command of the same name). It flows through the existing `PluginCommand → CommandInfo` mapping and appears in the picker.
- **Invoke:** the app invokes slash commands through the prompt path — `SendPromptRequest` carries both `command` and the session `model` — which the bridge routes to `plugin.sendCommand`. `OpenCodeService.sendCommand` intercepts `command == "compact"` and calls the new summarize path instead of the normal command endpoint, **reusing the existing synchronous-endpoint fast-fail dispatch window**.
- **Model:** OpenCode's summarize payload requires `providerID` + `modelID` (no server-side default). These are already threaded into `sendCommand` from the prompt request; a missing model fails loudly with a `400` rather than silently dropping the compaction.

## Changes (all in `bridge/sesori_plugin_opencode/`)

| Layer | File | Change |
|---|---|---|
| 0 | `lib/src/models/summarize_body.dart` (new) | Request body, mirrors `SendCommandBody`/`SendPromptBody` |
| 1 | `lib/src/opencode_api.dart` | `summarize()` → `POST /session/:id/summarize` |
| 2 | `lib/src/opencode_repository.dart` | `summarize()` builds body + normalizes directory |
| 3 | `lib/src/opencode_service.dart` | Synthetic command injection + invocation routing |
| – | `lib/opencode_plugin.dart` | Barrel export for the new model |

## Testing

- `make analyze` (interface, runtime, opencode, app): **clean** (`--fatal-infos` on the plugin: no issues).
- `make test`: interface 100, runtime 75, opencode 241, app 1304 — **all pass**.
- New/updated tests: `getCommands` injection + dedup, `sendCommand` → summarize routing, null-model `400`, repository payload + directory normalization, API HTTP `POST /summarize` URL/body shape.

## Reviews

- `aristotle-plan-review`: approved.
- `aristotle-impl-review`: approved (no violations).

## Notes

- Rendering of the resulting compaction summary already flows through the standard message SSE pipeline (the compaction turn arrives as a normal assistant message).
- The synthetic command uses `source: command`; invoking it on an empty session is an edge case handled by OpenCode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces OpenCode compaction in the mobile slash-command picker by injecting a synthetic `compact` command in the bridge. Invoking it calls POST /session/:id/summarize with the current model, with no mobile or interface changes.

- **New Features**
  - Injects a synthetic `compact` command in getCommands (deduped if a project already defines one).
  - Intercepts sendCommand for `compact` and routes to the summarize endpoint, using a 1s fast-fail dispatch window for acceptance.
  - Requires providerID/modelID for compaction; uses the model from the prompt and returns 400 if missing.
  - Adds SummarizeBody, OpenCodeApi.summarize, and OpenCodeRepository.summarize; compaction results arrive via existing SSE messages.

<sup>Written for commit d05c40e725b8d671790cab1100f4287dfda3a3bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

