### PR TITLE
fix(mobile): remove splash exit-animation listener to prevent SurfaceControl NPE

### DIFF
--- a/mobile/app/android/app/src/main/kotlin/com/sesori/app/MainActivity.kt
+++ b/mobile/app/android/app/src/main/kotlin/com/sesori/app/MainActivity.kt
@@ -17,7 +17,7 @@ class MainActivity : FlutterActivity(), FlutterUiDisplayListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         applyEdgeToEdge()
-        val splashScreen = installSplashScreen()
+        installSplashScreen()
         super.onCreate(savedInstanceState)
 
         flutterEngine?.renderer?.addIsDisplayingFlutterUiListener(this)
@@ -27,11 +27,6 @@ class MainActivity : FlutterActivity(), FlutterUiDisplayListener {
             rootLayout.setBackgroundColor(resources.getColor(R.color.splash_screen_background, null))
 
             View.inflate(this, R.layout.main_activity, rootLayout)
-
-            splashScreen.setOnExitAnimationListener { splashScreenViewProvider ->
-                splashScreenViewProvider.remove()
-                hideSplashOverlay()
-            }
         }
     }
 


### PR DESCRIPTION
## Problem

Firebase Crashlytics reports a fatal crash at launch on Android 12–13:

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke direct method
'void android.view.SurfaceControl.checkNotReleased()' on a null object reference
  at android.view.SurfaceControl$Transaction.hide(SurfaceControl.java:2840)
  at android.app.ActivityThread.syncTransferSplashscreenViewTransaction(ActivityThread.java:4198)
  at android.app.ActivityThread$1.onDraw(ActivityThread.java:4175)
  at android.view.ViewRootImpl.draw(...)
```

## Root cause

A known **Android 12–13 (API 31–33) platform race** in the system SplashScreen handoff: `syncTransferSplashscreenViewTransaction()` tries to `hide()` a `SurfaceControl` that has already been released/nulled. It is thrown entirely in framework code, not app code (Flutter [#125122](https://github.com/flutter/flutter/issues/125122) — closed with no upstream fix; Google issuetracker [242118185](https://issuetracker.google.com/issues/242118185)).

`MainActivity` opted the app **into** that crash path by registering `SplashScreen.setOnExitAnimationListener(...)`. Registering an exit-animation listener is exactly what makes the OS transfer the splash surface to the app window — the crashing `syncTransferSplashscreenViewTransaction` step. The listener performed **no actual animation**; it only called `splashScreenViewProvider.remove()` and `hideSplashOverlay()`.

## Fix

Remove the exit-animation listener. Per the documented `androidx.core.splashscreen` contract, when **no** listener is registered the framework auto-dismisses the system splash once the app is ready to draw — keeping the app out of the surface-transfer path entirely.

- `installSplashScreen()` is still called (applies `postSplashScreenTheme`); only its now-unused return value is dropped.
- The custom overlay (`R.id.container`, inflated into `android.R.id.content`) is unchanged and still torn down by `onFlutterUiDisplayed()` → `hideSplashOverlay()`, a Flutter-renderer callback independent of the splash listener. No visual regression.

```diff
     override fun onCreate(savedInstanceState: Bundle?) {
         applyEdgeToEdge()
-        val splashScreen = installSplashScreen()
+        installSplashScreen()
         super.onCreate(savedInstanceState)
@@
             View.inflate(this, R.layout.main_activity, rootLayout)
-
-            splashScreen.setOnExitAnimationListener { splashScreenViewProvider ->
-                splashScreenViewProvider.remove()
-                hideSplashOverlay()
-            }
         }
```

## Why not just version-gate the listener?

There is no verified "fixed-at" API boundary for this platform bug — public mitigations still treat it as not fully resolved on API 34+, and OEM builds vary. Since the listener provided no functional value here, full removal is both the proven mitigation and defensive against residual 34+ cases.

## Testing

- `aristotle-plan-review`: APPROVED
- `aristotle-impl-review`: APPROVED
- Kotlin LSP is not installed locally; the change is a pure deletion leaving valid Kotlin (all imports still referenced, no unused locals). CI is the compile/build gate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the system splash exit-animation listener in `MainActivity` to stop a launch crash on Android 12–13 caused by a `SurfaceControl` NPE during the splash handoff. The system now auto-dismisses the splash, and the custom overlay still hides on Flutter UI display.

- **Bug Fixes**
  - Removed `SplashScreen.setOnExitAnimationListener(...)`, which triggered the OS surface-transfer race on API 31–33.
  - Kept `installSplashScreen()` for theming; overlay teardown remains via `onFlutterUiDisplayed()` → `hideSplashOverlay()`.

<sup>Written for commit d008d32095a6887e30a5a5c1ba2acf3f2a66ccdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

