### PR TITLE
fix(bridge): Windows login fixes (token-path first-run + headless/SSH-aware OAuth browser launch)

### DIFF
--- a/bridge/app/lib/src/api/windows_default_editor_api.dart
+++ b/bridge/app/lib/src/api/windows_default_editor_api.dart
@@ -12,6 +12,14 @@ class WindowsDefaultEditorApi implements DefaultEditorApi {
 
   @override
   Future<void> openFile(String filePath) async {
+    // `start` is a cmd builtin, so it must run via `cmd /c`. The empty "" is the
+    // mandatory window-title argument — without it `start` treats a quoted path
+    // as the title and opens nothing. This deliberately differs from the OAuth
+    // URL launcher, which uses `rundll32 url.dll,FileProtocolHandler` because
+    // URLs carry `&` query separators that cmd would split into bogus commands.
+    // A local file path is the opposite trade-off: Process.run quotes any path
+    // containing spaces (so config files under C:\Users\... open correctly),
+    // whereas rundll32's FileProtocolHandler is unreliable for spaced paths.
     await _openWithCommand(
       executable: 'cmd',
       arguments: ['/c', 'start', '', filePath],

--- a/bridge/app/lib/src/auth/login_oauth_service.dart
+++ b/bridge/app/lib/src/auth/login_oauth_service.dart
@@ -46,28 +46,96 @@ Future<void> openOAuthBrowser(String url) async {
   }
 }
 
-/// Best-effort check for whether a graphical browser can be launched.
+/// Confidence that a URL can be opened in a graphical browser on this host.
+enum BrowserOpenability {
+  /// A graphical browser is almost certainly reachable — open it confidently.
+  yes,
+
+  /// No graphical browser is reachable (headless host, or an SSH session on a
+  /// platform where SSH cannot reach the desktop). Don't attempt a launch.
+  no,
+
+  /// Cannot be decided from the environment alone — attempt a best-effort open
+  /// and rely on the always-printed URL when it turns out to be a no-op.
+  unknown,
+}
+
+/// Detects whether a graphical browser can be launched on this host from the
+/// environment and platform. Injected into [LoginOAuthService] so tests can
+/// force a specific outcome; the decision table itself lives in the pure
+/// [resolveBrowserOpenability] for direct testing.
+BrowserOpenability detectBrowserOpenability() {
+  final env = Platform.environment;
+  final isLinux = Platform.isLinux;
+  return resolveBrowserOpenability(
+    isLinux: isLinux,
+    isMacOS: Platform.isMacOS,
+    isWindows: Platform.isWindows,
+    hasDisplay: (env["DISPLAY"] ?? "").isNotEmpty || (env["WAYLAND_DISPLAY"] ?? "").isNotEmpty,
+    isWsl: isLinux && _isWindowsSubsystemForLinux(env),
+    isSsh: _isSshSession(env),
+  );
+}
+
+/// Pure decision table for [detectBrowserOpenability], split out so the
+/// per-platform reasoning is unit-testable without touching the real host.
 ///
-/// Mirrors CPython's `webbrowser` gating: on Linux a GUI browser is only
-/// reachable when `DISPLAY` or `WAYLAND_DISPLAY` is set, so a headless server,
-/// SSH session, container, or CI box returns false and we skip a pointless (or
-/// hanging) `xdg-open`. macOS and Windows have no reliable environment-only
-/// probe — correct detection there needs platform APIs (e.g. the Win32
-/// `SM_REMOTESESSION` metric) we don't want to depend on — so they
-/// optimistically return true and rely on the always-printed URL as the
-/// fallback when an attempt turns out to be a no-op.
-bool canOpenBrowser() {
-  if (Platform.isLinux) {
-    final env = Platform.environment;
-    return (env["DISPLAY"] ?? "").isNotEmpty || (env["WAYLAND_DISPLAY"] ?? "").isNotEmpty;
+/// Mirrors CPython's `webbrowser` gating on Linux (a GUI browser is only
+/// reachable when `DISPLAY`/`WAYLAND_DISPLAY` is set, which also covers SSH X11
+/// forwarding and WSLg). WSL without a display may still reach the Windows
+/// browser via `wslview`, so it is `unknown` rather than `no`. SSH into Windows
+/// cannot reach the interactive desktop, so it is `no`; a local Windows or
+/// SSH-on-macOS session can't be proven either way without platform APIs, so it
+/// stays `unknown`.
+@visibleForTesting
+BrowserOpenability resolveBrowserOpenability({
+  required bool isLinux,
+  required bool isMacOS,
+  required bool isWindows,
+  required bool hasDisplay,
+  required bool isWsl,
+  required bool isSsh,
+}) {
+  if (isLinux) {
+    if (hasDisplay) {
+      return BrowserOpenability.yes;
+    }
+    if (isWsl) {
+      return BrowserOpenability.unknown;
+    }
+    return BrowserOpenability.no;
   }
-  return Platform.isMacOS || Platform.isWindows;
+  if (isMacOS) {
+    return isSsh ? BrowserOpenability.unknown : BrowserOpenability.yes;
+  }
+  if (isWindows) {
+    return isSsh ? BrowserOpenability.no : BrowserOpenability.unknown;
+  }
+  return BrowserOpenability.no;
+}
+
+bool _isSshSession(Map<String, String> env) =>
+    (env["SSH_CONNECTION"] ?? "").isNotEmpty ||
+    (env["SSH_CLIENT"] ?? "").isNotEmpty ||
+    (env["SSH_TTY"] ?? "").isNotEmpty;
+
+bool _isWindowsSubsystemForLinux(Map<String, String> env) {
+  if ((env["WSL_DISTRO_NAME"] ?? "").isNotEmpty || (env["WSL_INTEROP"] ?? "").isNotEmpty) {
+    return true;
+  }
+  // Fallback for shells that drop the WSL_* vars (e.g. after sudo): the WSL
+  // kernel advertises itself in /proc/version.
+  try {
+    return File("/proc/version").readAsStringSync().toLowerCase().contains("microsoft");
+  } on IOException {
+    return false;
+  }
 }
 
 class LoginOAuthService {
   final LoginOAuthApi _api;
   final Future<void> Function(String url) _browserLauncher;
-  final bool Function() _canLaunchBrowser;
+  final BrowserOpenability Function() _browserOpenability;
   final Duration _pollInterval;
   final Duration _pollTimeout;
   final Duration _perRequestTimeout;
@@ -76,14 +144,14 @@ class LoginOAuthService {
   LoginOAuthService({
     required LoginOAuthApi api,
     required Future<void> Function(String url) browserLauncher,
-    required bool Function() canLaunchBrowser,
+    required BrowserOpenability Function() browserOpenability,
     @visibleForTesting Duration pollInterval = _defaultPollInterval,
     @visibleForTesting Duration pollTimeout = _defaultPollTimeout,
     @visibleForTesting Duration perRequestTimeout = _defaultPerRequestTimeout,
     @visibleForTesting Future<void> Function(Duration duration)? delay,
   }) : _api = api,
        _browserLauncher = browserLauncher,
-       _canLaunchBrowser = canLaunchBrowser,
+       _browserOpenability = browserOpenability,
        _pollInterval = pollInterval,
        _pollTimeout = pollTimeout,
        _perRequestTimeout = perRequestTimeout,
@@ -106,18 +174,23 @@ class LoginOAuthService {
     // browser can be opened: the bridge frequently runs headless (servers, SSH
     // sessions, containers), and a launcher exit code of 0 only means the OS
     // accepted the request, not that a browser actually appeared. We attempt an
-    // automatic open only when a graphical browser is believed reachable. The
-    // wording is identical across platforms — only the environment differs.
-    final canOpen = _canLaunchBrowser();
-    if (canOpen) {
-      Log.i("Opening your browser to complete ${provider.label} login...");
-      Log.i("If it doesn't open automatically, open this URL manually to continue:");
-    } else {
-      Log.i("No graphical browser detected (e.g. a headless or SSH session).");
-      Log.i("Open this URL to complete ${provider.label} login:");
+    // automatic open unless we're confident none is reachable, and soften the
+    // wording from "Opening" to "Attempting to open" when it's uncertain. The
+    // messaging is identical across platforms — only the environment differs.
+    final openability = _browserOpenability();
+    switch (openability) {
+      case BrowserOpenability.yes:
+        Log.i("Opening your browser to complete ${provider.label} login...");
+        Log.i("If it doesn't open automatically, open this URL manually to continue:");
+      case BrowserOpenability.unknown:
+        Log.i("Attempting to open your browser to complete ${provider.label} login...");
+        Log.i("If it doesn't open, open this URL manually to continue:");
+      case BrowserOpenability.no:
+        Log.i("No graphical browser detected (e.g. a headless or SSH session).");
+        Log.i("Open this URL to complete ${provider.label} login:");
     }
     Log.i(initResp.authUrl);
-    if (canOpen) {
+    if (openability != BrowserOpenability.no) {
       try {
         await _browserLauncher(initResp.authUrl);
       } catch (e) {

--- a/bridge/app/lib/src/auth/login_oauth_service.dart
+++ b/bridge/app/lib/src/auth/login_oauth_service.dart
@@ -46,9 +46,28 @@ Future<void> openOAuthBrowser(String url) async {
   }
 }
 
+/// Best-effort check for whether a graphical browser can be launched.
+///
+/// Mirrors CPython's `webbrowser` gating: on Linux a GUI browser is only
+/// reachable when `DISPLAY` or `WAYLAND_DISPLAY` is set, so a headless server,
+/// SSH session, container, or CI box returns false and we skip a pointless (or
+/// hanging) `xdg-open`. macOS and Windows have no reliable environment-only
+/// probe — correct detection there needs platform APIs (e.g. the Win32
+/// `SM_REMOTESESSION` metric) we don't want to depend on — so they
+/// optimistically return true and rely on the always-printed URL as the
+/// fallback when an attempt turns out to be a no-op.
+bool canOpenBrowser() {
+  if (Platform.isLinux) {
+    final env = Platform.environment;
+    return (env["DISPLAY"] ?? "").isNotEmpty || (env["WAYLAND_DISPLAY"] ?? "").isNotEmpty;
+  }
+  return Platform.isMacOS || Platform.isWindows;
+}
+
 class LoginOAuthService {
   final LoginOAuthApi _api;
   final Future<void> Function(String url) _browserLauncher;
+  final bool Function() _canLaunchBrowser;
   final Duration _pollInterval;
   final Duration _pollTimeout;
   final Duration _perRequestTimeout;
@@ -57,12 +76,14 @@ class LoginOAuthService {
   LoginOAuthService({
     required LoginOAuthApi api,
     required Future<void> Function(String url) browserLauncher,
+    required bool Function() canLaunchBrowser,
     @visibleForTesting Duration pollInterval = _defaultPollInterval,
     @visibleForTesting Duration pollTimeout = _defaultPollTimeout,
     @visibleForTesting Duration perRequestTimeout = _defaultPerRequestTimeout,
     @visibleForTesting Future<void> Function(Duration duration)? delay,
   }) : _api = api,
        _browserLauncher = browserLauncher,
+       _canLaunchBrowser = canLaunchBrowser,
        _pollInterval = pollInterval,
        _pollTimeout = pollTimeout,
        _perRequestTimeout = perRequestTimeout,
@@ -81,18 +102,27 @@ class LoginOAuthService {
 
     _printUserCode(initResp.userCode);
 
-    // Always print the URL before attempting to open a browser. The bridge
-    // frequently runs headless (servers, SSH sessions, containers) where no
-    // browser exists, and a launcher exit code of 0 only means the OS accepted
-    // the request — not that a browser actually appeared. Printing it
-    // unconditionally guarantees the user can always finish login by hand.
-    Log.i("To authorize ${provider.label} login, open this URL in your browser:");
+    // The URL is ALWAYS printed, on its own line, so login works even when no
+    // browser can be opened: the bridge frequently runs headless (servers, SSH
+    // sessions, containers), and a launcher exit code of 0 only means the OS
+    // accepted the request, not that a browser actually appeared. We attempt an
+    // automatic open only when a graphical browser is believed reachable. The
+    // wording is identical across platforms — only the environment differs.
+    final canOpen = _canLaunchBrowser();
+    if (canOpen) {
+      Log.i("Opening your browser to complete ${provider.label} login...");
+      Log.i("If it doesn't open automatically, open this URL manually to continue:");
+    } else {
+      Log.i("No graphical browser detected (e.g. a headless or SSH session).");
+      Log.i("Open this URL to complete ${provider.label} login:");
+    }
     Log.i(initResp.authUrl);
-    Log.i("Attempting to open it in your default browser...");
-    try {
-      await _browserLauncher(initResp.authUrl);
-    } catch (e) {
-      Log.w("Could not open a browser automatically: $e");
+    if (canOpen) {
+      try {
+        await _browserLauncher(initResp.authUrl);
+      } catch (e) {
+        Log.w("Could not open a browser automatically; open the URL above manually: $e");
+      }
     }
 
     Log.i("Waiting for authorization...");

--- a/bridge/app/lib/src/auth/login_oauth_service.dart
+++ b/bridge/app/lib/src/auth/login_oauth_service.dart
@@ -21,7 +21,7 @@ const Duration _defaultPerRequestTimeout = Duration(seconds: _perRequestTimeoutS
 /// Platform-specific:
 /// - macOS: `open`
 /// - Linux: `xdg-open`
-/// - Windows: `cmd /c start`
+/// - Windows: `rundll32 url.dll,FileProtocolHandler`
 Future<void> openOAuthBrowser(String url) async {
   late final ProcessResult result;
   if (Platform.isMacOS) {
@@ -29,7 +29,14 @@ Future<void> openOAuthBrowser(String url) async {
   } else if (Platform.isLinux) {
     result = await Process.run("xdg-open", [url]);
   } else if (Platform.isWindows) {
-    result = await Process.run("cmd", ["/c", "start", url]);
+    // Hand the URL straight to the shell's protocol handler via rundll32
+    // instead of `cmd /c start`. cmd.exe treats the `&` query-string
+    // separators in an OAuth URL as command separators — it runs the first
+    // segment and then tries to execute each remaining "name=value" fragment
+    // as its own command — and `start` would additionally misread the URL as a
+    // window title. rundll32 is launched without a shell, so the URL (every
+    // `&` included) reaches the default browser verbatim.
+    result = await Process.run("rundll32", ["url.dll,FileProtocolHandler", url]);
   } else {
     throw UnsupportedError("Unsupported platform: ${Platform.operatingSystem}");
   }
@@ -74,12 +81,18 @@ class LoginOAuthService {
 
     _printUserCode(initResp.userCode);
 
-    Log.i("Opening browser for ${provider.label} login...");
+    // Always print the URL before attempting to open a browser. The bridge
+    // frequently runs headless (servers, SSH sessions, containers) where no
+    // browser exists, and a launcher exit code of 0 only means the OS accepted
+    // the request — not that a browser actually appeared. Printing it
+    // unconditionally guarantees the user can always finish login by hand.
+    Log.i("To authorize ${provider.label} login, open this URL in your browser:");
+    Log.i(initResp.authUrl);
+    Log.i("Attempting to open it in your default browser...");
     try {
       await _browserLauncher(initResp.authUrl);
     } catch (e) {
-      Log.w("Could not open browser automatically: $e");
-      Log.i("Open this URL manually:\n${initResp.authUrl}");
+      Log.w("Could not open a browser automatically: $e");
     }
 
     Log.i("Waiting for authorization...");

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart
@@ -77,11 +77,14 @@ class BridgeRuntimeAuthService {
       } catch (error) {
         throw Exception('validate stored tokens: $error');
       }
+    } on PathNotFoundException {
+      // Token file or its parent directory does not exist — fall through to
+      // login below. PathNotFoundException is the portable "missing path"
+      // signal: POSIX ENOENT, Windows ERROR_FILE_NOT_FOUND (errno 2), and
+      // Windows ERROR_PATH_NOT_FOUND (errno 3, e.g. the %LOCALAPPDATA%\sesori
+      // directory missing on first run) all surface as this type.
     } on FileSystemException catch (error) {
-      if (error.osError?.errorCode != 2) {
-        throw Exception('load stored tokens: $error');
-      }
-      // Token file not found — fall through to login below
+      throw Exception('load stored tokens: $error');
     } on FormatException {
       // Invalid token data (e.g., missing/invalid lastProvider) — treat as no valid tokens
       await clearTokens();
@@ -92,11 +95,10 @@ class BridgeRuntimeAuthService {
     try {
       final storedTokens = await loadTokens();
       provider = storedTokens.lastProvider;
-    } on FileSystemException catch (error) {
-      if (error.osError?.errorCode != 2) {
-        throw Exception('load stored tokens: $error');
-      }
+    } on PathNotFoundException {
       provider = await promptForProvider();
+    } on FileSystemException catch (error) {
+      throw Exception('load stored tokens: $error');
     } on FormatException {
       provider = await promptForProvider();
     }
@@ -138,12 +140,11 @@ class BridgeRuntimeAuthService {
     try {
       final existingTokens = await loadTokens();
       existingBridgeId = existingTokens.bridgeId;
-    } on FileSystemException catch (error) {
-      if (error.osError?.errorCode != 2) {
-        rethrow;
-      }
+    } on PathNotFoundException {
       // Token file missing — no previous bridge id to carry over.
       existingBridgeId = null;
+    } on FileSystemException {
+      rethrow;
     } on FormatException {
       // Token file corrupt — no previous bridge id to carry over.
       existingBridgeId = null;

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -166,7 +166,7 @@ class BridgeRuntimeRunner {
           client: httpClient,
         ),
         browserLauncher: openOAuthBrowser,
-        canLaunchBrowser: canOpenBrowser,
+        browserOpenability: detectBrowserOpenability,
       ),
       environment: environment,
     );

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -166,6 +166,7 @@ class BridgeRuntimeRunner {
           client: httpClient,
         ),
         browserLauncher: openOAuthBrowser,
+        canLaunchBrowser: canOpenBrowser,
       ),
       environment: environment,
     );

--- a/bridge/app/test/auth/login_test.dart
+++ b/bridge/app/test/auth/login_test.dart
@@ -83,6 +83,49 @@ void main() {
           throwsA(isA<Exception>().having((error) => error.toString(), 'message', contains('denied'))),
         );
       });
+
+      test('prints the auth URL verbatim and still completes login when the browser launcher fails', () async {
+        const authUrl =
+            'https://github.com/login/oauth/authorize?client_id=abc&redirect_uri=https%3A%2F%2Fapi.sesori.com%2Fauth%2Fgithub%2Fcallback&scope=read%3Auser&state=xyz';
+        final authServer = await _OAuthLongPollTestServer.start(
+          authUrl: authUrl,
+          statusResponses: [
+            AuthSessionStatusResponse.complete(
+              accessToken: 'github-access-token',
+              refreshToken: 'github-refresh-token',
+              user: AuthUser(
+                id: 'user-1',
+                provider: AuthProvider.github,
+                providerUserId: 'gh-1',
+                providerUsername: 'octocat',
+              ),
+            ),
+          ],
+        );
+        addTearDown(authServer.close);
+
+        final stdoutLines = <String>[];
+        String? accessToken;
+        await IOOverrides.runZoned(
+          () async {
+            final service = _createOAuthService(
+              authServer: authServer,
+              browserLauncher: (_) async => throw Exception('no browser available'),
+            );
+            final tokens = await service.performOAuthLogin(AuthProvider.github);
+            accessToken = tokens.accessToken;
+          },
+          stdout: () => _CapturingStdout(stdoutLines),
+          stderr: () => _CapturingStdout(<String>[]),
+        );
+
+        expect(accessToken, equals('github-access-token'));
+        expect(
+          stdoutLines,
+          contains(authUrl),
+          reason: 'the full auth URL (with & query separators) must be printed so headless/SSH users can open it manually',
+        );
+      });
     });
 
     group('Google OAuth', () {
@@ -597,4 +640,19 @@ class _PasswordLoginTestServer {
   Future<void> close() async {
     await _server.close(force: true);
   }
+}
+
+/// Captures [writeln] calls; [IOOverrides] swaps it in for stdout/stderr.
+class _CapturingStdout implements Stdout {
+  _CapturingStdout(this.lines);
+
+  final List<String> lines;
+
+  @override
+  void writeln([Object? object = '']) {
+    lines.add(object.toString());
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/bridge/app/test/auth/login_test.dart
+++ b/bridge/app/test/auth/login_test.dart
@@ -126,6 +126,56 @@ void main() {
           reason: 'the full auth URL (with & query separators) must be printed so headless/SSH users can open it manually',
         );
       });
+
+      test('skips the browser launch but still prints the URL when no browser is available', () async {
+        const authUrl =
+            'https://github.com/login/oauth/authorize?client_id=abc&scope=read%3Auser&state=xyz';
+        final authServer = await _OAuthLongPollTestServer.start(
+          authUrl: authUrl,
+          statusResponses: [
+            AuthSessionStatusResponse.complete(
+              accessToken: 'github-access-token',
+              refreshToken: 'github-refresh-token',
+              user: AuthUser(
+                id: 'user-1',
+                provider: AuthProvider.github,
+                providerUserId: 'gh-1',
+                providerUsername: 'octocat',
+              ),
+            ),
+          ],
+        );
+        addTearDown(authServer.close);
+
+        final launchedUrls = <String>[];
+        final stdoutLines = <String>[];
+        String? accessToken;
+        await IOOverrides.runZoned(
+          () async {
+            final service = _createOAuthService(
+              authServer: authServer,
+              browserLauncher: (url) async => launchedUrls.add(url),
+              canLaunchBrowser: () => false,
+            );
+            final tokens = await service.performOAuthLogin(AuthProvider.github);
+            accessToken = tokens.accessToken;
+          },
+          stdout: () => _CapturingStdout(stdoutLines),
+          stderr: () => _CapturingStdout(<String>[]),
+        );
+
+        expect(accessToken, equals('github-access-token'));
+        expect(
+          launchedUrls,
+          isEmpty,
+          reason: 'must not attempt to launch a browser when canLaunchBrowser() is false',
+        );
+        expect(
+          stdoutLines,
+          contains(authUrl),
+          reason: 'the URL must still be printed so the user can complete login manually',
+        );
+      });
     });
 
     group('Google OAuth', () {
@@ -340,6 +390,7 @@ void main() {
 LoginOAuthService _createOAuthService({
   required _OAuthLongPollTestServer authServer,
   required Future<void> Function(String url) browserLauncher,
+  bool Function() canLaunchBrowser = _alwaysCanLaunchBrowser,
   Duration pollTimeout = const Duration(seconds: 2),
   Duration pollInterval = Duration.zero,
   Future<void> Function(Duration duration)? delay,
@@ -350,11 +401,14 @@ LoginOAuthService _createOAuthService({
       client: authServer.client,
     ),
     browserLauncher: browserLauncher,
+    canLaunchBrowser: canLaunchBrowser,
     pollTimeout: pollTimeout,
     pollInterval: pollInterval,
     delay: delay,
   );
 }
+
+bool _alwaysCanLaunchBrowser() => true;
 
 class _MockLoginEmailApi implements LoginEmailApi {
   @override

--- a/bridge/app/test/auth/login_test.dart
+++ b/bridge/app/test/auth/login_test.dart
@@ -155,7 +155,7 @@ void main() {
             final service = _createOAuthService(
               authServer: authServer,
               browserLauncher: (url) async => launchedUrls.add(url),
-              canLaunchBrowser: () => false,
+              browserOpenability: () => BrowserOpenability.no,
             );
             final tokens = await service.performOAuthLogin(AuthProvider.github);
             accessToken = tokens.accessToken;
@@ -174,6 +174,55 @@ void main() {
           stdoutLines,
           contains(authUrl),
           reason: 'the URL must still be printed so the user can complete login manually',
+        );
+      });
+
+      test('uses tentative "Attempting to open" wording but still launches when openability is unknown', () async {
+        const authUrl =
+            'https://github.com/login/oauth/authorize?client_id=abc&scope=read%3Auser&state=xyz';
+        final authServer = await _OAuthLongPollTestServer.start(
+          authUrl: authUrl,
+          statusResponses: [
+            AuthSessionStatusResponse.complete(
+              accessToken: 'github-access-token',
+              refreshToken: 'github-refresh-token',
+              user: AuthUser(
+                id: 'user-1',
+                provider: AuthProvider.github,
+                providerUserId: 'gh-1',
+                providerUsername: 'octocat',
+              ),
+            ),
+          ],
+        );
+        addTearDown(authServer.close);
+
+        final launchedUrls = <String>[];
+        final stdoutLines = <String>[];
+        await IOOverrides.runZoned(
+          () async {
+            final service = _createOAuthService(
+              authServer: authServer,
+              browserLauncher: (url) async => launchedUrls.add(url),
+              browserOpenability: () => BrowserOpenability.unknown,
+            );
+            await service.performOAuthLogin(AuthProvider.github);
+          },
+          stdout: () => _CapturingStdout(stdoutLines),
+          stderr: () => _CapturingStdout(<String>[]),
+        );
+
+        expect(launchedUrls, equals([authUrl]), reason: 'unknown still attempts a best-effort launch');
+        expect(stdoutLines, contains(authUrl));
+        expect(
+          stdoutLines.any((line) => line.contains('Attempting to open')),
+          isTrue,
+          reason: 'unknown openability must use tentative wording',
+        );
+        expect(
+          stdoutLines.any((line) => line.startsWith('Opening your browser')),
+          isFalse,
+          reason: 'must not claim the browser is definitely opening when uncertain',
         );
       });
     });
@@ -260,6 +309,54 @@ void main() {
           throwsA(isA<TimeoutException>()),
         );
       });
+    });
+  });
+
+  group('resolveBrowserOpenability', () {
+    BrowserOpenability resolve({
+      bool isLinux = false,
+      bool isMacOS = false,
+      bool isWindows = false,
+      bool hasDisplay = false,
+      bool isWsl = false,
+      bool isSsh = false,
+    }) {
+      return resolveBrowserOpenability(
+        isLinux: isLinux,
+        isMacOS: isMacOS,
+        isWindows: isWindows,
+        hasDisplay: hasDisplay,
+        isWsl: isWsl,
+        isSsh: isSsh,
+      );
+    }
+
+    test('Linux with a display server is yes (incl. SSH X11 forwarding)', () {
+      expect(resolve(isLinux: true, hasDisplay: true), BrowserOpenability.yes);
+      expect(resolve(isLinux: true, hasDisplay: true, isSsh: true), BrowserOpenability.yes);
+    });
+
+    test('headless Linux without a display is no', () {
+      expect(resolve(isLinux: true), BrowserOpenability.no);
+      expect(resolve(isLinux: true, isSsh: true), BrowserOpenability.no);
+    });
+
+    test('WSL without a display is unknown (may reach the Windows browser via wslview)', () {
+      expect(resolve(isLinux: true, isWsl: true), BrowserOpenability.unknown);
+    });
+
+    test('macOS is yes locally and unknown over SSH', () {
+      expect(resolve(isMacOS: true), BrowserOpenability.yes);
+      expect(resolve(isMacOS: true, isSsh: true), BrowserOpenability.unknown);
+    });
+
+    test('Windows is unknown locally and no over SSH', () {
+      expect(resolve(isWindows: true), BrowserOpenability.unknown);
+      expect(resolve(isWindows: true, isSsh: true), BrowserOpenability.no);
+    });
+
+    test('an unrecognized platform is no', () {
+      expect(resolve(), BrowserOpenability.no);
     });
   });
 
@@ -390,7 +487,7 @@ void main() {
 LoginOAuthService _createOAuthService({
   required _OAuthLongPollTestServer authServer,
   required Future<void> Function(String url) browserLauncher,
-  bool Function() canLaunchBrowser = _alwaysCanLaunchBrowser,
+  BrowserOpenability Function() browserOpenability = _alwaysOpenableBrowser,
   Duration pollTimeout = const Duration(seconds: 2),
   Duration pollInterval = Duration.zero,
   Future<void> Function(Duration duration)? delay,
@@ -401,14 +498,14 @@ LoginOAuthService _createOAuthService({
       client: authServer.client,
     ),
     browserLauncher: browserLauncher,
-    canLaunchBrowser: canLaunchBrowser,
+    browserOpenability: browserOpenability,
     pollTimeout: pollTimeout,
     pollInterval: pollInterval,
     delay: delay,
   );
 }
 
-bool _alwaysCanLaunchBrowser() => true;
+BrowserOpenability _alwaysOpenableBrowser() => BrowserOpenability.yes;
 
 class _MockLoginEmailApi implements LoginEmailApi {
   @override


### PR DESCRIPTION
## Summary

Windows-focused fixes to the bridge login flow, found while running `dart run bridge/app/bin/bridge.dart` on a native Windows box over SSH. Two distinct problems:

1. **First-run crash loading tokens on Windows.**
2. **OAuth browser launch was broken/misleading over SSH and headless sessions.**

All changes are confined to the `bridge/app` auth + runtime code (plus tests). No `sesori_shared` or mobile changes.

## 1. Token path: treat a missing token file/dir as first-run on every OS

`ensureAuthenticated` decided "no stored tokens yet → log in" via `error.osError?.errorCode != 2`. POSIX reports `ENOENT` (errno 2) whether the token file *or* a parent dir is missing, so first run worked there. On Windows a missing **parent directory** (`%LOCALAPPDATA%\sesori\`, absent when running from source) reports `ERROR_PATH_NOT_FOUND` (**errno 3**), so the bridge crashed with `load stored tokens: PathNotFoundException` instead of prompting login.

Fix: catch Dart's portable `PathNotFoundException` (covers Windows errno 2 **and** 3 and POSIX `ENOENT`) at all three `loadTokens()` sites; real I/O errors still surface as `FileSystemException`.

## 2. OAuth browser launch: correct on Windows, honest everywhere

- **`cmd /c start <url>` → `rundll32 url.dll,FileProtocolHandler <url>`** on Windows. `cmd` treated the `&` query-string separators as command separators, so every `name=value` after `client_id` ran as a bogus command (`'redirect_uri' is not recognized...`). `rundll32` runs without a shell, so the URL is passed verbatim.
- **The auth URL is now always printed on its own line**, identically across platforms — a launcher exit code of `0` only means the OS accepted the request, not that a browser appeared.
- **Three-state openability detection** (`BrowserOpenability { yes, no, unknown }`) decides messaging and whether to even attempt a launch:

| Environment | Result | Behavior |
|---|---|---|
| Linux + `DISPLAY`/`WAYLAND_DISPLAY` (incl. SSH X11 fwd, WSLg) | `yes` | "Opening your browser…" + attempt |
| Linux headless / SSH without X11 | `no` | skip attempt, just print URL |
| WSL without a display | `unknown` | "Attempting to open…" (may reach Windows browser via `wslview`) |
| macOS local | `yes` | "Opening your browser…" + attempt |
| macOS over SSH | `unknown` | "Attempting to open…" + attempt |
| Windows local | `unknown` | "Attempting to open…" + attempt |
| **Windows over SSH** | `no` | **skip attempt, just print URL** |

SSH is detected via `SSH_CONNECTION`/`SSH_CLIENT`/`SSH_TTY` (set by Windows OpenSSH too); WSL via `WSL_DISTRO_NAME`/`WSL_INTEROP` or `/proc/version`. **No FFI / new dependencies.** The decision table is a pure, unit-tested `resolveBrowserOpenability()`.

## Notes

- `WindowsDefaultEditorApi` intentionally keeps `cmd /c start "" <file>` for opening the config file: `Process.run` quotes paths containing spaces (so `C:\Users\…` paths work), whereas `rundll32`'s `FileProtocolHandler` is unreliable for spaced local paths. Added a comment documenting why it differs from the URL launcher.

## Testing

- `dart analyze --fatal-infos` clean on all changed files.
- `dart test` (full `bridge/app`): **all 1313 tests pass**, including new regression tests:
  - URL printed verbatim (with `&`) when the launcher throws.
  - Headless (`no`) → launcher not called, URL still printed.
  - `unknown` → tentative "Attempting to open" wording, launch still attempted.
  - `resolveBrowserOpenability` decision-table cases (Linux/macOS/Windows × display/SSH/WSL).
- `aristotle-impl-review`: APPROVED (no architectural violations).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows first‑run login crash and makes OAuth login reliable in headless/SSH sessions. Switches Windows URL launch to `rundll32`, always prints the auth URL, and adds environment‑aware browser detection.

- **Bug Fixes**
  - Treat missing token file or parent directory as first run by catching `PathNotFoundException` at all token load sites (Windows errno 2/3 and POSIX `ENOENT`), preventing a crash.
  - On Windows, launch OAuth URLs via `rundll32 url.dll,FileProtocolHandler <url>` so `&` in query strings are passed verbatim (no more `cmd` splitting).

- **New Features**
  - Always print the OAuth URL on its own line so users can copy it, even if the browser doesn't open.
  - Add three‑state browser detection (yes/no/unknown) with SSH/WSL checks to skip launches on headless hosts and adjust messaging accordingly.

<sup>Written for commit bb3954dcb14d91035f99d04702d9a772ba090b8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

