### PR TITLE
fix(bridge): stop OpenCode HTTP calls from blocking bridge shutdown

### DIFF
--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -179,6 +179,20 @@ class OrchestratorSession {
 
   bool _cancelled = false;
 
+  /// When the first [cancel] was requested. Used only for shutdown timing
+  /// diagnostics (the logger emits no timestamps, so durations are explicit).
+  DateTime? _cancelRequestedAt;
+
+  /// Label ("METHOD path") of the relay request currently being routed, or
+  /// `null` when the read loop is idle. Surfaces which in-flight request is
+  /// blocking the read loop when a shutdown is requested mid-route.
+  String? _inFlightRequestLabel;
+
+  /// Completes when [cancel] is first called. Allows in-flight request routing
+  /// to abandon a response instead of awaiting an OpenCode HTTP call that has
+  /// outlived the relay session.
+  final Completer<void> _shutdownCompleter = Completer<void>();
+
   OrchestratorSession._({
     required this.config,
     required RelayClient client,
@@ -371,35 +385,72 @@ class OrchestratorSession {
         }
       }
     } finally {
+      final teardownSw = Stopwatch()..start();
+      final sinceCancelMs = _cancelRequestedAt == null
+          ? null
+          : DateTime.now().difference(_cancelRequestedAt!).inMilliseconds;
       Log.i("Disconnecting...");
+      Log.d(
+        "[shutdown] session teardown begin "
+        "(${sinceCancelMs == null ? "no cancel timestamp" : "${sinceCancelMs}ms since cancel()"}"
+        "${_inFlightRequestLabel == null ? "" : ", in-flight request: $_inFlightRequestLabel"})",
+      );
       await _subscriptions.cancel();
+      Log.v("[shutdown] subscriptions cancelled (+${teardownSw.elapsedMilliseconds}ms)");
       await _sessionAbortService.dispose();
+      Log.v("[shutdown] session abort service disposed (+${teardownSw.elapsedMilliseconds}ms)");
       await _completionListener.dispose();
+      Log.v("[shutdown] completion listener disposed (+${teardownSw.elapsedMilliseconds}ms)");
       _maintenanceListener.dispose();
       _prSyncService.dispose();
+      Log.v("[shutdown] maintenance + pr-sync listeners disposed (+${teardownSw.elapsedMilliseconds}ms)");
       // Plugin teardown is owned by BridgePlugin.shutdown(), run as the
       // shutdown coordinator's ordered step — the deprecated direct
       // api.dispose() call is gone since the descriptor flip.
-      Log.d("stopping sse manager...");
+      Log.v("stopping sse manager...");
       _sseManager.stop();
-      Log.d("sse manager stopped");
-      Log.d("disposing push notification service...");
+      Log.v("sse manager stopped (+${teardownSw.elapsedMilliseconds}ms)");
+      Log.v("disposing push notification service...");
       await _pushDispatcher.dispose();
-      Log.d("push notification service disposed");
+      Log.v("push notification service disposed (+${teardownSw.elapsedMilliseconds}ms)");
       await _bytesSentController.close();
       try {
-        Log.d("closing relay client...");
+        Log.v("closing relay client...");
         await _client.close();
-        Log.d("relay client closed");
+        Log.v("relay client closed (+${teardownSw.elapsedMilliseconds}ms)");
       } catch (e) {
         Log.e("error closing relay connection: $e");
       }
+      Log.d("[shutdown] session teardown complete (${teardownSw.elapsedMilliseconds}ms total)");
     }
   }
 
   Future<void> cancel() async {
+    if (_cancelRequestedAt == null) {
+      _cancelRequestedAt = DateTime.now();
+      Log.d(
+        "[shutdown] cancel() requested"
+        "${_inFlightRequestLabel == null ? "" : " — in-flight request: $_inFlightRequestLabel"}",
+      );
+    } else {
+      Log.v("[shutdown] cancel() again (already shutting down)");
+    }
     _cancelled = true;
+    if (!_shutdownCompleter.isCompleted) {
+      _shutdownCompleter.complete();
+    }
+    final sw = Stopwatch()..start();
     await _client.close();
+    Log.d("[shutdown] cancel(): relay client closed in ${sw.elapsedMilliseconds}ms");
+    // Fire-and-forget: closing the plugin's HTTP client is the only way to
+    // unblock an in-flight OpenCode request that the read loop is awaiting.
+    // Idempotent disposal still runs through the shutdown coordinator later;
+    // this call just makes it happen early enough to prevent a 15–30s hang.
+    unawaited(
+      _plugin.dispose().catchError((Object e) {
+        Log.v("[shutdown] early plugin dispose error (ignored): $e");
+      }),
+    );
   }
 
   Future<void> _processPluginEvent(BridgeSseEvent event) async {
@@ -641,13 +692,41 @@ class OrchestratorSession {
     switch (msg) {
       case final RelayRequest req:
         Log.v("RelayRequest: ${req.method} ${req.path}");
+        _inFlightRequestLabel = "${req.method} ${req.path}";
+        final routeSw = Stopwatch()..start();
         try {
-          final response = await _router.route(req);
+          final response = await Future.any<RelayResponse>([
+            _router.route(req),
+            _shutdownCompleter.future.then((_) => throw const _ShutdownInProgressException()),
+          ]);
+          if (_cancelled) {
+            Log.v(
+              "[shutdown] route ${req.method} ${req.path} completed after cancel — "
+              "dropping response (status=${response.status})",
+            );
+            return;
+          }
+          if (routeSw.elapsedMilliseconds > 1000) {
+            Log.d(
+              "[shutdown] slow route ${req.method} ${req.path} for connId $connID "
+              "took ${routeSw.elapsedMilliseconds}ms (cancelled=$_cancelled)",
+            );
+          }
           Log.v("response: status=${response.status}");
           await _encryptAndSend(connID: connID, message: response);
           Log.v("response sent to connID=$connID");
+        } on _ShutdownInProgressException {
+          Log.v(
+            "[shutdown] route ${req.method} ${req.path} abandoned because shutdown was requested",
+          );
         } catch (e) {
-          Log.e("request routing failed for connId $connID: $e");
+          if (_cancelled) {
+            Log.v("[shutdown] route ${req.method} ${req.path} failed during shutdown: $e");
+          } else {
+            Log.e("request routing failed for connId $connID: $e");
+          }
+        } finally {
+          _inFlightRequestLabel = null;
         }
       case final RelaySseSubscribe subscribe:
         Log.v("SseSubscribe: path=${subscribe.path}");
@@ -693,4 +772,9 @@ class OrchestratorSession {
     final framed = await frame(jsonBytes, encryptor: encryptor);
     _client.send(connID, framed);
   }
+}
+
+/// Thrown when a request is racing against shutdown and shutdown wins.
+class _ShutdownInProgressException implements Exception {
+  const _ShutdownInProgressException();
 }

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -446,8 +446,10 @@ class OrchestratorSession {
     // unblock an in-flight OpenCode request that the read loop is awaiting.
     // Idempotent disposal still runs through the shutdown coordinator later;
     // this call just makes it happen early enough to prevent a 15–30s hang.
+    // Future.sync so a synchronously-throwing dispose() (e.g. a test fake) is
+    // captured by catchError instead of escaping this method.
     unawaited(
-      _plugin.dispose().catchError((Object e) {
+      Future.sync(_plugin.dispose).catchError((Object e) {
         Log.v("[shutdown] early plugin dispose error (ignored): $e");
       }),
     );
@@ -694,9 +696,13 @@ class OrchestratorSession {
         Log.v("RelayRequest: ${req.method} ${req.path}");
         _inFlightRequestLabel = "${req.method} ${req.path}";
         final routeSw = Stopwatch()..start();
+        // If shutdown wins the race below, this future keeps running in the
+        // background. ignore() marks any later failure as handled so it can
+        // never surface as an unhandled async exception after abandonment.
+        final routeFuture = _router.route(req)..ignore();
         try {
           final response = await Future.any<RelayResponse>([
-            _router.route(req),
+            routeFuture,
             _shutdownCompleter.future.then((_) => throw const _ShutdownInProgressException()),
           ]);
           if (_cancelled) {

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
@@ -212,28 +212,25 @@ void registerSignalHandlers({
   required OrchestratorSession session,
   required CompositeSubscription subscriptions,
 }) {
-  var signalCount = 0;
-  ProcessSignal.sigint
-      .watch()
-      .listen((_) {
-        signalCount++;
-        if (signalCount >= 2) {
-          Log.e("[shutdown] SIGINT #2 — forcing immediate exit");
-          exit(1);
-        }
-        Log.i("[shutdown] SIGINT received (#$signalCount) — cancelling session");
-        unawaited(session.cancel());
-      })
-      .addTo(subscriptions);
+  // SIGINT and SIGTERM are equivalent shutdown triggers: the first of either
+  // requests a graceful cancel; a second shutdown signal of either kind is the
+  // emergency escape hatch that forces an immediate exit. Counting both through
+  // one counter keeps the two triggers symmetric (a prior SIGTERM must not let
+  // the first SIGINT skip straight to force-exit, and vice versa).
+  var shutdownSignalCount = 0;
+  void handleShutdownSignal(String name) {
+    shutdownSignalCount++;
+    if (shutdownSignalCount >= 2) {
+      Log.e("[shutdown] $name received (#$shutdownSignalCount) — forcing immediate exit");
+      exit(1);
+    }
+    Log.i("[shutdown] $name received (#$shutdownSignalCount) — cancelling session");
+    unawaited(session.cancel());
+  }
+
+  ProcessSignal.sigint.watch().listen((_) => handleShutdownSignal("SIGINT")).addTo(subscriptions);
   if (!Platform.isWindows) {
-    ProcessSignal.sigterm
-        .watch()
-        .listen((_) {
-          signalCount++;
-          Log.i("[shutdown] SIGTERM received (#$signalCount) — cancelling session");
-          unawaited(session.cancel());
-        })
-        .addTo(subscriptions);
+    ProcessSignal.sigterm.watch().listen((_) => handleShutdownSignal("SIGTERM")).addTo(subscriptions);
   }
 }
 

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
@@ -212,9 +212,28 @@ void registerSignalHandlers({
   required OrchestratorSession session,
   required CompositeSubscription subscriptions,
 }) {
-  ProcessSignal.sigint.watch().listen((_) => unawaited(session.cancel())).addTo(subscriptions);
+  var signalCount = 0;
+  ProcessSignal.sigint
+      .watch()
+      .listen((_) {
+        signalCount++;
+        if (signalCount >= 2) {
+          Log.e("[shutdown] SIGINT #2 — forcing immediate exit");
+          exit(1);
+        }
+        Log.i("[shutdown] SIGINT received (#$signalCount) — cancelling session");
+        unawaited(session.cancel());
+      })
+      .addTo(subscriptions);
   if (!Platform.isWindows) {
-    ProcessSignal.sigterm.watch().listen((_) => unawaited(session.cancel())).addTo(subscriptions);
+    ProcessSignal.sigterm
+        .watch()
+        .listen((_) {
+          signalCount++;
+          Log.i("[shutdown] SIGTERM received (#$signalCount) — cancelling session");
+          unawaited(session.cancel());
+        })
+        .addTo(subscriptions);
   }
 }
 

--- a/bridge/app/lib/src/bridge/runtime/bridge_shutdown_coordinator.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_shutdown_coordinator.dart
@@ -59,19 +59,32 @@ class BridgeShutdownCoordinator {
 
   Future<void> _shutdownInternal() async {
     final orderedBudget = _orderedSteps.fold(Duration.zero, (total, step) => total + step.budget);
+    final totalSw = Stopwatch()..start();
+    Log.d(
+      "[shutdown] coordinator start: ${_orderedSteps.length} ordered step(s), "
+      "${_disposables.length} disposable(s), backstop=${(orderedBudget + _backstopSlack).inSeconds}s",
+    );
     final backstop = Timer(orderedBudget + _backstopSlack, () {
-      Log.e("Failed to finish gracefully");
+      Log.e("Failed to finish gracefully after ${totalSw.elapsedMilliseconds}ms — forcing exit");
       _exitProcess(_backstopExitCode());
     });
 
     try {
       Object? firstOrderedError;
       StackTrace? firstOrderedStackTrace;
-      for (final step in _orderedSteps) {
+      for (var i = 0; i < _orderedSteps.length; i++) {
+        final step = _orderedSteps[i];
+        final stepSw = Stopwatch()..start();
+        Log.v(
+          "[shutdown] ordered step ${i + 1}/${_orderedSteps.length} start (budget=${step.budget.inSeconds}s)",
+        );
         try {
           await step.action();
+          Log.v(
+            "[shutdown] ordered step ${i + 1}/${_orderedSteps.length} done (${stepSw.elapsedMilliseconds}ms)",
+          );
         } catch (error, stackTrace) {
-          Log.e("Ordered shutdown step failed: $error");
+          Log.e("Ordered shutdown step failed after ${stepSw.elapsedMilliseconds}ms: $error");
           firstOrderedError ??= error;
           firstOrderedStackTrace ??= stackTrace;
         }
@@ -79,14 +92,18 @@ class BridgeShutdownCoordinator {
       // Future.sync (not Future.value(disposable())): a synchronously
       // throwing disposable must become a failed future, not abort the lazy
       // map iteration inside Future.wait and skip the disposables after it.
+      final parallelSw = Stopwatch()..start();
+      Log.v("[shutdown] parallel phase start (${_disposables.length} disposable(s))");
       await Future.wait(
         _disposables.map(Future.sync),
       );
+      Log.v("[shutdown] parallel phase done (${parallelSw.elapsedMilliseconds}ms)");
       if (firstOrderedError != null) {
         Error.throwWithStackTrace(firstOrderedError, firstOrderedStackTrace!);
       }
     } finally {
       backstop.cancel();
+      Log.d("[shutdown] coordinator complete (${totalSw.elapsedMilliseconds}ms total)");
     }
   }
 }

--- a/bridge/sesori_plugin_opencode/lib/opencode_plugin.dart
+++ b/bridge/sesori_plugin_opencode/lib/opencode_plugin.dart
@@ -19,6 +19,7 @@ export "src/models/send_prompt_body.dart";
 export "src/models/session.dart";
 export "src/models/session_status.dart";
 export "src/models/sse_event_data.dart";
+export "src/open_code_raw_http_client.dart";
 export "src/opencode_api.dart";
 export "src/opencode_db_api.dart";
 export "src/opencode_db_maintenance_service.dart";

--- a/bridge/sesori_plugin_opencode/lib/src/open_code_raw_http_client.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/open_code_raw_http_client.dart
@@ -1,0 +1,192 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:http/http.dart" as http;
+
+/// Soft deadline applied to every OpenCode REST call unless the caller passes
+/// an explicit [Duration] (or `null` to opt out).
+///
+/// A timeout is necessary because `http.Client` (specifically `IOClient`) does
+/// NOT impose a total request/response deadline by default — only optional
+/// connection/idle timeouts. An OpenCode server that accepts the connection
+/// and then stalls (a frequent failure mode) would otherwise hang the call
+/// indefinitely. Routing every request through this client guarantees the
+/// timeout (and success check) can't be forgotten on a new endpoint.
+const _defaultTimeout = Duration(seconds: 30);
+
+/// HTTP status reported when a request exceeds its timeout. 504 (Gateway
+/// Timeout) is the honest code: the bridge is a gateway and the upstream
+/// (OpenCode) did not respond in time. Using a real status lets phone-side
+/// error handling classify it like any other upstream failure.
+const _timeoutStatusCode = 504;
+
+enum _HttpMethod { get, post, patch, delete }
+
+/// Transport-level HTTP client for the OpenCode REST API.
+///
+/// Centralizes the three cross-cutting concerns every OpenCode call needs so
+/// individual endpoint methods (in [OpenCodeApi]) cannot bypass them:
+///   1. applies a request [timeout] (default [_defaultTimeout]),
+///   2. enforces a 2xx response (throws [OpenCodeApiException] otherwise),
+///   3. computes a debug endpoint label ("METHOD /path") for error messages.
+///
+/// It also owns Basic-auth header computation and URI construction. It performs
+/// no JSON decoding or model mapping — that stays in [OpenCodeApi].
+class OpenCodeRawHttpClient {
+  final String _serverURL;
+  final String? _password;
+  final http.Client _client;
+
+  OpenCodeRawHttpClient({
+    required String serverURL,
+    required String? password,
+    required http.Client client,
+  }) : _serverURL = serverURL,
+       _password = password,
+       _client = client;
+
+  Map<String, String> get _authHeaders {
+    final password = _password;
+    if (password == null) return const {};
+    final creds = base64.encode(utf8.encode("opencode:$password"));
+    return {"Authorization": "Basic $creds"};
+  }
+
+  Future<http.Response> get({
+    required String path,
+    Map<String, String>? queryParameters,
+    Map<String, String>? headers,
+    Duration? timeout = _defaultTimeout,
+  }) {
+    return _send(
+      method: _HttpMethod.get,
+      path: path,
+      queryParameters: queryParameters,
+      headers: headers,
+      timeout: timeout,
+    );
+  }
+
+  Future<http.Response> post({
+    required String path,
+    Map<String, String>? queryParameters,
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout = _defaultTimeout,
+  }) {
+    return _send(
+      method: _HttpMethod.post,
+      path: path,
+      queryParameters: queryParameters,
+      headers: headers,
+      body: body,
+      timeout: timeout,
+    );
+  }
+
+  Future<http.Response> patch({
+    required String path,
+    Map<String, String>? queryParameters,
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout = _defaultTimeout,
+  }) {
+    return _send(
+      method: _HttpMethod.patch,
+      path: path,
+      queryParameters: queryParameters,
+      headers: headers,
+      body: body,
+      timeout: timeout,
+    );
+  }
+
+  Future<http.Response> delete({
+    required String path,
+    Map<String, String>? queryParameters,
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout = _defaultTimeout,
+  }) {
+    return _send(
+      method: _HttpMethod.delete,
+      path: path,
+      queryParameters: queryParameters,
+      headers: headers,
+      body: body,
+      timeout: timeout,
+    );
+  }
+
+  /// Sends [method] to [path], applying auth headers, the optional [timeout],
+  /// and a 2xx success check. A `null` [timeout] means unbounded (only for
+  /// genuinely long-running synchronous endpoints).
+  Future<http.Response> _send({
+    required _HttpMethod method,
+    required String path,
+    Map<String, String>? queryParameters,
+    Map<String, String>? headers,
+    Object? body,
+    required Duration? timeout,
+  }) async {
+    final hasQuery = queryParameters != null && queryParameters.isNotEmpty;
+    final uri = Uri.parse(
+      "$_serverURL$path",
+    ).replace(queryParameters: hasQuery ? queryParameters : null);
+    final endpoint = "${method.name.toUpperCase()} $path";
+    final mergedHeaders = {..._authHeaders, ...?headers};
+
+    final request = switch (method) {
+      _HttpMethod.get => _client.get(uri, headers: mergedHeaders),
+      _HttpMethod.post => _client.post(uri, headers: mergedHeaders, body: body),
+      _HttpMethod.patch => _client.patch(uri, headers: mergedHeaders, body: body),
+      _HttpMethod.delete => _client.delete(uri, headers: mergedHeaders, body: body),
+    };
+
+    final http.Response response;
+    if (timeout == null) {
+      response = await request;
+    } else {
+      try {
+        response = await request.timeout(timeout);
+      } on TimeoutException {
+        throw OpenCodeApiException(
+          endpoint,
+          _timeoutStatusCode,
+          responseBody: "request timed out after ${timeout.inSeconds}s",
+        );
+      }
+    }
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw OpenCodeApiException(endpoint, response.statusCode, responseBody: response.body);
+    }
+    return response;
+  }
+}
+
+class OpenCodeApiException implements Exception {
+  static const _maxBodyLength = 500;
+
+  final String endpoint;
+  final int statusCode;
+
+  /// Upstream response body, truncated to [_maxBodyLength] characters.
+  /// OpenCode error bodies carry the actual failure reason (e.g.
+  /// `{"name":"UnknownError","data":{...}}`), which is essential for
+  /// diagnosing failures from logs.
+  final String? responseBody;
+
+  OpenCodeApiException(this.endpoint, this.statusCode, {String? responseBody})
+    : responseBody = switch (responseBody) {
+        null => null,
+        final body when body.length > _maxBodyLength => "${body.substring(0, _maxBodyLength)}…",
+        final body => body,
+      };
+
+  @override
+  String toString() {
+    final bodySuffix = responseBody == null || responseBody!.isEmpty ? "" : " body=$responseBody";
+    return "OpenCodeApiException: $endpoint failed with status $statusCode$bodySuffix";
+  }
+}

--- a/bridge/sesori_plugin_opencode/lib/src/open_code_raw_http_client.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/open_code_raw_http_client.dart
@@ -3,15 +3,16 @@ import "dart:convert";
 
 import "package:http/http.dart" as http;
 
-/// Soft deadline applied to every OpenCode REST call unless the caller passes
-/// an explicit [Duration] (or `null` to opt out).
+/// Soft deadline applied to idempotent GET reads by default. Writes
+/// (POST/PATCH/DELETE) default to no timeout — see [OpenCodeRawHttpClient] for
+/// why the two are treated differently.
 ///
-/// A timeout is necessary because `http.Client` (specifically `IOClient`) does
-/// NOT impose a total request/response deadline by default — only optional
-/// connection/idle timeouts. An OpenCode server that accepts the connection
-/// and then stalls (a frequent failure mode) would otherwise hang the call
-/// indefinitely. Routing every request through this client guarantees the
-/// timeout (and success check) can't be forgotten on a new endpoint.
+/// A read timeout is useful because `http.Client` (specifically `IOClient`)
+/// does NOT impose a total request/response deadline by default — only
+/// optional connection/idle timeouts. An OpenCode server that accepts the
+/// connection and then stalls (a frequent failure mode) would otherwise hang a
+/// read indefinitely. Abandoning a read this way is safe precisely because it
+/// has no side effects: a timed-out GET can simply be retried.
 const _defaultTimeout = Duration(seconds: 30);
 
 /// HTTP status reported when a request exceeds its timeout. 504 (Gateway
@@ -24,11 +25,28 @@ enum _HttpMethod { get, post, patch, delete }
 
 /// Transport-level HTTP client for the OpenCode REST API.
 ///
-/// Centralizes the three cross-cutting concerns every OpenCode call needs so
+/// Centralizes the cross-cutting concerns every OpenCode call needs so
 /// individual endpoint methods (in [OpenCodeApi]) cannot bypass them:
-///   1. applies a request [timeout] (default [_defaultTimeout]),
+///   1. applies a request [timeout] — idempotent reads ([get]) default to
+///      [_defaultTimeout]; non-idempotent writes ([post]/[patch]/[delete])
+///      default to no timeout (see below),
 ///   2. enforces a 2xx response (throws [OpenCodeApiException] otherwise),
 ///   3. computes a debug endpoint label ("METHOD /path") for error messages.
+///
+/// **Why reads time out but writes don't.** `Future.timeout` cannot cancel an
+/// in-flight HTTP request — it only stops *waiting* for the response. For an
+/// idempotent GET that is harmless: report a 504 and let the caller retry. For
+/// a non-idempotent write it is dangerous: OpenCode may have accepted the
+/// mutation and merely be slow to respond, so a client-side timeout would
+/// surface a false 504 while the write still commits server-side, leaving the
+/// caller free to retry or run cleanup against state that actually changed. A
+/// *longer* write timeout only widens the window before that same race; it
+/// does not remove it. Writes therefore impose no timeout by default. They
+/// never block shutdown anyway: the orchestrator abandons in-flight routes on
+/// teardown, and the genuinely long-running synchronous endpoints
+/// ([OpenCodeApi.sendCommand]/[OpenCodeApi.summarize]) are detached by
+/// `OpenCodeService`. A caller may still pass an explicit [timeout] to a write
+/// if it has a concrete reason to bound it.
 ///
 /// It also owns Basic-auth header computation and URI construction. It performs
 /// no JSON decoding or model mapping — that stays in [OpenCodeApi].
@@ -72,7 +90,7 @@ class OpenCodeRawHttpClient {
     Map<String, String>? queryParameters,
     Map<String, String>? headers,
     Object? body,
-    Duration? timeout = _defaultTimeout,
+    Duration? timeout, // unbounded by default — non-idempotent; see class docs
   }) {
     return _send(
       method: _HttpMethod.post,
@@ -89,7 +107,7 @@ class OpenCodeRawHttpClient {
     Map<String, String>? queryParameters,
     Map<String, String>? headers,
     Object? body,
-    Duration? timeout = _defaultTimeout,
+    Duration? timeout, // unbounded by default — non-idempotent; see class docs
   }) {
     return _send(
       method: _HttpMethod.patch,
@@ -106,7 +124,7 @@ class OpenCodeRawHttpClient {
     Map<String, String>? queryParameters,
     Map<String, String>? headers,
     Object? body,
-    Duration? timeout = _defaultTimeout,
+    Duration? timeout, // unbounded by default — non-idempotent; see class docs
   }) {
     return _send(
       method: _HttpMethod.delete,
@@ -119,8 +137,9 @@ class OpenCodeRawHttpClient {
   }
 
   /// Sends [method] to [path], applying auth headers, the optional [timeout],
-  /// and a 2xx success check. A `null` [timeout] means unbounded (only for
-  /// genuinely long-running synchronous endpoints).
+  /// and a 2xx success check. A `null` [timeout] means unbounded — the default
+  /// for writes and for the long-running synchronous command/summarize
+  /// endpoints.
   Future<http.Response> _send({
     required _HttpMethod method,
     required String path,

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:convert";
 
 import "package:http/http.dart" as http;
@@ -18,6 +19,13 @@ import "models/session_status.dart";
 
 const _directoryOpenCodeHeader = "x-opencode-directory";
 
+/// Soft deadline for read-only OpenCode REST calls.
+const _readTimeout = Duration(seconds: 30);
+
+/// Soft deadline for mutating OpenCode REST calls (create, update, delete,
+/// prompts). Longer than reads because some endpoints perform local work.
+const _writeTimeout = Duration(seconds: 60);
+
 class OpenCodeApi {
   final String serverURL;
   final String? _password;
@@ -36,6 +44,25 @@ class OpenCodeApi {
     return {"Authorization": "Basic $creds"};
   }
 
+  /// Runs [request] with [timeout], converting a [TimeoutException] into an
+  /// [OpenCodeApiException] so callers treat a hung localhost request as a
+  /// transport failure.
+  Future<http.Response> _withTimeout(
+    Future<http.Response> request,
+    String endpoint,
+    Duration timeout,
+  ) async {
+    try {
+      return await request.timeout(timeout);
+    } on TimeoutException {
+      throw OpenCodeApiException(
+        endpoint,
+        0,
+        responseBody: "request timed out after ${timeout.inSeconds}s",
+      );
+    }
+  }
+
   Future<bool> healthCheck() async {
     try {
       final response = await _client
@@ -48,9 +75,13 @@ class OpenCodeApi {
   }
 
   Future<List<Project>> listProjects() async {
-    final response = await _client.get(
-      Uri.parse("$serverURL/project"),
-      headers: _authHeaders,
+    final response = await _withTimeout(
+      _client.get(
+        Uri.parse("$serverURL/project"),
+        headers: _authHeaders,
+      ),
+      "GET /project",
+      _readTimeout,
     );
     _ensureSuccess(response, "GET /project");
 
@@ -59,9 +90,13 @@ class OpenCodeApi {
   }
 
   Future<List<Session>> listRootSessions() async {
-    final response = await _client.get(
-      Uri.parse("$serverURL/session?roots=true"),
-      headers: _authHeaders,
+    final response = await _withTimeout(
+      _client.get(
+        Uri.parse("$serverURL/session?roots=true"),
+        headers: _authHeaders,
+      ),
+      "GET /session?roots=true",
+      _readTimeout,
     );
     _ensureSuccess(response, "GET /session?roots=true");
 
@@ -79,11 +114,15 @@ class OpenCodeApi {
       if (roots) "roots": "true",
     };
 
-    final response = await _client.get(
-      Uri.parse("$serverURL/session").replace(
-        queryParameters: queryParams.isEmpty ? null : queryParams,
+    final response = await _withTimeout(
+      _client.get(
+        Uri.parse("$serverURL/session").replace(
+          queryParameters: queryParams.isEmpty ? null : queryParams,
+        ),
+        headers: headers,
       ),
-      headers: headers,
+      "GET /session",
+      _readTimeout,
     );
     _ensureSuccess(response, "GET /session");
 
@@ -96,9 +135,13 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory,
     };
-    final response = await _client.get(
-      Uri.parse("$serverURL/command"),
-      headers: headers,
+    final response = await _withTimeout(
+      _client.get(
+        Uri.parse("$serverURL/command"),
+        headers: headers,
+      ),
+      "GET /command",
+      _readTimeout,
     );
     _ensureSuccess(response, "GET /command");
 
@@ -121,14 +164,18 @@ class OpenCodeApi {
     if (parentSessionId case final id?) {
       body["parentID"] = id;
     }
-    final response = await _client.post(
-      Uri.parse("$serverURL/session"),
-      headers: {
-        ..._authHeaders,
-        "content-type": "application/json",
-        _directoryOpenCodeHeader: directory,
-      },
-      body: jsonEncode(body),
+    final response = await _withTimeout(
+      _client.post(
+        Uri.parse("$serverURL/session"),
+        headers: {
+          ..._authHeaders,
+          "content-type": "application/json",
+          _directoryOpenCodeHeader: directory,
+        },
+        body: jsonEncode(body),
+      ),
+      "POST /session",
+      _writeTimeout,
     );
     _ensureSuccess(response, "POST /session");
     return Session.fromJson(jsonDecodeMap(response.body));
@@ -142,9 +189,13 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory,
     };
-    final response = await _client.get(
-      Uri.parse("$serverURL/session/$sessionId"),
-      headers: headers,
+    final response = await _withTimeout(
+      _client.get(
+        Uri.parse("$serverURL/session/$sessionId"),
+        headers: headers,
+      ),
+      "GET /session/$sessionId",
+      _readTimeout,
     );
     _ensureSuccess(response, "GET /session/$sessionId");
     return Session.fromJson(jsonDecodeMap(response.body));
@@ -155,14 +206,18 @@ class OpenCodeApi {
     required Map<String, dynamic> body,
     required String? directory,
   }) async {
-    final response = await _client.patch(
-      Uri.parse("$serverURL/session/$sessionId"),
-      headers: {
-        ..._authHeaders,
-        "content-type": "application/json",
-        _directoryOpenCodeHeader: ?directory,
-      },
-      body: jsonEncode(body),
+    final response = await _withTimeout(
+      _client.patch(
+        Uri.parse("$serverURL/session/$sessionId"),
+        headers: {
+          ..._authHeaders,
+          "content-type": "application/json",
+          _directoryOpenCodeHeader: ?directory,
+        },
+        body: jsonEncode(body),
+      ),
+      "PATCH /session/$sessionId",
+      _writeTimeout,
     );
     _ensureSuccess(response, "PATCH /session/$sessionId");
     return Session.fromJson(jsonDecodeMap(response.body));
@@ -175,14 +230,18 @@ class OpenCodeApi {
     required String directory,
     required Map<String, dynamic> body,
   }) async {
-    final response = await _client.patch(
-      Uri.parse("$serverURL/project/$projectId"),
-      headers: {
-        ..._authHeaders,
-        "content-type": "application/json",
-        _directoryOpenCodeHeader: directory,
-      },
-      body: jsonEncode(body),
+    final response = await _withTimeout(
+      _client.patch(
+        Uri.parse("$serverURL/project/$projectId"),
+        headers: {
+          ..._authHeaders,
+          "content-type": "application/json",
+          _directoryOpenCodeHeader: directory,
+        },
+        body: jsonEncode(body),
+      ),
+      "PATCH /project/$projectId",
+      _writeTimeout,
     );
     _ensureSuccess(response, "PATCH /project/$projectId");
     return Project.fromJson(jsonDecodeMap(response.body));
@@ -196,9 +255,13 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory,
     };
-    final response = await _client.delete(
-      Uri.parse("$serverURL/session/$sessionId"),
-      headers: headers,
+    final response = await _withTimeout(
+      _client.delete(
+        Uri.parse("$serverURL/session/$sessionId"),
+        headers: headers,
+      ),
+      "DELETE /session/$sessionId",
+      _writeTimeout,
     );
     _ensureSuccess(response, "DELETE /session/$sessionId");
   }
@@ -212,14 +275,18 @@ class OpenCodeApi {
     required String directory,
     required String worktreePath,
   }) async {
-    final response = await _client.delete(
-      Uri.parse("$serverURL/experimental/worktree"),
-      headers: {
-        ..._authHeaders,
-        "content-type": "application/json",
-        _directoryOpenCodeHeader: directory,
-      },
-      body: jsonEncode({"directory": worktreePath}),
+    final response = await _withTimeout(
+      _client.delete(
+        Uri.parse("$serverURL/experimental/worktree"),
+        headers: {
+          ..._authHeaders,
+          "content-type": "application/json",
+          _directoryOpenCodeHeader: directory,
+        },
+        body: jsonEncode({"directory": worktreePath}),
+      ),
+      "DELETE /experimental/worktree",
+      _writeTimeout,
     );
     _ensureSuccess(response, "DELETE /experimental/worktree");
   }
@@ -232,9 +299,13 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory, // probably irrelevant for this endpoint
     };
-    final response = await _client.get(
-      Uri.parse("$serverURL/session/$sessionId/children"),
-      headers: headers,
+    final response = await _withTimeout(
+      _client.get(
+        Uri.parse("$serverURL/session/$sessionId/children"),
+        headers: headers,
+      ),
+      "GET /session/$sessionId/children",
+      _readTimeout,
     );
     _ensureSuccess(response, "GET /session/$sessionId/children");
 
@@ -246,12 +317,16 @@ class OpenCodeApi {
     required String sessionId,
     required String directory,
   }) async {
-    final response = await _client.post(
-      Uri.parse("$serverURL/session/$sessionId/fork"),
-      headers: {
-        ..._authHeaders,
-        _directoryOpenCodeHeader: directory,
-      },
+    final response = await _withTimeout(
+      _client.post(
+        Uri.parse("$serverURL/session/$sessionId/fork"),
+        headers: {
+          ..._authHeaders,
+          _directoryOpenCodeHeader: directory,
+        },
+      ),
+      "POST /session/$sessionId/fork",
+      _writeTimeout,
     );
     _ensureSuccess(response, "POST /session/$sessionId/fork");
     return Session.fromJson(jsonDecodeMap(response.body));
@@ -265,9 +340,13 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory, // probably irrelevant for this endpoint
     };
-    final response = await _client.get(
-      Uri.parse("$serverURL/session/$sessionId/message"),
-      headers: headers,
+    final response = await _withTimeout(
+      _client.get(
+        Uri.parse("$serverURL/session/$sessionId/message"),
+        headers: headers,
+      ),
+      "GET /session/$sessionId/message",
+      _readTimeout,
     );
     _ensureSuccess(response, "GET /session/$sessionId/message");
 
@@ -282,14 +361,18 @@ class OpenCodeApi {
     // because otherwise it picks the CWD of where bridge is running
     required String? directory,
   }) async {
-    final response = await _client.post(
-      Uri.parse("$serverURL/session/$sessionId/prompt_async"),
-      headers: {
-        ..._authHeaders,
-        "content-type": "application/json",
-        _directoryOpenCodeHeader: ?directory,
-      },
-      body: jsonEncode(body.toJson()),
+    final response = await _withTimeout(
+      _client.post(
+        Uri.parse("$serverURL/session/$sessionId/prompt_async"),
+        headers: {
+          ..._authHeaders,
+          "content-type": "application/json",
+          _directoryOpenCodeHeader: ?directory,
+        },
+        body: jsonEncode(body.toJson()),
+      ),
+      "POST /session/$sessionId/prompt_async",
+      _writeTimeout,
     );
     _ensureSuccess(response, "POST /session/$sessionId/prompt_async");
   }
@@ -327,10 +410,14 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory,
     };
-    final response = await _client.post(
-      Uri.parse("$serverURL/session/$sessionId/abort"),
-      headers: headers,
-      body: "",
+    final response = await _withTimeout(
+      _client.post(
+        Uri.parse("$serverURL/session/$sessionId/abort"),
+        headers: headers,
+        body: "",
+      ),
+      "POST /session/$sessionId/abort",
+      _writeTimeout,
     );
     _ensureSuccess(response, "POST /session/$sessionId/abort");
   }
@@ -342,7 +429,11 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: directory,
     };
-    final response = await _client.get(Uri.parse("$serverURL/agent"), headers: headers);
+    final response = await _withTimeout(
+      _client.get(Uri.parse("$serverURL/agent"), headers: headers),
+      "GET /agent",
+      _readTimeout,
+    );
     _ensureSuccess(response, "GET /agent");
 
     final decoded = jsonDecodeListMap(response.body);
@@ -356,7 +447,11 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory,
     };
-    final response = await _client.get(Uri.parse("$serverURL/question"), headers: headers);
+    final response = await _withTimeout(
+      _client.get(Uri.parse("$serverURL/question"), headers: headers),
+      "GET /question",
+      _readTimeout,
+    );
     Log.v("[getPendingQuestions] response: ${response.body}");
     _ensureSuccess(response, "GET /question");
 
@@ -367,12 +462,16 @@ class OpenCodeApi {
   Future<List<PendingPermission>> getPendingPermissions({
     required String? directory,
   }) async {
-    final response = await _client.get(
-      Uri.parse("$serverURL/permission"),
-      headers: {
-        ..._authHeaders,
-        _directoryOpenCodeHeader: ?directory,
-      },
+    final response = await _withTimeout(
+      _client.get(
+        Uri.parse("$serverURL/permission"),
+        headers: {
+          ..._authHeaders,
+          _directoryOpenCodeHeader: ?directory,
+        },
+      ),
+      "GET /permission",
+      _readTimeout,
     );
     Log.v("[getPendingPermissions] response: ${response.body}");
     _ensureSuccess(response, "GET /permission");
@@ -388,14 +487,18 @@ class OpenCodeApi {
   }) async {
     final encodedBody = jsonEncode(body);
     Log.d("[question-api] POST /question/$questionId/reply body=$encodedBody");
-    final response = await _client.post(
-      Uri.parse("$serverURL/question/$questionId/reply"),
-      headers: {
-        ..._authHeaders,
-        _directoryOpenCodeHeader: ?directory, // doesn't work well with the directory header
-        "content-type": "application/json",
-      },
-      body: encodedBody,
+    final response = await _withTimeout(
+      _client.post(
+        Uri.parse("$serverURL/question/$questionId/reply"),
+        headers: {
+          ..._authHeaders,
+          _directoryOpenCodeHeader: ?directory, // doesn't work well with the directory header
+          "content-type": "application/json",
+        },
+        body: encodedBody,
+      ),
+      "POST /question/$questionId/reply",
+      _writeTimeout,
     );
     Log.d("[question-api] POST /question/$questionId/reply => ${response.statusCode} body=${response.body}");
     _ensureSuccess(response, "POST /question/$questionId/reply");
@@ -408,13 +511,17 @@ class OpenCodeApi {
   }) async {
     final body = jsonEncode({"reply": reply.name});
     Log.d("[permission-api] POST /permission/$requestId/reply for session $sessionId");
-    final httpResponse = await _client.post(
-      Uri.parse("$serverURL/permission/$requestId/reply"),
-      headers: {
-        ..._authHeaders,
-        "content-type": "application/json",
-      },
-      body: body,
+    final httpResponse = await _withTimeout(
+      _client.post(
+        Uri.parse("$serverURL/permission/$requestId/reply"),
+        headers: {
+          ..._authHeaders,
+          "content-type": "application/json",
+        },
+        body: body,
+      ),
+      "POST /permission/$requestId/reply",
+      _writeTimeout,
     );
     _ensureSuccess(
       httpResponse,
@@ -426,10 +533,14 @@ class OpenCodeApi {
     required String questionId,
   }) async {
     Log.d("[question-api] POST /question/$questionId/reject");
-    final response = await _client.post(
-      Uri.parse("$serverURL/question/$questionId/reject"),
-      headers: _authHeaders,
-      body: "",
+    final response = await _withTimeout(
+      _client.post(
+        Uri.parse("$serverURL/question/$questionId/reject"),
+        headers: _authHeaders,
+        body: "",
+      ),
+      "POST /question/$questionId/reject",
+      _writeTimeout,
     );
     Log.d("[question-api] POST /question/$questionId/reject => ${response.statusCode} body=${response.body}");
     _ensureSuccess(response, "POST /question/$questionId/reject");
@@ -438,12 +549,16 @@ class OpenCodeApi {
   Future<Project> getProject({
     required String directory,
   }) async {
-    final response = await _client.get(
-      Uri.parse("$serverURL/project/current"),
-      headers: {
-        ..._authHeaders,
-        _directoryOpenCodeHeader: directory,
-      },
+    final response = await _withTimeout(
+      _client.get(
+        Uri.parse("$serverURL/project/current"),
+        headers: {
+          ..._authHeaders,
+          _directoryOpenCodeHeader: directory,
+        },
+      ),
+      "GET /project/current",
+      _readTimeout,
     );
     _ensureSuccess(response, "GET /project/current");
     return Project.fromJson(jsonDecodeMap(response.body));
@@ -477,7 +592,11 @@ class OpenCodeApi {
     final uri = Uri.parse(
       "$serverURL/experimental/session",
     ).replace(queryParameters: queryParams.isEmpty ? null : queryParams);
-    final response = await _client.get(uri, headers: _authHeaders);
+    final response = await _withTimeout(
+      _client.get(uri, headers: _authHeaders),
+      "GET /experimental/session",
+      _readTimeout,
+    );
     _ensureSuccess(response, "GET /experimental/session");
 
     final decoded = jsonDecodeListMap(response.body);
@@ -485,9 +604,13 @@ class OpenCodeApi {
   }
 
   Future<ProviderListResponse> listProviders() async {
-    final response = await _client.get(
-      Uri.parse("$serverURL/provider"),
-      headers: _authHeaders,
+    final response = await _withTimeout(
+      _client.get(
+        Uri.parse("$serverURL/provider"),
+        headers: _authHeaders,
+      ),
+      "GET /provider",
+      _readTimeout,
     );
     _ensureSuccess(response, "GET /provider");
     return ProviderListResponse.fromJson(jsonDecodeMap(response.body));
@@ -498,9 +621,13 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory,
     };
-    final response = await _client.get(
-      Uri.parse("$serverURL/config/providers"),
-      headers: headers,
+    final response = await _withTimeout(
+      _client.get(
+        Uri.parse("$serverURL/config/providers"),
+        headers: headers,
+      ),
+      "GET /config/providers",
+      _readTimeout,
     );
     _ensureSuccess(response, "GET /config/providers");
     return ProviderListResponse.fromJson(
@@ -514,9 +641,13 @@ class OpenCodeApi {
       _directoryOpenCodeHeader: ?directory,
     };
 
-    final response = await _client.get(
-      Uri.parse("$serverURL/session/status"),
-      headers: headers,
+    final response = await _withTimeout(
+      _client.get(
+        Uri.parse("$serverURL/session/status"),
+        headers: headers,
+      ),
+      "GET /session/status",
+      _readTimeout,
     );
     _ensureSuccess(response, "GET /session/status");
 

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -1,7 +1,5 @@
-import "dart:async";
 import "dart:convert";
 
-import "package:http/http.dart" as http;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" show jsonDecodeListMap, jsonDecodeMap;
 
@@ -16,138 +14,73 @@ import "models/send_command_body.dart";
 import "models/send_prompt_body.dart";
 import "models/session.dart";
 import "models/session_status.dart";
+import "open_code_raw_http_client.dart";
 
 const _directoryOpenCodeHeader = "x-opencode-directory";
 
-/// Soft deadline for read-only OpenCode REST calls.
+/// Typed facade over the OpenCode REST API.
 ///
-/// Only GET reads are timed out. Reads are idempotent, so abandoning a slow
-/// one is safe. Mutating requests are deliberately NOT timed out:
-/// `Future.timeout` does not abort the underlying HTTP request, so a
-/// client-side timeout on a non-idempotent write (e.g. createSession's prompt)
-/// could trigger compensating cleanup while OpenCode still commits the
-/// mutation server-side.
-const _readTimeout = Duration(seconds: 30);
-
-/// HTTP status reported when a read times out. 504 (Gateway Timeout) is the
-/// honest code: the bridge is a gateway and the upstream (OpenCode) did not
-/// respond in time. Using a real status lets phone-side error handling
-/// classify it like any other upstream failure.
-const _readTimeoutStatus = 504;
-
+/// Knows each endpoint's path, request-specific headers, body encoding, and how
+/// to map the JSON response into models. All transport concerns — timeouts,
+/// success enforcement, auth headers, endpoint labeling — are delegated to
+/// [OpenCodeRawHttpClient], so they apply uniformly and can't be forgotten on a
+/// new endpoint.
 class OpenCodeApi {
-  final String serverURL;
-  final String? _password;
-  final http.Client _client;
+  final OpenCodeRawHttpClient _client;
 
-  OpenCodeApi({
-    required this.serverURL,
-    required String? password,
-    required http.Client client,
-  }) : _password = password,
-       _client = client;
-
-  Map<String, String> get _authHeaders {
-    if (_password == null) return const {};
-    final creds = base64.encode(utf8.encode("opencode:$_password"));
-    return {"Authorization": "Basic $creds"};
-  }
-
-  /// Runs a read [request] with [_readTimeout], converting a [TimeoutException]
-  /// into an [OpenCodeApiException] with a 504 status so callers treat a hung
-  /// localhost read as an upstream gateway timeout.
-  Future<http.Response> _readWithTimeout(
-    Future<http.Response> request,
-    String endpoint,
-  ) async {
-    try {
-      return await request.timeout(_readTimeout);
-    } on TimeoutException {
-      throw OpenCodeApiException(
-        endpoint,
-        _readTimeoutStatus,
-        responseBody: "request timed out after ${_readTimeout.inSeconds}s",
-      );
-    }
-  }
+  OpenCodeApi({required OpenCodeRawHttpClient client}) : _client = client;
 
   Future<bool> healthCheck() async {
     try {
-      final response = await _client
-          .get(Uri.parse("$serverURL/global/health"), headers: _authHeaders)
-          .timeout(const Duration(seconds: 5));
-      return response.statusCode >= 200 && response.statusCode < 300;
+      await _client.get(
+        path: "/global/health",
+        timeout: const Duration(seconds: 5),
+      );
+      return true;
     } catch (_) {
       return false;
     }
   }
 
   Future<List<Project>> listProjects() async {
-    final response = await _readWithTimeout(
-      _client.get(
-        Uri.parse("$serverURL/project"),
-        headers: _authHeaders,
-      ),
-      "GET /project",
-    );
-    _ensureSuccess(response, "GET /project");
+    final response = await _client.get(path: "/project");
 
     final decoded = jsonDecodeListMap(response.body);
     return decoded.map(Project.fromJson).toList();
   }
 
   Future<List<Session>> listRootSessions() async {
-    final response = await _readWithTimeout(
-      _client.get(
-        Uri.parse("$serverURL/session?roots=true"),
-        headers: _authHeaders,
-      ),
-      "GET /session?roots=true",
+    final response = await _client.get(
+      path: "/session",
+      queryParameters: const {"roots": "true"},
     );
-    _ensureSuccess(response, "GET /session?roots=true");
 
     final decoded = jsonDecodeListMap(response.body);
     return decoded.map(Session.fromJson).toList();
   }
 
   Future<List<Session>> listSessions({String? directory, required bool roots}) async {
-    final headers = <String, String>{
-      ..._authHeaders,
-      _directoryOpenCodeHeader: ?directory,
-    };
-
-    final queryParams = <String, String>{
-      if (roots) "roots": "true",
-    };
-
-    final response = await _readWithTimeout(
-      _client.get(
-        Uri.parse("$serverURL/session").replace(
-          queryParameters: queryParams.isEmpty ? null : queryParams,
-        ),
-        headers: headers,
-      ),
-      "GET /session",
+    final response = await _client.get(
+      path: "/session",
+      queryParameters: {
+        if (roots) "roots": "true",
+      },
+      headers: {
+        _directoryOpenCodeHeader: ?directory,
+      },
     );
-    _ensureSuccess(response, "GET /session");
 
     final decoded = jsonDecodeListMap(response.body);
     return decoded.map(Session.fromJson).toList();
   }
 
   Future<List<Command>> listCommands({required String? directory}) async {
-    final headers = <String, String>{
-      ..._authHeaders,
-      _directoryOpenCodeHeader: ?directory,
-    };
-    final response = await _readWithTimeout(
-      _client.get(
-        Uri.parse("$serverURL/command"),
-        headers: headers,
-      ),
-      "GET /command",
+    final response = await _client.get(
+      path: "/command",
+      headers: {
+        _directoryOpenCodeHeader: ?directory,
+      },
     );
-    _ensureSuccess(response, "GET /command");
 
     final decoded = jsonDecodeListMap(response.body);
     return decoded.map(Command.fromJson).toList();
@@ -168,19 +101,14 @@ class OpenCodeApi {
     if (parentSessionId case final id?) {
       body["parentID"] = id;
     }
-    // Not timed out: createSession is non-idempotent. Future.timeout would not
-    // abort the underlying HTTP request, so a client-side timeout could trigger
-    // compensating cleanup while OpenCode still commits the new session.
     final response = await _client.post(
-      Uri.parse("$serverURL/session"),
+      path: "/session",
       headers: {
-        ..._authHeaders,
         "content-type": "application/json",
         _directoryOpenCodeHeader: directory,
       },
       body: jsonEncode(body),
     );
-    _ensureSuccess(response, "POST /session");
     return Session.fromJson(jsonDecodeMap(response.body));
   }
 
@@ -188,18 +116,12 @@ class OpenCodeApi {
     required String sessionId,
     required String? directory,
   }) async {
-    final headers = <String, String>{
-      ..._authHeaders,
-      _directoryOpenCodeHeader: ?directory,
-    };
-    final response = await _readWithTimeout(
-      _client.get(
-        Uri.parse("$serverURL/session/$sessionId"),
-        headers: headers,
-      ),
-      "GET /session/$sessionId",
+    final response = await _client.get(
+      path: "/session/$sessionId",
+      headers: {
+        _directoryOpenCodeHeader: ?directory,
+      },
     );
-    _ensureSuccess(response, "GET /session/$sessionId");
     return Session.fromJson(jsonDecodeMap(response.body));
   }
 
@@ -208,17 +130,14 @@ class OpenCodeApi {
     required Map<String, dynamic> body,
     required String? directory,
   }) async {
-    // Not timed out: mutating request (see createSession).
     final response = await _client.patch(
-      Uri.parse("$serverURL/session/$sessionId"),
+      path: "/session/$sessionId",
       headers: {
-        ..._authHeaders,
         "content-type": "application/json",
         _directoryOpenCodeHeader: ?directory,
       },
       body: jsonEncode(body),
     );
-    _ensureSuccess(response, "PATCH /session/$sessionId");
     return Session.fromJson(jsonDecodeMap(response.body));
   }
 
@@ -229,17 +148,14 @@ class OpenCodeApi {
     required String directory,
     required Map<String, dynamic> body,
   }) async {
-    // Not timed out: mutating request (see createSession).
     final response = await _client.patch(
-      Uri.parse("$serverURL/project/$projectId"),
+      path: "/project/$projectId",
       headers: {
-        ..._authHeaders,
         "content-type": "application/json",
         _directoryOpenCodeHeader: directory,
       },
       body: jsonEncode(body),
     );
-    _ensureSuccess(response, "PATCH /project/$projectId");
     return Project.fromJson(jsonDecodeMap(response.body));
   }
 
@@ -247,16 +163,12 @@ class OpenCodeApi {
     required String sessionId,
     required String? directory,
   }) async {
-    final headers = <String, String>{
-      ..._authHeaders,
-      _directoryOpenCodeHeader: ?directory,
-    };
-    // Not timed out: mutating request (see createSession).
-    final response = await _client.delete(
-      Uri.parse("$serverURL/session/$sessionId"),
-      headers: headers,
+    await _client.delete(
+      path: "/session/$sessionId",
+      headers: {
+        _directoryOpenCodeHeader: ?directory,
+      },
     );
-    _ensureSuccess(response, "DELETE /session/$sessionId");
   }
 
   /// Removes a worktree (workspace) from OpenCode.
@@ -268,35 +180,26 @@ class OpenCodeApi {
     required String directory,
     required String worktreePath,
   }) async {
-    // Not timed out: mutating request (see createSession).
-    final response = await _client.delete(
-      Uri.parse("$serverURL/experimental/worktree"),
+    await _client.delete(
+      path: "/experimental/worktree",
       headers: {
-        ..._authHeaders,
         "content-type": "application/json",
         _directoryOpenCodeHeader: directory,
       },
       body: jsonEncode({"directory": worktreePath}),
     );
-    _ensureSuccess(response, "DELETE /experimental/worktree");
   }
 
   Future<List<Session>> getChildren({
     required String sessionId,
     required String? directory,
   }) async {
-    final headers = <String, String>{
-      ..._authHeaders,
-      _directoryOpenCodeHeader: ?directory, // probably irrelevant for this endpoint
-    };
-    final response = await _readWithTimeout(
-      _client.get(
-        Uri.parse("$serverURL/session/$sessionId/children"),
-        headers: headers,
-      ),
-      "GET /session/$sessionId/children",
+    final response = await _client.get(
+      path: "/session/$sessionId/children",
+      headers: {
+        _directoryOpenCodeHeader: ?directory, // probably irrelevant for this endpoint
+      },
     );
-    _ensureSuccess(response, "GET /session/$sessionId/children");
 
     final decoded = jsonDecodeListMap(response.body);
     return decoded.map(Session.fromJson).toList();
@@ -306,15 +209,12 @@ class OpenCodeApi {
     required String sessionId,
     required String directory,
   }) async {
-    // Not timed out: mutating request (see createSession).
     final response = await _client.post(
-      Uri.parse("$serverURL/session/$sessionId/fork"),
+      path: "/session/$sessionId/fork",
       headers: {
-        ..._authHeaders,
         _directoryOpenCodeHeader: directory,
       },
     );
-    _ensureSuccess(response, "POST /session/$sessionId/fork");
     return Session.fromJson(jsonDecodeMap(response.body));
   }
 
@@ -322,18 +222,12 @@ class OpenCodeApi {
     required String sessionId,
     required String? directory,
   }) async {
-    final headers = <String, String>{
-      ..._authHeaders,
-      _directoryOpenCodeHeader: ?directory, // probably irrelevant for this endpoint
-    };
-    final response = await _readWithTimeout(
-      _client.get(
-        Uri.parse("$serverURL/session/$sessionId/message"),
-        headers: headers,
-      ),
-      "GET /session/$sessionId/message",
+    final response = await _client.get(
+      path: "/session/$sessionId/message",
+      headers: {
+        _directoryOpenCodeHeader: ?directory, // probably irrelevant for this endpoint
+      },
     );
-    _ensureSuccess(response, "GET /session/$sessionId/message");
 
     final decoded = jsonDecodeListMap(response.body);
     return decoded.map(MessageWithParts.fromJson).toList();
@@ -346,19 +240,14 @@ class OpenCodeApi {
     // because otherwise it picks the CWD of where bridge is running
     required String? directory,
   }) async {
-    // Not timed out: non-idempotent write. A client-side timeout here would let
-    // OpenCodeService.createSession delete a session whose prompt OpenCode may
-    // still be committing (see createSession).
-    final response = await _client.post(
-      Uri.parse("$serverURL/session/$sessionId/prompt_async"),
+    await _client.post(
+      path: "/session/$sessionId/prompt_async",
       headers: {
-        ..._authHeaders,
         "content-type": "application/json",
         _directoryOpenCodeHeader: ?directory,
       },
       body: jsonEncode(body.toJson()),
     );
-    _ensureSuccess(response, "POST /session/$sessionId/prompt_async");
   }
 
   /// Sends a slash command to a session via `POST /session/:id/command`.
@@ -369,52 +258,51 @@ class OpenCodeApi {
   /// variant exists upstream (unlike prompts, which have `prompt_async`).
   /// Callers that must not block on the run (see [OpenCodeService]) are
   /// responsible for detaching; this Layer 1 method stays a dumb HTTP call.
+  ///
+  /// This is the one request sent with `timeout: null` (unbounded). A fixed
+  /// client-side timeout could not abort the synchronous run (`Future.timeout`
+  /// does not cancel the HTTP request) and would only surface as a spurious
+  /// post-dispatch failure. [OpenCodeService] already detaches after a
+  /// fast-fail window, and the orchestrator abandons in-flight routes on
+  /// shutdown, so an unbounded command never blocks teardown.
   Future<void> sendCommand({
     required String sessionId,
     required SendCommandBody body,
     required String? directory,
   }) async {
-    final response = await _client.post(
-      Uri.parse("$serverURL/session/$sessionId/command"),
+    await _client.post(
+      path: "/session/$sessionId/command",
       headers: {
-        ..._authHeaders,
         "content-type": "application/json",
         _directoryOpenCodeHeader: ?directory,
       },
       body: jsonEncode(body.toJson()),
+      timeout: null,
     );
-    _ensureSuccess(response, "POST /session/$sessionId/command");
   }
 
   Future<void> abortSession({
     required String sessionId,
     required String? directory,
   }) async {
-    final headers = <String, String>{
-      ..._authHeaders,
-      _directoryOpenCodeHeader: ?directory,
-    };
-    // Not timed out: mutating request (see createSession).
-    final response = await _client.post(
-      Uri.parse("$serverURL/session/$sessionId/abort"),
-      headers: headers,
+    await _client.post(
+      path: "/session/$sessionId/abort",
+      headers: {
+        _directoryOpenCodeHeader: ?directory,
+      },
       body: "",
     );
-    _ensureSuccess(response, "POST /session/$sessionId/abort");
   }
 
   Future<List<AgentInfo>> listAgents({required String directory}) async {
     // OpenCode resolves agents per project; newer releases reject requests
     // that carry no directory context with a 500.
-    final headers = <String, String>{
-      ..._authHeaders,
-      _directoryOpenCodeHeader: directory,
-    };
-    final response = await _readWithTimeout(
-      _client.get(Uri.parse("$serverURL/agent"), headers: headers),
-      "GET /agent",
+    final response = await _client.get(
+      path: "/agent",
+      headers: {
+        _directoryOpenCodeHeader: directory,
+      },
     );
-    _ensureSuccess(response, "GET /agent");
 
     final decoded = jsonDecodeListMap(response.body);
     return decoded.map(AgentInfo.fromJson).toList();
@@ -423,16 +311,13 @@ class OpenCodeApi {
   Future<List<PendingQuestion>> getPendingQuestions({
     required String? directory,
   }) async {
-    final headers = <String, String>{
-      ..._authHeaders,
-      _directoryOpenCodeHeader: ?directory,
-    };
-    final response = await _readWithTimeout(
-      _client.get(Uri.parse("$serverURL/question"), headers: headers),
-      "GET /question",
+    final response = await _client.get(
+      path: "/question",
+      headers: {
+        _directoryOpenCodeHeader: ?directory,
+      },
     );
     Log.v("[getPendingQuestions] response: ${response.body}");
-    _ensureSuccess(response, "GET /question");
 
     final decoded = jsonDecodeListMap(response.body);
     return decoded.map(PendingQuestion.fromJson).toList();
@@ -441,18 +326,13 @@ class OpenCodeApi {
   Future<List<PendingPermission>> getPendingPermissions({
     required String? directory,
   }) async {
-    final response = await _readWithTimeout(
-      _client.get(
-        Uri.parse("$serverURL/permission"),
-        headers: {
-          ..._authHeaders,
-          _directoryOpenCodeHeader: ?directory,
-        },
-      ),
-      "GET /permission",
+    final response = await _client.get(
+      path: "/permission",
+      headers: {
+        _directoryOpenCodeHeader: ?directory,
+      },
     );
     Log.v("[getPendingPermissions] response: ${response.body}");
-    _ensureSuccess(response, "GET /permission");
 
     final decoded = jsonDecodeListMap(response.body);
     return decoded.map(PendingPermission.fromJson).toList();
@@ -465,18 +345,15 @@ class OpenCodeApi {
   }) async {
     final encodedBody = jsonEncode(body);
     Log.d("[question-api] POST /question/$questionId/reply body=$encodedBody");
-    // Not timed out: mutating request (see createSession).
     final response = await _client.post(
-      Uri.parse("$serverURL/question/$questionId/reply"),
+      path: "/question/$questionId/reply",
       headers: {
-        ..._authHeaders,
         _directoryOpenCodeHeader: ?directory, // doesn't work well with the directory header
         "content-type": "application/json",
       },
       body: encodedBody,
     );
     Log.d("[question-api] POST /question/$questionId/reply => ${response.statusCode} body=${response.body}");
-    _ensureSuccess(response, "POST /question/$questionId/reply");
   }
 
   Future<void> replyToPermission({
@@ -486,18 +363,12 @@ class OpenCodeApi {
   }) async {
     final body = jsonEncode({"reply": reply.name});
     Log.d("[permission-api] POST /permission/$requestId/reply for session $sessionId");
-    // Not timed out: mutating request (see createSession).
-    final httpResponse = await _client.post(
-      Uri.parse("$serverURL/permission/$requestId/reply"),
+    await _client.post(
+      path: "/permission/$requestId/reply",
       headers: {
-        ..._authHeaders,
         "content-type": "application/json",
       },
       body: body,
-    );
-    _ensureSuccess(
-      httpResponse,
-      "POST /permission/$requestId/reply",
     );
   }
 
@@ -505,30 +376,22 @@ class OpenCodeApi {
     required String questionId,
   }) async {
     Log.d("[question-api] POST /question/$questionId/reject");
-    // Not timed out: mutating request (see createSession).
     final response = await _client.post(
-      Uri.parse("$serverURL/question/$questionId/reject"),
-      headers: _authHeaders,
+      path: "/question/$questionId/reject",
       body: "",
     );
     Log.d("[question-api] POST /question/$questionId/reject => ${response.statusCode} body=${response.body}");
-    _ensureSuccess(response, "POST /question/$questionId/reject");
   }
 
   Future<Project> getProject({
     required String directory,
   }) async {
-    final response = await _readWithTimeout(
-      _client.get(
-        Uri.parse("$serverURL/project/current"),
-        headers: {
-          ..._authHeaders,
-          _directoryOpenCodeHeader: directory,
-        },
-      ),
-      "GET /project/current",
+    final response = await _client.get(
+      path: "/project/current",
+      headers: {
+        _directoryOpenCodeHeader: directory,
+      },
     );
-    _ensureSuccess(response, "GET /project/current");
     return Project.fromJson(jsonDecodeMap(response.body));
   }
 
@@ -551,105 +414,47 @@ class OpenCodeApi {
     required String? directory,
     required bool roots,
   }) async {
-    final queryParams = <String, String>{
-      // unlike the other endpoints, this uses a query param for the directory
-      "directory": ?directory,
-      if (roots) "roots": "true",
-    };
-
-    final uri = Uri.parse(
-      "$serverURL/experimental/session",
-    ).replace(queryParameters: queryParams.isEmpty ? null : queryParams);
-    final response = await _readWithTimeout(
-      _client.get(uri, headers: _authHeaders),
-      "GET /experimental/session",
+    final response = await _client.get(
+      path: "/experimental/session",
+      queryParameters: {
+        // unlike the other endpoints, this uses a query param for the directory
+        "directory": ?directory,
+        if (roots) "roots": "true",
+      },
     );
-    _ensureSuccess(response, "GET /experimental/session");
 
     final decoded = jsonDecodeListMap(response.body);
     return decoded.map(GlobalSession.fromJson).toList();
   }
 
   Future<ProviderListResponse> listProviders() async {
-    final response = await _readWithTimeout(
-      _client.get(
-        Uri.parse("$serverURL/provider"),
-        headers: _authHeaders,
-      ),
-      "GET /provider",
-    );
-    _ensureSuccess(response, "GET /provider");
+    final response = await _client.get(path: "/provider");
     return ProviderListResponse.fromJson(jsonDecodeMap(response.body));
   }
 
   Future<ProviderListResponse> listConfigProviders({required String? directory}) async {
-    final headers = <String, String>{
-      ..._authHeaders,
-      _directoryOpenCodeHeader: ?directory,
-    };
-    final response = await _readWithTimeout(
-      _client.get(
-        Uri.parse("$serverURL/config/providers"),
-        headers: headers,
-      ),
-      "GET /config/providers",
+    final response = await _client.get(
+      path: "/config/providers",
+      headers: {
+        _directoryOpenCodeHeader: ?directory,
+      },
     );
-    _ensureSuccess(response, "GET /config/providers");
     return ProviderListResponse.fromJson(
       jsonDecodeMap(response.body),
     );
   }
 
   Future<Map<String, SessionStatus>> getSessionStatuses({required String? directory}) async {
-    final headers = <String, String>{
-      ..._authHeaders,
-      _directoryOpenCodeHeader: ?directory,
-    };
-
-    final response = await _readWithTimeout(
-      _client.get(
-        Uri.parse("$serverURL/session/status"),
-        headers: headers,
-      ),
-      "GET /session/status",
+    final response = await _client.get(
+      path: "/session/status",
+      headers: {
+        _directoryOpenCodeHeader: ?directory,
+      },
     );
-    _ensureSuccess(response, "GET /session/status");
 
     final decoded = jsonDecodeMap(response.body);
     return decoded.map(
       (key, value) => MapEntry(key, SessionStatus.fromJson(value as Map<String, dynamic>)),
     );
-  }
-
-  static void _ensureSuccess(http.Response response, String endpoint) {
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw OpenCodeApiException(endpoint, response.statusCode, responseBody: response.body);
-    }
-  }
-}
-
-class OpenCodeApiException implements Exception {
-  static const _maxBodyLength = 500;
-
-  final String endpoint;
-  final int statusCode;
-
-  /// Upstream response body, truncated to [_maxBodyLength] characters.
-  /// OpenCode error bodies carry the actual failure reason (e.g.
-  /// `{"name":"UnknownError","data":{...}}`), which is essential for
-  /// diagnosing failures from logs.
-  final String? responseBody;
-
-  OpenCodeApiException(this.endpoint, this.statusCode, {String? responseBody})
-    : responseBody = switch (responseBody) {
-        null => null,
-        final body when body.length > _maxBodyLength => "${body.substring(0, _maxBodyLength)}…",
-        final body => body,
-      };
-
-  @override
-  String toString() {
-    final bodySuffix = responseBody == null || responseBody!.isEmpty ? "" : " body=$responseBody";
-    return "OpenCodeApiException: $endpoint failed with status $statusCode$bodySuffix";
   }
 }

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -20,11 +20,20 @@ import "models/session_status.dart";
 const _directoryOpenCodeHeader = "x-opencode-directory";
 
 /// Soft deadline for read-only OpenCode REST calls.
+///
+/// Only GET reads are timed out. Reads are idempotent, so abandoning a slow
+/// one is safe. Mutating requests are deliberately NOT timed out:
+/// `Future.timeout` does not abort the underlying HTTP request, so a
+/// client-side timeout on a non-idempotent write (e.g. createSession's prompt)
+/// could trigger compensating cleanup while OpenCode still commits the
+/// mutation server-side.
 const _readTimeout = Duration(seconds: 30);
 
-/// Soft deadline for mutating OpenCode REST calls (create, update, delete,
-/// prompts). Longer than reads because some endpoints perform local work.
-const _writeTimeout = Duration(seconds: 60);
+/// HTTP status reported when a read times out. 504 (Gateway Timeout) is the
+/// honest code: the bridge is a gateway and the upstream (OpenCode) did not
+/// respond in time. Using a real status lets phone-side error handling
+/// classify it like any other upstream failure.
+const _readTimeoutStatus = 504;
 
 class OpenCodeApi {
   final String serverURL;
@@ -44,21 +53,20 @@ class OpenCodeApi {
     return {"Authorization": "Basic $creds"};
   }
 
-  /// Runs [request] with [timeout], converting a [TimeoutException] into an
-  /// [OpenCodeApiException] so callers treat a hung localhost request as a
-  /// transport failure.
-  Future<http.Response> _withTimeout(
+  /// Runs a read [request] with [_readTimeout], converting a [TimeoutException]
+  /// into an [OpenCodeApiException] with a 504 status so callers treat a hung
+  /// localhost read as an upstream gateway timeout.
+  Future<http.Response> _readWithTimeout(
     Future<http.Response> request,
     String endpoint,
-    Duration timeout,
   ) async {
     try {
-      return await request.timeout(timeout);
+      return await request.timeout(_readTimeout);
     } on TimeoutException {
       throw OpenCodeApiException(
         endpoint,
-        0,
-        responseBody: "request timed out after ${timeout.inSeconds}s",
+        _readTimeoutStatus,
+        responseBody: "request timed out after ${_readTimeout.inSeconds}s",
       );
     }
   }
@@ -75,13 +83,12 @@ class OpenCodeApi {
   }
 
   Future<List<Project>> listProjects() async {
-    final response = await _withTimeout(
+    final response = await _readWithTimeout(
       _client.get(
         Uri.parse("$serverURL/project"),
         headers: _authHeaders,
       ),
       "GET /project",
-      _readTimeout,
     );
     _ensureSuccess(response, "GET /project");
 
@@ -90,13 +97,12 @@ class OpenCodeApi {
   }
 
   Future<List<Session>> listRootSessions() async {
-    final response = await _withTimeout(
+    final response = await _readWithTimeout(
       _client.get(
         Uri.parse("$serverURL/session?roots=true"),
         headers: _authHeaders,
       ),
       "GET /session?roots=true",
-      _readTimeout,
     );
     _ensureSuccess(response, "GET /session?roots=true");
 
@@ -114,7 +120,7 @@ class OpenCodeApi {
       if (roots) "roots": "true",
     };
 
-    final response = await _withTimeout(
+    final response = await _readWithTimeout(
       _client.get(
         Uri.parse("$serverURL/session").replace(
           queryParameters: queryParams.isEmpty ? null : queryParams,
@@ -122,7 +128,6 @@ class OpenCodeApi {
         headers: headers,
       ),
       "GET /session",
-      _readTimeout,
     );
     _ensureSuccess(response, "GET /session");
 
@@ -135,13 +140,12 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory,
     };
-    final response = await _withTimeout(
+    final response = await _readWithTimeout(
       _client.get(
         Uri.parse("$serverURL/command"),
         headers: headers,
       ),
       "GET /command",
-      _readTimeout,
     );
     _ensureSuccess(response, "GET /command");
 
@@ -164,18 +168,17 @@ class OpenCodeApi {
     if (parentSessionId case final id?) {
       body["parentID"] = id;
     }
-    final response = await _withTimeout(
-      _client.post(
-        Uri.parse("$serverURL/session"),
-        headers: {
-          ..._authHeaders,
-          "content-type": "application/json",
-          _directoryOpenCodeHeader: directory,
-        },
-        body: jsonEncode(body),
-      ),
-      "POST /session",
-      _writeTimeout,
+    // Not timed out: createSession is non-idempotent. Future.timeout would not
+    // abort the underlying HTTP request, so a client-side timeout could trigger
+    // compensating cleanup while OpenCode still commits the new session.
+    final response = await _client.post(
+      Uri.parse("$serverURL/session"),
+      headers: {
+        ..._authHeaders,
+        "content-type": "application/json",
+        _directoryOpenCodeHeader: directory,
+      },
+      body: jsonEncode(body),
     );
     _ensureSuccess(response, "POST /session");
     return Session.fromJson(jsonDecodeMap(response.body));
@@ -189,13 +192,12 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory,
     };
-    final response = await _withTimeout(
+    final response = await _readWithTimeout(
       _client.get(
         Uri.parse("$serverURL/session/$sessionId"),
         headers: headers,
       ),
       "GET /session/$sessionId",
-      _readTimeout,
     );
     _ensureSuccess(response, "GET /session/$sessionId");
     return Session.fromJson(jsonDecodeMap(response.body));
@@ -206,18 +208,15 @@ class OpenCodeApi {
     required Map<String, dynamic> body,
     required String? directory,
   }) async {
-    final response = await _withTimeout(
-      _client.patch(
-        Uri.parse("$serverURL/session/$sessionId"),
-        headers: {
-          ..._authHeaders,
-          "content-type": "application/json",
-          _directoryOpenCodeHeader: ?directory,
-        },
-        body: jsonEncode(body),
-      ),
-      "PATCH /session/$sessionId",
-      _writeTimeout,
+    // Not timed out: mutating request (see createSession).
+    final response = await _client.patch(
+      Uri.parse("$serverURL/session/$sessionId"),
+      headers: {
+        ..._authHeaders,
+        "content-type": "application/json",
+        _directoryOpenCodeHeader: ?directory,
+      },
+      body: jsonEncode(body),
     );
     _ensureSuccess(response, "PATCH /session/$sessionId");
     return Session.fromJson(jsonDecodeMap(response.body));
@@ -230,18 +229,15 @@ class OpenCodeApi {
     required String directory,
     required Map<String, dynamic> body,
   }) async {
-    final response = await _withTimeout(
-      _client.patch(
-        Uri.parse("$serverURL/project/$projectId"),
-        headers: {
-          ..._authHeaders,
-          "content-type": "application/json",
-          _directoryOpenCodeHeader: directory,
-        },
-        body: jsonEncode(body),
-      ),
-      "PATCH /project/$projectId",
-      _writeTimeout,
+    // Not timed out: mutating request (see createSession).
+    final response = await _client.patch(
+      Uri.parse("$serverURL/project/$projectId"),
+      headers: {
+        ..._authHeaders,
+        "content-type": "application/json",
+        _directoryOpenCodeHeader: directory,
+      },
+      body: jsonEncode(body),
     );
     _ensureSuccess(response, "PATCH /project/$projectId");
     return Project.fromJson(jsonDecodeMap(response.body));
@@ -255,13 +251,10 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory,
     };
-    final response = await _withTimeout(
-      _client.delete(
-        Uri.parse("$serverURL/session/$sessionId"),
-        headers: headers,
-      ),
-      "DELETE /session/$sessionId",
-      _writeTimeout,
+    // Not timed out: mutating request (see createSession).
+    final response = await _client.delete(
+      Uri.parse("$serverURL/session/$sessionId"),
+      headers: headers,
     );
     _ensureSuccess(response, "DELETE /session/$sessionId");
   }
@@ -275,18 +268,15 @@ class OpenCodeApi {
     required String directory,
     required String worktreePath,
   }) async {
-    final response = await _withTimeout(
-      _client.delete(
-        Uri.parse("$serverURL/experimental/worktree"),
-        headers: {
-          ..._authHeaders,
-          "content-type": "application/json",
-          _directoryOpenCodeHeader: directory,
-        },
-        body: jsonEncode({"directory": worktreePath}),
-      ),
-      "DELETE /experimental/worktree",
-      _writeTimeout,
+    // Not timed out: mutating request (see createSession).
+    final response = await _client.delete(
+      Uri.parse("$serverURL/experimental/worktree"),
+      headers: {
+        ..._authHeaders,
+        "content-type": "application/json",
+        _directoryOpenCodeHeader: directory,
+      },
+      body: jsonEncode({"directory": worktreePath}),
     );
     _ensureSuccess(response, "DELETE /experimental/worktree");
   }
@@ -299,13 +289,12 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory, // probably irrelevant for this endpoint
     };
-    final response = await _withTimeout(
+    final response = await _readWithTimeout(
       _client.get(
         Uri.parse("$serverURL/session/$sessionId/children"),
         headers: headers,
       ),
       "GET /session/$sessionId/children",
-      _readTimeout,
     );
     _ensureSuccess(response, "GET /session/$sessionId/children");
 
@@ -317,16 +306,13 @@ class OpenCodeApi {
     required String sessionId,
     required String directory,
   }) async {
-    final response = await _withTimeout(
-      _client.post(
-        Uri.parse("$serverURL/session/$sessionId/fork"),
-        headers: {
-          ..._authHeaders,
-          _directoryOpenCodeHeader: directory,
-        },
-      ),
-      "POST /session/$sessionId/fork",
-      _writeTimeout,
+    // Not timed out: mutating request (see createSession).
+    final response = await _client.post(
+      Uri.parse("$serverURL/session/$sessionId/fork"),
+      headers: {
+        ..._authHeaders,
+        _directoryOpenCodeHeader: directory,
+      },
     );
     _ensureSuccess(response, "POST /session/$sessionId/fork");
     return Session.fromJson(jsonDecodeMap(response.body));
@@ -340,13 +326,12 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory, // probably irrelevant for this endpoint
     };
-    final response = await _withTimeout(
+    final response = await _readWithTimeout(
       _client.get(
         Uri.parse("$serverURL/session/$sessionId/message"),
         headers: headers,
       ),
       "GET /session/$sessionId/message",
-      _readTimeout,
     );
     _ensureSuccess(response, "GET /session/$sessionId/message");
 
@@ -361,18 +346,17 @@ class OpenCodeApi {
     // because otherwise it picks the CWD of where bridge is running
     required String? directory,
   }) async {
-    final response = await _withTimeout(
-      _client.post(
-        Uri.parse("$serverURL/session/$sessionId/prompt_async"),
-        headers: {
-          ..._authHeaders,
-          "content-type": "application/json",
-          _directoryOpenCodeHeader: ?directory,
-        },
-        body: jsonEncode(body.toJson()),
-      ),
-      "POST /session/$sessionId/prompt_async",
-      _writeTimeout,
+    // Not timed out: non-idempotent write. A client-side timeout here would let
+    // OpenCodeService.createSession delete a session whose prompt OpenCode may
+    // still be committing (see createSession).
+    final response = await _client.post(
+      Uri.parse("$serverURL/session/$sessionId/prompt_async"),
+      headers: {
+        ..._authHeaders,
+        "content-type": "application/json",
+        _directoryOpenCodeHeader: ?directory,
+      },
+      body: jsonEncode(body.toJson()),
     );
     _ensureSuccess(response, "POST /session/$sessionId/prompt_async");
   }
@@ -410,14 +394,11 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory,
     };
-    final response = await _withTimeout(
-      _client.post(
-        Uri.parse("$serverURL/session/$sessionId/abort"),
-        headers: headers,
-        body: "",
-      ),
-      "POST /session/$sessionId/abort",
-      _writeTimeout,
+    // Not timed out: mutating request (see createSession).
+    final response = await _client.post(
+      Uri.parse("$serverURL/session/$sessionId/abort"),
+      headers: headers,
+      body: "",
     );
     _ensureSuccess(response, "POST /session/$sessionId/abort");
   }
@@ -429,10 +410,9 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: directory,
     };
-    final response = await _withTimeout(
+    final response = await _readWithTimeout(
       _client.get(Uri.parse("$serverURL/agent"), headers: headers),
       "GET /agent",
-      _readTimeout,
     );
     _ensureSuccess(response, "GET /agent");
 
@@ -447,10 +427,9 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory,
     };
-    final response = await _withTimeout(
+    final response = await _readWithTimeout(
       _client.get(Uri.parse("$serverURL/question"), headers: headers),
       "GET /question",
-      _readTimeout,
     );
     Log.v("[getPendingQuestions] response: ${response.body}");
     _ensureSuccess(response, "GET /question");
@@ -462,7 +441,7 @@ class OpenCodeApi {
   Future<List<PendingPermission>> getPendingPermissions({
     required String? directory,
   }) async {
-    final response = await _withTimeout(
+    final response = await _readWithTimeout(
       _client.get(
         Uri.parse("$serverURL/permission"),
         headers: {
@@ -471,7 +450,6 @@ class OpenCodeApi {
         },
       ),
       "GET /permission",
-      _readTimeout,
     );
     Log.v("[getPendingPermissions] response: ${response.body}");
     _ensureSuccess(response, "GET /permission");
@@ -487,18 +465,15 @@ class OpenCodeApi {
   }) async {
     final encodedBody = jsonEncode(body);
     Log.d("[question-api] POST /question/$questionId/reply body=$encodedBody");
-    final response = await _withTimeout(
-      _client.post(
-        Uri.parse("$serverURL/question/$questionId/reply"),
-        headers: {
-          ..._authHeaders,
-          _directoryOpenCodeHeader: ?directory, // doesn't work well with the directory header
-          "content-type": "application/json",
-        },
-        body: encodedBody,
-      ),
-      "POST /question/$questionId/reply",
-      _writeTimeout,
+    // Not timed out: mutating request (see createSession).
+    final response = await _client.post(
+      Uri.parse("$serverURL/question/$questionId/reply"),
+      headers: {
+        ..._authHeaders,
+        _directoryOpenCodeHeader: ?directory, // doesn't work well with the directory header
+        "content-type": "application/json",
+      },
+      body: encodedBody,
     );
     Log.d("[question-api] POST /question/$questionId/reply => ${response.statusCode} body=${response.body}");
     _ensureSuccess(response, "POST /question/$questionId/reply");
@@ -511,17 +486,14 @@ class OpenCodeApi {
   }) async {
     final body = jsonEncode({"reply": reply.name});
     Log.d("[permission-api] POST /permission/$requestId/reply for session $sessionId");
-    final httpResponse = await _withTimeout(
-      _client.post(
-        Uri.parse("$serverURL/permission/$requestId/reply"),
-        headers: {
-          ..._authHeaders,
-          "content-type": "application/json",
-        },
-        body: body,
-      ),
-      "POST /permission/$requestId/reply",
-      _writeTimeout,
+    // Not timed out: mutating request (see createSession).
+    final httpResponse = await _client.post(
+      Uri.parse("$serverURL/permission/$requestId/reply"),
+      headers: {
+        ..._authHeaders,
+        "content-type": "application/json",
+      },
+      body: body,
     );
     _ensureSuccess(
       httpResponse,
@@ -533,14 +505,11 @@ class OpenCodeApi {
     required String questionId,
   }) async {
     Log.d("[question-api] POST /question/$questionId/reject");
-    final response = await _withTimeout(
-      _client.post(
-        Uri.parse("$serverURL/question/$questionId/reject"),
-        headers: _authHeaders,
-        body: "",
-      ),
-      "POST /question/$questionId/reject",
-      _writeTimeout,
+    // Not timed out: mutating request (see createSession).
+    final response = await _client.post(
+      Uri.parse("$serverURL/question/$questionId/reject"),
+      headers: _authHeaders,
+      body: "",
     );
     Log.d("[question-api] POST /question/$questionId/reject => ${response.statusCode} body=${response.body}");
     _ensureSuccess(response, "POST /question/$questionId/reject");
@@ -549,7 +518,7 @@ class OpenCodeApi {
   Future<Project> getProject({
     required String directory,
   }) async {
-    final response = await _withTimeout(
+    final response = await _readWithTimeout(
       _client.get(
         Uri.parse("$serverURL/project/current"),
         headers: {
@@ -558,7 +527,6 @@ class OpenCodeApi {
         },
       ),
       "GET /project/current",
-      _readTimeout,
     );
     _ensureSuccess(response, "GET /project/current");
     return Project.fromJson(jsonDecodeMap(response.body));
@@ -592,10 +560,9 @@ class OpenCodeApi {
     final uri = Uri.parse(
       "$serverURL/experimental/session",
     ).replace(queryParameters: queryParams.isEmpty ? null : queryParams);
-    final response = await _withTimeout(
+    final response = await _readWithTimeout(
       _client.get(uri, headers: _authHeaders),
       "GET /experimental/session",
-      _readTimeout,
     );
     _ensureSuccess(response, "GET /experimental/session");
 
@@ -604,13 +571,12 @@ class OpenCodeApi {
   }
 
   Future<ProviderListResponse> listProviders() async {
-    final response = await _withTimeout(
+    final response = await _readWithTimeout(
       _client.get(
         Uri.parse("$serverURL/provider"),
         headers: _authHeaders,
       ),
       "GET /provider",
-      _readTimeout,
     );
     _ensureSuccess(response, "GET /provider");
     return ProviderListResponse.fromJson(jsonDecodeMap(response.body));
@@ -621,13 +587,12 @@ class OpenCodeApi {
       ..._authHeaders,
       _directoryOpenCodeHeader: ?directory,
     };
-    final response = await _withTimeout(
+    final response = await _readWithTimeout(
       _client.get(
         Uri.parse("$serverURL/config/providers"),
         headers: headers,
       ),
       "GET /config/providers",
-      _readTimeout,
     );
     _ensureSuccess(response, "GET /config/providers");
     return ProviderListResponse.fromJson(
@@ -641,13 +606,12 @@ class OpenCodeApi {
       _directoryOpenCodeHeader: ?directory,
     };
 
-    final response = await _withTimeout(
+    final response = await _readWithTimeout(
       _client.get(
         Uri.parse("$serverURL/session/status"),
         headers: headers,
       ),
       "GET /session/status",
-      _readTimeout,
     );
     _ensureSuccess(response, "GET /session/status");
 

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -260,12 +260,14 @@ class OpenCodeApi {
   /// Callers that must not block on the run (see [OpenCodeService]) are
   /// responsible for detaching; this Layer 1 method stays a dumb HTTP call.
   ///
-  /// This is the one request sent with `timeout: null` (unbounded). A fixed
-  /// client-side timeout could not abort the synchronous run (`Future.timeout`
-  /// does not cancel the HTTP request) and would only surface as a spurious
-  /// post-dispatch failure. [OpenCodeService] already detaches after a
-  /// fast-fail window, and the orchestrator abandons in-flight routes on
-  /// shutdown, so an unbounded command never blocks teardown.
+  /// Passed `timeout: null` explicitly. Writes already default to no timeout
+  /// (`Future.timeout` cannot abort the underlying request, so a client-side
+  /// deadline on this synchronous, minutes-long run would only surface a
+  /// spurious post-dispatch failure), but stating it at the call site keeps
+  /// that intent obvious for an endpoint where an accidental timeout would be
+  /// especially harmful. [OpenCodeService] already detaches after a fast-fail
+  /// window, and the orchestrator abandons in-flight routes on shutdown, so an
+  /// unbounded command never blocks teardown.
   Future<void> sendCommand({
     required String sessionId,
     required SendCommandBody body,

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -162,10 +162,18 @@ class OpenCodePlugin implements OpenCodeManagedApi {
 
   @override
   Future<void> dispose() async {
+    if (_disposed) {
+      Log.v("[shutdown] OpenCodePlugin.dispose: already disposed, skipping");
+      return;
+    }
     _disposed = true;
+    Log.v("[shutdown] OpenCodePlugin.dispose: stopping SSE connection");
     _sseConnection.stop();
+    Log.v("[shutdown] OpenCodePlugin.dispose: force-closing http client");
     _httpClient.close(force: true);
+    final sw = Stopwatch()..start();
     await _eventBuffer.close();
+    Log.d("[shutdown] OpenCodePlugin.dispose: event buffer closed in ${sw.elapsedMilliseconds}ms");
   }
 
   @override

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -53,9 +53,11 @@ class OpenCodePlugin implements OpenCodeManagedApi {
   }) {
     final httpClient = io.HttpClient();
     final api = OpenCodeApi(
-      serverURL: serverUrl,
-      password: password,
-      client: IOClient(httpClient),
+      client: OpenCodeRawHttpClient(
+        serverURL: serverUrl,
+        password: password,
+        client: IOClient(httpClient),
+      ),
     );
     final repository = OpenCodeRepository(api);
     final tracker = ActiveSessionTracker(repository);

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -205,9 +205,13 @@ class OpenCodeService {
   }
 
   Future<void> coldStart() async {
+    final trackerSw = Stopwatch()..start();
     await tracker.coldStart();
+    Log.v("[coldStart] tracker.coldStart finished in ${trackerSw.elapsedMilliseconds}ms");
     try {
+      final hydrateSw = Stopwatch()..start();
       await _hydratePendingInput();
+      Log.v("[coldStart] hydratePendingInput finished in ${hydrateSw.elapsedMilliseconds}ms");
     } catch (e, st) {
       Log.w("coldStart: failed to hydrate pending input: $e\n$st");
     }

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_bridge_plugin.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_bridge_plugin.dart
@@ -161,6 +161,8 @@ class OpenCodeBridgePlugin implements BridgePlugin {
   Future<void> shutdown({required Duration? budget}) => _shutdown ??= _shutdownNow();
 
   Future<void> _shutdownNow() async {
+    final sw = Stopwatch()..start();
+    Log.d("[shutdown] OpenCode plugin stop begin (mode=${_ownedRecord == null ? "attached" : "managed"})");
     _reporter.dispose();
     if (!_status.isClosed && _status.current is! PluginStopped) {
       _status.trySet(const PluginStopping());
@@ -179,6 +181,7 @@ class OpenCodeBridgePlugin implements BridgePlugin {
         // Disarm before signaling the child so its deliberate exit is not
         // mistaken for a crash (no spurious restart / PluginFailed).
         await _monitor.disarm();
+        Log.v("[shutdown] OpenCode monitor disarmed (+${sw.elapsedMilliseconds}ms)");
       } on Object catch (error, stackTrace) {
         Log.e("[opencode] monitor disarm failed: $error");
         primaryError = error;
@@ -187,6 +190,7 @@ class OpenCodeBridgePlugin implements BridgePlugin {
 
       try {
         await api.dispose();
+        Log.v("[shutdown] OpenCode api disposed (+${sw.elapsedMilliseconds}ms)");
       } on Object catch (error, stackTrace) {
         primaryError ??= error;
         primaryStackTrace ??= stackTrace;
@@ -200,11 +204,14 @@ class OpenCodeBridgePlugin implements BridgePlugin {
       if (record != null) {
         try {
           await _service.stopOwnedRuntime(record: record);
+          Log.v("[shutdown] OpenCode owned runtime stopped (+${sw.elapsedMilliseconds}ms)");
         } on Object catch (error, stackTrace) {
           Log.e("[opencode] stop owned runtime failed: $error");
           primaryError ??= error;
           primaryStackTrace ??= stackTrace;
         }
+      } else {
+        Log.v("[shutdown] OpenCode has no owned runtime to stop (attach mode)");
       }
 
       if (primaryError != null) {
@@ -214,6 +221,7 @@ class OpenCodeBridgePlugin implements BridgePlugin {
       if (!_status.isClosed) {
         _status.trySet(const PluginStopped());
       }
+      Log.d("[shutdown] OpenCode plugin stop complete (${sw.elapsedMilliseconds}ms total)");
     }
   }
 }

--- a/bridge/sesori_plugin_opencode/lib/src/sse/sse_connection.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse/sse_connection.dart
@@ -76,10 +76,10 @@ class SseConnection {
         // every reconnect (the lifecycle status follows the live stream).
         _onConnected?.call();
 
-        if (!isFirstConnect) {
+        if (!isFirstConnect && _onReconnect != null) {
           final reconnectSw = Stopwatch()..start();
           Log.v("[sse-conn] reconnect: running onReconnect cold-start");
-          await _onReconnect?.call();
+          await _onReconnect();
           if (!_active || _generation != generation) {
             Log.v("[sse-conn] reconnect: shutdown requested during onReconnect, dropping");
             return;

--- a/bridge/sesori_plugin_opencode/lib/src/sse/sse_connection.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse/sse_connection.dart
@@ -38,6 +38,7 @@ class SseConnection {
   }
 
   void stop() {
+    Log.v("[shutdown] SseConnection.stop: active=$_active -> false, closing current client");
     _active = false;
     _generation++;
     _currentClient?.close();
@@ -76,7 +77,14 @@ class SseConnection {
         _onConnected?.call();
 
         if (!isFirstConnect) {
+          final reconnectSw = Stopwatch()..start();
+          Log.v("[sse-conn] reconnect: running onReconnect cold-start");
           await _onReconnect?.call();
+          if (!_active || _generation != generation) {
+            Log.v("[sse-conn] reconnect: shutdown requested during onReconnect, dropping");
+            return;
+          }
+          Log.v("[sse-conn] reconnect: onReconnect cold-start finished in ${reconnectSw.elapsedMilliseconds}ms");
         }
         isFirstConnect = false;
         reconnectDelay = const Duration(seconds: 1);

--- a/bridge/sesori_plugin_opencode/pubspec.yaml
+++ b/bridge/sesori_plugin_opencode/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: any
+  fake_async: ^1.3.3
   freezed: ^3.2.5
   json_serializable: ^6.14.0
   test: ^1.25.0

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -1096,9 +1096,6 @@ class _FakeApi implements OpenCodeApi {
        _statuses = statuses ?? {};
 
   @override
-  String get serverURL => "http://fake";
-
-  @override
   Future<bool> healthCheck() async => true;
 
   @override

--- a/bridge/sesori_plugin_opencode/test/open_code_raw_http_client_test.dart
+++ b/bridge/sesori_plugin_opencode/test/open_code_raw_http_client_test.dart
@@ -1,5 +1,6 @@
 import "dart:convert";
 
+import "package:fake_async/fake_async.dart";
 import "package:http/http.dart" as http;
 import "package:http/testing.dart";
 import "package:opencode_plugin/opencode_plugin.dart";
@@ -134,6 +135,75 @@ void main() {
       );
 
       expect(response.body, equals("done"));
+    });
+
+    test("applies the default 30s timeout to idempotent GET reads", () {
+      fakeAsync((async) {
+        final mockClient = MockClient((request) async {
+          await Future<void>.delayed(const Duration(minutes: 5));
+          return http.Response("late", 200);
+        });
+
+        final client = OpenCodeRawHttpClient(
+          serverURL: "http://localhost:1234",
+          password: null,
+          client: mockClient,
+        );
+
+        Object? error;
+        () async {
+          try {
+            await client.get(path: "/session");
+          } catch (e) {
+            error = e;
+          }
+        }();
+
+        // A read with no explicit timeout must abort at the 30s default.
+        async.elapse(const Duration(seconds: 31));
+
+        expect(error, isA<OpenCodeApiException>());
+        expect((error! as OpenCodeApiException).statusCode, equals(504));
+      });
+    });
+
+    test("imposes no default timeout on non-idempotent writes", () {
+      // Guards the regression the PR fixes: a POST/PATCH/DELETE that inherits
+      // the read timeout would surface a false 504 while OpenCode still commits
+      // the mutation. Writes must wait for the real response instead.
+      fakeAsync((async) {
+        final mockClient = MockClient((request) async {
+          await Future<void>.delayed(const Duration(minutes: 5));
+          return http.Response("done", 200);
+        });
+
+        final client = OpenCodeRawHttpClient(
+          serverURL: "http://localhost:1234",
+          password: null,
+          client: mockClient,
+        );
+
+        Object? error;
+        http.Response? response;
+        () async {
+          try {
+            response = await client.post(path: "/session", body: "x");
+          } catch (e) {
+            error = e;
+          }
+        }();
+
+        // Well past the 30s read deadline: the write must NOT have timed out.
+        async.elapse(const Duration(seconds: 31));
+        expect(error, isNull);
+        expect(response, isNull);
+
+        // It still completes once OpenCode eventually responds.
+        async.elapse(const Duration(minutes: 5));
+        async.flushMicrotasks();
+        expect(error, isNull);
+        expect(response?.body, equals("done"));
+      });
     });
   });
 }

--- a/bridge/sesori_plugin_opencode/test/open_code_raw_http_client_test.dart
+++ b/bridge/sesori_plugin_opencode/test/open_code_raw_http_client_test.dart
@@ -1,0 +1,139 @@
+import "dart:convert";
+
+import "package:http/http.dart" as http;
+import "package:http/testing.dart";
+import "package:opencode_plugin/opencode_plugin.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("OpenCodeRawHttpClient", () {
+    test("builds the URL with query params and merges Basic auth + caller headers", () async {
+      late http.BaseRequest captured;
+      final mockClient = MockClient((request) async {
+        captured = request;
+        return http.Response("[]", 200);
+      });
+
+      final client = OpenCodeRawHttpClient(
+        serverURL: "http://localhost:1234",
+        password: "pw",
+        client: mockClient,
+      );
+
+      await client.get(
+        path: "/session",
+        queryParameters: const {"roots": "true"},
+        headers: const {"x-opencode-directory": "/repo"},
+      );
+
+      expect(captured.method, equals("GET"));
+      expect(captured.url.toString(), equals("http://localhost:1234/session?roots=true"));
+      expect(
+        captured.headers["authorization"],
+        equals("Basic ${base64.encode(utf8.encode("opencode:pw"))}"),
+      );
+      expect(captured.headers["x-opencode-directory"], equals("/repo"));
+    });
+
+    test("omits the auth header when no password is configured", () async {
+      late http.BaseRequest captured;
+      final mockClient = MockClient((request) async {
+        captured = request;
+        return http.Response("{}", 200);
+      });
+
+      final client = OpenCodeRawHttpClient(
+        serverURL: "http://localhost:1234",
+        password: null,
+        client: mockClient,
+      );
+
+      await client.get(path: "/project");
+
+      expect(captured.headers.containsKey("authorization"), isFalse);
+    });
+
+    test("forwards the body on POST", () async {
+      late String capturedBody;
+      final mockClient = MockClient((request) async {
+        capturedBody = request.body;
+        return http.Response("true", 200);
+      });
+
+      final client = OpenCodeRawHttpClient(
+        serverURL: "http://localhost:1234",
+        password: null,
+        client: mockClient,
+      );
+
+      await client.post(path: "/session/s1/command", body: '{"command":"/x"}');
+
+      expect(capturedBody, equals('{"command":"/x"}'));
+    });
+
+    test("throws OpenCodeApiException carrying the upstream status, body, and endpoint label", () async {
+      final mockClient = MockClient((request) async {
+        return http.Response('{"name":"UnknownError"}', 500);
+      });
+
+      final client = OpenCodeRawHttpClient(
+        serverURL: "http://localhost:1234",
+        password: null,
+        client: mockClient,
+      );
+
+      await expectLater(
+        client.get(path: "/agent"),
+        throwsA(
+          isA<OpenCodeApiException>()
+              .having((e) => e.statusCode, "statusCode", 500)
+              .having((e) => e.responseBody, "responseBody", contains("UnknownError"))
+              .having((e) => e.endpoint, "endpoint", "GET /agent"),
+        ),
+      );
+    });
+
+    test("maps a timeout to OpenCodeApiException with status 504", () async {
+      final mockClient = MockClient((request) async {
+        await Future<void>.delayed(const Duration(milliseconds: 80));
+        return http.Response("late", 200);
+      });
+
+      final client = OpenCodeRawHttpClient(
+        serverURL: "http://localhost:1234",
+        password: null,
+        client: mockClient,
+      );
+
+      await expectLater(
+        client.get(path: "/session", timeout: const Duration(milliseconds: 10)),
+        throwsA(
+          isA<OpenCodeApiException>()
+              .having((e) => e.statusCode, "statusCode", 504)
+              .having((e) => e.endpoint, "endpoint", "GET /session"),
+        ),
+      );
+    });
+
+    test("a null timeout lets a slow request complete", () async {
+      final mockClient = MockClient((request) async {
+        await Future<void>.delayed(const Duration(milliseconds: 40));
+        return http.Response("done", 200);
+      });
+
+      final client = OpenCodeRawHttpClient(
+        serverURL: "http://localhost:1234",
+        password: null,
+        client: mockClient,
+      );
+
+      final response = await client.post(
+        path: "/session/s1/command",
+        body: "x",
+        timeout: null,
+      );
+
+      expect(response.body, equals("done"));
+    });
+  });
+}

--- a/bridge/sesori_plugin_opencode/test/opencode_api_http_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_api_http_test.dart
@@ -39,9 +39,11 @@ void main() {
       });
 
       final api = OpenCodeApi(
-        serverURL: "http://localhost:1234",
-        password: "test-pass",
-        client: mockClient,
+        client: OpenCodeRawHttpClient(
+          serverURL: "http://localhost:1234",
+          password: "test-pass",
+          client: mockClient,
+        ),
       );
 
       final response = await api.listConfigProviders(directory: "/repo");
@@ -73,9 +75,11 @@ void main() {
       });
 
       final api = OpenCodeApi(
-        serverURL: "http://localhost:1234",
-        password: "test-pass",
-        client: mockClient,
+        client: OpenCodeRawHttpClient(
+          serverURL: "http://localhost:1234",
+          password: "test-pass",
+          client: mockClient,
+        ),
       );
 
       final agents = await api.listAgents(directory: "/repo");
@@ -92,9 +96,11 @@ void main() {
       });
 
       final api = OpenCodeApi(
-        serverURL: "http://localhost:1234",
-        password: "test-pass",
-        client: mockClient,
+        client: OpenCodeRawHttpClient(
+          serverURL: "http://localhost:1234",
+          password: "test-pass",
+          client: mockClient,
+        ),
       );
 
       await expectLater(
@@ -122,9 +128,11 @@ void main() {
       });
 
       final api = OpenCodeApi(
-        serverURL: "http://localhost:1234",
-        password: "test-pass",
-        client: mockClient,
+        client: OpenCodeRawHttpClient(
+          serverURL: "http://localhost:1234",
+          password: "test-pass",
+          client: mockClient,
+        ),
       );
 
       await api.sendCommand(
@@ -196,9 +204,11 @@ void main() {
       });
 
       final api = OpenCodeApi(
-        serverURL: "http://localhost:1234",
-        password: "test-pass",
-        client: mockClient,
+        client: OpenCodeRawHttpClient(
+          serverURL: "http://localhost:1234",
+          password: "test-pass",
+          client: mockClient,
+        ),
       );
 
       await api.replyToPermission(
@@ -223,9 +233,11 @@ void main() {
       });
 
       final api = OpenCodeApi(
-        serverURL: "http://localhost:1234",
-        password: "test-pass",
-        client: mockClient,
+        client: OpenCodeRawHttpClient(
+          serverURL: "http://localhost:1234",
+          password: "test-pass",
+          client: mockClient,
+        ),
       );
 
       expect(

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -548,9 +548,6 @@ class _FakeApi implements OpenCodeApi {
        _createdSession = createdSession;
 
   @override
-  String get serverURL => "http://fake";
-
-  @override
   Future<bool> healthCheck() async => true;
 
   @override

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -610,9 +610,6 @@ String? _messageId(plugin.MessageWithParts message) {
 }
 
 class FakeOpenCodeApi implements OpenCodeApi {
-  @override
-  String get serverURL => "http://fake";
-
   List<plugin.MessageWithParts> messages;
   Object? messagesError;
   String? lastRequestedSessionId;


### PR DESCRIPTION
## Problem
When the bridge received SIGINT while an OpenCode REST request was in progress, the relay read loop blocked inside `_router.route(req)` until the localhost HTTP call timed out (often 15–30s). Shutdown felt hung.

## Changes
- `OrchestratorSession.cancel()` now triggers `_plugin.dispose()` fire-and-forget. This force-closes the plugin's HTTP client and unblocks the in-flight route immediately. `dispose()` is idempotent, so the later shutdown coordinator call is harmless.
- Request routing races against a shutdown completer; if shutdown wins, the route is abandoned and no response is sent over the already-closed relay.
- `OpenCodeApi` now applies per-method timeouts (30s reads, 60s writes) so hung requests fail loudly instead of blocking forever. `sendCommand` intentionally keeps its existing fast-fail semantics in `OpenCodeService`.
- `SseConnection.onReconnect` checks `_active` after the cold-start callback and returns early if shutdown was requested mid-reconnect.
- `registerSignalHandlers()` forces `exit(1)` on a second SIGINT as an emergency escape hatch.
- Shutdown timing logs are retained, but per-step timings are now verbose level; only aggregate totals stay at debug level.

## Verification
- `dart analyze --fatal-infos` clean in `bridge/app` and `bridge/sesori_plugin_opencode`.
- `dart test` passes in `bridge/app` and `bridge/sesori_plugin_opencode`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the bridge from hanging on shutdown when an OpenCode REST request is in flight. Adds a transport client with a 30s default timeout on GETs (writes unbounded; `sendCommand`/`summarize` explicitly unbounded) and predictable shutdown behavior.

- **Bug Fixes**
  - `cancel()` now fire-and-forgets `plugin.dispose()` via `Future.sync` to force-close the HTTP client and unblock in-flight calls; errors are logged and ignored.
  - Each request now races against a shutdown completer; if shutdown wins, the route is abandoned and its future is ignored so it can’t surface later errors, and no response is sent over the closed relay.
  - OpenCode timeouts: GETs default to 30s; POST/PATCH/DELETE have no default timeout; `sendCommand` and `summarize` are explicitly unbounded. Read timeouts surface as HTTP 504.
  - `SseConnection` drops during reconnect if shutdown is requested mid `onReconnect`.
  - Signal handling: the first of SIGINT/SIGTERM triggers graceful cancel; the second of either forces `exit(1)`.

- **Refactors**
  - Introduced `OpenCodeRawHttpClient` to centralize auth, timeouts, 2xx enforcement, and endpoint labeling; `OpenCodeApi` now delegates all transport concerns to it.
  - Added unit tests for the new client and regression tests (using `fake_async`) to lock in GET timeout and unbounded write behavior; updated API tests/fakes (including `summarize`).

<sup>Written for commit 90b5598668ef2e851f720d97104abbe0935dc57c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

