### PR TITLE
feat(mobile): migrate session detail chat to flutter_chat_ui v2

### DIFF
--- a/mobile/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/mobile/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -1,4 +1,8 @@
+import "dart:async";
+
 import "package:flutter/material.dart";
+import "package:flutter_chat_core/flutter_chat_core.dart" as chat_core;
+import "package:flutter_chat_ui/flutter_chat_ui.dart" as chat_ui;
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../../../core/extensions/build_context_x.dart";
@@ -10,31 +14,46 @@ import "retry_error_message_card.dart";
 import "scroll_follow_tracker.dart";
 import "user_message_card.dart";
 
-/// Chat-style message list for the session detail screen.
+/// Chat-style message list for the session detail screen, rendered with
+/// the flyerhq `flutter_chat_ui` v2 stack (`Chat` +
+/// `ChatAnimatedListReversed` + `InMemoryChatController`).
 ///
-/// Scroll behaviour — "follow / detach":
+/// Integration model:
 ///
-/// - Uses a `reverse: true` `ListView.builder` so the newest message
-///   renders at the visual bottom (scroll offset `0`).
+/// - The [chat_core.ChatController] holds **content-stable index
+///   entries** only — one `CustomMessage(id, authorId)` per domain
+///   message (plus one synthetic entry for the retry-error row). All
+///   visible content (message parts, streaming text, tool state) is
+///   resolved from the cubit-provided widget props inside the row
+///   builders, keyed by message id. Token deltas therefore never
+///   round-trip through the controller: `setMessages` diffs (by id +
+///   freezed equality) emit operations only when the message *set*
+///   changes, and in-place content updates flow through ordinary
+///   widget rebuilds.
+/// - Every per-row default of the package is replaced: the row wrapper
+///   (`chatMessageBuilder` returns the bare child — no bubble, no
+///   alignment, no gestures), the composer (the prompt input lives
+///   outside this widget), the scroll-to-bottom button and the empty
+///   state (both owned by this feature already).
+///
+/// Scroll behaviour — "follow / detach" (unchanged semantics):
+///
+/// - The list is reversed, so the newest message renders at the visual
+///   bottom (scroll offset `0`).
 /// - While **following**, a coalesced post-frame `jumpTo(0)` runs via
-///   the [ScrollFollowTracker] — race-free pin-to-edge, never a
-///   delta-based compensation.
+///   the [ScrollFollowTracker] — race-free pin-to-edge. The package's
+///   own auto-scroll is disabled (`shouldScrollToEndWhenSendingMessage:
+///   false`; the at-bottom variant is a no-op for reversed lists).
 /// - While **detached** (user dragged / trackpad-scrolled / pan-zoomed
 ///   away from the bottom), the full set of rendered inputs
 ///   (`messages`, `streamingText`, `children`, `childStatuses`) is
-///   snapshotted and rendered in place of the live values. New data
-///   still arrives in the background but nothing below (or above) the
-///   user's viewport can grow, shrink, or reorder under them. The
-///   snapshot is cleared the moment the user reattaches.
-/// - `findChildIndexCallback` is mandatory: every append shifts every
-///   existing item's builder index by 1 (we append to the data list
-///   then flip with `messages.length - 1 - index`), so without it
-///   `SliverChildBuilderDelegate` loses child identity and preserved
-///   element state.
+///   snapshotted AND controller syncing is suspended, so nothing below
+///   (or above) the user's viewport can grow, shrink, or reorder under
+///   them. Both freezes lift the moment the user reattaches.
 ///
 /// Gesture plumbing and the detached overlay toggle live in
-/// [FollowDetachScrollable]; this widget only owns message rendering,
-/// the detached snapshot, and the follow controller lifecycle.
+/// [FollowDetachScrollable]; this widget owns message rendering, the
+/// detached snapshot, and the follow/chat controller lifecycles.
 class SessionDetailMessageList extends StatefulWidget {
   final String? projectId;
   final List<MessageWithParts> messages;
@@ -72,22 +91,32 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
   static const _kListViewKey = Key("session-detail-message-list-view");
   static const _kJumpToLatestKey = Key("session-detail-jump-to-latest");
 
+  /// Synthetic controller-entry id for the shimmering retry-error row
+  /// pinned at the newest edge. Domain message ids come from the
+  /// assistant backend and cannot collide with this.
+  static const _kRetryErrorRowId = "session-detail-retry-error-row";
+
+  static const _kUserAuthorId = "user";
+  static const _kAgentAuthorId = "agent";
+
   late final ScrollFollowTracker _follow;
+  late final chat_core.InMemoryChatController _chatController;
 
   /// Snapshot taken at the moment of detach. `null` means "not frozen
   /// — use live `widget.*` props".
   _DetachedSnapshot? _snapshot;
 
-  /// Cache for the id → builder-index map consumed by
-  /// `findChildIndexCallback`. Keyed on a content signature of
-  /// `(length, firstId, lastId)` — NOT list identity. The cubit's
-  /// `state.messages` getter is the Freezed-generated
-  /// `EqualUnmodifiableListView` wrapper which is recreated on every
-  /// access, so an `identical(...)` cache would miss on every emit.
-  /// The content signature is cheap (three reads) and correct for
-  /// every mutation the cubit performs today: append, remove, and
-  /// same-order part updates all either change the signature or
-  /// preserve the full id ordering. `null` means "cache empty".
+  /// Cache for the id → data-source-index map consumed by the row
+  /// builder. Keyed on a content signature of `(length, firstId,
+  /// lastId)` — NOT list identity. The cubit's `state.messages` getter
+  /// is the Freezed-generated `EqualUnmodifiableListView` wrapper which
+  /// is recreated on every access, so an `identical(...)` cache would
+  /// miss on every emit. The content signature is cheap (three reads)
+  /// and correct for every mutation the cubit performs today: append,
+  /// remove, and same-order in-place part updates all either change the
+  /// signature or preserve the full id ordering. Values are positions,
+  /// not message objects, so in-place part updates (which keep the
+  /// signature stable) still resolve fresh content from the live list.
   int? _indexSignature;
   Map<String, int> _indexById = const <String, int>{};
 
@@ -95,21 +124,40 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
   void initState() {
     super.initState();
     _follow = ScrollFollowTracker(edge: ScrollFollowEdge.min);
-    _follow.addListener(_syncSnapshot);
+    _follow.addListener(_onFollowChanged);
+    _chatController = chat_core.InMemoryChatController(
+      messages: _chatEntriesFor(
+        messages: widget.messages,
+        hasRetryError: widget.retryErrorMessage != null,
+      ),
+    );
   }
 
   @override
   void dispose() {
-    _follow.removeListener(_syncSnapshot);
+    _follow.removeListener(_onFollowChanged);
     _follow.dispose();
+    _chatController.dispose();
     super.dispose();
   }
 
-  void _syncSnapshot() {
+  @override
+  void didUpdateWidget(SessionDetailMessageList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // While detached the controller is intentionally left stale so the
+    // list structure cannot shift under the reader; `_onFollowChanged`
+    // re-syncs on reattach.
+    if (_follow.following) {
+      _syncChatController();
+    }
+  }
+
+  void _onFollowChanged() {
     if (!mounted) return;
     setState(() {
       if (_follow.following) {
         _snapshot = null;
+        _syncChatController();
       } else {
         _snapshot ??= (
           messages: List<MessageWithParts>.unmodifiable(widget.messages),
@@ -122,6 +170,58 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
     });
   }
 
+  /// Mirrors the domain transcript into the chat controller. Entries
+  /// are value-equal for unchanged messages, so the controller's
+  /// diff-based `setMessages` emits insert/remove operations only for
+  /// genuine set changes — streaming emits are filtered out by the
+  /// cheap id comparison below and never touch the animated list.
+  void _syncChatController() {
+    final target = _chatEntriesFor(
+      messages: widget.messages,
+      hasRetryError: widget.retryErrorMessage != null,
+    );
+    final current = _chatController.messages;
+    if (_entriesMatch(current: current, target: target)) return;
+    // Structural change: drop the id → index cache so the next build can
+    // never pair the new entry set with positions cached under a
+    // colliding signature. Unreachable with today's strictly id-sorted
+    // transcripts — defense-in-depth against future backend flows that
+    // could re-introduce a previously removed message id.
+    _indexSignature = null;
+    unawaited(_chatController.setMessages(target, animated: false));
+  }
+
+  bool _entriesMatch({
+    required List<chat_core.Message> current,
+    required List<chat_core.Message> target,
+  }) {
+    if (current.length != target.length) return false;
+    for (var i = 0; i < target.length; i++) {
+      if (current[i].id != target[i].id) return false;
+    }
+    return true;
+  }
+
+  List<chat_core.Message> _chatEntriesFor({
+    required List<MessageWithParts> messages,
+    required bool hasRetryError,
+  }) {
+    return <chat_core.Message>[
+      for (final message in messages)
+        chat_core.Message.custom(
+          id: message.info.id,
+          authorId: switch (message.info) {
+            MessageUser() => _kUserAuthorId,
+            MessageAssistant() => _kAgentAuthorId,
+            MessageError() => _kAgentAuthorId,
+          },
+        ),
+      if (hasRetryError) const chat_core.Message.custom(id: _kRetryErrorRowId, authorId: _kAgentAuthorId),
+    ];
+  }
+
+  static Future<chat_core.User?> _resolveUser(String id) async => chat_core.User(id: id);
+
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
@@ -132,18 +232,11 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
     final childStatuses = snap?.childStatuses ?? widget.childStatuses;
     final retryErrorMessage = snap?.retryErrorMessage ?? widget.retryErrorMessage;
 
-    // Map message id → data-source index. Consulted by
-    // `findChildIndexCallback` so the reversed builder keeps stable
-    // element identity across appends that shift every existing index.
-    // Recomputed only when the content signature changes — skips the
-    // O(N) rebuild on every streaming-text emit.
     final indexById = _indexByIdFor(messages: messages);
 
     // Coalesced post-frame pin-to-edge while following. The scheduler
     // collapses repeated calls within a frame and the jump is skipped
-    // when `position.pixels` is already at the edge. Completely
-    // different from the old delta-compensation logic — there are no
-    // stale captures and the target is always `0`.
+    // when `position.pixels` is already at the edge.
     _follow.scheduleJumpToEdge();
 
     return FollowDetachScrollable(
@@ -153,36 +246,95 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
         label: loc.sessionDetailJumpToLatest,
         onTap: () => _follow.animateToEdge(),
       ),
-        child: ListView.builder(
-          key: _kListViewKey,
-          controller: _follow.scrollController,
-          reverse: true,
-          padding: const EdgeInsets.symmetric(vertical: 8),
-          itemCount: messages.length + (retryErrorMessage != null ? 1 : 0),
-          findChildIndexCallback: (key) => _findChildIndex(
-            key: key,
-            indexById: indexById,
-            totalCount: messages.length,
-            hasRetryError: retryErrorMessage != null,
-          ),
-          itemBuilder: (context, index) {
-            if (retryErrorMessage != null && index == 0) {
-              return RetryErrorMessageCard(message: retryErrorMessage);
-            }
-            final messageIndex = retryErrorMessage != null ? index - 1 : index;
-            final message = messages[messages.length - 1 - messageIndex];
-            return KeyedSubtree(
-              key: ValueKey(message.info.id),
-              child: _buildCard(
-                message: message,
+      child: chat_ui.Chat(
+        key: _kListViewKey,
+        currentUserId: _kUserAuthorId,
+        resolveUser: _resolveUser,
+        chatController: _chatController,
+        theme: chat_core.ChatTheme.fromThemeData(Theme.of(context)),
+        backgroundColor: Colors.transparent,
+        builders: chat_core.Builders(
+          // Full-row control: drop the package's bubble/alignment/
+          // gesture wrapper and render our cards bare, exactly as the
+          // previous ListView did.
+          chatMessageBuilder:
+              (
+                context,
+                message,
+                index,
+                animation,
+                child, {
+                bool? isRemoved,
+                required bool isSentByMe,
+                chat_core.MessageGroupStatus? groupStatus,
+              }) => child,
+          customMessageBuilder:
+              (
+                context,
+                message,
+                index, {
+                required bool isSentByMe,
+                chat_core.MessageGroupStatus? groupStatus,
+              }) => _buildRow(
+                entry: message,
+                messages: messages,
+                indexById: indexById,
                 streamingText: streamingText,
                 children: children,
                 childStatuses: childStatuses,
+                retryErrorMessage: retryErrorMessage,
               ),
-            );
-          },
+          // The prompt input, queued bubbles and tasks bar live outside
+          // this widget; reserve no composer space inside the list.
+          composerBuilder: (context) => const SizedBox.shrink(),
+          // Follow/detach owns the jump affordance via the overlay pill.
+          scrollToBottomBuilder: (context, animation, onPressed) => const SizedBox.shrink(),
+          // The loaded view renders its own empty state before this
+          // widget is ever mounted.
+          emptyChatListBuilder: (context) => const SizedBox.shrink(),
+          chatAnimatedListBuilder: (context, itemBuilder) => chat_ui.ChatAnimatedListReversed(
+            itemBuilder: itemBuilder,
+            scrollController: _follow.scrollController,
+            insertAnimationDuration: Duration.zero,
+            removeAnimationDuration: Duration.zero,
+            shouldScrollToEndWhenSendingMessage: false,
+            topPadding: 8,
+            bottomPadding: 8,
+            handleSafeArea: false,
+            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.manual,
+          ),
         ),
+      ),
     );
+  }
+
+  Widget _buildRow({
+    required chat_core.CustomMessage entry,
+    required List<MessageWithParts> messages,
+    required Map<String, int> indexById,
+    required Map<String, String> streamingText,
+    required List<Session> children,
+    required Map<String, SessionStatus> childStatuses,
+    required String? retryErrorMessage,
+  }) {
+    if (entry.id == _kRetryErrorRowId) {
+      if (retryErrorMessage == null) return const SizedBox.shrink();
+      return RetryErrorMessageCard(message: retryErrorMessage);
+    }
+    final index = indexById[entry.id];
+    if (index == null || index >= messages.length) return const SizedBox.shrink();
+    final message = messages[index];
+    return switch (message.info) {
+      MessageUser() => UserMessageCard(message: message),
+      MessageAssistant() => AssistantMessageCard(
+        projectId: widget.projectId,
+        message: message,
+        streamingText: streamingText,
+        children: children,
+        childStatuses: childStatuses,
+      ),
+      final MessageError messageError => ErrorMessageCard(message: messageError),
+    };
   }
 
   Map<String, int> _indexByIdFor({required List<MessageWithParts> messages}) {
@@ -197,37 +349,5 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> {
   int _signatureOf({required List<MessageWithParts> messages}) {
     if (messages.isEmpty) return 0;
     return Object.hash(messages.length, messages.first.info.id, messages.last.info.id);
-  }
-
-  int? _findChildIndex({
-    required Key key,
-    required Map<String, int> indexById,
-    required int totalCount,
-    required bool hasRetryError,
-  }) {
-    if (key is! ValueKey<String>) return null;
-    final sourceIndex = indexById[key.value];
-    if (sourceIndex == null) return null;
-    final builderIndex = totalCount - 1 - sourceIndex;
-    return hasRetryError ? builderIndex + 1 : builderIndex;
-  }
-
-  Widget _buildCard({
-    required MessageWithParts message,
-    required Map<String, String> streamingText,
-    required List<Session> children,
-    required Map<String, SessionStatus> childStatuses,
-  }) {
-    return switch (message.info) {
-      MessageUser() => UserMessageCard(message: message),
-      MessageAssistant() => AssistantMessageCard(
-        projectId: widget.projectId,
-        message: message,
-        streamingText: streamingText,
-        children: children,
-        childStatuses: childStatuses,
-      ),
-      final MessageError messageError => ErrorMessageCard(message: messageError),
-    };
   }
 }

--- a/mobile/app/pubspec.yaml
+++ b/mobile/app/pubspec.yaml
@@ -78,6 +78,8 @@ dependencies:
   sign_in_with_apple: ^8.0.0
   crypto: ^3.0.6
   vector_graphics: ^1.2.2
+  flutter_chat_ui: ^2.11.1
+  flutter_chat_core: ^2.9.0
 
 dev_dependencies:
   flutter_test:

--- a/mobile/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -1,6 +1,7 @@
 import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
+import "package:sesori_mobile/features/session_detail/widgets/retry_error_message_card.dart";
 import "package:sesori_mobile/features/session_detail/widgets/session_detail_message_list.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -9,11 +10,13 @@ import "package:theme_zyra/module_zyra.dart";
 class _SessionDetailMessageListHarness extends StatefulWidget {
   final List<MessageWithParts> initialMessages;
   final Map<String, String> initialStreamingText;
+  final String? initialRetryErrorMessage;
 
   const _SessionDetailMessageListHarness({
     super.key,
     required this.initialMessages,
     required this.initialStreamingText,
+    this.initialRetryErrorMessage,
   });
 
   @override
@@ -23,20 +26,30 @@ class _SessionDetailMessageListHarness extends StatefulWidget {
 class _SessionDetailMessageListHarnessState extends State<_SessionDetailMessageListHarness> {
   late List<MessageWithParts> _messages;
   late Map<String, String> _streamingText;
+  late String? _retryErrorMessage;
 
   @override
   void initState() {
     super.initState();
     _messages = widget.initialMessages;
     _streamingText = widget.initialStreamingText;
+    _retryErrorMessage = widget.initialRetryErrorMessage;
   }
 
   void appendNewestMessage(MessageWithParts message) {
     setState(() => _messages = [..._messages, message]);
   }
 
+  void removeMessage(String messageId) {
+    setState(() => _messages = [..._messages.where((m) => m.info.id != messageId)]);
+  }
+
   void updateStreamingText({required String partId, required String text}) {
     setState(() => _streamingText = {..._streamingText, partId: text});
+  }
+
+  void setRetryErrorMessage(String? message) {
+    setState(() => _retryErrorMessage = message);
   }
 
   @override
@@ -53,6 +66,7 @@ class _SessionDetailMessageListHarnessState extends State<_SessionDetailMessageL
           streamingText: _streamingText,
           children: const <Session>[],
           childStatuses: const <String, SessionStatus>{},
+          retryErrorMessage: _retryErrorMessage,
         ),
       ),
     );
@@ -113,7 +127,13 @@ const _jumpToLatestKey = Key("session-detail-jump-to-latest");
 Finder _messageKey(String messageId) => find.byKey(ValueKey(messageId));
 
 ScrollPosition _position(WidgetTester tester) {
-  return tester.widget<ListView>(find.byKey(_listViewKey)).controller!.position;
+  // The list key sits on the flutter_chat_ui `Chat` widget; the actual
+  // scrollable is the `CustomScrollView` built by `ChatAnimatedListReversed`,
+  // wired to the feature's own follow/detach scroll controller.
+  final scrollView = tester.widget<CustomScrollView>(
+    find.descendant(of: find.byKey(_listViewKey), matching: find.byType(CustomScrollView)),
+  );
+  return scrollView.controller!.position;
 }
 
 Future<void> _pumpListUpdate(WidgetTester tester) async {
@@ -421,5 +441,141 @@ void main() {
     // not snapped to the newest message.
     expect(find.byKey(_jumpToLatestKey), findsOneWidget);
     expect(_position(tester).pixels, greaterThan(20));
+  });
+
+  // --- New-architecture coverage: chat-controller resync and content paths ---
+
+  testWidgets("reattach catches up on messages that arrived while detached", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final harnessKey = GlobalKey<_SessionDetailMessageListHarnessState>();
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        key: harnessKey,
+        initialMessages: _userMessages(count: 12),
+        initialStreamingText: const {},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await _detachViewport(tester);
+
+    // Arrives while frozen: neither the snapshot nor the suspended
+    // chat-controller sync may surface it yet.
+    harnessKey.currentState!.appendNewestMessage(
+      _message(
+        messageId: "user-while-detached",
+        role: "user",
+        text: _multilineText(label: "Arrived while detached", lines: 6),
+      ),
+    );
+    await _pumpListUpdate(tester);
+    expect(_messageKey("user-while-detached"), findsNothing);
+
+    // Reattaching must resync the controller and reveal the message at
+    // the newest edge.
+    await tester.tap(find.byKey(_jumpToLatestKey));
+    await tester.pumpAndSettle();
+
+    expect(_position(tester).pixels, 0);
+    expect(find.byKey(_jumpToLatestKey), findsNothing);
+    expect(_messageKey("user-while-detached"), findsOneWidget);
+  });
+
+  testWidgets("retry error renders as the newest row and disappears when cleared", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    // NOTE: RetryErrorMessageCard runs a repeating shimmer animation, so
+    // this test must never call pumpAndSettle while the card is visible.
+    final harnessKey = GlobalKey<_SessionDetailMessageListHarnessState>();
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        key: harnessKey,
+        initialMessages: _userMessages(count: 3),
+        initialStreamingText: const {},
+        initialRetryErrorMessage: "Provider is overloaded",
+      ),
+    );
+    await tester.pump();
+
+    final retryCard = find.byType(RetryErrorMessageCard);
+    expect(retryCard, findsOneWidget);
+
+    // The synthetic row must sit at the visual bottom — below the
+    // newest real message — exactly like the old reverse-list index 0.
+    final newestMessageBottom = tester.getBottomLeft(_messageKey("user-2")).dy;
+    expect(tester.getCenter(retryCard).dy, greaterThan(newestMessageBottom));
+
+    harnessKey.currentState!.setRetryErrorMessage(null);
+    await _pumpListUpdate(tester);
+
+    expect(find.byType(RetryErrorMessageCard), findsNothing);
+    expect(_messageKey("user-2"), findsOneWidget);
+  });
+
+  testWidgets("removing a message while following drops its row and stays pinned", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final harnessKey = GlobalKey<_SessionDetailMessageListHarnessState>();
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        key: harnessKey,
+        initialMessages: _userMessages(count: 12),
+        initialStreamingText: const {},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(_messageKey("user-10"), findsOneWidget);
+
+    harnessKey.currentState!.removeMessage("user-10");
+    await _pumpListUpdate(tester);
+
+    expect(_messageKey("user-10"), findsNothing);
+    expect(_messageKey("user-11"), findsOneWidget);
+    expect(_position(tester).pixels, 0);
+    expect(find.byKey(_jumpToLatestKey), findsNothing);
+  });
+
+  testWidgets("streaming text growth is visible while following", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    const streamingPartId = "assistant-stream-part";
+    final harnessKey = GlobalKey<_SessionDetailMessageListHarnessState>();
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        key: harnessKey,
+        initialMessages: [
+          _message(
+            messageId: "assistant-newest",
+            role: "assistant",
+            text: "",
+            partId: streamingPartId,
+          ),
+        ],
+        initialStreamingText: const {streamingPartId: "Streaming start"},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining("Streaming start", findRichText: true), findsOneWidget);
+    expect(find.textContaining("freshly streamed token", findRichText: true), findsNothing);
+
+    // Content updates bypass the chat controller entirely — they must
+    // reach the visible row through the rebuilt builders on the very
+    // next frame while the list stays pinned to the newest edge.
+    harnessKey.currentState!.updateStreamingText(
+      partId: streamingPartId,
+      text: "Streaming start with a freshly streamed token",
+    );
+    await tester.pump();
+
+    expect(find.textContaining("freshly streamed token", findRichText: true), findsOneWidget);
+    expect(_position(tester).pixels, 0);
+    expect(find.byKey(_jumpToLatestKey), findsNothing);
   });
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -249,6 +249,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  cross_cache:
+    dependency: transitive
+    description:
+      name: cross_cache
+      sha256: "4983a16603cc99b0a14de6a772fa8ee4533411f46f3c423f1386fea7566049c5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -321,6 +337,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.1"
+  diffutil_dart:
+    dependency: transitive
+    description:
+      name: diffutil_dart
+      sha256: "5e74883aedf87f3b703cb85e815bdc1ed9208b33501556e4a8a5572af9845c81"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.1"
+  dio:
+    dependency: transitive
+    description:
+      name: dio
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.2"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   equatable:
     dependency: transitive
     description:
@@ -470,6 +510,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.1.1"
+  flutter_chat_core:
+    dependency: transitive
+    description:
+      name: flutter_chat_core
+      sha256: "8c46790f64f106bf6e610e2a7324b3844320e9e295867c06d45d9deb134d848d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.0"
+  flutter_chat_ui:
+    dependency: transitive
+    description:
+      name: flutter_chat_ui
+      sha256: cfbaac38f429beb33d9cc1ca920ae7ccbadbed282c99335d590d61306d3a3d0f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
   flutter_lints:
     dependency: transitive
     description:
@@ -725,6 +781,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  idb_shim:
+    dependency: transitive
+    description:
+      name: idb_shim
+      sha256: "65d2fbda05f707f9c6e0b502bc4bf411d9f799d391f709c121aeb44d0dc0fd2a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.4"
   image:
     dependency: transitive
     description:
@@ -1188,6 +1252,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  scrollview_observer:
+    dependency: transitive
+    description:
+      name: scrollview_observer
+      sha256: "5ce907c5757d0805de974de8b17c0185f982dfe805dde22a0acb016b39182ece"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.27.0"
+  sembast:
+    dependency: transitive
+    description:
+      name: sembast
+      sha256: "60746eb3377fe953367c10d549e9d99a3e0bccb464f32d0528d4e44933898597"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.8.9"
   sesori_shared:
     dependency: transitive
     description:
@@ -1328,6 +1408,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "93b153dcb6a26dcddee6ca087dd634b53e38c10b5aa163e8e49501a776456153"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
   term_glyph:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

Migrates the AI-agent chat (session detail) message list to the [flyerhq **flutter_chat_ui** v2](https://github.com/flyerhq/flutter_chat_ui) stack (`flutter_chat_ui` ^2.11.1 + `flutter_chat_core` ^2.9.0), as requested, with **full functional parity** and **mobile-side changes only** — the bridge protocol, the `SessionDetailCubit`, every message-part card, the prompt input, the modals and the pickers are all untouched.

`SessionDetailMessageList` now renders on `Chat` + `ChatAnimatedListReversed` + `InMemoryChatController` instead of a hand-rolled reversed `ListView`.

### How it integrates (the design that keeps the cubit untouched)

- The chat controller holds **content-stable index entries only** — one `CustomMessage(id, authorId)` per domain message, plus one synthetic entry for the retry-error row. All visible content (markdown text, tool state, reasoning, subtask/agent/retry parts, streaming text) is resolved from the cubit's existing state **by message id** inside the row builders.
- **Streaming tokens never round-trip through the package.** They keep flowing through the cubit's existing 50 ms-throttled `streamingText` overlay; `setMessages` diffing (by id + freezed equality) fires only when the message *set* actually changes, so token deltas are ordinary widget rebuilds.
- The **follow / detach** system is preserved exactly: the `ScrollFollowTracker`, the detached-snapshot freeze (now *also* suspending controller sync so the list structure can't shift while you read history), and the **Jump to latest** pill. Reattach re-syncs the controller.
- Every package default is replaced so nothing leaks visually: row wrapper (`chatMessageBuilder` → bare child, no bubble/alignment/gestures), composer, scroll-to-bottom button and empty state are all suppressed (each owned elsewhere in the feature). Insert/remove animations set to `Duration.zero`.

## Visual evidence

Captured on an iOS simulator (iPhone, iOS 26) rendering the migrated widget with fixture data covering every part type.

### Light — full transcript (markdown, tool card, subtask, retry part, error row)
<img src="https://raw.githubusercontent.com/rndteams-habbibi/sesori_apps_monorepo/evidence/chat-ui-migration/screenshots/01_light_transcript.png" width="300" />

### Light — streaming overlay  ·  Light — retry-error row pinned at newest edge
<img src="https://raw.githubusercontent.com/rndteams-habbibi/sesori_apps_monorepo/evidence/chat-ui-migration/screenshots/02_light_streaming.png" width="300" /> <img src="https://raw.githubusercontent.com/rndteams-habbibi/sesori_apps_monorepo/evidence/chat-ui-migration/screenshots/03_light_retry.png" width="300" />

### Light — detached + "Jump to latest" pill (also shows the right-aligned user bubble, the `build` agent part and the collapsed reasoning "Thought" card)
<img src="https://raw.githubusercontent.com/rndteams-habbibi/sesori_apps_monorepo/evidence/chat-ui-migration/screenshots/04_light_detached_pill.png" width="300" />

### Dark — detached  ·  Dark — full transcript
<img src="https://raw.githubusercontent.com/rndteams-habbibi/sesori_apps_monorepo/evidence/chat-ui-migration/screenshots/05_dark_detached.png" width="300" /> <img src="https://raw.githubusercontent.com/rndteams-habbibi/sesori_apps_monorepo/evidence/chat-ui-migration/screenshots/06_dark_transcript.png" width="300" />

> Theming is bound to the app's existing design system via `ChatTheme.fromThemeData(Theme.of(context))`, so light/dark follow Zyra tokens automatically.

## Tests

- Adapted the existing scroll-behavior suite (8 tests) to the new widget tree — all green against the real `flutter_chat_ui` stack.
- Added **4 new tests** for the new architecture:
  - reattach catch-up after messages arrive while detached *(mutation-verified: fails if the re-sync call is removed)*
  - retry-error row placement at the newest edge + disappearance when cleared
  - message removal while following
  - streaming-text growth visible while pinned

## Verification

- `dart analyze --fatal-infos` clean across `app`, `module_core`, `module_auth`
- `flutter test` (app) and `dart test` (module_core) fully green
- No iOS/macOS SPM drift — every new transitive dependency is pure Dart

An adversarial multi-agent review confirmed parity point-by-point (retry-row placement, 8/8 px padding, element-state preservation across appends, text selection, keyboard behavior). Its one High finding (a theoretical stale-cache collision) was refuted as unreachable with today's strictly id-sorted transcripts; a one-line cache-invalidation hardening was added anyway.

> **Note:** screenshots live on the throwaway `evidence/chat-ui-migration` branch (referenced by raw URL) and the preview harness used to capture them is not part of this PR — the diff is the 4 files below. One upstream caveat: `flutter_chat_ui`'s last release was Dec 2025, so budget for pinning / small forks over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the session detail chat to `flutter_chat_ui` v2 for a simpler, more reliable message list with full feature parity. Only mobile UI is touched; the cubit, message cards, and input stay the same.

- **Refactors**
  - Replaces the custom reversed list with Chat + ChatAnimatedListReversed + InMemoryChatController, wired to our follow tracker; disables package auto-scroll and sets insert/remove animations to zero.
  - Controller stores CustomMessage(id, authorId) per domain message (+ a synthetic retry-error row); row content resolves by id from cubit state.
  - Preserves follow/detach and "Jump to latest"; snapshot is frozen and controller sync pauses while detached, then resyncs on reattach.
  - Streaming tokens render via ordinary rebuilds; controller only diffs when the message set changes.

- **Dependencies**
  - Adds `flutter_chat_ui` ^2.11.1 and `flutter_chat_core` ^2.9.0.

<sup>Written for commit 74dcaffb126524c97675d35faa263b4bc0dc2bd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

