### PR TITLE
feat(bridge): selectable release track (stable|internal) for the auto-updater

### DIFF
--- a/bridge/INSTALL.md
+++ b/bridge/INSTALL.md
@@ -87,6 +87,7 @@ sesori-bridge
 - Release checksum manifests use archive basenames such as `sesori-bridge-macos-arm64.tar.gz`; installers match that basename instead of a temp download path
 - Startup auto-update only applies to managed installs under the Sesori install root (`~/.local/share/sesori/bin` on macOS/Linux, `%LOCALAPPDATA%\sesori\bin` on Windows)
 - Runtime auto-update also performs periodic polling every 4 hours while the managed bridge is running, and it is skipped in CI and when `SESORI_NO_UPDATE=1` is set
+- The update track selects which releases auto-update follows: `stable` (default) tracks stable `vX.Y.Z` releases, while `internal` additionally tracks the `vX.Y.Z-internal.N` pre-releases. Switch with `sesori-bridge config track internal` (and back with `sesori-bridge config track stable`), then restart the bridge to apply. The shell and npm installers always fetch the latest stable release regardless of the configured track
 - Periodic polling only notifies that an update is available — the update is applied at the next startup. For a bridge running under a service manager (e.g. systemd), restart the service to apply updates (see [`docs/SETUP_HEADLESS_VM.md`](../docs/SETUP_HEADLESS_VM.md))
 - Direct execution of package binaries from npm-owned `node_modules` locations is unsupported
 

--- a/bridge/RELEASING.md
+++ b/bridge/RELEASING.md
@@ -4,7 +4,7 @@
 
 - **Enabled by default:** GitHub Releases
 - **Enabled by default:** npm publish via npm trusted publishing
-- **Release selector:** installers and updater accept stable GitHub releases tagged `v*`.
+- **Release selector:** installers always use the newest stable GitHub release tagged `v*`. The runtime auto-updater follows the configured update track — `stable` (default) uses stable `v*` releases, while `internal` also picks up `v*-internal.*` pre-releases (see `config track` in [INSTALL.md](INSTALL.md)).
 
 ## Release tag
 
@@ -94,7 +94,7 @@ That bump step is the source of truth for the release version. It must keep `bri
 
 ### 2. Merge to main
 
-Every main merge runs `release-all-platforms.yml`: it uploads the mobile apps to TestFlight / Play internal, builds all five bridge platform archives with `X.Y.Z-internal.<N>` baked in, and — only when everything succeeded — pushes a `v<X.Y.Z>-internal.<N>` tag and rolls the single internal GitHub pre-release onto it (binaries + `checksums.txt` + regenerated notes). The auto-updater ignores pre-releases.
+Every main merge runs `release-all-platforms.yml`: it uploads the mobile apps to TestFlight / Play internal, builds all five bridge platform archives with `X.Y.Z-internal.<N>` baked in, and — only when everything succeeded — pushes a `v<X.Y.Z>-internal.<N>` tag and rolls the single internal GitHub pre-release onto it (binaries + `checksums.txt` + regenerated notes). The auto-updater ignores pre-releases on the default `stable` track; bridges switched to the `internal` track (`sesori-bridge config track internal`) pick up these `-internal.<N>` pre-releases.
 
 ### 3. Submit to production
 

--- a/bridge/app/README.md
+++ b/bridge/app/README.md
@@ -75,6 +75,7 @@ Both paths install the same managed runtime under `~/.local/share/sesori/` on ma
 - Auto-update is skipped in CI.
 - Auto-update is skipped when `SESORI_NO_UPDATE=1` is set.
 - If you want to refresh immediately, rerun either the shell installer or `npx @sesori/bridge`.
+- The **update track** selects which releases the auto-updater follows. `stable` (the default) follows stable `vX.Y.Z` releases; `internal` additionally follows the `vX.Y.Z-internal.N` pre-releases. Set it with `sesori-bridge config track internal` and restart the bridge to apply. The shell/npm installers always install the latest stable release regardless of track.
 
 Direct execution from npm-owned package payloads inside `node_modules` is unsupported. The supported steady-state command is always the managed `sesori-bridge` launcher.
 
@@ -141,7 +142,8 @@ In addition to flags, the bridge supports subcommands:
 | Command | Description |
 |---------|-------------|
 | `help` | Show the help message (also available via `--help` or `-h`) |
-| `config` | Open the bridge configuration file in your default editor |
+| `config track [stable\|internal]` | Show or set the update track. With no argument, prints the current track. |
+| `config edit` | Open the bridge configuration file in your default editor |
 | `logout` | Clear stored authentication tokens. You will be asked to log in again on next start. |
 
 ## Examples

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -30,6 +30,7 @@ import 'package:sesori_bridge/src/server/repositories/terminal_prompt_repository
 import 'package:sesori_bridge/src/server/services/bridge_instance_service.dart';
 import 'package:sesori_bridge/src/services/bridge_config_service.dart';
 import 'package:sesori_bridge/src/services/sleep_prevention_service.dart';
+import 'package:sesori_bridge/src/updater/foundation/release_track.dart';
 import 'package:sesori_bridge/src/version.dart';
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart'
     show BridgePluginDescriptor, Log, LogLevel, PluginConfig, PluginConfigException, ProcessUser, ServerClock;
@@ -271,6 +272,19 @@ class ConfigCommand extends cli.Command<void> {
   final name = 'config';
 
   @override
+  final description = 'Manage bridge configuration';
+
+  ConfigCommand() {
+    addSubcommand(ConfigTrackCommand());
+    addSubcommand(ConfigEditCommand());
+  }
+}
+
+class ConfigEditCommand extends cli.Command<void> {
+  @override
+  final name = 'edit';
+
+  @override
   final description = 'Open the bridge configuration file in your default editor';
 
   @override
@@ -289,6 +303,52 @@ class ConfigCommand extends cli.Command<void> {
 
     final configFilePath = await configService.openConfigFile();
     stdout.writeln('Opening config file at $configFilePath');
+  }
+}
+
+class ConfigTrackCommand extends cli.Command<void> {
+  @override
+  final name = 'track';
+
+  @override
+  final description = 'Show or set the bridge update track (stable|internal)';
+
+  @override
+  Future<void> run() async {
+    final rest = argResults!.rest;
+    final repository = BridgeSettingsRepository(api: BridgeSettingsApi());
+
+    if (rest.isEmpty) {
+      final settings = await repository.loadSettings();
+      stdout.writeln('Release track: ${settings.releaseTrack.wireValue}');
+      return;
+    }
+
+    if (rest.length > 1) {
+      usageException('Expected a single track value: stable or internal.');
+    }
+
+    final ReleaseTrack track = _parseTrackArgument(rest.single);
+    await repository.updateReleaseTrack(track: track);
+    stdout.writeln('Release track set to ${track.wireValue}.');
+    if (track == ReleaseTrack.internal) {
+      stdout.writeln(
+        'Warning: internal builds are pre-release and may be unstable. '
+        'The bridge will auto-update to the latest internal build on next start.',
+      );
+    }
+    stdout.writeln('Restart sesori-bridge to apply.');
+  }
+
+  ReleaseTrack _parseTrackArgument(String value) {
+    switch (value) {
+      case 'stable':
+        return ReleaseTrack.stable;
+      case 'internal':
+        return ReleaseTrack.internal;
+      default:
+        usageException('Track must be "stable" or "internal".');
+    }
   }
 }
 

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -315,7 +315,11 @@ class ConfigTrackCommand extends cli.Command<void> {
 
   @override
   Future<void> run() async {
-    final rest = argResults!.rest;
+    final results = argResults;
+    if (results == null) {
+      usageException('Unable to read command arguments.');
+    }
+    final rest = results.rest;
     final repository = BridgeSettingsRepository(api: BridgeSettingsApi());
 
     if (rest.isEmpty) {

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -184,11 +184,12 @@ class BridgeRuntimeRunner {
         return 1;
       }
 
-      final releaseTrack = await _resolveReleaseTrack();
+      final settingsRepository = BridgeSettingsRepository(api: BridgeSettingsApi());
+      final releaseTrack = await _readReleaseTrack(settingsRepository: settingsRepository);
       if (releaseTrack == ReleaseTrack.internal) {
         Log.w("Release track: internal (pre-release auto-updates enabled)");
       } else {
-        Log.i("Release track: ${releaseTrack.wireValue}");
+        Log.d("Release track: ${releaseTrack.wireValue}");
       }
 
       final updateService = _createUpdateService(
@@ -442,9 +443,11 @@ class BridgeRuntimeRunner {
     return attemptStart(attempt: 1);
   }
 
-  static Future<ReleaseTrack> _resolveReleaseTrack() async {
+  static Future<ReleaseTrack> _readReleaseTrack({
+    required BridgeSettingsRepository settingsRepository,
+  }) async {
     try {
-      final settings = await BridgeSettingsRepository(api: BridgeSettingsApi()).loadSettings();
+      final settings = await settingsRepository.loadSettings();
       return settings.releaseTrack;
     } on Object catch (error) {
       Log.w("Failed to read release track from settings; defaulting to stable: $error");

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -19,6 +19,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
         StartAbortController,
         StartAbortSignal;
 
+import "../../api/bridge_settings_api.dart";
 import "../../auth/bridge_registration_api.dart";
 import "../../auth/bridge_registration_repository.dart";
 import "../../auth/bridge_registration_service.dart";
@@ -28,6 +29,7 @@ import "../../auth/login_oauth_api.dart";
 import "../../auth/login_oauth_service.dart";
 import "../../auth/token.dart";
 import "../../auth/token_manager.dart";
+import "../../repositories/bridge_settings_repository.dart";
 import "../../server/api/loopback_port_api.dart";
 import "../../server/api/runtime_file_api.dart";
 import "../../server/api/system_process_api.dart";
@@ -49,6 +51,7 @@ import "../../updater/api/file_replacement_api.dart";
 import "../../updater/api/github_releases_api.dart";
 import "../../updater/api/update_cache_api.dart";
 import "../../updater/api/update_download_api.dart";
+import "../../updater/foundation/release_track.dart";
 import "../../updater/foundation/update_lock.dart";
 import "../../updater/foundation/update_policy.dart";
 import "../../updater/foundation/update_relaunch_client.dart";
@@ -181,10 +184,18 @@ class BridgeRuntimeRunner {
         return 1;
       }
 
+      final releaseTrack = await _resolveReleaseTrack();
+      if (releaseTrack == ReleaseTrack.internal) {
+        Log.w("Release track: internal (pre-release auto-updates enabled)");
+      } else {
+        Log.i("Release track: ${releaseTrack.wireValue}");
+      }
+
       final updateService = _createUpdateService(
         httpClient: httpClient,
         processRunner: processRunner,
         managedRuntimePaths: managedRuntimePaths,
+        releaseTrack: releaseTrack,
       );
       await updateService.checkAndApplyUpdate(cliArgs: options.cliArgs);
 
@@ -431,10 +442,21 @@ class BridgeRuntimeRunner {
     return attemptStart(attempt: 1);
   }
 
+  static Future<ReleaseTrack> _resolveReleaseTrack() async {
+    try {
+      final settings = await BridgeSettingsRepository(api: BridgeSettingsApi()).loadSettings();
+      return settings.releaseTrack;
+    } on Object catch (error) {
+      Log.w("Failed to read release track from settings; defaulting to stable: $error");
+      return ReleaseTrack.stable;
+    }
+  }
+
   static UpdateService _createUpdateService({
     required http.Client httpClient,
     required ProcessRunner processRunner,
     required ManagedRuntimePaths managedRuntimePaths,
+    required ReleaseTrack releaseTrack,
   }) {
     final installedFileRepository = InstalledFileRepository(
       fileReplacementApi: FileReplacementApi(processRunner: processRunner),
@@ -449,6 +471,7 @@ class BridgeRuntimeRunner {
         ),
         currentVersion: appVersion,
         target: currentDistributionTarget(),
+        track: releaseTrack,
       ),
       updateInstallerService: UpdateInstallService(
         updateArtifactRepository: UpdateArtifactRepository(

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -184,8 +184,18 @@ class BridgeRuntimeRunner {
         return 1;
       }
 
-      final settingsRepository = BridgeSettingsRepository(api: BridgeSettingsApi());
-      final releaseTrack = await _readReleaseTrack(settingsRepository: settingsRepository);
+      // Resolve the configured release track once, here in the composition
+      // root. Constructing settings access (BridgeSettingsApi reads HOME) or
+      // reading the config can throw; a settings failure must never block the
+      // bridge from starting, so any error falls back to the stable track.
+      ReleaseTrack? configuredTrack;
+      try {
+        final settingsRepository = BridgeSettingsRepository(api: BridgeSettingsApi());
+        configuredTrack = (await settingsRepository.loadSettings()).releaseTrack;
+      } on Object catch (error) {
+        Log.w("Failed to resolve release track; defaulting to stable: $error");
+      }
+      final releaseTrack = configuredTrack ?? ReleaseTrack.stable;
       if (releaseTrack == ReleaseTrack.internal) {
         Log.w("Release track: internal (pre-release auto-updates enabled)");
       } else {
@@ -441,18 +451,6 @@ class BridgeRuntimeRunner {
     }
 
     return attemptStart(attempt: 1);
-  }
-
-  static Future<ReleaseTrack> _readReleaseTrack({
-    required BridgeSettingsRepository settingsRepository,
-  }) async {
-    try {
-      final settings = await settingsRepository.loadSettings();
-      return settings.releaseTrack;
-    } on Object catch (error) {
-      Log.w("Failed to read release track from settings; defaulting to stable: $error");
-      return ReleaseTrack.stable;
-    }
   }
 
   static UpdateService _createUpdateService({

--- a/bridge/app/lib/src/repositories/bridge_settings.dart
+++ b/bridge/app/lib/src/repositories/bridge_settings.dart
@@ -1,3 +1,5 @@
+import '../updater/foundation/release_track.dart';
+
 enum SleepPreventionMode {
   off,
   always,
@@ -12,15 +14,22 @@ class BridgeSettings {
   /// active plugins, more than one entry is rejected at startup.
   final List<String>? enabledPlugins;
 
+  /// Which release channel the auto-updater follows. Defaults to
+  /// [ReleaseTrack.stable] so existing installs keep getting only stable
+  /// releases unless the user opts in via `config track internal`.
+  final ReleaseTrack releaseTrack;
+
   const BridgeSettings({
     this.sleepPrevention = SleepPreventionMode.always,
     this.enabledPlugins,
+    this.releaseTrack = ReleaseTrack.stable,
   });
 
   factory BridgeSettings.fromJson(Map<String, dynamic> json) {
     return BridgeSettings(
       sleepPrevention: _parseSleepPrevention(json['sleepPrevention']),
       enabledPlugins: _parseEnabledPlugins(json['enabledPlugins']),
+      releaseTrack: _parseReleaseTrack(json['releaseTrack']),
     );
   }
 
@@ -30,10 +39,26 @@ class BridgeSettings {
         SleepPreventionMode.off => 'off',
         SleepPreventionMode.always => 'always',
       },
+      // Always written (like sleepPrevention) so the option is discoverable
+      // via `config edit`. Existing valid configs are only rewritten on
+      // create/repair, so untouched installs do not churn.
+      'releaseTrack': releaseTrack.wireValue,
       // Only written when set: the defaults file must keep its exact
       // pre-existing shape for installs that never touched the key.
       if (enabledPlugins != null) 'enabledPlugins': enabledPlugins,
     };
+  }
+
+  BridgeSettings copyWith({
+    SleepPreventionMode? sleepPrevention,
+    List<String>? enabledPlugins,
+    ReleaseTrack? releaseTrack,
+  }) {
+    return BridgeSettings(
+      sleepPrevention: sleepPrevention ?? this.sleepPrevention,
+      enabledPlugins: enabledPlugins ?? this.enabledPlugins,
+      releaseTrack: releaseTrack ?? this.releaseTrack,
+    );
   }
 
   static SleepPreventionMode _parseSleepPrevention(Object? rawValue) {
@@ -49,5 +74,9 @@ class BridgeSettings {
       return null;
     }
     return rawValue.whereType<String>().toList();
+  }
+
+  static ReleaseTrack _parseReleaseTrack(Object? rawValue) {
+    return ReleaseTrack.fromWire(rawValue is String ? rawValue : null);
   }
 }

--- a/bridge/app/lib/src/repositories/bridge_settings_repository.dart
+++ b/bridge/app/lib/src/repositories/bridge_settings_repository.dart
@@ -4,6 +4,7 @@ import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Log;
 import 'package:sesori_shared/sesori_shared.dart' show jsonDecodeMap;
 
 import '../api/bridge_settings_api.dart';
+import '../updater/foundation/release_track.dart';
 import 'bridge_settings.dart';
 
 class BridgeSettingsRepository {
@@ -64,5 +65,13 @@ class BridgeSettingsRepository {
 
   Future<void> saveSettings({required BridgeSettings settings}) {
     return _api.writeConfig(_jsonEncoder.convert(settings.toJson()));
+  }
+
+  /// Read-modify-write of the persisted [ReleaseTrack], preserving every
+  /// other setting. Loads via [loadSettings] (which creates/repairs the file
+  /// with defaults if needed) so the write always starts from a valid base.
+  Future<void> updateReleaseTrack({required ReleaseTrack track}) async {
+    final current = await loadSettings();
+    await saveSettings(settings: current.copyWith(releaseTrack: track));
   }
 }

--- a/bridge/app/lib/src/updater/foundation/release_track.dart
+++ b/bridge/app/lib/src/updater/foundation/release_track.dart
@@ -1,0 +1,23 @@
+/// The release channel the bridge auto-updater follows.
+///
+/// - [stable]: only stable `vX.Y.Z` GitHub releases (the default).
+/// - [internal]: the newest of stable releases and `vX.Y.Z-internal.N`
+///   pre-releases, so internal users ride the per-merge internal channel.
+enum ReleaseTrack {
+  stable,
+  internal;
+
+  /// The string persisted in the bridge config file and accepted on the CLI.
+  String get wireValue => name;
+
+  /// Maps a persisted/CLI string to a track, defaulting unknown or null
+  /// values to [stable] so a malformed config can never silently opt a user
+  /// into pre-releases.
+  static ReleaseTrack fromWire(String? value) {
+    return switch (value) {
+      'stable' => ReleaseTrack.stable,
+      'internal' => ReleaseTrack.internal,
+      _ => ReleaseTrack.stable,
+    };
+  }
+}

--- a/bridge/app/lib/src/updater/foundation/release_track.dart
+++ b/bridge/app/lib/src/updater/foundation/release_track.dart
@@ -1,3 +1,5 @@
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Log;
+
 /// The release channel the bridge auto-updater follows.
 ///
 /// - [stable]: only stable `vX.Y.Z` GitHub releases (the default).
@@ -10,14 +12,24 @@ enum ReleaseTrack {
   /// The string persisted in the bridge config file and accepted on the CLI.
   String get wireValue => name;
 
-  /// Maps a persisted/CLI string to a track, defaulting unknown or null
-  /// values to [stable] so a malformed config can never silently opt a user
-  /// into pre-releases.
+  /// Maps a persisted/CLI string to a track.
+  ///
+  /// A missing value (`null`) is the normal "not configured" case and resolves
+  /// to [stable] silently. An unrecognized non-null value is a misconfiguration:
+  /// it still falls back to [stable], but is logged via [Log.e] (stderr) so it
+  /// is visible without polluting the machine-readable stdout that
+  /// `--version`/`--help` rely on — track parsing runs during plugin selection
+  /// for every command.
   static ReleaseTrack fromWire(String? value) {
-    return switch (value) {
-      'stable' => ReleaseTrack.stable,
-      'internal' => ReleaseTrack.internal,
-      _ => ReleaseTrack.stable,
-    };
+    switch (value) {
+      case null:
+      case 'stable':
+        return ReleaseTrack.stable;
+      case 'internal':
+        return ReleaseTrack.internal;
+      default:
+        Log.e("Unknown release track '$value' in bridge settings; defaulting to stable.");
+        return ReleaseTrack.stable;
+    }
   }
 }

--- a/bridge/app/lib/src/updater/models/cached_release.dart
+++ b/bridge/app/lib/src/updater/models/cached_release.dart
@@ -22,7 +22,9 @@ sealed class CachedRelease with _$CachedRelease {
     /// The release track ([ReleaseTrack.wireValue]) this cache entry was
     /// resolved for. A cache entry from a different track is ignored so a
     /// recent stable check can't mask an internal build (or vice versa).
-    required String track,
+    /// Defaults to `stable` so cache files written before this field existed
+    /// (always the stable channel) parse without throwing during upgrades.
+    @Default('stable') String track,
 
     /// When this release was published upstream.
     required DateTime publishedAt,

--- a/bridge/app/lib/src/updater/models/cached_release.dart
+++ b/bridge/app/lib/src/updater/models/cached_release.dart
@@ -19,6 +19,11 @@ sealed class CachedRelease with _$CachedRelease {
     /// The release asset name this cache entry was resolved for.
     required String assetName,
 
+    /// The release track ([ReleaseTrack.wireValue]) this cache entry was
+    /// resolved for. A cache entry from a different track is ignored so a
+    /// recent stable check can't mask an internal build (or vice versa).
+    required String track,
+
     /// When this release was published upstream.
     required DateTime publishedAt,
 

--- a/bridge/app/lib/src/updater/models/cached_release.freezed.dart
+++ b/bridge/app/lib/src/updater/models/cached_release.freezed.dart
@@ -22,6 +22,8 @@ mixin _$CachedRelease {
  String get assetName;/// The release track ([ReleaseTrack.wireValue]) this cache entry was
 /// resolved for. A cache entry from a different track is ignored so a
 /// recent stable check can't mask an internal build (or vice versa).
+/// Defaults to `stable` so cache files written before this field existed
+/// (always the stable channel) parse without throwing during upgrades.
  String get track;/// When this release was published upstream.
  DateTime get publishedAt;/// When this cache entry was created.
  DateTime get checkedAt;
@@ -95,7 +97,7 @@ as DateTime,
 @JsonSerializable()
 
 class _CachedRelease implements CachedRelease {
-  const _CachedRelease({required this.latestVersion, required this.downloadUrl, required this.checksumsUrl, required this.assetName, required this.track, required this.publishedAt, required this.checkedAt});
+  const _CachedRelease({required this.latestVersion, required this.downloadUrl, required this.checksumsUrl, required this.assetName, this.track = 'stable', required this.publishedAt, required this.checkedAt});
   factory _CachedRelease.fromJson(Map<String, dynamic> json) => _$CachedReleaseFromJson(json);
 
 /// The latest version string found during the check.
@@ -109,7 +111,9 @@ class _CachedRelease implements CachedRelease {
 /// The release track ([ReleaseTrack.wireValue]) this cache entry was
 /// resolved for. A cache entry from a different track is ignored so a
 /// recent stable check can't mask an internal build (or vice versa).
-@override final  String track;
+/// Defaults to `stable` so cache files written before this field existed
+/// (always the stable channel) parse without throwing during upgrades.
+@override@JsonKey() final  String track;
 /// When this release was published upstream.
 @override final  DateTime publishedAt;
 /// When this cache entry was created.

--- a/bridge/app/lib/src/updater/models/cached_release.freezed.dart
+++ b/bridge/app/lib/src/updater/models/cached_release.freezed.dart
@@ -19,7 +19,10 @@ mixin _$CachedRelease {
  String get latestVersion;/// The download URL for the latest release.
  String get downloadUrl;/// The URL to the checksums file for verification.
  String get checksumsUrl;/// The release asset name this cache entry was resolved for.
- String get assetName;/// When this release was published upstream.
+ String get assetName;/// The release track ([ReleaseTrack.wireValue]) this cache entry was
+/// resolved for. A cache entry from a different track is ignored so a
+/// recent stable check can't mask an internal build (or vice versa).
+ String get track;/// When this release was published upstream.
  DateTime get publishedAt;/// When this cache entry was created.
  DateTime get checkedAt;
 /// Create a copy of CachedRelease
@@ -34,16 +37,16 @@ $CachedReleaseCopyWith<CachedRelease> get copyWith => _$CachedReleaseCopyWithImp
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CachedRelease&&(identical(other.latestVersion, latestVersion) || other.latestVersion == latestVersion)&&(identical(other.downloadUrl, downloadUrl) || other.downloadUrl == downloadUrl)&&(identical(other.checksumsUrl, checksumsUrl) || other.checksumsUrl == checksumsUrl)&&(identical(other.assetName, assetName) || other.assetName == assetName)&&(identical(other.publishedAt, publishedAt) || other.publishedAt == publishedAt)&&(identical(other.checkedAt, checkedAt) || other.checkedAt == checkedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CachedRelease&&(identical(other.latestVersion, latestVersion) || other.latestVersion == latestVersion)&&(identical(other.downloadUrl, downloadUrl) || other.downloadUrl == downloadUrl)&&(identical(other.checksumsUrl, checksumsUrl) || other.checksumsUrl == checksumsUrl)&&(identical(other.assetName, assetName) || other.assetName == assetName)&&(identical(other.track, track) || other.track == track)&&(identical(other.publishedAt, publishedAt) || other.publishedAt == publishedAt)&&(identical(other.checkedAt, checkedAt) || other.checkedAt == checkedAt));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,latestVersion,downloadUrl,checksumsUrl,assetName,publishedAt,checkedAt);
+int get hashCode => Object.hash(runtimeType,latestVersion,downloadUrl,checksumsUrl,assetName,track,publishedAt,checkedAt);
 
 @override
 String toString() {
-  return 'CachedRelease(latestVersion: $latestVersion, downloadUrl: $downloadUrl, checksumsUrl: $checksumsUrl, assetName: $assetName, publishedAt: $publishedAt, checkedAt: $checkedAt)';
+  return 'CachedRelease(latestVersion: $latestVersion, downloadUrl: $downloadUrl, checksumsUrl: $checksumsUrl, assetName: $assetName, track: $track, publishedAt: $publishedAt, checkedAt: $checkedAt)';
 }
 
 
@@ -54,7 +57,7 @@ abstract mixin class $CachedReleaseCopyWith<$Res>  {
   factory $CachedReleaseCopyWith(CachedRelease value, $Res Function(CachedRelease) _then) = _$CachedReleaseCopyWithImpl;
 @useResult
 $Res call({
- String latestVersion, String downloadUrl, String checksumsUrl, String assetName, DateTime publishedAt, DateTime checkedAt
+ String latestVersion, String downloadUrl, String checksumsUrl, String assetName, String track, DateTime publishedAt, DateTime checkedAt
 });
 
 
@@ -71,12 +74,13 @@ class _$CachedReleaseCopyWithImpl<$Res>
 
 /// Create a copy of CachedRelease
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? latestVersion = null,Object? downloadUrl = null,Object? checksumsUrl = null,Object? assetName = null,Object? publishedAt = null,Object? checkedAt = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? latestVersion = null,Object? downloadUrl = null,Object? checksumsUrl = null,Object? assetName = null,Object? track = null,Object? publishedAt = null,Object? checkedAt = null,}) {
   return _then(_self.copyWith(
 latestVersion: null == latestVersion ? _self.latestVersion : latestVersion // ignore: cast_nullable_to_non_nullable
 as String,downloadUrl: null == downloadUrl ? _self.downloadUrl : downloadUrl // ignore: cast_nullable_to_non_nullable
 as String,checksumsUrl: null == checksumsUrl ? _self.checksumsUrl : checksumsUrl // ignore: cast_nullable_to_non_nullable
 as String,assetName: null == assetName ? _self.assetName : assetName // ignore: cast_nullable_to_non_nullable
+as String,track: null == track ? _self.track : track // ignore: cast_nullable_to_non_nullable
 as String,publishedAt: null == publishedAt ? _self.publishedAt : publishedAt // ignore: cast_nullable_to_non_nullable
 as DateTime,checkedAt: null == checkedAt ? _self.checkedAt : checkedAt // ignore: cast_nullable_to_non_nullable
 as DateTime,
@@ -91,7 +95,7 @@ as DateTime,
 @JsonSerializable()
 
 class _CachedRelease implements CachedRelease {
-  const _CachedRelease({required this.latestVersion, required this.downloadUrl, required this.checksumsUrl, required this.assetName, required this.publishedAt, required this.checkedAt});
+  const _CachedRelease({required this.latestVersion, required this.downloadUrl, required this.checksumsUrl, required this.assetName, required this.track, required this.publishedAt, required this.checkedAt});
   factory _CachedRelease.fromJson(Map<String, dynamic> json) => _$CachedReleaseFromJson(json);
 
 /// The latest version string found during the check.
@@ -102,6 +106,10 @@ class _CachedRelease implements CachedRelease {
 @override final  String checksumsUrl;
 /// The release asset name this cache entry was resolved for.
 @override final  String assetName;
+/// The release track ([ReleaseTrack.wireValue]) this cache entry was
+/// resolved for. A cache entry from a different track is ignored so a
+/// recent stable check can't mask an internal build (or vice versa).
+@override final  String track;
 /// When this release was published upstream.
 @override final  DateTime publishedAt;
 /// When this cache entry was created.
@@ -120,16 +128,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CachedRelease&&(identical(other.latestVersion, latestVersion) || other.latestVersion == latestVersion)&&(identical(other.downloadUrl, downloadUrl) || other.downloadUrl == downloadUrl)&&(identical(other.checksumsUrl, checksumsUrl) || other.checksumsUrl == checksumsUrl)&&(identical(other.assetName, assetName) || other.assetName == assetName)&&(identical(other.publishedAt, publishedAt) || other.publishedAt == publishedAt)&&(identical(other.checkedAt, checkedAt) || other.checkedAt == checkedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CachedRelease&&(identical(other.latestVersion, latestVersion) || other.latestVersion == latestVersion)&&(identical(other.downloadUrl, downloadUrl) || other.downloadUrl == downloadUrl)&&(identical(other.checksumsUrl, checksumsUrl) || other.checksumsUrl == checksumsUrl)&&(identical(other.assetName, assetName) || other.assetName == assetName)&&(identical(other.track, track) || other.track == track)&&(identical(other.publishedAt, publishedAt) || other.publishedAt == publishedAt)&&(identical(other.checkedAt, checkedAt) || other.checkedAt == checkedAt));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,latestVersion,downloadUrl,checksumsUrl,assetName,publishedAt,checkedAt);
+int get hashCode => Object.hash(runtimeType,latestVersion,downloadUrl,checksumsUrl,assetName,track,publishedAt,checkedAt);
 
 @override
 String toString() {
-  return 'CachedRelease(latestVersion: $latestVersion, downloadUrl: $downloadUrl, checksumsUrl: $checksumsUrl, assetName: $assetName, publishedAt: $publishedAt, checkedAt: $checkedAt)';
+  return 'CachedRelease(latestVersion: $latestVersion, downloadUrl: $downloadUrl, checksumsUrl: $checksumsUrl, assetName: $assetName, track: $track, publishedAt: $publishedAt, checkedAt: $checkedAt)';
 }
 
 
@@ -140,7 +148,7 @@ abstract mixin class _$CachedReleaseCopyWith<$Res> implements $CachedReleaseCopy
   factory _$CachedReleaseCopyWith(_CachedRelease value, $Res Function(_CachedRelease) _then) = __$CachedReleaseCopyWithImpl;
 @override @useResult
 $Res call({
- String latestVersion, String downloadUrl, String checksumsUrl, String assetName, DateTime publishedAt, DateTime checkedAt
+ String latestVersion, String downloadUrl, String checksumsUrl, String assetName, String track, DateTime publishedAt, DateTime checkedAt
 });
 
 
@@ -157,12 +165,13 @@ class __$CachedReleaseCopyWithImpl<$Res>
 
 /// Create a copy of CachedRelease
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? latestVersion = null,Object? downloadUrl = null,Object? checksumsUrl = null,Object? assetName = null,Object? publishedAt = null,Object? checkedAt = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? latestVersion = null,Object? downloadUrl = null,Object? checksumsUrl = null,Object? assetName = null,Object? track = null,Object? publishedAt = null,Object? checkedAt = null,}) {
   return _then(_CachedRelease(
 latestVersion: null == latestVersion ? _self.latestVersion : latestVersion // ignore: cast_nullable_to_non_nullable
 as String,downloadUrl: null == downloadUrl ? _self.downloadUrl : downloadUrl // ignore: cast_nullable_to_non_nullable
 as String,checksumsUrl: null == checksumsUrl ? _self.checksumsUrl : checksumsUrl // ignore: cast_nullable_to_non_nullable
 as String,assetName: null == assetName ? _self.assetName : assetName // ignore: cast_nullable_to_non_nullable
+as String,track: null == track ? _self.track : track // ignore: cast_nullable_to_non_nullable
 as String,publishedAt: null == publishedAt ? _self.publishedAt : publishedAt // ignore: cast_nullable_to_non_nullable
 as DateTime,checkedAt: null == checkedAt ? _self.checkedAt : checkedAt // ignore: cast_nullable_to_non_nullable
 as DateTime,

--- a/bridge/app/lib/src/updater/models/cached_release.g.dart
+++ b/bridge/app/lib/src/updater/models/cached_release.g.dart
@@ -11,6 +11,7 @@ _CachedRelease _$CachedReleaseFromJson(Map json) => _CachedRelease(
   downloadUrl: json['downloadUrl'] as String,
   checksumsUrl: json['checksumsUrl'] as String,
   assetName: json['assetName'] as String,
+  track: json['track'] as String,
   publishedAt: DateTime.parse(json['publishedAt'] as String),
   checkedAt: DateTime.parse(json['checkedAt'] as String),
 );
@@ -21,6 +22,7 @@ Map<String, dynamic> _$CachedReleaseToJson(_CachedRelease instance) =>
       'downloadUrl': instance.downloadUrl,
       'checksumsUrl': instance.checksumsUrl,
       'assetName': instance.assetName,
+      'track': instance.track,
       'publishedAt': instance.publishedAt.toIso8601String(),
       'checkedAt': instance.checkedAt.toIso8601String(),
     };

--- a/bridge/app/lib/src/updater/models/cached_release.g.dart
+++ b/bridge/app/lib/src/updater/models/cached_release.g.dart
@@ -11,7 +11,7 @@ _CachedRelease _$CachedReleaseFromJson(Map json) => _CachedRelease(
   downloadUrl: json['downloadUrl'] as String,
   checksumsUrl: json['checksumsUrl'] as String,
   assetName: json['assetName'] as String,
-  track: json['track'] as String,
+  track: json['track'] as String? ?? 'stable',
   publishedAt: DateTime.parse(json['publishedAt'] as String),
   checkedAt: DateTime.parse(json['checkedAt'] as String),
 );

--- a/bridge/app/lib/src/updater/repositories/release_repository.dart
+++ b/bridge/app/lib/src/updater/repositories/release_repository.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 
 import '../api/github_releases_api.dart';
 import '../api/update_cache_api.dart';
+import '../foundation/release_track.dart';
 import '../models/bridge_version.dart';
 import '../models/cached_release.dart';
 import '../models/distribution_target.dart';
@@ -13,21 +14,38 @@ class ReleaseRepository {
   final UpdateCacheApi _cache;
   final BridgeVersion _currentVersion;
   final DistributionTarget _target;
+  final ReleaseTrack _track;
 
   ReleaseRepository({
     required GitHubReleasesApi api,
     required UpdateCacheApi cache,
     required String currentVersion,
     required DistributionTarget target,
+    required ReleaseTrack track,
   }) : _api = api,
        _cache = cache,
        _currentVersion = BridgeVersion.parse(value: currentVersion),
-       _target = target;
+       _target = target,
+       _track = track;
+
+  /// Whether [version] is eligible for the active [ReleaseTrack]:
+  /// - stable: only stable releases.
+  /// - internal: stable releases plus `-internal.*` pre-releases. Other
+  ///   pre-release kinds (e.g. `-rc`, `-beta`) are intentionally excluded so
+  ///   "internal" means exactly the internal lane, not "any non-stable build".
+  bool _isEligible(BridgeVersion version) {
+    if (version.isStable) {
+      return true;
+    }
+    return _track == ReleaseTrack.internal &&
+        version.prereleaseIdentifiers.isNotEmpty &&
+        version.prereleaseIdentifiers.first == 'internal';
+  }
 
   Future<ReleaseInfo?> checkForNewerRelease() async {
     final cached = await _cache.read(ttl: const Duration(minutes: 10));
     if (cached != null) {
-      if (cached.assetName == _target.assetName) {
+      if (cached.assetName == _target.assetName && cached.track == _track.wireValue) {
         return _evaluateCached(cached: cached);
       }
     }
@@ -36,12 +54,12 @@ class ReleaseRepository {
   }
 
   ReleaseInfo? _evaluateCached({required CachedRelease cached}) {
-    if (cached.assetName != _target.assetName) {
+    if (cached.assetName != _target.assetName || cached.track != _track.wireValue) {
       return null;
     }
 
     final BridgeVersion? latestVersion = BridgeVersion.tryParse(value: cached.latestVersion);
-    if (latestVersion == null || !latestVersion.isStable) {
+    if (latestVersion == null || !_isEligible(latestVersion)) {
       return null;
     }
 
@@ -73,7 +91,6 @@ class ReleaseRepository {
         .where(
           (release) =>
               !release.draft &&
-              !release.prerelease &&
               release.tagName.startsWith('v'),
         )
         .map(
@@ -81,7 +98,7 @@ class ReleaseRepository {
             final tagName = release.tagName;
             final versionString = tagName.replaceFirst('v', '');
             final version = BridgeVersion.tryParse(value: versionString);
-            return version != null && version.isStable
+            return version != null && _isEligible(version)
                 ? (
                     release: release,
                     version: version,
@@ -150,13 +167,14 @@ class ReleaseRepository {
           downloadUrl: assetUrl,
           checksumsUrl: checksumsUrl,
           assetName: assetName,
+          track: _track.wireValue,
           publishedAt: publishedAt,
           checkedAt: DateTime.now(),
         ),
       );
     }
 
-    if (!latestVersion.isStable) {
+    if (!_isEligible(latestVersion)) {
       return null;
     }
     if (latestVersion.compareTo(_currentVersion) <= 0) {

--- a/bridge/app/lib/src/updater/repositories/release_repository.dart
+++ b/bridge/app/lib/src/updater/repositories/release_repository.dart
@@ -39,7 +39,7 @@ class ReleaseRepository {
     }
     return _track == ReleaseTrack.internal &&
         version.prereleaseIdentifiers.isNotEmpty &&
-        version.prereleaseIdentifiers.first == 'internal';
+        version.prereleaseIdentifiers.first == ReleaseTrack.internal.wireValue;
   }
 
   Future<ReleaseInfo?> checkForNewerRelease() async {

--- a/bridge/app/test/bridge_config_service_test.dart
+++ b/bridge/app/test/bridge_config_service_test.dart
@@ -2,6 +2,7 @@ import 'package:sesori_bridge/src/repositories/bridge_settings.dart';
 import 'package:sesori_bridge/src/repositories/bridge_settings_repository.dart';
 import 'package:sesori_bridge/src/repositories/default_editor_repository.dart';
 import 'package:sesori_bridge/src/services/bridge_config_service.dart';
+import 'package:sesori_bridge/src/updater/foundation/release_track.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -44,6 +45,9 @@ class _FakeBridgeSettingsRepository implements BridgeSettingsRepository {
 
   @override
   Future<void> saveSettings({required BridgeSettings settings}) async {}
+
+  @override
+  Future<void> updateReleaseTrack({required ReleaseTrack track}) async {}
 }
 
 class _FakeDefaultEditorRepository implements DefaultEditorRepository {

--- a/bridge/app/test/bridge_settings_repository_test.dart
+++ b/bridge/app/test/bridge_settings_repository_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:sesori_bridge/src/api/bridge_settings_api.dart';
 import 'package:sesori_bridge/src/repositories/bridge_settings.dart';
 import 'package:sesori_bridge/src/repositories/bridge_settings_repository.dart';
+import 'package:sesori_bridge/src/updater/foundation/release_track.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -149,7 +150,19 @@ void main() {
 
       expect(
         api.lastWrittenConfig,
-        equals('{\n  "sleepPrevention": "off"\n}'),
+        equals('{\n  "sleepPrevention": "off",\n  "releaseTrack": "stable"\n}'),
+      );
+    });
+
+    test('updateReleaseTrack persists the track and preserves other settings', () async {
+      final api = FakeBridgeSettingsApi(readResult: '{"sleepPrevention":"off"}');
+      final repository = BridgeSettingsRepository(api: api);
+
+      await repository.updateReleaseTrack(track: ReleaseTrack.internal);
+
+      expect(
+        api.lastWrittenConfig,
+        equals('{\n  "sleepPrevention": "off",\n  "releaseTrack": "internal"\n}'),
       );
     });
 
@@ -165,7 +178,7 @@ void main() {
   });
 }
 
-const _defaultJson = '{\n  "sleepPrevention": "always"\n}';
+const _defaultJson = '{\n  "sleepPrevention": "always",\n  "releaseTrack": "stable"\n}';
 
 /// Captures [writeln] calls; [IOOverrides] swaps it in for stdout/stderr.
 class _CapturingStdout implements Stdout {

--- a/bridge/app/test/bridge_settings_test.dart
+++ b/bridge/app/test/bridge_settings_test.dart
@@ -1,4 +1,5 @@
 import 'package:sesori_bridge/src/repositories/bridge_settings.dart';
+import 'package:sesori_bridge/src/updater/foundation/release_track.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -38,13 +39,19 @@ void main() {
     test('toJson serializes always mode', () {
       const settings = BridgeSettings(sleepPrevention: SleepPreventionMode.always);
 
-      expect(settings.toJson(), equals({'sleepPrevention': 'always'}));
+      expect(
+        settings.toJson(),
+        equals({'sleepPrevention': 'always', 'releaseTrack': 'stable'}),
+      );
     });
 
     test('toJson serializes off mode', () {
       const settings = BridgeSettings(sleepPrevention: SleepPreventionMode.off);
 
-      expect(settings.toJson(), equals({'sleepPrevention': 'off'}));
+      expect(
+        settings.toJson(),
+        equals({'sleepPrevention': 'off', 'releaseTrack': 'stable'}),
+      );
     });
 
     test('enabledPlugins defaults to unset', () {
@@ -84,7 +91,10 @@ void main() {
     test('toJson omits enabledPlugins when unset, keeping the defaults file shape', () {
       const settings = BridgeSettings();
 
-      expect(settings.toJson(), equals({'sleepPrevention': 'always'}));
+      expect(
+        settings.toJson(),
+        equals({'sleepPrevention': 'always', 'releaseTrack': 'stable'}),
+      );
     });
 
     test('toJson includes enabledPlugins when set', () {
@@ -94,9 +104,59 @@ void main() {
         settings.toJson(),
         equals({
           'sleepPrevention': 'always',
+          'releaseTrack': 'stable',
           'enabledPlugins': ['opencode'],
         }),
       );
+    });
+
+    test('releaseTrack defaults to stable', () {
+      const settings = BridgeSettings();
+
+      expect(settings.releaseTrack, ReleaseTrack.stable);
+    });
+
+    test('fromJson parses the internal track', () {
+      final settings = BridgeSettings.fromJson({'releaseTrack': 'internal'});
+
+      expect(settings.releaseTrack, ReleaseTrack.internal);
+    });
+
+    test('fromJson defaults an unknown releaseTrack to stable', () {
+      final settings = BridgeSettings.fromJson({'releaseTrack': 'nightly'});
+
+      expect(settings.releaseTrack, ReleaseTrack.stable);
+    });
+
+    test('fromJson defaults a missing releaseTrack to stable', () {
+      final settings = BridgeSettings.fromJson({'sleepPrevention': 'always'});
+
+      expect(settings.releaseTrack, ReleaseTrack.stable);
+    });
+
+    test('fromJson defaults a non-string releaseTrack to stable', () {
+      final settings = BridgeSettings.fromJson({'releaseTrack': 42});
+
+      expect(settings.releaseTrack, ReleaseTrack.stable);
+    });
+
+    test('toJson always serializes the release track', () {
+      const settings = BridgeSettings(releaseTrack: ReleaseTrack.internal);
+
+      expect(settings.toJson()['releaseTrack'], equals('internal'));
+    });
+
+    test('copyWith changes only releaseTrack and preserves other fields', () {
+      const settings = BridgeSettings(
+        sleepPrevention: SleepPreventionMode.off,
+        enabledPlugins: ['opencode'],
+      );
+
+      final updated = settings.copyWith(releaseTrack: ReleaseTrack.internal);
+
+      expect(updated.releaseTrack, ReleaseTrack.internal);
+      expect(updated.sleepPrevention, SleepPreventionMode.off);
+      expect(updated.enabledPlugins, equals(['opencode']));
     });
   });
 }

--- a/bridge/app/test/updater/release_contract_test.dart
+++ b/bridge/app/test/updater/release_contract_test.dart
@@ -8,6 +8,7 @@ import 'package:path/path.dart' as p;
 import 'package:sesori_bridge/src/updater/api/github_releases_api.dart';
 import 'package:sesori_bridge/src/updater/api/update_cache_api.dart';
 import 'package:sesori_bridge/src/updater/foundation/platform_info.dart';
+import 'package:sesori_bridge/src/updater/foundation/release_track.dart';
 import 'package:sesori_bridge/src/updater/models/cached_release.dart';
 import 'package:sesori_bridge/src/updater/models/distribution_target.dart';
 import 'package:sesori_bridge/src/updater/repositories/release_repository.dart';
@@ -124,6 +125,7 @@ void main() {
         cache: _NoCache(),
         currentVersion: '0.2.0',
         target: target,
+        track: ReleaseTrack.stable,
       );
     });
 

--- a/bridge/app/test/updater/release_repository_test.dart
+++ b/bridge/app/test/updater/release_repository_test.dart
@@ -7,6 +7,7 @@ import 'package:http/testing.dart';
 import 'package:sesori_bridge/src/updater/api/github_releases_api.dart';
 import 'package:sesori_bridge/src/updater/api/update_cache_api.dart';
 import 'package:sesori_bridge/src/updater/foundation/platform_info.dart';
+import 'package:sesori_bridge/src/updater/foundation/release_track.dart';
 import 'package:sesori_bridge/src/updater/models/bridge_version.dart';
 import 'package:sesori_bridge/src/updater/models/cached_release.dart';
 import 'package:sesori_bridge/src/updater/models/distribution_target.dart';
@@ -84,6 +85,7 @@ ReleaseRepository _makeRepository({
   _FakeCache? cache,
   String currentVersion = '0.2.0',
   DistributionTarget? target,
+  ReleaseTrack track = ReleaseTrack.stable,
 }) {
   final resolvedTarget = target ?? _defaultTarget;
 
@@ -92,6 +94,7 @@ ReleaseRepository _makeRepository({
     cache: cache ?? _FakeCache(),
     currentVersion: currentVersion,
     target: resolvedTarget,
+    track: track,
   );
 }
 
@@ -388,6 +391,7 @@ void main() {
           downloadUrl: 'https://example.com/dl/asset.tar.gz',
           checksumsUrl: 'https://example.com/dl/checksums.txt',
           assetName: _defaultTarget.assetName,
+          track: 'stable',
           publishedAt: DateTime.parse('2024-06-01T00:00:00Z'),
           checkedAt: DateTime.now(),
         );
@@ -417,6 +421,7 @@ void main() {
           downloadUrl: 'https://example.com/dl/asset.tar.gz',
           checksumsUrl: 'https://example.com/dl/checksums.txt',
           assetName: _defaultTarget.assetName,
+          track: 'stable',
           publishedAt: DateTime.parse('2024-06-01T00:00:00Z'),
           checkedAt: DateTime.now(),
         );
@@ -442,6 +447,7 @@ void main() {
           downloadUrl: 'https://example.com/dl/asset.tar.gz',
           checksumsUrl: 'https://example.com/dl/checksums.txt',
           assetName: _defaultTarget.assetName,
+          track: 'stable',
           publishedAt: DateTime.parse('2024-06-01T00:00:00Z'),
           checkedAt: DateTime.now(),
         );
@@ -550,6 +556,7 @@ void main() {
           downloadUrl: 'https://example.com/dl/windows.zip',
           checksumsUrl: 'https://example.com/dl/checksums.txt',
           assetName: 'sesori-bridge-windows-x64.zip',
+          track: 'stable',
           publishedAt: DateTime.parse('2024-06-01T00:00:00Z'),
           checkedAt: DateTime.now(),
         );
@@ -617,6 +624,164 @@ void main() {
 
         expect(result, isNotNull);
         expect(result!.version, equals('0.3.1'));
+      });
+    });
+    // -----------------------------------------------------------------------
+    group('release track', () {
+      test('stable track ignores a newer internal pre-release', () async {
+        final repository = _makeRepository(
+          httpClient: _mockOk(
+            body: [
+              _releaseJson(version: '0.5.0-internal.3', prerelease: true),
+              _releaseJson(version: '0.3.1'),
+            ],
+          ),
+          currentVersion: '0.2.0',
+        );
+
+        final result = await repository.checkForNewerRelease();
+
+        expect(result, isNotNull);
+        expect(result!.version, equals('0.3.1'));
+      });
+
+      test('internal track selects a newer internal pre-release', () async {
+        final repository = _makeRepository(
+          httpClient: _mockOk(
+            body: [
+              _releaseJson(version: '0.5.0-internal.3', prerelease: true),
+              _releaseJson(version: '0.3.1'),
+            ],
+          ),
+          currentVersion: '0.2.0',
+          track: ReleaseTrack.internal,
+        );
+
+        final result = await repository.checkForNewerRelease();
+
+        expect(result, isNotNull);
+        expect(result!.version, equals('0.5.0-internal.3'));
+      });
+
+      test('internal track picks the newest of stable and internal', () async {
+        final repository = _makeRepository(
+          httpClient: _mockOk(
+            body: [
+              _releaseJson(version: '0.4.0-internal.2', prerelease: true),
+              _releaseJson(version: '0.4.0'),
+            ],
+          ),
+          currentVersion: '0.2.0',
+          track: ReleaseTrack.internal,
+        );
+
+        final result = await repository.checkForNewerRelease();
+
+        expect(result, isNotNull);
+        // Stable 0.4.0 outranks its own 0.4.0-internal.2 pre-release.
+        expect(result!.version, equals('0.4.0'));
+      });
+
+      test('internal track ignores non-internal pre-releases (rc/beta)', () async {
+        final repository = _makeRepository(
+          httpClient: _mockOk(
+            body: [
+              _releaseJson(version: '0.5.0-rc.1', prerelease: true),
+              _releaseJson(version: '0.5.0-beta.2', prerelease: true),
+              _releaseJson(version: '0.3.1'),
+            ],
+          ),
+          currentVersion: '0.2.0',
+          track: ReleaseTrack.internal,
+        );
+
+        final result = await repository.checkForNewerRelease();
+
+        expect(result, isNotNull);
+        expect(result!.version, equals('0.3.1'));
+      });
+
+      test('internal track is forward-only: stable older than current internal → null', () async {
+        final repository = _makeRepository(
+          httpClient: _mockOk(
+            body: [
+              _releaseJson(version: '0.3.0'),
+            ],
+          ),
+          currentVersion: '0.4.0-internal.3',
+          track: ReleaseTrack.internal,
+        );
+
+        // 0.3.0 < 0.4.0-internal.3, so no update (no downgrade to stable).
+        expect(await repository.checkForNewerRelease(), isNull);
+      });
+
+      test('internal track selects the highest internal build number', () async {
+        final repository = _makeRepository(
+          httpClient: _mockOk(
+            body: [
+              _releaseJson(version: '0.4.0-internal.9', prerelease: true),
+              _releaseJson(version: '0.4.0-internal.53', prerelease: true),
+              _releaseJson(version: '0.4.0-internal.12', prerelease: true),
+            ],
+          ),
+          currentVersion: '0.2.0',
+          track: ReleaseTrack.internal,
+        );
+
+        final result = await repository.checkForNewerRelease();
+
+        expect(result, isNotNull);
+        expect(result!.version, equals('0.4.0-internal.53'));
+      });
+
+      test('internal track writes the track into the cache', () async {
+        final cache = _FakeCache();
+        final repository = _makeRepository(
+          httpClient: _mockOk(body: [_releaseJson(version: '0.5.0-internal.3', prerelease: true)]),
+          cache: cache,
+          currentVersion: '0.2.0',
+          track: ReleaseTrack.internal,
+        );
+
+        await repository.checkForNewerRelease();
+
+        expect(cache.writtenReleases, hasLength(1));
+        expect(cache.writtenReleases.first.track, equals('internal'));
+        expect(cache.writtenReleases.first.latestVersion, equals('0.5.0-internal.3'));
+      });
+
+      test('cache entry from a different track is ignored and refreshed from HTTP', () async {
+        var httpCallCount = 0;
+        final client = MockClient((_) async {
+          httpCallCount++;
+          return http.Response(
+            jsonEncode([_releaseJson(version: '0.5.0-internal.4', prerelease: true)]),
+            200,
+          );
+        });
+
+        final cached = CachedRelease(
+          latestVersion: '9.9.9',
+          downloadUrl: 'https://example.com/dl/asset.tar.gz',
+          checksumsUrl: 'https://example.com/dl/checksums.txt',
+          assetName: _defaultTarget.assetName,
+          track: 'stable',
+          publishedAt: DateTime.parse('2024-06-01T00:00:00Z'),
+          checkedAt: DateTime.now(),
+        );
+        final repository = _makeRepository(
+          httpClient: client,
+          cache: _FakeCache(readResult: cached),
+          currentVersion: '0.2.0',
+          track: ReleaseTrack.internal,
+        );
+
+        final result = await repository.checkForNewerRelease();
+
+        expect(result, isNotNull);
+        expect(result!.version, equals('0.5.0-internal.4'));
+        expect(httpCallCount, equals(1), reason: 'a stable cache must not satisfy an internal-track check');
       });
     });
   });

--- a/bridge/app/test/updater/release_track_test.dart
+++ b/bridge/app/test/updater/release_track_test.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+
+import 'package:sesori_bridge/src/updater/foundation/release_track.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ReleaseTrack', () {
+    test('wireValue is the enum name', () {
+      expect(ReleaseTrack.stable.wireValue, equals('stable'));
+      expect(ReleaseTrack.internal.wireValue, equals('internal'));
+    });
+
+    group('fromWire', () {
+      test('maps known values', () {
+        expect(ReleaseTrack.fromWire('stable'), ReleaseTrack.stable);
+        expect(ReleaseTrack.fromWire('internal'), ReleaseTrack.internal);
+      });
+
+      test('treats a missing value (null) as stable without logging', () {
+        final stderrLines = <String>[];
+        late final ReleaseTrack track;
+
+        IOOverrides.runZoned(
+          () => track = ReleaseTrack.fromWire(null),
+          stderr: () => _CapturingStdout(stderrLines),
+        );
+
+        expect(track, ReleaseTrack.stable);
+        expect(stderrLines, isEmpty, reason: 'the unconfigured case is expected, not a warning');
+      });
+
+      test('falls back to stable and logs to stderr for an unexpected value', () {
+        final stderrLines = <String>[];
+        final stdoutLines = <String>[];
+        late final ReleaseTrack track;
+
+        IOOverrides.runZoned(
+          () => track = ReleaseTrack.fromWire('nightly'),
+          stderr: () => _CapturingStdout(stderrLines),
+          stdout: () => _CapturingStdout(stdoutLines),
+        );
+
+        expect(track, ReleaseTrack.stable);
+        expect(stderrLines, hasLength(1));
+        expect(stderrLines.single, contains("Unknown release track 'nightly'"));
+        expect(stdoutLines, isEmpty, reason: 'stdout must stay machine-clean for --version/--help');
+      });
+    });
+  });
+}
+
+/// Captures `writeln` calls; [IOOverrides] swaps it in for stdout/stderr.
+class _CapturingStdout implements Stdout {
+  _CapturingStdout(this.lines);
+
+  final List<String> lines;
+
+  @override
+  void writeln([Object? object = '']) {
+    lines.add(object.toString());
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/updater/update_cache_test.dart
+++ b/bridge/app/test/updater/update_cache_test.dart
@@ -57,6 +57,29 @@ void main() {
       expect(cached.checkedAt, equals(now));
     });
 
+    test('legacy cache without track field defaults to stable without throwing', () async {
+      final now = DateTime(2024, 1, 1, 12, 0, 0);
+      final cache = UpdateCacheApi(
+        cacheDirectory: tempDir,
+        clock: Clock.fixed(now),
+      );
+
+      await Directory(tempDir).create(recursive: true);
+      // A cache file written before the `track` field existed.
+      await File('$tempDir/update_cache.json').writeAsString(
+        '{"latestVersion":"1.2.3","downloadUrl":"https://example.com/d",'
+        '"checksumsUrl":"https://example.com/c",'
+        '"assetName":"sesori-bridge-macos-arm64.tar.gz",'
+        '"publishedAt":"2023-12-31T12:00:00.000","checkedAt":"2024-01-01T12:00:00.000"}',
+      );
+
+      final cached = await cache.read(ttl: const Duration(hours: 1));
+
+      expect(cached, isNotNull);
+      expect(cached!.track, equals('stable'));
+      expect(cached.latestVersion, equals('1.2.3'));
+    });
+
     test('expired: data older than TTL returns null', () async {
       final checkedAt = DateTime(2024, 1, 1, 12, 0, 0);
       const ttl = Duration(hours: 1);

--- a/bridge/app/test/updater/update_cache_test.dart
+++ b/bridge/app/test/updater/update_cache_test.dart
@@ -36,6 +36,7 @@ void main() {
         downloadUrl: 'https://example.com/download/1.2.3',
         checksumsUrl: 'https://example.com/checksums/1.2.3',
         assetName: 'sesori-bridge-macos-arm64.tar.gz',
+        track: 'stable',
         publishedAt: now.subtract(const Duration(days: 1)),
         checkedAt: now,
       );
@@ -51,6 +52,7 @@ void main() {
       expect(cached.downloadUrl, equals('https://example.com/download/1.2.3'));
       expect(cached.checksumsUrl, equals('https://example.com/checksums/1.2.3'));
       expect(cached.assetName, equals('sesori-bridge-macos-arm64.tar.gz'));
+      expect(cached.track, equals('stable'));
       expect(cached.publishedAt, equals(now.subtract(const Duration(days: 1))));
       expect(cached.checkedAt, equals(now));
     });
@@ -69,6 +71,7 @@ void main() {
         downloadUrl: 'https://example.com/download/1.2.3',
         checksumsUrl: 'https://example.com/checksums/1.2.3',
         assetName: 'sesori-bridge-macos-arm64.tar.gz',
+        track: 'stable',
         publishedAt: checkedAt.subtract(const Duration(days: 1)),
         checkedAt: checkedAt,
       );
@@ -102,6 +105,7 @@ void main() {
         downloadUrl: 'https://example.com/download/1.2.3',
         checksumsUrl: 'https://example.com/checksums/1.2.3',
         assetName: 'sesori-bridge-macos-arm64.tar.gz',
+        track: 'stable',
         publishedAt: checkedAt.subtract(const Duration(days: 1)),
         checkedAt: checkedAt,
       );
@@ -164,6 +168,7 @@ void main() {
         downloadUrl: 'https://example.com/download/1.0.0',
         checksumsUrl: 'https://example.com/checksums/1.0.0',
         assetName: 'sesori-bridge-macos-arm64.tar.gz',
+        track: 'stable',
         publishedAt: DateTime.now(),
         checkedAt: DateTime.now(),
       );
@@ -192,6 +197,7 @@ void main() {
         downloadUrl: 'https://example.com/download/1.2.3',
         checksumsUrl: 'https://example.com/checksums/1.2.3',
         assetName: 'sesori-bridge-macos-arm64.tar.gz',
+        track: 'stable',
         publishedAt: checkedAt.subtract(const Duration(days: 1)),
         checkedAt: checkedAt,
       );
@@ -226,6 +232,7 @@ void main() {
         downloadUrl: 'https://example.com/download/1.0.0',
         checksumsUrl: 'https://example.com/checksums/1.0.0',
         assetName: 'sesori-bridge-macos-arm64.tar.gz',
+        track: 'stable',
         publishedAt: now.subtract(const Duration(days: 2)),
         checkedAt: now,
       );
@@ -237,6 +244,7 @@ void main() {
         downloadUrl: 'https://example.com/download/2.0.0',
         checksumsUrl: 'https://example.com/checksums/2.0.0',
         assetName: 'sesori-bridge-macos-arm64.tar.gz',
+        track: 'stable',
         publishedAt: now.subtract(const Duration(days: 1)),
         checkedAt: now,
       );
@@ -260,6 +268,7 @@ void main() {
         downloadUrl: 'https://example.com/download/1.0.0',
         checksumsUrl: 'https://example.com/checksums/1.0.0',
         assetName: 'sesori-bridge-macos-arm64.tar.gz',
+        track: 'stable',
         publishedAt: DateTime.now(),
         checkedAt: DateTime.now(),
       );


### PR DESCRIPTION
## Summary

Lets a bridge user choose which GitHub release channel the **runtime auto-updater** follows, via a new CLI command. The internal pre-release channel (`vX.Y.Z-internal.N`) is already produced by CI on every `main` merge but was invisible to the updater until now.

```
sesori-bridge config track internal   # follow internal pre-releases
sesori-bridge config track stable      # back to stable (default)
sesori-bridge config track             # print the current track
```

## Behavior

- **`stable`** (default, unchanged): only stable `vX.Y.Z` releases.
- **`internal`**: newest of `{stable} ∪ {vX.Y.Z-internal.N}` by semver. Only the `-internal.*` line is honored — other pre-release kinds (`-rc`, `-beta`) are ignored.
- **Forward-only**: switching back to `stable` never auto-downgrades a binary that's ahead of latest stable (avoids an older binary opening a newer Drift schema). You converge to stable once it catches up.
- Track is read once at startup and injected into `ReleaseRepository`; a change applies on **next restart** (consistent with the existing "updates apply at next startup" model). The active track is logged at startup.
- The 10-min release cache is now **track-aware**, so a recent stable check can't mask an internal build.
- Installers (`install.sh` / `install.ps1` / npm bootstrap) remain **stable-only** by design.

## Design

The full design was driven by an interview and captured before implementation. Decisions: internal = superset of stable; runtime-updater-only scope; forward-only (no downgrade); `stable`/`internal` naming; `config` becomes a command group (`config track`, `config edit`); next-restart application; no env override; warn-on-internal + startup log; `-internal.*`-only matching.

## Implementation

- New `ReleaseTrack { stable, internal }` enum (updater foundation), persisted in `BridgeSettings` (`releaseTrack`, default `stable`, always serialized, tolerant parse).
- `BridgeSettingsRepository.updateReleaseTrack` (read-modify-write).
- `ReleaseRepository` gains a `track` + `_isEligible` predicate; `CachedRelease` gains a `track` field (old caches invalidate gracefully).
- `config` restructured into a branch command (`config track` / `config edit`); bare `config` now lists subcommands.
- Docs updated (README / INSTALL / RELEASING).

No DB schema change.

## Review & verification

- ✅ `aristotle-plan-review`: approved.
- ✅ `aristotle-impl-review`: approved (one magic-string finding fixed in 49a7381b).
- ✅ `dart analyze --fatal-infos` clean; `dart test` 1329 passing (incl. new stable/internal selection, forward-only, cache-track, settings, and `updateReleaseTrack` tests).

## Out of scope (deferred)

Installers honoring the track; `SESORI_TRACK` env override; auto-downgrade; non-`internal` pre-release channels.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a selectable update track for the runtime auto-updater: choose `stable` (default) or `internal` via `sesori-bridge config track`. Internal builds can auto‑update without affecting stable users; updates remain forward‑only.

- **New Features**
  - New CLI: `sesori-bridge config track [stable|internal]` (no args prints the current track); invalid args show a usage error; `config edit` opens the config.
  - Persisted `releaseTrack` with default `stable`; read at startup and logged (warning for `internal`, debug for `stable`). Missing/unreadable value resolves silently to `stable`; unexpected value falls back to `stable` with an error on stderr so stdout stays clean and startup never blocks.
  - Updater honors track: `internal` = newest of stable and `vX.Y.Z-internal.N`; other prereleases ignored; no auto‑downgrade when switching back to `stable`.
  - Release cache is track‑aware and stores the track; legacy cache files default to `stable`; installers (shell/PowerShell/`@sesori/bridge`) remain stable‑only.

- **Migration**
  - If you used `sesori-bridge config` to open the config, use `sesori-bridge config edit`.
  - After changing the track, restart the bridge to apply.

<sup>Written for commit 366323f385595e17a621ba55e278bff4d9499414. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

