### PR TITLE
chore: bump pr-monitor plugin to v0.1.2 and simplify monitor-pr skill

### DIFF
--- a/.opencode/skills/monitor-pr/SKILL.md
+++ b/.opencode/skills/monitor-pr/SKILL.md
@@ -48,5 +48,5 @@ the flush. Just handle everything in the report in one batch, then wait for the 
 ## Other actions
 
 - `pr_monitor(action: "status")` — list this session's monitors (also useful before ending a work session).
-- `pr_monitor(action: "flush", pr: "owner/repo#123" | "all")` — force an immediate full status report on demand (this also advances the baseline). Use it only when you want the current state right now instead of waiting for the next scheduled report — never as a routine step after handling a report.
-- `pr_monitor(action: "stop", pr: "owner/repo#123" | "all")` — stop watching without waiting for merge.
+- `pr_monitor(action: "flush", pr: "owner/repo#123")` or `pr_monitor(action: "flush", pr: "all")` — force an immediate full status report on demand (this also advances the baseline). Use it only when you want the current state right now instead of waiting for the next scheduled report — never as a routine step after handling a report.
+- `pr_monitor(action: "stop", pr: "owner/repo#123")` or `pr_monitor(action: "stop", pr: "all")` — stop watching without waiting for merge.

--- a/.opencode/skills/monitor-pr/SKILL.md
+++ b/.opencode/skills/monitor-pr/SKILL.md
@@ -38,19 +38,15 @@ act as follows, addressing everything in the report in one batch:
 | Approved + CI passing + 0 unresolved threads | Nothing to fix — summarize the PR state to the user. |
 | `— MERGED` / `— CLOSED` | The monitor already stopped itself. Nothing to do. |
 
-## After handling a report — ALWAYS flush
+## After handling a report — no manual flush needed
 
-Finish every handled cycle with:
-
-```
-pr_monitor(action: "flush", pr: "owner/repo#123")
-```
-
-This returns the current full status and advances the "new since last flush" baseline
-past your own pushes and replies, so they are not echoed back as new activity. Skipping
-this step causes a redundant wake-up report about your own follow-up comments.
+A delivered `[PR Monitor]` report has **already advanced** the "new since last flush"
+baseline, so the activity it reported is not echoed back at you. The report itself acts as
+the flush. Just handle everything in the report in one batch, then wait for the next report
+(or for merge/close). Do **not** flush as a routine step after handling a report.
 
 ## Other actions
 
 - `pr_monitor(action: "status")` — list this session's monitors (also useful before ending a work session).
+- `pr_monitor(action: "flush", pr: "owner/repo#123" | "all")` — force an immediate full status report on demand (this also advances the baseline). Use it only when you want the current state right now instead of waiting for the next scheduled report — never as a routine step after handling a report.
 - `pr_monitor(action: "stop", pr: "owner/repo#123" | "all")` — stop watching without waiting for merge.

--- a/opencode.json
+++ b/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["github:sesori-ai/opencode-pr-monitor#v0.1.0"],
+  "plugin": ["github:sesori-ai/opencode-pr-monitor#v0.1.2"],
   "mcp": {
     "mobile-mcp": {
       "type": "local",


### PR DESCRIPTION
## What

- Bump the `sesori-ai/opencode-pr-monitor` plugin pin in `opencode.json` from `v0.1.0` → `v0.1.2`.
- Update the `monitor-pr` skill to match v0.1.2 behavior:
  - Remove the "After handling a report — ALWAYS flush" step.
  - Document that a delivered `[PR Monitor]` report already advances the "new since last flush" baseline — the report itself acts as the flush.
  - Reframe `flush` as an on-demand "force a full status report now" override.

## Why

In v0.1.2 the plugin advances the baseline on every successfully delivered report (confirmed in the plugin README/CHANGELOG and `src/watch.ts`). Manually flushing after handling a report is therefore redundant and previously caused a duplicate wake-up report about the agent's own follow-up pushes/replies. The skill's always-flush cycle no longer reflects how the plugin works.

## Notes

- No action-set or config-key changes in v0.1.2 (`start`/`stop`/`flush`/`status`; same `.opencode/pr-monitor.json` keys), so no further skill changes were required.
- The new plugin version takes effect on the next opencode start.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped `sesori-ai/opencode-pr-monitor` to v0.1.2 and aligned the `monitor-pr` skill with auto-advancing reports. Clarified `flush`/`stop` examples to avoid ambiguous calls.

- **Dependencies**
  - Pin `sesori-ai/opencode-pr-monitor` to v0.1.2 in `opencode.json` (was v0.1.0).

- **Refactors**
  - Remove the “ALWAYS flush after handling a report” step; delivered reports already advance the baseline.
  - Reframe `pr_monitor(action: "flush")` as an on-demand “full status now” override, not a routine step.
  - Show `flush` and `stop` examples as distinct calls (no union-type `|`) to prevent literal pipe usage in tool calls.

<sup>Written for commit db15dd1fc991d5bc5ef3ef483b3464ffd0445a47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

