### PR TITLE
fix(mobile): harden resume reconnect — stale-socket teardown + revert bridge-offline (follow-up to #262)

### DIFF
--- a/docs/plans/auth-reconnect-ux-plan.md
+++ b/docs/plans/auth-reconnect-ux-plan.md
@@ -4,8 +4,12 @@ Status: **in progress** · Owner: mobile/transport · Branch strategy: **one sma
 
 ## Current stage
 
-**PR 1 implemented** (proactive reconnect on resume, including the
-bridge-offline state).
+**PR 1a implemented** — review follow-ups on PR 1: detach the stale socket on
+resume so requests fail fast instead of blocking on the dead connection, and
+revert the bridge-offline case from the proactive check (the E2E handshake can't
+complete while the bridge is down, so forcing a reconnect regressed it to the
+blocking ConnectionLost state). PR 1 (proactive reconnect on resume) shipped in
+#262.
 
 > **Maintenance rule:** this **Current stage** line (and the Status tracker
 > table at the bottom) MUST be updated as part of **every** PR in this series.
@@ -178,7 +182,9 @@ Tier 4 stand alone. Ship and validate each before starting the next.
 | PR | Tier | Status |
 | --- | --- | --- |
 | PR 1 — proactive reconnect on resume | 1 | implemented (#262) |
+| PR 1a — review follow-ups (stale-socket teardown; revert bridge-offline) | 1 | implemented |
 | PR 2 — immediate first attempt | 1 | not started |
+| (deferred) bridge-offline recovery without a completed handshake | 1/3 | not started |
 | PR 3 — skip health after resume | 1 | not started |
 | PR 4 — room-key memory cache | 2 | not started |
 | PR 5 — token read memory cache | 2 | not started |

--- a/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -65,6 +65,7 @@ class ConnectionService {
   Timer? _reconnectTimer;
   Completer<void>? _reconnectDelayCompleter;
   Future<bool>? _activeAuthConnect;
+  Future<void>? _activeDisconnect;
   int _requestCounter = 0;
   final Random _requestIdRandom = Random();
   int _authRetryCount = 0;
@@ -418,7 +419,19 @@ class ConnectionService {
     }
   }
 
-  Future<void> _disconnectRelayClient() async {
+  /// Tears down the active relay client, coalescing concurrent callers so an
+  /// eager teardown (e.g. on resume) and the reconnect path's own teardown share
+  /// a single in-flight operation. A replacement socket is therefore never
+  /// opened until the previous client's disconnect has fully completed, avoiding
+  /// briefly holding two phone sockets for the same account (which the relay can
+  /// reject as account-full at the device limit).
+  Future<void> _disconnectRelayClient() {
+    return _activeDisconnect ??= _doDisconnectRelayClient().whenComplete(() {
+      _activeDisconnect = null;
+    });
+  }
+
+  Future<void> _doDisconnectRelayClient() async {
     // Detach the client synchronously first so callers (e.g. RelayHttpApiClient)
     // stop routing requests through a socket we're tearing down, rather than
     // during the async subscription cancellations below.

--- a/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -419,14 +419,18 @@ class ConnectionService {
   }
 
   Future<void> _disconnectRelayClient() async {
+    // Detach the client synchronously first so callers (e.g. RelayHttpApiClient)
+    // stop routing requests through a socket we're tearing down, rather than
+    // during the async subscription cancellations below.
+    final relayClient = _relayClient;
+    _relayClient = null;
+
     await _relaySseSubscription?.cancel();
     _relaySseSubscription = null;
 
     await _bridgeStatusSubscription?.cancel();
     _bridgeStatusSubscription = null;
 
-    final relayClient = _relayClient;
-    _relayClient = null;
     if (relayClient == null) {
       return;
     }
@@ -461,21 +465,29 @@ class ConnectionService {
     if (config == null) return;
 
     // The relay closes backgrounded phones once its ping/pong window lapses
-    // (~30-45s). Past [_resumeReconnectThreshold], any status that still holds
-    // an open relay socket (connected, or bridge-offline while waiting for the
-    // bridge to return) is almost certainly a dead socket, so reconnect
-    // proactively rather than discovering it later via a request timeout.
-    // Bridge-offline especially must reconnect: its recovery depends on a relay
-    // frame (BridgeStatus.online) that a dead socket will never deliver.
+    // (~30-45s). Past [_resumeReconnectThreshold], a still-"connected" status is
+    // almost certainly a dead socket, so reconnect proactively rather than
+    // discovering it later via a request timeout.
+    //
+    // ConnectionBridgeOffline is deliberately NOT treated as stale here: while
+    // the bridge is offline the E2E handshake cannot complete, so a forced
+    // reconnect would fail and drop us into the blocking ConnectionLost state,
+    // losing the watcher for the bridge's return. Bridge-offline recovery keeps
+    // relying on its relay status watcher and the socket's own drop (onDone).
+    // Re-establishing a relay-level watcher without a completed handshake is a
+    // separate, larger change (tracked in the reconnect UX plan).
     final connectionLikelyStale =
-        (status is ConnectionConnected || status is ConnectionBridgeOffline) &&
-        backgroundedFor >= _resumeReconnectThreshold;
+        status is ConnectionConnected && backgroundedFor >= _resumeReconnectThreshold;
 
     final needsReconnect =
         status is ConnectionLost || status is ConnectionReconnecting || connectionLikelyStale;
     if (!needsReconnect) return;
 
     logd("App resumed — triggering reconnect (status=${status.runtimeType}, backgrounded=$backgroundedFor)");
+    // Detach the likely-dead socket immediately so requests fired right after
+    // foregrounding fail fast instead of routing through the zombie connection
+    // and blocking on the 30s request timeout during the reconnect backoff.
+    unawaited(_disconnectRelayClient());
     _relayReconnectBackoff = const Duration(seconds: 1);
     _status.add(ConnectionStatus.reconnecting(config: config));
     unawaited(_reconnectRelayWithRefresh(config));

--- a/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -425,10 +425,21 @@ class ConnectionService {
     final relayClient = _relayClient;
     _relayClient = null;
 
-    await _relaySseSubscription?.cancel();
+    // Never let teardown complete with an error: several callers invoke this via
+    // `unawaited(...)`, so a thrown cancellation/disconnect error would surface
+    // as an uncaught async error in the zone.
+    try {
+      await _relaySseSubscription?.cancel();
+    } catch (error, stackTrace) {
+      loge("Failed to cancel relay SSE subscription", error, stackTrace);
+    }
     _relaySseSubscription = null;
 
-    await _bridgeStatusSubscription?.cancel();
+    try {
+      await _bridgeStatusSubscription?.cancel();
+    } catch (error, stackTrace) {
+      loge("Failed to cancel bridge status subscription", error, stackTrace);
+    }
     _bridgeStatusSubscription = null;
 
     if (relayClient == null) {

--- a/mobile/module_core/test/capabilities/connection_service_stale_test.dart
+++ b/mobile/module_core/test/capabilities/connection_service_stale_test.dart
@@ -49,6 +49,7 @@ class _TestClockProvider extends ClockProvider {
 
 void main() {
   setUpAll(() {
+    registerFallbackValue(const Duration(minutes: 1));
     registerFallbackValue(
       const RelayRequest(id: "fallback", method: "GET", path: "/health", headers: {}, body: null),
     );
@@ -268,6 +269,8 @@ void main() {
       when(() => relayClient.subscribeSse(any())).thenAnswer((_) => sseController.stream);
       when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
       when(relayClient.disconnect).thenAnswer((_) async {});
+      when(() => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl")))
+          .thenAnswer((_) async => "token");
 
       final staleService = ConnectionService(
         cryptoService,

--- a/mobile/module_core/test/capabilities/connection_service_stale_test.dart
+++ b/mobile/module_core/test/capabilities/connection_service_stale_test.dart
@@ -3,6 +3,7 @@ import "dart:async";
 import "package:mocktail/mocktail.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_dart_core/src/capabilities/relay/relay_client.dart";
 import "package:sesori_dart_core/src/capabilities/relay/room_key_storage.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/connection_service.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/models/connection_status.dart";
@@ -23,6 +24,21 @@ class MockLifecycleSource extends Mock implements LifecycleSource {}
 
 class MockFailureReporter extends Mock implements FailureReporter {}
 
+class MockRelayClient extends Mock implements RelayClient {}
+
+class _TestRelayClientFactory extends RelayClientFactory {
+  final RelayClient _client;
+  _TestRelayClientFactory(this._client);
+
+  @override
+  RelayClient call({
+    required String relayHost,
+    required RelayCryptoService cryptoService,
+    required RoomKeyStorage roomKeyStorage,
+    required String? authToken,
+  }) => _client;
+}
+
 class _TestClockProvider extends ClockProvider {
   final DateTime Function() _now;
   _TestClockProvider(this._now);
@@ -32,6 +48,12 @@ class _TestClockProvider extends ClockProvider {
 }
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      const RelayRequest(id: "fallback", method: "GET", path: "/health", headers: {}, body: null),
+    );
+  });
+
   group("ConnectionService stale reconnect", () {
     late MockRelayCryptoService cryptoService;
     late MockRoomKeyStorage roomKeyStorage;
@@ -217,10 +239,11 @@ void main() {
       expect(service.currentStatus, isA<ConnectionConnected>());
     });
 
-    test("proactively reconnects when resuming past the threshold while bridge offline", () async {
-      // Bridge-offline keeps an open relay socket waiting for the bridge to
-      // return; the relay still drops it while backgrounded, so resume must
-      // reconnect or the BridgeStatus.online frame would never arrive.
+    test("does NOT proactively reconnect on resume while bridge offline", () async {
+      // While the bridge is offline the E2E handshake cannot complete, so a
+      // forced reconnect would fail into the blocking ConnectionLost state.
+      // Bridge-offline recovery instead relies on its relay watcher / socket
+      // drop, so resume must leave the status untouched.
       service.emitStatusForTesting(const ConnectionStatus.bridgeOffline(config: config, health: health));
 
       lifecycleController.add(LifecycleState.paused);
@@ -229,7 +252,47 @@ void main() {
       lifecycleController.add(LifecycleState.resumed);
       await flush();
 
-      expect(service.currentStatus, isA<ConnectionReconnecting>());
+      expect(service.currentStatus, isA<ConnectionBridgeOffline>());
+    });
+
+    test("detaches the stale relay client on resume so requests stop using the dead socket", () async {
+      final sseController = StreamController<RelaySseEvent>.broadcast();
+      addTearDown(sseController.close);
+
+      final relayClient = MockRelayClient();
+      when(relayClient.connect).thenAnswer((_) async {});
+      when(() => relayClient.isConnected).thenReturn(true);
+      when(() => relayClient.sendRequest(any())).thenAnswer(
+        (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
+      );
+      when(() => relayClient.subscribeSse(any())).thenAnswer((_) => sseController.stream);
+      when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
+      when(relayClient.disconnect).thenAnswer((_) async {});
+
+      final staleService = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        MockFailureReporter(),
+        clock: _TestClockProvider(() => now),
+        relayClientFactory: _TestRelayClientFactory(relayClient),
+      );
+      addTearDown(staleService.dispose);
+
+      await staleService.connect(config);
+      expect(staleService.relayClient, isNotNull);
+
+      lifecycleController.add(LifecycleState.paused);
+      await flush();
+      now = now.add(const Duration(seconds: 30));
+      lifecycleController.add(LifecycleState.resumed);
+      await flush();
+
+      // Eager teardown nulls the client immediately (before the reconnect
+      // backoff elapses), so RelayHttpApiClient won't route through the zombie.
+      expect(staleService.relayClient, isNull);
     });
   });
 }

--- a/mobile/module_core/test/capabilities/connection_service_stale_test.dart
+++ b/mobile/module_core/test/capabilities/connection_service_stale_test.dart
@@ -28,7 +28,7 @@ class MockRelayClient extends Mock implements RelayClient {}
 
 class _TestRelayClientFactory extends RelayClientFactory {
   final RelayClient _client;
-  _TestRelayClientFactory(this._client);
+  _TestRelayClientFactory({required RelayClient client}) : _client = client;
 
   @override
   RelayClient call({
@@ -280,7 +280,7 @@ void main() {
         lifecycleSource,
         MockFailureReporter(),
         clock: _TestClockProvider(() => now),
-        relayClientFactory: _TestRelayClientFactory(relayClient),
+        relayClientFactory: _TestRelayClientFactory(client: relayClient),
       );
       addTearDown(staleService.dispose);
 


### PR DESCRIPTION
Follow-up to #262, addressing two valid post-merge review findings from `chatgpt-codex-connector`.

## 1. Stop routing requests through the stale socket
On a stale-connected resume, PR #262 set status to `reconnecting` but only tore down the relay client *after* the reconnect backoff. During that window `RelayHttpApiClient` still used the client (`isConnected == true`), so a request fired right after foregrounding could still go over the zombie socket and hit the 30s timeout PR #262 was meant to avoid.

- `_onAppResumed` now detaches the relay client immediately when it triggers a reconnect.
- `_disconnectRelayClient` nulls `_relayClient` **synchronously** (before the async subscription cancellations), so callers stop using it right away.

## 2. Revert the bridge-offline case from the proactive stale check
PR #262 included `ConnectionBridgeOffline` in the proactive reconnect. But while the bridge is offline the E2E handshake can't complete, so forcing a reconnect **fails into the blocking `ConnectionLost` state** and loses the watcher for the bridge's return — turning a non-blocking auto-recovery state into a blocking/manual one.

- `connectionLikelyStale` is back to `ConnectionConnected`-only.
- Bridge-offline recovery keeps relying on its relay status watcher and the socket's own drop (`onDone`).
- Proper relay-level watching without a completed handshake is a larger change, tracked as a **deferred** item in `docs/plans/auth-reconnect-ux-plan.md`.

## Tests
- Updated `connection_service_stale_test.dart`: bridge-offline resume now asserts it **stays** `ConnectionBridgeOffline`; added a test that the stale relay client is **detached** on resume.
- `dart analyze --fatal-infos` clean; stale suite green (10/10), reconnect suite green (Dart 3.12.2 / Flutter 3.44.2).

## Plan doc
Current stage bumped to **PR 1a** per the doc's maintenance rule.

Refs: #262

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Immediately detach the relay client on app resume, coalesce teardown so reconnect waits for the old disconnect, and revert proactive reconnect for `ConnectionBridgeOffline`. This stops zombie-socket requests, prevents duplicate sockets, and avoids falling into `ConnectionLost` during bridge outages.

- **Bug Fixes**
  - Detach stale socket on resume; `_disconnectRelayClient` nulls `_relayClient` before async cancellations so requests fail fast.
  - Coalesce relay teardown via single-flight `_activeDisconnect` so reconnect awaits the previous disconnect; prevents briefly holding two phone sockets.
  - Treat only `ConnectionConnected` as stale on resume; keep `ConnectionBridgeOffline` unchanged to preserve the watcher for the bridge’s return.
  - Guard subscription cancellations so teardown never throws, keeping `unawaited(...)` call sites safe from uncaught async errors.

- **Refactors**
  - Test relay client factory now uses a named required argument for `client` to match repo conventions.

<sup>Written for commit b37f4028b6e0c7bdee1a1a1b9d63ff191d6f9470. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

