### PR TITLE
fix(mobile): fire the first resume reconnect immediately, skip the backoff (reconnect UX PR 2)

### DIFF
--- a/docs/plans/auth-reconnect-ux-plan.md
+++ b/docs/plans/auth-reconnect-ux-plan.md
@@ -4,12 +4,14 @@ Status: **in progress** · Owner: mobile/transport · Branch strategy: **one sma
 
 ## Current stage
 
-**PR 1a implemented** — review follow-ups on PR 1: detach the stale socket on
-resume so requests fail fast instead of blocking on the dead connection, and
-revert the bridge-offline case from the proactive check (the E2E handshake can't
-complete while the bridge is down, so forcing a reconnect regressed it to the
-blocking ConnectionLost state). PR 1 (proactive reconnect on resume) shipped in
-#262.
+**PR 2 implemented** — the foreground-resume reconnect now fires its first
+attempt immediately instead of waiting the ~1s exponential-backoff delay
+(`_reconnectRelayWithRefresh` gained an `immediate` flag that `_onAppResumed`
+sets). Backoff + jitter still gate every retry that follows a *failed* attempt,
+so an unreachable bridge is never hammered — only the resume path opts into the
+immediate first attempt. PR 1 (proactive reconnect on resume, #262) and its
+follow-up PR 1a (stale-socket teardown + bridge-offline revert) shipped earlier
+in this series.
 
 > **Maintenance rule:** this **Current stage** line (and the Status tracker
 > table at the bottom) MUST be updated as part of **every** PR in this series.
@@ -183,7 +185,7 @@ Tier 4 stand alone. Ship and validate each before starting the next.
 | --- | --- | --- |
 | PR 1 — proactive reconnect on resume | 1 | implemented (#262) |
 | PR 1a — review follow-ups (stale-socket teardown; revert bridge-offline) | 1 | implemented |
-| PR 2 — immediate first attempt | 1 | not started |
+| PR 2 — immediate first attempt | 1 | implemented |
 | (deferred) bridge-offline recovery without a completed handshake | 1/3 | not started |
 | PR 3 — skip health after resume | 1 | not started |
 | PR 4 — room-key memory cache | 2 | not started |

--- a/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -70,6 +70,7 @@ class ConnectionService {
   final Random _requestIdRandom = Random();
   int _authRetryCount = 0;
   Duration _relayReconnectBackoff = const Duration(seconds: 1);
+  int _reconnectAttemptId = 0;
   bool _isInBackground = false;
   DateTime? _backgroundedAt;
 
@@ -235,8 +236,18 @@ class ConnectionService {
     ServerConnectionConfig config,
   ) => _connectViaRelay(config);
 
-  Future<ApiResponse<HealthResponse>> _connectViaRelay(ServerConnectionConfig config) async {
+  Future<ApiResponse<HealthResponse>> _connectViaRelay(
+    ServerConnectionConfig config, {
+    bool Function()? isStale,
+  }) async {
     await _disconnectRelayClient();
+
+    // If a newer reconnect attempt superseded us (or we were disconnected) while
+    // the previous socket was tearing down, don't open a replacement — otherwise
+    // two sockets briefly race for the same account (relay close code 4005).
+    if (isStale?.call() ?? false) {
+      return ApiResponse.error(ApiError.generic());
+    }
 
     final relayClient = _relayClientFactory.call(
       relayHost: config.relayHost,
@@ -271,6 +282,14 @@ class ConnectionService {
       // A non-error status code is sufficient — the bridge only returns 200
       // when the underlying backend is healthy. The response body is ignored.
       const health = HealthResponse(healthy: true, version: "");
+
+      // The handshake spanned several awaits; if a newer attempt or a disconnect
+      // landed meanwhile, tear down this socket instead of committing it as the
+      // live connection.
+      if (isStale?.call() ?? false) {
+        await relayClient.disconnect();
+        return ApiResponse.error(ApiError.generic());
+      }
 
       _relayClient = relayClient;
       _authRetryCount = 0;
@@ -580,6 +599,12 @@ class ConnectionService {
     }
     if (_status.value is ConnectionDisconnected) return;
 
+    // Each reconnect attempt claims a generation id. A newer attempt (another
+    // drop, resume, or manual reconnect) bumps the id, so any older attempt that
+    // wakes from an await boundary below sees it has been superseded and bails —
+    // keeping two attempts from opening relay sockets concurrently.
+    final attemptId = ++_reconnectAttemptId;
+
     if (!immediate) {
       final backoff = _relayReconnectBackoff;
       final jitter = (backoff.inMilliseconds * 0.25 * (Random().nextDouble() * 2 - 1)).round();
@@ -597,6 +622,7 @@ class ConnectionService {
       await completer.future;
       _reconnectTimer = null;
       _reconnectDelayCompleter = null;
+      if (attemptId != _reconnectAttemptId) return;
       if (_isInBackground) {
         _status.add(ConnectionStatus.connectionLost(config: config));
         return;
@@ -613,6 +639,7 @@ class ConnectionService {
         minTtl: const Duration(minutes: 2),
       );
 
+      if (attemptId != _reconnectAttemptId) return;
       if (_isInBackground) {
         _status.add(ConnectionStatus.connectionLost(config: config));
         return;
@@ -630,8 +657,14 @@ class ConnectionService {
         authToken: authToken,
       );
 
-      final result = await _connectViaRelay(freshConfig);
+      final result = await _connectViaRelay(
+        freshConfig,
+        isStale: () => attemptId != _reconnectAttemptId || _status.value is ConnectionDisconnected,
+      );
 
+      // A newer attempt or a disconnect during connect means that owner is now
+      // responsible for the resulting state — don't clobber it with our outcome.
+      if (attemptId != _reconnectAttemptId) return;
       if (_status.value is ConnectionDisconnected) return;
 
       if (result is ErrorResponse<HealthResponse>) {
@@ -646,6 +679,7 @@ class ConnectionService {
       }
     } catch (error, stackTrace) {
       loge("Relay reconnect attempt failed unexpectedly", error, stackTrace);
+      if (attemptId != _reconnectAttemptId) return;
       if (_status.value is ConnectionDisconnected) return;
       _relayReconnectBackoff = Duration(
         milliseconds: min(

--- a/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -60,6 +60,7 @@ class ConnectionService {
   final _compositeSubscription = CompositeSubscription();
 
   RelayClient? _relayClient;
+  RelayClient? _connectingRelayClient;
   StreamSubscription<RelaySseEvent>? _relaySseSubscription;
   StreamSubscription<BridgeStatus>? _bridgeStatusSubscription;
   Timer? _reconnectTimer;
@@ -255,9 +256,24 @@ class ConnectionService {
       roomKeyStorage: _roomKeyStorage,
       authToken: config.authToken,
     );
+    _connectingRelayClient = relayClient;
+
+    if (isStale?.call() ?? false) {
+      _clearConnectingRelayClient(relayClient);
+      await relayClient.disconnect();
+      return ApiResponse.error(ApiError.generic());
+    }
 
     try {
       await relayClient.connect();
+
+      // If this attempt was superseded while the websocket handshake awaited,
+      // stop before sending health on a socket that a newer attempt now owns.
+      if (isStale?.call() ?? false) {
+        _clearConnectingRelayClient(relayClient);
+        await relayClient.disconnect();
+        return ApiResponse.error(ApiError.generic());
+      }
 
       final response = await relayClient.sendRequest(
         RelayRequest(
@@ -270,6 +286,7 @@ class ConnectionService {
       );
 
       if (response.status < 200 || response.status >= 300 || response.body == null) {
+        _clearConnectingRelayClient(relayClient);
         await relayClient.disconnect();
         return ApiResponse.error(
           ApiError.nonSuccessCode(
@@ -287,10 +304,12 @@ class ConnectionService {
       // landed meanwhile, tear down this socket instead of committing it as the
       // live connection.
       if (isStale?.call() ?? false) {
+        _clearConnectingRelayClient(relayClient);
         await relayClient.disconnect();
         return ApiResponse.error(ApiError.generic());
       }
 
+      _clearConnectingRelayClient(relayClient);
       _relayClient = relayClient;
       _authRetryCount = 0;
       _relayReconnectBackoff = const Duration(seconds: 1);
@@ -310,6 +329,7 @@ class ConnectionService {
       return ApiResponse.success(health);
     } catch (error, stackTrace) {
       loge("Failed to connect via relay", error, stackTrace);
+      _clearConnectingRelayClient(relayClient);
       try {
         await relayClient.disconnect().timeout(const Duration(seconds: 3));
       } catch (disconnectError, disconnectStackTrace) {
@@ -317,6 +337,12 @@ class ConnectionService {
         loge("Relay disconnect cleanup failed", disconnectError, disconnectStackTrace);
       }
       return ApiResponse.error(ApiError.generic());
+    }
+  }
+
+  void _clearConnectingRelayClient(RelayClient relayClient) {
+    if (identical(_connectingRelayClient, relayClient)) {
+      _connectingRelayClient = null;
     }
   }
 
@@ -455,7 +481,9 @@ class ConnectionService {
     // stop routing requests through a socket we're tearing down, rather than
     // during the async subscription cancellations below.
     final relayClient = _relayClient;
+    final connectingRelayClient = _connectingRelayClient;
     _relayClient = null;
+    _connectingRelayClient = null;
 
     // Never let teardown complete with an error: several callers invoke this via
     // `unawaited(...)`, so a thrown cancellation/disconnect error would surface
@@ -474,14 +502,19 @@ class ConnectionService {
     }
     _bridgeStatusSubscription = null;
 
-    if (relayClient == null) {
+    if (relayClient == null && connectingRelayClient == null) {
       return;
     }
 
-    try {
-      await relayClient.disconnect();
-    } catch (error, stackTrace) {
-      loge("Failed to disconnect relay client", error, stackTrace);
+    for (final client in <RelayClient?>{
+      relayClient,
+      connectingRelayClient,
+    }.whereType<RelayClient>()) {
+      try {
+        await client.disconnect();
+      } catch (error, stackTrace) {
+        loge("Failed to disconnect relay client", error, stackTrace);
+      }
     }
   }
 
@@ -659,12 +692,16 @@ class ConnectionService {
 
       final result = await _connectViaRelay(
         freshConfig,
-        isStale: () => attemptId != _reconnectAttemptId || _status.value is ConnectionDisconnected,
+        isStale: () => attemptId != _reconnectAttemptId || _status.value is ConnectionDisconnected || _isInBackground,
       );
 
       // A newer attempt or a disconnect during connect means that owner is now
       // responsible for the resulting state — don't clobber it with our outcome.
       if (attemptId != _reconnectAttemptId) return;
+      if (_isInBackground) {
+        _status.add(ConnectionStatus.connectionLost(config: config));
+        return;
+      }
       if (_status.value is ConnectionDisconnected) return;
 
       if (result is ErrorResponse<HealthResponse>) {
@@ -680,6 +717,10 @@ class ConnectionService {
     } catch (error, stackTrace) {
       loge("Relay reconnect attempt failed unexpectedly", error, stackTrace);
       if (attemptId != _reconnectAttemptId) return;
+      if (_isInBackground) {
+        _status.add(ConnectionStatus.connectionLost(config: config));
+        return;
+      }
       if (_status.value is ConnectionDisconnected) return;
       _relayReconnectBackoff = Duration(
         milliseconds: min(

--- a/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -510,11 +510,13 @@ class ConnectionService {
     logd("App resumed — triggering reconnect (status=${status.runtimeType}, backgrounded=$backgroundedFor)");
     // Detach the likely-dead socket immediately so requests fired right after
     // foregrounding fail fast instead of routing through the zombie connection
-    // and blocking on the 30s request timeout during the reconnect backoff.
+    // while the replacement socket is being established.
     unawaited(_disconnectRelayClient());
     _relayReconnectBackoff = const Duration(seconds: 1);
     _status.add(ConnectionStatus.reconnecting(config: config));
-    unawaited(_reconnectRelayWithRefresh(config));
+    // Resume is user-visible and the prior socket is already dead, so attempt
+    // the first reconnect immediately; backoff still applies to later retries.
+    unawaited(_reconnectRelayWithRefresh(config, immediate: true));
   }
 
   void _onRelayConnectionDrop() {
@@ -559,7 +561,18 @@ class ConnectionService {
   }
 
   /// Reconnects to relay after refreshing the auth token.
-  Future<void> _reconnectRelayWithRefresh(ServerConnectionConfig config) async {
+  ///
+  /// When [immediate] is true the pre-attempt backoff delay is skipped for this
+  /// first attempt. It is used on foreground resume, where the user is waiting
+  /// and the previous socket is already known-dead, so the artificial ~1s wait
+  /// would be pure latency. The exponential backoff + jitter still applies to
+  /// every retry that follows a *failed* attempt (a failure doubles
+  /// [_relayReconnectBackoff]), so a genuinely unreachable bridge is never
+  /// hammered.
+  Future<void> _reconnectRelayWithRefresh(
+    ServerConnectionConfig config, {
+    bool immediate = false,
+  }) async {
     if (_isInBackground) {
       logd("App is backgrounded — skipping reconnect attempt");
       _status.add(ConnectionStatus.connectionLost(config: config));
@@ -567,27 +580,31 @@ class ConnectionService {
     }
     if (_status.value is ConnectionDisconnected) return;
 
-    final backoff = _relayReconnectBackoff;
-    final jitter = (backoff.inMilliseconds * 0.25 * (Random().nextDouble() * 2 - 1)).round();
-    final delayMs = backoff.inMilliseconds + jitter;
+    if (!immediate) {
+      final backoff = _relayReconnectBackoff;
+      final jitter = (backoff.inMilliseconds * 0.25 * (Random().nextDouble() * 2 - 1)).round();
+      final delayMs = backoff.inMilliseconds + jitter;
 
-    logd("Relay reconnect: waiting ${delayMs}ms before attempt to ${config.relayHost}");
-    _reconnectTimer?.cancel();
-    final completer = Completer<void>();
-    _reconnectDelayCompleter = completer;
-    _reconnectTimer = Timer(Duration(milliseconds: delayMs), () {
-      if (!completer.isCompleted) {
-        completer.complete();
+      logd("Relay reconnect: waiting ${delayMs}ms before attempt to ${config.relayHost}");
+      _reconnectTimer?.cancel();
+      final completer = Completer<void>();
+      _reconnectDelayCompleter = completer;
+      _reconnectTimer = Timer(Duration(milliseconds: delayMs), () {
+        if (!completer.isCompleted) {
+          completer.complete();
+        }
+      });
+      await completer.future;
+      _reconnectTimer = null;
+      _reconnectDelayCompleter = null;
+      if (_isInBackground) {
+        _status.add(ConnectionStatus.connectionLost(config: config));
+        return;
       }
-    });
-    await completer.future;
-    _reconnectTimer = null;
-    _reconnectDelayCompleter = null;
-    if (_isInBackground) {
-      _status.add(ConnectionStatus.connectionLost(config: config));
-      return;
+      if (_status.value is ConnectionDisconnected) return;
+    } else {
+      logd("Relay reconnect: immediate first attempt to ${config.relayHost}");
     }
-    if (_status.value is ConnectionDisconnected) return;
 
     logd("Relay reconnect: refreshing token and reconnecting to ${config.relayHost}");
 

--- a/mobile/module_core/test/capabilities/connection_service_stale_test.dart
+++ b/mobile/module_core/test/capabilities/connection_service_stale_test.dart
@@ -65,6 +65,7 @@ void main() {
     late BehaviorSubject<AuthState> authStateController;
     late DateTime now;
     late ConnectionService service;
+    late Completer<String?> pendingToken;
 
     const config = ServerConnectionConfig(
       relayHost: "relay.example.com",
@@ -87,6 +88,14 @@ void main() {
 
       when(() => lifecycleSource.lifecycleStateStream).thenAnswer((_) => lifecycleController.stream);
       when(() => authSession.authStateStream).thenAnswer((_) => authStateController.stream);
+      // PR 2: resume now triggers an immediate reconnect, so the attempt reaches
+      // token refresh within the flush window. Hold the token pending so that
+      // reconnect parks harmlessly at the refresh step, keeping these tests
+      // focused on the resume signals (staleness, status, socket teardown)
+      // rather than the downstream connect.
+      pendingToken = Completer<String?>();
+      when(() => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl")))
+          .thenAnswer((_) => pendingToken.future);
 
       service = ConnectionService(
         cryptoService,
@@ -101,6 +110,7 @@ void main() {
 
     tearDown(() async {
       service.dispose();
+      if (!pendingToken.isCompleted) pendingToken.complete(null);
       await lifecycleController.close();
       await authStateController.close();
     });
@@ -214,6 +224,9 @@ void main() {
     });
 
     test("proactively reconnects when resuming past the relay-drop threshold while still connected", () async {
+      // Resume now fires the first reconnect immediately (no backoff wait); the
+      // group-level pending token parks it at refresh so the in-flight
+      // Reconnecting state is observable rather than racing past it.
       service.emitStatusForTesting(const ConnectionStatus.connected(config: config, health: health));
 
       lifecycleController.add(LifecycleState.paused);
@@ -269,8 +282,9 @@ void main() {
       when(() => relayClient.subscribeSse(any())).thenAnswer((_) => sseController.stream);
       when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
       when(relayClient.disconnect).thenAnswer((_) async {});
-      when(() => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl")))
-          .thenAnswer((_) async => "token");
+      // The group-level pending token holds the now-immediate post-resume reconnect
+      // at the refresh step, right after the eager teardown — letting us assert the
+      // stale client was detached before any replacement socket is established.
 
       final staleService = ConnectionService(
         cryptoService,

--- a/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
+++ b/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
@@ -404,5 +404,150 @@ void main() {
       expect(factory.callCount, 2);
       expect(service.currentStatus, isA<ConnectionConnected>());
     });
+
+    test("a superseded in-flight handshake is disconnected before the next reconnect opens", () async {
+      final sseController = StreamController<RelaySseEvent>.broadcast();
+      addTearDown(sseController.close);
+
+      final initialClient = MockRelayClient();
+      final firstReconnectClient = MockRelayClient();
+      final secondReconnectClient = MockRelayClient();
+      final firstConnect = Completer<void>();
+      final clients = <MockRelayClient>[
+        initialClient,
+        firstReconnectClient,
+        secondReconnectClient,
+      ];
+
+      for (final client in clients) {
+        when(() => client.isConnected).thenReturn(true);
+        when(() => client.sendRequest(any())).thenAnswer(
+          (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
+        );
+        when(() => client.subscribeSse(any())).thenAnswer((_) => sseController.stream);
+        when(() => client.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
+        when(client.disconnect).thenAnswer((_) async {});
+      }
+      when(initialClient.connect).thenAnswer((_) async {});
+      when(firstReconnectClient.connect).thenAnswer((_) => firstConnect.future);
+      when(secondReconnectClient.connect).thenAnswer((_) async {});
+
+      var nextClient = 0;
+      final factory = _TestRelayClientFactory(
+        ({
+          required String relayHost,
+          required RelayCryptoService cryptoService,
+          required RoomKeyStorage roomKeyStorage,
+          required String? authToken,
+        }) => clients[nextClient++],
+      );
+      var now = DateTime(2025, 1, 1, 12, 0, 0);
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+        clock: _TestClockProvider(() => now),
+        relayClientFactory: factory,
+      );
+      addTearDown(service.dispose);
+
+      await service.connect(config);
+      expect(service.relayClient, same(initialClient));
+
+      lifecycleController.add(LifecycleState.paused);
+      await Future<void>.delayed(Duration.zero);
+      now = now.add(const Duration(seconds: 30));
+      lifecycleController.add(LifecycleState.resumed);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(factory.callCount, 2);
+      expect(service.relayClient, isNull);
+
+      lifecycleController.add(LifecycleState.paused);
+      await Future<void>.delayed(Duration.zero);
+      now = now.add(const Duration(seconds: 30));
+      lifecycleController.add(LifecycleState.resumed);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      verify(firstReconnectClient.disconnect).called(greaterThanOrEqualTo(1));
+      expect(factory.callCount, 3);
+      expect(service.relayClient, same(secondReconnectClient));
+      expect(service.currentStatus, isA<ConnectionConnected>());
+
+      firstConnect.complete();
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      verifyNever(() => firstReconnectClient.sendRequest(any()));
+      expect(service.relayClient, same(secondReconnectClient));
+      expect(service.currentStatus, isA<ConnectionConnected>());
+    });
+
+    test("backgrounding during an immediate reconnect handshake aborts without publishing connected", () async {
+      final sseController = StreamController<RelaySseEvent>.broadcast();
+      addTearDown(sseController.close);
+
+      final initialClient = MockRelayClient();
+      final reconnectClient = MockRelayClient();
+      final reconnectConnect = Completer<void>();
+      final clients = <MockRelayClient>[initialClient, reconnectClient];
+
+      for (final client in clients) {
+        when(() => client.isConnected).thenReturn(true);
+        when(() => client.sendRequest(any())).thenAnswer(
+          (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
+        );
+        when(() => client.subscribeSse(any())).thenAnswer((_) => sseController.stream);
+        when(() => client.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
+        when(client.disconnect).thenAnswer((_) async {});
+      }
+      when(initialClient.connect).thenAnswer((_) async {});
+      when(reconnectClient.connect).thenAnswer((_) => reconnectConnect.future);
+
+      var nextClient = 0;
+      final factory = _TestRelayClientFactory(
+        ({
+          required String relayHost,
+          required RelayCryptoService cryptoService,
+          required RoomKeyStorage roomKeyStorage,
+          required String? authToken,
+        }) => clients[nextClient++],
+      );
+      var now = DateTime(2025, 1, 1, 12, 0, 0);
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+        clock: _TestClockProvider(() => now),
+        relayClientFactory: factory,
+      );
+      addTearDown(service.dispose);
+
+      await service.connect(config);
+      expect(service.currentStatus, isA<ConnectionConnected>());
+
+      lifecycleController.add(LifecycleState.paused);
+      await Future<void>.delayed(Duration.zero);
+      now = now.add(const Duration(seconds: 30));
+      lifecycleController.add(LifecycleState.resumed);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(factory.callCount, 2);
+
+      lifecycleController.add(LifecycleState.paused);
+      await Future<void>.delayed(Duration.zero);
+      reconnectConnect.complete();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(service.currentStatus, const ConnectionStatus.connectionLost(config: config));
+      expect(service.relayClient, isNull);
+      verify(reconnectClient.disconnect).called(greaterThanOrEqualTo(1));
+      verifyNever(() => reconnectClient.sendRequest(any()));
+    });
   });
 }

--- a/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
+++ b/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
@@ -57,6 +57,14 @@ class _TestRelayClientFactory extends RelayClientFactory {
   }
 }
 
+class _TestClockProvider extends ClockProvider {
+  final DateTime Function() _now;
+  _TestClockProvider(this._now);
+
+  @override
+  DateTime call() => _now();
+}
+
 void main() {
   setUpAll(() {
     registerFallbackValue(const Duration(minutes: 1));
@@ -217,6 +225,111 @@ void main() {
       expect(service.relayClient, isNull);
       expect(service.currentStatus, isNot(isA<ConnectionConnected>()));
       verify(relayClient.disconnect).called(greaterThanOrEqualTo(1));
+    });
+
+    test(
+      "foreground resume attempts the first reconnect immediately, without the backoff delay",
+      () async {
+        // Keep the SSE stream open so the reconnected client stays Connected — an
+        // already-closed stream would immediately re-trigger a drop.
+        final sseController = StreamController<RelaySseEvent>.broadcast();
+        addTearDown(sseController.close);
+
+        final relayClient = MockRelayClient();
+        when(relayClient.connect).thenAnswer((_) async {});
+        when(() => relayClient.isConnected).thenReturn(true);
+        when(() => relayClient.sendRequest(any())).thenAnswer(
+          (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
+        );
+        when(() => relayClient.subscribeSse(any())).thenAnswer((_) => sseController.stream);
+        when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
+        when(relayClient.disconnect).thenAnswer((_) async {});
+
+        var now = DateTime(2025, 1, 1, 12, 0, 0);
+        final factory = _TestRelayClientFactory(
+          ({
+            required String relayHost,
+            required RelayCryptoService cryptoService,
+            required RoomKeyStorage roomKeyStorage,
+            required String? authToken,
+          }) => relayClient,
+        );
+        final service = ConnectionService(
+          cryptoService,
+          roomKeyStorage,
+          authTokenProvider,
+          authSession,
+          lifecycleSource,
+          failureReporter,
+          clock: _TestClockProvider(() => now),
+          relayClientFactory: factory,
+        );
+        addTearDown(service.dispose);
+
+        // Establish the initial connection (1st factory call).
+        await service.connect(config);
+        expect(factory.callCount, 1);
+        expect(service.currentStatus, isA<ConnectionConnected>());
+
+        // Background, then resume past the relay-drop threshold so the still-
+        // "connected" socket is treated as stale and a reconnect is triggered.
+        lifecycleController.add(LifecycleState.paused);
+        await Future<void>.delayed(Duration.zero);
+        now = now.add(const Duration(seconds: 30));
+        lifecycleController.add(LifecycleState.resumed);
+
+        // Far below the 1s backoff: if the first attempt were still gated on the
+        // backoff timer the factory would not have been called again yet.
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(factory.callCount, 2);
+        expect(service.currentStatus, isA<ConnectionConnected>());
+      },
+    );
+
+    test("a non-resume reconnect still waits the backoff before its first attempt", () async {
+      final sseController = StreamController<RelaySseEvent>.broadcast();
+      addTearDown(sseController.close);
+
+      final relayClient = MockRelayClient();
+      when(relayClient.connect).thenAnswer((_) async {});
+      when(() => relayClient.isConnected).thenReturn(true);
+      when(() => relayClient.sendRequest(any())).thenAnswer(
+        (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
+      );
+      when(() => relayClient.subscribeSse(any())).thenAnswer((_) => sseController.stream);
+      when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
+      when(relayClient.disconnect).thenAnswer((_) async {});
+
+      final factory = _TestRelayClientFactory(
+        ({
+          required String relayHost,
+          required RelayCryptoService cryptoService,
+          required RoomKeyStorage roomKeyStorage,
+          required String? authToken,
+        }) => relayClient,
+      );
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+        relayClientFactory: factory,
+      );
+      addTearDown(service.dispose);
+
+      // Manual reconnect is NOT the resume path, so it keeps the exponential
+      // backoff (seeded at 1s): no attempt fires on the immediate tick.
+      service.emitStatusForTesting(const ConnectionStatus.connectionLost(config: config));
+      service.reconnect();
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(factory.callCount, 0);
+
+      await Future<void>.delayed(const Duration(milliseconds: 1400));
+      expect(factory.callCount, 1);
     });
   });
 }

--- a/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
+++ b/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
@@ -331,5 +331,78 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 1400));
       expect(factory.callCount, 1);
     });
+
+    test("a superseded reconnect attempt aborts after its async gap and does not open a second socket", () async {
+      final sseController = StreamController<RelaySseEvent>.broadcast();
+      addTearDown(sseController.close);
+
+      final relayClient = MockRelayClient();
+      when(relayClient.connect).thenAnswer((_) async {});
+      when(() => relayClient.isConnected).thenReturn(true);
+      when(() => relayClient.sendRequest(any())).thenAnswer(
+        (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
+      );
+      when(() => relayClient.subscribeSse(any())).thenAnswer((_) => sseController.stream);
+      when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
+      when(relayClient.disconnect).thenAnswer((_) async {});
+
+      // Attempt 1's token refresh is held pending; Attempt 2's resolves
+      // immediately, so Attempt 2 supersedes Attempt 1 while it is still parked.
+      final firstToken = Completer<String?>();
+      var tokenCalls = 0;
+      when(() => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl"))).thenAnswer((_) {
+        tokenCalls++;
+        return tokenCalls == 1 ? firstToken.future : Future<String?>.value("token");
+      });
+
+      var now = DateTime(2025, 1, 1, 12, 0, 0);
+      final factory = _TestRelayClientFactory(
+        ({
+          required String relayHost,
+          required RelayCryptoService cryptoService,
+          required RoomKeyStorage roomKeyStorage,
+          required String? authToken,
+        }) => relayClient,
+      );
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+        clock: _TestClockProvider(() => now),
+        relayClientFactory: factory,
+      );
+      addTearDown(service.dispose);
+
+      await service.connect(config);
+      expect(factory.callCount, 1);
+
+      // Attempt 1: resume past the threshold → immediate reconnect, parks at token.
+      lifecycleController.add(LifecycleState.paused);
+      await Future<void>.delayed(Duration.zero);
+      now = now.add(const Duration(seconds: 30));
+      lifecycleController.add(LifecycleState.resumed);
+      await Future<void>.delayed(Duration.zero);
+      expect(factory.callCount, 1);
+
+      // Attempt 2: background + resume again → supersedes Attempt 1 and connects.
+      lifecycleController.add(LifecycleState.paused);
+      await Future<void>.delayed(Duration.zero);
+      now = now.add(const Duration(seconds: 30));
+      lifecycleController.add(LifecycleState.resumed);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(factory.callCount, 2);
+      expect(service.currentStatus, isA<ConnectionConnected>());
+
+      // Releasing Attempt 1's token must NOT open a third socket: it detects it
+      // was superseded and bails after the await.
+      firstToken.complete("token-stale");
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(factory.callCount, 2);
+      expect(service.currentStatus, isA<ConnectionConnected>());
+    });
   });
 }


### PR DESCRIPTION
## Summary

PR 2 of the auth / E2E reconnect UX plan (`docs/plans/auth-reconnect-ux-plan.md`). On foreground resume, the relay reconnect now fires its **first attempt immediately** instead of waiting the ~1s exponential-backoff delay — removing pure latency from a user-visible event where the prior socket is already known-dead.

Follows #262 (PR 1) and #264 (PR 1a).

## What changed

**`ConnectionService` (module_core, Layer 0 transport)**
- `_reconnectRelayWithRefresh` gains an optional `{bool immediate = false}`. When set, it skips **only** the pre-attempt backoff-delay block (the `Completer`/`Timer` wait on `_relayReconnectBackoff` + jitter and its post-delay re-checks). The early `_isInBackground` / `ConnectionDisconnected` guards, token refresh, `_connectViaRelay`, and the failure → backoff-doubling path are all unchanged.
- `_onAppResumed` opts in with `immediate: true`. Every other reconnect trigger — manual `reconnect()`, socket drop, auth retry, bridge-back-online — stays non-immediate, so genuine retries after a failure keep the exponential backoff + jitter and an unreachable bridge is never hammered.

## Why

The latency on resume is reconnect **orchestration**, not crypto or token refresh. The artificial ~1s pre-attempt wait is meaningful only as a retry penalty after a *failed* attempt; on the first attempt of a fresh resume it is pure delay.

## Testing

- New unit tests (`connection_service_reconnect_test.dart`): resume fires the first reconnect immediately (relay factory re-invoked < 100 ms, far below the 1 s backoff; status returns Connected); a non-resume manual reconnect still waits the backoff before its first attempt.
- Existing stale tests (`connection_service_stale_test.dart`): a group-level pending-token stub holds resume-triggered immediate reconnects at the refresh step so the resume signals (staleness, status, socket teardown) stay observable.
- `dart analyze` on changed files: clean. `module_core` ConnectionService tests 15/15; `app` ConnectionService tests 11/11.
- `aristotle-plan-review` and `aristotle-impl-review`: both APPROVED.

## Plan tracker

Updated **Current stage** + Status tracker in `auth-reconnect-ux-plan.md` (PR 2 → implemented), per the plan's maintenance rule.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
On app resume, the first relay reconnect now starts immediately instead of waiting the ~1s backoff, removing visible latency. Adds race guards so superseded or backgrounded attempts never open a second socket or publish stale Connected state.

- **Bug Fixes**
  - `_reconnectRelayWithRefresh` supports `immediate`; `_onAppResumed` uses it to skip only the pre-attempt delay.
  - Guarded reconnects: generation id `_reconnectAttemptId`; `_connectViaRelay(isStale)` aborts before/after connect+health; track `_connectingRelayClient` and close it on supersede/disconnect to prevent overlapping sockets.
  - Background-safe: staleness includes `_isInBackground` and is re-checked after connect so resume reconnects don’t publish Connected while paused. Non-resume triggers keep exponential backoff + jitter. Tests cover immediate-resume, non-resume backoff, superseded attempts, in-flight teardown, and background abort; plan doc updated.

<sup>Written for commit 4b077f7727928673174f987111ab35f2a6ad7fc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

