### PR TITLE
fix(mobile): skip the redundant GET /health round-trip on a resumed relay reconnect (reconnect UX PR 3)

### DIFF
--- a/docs/plans/auth-reconnect-ux-plan.md
+++ b/docs/plans/auth-reconnect-ux-plan.md
@@ -4,14 +4,12 @@ Status: **in progress** · Owner: mobile/transport · Branch strategy: **one sma
 
 ## Current stage
 
-**PR 2 implemented** — the foreground-resume reconnect now fires its first
-attempt immediately instead of waiting the ~1s exponential-backoff delay
-(`_reconnectRelayWithRefresh` gained an `immediate` flag that `_onAppResumed`
-sets). Backoff + jitter still gate every retry that follows a *failed* attempt,
-so an unreachable bridge is never hammered — only the resume path opts into the
-immediate first attempt. PR 1 (proactive reconnect on resume, #262) and its
-follow-up PR 1a (stale-socket teardown + bridge-offline revert) shipped earlier
-in this series.
+**PR 3 implemented** — a reconnect that successfully resumes with the stored
+room key now skips the redundant `GET /health` round-trip because `resume_ack`
+already proves the bridge is reachable. Fresh-DH connects still perform the
+health check before committing the relay client. PR 1 (proactive reconnect on
+resume, #262), PR 1a (stale-socket teardown + bridge-offline revert), and PR 2
+(immediate first reconnect attempt, #265) shipped earlier in this series.
 
 > **Maintenance rule:** this **Current stage** line (and the Status tracker
 > table at the bottom) MUST be updated as part of **every** PR in this series.
@@ -185,9 +183,9 @@ Tier 4 stand alone. Ship and validate each before starting the next.
 | --- | --- | --- |
 | PR 1 — proactive reconnect on resume | 1 | implemented (#262) |
 | PR 1a — review follow-ups (stale-socket teardown; revert bridge-offline) | 1 | implemented |
-| PR 2 — immediate first attempt | 1 | implemented |
+| PR 2 — immediate first attempt | 1 | merged (#265) |
 | (deferred) bridge-offline recovery without a completed handshake | 1/3 | not started |
-| PR 3 — skip health after resume | 1 | not started |
+| PR 3 — skip health after resume | 1 | implemented |
 | PR 4 — room-key memory cache | 2 | not started |
 | PR 5 — token read memory cache | 2 | not started |
 | PR 6 — bridge SSE auto-resume | 3 | not started |

--- a/mobile/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/mobile/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -33,6 +33,7 @@ class RelayClient {
 
   RelayClientConnectionState _connectionState = RelayClientConnectionState.disconnected;
   bool _disposed = false;
+  bool _didResume = false;
 
   static const int _messageVersion = 0x01;
   static const Duration _handshakeTimeout = Duration(seconds: 15);
@@ -50,6 +51,7 @@ class RelayClient {
 
   RelayClientConnectionState get connectionState => _connectionState;
   bool get isConnected => _connectionState == RelayClientConnectionState.connected;
+  bool get didResume => _didResume;
 
   /// Stream of bridge online/offline events sent as text control frames by the relay.
   Stream<BridgeStatus> get bridgeStatus => _bridgeStatusController.stream;
@@ -66,6 +68,7 @@ class RelayClient {
     }
 
     _connectionState = RelayClientConnectionState.connecting;
+    _didResume = false;
     _lastCloseCode = null;
     final uri = Uri.parse("wss://$relayHost/ws");
 
@@ -117,6 +120,7 @@ class RelayClient {
         if (resumed) {
           if (_disposed) return;
           _connectionState = RelayClientConnectionState.connected;
+          _didResume = true;
           logd("Relay resumed with stored room key");
           return;
         }

--- a/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -275,25 +275,29 @@ class ConnectionService {
         return ApiResponse.error(ApiError.generic());
       }
 
-      final response = await relayClient.sendRequest(
-        RelayRequest(
-          id: _nextRelayRequestId(),
-          method: "GET",
-          path: ApiPaths.health,
-          headers: {},
-          body: null,
-        ),
-      );
-
-      if (response.status < 200 || response.status >= 300 || response.body == null) {
-        _clearConnectingRelayClient(relayClient);
-        await relayClient.disconnect();
-        return ApiResponse.error(
-          ApiError.nonSuccessCode(
-            errorCode: response.status,
-            rawErrorString: response.body,
+      // A resume_ack already proves the bridge is reachable; only fresh-DH
+      // connects need the extra health round-trip.
+      if (!relayClient.didResume) {
+        final response = await relayClient.sendRequest(
+          RelayRequest(
+            id: _nextRelayRequestId(),
+            method: "GET",
+            path: ApiPaths.health,
+            headers: {},
+            body: null,
           ),
         );
+
+        if (response.status < 200 || response.status >= 300 || response.body == null) {
+          _clearConnectingRelayClient(relayClient);
+          await relayClient.disconnect();
+          return ApiResponse.error(
+            ApiError.nonSuccessCode(
+              errorCode: response.status,
+              rawErrorString: response.body,
+            ),
+          );
+        }
       }
 
       // A non-error status code is sufficient — the bridge only returns 200

--- a/mobile/module_core/test/capabilities/connection_service_stale_test.dart
+++ b/mobile/module_core/test/capabilities/connection_service_stale_test.dart
@@ -275,6 +275,7 @@ void main() {
 
       final relayClient = MockRelayClient();
       when(relayClient.connect).thenAnswer((_) async {});
+      when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.isConnected).thenReturn(true);
       when(() => relayClient.sendRequest(any())).thenAnswer(
         (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),

--- a/mobile/module_core/test/capabilities/server_connection/connection_service_auth_state_test.dart
+++ b/mobile/module_core/test/capabilities/server_connection/connection_service_auth_state_test.dart
@@ -90,6 +90,7 @@ void main() {
 
       final relayClient = _MockRelayClient();
       when(relayClient.connect).thenAnswer((_) async {});
+      when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.sendRequest(any())).thenAnswer(
         (_) async => const RelayResponse(id: "r", status: 500, headers: {}, body: null),
       );

--- a/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
+++ b/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
@@ -188,6 +188,7 @@ void main() {
       final relayClient = MockRelayClient();
 
       when(relayClient.connect).thenAnswer((_) async {});
+      when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.sendRequest(any())).thenAnswer(
         (_) async => RelayResponse(
           id: "1",
@@ -227,6 +228,81 @@ void main() {
       verify(relayClient.disconnect).called(greaterThanOrEqualTo(1));
     });
 
+    test("resumed connect skips the GET /health round-trip", () async {
+      final sseController = StreamController<RelaySseEvent>.broadcast();
+      addTearDown(sseController.close);
+
+      final relayClient = MockRelayClient();
+      when(relayClient.connect).thenAnswer((_) async {});
+      when(() => relayClient.didResume).thenReturn(true);
+      when(() => relayClient.subscribeSse(any())).thenAnswer((_) => sseController.stream);
+      when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
+      when(relayClient.disconnect).thenAnswer((_) async {});
+
+      final factory = _TestRelayClientFactory(
+        ({
+          required String relayHost,
+          required RelayCryptoService cryptoService,
+          required RoomKeyStorage roomKeyStorage,
+          required String? authToken,
+        }) => relayClient,
+      );
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+        relayClientFactory: factory,
+      );
+      addTearDown(service.dispose);
+
+      await service.connect(config);
+
+      verifyNever(() => relayClient.sendRequest(any()));
+      expect(service.currentStatus, isA<ConnectionConnected>());
+    });
+
+    test("fresh-DH connect still sends GET /health", () async {
+      final sseController = StreamController<RelaySseEvent>.broadcast();
+      addTearDown(sseController.close);
+
+      final relayClient = MockRelayClient();
+      when(relayClient.connect).thenAnswer((_) async {});
+      when(() => relayClient.didResume).thenReturn(false);
+      when(() => relayClient.sendRequest(any())).thenAnswer(
+        (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
+      );
+      when(() => relayClient.subscribeSse(any())).thenAnswer((_) => sseController.stream);
+      when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
+      when(relayClient.disconnect).thenAnswer((_) async {});
+
+      final factory = _TestRelayClientFactory(
+        ({
+          required String relayHost,
+          required RelayCryptoService cryptoService,
+          required RoomKeyStorage roomKeyStorage,
+          required String? authToken,
+        }) => relayClient,
+      );
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+        relayClientFactory: factory,
+      );
+      addTearDown(service.dispose);
+
+      await service.connect(config);
+
+      verify(() => relayClient.sendRequest(any())).called(1);
+      expect(service.currentStatus, isA<ConnectionConnected>());
+    });
+
     test(
       "foreground resume attempts the first reconnect immediately, without the backoff delay",
       () async {
@@ -237,6 +313,7 @@ void main() {
 
         final relayClient = MockRelayClient();
         when(relayClient.connect).thenAnswer((_) async {});
+        when(() => relayClient.didResume).thenReturn(false);
         when(() => relayClient.isConnected).thenReturn(true);
         when(() => relayClient.sendRequest(any())).thenAnswer(
           (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
@@ -293,6 +370,7 @@ void main() {
 
       final relayClient = MockRelayClient();
       when(relayClient.connect).thenAnswer((_) async {});
+      when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.isConnected).thenReturn(true);
       when(() => relayClient.sendRequest(any())).thenAnswer(
         (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
@@ -338,6 +416,7 @@ void main() {
 
       final relayClient = MockRelayClient();
       when(relayClient.connect).thenAnswer((_) async {});
+      when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.isConnected).thenReturn(true);
       when(() => relayClient.sendRequest(any())).thenAnswer(
         (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
@@ -420,6 +499,7 @@ void main() {
       ];
 
       for (final client in clients) {
+        when(() => client.didResume).thenReturn(false);
         when(() => client.isConnected).thenReturn(true);
         when(() => client.sendRequest(any())).thenAnswer(
           (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
@@ -495,6 +575,7 @@ void main() {
       final clients = <MockRelayClient>[initialClient, reconnectClient];
 
       for (final client in clients) {
+        when(() => client.didResume).thenReturn(false);
         when(() => client.isConnected).thenReturn(true);
         when(() => client.sendRequest(any())).thenAnswer(
           (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),


### PR DESCRIPTION
## Summary

PR 3 of the auth / E2E reconnect UX plan (`docs/plans/auth-reconnect-ux-plan.md`). On the common reconnect path the relay session **resumes** (encrypted `resume` → bridge `resume_ack`, skipping the X25519 DH exchange). That `resume_ack` already proves the bridge is reachable, so the follow-up `GET /health` round-trip in `_connectViaRelay` is pure latency. This drops it on resumed reconnects.

Follows #262 (PR 1), #264 (PR 1a), #265 (PR 2).

## What changed

- **`RelayClient`** (Layer 0 transport): exposes `bool get didResume` — `true` when `connect()` resumes via `resume_ack`, `false` on a fresh DH exchange (reset at the start of each connect attempt).
- **`ConnectionService._connectViaRelay`**: the `GET /health` request is now gated behind `if (!relayClient.didResume)`. Resumed reconnects skip the round-trip; fresh-DH connects health-check exactly as before. The `const health`, the in-flight/staleness teardown guards, the commit, SSE setup, and connected-status emission are unchanged.

## Why it's safe

Bridge liveness on a resumed connection is still surfaced through the existing `bridgeOffline` control-frame stream and the first real request — the health check was redundant confirmation on resume, not the only signal.

## Testing

- New unit tests: resumed connect (`didResume == true`) sends **no** `GET /health` (`verifyNever(sendRequest)`) and reaches `Connected`; fresh-DH connect (`didResume == false`) still sends health.
- Existing `MockRelayClient` connect paths updated to stub `didResume` (default false).
- `module_core` capability tests **50/50**; app `ConnectionService` + `RelayClient` tests **28/28**; `dart analyze` clean.
- `aristotle-plan-review` and `aristotle-impl-review`: both APPROVED.

## Plan tracker

`auth-reconnect-ux-plan.md` updated: Current stage → PR 3; tracker PR 2 → merged (#265), PR 3 → implemented.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the redundant GET /health after a resumed relay reconnect to remove an extra round-trip and reduce latency.
`RelayClient` adds `didResume`, and `_connectViaRelay` only health-checks on fresh DH connects; resumed paths still surface liveness via bridge status frames and the first real request.

<sup>Written for commit fe8c88baa6fee5ce641d76da60bc3ad380f14224. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

