### PR TITLE
fix(mobile): defer new-session launching snackbar past build phase

### DIFF
--- a/mobile/app/lib/features/new_session/new_session_screen.dart
+++ b/mobile/app/lib/features/new_session/new_session_screen.dart
@@ -180,12 +180,22 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
         canPop: true,
         onPopInvokedWithResult: (didPop, result) {
           if (didPop && isSending && !_navigatingToCreatedSession) {
-            scaffoldMessenger.showSnackBar(
-              SnackBar(
-                content: Text(loc.newSessionLaunchingInBackground),
-                duration: const Duration(seconds: 3),
-              ),
-            );
+            // This pop can fire during the Navigator's build phase — e.g. when
+            // opening another session from the split-view list while creation
+            // is in flight, go_router swaps the underlying detail route in
+            // place and pops this pushed new-session route in the same frame.
+            // showSnackBar throws if called during build, so defer it to the
+            // next frame. The captured root messenger outlives this route;
+            // guard it with `mounted` since the route may already be gone.
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (!scaffoldMessenger.mounted) return;
+              scaffoldMessenger.showSnackBar(
+                SnackBar(
+                  content: Text(loc.newSessionLaunchingInBackground),
+                  duration: const Duration(seconds: 3),
+                ),
+              );
+            });
           }
         },
         child: Scaffold(

--- a/mobile/app/test/core/widgets/session_split/session_split_shell_test.dart
+++ b/mobile/app/test/core/widgets/session_split/session_split_shell_test.dart
@@ -1,12 +1,17 @@
+import "dart:async";
+
 import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_test/flutter_test.dart";
+import "package:mocktail/mocktail.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/core/widgets/sesori_background_widget.dart";
 import "package:sesori_mobile/core/widgets/session_split/empty_session_detail_panel.dart";
 import "package:sesori_mobile/core/widgets/session_split/session_split_breakpoints.dart";
 import "package:sesori_mobile/core/widgets/session_split/session_split_scope.dart";
+import "package:sesori_mobile/features/new_session/new_session_screen.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_zyra/module_zyra.dart";
 
 import "../../../helpers/test_helpers.dart";
@@ -138,6 +143,86 @@ void main() {
         findsOneWidget,
       );
       expect(tester.getSize(find.byType(SnackBar)).width, 1024);
+    });
+
+    testWidgets("opening another session while a new session is sending does not crash", (tester) async {
+      final harness = AdaptiveSessionRouterTestHarness();
+      await tester.binding.setSurfaceSize(const Size(1024, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      addTearDown(harness.tearDown);
+      // Start from an already-open session detail (the failing real path). The
+      // underlying detail page shares a pattern-based page key, so swapping
+      // s1 -> s2 updates it in place while the pushed new-session page becomes
+      // the exiting route that Flutter pops during build.
+      await harness.setUp(
+        initialLocation: "/projects/p1/sessions/s1?title=Session+One&readOnly=false&name=Project+One",
+        currentRouteDef: AppRouteDef.sessionDetail,
+        sessionsByProject: {
+          "p1": [
+            adaptiveTestSession(projectId: "p1", id: "s1", title: "Session One"),
+            adaptiveTestSession(projectId: "p1", id: "s2", title: "Session Two"),
+          ],
+        },
+      );
+
+      // Creation stays in flight: the user navigates away before it resolves.
+      final createCompleter = Completer<ApiResponse<Session>>();
+      addTearDown(() {
+        if (!createCompleter.isCompleted) {
+          createCompleter.complete(ApiResponse.error(ApiError.generic()));
+        }
+      });
+      when(
+        () => harness.sessionRepository.createSessionWithMessage(
+          projectId: any(named: "projectId"),
+          text: any(named: "text"),
+          agent: any(named: "agent"),
+          model: any(named: "model"),
+          variant: any(named: "variant"),
+          command: any(named: "command"),
+          dedicatedWorktree: any(named: "dedicatedWorktree"),
+        ),
+      ).thenAnswer((_) => createCompleter.future);
+
+      await tester.pumpWidget(harness.buildApp());
+      await tester.pumpAndSettle();
+
+      final leftPane = find.byKey(const Key("session-split-left-pane"));
+      final loc = AppLocalizations.of(
+        tester.element(find.descendant(of: leftPane, matching: find.text("Session Two"))),
+      )!;
+
+      // Open the new-session composer — pushed imperatively onto the pane
+      // navigator (mirrors the list pane's "New session" button).
+      await tester.tap(find.descendant(of: leftPane, matching: find.byIcon(Icons.add)));
+      await tester.pumpAndSettle();
+      expect(find.byType(NewSessionScreen), findsOneWidget);
+
+      // Start sending; creation is now in flight. Scope to the composer — the
+      // session-detail route behind the pushed overlay also has a prompt field.
+      final newSession = find.byType(NewSessionScreen);
+      await tester.enterText(find.descendant(of: newSession, matching: find.byType(TextField)), "do the thing");
+      await tester.tap(find.descendant(of: newSession, matching: find.byIcon(Icons.send)), warnIfMissed: false);
+      await tester.pump();
+      expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);
+
+      // Open a different existing session from the list. go_router swaps the
+      // underlying detail in place and pops the pushed new-session page during
+      // the Navigator's build phase, invoking PopScope.onPopInvokedWithResult
+      // mid-build — where calling showSnackBar directly throws
+      // "showSnackBar() called during build".
+      await tester.tap(find.descendant(of: leftPane, matching: find.text("Session Two")));
+      await tester.pump();
+
+      // The launching-in-background snackbar must be deferred past the current
+      // frame, not thrown during build.
+      expect(tester.takeException(), isNull);
+
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.byType(NewSessionScreen), findsNothing);
+      expect(find.text(loc.newSessionLaunchingInBackground), findsOneWidget);
     });
 
     testWidgets("wide to narrow resize preserves the same SessionListCubit instance", (tester) async {

--- a/mobile/app/test/features/new_session/new_session_screen_test.dart
+++ b/mobile/app/test/features/new_session/new_session_screen_test.dart
@@ -340,6 +340,9 @@ void main() {
     // Simulate system back navigation (which should be allowed while sending).
     await tester.pageBack();
     await tester.pump();
+    // The snackbar is scheduled via a post-frame callback (so it stays safe
+    // when the pop is invoked during build), so pump once more to render it.
+    await tester.pump();
 
     // Snackbar should appear before the screen pops.
     expect(find.text(loc.newSessionLaunchingInBackground), findsOneWidget);
@@ -377,6 +380,9 @@ void main() {
 
     // User leaves while the creation request is still in flight.
     await tester.pageBack();
+    await tester.pump();
+    // The launching-in-background snackbar is deferred to a post-frame
+    // callback; pump once more to render it.
     await tester.pump();
     expect(find.text(loc.newSessionLaunchingInBackground), findsOneWidget);
 


### PR DESCRIPTION
## Problem

Opening another session from the split-view list **while a new session is still being created** crashed the app with:

> The showSnackBar() method cannot be called during build.

Repro: view an existing session → tap **New session** → send → before creation finishes, open a different session from the list.

## Root cause

`NewSessionScreen` shows a "launching in background" snackbar from `PopScope.onPopInvokedWithResult`. In the split layout, session-detail pages share a pattern-based go_router page key, so switching `s1 → s2` updates the underlying detail route **in place** while the imperatively-pushed new-session route becomes the exiting route. Flutter pops it during the Navigator's build phase (`didUpdateWidget → _updatePages → _flushHistoryUpdates → onPopInvokedWithResult`), so calling `ScaffoldMessenger.showSnackBar` synchronously there trips the build-phase assertion.

(An empty-sessions → new → detail path does *not* reproduce it — there the new-session page is removed/completed rather than popped, so the callback never fires.)

## Fix

Defer the snackbar to the next frame via `WidgetsBinding.instance.addPostFrameCallback`, guarding the captured root messenger with `mounted`. The snackbar still shows, one frame later.

## Tests

- Added a regression widget test in `session_split_shell_test.dart` (real-routing harness) that reproduces the exact crash and asserts no exception + snackbar shown. Verified it fails before the fix (identical ScaffoldMessenger ownership chain to the report) and passes after.
- Updated two existing `new_session_screen_test.dart` tests with one extra `pump()` for the one-frame deferral.
- `dart analyze` clean; new-session and split-shell suites green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a crash when opening another session while a new session is being created by deferring the “launching in background” snackbar to the next frame. Fixes the “showSnackBar() called during build” error in split view.

- **Bug Fixes**
  - Defer `ScaffoldMessenger.showSnackBar` from `PopScope.onPopInvokedWithResult` via `WidgetsBinding.instance.addPostFrameCallback` (guarded by `mounted`) to avoid build-phase calls when `go_router` swaps the detail route and pops the new-session route.
  - Added a regression widget test that reproduces the split-view path and asserts no exception + snackbar shown; updated two existing tests with one extra `pump()` for the one-frame deferral.

<sup>Written for commit 4acfef8e9e9f3593b9022e481c06e07a362d92bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

