### PR TITLE
chore: weekly dependency update (2026-06-15)

### DIFF
--- a/bridge/app/lib/src/bridge/persistence/database.g.dart
+++ b/bridge/app/lib/src/bridge/persistence/database.g.dart
@@ -1326,10 +1326,7 @@ final class $$ProjectsTableTableReferences
   static MultiTypedResultKey<$SessionTableTable, List<SessionDto>>
   _sessionTableRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
     db.sessionTable,
-    aliasName: $_aliasNameGenerator(
-      db.projectsTable.projectId,
-      db.sessionTable.projectId,
-    ),
+    aliasName: 'projects_table__project_id__sessions_table__project_id',
   );
 
   $$SessionTableTableProcessedTableManager get sessionTableRefs {
@@ -1350,10 +1347,8 @@ final class $$ProjectsTableTableReferences
   _pullRequestsTableRefsTable(_$AppDatabase db) =>
       MultiTypedResultKey.fromTable(
         db.pullRequestsTable,
-        aliasName: $_aliasNameGenerator(
-          db.projectsTable.projectId,
-          db.pullRequestsTable.projectId,
-        ),
+        aliasName:
+            'projects_table__project_id__pull_requests_table__project_id',
       );
 
   $$PullRequestsTableTableProcessedTableManager get pullRequestsTableRefs {
@@ -1735,13 +1730,9 @@ final class $$SessionTableTableReferences
     extends BaseReferences<_$AppDatabase, $SessionTableTable, SessionDto> {
   $$SessionTableTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
-  static $ProjectsTableTable _projectIdTable(_$AppDatabase db) =>
-      db.projectsTable.createAlias(
-        $_aliasNameGenerator(
-          db.sessionTable.projectId,
-          db.projectsTable.projectId,
-        ),
-      );
+  static $ProjectsTableTable _projectIdTable(_$AppDatabase db) => db
+      .projectsTable
+      .createAlias('sessions_table__project_id__projects_table__project_id');
 
   $$ProjectsTableTableProcessedTableManager get projectId {
     final $_column = $_itemColumn<String>('project_id')!;
@@ -2188,10 +2179,7 @@ final class $$PullRequestsTableTableReferences
 
   static $ProjectsTableTable _projectIdTable(_$AppDatabase db) =>
       db.projectsTable.createAlias(
-        $_aliasNameGenerator(
-          db.pullRequestsTable.projectId,
-          db.projectsTable.projectId,
-        ),
+        'pull_requests_table__project_id__projects_table__project_id',
       );
 
   $$ProjectsTableTableProcessedTableManager get projectId {

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -8,12 +8,12 @@ environment:
   sdk: ^3.12.2
 
 dependencies:
-  args: ^2.6.0
+  args: ^2.7.0
   cryptography: ^2.9.0
-  web_socket_channel: ^3.0.0
-  http: ^1.3.0
-  crypto: ^3.0.0
-  path: ^1.9.0
+  web_socket_channel: ^3.0.3
+  http: ^1.6.0
+  crypto: ^3.0.7
+  path: ^1.9.1
   sesori_shared:
     path: ../../shared/sesori_shared
   clock: ^1.1.2
@@ -26,19 +26,19 @@ dependencies:
     path: ../sesori_plugin_runtime
   opencode_plugin:
     path: ../sesori_plugin_opencode
-  meta: ^1.17.0
-  drift: ^2.32.1
+  meta: ^1.18.3
+  drift: ^2.34.0
   collection: ^1.19.1
-  win32: ^6.0.0
+  win32: ^6.3.0
 
 dev_dependencies:
-  test: ^1.25.0
+  test: ^1.31.1
   lints: ^6.1.0
   fake_async: ^1.3.3
   # Tests exercise raw sqlite3 directly (drift migrations, DAO tests);
   # production code reaches sqlite3 only transitively through drift.
-  sqlite3: ^3.2.0
+  sqlite3: ^3.3.3
   build_runner: any
   freezed: ^3.2.5
   json_serializable: ^6.14.0
-  drift_dev: ^2.32.1
+  drift_dev: ^2.34.0

--- a/bridge/pubspec.lock
+++ b/bridge/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      sha256: "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.15.1"
   crypto:
     dependency: transitive
     description:
@@ -189,18 +189,18 @@ packages:
     dependency: transitive
     description:
       name: drift
-      sha256: "8033500116b24398fba0cca0369cc31678cd627c01e41753a61186911cea743e"
+      sha256: "6cc0b623c0e83f7080524d8396e9301b1d78b9c66a4fdceeb0f798211303254c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.33.0"
+    version: "2.34.0"
   drift_dev:
     dependency: transitive
     description:
       name: drift_dev
-      sha256: b3dd5b75e30522a91da8abda9f5bb17230cb038097f6d15fa75d42bb563428aa
+      sha256: "9cfff1576b49725da0d32c040651a41ae195e8c4af8d8da301593e41d7abc2f7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.33.0"
+    version: "2.34.0"
   fake_async:
     dependency: transitive
     description:
@@ -365,10 +365,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: df0c643f44ad098eb37988027a8e2b2b5a031fd3977f06bbfd3a76637e8df739
+      sha256: c82594181e3312f3d0695fc95aaaf7758d75b8d4ae2bbecf223b9fd5109a059d
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.2"
+    version: "1.18.3"
   mime:
     dependency: transitive
     description:
@@ -540,18 +540,18 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "9488c7d2cdb1091c91cacf7e207cff81b28bff8e366f042bad3afe7d34afe189"
+      sha256: "37356bcb56ce0d9404d602c41e4bdb7765e7e9732a3e47adb3d98c556a6abdad"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.2"
+    version: "3.3.3"
   sqlparser:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: ecdc06d4a7d79dcbc928d99afd2f7f5b0f98a637c46f89be83d911617f759978
+      sha256: "40bdddb306a727be9ce510bd2d2b9a6c9db6c586d846ef7b22e3990a2b24f02d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.44.4"
+    version: "0.44.5"
   stack_trace:
     dependency: transitive
     description:

--- a/bridge/sesori_plugin_interface/pubspec.yaml
+++ b/bridge/sesori_plugin_interface/pubspec.yaml
@@ -9,11 +9,11 @@ environment:
 dependencies:
   freezed_annotation: ^3.1.0
   json_annotation: ^4.12.0
-  meta: ^1.0.0
+  meta: ^1.18.3
 
 dev_dependencies:
   lints: ^6.1.0
   freezed: ^3.2.5
   json_serializable: ^6.14.0
   build_runner: any
-  test: ^1.25.0
+  test: ^1.31.1

--- a/bridge/sesori_plugin_opencode/pubspec.yaml
+++ b/bridge/sesori_plugin_opencode/pubspec.yaml
@@ -13,15 +13,15 @@ dependencies:
     path: ../sesori_plugin_runtime
   sesori_shared:
     path: ../../shared/sesori_shared
-  http: ^1.3.0
+  http: ^1.6.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.12.0
-  sqlite3: ^3.2.0
+  sqlite3: ^3.3.3
 
 dev_dependencies:
   build_runner: any
   fake_async: ^1.3.3
   freezed: ^3.2.5
   json_serializable: ^6.14.0
-  test: ^1.25.0
+  test: ^1.31.1
   lints: ^6.1.0

--- a/mobile/app/android/Gemfile.lock
+++ b/mobile/app/android/Gemfile.lock
@@ -8,8 +8,8 @@ GEM
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1258.0)
-    aws-sdk-core (3.251.0)
+    aws-partitions (1.1260.0)
+    aws-sdk-core (3.252.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -20,7 +20,7 @@ GEM
     aws-sdk-kms (1.129.0)
       aws-sdk-core (~> 3, >= 3.248.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.225.0)
+    aws-sdk-s3 (1.225.1)
       aws-sdk-core (~> 3, >= 3.248.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
@@ -72,7 +72,7 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.4.1)
-    fastlane (2.236.0)
+    fastlane (2.236.1)
       CFPropertyList (>= 2.3, < 5.0.0)
       abbrev (~> 0.1)
       addressable (>= 2.8, < 3.0.0)
@@ -141,14 +141,14 @@ GEM
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-storage_v1 (0.63.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-core (1.8.0)
+    google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
     google-cloud-env (2.2.2)
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.6.0)
-    google-cloud-storage (1.60.0)
+    google-cloud-storage (1.61.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
       google-apis-core (>= 0.18, < 2)
@@ -172,7 +172,7 @@ GEM
     httpclient (2.9.0)
       mutex_m
     jmespath (1.6.2)
-    json (2.19.8)
+    json (2.19.9)
     jwt (3.2.0)
       base64
     logger (1.7.0)
@@ -183,7 +183,7 @@ GEM
     mutex_m (0.3.0)
     nanaimo (0.4.0)
     naturally (2.3.0)
-    nkf (0.2.0)
+    nkf (0.3.0)
     optparse (0.8.1)
     os (1.1.4)
     ostruct (0.6.3)
@@ -246,10 +246,10 @@ CHECKSUMS
   artifactory (3.0.17) sha256=3023d5c964c31674090d655a516f38ca75665c15084140c08b7f2841131af263
   atomos (0.1.3) sha256=7d43b22f2454a36bace5532d30785b06de3711399cb1c6bf932573eda536789f
   aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
-  aws-partitions (1.1258.0) sha256=3fee017570594ecf5e7f4c845b115fef8000530e57bdaf2b927357e5bf08967f
-  aws-sdk-core (3.251.0) sha256=ef8186cb5509147e590310da58fab4c5b0901eba0e85a72955abdf772e425c87
+  aws-partitions (1.1260.0) sha256=045aff79be010126538f39e03141088e1fd2428d2d065e220e7fb3c3ba2b337a
+  aws-sdk-core (3.252.0) sha256=09c042cbfc2acf2239441cc9b982ebab2a999bed2ef6bdc51849e7b3d6e48a1c
   aws-sdk-kms (1.129.0) sha256=363f548df321f4a4fcfd05523384e591060b400f8e65133ed7ef0793155a3343
-  aws-sdk-s3 (1.225.0) sha256=734752cc77e369c645ff5285b70ff5af207b0dcd3388346de2f727cd4e943924
+  aws-sdk-s3 (1.225.1) sha256=d4b23a8db9b0a5548766b52d382b184f47f7e126560acdb731dd46adb5e26512
   aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
   babosa (1.0.4) sha256=18dea450f595462ed7cb80595abd76b2e535db8c91b350f6c4b3d73986c5bc99
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
@@ -280,7 +280,7 @@ CHECKSUMS
   faraday-retry (1.0.4) sha256=dc659233777fabf96c69c2ffe56c0a5d2c102af90321a42cc6c90157bcd716aa
   faraday_middleware (1.2.1) sha256=d45b78c8ee864c4783fbc276f845243d4a7918a67301c052647bacabec0529e9
   fastimage (2.4.1) sha256=c64bebd46b6fd8943ab70c1e6e85ff728f970f2e48f92ecd249b6bc3a540ad20
-  fastlane (2.236.0) sha256=a496b8235ebce61c6311ca4cc1fd274b599e497f65d3035d7cb409d5591150d8
+  fastlane (2.236.1) sha256=fb89e618e0f38636e487743622cf710ad722723f5d33a63f19e367f84d3770bc
   fastlane-sirp (1.1.0) sha256=10bc94f9682efd8e1badfb31452a76dd8981f1f3a33717c765fde6d75b54d847
   gh_inspector (1.1.3) sha256=04cca7171b87164e053aa43147971d3b7f500fcb58177698886b48a9fc4a1939
   google-apis-androidpublisher_v3 (0.102.0) sha256=562415c44bd7f81cc808abbea11845ede16cdc3696d95f95efcf50aaffb159cf
@@ -288,17 +288,17 @@ CHECKSUMS
   google-apis-iamcredentials_v1 (0.27.0) sha256=9289f29968610754ef11d98b9ec627f0153f3e2616fef839aef096de529f6d1e
   google-apis-playcustomapp_v1 (0.17.0) sha256=d5bc90b705f3f862bab4998086449b0abe704ee1685a84821daa90ca7fa95a78
   google-apis-storage_v1 (0.63.0) sha256=7063a6c19c40f5ef96d5894df33c4f9ac915e3107e632b1870ba5247e3bb633f
-  google-cloud-core (1.8.0) sha256=e572edcbf189cfcab16590628a516cec3f4f63454b730e59f0b36575120281cf
+  google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.2.2) sha256=94bed40e05a67e9468ce1cb38389fba9a90aa8fc62fc9e173204c1dca59e21e7
   google-cloud-errors (1.6.0) sha256=1da8476dd706ad04b9d32e3c4b90d07d3463b37d6407cb56d41342ea7647d0a1
-  google-cloud-storage (1.60.0) sha256=b21b752d37945d678a4533be5ef4303f15d33a964d8bc709c7c41c3600f650db
+  google-cloud-storage (1.61.0) sha256=a77f10f4a603289948b09e81c3e23d762a18733fd69d70a4c1399663fbd96002
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   googleauth (1.17.0) sha256=dbddcaa3b78469fa9392c0e784ab6d8f3f760a1e5f6c6dbbbaa44a612c4198b0
   highline (2.0.3) sha256=2ddd5c127d4692721486f91737307236fe005352d12a4202e26c48614f719479
   http-cookie (1.0.8) sha256=b14fe0445cf24bf9ae098633e9b8d42e4c07c3c1f700672b09fbfe32ffd41aa6
   httpclient (2.9.0) sha256=4b645958e494b2f86c2f8a2f304c959baa273a310e77a2931ddb986d83e498c8
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
-  json (2.19.8) sha256=6354310fd76ef69b87d5bd1f38b40d730613baf90b6803d2d0a48f618d32dfaa
+  json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_magick (4.13.2) sha256=71d6258e0e8a3d04a9a0a09784d5d857b403a198a51dd4f882510435eb95ddd9
@@ -308,7 +308,7 @@ CHECKSUMS
   mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
   nanaimo (0.4.0) sha256=faf069551bab17f15169c1f74a1c73c220657e71b6e900919897a10d991d0723
   naturally (2.3.0) sha256=459923cf76c2e6613048301742363200c3c7e4904c324097d54a67401e179e01
-  nkf (0.2.0) sha256=fbc151bda025451f627fafdfcb3f4f13d0b22ae11f58c6d3a2939c76c5f5f126
+  nkf (0.3.0) sha256=357a8dbeba38b727b75930f665146546076a394a1c243faf634ff176e3588895
   optparse (0.8.1) sha256=42bea10d53907ccff4f080a69991441d611fbf8733b60ed1ce9ee365ce03bd1a
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912

--- a/mobile/app/ios/Gemfile.lock
+++ b/mobile/app/ios/Gemfile.lock
@@ -23,8 +23,8 @@ GEM
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1258.0)
-    aws-sdk-core (3.251.0)
+    aws-partitions (1.1260.0)
+    aws-sdk-core (3.252.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -35,7 +35,7 @@ GEM
     aws-sdk-kms (1.129.0)
       aws-sdk-core (~> 3, >= 3.248.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.225.0)
+    aws-sdk-s3 (1.225.1)
       aws-sdk-core (~> 3, >= 3.248.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
@@ -131,7 +131,7 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.4.1)
-    fastlane (2.236.0)
+    fastlane (2.236.1)
       CFPropertyList (>= 2.3, < 5.0.0)
       abbrev (~> 0.1)
       addressable (>= 2.8, < 3.0.0)
@@ -204,14 +204,14 @@ GEM
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-storage_v1 (0.63.0)
       google-apis-core (>= 0.15.0, < 2.a)
-    google-cloud-core (1.8.0)
+    google-cloud-core (1.9.0)
       google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
     google-cloud-env (2.2.2)
       base64 (~> 0.2)
       faraday (>= 1.0, < 3.a)
     google-cloud-errors (1.6.0)
-    google-cloud-storage (1.60.0)
+    google-cloud-storage (1.61.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
       google-apis-core (>= 0.18, < 2)
@@ -237,7 +237,7 @@ GEM
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
-    json (2.19.8)
+    json (2.19.9)
     jwt (3.2.0)
       base64
     logger (1.7.0)
@@ -254,7 +254,7 @@ GEM
     nap (1.1.0)
     naturally (2.3.0)
     netrc (0.11.0)
-    nkf (0.2.0)
+    nkf (0.3.0)
     optparse (0.8.1)
     os (1.1.4)
     ostruct (0.6.3)
@@ -326,10 +326,10 @@ CHECKSUMS
   artifactory (3.0.17) sha256=3023d5c964c31674090d655a516f38ca75665c15084140c08b7f2841131af263
   atomos (0.1.3) sha256=7d43b22f2454a36bace5532d30785b06de3711399cb1c6bf932573eda536789f
   aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
-  aws-partitions (1.1258.0) sha256=3fee017570594ecf5e7f4c845b115fef8000530e57bdaf2b927357e5bf08967f
-  aws-sdk-core (3.251.0) sha256=ef8186cb5509147e590310da58fab4c5b0901eba0e85a72955abdf772e425c87
+  aws-partitions (1.1260.0) sha256=045aff79be010126538f39e03141088e1fd2428d2d065e220e7fb3c3ba2b337a
+  aws-sdk-core (3.252.0) sha256=09c042cbfc2acf2239441cc9b982ebab2a999bed2ef6bdc51849e7b3d6e48a1c
   aws-sdk-kms (1.129.0) sha256=363f548df321f4a4fcfd05523384e591060b400f8e65133ed7ef0793155a3343
-  aws-sdk-s3 (1.225.0) sha256=734752cc77e369c645ff5285b70ff5af207b0dcd3388346de2f727cd4e943924
+  aws-sdk-s3 (1.225.1) sha256=d4b23a8db9b0a5548766b52d382b184f47f7e126560acdb731dd46adb5e26512
   aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
   babosa (1.0.4) sha256=18dea450f595462ed7cb80595abd76b2e535db8c91b350f6c4b3d73986c5bc99
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
@@ -373,7 +373,7 @@ CHECKSUMS
   faraday-retry (1.0.4) sha256=dc659233777fabf96c69c2ffe56c0a5d2c102af90321a42cc6c90157bcd716aa
   faraday_middleware (1.2.1) sha256=d45b78c8ee864c4783fbc276f845243d4a7918a67301c052647bacabec0529e9
   fastimage (2.4.1) sha256=c64bebd46b6fd8943ab70c1e6e85ff728f970f2e48f92ecd249b6bc3a540ad20
-  fastlane (2.236.0) sha256=a496b8235ebce61c6311ca4cc1fd274b599e497f65d3035d7cb409d5591150d8
+  fastlane (2.236.1) sha256=fb89e618e0f38636e487743622cf710ad722723f5d33a63f19e367f84d3770bc
   fastlane-sirp (1.1.0) sha256=10bc94f9682efd8e1badfb31452a76dd8981f1f3a33717c765fde6d75b54d847
   ffi (1.17.4-arm64-darwin) sha256=19071aaf1419251b0a46852abf960e77330a3b334d13a4ab51d58b31a937001b
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
@@ -385,10 +385,10 @@ CHECKSUMS
   google-apis-iamcredentials_v1 (0.27.0) sha256=9289f29968610754ef11d98b9ec627f0153f3e2616fef839aef096de529f6d1e
   google-apis-playcustomapp_v1 (0.17.0) sha256=d5bc90b705f3f862bab4998086449b0abe704ee1685a84821daa90ca7fa95a78
   google-apis-storage_v1 (0.63.0) sha256=7063a6c19c40f5ef96d5894df33c4f9ac915e3107e632b1870ba5247e3bb633f
-  google-cloud-core (1.8.0) sha256=e572edcbf189cfcab16590628a516cec3f4f63454b730e59f0b36575120281cf
+  google-cloud-core (1.9.0) sha256=ab55409f51488e8deefb6edcc1ce4771dfb5da2fe7b3bc075709a030c2b682a4
   google-cloud-env (2.2.2) sha256=94bed40e05a67e9468ce1cb38389fba9a90aa8fc62fc9e173204c1dca59e21e7
   google-cloud-errors (1.6.0) sha256=1da8476dd706ad04b9d32e3c4b90d07d3463b37d6407cb56d41342ea7647d0a1
-  google-cloud-storage (1.60.0) sha256=b21b752d37945d678a4533be5ef4303f15d33a964d8bc709c7c41c3600f650db
+  google-cloud-storage (1.61.0) sha256=a77f10f4a603289948b09e81c3e23d762a18733fd69d70a4c1399663fbd96002
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   googleauth (1.17.0) sha256=dbddcaa3b78469fa9392c0e784ab6d8f3f760a1e5f6c6dbbbaa44a612c4198b0
   highline (2.0.3) sha256=2ddd5c127d4692721486f91737307236fe005352d12a4202e26c48614f719479
@@ -396,7 +396,7 @@ CHECKSUMS
   httpclient (2.9.0) sha256=4b645958e494b2f86c2f8a2f304c959baa273a310e77a2931ddb986d83e498c8
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
-  json (2.19.8) sha256=6354310fd76ef69b87d5bd1f38b40d730613baf90b6803d2d0a48f618d32dfaa
+  json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_magick (4.13.2) sha256=71d6258e0e8a3d04a9a0a09784d5d857b403a198a51dd4f882510435eb95ddd9
@@ -410,7 +410,7 @@ CHECKSUMS
   nap (1.1.0) sha256=949691660f9d041d75be611bb2a8d2fd559c467537deac241f4097d9b5eea576
   naturally (2.3.0) sha256=459923cf76c2e6613048301742363200c3c7e4904c324097d54a67401e179e01
   netrc (0.11.0) sha256=de1ce33da8c99ab1d97871726cba75151113f117146becbe45aa85cb3dabee3f
-  nkf (0.2.0) sha256=fbc151bda025451f627fafdfcb3f4f13d0b22ae11f58c6d3a2939c76c5f5f126
+  nkf (0.3.0) sha256=357a8dbeba38b727b75930f665146546076a394a1c243faf634ff176e3588895
   optparse (0.8.1) sha256=42bea10d53907ccff4f080a69991441d611fbf8733b60ed1ce9ee365ce03bd1a
   os (1.1.4) sha256=57816d6a334e7bd6aed048f4b0308226c5fb027433b67d90a9ab435f35108d3f
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912

--- a/mobile/app/pubspec.yaml
+++ b/mobile/app/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   collection: ^1.19.1
   rxdart: ^0.28.0
   flutter_bloc: ^9.1.1
-  go_router: ^17.1.0
+  go_router: ^17.3.0
   get_it: ^9.2.1
   injectable: ^3.0.0
   flutter_markdown_plus: ^1.0.7
@@ -59,24 +59,24 @@ dependencies:
   cryptography: ^2.9.0
   cryptography_flutter: ^2.3.4
   web_socket_channel: ^3.0.3
-  flutter_secure_storage: ^10.2.0
-  app_links: ^7.0.0
+  flutter_secure_storage: ^10.3.1
+  app_links: ^7.1.2
   url_launcher: ^6.3.2
   universal_platform: ^1.1.0
-  record: ^7.0.0
+  record: ^7.1.0
   path: any
   path_provider: ^2.1.5
   re_highlight: ^0.0.3
-  wakelock_plus: ^1.5.1
-  firebase_core: ^4.6.0
-  firebase_analytics: ^12.2.0
-  firebase_crashlytics: ^5.1.0
-  firebase_messaging: ^16.1.3
-  flutter_local_notifications: ^22.0.0
-  flutter_svg: ^2.2.4
+  wakelock_plus: ^1.6.1
+  firebase_core: ^4.10.0
+  firebase_analytics: ^12.4.2
+  firebase_crashlytics: ^5.2.3
+  firebase_messaging: ^16.3.0
+  flutter_local_notifications: ^22.0.1
+  flutter_svg: ^2.3.0
   cue: ^0.3.1
-  sign_in_with_apple: ^8.0.0
-  crypto: ^3.0.6
+  sign_in_with_apple: ^8.1.0
+  crypto: ^3.0.7
   vector_graphics: ^1.2.2
   flutter_chat_ui: ^2.11.1
   flutter_chat_core: ^2.9.0
@@ -91,8 +91,8 @@ dev_dependencies:
   injectable_generator: ^3.0.2
   bloc_test: ^10.0.0
   build_runner: any
-  mocktail: ^1.0.4
-  flutter_native_splash: ^2.4.7
+  mocktail: ^1.0.5
+  flutter_native_splash: ^2.4.8
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
@@ -101,7 +101,7 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^6.0.0
   fake_async: ^1.3.3
-  vector_graphics_compiler: ^1.2.3
+  vector_graphics_compiler: ^1.2.5
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/mobile/module_auth/pubspec.yaml
+++ b/mobile/module_auth/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   http: ^1.6.0
   injectable: ^3.0.0
   json_annotation: ^4.12.0
-  meta: ^1.16.0
+  meta: ^1.18.0
   rxdart: ^0.28.0
   sesori_shared:
     path: ../../shared/sesori_shared
@@ -27,5 +27,5 @@ dev_dependencies:
   freezed: ^3.2.5
   injectable_generator: ^3.0.2
   json_serializable: ^6.14.0
-  mocktail: ^1.0.4
-  test: ^1.25.0
+  mocktail: ^1.0.5
+  test: ^1.31.0

--- a/mobile/module_core/pubspec.yaml
+++ b/mobile/module_core/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ^3.12.2
 
 dependencies:
-  bloc: ^9.0.0
+  bloc: ^9.2.1
   collection: ^1.19.1
   diff_match_patch: ^0.4.1
   cryptography: ^2.9.0
@@ -18,13 +18,13 @@ dependencies:
   injectable: ^3.0.0
   intl: any
   json_annotation: ^4.12.0
-  meta: ^1.16.0
+  meta: ^1.18.0
   rxdart: ^0.28.0
   sesori_auth:
     path: ../module_auth
   sesori_shared:
     path: ../../shared/sesori_shared
-  web_socket_channel: ^3.0.1
+  web_socket_channel: ^3.0.3
 
 dev_dependencies:
   no_slop_linter:
@@ -34,6 +34,6 @@ dev_dependencies:
   freezed: ^3.2.5
   injectable_generator: ^3.0.2
   json_serializable: ^6.14.0
-  mocktail: ^1.0.4
-  test: ^1.25.0
+  mocktail: ^1.0.5
+  test: ^1.31.0
   fake_async: ^1.3.3

--- a/mobile/module_zyra/pubspec.yaml
+++ b/mobile/module_zyra/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.16.0
-  flutter_svg: ^2.2.4
+  meta: ^1.18.0
+  flutter_svg: ^2.3.0
   universal_platform: ^1.1.0
   liquid_glass_plus: ^0.3.1+1
 
@@ -75,6 +75,6 @@ dev_dependencies:
   no_slop_linter:
     path: "../../shared/no_slop_linter"
   build_runner: any
-  mocktail: ^1.0.4
-  test: ^1.25.0
+  mocktail: ^1.0.5
+  test: ^1.31.0
   fake_async: ^1.3.3

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
+      sha256: "3b19a47f6ea7c2632760777c78174f47f6aec1e05f0cd611380d4593b8af1dbc"
       url: "https://pub.dev"
     source: hosted
-    version: "93.0.0"
+    version: "96.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -21,26 +21,26 @@ packages:
     dependency: transitive
     description:
       name: analysis_server_plugin
-      sha256: "5f3920acbd5765764ec9ef6c5bbdd102015424281232ee4fb4f5431c87abb4eb"
+      sha256: c9611c4b053f868434400e734c594a7e8464f307f8eaf7ff266d903cd2d615c0
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.7"
+    version: "0.3.10"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
+      sha256: "0c516bc4ad36a1a75759e54d5047cb9d15cded4459df01aa35a0b5ec7db2c2a0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.1"
+    version: "10.2.0"
   analyzer_plugin:
     dependency: transitive
     description:
       name: analyzer_plugin
-      sha256: "7df504f0c9d6891bacc9f73a5a8c5f6fe4fc49c90ec8e3379916372906ba0b32"
+      sha256: a886aaa94fb128ffe9cf5ee2495d9ef42ef129fe2e265b84b8820987ca15f4cd
       url: "https://pub.dev"
     source: hosted
-    version: "0.14.1"
+    version: "0.14.4"
   ansicolor:
     dependency: transitive
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: app_links
-      sha256: "3462d9defc61565fde4944858b59bec5be2b9d5b05f20aed190adb3ad08a7abc"
+      sha256: "4ec328cd9fd51fd0e7eb8870a9612c1fde0f091901932238c4f4e60b5f7f1315"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.1.2"
   app_links_linux:
     dependency: transitive
     description:
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: app_links_platform_interface
-      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      sha256: "78a18580eecac98108d1eef52a7db668bc317714f5205e616973363326efe333"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   app_links_web:
     dependency: transitive
     description:
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      sha256: "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.15.1"
   cross_cache:
     dependency: transitive
     description:
@@ -325,10 +325,10 @@ packages:
     dependency: transitive
     description:
       name: dbus
-      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      sha256: "792974a4007974fbc5c1b5433eb2330a9db3e368c3f906253af4c007d0f49a91"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.12"
+    version: "0.7.13"
   diff_match_patch:
     dependency: transitive
     description:
@@ -538,10 +538,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_local_notifications
-      sha256: be38e3854d2baabcda8e16966a5fe8748cebb655bb94701494da0f052c2fc352
+      sha256: a0d7141f14cabcee42967470a858dfc99dd6cfb70d3cab404bacfcafa9e84e70
       url: "https://pub.dev"
     source: hosted
-    version: "22.0.0"
+    version: "22.0.1"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
@@ -570,10 +570,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_local_notifications_windows
-      sha256: "5aeed973a0c1480706784fad05c5c3a911335ebb561b2274b47fe80b375201e1"
+      sha256: "6f43bdd03b171b7a90f22647506fea33e2bb12294b7c7c7a3d690e960a382945"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
   flutter_localizations:
     dependency: transitive
     description: flutter
@@ -591,10 +591,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_native_splash
-      sha256: "4fb9f4113350d3a80841ce05ebf1976a36de622af7d19aca0ca9a9911c7ff002"
+      sha256: "9db4b80b044e9af17cc4b1272137fc7ace0054d879ef8210a76adc34aaf4cdff"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.7"
+    version: "2.4.8"
   flutter_secure_storage:
     dependency: transitive
     description:
@@ -793,10 +793,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
+      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.9.1"
   injectable:
     dependency: transitive
     description:
@@ -1176,50 +1176,50 @@ packages:
     dependency: transitive
     description:
       name: record
-      sha256: "11bab1e1d9e75229588222f66a468aae1967e1ce490c80f8bd782aa165ec822b"
+      sha256: d28ec249ee4af6753a68a7a5077d6a2eee71e38dc61a241724aded53263274ba
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.1.0"
   record_android:
     dependency: transitive
     description:
       name: record_android
-      sha256: "16e28607ad92dc2e7d93328f4f4720a9f82a78b639497690022e0e135a326f8e"
+      sha256: "6722be803d8b2a0945112d69cfbda1391970c5cff2cb53c16afd307a6b7ef0c4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.1"
   record_ios:
     dependency: transitive
     description:
       name: record_ios
-      sha256: a7f456c9b2c5ba10f1ad0a7dfe19dcabcbfda0c2a09d4eef0c43e48e762a7b00
+      sha256: de6f660b02c2a909c963d5c3c929fdf100b03cea9e5552599d0e5ae1b7d1a89d
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   record_linux:
     dependency: transitive
     description:
       name: record_linux
-      sha256: "64c70dede6f3a8235927531067ceb8e2ef1b737071f2ff72390ab49f88644f2a"
+      sha256: "305526af0560866a0cc4219aa3726ef8541f819e14bd5f65b73ffdb7dc5911be"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   record_macos:
     dependency: transitive
     description:
       name: record_macos
-      sha256: b8cd9dd88aff1b7a5873bb2a2a875b376ce1a68c6f84bce3ce0448e413a84700
+      sha256: "9c29a7efdace0662db2aa7284873d49f8b48992432db3b5f0d38cbe2da8eecde"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   record_platform_interface:
     dependency: transitive
     description:
       name: record_platform_interface
-      sha256: fc1b2b26113b8ab2bffa39148288b0b588c7b3b356a21aeee7bea24b91b6f1a4
+      sha256: d94b37cadb8fe203e64b0e9893271c0b71b34f2550ee7fb0c6105d650e00c1f5
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   record_use:
     dependency: transitive
     description:
@@ -1232,18 +1232,18 @@ packages:
     dependency: transitive
     description:
       name: record_web
-      sha256: f3374c9ba6b6f9edcb3589be37515e420faba631b9d54421bb28562667831b05
+      sha256: "9d2d43162afff63d8608eb09c2982b9c6898dd8fbf5b05395ca7d08305b6db40"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   record_windows:
     dependency: transitive
     description:
       name: record_windows
-      sha256: "603429b542a2a7120ad988218ebebe50ed5565087db68ab694ae6c2d5a6e7749"
+      sha256: a1db1c0b996acd4161a93cc412b81a2a09a4fd7161c6353f32bf97683003b52f
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   rxdart:
     dependency: transitive
     description:
@@ -1492,10 +1492,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c"
+      sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.30"
+    version: "6.3.32"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1660,10 +1660,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.1"
+    version: "7.0.1"
   xxh3:
     dependency: transitive
     description:

--- a/shared/sesori_shared/pubspec.lock
+++ b/shared/sesori_shared/pubspec.lock
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      sha256: "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.15.1"
   crypto:
     dependency: transitive
     description:
@@ -285,10 +285,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: df0c643f44ad098eb37988027a8e2b2b5a031fd3977f06bbfd3a76637e8df739
+      sha256: c82594181e3312f3d0695fc95aaaf7758d75b8d4ae2bbecf223b9fd5109a059d
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.2"
+    version: "1.18.3"
   mime:
     dependency: transitive
     description:


### PR DESCRIPTION
## Weekly dependency update

Automated weekly dependency refresh run via the `update-dependencies` skill, based on the latest `upstream/main` (`1ec52558`).

### Environment
- Flutter **3.44.2** / Dart **3.12.2** — already the latest stable; no SDK bump. All pubspec `environment` constraints already current (`sdk: ^3.12.2`, `flutter: ">=3.44.2 <3.45.0"`).

### Dart dependencies
- **pubspec.yaml constraint floors raised** to the latest resolvable version for every direct dependency across the bridge and mobile packages (skipping `any`/path/sdk deps and `no_slop_linter`).
- **Lockfiles regenerated** against latest resolvable transitive versions.

Notable floor bumps:
- **bridge**: `drift`/`drift_dev` ^2.32.1→^2.34.0 (regenerated `database.g.dart`), `sqlite3` ^3.2.0→^3.3.3, `meta`→^1.18.3, `http` ^1.3.0→^1.6.0, `args` ^2.6.0→^2.7.0, `win32` ^6.0.0→^6.3.0, `web_socket_channel`/`crypto`/`path`, `test`→^1.31.1
- **mobile**: `firebase_core` ^4.10.0, `firebase_analytics` ^12.4.2, `firebase_crashlytics` ^5.2.3, `firebase_messaging` ^16.3.0, `go_router` ^17.1.0→^17.3.0, `flutter_secure_storage` ^10.3.1, `app_links` ^7.1.2, `record` ^7.1.0, `wakelock_plus` ^1.6.1, `sign_in_with_apple` ^8.1.0, `flutter_svg` ^2.3.0, `bloc` ^9.0.0→^9.2.1, `meta`→^1.18.0, `mocktail` ^1.0.5, `test` ^1.31.0, `flutter_native_splash`/`vector_graphics_compiler`/`crypto`

### Fastlane / Ruby gems
- `fastlane` 2.236.0 → 2.236.1 (within existing `~> 2.236` constraint; no Gemfile edit)
- Regenerated `Gemfile.lock` for iOS and Android (aws-sdk, google-cloud, json, nkf transitive bumps)
- No CocoaPods changes (iOS is SPM-only)

### Deferred (blocked by transitive constraints — floor left at resolvable)
| Dependency | Resolvable | Latest | Reason |
|---|---|---|---|
| `meta` (mobile) | 1.18.0 | 1.18.3 | pinned by Flutter SDK |
| `test` (mobile) | 1.31.0 | 1.31.1 | pinned by Flutter SDK |
| `injectable_generator` | 3.0.2 | 3.1.0 | pinned by `injectable` runtime |

`no_slop_linter` intentionally excluded from this workflow (manually managed analyzer constraints).

### Verification
- `make analyze` — ✅ clean (shared, bridge, mobile; mobile with `--fatal-infos`)
- `make test` — ✅ all pass (197 shared, 1334 bridge, 491 mobile)
- `make codegen` — ✅ completes cleanly
- `bundle exec fastlane --version` — ✅ 2.236.1 (iOS + Android)
- No SPM `Package.resolved` drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)