### PR TITLE
fix(bridge): friendlier update-check rate-limit messaging + opportunistic GitHub auth

### DIFF
--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -472,7 +472,10 @@ class BridgeRuntimeRunner {
     final githubToken = [
       io.Platform.environment['GITHUB_TOKEN'],
       io.Platform.environment['GH_TOKEN'],
-    ].firstWhere((token) => token != null && token.isNotEmpty, orElse: () => null);
+    ].map((token) => token?.trim()).firstWhere(
+      (token) => token != null && token.isNotEmpty,
+      orElse: () => null,
+    );
 
     return UpdateService(
       releaseRepository: ReleaseRepository(

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -466,9 +466,13 @@ class BridgeRuntimeRunner {
     // Opportunistically authenticate GitHub release checks when a token is
     // present in the environment. Unauthenticated requests share a 60/hour
     // per-IP budget that is easily exhausted behind shared/NAT'd networks; a
-    // token lifts the bridge to the authenticated 5000/hour limit.
-    final githubToken =
-        io.Platform.environment['GITHUB_TOKEN'] ?? io.Platform.environment['GH_TOKEN'];
+    // token lifts the bridge to the authenticated 5000/hour limit. Resolve the
+    // first non-empty value so a blank GITHUB_TOKEN does not shadow a valid
+    // GH_TOKEN.
+    final githubToken = [
+      io.Platform.environment['GITHUB_TOKEN'],
+      io.Platform.environment['GH_TOKEN'],
+    ].firstWhere((token) => token != null && token.isNotEmpty, orElse: () => null);
 
     return UpdateService(
       releaseRepository: ReleaseRepository(

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -463,9 +463,16 @@ class BridgeRuntimeRunner {
       fileReplacementApi: FileReplacementApi(processRunner: processRunner),
     );
 
+    // Opportunistically authenticate GitHub release checks when a token is
+    // present in the environment. Unauthenticated requests share a 60/hour
+    // per-IP budget that is easily exhausted behind shared/NAT'd networks; a
+    // token lifts the bridge to the authenticated 5000/hour limit.
+    final githubToken =
+        io.Platform.environment['GITHUB_TOKEN'] ?? io.Platform.environment['GH_TOKEN'];
+
     return UpdateService(
       releaseRepository: ReleaseRepository(
-        api: GitHubReleasesApi(httpClient: httpClient),
+        api: GitHubReleasesApi(httpClient: httpClient, authToken: githubToken),
         cache: UpdateCacheApi(
           cacheDirectory: managedRuntimePaths.cacheDirectory,
           clock: const Clock(),

--- a/bridge/app/lib/src/updater/api/github_releases_api.dart
+++ b/bridge/app/lib/src/updater/api/github_releases_api.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:http/http.dart' as http;
 import 'package:sesori_shared/sesori_shared.dart';
 
@@ -14,7 +15,7 @@ class GitHubReleasesApi {
   final http.Client _httpClient;
   final String? _authToken;
 
-  GitHubReleasesApi({required http.Client httpClient, String? authToken})
+  GitHubReleasesApi({required http.Client httpClient, required String? authToken})
     : _httpClient = httpClient,
       _authToken = authToken;
 
@@ -66,14 +67,19 @@ class GitHubReleasesApi {
   }
 
   /// GitHub signals a primary rate limit with HTTP 403 and
-  /// `x-ratelimit-remaining: 0`, and a secondary/abuse limit with HTTP 429. A
-  /// 403 without an exhausted remaining count is a different failure (e.g. a
-  /// blocked request) and is intentionally not treated as a rate limit.
+  /// `x-ratelimit-remaining: 0`. Secondary/abuse limits arrive as HTTP 429, or
+  /// as HTTP 403 carrying a `retry-after` hint (where the remaining count may
+  /// still be non-zero). A 403 with neither signal is a different failure (e.g.
+  /// a blocked request) and is intentionally not treated as a rate limit.
   bool _isRateLimited(http.Response response) {
     if (response.statusCode == 429) {
       return true;
     }
-    return response.statusCode == 403 && response.headers['x-ratelimit-remaining'] == '0';
+    if (response.statusCode != 403) {
+      return false;
+    }
+    return response.headers['x-ratelimit-remaining'] == '0' ||
+        response.headers.containsKey('retry-after');
   }
 
   DateTime? _parseResetAt(http.Response response) {
@@ -87,7 +93,7 @@ class GitHubReleasesApi {
 
     final retryAfterSeconds = int.tryParse(response.headers['retry-after'] ?? '');
     if (retryAfterSeconds != null) {
-      return DateTime.now().add(Duration(seconds: retryAfterSeconds));
+      return clock.now().add(Duration(seconds: retryAfterSeconds));
     }
 
     return null;

--- a/bridge/app/lib/src/updater/api/github_releases_api.dart
+++ b/bridge/app/lib/src/updater/api/github_releases_api.dart
@@ -29,9 +29,7 @@ class GitHubReleasesApi {
           'page': '$page',
         },
       );
-      final http.Response response = await _httpClient
-          .get(uri, headers: _buildHeaders())
-          .timeout(const Duration(seconds: 5));
+      final http.Response response = await _getWithOpportunisticAuth(uri);
 
       if (_isRateLimited(response)) {
         throw GitHubRateLimitException(resetAt: _parseResetAt(response));
@@ -52,6 +50,38 @@ class GitHubReleasesApi {
     }
 
     return releases;
+  }
+
+  /// Fetches [uri], sending the auth token when present. Authentication is
+  /// opportunistic: a stale or invalid token must never leave the updater worse
+  /// off than running unauthenticated. The releases endpoint is public, so an
+  /// auth rejection triggers a single retry without the `Authorization` header.
+  Future<http.Response> _getWithOpportunisticAuth(Uri uri) async {
+    final headers = _buildHeaders();
+    final http.Response response = await _httpClient
+        .get(uri, headers: headers)
+        .timeout(const Duration(seconds: 5));
+
+    if (!headers.containsKey('Authorization') || !_isAuthRejection(response)) {
+      return response;
+    }
+
+    final unauthenticatedHeaders = Map<String, String>.of(headers)..remove('Authorization');
+    return _httpClient
+        .get(uri, headers: unauthenticatedHeaders)
+        .timeout(const Duration(seconds: 5));
+  }
+
+  /// Whether [response] indicates the supplied token was rejected (as opposed to
+  /// a rate limit or success). HTTP 401 is GitHub's "Bad credentials"; a 403
+  /// that is not a rate limit on this public endpoint is most likely a token
+  /// problem (missing scope, SSO enforcement). Both warrant an unauthenticated
+  /// retry.
+  bool _isAuthRejection(http.Response response) {
+    if (response.statusCode == 401) {
+      return true;
+    }
+    return response.statusCode == 403 && !_isRateLimited(response);
   }
 
   /// Builds the request headers. An `Authorization` header is sent only when a

--- a/bridge/app/lib/src/updater/api/github_releases_api.dart
+++ b/bridge/app/lib/src/updater/api/github_releases_api.dart
@@ -29,10 +29,13 @@ class GitHubReleasesApi {
           'page': '$page',
         },
       );
-      final http.Response response = await _getWithOpportunisticAuth(uri);
+      final (:http.Response response, :bool authenticated) = await _getWithOpportunisticAuth(uri);
 
       if (_isRateLimited(response)) {
-        throw GitHubRateLimitException(resetAt: _parseResetAt(response));
+        throw GitHubRateLimitException(
+          resetAt: _parseResetAt(response),
+          authenticated: authenticated,
+        );
       }
       if (response.statusCode == 404) {
         throw StateError('GitHub releases endpoint not found');
@@ -56,20 +59,22 @@ class GitHubReleasesApi {
   /// opportunistic: a stale or invalid token must never leave the updater worse
   /// off than running unauthenticated. The releases endpoint is public, so an
   /// auth rejection triggers a single retry without the `Authorization` header.
-  Future<http.Response> _getWithOpportunisticAuth(Uri uri) async {
+  Future<({http.Response response, bool authenticated})> _getWithOpportunisticAuth(Uri uri) async {
     final headers = _buildHeaders();
+    final bool authenticated = headers.containsKey('Authorization');
     final http.Response response = await _httpClient
         .get(uri, headers: headers)
         .timeout(const Duration(seconds: 5));
 
-    if (!headers.containsKey('Authorization') || !_isAuthRejection(response)) {
-      return response;
+    if (!authenticated || !_isAuthRejection(response)) {
+      return (response: response, authenticated: authenticated);
     }
 
     final unauthenticatedHeaders = Map<String, String>.of(headers)..remove('Authorization');
-    return _httpClient
+    final http.Response retried = await _httpClient
         .get(uri, headers: unauthenticatedHeaders)
         .timeout(const Duration(seconds: 5));
+    return (response: retried, authenticated: false);
   }
 
   /// Whether [response] indicates the supplied token was rejected (as opposed to
@@ -112,18 +117,21 @@ class GitHubReleasesApi {
         response.headers.containsKey('retry-after');
   }
 
+  /// Resolves when the caller may retry. `retry-after` (the explicit
+  /// secondary-limit cooldown) takes precedence when present; otherwise the
+  /// primary `x-ratelimit-reset` window is used.
   DateTime? _parseResetAt(http.Response response) {
+    final retryAfterSeconds = int.tryParse(response.headers['retry-after'] ?? '');
+    if (retryAfterSeconds != null) {
+      return clock.now().add(Duration(seconds: retryAfterSeconds));
+    }
+
     final resetEpochSeconds = int.tryParse(response.headers['x-ratelimit-reset'] ?? '');
     if (resetEpochSeconds != null) {
       return DateTime.fromMillisecondsSinceEpoch(
         resetEpochSeconds * 1000,
         isUtc: true,
       ).toLocal();
-    }
-
-    final retryAfterSeconds = int.tryParse(response.headers['retry-after'] ?? '');
-    if (retryAfterSeconds != null) {
-      return clock.now().add(Duration(seconds: retryAfterSeconds));
     }
 
     return null;

--- a/bridge/app/lib/src/updater/api/github_releases_api.dart
+++ b/bridge/app/lib/src/updater/api/github_releases_api.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:sesori_shared/sesori_shared.dart';
 
+import '../foundation/github_rate_limit_exception.dart';
 import '../models/github_release_dto.dart';
 
 const _kGithubApiBaseUrl = 'https://api.github.com/repos/sesori-ai/sesori_apps_monorepo/releases';
@@ -12,8 +12,11 @@ const _kGithubReleasesMaxPages = 1;
 
 class GitHubReleasesApi {
   final http.Client _httpClient;
+  final String? _authToken;
 
-  GitHubReleasesApi({required http.Client httpClient}) : _httpClient = httpClient;
+  GitHubReleasesApi({required http.Client httpClient, String? authToken})
+    : _httpClient = httpClient,
+      _authToken = authToken;
 
   Future<List<GitHubReleaseDto>> fetchReleases() async {
     final releases = <GitHubReleaseDto>[];
@@ -25,13 +28,12 @@ class GitHubReleasesApi {
           'page': '$page',
         },
       );
-      final http.Response response = await _httpClient.get(uri).timeout(const Duration(seconds: 5));
+      final http.Response response = await _httpClient
+          .get(uri, headers: _buildHeaders())
+          .timeout(const Duration(seconds: 5));
 
-      if (response.statusCode == 403) {
-        stderr.writeln(
-          'sesori-bridge: GitHub API rate limit reached, skipping update check',
-        );
-        throw StateError('GitHub releases request was rate limited');
+      if (_isRateLimited(response)) {
+        throw GitHubRateLimitException(resetAt: _parseResetAt(response));
       }
       if (response.statusCode == 404) {
         throw StateError('GitHub releases endpoint not found');
@@ -49,5 +51,45 @@ class GitHubReleasesApi {
     }
 
     return releases;
+  }
+
+  /// Builds the request headers. An `Authorization` header is sent only when a
+  /// non-empty token is available, lifting the GitHub limit from 60/hour per IP
+  /// (unauthenticated) to 5000/hour for the authenticated user.
+  Map<String, String> _buildHeaders() {
+    final headers = <String, String>{'Accept': 'application/vnd.github+json'};
+    final token = _authToken;
+    if (token != null && token.isNotEmpty) {
+      headers['Authorization'] = 'Bearer $token';
+    }
+    return headers;
+  }
+
+  /// GitHub signals a primary rate limit with HTTP 403 and
+  /// `x-ratelimit-remaining: 0`, and a secondary/abuse limit with HTTP 429. A
+  /// 403 without an exhausted remaining count is a different failure (e.g. a
+  /// blocked request) and is intentionally not treated as a rate limit.
+  bool _isRateLimited(http.Response response) {
+    if (response.statusCode == 429) {
+      return true;
+    }
+    return response.statusCode == 403 && response.headers['x-ratelimit-remaining'] == '0';
+  }
+
+  DateTime? _parseResetAt(http.Response response) {
+    final resetEpochSeconds = int.tryParse(response.headers['x-ratelimit-reset'] ?? '');
+    if (resetEpochSeconds != null) {
+      return DateTime.fromMillisecondsSinceEpoch(
+        resetEpochSeconds * 1000,
+        isUtc: true,
+      ).toLocal();
+    }
+
+    final retryAfterSeconds = int.tryParse(response.headers['retry-after'] ?? '');
+    if (retryAfterSeconds != null) {
+      return DateTime.now().add(Duration(seconds: retryAfterSeconds));
+    }
+
+    return null;
   }
 }

--- a/bridge/app/lib/src/updater/foundation/github_rate_limit_exception.dart
+++ b/bridge/app/lib/src/updater/foundation/github_rate_limit_exception.dart
@@ -1,0 +1,25 @@
+/// Thrown when the GitHub releases API rejects a request because the caller has
+/// exhausted its rate-limit budget (HTTP 429, or HTTP 403 with
+/// `x-ratelimit-remaining: 0`).
+///
+/// Unauthenticated requests share a budget of 60 requests/hour per source IP,
+/// so this is commonly hit from behind shared/NAT'd networks even when this
+/// bridge itself only checks for updates a handful of times per day.
+class GitHubRateLimitException implements Exception {
+  /// When the rate-limit window resets, in local time, when the response
+  /// advertised it via `x-ratelimit-reset` (epoch seconds) or `retry-after`.
+  /// Null when the response carried no usable reset hint.
+  final DateTime? resetAt;
+
+  const GitHubRateLimitException({this.resetAt});
+
+  @override
+  String toString() {
+    final reset = resetAt;
+    if (reset == null) {
+      return 'GitHubRateLimitException: GitHub API rate limit reached';
+    }
+    return 'GitHubRateLimitException: GitHub API rate limit reached '
+        '(resets at ${reset.toIso8601String()})';
+  }
+}

--- a/bridge/app/lib/src/updater/foundation/github_rate_limit_exception.dart
+++ b/bridge/app/lib/src/updater/foundation/github_rate_limit_exception.dart
@@ -7,11 +7,17 @@
 /// bridge itself only checks for updates a handful of times per day.
 class GitHubRateLimitException implements Exception {
   /// When the rate-limit window resets, in local time, when the response
-  /// advertised it via `x-ratelimit-reset` (epoch seconds) or `retry-after`.
-  /// Null when the response carried no usable reset hint.
+  /// advertised it via `retry-after` (seconds) or `x-ratelimit-reset` (epoch
+  /// seconds). Null when the response carried no usable reset hint.
   final DateTime? resetAt;
 
-  const GitHubRateLimitException({required this.resetAt});
+  /// Whether the rate-limited request was sent with an `Authorization` header.
+  /// Drives the user-facing hint: an unauthenticated caller is told to set a
+  /// token, whereas an authenticated caller hit the larger token budget (or a
+  /// secondary limit) and must not be told to do something already done.
+  final bool authenticated;
+
+  const GitHubRateLimitException({required this.resetAt, required this.authenticated});
 
   @override
   String toString() {

--- a/bridge/app/lib/src/updater/foundation/github_rate_limit_exception.dart
+++ b/bridge/app/lib/src/updater/foundation/github_rate_limit_exception.dart
@@ -11,7 +11,7 @@ class GitHubRateLimitException implements Exception {
   /// Null when the response carried no usable reset hint.
   final DateTime? resetAt;
 
-  const GitHubRateLimitException({this.resetAt});
+  const GitHubRateLimitException({required this.resetAt});
 
   @override
   String toString() {

--- a/bridge/app/lib/src/updater/services/update_service.dart
+++ b/bridge/app/lib/src/updater/services/update_service.dart
@@ -63,6 +63,12 @@ class UpdateService {
   @visibleForTesting
   void Function(String message) writeToStderr = stderr.writeln;
 
+  @visibleForTesting
+  void Function(String message) logWarning = Log.w;
+
+  @visibleForTesting
+  void Function(String message, Object error, StackTrace stackTrace) logError = Log.e;
+
   UpdateService({
     required ReleaseRepository releaseRepository,
     required UpdateInstallService updateInstallerService,
@@ -125,13 +131,13 @@ class UpdateService {
     required String stageDescription,
   }) {
     if (error is GitHubRateLimitException) {
-      Log.w(_rateLimitMessage(error));
+      logWarning(_rateLimitMessage(error));
       return;
     }
     // Keep the concise cause on the default line (e.g. a timeout vs. a parse
     // error); Log only appends the error object and stack trace at
     // debug/verbose levels.
-    Log.e('$stageDescription: $error', error, stackTrace);
+    logError('$stageDescription: $error', error, stackTrace);
   }
 
   String _rateLimitMessage(GitHubRateLimitException error) {

--- a/bridge/app/lib/src/updater/services/update_service.dart
+++ b/bridge/app/lib/src/updater/services/update_service.dart
@@ -128,12 +128,19 @@ class UpdateService {
       Log.w(_rateLimitMessage(error));
       return;
     }
-    Log.e(stageDescription, error, stackTrace);
+    // Keep the concise cause on the default line (e.g. a timeout vs. a parse
+    // error); Log only appends the error object and stack trace at
+    // debug/verbose levels.
+    Log.e('$stageDescription: $error', error, stackTrace);
   }
 
   String _rateLimitMessage(GitHubRateLimitException error) {
     final reset = error.resetAt;
     final resetHint = reset == null ? '' : ' Limit resets around ${_formatLocalTime(reset)}.';
+    if (error.authenticated) {
+      return 'Skipping update check — GitHub API rate limit reached for the '
+          'authenticated token (usually a temporary secondary limit).$resetHint';
+    }
     return 'Skipping update check — GitHub API rate limit reached. '
         'Unauthenticated requests are capped at 60/hour per IP; set GITHUB_TOKEN '
         '(or GH_TOKEN) to raise this to 5000/hour.$resetHint';

--- a/bridge/app/lib/src/updater/services/update_service.dart
+++ b/bridge/app/lib/src/updater/services/update_service.dart
@@ -6,6 +6,7 @@ import 'package:path/path.dart' as p;
 import 'package:rxdart/rxdart.dart';
 import 'package:sesori_shared/sesori_shared.dart';
 
+import '../foundation/github_rate_limit_exception.dart';
 import '../foundation/update_lock.dart';
 import '../foundation/update_policy.dart';
 import '../foundation/update_relaunch_client.dart';
@@ -98,10 +99,32 @@ class UpdateService {
   Future<ReleaseInfo?> _checkForPollingUpdate() async {
     try {
       return await _releaseRepository.checkForNewerRelease();
-    } on Object catch (error, stackTrace) {
-      writeToStderr('Warning: periodic update check failed: $error\n$stackTrace');
+    } on Object catch (error) {
+      writeToStderr(_describeUpdateCheckFailure(error));
       return null;
     }
+  }
+
+  /// Produces a single concise, user-facing line for a failed update check.
+  ///
+  /// A rate limit is an expected, benign condition for a best-effort updater,
+  /// so it gets a friendly explanation (and a hint to authenticate) rather than
+  /// a stack trace. Genuinely unexpected failures surface their error message
+  /// without an alarming async stack dump.
+  String _describeUpdateCheckFailure(Object error) {
+    if (error is GitHubRateLimitException) {
+      final reset = error.resetAt;
+      final resetHint = reset == null ? '' : ' Limit resets around ${_formatLocalTime(reset)}.';
+      return 'sesori-bridge: skipping update check — GitHub API rate limit reached. '
+          'Unauthenticated requests are capped at 60/hour per IP; set GITHUB_TOKEN '
+          '(or GH_TOKEN) to raise this to 5000/hour.$resetHint';
+    }
+    return 'sesori-bridge: update check failed: $error';
+  }
+
+  String _formatLocalTime(DateTime time) {
+    String pad(int value) => value.toString().padLeft(2, '0');
+    return '${pad(time.hour)}:${pad(time.minute)}';
   }
 
   Future<void> checkAndApplyUpdate({required List<String> cliArgs}) async {
@@ -161,9 +184,9 @@ class UpdateService {
           'Warning: failed to update to ${release.version} (${installResult.result}). Continuing with current version.',
         );
       }
-    } on Object catch (error, stackTrace) {
+    } on Object catch (error) {
       if (hasTerminal()) {
-        writeToStderr('Warning: automatic update failed: $error\n$stackTrace');
+        writeToStderr(_describeUpdateCheckFailure(error));
       }
     }
   }

--- a/bridge/app/lib/src/updater/services/update_service.dart
+++ b/bridge/app/lib/src/updater/services/update_service.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:rxdart/rxdart.dart';
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
 import 'package:sesori_shared/sesori_shared.dart';
 
 import '../foundation/github_rate_limit_exception.dart';
@@ -99,27 +100,43 @@ class UpdateService {
   Future<ReleaseInfo?> _checkForPollingUpdate() async {
     try {
       return await _releaseRepository.checkForNewerRelease();
-    } on Object catch (error) {
-      writeToStderr(_describeUpdateCheckFailure(error));
+    } on Object catch (error, stackTrace) {
+      _reportUpdateFailure(
+        error: error,
+        stackTrace: stackTrace,
+        stageDescription: 'Periodic update check failed',
+      );
       return null;
     }
   }
 
-  /// Produces a single concise, user-facing line for a failed update check.
+  /// Logs a failed update attempt through [Log].
   ///
   /// A rate limit is an expected, benign condition for a best-effort updater,
-  /// so it gets a friendly explanation (and a hint to authenticate) rather than
-  /// a stack trace. Genuinely unexpected failures surface their error message
-  /// without an alarming async stack dump.
-  String _describeUpdateCheckFailure(Object error) {
+  /// so it is surfaced as a warning with a friendly explanation (and a hint to
+  /// authenticate) and no stack trace. Genuinely unexpected failures are logged
+  /// as errors with their [error] and [stackTrace]; [Log] only appends those at
+  /// debug/verbose levels, so normal output stays clean while `--log-level
+  /// debug` still gets full context. [stageDescription] distinguishes which
+  /// stage failed (check vs. install/restart).
+  void _reportUpdateFailure({
+    required Object error,
+    required StackTrace stackTrace,
+    required String stageDescription,
+  }) {
     if (error is GitHubRateLimitException) {
-      final reset = error.resetAt;
-      final resetHint = reset == null ? '' : ' Limit resets around ${_formatLocalTime(reset)}.';
-      return 'sesori-bridge: skipping update check — GitHub API rate limit reached. '
-          'Unauthenticated requests are capped at 60/hour per IP; set GITHUB_TOKEN '
-          '(or GH_TOKEN) to raise this to 5000/hour.$resetHint';
+      Log.w(_rateLimitMessage(error));
+      return;
     }
-    return 'sesori-bridge: update check failed: $error';
+    Log.e(stageDescription, error, stackTrace);
+  }
+
+  String _rateLimitMessage(GitHubRateLimitException error) {
+    final reset = error.resetAt;
+    final resetHint = reset == null ? '' : ' Limit resets around ${_formatLocalTime(reset)}.';
+    return 'Skipping update check — GitHub API rate limit reached. '
+        'Unauthenticated requests are capped at 60/hour per IP; set GITHUB_TOKEN '
+        '(or GH_TOKEN) to raise this to 5000/hour.$resetHint';
   }
 
   String _formatLocalTime(DateTime time) {
@@ -184,10 +201,12 @@ class UpdateService {
           'Warning: failed to update to ${release.version} (${installResult.result}). Continuing with current version.',
         );
       }
-    } on Object catch (error) {
-      if (hasTerminal()) {
-        writeToStderr(_describeUpdateCheckFailure(error));
-      }
+    } on Object catch (error, stackTrace) {
+      _reportUpdateFailure(
+        error: error,
+        stackTrace: stackTrace,
+        stageDescription: 'Automatic update failed',
+      );
     }
   }
 

--- a/bridge/app/test/updater/github_releases_api_test.dart
+++ b/bridge/app/test/updater/github_releases_api_test.dart
@@ -45,6 +45,55 @@ void main() {
       });
     });
 
+    group('opportunistic auth fallback', () {
+      test('rejected token (401) → retries once without Authorization and succeeds', () async {
+        final authHeaderSeen = <bool>[];
+        final client = MockClient((request) async {
+          final attempt = authHeaderSeen.length;
+          authHeaderSeen.add(request.headers.containsKey('authorization'));
+          return attempt == 0
+              ? http.Response('Bad credentials', 401)
+              : http.Response('[]', 200);
+        });
+
+        final releases =
+            await GitHubReleasesApi(httpClient: client, authToken: 'stale-token').fetchReleases();
+
+        expect(releases, isEmpty);
+        // Authenticated first, then an unauthenticated retry.
+        expect(authHeaderSeen, equals([true, false]));
+      });
+
+      test('token-related 403 (no rate-limit signal) → retries unauthenticated', () async {
+        final authHeaderSeen = <bool>[];
+        final client = MockClient((request) async {
+          final attempt = authHeaderSeen.length;
+          authHeaderSeen.add(request.headers.containsKey('authorization'));
+          return attempt == 0 ? http.Response('', 403) : http.Response('[]', 200);
+        });
+
+        final releases =
+            await GitHubReleasesApi(httpClient: client, authToken: 'scopeless-token').fetchReleases();
+
+        expect(releases, isEmpty);
+        expect(authHeaderSeen, equals([true, false]));
+      });
+
+      test('rate-limited 403 with a token → does NOT retry, surfaces the rate limit', () async {
+        var calls = 0;
+        final client = MockClient((_) async {
+          calls++;
+          return http.Response('', 403, headers: {'x-ratelimit-remaining': '0'});
+        });
+
+        await expectLater(
+          GitHubReleasesApi(httpClient: client, authToken: 'valid-token').fetchReleases(),
+          throwsA(isA<GitHubRateLimitException>()),
+        );
+        expect(calls, equals(1));
+      });
+    });
+
     group('rate limiting', () {
       test('HTTP 403 with x-ratelimit-remaining: 0 → GitHubRateLimitException with reset time', () async {
         final resetEpochSeconds = DateTime.utc(2030, 6, 1, 15).millisecondsSinceEpoch ~/ 1000;

--- a/bridge/app/test/updater/github_releases_api_test.dart
+++ b/bridge/app/test/updater/github_releases_api_test.dart
@@ -1,0 +1,93 @@
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:sesori_bridge/src/updater/api/github_releases_api.dart';
+import 'package:sesori_bridge/src/updater/foundation/github_rate_limit_exception.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GitHubReleasesApi', () {
+    group('authentication', () {
+      test('sends a Bearer Authorization header when a token is provided', () async {
+        String? authorization;
+        final client = MockClient((request) async {
+          authorization = request.headers['authorization'];
+          return http.Response('[]', 200);
+        });
+
+        await GitHubReleasesApi(httpClient: client, authToken: 'secret-token').fetchReleases();
+
+        expect(authorization, equals('Bearer secret-token'));
+      });
+
+      test('omits the Authorization header when no token is provided', () async {
+        var hadAuthorization = true;
+        final client = MockClient((request) async {
+          hadAuthorization = request.headers.containsKey('authorization');
+          return http.Response('[]', 200);
+        });
+
+        await GitHubReleasesApi(httpClient: client).fetchReleases();
+
+        expect(hadAuthorization, isFalse);
+      });
+
+      test('omits the Authorization header when the token is empty', () async {
+        var hadAuthorization = true;
+        final client = MockClient((request) async {
+          hadAuthorization = request.headers.containsKey('authorization');
+          return http.Response('[]', 200);
+        });
+
+        await GitHubReleasesApi(httpClient: client, authToken: '').fetchReleases();
+
+        expect(hadAuthorization, isFalse);
+      });
+    });
+
+    group('rate limiting', () {
+      test('HTTP 403 with x-ratelimit-remaining: 0 → GitHubRateLimitException with reset time', () async {
+        final resetEpochSeconds = DateTime.utc(2030, 6, 1, 15).millisecondsSinceEpoch ~/ 1000;
+        final client = MockClient(
+          (_) async => http.Response('', 403, headers: {
+            'x-ratelimit-remaining': '0',
+            'x-ratelimit-reset': '$resetEpochSeconds',
+          }),
+        );
+
+        await expectLater(
+          GitHubReleasesApi(httpClient: client).fetchReleases(),
+          throwsA(
+            isA<GitHubRateLimitException>().having(
+              (exception) => exception.resetAt,
+              'resetAt',
+              equals(
+                DateTime.fromMillisecondsSinceEpoch(
+                  resetEpochSeconds * 1000,
+                  isUtc: true,
+                ).toLocal(),
+              ),
+            ),
+          ),
+        );
+      });
+
+      test('HTTP 429 → GitHubRateLimitException', () async {
+        final client = MockClient((_) async => http.Response('', 429));
+
+        await expectLater(
+          GitHubReleasesApi(httpClient: client).fetchReleases(),
+          throwsA(isA<GitHubRateLimitException>()),
+        );
+      });
+
+      test('HTTP 403 without an exhausted budget → StateError, not a rate limit', () async {
+        final client = MockClient((_) async => http.Response('', 403));
+
+        await expectLater(
+          GitHubReleasesApi(httpClient: client).fetchReleases(),
+          throwsA(isA<StateError>()),
+        );
+      });
+    });
+  });
+}

--- a/bridge/app/test/updater/github_releases_api_test.dart
+++ b/bridge/app/test/updater/github_releases_api_test.dart
@@ -1,3 +1,4 @@
+import 'package:clock/clock.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:sesori_bridge/src/updater/api/github_releases_api.dart';
@@ -26,7 +27,7 @@ void main() {
           return http.Response('[]', 200);
         });
 
-        await GitHubReleasesApi(httpClient: client).fetchReleases();
+        await GitHubReleasesApi(httpClient: client, authToken: null).fetchReleases();
 
         expect(hadAuthorization, isFalse);
       });
@@ -55,7 +56,7 @@ void main() {
         );
 
         await expectLater(
-          GitHubReleasesApi(httpClient: client).fetchReleases(),
+          GitHubReleasesApi(httpClient: client, authToken: null).fetchReleases(),
           throwsA(
             isA<GitHubRateLimitException>().having(
               (exception) => exception.resetAt,
@@ -75,16 +76,38 @@ void main() {
         final client = MockClient((_) async => http.Response('', 429));
 
         await expectLater(
-          GitHubReleasesApi(httpClient: client).fetchReleases(),
+          GitHubReleasesApi(httpClient: client, authToken: null).fetchReleases(),
           throwsA(isA<GitHubRateLimitException>()),
         );
       });
 
-      test('HTTP 403 without an exhausted budget → StateError, not a rate limit', () async {
+      test('secondary HTTP 403 with retry-after → GitHubRateLimitException, reset from clock', () async {
+        final now = DateTime.utc(2030, 6, 1, 15);
+        final client = MockClient(
+          (_) async => http.Response('', 403, headers: {'retry-after': '120'}),
+        );
+
+        Object? caught;
+        await withClock(Clock.fixed(now), () async {
+          try {
+            await GitHubReleasesApi(httpClient: client, authToken: null).fetchReleases();
+          } on Object catch (error) {
+            caught = error;
+          }
+        });
+
+        expect(caught, isA<GitHubRateLimitException>());
+        expect(
+          (caught! as GitHubRateLimitException).resetAt,
+          equals(now.add(const Duration(seconds: 120))),
+        );
+      });
+
+      test('HTTP 403 without an exhausted budget or retry-after → StateError, not a rate limit', () async {
         final client = MockClient((_) async => http.Response('', 403));
 
         await expectLater(
-          GitHubReleasesApi(httpClient: client).fetchReleases(),
+          GitHubReleasesApi(httpClient: client, authToken: null).fetchReleases(),
           throwsA(isA<StateError>()),
         );
       });

--- a/bridge/app/test/updater/github_releases_api_test.dart
+++ b/bridge/app/test/updater/github_releases_api_test.dart
@@ -88,7 +88,13 @@ void main() {
 
         await expectLater(
           GitHubReleasesApi(httpClient: client, authToken: 'valid-token').fetchReleases(),
-          throwsA(isA<GitHubRateLimitException>()),
+          throwsA(
+            isA<GitHubRateLimitException>().having(
+              (exception) => exception.authenticated,
+              'authenticated',
+              isTrue,
+            ),
+          ),
         );
         expect(calls, equals(1));
       });
@@ -107,16 +113,18 @@ void main() {
         await expectLater(
           GitHubReleasesApi(httpClient: client, authToken: null).fetchReleases(),
           throwsA(
-            isA<GitHubRateLimitException>().having(
-              (exception) => exception.resetAt,
-              'resetAt',
-              equals(
-                DateTime.fromMillisecondsSinceEpoch(
-                  resetEpochSeconds * 1000,
-                  isUtc: true,
-                ).toLocal(),
-              ),
-            ),
+            isA<GitHubRateLimitException>()
+                .having(
+                  (exception) => exception.resetAt,
+                  'resetAt',
+                  equals(
+                    DateTime.fromMillisecondsSinceEpoch(
+                      resetEpochSeconds * 1000,
+                      isUtc: true,
+                    ).toLocal(),
+                  ),
+                )
+                .having((exception) => exception.authenticated, 'authenticated', isFalse),
           ),
         );
       });
@@ -127,6 +135,34 @@ void main() {
         await expectLater(
           GitHubReleasesApi(httpClient: client, authToken: null).fetchReleases(),
           throwsA(isA<GitHubRateLimitException>()),
+        );
+      });
+
+      test('retry-after takes precedence over x-ratelimit-reset for the reset hint', () async {
+        final now = DateTime.utc(2030, 6, 1, 15);
+        final farFutureReset = now.add(const Duration(hours: 1)).millisecondsSinceEpoch ~/ 1000;
+        final client = MockClient(
+          (_) async => http.Response('', 403, headers: {
+            'x-ratelimit-remaining': '0',
+            'x-ratelimit-reset': '$farFutureReset',
+            'retry-after': '60',
+          }),
+        );
+
+        Object? caught;
+        await withClock(Clock.fixed(now), () async {
+          try {
+            await GitHubReleasesApi(httpClient: client, authToken: null).fetchReleases();
+          } on Object catch (error) {
+            caught = error;
+          }
+        });
+
+        // The shorter secondary cooldown (retry-after) wins over the hourly
+        // primary window.
+        expect(
+          (caught! as GitHubRateLimitException).resetAt,
+          equals(now.add(const Duration(seconds: 60))),
         );
       });
 

--- a/bridge/app/test/updater/release_contract_test.dart
+++ b/bridge/app/test/updater/release_contract_test.dart
@@ -121,7 +121,7 @@ void main() {
       });
 
       repository = ReleaseRepository(
-        api: GitHubReleasesApi(httpClient: client),
+        api: GitHubReleasesApi(httpClient: client, authToken: null),
         cache: _NoCache(),
         currentVersion: '0.2.0',
         target: target,

--- a/bridge/app/test/updater/release_repository_test.dart
+++ b/bridge/app/test/updater/release_repository_test.dart
@@ -241,7 +241,7 @@ void main() {
         );
       });
 
-      test('HTTP 403 (rate limit) → throws', () async {
+      test('HTTP 403 without rate-limit headers → throws StateError', () async {
         await expectLater(
           _makeRepository(httpClient: _mockStatus(403)).checkForNewerRelease(),
           throwsA(isA<StateError>()),

--- a/bridge/app/test/updater/release_repository_test.dart
+++ b/bridge/app/test/updater/release_repository_test.dart
@@ -90,7 +90,7 @@ ReleaseRepository _makeRepository({
   final resolvedTarget = target ?? _defaultTarget;
 
   return ReleaseRepository(
-    api: GitHubReleasesApi(httpClient: httpClient),
+    api: GitHubReleasesApi(httpClient: httpClient, authToken: null),
     cache: cache ?? _FakeCache(),
     currentVersion: currentVersion,
     target: resolvedTarget,

--- a/bridge/app/test/updater/update_orchestrator_test.dart
+++ b/bridge/app/test/updater/update_orchestrator_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:fake_async/fake_async.dart';
 import 'package:sesori_bridge/src/bridge/foundation/process_runner.dart';
+import 'package:sesori_bridge/src/updater/foundation/github_rate_limit_exception.dart';
 import 'package:sesori_bridge/src/updater/foundation/update_lock.dart';
 import 'package:sesori_bridge/src/updater/foundation/update_relaunch_client.dart';
 import 'package:sesori_bridge/src/updater/models/file_replacement_result.dart';
@@ -223,6 +224,58 @@ void main() {
 
       expect(repository.checkCallCount, equals(1));
       expect(updater.performUpdateCallCount, equals(1));
+    });
+
+    test('rate-limited check → concise message, no stack trace', () async {
+      final repository = _MockReleaseRepository()
+        ..onCheckForNewerRelease = () async =>
+            throw GitHubRateLimitException(resetAt: DateTime(2030, 1, 1, 9, 5));
+      final messages = <String>[];
+
+      final service = _buildService(
+        repository: repository,
+        updater: _MockUpdateInstallerService(),
+        installedFileRepository: _MockInstalledFileRepository(),
+        updateRelaunchClient: _MockUpdateRelaunchClient(),
+        executablePath: '/usr/local/bin/sesori-bridge',
+        environment: const {},
+      );
+      service.hasTerminal = () => true;
+      service.writeToStderr = messages.add;
+
+      await service.checkAndApplyUpdate(cliArgs: const []);
+
+      expect(messages, hasLength(1));
+      final message = messages.single;
+      expect(message, contains('rate limit'));
+      expect(message, contains('GITHUB_TOKEN'));
+      expect(message, contains('09:05'));
+      expect(message, isNot(contains('#0')));
+      expect(message, isNot(contains('\n')));
+      expect(message, isNot(contains('GitHubRateLimitException')));
+    });
+
+    test('unexpected check failure → message without async stack trace', () async {
+      final repository = _MockReleaseRepository()
+        ..onCheckForNewerRelease = () async => throw StateError('network exploded');
+      final messages = <String>[];
+
+      final service = _buildService(
+        repository: repository,
+        updater: _MockUpdateInstallerService(),
+        installedFileRepository: _MockInstalledFileRepository(),
+        updateRelaunchClient: _MockUpdateRelaunchClient(),
+        executablePath: '/usr/local/bin/sesori-bridge',
+        environment: const {},
+      );
+      service.hasTerminal = () => true;
+      service.writeToStderr = messages.add;
+
+      await service.checkAndApplyUpdate(cliArgs: const []);
+
+      expect(messages, hasLength(1));
+      expect(messages.single, contains('network exploded'));
+      expect(messages.single, isNot(contains('\n')));
     });
 
     test('CI guard enabled → repository is never called', () async {

--- a/bridge/app/test/updater/update_orchestrator_test.dart
+++ b/bridge/app/test/updater/update_orchestrator_test.dart
@@ -16,7 +16,6 @@ import 'package:sesori_bridge/src/updater/repositories/installed_file_repository
 import 'package:sesori_bridge/src/updater/repositories/release_repository.dart';
 import 'package:sesori_bridge/src/updater/services/update_install_service.dart';
 import 'package:sesori_bridge/src/updater/services/update_service.dart';
-import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
 
 import 'package:test/test.dart';
 
@@ -151,9 +150,6 @@ UpdateService _buildService({
 
 void main() {
   setUp(() async {
-    // Pin a deterministic log level: these tests capture Log output, and the
-    // ambient level can otherwise vary across the suite/CI (filtering Log.w).
-    Log.level = LogLevel.info;
     await Directory(_testManagedPaths.installRoot).create(recursive: true);
     final lockFile = File('${_testManagedPaths.installRoot}/.update.lock');
     if (lockFile.existsSync()) {
@@ -230,7 +226,7 @@ void main() {
       expect(updater.performUpdateCallCount, equals(1));
     });
 
-    test('unauthenticated rate limit → warning on stdout hints at GITHUB_TOKEN', () async {
+    test('unauthenticated rate limit → warning hints at GITHUB_TOKEN, not an error', () async {
       final repository = _MockReleaseRepository()
         ..onCheckForNewerRelease = () async =>
             throw GitHubRateLimitException(resetAt: DateTime(2030, 1, 1, 9, 5), authenticated: false);
@@ -242,24 +238,19 @@ void main() {
         executablePath: '/usr/local/bin/sesori-bridge',
         environment: const {},
       );
+      final warnings = <String>[];
+      var errorLogged = false;
+      service.logWarning = warnings.add;
+      service.logError = (_, __, ___) => errorLogged = true;
 
-      final stdoutLines = <String>[];
-      final stderrLines = <String>[];
-      await IOOverrides.runZoned(
-        () => service.checkAndApplyUpdate(cliArgs: const []),
-        stdout: () => _CapturingStdout(stdoutLines),
-        stderr: () => _CapturingStdout(stderrLines),
-      );
+      await service.checkAndApplyUpdate(cliArgs: const []);
 
-      // A rate limit is benign, so it is logged via Log.w (stdout), not the
-      // alarming Log.e (stderr) path.
-      expect(stdoutLines, hasLength(1));
-      final message = stdoutLines.single;
-      expect(message, contains('rate limit'));
-      expect(message, contains('GITHUB_TOKEN'));
-      expect(message, contains('09:05'));
-      expect(message, isNot(contains('#0')));
-      expect(stderrLines, isEmpty);
+      // A rate limit is benign: a warning, never an error.
+      expect(warnings, hasLength(1));
+      expect(warnings.single, contains('rate limit'));
+      expect(warnings.single, contains('GITHUB_TOKEN'));
+      expect(warnings.single, contains('09:05'));
+      expect(errorLogged, isFalse);
     });
 
     test('authenticated rate limit → warning does not tell the user to set a token', () async {
@@ -274,22 +265,18 @@ void main() {
         executablePath: '/usr/local/bin/sesori-bridge',
         environment: const {},
       );
+      final warnings = <String>[];
+      service.logWarning = warnings.add;
 
-      final stdoutLines = <String>[];
-      await IOOverrides.runZoned(
-        () => service.checkAndApplyUpdate(cliArgs: const []),
-        stdout: () => _CapturingStdout(stdoutLines),
-        stderr: () => _CapturingStdout(<String>[]),
-      );
+      await service.checkAndApplyUpdate(cliArgs: const []);
 
-      expect(stdoutLines, hasLength(1));
-      final message = stdoutLines.single;
-      expect(message, contains('rate limit'));
-      expect(message, contains('authenticated'));
-      expect(message, isNot(contains('GITHUB_TOKEN')));
+      expect(warnings, hasLength(1));
+      expect(warnings.single, contains('rate limit'));
+      expect(warnings.single, contains('authenticated'));
+      expect(warnings.single, isNot(contains('GITHUB_TOKEN')));
     });
 
-    test('unexpected failure → error cause on stderr, stack trace suppressed at info level', () async {
+    test('unexpected failure → logged as error with the cause and stack trace', () async {
       final repository = _MockReleaseRepository()
         ..onCheckForNewerRelease = () async => throw StateError('network exploded');
       final service = _buildService(
@@ -300,47 +287,26 @@ void main() {
         executablePath: '/usr/local/bin/sesori-bridge',
         environment: const {},
       );
+      String? errorMessage;
+      Object? loggedError;
+      StackTrace? loggedStackTrace;
+      var warned = false;
+      service.logWarning = (_) => warned = true;
+      service.logError = (message, error, stackTrace) {
+        errorMessage = message;
+        loggedError = error;
+        loggedStackTrace = stackTrace;
+      };
 
-      final stderrLines = <String>[];
-      await IOOverrides.runZoned(
-        () => service.checkAndApplyUpdate(cliArgs: const []),
-        stdout: () => _CapturingStdout(<String>[]),
-        stderr: () => _CapturingStdout(stderrLines),
-      );
+      await service.checkAndApplyUpdate(cliArgs: const []);
 
-      // The concise cause stays on the default line; only the async stack trace
-      // is withheld until debug/verbose.
-      expect(stderrLines, hasLength(1));
-      expect(stderrLines.single, contains('Automatic update failed'));
-      expect(stderrLines.single, contains('network exploded'));
-      expect(stderrLines.single, isNot(contains('#0')));
-    });
-
-    test('unexpected failure preserves error + stack trace at debug level', () async {
-      final previousLevel = Log.level;
-      Log.level = LogLevel.debug;
-      addTearDown(() => Log.level = previousLevel);
-
-      final repository = _MockReleaseRepository()
-        ..onCheckForNewerRelease = () async => throw StateError('network exploded');
-      final service = _buildService(
-        repository: repository,
-        updater: _MockUpdateInstallerService(),
-        installedFileRepository: _MockInstalledFileRepository(),
-        updateRelaunchClient: _MockUpdateRelaunchClient(),
-        executablePath: '/usr/local/bin/sesori-bridge',
-        environment: const {},
-      );
-
-      final stderrLines = <String>[];
-      await IOOverrides.runZoned(
-        () => service.checkAndApplyUpdate(cliArgs: const []),
-        stdout: () => _CapturingStdout(<String>[]),
-        stderr: () => _CapturingStdout(stderrLines),
-      );
-
-      expect(stderrLines, isNotEmpty);
-      expect(stderrLines.join('\n'), contains('network exploded'));
+      // The stage label plus the concise cause are passed to Log.e, which keeps
+      // the error object and stack trace for debug/verbose output.
+      expect(errorMessage, contains('Automatic update failed'));
+      expect(errorMessage, contains('network exploded'));
+      expect(loggedError, isA<StateError>());
+      expect(loggedStackTrace, isNotNull);
+      expect(warned, isFalse);
     });
 
     test('CI guard enabled → repository is never called', () async {
@@ -748,20 +714,4 @@ void main() {
       );
     });
   });
-}
-
-/// Captures `writeln` calls; [IOOverrides] swaps it in for stdout/stderr so
-/// tests can assert on what `Log` emitted.
-class _CapturingStdout implements Stdout {
-  _CapturingStdout(this.lines);
-
-  final List<String> lines;
-
-  @override
-  void writeln([Object? object = '']) {
-    lines.add(object.toString());
-  }
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/bridge/app/test/updater/update_orchestrator_test.dart
+++ b/bridge/app/test/updater/update_orchestrator_test.dart
@@ -227,10 +227,10 @@ void main() {
       expect(updater.performUpdateCallCount, equals(1));
     });
 
-    test('rate-limited check → friendly warning on stdout, no stack trace', () async {
+    test('unauthenticated rate limit → warning on stdout hints at GITHUB_TOKEN', () async {
       final repository = _MockReleaseRepository()
         ..onCheckForNewerRelease = () async =>
-            throw GitHubRateLimitException(resetAt: DateTime(2030, 1, 1, 9, 5));
+            throw GitHubRateLimitException(resetAt: DateTime(2030, 1, 1, 9, 5), authenticated: false);
       final service = _buildService(
         repository: repository,
         updater: _MockUpdateInstallerService(),
@@ -259,7 +259,34 @@ void main() {
       expect(stderrLines, isEmpty);
     });
 
-    test('unexpected failure → error on stderr, stack trace suppressed at info level', () async {
+    test('authenticated rate limit → warning does not tell the user to set a token', () async {
+      final repository = _MockReleaseRepository()
+        ..onCheckForNewerRelease = () async =>
+            throw GitHubRateLimitException(resetAt: DateTime(2030, 1, 1, 9, 5), authenticated: true);
+      final service = _buildService(
+        repository: repository,
+        updater: _MockUpdateInstallerService(),
+        installedFileRepository: _MockInstalledFileRepository(),
+        updateRelaunchClient: _MockUpdateRelaunchClient(),
+        executablePath: '/usr/local/bin/sesori-bridge',
+        environment: const {},
+      );
+
+      final stdoutLines = <String>[];
+      await IOOverrides.runZoned(
+        () => service.checkAndApplyUpdate(cliArgs: const []),
+        stdout: () => _CapturingStdout(stdoutLines),
+        stderr: () => _CapturingStdout(<String>[]),
+      );
+
+      expect(stdoutLines, hasLength(1));
+      final message = stdoutLines.single;
+      expect(message, contains('rate limit'));
+      expect(message, contains('authenticated'));
+      expect(message, isNot(contains('GITHUB_TOKEN')));
+    });
+
+    test('unexpected failure → error cause on stderr, stack trace suppressed at info level', () async {
       final repository = _MockReleaseRepository()
         ..onCheckForNewerRelease = () async => throw StateError('network exploded');
       final service = _buildService(
@@ -278,10 +305,11 @@ void main() {
         stderr: () => _CapturingStdout(stderrLines),
       );
 
-      // Log.e writes to stderr; at the default info level the raw error and
-      // async stack trace are not appended, so the line stays clean.
+      // The concise cause stays on the default line; only the async stack trace
+      // is withheld until debug/verbose.
       expect(stderrLines, hasLength(1));
       expect(stderrLines.single, contains('Automatic update failed'));
+      expect(stderrLines.single, contains('network exploded'));
       expect(stderrLines.single, isNot(contains('#0')));
     });
 

--- a/bridge/app/test/updater/update_orchestrator_test.dart
+++ b/bridge/app/test/updater/update_orchestrator_test.dart
@@ -151,6 +151,9 @@ UpdateService _buildService({
 
 void main() {
   setUp(() async {
+    // Pin a deterministic log level: these tests capture Log output, and the
+    // ambient level can otherwise vary across the suite/CI (filtering Log.w).
+    Log.level = LogLevel.info;
     await Directory(_testManagedPaths.installRoot).create(recursive: true);
     final lockFile = File('${_testManagedPaths.installRoot}/.update.lock');
     if (lockFile.existsSync()) {

--- a/bridge/app/test/updater/update_orchestrator_test.dart
+++ b/bridge/app/test/updater/update_orchestrator_test.dart
@@ -16,6 +16,7 @@ import 'package:sesori_bridge/src/updater/repositories/installed_file_repository
 import 'package:sesori_bridge/src/updater/repositories/release_repository.dart';
 import 'package:sesori_bridge/src/updater/services/update_install_service.dart';
 import 'package:sesori_bridge/src/updater/services/update_service.dart';
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
 
 import 'package:test/test.dart';
 
@@ -226,12 +227,10 @@ void main() {
       expect(updater.performUpdateCallCount, equals(1));
     });
 
-    test('rate-limited check → concise message, no stack trace', () async {
+    test('rate-limited check → friendly warning on stdout, no stack trace', () async {
       final repository = _MockReleaseRepository()
         ..onCheckForNewerRelease = () async =>
             throw GitHubRateLimitException(resetAt: DateTime(2030, 1, 1, 9, 5));
-      final messages = <String>[];
-
       final service = _buildService(
         repository: repository,
         updater: _MockUpdateInstallerService(),
@@ -240,26 +239,29 @@ void main() {
         executablePath: '/usr/local/bin/sesori-bridge',
         environment: const {},
       );
-      service.hasTerminal = () => true;
-      service.writeToStderr = messages.add;
 
-      await service.checkAndApplyUpdate(cliArgs: const []);
+      final stdoutLines = <String>[];
+      final stderrLines = <String>[];
+      await IOOverrides.runZoned(
+        () => service.checkAndApplyUpdate(cliArgs: const []),
+        stdout: () => _CapturingStdout(stdoutLines),
+        stderr: () => _CapturingStdout(stderrLines),
+      );
 
-      expect(messages, hasLength(1));
-      final message = messages.single;
+      // A rate limit is benign, so it is logged via Log.w (stdout), not the
+      // alarming Log.e (stderr) path.
+      expect(stdoutLines, hasLength(1));
+      final message = stdoutLines.single;
       expect(message, contains('rate limit'));
       expect(message, contains('GITHUB_TOKEN'));
       expect(message, contains('09:05'));
       expect(message, isNot(contains('#0')));
-      expect(message, isNot(contains('\n')));
-      expect(message, isNot(contains('GitHubRateLimitException')));
+      expect(stderrLines, isEmpty);
     });
 
-    test('unexpected check failure → message without async stack trace', () async {
+    test('unexpected failure → error on stderr, stack trace suppressed at info level', () async {
       final repository = _MockReleaseRepository()
         ..onCheckForNewerRelease = () async => throw StateError('network exploded');
-      final messages = <String>[];
-
       final service = _buildService(
         repository: repository,
         updater: _MockUpdateInstallerService(),
@@ -268,14 +270,46 @@ void main() {
         executablePath: '/usr/local/bin/sesori-bridge',
         environment: const {},
       );
-      service.hasTerminal = () => true;
-      service.writeToStderr = messages.add;
 
-      await service.checkAndApplyUpdate(cliArgs: const []);
+      final stderrLines = <String>[];
+      await IOOverrides.runZoned(
+        () => service.checkAndApplyUpdate(cliArgs: const []),
+        stdout: () => _CapturingStdout(<String>[]),
+        stderr: () => _CapturingStdout(stderrLines),
+      );
 
-      expect(messages, hasLength(1));
-      expect(messages.single, contains('network exploded'));
-      expect(messages.single, isNot(contains('\n')));
+      // Log.e writes to stderr; at the default info level the raw error and
+      // async stack trace are not appended, so the line stays clean.
+      expect(stderrLines, hasLength(1));
+      expect(stderrLines.single, contains('Automatic update failed'));
+      expect(stderrLines.single, isNot(contains('#0')));
+    });
+
+    test('unexpected failure preserves error + stack trace at debug level', () async {
+      final previousLevel = Log.level;
+      Log.level = LogLevel.debug;
+      addTearDown(() => Log.level = previousLevel);
+
+      final repository = _MockReleaseRepository()
+        ..onCheckForNewerRelease = () async => throw StateError('network exploded');
+      final service = _buildService(
+        repository: repository,
+        updater: _MockUpdateInstallerService(),
+        installedFileRepository: _MockInstalledFileRepository(),
+        updateRelaunchClient: _MockUpdateRelaunchClient(),
+        executablePath: '/usr/local/bin/sesori-bridge',
+        environment: const {},
+      );
+
+      final stderrLines = <String>[];
+      await IOOverrides.runZoned(
+        () => service.checkAndApplyUpdate(cliArgs: const []),
+        stdout: () => _CapturingStdout(<String>[]),
+        stderr: () => _CapturingStdout(stderrLines),
+      );
+
+      expect(stderrLines, isNotEmpty);
+      expect(stderrLines.join('\n'), contains('network exploded'));
     });
 
     test('CI guard enabled → repository is never called', () async {
@@ -683,4 +717,20 @@ void main() {
       );
     });
   });
+}
+
+/// Captures `writeln` calls; [IOOverrides] swaps it in for stdout/stderr so
+/// tests can assert on what `Log` emitted.
+class _CapturingStdout implements Stdout {
+  _CapturingStdout(this.lines);
+
+  final List<String> lines;
+
+  @override
+  void writeln([Object? object = '']) {
+    lines.add(object.toString());
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }


### PR DESCRIPTION
## Problem

A developer on the latest public bridge release saw repeated GitHub rate-limit errors in their logs — and they kept happening a day later, which is suspicious since GitHub's primary rate limit resets hourly.

\`\`\`
sesori-bridge: GitHub API rate limit reached, skipping update check
Warning: automatic update failed: Bad state: GitHub releases request was rate limited
#0      GitHubReleasesApi.fetchReleases ...
<asynchronous suspension>
... (full async stack trace, printed twice at startup)
\`\`\`

### Root cause

- The updater calls the GitHub releases API **unauthenticated**, which is limited to **60 requests/hour per source IP** (not per machine). A single bridge makes ~6 calls/day, so it can't exhaust that budget on its own — the developer's **public IP is shared** (corporate NAT / VPN / CGNAT), and the shared budget stays drained. That's why it persists "a day later" instead of resetting within the hour.
- On a 403 the API threw a generic \`StateError\` that propagated up and got dumped to stderr **with a full async stack trace** — once from the startup check and once from the polling stream's first tick — so it looked like a crash.

## Changes (scoped to messaging + auth; no backoff/caching)

- **Opportunistic auth** (\`GitHubReleasesApi\`): sends \`Authorization: Bearer <token>\` when \`GITHUB_TOKEN\` or \`GH_TOKEN\` is present in the environment, lifting the limit to 5000/hour. The composition root (\`BridgeRuntimeRunner\`) reads the token and injects it.
- **Typed rate-limit detection**: HTTP 429, or 403 + \`x-ratelimit-remaining: 0\`, now throws \`GitHubRateLimitException\` (new, Layer 0) carrying the reset time parsed from \`x-ratelimit-reset\`/\`retry-after\`. A plain 403 is no longer mislabeled as a rate limit. The API no longer writes to stderr.
- **Clean messaging** (\`UpdateService\`): failed checks now print a single, stack-trace-free line. Rate limits get a friendly explanation plus a \`GITHUB_TOKEN\` hint and the reset time; other errors print just the message.

A backoff / negative-cache mechanism was intentionally left out of scope.

## Verification

- \`dart analyze --fatal-infos\` (bridge/app): **No issues found**
- \`dart test\` (full bridge app suite): **1342 passing**, including new coverage for the auth header, typed rate-limit detection + reset parsing, and the concise messaging path.
- Reviewed by \`aristotle-plan-review\` (plan) and \`aristotle-impl-review\` (implementation): both approved, no architectural violations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve update checks with opportunistic GitHub auth, accurate rate-limit detection, and cleaner logs. This reduces shared-IP rate-limit hits and avoids noisy stack traces while giving targeted, useful hints.

- New Features
  - Opportunistic GitHub auth with safe fallback: sends Authorization when a token is set (injected by `BridgeRuntimeRunner`), trims and resolves the first non-empty of `GITHUB_TOKEN`/`GH_TOKEN` so whitespace-only or blank values don’t shadow a valid one; retries once unauthenticated on 401 or non–rate-limit 403.

- Bug Fixes
  - Smarter rate-limit handling: treat 429, 403 with `x-ratelimit-remaining: 0`, and 403 with `retry-after` as limits; prefer `retry-after` over `x-ratelimit-reset` for the reset time (via `clock.now()`); surface `GitHubRateLimitException` carrying the reset time and whether the request was authenticated.
  - Cleaner logging: route through `Log`; single-line warning for rate limits with reset time and a `GITHUB_TOKEN` hint only when unauthenticated; keep the concise error cause on the default line; stack traces are debug-only; distinct labels for check vs. install failures; the API no longer writes to stderr.
  - Stabilized tests: use injectable `logWarning`/`logError` seams for deterministic logging assertions; pin `Log.level` where needed.

<sup>Written for commit 1f4ebab779f9a77b9267b9dc2faf371b1c588bf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

