### PR TITLE
feat(bridge): separate user-facing output from diagnostic logging

### DIFF
--- a/bridge/app/AGENTS.md
+++ b/bridge/app/AGENTS.md
@@ -55,6 +55,7 @@ bridge/ workspace modules (siblings of app/):
 
 - **Plugin architecture** — all backend-specific code lives in sibling plugin packages under `bridge/` (e.g. `sesori_plugin_opencode`). The bridge `lib/src/` is plugin-agnostic — it only imports from `sesori_plugin_interface`, never from concrete plugins. `bin/bridge.dart`'s registry (`plugin_registry.dart`) imports `opencode_plugin` for the const descriptor — that is the supported descriptor registration point.
 - **Explicit routing** — every supported route has a dedicated handler; `RequestRouter` returns 404 for unmatched routes (no catch-all proxy).
+- **User-facing output vs logging** — use `Console` (from `sesori_plugin_interface`) for anything the user must see to operate the bridge: prompts, requests, the login URL/code, essential startup status. `Console.message` writes to stdout, `Console.error` to stderr, and neither is gated by `--log-level`. Use `Log` only for diagnostics that can be safely ignored; all `Log` levels write to stderr and are suppressible via `--log-level`. The bridge must stay fully operable with logging silenced (`--log-level error` or `2>/dev/null`), so never put an essential prompt or actionable status behind `Log`.
 - **Crypto from `sesori_shared`** — all crypto primitives imported from shared package, not duplicated
 - **Linting**: `package:lints/recommended.yaml` (lighter than mobile's `all_lint_rules`)
 - **Binary distribution**: npm wrapper package with platform-specific optional deps (darwin/linux/windows × arm64/x64)

--- a/bridge/app/README.md
+++ b/bridge/app/README.md
@@ -122,8 +122,10 @@ Bridge core flags:
 | `--plugin` | `opencode` | Plugin backend to run |
 | `--auth-backend` | `https://api.sesori.com` | Auth backend URL (also reads `AUTH_BACKEND_URL` env var) |
 | `--debug-port` | *(disabled)* | Start a debug HTTP server on this port for Postman/curl testing |
-| `--log-level` | `info` | Minimum log level: `verbose`, `debug`, `info`, `warning`, `error` |
+| `--log-level` | `info` | Minimum **diagnostic log** level (written to stderr): `verbose`, `debug`, `info`, `warning`, `error` |
 | `--version` | — | Print the bridge version and exit |
+
+> `--log-level` controls **diagnostic logging only**. Logs are written to stderr and can be silenced freely. User-facing messages — login prompts, the authorization URL and code, startup status, "Authenticated as…" — are written to stdout and are **always shown regardless of `--log-level`**, so the bridge stays operable even with logging disabled (`--log-level error`, or redirecting stderr with `2>/dev/null`).
 
 The selected plugin contributes its own options, parsed after `--plugin` resolves the backend. Run `--help` to see the options for the selected plugin. The OpenCode plugin adds:
 

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -32,7 +32,7 @@ import 'package:sesori_bridge/src/services/bridge_config_service.dart';
 import 'package:sesori_bridge/src/services/sleep_prevention_service.dart';
 import 'package:sesori_bridge/src/version.dart';
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart'
-    show BridgePluginDescriptor, Log, LogLevel, PluginConfig, PluginConfigException, ProcessUser, ServerClock;
+    show BridgePluginDescriptor, Console, Log, LogLevel, PluginConfig, PluginConfigException, ProcessUser, ServerClock;
 
 const String _defaultRelayURL = 'wss://relay.sesori.com';
 const String _defaultAuthURL = 'https://api.sesori.com';
@@ -208,18 +208,18 @@ class LogoutCommand extends cli.Command<void> {
     final result = await logoutRunner.logout(currentPid: pid);
     switch (result.status) {
       case BridgeLogoutStatus.loggedOut:
-        stdout.writeln('Authentication cleared. You will be asked to log in on next start.');
+        Console.message('Authentication cleared. You will be asked to log in on next start.');
       case BridgeLogoutStatus.loggedOutWithRunningBridges:
-        stdout.writeln('Authentication cleared. You will be asked to log in on next start.');
-        stdout.writeln(
+        Console.message('Authentication cleared. You will be asked to log in on next start.');
+        Console.message(
           'Warning: ${result.runningBridgeCount} bridge instance(s) are still running '
           'and may re-create tokens when they refresh their session.',
         );
       case BridgeLogoutStatus.cancelled:
-        stdout.writeln('Logout cancelled; stored tokens were not cleared.');
+        Console.message('Logout cancelled; stored tokens were not cleared.');
         exitCode = 1;
       case BridgeLogoutStatus.failed:
-        stderr.writeln('Error: Failed to clear authentication tokens: ${result.error}');
+        Console.error('Error: Failed to clear authentication tokens: ${result.error}');
         exitCode = 1;
     }
   }
@@ -288,7 +288,7 @@ class ConfigCommand extends cli.Command<void> {
     );
 
     final configFilePath = await configService.openConfigFile();
-    stdout.writeln('Opening config file at $configFilePath');
+    Console.message('Opening config file at $configFilePath');
   }
 }
 

--- a/bridge/app/lib/src/auth/login_email_repository.dart
+++ b/bridge/app/lib/src/auth/login_email_repository.dart
@@ -1,4 +1,4 @@
-import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Log;
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Console, Log;
 import 'package:sesori_shared/sesori_shared.dart';
 
 import 'login_email_api.dart';
@@ -22,9 +22,9 @@ class LoginEmailRepository {
         password: credentials.password,
       );
       if (username.isNotEmpty) {
-        Log.i('Login successful! Welcome, $username');
+        Console.message('Login successful! Welcome, $username');
       } else {
-        Log.i('Login successful!');
+        Console.message('Login successful!');
       }
       return tokens;
     } on EmailLoginException catch (e) {

--- a/bridge/app/lib/src/auth/login_oauth_service.dart
+++ b/bridge/app/lib/src/auth/login_oauth_service.dart
@@ -4,7 +4,7 @@ import "dart:math";
 import "dart:typed_data";
 
 import "package:meta/meta.dart";
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Console;
 import "package:sesori_shared/sesori_shared.dart";
 
 import "login_oauth_api.dart";
@@ -180,25 +180,25 @@ class LoginOAuthService {
     final openability = _browserOpenability();
     switch (openability) {
       case BrowserOpenability.yes:
-        Log.i("Opening your browser to complete ${provider.label} login...");
-        Log.i("If it doesn't open automatically, open this URL manually to continue:");
+        Console.message("Opening your browser to complete ${provider.label} login...");
+        Console.message("If it doesn't open automatically, open this URL manually to continue:");
       case BrowserOpenability.unknown:
-        Log.i("Attempting to open your browser to complete ${provider.label} login...");
-        Log.i("If it doesn't open, open this URL manually to continue:");
+        Console.message("Attempting to open your browser to complete ${provider.label} login...");
+        Console.message("If it doesn't open, open this URL manually to continue:");
       case BrowserOpenability.no:
-        Log.i("No graphical browser detected (e.g. a headless or SSH session).");
-        Log.i("Open this URL to complete ${provider.label} login:");
+        Console.message("No graphical browser detected (e.g. a headless or SSH session).");
+        Console.message("Open this URL to complete ${provider.label} login:");
     }
-    Log.i(initResp.authUrl);
+    Console.message(initResp.authUrl);
     if (openability != BrowserOpenability.no) {
       try {
         await _browserLauncher(initResp.authUrl);
       } catch (e) {
-        Log.w("Could not open a browser automatically; open the URL above manually: $e");
+        Console.message("Could not open a browser automatically; open the URL above manually: $e");
       }
     }
 
-    Log.i("Waiting for authorization...");
+    Console.message("Waiting for authorization...");
     return _pollForCompletion(provider: provider, sessionToken: sessionToken);
   }
 
@@ -226,9 +226,9 @@ class LoginOAuthService {
             }
             final username = user.providerUsername ?? "";
             if (username.isNotEmpty) {
-              Log.i("Login successful! Welcome, $username");
+              Console.message("Login successful! Welcome, $username");
             } else {
-              Log.i("Login successful!");
+              Console.message("Login successful!");
             }
             return TokenData(
               accessToken: accessToken,
@@ -271,16 +271,16 @@ class LoginOAuthService {
 
     const bottomLine = "└──────────────────────────────────────────┘";
 
-    Log.i("");
-    Log.i(line);
-    Log.i(empty);
-    Log.i(codeLine);
-    Log.i(empty);
-    Log.i(confirmLine);
-    Log.i(beforeLine);
-    Log.i(empty);
-    Log.i(bottomLine);
-    Log.i("");
+    Console.message("");
+    Console.message(line);
+    Console.message(empty);
+    Console.message(codeLine);
+    Console.message(empty);
+    Console.message(confirmLine);
+    Console.message(beforeLine);
+    Console.message(empty);
+    Console.message(bottomLine);
+    Console.message("");
   }
 
   String _generateSessionToken() {

--- a/bridge/app/lib/src/auth/login_oauth_service.dart
+++ b/bridge/app/lib/src/auth/login_oauth_service.dart
@@ -271,16 +271,21 @@ class LoginOAuthService {
 
     const bottomLine = "└──────────────────────────────────────────┘";
 
-    Console.message("");
-    Console.message(line);
-    Console.message(empty);
-    Console.message(codeLine);
-    Console.message(empty);
-    Console.message(confirmLine);
-    Console.message(beforeLine);
-    Console.message(empty);
-    Console.message(bottomLine);
-    Console.message("");
+    // Printed as a single write so the box renders atomically as one block.
+    Console.message(
+      [
+        "",
+        line,
+        empty,
+        codeLine,
+        empty,
+        confirmLine,
+        beforeLine,
+        empty,
+        bottomLine,
+        "",
+      ].join("\n"),
+    );
   }
 
   String _generateSessionToken() {

--- a/bridge/app/lib/src/bridge/debug_server.dart
+++ b/bridge/app/lib/src/bridge/debug_server.dart
@@ -51,7 +51,7 @@ class DebugServer {
     final server = await HttpServer.bind(InternetAddress.loopbackIPv4, port);
     _server = server;
 
-    Log.i("Debug server listening on http://127.0.0.1:${server.port}");
+    Console.message("Debug server listening on http://127.0.0.1:${server.port}");
     server.listen(_handleRequest).addTo(_compositeSubscription);
   }
 

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -321,9 +321,9 @@ class OrchestratorSession {
       throw Exception("failed to connect to relay: $e");
     }
 
-    Log.i("Relay:  ${config.relayURL}");
-    Log.i("Target: ${config.pluginEndpoint}\n");
-    Log.i("Waiting for relay events...");
+    Console.message("Relay:  ${config.relayURL}");
+    Console.message("Target: ${config.pluginEndpoint}\n");
+    Console.message("Waiting for relay events...");
 
     try {
       while (!_cancelled) {

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Log;
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Console, Log;
 
 import 'package:sesori_shared/sesori_shared.dart';
 import '../../auth/login_email_repository.dart';
@@ -115,7 +115,7 @@ class BridgeRuntimeAuthService {
   }) async {
     try {
       final username = await fetchUsername(authBackendUrl, accessToken);
-      Log.i('Authenticated as $username');
+      Console.message('Authenticated as $username');
     } catch (error) {
       Log.w('Authenticated (unable to fetch profile username: $error)');
     }

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -9,6 +9,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
     show
         BridgePlugin,
         BridgePluginDescriptor,
+        Console,
         Log,
         PluginConfig,
         PluginFailed,
@@ -292,7 +293,7 @@ class BridgeRuntimeRunner {
       registerSignalHandlers(session: runtime.session, subscriptions: subscriptions);
       updateService.updateAvailable
           .listen((version) {
-            Log.i("A new bridge version ($version) is available. Restart to update.");
+            Console.message("A new bridge version ($version) is available. Restart to update.");
           })
           .addTo(subscriptions);
 

--- a/bridge/app/test/push/push_dispatcher_test.dart
+++ b/bridge/app/test/push/push_dispatcher_test.dart
@@ -360,13 +360,13 @@ void main() {
     test("maintenance logs telemetry snapshots", () {
       final harness = _newHarness();
 
-      final stdout = _captureStdout(
+      final logOutput = _captureLogOutput(
         level: LogLevel.debug,
         action: harness.maintenanceListener.runNow,
       );
 
       expect(harness.maintenanceListener.lastMaintenanceTelemetry, isNotNull);
-      expect(stdout, contains(harness.maintenanceListener.lastMaintenanceTelemetry!.toLogMessage()));
+      expect(logOutput, contains(harness.maintenanceListener.lastMaintenanceTelemetry!.toLogMessage()));
     });
 
     test("M3b: maintenance continues when root pruning throws", () {
@@ -578,7 +578,7 @@ class _BufferingStdout implements Stdout {
   }
 }
 
-String _captureStdout({required LogLevel level, required void Function() action}) {
+String _captureLogOutput({required LogLevel level, required void Function() action}) {
   final stdoutBuffer = _BufferingStdout();
   final stderrBuffer = _BufferingStdout();
   final previousLevel = Log.level;
@@ -593,7 +593,8 @@ String _captureStdout({required LogLevel level, required void Function() action}
     Log.level = previousLevel;
   }
 
-  return stdoutBuffer.text;
+  // Diagnostic logs (including maintenance telemetry) are written to stderr.
+  return stderrBuffer.text;
 }
 
 Session _session({

--- a/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
+++ b/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
@@ -1,6 +1,7 @@
 export "src/bridge_plugin.dart";
 export "src/bridge_sse_event.dart";
 export "src/buffered_stream.dart";
+export "src/console.dart";
 export "src/host/bridge_host_info.dart";
 export "src/host/host_json_store.dart";
 export "src/host/host_port_service.dart";

--- a/bridge/sesori_plugin_interface/lib/src/console.dart
+++ b/bridge/sesori_plugin_interface/lib/src/console.dart
@@ -1,0 +1,20 @@
+import "dart:io";
+
+/// User-facing console output for the bridge and its plugins.
+///
+/// Distinct from [Log]: [Console] messages are shown to the user regardless of
+/// the configured log level, because the bridge must remain operable even when
+/// logging is silenced (e.g. `--log-level error`, or redirecting stderr with
+/// `2>/dev/null`). Use it for prompts, requests, and status the user must see
+/// to operate the bridge — never for diagnostics, which belong in [Log].
+///
+/// Routine output goes to stdout; [Console.error] goes to stderr.
+class Console {
+  Console._();
+
+  /// Writes a user-facing message to stdout, followed by a newline.
+  static void message(String text) => stdout.writeln(text);
+
+  /// Writes a user-facing error to stderr, followed by a newline.
+  static void error(String text) => stderr.writeln(text);
+}

--- a/bridge/sesori_plugin_interface/lib/src/log.dart
+++ b/bridge/sesori_plugin_interface/lib/src/log.dart
@@ -12,12 +12,14 @@ enum LogLevel {
   error,
 }
 
-/// Lightweight global logger for the bridge and its plugins.
+/// Lightweight global diagnostic logger for the bridge and its plugins.
 ///
-/// Set [Log.level] once at startup (defaults to [LogLevel.info]).
-/// Messages below that level are silently discarded.
-///
-/// [Log.e] writes to stderr; all other levels write to stdout.
+/// Set [Log.level] once at startup (defaults to [LogLevel.info]); messages
+/// below that level are silently discarded. All levels write to stderr, so the
+/// log stream can be redirected or silenced (`--log-level error`, `2>/dev/null`)
+/// without affecting user-facing output. For messages the user must see to
+/// operate the bridge — prompts, requests, essential status — use [Console]
+/// instead; it always writes to stdout regardless of [Log.level].
 class Log {
   Log._();
 
@@ -36,7 +38,7 @@ class Log {
   /// Log a warning-level message.
   static void w(String message, [Object? error, StackTrace? st]) => _write(LogLevel.warning, message, error, st);
 
-  /// Log an error-level message. Always written to stderr.
+  /// Log an error-level message.
   static void e(String message, [Object? error, StackTrace? st]) => _write(LogLevel.error, message, error, st);
 
   static void _write(
@@ -47,48 +49,44 @@ class Log {
   ) {
     if (msgLevel.index < level.index) return;
 
-    final String message = msgLevel == .info
-        ? rawMessage
-        : () {
-            final callerClass = _getCallerClassName();
+    final callerClass = _getCallerClassName();
 
-            final buffer = StringBuffer();
-            buffer.write("[$callerClass]");
-            if (!rawMessage.startsWith("[")) {
-              buffer.write(" ");
-            }
-            buffer.write(rawMessage);
-            if (error != null && level.index < LogLevel.info.index) {
-              buffer.write("\n -- Error on next line(s)");
-              buffer.write(error.toString());
-            }
-            if (st != null && level.index < LogLevel.info.index) {
-              buffer.write(st.toString());
-            }
-
-            return buffer.toString();
-          }();
-
-    if (msgLevel == LogLevel.error) {
-      stderr.writeln(message);
-    } else {
-      stdout.writeln(message);
+    final buffer = StringBuffer();
+    buffer.write("[$callerClass]");
+    if (!rawMessage.startsWith("[")) {
+      buffer.write(" ");
     }
+    buffer.write(rawMessage);
+    if (error != null && level.index < LogLevel.info.index) {
+      buffer.write("\n -- Error on next line(s)");
+      buffer.write(error.toString());
+    }
+    if (st != null && level.index < LogLevel.info.index) {
+      buffer.write(st.toString());
+    }
+
+    // All diagnostic logs go to stderr so the log stream stays separate from
+    // user-facing output (which [Console] writes to stdout) and can be
+    // silenced without making the bridge unoperable.
+    stderr.writeln(buffer.toString());
   }
 
   static String _getCallerClassName() {
-    const vallerLineIndex = 4;
+    // Stack frames from this method up to the original caller:
+    //   #0 Log._getCallerClassName
+    //   #1 Log._write
+    //   #2 Log.<v|d|i|w|e>      (the public entry point)
+    //   #3 <caller>             (the class we want to name)
+    const callerLineIndex = 3;
     final trace = StackTrace.current.toString().split('\n');
 
-    if (trace.length < vallerLineIndex + 1) {
+    if (trace.length < callerLineIndex + 1) {
       return "Unknown0";
     }
 
-    // Example trace:
-    // ...
-    // #3      Log.d (package:sesori_plugin_interface/src/log.dart:31:36)
-    // #4      OrchestratorSession.run (package:sesori_bridge/src/bridge/orchestrator.dart:369:13)
-    final line = trace[4];
+    // Example frame:
+    // #3      OrchestratorSession.run (package:sesori_bridge/src/bridge/orchestrator.dart:369:13)
+    final line = trace[callerLineIndex];
 
     final match = RegExp(r'#\d+\s+(.+?)\.').firstMatch(line);
 

--- a/bridge/sesori_plugin_interface/test/console_test.dart
+++ b/bridge/sesori_plugin_interface/test/console_test.dart
@@ -1,0 +1,68 @@
+import "dart:io";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("Console", () {
+    test("message writes to stdout and never to stderr", () {
+      final out = <String>[];
+      final err = <String>[];
+
+      IOOverrides.runZoned(
+        () => Console.message("hello, user"),
+        stdout: () => _CapturingStdout(out),
+        stderr: () => _CapturingStdout(err),
+      );
+
+      expect(out, equals(["hello, user"]));
+      expect(err, isEmpty);
+    });
+
+    test("error writes to stderr and never to stdout", () {
+      final out = <String>[];
+      final err = <String>[];
+
+      IOOverrides.runZoned(
+        () => Console.error("something went wrong"),
+        stdout: () => _CapturingStdout(out),
+        stderr: () => _CapturingStdout(err),
+      );
+
+      expect(err, equals(["something went wrong"]));
+      expect(out, isEmpty);
+    });
+
+    test("message output is never gated by Log.level", () {
+      final originalLevel = Log.level;
+      addTearDown(() => Log.level = originalLevel);
+      // Silence diagnostics entirely; user-facing output must still appear.
+      Log.level = LogLevel.error;
+
+      final out = <String>[];
+
+      IOOverrides.runZoned(
+        () => Console.message("must still be visible"),
+        stdout: () => _CapturingStdout(out),
+        stderr: () => _CapturingStdout(<String>[]),
+      );
+
+      expect(out, equals(["must still be visible"]));
+    });
+  });
+}
+
+/// Captures [writeln] calls; [IOOverrides] swaps it in for stdout/stderr.
+class _CapturingStdout implements Stdout {
+  _CapturingStdout(this.lines);
+
+  final List<String> lines;
+
+  @override
+  void writeln([Object? object = ""]) {
+    lines.add(object.toString());
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/sesori_plugin_interface/test/log_test.dart
+++ b/bridge/sesori_plugin_interface/test/log_test.dart
@@ -1,0 +1,92 @@
+import "dart:io";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("Log", () {
+    late LogLevel originalLevel;
+
+    setUp(() => originalLevel = Log.level);
+    tearDown(() => Log.level = originalLevel);
+
+    test("every level writes to stderr and never to stdout", () {
+      Log.level = LogLevel.verbose;
+      final out = <String>[];
+      final err = <String>[];
+
+      IOOverrides.runZoned(
+        () {
+          Log.v("v-msg");
+          Log.d("d-msg");
+          Log.i("i-msg");
+          Log.w("w-msg");
+          Log.e("e-msg");
+        },
+        stdout: () => _CapturingStdout(out),
+        stderr: () => _CapturingStdout(err),
+      );
+
+      expect(out, isEmpty, reason: "diagnostic logs must never pollute stdout");
+      expect(err, hasLength(5));
+    });
+
+    test("messages below Log.level are discarded", () {
+      Log.level = LogLevel.warning;
+      final err = <String>[];
+
+      IOOverrides.runZoned(
+        () {
+          Log.v("verbose");
+          Log.d("debug");
+          Log.i("info");
+          Log.w("warning");
+          Log.e("error");
+        },
+        stdout: () => _CapturingStdout(<String>[]),
+        stderr: () => _CapturingStdout(err),
+      );
+
+      expect(err, hasLength(2), reason: "only warning and error pass at the warning level");
+    });
+
+    test("info level is prefixed with the resolved caller class like every other level", () {
+      Log.level = LogLevel.info;
+      final err = <String>[];
+
+      IOOverrides.runZoned(
+        () => _LogCaller().emit(),
+        stdout: () => _CapturingStdout(<String>[]),
+        stderr: () => _CapturingStdout(err),
+      );
+
+      expect(err, hasLength(1));
+      expect(
+        err.single,
+        startsWith("[_LogCaller]"),
+        reason: "the caller-frame index must resolve to the calling class",
+      );
+      expect(err.single, contains("from-caller"));
+    });
+  });
+}
+
+/// Helper whose class name should appear in the resolved log prefix.
+class _LogCaller {
+  void emit() => Log.i("from-caller");
+}
+
+/// Captures [writeln] calls; [IOOverrides] swaps it in for stdout/stderr.
+class _CapturingStdout implements Stdout {
+  _CapturingStdout(this.lines);
+
+  final List<String> lines;
+
+  @override
+  void writeln([Object? object = ""]) {
+    lines.add(object.toString());
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}


### PR DESCRIPTION
## Problem

The bridge conflated two unrelated concerns on the global `Log`:

- **Diagnostic logging** — ignorable operator noise.
- **User-facing output** — prompts/requests/status the user must see to operate the bridge.

`Log` wrote everything except errors to **stdout**, and `Log` is filtered by `--log-level`. So running `sesori-bridge --log-level warning` **silently disabled the entire login flow** (no auth URL, no code, no "Waiting for authorization…") — the bridge became unoperable. A third path (raw `stdout.writeln` + `TerminalPromptApi`) emitted yet more user-facing text, so nothing single-owned user output. The `Log` class had even been bent to special-case `info` (printing it raw, without the `[Class]` prefix) — a smell showing the logger was already doubling as a user-output channel.

## Change

- **New `Console` channel** in `sesori_plugin_interface` (Layer 0, peer of `Log`): `Console.message` → stdout, `Console.error` → stderr. **Never gated by `--log-level`.**
- **All `Log` levels now write to stderr** (previously only errors). Dropped the `info`-is-raw special case so every level uniformly carries the `[Class]` prefix.
- **Migrated genuinely user-facing emissions** to `Console`: the login URL/code box, browser guidance, "Waiting for authorization…", "Login successful!", the startup banner (`Relay:`/`Target:`/`Waiting for relay events…`), "Authenticated as…", the update-available notice, the debug-server URL, and the `logout`/`config` CLI results. Operational diagnostics stay on `Log`.

### Result

`sesori-bridge 2>/dev/null` (logs silenced) stays fully operable — user prompts/status still print. stdout now carries only `--version` + user messages; stderr carries all diagnostics.

## Design decisions

- **Channel home:** `sesori_plugin_interface`, symmetric with `Log`, usable by plugins too.
- **stdout vs stderr:** user messages → stdout; diagnostics → stderr; `--version` stays on stdout and exits before the daemon loop.
- **No `--quiet` flag:** user output is a separate, always-shown channel, so the bug is fixed without it (documented as a future option).
- **Full migration**, not a partial pass — consistency is the whole point.

## Testing

- New `console_test.dart` + `log_test.dart` (stdout/stderr separation, level gating, caller-frame `[Class]` prefix).
- Updated `push_dispatcher_test.dart` to capture stderr (diagnostic telemetry moved there).
- `make analyze`, `dart analyze --fatal-infos` (interface + app), and the full `make test` (**1313 tests**) all green.

## Reviews

- `aristotle-plan-review`: **APPROVED** — no violations.
- `aristotle-impl-review`: **APPROVED** — no violations.

## Docs

- `bridge/app/README.md`: clarified `--log-level` controls diagnostics only; user output is always shown.
- `bridge/app/AGENTS.md`: added a "User-facing output vs logging" convention.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separated user-facing output from diagnostic logs so the bridge works at any log level. Added `Console` (stdout) and routed all `Log` levels to stderr; fixes the bug where `--log-level warning|error` hid the login flow.

- **New Features**
  - Added `Console` in `sesori_plugin_interface`: `Console.message` → stdout, `Console.error` → stderr; never gated by `--log-level`.

- **Refactors**
  - All `Log` levels now write to stderr and include the `[Class]` prefix; migrated user-facing prompts/status to `Console`.
  - OAuth login code box is printed via one atomic `Console.message` to avoid interleaving; output unchanged.

<sup>Written for commit 4b06a5d7c4c0561b2dd8f67bbf63181ccf6eb2c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

