### PR TITLE
fix(bridge): surface deeply-nested busy sessions on their root in active session summary

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -263,63 +263,57 @@ class ActiveSessionTracker {
   }
 
   List<ProjectActivitySummary> buildSummary() {
-    // Partition active (busy/retry) sessions into root vs child.
-    final activeRoots = <String>{};
-    final activeChildrenByParent = <String, List<String>>{};
+    // Attribute every active (busy/retry) session to its root ancestor by
+    // walking the parent chain. Any active descendant — a direct child or
+    // deeper — surfaces on its root session's row, because the session list
+    // only renders root sessions. Sessions whose chain cannot be resolved to a
+    // known root (an ancestor was never observed, or a cycle is detected) are
+    // ignored: there is no root row to attribute them to.
+    final activeDescendantsByRoot = <String, List<String>>{};
+    final directlyActiveRoots = <String>{};
 
     for (final sessionId in _sessionStatuses.keys) {
-      final parentId = _sessionParentIds[sessionId];
-      if (parentId == null) {
-        // Root session (or unknown parent — treated as root).
-        activeRoots.add(sessionId);
+      final rootId = _resolveRootSession(sessionId);
+      if (rootId == null) continue;
+      if (rootId == sessionId) {
+        directlyActiveRoots.add(sessionId);
       } else {
-        // Child session — only include if parent is a known root (direct descendant).
-        // A "known root" is a session we've observed whose own parentId is null.
-        // Use containsKey to distinguish "known root" from "never observed".
-        if (_sessionParentIds.containsKey(parentId) && _sessionParentIds[parentId] == null) {
-          activeChildrenByParent.putIfAbsent(parentId, () => []).add(sessionId);
-        }
-        // Parent not in _sessionParentIds → never observed → orphan → ignore.
-        // Parent's parentId != null → deeper nesting → ignore.
+        activeDescendantsByRoot.putIfAbsent(rootId, () => []).add(sessionId);
       }
     }
 
-    // Merge: roots that are directly active + idle roots with active children.
-    final allActiveRoots = <String>{...activeRoots};
-    activeChildrenByParent.keys.forEach(allActiveRoots.add);
+    // Roots that are themselves active + roots that only have active descendants.
+    final allActiveRoots = <String>{...directlyActiveRoots, ...activeDescendantsByRoot.keys};
 
     // Build ActiveSession per root, grouped by worktree.
     final byWorktree = <String, List<ActiveSession>>{};
     for (final rootId in allActiveRoots) {
+      final descendants = activeDescendantsByRoot[rootId] ?? const <String>[];
       var worktree = _sessionWorktrees[rootId];
-      // Parent may not have a worktree if we only observed its children
+      // The root may lack a worktree if we only observed its descendants
       // (e.g. bridge reconnected after the root session was created).
-      // Fall back to any child's worktree — children share the same project.
+      // Fall back to any descendant's worktree — they share the same project.
       if (worktree == null) {
-        final children = activeChildrenByParent[rootId];
-        if (children != null) {
-          for (final childId in children) {
-            worktree = _sessionWorktrees[childId];
-            if (worktree != null) break;
-          }
+        for (final descendantId in descendants) {
+          worktree = _sessionWorktrees[descendantId];
+          if (worktree != null) break;
         }
       }
       if (worktree == null) {
         Log.w("buildSummary: no worktree for session $rootId");
         continue;
       }
-      final children = activeChildrenByParent[rootId] ?? const <String>[];
       final isRetrying = _sessionStatuses[rootId] is SessionStatusRetry ||
-          children.any((childId) => _sessionStatuses[childId] is SessionStatusRetry);
+          descendants.any((id) => _sessionStatuses[id] is SessionStatusRetry);
       byWorktree
           .putIfAbsent(worktree, () => [])
           .add(
             ActiveSession(
               id: rootId,
-              mainAgentRunning: activeRoots.contains(rootId),
-              awaitingInput: _rootHasPendingInput(rootId, children),
+              mainAgentRunning: directlyActiveRoots.contains(rootId),
+              awaitingInput: _rootHasPendingInput(rootId, descendants),
               isRetrying: isRetrying,
-              childSessionIds: children,
+              childSessionIds: descendants,
             ),
           );
     }
@@ -332,6 +326,26 @@ class ActiveSessionTracker {
           ),
         )
         .toList();
+  }
+
+  /// Walks the parent chain from [sessionId] up to its root ancestor — the
+  /// first session whose `parentID` is null.
+  ///
+  /// Returns null when the chain cannot be resolved to a known root: an
+  /// ancestor was never observed (`_sessionParentIds` has no entry for it) or a
+  /// cycle is detected. Callers treat an unresolved session as un-attributable
+  /// and drop it from the summary.
+  String? _resolveRootSession(String sessionId) {
+    var current = sessionId;
+    final visited = <String>{};
+    while (visited.add(current)) {
+      if (!_sessionParentIds.containsKey(current)) return null;
+      final parentId = _sessionParentIds[current];
+      if (parentId == null) return current;
+      current = parentId;
+    }
+    Log.w("buildSummary: cycle detected resolving root for $sessionId");
+    return null;
   }
 
   /// Raw count of all busy/retry sessions per worktree.
@@ -368,14 +382,14 @@ class ActiveSessionTracker {
     return (_pendingQuestions[sessionId]?.isNotEmpty ?? false) || (_pendingPermissions[sessionId]?.isNotEmpty ?? false);
   }
 
-  /// Returns true if the root session OR any of its direct child sessions
+  /// Returns true if the root session OR any of its active descendant sessions
   /// has pending input (question or permission).
   ///
-  /// Child sessions are included so that sub-agent questions/permissions
-  /// surface on the root session row in the session list.
-  bool _rootHasPendingInput(String rootId, List<String> childIds) {
+  /// Descendants are included so that sub-agent questions/permissions surface
+  /// on the root session row in the session list, at any nesting depth.
+  bool _rootHasPendingInput(String rootId, List<String> descendantIds) {
     if (_hasPendingInput(rootId)) return true;
-    return childIds.any(_hasPendingInput);
+    return descendantIds.any(_hasPendingInput);
   }
 
   /// Raw set of session IDs (including children) that currently have any

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -105,29 +105,39 @@ class ActiveSessionTracker {
       case SseSessionCreated():
         _sessionDirectories[event.info.id] = event.info.directory;
         _updateSessionWorktree(event.info.id, event.info.directory);
+        final wasObserved = _sessionParentIds.containsKey(event.info.id);
         final prevParentId = _sessionParentIds[event.info.id];
         _sessionParentIds[event.info.id] = event.info.parentID;
-        // A parent-link change can move active sessions between roots, or make a
-        // previously-orphaned active descendant resolvable, without changing the
-        // per-worktree counts — so re-emit when this session is itself active or
-        // is an ancestor of an active session.
-        if (prevParentId != event.info.parentID && _participatesInActiveSubtree(event.info.id)) {
+        // Newly observing a session — even a root, whose parentID is null and so
+        // would compare equal to the absent value — or changing its parent link
+        // can re-home active descendants between roots without moving the
+        // per-worktree counts. Re-emit when this session is itself active or is
+        // an ancestor of an active session.
+        if ((!wasObserved || prevParentId != event.info.parentID) && _participatesInActiveSubtree(event.info.id)) {
           forceReemit = true;
         }
       case SseSessionUpdated():
         _sessionDirectories[event.info.id] = event.info.directory;
         _updateSessionWorktree(event.info.id, event.info.directory);
+        final wasObserved = _sessionParentIds.containsKey(event.info.id);
         final prevParentId = _sessionParentIds[event.info.id];
         _sessionParentIds[event.info.id] = event.info.parentID;
-        if (prevParentId != event.info.parentID && _participatesInActiveSubtree(event.info.id)) {
+        if ((!wasObserved || prevParentId != event.info.parentID) && _participatesInActiveSubtree(event.info.id)) {
           forceReemit = true;
         }
       case SseSessionDeleted():
+        // Deleting an ancestor can orphan an active descendant (changing its
+        // root attribution) without moving the per-worktree counts, so capture
+        // participation before dropping the metadata.
+        final affectedActiveSubtree = _participatesInActiveSubtree(event.info.id);
         _sessionDirectories.remove(event.info.id);
         _sessionWorktrees.remove(event.info.id);
         _sessionStatuses.remove(event.info.id);
         _sessionParentIds.remove(event.info.id);
         _clearPendingInputForSession(event.info.id);
+        if (affectedActiveSubtree) {
+          forceReemit = true;
+        }
       case SseSessionStatus():
         if (!_sessionWorktrees.containsKey(event.sessionID) && directory != null) {
           _updateSessionWorktree(event.sessionID, directory);

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -280,7 +280,7 @@ class ActiveSessionTracker {
     // deeper — surfaces on its root session's row, because the session list
     // only renders root sessions. Sessions whose chain cannot be resolved to a
     // known root (an ancestor was never observed, or a cycle is detected) are
-    // ignored: there is no root row to attribute them to.
+    // dropped, because there is no root row to attribute them to.
     final activeDescendantsByRoot = <String, List<String>>{};
     final directlyActiveRoots = <String>{};
 

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -107,9 +107,11 @@ class ActiveSessionTracker {
         _updateSessionWorktree(event.info.id, event.info.directory);
         final prevParentId = _sessionParentIds[event.info.id];
         _sessionParentIds[event.info.id] = event.info.parentID;
-        // Parent metadata changed for an active session — grouping may differ
-        // even though per-worktree counts haven't changed.
-        if (_sessionStatuses.containsKey(event.info.id) && prevParentId != event.info.parentID) {
+        // A parent-link change can move active sessions between roots, or make a
+        // previously-orphaned active descendant resolvable, without changing the
+        // per-worktree counts — so re-emit when this session is itself active or
+        // is an ancestor of an active session.
+        if (prevParentId != event.info.parentID && _participatesInActiveSubtree(event.info.id)) {
           forceReemit = true;
         }
       case SseSessionUpdated():
@@ -117,7 +119,7 @@ class ActiveSessionTracker {
         _updateSessionWorktree(event.info.id, event.info.directory);
         final prevParentId = _sessionParentIds[event.info.id];
         _sessionParentIds[event.info.id] = event.info.parentID;
-        if (_sessionStatuses.containsKey(event.info.id) && prevParentId != event.info.parentID) {
+        if (prevParentId != event.info.parentID && _participatesInActiveSubtree(event.info.id)) {
           forceReemit = true;
         }
       case SseSessionDeleted():
@@ -289,6 +291,12 @@ class ActiveSessionTracker {
     final byWorktree = <String, List<ActiveSession>>{};
     for (final rootId in allActiveRoots) {
       final descendants = activeDescendantsByRoot[rootId] ?? const <String>[];
+      // childSessionIds carries DIRECT active children only. Consumers such as
+      // PushSessionStateTracker treat these as parent→child links for hierarchy
+      // repair, so listing deeper descendants here would flatten the tree.
+      // Deeper active descendants still surface the root above; they are just
+      // not reported as its direct children.
+      final directChildren = descendants.where((id) => _sessionParentIds[id] == rootId).toList();
       var worktree = _sessionWorktrees[rootId];
       // The root may lack a worktree if we only observed its descendants
       // (e.g. bridge reconnected after the root session was created).
@@ -303,6 +311,8 @@ class ActiveSessionTracker {
         Log.w("buildSummary: no worktree for session $rootId");
         continue;
       }
+      // Retry / awaiting-input are activity badge signals (not hierarchy), so
+      // they reflect the whole active subtree, not just the direct children.
       final isRetrying = _sessionStatuses[rootId] is SessionStatusRetry ||
           descendants.any((id) => _sessionStatuses[id] is SessionStatusRetry);
       byWorktree
@@ -313,7 +323,7 @@ class ActiveSessionTracker {
               mainAgentRunning: directlyActiveRoots.contains(rootId),
               awaitingInput: _rootHasPendingInput(rootId, descendants),
               isRetrying: isRetrying,
-              childSessionIds: descendants,
+              childSessionIds: directChildren,
             ),
           );
     }
@@ -331,21 +341,49 @@ class ActiveSessionTracker {
   /// Walks the parent chain from [sessionId] up to its root ancestor — the
   /// first session whose `parentID` is null.
   ///
-  /// Returns null when the chain cannot be resolved to a known root: an
-  /// ancestor was never observed (`_sessionParentIds` has no entry for it) or a
-  /// cycle is detected. Callers treat an unresolved session as un-attributable
-  /// and drop it from the summary.
+  /// If [sessionId] itself has no observed parent metadata, it is treated as its
+  /// own root. This preserves the prior fallback for active sessions seen only
+  /// via a status event (no `session.created`/cold-start metadata yet), which
+  /// would otherwise be dropped from the summary entirely.
+  ///
+  /// Returns null only when an *ancestor* in the chain was never observed (an
+  /// orphan child whose parent we have not seen) or a cycle is detected — such
+  /// sessions cannot be attributed to a root row and are dropped.
   String? _resolveRootSession(String sessionId) {
     var current = sessionId;
     final visited = <String>{};
     while (visited.add(current)) {
-      if (!_sessionParentIds.containsKey(current)) return null;
+      if (!_sessionParentIds.containsKey(current)) {
+        return current == sessionId ? sessionId : null;
+      }
       final parentId = _sessionParentIds[current];
       if (parentId == null) return current;
       current = parentId;
     }
     Log.w("buildSummary: cycle detected resolving root for $sessionId");
     return null;
+  }
+
+  /// Whether [sessionId] is itself active, or is an ancestor of any active
+  /// session.
+  ///
+  /// A parent-link change on such a session can move an active session to a
+  /// different root — or make a previously-orphaned active descendant
+  /// resolvable — without changing the per-worktree active counts, so the
+  /// summary must be re-emitted when this returns true.
+  bool _participatesInActiveSubtree(String sessionId) {
+    if (_sessionStatuses.containsKey(sessionId)) return true;
+    for (final activeId in _sessionStatuses.keys) {
+      var current = activeId;
+      final visited = <String>{};
+      while (visited.add(current)) {
+        if (current == sessionId) return true;
+        final parentId = _sessionParentIds[current];
+        if (parentId == null) break;
+        current = parentId;
+      }
+    }
+    return false;
   }
 
   /// Raw count of all busy/retry sessions per worktree.

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -628,7 +628,7 @@ void main() {
       expect(summary.first.activeSessions.first.childSessionIds, equals(["c1"]));
     });
 
-    test("deeply nested children are ignored", () async {
+    test("deeply nested busy descendants bubble up to their root", () async {
       final tracker = await _coldStartedTracker(
         projects: [const Project(id: "p1", worktree: "/repo")],
       );
@@ -654,8 +654,33 @@ void main() {
 
       expect(summary, hasLength(1));
       expect(summary.first.activeSessions.length, equals(1));
-      expect(summary.first.activeSessions.first.id, equals("s1"));
-      expect(summary.first.activeSessions.first.childSessionIds, equals(["c1"]));
+      final root = summary.first.activeSessions.first;
+      expect(root.id, equals("s1"));
+      expect(root.mainAgentRunning, isTrue);
+      // The grandchild (g1) is attributed to the root alongside the direct
+      // child (c1), not dropped for being deeper than one level.
+      expect(root.childSessionIds, unorderedEquals(["c1", "g1"]));
+    });
+
+    test("idle root with only a busy grandchild appears in summary", () async {
+      final tracker = await _coldStartedTracker(
+        projects: [const Project(id: "p1", worktree: "/repo")],
+      );
+
+      tracker.handleEvent(_sessionCreated("s1", "/repo"), null);
+      tracker.handleEvent(_childSessionCreated("c1", "s1", "/repo"), null);
+      tracker.handleEvent(_childSessionCreated("g1", "c1", "/repo"), null);
+      // Only the grandchild is busy; root and intermediate child are idle.
+      tracker.handleEvent(_sessionBusy("g1"), null);
+
+      final summary = tracker.buildSummary();
+
+      expect(summary, hasLength(1));
+      expect(summary.first.activeSessions.length, equals(1));
+      final root = summary.first.activeSessions.first;
+      expect(root.id, equals("s1"));
+      expect(root.mainAgentRunning, isFalse);
+      expect(root.childSessionIds, equals(["g1"]));
     });
 
     group("pending input tracking", () {

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -718,6 +718,47 @@ void main() {
       expect(summary.first.activeSessions.first.id, equals("s1"));
     });
 
+    test("late root session.created re-emits when it completes an active descendant chain", () async {
+      final tracker = await _coldStartedTracker(
+        projects: [const Project(id: "p1", worktree: "/repo")],
+      );
+
+      // A busy child points at root r, but r has not been observed yet, so the
+      // child is currently an unresolvable orphan.
+      tracker.handleEvent(_childSessionCreated("c1", "r", "/repo"), null);
+      tracker.handleEvent(_sessionBusy("c1"), null);
+      expect(tracker.buildSummary(), isEmpty);
+
+      // r's creation arrives. Its parentID is null, so the previous (absent)
+      // value compares equal — the re-emit must instead trigger on r being
+      // newly observed as an ancestor of the busy child.
+      final changed = tracker.handleEvent(_sessionCreated("r", "/repo"), null);
+
+      expect(changed, isTrue);
+      final summary = tracker.buildSummary();
+      expect(summary, hasLength(1));
+      expect(summary.first.activeSessions.first.id, equals("r"));
+    });
+
+    test("deleting an idle intermediate ancestor re-emits and drops the orphaned root", () async {
+      final tracker = await _coldStartedTracker(
+        projects: [const Project(id: "p1", worktree: "/repo")],
+      );
+
+      tracker.handleEvent(_sessionCreated("s1", "/repo"), null);
+      tracker.handleEvent(_childSessionCreated("c1", "s1", "/repo"), null);
+      tracker.handleEvent(_childSessionCreated("g1", "c1", "/repo"), null);
+      tracker.handleEvent(_sessionBusy("g1"), null);
+      expect(tracker.buildSummary(), hasLength(1));
+
+      // Deleting the idle intermediate c1 orphans the busy grandchild g1; the
+      // active count is unchanged, so the delete must force a re-emit.
+      final changed = tracker.handleEvent(_sessionDeleted("c1", "/repo"), null);
+
+      expect(changed, isTrue);
+      expect(tracker.buildSummary(), isEmpty);
+    });
+
     group("pending input tracking", () {
       test("question asked sets awaitingInput true, replied clears it", () async {
         final tracker = await _coldStartedTracker(

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -628,26 +628,16 @@ void main() {
       expect(summary.first.activeSessions.first.childSessionIds, equals(["c1"]));
     });
 
-    test("deeply nested busy descendants bubble up to their root", () async {
+    test("deeply nested descendants surface the root but are not direct children", () async {
       final tracker = await _coldStartedTracker(
         projects: [const Project(id: "p1", worktree: "/repo")],
       );
 
       tracker.handleEvent(_sessionCreated("s1", "/repo"), null);
       tracker.handleEvent(_sessionBusy("s1"), null);
-      tracker.handleEvent(
-        const SseEventData.sessionCreated(
-          info: Session(id: "c1", projectID: "project", directory: "/repo", parentID: "s1"),
-        ),
-        null,
-      );
+      tracker.handleEvent(_childSessionCreated("c1", "s1", "/repo"), null);
       tracker.handleEvent(_sessionBusy("c1"), null);
-      tracker.handleEvent(
-        const SseEventData.sessionCreated(
-          info: Session(id: "g1", projectID: "project", directory: "/repo", parentID: "c1"),
-        ),
-        null,
-      );
+      tracker.handleEvent(_childSessionCreated("g1", "c1", "/repo"), null);
       tracker.handleEvent(_sessionBusy("g1"), null);
 
       final summary = tracker.buildSummary();
@@ -657,12 +647,13 @@ void main() {
       final root = summary.first.activeSessions.first;
       expect(root.id, equals("s1"));
       expect(root.mainAgentRunning, isTrue);
-      // The grandchild (g1) is attributed to the root alongside the direct
-      // child (c1), not dropped for being deeper than one level.
-      expect(root.childSessionIds, unorderedEquals(["c1", "g1"]));
+      // Only the direct child is listed; the grandchild (g1) surfaces the root
+      // above but is not flattened into the root's direct-children list, which
+      // downstream consumers treat as a single parent->child hierarchy level.
+      expect(root.childSessionIds, equals(["c1"]));
     });
 
-    test("idle root with only a busy grandchild appears in summary", () async {
+    test("idle root with only a busy grandchild still surfaces the root", () async {
       final tracker = await _coldStartedTracker(
         projects: [const Project(id: "p1", worktree: "/repo")],
       );
@@ -680,7 +671,51 @@ void main() {
       final root = summary.first.activeSessions.first;
       expect(root.id, equals("s1"));
       expect(root.mainAgentRunning, isFalse);
-      expect(root.childSessionIds, equals(["g1"]));
+      // The grandchild is not a direct child, so it is not listed, but it still
+      // surfaces the (idle) root as active in the list.
+      expect(root.childSessionIds, isEmpty);
+    });
+
+    test("active session seen only via status (no parent metadata) surfaces as a root", () async {
+      final tracker = await _coldStartedTracker(
+        projects: [const Project(id: "p1", worktree: "/repo")],
+      );
+
+      // A status event arrives with a directory but WITHOUT a session.created
+      // event, so _sessionParentIds has no entry for s1. It must still be
+      // surfaced as its own root rather than dropped.
+      tracker.handleEvent(_sessionBusy("s1"), "/repo");
+
+      final summary = tracker.buildSummary();
+
+      expect(summary, hasLength(1));
+      expect(summary.first.id, equals("/repo"));
+      final root = summary.first.activeSessions.first;
+      expect(root.id, equals("s1"));
+      expect(root.mainAgentRunning, isTrue);
+    });
+
+    test("late intermediate session.created re-emits when it bridges an active descendant", () async {
+      final tracker = await _coldStartedTracker(
+        projects: [const Project(id: "p1", worktree: "/repo")],
+      );
+
+      // Root known; grandchild busy but its intermediate parent c1 has not been
+      // observed yet, so the grandchild is currently an unresolvable orphan.
+      tracker.handleEvent(_sessionCreated("s1", "/repo"), null);
+      tracker.handleEvent(_childSessionCreated("g1", "c1", "/repo"), null);
+      tracker.handleEvent(_sessionBusy("g1"), null);
+      expect(tracker.buildSummary(), isEmpty);
+
+      // c1's creation arrives. Even though c1 is idle, it now bridges g1 up to
+      // s1, changing attribution without changing active counts, so handleEvent
+      // must report a change to trigger a summary re-emit.
+      final changed = tracker.handleEvent(_childSessionCreated("c1", "s1", "/repo"), null);
+
+      expect(changed, isTrue);
+      final summary = tracker.buildSummary();
+      expect(summary, hasLength(1));
+      expect(summary.first.activeSessions.first.id, equals("s1"));
     });
 
     group("pending input tracking", () {

--- a/shared/sesori_shared/lib/src/models/sesori/active_session.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/active_session.dart
@@ -3,12 +3,13 @@ import "package:freezed_annotation/freezed_annotation.dart";
 part "active_session.freezed.dart";
 part "active_session.g.dart";
 
-/// A root session that is currently active, along with its direct child sessions
-/// that are also active (busy or retrying).
+/// A root session that is currently active, along with the active (busy or
+/// retrying) descendant sessions nested beneath it.
 ///
-/// A session is considered active when either the main agent or any of its
-/// direct child tasks are running. Only direct descendants are tracked —
-/// deeper nesting is ignored.
+/// A session is considered active when either the main agent or any task in its
+/// subtree is running. Active descendants at any depth are attributed to their
+/// root session; [childSessionIds] therefore lists every active descendant, not
+/// only direct children.
 @Freezed(fromJson: true, toJson: true)
 sealed class ActiveSession with _$ActiveSession {
   const factory ActiveSession({

--- a/shared/sesori_shared/lib/src/models/sesori/active_session.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/active_session.dart
@@ -3,13 +3,13 @@ import "package:freezed_annotation/freezed_annotation.dart";
 part "active_session.freezed.dart";
 part "active_session.g.dart";
 
-/// A root session that is currently active, along with the active (busy or
-/// retrying) descendant sessions nested beneath it.
+/// A root session that is currently active — either because its own main agent
+/// is running, or because a task somewhere in its subtree is.
 ///
-/// A session is considered active when either the main agent or any task in its
-/// subtree is running. Active descendants at any depth are attributed to their
-/// root session; [childSessionIds] therefore lists every active descendant, not
-/// only direct children.
+/// [childSessionIds] lists only the root's DIRECT active children. Deeper active
+/// descendants still cause the root to surface here (so the session list shows
+/// it as running), but they are not listed individually — the field represents
+/// a single level of parent→child hierarchy, which is what consumers rely on.
 @Freezed(fromJson: true, toJson: true)
 sealed class ActiveSession with _$ActiveSession {
   const factory ActiveSession({


### PR DESCRIPTION
## Problem
On the mobile **session list**, a running session is not shown as running (no "Running / N background tasks" badge), even after pull-to-refresh — while the **session detail** view shows it running correctly.

## Root cause
The list badge is driven solely by the `projects.summary` SSE event, built by `ActiveSessionTracker.buildSummary()`. That method only attributed a busy session to a root when it was the root or a **direct child**. OpenCode nests sub-agent sessions deeper than one level (it resolves roots by walking the `parentID` chain — see opencode `packages/app/src/pages/layout/helpers.ts`), so when a root's only running work is a **grandchild (or deeper)** sub-agent, the root never appeared in the summary. Detail is unaffected (it reads `/session/status`), and pull-to-refresh only re-fetches the status-less `/sessions` list.

## Fix
`buildSummary()` now walks each busy session's `parentID` chain to its root ancestor (`_resolveRootSession`, with a visited-set cycle guard) and **surfaces that root** whenever any descendant at any depth is active. Per root:
- `childSessionIds` — **direct active children only**. `PushSessionStateTracker._applyProjectsSummaryChildLinks` consumes this list as parent→child hierarchy-repair links, so deeper descendants are intentionally *not* listed here (that would flatten the tree). Deeper descendants still surface their root; they just are not reported as its direct children.
- `mainAgentRunning` — root itself busy/retry
- `isRetrying` / `awaitingInput` — badge signals, aggregated across the whole active subtree

`_resolveRootSession` treats a session with **no observed parent metadata** as its own root (preserving the prior fallback for status-only sessions); only genuine orphans (an unobserved ancestor) or cycles are dropped.

A late `session.created`/`session.updated` that **bridges** an active descendant to its root now forces a summary re-emit (`_participatesInActiveSubtree`), so attribution changes that do not move the active-count/retry/pending sets are not missed.

Shared `ActiveSession` doc updated to state the single-level `childSessionIds` semantics (doc-only; no wire change).

## Testing
- `dart test test/active_session_tracker_test.dart` -> 61 pass
- Added tests: deep descendant surfaces root (direct children only); idle root with busy grandchild surfaces; status-only session surfaces as root; late bridging `session.created` re-emits
- `lsp_diagnostics` clean on changed files

## Reviews
Passed `aristotle-plan-review` and `aristotle-impl-review`. Review feedback from gemini-code-assist, cubic-dev-ai, and chatgpt-codex-connector addressed in a follow-up commit.