### PR TITLE
feat(bridge): fail fast with install guidance when OpenCode is unavailable

### DIFF
--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -14,6 +14,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
         PluginConfig,
         PluginFailed,
         PluginStartAbortedException,
+        PluginUnavailable,
         ProcessIdentity,
         ProcessUser,
         ServerClock,
@@ -227,6 +228,29 @@ class BridgeRuntimeRunner {
       final ownerSessionId = _buildOwnerSessionId(currentBridgeIdentity: currentBridgeIdentity);
 
       final descriptor = knownPlugins.firstWhere((descriptor) => descriptor.id == pluginId);
+
+      // Fail fast with clear, user-facing guidance if the selected plugin's
+      // backend is unavailable — BEFORE the startup mutex and single-live-bridge
+      // enforcement, so a missing backend (e.g. OpenCode not installed) can
+      // never terminate a healthy resident bridge. The probe is read-only.
+      final hostProcessService = BridgeHostProcessService(
+        processStarter: io.Process.start,
+        processRepository: processRepository,
+        clock: serverClock,
+        currentUser: currentUser,
+        isWindows: io.Platform.isWindows,
+        platform: io.Platform.operatingSystem,
+      );
+      final availability = await descriptor.checkAvailability(
+        config: pluginConfig,
+        processes: hostProcessService,
+        environment: environment,
+      );
+      if (availability is PluginUnavailable) {
+        Console.error(availability.message);
+        return 1;
+      }
+
       final startAbortController = StartAbortController();
       final pluginManager = PluginManager();
       pluginManager.register(

--- a/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
+++ b/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
@@ -9,6 +9,7 @@ export "src/host/host_process_service.dart";
 export "src/host/plugin_host.dart";
 export "src/lifecycle/bridge_plugin.dart";
 export "src/lifecycle/bridge_plugin_descriptor.dart";
+export "src/lifecycle/plugin_availability.dart";
 export "src/lifecycle/plugin_config.dart";
 export "src/lifecycle/plugin_diagnostics.dart";
 export "src/lifecycle/plugin_option.dart";

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin_descriptor.dart
@@ -1,7 +1,9 @@
 import "package:meta/meta.dart";
 
+import "../host/host_process_service.dart";
 import "../host/plugin_host.dart";
 import "bridge_plugin.dart";
+import "plugin_availability.dart";
 import "plugin_config.dart";
 import "plugin_option.dart";
 
@@ -34,6 +36,28 @@ abstract class BridgePluginDescriptor {
   ///
   /// Must be pure: no I/O, no side effects. The default accepts everything.
   void validateConfig(PluginConfig config) {}
+
+  /// Reports whether this plugin's backend is available to run.
+  ///
+  /// Runs after authentication but **before** the cross-instance startup mutex
+  /// and before [start], so an unavailable backend never terminates a healthy
+  /// resident bridge (the same invariant that keeps [validateConfig] ahead of
+  /// the mutex). Must be read-only — probe only, acquire nothing.
+  ///
+  /// Return [PluginUnavailable] with a user-facing [PluginUnavailable.message]
+  /// (install guidance plus a verification command) when the backend cannot be
+  /// used; the bridge core prints that message via `Console.error` and exits
+  /// non-zero. Return [PluginAvailable] to let startup proceed.
+  ///
+  /// [config] carries the parsed CLI options, [processes] lets a plugin probe a
+  /// local binary (e.g. run `--version`), and [environment] is the process
+  /// environment (PATH, etc.). The default accepts everything, which suits
+  /// plugins that need no local backend (e.g. remote-server plugins).
+  Future<PluginAvailability> checkAvailability({
+    required PluginConfig config,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+  }) async => const PluginAvailable();
 
   /// Starts the plugin and returns its live instance.
   ///

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_availability.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_availability.dart
@@ -1,0 +1,61 @@
+import "package:meta/meta.dart";
+
+/// Result of a plugin's pre-start availability check.
+///
+/// Reported by `BridgePluginDescriptor.checkAvailability` before the bridge
+/// takes any irreversible startup step — strictly before the cross-instance
+/// startup mutex and before `start()`, so a missing backend can never
+/// terminate a healthy resident bridge. The bridge core treats
+/// [PluginUnavailable] as a fatal, user-facing startup error: it prints
+/// [PluginUnavailable.message] via `Console.error` and exits non-zero.
+///
+/// The check is plugin-owned because *how* a backend proves it is usable is
+/// backend-specific (e.g. the OpenCode plugin runs `opencode --version`). The
+/// remediation message is authored by the plugin too, so the plugin-agnostic
+/// bridge core never needs to know how to install or repair a particular
+/// backend.
+@immutable
+sealed class PluginAvailability {
+  const PluginAvailability();
+}
+
+/// The plugin's backend is present and usable; startup may proceed.
+///
+/// This is the default for descriptors that need no local backend (e.g.
+/// remote-server plugins), and the result the OpenCode plugin returns in
+/// attach mode (`--no-auto-start`), where the user runs the server themselves.
+final class PluginAvailable extends PluginAvailability {
+  const PluginAvailable();
+
+  @override
+  bool operator ==(Object other) => other is PluginAvailable;
+
+  @override
+  int get hashCode => (PluginAvailable).hashCode;
+
+  @override
+  String toString() => "PluginAvailable";
+}
+
+/// The plugin's backend is missing or not usable; startup must abort.
+///
+/// [message] is a user-facing explanation (shown via `Console.error`, which is
+/// never gated by `--log-level`) that tells the user how to make the backend
+/// available — e.g. install instructions and a verification command. It is
+/// authored by the plugin, never by the bridge core.
+final class PluginUnavailable extends PluginAvailability {
+  const PluginUnavailable({required this.message});
+
+  /// User-facing guidance printed to the user immediately before the bridge
+  /// exits non-zero.
+  final String message;
+
+  @override
+  bool operator ==(Object other) => other is PluginUnavailable && other.message == message;
+
+  @override
+  int get hashCode => message.hashCode;
+
+  @override
+  String toString() => "PluginUnavailable(message: $message)";
+}

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_availability.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/plugin_availability.dart
@@ -44,7 +44,9 @@ final class PluginAvailable extends PluginAvailability {
 /// available — e.g. install instructions and a verification command. It is
 /// authored by the plugin, never by the bridge core.
 final class PluginUnavailable extends PluginAvailability {
-  const PluginUnavailable({required this.message});
+  PluginUnavailable({required String message})
+    : assert(message.isNotEmpty, "PluginUnavailable.message must not be empty"),
+      message = message;
 
   /// User-facing guidance printed to the user immediately before the bridge
   /// exits non-zero.

--- a/bridge/sesori_plugin_interface/test/lifecycle/bridge_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_interface/test/lifecycle/bridge_plugin_descriptor_test.dart
@@ -23,6 +23,18 @@ void main() {
         throwsA(isA<PluginConfigException>()),
       );
     });
+
+    test('checkAvailability reports available by default', () async {
+      const descriptor = _MinimalDescriptor();
+
+      final availability = await descriptor.checkAvailability(
+        config: const PluginConfig.empty(),
+        processes: const _UnusedProcessService(),
+        environment: const <String, String>{},
+      );
+
+      expect(availability, isA<PluginAvailable>());
+    });
   });
 
   group('PluginOption', () {
@@ -131,6 +143,33 @@ class _MinimalDescriptor extends BridgePluginDescriptor {
   Future<BridgePlugin> start(PluginHost host) {
     throw UnsupportedError('start is not exercised in this test');
   }
+}
+
+/// The default `checkAvailability` ignores its process service, so this fake
+/// throws on every call to prove the default never touches it.
+class _UnusedProcessService implements HostProcessService {
+  const _UnusedProcessService();
+
+  @override
+  Future<SpawnedProcess> spawn({
+    required String executable,
+    required List<String> arguments,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+    required bool runInShell,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<ProcessIdentity?> inspect({required int pid}) => throw UnimplementedError();
+
+  @override
+  Future<List<ProcessIdentity>> list({required int? excludePid}) => throw UnimplementedError();
+
+  @override
+  Future<SignalResult> signalGraceful({required int pid}) => throw UnimplementedError();
+
+  @override
+  Future<SignalResult> signalForce({required int pid}) => throw UnimplementedError();
 }
 
 class _ValidatingDescriptor extends BridgePluginDescriptor {

--- a/bridge/sesori_plugin_interface/test/lifecycle/plugin_availability_test.dart
+++ b/bridge/sesori_plugin_interface/test/lifecycle/plugin_availability_test.dart
@@ -1,0 +1,30 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("PluginAvailability", () {
+    test("PluginAvailable is const and equal by type", () {
+      expect(const PluginAvailable(), equals(const PluginAvailable()));
+      expect(const PluginAvailable().hashCode, equals(const PluginAvailable().hashCode));
+      expect(const PluginAvailable().toString(), equals("PluginAvailable"));
+    });
+
+    test("PluginUnavailable carries its message and value equality", () {
+      final first = PluginUnavailable(message: "install opencode");
+      final second = PluginUnavailable(message: "install opencode");
+      final different = PluginUnavailable(message: "different message");
+
+      expect(first, equals(second));
+      expect(first.hashCode, equals(second.hashCode));
+      expect(first, isNot(equals(different)));
+      expect(first.toString(), equals("PluginUnavailable(message: install opencode)"));
+    });
+
+    test("PluginUnavailable rejects an empty message", () {
+      expect(
+        () => PluginUnavailable(message: ""),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+}

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
@@ -179,7 +179,7 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
     if (config.flag("no-auto-start")) {
       return const PluginAvailable();
     }
-    final executablePath = config.value("opencode-bin")!;
+    final executablePath = config.value("opencode-bin") ?? "opencode";
     return _probeOpenCodeBinary(
       executablePath: executablePath,
       processes: processes,
@@ -240,6 +240,9 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
       } on Object {
         // Best-effort: reap the hung probe so it does not linger.
       }
+      return PluginUnavailable(message: _notWorkingMessage(executablePath: executablePath));
+    } on Object catch (error) {
+      Log.d("[opencode] availability probe '$executablePath --version' failed with error: $error");
       return PluginUnavailable(message: _notWorkingMessage(executablePath: executablePath));
     } finally {
       await stdoutSubscription.cancel();

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
@@ -1,4 +1,6 @@
 import "dart:async";
+import "dart:convert";
+import "dart:io" as io;
 import "dart:math";
 
 import "package:http/http.dart" as http;
@@ -86,6 +88,7 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
     Random? random,
     Duration degradedDebounce = const Duration(seconds: 5),
     Duration coldStartBudget = openCodeColdStartBudget,
+    Duration versionProbeTimeout = openCodeVersionProbeTimeout,
     OpenCodeDbOptimizer? optimizeDb,
   }) : _buildApi = buildApi,
        _probeClientFactory = probeClientFactory,
@@ -93,6 +96,7 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
        _random = random,
        _degradedDebounce = degradedDebounce,
        _coldStartBudget = coldStartBudget,
+       _versionProbeTimeout = versionProbeTimeout,
        _optimizeDb = optimizeDb;
 
   final OpenCodeManagedApiFactory? _buildApi;
@@ -101,6 +105,7 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
   final Random? _random;
   final Duration _degradedDebounce;
   final Duration _coldStartBudget;
+  final Duration _versionProbeTimeout;
   final OpenCodeDbOptimizer? _optimizeDb;
 
   /// The four OpenCode CLI options, names/help/defaults identical to the flags
@@ -154,6 +159,113 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
 
   @override
   void validateConfig(PluginConfig config) => validateConfigValues(config);
+
+  /// Confirms the OpenCode CLI is installed and runnable before the bridge
+  /// commits to startup.
+  ///
+  /// Only the managed (auto-start) path needs a local binary: in attach mode
+  /// (`--no-auto-start`) the user runs their own server, so the binary is
+  /// irrelevant and we report available — `start()` keeps its existing
+  /// fail-soft reachability behavior there. Otherwise we run
+  /// `<opencode-bin> --version`: exit 0 within [openCodeVersionProbeTimeout]
+  /// means available; a failed launch (not installed / not on PATH), a
+  /// non-zero exit, or a timeout mean unavailable.
+  @override
+  Future<PluginAvailability> checkAvailability({
+    required PluginConfig config,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+  }) async {
+    if (config.flag("no-auto-start")) {
+      return const PluginAvailable();
+    }
+    final executablePath = config.value("opencode-bin")!;
+    return _probeOpenCodeBinary(
+      executablePath: executablePath,
+      processes: processes,
+      environment: environment,
+    );
+  }
+
+  /// Runs `<executablePath> --version` and classifies the outcome. Never
+  /// throws: every failure mode maps to a [PluginUnavailable] with user-facing
+  /// guidance.
+  Future<PluginAvailability> _probeOpenCodeBinary({
+    required String executablePath,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+  }) async {
+    final SpawnedProcess process;
+    try {
+      process = await processes.spawn(
+        executable: executablePath,
+        arguments: const ["--version"],
+        environment: environment,
+        workingDirectory: null,
+        // On Windows the binary is typically an `opencode.cmd`/`.ps1` shim that
+        // only resolves through a shell — matching how the managed runtime
+        // spawns `opencode serve`.
+        runInShell: io.Platform.isWindows,
+      );
+    } on Object catch (error) {
+      // Spawn could not launch at all — almost always ENOENT: the binary is not
+      // installed or not on PATH.
+      Log.d("[opencode] availability probe could not launch '$executablePath --version': $error");
+      return PluginUnavailable(message: _notInstalledMessage(executablePath: executablePath));
+    }
+
+    // Accumulate stdout (the version string, for diagnostics) and drain stderr
+    // so the child can never block on a full pipe. Subscriptions, not joined
+    // futures, so a hung binary that never closes its streams cannot keep us
+    // waiting past the timeout below.
+    final stdoutBuffer = StringBuffer();
+    final stdoutSubscription = process.stdout.transform(utf8.decoder).listen(stdoutBuffer.write, onError: (Object _) {});
+    final stderrSubscription = process.stderr.listen((_) {}, onError: (Object _) {});
+    try {
+      final exitCode = await process.exitCode.timeout(_versionProbeTimeout);
+      if (exitCode == 0) {
+        final version = stdoutBuffer.toString().trim();
+        Log.d("[opencode] available: '$executablePath --version' -> ${version.isEmpty ? "exit 0 (no output)" : version}");
+        return const PluginAvailable();
+      }
+      Log.d("[opencode] availability probe '$executablePath --version' exited with code $exitCode");
+      return PluginUnavailable(message: _notWorkingMessage(executablePath: executablePath));
+    } on TimeoutException {
+      Log.d(
+        "[opencode] availability probe '$executablePath --version' did not exit within "
+        "${_versionProbeTimeout.inSeconds}s",
+      );
+      try {
+        await processes.signalForce(pid: process.pid);
+      } on Object {
+        // Best-effort: reap the hung probe so it does not linger.
+      }
+      return PluginUnavailable(message: _notWorkingMessage(executablePath: executablePath));
+    } finally {
+      await stdoutSubscription.cancel();
+      await stderrSubscription.cancel();
+    }
+  }
+
+  /// Message for "the OpenCode binary could not be found / launched".
+  String _notInstalledMessage({required String executablePath}) {
+    return [
+      "OpenCode was not found — the Sesori bridge needs the OpenCode CLI to run.",
+      "",
+      "Verify it is installed:  $executablePath --version",
+      "Install OpenCode:        https://opencode.ai/docs#install",
+    ].join("\n");
+  }
+
+  /// Message for "the OpenCode binary was found but `--version` failed/hung".
+  String _notWorkingMessage({required String executablePath}) {
+    return [
+      'OpenCode is installed but did not respond to "$executablePath --version".',
+      "",
+      "Re-check your install:  $executablePath --version",
+      "Reinstall OpenCode:     https://opencode.ai/docs#install",
+    ].join("\n");
+  }
 
   @override
   Future<OpenCodeBridgePlugin> start(PluginHost host) async {

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_policy.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_policy.dart
@@ -51,6 +51,11 @@ const Duration openCodeHealthPollInterval = Duration(milliseconds: 500);
 /// cold-start keeps running in the background after the budget elapses.
 const Duration openCodeColdStartBudget = Duration(seconds: 15);
 
+/// Total budget for the pre-start `opencode --version` availability probe. A
+/// binary that hangs instead of promptly printing its version must not stall
+/// bridge startup, so the probe is treated as unavailable once this elapses.
+const Duration openCodeVersionProbeTimeout = Duration(seconds: 10);
+
 /// The loopback host OpenCode binds to and is probed on.
 const String openCodeLoopbackHost = "127.0.0.1";
 

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_availability_test.dart
@@ -1,0 +1,203 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+
+import "package:opencode_plugin/src/runtime/open_code_plugin_descriptor.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("OpenCodePluginDescriptor.checkAvailability", () {
+    const managedConfig = PluginConfig(
+      values: {"no-auto-start": false, "port": null, "password": "", "opencode-bin": "opencode"},
+    );
+
+    test("attach mode (--no-auto-start) reports available without spawning a probe", () async {
+      final processes = _ProbeProcessService(
+        spawnError: StateError("spawn must not be called in attach mode"),
+      );
+
+      final result = await const OpenCodePluginDescriptor().checkAvailability(
+        config: const PluginConfig(
+          values: {"no-auto-start": true, "port": "4096", "password": "", "opencode-bin": "opencode"},
+        ),
+        processes: processes,
+        environment: const <String, String>{},
+      );
+
+      expect(result, isA<PluginAvailable>());
+      expect(processes.spawnedExecutables, isEmpty);
+    });
+
+    test("reports available when '<bin> --version' exits 0", () async {
+      final processes = _ProbeProcessService(
+        process: _ProbeProcess(pid: 4242, stdoutBytes: utf8.encode("opencode 0.5.0\n"), exitCode: Future<int>.value(0)),
+      );
+
+      final result = await const OpenCodePluginDescriptor().checkAvailability(
+        config: managedConfig,
+        processes: processes,
+        environment: const <String, String>{"PATH": "/usr/bin"},
+      );
+
+      expect(result, isA<PluginAvailable>());
+      // The probe runs exactly `<bin> --version`.
+      expect(processes.spawnedExecutables, equals(<String>["opencode"]));
+      expect(processes.spawnedArguments.single, equals(<String>["--version"]));
+    });
+
+    test("reports unavailable (not installed) when the binary cannot be launched", () async {
+      final processes = _ProbeProcessService(
+        spawnError: const ProcessException("opencode", ["--version"], "No such file or directory", 2),
+      );
+
+      final result = await const OpenCodePluginDescriptor().checkAvailability(
+        config: managedConfig,
+        processes: processes,
+        environment: const <String, String>{},
+      );
+
+      expect(result, isA<PluginUnavailable>());
+      final message = (result as PluginUnavailable).message;
+      expect(message, contains("OpenCode was not found"));
+      expect(message, contains("opencode --version"));
+      expect(message, contains("https://opencode.ai/docs#install"));
+    });
+
+    test("reports unavailable (not working) when '--version' exits non-zero", () async {
+      final processes = _ProbeProcessService(
+        process: _ProbeProcess(pid: 7, stdoutBytes: const <int>[], exitCode: Future<int>.value(1)),
+      );
+
+      final result = await const OpenCodePluginDescriptor().checkAvailability(
+        config: managedConfig,
+        processes: processes,
+        environment: const <String, String>{},
+      );
+
+      expect(result, isA<PluginUnavailable>());
+      final message = (result as PluginUnavailable).message;
+      expect(message, contains("did not respond"));
+      expect(message, contains("https://opencode.ai/docs#install"));
+    });
+
+    test("reports unavailable and force-kills the probe when '--version' hangs", () async {
+      final processes = _ProbeProcessService(
+        // exitCode never completes -> the probe must time out.
+        process: _ProbeProcess(pid: 99, stdoutBytes: const <int>[], exitCode: Completer<int>().future),
+      );
+      const descriptor = OpenCodePluginDescriptor(versionProbeTimeout: Duration(milliseconds: 20));
+
+      final result = await descriptor.checkAvailability(
+        config: managedConfig,
+        processes: processes,
+        environment: const <String, String>{},
+      );
+
+      expect(result, isA<PluginUnavailable>());
+      expect((result as PluginUnavailable).message, contains("did not respond"));
+      // The hung probe is reaped so it cannot linger.
+      expect(processes.forceSignals, equals(<int>[99]));
+    });
+
+    test("uses the configured --opencode-bin path in the spawn and the message", () async {
+      final processes = _ProbeProcessService(
+        spawnError: const ProcessException("/custom/opencode", ["--version"], "No such file or directory", 2),
+      );
+
+      final result = await const OpenCodePluginDescriptor().checkAvailability(
+        config: const PluginConfig(
+          values: {"no-auto-start": false, "port": null, "password": "", "opencode-bin": "/custom/opencode"},
+        ),
+        processes: processes,
+        environment: const <String, String>{},
+      );
+
+      expect(result, isA<PluginUnavailable>());
+      expect((result as PluginUnavailable).message, contains("/custom/opencode --version"));
+      expect(processes.spawnedExecutables, equals(<String>["/custom/opencode"]));
+    });
+  });
+}
+
+/// A [HostProcessService] that either throws on [spawn] (to simulate ENOENT) or
+/// returns a single canned [_ProbeProcess]. Records the spawn arguments and any
+/// force-kill it is asked to deliver.
+class _ProbeProcessService implements HostProcessService {
+  _ProbeProcessService({this.spawnError, this.process});
+
+  final Object? spawnError;
+  final _ProbeProcess? process;
+  final List<String> spawnedExecutables = <String>[];
+  final List<List<String>> spawnedArguments = <List<String>>[];
+  final List<int> forceSignals = <int>[];
+
+  @override
+  Future<SpawnedProcess> spawn({
+    required String executable,
+    required List<String> arguments,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+    required bool runInShell,
+  }) async {
+    spawnedExecutables.add(executable);
+    spawnedArguments.add(List<String>.from(arguments));
+    final error = spawnError;
+    if (error != null) {
+      throw error;
+    }
+    return process!;
+  }
+
+  @override
+  Future<ProcessIdentity?> inspect({required int pid}) async => null;
+
+  @override
+  Future<List<ProcessIdentity>> list({required int? excludePid}) async => const <ProcessIdentity>[];
+
+  @override
+  Future<SignalResult> signalGraceful({required int pid}) async => _signal(pid);
+
+  @override
+  Future<SignalResult> signalForce({required int pid}) async {
+    forceSignals.add(pid);
+    return _signal(pid);
+  }
+
+  SignalResult _signal(int pid) => SignalResult(
+    pid: pid,
+    requestedSignal: ShutdownSignal.force,
+    deliveredSignal: ProcessSignal.sigkill,
+    wasRequested: true,
+    attemptedAt: DateTime.utc(2026, 6, 1),
+  );
+}
+
+/// A canned [SpawnedProcess] with a fixed stdout payload and a caller-supplied
+/// [exitCode] future (which may never complete, to simulate a hang).
+class _ProbeProcess implements SpawnedProcess {
+  _ProbeProcess({required this.pid, required List<int> stdoutBytes, required Future<int> exitCode})
+    : _stdoutBytes = stdoutBytes,
+      _exitCode = exitCode;
+
+  @override
+  final int pid;
+
+  final List<int> _stdoutBytes;
+  final Future<int> _exitCode;
+
+  @override
+  Future<int> get exitCode => _exitCode;
+
+  @override
+  Stream<List<int>> get stdout => Stream<List<int>>.value(_stdoutBytes);
+
+  @override
+  Stream<List<int>> get stderr => const Stream<List<int>>.empty();
+
+  @override
+  IOSink get stdin => throw UnimplementedError();
+
+  @override
+  ProcessIdentity get identity => throw UnimplementedError();
+}

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_availability_test.dart
@@ -100,6 +100,47 @@ void main() {
       expect(processes.forceSignals, equals(<int>[99]));
     });
 
+    test("falls back to 'opencode' when --opencode-bin is null", () async {
+      final processes = _ProbeProcessService(
+        spawnError: const ProcessException("opencode", ["--version"], "No such file or directory", 2),
+      );
+
+      final result = await const OpenCodePluginDescriptor().checkAvailability(
+        config: const PluginConfig(
+          values: {"no-auto-start": false, "port": null, "password": "", "opencode-bin": null},
+        ),
+        processes: processes,
+        environment: const <String, String>{},
+      );
+
+      expect(result, isA<PluginUnavailable>());
+      expect((result as PluginUnavailable).message, contains("opencode --version"));
+      expect(processes.spawnedExecutables, equals(<String>["opencode"]));
+    });
+
+    test("reports unavailable when exitCode completes with an error", () async {
+      final completer = Completer<int>();
+      final processes = _ProbeProcessService(
+        process: _ProbeProcess(
+          pid: 11,
+          stdoutBytes: const <int>[],
+          exitCode: completer.future,
+        ),
+      );
+      scheduleMicrotask(() => completer.completeError(StateError("unexpected exit error")));
+
+      final result = await const OpenCodePluginDescriptor().checkAvailability(
+        config: managedConfig,
+        processes: processes,
+        environment: const <String, String>{},
+      );
+
+      expect(result, isA<PluginUnavailable>());
+      expect((result as PluginUnavailable).message, contains("did not respond"));
+      // A process whose exitCode errors is not hung; we should not force-kill it.
+      expect(processes.forceSignals, isEmpty);
+    });
+
     test("uses the configured --opencode-bin path in the spawn and the message", () async {
       final processes = _ProbeProcessService(
         spawnError: const ProcessException("/custom/opencode", ["--version"], "No such file or directory", 2),


### PR DESCRIPTION
## What & why

In its default (managed) mode the bridge spawns the OpenCode CLI. Until now, if `opencode` was missing or not runnable, startup failed **late** — after the bridge self-update, an interactive login, and acquiring the cross-instance startup mutex — and only as a cryptic `ProcessException` logged through `Log.e` (suppressible via `--log-level`), with no install guidance.

This adds an **early, plugin-generic availability gate** that fails fast with a clear, user-facing message before any irreversible step.

## How it works

- **`sesori_plugin_interface`** — new sealed `PluginAvailability` (`PluginAvailable` / `PluginUnavailable(message)`) and a `BridgePluginDescriptor.checkAvailability({config, processes, environment})` hook that defaults to available (plugins needing no local backend are unaffected).
- **`sesori_plugin_opencode`** — `OpenCodePluginDescriptor` probes `<opencode-bin> --version` in managed mode; `--no-auto-start` (attach mode) skips the probe. `ENOENT` / non-zero exit / timeout map to `PluginUnavailable` with a message pointing at `https://opencode.ai/docs#install`; a hung probe is force-killed.
- **`app`** — `BridgeRuntimeRunner.run()` runs the gate **after auth and before `startPlugin()`** (before the startup mutex / single-live-bridge enforcement, so it can never terminate a healthy resident bridge). On `PluginUnavailable` it prints via `Console.error` and exits 1.

Informational commands (`--version`, `--help`, `logout`, `config`) and attach-mode behavior are unchanged.

## Testing

- `dart analyze --fatal-infos` clean in all three changed modules.
- `dart test`: interface **107** passed, opencode **258** passed (incl. 6 new `checkAvailability` branch tests: attach-skip / exit-0 / ENOENT / non-zero / timeout+force-kill / custom `--opencode-bin`), app `runtime/` **89** passed.
- Reviewed by `aristotle-plan-review` (plan) and `aristotle-impl-review` (implementation) — both approved.

No codegen (hand-written sealed type, matching `PluginStatus`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast when the OpenCode CLI is missing or not runnable. The bridge now checks plugin availability early and exits with clear install guidance before any mutex or startup side effects.

- **New Features**
  - `sesori_plugin_interface`: added `PluginAvailability` (`PluginAvailable` / `PluginUnavailable`) and `BridgePluginDescriptor.checkAvailability(...)` (defaults to available).
  - `sesori_plugin_opencode`: in managed mode, probes `<opencode-bin> --version` with a 10s timeout; ENOENT/non‑zero/timeout return `PluginUnavailable` with a docs link. Skipped in `--no-auto-start`. Uses shell on Windows, captures version output, drains stderr, and force‑kills hung probes.
  - `app`: runs the availability gate after auth and before `startPlugin()`/startup mutex; prints the message via `Console.error` and exits 1.
  - Tests cover attach-mode skip, success, ENOENT, non-zero exit, timeout (force‑killed), exitCode error, and custom `--opencode-bin`.

<sup>Written for commit b4bbf5e162b43703ed5e4fb5d87d61822a14c2f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

