### PR TITLE
fix(mobile): bottom-align message timestamp + desktop trackpad peek

### DIFF
--- a/mobile/app/lib/features/session_detail/widgets/message_timestamp_reveal.dart
+++ b/mobile/app/lib/features/session_detail/widgets/message_timestamp_reveal.dart
@@ -13,7 +13,9 @@ import "../../../core/extensions/build_context_x.dart";
 /// `progress * maxReveal` while the timestamp gutter slides in from
 /// off-screen on the right by the same amount: the two meet exactly at
 /// the content's new right edge, so the timestamp never overlaps the
-/// message and never bleeds through transparent rows while closed.
+/// message and never bleeds through transparent rows while closed. The
+/// label is bottom-aligned within the gutter so it reads as belonging to
+/// the foot of its message.
 ///
 /// Rows without a timestamp ([createdAtMs] is null — e.g. the synthetic
 /// retry-error row) still translate in lockstep but render no gutter.
@@ -66,9 +68,12 @@ class MessageTimestampReveal extends StatelessWidget {
                 // right edge when fully revealed.
                 right: -maxReveal * (1 - p),
                 child: Align(
-                  alignment: Alignment.centerLeft,
+                  // Bottom-aligned so the timestamp sits at the foot of the
+                  // message it belongs to (matching the iMessage reveal),
+                  // rather than floating at the row's vertical centre.
+                  alignment: Alignment.bottomLeft,
                   child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    padding: const EdgeInsetsDirectional.fromSTEB(8, 0, 8, 6),
                     child: Text(
                       label,
                       maxLines: 1,

--- a/mobile/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/mobile/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -1,5 +1,7 @@
 import "dart:async";
 
+import "package:flutter/foundation.dart";
+import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
 import "package:flutter_chat_core/flutter_chat_core.dart" as chat_core;
 import "package:flutter_chat_ui/flutter_chat_ui.dart" as chat_ui;
@@ -280,7 +282,7 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
         label: loc.sessionDetailJumpToLatest,
         onTap: () => _follow.animateToEdge(),
       ),
-      // Horizontal "peek" gesture: drag the transcript left to reveal
+      // Horizontal "peek" gesture: slide the transcript left to reveal
       // each message's timestamp on the right. Driven by a raw [Listener]
       // rather than a drag GestureDetector on purpose — a competing
       // horizontal drag recognizer would join the gesture arena and stop
@@ -288,14 +290,25 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
       // which would break small-drag detach. The Listener never joins the
       // arena, so vertical scrolling is untouched; we disambiguate
       // direction ourselves and only steer the reveal on horizontal-
-      // dominant drags. `translucent` so the whole list area is tracked
+      // dominant gestures. `translucent` so the whole list area is tracked
       // while taps and selection still reach the cards below.
+      //
+      // Input source depends on the platform ([_usePointerDragReveal]):
+      //
+      // - Touch (iOS/Android): a finger drag — pointer down/move/up.
+      // - Desktop (macOS/Windows/Linux): a horizontal trackpad/mouse
+      //   gesture — pointer pan-zoom. A button press-and-drag is left
+      //   untouched there so it keeps selecting message text; hijacking it
+      //   for the peek would make text selection impossible.
       child: Listener(
         behavior: HitTestBehavior.translucent,
-        onPointerDown: _onRevealPointerDown,
-        onPointerMove: _onRevealPointerMove,
-        onPointerUp: _onRevealPointerUp,
-        onPointerCancel: _onRevealPointerCancel,
+        onPointerDown: _usePointerDragReveal ? _onRevealPointerDown : null,
+        onPointerMove: _usePointerDragReveal ? _onRevealPointerMove : null,
+        onPointerUp: _usePointerDragReveal ? _onRevealPointerUp : null,
+        onPointerCancel: _usePointerDragReveal ? _onRevealPointerCancel : null,
+        onPointerPanZoomStart: _usePointerDragReveal ? null : _onRevealPanZoomStart,
+        onPointerPanZoomUpdate: _usePointerDragReveal ? null : _onRevealPanZoomUpdate,
+        onPointerPanZoomEnd: _usePointerDragReveal ? null : _onRevealPanZoomEnd,
         child: chat_ui.Chat(
           key: _kListViewKey,
           currentUserId: _kUserAuthorId,
@@ -403,6 +416,27 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
     );
   }
 
+  /// Whether the timestamp peek is driven by a finger drag (pointer
+  /// down/move/up) rather than a horizontal trackpad/mouse pan-zoom.
+  ///
+  /// Touch platforms have no separate pan-zoom stream and no competing
+  /// text-selection drag, so a finger drag is the natural input. Desktop
+  /// platforms reserve button press-and-drag for selecting message text
+  /// and expose the peek through a horizontal trackpad swipe / mouse
+  /// gesture instead.
+  bool get _usePointerDragReveal {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.iOS:
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+        return true;
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+      case TargetPlatform.linux:
+        return false;
+    }
+  }
+
   void _onRevealPointerDown(PointerDownEvent event) {
     // The first pointer owns the peek for its whole lifetime; ignore
     // secondary touches so a stray second finger can't strand the
@@ -464,6 +498,52 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
     if (event.pointer != _revealPointer) return;
     _endReveal();
   }
+
+  // ---------------------------------------------------------------------------
+  // Desktop reveal: horizontal trackpad / mouse pan-zoom. Mirrors the
+  // touch pointer-drag path above (slop, horizontal-dominant gating,
+  // detach suppression, spring-back) but reads the cumulative `pan` and
+  // per-event `panDelta` from the pan-zoom stream instead of raw pointer
+  // positions. Reuses the same engage/reject/started-following latches —
+  // only one input path is wired at a time (see [_usePointerDragReveal]),
+  // so they never overlap.
+  // ---------------------------------------------------------------------------
+
+  void _onRevealPanZoomStart(PointerPanZoomStartEvent event) {
+    _revealEngaged = false;
+    _revealRejected = false;
+    _revealStartedFollowing = _follow.following;
+  }
+
+  void _onRevealPanZoomUpdate(PointerPanZoomUpdateEvent event) {
+    if (_revealRejected) return;
+
+    if (!_revealEngaged) {
+      // Same direction disambiguation as the touch path: only a clear
+      // leftward pan opens the right-hand gutter; vertical, ambiguous and
+      // rightward pans are left for the list's own scroll handling.
+      final dx = event.pan.dx;
+      final dy = event.pan.dy;
+      if (dx.abs() < _kRevealEngageSlop && dy.abs() < _kRevealEngageSlop) return;
+      if (dy.abs() >= dx.abs() || dx > 0) {
+        _revealRejected = true;
+        return;
+      }
+      _revealEngaged = true;
+      _revealController.stop();
+      // The list's scroll plumbing detaches on pan-zoom start; undo that
+      // for a horizontal peek, but only when we began following (see the
+      // touch path for the rationale).
+      if (_revealStartedFollowing) {
+        _follow.suppressDetach();
+      }
+    }
+
+    final next = (_revealController.value - event.panDelta.dx / _kMaxReveal).clamp(0.0, 1.0);
+    _revealController.value = next;
+  }
+
+  void _onRevealPanZoomEnd(PointerPanZoomEndEvent event) => _endReveal();
 
   void _endReveal() {
     _revealPointer = null;

--- a/mobile/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/mobile/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -1,6 +1,5 @@
 import "dart:async";
 
-import "package:flutter/foundation.dart";
 import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
 import "package:flutter_chat_core/flutter_chat_core.dart" as chat_core;
@@ -293,22 +292,27 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
       // dominant gestures. `translucent` so the whole list area is tracked
       // while taps and selection still reach the cards below.
       //
-      // Input source depends on the platform ([_usePointerDragReveal]):
+      // Input source is chosen by the pointer's *device kind*, not the
+      // OS — so a desktop touchscreen still peeks by finger and an
+      // attached mouse on mobile still selects text:
       //
-      // - Touch (iOS/Android): a finger drag — pointer down/move/up.
-      // - Desktop (macOS/Windows/Linux): a horizontal trackpad/mouse
-      //   gesture — pointer pan-zoom. A button press-and-drag is left
-      //   untouched there so it keeps selecting message text; hijacking it
-      //   for the peek would make text selection impossible.
+      // - Touch / stylus: a finger drag — pointer down/move/up.
+      // - Trackpad: a horizontal two-finger swipe — pointer pan-zoom.
+      // - Mouse: a button press-and-drag is left untouched (the pointer
+      //   path ignores the mouse kind) so it keeps selecting message
+      //   text; hijacking it for the peek would make selection impossible.
+      //
+      // Both handler sets are always bound; each only fires for its own
+      // device kind, so they never compete.
       child: Listener(
         behavior: HitTestBehavior.translucent,
-        onPointerDown: _usePointerDragReveal ? _onRevealPointerDown : null,
-        onPointerMove: _usePointerDragReveal ? _onRevealPointerMove : null,
-        onPointerUp: _usePointerDragReveal ? _onRevealPointerUp : null,
-        onPointerCancel: _usePointerDragReveal ? _onRevealPointerCancel : null,
-        onPointerPanZoomStart: _usePointerDragReveal ? null : _onRevealPanZoomStart,
-        onPointerPanZoomUpdate: _usePointerDragReveal ? null : _onRevealPanZoomUpdate,
-        onPointerPanZoomEnd: _usePointerDragReveal ? null : _onRevealPanZoomEnd,
+        onPointerDown: _onRevealPointerDown,
+        onPointerMove: _onRevealPointerMove,
+        onPointerUp: _onRevealPointerUp,
+        onPointerCancel: _onRevealPointerCancel,
+        onPointerPanZoomStart: _onRevealPanZoomStart,
+        onPointerPanZoomUpdate: _onRevealPanZoomUpdate,
+        onPointerPanZoomEnd: _onRevealPanZoomEnd,
         child: chat_ui.Chat(
           key: _kListViewKey,
           currentUserId: _kUserAuthorId,
@@ -416,32 +420,16 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
     );
   }
 
-  /// Whether the timestamp peek is driven by a finger drag (pointer
-  /// down/move/up) rather than a horizontal trackpad/mouse pan-zoom.
-  ///
-  /// Touch platforms have no separate pan-zoom stream and no competing
-  /// text-selection drag, so a finger drag is the natural input. Desktop
-  /// platforms reserve button press-and-drag for selecting message text
-  /// and expose the peek through a horizontal trackpad swipe / mouse
-  /// gesture instead.
-  bool get _usePointerDragReveal {
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.iOS:
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-        return true;
-      case TargetPlatform.macOS:
-      case TargetPlatform.windows:
-      case TargetPlatform.linux:
-        return false;
-    }
-  }
-
   void _onRevealPointerDown(PointerDownEvent event) {
     // The first pointer owns the peek for its whole lifetime; ignore
     // secondary touches so a stray second finger can't strand the
     // gesture state (and the detach suppression) on the wrong pointer.
     if (_revealPointer != null) return;
+    // A mouse press-and-drag is the text-selection gesture, so never
+    // hijack it for the peek — regardless of OS. (A trackpad click also
+    // reports as a mouse pointer; its two-finger swipe arrives separately
+    // via the pan-zoom path.) Finger and stylus drags drive the peek.
+    if (event.kind == PointerDeviceKind.mouse) return;
     _revealPointer = event.pointer;
     _revealStart = event.position;
     _revealEngaged = false;
@@ -500,13 +488,13 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
   }
 
   // ---------------------------------------------------------------------------
-  // Desktop reveal: horizontal trackpad / mouse pan-zoom. Mirrors the
-  // touch pointer-drag path above (slop, horizontal-dominant gating,
-  // detach suppression, spring-back) but reads the cumulative `pan` and
+  // Trackpad reveal: horizontal two-finger pan-zoom. Mirrors the touch
+  // pointer-drag path above (slop, horizontal-dominant gating, detach
+  // suppression, spring-back) but reads the cumulative `pan` and
   // per-event `panDelta` from the pan-zoom stream instead of raw pointer
   // positions. Reuses the same engage/reject/started-following latches —
-  // only one input path is wired at a time (see [_usePointerDragReveal]),
-  // so they never overlap.
+  // pan-zoom (trackpad) and pointer drags (finger/stylus) never arrive
+  // from the same device at once, so they never overlap.
   // ---------------------------------------------------------------------------
 
   void _onRevealPanZoomStart(PointerPanZoomStartEvent event) {

--- a/mobile/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/mobile/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -132,6 +132,15 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
   bool _revealRejected = false;
   bool _revealStartedFollowing = false;
 
+  /// True while a trackpad pan-zoom owns the reveal. The pointer-drag and
+  /// pan-zoom paths share the engage/reject latches above, so exactly one
+  /// may drive the peek at a time: whichever gesture starts first claims
+  /// ownership (`_revealPointer` for finger/stylus, this flag for
+  /// trackpad) and the other path no-ops until it releases. Guards against
+  /// a stray pan on a touchscreen-plus-trackpad device resetting the
+  /// latches — or springing the gutter shut — mid touch drag.
+  bool _revealPanActive = false;
+
   /// Snapshot taken at the moment of detach. `null` means "not frozen
   /// — use live `widget.*` props".
   _DetachedSnapshot? _snapshot;
@@ -425,6 +434,9 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
     // secondary touches so a stray second finger can't strand the
     // gesture state (and the detach suppression) on the wrong pointer.
     if (_revealPointer != null) return;
+    // A trackpad pan already owns the reveal — don't let a concurrent
+    // touch claim the shared latches out from under it.
+    if (_revealPanActive) return;
     // A mouse press-and-drag is the text-selection gesture, so never
     // hijack it for the peek — regardless of OS. (A trackpad click also
     // reports as a mouse pointer; its two-finger swipe arrives separately
@@ -492,19 +504,24 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
   // pointer-drag path above (slop, horizontal-dominant gating, detach
   // suppression, spring-back) but reads the cumulative `pan` and
   // per-event `panDelta` from the pan-zoom stream instead of raw pointer
-  // positions. Reuses the same engage/reject/started-following latches —
-  // pan-zoom (trackpad) and pointer drags (finger/stylus) never arrive
-  // from the same device at once, so they never overlap.
+  // positions. Reuses the same engage/reject/started-following latches as
+  // the pointer path, so a [_revealPanActive] / `_revealPointer`
+  // ownership handshake keeps the two from clobbering each other when a
+  // device has both a touchscreen and a trackpad.
   // ---------------------------------------------------------------------------
 
   void _onRevealPanZoomStart(PointerPanZoomStartEvent event) {
+    // A finger/stylus drag already owns the reveal — don't reset its
+    // latches from under it (see [_revealPanActive]).
+    if (_revealPointer != null) return;
+    _revealPanActive = true;
     _revealEngaged = false;
     _revealRejected = false;
     _revealStartedFollowing = _follow.following;
   }
 
   void _onRevealPanZoomUpdate(PointerPanZoomUpdateEvent event) {
-    if (_revealRejected) return;
+    if (!_revealPanActive || _revealRejected) return;
 
     if (!_revealEngaged) {
       // Same direction disambiguation as the touch path: only a clear
@@ -531,10 +548,15 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
     _revealController.value = next;
   }
 
-  void _onRevealPanZoomEnd(PointerPanZoomEndEvent event) => _endReveal();
+  void _onRevealPanZoomEnd(PointerPanZoomEndEvent event) {
+    // Ignore a pan that never claimed the reveal (a finger drag owned it).
+    if (!_revealPanActive) return;
+    _endReveal();
+  }
 
   void _endReveal() {
     _revealPointer = null;
+    _revealPanActive = false;
     _revealEngaged = false;
     _revealRejected = false;
     _follow.releaseDetachSuppression();

--- a/mobile/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -728,6 +728,60 @@ void main() {
     expect(tester.getTopLeft(textFinder).dx, closeTo(restX, 0.5));
   });
 
+  testWidgets("a trackpad pan during a touch peek does not hijack or cancel it", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final created = DateTime.now().millisecondsSinceEpoch;
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        initialMessages: [
+          for (var i = 0; i < 12; i++)
+            _message(
+              messageId: "u$i",
+              role: "user",
+              text: _multilineText(label: "Message $i", lines: 6),
+              createdAtMs: created,
+            ),
+        ],
+        initialStreamingText: const {},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final textFinder = find.textContaining("Message 11").first;
+    final restX = tester.getTopLeft(textFinder).dx;
+
+    // A finger drag engages the peek.
+    final finger = await tester.startGesture(const Offset(450, 350));
+    await finger.moveBy(const Offset(-160, 0));
+    await tester.pump();
+    final peekedX = tester.getTopLeft(textFinder).dx;
+    expect(peekedX, lessThan(restX));
+
+    // On a device with both a touchscreen and a trackpad, a stray trackpad
+    // pan-zoom must not seize the shared reveal state from the active touch
+    // drag — the finger owns the peek until it lifts.
+    final trackpad = await tester.createGesture(kind: PointerDeviceKind.trackpad);
+    await trackpad.panZoomStart(const Offset(200, 300));
+    await trackpad.panZoomUpdate(const Offset(200, 300), pan: const Offset(-120, 0));
+    await trackpad.panZoomEnd();
+    // Settle so that any spurious spring-back the stray pan triggered would
+    // run to completion (and fail the assertion) rather than hide behind an
+    // in-flight animation.
+    await tester.pumpAndSettle();
+    expect(
+      tester.getTopLeft(textFinder).dx,
+      peekedX,
+      reason: "trackpad pan must not hijack or close the active touch peek",
+    );
+
+    // The owning finger lifts: now it springs back.
+    await finger.up();
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(textFinder).dx, closeTo(restX, 0.5));
+  });
+
   testWidgets("a rightward drag does not engage the peek (gutter is on the right)", (tester) async {
     await tester.binding.setSurfaceSize(const Size(900, 700));
     addTearDown(() => tester.binding.setSurfaceSize(null));

--- a/mobile/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -1,4 +1,3 @@
-import "package:flutter/foundation.dart";
 import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
@@ -765,101 +764,90 @@ void main() {
     await tester.pumpAndSettle();
   });
 
-  testWidgets("on desktop a mouse click-and-drag does not peek (left free for text selection)", (tester) async {
+  testWidgets("a mouse click-and-drag does not peek (left free for text selection)", (tester) async {
     await tester.binding.setSurfaceSize(const Size(900, 700));
     addTearDown(() => tester.binding.setSurfaceSize(null));
-    // Reset in `finally` rather than `addTearDown`: the binding's
-    // end-of-test invariant check (which runs before tear-downs) asserts
-    // foundation debug vars are unset.
-    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
-    try {
-      final created = DateTime.now().millisecondsSinceEpoch;
-      await tester.pumpWidget(
-        _SessionDetailMessageListHarness(
-          initialMessages: [
-            for (var i = 0; i < 12; i++)
-              _message(
-                messageId: "u$i",
-                role: "user",
-                text: _multilineText(label: "Message $i", lines: 6),
-                createdAtMs: created,
-              ),
-          ],
-          initialStreamingText: const {},
-        ),
-      );
-      await tester.pumpAndSettle();
 
-      final textFinder = find.textContaining("Message 11").first;
-      final restX = tester.getTopLeft(textFinder).dx;
+    final created = DateTime.now().millisecondsSinceEpoch;
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        initialMessages: [
+          for (var i = 0; i < 12; i++)
+            _message(
+              messageId: "u$i",
+              role: "user",
+              text: _multilineText(label: "Message $i", lines: 6),
+              createdAtMs: created,
+            ),
+        ],
+        initialStreamingText: const {},
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      // A mouse press-and-drag is the text-selection gesture on desktop;
-      // it must NOT slide the transcript, or selecting message text
-      // becomes impossible.
-      final gesture = await tester.startGesture(
-        tester.getCenter(find.byKey(_listViewKey)),
-        kind: PointerDeviceKind.mouse,
-      );
-      await gesture.moveBy(const Offset(-160, 0));
-      await tester.pump();
+    final textFinder = find.textContaining("Message 11").first;
+    final restX = tester.getTopLeft(textFinder).dx;
 
-      expect(tester.getTopLeft(textFinder).dx, restX, reason: "click-drag must not open the gutter on desktop");
+    // A mouse press-and-drag is the text-selection gesture; it must NOT
+    // slide the transcript, or selecting message text becomes impossible.
+    // Gated by pointer device kind, so this holds on every platform.
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(_listViewKey)),
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.moveBy(const Offset(-160, 0));
+    await tester.pump();
 
-      await gesture.up();
-      await tester.pumpAndSettle();
-    } finally {
-      debugDefaultTargetPlatformOverride = null;
-    }
+    expect(tester.getTopLeft(textFinder).dx, restX, reason: "mouse click-drag must not open the gutter");
+
+    await gesture.up();
+    await tester.pumpAndSettle();
   });
 
-  testWidgets("on desktop a horizontal trackpad pan peeks timestamps without scrolling", (tester) async {
+  testWidgets("a horizontal trackpad pan peeks timestamps without scrolling", (tester) async {
     await tester.binding.setSurfaceSize(const Size(900, 700));
     addTearDown(() => tester.binding.setSurfaceSize(null));
-    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
-    try {
-      final created = DateTime.now().millisecondsSinceEpoch;
-      await tester.pumpWidget(
-        _SessionDetailMessageListHarness(
-          initialMessages: [
-            for (var i = 0; i < 12; i++)
-              _message(
-                messageId: "u$i",
-                role: "user",
-                text: _multilineText(label: "Message $i", lines: 6),
-                createdAtMs: created,
-              ),
-          ],
-          initialStreamingText: const {},
-        ),
-      );
-      await tester.pumpAndSettle();
 
-      final textFinder = find.textContaining("Message 11").first;
-      final restX = tester.getTopLeft(textFinder).dx;
-      final restPixels = _position(tester).pixels;
+    final created = DateTime.now().millisecondsSinceEpoch;
+    await tester.pumpWidget(
+      _SessionDetailMessageListHarness(
+        initialMessages: [
+          for (var i = 0; i < 12; i++)
+            _message(
+              messageId: "u$i",
+              role: "user",
+              text: _multilineText(label: "Message $i", lines: 6),
+              createdAtMs: created,
+            ),
+        ],
+        initialStreamingText: const {},
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      // A horizontal two-finger trackpad swipe (pan-zoom) is the desktop
-      // peek gesture — it slides the content left without scrolling the
-      // list or detaching follow mode.
-      final center = tester.getCenter(find.byKey(_listViewKey));
-      final gesture = await tester.createGesture(kind: PointerDeviceKind.trackpad);
-      await gesture.panZoomStart(center);
-      await gesture.panZoomUpdate(center, pan: const Offset(-160, 0));
-      await tester.pump();
+    final textFinder = find.textContaining("Message 11").first;
+    final restX = tester.getTopLeft(textFinder).dx;
+    final restPixels = _position(tester).pixels;
 
-      expect(
-        tester.getTopLeft(textFinder).dx,
-        lessThan(restX),
-        reason: "horizontal trackpad pan should slide the content to expose the timestamp",
-      );
-      expect(_position(tester).pixels, restPixels, reason: "horizontal peek must not scroll the list");
-      expect(find.byKey(_jumpToLatestKey), findsNothing, reason: "horizontal peek must not detach follow mode");
+    // A horizontal two-finger trackpad swipe (pan-zoom) is the trackpad
+    // peek gesture — it slides the content left without scrolling the
+    // list or detaching follow mode.
+    final center = tester.getCenter(find.byKey(_listViewKey));
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.trackpad);
+    await gesture.panZoomStart(center);
+    await gesture.panZoomUpdate(center, pan: const Offset(-160, 0));
+    await tester.pump();
 
-      await gesture.panZoomEnd();
-      await tester.pumpAndSettle();
-      expect(tester.getTopLeft(textFinder).dx, closeTo(restX, 0.5));
-    } finally {
-      debugDefaultTargetPlatformOverride = null;
-    }
+    expect(
+      tester.getTopLeft(textFinder).dx,
+      lessThan(restX),
+      reason: "horizontal trackpad pan should slide the content to expose the timestamp",
+    );
+    expect(_position(tester).pixels, restPixels, reason: "horizontal peek must not scroll the list");
+    expect(find.byKey(_jumpToLatestKey), findsNothing, reason: "horizontal peek must not detach follow mode");
+
+    await gesture.panZoomEnd();
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(textFinder).dx, closeTo(restX, 0.5));
   });
 }

--- a/mobile/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
+++ b/mobile/app/test/features/session_detail/widgets/session_detail_message_list_test.dart
@@ -1,3 +1,4 @@
+import "package:flutter/foundation.dart";
 import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
@@ -762,5 +763,103 @@ void main() {
 
     await gesture.up();
     await tester.pumpAndSettle();
+  });
+
+  testWidgets("on desktop a mouse click-and-drag does not peek (left free for text selection)", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    // Reset in `finally` rather than `addTearDown`: the binding's
+    // end-of-test invariant check (which runs before tear-downs) asserts
+    // foundation debug vars are unset.
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    try {
+      final created = DateTime.now().millisecondsSinceEpoch;
+      await tester.pumpWidget(
+        _SessionDetailMessageListHarness(
+          initialMessages: [
+            for (var i = 0; i < 12; i++)
+              _message(
+                messageId: "u$i",
+                role: "user",
+                text: _multilineText(label: "Message $i", lines: 6),
+                createdAtMs: created,
+              ),
+          ],
+          initialStreamingText: const {},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final textFinder = find.textContaining("Message 11").first;
+      final restX = tester.getTopLeft(textFinder).dx;
+
+      // A mouse press-and-drag is the text-selection gesture on desktop;
+      // it must NOT slide the transcript, or selecting message text
+      // becomes impossible.
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byKey(_listViewKey)),
+        kind: PointerDeviceKind.mouse,
+      );
+      await gesture.moveBy(const Offset(-160, 0));
+      await tester.pump();
+
+      expect(tester.getTopLeft(textFinder).dx, restX, reason: "click-drag must not open the gutter on desktop");
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
+  });
+
+  testWidgets("on desktop a horizontal trackpad pan peeks timestamps without scrolling", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(900, 700));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    try {
+      final created = DateTime.now().millisecondsSinceEpoch;
+      await tester.pumpWidget(
+        _SessionDetailMessageListHarness(
+          initialMessages: [
+            for (var i = 0; i < 12; i++)
+              _message(
+                messageId: "u$i",
+                role: "user",
+                text: _multilineText(label: "Message $i", lines: 6),
+                createdAtMs: created,
+              ),
+          ],
+          initialStreamingText: const {},
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final textFinder = find.textContaining("Message 11").first;
+      final restX = tester.getTopLeft(textFinder).dx;
+      final restPixels = _position(tester).pixels;
+
+      // A horizontal two-finger trackpad swipe (pan-zoom) is the desktop
+      // peek gesture — it slides the content left without scrolling the
+      // list or detaching follow mode.
+      final center = tester.getCenter(find.byKey(_listViewKey));
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.trackpad);
+      await gesture.panZoomStart(center);
+      await gesture.panZoomUpdate(center, pan: const Offset(-160, 0));
+      await tester.pump();
+
+      expect(
+        tester.getTopLeft(textFinder).dx,
+        lessThan(restX),
+        reason: "horizontal trackpad pan should slide the content to expose the timestamp",
+      );
+      expect(_position(tester).pixels, restPixels, reason: "horizontal peek must not scroll the list");
+      expect(find.byKey(_jumpToLatestKey), findsNothing, reason: "horizontal peek must not detach follow mode");
+
+      await gesture.panZoomEnd();
+      await tester.pumpAndSettle();
+      expect(tester.getTopLeft(textFinder).dx, closeTo(restX, 0.5));
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
   });
 }


### PR DESCRIPTION
## Summary

Follow-up fixes to the per-message timestamp peek (#275, now on `main`):

- **Timestamp at the bottom of each message.** The revealed timestamp was vertically centered in its gutter; it's now bottom-aligned (`Alignment.bottomLeft` + small bottom inset) so it reads as belonging to the foot of its message — matching the iMessage interaction.
- **Desktop uses a trackpad/mouse gesture instead of click-and-drag.** On desktop (macOS/Windows/Linux) a button press-and-drag *is* the text-selection gesture, so the old pointer-drag peek hijacked it and made text selection impossible. The peek is now driven by a horizontal trackpad/mouse **pan-zoom** gesture, leaving click-and-drag free for selecting message text. Touch platforms (iOS/Android) keep the finger-drag peek unchanged.

## Implementation

A new `_usePointerDragReveal` getter splits the input source by platform. The desktop pan-zoom handlers (`onPointerPanZoomStart/Update/End`) mirror the touch path exactly — same engage slop, horizontal-dominant gating (only a leftward gesture opens the right-hand gutter), detach suppression so a peek doesn't flip follow mode, and spring-back on release — reading `event.pan`/`event.panDelta` instead of raw pointer positions.

## Testing

- `flutter test test/features/session_detail/widgets/ test/core/extensions/build_context_x_test.dart` — all pass.
- Added two desktop tests (under a `macOS` platform override): a mouse click-and-drag does **not** peek (selection stays usable), and a horizontal trackpad pan **does** peek without scrolling or detaching.
- Existing touch-drag tests are unaffected (Flutter test default platform is Android → finger-drag path).

Not yet verified on a real macOS desktop build — widget-test verified only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bottom-aligned per‑message timestamps and switched desktop reveal to trackpad pan‑zoom, gated by pointer device kind so mouse drag stays for text selection. Touch drag is unchanged; mixed‑input devices work correctly and trackpad pans can’t hijack an active touch peek.

- **Bug Fixes**
  - Timestamp label is bottom‑aligned in its gutter with a small bottom inset, matching iMessage.
  - Peek uses trackpad pan‑zoom and finger/stylus pointer‑drag, both always bound and gated by pointer device kind (not OS). Mouse click‑drag never peeks; only leftward, horizontal‑dominant pans reveal; vertical scroll and follow mode remain intact.
  - Added a gesture‑ownership guard so the first gesture (touch or trackpad) owns the reveal. Tests use `PointerDeviceKind` and cover mouse no‑peek, trackpad peek without scroll/detach, and “trackpad during touch” non‑hijack.

<sup>Written for commit fd360cf90d9027b6b002307522a75553c32f1140. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

