### PR TITLE
fix(ci): always set iOS "What's New" before production submit

### DIFF
--- a/.github/workflows/submit-release.yml
+++ b/.github/workflows/submit-release.yml
@@ -231,6 +231,13 @@ jobs:
           # nothing (binary submit only). Empty also when the checkout was skipped.
           IOS_METADATA_PATH:                 ${{ steps.gate.outputs.publish == 'true' && format('{0}/store-metadata/ios/metadata', github.workspace) || '' }}
           IOS_SCREENSHOTS_PATH:              ${{ steps.gate.outputs.publish == 'true' && format('{0}/store-metadata/ios/screenshots', github.workspace) || '' }}
+          # Release notes ("What's New") are version-scoped: Apple requires them on
+          # every new version before review, even when the listing copy is unchanged
+          # and the gated upload above is skipped. Expose the cloned metadata dir
+          # whenever the repo was checked out (independent of the publish gate) so
+          # submit_ios can apply the fixed release_notes.txt to the version being
+          # submitted. Empty when no metadata repo is configured (checkout skipped).
+          IOS_RELEASE_NOTES_PATH:            ${{ steps.cometa.outcome == 'success' && format('{0}/store-metadata/ios/metadata', github.workspace) || '' }}
         run: bundle exec fastlane submit_ios
 
       - name: Summary

--- a/docs/STORE_METADATA.md
+++ b/docs/STORE_METADATA.md
@@ -95,10 +95,22 @@ the lane separates them too:
 - **Pass 1** — metadata only (`submit_for_review: false`). A metadata error here
   fails *before* the build is attached/submitted, so it can never orphan a
   half-submitted version. The already-uploaded TestFlight binary is never
-  touched (`skip_binary_upload: true`).
+  touched (`skip_binary_upload: true`). Runs only when the listing is being
+  (re)published (HEAD untagged).
+- **Pass 1b** — release notes only (`submit_for_review: false`). Runs when Pass 1
+  is skipped (listing unchanged). "What's New" (`whatsNew`) is **version-scoped**:
+  App Store Connect requires it on every new version before review, even when the
+  store copy is identical to the last release. Pass 1 uploads it as part of the
+  full listing, but when that's skipped this pass applies just the fixed
+  `release_notes.txt` (from a temp tree containing only release notes, so nothing
+  else in the unchanged listing is touched). Without it, Pass 2 fails with
+  `appStoreVersions ... is not in valid state ... You must provide a value for
+  the attribute 'whatsNew'`. The version's release notes path is exposed via
+  `IOS_RELEASE_NOTES_PATH`, set independently of the publish gate.
 - **Pass 2** — attach the existing build (`build_number:`) and submit for review
-  (`skip_metadata: true`, since pass 1 handled it). `automatic_release: false`,
-  so a human approves the actual release after Apple's review.
+  (`skip_metadata: true`, since the earlier passes handled it).
+  `automatic_release: false`, so a human approves the actual release after
+  Apple's review.
 
 ### Android — one atomic edit (`submit_android`)
 
@@ -124,8 +136,11 @@ Two distinct sources, by intent:
   iOS uploads `ios/metadata/<locale>/release_notes.txt`; Android falls back to
   `android/<locale>/changelogs/default.txt` (a production promotion never has a
   matching `<versionCode>.txt`). **Keep those two files identical** — that single
-  copy is the production "What's new" every release. It is intentionally NOT
-  per-release: there is nothing to edit at submit time.
+  copy is the production "What's new" every release. The *text* is not edited per
+  release, but iOS **re-applies it to every new version** (App Store Connect
+  requires `whatsNew` on each version before review, even when the listing is
+  otherwise unchanged — see Pass 1b above). Keep a non-empty `release_notes.txt`
+  for every iOS locale, or production submits will be rejected.
 - **Test builds (TestFlight + Play internal): the build commit's message.**
   `deploy_testflight` / `deploy_internal` set the changelog to the message of the
   commit the build was made from, plus a `commit: <sha>` trailer, truncated to

--- a/mobile/app/ios/fastlane/Fastfile
+++ b/mobile/app/ios/fastlane/Fastfile
@@ -77,6 +77,33 @@ def build_commit_changelog(max_length: nil)
   text
 end
 
+# App Store "What's New" (the `whatsNew` attribute) is VERSION-scoped: every new
+# marketing version must carry release notes before Apple accepts it for review,
+# even when the copy is identical to the previous release. Our submit flow only
+# uploads the listing (release notes included) when the store copy changed (see
+# submit-release.yml's tag-driven metadata gate). On the common "version bump,
+# same copy" release that upload is skipped, leaving the new version with empty
+# release notes so `submit_for_review` fails with:
+#   appStoreVersions ... is not in valid state. ... You must provide a value for
+#   the attribute 'whatsNew' with this request
+# This reads the fixed production release notes (ios/metadata/<locale>/
+# release_notes.txt) from the cloned metadata repo into a { locale => text }
+# hash so submit_ios can apply them to the version under review. Returns nil
+# when the directory is unset or holds no non-empty release_notes.txt.
+def release_notes_by_locale(dir)
+  return nil if dir.nil?
+
+  notes = {}
+  Dir.children(dir).each do |entry|
+    path = File.join(dir, entry, "release_notes.txt")
+    next unless File.file?(path)
+
+    text = File.read(path).strip
+    notes[entry] = text unless text.empty?
+  end
+  notes.empty? ? nil : notes
+end
+
 platform :ios do
   # Reads the marketing version (e.g. "1.0.6") from pubspec.yaml two dirs up.
   # The build-number suffix after `+` is intentionally ignored — store APIs
@@ -258,6 +285,50 @@ platform :ios do
           meta_opts[:overwrite_screenshots] = true # deterministic set in the targeted locales
         end
         deliver(meta_opts)
+      end
+
+      # Pass 1b — release notes only. "What's New" (the `whatsNew` attribute) is
+      # version-scoped: Apple requires it on every NEW version before review,
+      # even when the listing copy is unchanged. Pass 1 only uploads it when the
+      # full listing is (re)published (metadata_dir present); on the common
+      # "version bump, same copy" release that pass is skipped, so we apply the
+      # fixed production release_notes.txt here. IOS_RELEASE_NOTES_PATH points at
+      # the cloned metadata repo regardless of the publish gate (see
+      # submit-release.yml). Uploaded from a temp tree holding only
+      # release_notes.txt, with submit_for_review:false, so nothing else in the
+      # unchanged listing is touched and a metadata error can't orphan a
+      # half-submitted version. Without this, Pass 2 fails with
+      # "You must provide a value for the attribute 'whatsNew'".
+      if metadata_dir.nil?
+        notes = release_notes_by_locale(metadata_dir_from_env("IOS_RELEASE_NOTES_PATH"))
+        if notes
+          require "tmpdir"
+          require "fileutils"
+          Dir.mktmpdir("ios_release_notes") do |notes_dir|
+            notes.each do |locale, text|
+              FileUtils.mkdir_p(File.join(notes_dir, locale))
+              File.write(File.join(notes_dir, locale, "release_notes.txt"), text)
+            end
+            UI.message("Applying release notes (#{notes.keys.join(', ')}) to v#{version} before submission")
+            deliver(
+              api_key: api_key,
+              app_version: version,
+              metadata_path: notes_dir,
+              skip_binary_upload: true,
+              skip_screenshots: true,
+              skip_metadata: false,
+              submit_for_review: false,
+              force: true,
+              run_precheck_before_submit: false
+            )
+          end
+        else
+          UI.important(
+            "No release_notes.txt in the metadata repo — submitting without setting " \
+            "'What's New'. If this version has none on App Store Connect yet, Apple " \
+            "will reject the submission."
+          )
+        end
       end
 
       # Pass 2 — attach the already-uploaded build and submit for review.

--- a/mobile/app/ios/fastlane/Fastfile
+++ b/mobile/app/ios/fastlane/Fastfile
@@ -300,7 +300,8 @@ platform :ios do
       # half-submitted version. Without this, Pass 2 fails with
       # "You must provide a value for the attribute 'whatsNew'".
       if metadata_dir.nil?
-        notes = release_notes_by_locale(metadata_dir_from_env("IOS_RELEASE_NOTES_PATH"))
+        release_notes_dir = metadata_dir_from_env("IOS_RELEASE_NOTES_PATH")
+        notes = release_notes_by_locale(release_notes_dir)
         if notes
           require "tmpdir"
           require "fileutils"
@@ -322,7 +323,7 @@ platform :ios do
               run_precheck_before_submit: false
             )
           end
-        else
+        elsif release_notes_dir
           UI.important(
             "No release_notes.txt in the metadata repo — submitting without setting " \
             "'What's New'. If this version has none on App Store Connect yet, Apple " \


### PR DESCRIPTION
## Problem

The iOS production submission [failed](https://github.com/sesori-ai/sesori_apps_monorepo/actions/runs/27573515939/job/81515831170) (build 108 / v1.0.9). The visible error is the generic spaceship wrapper:

```
appStoreVersions with id 'b43e6e48-...' is not in valid state.
- This resource cannot be reviewed, please check associated errors to see why.
```

The **actual** associated error (next line in the log) is the real cause:

```
The provided entity is missing a required attribute
- You must provide a value for the attribute 'whatsNew' with this request
```

The version 1.0.9 had **no "What's New" release notes** when `submit_for_review` ran, so Apple rejected the submission.

**This is not an App Store Connect API change and not a fastlane bug** — it's a gap in our own submit logic. (Cross-checked against fastlane issues [#20566](https://github.com/fastlane/fastlane/issues/20566), [#20612](https://github.com/fastlane/fastlane/issues/20612), [#20652](https://github.com/fastlane/fastlane/issues/20652) — all the same missing-`whatsNew` requirement.)

## Root cause

`submit_ios` uploads release notes only as part of the **full listing** upload (Pass 1), which runs **only when the store-metadata listing changed** (`submit-release.yml`'s tag-driven gate, `publish=true`). But App Store Connect requires the `whatsNew` attribute on **every new version** before it can be reviewed — it is version-scoped state, not account-scoped.

On the common **"version bump, same store copy"** release, the metadata HEAD is still `v*`-tagged → the gate sets `publish=false` → Pass 1 is skipped → the new version is created with **empty release notes** → submission fails.

The retry "succeeding" 13 minutes later was misleading: attempt 2 had the **identical** gate decision (`publish=false`, no release-notes upload), so it only passed because someone entered "What's New" **manually in App Store Connect** between attempts.

This would fail deterministically on most releases (store copy rarely changes between versions).

## Fix

Add a **release-notes-only pass (Pass 1b)** in `submit_ios` that runs when the full-listing upload is skipped. It applies the fixed production `release_notes.txt` from the cloned metadata repo to the version being submitted, uploaded from a temp tree containing **only** release notes (`submit_for_review: false`, `skip_screenshots: true`) so nothing else in the unchanged listing is touched and a metadata error can't orphan a half-submitted version.

The metadata path is now exposed via a new `IOS_RELEASE_NOTES_PATH` env var, set whenever the metadata repo was checked out — **independent of the publish gate**.

### Changes
- `mobile/app/ios/fastlane/Fastfile` — `release_notes_by_locale` helper + Pass 1b.
- `.github/workflows/submit-release.yml` — `IOS_RELEASE_NOTES_PATH` (gate-independent).
- `docs/STORE_METADATA.md` — document Pass 1b and the per-version `whatsNew` requirement.

## Behaviour matrix
| Scenario | Before | After |
|---|---|---|
| Listing changed (`publish=true`) | Pass 1 uploads notes → OK | unchanged (Pass 1b skipped) |
| Listing unchanged (`publish=false`) | **no notes → submit fails** | Pass 1b applies fixed notes → OK |
| No metadata repo configured | no notes (unchanged) | no notes (unchanged) |

## Testing
- `ruby -c Fastfile` → Syntax OK; workflow YAML validated.
- Verified against fastlane 2.236.1 `deliver` source: `skip_metadata: true` short-circuits all metadata incl. release notes (`upload_metadata.rb:95`); `release_notes` → `whats_new` (`:14`); release notes required for updates, skipped for first version (`:152`). `Loader.language_folders` is `Dir.glob`-based, so the temp-tree path uploads exactly the release notes present.

Full-pipeline verification requires a real production submit (needs `store-production` approval + a build pending review).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always set iOS “What’s New” before production submit so App Store review doesn’t reject versions when the listing is unchanged. Adds a release-notes-only pass and exposes `IOS_RELEASE_NOTES_PATH` in CI. Also suppresses a misleading warning when no metadata repo is configured.

- **Bug Fixes**
  - Added Pass 1b in `mobile/app/ios/fastlane/Fastfile` to upload only release notes when the full listing upload is skipped (temp tree, `submit_for_review: false`, `skip_screenshots: true`).
  - Set `IOS_RELEASE_NOTES_PATH` in `.github/workflows/submit-release.yml` regardless of the publish gate, pointing to the cloned metadata dir when available.
  - Warn only when a metadata repo exists but lacks `release_notes.txt`; stay silent if `IOS_RELEASE_NOTES_PATH` is unset.
  - Updated `docs/STORE_METADATA.md` to document Pass 1b and the per-version `whatsNew` requirement.

<sup>Written for commit c5e5fe5bb5785898749c79b57693d1146465c95a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

