### PR TITLE
chore: weekly dependency update (2026-06-16)

### DIFF
--- a/bridge/sesori_plugin_runtime/pubspec.yaml
+++ b/bridge/sesori_plugin_runtime/pubspec.yaml
@@ -16,4 +16,4 @@ dev_dependencies:
   freezed: ^3.2.5
   json_serializable: ^6.14.0
   build_runner: any
-  test: ^1.25.0
+  test: ^1.31.1

--- a/mobile/app/pubspec.yaml
+++ b/mobile/app/pubspec.yaml
@@ -65,7 +65,7 @@ dependencies:
   universal_platform: ^1.1.0
   record: ^7.1.0
   path: any
-  path_provider: ^2.1.5
+  path_provider: ^2.1.6
   re_highlight: ^0.0.3
   wakelock_plus: ^1.6.1
   firebase_core: ^4.10.0

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1048,10 +1048,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   path_provider_android:
     dependency: transitive
     description:
@@ -1080,10 +1080,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   path_provider_windows:
     dependency: transitive
     description:


### PR DESCRIPTION
## Weekly dependency update

Automated run of the `update-dependencies` workflow.

### Changed
- **path_provider** floor `^2.1.5` → `^2.1.6` (`mobile/app`) — pulls `path_provider_platform_interface` 2.1.2 → 2.1.3 in the mobile workspace lock.
- **test** floor `^1.25.0` → `^1.31.1` (`bridge/sesori_plugin_runtime`) — aligns the floor with the already-resolved version.
- Regenerated the mobile workspace lockfile.

### No-ops this cycle
- Flutter 3.44.2 / Dart 3.12.2 already the latest stable → no environment-constraint changes.
- `shared` and `bridge` workspace locks unchanged after re-resolution.
- fastlane already at latest (2.236.1, constraint `~> 2.236`) → no Gemfile/Gemfile.lock changes.

### Blocked / deferred
Resolvable == current, gated by SDK or transitive constraints:

| Dependency | Current | Latest | Reason |
|------------|---------|--------|--------|
| meta | 1.18.0 | 1.18.3 | pinned by Flutter SDK |
| injectable_generator | 3.0.2 | 3.1.0 | gated by `injectable` constraint |
| test (mobile workspace) | 1.31.0 | 1.31.1 | gated by `flutter_test` |

### Verification
- `make analyze` ✅ shared, bridge, mobile (mobile with `--fatal-infos`)
- `make test` ✅ shared, bridge, mobile
- `make codegen` ✅ all units, no generated-file diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
