### PR TITLE
fix(bridge): show running badge for root sessions with busy direct children

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -256,12 +256,21 @@ class ActiveSessionTracker {
     required String? parentId,
   }) {
     _sessionDirectories[sessionId] = directory;
+    // Resolve the directory into a worktree now. On the dropped-`session.created`
+    // recovery path a bare `session.status` frame carries no directory, so this
+    // call is the only place that learns it. buildSummary and
+    // _activeSessionCounts key off _sessionWorktrees, so without this the
+    // recovered root would still have no worktree and produce no summary row.
+    _updateSessionWorktree(sessionId, directory);
 
-    final hadParent = _sessionParentIds.containsKey(sessionId);
     final previousParent = _sessionParentIds[sessionId];
     _sessionParentIds[sessionId] = parentId;
 
-    final parentChanged = !hadParent || previousParent != parentId;
+    // A missing entry already resolves to null in buildSummary, so comparing
+    // against the previous lookup (null when absent) is sufficient: an
+    // unobserved→root (null) transition is not a grouping change and must not
+    // trigger a redundant re-emit.
+    final parentChanged = previousParent != parentId;
     // Only an active session affects the summary grouping.
     return parentChanged && _sessionStatuses.containsKey(sessionId);
   }

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -261,18 +261,25 @@ class ActiveSessionTracker {
     // call is the only place that learns it. buildSummary and
     // _activeSessionCounts key off _sessionWorktrees, so without this the
     // recovered root would still have no worktree and produce no summary row.
+    final previousWorktree = _sessionWorktrees[sessionId];
     _updateSessionWorktree(sessionId, directory);
+    final worktreeChanged = _sessionWorktrees[sessionId] != previousWorktree;
 
     final previousParent = _sessionParentIds[sessionId];
     _sessionParentIds[sessionId] = parentId;
-
-    // A missing entry already resolves to null in buildSummary, so comparing
-    // against the previous lookup (null when absent) is sufficient: an
-    // unobserved→root (null) transition is not a grouping change and must not
-    // trigger a redundant re-emit.
     final parentChanged = previousParent != parentId;
+
+    // Re-emit when this call changes how an active session appears in the
+    // summary: either its grouping (parent) changed, or it just gained/changed a
+    // worktree. The latter matters for a root recovered on the no-directory
+    // path: its parent stays null, but it transitions from "no worktree / no
+    // row" to a visible root row, so a worktree-only change must still
+    // invalidate. A missing parent entry already resolves to null in
+    // buildSummary, so an unobserved→root transition whose worktree is unchanged
+    // is correctly NOT a change and avoids a redundant re-emit.
+    final summaryChanged = parentChanged || worktreeChanged;
     // Only an active session affects the summary grouping.
-    return parentChanged && _sessionStatuses.containsKey(sessionId);
+    return summaryChanged && _sessionStatuses.containsKey(sessionId);
   }
 
   /// Whether the tracker already knows this session's parent attribution.

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -237,9 +237,42 @@ class ActiveSessionTracker {
     return true;
   }
 
-  /// Register a known session -> directory mapping (e.g., after session creation).
-  void registerSession({required String sessionId, required String directory}) {
+  /// Registers what we know about a session: its directory and its parent ID.
+  ///
+  /// Used both at request time (session creation, listing, pending-question
+  /// lookups) and after a one-shot parent-ID resolution. Recording the parent
+  /// ID here is the defense-in-depth half of the phantom-root fix: whenever any
+  /// flow already holds the session object, we capture [parentId] so a later
+  /// busy status for this session is attributed to the correct root instead of
+  /// being misclassified as its own root.
+  ///
+  /// Returns `true` when this call changes the activity summary grouping — i.e.
+  /// the session is currently active (busy/retry) and its recorded parent ID
+  /// actually changed. Callers that drive summary re-emits (the SSE-resolution
+  /// path) use this; request-time callers may ignore it.
+  bool registerSession({
+    required String sessionId,
+    required String directory,
+    required String? parentId,
+  }) {
     _sessionDirectories[sessionId] = directory;
+
+    final hadParent = _sessionParentIds.containsKey(sessionId);
+    final previousParent = _sessionParentIds[sessionId];
+    _sessionParentIds[sessionId] = parentId;
+
+    final parentChanged = !hadParent || previousParent != parentId;
+    // Only an active session affects the summary grouping.
+    return parentChanged && _sessionStatuses.containsKey(sessionId);
+  }
+
+  /// Whether the tracker already knows this session's parent attribution.
+  ///
+  /// Distinguishes "known root" (recorded value is `null`) from "never
+  /// observed" (no entry). The SSE-resolution path uses this to decide whether
+  /// a busy session still needs a one-shot parent-ID lookup.
+  bool knowsParent({required String sessionId}) {
+    return _sessionParentIds.containsKey(sessionId);
   }
 
   /// Look up the directory for a session. Returns null if unknown.
@@ -270,17 +303,17 @@ class ActiveSessionTracker {
     for (final sessionId in _sessionStatuses.keys) {
       final parentId = _sessionParentIds[sessionId];
       if (parentId == null) {
-        // Root session (or unknown parent — treated as root).
+        // Root session, or parent not yet resolved — treat as root. A busy
+        // session whose parent is still unknown surfaces as its own root row
+        // transiently; the one-shot parent-ID resolution re-emits the summary
+        // once the real root is known (see OpenCodeService).
         activeRoots.add(sessionId);
       } else {
-        // Child session — only include if parent is a known root (direct descendant).
-        // A "known root" is a session we've observed whose own parentId is null.
-        // Use containsKey to distinguish "known root" from "never observed".
-        if (_sessionParentIds.containsKey(parentId) && _sessionParentIds[parentId] == null) {
-          activeChildrenByParent.putIfAbsent(parentId, () => []).add(sessionId);
-        }
-        // Parent not in _sessionParentIds → never observed → orphan → ignore.
-        // Parent's parentId != null → deeper nesting → ignore.
+        // Direct child — surface its parent as the active root row directly.
+        // We intentionally model only two levels (root + direct child): a
+        // non-null parent ID is always treated as a direct child of a root,
+        // with no grandchild/deep-descendant handling.
+        activeChildrenByParent.putIfAbsent(parentId, () => []).add(sessionId);
       }
     }
 

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -176,8 +176,18 @@ class OpenCodePlugin implements OpenCodeManagedApi {
     _disposed = true;
     Log.v("[shutdown] OpenCodePlugin.dispose: stopping SSE connection");
     _sseConnection.stop();
-    await _summarySubscription.cancel();
-    await _service.dispose();
+    // Each teardown step is isolated so a failure in one does not prevent the
+    // remaining cleanup (http client + event buffer below) from running.
+    try {
+      await _summarySubscription.cancel();
+    } on Object catch (e, st) {
+      Log.w("[shutdown] OpenCodePlugin.dispose: failed to cancel summary subscription", e, st);
+    }
+    try {
+      await _service.dispose();
+    } on Object catch (e, st) {
+      Log.w("[shutdown] OpenCodePlugin.dispose: failed to dispose service", e, st);
+    }
     Log.v("[shutdown] OpenCodePlugin.dispose: force-closing http client");
     _httpClient.close(force: true);
     final sw = Stopwatch()..start();

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -33,6 +33,7 @@ class OpenCodePlugin implements OpenCodeManagedApi {
   final io.HttpClient _httpClient;
   final SseEventMapper _mapper = SseEventMapper();
   late final SseConnection _sseConnection;
+  late final StreamSubscription<void> _summarySubscription;
   Future<void>? _initializeFuture;
   bool _disposed = false;
 
@@ -96,6 +97,10 @@ class OpenCodePlugin implements OpenCodeManagedApi {
       onConnected: onConnected,
       onDisconnected: onDisconnected,
     );
+    // The service resolves missing parent IDs out-of-band (after handleSseEvent
+    // has already returned); re-emit the activity summary when it does so the
+    // running badge surfaces on the correct root session.
+    _summarySubscription = _service.summaryInvalidations.listen((_) => _emitProjectsSummary());
     if (autoInitialize) {
       // Legacy behavior: cold-start fire-and-forget so direct construction never
       // throws (the descriptor awaits initialize() instead). The failure is
@@ -171,6 +176,8 @@ class OpenCodePlugin implements OpenCodeManagedApi {
     _disposed = true;
     Log.v("[shutdown] OpenCodePlugin.dispose: stopping SSE connection");
     _sseConnection.stop();
+    await _summarySubscription.cancel();
+    await _service.dispose();
     Log.v("[shutdown] OpenCodePlugin.dispose: force-closing http client");
     _httpClient.close(force: true);
     final sw = Stopwatch()..start();
@@ -205,6 +212,7 @@ class OpenCodePlugin implements OpenCodeManagedApi {
       _service.tracker.registerSession(
         sessionId: session.id,
         directory: session.directory,
+        parentId: session.parentID,
       );
     }
     return sessions

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -39,6 +39,18 @@ class OpenCodeService {
   final ActiveSessionTracker tracker;
   final Duration _commandDispatchFastFailWindow;
 
+  /// Signals that an out-of-band parent-ID resolution changed the activity
+  /// summary and the consumer (the plugin) should re-emit it. Broadcast so the
+  /// single plugin subscriber can attach in its constructor; the service never
+  /// emits SSE events itself (the plugin owns that decision).
+  final StreamController<void> _summaryInvalidations = StreamController<void>.broadcast();
+
+  /// Session IDs with an in-flight one-shot parent-ID lookup, used to dedupe
+  /// concurrent resolutions. This is event-driven, not polling: a lookup fires
+  /// only when a busy/retry status arrives for a session whose parent is still
+  /// unknown, and the entry is cleared once the lookup settles.
+  final Set<String> _parentIdLookupsInFlight = {};
+
   /// [commandDispatchFastFailWindow] bounds how long [sendCommand] waits on
   /// OpenCode's synchronous command/summarize endpoints before treating the run
   /// as accepted and detaching (see [sendCommand]). Genuine dispatch rejections
@@ -109,7 +121,11 @@ class OpenCodeService {
         directory: null,
       );
       directory = session.directory;
-      tracker.registerSession(sessionId: sessionId, directory: directory);
+      tracker.registerSession(
+        sessionId: sessionId,
+        directory: directory,
+        parentId: session.parentID,
+      );
       Log.d(
         "getPendingQuestionsForSession: resolved missing directory "
         "for session $sessionId via getSession: $directory",
@@ -172,7 +188,11 @@ class OpenCodeService {
       }
     }
 
-    tracker.registerSession(sessionId: session.id, directory: session.directory);
+    tracker.registerSession(
+      sessionId: session.id,
+      directory: session.directory,
+      parentId: session.parentID,
+    );
     return session;
   }
 
@@ -281,8 +301,61 @@ class OpenCodeService {
     );
   }
 
+  /// Fires when an out-of-band parent-ID resolution updates the activity
+  /// summary grouping. The plugin subscribes and re-emits the summary.
+  Stream<void> get summaryInvalidations => _summaryInvalidations.stream;
+
   bool handleSseEvent(SseEventData event, String? directory) {
-    return tracker.handleEvent(event, directory);
+    final changed = tracker.handleEvent(event, directory);
+    _maybeResolveParentId(event, directory);
+    return changed;
+  }
+
+  /// When a busy/retry status arrives for a session whose parent attribution is
+  /// still unknown, kick off a one-shot lookup so the session is grouped under
+  /// its real root instead of becoming a phantom root.
+  ///
+  /// OpenCode emits `session.created` (which carries `parentID`) before
+  /// `session.status:busy`, but a dropped/late `session.created` frame leaves
+  /// the tracker without the parent ID — and `session.status` has no `parentID`
+  /// field to recover it. This resolves the gap on demand.
+  void _maybeResolveParentId(SseEventData event, String? directory) {
+    if (event is! SseSessionStatus) return;
+    final status = event.status;
+    if (status is! SessionStatusBusy && status is! SessionStatusRetry) return;
+
+    final sessionId = event.sessionID;
+    if (tracker.knowsParent(sessionId: sessionId)) return;
+    if (_parentIdLookupsInFlight.contains(sessionId)) return;
+
+    _parentIdLookupsInFlight.add(sessionId);
+    unawaited(_resolveParentId(sessionId: sessionId, directory: directory));
+  }
+
+  Future<void> _resolveParentId({
+    required String sessionId,
+    required String? directory,
+  }) async {
+    try {
+      final lookupDirectory = directory ?? tracker.getSessionDirectory(sessionId: sessionId);
+      final session = await repository.getSession(
+        sessionId: sessionId,
+        directory: lookupDirectory,
+      );
+      final changed = tracker.registerSession(
+        sessionId: sessionId,
+        directory: session.directory,
+        parentId: session.parentID,
+      );
+      if (changed && !_summaryInvalidations.isClosed) {
+        _summaryInvalidations.add(null);
+      }
+    } catch (e, st) {
+      // Best-effort: leave the parent unknown so a later status event can retry.
+      Log.w("failed to resolve parentID for session $sessionId: $e\n$st");
+    } finally {
+      _parentIdLookupsInFlight.remove(sessionId);
+    }
   }
 
   Future<void> coldStart() async {
@@ -321,6 +394,13 @@ class OpenCodeService {
 
   void reset() {
     tracker.reset();
+  }
+
+  /// Releases the summary-invalidation stream. Called by the plugin on dispose.
+  /// Distinct from [reset] (invoked on SSE reconnect), which must keep the
+  /// stream alive so the plugin's subscription survives reconnects.
+  Future<void> dispose() async {
+    await _summaryInvalidations.close();
   }
 
   List<ProjectActivitySummary> buildSummary() {

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -352,7 +352,7 @@ class OpenCodeService {
       }
     } catch (e, st) {
       // Best-effort: leave the parent unknown so a later status event can retry.
-      Log.w("failed to resolve parentID for session $sessionId: $e\n$st");
+      Log.w("failed to resolve parentID for session $sessionId", e, st);
     } finally {
       _parentIdLookupsInFlight.remove(sessionId);
     }

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -18,7 +18,7 @@ void main() {
       test("registerSession stores directory for lookup", () {
         final tracker = ActiveSessionTracker(_fakeRepository());
 
-        tracker.registerSession(sessionId: "s1", directory: "/projects/foo");
+        tracker.registerSession(sessionId: "s1", directory: "/projects/foo", parentId: null);
 
         expect(tracker.getSessionDirectory(sessionId: "s1"), equals("/projects/foo"));
       });
@@ -32,7 +32,11 @@ void main() {
       test("registerSession preserves raw directory without worktree normalization", () {
         final tracker = ActiveSessionTracker(_fakeRepository());
 
-        tracker.registerSession(sessionId: "s1", directory: "/projects/foo/packages/bar");
+        tracker.registerSession(
+          sessionId: "s1",
+          directory: "/projects/foo/packages/bar",
+          parentId: null,
+        );
 
         expect(
           tracker.getSessionDirectory(sessionId: "s1"),
@@ -105,7 +109,7 @@ void main() {
       test("reset clears session directories", () {
         final tracker = ActiveSessionTracker(_fakeRepository());
 
-        tracker.registerSession(sessionId: "s1", directory: "/projects/foo");
+        tracker.registerSession(sessionId: "s1", directory: "/projects/foo", parentId: null);
         expect(tracker.getSessionDirectory(sessionId: "s1"), isNotNull);
 
         tracker.reset();
@@ -588,14 +592,19 @@ void main() {
       expect(summary.first.activeSessions.first.childSessionIds, equals(["c1"]));
     });
 
-    test("orphan child sessions are ignored", () async {
+    test("busy child surfaces its parent row even when the parent was never observed", () async {
+      // Two-level model: a busy session with a non-null parent ID is always a
+      // direct child of a root, so its parent row is surfaced directly — even
+      // if the parent session itself was never observed by the tracker. This is
+      // the core of the phantom-root fix: the real root lights up instead of
+      // the child becoming its own (phantom) root.
       final tracker = await _coldStartedTracker(
         projects: [const Project(id: "p1", worktree: "/repo")],
       );
 
       tracker.handleEvent(
         const SseEventData.sessionCreated(
-          info: Session(id: "c1", projectID: "project", directory: "/repo", parentID: "unknown"),
+          info: Session(id: "c1", projectID: "project", directory: "/repo", parentID: "root"),
         ),
         null,
       );
@@ -603,7 +612,10 @@ void main() {
 
       final summary = tracker.buildSummary();
 
-      expect(summary, isEmpty);
+      expect(summary, hasLength(1));
+      expect(summary.first.activeSessions.first.id, equals("root"));
+      expect(summary.first.activeSessions.first.mainAgentRunning, isFalse);
+      expect(summary.first.activeSessions.first.childSessionIds, equals(["c1"]));
     });
 
     test("coldStart resolves busy child sessions not in root list", () async {
@@ -628,7 +640,12 @@ void main() {
       expect(summary.first.activeSessions.first.childSessionIds, equals(["c1"]));
     });
 
-    test("deeply nested children are ignored", () async {
+    test("each busy session is attributed to its immediate parent (two-level model)", () async {
+      // Product scope tracks only root + direct children; grandchildren do not
+      // occur in practice. The tracker therefore models exactly two levels:
+      // every busy session is either a root (parentID == null) or a direct
+      // child surfaced under its immediate parent. A hypothetical grandchild is
+      // attributed to its immediate parent rather than walked up to the root.
       final tracker = await _coldStartedTracker(
         projects: [const Project(id: "p1", worktree: "/repo")],
       );
@@ -653,9 +670,85 @@ void main() {
       final summary = tracker.buildSummary();
 
       expect(summary, hasLength(1));
-      expect(summary.first.activeSessions.length, equals(1));
-      expect(summary.first.activeSessions.first.id, equals("s1"));
-      expect(summary.first.activeSessions.first.childSessionIds, equals(["c1"]));
+      final byId = {for (final a in summary.first.activeSessions) a.id: a};
+      // s1 is a root with direct child c1.
+      expect(byId["s1"]!.mainAgentRunning, isTrue);
+      expect(byId["s1"]!.childSessionIds, equals(["c1"]));
+      // g1's immediate parent c1 is surfaced as its own row (no deep walk-up).
+      expect(byId["c1"]!.childSessionIds, equals(["g1"]));
+    });
+
+    group("parent-ID resolution (phantom-root fix)", () {
+      test("busy child with unknown parent is a phantom root until resolved", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+        );
+
+        // Busy status arrives for a child with no preceding session.created, so
+        // its parent ID is unknown — it transiently surfaces as its own root.
+        final changedOnBusy = tracker.handleEvent(_sessionBusy("c1"), "/repo");
+        expect(changedOnBusy, isTrue);
+
+        final phantom = tracker.buildSummary();
+        expect(phantom, hasLength(1));
+        expect(phantom.first.activeSessions.first.id, equals("c1"));
+        expect(phantom.first.activeSessions.first.mainAgentRunning, isTrue);
+        expect(tracker.knowsParent(sessionId: "c1"), isFalse);
+
+        // Resolving the parent (as OpenCodeService does via getSession)
+        // re-attributes the busy child to its real root and removes the phantom.
+        final changed = tracker.registerSession(
+          sessionId: "c1",
+          directory: "/repo",
+          parentId: "root",
+        );
+        expect(changed, isTrue, reason: "active child re-parented must invalidate the summary");
+        expect(tracker.knowsParent(sessionId: "c1"), isTrue);
+
+        final resolved = tracker.buildSummary();
+        expect(resolved, hasLength(1));
+        expect(resolved.first.activeSessions.first.id, equals("root"));
+        expect(resolved.first.activeSessions.first.mainAgentRunning, isFalse);
+        expect(resolved.first.activeSessions.first.childSessionIds, equals(["c1"]));
+        // The phantom "c1" root is gone.
+        expect(
+          resolved.first.activeSessions.map((s) => s.id),
+          isNot(contains("c1")),
+        );
+      });
+
+      test("registerSession returns false when the session is not active", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+        );
+
+        final changed = tracker.registerSession(
+          sessionId: "c1",
+          directory: "/repo",
+          parentId: "root",
+        );
+
+        expect(changed, isFalse, reason: "idle sessions do not affect the summary");
+        expect(tracker.knowsParent(sessionId: "c1"), isTrue);
+      });
+
+      test("registerSession returns false when the parent is unchanged", () async {
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+        );
+
+        tracker.handleEvent(_sessionBusy("c1"), "/repo");
+        expect(
+          tracker.registerSession(sessionId: "c1", directory: "/repo", parentId: "root"),
+          isTrue,
+        );
+
+        // Re-registering the same parent must not re-invalidate the summary.
+        expect(
+          tracker.registerSession(sessionId: "c1", directory: "/repo", parentId: "root"),
+          isFalse,
+        );
+      });
     });
 
     group("pending input tracking", () {

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -717,6 +717,32 @@ void main() {
         );
       });
 
+      test("registerSession resolves the worktree so a recovered root surfaces", () async {
+        // Busy status with no directory: the worktree is never learned from the
+        // status event, so the busy child produces no row yet.
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+        );
+
+        tracker.handleEvent(_sessionBusy("c1"), null);
+        expect(tracker.buildSummary(), isEmpty);
+
+        // Resolution supplies the directory; registerSession must resolve it
+        // into a worktree, otherwise buildSummary still yields no row.
+        final changed = tracker.registerSession(
+          sessionId: "c1",
+          directory: "/repo",
+          parentId: "root",
+        );
+        expect(changed, isTrue);
+
+        final summary = tracker.buildSummary();
+        expect(summary, hasLength(1));
+        expect(summary.first.id, equals("/repo"));
+        expect(summary.first.activeSessions.first.id, equals("root"));
+        expect(summary.first.activeSessions.first.childSessionIds, equals(["c1"]));
+      });
+
       test("registerSession returns false when the session is not active", () async {
         final tracker = await _coldStartedTracker(
           projects: [const Project(id: "p1", worktree: "/repo")],

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -743,6 +743,48 @@ void main() {
         expect(summary.first.activeSessions.first.childSessionIds, equals(["c1"]));
       });
 
+      test("registerSession returns true when a root's worktree is newly resolved", () async {
+        // Root recovery: parentId stays null, but the worktree is learned for
+        // the first time, so the active session goes from no row to a visible
+        // root row and registerSession must report the change.
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+        );
+
+        tracker.handleEvent(_sessionBusy("s1"), null);
+        expect(tracker.buildSummary(), isEmpty);
+
+        final changed = tracker.registerSession(
+          sessionId: "s1",
+          directory: "/repo",
+          parentId: null,
+        );
+        expect(changed, isTrue);
+
+        final summary = tracker.buildSummary();
+        expect(summary, hasLength(1));
+        expect(summary.first.activeSessions.first.id, equals("s1"));
+        expect(summary.first.activeSessions.first.mainAgentRunning, isTrue);
+      });
+
+      test("registerSession returns false when neither worktree nor parent changes", () async {
+        // The genuinely redundant case: the worktree was already resolved (the
+        // busy status carried a directory) and the parent is unchanged, so a
+        // re-registration must not trigger a redundant re-emit.
+        final tracker = await _coldStartedTracker(
+          projects: [const Project(id: "p1", worktree: "/repo")],
+        );
+
+        tracker.handleEvent(_sessionBusy("s1"), "/repo");
+
+        final changed = tracker.registerSession(
+          sessionId: "s1",
+          directory: "/repo",
+          parentId: null,
+        );
+        expect(changed, isFalse);
+      });
+
       test("registerSession returns false when the session is not active", () async {
         final tracker = await _coldStartedTracker(
           projects: [const Project(id: "p1", worktree: "/repo")],

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -710,6 +710,34 @@ void main() {
       expect(summary.first.activeSessions.first.childSessionIds, equals(["c1"]));
     });
 
+    test("busy status with no directory resolves worktree via getSession and surfaces root", () async {
+      // Regression for the dropped-session.created recovery path: a bare status
+      // frame carries no directory, so the worktree is only learned during the
+      // one-shot getSession lookup. registerSession must resolve it into a
+      // worktree, otherwise buildSummary produces no row and the badge stays
+      // missing.
+      final (service, repository, emissions) = await build(
+        sessions: [
+          const Session(id: "c1", projectID: "p1", directory: "/repo", parentID: "root"),
+        ],
+      );
+
+      service.handleSseEvent(
+        const SseEventData.sessionStatus(sessionID: "c1", status: SessionStatus.busy()),
+        null,
+      );
+      await pump();
+
+      expect(repository.getSessionCalls, equals(1));
+      expect(emissions, hasLength(1));
+
+      final summary = service.buildSummary();
+      expect(summary, hasLength(1));
+      expect(summary.first.id, equals("/repo"));
+      expect(summary.first.activeSessions.first.id, equals("root"));
+      expect(summary.first.activeSessions.first.childSessionIds, equals(["c1"]));
+    });
+
     test("concurrent busy statuses for the same session trigger a single lookup", () async {
       final (service, repository, _) = await build(
         sessions: [

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -738,6 +738,34 @@ void main() {
       expect(summary.first.activeSessions.first.childSessionIds, equals(["c1"]));
     });
 
+    test("busy root with no directory resolves worktree and invalidates summary", () async {
+      // A root session (parentID == null) whose status arrives with no
+      // directory: the parent does not change during resolution, but the
+      // worktree is newly learned, so the summary must still be invalidated —
+      // otherwise the empty -> {worktree: 1} transition goes unannounced and the
+      // badge stays missing until a later SSE event.
+      final (service, repository, emissions) = await build(
+        sessions: [
+          const Session(id: "s1", projectID: "p1", directory: "/repo"),
+        ],
+      );
+
+      service.handleSseEvent(
+        const SseEventData.sessionStatus(sessionID: "s1", status: SessionStatus.busy()),
+        null,
+      );
+      await pump();
+
+      expect(repository.getSessionCalls, equals(1));
+      expect(emissions, hasLength(1));
+
+      final summary = service.buildSummary();
+      expect(summary, hasLength(1));
+      expect(summary.first.id, equals("/repo"));
+      expect(summary.first.activeSessions.first.id, equals("s1"));
+      expect(summary.first.activeSessions.first.mainAgentRunning, isTrue);
+    });
+
     test("concurrent busy statuses for the same session trigger a single lookup", () async {
       final (service, repository, _) = await build(
         sessions: [

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -669,6 +669,129 @@ void main() {
     });
   });
 
+  group("OpenCodeService parent-ID resolution", () {
+    Future<void> pump() => Future<void>.delayed(const Duration(milliseconds: 10));
+
+    Future<(OpenCodeService, FakeOpenCodeRepository, List<void>)> build({
+      List<Session> sessions = const [],
+    }) async {
+      final repository = FakeOpenCodeRepository(
+        projects: [const Project(id: "p1", worktree: "/repo")],
+        sessions: sessions,
+      );
+      final tracker = ActiveSessionTracker(repository);
+      await tracker.coldStart();
+      final service = OpenCodeService(repository, tracker);
+      final emissions = <void>[];
+      service.summaryInvalidations.listen((_) => emissions.add(null));
+      return (service, repository, emissions);
+    }
+
+    test("busy status with unknown parent resolves parent and invalidates summary", () async {
+      final (service, repository, emissions) = await build(
+        sessions: [
+          const Session(id: "c1", projectID: "p1", directory: "/repo", parentID: "root"),
+        ],
+      );
+
+      service.handleSseEvent(
+        const SseEventData.sessionStatus(sessionID: "c1", status: SessionStatus.busy()),
+        "/repo",
+      );
+      await pump();
+
+      expect(repository.getSessionCalls, equals(1));
+      expect(repository.lastGetSessionId, equals("c1"));
+      expect(emissions, hasLength(1));
+
+      final summary = service.buildSummary();
+      expect(summary, hasLength(1));
+      expect(summary.first.activeSessions.first.id, equals("root"));
+      expect(summary.first.activeSessions.first.childSessionIds, equals(["c1"]));
+    });
+
+    test("concurrent busy statuses for the same session trigger a single lookup", () async {
+      final (service, repository, _) = await build(
+        sessions: [
+          const Session(id: "c1", projectID: "p1", directory: "/repo", parentID: "root"),
+        ],
+      );
+
+      // Both events are dispatched synchronously, before the first lookup
+      // settles, so the in-flight dedupe must collapse them to one call.
+      service.handleSseEvent(
+        const SseEventData.sessionStatus(sessionID: "c1", status: SessionStatus.busy()),
+        "/repo",
+      );
+      service.handleSseEvent(
+        const SseEventData.sessionStatus(sessionID: "c1", status: SessionStatus.busy()),
+        "/repo",
+      );
+      await pump();
+
+      expect(repository.getSessionCalls, equals(1));
+    });
+
+    test("busy status for a session with a known parent does not trigger a lookup", () async {
+      final (service, repository, _) = await build();
+
+      service.handleSseEvent(
+        const SseEventData.sessionCreated(
+          info: Session(id: "c1", projectID: "p1", directory: "/repo", parentID: "root"),
+        ),
+        "/repo",
+      );
+      service.handleSseEvent(
+        const SseEventData.sessionStatus(sessionID: "c1", status: SessionStatus.busy()),
+        "/repo",
+      );
+      await pump();
+
+      expect(repository.getSessionCalls, equals(0));
+    });
+
+    test("a known root busy status does not trigger a lookup", () async {
+      final (service, repository, _) = await build();
+
+      service.handleSseEvent(
+        const SseEventData.sessionCreated(
+          info: Session(id: "s1", projectID: "p1", directory: "/repo"),
+        ),
+        "/repo",
+      );
+      service.handleSseEvent(
+        const SseEventData.sessionStatus(sessionID: "s1", status: SessionStatus.busy()),
+        "/repo",
+      );
+      await pump();
+
+      expect(repository.getSessionCalls, equals(0));
+    });
+
+    test("a failed lookup is swallowed and a later status event retries", () async {
+      // No sessions seeded → FakeOpenCodeRepository.getSession throws.
+      final (service, repository, emissions) = await build();
+
+      service.handleSseEvent(
+        const SseEventData.sessionStatus(sessionID: "c1", status: SessionStatus.busy()),
+        "/repo",
+      );
+      await pump();
+
+      expect(repository.getSessionCalls, equals(1));
+      expect(emissions, isEmpty);
+
+      // Parent still unknown, so the next status event is allowed to retry.
+      service.handleSseEvent(
+        const SseEventData.sessionStatus(sessionID: "c1", status: SessionStatus.busy()),
+        "/repo",
+      );
+      await pump();
+
+      expect(repository.getSessionCalls, equals(2));
+    });
+  });
+
   group("OpenCodeService tracker delegation", () {
     test("coldStart delegates to tracker", () async {
       final tracker = FakeActiveSessionTracker();
@@ -1083,6 +1206,8 @@ class FakeActiveSessionTracker extends ActiveSessionTracker {
   final String? resolvedWorktree;
   String? lastRegisteredSessionId;
   String? lastRegisteredDirectory;
+  String? lastRegisteredParentId;
+  bool registerSessionReturns = false;
   List<PendingQuestion> populatedQuestions = const [];
   List<PendingPermission> populatedPermissions = const [];
 
@@ -1104,10 +1229,16 @@ class FakeActiveSessionTracker extends ActiveSessionTracker {
   }
 
   @override
-  void registerSession({required String sessionId, required String directory}) {
+  bool registerSession({
+    required String sessionId,
+    required String directory,
+    required String? parentId,
+  }) {
     lastRegisteredSessionId = sessionId;
     lastRegisteredDirectory = directory;
+    lastRegisteredParentId = parentId;
     _sessionDirectories[sessionId] = directory;
+    return registerSessionReturns;
   }
 
   @override


### PR DESCRIPTION
## Problem

In the mobile session list, a root session whose direct-child subagent is busy did **not** show the **Running** badge, even though the session-detail view showed it running and pull-to-refresh didn't fix it. Only some sessions were affected; siblings in the same project showed running fine.

## Root cause (parentID attribution gap — not nesting depth)

The mobile row lights up only when `projects.summary` contains an entry keyed by that root's own session id (`ActiveSession.id`). The bridge's `ActiveSessionTracker.buildSummary()` attributed a busy direct child to its root only when:

1. the child's `parentID` was already known, **and**
2. the parent had been observed as a confirmed root.

`_sessionParentIds` is populated only by `coldStart()` and live `session.created`/`session.updated` events — **never** by `session.status` (which has no `parentID` field) or `registerSession()`. OpenCode emits `session.created` (with `parentID`) before `session.status:busy`, but a dropped/late `session.created` frame leaves the busy child's `parentID` unknown. It was then misclassified as its own **phantom root**, so the real root's row stayed idle. The detail view was unaffected (it reads `/session/status` + children directly); refresh only re-fetches the status-less `/sessions`, so it couldn't repair the tracker.

## Fix (direct-children-only)

Scope is intentionally limited to **root + DIRECT children** — no grandchild/deep-descendant handling.

- **`ActiveSessionTracker`** (Layer 2, pure state): `buildSummary()` now uses a two-level model — a busy session is either a root (`parentID == null`) or a direct child surfaced under its `parentID` (the confirmed-known-root gate is dropped). Added `knowsParent`; `registerSession` now also records `parentID` and returns whether the active-session grouping changed.
- **`OpenCodeService`** (Layer 3, coordination): when a busy/retry status arrives for a session whose parent is unknown, it runs a **one-shot, deduped** `getSession` lookup, records the `parentID`, and signals a summary re-emit via a new `summaryInvalidations` stream. Event-driven, not polling.
- **`OpenCodePlugin`** (Layer 4): subscribes to `summaryInvalidations` to re-emit the activity summary; disposes the service + subscription on shutdown; captures `parentID` at `registerSession` call sites (defense-in-depth so the phantom never forms when a session object is already in hand).

No shared-model or mobile changes required — the mobile client already keys on the root session id.

## Tests

- `ActiveSessionTracker`: busy child with unknown parent is a phantom root until resolved, then surfaces its real root (phantom gone); `registerSession` change-signal semantics; two-level attribution.
- `OpenCodeService`: one-shot resolution + invalidation; in-flight dedupe (single lookup for concurrent statuses); no lookup when parent already known / for roots; failed lookup is swallowed and a later status event retries.

## Verification

- `dart test` in `bridge/sesori_plugin_opencode`: 268 passing
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_opencode` and `bridge/app`: no issues
- `aristotle-plan-review` and `aristotle-impl-review`: both passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the mobile session list so a root shows the Running badge when its direct child is busy. Uses a two-level model (root or direct child), resolves missing parent IDs on demand to prevent phantom roots, and re-emits when a root’s worktree is learned so badges appear even if `session.created` was dropped.

- **Bug Fixes**
  - ActiveSessionTracker: two-level attribution; dropped “known root” gate; added `knowsParent`; `registerSession(sessionId, directory, parentId)` records the parent, resolves the directory into a worktree, and returns true when an active session’s parent changes or its worktree is newly learned/changed. Scope: root + direct children.
  - OpenCodeService: on busy/retry for a session with unknown parent, run a one‑shot, deduped `getSession`, update the tracker, and emit `summaryInvalidations` when the summary grouping/worktree changes; failures are logged and retried on later status events.
  - OpenCodePlugin: subscribes to `summaryInvalidations` to re‑emit summaries; passes `parentID` to `registerSession`; isolates summary‑subscription cancel and service dispose during shutdown.

<sup>Written for commit 290d923fd95cc46dee2dc3d2a6df91f469a82ebc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

