### PR TITLE
feat(mobile): show signed-in account in settings

### DIFF
--- a/mobile/app/lib/features/settings/settings_screen.dart
+++ b/mobile/app/lib/features/settings/settings_screen.dart
@@ -53,6 +53,7 @@ class _SettingsBody extends StatelessWidget {
         appBar: AppBar(title: Text(loc.settingsTitle)),
         body: ListView(
           children: [
+            const _AccountTile(),
             ...switch (notificationState) {
               NotificationPreferencesLoading() => const [
                 SizedBox(height: 32),
@@ -123,6 +124,49 @@ class _SettingsBody extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// Header tile showing which account this device is signed in as — the same
+/// account surfaced during onboarding (see `_AccountLine`).
+///
+/// Subscribes to the auth state rather than reading a one-shot snapshot: the
+/// session is restored asynchronously on launch, so the account may resolve
+/// after this tile first builds. Renders nothing until authenticated, so the
+/// trailing [Divider] never hangs above an empty tile.
+class _AccountTile extends StatelessWidget {
+  const _AccountTile();
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = context.loc;
+    final authSession = getIt<AuthSession>();
+
+    return StreamBuilder<AuthState>(
+      stream: authSession.authStateStream,
+      initialData: authSession.currentState,
+      builder: (context, snapshot) {
+        final authState = snapshot.data ?? authSession.currentState;
+        if (authState is! AuthAuthenticated) return const SizedBox.shrink();
+
+        final user = authState.user;
+        final providerLabel = loc.settingsAccountSignedInWith(user.provider.label);
+        final account = user.providerUsername;
+        final hasAccount = account != null && account.isNotEmpty;
+
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.account_circle_outlined),
+              title: Text(hasAccount ? account : providerLabel),
+              subtitle: hasAccount ? Text(providerLabel) : null,
+            ),
+            const Divider(),
+          ],
+        );
+      },
     );
   }
 }

--- a/mobile/app/lib/features/settings/settings_screen.dart
+++ b/mobile/app/lib/features/settings/settings_screen.dart
@@ -36,24 +36,30 @@ class _SettingsBody extends StatelessWidget {
     final prego = context.prego;
     final notificationState = context.watch<NotificationPreferencesCubit>().state;
     final settingsState = context.watch<SettingsCubit>().state;
-    final isLoggingOut = settingsState is SettingsLoggingOut;
+    final isLoggingOut = settingsState.logoutStatus == SettingsLogoutStatus.inProgress;
 
     return BlocListener<SettingsCubit, SettingsState>(
+      // Only react to logout transitions — account updates from the auth
+      // stream also emit new states and must not re-trigger navigation.
+      listenWhen: (prev, curr) => prev.logoutStatus != curr.logoutStatus,
       listener: (context, settingsState) {
-        if (settingsState is SettingsLoggedOut) {
-          context.goRoute(const AppRoute.splash());
-        }
-        if (settingsState is SettingsLogoutFailed) {
-          ScaffoldMessenger.of(context)
-            ..clearSnackBars()
-            ..showSnackBar(SnackBar(content: Text(loc.connectErrorUnknown)));
+        switch (settingsState.logoutStatus) {
+          case SettingsLogoutStatus.success:
+            context.goRoute(const AppRoute.splash());
+          case SettingsLogoutStatus.failure:
+            ScaffoldMessenger.of(context)
+              ..clearSnackBars()
+              ..showSnackBar(SnackBar(content: Text(loc.connectErrorUnknown)));
+          case SettingsLogoutStatus.idle:
+          case SettingsLogoutStatus.inProgress:
+            break;
         }
       },
       child: Scaffold(
         appBar: AppBar(title: Text(loc.settingsTitle)),
         body: ListView(
           children: [
-            const _AccountTile(),
+            _AccountTile(account: settingsState.account),
             ...switch (notificationState) {
               NotificationPreferencesLoading() => const [
                 SizedBox(height: 32),
@@ -131,42 +137,40 @@ class _SettingsBody extends StatelessWidget {
 /// Header tile showing which account this device is signed in as — the same
 /// account surfaced during onboarding (see `_AccountLine`).
 ///
-/// Subscribes to the auth state rather than reading a one-shot snapshot: the
-/// session is restored asynchronously on launch, so the account may resolve
-/// after this tile first builds. Renders nothing until authenticated, so the
-/// trailing [Divider] never hangs above an empty tile.
+/// The [account] is sourced from [SettingsCubit] state (which subscribes to
+/// the auth stream), so it stays in sync as the session resolves on launch.
+/// Renders nothing when there is no account, so the trailing [Divider] never
+/// hangs above an empty tile.
 class _AccountTile extends StatelessWidget {
-  const _AccountTile();
+  const _AccountTile({required this.account});
+
+  final AuthUser? account;
 
   @override
   Widget build(BuildContext context) {
+    final user = account;
+    if (user == null) return const SizedBox.shrink();
+
     final loc = context.loc;
-    final authSession = getIt<AuthSession>();
+    final providerLabel = loc.settingsAccountSignedInWith(user.provider.label);
+    final username = user.providerUsername;
 
-    return StreamBuilder<AuthState>(
-      stream: authSession.authStateStream,
-      initialData: authSession.currentState,
-      builder: (context, snapshot) {
-        final authState = snapshot.data ?? authSession.currentState;
-        if (authState is! AuthAuthenticated) return const SizedBox.shrink();
-
-        final user = authState.user;
-        final providerLabel = loc.settingsAccountSignedInWith(user.provider.label);
-        final account = user.providerUsername;
-        final hasAccount = account != null && account.isNotEmpty;
-
-        return Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ListTile(
-              leading: const Icon(Icons.account_circle_outlined),
-              title: Text(hasAccount ? account : providerLabel),
-              subtitle: hasAccount ? Text(providerLabel) : null,
-            ),
-            const Divider(),
-          ],
-        );
-      },
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ListTile(
+          leading: const Icon(Icons.account_circle_outlined),
+          title: Text(switch (username) {
+            final String name when name.isNotEmpty => name,
+            _ => providerLabel,
+          }),
+          subtitle: switch (username) {
+            final String name when name.isNotEmpty => Text(providerLabel),
+            _ => null,
+          },
+        ),
+        const Divider(),
+      ],
     );
   }
 }

--- a/mobile/app/lib/l10n/app_en.arb
+++ b/mobile/app/lib/l10n/app_en.arb
@@ -64,6 +64,14 @@
   "bridgeOfflineTitle": "Bridge Offline",
   "bridgeOfflineMessage": "Start sesori-bridge on your laptop",
   "settingsTitle": "Settings",
+  "settingsAccountSignedInWith": "Signed in with {provider}",
+  "@settingsAccountSignedInWith": {
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      }
+    }
+  },
   "settingsLogout": "Log Out",
   "notificationCategoryAiInteraction": "AI Interactions",
   "notificationCategoryAiInteractionDescription": "Questions and permission requests from active AI sessions",

--- a/mobile/app/lib/l10n/app_localizations.dart
+++ b/mobile/app/lib/l10n/app_localizations.dart
@@ -349,6 +349,12 @@ abstract class AppLocalizations {
   /// **'Settings'**
   String get settingsTitle;
 
+  /// No description provided for @settingsAccountSignedInWith.
+  ///
+  /// In en, this message translates to:
+  /// **'Signed in with {provider}'**
+  String settingsAccountSignedInWith(String provider);
+
   /// No description provided for @settingsLogout.
   ///
   /// In en, this message translates to:

--- a/mobile/app/lib/l10n/app_localizations_en.dart
+++ b/mobile/app/lib/l10n/app_localizations_en.dart
@@ -150,6 +150,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsTitle => 'Settings';
 
   @override
+  String settingsAccountSignedInWith(String provider) {
+    return 'Signed in with $provider';
+  }
+
+  @override
   String get settingsLogout => 'Log Out';
 
   @override

--- a/mobile/module_auth/lib/sesori_auth.dart
+++ b/mobile/module_auth/lib/sesori_auth.dart
@@ -1,7 +1,10 @@
 /// Authentication package for Sesori — token lifecycle, OAuth flow, authenticated HTTP client.
 library;
 
-export "package:sesori_shared/sesori_shared.dart" show AuthProvider, AuthUser;
+// $AuthUserCopyWith is the freezed-generated copyWith for AuthUser; re-export it
+// alongside the type so downstream freezed models (e.g. SettingsState) with an
+// AuthUser field can resolve their generated nested copyWith.
+export "package:sesori_shared/sesori_shared.dart" show $AuthUserCopyWith, AuthProvider, AuthUser;
 
 export "src/auth_config.dart";
 export "src/client/api_error.dart";

--- a/mobile/module_core/lib/src/cubits/settings/settings_cubit.dart
+++ b/mobile/module_core/lib/src/cubits/settings/settings_cubit.dart
@@ -1,25 +1,53 @@
+import "dart:async";
+
 import "package:bloc/bloc.dart";
+import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
 
 import "settings_state.dart";
 
 class SettingsCubit extends Cubit<SettingsState> {
   final AuthSession _authSession;
+  final CompositeSubscription _subscriptions = CompositeSubscription();
 
-  SettingsCubit({required AuthSession authSession}) : _authSession = authSession, super(const SettingsState.initial());
+  SettingsCubit({required AuthSession authSession})
+    : _authSession = authSession,
+      super(SettingsState(account: _accountFrom(authSession.currentState))) {
+    // Keep the signed-in account in sync: the session is restored
+    // asynchronously on launch, so the account may resolve after the cubit is
+    // first constructed. Initial value comes from currentState above so the UI
+    // renders without a flash.
+    _subscriptions.add(
+      _authSession.authStateStream.listen((authState) {
+        if (isClosed) return;
+        emit(state.copyWith(account: _accountFrom(authState)));
+      }),
+    );
+  }
+
+  static AuthUser? _accountFrom(AuthState authState) => switch (authState) {
+    AuthAuthenticated(:final user) => user,
+    AuthInitial() || AuthUnauthenticated() || AuthAuthenticating() || AuthFailed() => null,
+  };
 
   Future<void> logout() async {
-    if (state is SettingsLoggingOut) return;
+    if (state.logoutStatus == SettingsLogoutStatus.inProgress) return;
 
-    emit(const SettingsState.loggingOut());
+    emit(state.copyWith(logoutStatus: SettingsLogoutStatus.inProgress));
 
     try {
       await _authSession.logoutCurrentDevice();
       if (isClosed) return;
-      emit(const SettingsState.loggedOut());
+      emit(state.copyWith(logoutStatus: SettingsLogoutStatus.success));
     } catch (_) {
       if (isClosed) return;
-      emit(const SettingsState.logoutFailed());
+      emit(state.copyWith(logoutStatus: SettingsLogoutStatus.failure));
     }
+  }
+
+  @override
+  Future<void> close() {
+    _subscriptions.dispose();
+    return super.close();
   }
 }

--- a/mobile/module_core/lib/src/cubits/settings/settings_state.dart
+++ b/mobile/module_core/lib/src/cubits/settings/settings_state.dart
@@ -1,14 +1,17 @@
 import "package:freezed_annotation/freezed_annotation.dart";
+import "package:sesori_shared/sesori_shared.dart";
 
 part "settings_state.freezed.dart";
 
+/// Progress of the logout action initiated from the settings screen.
+enum SettingsLogoutStatus { idle, inProgress, success, failure }
+
 @Freezed()
 sealed class SettingsState with _$SettingsState {
-  const factory SettingsState.initial() = SettingsInitial;
-
-  const factory SettingsState.loggingOut() = SettingsLoggingOut;
-
-  const factory SettingsState.loggedOut() = SettingsLoggedOut;
-
-  const factory SettingsState.logoutFailed() = SettingsLogoutFailed;
+  const factory SettingsState({
+    /// The account this device is signed in as, or `null` when there is no
+    /// authenticated session. Driven reactively by the auth state stream.
+    required AuthUser? account,
+    @Default(SettingsLogoutStatus.idle) SettingsLogoutStatus logoutStatus,
+  }) = _SettingsState;
 }

--- a/mobile/module_core/lib/src/cubits/settings/settings_state.dart
+++ b/mobile/module_core/lib/src/cubits/settings/settings_state.dart
@@ -1,5 +1,5 @@
 import "package:freezed_annotation/freezed_annotation.dart";
-import "package:sesori_shared/sesori_shared.dart";
+import "package:sesori_auth/sesori_auth.dart";
 
 part "settings_state.freezed.dart";
 

--- a/mobile/module_core/lib/src/cubits/settings/settings_state.freezed.dart
+++ b/mobile/module_core/lib/src/cubits/settings/settings_state.freezed.dart
@@ -14,30 +14,76 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$SettingsState {
 
-
+/// The account this device is signed in as, or `null` when there is no
+/// authenticated session. Driven reactively by the auth state stream.
+ AuthUser? get account; SettingsLogoutStatus get logoutStatus;
+/// Create a copy of SettingsState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SettingsStateCopyWith<SettingsState> get copyWith => _$SettingsStateCopyWithImpl<SettingsState>(this as SettingsState, _$identity);
 
 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsState);
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsState&&(identical(other.account, account) || other.account == account)&&(identical(other.logoutStatus, logoutStatus) || other.logoutStatus == logoutStatus));
 }
 
 
 @override
-int get hashCode => runtimeType.hashCode;
+int get hashCode => Object.hash(runtimeType,account,logoutStatus);
 
 @override
 String toString() {
-  return 'SettingsState()';
+  return 'SettingsState(account: $account, logoutStatus: $logoutStatus)';
 }
 
 
 }
 
 /// @nodoc
-class $SettingsStateCopyWith<$Res>  {
-$SettingsStateCopyWith(SettingsState _, $Res Function(SettingsState) __);
+abstract mixin class $SettingsStateCopyWith<$Res>  {
+  factory $SettingsStateCopyWith(SettingsState value, $Res Function(SettingsState) _then) = _$SettingsStateCopyWithImpl;
+@useResult
+$Res call({
+ AuthUser? account, SettingsLogoutStatus logoutStatus
+});
+
+
+$AuthUserCopyWith<$Res>? get account;
+
+}
+/// @nodoc
+class _$SettingsStateCopyWithImpl<$Res>
+    implements $SettingsStateCopyWith<$Res> {
+  _$SettingsStateCopyWithImpl(this._self, this._then);
+
+  final SettingsState _self;
+  final $Res Function(SettingsState) _then;
+
+/// Create a copy of SettingsState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? account = freezed,Object? logoutStatus = null,}) {
+  return _then(_self.copyWith(
+account: freezed == account ? _self.account : account // ignore: cast_nullable_to_non_nullable
+as AuthUser?,logoutStatus: null == logoutStatus ? _self.logoutStatus : logoutStatus // ignore: cast_nullable_to_non_nullable
+as SettingsLogoutStatus,
+  ));
+}
+/// Create a copy of SettingsState
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$AuthUserCopyWith<$Res>? get account {
+    if (_self.account == null) {
+    return null;
+  }
+
+  return $AuthUserCopyWith<$Res>(_self.account!, (value) {
+    return _then(_self.copyWith(account: value));
+  });
+}
 }
 
 
@@ -45,129 +91,83 @@ $SettingsStateCopyWith(SettingsState _, $Res Function(SettingsState) __);
 /// @nodoc
 
 
-class SettingsInitial implements SettingsState {
-  const SettingsInitial();
+class _SettingsState implements SettingsState {
+  const _SettingsState({required this.account, this.logoutStatus = SettingsLogoutStatus.idle});
   
 
+/// The account this device is signed in as, or `null` when there is no
+/// authenticated session. Driven reactively by the auth state stream.
+@override final  AuthUser? account;
+@override@JsonKey() final  SettingsLogoutStatus logoutStatus;
 
-
+/// Create a copy of SettingsState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SettingsStateCopyWith<_SettingsState> get copyWith => __$SettingsStateCopyWithImpl<_SettingsState>(this, _$identity);
 
 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsInitial);
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SettingsState&&(identical(other.account, account) || other.account == account)&&(identical(other.logoutStatus, logoutStatus) || other.logoutStatus == logoutStatus));
 }
 
 
 @override
-int get hashCode => runtimeType.hashCode;
+int get hashCode => Object.hash(runtimeType,account,logoutStatus);
 
 @override
 String toString() {
-  return 'SettingsState.initial()';
+  return 'SettingsState(account: $account, logoutStatus: $logoutStatus)';
 }
 
 
 }
-
-
-
 
 /// @nodoc
+abstract mixin class _$SettingsStateCopyWith<$Res> implements $SettingsStateCopyWith<$Res> {
+  factory _$SettingsStateCopyWith(_SettingsState value, $Res Function(_SettingsState) _then) = __$SettingsStateCopyWithImpl;
+@override @useResult
+$Res call({
+ AuthUser? account, SettingsLogoutStatus logoutStatus
+});
 
 
-class SettingsLoggingOut implements SettingsState {
-  const SettingsLoggingOut();
-  
-
-
-
-
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsLoggingOut);
-}
-
-
-@override
-int get hashCode => runtimeType.hashCode;
-
-@override
-String toString() {
-  return 'SettingsState.loggingOut()';
-}
-
+@override $AuthUserCopyWith<$Res>? get account;
 
 }
-
-
-
-
 /// @nodoc
+class __$SettingsStateCopyWithImpl<$Res>
+    implements _$SettingsStateCopyWith<$Res> {
+  __$SettingsStateCopyWithImpl(this._self, this._then);
 
+  final _SettingsState _self;
+  final $Res Function(_SettingsState) _then;
 
-class SettingsLoggedOut implements SettingsState {
-  const SettingsLoggedOut();
-  
-
-
-
-
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsLoggedOut);
+/// Create a copy of SettingsState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? account = freezed,Object? logoutStatus = null,}) {
+  return _then(_SettingsState(
+account: freezed == account ? _self.account : account // ignore: cast_nullable_to_non_nullable
+as AuthUser?,logoutStatus: null == logoutStatus ? _self.logoutStatus : logoutStatus // ignore: cast_nullable_to_non_nullable
+as SettingsLogoutStatus,
+  ));
 }
 
-
+/// Create a copy of SettingsState
+/// with the given fields replaced by the non-null parameter values.
 @override
-int get hashCode => runtimeType.hashCode;
+@pragma('vm:prefer-inline')
+$AuthUserCopyWith<$Res>? get account {
+    if (_self.account == null) {
+    return null;
+  }
 
-@override
-String toString() {
-  return 'SettingsState.loggedOut()';
+  return $AuthUserCopyWith<$Res>(_self.account!, (value) {
+    return _then(_self.copyWith(account: value));
+  });
 }
-
-
 }
-
-
-
-
-/// @nodoc
-
-
-class SettingsLogoutFailed implements SettingsState {
-  const SettingsLogoutFailed();
-  
-
-
-
-
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SettingsLogoutFailed);
-}
-
-
-@override
-int get hashCode => runtimeType.hashCode;
-
-@override
-String toString() {
-  return 'SettingsState.logoutFailed()';
-}
-
-
-}
-
-
-
 
 // dart format on

--- a/mobile/module_core/test/cubits/settings/settings_cubit_test.dart
+++ b/mobile/module_core/test/cubits/settings/settings_cubit_test.dart
@@ -1,6 +1,7 @@
 import "dart:async";
 
 import "package:mocktail/mocktail.dart";
+import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_dart_core/src/cubits/settings/settings_cubit.dart";
 import "package:sesori_dart_core/src/cubits/settings/settings_state.dart";
@@ -11,51 +12,73 @@ class _MockAuthSession extends Mock implements AuthSession {}
 void main() {
   group("SettingsCubit", () {
     late _MockAuthSession authSession;
+    late BehaviorSubject<AuthState> authStates;
+
+    const user = AuthUser(
+      id: "u1",
+      provider: AuthProvider.github,
+      providerUserId: "gh1",
+      providerUsername: "octocat",
+    );
 
     setUp(() {
       authSession = _MockAuthSession();
+      authStates = BehaviorSubject<AuthState>.seeded(const AuthState.unauthenticated());
+      when(() => authSession.currentState).thenAnswer((_) => authStates.value);
+      when(() => authSession.authStateStream).thenAnswer((_) => authStates);
     });
 
-    test("initial state is SettingsInitial", () {
+    tearDown(() => authStates.close());
+
+    test("initial state is idle with the account from the current auth state", () {
+      authStates.add(const AuthState.authenticated(user: user));
+
       final cubit = SettingsCubit(authSession: authSession);
       addTearDown(cubit.close);
 
-      expect(cubit.state, isA<SettingsInitial>());
+      expect(cubit.state.logoutStatus, SettingsLogoutStatus.idle);
+      expect(cubit.state.account, user);
     });
 
-    test("emits loggingOut then loggedOut after logout succeeds", () async {
+    test("updates the account when the auth state stream emits", () async {
+      final cubit = SettingsCubit(authSession: authSession);
+      addTearDown(cubit.close);
+
+      expect(cubit.state.account, isNull);
+
+      final next = cubit.stream.firstWhere((s) => s.account != null);
+      authStates.add(const AuthState.authenticated(user: user));
+
+      expect((await next).account, user);
+    });
+
+    test("emits inProgress then success after logout succeeds", () async {
       when(() => authSession.logoutCurrentDevice()).thenAnswer((_) async {});
 
       final cubit = SettingsCubit(authSession: authSession);
       addTearDown(cubit.close);
 
-      final futureStates = cubit.stream.take(2).toList();
+      final futureStatuses = cubit.stream.map((s) => s.logoutStatus).take(2).toList();
       await cubit.logout();
 
-      final states = await futureStates;
-
-      expect(states[0], isA<SettingsLoggingOut>());
-      expect(states[1], isA<SettingsLoggedOut>());
+      expect(await futureStatuses, [SettingsLogoutStatus.inProgress, SettingsLogoutStatus.success]);
       verify(() => authSession.logoutCurrentDevice()).called(1);
     });
 
-    test("emits loggingOut then logoutFailed when logout throws", () async {
+    test("emits inProgress then failure when logout throws", () async {
       when(() => authSession.logoutCurrentDevice()).thenThrow(StateError("boom"));
 
       final cubit = SettingsCubit(authSession: authSession);
       addTearDown(cubit.close);
 
-      final futureStates = cubit.stream.take(2).toList();
+      final futureStatuses = cubit.stream.map((s) => s.logoutStatus).take(2).toList();
       await cubit.logout();
 
-      final states = await futureStates;
-
-      expect(states[0], isA<SettingsLoggingOut>());
-      expect(states[1], isA<SettingsLogoutFailed>());
+      expect(await futureStatuses, [SettingsLogoutStatus.inProgress, SettingsLogoutStatus.failure]);
       verify(() => authSession.logoutCurrentDevice()).called(1);
     });
 
-    test("ignores duplicate logout calls while already loggingOut", () async {
+    test("ignores duplicate logout calls while already in progress", () async {
       final completer = Completer<void>();
       when(() => authSession.logoutCurrentDevice()).thenAnswer((_) => completer.future);
 
@@ -64,14 +87,14 @@ void main() {
 
       final firstLogout = cubit.logout();
       await Future<void>.delayed(Duration.zero);
-      expect(cubit.state, isA<SettingsLoggingOut>());
+      expect(cubit.state.logoutStatus, SettingsLogoutStatus.inProgress);
 
       await cubit.logout();
 
       completer.complete();
       await firstLogout;
 
-      expect(cubit.state, isA<SettingsLoggedOut>());
+      expect(cubit.state.logoutStatus, SettingsLogoutStatus.success);
       verify(() => authSession.logoutCurrentDevice()).called(1);
     });
   });


### PR DESCRIPTION
## Summary

Surfaces the signed-in account at the top of the **Settings** screen, mirroring the account already shown during onboarding (`_AccountLine`).

- New `_AccountTile` subscribes to `AuthSession.authStateStream` (the same reactive pattern onboarding uses, so it stays in sync as the session restores asynchronously on launch).
- When authenticated, renders a `ListTile`: account icon + `providerUsername` as the title and a "Signed in with {provider}" subtitle, followed by a divider.
- Falls back to "Signed in with {provider}" as the title when `providerUsername` is absent (e.g. Apple/Email).
- Renders nothing while unauthenticated, so the trailing divider never hangs above an empty tile.

Resulting layout: **Account tile → notification toggles → Log Out**.

## Changes
- `settings_screen.dart` — add `_AccountTile` as the first settings list item.
- `app_en.arb` — add `settingsAccountSignedInWith` ("Signed in with {provider}") and regenerate localizations.

## Testing
- `flutter analyze` on the changed files: clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the signed-in account at the top of Settings via a new `_AccountTile` driven by `SettingsCubit`, which listens to `AuthSession.authStateStream` so it stays in sync after launch. The tile shows the username with a “Signed in with {provider}” subtitle (or just the provider), hides when logged out, and logout handling now uses a `logoutStatus` enum to avoid navigation during auth updates.

- **Refactors**
  - Source `AuthUser` from `sesori_auth`; re-export `$AuthUserCopyWith` to support Freezed nested `copyWith` in `SettingsState`.
  - Replace union states with `SettingsState(account, logoutStatus)`; UI listens only to logout status transitions.
  - Add `settingsAccountSignedInWith` localization and wire it to the tile.

<sup>Written for commit eb13b0e52fe1924633385f9b378894e15f2e60e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-17 at 13 54 37" src="https://github.com/user-attachments/assets/bfc0e748-99d8-4b73-b4f1-6d45ad2faebf" />

