### PR TITLE
fix: brace ReleasesApiUrl in install.ps1 for PowerShell 5.1

### DIFF
--- a/bridge/app/test/tool/installers_test.dart
+++ b/bridge/app/test/tool/installers_test.dart
@@ -400,7 +400,7 @@ cat "\$HOME/.zprofile"
       expect(script, contains(r'''$release.draft -or $release.prerelease'''));
       expect(script, contains(r'[version]::TryParse($versionText, [ref]$parsedVersion)'));
       expect(script, contains(r'$page -le $ReleasesMaxPages'));
-      expect(script, contains(r'"$ReleasesApiUrl?per_page=$ReleasesPerPage&page=$page"'));
+      expect(script, contains(r'"${ReleasesApiUrl}?per_page=$ReleasesPerPage&page=$page"'));
       expect(script, contains('Sort-Object Version -Descending'));
       expect(script, contains(r'''Where-Object { $_.name -eq $ArchiveName }'''));
       expect(script, contains(r'''Where-Object { $_.name -eq 'checksums.txt' }'''));

--- a/bridge/app/test/updater/release_contract_test.dart
+++ b/bridge/app/test/updater/release_contract_test.dart
@@ -170,7 +170,7 @@ void main() {
       expect(script, contains(r'$ReleasesApiUrl = "https://api.github.com/repos/$RepoOwner/$RepoName/releases"'));
       expect(script, contains(r'$ReleasesPerPage = 100'));
       expect(script, contains(r'$ReleasesMaxPages = 10'));
-      expect(script, contains(r'"$ReleasesApiUrl?per_page=$ReleasesPerPage&page=$page"'));
+      expect(script, contains(r'"${ReleasesApiUrl}?per_page=$ReleasesPerPage&page=$page"'));
       expect(script, contains("StartsWith('v')"));
       expect(script, contains(r'''$release.draft -or $release.prerelease'''));
       expect(script, contains('Sort-Object Version -Descending'));

--- a/install.ps1
+++ b/install.ps1
@@ -65,7 +65,7 @@ function Resolve-BridgeRelease {
 
     $releases = @()
     for ($page = 1; $page -le $ReleasesMaxPages; $page++) {
-        $pageReleases = Invoke-RestMethod -Uri "$ReleasesApiUrl?per_page=$ReleasesPerPage&page=$page" -Headers @{
+        $pageReleases = Invoke-RestMethod -Uri "${ReleasesApiUrl}?per_page=$ReleasesPerPage&page=$page" -Headers @{
             'Accept' = 'application/vnd.github+json'
             'User-Agent' = 'sesori-bridge-installer'
         }


### PR DESCRIPTION
## Problem

The Windows installer (`install.ps1`) fails on **PowerShell 5.1** during release resolution. PS 5.1 treats `?` as a valid variable-name character, so the interpolation in:

```powershell
Invoke-RestMethod -Uri "$ReleasesApiUrl?per_page=$ReleasesPerPage&page=$page"
```

resolves the *undefined* variable `$ReleasesApiUrl?per_page` (→ empty), collapsing the URI to `=100&page=1` and failing with `hostname could not be parsed`.

## Fix

Brace the variable so PowerShell delimits it correctly:

```powershell
Invoke-RestMethod -Uri "${ReleasesApiUrl}?per_page=$ReleasesPerPage&page=$page"
```

This works on both PowerShell 5.1 and PowerShell 7+.

## Changes

- `install.ps1`: brace `${ReleasesApiUrl}` in the releases API call.
- Updated the two install.ps1 contract tests to assert the braced form.

## Testing

- `dart test test/tool/installers_test.dart test/updater/release_contract_test.dart` — all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows installer failure on PowerShell 5.1 by bracing `${ReleasesApiUrl}` in `install.ps1` so the query string isn’t parsed as part of the variable. The releases API URL now resolves correctly on PS 5.1 and PS 7+; updated two tests to assert the braced form.

<sup>Written for commit 07030a64db624cbcb619b7137ee24f6d5cc960cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

