### PR TITLE
fix(mobile): pin tool-output copy button to top-right for short output

### DIFF
--- a/mobile/app/lib/features/session_detail/widgets/tool_part_widget.dart
+++ b/mobile/app/lib/features/session_detail/widgets/tool_part_widget.dart
@@ -168,14 +168,17 @@ class _ToolOutputBlockState extends State<_ToolOutputBlock> {
             children: [
               Stack(
                 children: [
-                  Padding(
-                    // Reserve trailing room for the overlaid copy button.
-                    padding: const EdgeInsetsDirectional.only(end: _copyButtonReserve),
-                    child: Text(
-                      output,
-                      style: monoStyle,
-                      maxLines: _expanded ? null : _collapsedMaxLines,
-                      overflow: _expanded ? TextOverflow.clip : TextOverflow.ellipsis,
+                  SizedBox(
+                    width: double.infinity,
+                    child: Padding(
+                      // Reserve trailing room for the overlaid copy button.
+                      padding: const EdgeInsetsDirectional.only(end: _copyButtonReserve),
+                      child: Text(
+                        output,
+                        style: monoStyle,
+                        maxLines: _expanded ? null : _collapsedMaxLines,
+                        overflow: _expanded ? TextOverflow.clip : TextOverflow.ellipsis,
+                      ),
                     ),
                   ),
                   PositionedDirectional(


### PR DESCRIPTION
## Problem

In the chat/session screen, the copy button on tool-output boxes was misplaced for short single-line outputs — it appeared near the middle/bottom of the box instead of the top-right corner. Multi-line outputs were unaffected.

## Root cause

The copy icon is overlaid with `PositionedDirectional(top: 0, end: 0)` inside a `Stack`, and a `Stack` sizes itself to its non-positioned child (the text).

- **Multi-line output:** the text wraps and fills the full width, so the Stack is full-width and `end: 0` lands at the box's trailing edge → icon at top-right. ✓
- **Short single-line output** (e.g. `posted=12 failed=0 total=12`): the text is narrow, so the Stack collapsed to the text's width. `end: 0` then resolved to just past the text (mid-box), and since one line is shorter than the icon button, the icon's center fell slightly below the line → icon at mid/bottom. ✗

## Fix

Wrap the non-positioned text child in `SizedBox(width: double.infinity)` so the Stack always spans the full box width regardless of content length. This is a no-op for multi-line output (already full-width) and pins the button to the true top-right for short output.

`flutter analyze` passes clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the copy button position in tool-output boxes on mobile so it stays pinned to the top-right, even for short single-line outputs. Improves UI consistency and tap target placement.

- **Bug Fixes**
  - Wrapped the text in `SizedBox(width: double.infinity)` so the `Stack` spans full width and `PositionedDirectional(top: 0, end: 0)` reliably anchors the copy button for short and multi-line outputs.

<sup>Written for commit bb4863447685f3da1f1bde47c99c8727a4577abc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

