### PR TITLE
feat(bridge): add Cursor backend via ACP (multi-project, model/mode, history, resume)

### DIFF
--- a/bridge/Makefile
+++ b/bridge/Makefile
@@ -2,7 +2,7 @@ TOOL_VERSIONS := $(shell git rev-parse --show-toplevel)/.tool-versions
 FLUTTER_VERSION := $(shell grep '^flutter' $(TOOL_VERSIONS) | awk '{print $$2}')
 DART := $(HOME)/.asdf/installs/flutter/$(FLUTTER_VERSION)/bin/cache/dart-sdk/bin/dart
 
-MODULES := sesori_plugin_interface sesori_plugin_runtime sesori_plugin_opencode app
+MODULES := sesori_plugin_interface sesori_plugin_runtime sesori_plugin_acp sesori_plugin_opencode sesori_plugin_cursor app
 
 .PHONY: codegen opencode-codegen pub-get test analyze
 

--- a/bridge/app/lib/src/bridge/runtime/bridge_cli_options.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_cli_options.dart
@@ -3,8 +3,6 @@ import "package:args/args.dart" show ArgResults;
 class BridgeCliOptions {
   final List<String> cliArgs;
   final String relayUrl;
-  final int? port;
-  final String password;
   final String authBackendUrl;
   final int? debugPort;
   final String logLevelName;
@@ -12,8 +10,6 @@ class BridgeCliOptions {
   const BridgeCliOptions({
     required this.cliArgs,
     required this.relayUrl,
-    required this.port,
-    required this.password,
     required this.authBackendUrl,
     required this.debugPort,
     required this.logLevelName,
@@ -32,13 +28,10 @@ class BridgeCliOptions {
       defaultAuthUrl: defaultAuthUrl,
     );
     final debugPortRaw = results["debug-port"] as String;
-    final portRaw = results["port"] as String?;
 
     return BridgeCliOptions(
       cliArgs: cliArgs,
       relayUrl: results["relay"] as String,
-      port: portRaw == null || portRaw.isEmpty ? null : int.parse(portRaw),
-      password: results["password"] as String,
       authBackendUrl: authBackendUrl,
       debugPort: debugPortRaw.isNotEmpty ? int.tryParse(debugPortRaw) : null,
       logLevelName: results["log-level"] as String,

--- a/bridge/app/lib/src/bridge/runtime/plugin_registry.dart
+++ b/bridge/app/lib/src/bridge/runtime/plugin_registry.dart
@@ -1,3 +1,4 @@
+import "package:cursor_plugin/cursor_plugin.dart" show CursorPluginDescriptor;
 import "package:opencode_plugin/opencode_plugin.dart" show OpenCodePluginDescriptor;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginDescriptor;
 
@@ -9,7 +10,10 @@ import "../../server/host/plugin_state_directory.dart" show openCodePluginId;
 /// `bin/bridge.dart` reads the parse-time surface (`id`, `options`,
 /// `validateConfig`) straight off the selected descriptor, and the runner
 /// later calls its `start(host)` under the startup mutex.
-const List<BridgePluginDescriptor> knownPlugins = [OpenCodePluginDescriptor()];
+const List<BridgePluginDescriptor> knownPlugins = [
+  OpenCodePluginDescriptor(),
+  CursorPluginDescriptor(),
+];
 
 /// The plugin used when neither `--plugin` nor `enabledPlugins` selects one,
 /// so existing installs see zero change.

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -26,6 +26,10 @@ dependencies:
     path: ../sesori_plugin_runtime
   opencode_plugin:
     path: ../sesori_plugin_opencode
+  acp_plugin:
+    path: ../sesori_plugin_acp
+  cursor_plugin:
+    path: ../sesori_plugin_cursor
   meta: ^1.18.3
   drift: ^2.34.0
   collection: ^1.19.1

--- a/bridge/app/test/bridge/runtime/bridge_cli_options_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_cli_options_test.dart
@@ -3,16 +3,16 @@ import "package:sesori_bridge/src/bridge/runtime/bridge_cli_options.dart";
 import "package:test/test.dart";
 
 void main() {
-  test("omitted port stays unset", () {
-    final options = _parseOptions(args: ["--relay", "wss://relay.sesori.test"]);
+  test("relay falls back to the parser default", () {
+    final options = _parseOptions(args: const []);
 
-    expect(options.port, isNull);
+    expect(options.relayUrl, "wss://relay.sesori.com");
   });
 
-  test("explicit 4096 is preserved", () {
-    final options = _parseOptions(args: ["--port", "4096"]);
+  test("explicit relay is preserved", () {
+    final options = _parseOptions(args: ["--relay", "wss://relay.sesori.test"]);
 
-    expect(options.port, 4096);
+    expect(options.relayUrl, "wss://relay.sesori.test");
   });
 
   test("auth backend falls back to the default URL", () {
@@ -29,10 +29,12 @@ void main() {
 }
 
 BridgeCliOptions _parseOptions({required List<String> args}) {
+  // Only the core options the RunCommand parser registers. Plugin-owned
+  // options (e.g. opencode's --port/--password) are intentionally absent:
+  // BridgeCliOptions must not read them, or selecting a plugin that doesn't
+  // declare them (e.g. cursor) would crash at parse time.
   final parser = ArgParser()
     ..addOption("relay", defaultsTo: "wss://relay.sesori.com")
-    ..addOption("port")
-    ..addOption("password", defaultsTo: "")
     ..addOption("auth-backend", defaultsTo: "")
     ..addOption("debug-port", defaultsTo: "")
     ..addOption(

--- a/bridge/app/test/bridge/runtime/bridge_runtime_auth_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_auth_test.dart
@@ -148,8 +148,6 @@ BridgeCliOptions _options({required String authBackendUrl}) {
   return BridgeCliOptions(
     cliArgs: const [],
     relayUrl: 'wss://relay.example.com',
-    port: null,
-    password: 'password',
     authBackendUrl: authBackendUrl,
     debugPort: null,
     logLevelName: 'info',

--- a/bridge/app/test/bridge/runtime/plugin_registry_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_registry_test.dart
@@ -1,3 +1,4 @@
+import "package:cursor_plugin/cursor_plugin.dart" show CursorPluginDescriptor;
 import "package:opencode_plugin/opencode_plugin.dart" show OpenCodePluginDescriptor;
 import "package:sesori_bridge/src/bridge/runtime/plugin_registry.dart";
 import "package:sesori_bridge/src/server/host/plugin_state_directory.dart";
@@ -7,11 +8,18 @@ import "package:test/test.dart";
 
 void main() {
   group("knownPlugins", () {
-    test("registers the real OpenCode descriptor", () {
-      expect(knownPlugins, hasLength(1));
-      expect(knownPlugins.single, isA<OpenCodePluginDescriptor>());
-      expect(knownPlugins.single.id, openCodePluginId);
-      expect(identical(knownPlugins.single.options, OpenCodePluginDescriptor.cliOptions), isTrue);
+    test("registers the real OpenCode and Cursor descriptors", () {
+      expect(knownPlugins, hasLength(2));
+
+      final opencode = knownPlugins.firstWhere((plugin) => plugin.id == openCodePluginId);
+      expect(opencode, isA<OpenCodePluginDescriptor>());
+      expect(identical(opencode.options, OpenCodePluginDescriptor.cliOptions), isTrue);
+
+      final cursor = knownPlugins.firstWhere((plugin) => plugin.id == "cursor");
+      expect(cursor, isA<CursorPluginDescriptor>());
+
+      // OpenCode stays the default so existing installs see no change; Cursor
+      // is opt-in via --plugin cursor or enabledPlugins.
       expect(defaultPluginId, openCodePluginId);
     });
   });

--- a/bridge/app/tool/cursor_smoke.dart
+++ b/bridge/app/tool/cursor_smoke.dart
@@ -1,0 +1,68 @@
+// Local smoke test for the Cursor backend. Drives CursorPlugin directly
+// against a real `cursor-agent acp` — no relay, no Sesori account needed.
+//
+// Prereqs: `cursor-agent` on PATH, authenticated (`cursor-agent login`), and
+// recent enough to expose the `acp` subcommand (`cursor-agent update`).
+//
+// Usage:
+//   dart run tool/cursor_smoke.dart "Reply with exactly: hello world"
+import "dart:io";
+
+import "package:cursor_plugin/cursor_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+Future<void> main(List<String> args) async {
+  final prompt = args.isEmpty ? "Reply with exactly: hello world" : args.first;
+  final cwd = Directory.current.path;
+  final plugin = CursorPlugin(projectCwd: cwd);
+  final assistant = StringBuffer();
+
+  plugin.events.listen((e) {
+    if (e is BridgeSseMessagePartDelta) assistant.write(e.delta);
+    if (e is BridgeSsePermissionAsked) {
+      stdout.writeln("[permission asked] ${e.tool}: ${e.description}");
+    }
+    if (e is BridgeSseQuestionAsked) {
+      stdout.writeln("[question asked] ${e.questions}");
+    }
+  });
+
+  stdout.writeln("healthCheck: ${await plugin.healthCheck()}");
+
+  final session = await plugin.createSession(
+    directory: cwd,
+    parentSessionId: null,
+    parts: [PluginPromptPart.text(text: prompt)],
+    variant: null,
+    agent: null,
+    model: null,
+  );
+  stdout.writeln("session: ${session.id}");
+
+  // Wait for the turn to finish (status flips back to idle).
+  final statuses = await _waitIdle(plugin, session.id, const Duration(seconds: 90));
+  stdout.writeln("status: $statuses");
+  stdout.writeln("assistant: ${assistant.toString().trim()}");
+
+  final agents = await plugin.getAgents(projectId: cwd);
+  stdout.writeln("agents: ${agents.map((a) => '${a.name} (${a.model?.modelID})').toList()}");
+  final providers = await plugin.getProviders(projectId: cwd);
+  stdout.writeln(
+    "providers: ${providers.providers.length}, "
+    "models: ${providers.providers.isEmpty ? 0 : providers.providers.first.models.length}",
+  );
+
+  await plugin.dispose();
+  exit(0);
+}
+
+Future<String> _waitIdle(BridgePluginApi plugin, String sessionId, Duration timeout) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    final statuses = await plugin.getSessionStatuses();
+    final status = statuses[sessionId];
+    if (status is PluginSessionStatusIdle) return "idle";
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+  }
+  return "timeout";
+}

--- a/bridge/pubspec.yaml
+++ b/bridge/pubspec.yaml
@@ -9,3 +9,5 @@ workspace:
   - sesori_plugin_opencode
   - sesori_plugin_runtime
   - sesori_plugin_interface
+  - sesori_plugin_acp
+  - sesori_plugin_cursor

--- a/bridge/sesori_plugin_acp/analysis_options.yaml
+++ b/bridge/sesori_plugin_acp/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../app/analysis_options.yaml

--- a/bridge/sesori_plugin_acp/build.yaml
+++ b/bridge/sesori_plugin_acp/build.yaml
@@ -1,0 +1,12 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          any_map: true
+          explicit_to_json: true
+      freezed:
+        options:
+          format: false
+          map: false
+          when: false

--- a/bridge/sesori_plugin_acp/lib/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/acp_plugin.dart
@@ -1,0 +1,18 @@
+// Generic ACP (Agent Client Protocol) backend machinery for the Sesori bridge.
+//
+// Provides a reusable stdio JSON-RPC transport, protocol builders/parsers, a
+// base session/update -> BridgeSseEvent mapper, a base permission registry,
+// session/load history replay, and a concrete AcpPlugin. Concrete harnesses
+// (e.g. cursor_plugin) consume these and layer on their own quirks.
+export "src/acp_approval_registry.dart";
+export "src/acp_event_mapper.dart";
+export "src/acp_plugin.dart";
+export "src/acp_process_factory.dart";
+export "src/acp_project_registry.dart";
+export "src/acp_protocol.dart";
+export "src/acp_session_loader.dart";
+export "src/acp_stdio_client.dart";
+// Plugin-lifecycle housing: the BridgePlugin wrapper + the host-backed process
+// factory a descriptor uses to run an ACP agent under the bridge's lifecycle.
+export "src/runtime/acp_bridge_plugin.dart";
+export "src/runtime/host_process_acp_factory.dart";

--- a/bridge/sesori_plugin_acp/lib/acp_testing.dart
+++ b/bridge/sesori_plugin_acp/lib/acp_testing.dart
@@ -1,0 +1,3 @@
+// Test utilities for ACP harness packages (FakeAcpProcess etc.). Import from
+// test code only: `package:acp_plugin/acp_testing.dart`.
+export "src/testing/fake_acp_process.dart";

--- a/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
@@ -1,0 +1,317 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "acp_protocol.dart";
+import "acp_stdio_client.dart";
+
+typedef AcpResponder = void Function(Object id, Object? result);
+typedef AcpErrorResponder = void Function(Object id, int code, String message);
+
+/// Builds the harness-specific reply payload for a pending question from the
+/// bridge's `List<List<String>>` answers (outer = per question, inner =
+/// selected values).
+typedef AcpQuestionReplyBuilder = Object? Function(List<List<String>> answers);
+
+enum _PendingKind { permission, question }
+
+class _PendingApproval {
+  _PendingApproval({
+    required this.bridgeRequestId,
+    required this.acpId,
+    required this.sessionId,
+    required this.kind,
+    this.params = const {},
+    this.questions = const [],
+    this.replyBuilder,
+  });
+
+  final String bridgeRequestId;
+
+  /// Original JSON-RPC `id` — echoed when responding.
+  final Object acpId;
+  final String sessionId;
+  final _PendingKind kind;
+
+  /// Raw request params (permission: carries the `options[]`).
+  final Map<String, dynamic> params;
+
+  /// Rendered questions for `getPendingQuestions` (question kind only).
+  final List<PluginQuestionInfo> questions;
+
+  /// Builds the reply payload (question kind only).
+  final AcpQuestionReplyBuilder? replyBuilder;
+}
+
+/// Routes ACP server-originated requests to the bridge SSE stream and answers
+/// them when the bridge consumer replies.
+///
+/// Handles the standard `session/request_permission` (the client must echo a
+/// server-supplied `optionId`). Harness extensions (e.g. Cursor's
+/// `cursor/ask_question`) are caught by overriding [handleExtensionRequest]
+/// and registering a pending question via [addPendingQuestion].
+class AcpApprovalRegistry {
+  AcpApprovalRegistry({
+    required void Function(BridgeSseEvent event) emit,
+    required AcpResponder respond,
+    required AcpErrorResponder respondError,
+    String Function()? idGenerator,
+  }) : _emit = emit,
+       _respond = respond,
+       _respondError = respondError,
+       _injectedIdGenerator = idGenerator;
+
+  /// Convenience constructor wiring the responders to an [AcpStdioClient].
+  factory AcpApprovalRegistry.forClient({
+    required AcpStdioClient client,
+    required void Function(BridgeSseEvent event) emit,
+    String Function()? idGenerator,
+  }) {
+    return AcpApprovalRegistry(
+      emit: emit,
+      respond: (id, result) => client.respondToServerRequest(id: id, result: result),
+      respondError: (id, code, message) =>
+          client.respondToServerRequestWithError(id: id, code: code, message: message),
+      idGenerator: idGenerator,
+    );
+  }
+
+  final void Function(BridgeSseEvent event) _emit;
+  final AcpResponder _respond;
+  final AcpErrorResponder _respondError;
+  final String Function()? _injectedIdGenerator;
+
+  StreamSubscription<AcpServerRequest>? _subscription;
+  int _seq = 0;
+  final Map<String, _PendingApproval> _pending = {};
+
+  // --- Hooks / helpers for subclasses (public: cross-package subclassing) ---
+
+  /// Emit a bridge event (e.g. from a subclass extension handler).
+  void emit(BridgeSseEvent event) => _emit(event);
+
+  /// Respond to a server request with a result payload.
+  void respond(Object acpId, Object? result) => _respond(acpId, result);
+
+  /// Respond to a server request with a JSON-RPC error.
+  void respondError(Object acpId, int code, String message) =>
+      _respondError(acpId, code, message);
+
+  /// Generates the next stable bridge request id (`br-N`).
+  String generateBridgeId() {
+    final injected = _injectedIdGenerator;
+    if (injected != null) return injected();
+    _seq++;
+    return "br-$_seq";
+  }
+
+  /// Registers a pending question (used by extension handlers). Caller is
+  /// responsible for emitting [BridgeSseQuestionAsked].
+  void addPendingQuestion({
+    required String bridgeRequestId,
+    required Object acpId,
+    required String sessionId,
+    required List<PluginQuestionInfo> questions,
+    required AcpQuestionReplyBuilder replyBuilder,
+  }) {
+    _pending[bridgeRequestId] = _PendingApproval(
+      bridgeRequestId: bridgeRequestId,
+      acpId: acpId,
+      sessionId: sessionId,
+      kind: _PendingKind.question,
+      questions: questions,
+      replyBuilder: replyBuilder,
+    );
+  }
+
+  /// Override to handle harness-specific server requests (e.g. Cursor's
+  /// `cursor/ask_question`). Return true if handled. Base handles none.
+  bool handleExtensionRequest(AcpServerRequest request) => false;
+
+  // --- Lifecycle ---
+
+  StreamSubscription<AcpServerRequest> attach(Stream<AcpServerRequest> stream) {
+    final subscription = stream.listen(_handle);
+    _subscription = subscription;
+    return subscription;
+  }
+
+  Future<void> dispose() async {
+    await _subscription?.cancel();
+    _subscription = null;
+    final remaining = List<_PendingApproval>.from(_pending.values);
+    _pending.clear();
+    for (final entry in remaining) {
+      try {
+        if (entry.kind == _PendingKind.permission) {
+          _respond(entry.acpId, const {
+            "outcome": {"outcome": "cancelled"},
+          });
+        } else {
+          _respondError(entry.acpId, -32000, "bridge dispose");
+        }
+      } catch (_) {
+        // Best-effort.
+      }
+    }
+  }
+
+  // --- Queries ---
+
+  List<PluginPendingQuestion> pendingForSession(String sessionId) {
+    return _pending.values
+        .where((e) => e.kind == _PendingKind.question && e.sessionId == sessionId)
+        .map(_toPluginPendingQuestion)
+        .toList(growable: false);
+  }
+
+  List<PluginPendingQuestion> pendingForProject(Iterable<String> sessionIds) {
+    final set = Set<String>.from(sessionIds);
+    return _pending.values
+        .where((e) => e.kind == _PendingKind.question && set.contains(e.sessionId))
+        .map(_toPluginPendingQuestion)
+        .toList(growable: false);
+  }
+
+  String? sessionIdFor(String bridgeRequestId) =>
+      _pending[bridgeRequestId]?.sessionId;
+
+  /// Whether [sessionId] is blocked awaiting user input — a pending permission
+  /// ask or question. Both kinds count, mirroring the OpenCode tracker's
+  /// "awaiting input" notion (see `_rootHasPendingInput`).
+  bool hasPendingInput(String sessionId) =>
+      _pending.values.any((e) => e.sessionId == sessionId);
+
+  // --- Replies ---
+
+  /// Acknowledges a permission ask. Maps the once/always/reject decision onto
+  /// the server-supplied option whose `kind` matches and echoes its
+  /// `optionId` (ACP requires the client to select a provided option).
+  bool replyPermission(String bridgeRequestId, PluginPermissionReply reply) {
+    final entry = _pending.remove(bridgeRequestId);
+    if (entry == null || entry.kind != _PendingKind.permission) return false;
+    final optionId = _selectOptionId(_optionsFrom(entry.params), reply);
+    if (optionId == null) {
+      _respond(entry.acpId, const {
+        "outcome": {"outcome": "cancelled"},
+      });
+    } else {
+      _respond(entry.acpId, {
+        "outcome": {"outcome": "selected", "optionId": optionId},
+      });
+    }
+    _emit(
+      BridgeSsePermissionReplied(
+        requestID: bridgeRequestId,
+        sessionID: entry.sessionId,
+        reply: reply.name,
+      ),
+    );
+    return true;
+  }
+
+  bool replyQuestion(String bridgeRequestId, List<List<String>> answers) {
+    final entry = _pending.remove(bridgeRequestId);
+    if (entry == null || entry.kind != _PendingKind.question) return false;
+    final payload = entry.replyBuilder?.call(answers) ??
+        {"answers": answers.map((row) => row.toList()).toList()};
+    _respond(entry.acpId, payload);
+    _emit(
+      BridgeSseQuestionReplied(
+        requestID: bridgeRequestId,
+        sessionID: entry.sessionId,
+      ),
+    );
+    return true;
+  }
+
+  bool rejectQuestion(String bridgeRequestId) {
+    final entry = _pending.remove(bridgeRequestId);
+    if (entry == null || entry.kind != _PendingKind.question) return false;
+    _respondError(entry.acpId, -32603, "user rejected");
+    _emit(
+      BridgeSseQuestionRejected(
+        requestID: bridgeRequestId,
+        sessionID: entry.sessionId,
+      ),
+    );
+    return true;
+  }
+
+  // --- Internals ---
+
+  void _handle(AcpServerRequest request) {
+    if (request.method == AcpMethods.sessionRequestPermission) {
+      _handlePermission(request);
+      return;
+    }
+    if (handleExtensionRequest(request)) return;
+    _respondError(
+      request.id,
+      -32601,
+      "method not handled by bridge: ${request.method}",
+    );
+  }
+
+  void _handlePermission(AcpServerRequest request) {
+    final toolCall = _asMap(request.params["toolCall"]) ?? const {};
+    final sessionId = (request.params["sessionId"] as String?) ?? "";
+    final bridgeRequestId = generateBridgeId();
+    _pending[bridgeRequestId] = _PendingApproval(
+      bridgeRequestId: bridgeRequestId,
+      acpId: request.id,
+      sessionId: sessionId,
+      kind: _PendingKind.permission,
+      params: request.params,
+    );
+    _emit(
+      BridgeSsePermissionAsked(
+        requestID: bridgeRequestId,
+        sessionID: sessionId,
+        tool: (toolCall["kind"] as String?) ?? "tool",
+        description: (toolCall["title"] as String?) ??
+            (toolCall["toolCallId"] as String?) ??
+            "permission requested",
+      ),
+    );
+  }
+
+  PluginPendingQuestion _toPluginPendingQuestion(_PendingApproval entry) {
+    return PluginPendingQuestion(
+      id: entry.bridgeRequestId,
+      sessionID: entry.sessionId,
+      questions: entry.questions,
+    );
+  }
+
+  List<Map<String, dynamic>> _optionsFrom(Map<String, dynamic> params) {
+    final raw = params["options"];
+    if (raw is! List) return const [];
+    return raw
+        .whereType<Map<dynamic, dynamic>>()
+        .map((m) => m.cast<String, dynamic>())
+        .toList(growable: false);
+  }
+
+  String? _selectOptionId(
+    List<Map<String, dynamic>> options,
+    PluginPermissionReply reply,
+  ) {
+    final preference = switch (reply) {
+      PluginPermissionReply.once => const ["allow_once", "allow_always"],
+      PluginPermissionReply.always => const ["allow_always", "allow_once"],
+      PluginPermissionReply.reject => const ["reject_once", "reject_always"],
+    };
+    for (final kind in preference) {
+      for (final option in options) {
+        if (option["kind"] == kind) return option["optionId"] as String?;
+      }
+    }
+    return null;
+  }
+
+  Map<String, dynamic>? _asMap(Object? value) {
+    if (value is Map) return value.cast<String, dynamic>();
+    return null;
+  }
+}

--- a/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
@@ -137,7 +137,13 @@ class AcpApprovalRegistry {
   }
 
   Future<void> dispose() async {
-    await _subscription?.cancel();
+    // Isolated so a failed cancel cannot skip the pending-approval cleanup
+    // below, which unblocks callers awaiting a permission/question reply.
+    try {
+      await _subscription?.cancel();
+    } on Object catch (e, st) {
+      Log.w("[acp] failed to cancel approval subscription", e, st);
+    }
     _subscription = null;
     final remaining = List<_PendingApproval>.from(_pending.values);
     _pending.clear();

--- a/bridge/sesori_plugin_acp/lib/src/acp_content.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_content.dart
@@ -1,0 +1,75 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+/// Shared parsing helpers for ACP `tool_call`/content payloads.
+///
+/// Both the live [AcpEventMapper] and the [AcpSessionLoader] replay path render
+/// the same ACP shapes; these are the single implementation so the live and
+/// history renderings cannot drift apart.
+
+/// Maps an ACP tool-call status string onto the [PluginToolStatus] the mobile
+/// tool renderer consumes. Tuned during end-to-end verification.
+PluginToolStatus acpToolStatus(Object? raw) {
+  return switch (raw) {
+    "pending" => PluginToolStatus.pending,
+    "in_progress" => PluginToolStatus.running,
+    "completed" => PluginToolStatus.completed,
+    "failed" => PluginToolStatus.error,
+    _ => PluginToolStatus.pending,
+  };
+}
+
+/// Tool output for a `tool_call`/`tool_call_update`: prefers an ACP `content`
+/// block, else falls back to the harness `rawOutput` (cursor reports an executed
+/// command's stdout/stderr there, not in `content`). Truncated to
+/// [maxToolOutputLength] so the mobile tool renderer is not flooded.
+String? acpToolOutputText(Map<String, dynamic> update) {
+  final text =
+      acpContentText(update["content"]) ?? acpRawOutputText(update["rawOutput"]);
+  if (text == null || text.isEmpty) return null;
+  return text.length > maxToolOutputLength
+      ? "${text.substring(0, maxToolOutputLength)}…"
+      : text;
+}
+
+/// Flattens a `rawOutput` block into displayable text. Exec-style tools report
+/// `{exitCode, stdout, stderr}`; read/other tools report `{content}` (string or
+/// ContentBlock(s)); some report a bare string.
+String? acpRawOutputText(Object? raw) {
+  if (raw is String) return raw.isEmpty ? null : raw;
+  if (raw is! Map) return null;
+  final map = raw.cast<String, dynamic>();
+  final out = (map["stdout"] as String?)?.trimRight() ?? "";
+  final err = (map["stderr"] as String?)?.trimRight() ?? "";
+  if (out.isNotEmpty || err.isNotEmpty) {
+    final buffer = StringBuffer(out);
+    if (err.isNotEmpty) {
+      if (buffer.isNotEmpty) buffer.write("\n");
+      buffer.write(err);
+    }
+    return buffer.toString();
+  }
+  final content = acpContentText(map["content"])?.trimRight();
+  return (content == null || content.isEmpty) ? null : content;
+}
+
+/// Extracts text from an ACP `ContentBlock` (`{type:text,text}`) or a list of
+/// them.
+String? acpContentText(Object? content) {
+  if (content is String) return content.isEmpty ? null : content;
+  if (content is Map) {
+    final text = content["text"];
+    return text is String && text.isNotEmpty ? text : null;
+  }
+  if (content is List) {
+    final buffer = StringBuffer();
+    for (final entry in content) {
+      if (entry is Map) {
+        final text = entry["text"];
+        if (text is String) buffer.write(text);
+      }
+    }
+    final result = buffer.toString();
+    return result.isEmpty ? null : result;
+  }
+  return null;
+}

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -1,0 +1,425 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" as shared;
+
+import "acp_protocol.dart";
+import "acp_stdio_client.dart";
+
+/// Translates ACP `session/update` notifications into bridge-neutral
+/// [BridgeSseEvent]s.
+///
+/// Like the codex mapper, the `info` maps on session/message events MUST be
+/// sesori-schema JSON (parseable by `Message.fromJson` / `Session.fromJson`),
+/// so we build typed `sesori_shared` models and `.toJson()` them.
+///
+/// ACP differs from codex's app-server protocol in two ways that shape this
+/// mapper:
+///  1. There are no `turn/started` / `turn/completed` notifications — the
+///     plugin derives busy/idle from the `session/prompt` future, so this
+///     mapper does not emit session-status events.
+///  2. Streaming chunks (`agent_message_chunk`, …) carry no message id, so we
+///     synthesize a stable per-turn id. The plugin calls [beginTurn] before
+///     each `session/prompt` to advance the turn counter.
+///
+/// Harness-specific notifications (e.g. Cursor's `cursor/*`) are routed to
+/// [mapExtension], which subclasses override.
+class AcpEventMapper {
+  AcpEventMapper({required this.projectCwd, required this.agentId});
+
+  /// The bridge launch CWD — the single synthesized project id.
+  final String projectCwd;
+
+  /// Agent name stamped on assistant messages (e.g. "cursor").
+  final String agentId;
+
+  /// Global fallback model/provider stamped on assistant messages when a
+  /// session has no specific model recorded. The plugin sets these once the
+  /// model catalog resolves.
+  String? currentModelId;
+  String? currentProviderId;
+
+  /// Per-session model/provider. ACP's live `*_chunk` notifications carry no
+  /// model, so the plugin records the resolved per-session model here (via
+  /// [setSessionModel]); without it every streamed message would be stamped
+  /// with the global [currentModelId], making a per-session model switch look
+  /// like it never took effect.
+  final Map<String, String> _sessionModel = {};
+  final Map<String, String> _sessionProvider = {};
+
+  /// Records the model/provider resolved for [sessionId]. A null/empty
+  /// [modelId] clears the override (falls back to [currentModelId]).
+  void setSessionModel(String sessionId, String? modelId, {String? providerId}) {
+    if (modelId == null || modelId.isEmpty) {
+      _sessionModel.remove(sessionId);
+    } else {
+      _sessionModel[sessionId] = modelId;
+    }
+    if (providerId != null && providerId.isNotEmpty) {
+      _sessionProvider[sessionId] = providerId;
+    }
+  }
+
+  /// The model/provider to stamp on [sessionId]'s assistant messages.
+  String? modelForSession(String sessionId) =>
+      _sessionModel[sessionId] ?? currentModelId;
+  String? providerForSession(String sessionId) =>
+      _sessionProvider[sessionId] ?? currentProviderId;
+
+  /// sessionId -> current turn number, advanced by [beginTurn].
+  final Map<String, int> _turnSeq = {};
+
+  /// Part ids whose envelope/part has already been emitted this run.
+  final Set<String> _startedParts = {};
+
+  /// Advance the turn counter for [sessionId]. Call before `session/prompt`
+  /// so the next batch of streamed chunks groups under a fresh message id.
+  void beginTurn(String sessionId) {
+    _turnSeq[sessionId] = (_turnSeq[sessionId] ?? 0) + 1;
+  }
+
+  int _turn(String sessionId) => _turnSeq[sessionId] ?? 1;
+
+  /// Maps a single notification to zero or more bridge events.
+  List<BridgeSseEvent> map(AcpNotification notification) {
+    if (notification.method != AcpMethods.sessionUpdate) {
+      return mapExtension(notification);
+    }
+    final params = notification.params;
+    final sessionId = params["sessionId"] as String?;
+    final update = _asMap(params["update"]);
+    if (sessionId == null || sessionId.isEmpty || update == null) {
+      return const [];
+    }
+
+    switch (update["sessionUpdate"] as String?) {
+      case "agent_message_chunk":
+        return _textChunk(
+          sessionId: sessionId,
+          update: update,
+          role: _ChunkRole.assistant,
+          partSuffix: "text",
+          partType: PluginMessagePartType.text,
+        );
+      case "agent_thought_chunk":
+        return _textChunk(
+          sessionId: sessionId,
+          update: update,
+          role: _ChunkRole.assistant,
+          partSuffix: "reasoning",
+          partType: PluginMessagePartType.reasoning,
+        );
+      case "user_message_chunk":
+        return _textChunk(
+          sessionId: sessionId,
+          update: update,
+          role: _ChunkRole.user,
+          partSuffix: "text",
+          partType: PluginMessagePartType.text,
+        );
+      case "tool_call":
+        return _toolCall(sessionId: sessionId, update: update);
+      case "tool_call_update":
+        return _toolCallUpdate(sessionId: sessionId, update: update);
+      case "plan":
+        return [BridgeSseTodoUpdated(sessionID: sessionId)];
+      case "available_commands_update":
+        return const [BridgeSseProjectUpdated()];
+      case "session_info_update":
+        // The agent's auto-generated title for the thread. Surfaced as a
+        // session update so the mobile session list / app bar live-update.
+        final title = update["title"] as String?;
+        if (title == null || title.isEmpty) return const [];
+        return [
+          BridgeSseSessionUpdated(info: _minimalSession(sessionId, title).toJson()),
+        ];
+    }
+
+    // Dropped intentionally: current_mode_update (the mode is surfaced as the
+    // session "variant", driven by the plugin, not a message event), and any
+    // future standard variants the mobile UI has no renderer for.
+    return const [];
+  }
+
+  /// Hook for non-`session/update` notifications (harness extensions such as
+  /// Cursor's `cursor/update_todos`). Base implementation drops them.
+  List<BridgeSseEvent> mapExtension(AcpNotification notification) => const [];
+
+  List<BridgeSseEvent> _textChunk({
+    required String sessionId,
+    required Map<String, dynamic> update,
+    required _ChunkRole role,
+    required String partSuffix,
+    required PluginMessagePartType partType,
+  }) {
+    final text = _contentText(update["content"]);
+    if (text == null || text.isEmpty) return const [];
+
+    final messageId = "$sessionId-t${_turn(sessionId)}-${role.name}";
+    final partId = "$messageId-$partSuffix";
+
+    final events = <BridgeSseEvent>[];
+    if (_startedParts.add(partId)) {
+      events.add(
+        BridgeSseMessageUpdated(info: _messageFor(role, messageId, sessionId).toJson()),
+      );
+      events.add(
+        BridgeSseMessagePartUpdated(
+          part: _part(
+            partId: partId,
+            messageId: messageId,
+            sessionId: sessionId,
+            type: partType,
+            text: "",
+          ),
+        ),
+      );
+    }
+    events.add(
+      BridgeSseMessagePartDelta(
+        sessionID: sessionId,
+        messageID: messageId,
+        partID: partId,
+        field: "text",
+        delta: text,
+      ),
+    );
+    return events;
+  }
+
+  List<BridgeSseEvent> _toolCall({
+    required String sessionId,
+    required Map<String, dynamic> update,
+  }) {
+    final toolCallId = update["toolCallId"] as String?;
+    if (toolCallId == null || toolCallId.isEmpty) return const [];
+    final messageId = "$sessionId-tool-$toolCallId";
+    final partId = "$messageId-call";
+    _startedParts.add(partId);
+    final title = update["title"] as String?;
+    final kind = update["kind"] as String?;
+    final status = _toolStatus(update["status"]);
+    final output = toolOutputText(update);
+    return [
+      BridgeSseMessageUpdated(
+        info: shared.Message.assistant(
+          id: messageId,
+          sessionID: sessionId,
+          agent: agentId,
+          modelID: modelForSession(sessionId),
+          providerID: providerForSession(sessionId),
+          // ACP carries no per-message timestamps; the mobile model treats
+          // a null time as "unknown".
+          time: null,
+        ).toJson(),
+      ),
+      BridgeSseMessagePartUpdated(
+        part: _toolPart(
+          partId: partId,
+          messageId: messageId,
+          sessionId: sessionId,
+          tool: kind ?? title ?? "tool",
+          state: PluginToolState(
+            status: status,
+            title: title,
+            output: output,
+            error: status == PluginToolStatus.error ? output : null,
+          ),
+        ),
+      ),
+    ];
+  }
+
+  List<BridgeSseEvent> _toolCallUpdate({
+    required String sessionId,
+    required Map<String, dynamic> update,
+  }) {
+    final toolCallId = update["toolCallId"] as String?;
+    if (toolCallId == null || toolCallId.isEmpty) return const [];
+    final messageId = "$sessionId-tool-$toolCallId";
+    final partId = "$messageId-call";
+    final status = _toolStatus(update["status"]);
+    final output = toolOutputText(update);
+    final events = <BridgeSseEvent>[
+      BridgeSseMessagePartUpdated(
+        part: _toolPart(
+          partId: partId,
+          messageId: messageId,
+          sessionId: sessionId,
+          tool: (update["kind"] ?? update["title"] ?? "tool") as String,
+          state: PluginToolState(
+            status: status,
+            title: update["title"] as String?,
+            output: output,
+            error: status == PluginToolStatus.error ? output : null,
+          ),
+        ),
+      ),
+    ];
+    if (_isFileMutation(update)) {
+      events.add(BridgeSseSessionDiff(sessionID: sessionId));
+    }
+    return events;
+  }
+
+  shared.Message _messageFor(_ChunkRole role, String messageId, String sessionId) {
+    return switch (role) {
+      _ChunkRole.user => shared.Message.user(
+        id: messageId,
+        sessionID: sessionId,
+        agent: null,
+        time: null,
+      ),
+      _ChunkRole.assistant => shared.Message.assistant(
+        id: messageId,
+        sessionID: sessionId,
+        agent: agentId,
+        modelID: modelForSession(sessionId),
+        providerID: providerForSession(sessionId),
+        time: null,
+      ),
+    };
+  }
+
+  /// A minimal [shared.Session] for a `session_info_update`; the bridge
+  /// enrichment + mobile merge it against existing state, so only the id and
+  /// title matter here.
+  shared.Session _minimalSession(String id, String? title) {
+    return shared.Session(
+      id: id,
+      projectID: projectCwd,
+      directory: projectCwd,
+      parentID: null,
+      title: title,
+      time: null,
+      summary: null,
+      pullRequest: null,
+      promptDefaults: null,
+    );
+  }
+
+  PluginMessagePart _part({
+    required String partId,
+    required String messageId,
+    required String sessionId,
+    required PluginMessagePartType type,
+    required String text,
+  }) {
+    return PluginMessagePart(
+      id: partId,
+      sessionID: sessionId,
+      messageID: messageId,
+      type: type,
+      text: text,
+      tool: null,
+      state: null,
+      prompt: null,
+      description: null,
+      agent: null,
+      agentName: null,
+      attempt: null,
+      retryError: null,
+    );
+  }
+
+  PluginMessagePart _toolPart({
+    required String partId,
+    required String messageId,
+    required String sessionId,
+    required String tool,
+    required PluginToolState state,
+  }) {
+    return PluginMessagePart(
+      id: partId,
+      sessionID: sessionId,
+      messageID: messageId,
+      type: PluginMessagePartType.tool,
+      text: null,
+      tool: tool,
+      state: state,
+      prompt: null,
+      description: null,
+      agent: null,
+      agentName: null,
+      attempt: null,
+      retryError: null,
+    );
+  }
+
+  /// Normalizes an ACP tool-call status onto the [PluginToolStatus] the mobile
+  /// tool renderer consumes. Tuned during end-to-end verification.
+  PluginToolStatus _toolStatus(Object? raw) {
+    return switch (raw) {
+      "pending" => PluginToolStatus.pending,
+      "in_progress" => PluginToolStatus.running,
+      "completed" => PluginToolStatus.completed,
+      "failed" => PluginToolStatus.error,
+      _ => PluginToolStatus.pending,
+    };
+  }
+
+  bool _isFileMutation(Map<String, dynamic> update) {
+    final kind = update["kind"] as String?;
+    return kind == "edit" || kind == "delete" || kind == "move";
+  }
+
+  /// Tool output for a `tool_call`/`tool_call_update`: prefers an ACP
+  /// `content` block, else falls back to the harness `rawOutput` (cursor
+  /// reports an executed command's stdout/stderr there, not in `content`).
+  /// Truncated to [maxToolOutputLength] so the mobile tool renderer is not
+  /// flooded by large command output.
+  String? toolOutputText(Map<String, dynamic> update) {
+    final text = _contentText(update["content"]) ?? _rawOutputText(update["rawOutput"]);
+    if (text == null || text.isEmpty) return null;
+    return text.length > maxToolOutputLength
+        ? "${text.substring(0, maxToolOutputLength)}…"
+        : text;
+  }
+
+  /// Flattens a `rawOutput` block into displayable text. Exec-style tools report
+  /// `{exitCode, stdout, stderr}`; read/other tools report `{content}` (string
+  /// or ContentBlock(s)); some report a bare string.
+  String? _rawOutputText(Object? raw) {
+    if (raw is String) return raw.isEmpty ? null : raw;
+    if (raw is! Map) return null;
+    final map = raw.cast<String, dynamic>();
+    final out = (map["stdout"] as String?)?.trimRight() ?? "";
+    final err = (map["stderr"] as String?)?.trimRight() ?? "";
+    if (out.isNotEmpty || err.isNotEmpty) {
+      final buffer = StringBuffer(out);
+      if (err.isNotEmpty) {
+        if (buffer.isNotEmpty) buffer.write("\n");
+        buffer.write(err);
+      }
+      return buffer.toString();
+    }
+    final content = _contentText(map["content"])?.trimRight();
+    return (content == null || content.isEmpty) ? null : content;
+  }
+
+  /// Extracts text from an ACP `ContentBlock` (`{type:text,text}`) or a list
+  /// of them.
+  String? _contentText(Object? content) {
+    if (content is String) return content.isEmpty ? null : content;
+    if (content is Map) {
+      final text = content["text"];
+      return text is String && text.isNotEmpty ? text : null;
+    }
+    if (content is List) {
+      final buffer = StringBuffer();
+      for (final entry in content) {
+        final map = _asMap(entry);
+        final text = map?["text"];
+        if (text is String) buffer.write(text);
+      }
+      final result = buffer.toString();
+      return result.isEmpty ? null : result;
+    }
+    return null;
+  }
+
+  Map<String, dynamic>? _asMap(Object? value) {
+    if (value is Map) return value.cast<String, dynamic>();
+    return null;
+  }
+}
+
+enum _ChunkRole { user, assistant }

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -1,6 +1,7 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" as shared;
 
+import "acp_content.dart";
 import "acp_protocol.dart";
 import "acp_stdio_client.dart";
 
@@ -63,6 +64,29 @@ class AcpEventMapper {
       _sessionModel[sessionId] ?? currentModelId;
   String? providerForSession(String sessionId) =>
       _sessionProvider[sessionId] ?? currentProviderId;
+
+  /// Per-session project directory (an ACP project id *is* its `cwd`). The
+  /// plugin records it so `session_info_update` (title) events are filed under
+  /// the session's real project, not the launch [projectCwd]. The mobile
+  /// session list drops `session.updated` events whose projectID does not match
+  /// the active project, so a session opened outside the launch directory would
+  /// otherwise have its title updates ignored (or misrouted to the launch
+  /// project).
+  final Map<String, String> _sessionProject = {};
+
+  /// Records the project directory [sessionId] belongs to. A null/empty
+  /// [directory] clears the override (falls back to [projectCwd]).
+  void setSessionProject(String sessionId, String? directory) {
+    if (directory == null || directory.isEmpty) {
+      _sessionProject.remove(sessionId);
+    } else {
+      _sessionProject[sessionId] = directory;
+    }
+  }
+
+  /// The project id/directory to stamp on [sessionId]'s session-level events.
+  String projectForSession(String sessionId) =>
+      _sessionProject[sessionId] ?? projectCwd;
 
   /// sessionId -> current turn number, advanced by [beginTurn].
   final Map<String, int> _turnSeq = {};
@@ -150,7 +174,7 @@ class AcpEventMapper {
     required String partSuffix,
     required PluginMessagePartType partType,
   }) {
-    final text = _contentText(update["content"]);
+    final text = acpContentText(update["content"]);
     if (text == null || text.isEmpty) return const [];
 
     final messageId = "$sessionId-t${_turn(sessionId)}-${role.name}";
@@ -196,8 +220,8 @@ class AcpEventMapper {
     _startedParts.add(partId);
     final title = update["title"] as String?;
     final kind = update["kind"] as String?;
-    final status = _toolStatus(update["status"]);
-    final output = toolOutputText(update);
+    final status = acpToolStatus(update["status"]);
+    final output = acpToolOutputText(update);
     return [
       BridgeSseMessageUpdated(
         info: shared.Message.assistant(
@@ -236,8 +260,8 @@ class AcpEventMapper {
     if (toolCallId == null || toolCallId.isEmpty) return const [];
     final messageId = "$sessionId-tool-$toolCallId";
     final partId = "$messageId-call";
-    final status = _toolStatus(update["status"]);
-    final output = toolOutputText(update);
+    final status = acpToolStatus(update["status"]);
+    final output = acpToolOutputText(update);
     final events = <BridgeSseEvent>[
       BridgeSseMessagePartUpdated(
         part: _toolPart(
@@ -283,10 +307,11 @@ class AcpEventMapper {
   /// enrichment + mobile merge it against existing state, so only the id and
   /// title matter here.
   shared.Session _minimalSession(String id, String? title) {
+    final project = projectForSession(id);
     return shared.Session(
       id: id,
-      projectID: projectCwd,
-      directory: projectCwd,
+      projectID: project,
+      directory: project,
       parentID: null,
       title: title,
       time: null,
@@ -344,76 +369,9 @@ class AcpEventMapper {
     );
   }
 
-  /// Normalizes an ACP tool-call status onto the [PluginToolStatus] the mobile
-  /// tool renderer consumes. Tuned during end-to-end verification.
-  PluginToolStatus _toolStatus(Object? raw) {
-    return switch (raw) {
-      "pending" => PluginToolStatus.pending,
-      "in_progress" => PluginToolStatus.running,
-      "completed" => PluginToolStatus.completed,
-      "failed" => PluginToolStatus.error,
-      _ => PluginToolStatus.pending,
-    };
-  }
-
   bool _isFileMutation(Map<String, dynamic> update) {
     final kind = update["kind"] as String?;
     return kind == "edit" || kind == "delete" || kind == "move";
-  }
-
-  /// Tool output for a `tool_call`/`tool_call_update`: prefers an ACP
-  /// `content` block, else falls back to the harness `rawOutput` (cursor
-  /// reports an executed command's stdout/stderr there, not in `content`).
-  /// Truncated to [maxToolOutputLength] so the mobile tool renderer is not
-  /// flooded by large command output.
-  String? toolOutputText(Map<String, dynamic> update) {
-    final text = _contentText(update["content"]) ?? _rawOutputText(update["rawOutput"]);
-    if (text == null || text.isEmpty) return null;
-    return text.length > maxToolOutputLength
-        ? "${text.substring(0, maxToolOutputLength)}…"
-        : text;
-  }
-
-  /// Flattens a `rawOutput` block into displayable text. Exec-style tools report
-  /// `{exitCode, stdout, stderr}`; read/other tools report `{content}` (string
-  /// or ContentBlock(s)); some report a bare string.
-  String? _rawOutputText(Object? raw) {
-    if (raw is String) return raw.isEmpty ? null : raw;
-    if (raw is! Map) return null;
-    final map = raw.cast<String, dynamic>();
-    final out = (map["stdout"] as String?)?.trimRight() ?? "";
-    final err = (map["stderr"] as String?)?.trimRight() ?? "";
-    if (out.isNotEmpty || err.isNotEmpty) {
-      final buffer = StringBuffer(out);
-      if (err.isNotEmpty) {
-        if (buffer.isNotEmpty) buffer.write("\n");
-        buffer.write(err);
-      }
-      return buffer.toString();
-    }
-    final content = _contentText(map["content"])?.trimRight();
-    return (content == null || content.isEmpty) ? null : content;
-  }
-
-  /// Extracts text from an ACP `ContentBlock` (`{type:text,text}`) or a list
-  /// of them.
-  String? _contentText(Object? content) {
-    if (content is String) return content.isEmpty ? null : content;
-    if (content is Map) {
-      final text = content["text"];
-      return text is String && text.isNotEmpty ? text : null;
-    }
-    if (content is List) {
-      final buffer = StringBuffer();
-      for (final entry in content) {
-        final map = _asMap(entry);
-        final text = map?["text"];
-        if (text is String) buffer.write(text);
-      }
-      final result = buffer.toString();
-      return result.isEmpty ? null : result;
-    }
-    return null;
   }
 
   Map<String, dynamic>? _asMap(Object? value) {

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -73,6 +73,14 @@ class AcpPlugin implements BridgePluginApi {
   AcpApprovalRegistry? _approvalRegistry;
   AcpInitializeResult? _initResult;
 
+  /// Emits after each successful (re)connect — including a lazy reconnect that
+  /// follows [resetConnectionAfterExit] — so the lifecycle wrapper can re-arm
+  /// its exit watch on the new client and flip back to ready. Broadcast (no
+  /// buffering): the initial connect, driven by the wrapper directly, is not a
+  /// subscriber so it is not double-handled.
+  final StreamController<void> _connected = StreamController<void>.broadcast();
+  Stream<void> get onConnected => _connected.stream;
+
   final Map<String, PluginSessionStatus> _sessionStatuses = {};
   final Set<String> _activeSessions = {};
 
@@ -165,6 +173,7 @@ class AcpPlugin implements BridgePluginApi {
         _approvalRegistry = registry;
         registry.attach(client.serverRequests);
         _initResult = await _initialize(client);
+        if (!_connected.isClosed) _connected.add(null);
         return true;
       } catch (error) {
         await client.dispose();
@@ -900,6 +909,11 @@ class AcpPlugin implements BridgePluginApi {
       await _eventBuffer.close();
     } on Object catch (e, st) {
       Log.w("[$id] failed to close event buffer", e, st);
+    }
+    try {
+      await _connected.close();
+    } on Object catch (e, st) {
+      Log.w("[$id] failed to close connected stream", e, st);
     }
   }
 }

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -216,6 +216,44 @@ class AcpPlugin implements BridgePluginApi {
     return client;
   }
 
+  /// Tears down the cached ACP connection after the agent subprocess exits, so
+  /// the next [ensureConnected] spawns a fresh agent instead of writing to the
+  /// dead process. The lifecycle wrapper calls this from its exit watch when an
+  /// unexpected exit flips the plugin to degraded; without it the cached
+  /// `_connectFuture`/`_client` keep reporting a successful connection and
+  /// requests are written to the exited process until they fail or time out.
+  ///
+  /// Resident sessions are forgotten: the replacement process holds no sessions
+  /// until they are re-created or resumed via `session/load`. The event channel
+  /// and project registry are left intact — the plugin stays alive, only the
+  /// connection is reset. Never throws.
+  Future<void> resetConnectionAfterExit() async {
+    _connectFuture = null;
+    _initResult = null;
+    _residentSessions.clear();
+    final sub = _notificationSubscription;
+    _notificationSubscription = null;
+    final registry = _approvalRegistry;
+    _approvalRegistry = null;
+    final client = _client;
+    _client = null;
+    try {
+      await sub?.cancel();
+    } on Object catch (e, st) {
+      Log.w("[$id] failed to cancel notification subscription on reset", e, st);
+    }
+    try {
+      await registry?.dispose();
+    } on Object catch (e, st) {
+      Log.w("[$id] failed to dispose approval registry on reset", e, st);
+    }
+    try {
+      await client?.dispose();
+    } on Object catch (e, st) {
+      Log.w("[$id] failed to dispose client on reset", e, st);
+    }
+  }
+
   @override
   Future<bool> healthCheck() async {
     try {
@@ -277,7 +315,10 @@ class AcpPlugin implements BridgePluginApi {
     final id = (raw["sessionId"] ?? "") as String;
     // Remember which project this session belongs to so a later turn/history
     // load uses its own cwd and the activity badge lands on the right project.
-    if (id.isNotEmpty) _sessionProjects[id] = projectId;
+    if (id.isNotEmpty) {
+      _sessionProjects[id] = projectId;
+      eventMapper.setSessionProject(id, projectId);
+    }
     return PluginSession(
       id: id,
       projectID: projectId,
@@ -320,6 +361,7 @@ class AcpPlugin implements BridgePluginApi {
       throw StateError("session/new response missing sessionId");
     }
     _sessionProjects[session.sessionId] = projectId;
+    eventMapper.setSessionProject(session.sessionId, projectId);
     captureSessionConfig(session.raw, sessionId: session.sessionId);
     // session/new leaves the session resident in the agent process.
     _residentSessions.add(session.sessionId);
@@ -542,6 +584,7 @@ class AcpPlugin implements BridgePluginApi {
     _sessionStatuses.remove(sessionId);
     _residentSessions.remove(sessionId);
     _sessionProjects.remove(sessionId);
+    eventMapper.setSessionProject(sessionId, null);
   }
 
   @override
@@ -623,8 +666,16 @@ class AcpPlugin implements BridgePluginApi {
     } catch (_) {
       return const [];
     } finally {
-      await sub?.cancel();
-      await replayClient.dispose();
+      try {
+        await sub?.cancel();
+      } on Object catch (e, st) {
+        Log.w("[$id] failed to cancel replay subscription", e, st);
+      }
+      try {
+        await replayClient.dispose();
+      } on Object catch (e, st) {
+        Log.w("[$id] failed to dispose replay client", e, st);
+      }
     }
   }
 
@@ -821,12 +872,34 @@ class AcpPlugin implements BridgePluginApi {
 
   @override
   Future<void> dispose() async {
-    await _notificationSubscription?.cancel();
-    _notificationSubscription = null;
-    await _approvalRegistry?.dispose();
-    _approvalRegistry = null;
-    await _client?.dispose();
-    _client = null;
-    await _eventBuffer.close();
+    // Each teardown step is isolated so a failure in one (e.g. a hung
+    // subscription) cannot skip a later one (e.g. reaping the agent
+    // subprocess). dispose() must not throw — log and continue.
+    try {
+      await _notificationSubscription?.cancel();
+    } on Object catch (e, st) {
+      Log.w("[$id] failed to cancel notification subscription", e, st);
+    } finally {
+      _notificationSubscription = null;
+    }
+    try {
+      await _approvalRegistry?.dispose();
+    } on Object catch (e, st) {
+      Log.w("[$id] failed to dispose approval registry", e, st);
+    } finally {
+      _approvalRegistry = null;
+    }
+    try {
+      await _client?.dispose();
+    } on Object catch (e, st) {
+      Log.w("[$id] failed to dispose client", e, st);
+    } finally {
+      _client = null;
+    }
+    try {
+      await _eventBuffer.close();
+    } on Object catch (e, st) {
+      Log.w("[$id] failed to close event buffer", e, st);
+    }
   }
 }

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1,0 +1,832 @@
+import "dart:async";
+
+import "package:path/path.dart" as p;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" as shared;
+
+import "acp_approval_registry.dart";
+import "acp_event_mapper.dart";
+import "acp_process_factory.dart";
+import "acp_project_registry.dart";
+import "acp_protocol.dart";
+import "acp_session_loader.dart";
+import "acp_stdio_client.dart";
+
+/// Base [BridgePluginApi] implementation for any ACP (Agent Client Protocol)
+/// agent driven over stdio.
+///
+/// Concrete so a vanilla ACP harness needs only an [id] + [agentDisplayName]
+/// (the "config row" case). Harnesses with quirks (e.g. Cursor's model
+/// selection and `cursor/*` extensions) subclass and override the hooks:
+/// [buildApprovalRegistry], [applyModelSelection], [authMethodId],
+/// [initializeCapabilityMeta], [getAgents], [getProviders].
+///
+/// Unlike the codex plugin (which connects to a process listening on a ws
+/// port), this owns the agent subprocess: it spawns lazily on first use and
+/// reaps it on [dispose].
+class AcpPlugin implements BridgePluginApi {
+  AcpPlugin({
+    required this.id,
+    required this.agentDisplayName,
+    required this.launchSpec,
+    required this.projectCwd,
+    required this.eventMapper,
+    AcpProcessFactory? processFactory,
+    HostJsonStore? projectStore,
+  }) : _processFactory = processFactory,
+       _eventBuffer = BufferedUntilFirstListener<BridgeSseEvent>(),
+       _projects = AcpProjectRegistry(cwd: projectCwd, store: projectStore);
+
+  @override
+  final String id;
+
+  /// Human-facing agent name used for synthesized agents/providers.
+  final String agentDisplayName;
+
+  final AcpLaunchSpec launchSpec;
+
+  /// Bridge launch CWD — the implicit default project (always present in the
+  /// [_projects] registry, even before any directory is explicitly opened).
+  final String projectCwd;
+
+  /// The live event mapper (subclasses may pass a specialized one).
+  final AcpEventMapper eventMapper;
+
+  final AcpProcessFactory? _processFactory;
+  final BufferedUntilFirstListener<BridgeSseEvent> _eventBuffer;
+
+  /// Persistent set of directories opened as projects (seeded with
+  /// [projectCwd]). ACP agents have no project list of their own — each session
+  /// just carries a `cwd` — so the plugin tracks them here and persists across
+  /// restarts via the host JSON store.
+  final AcpProjectRegistry _projects;
+
+  /// sessionId -> the canonical project id (directory) the session belongs to.
+  /// Populated on create, on `session/list`, and lets a turn/history load use
+  /// the session's own `cwd` (not the launch CWD) and the activity summary be
+  /// grouped under the right project.
+  final Map<String, String> _sessionProjects = {};
+
+  AcpStdioClient? _client;
+  Future<bool>? _connectFuture;
+  StreamSubscription<AcpNotification>? _notificationSubscription;
+  AcpApprovalRegistry? _approvalRegistry;
+  AcpInitializeResult? _initResult;
+
+  final Map<String, PluginSessionStatus> _sessionStatuses = {};
+  final Set<String> _activeSessions = {};
+
+  /// Sessions resident in the live agent process (created via `session/new` or
+  /// resumed via `session/load` this run). ACP agents hold sessions in memory
+  /// per process, so a session from a prior bridge run must be re-loaded before
+  /// a turn or the agent rejects it ("session not found").
+  final Set<String> _residentSessions = {};
+
+  /// Sessions whose `session/update` notifications are currently dropped — a
+  /// resume `session/load` is in flight and its history replay must not leak
+  /// into the live stream.
+  final Set<String> _suppressedSessions = {};
+  int _suppressedReplayCount = 0;
+
+  // --- Overridable hooks ---
+
+  String get clientName => "sesori-bridge";
+  String get clientVersion => "0.0.0";
+
+  /// Auth method id to call if the agent reports it requires auth. `null`
+  /// uses the first advertised method.
+  String? get authMethodId => null;
+
+  /// Non-standard capability hints sent under `clientCapabilities._meta`
+  /// (e.g. Cursor's `parameterizedModelPicker`).
+  Map<String, dynamic>? get initializeCapabilityMeta => null;
+
+  /// Builds the approval registry. Override to return a harness-specific
+  /// subclass (e.g. one that also handles `cursor/ask_question`).
+  AcpApprovalRegistry buildApprovalRegistry(AcpStdioClient client) {
+    return AcpApprovalRegistry.forClient(client: client, emit: _eventBuffer.add);
+  }
+
+  /// Captures the model/mode catalog from a `session/new` or `session/load`
+  /// result (config-option ids, available models/modes, current values) and
+  /// seeds the event mapper's fallback model. When [sessionId] is known, the
+  /// session's current model is recorded for per-message stamping. Base does
+  /// nothing; Cursor overrides for its `configOptions` picker.
+  void captureSessionConfig(Map<String, dynamic> result, {String? sessionId}) {}
+
+  /// Applies the requested [model] and [variant] for a turn on [sessionId]
+  /// before the prompt is dispatched. Called from [createSession] and from
+  /// [sendPrompt]/[sendCommand], so a mid-conversation switch takes effect.
+  /// Base does nothing (the agent's defaults are used). Cursor overrides to
+  /// drive its model + mode `session/set_config_option` calls.
+  Future<void> applyTurnSelection({
+    required AcpStdioClient client,
+    required String sessionId,
+    required ({String providerID, String modelID})? model,
+    required PluginSessionVariant? variant,
+  }) async {}
+
+  // --- Protected accessors for subclasses ---
+
+  AcpStdioClient? get client => _client;
+  AcpInitializeResult? get initializeResult => _initResult;
+  void emitEvent(BridgeSseEvent event) => _eventBuffer.add(event);
+
+  // --- BridgePluginApi ---
+
+  @override
+  Stream<BridgeSseEvent> get events => _eventBuffer.stream;
+
+  Future<bool> ensureConnected() {
+    final existing = _connectFuture;
+    if (existing != null) return existing;
+    final future = () async {
+      final client = AcpStdioClient(
+        launchSpec: launchSpec,
+        processFactory: _processFactory,
+        logTag: id,
+      );
+      _client = client;
+      try {
+        await client.connect();
+        _notificationSubscription = client.notifications.listen((notification) {
+          if (notification.method == AcpMethods.sessionUpdate) {
+            final sid = notification.params["sessionId"];
+            if (sid is String && _suppressedSessions.contains(sid)) {
+              // Replay from an in-flight resume-load — drop so old history does
+              // not re-stream into the live conversation.
+              _suppressedReplayCount++;
+              return;
+            }
+          }
+          eventMapper.map(notification).forEach(_eventBuffer.add);
+        });
+        final registry = buildApprovalRegistry(client);
+        _approvalRegistry = registry;
+        registry.attach(client.serverRequests);
+        _initResult = await _initialize(client);
+        return true;
+      } catch (error) {
+        await client.dispose();
+        _client = null;
+        _connectFuture = null;
+        return Future<bool>.error(error);
+      }
+    }();
+    _connectFuture = future.catchError((Object _) => false);
+    return _connectFuture!;
+  }
+
+  /// Runs the ACP `initialize` handshake (and `authenticate` if the agent
+  /// advertises an auth method) on [client], returning the parsed result. Does
+  /// not store it — the caller decides (the live connect persists it as
+  /// [_initResult]; the replay client in [getSessionMessages] keeps it local so
+  /// it never clobbers the live capabilities).
+  Future<AcpInitializeResult> _initialize(AcpStdioClient client) async {
+    final raw = await client.request(
+      method: AcpMethods.initialize,
+      params: buildInitializeParams(
+        clientName: clientName,
+        clientVersion: clientVersion,
+        capabilityMeta: initializeCapabilityMeta,
+      ),
+    );
+    final init = AcpInitializeResult.fromJson(
+      (raw as Map?)?.cast<String, dynamic>() ?? const {},
+    );
+    if (init.requiresAuth) {
+      final methodId = authMethodId ??
+          (init.authMethods.isNotEmpty ? init.authMethods.first.id : null);
+      if (methodId != null) {
+        await client.request(
+          method: AcpMethods.authenticate,
+          params: {"methodId": methodId},
+        );
+      }
+    }
+    return init;
+  }
+
+  Future<AcpStdioClient> _connectedClient() async {
+    final ok = await ensureConnected();
+    final client = _client;
+    if (!ok || client == null) {
+      throw StateError("$id agent is not connected");
+    }
+    return client;
+  }
+
+  @override
+  Future<bool> healthCheck() async {
+    try {
+      return await ensureConnected();
+    } catch (_) {
+      return false;
+    }
+  }
+
+  @override
+  Future<List<PluginProject>> getProjects() async {
+    await _projects.ensureLoaded();
+    return _projects.list();
+  }
+
+  /// Returns the project for [projectId], registering it as a known project.
+  ///
+  /// This is the `POST /project/open` ("open a directory as a project") path as
+  /// well as the per-project metadata lookup, so opening a new directory adds it
+  /// to [getProjects]. Registration is idempotent for an already-known project.
+  @override
+  Future<PluginProject> getProject(String projectId) async {
+    final id = await _projects.register(projectId);
+    return _projects.projectFor(id);
+  }
+
+  @override
+  Future<List<PluginSession>> getSessions(
+    String projectId, {
+    int? start,
+    int? limit,
+  }) async {
+    final client = await _connectedClient();
+    if (!(_initResult?.agentCapabilities.listSessions ?? false)) return const [];
+    try {
+      final raw = await client.request(
+        method: "session/list",
+        params: {"cwd": projectId},
+      );
+      final map = (raw as Map?)?.cast<String, dynamic>() ?? const {};
+      final sessions = (map["sessions"] as List?) ?? const [];
+      final mapped = sessions
+          .whereType<Map<dynamic, dynamic>>()
+          .map((s) => _toPluginSession(s.cast<String, dynamic>(), projectId))
+          .toList(growable: false);
+      final from = start ?? 0;
+      if (from >= mapped.length) return const [];
+      final until =
+          limit == null ? mapped.length : (from + limit).clamp(0, mapped.length);
+      return mapped.sublist(from, until);
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  PluginSession _toPluginSession(Map<String, dynamic> raw, String projectId) {
+    final updated = raw["updatedAt"];
+    final ts = updated is num ? updated.round() : null;
+    final id = (raw["sessionId"] ?? "") as String;
+    // Remember which project this session belongs to so a later turn/history
+    // load uses its own cwd and the activity badge lands on the right project.
+    if (id.isNotEmpty) _sessionProjects[id] = projectId;
+    return PluginSession(
+      id: id,
+      projectID: projectId,
+      directory: (raw["cwd"] as String?) ?? projectId,
+      parentID: null,
+      title: raw["title"] as String?,
+      time: ts == null
+          ? null
+          : PluginSessionTime(created: ts, updated: ts, archived: null),
+      summary: null,
+    );
+  }
+
+  @override
+  Future<List<PluginCommand>> getCommands({required String? projectId}) async =>
+      const [];
+
+  @override
+  Future<PluginSession> createSession({
+    required String directory,
+    required String? parentSessionId,
+    required List<PluginPromptPart> parts,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async {
+    final client = await _connectedClient();
+    // The directory is a project the session lives in — make sure it is a known
+    // project (the app normally creates sessions in an already-opened project,
+    // but a session created directly should still surface its directory).
+    final projectId = await _projects.register(directory);
+    final raw = await client.request(
+      method: AcpMethods.sessionNew,
+      params: {"cwd": directory, "mcpServers": const <Object?>[]},
+    );
+    final session = AcpNewSessionResult.fromJson(
+      (raw as Map?)?.cast<String, dynamic>() ?? const {},
+    );
+    if (session.sessionId.isEmpty) {
+      throw StateError("session/new response missing sessionId");
+    }
+    _sessionProjects[session.sessionId] = projectId;
+    captureSessionConfig(session.raw, sessionId: session.sessionId);
+    // session/new leaves the session resident in the agent process.
+    _residentSessions.add(session.sessionId);
+    await applyTurnSelection(
+      client: client,
+      sessionId: session.sessionId,
+      model: model,
+      variant: variant,
+    );
+    _sessionStatuses[session.sessionId] = const PluginSessionStatus.idle();
+    if (parts.isNotEmpty) {
+      _dispatchPrompt(client, session.sessionId, parts);
+    }
+    final now = DateTime.now().millisecondsSinceEpoch;
+    return PluginSession(
+      id: session.sessionId,
+      projectID: projectId,
+      directory: directory,
+      parentID: parentSessionId,
+      title: null,
+      time: PluginSessionTime(created: now, updated: now, archived: null),
+      summary: null,
+    );
+  }
+
+  @override
+  Future<void> sendPrompt({
+    required String sessionId,
+    required List<PluginPromptPart> parts,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async {
+    final client = await _connectedClient();
+    await _ensureResident(client, sessionId);
+    await applyTurnSelection(
+      client: client,
+      sessionId: sessionId,
+      model: model,
+      variant: variant,
+    );
+    _dispatchPrompt(client, sessionId, parts);
+  }
+
+  @override
+  Future<void> sendCommand({
+    required String sessionId,
+    required String command,
+    required String arguments,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async {
+    final body = arguments.isEmpty ? "/$command" : "/$command $arguments";
+    final client = await _connectedClient();
+    await _ensureResident(client, sessionId);
+    await applyTurnSelection(
+      client: client,
+      sessionId: sessionId,
+      model: model,
+      variant: variant,
+    );
+    _dispatchPrompt(client, sessionId, [PluginPromptPart.text(text: body)]);
+  }
+
+  /// Ensures [sessionId] is resident in the agent process before a turn. A
+  /// session created/resumed this run is already resident; one from a prior
+  /// bridge run is re-loaded via `session/load` (its history replay suppressed
+  /// so it does not re-stream into the live conversation). Best-effort: on a
+  /// failed/unsupported load the session is still marked resident so the turn
+  /// proceeds and surfaces any error itself, rather than looping.
+  /// The directory a session should be loaded/operated in — its own project's
+  /// cwd when known, else the launch CWD.
+  String _sessionCwd(String sessionId) => _sessionProjects[sessionId] ?? projectCwd;
+
+  Future<void> _ensureResident(AcpStdioClient client, String sessionId) async {
+    if (_residentSessions.contains(sessionId)) return;
+    if (!(_initResult?.agentCapabilities.loadSession ?? false)) {
+      _residentSessions.add(sessionId);
+      return;
+    }
+    _suppressedSessions.add(sessionId);
+    try {
+      final raw = await client.request(
+        method: AcpMethods.sessionLoad,
+        params: {
+          "sessionId": sessionId,
+          "cwd": _sessionCwd(sessionId),
+          "mcpServers": const <Object?>[],
+        },
+        timeout: const Duration(minutes: 2),
+      );
+      captureSessionConfig(
+        (raw as Map?)?.cast<String, dynamic>() ?? const {},
+        sessionId: sessionId,
+      );
+      // Keep suppressing until the (post-response) replay stream goes quiet.
+      await _drainReplay(() => _suppressedReplayCount);
+    } catch (error, stack) {
+      Log.w("[$id] resume-load of $sessionId failed; proceeding", error, stack);
+    } finally {
+      _suppressedSessions.remove(sessionId);
+      _residentSessions.add(sessionId);
+    }
+  }
+
+  /// Sends a prompt turn fire-and-forget: marks the session busy now, streams
+  /// events via the notification listener, and flips to idle when the
+  /// `session/prompt` future resolves (ACP carries no turn-complete event).
+  void _dispatchPrompt(
+    AcpStdioClient client,
+    String sessionId,
+    List<PluginPromptPart> parts,
+  ) {
+    final blocks = parts
+        .map(_promptPartToContentBlock)
+        .whereType<Map<String, dynamic>>()
+        .toList(growable: false);
+    if (blocks.isEmpty) return;
+
+    eventMapper.beginTurn(sessionId);
+    _sessionStatuses[sessionId] = const PluginSessionStatus.busy();
+    _eventBuffer.add(
+      BridgeSseSessionStatus(
+        sessionID: sessionId,
+        status: const shared.SessionStatus.busy().toJson(),
+      ),
+    );
+
+    final future = client.request(
+      method: AcpMethods.sessionPrompt,
+      params: {"sessionId": sessionId, "prompt": blocks},
+      timeout: const Duration(minutes: 30),
+    );
+    _activeSessions.add(sessionId);
+    unawaited(
+      future.then((raw) {
+        final result = AcpPromptResult.fromJson(
+          (raw as Map?)?.cast<String, dynamic>() ?? const {},
+        );
+        _onTurnEnd(sessionId, result.stopReason);
+      }).catchError((Object _) {
+        _onTurnEnd(sessionId, AcpStopReason.unknown);
+      }),
+    );
+  }
+
+  void _onTurnEnd(String sessionId, AcpStopReason reason) {
+    _activeSessions.remove(sessionId);
+    _sessionStatuses[sessionId] = const PluginSessionStatus.idle();
+    _eventBuffer.add(BridgeSseSessionIdle(sessionID: sessionId));
+    if (reason == AcpStopReason.refusal) {
+      _eventBuffer.add(BridgeSseSessionError(sessionID: sessionId));
+    }
+  }
+
+  Map<String, dynamic>? _promptPartToContentBlock(PluginPromptPart part) {
+    return switch (part) {
+      PluginPromptPartText(:final text) => textContentBlock(text),
+      PluginPromptPartFilePath(:final path, :final filename) => {
+        "type": "resource_link",
+        "uri": "file://$path",
+        "name": filename ?? p.basename(path),
+      },
+      PluginPromptPartFileUrl(:final url, :final filename) => {
+        "type": "resource_link",
+        "uri": url,
+        "name": filename ?? url,
+      },
+      // Inline base64 has no clean ACP ContentBlock without a mime contract;
+      // dropped until a real trace shows the expected shape.
+      PluginPromptPartFileData() => null,
+    };
+  }
+
+  @override
+  Future<void> abortSession({required String sessionId}) async {
+    final client = _client;
+    if (client == null) return;
+    client.notify(
+      method: AcpMethods.sessionCancel,
+      params: {"sessionId": sessionId},
+    );
+  }
+
+  @override
+  Future<PluginSession> renameSession({
+    required String sessionId,
+    required String title,
+  }) async {
+    // ACP has no standard rename; honour the contract optimistically so any
+    // local UI cache stays consistent. The mobile DB is authoritative.
+    final cwd = _sessionCwd(sessionId);
+    return PluginSession(
+      id: sessionId,
+      projectID: cwd,
+      directory: cwd,
+      parentID: null,
+      title: title,
+      time: null,
+      summary: null,
+    );
+  }
+
+  @override
+  Future<PluginProject> renameProject({
+    required String projectId,
+    required String name,
+  }) async {
+    await _projects.rename(path: projectId, name: name);
+    return _projects.projectFor(projectId);
+  }
+
+  @override
+  Future<void> deleteSession(String sessionId) async {
+    if (_activeSessions.contains(sessionId)) {
+      await abortSession(sessionId: sessionId);
+    }
+    _activeSessions.remove(sessionId);
+    _sessionStatuses.remove(sessionId);
+    _residentSessions.remove(sessionId);
+    _sessionProjects.remove(sessionId);
+  }
+
+  @override
+  Future<void> archiveSession({required String sessionId}) async {
+    // Best-effort — mobile DB archive state is authoritative.
+  }
+
+  @override
+  Future<void> deleteWorkspace({
+    required String projectId,
+    required String worktreePath,
+  }) async {
+    // ACP agents don't manage worktrees.
+  }
+
+  @override
+  Future<List<PluginSession>> getChildSessions(String sessionId) async =>
+      const [];
+
+  @override
+  Future<Map<String, PluginSessionStatus>> getSessionStatuses() async =>
+      Map.unmodifiable(_sessionStatuses);
+
+  @override
+  Future<List<PluginMessageWithParts>> getSessionMessages(
+    String sessionId,
+  ) async {
+    // History via `session/load` replay on a dedicated short-lived client so
+    // replayed updates don't interleave with the live session's stream.
+    final replayClient = AcpStdioClient(
+      launchSpec: launchSpec,
+      processFactory: _processFactory,
+      logTag: "$id-replay",
+    );
+    final collector = AcpReplayCollector(
+      sessionId: sessionId,
+      agentId: agentDisplayName,
+      modelId: eventMapper.modelForSession(sessionId),
+      providerId: eventMapper.providerForSession(sessionId),
+    );
+    StreamSubscription<AcpNotification>? sub;
+    try {
+      await replayClient.connect();
+      final replayInit = await _initialize(replayClient);
+      if (!replayClient.isConnected || !replayInit.agentCapabilities.loadSession) {
+        return const [];
+      }
+      var received = 0;
+      sub = replayClient.notifications.listen((notification) {
+        if (notification.method == AcpMethods.sessionUpdate) {
+          received++;
+          collector.consume(notification.params);
+        }
+      });
+      final raw = await replayClient.request(
+        method: AcpMethods.sessionLoad,
+        params: {
+          "sessionId": sessionId,
+          "cwd": _sessionCwd(sessionId),
+          "mcpServers": const <Object?>[],
+        },
+        timeout: const Duration(minutes: 2),
+      );
+      // The load result also carries the model/mode catalog (and the loaded
+      // session's current model) — capture it so the picker is populated and
+      // replayed messages are stamped with the session's real model.
+      captureSessionConfig(
+        (raw as Map?)?.cast<String, dynamic>() ?? const {},
+        sessionId: sessionId,
+      );
+      // The ACP spec replays the whole thread via `session/update` BEFORE the
+      // `session/load` response resolves, but cursor-agent streams later turns
+      // AFTER it. Drain until the replay stream goes quiet so multi-turn history
+      // is captured in full, bounded so a chatty agent can't hang the request.
+      await _drainReplay(() => received);
+      collector.modelId = eventMapper.modelForSession(sessionId);
+      collector.providerId = eventMapper.providerForSession(sessionId);
+      return collector.build();
+    } catch (_) {
+      return const [];
+    } finally {
+      await sub?.cancel();
+      await replayClient.dispose();
+    }
+  }
+
+  /// Waits until the replay `session/update` stream goes quiet — no new
+  /// notification within one [quiet] window — bounded by [max]. [count] returns
+  /// the running number of replay notifications seen so far.
+  Future<void> _drainReplay(
+    int Function() count, {
+    Duration quiet = const Duration(milliseconds: 250),
+    Duration max = const Duration(seconds: 6),
+  }) async {
+    var elapsed = Duration.zero;
+    var last = -1;
+    while (elapsed < max) {
+      final snapshot = count();
+      if (snapshot == last) return;
+      last = snapshot;
+      await Future<void>.delayed(quiet);
+      elapsed += quiet;
+    }
+  }
+
+  /// Populates the config catalog (models/modes) by `session/load`-ing the most
+  /// recent existing session on a short-lived client and feeding the result to
+  /// [captureSessionConfig]. Reads the catalog from the load *result*, so it
+  /// never pollutes the live event stream with replayed history, and — unlike
+  /// a `session/new` probe — creates no throwaway session (the ACP agents this
+  /// drives have no session-delete). No-op when there are no existing sessions
+  /// (a brand-new account's first `session/new` populates the catalog instead).
+  Future<void> probeCatalogFromExistingSession() async {
+    if (_client == null) return;
+    final List<PluginSession> sessions;
+    try {
+      sessions = await getSessions(projectCwd);
+    } catch (_) {
+      return;
+    }
+    if (sessions.isEmpty) return;
+    // `session/list` returns newest-first; the first entry is the freshest
+    // source for the (account-stable) catalog.
+    final newestId = sessions.first.id;
+    final probe = AcpStdioClient(
+      launchSpec: launchSpec,
+      processFactory: _processFactory,
+      logTag: "$id-probe",
+    );
+    try {
+      await probe.connect();
+      final init = await _initialize(probe);
+      if (!init.agentCapabilities.loadSession) return;
+      final raw = await probe.request(
+        method: AcpMethods.sessionLoad,
+        params: {
+          "sessionId": newestId,
+          "cwd": projectCwd,
+          "mcpServers": const <Object?>[],
+        },
+        timeout: const Duration(minutes: 1),
+      );
+      captureSessionConfig((raw as Map?)?.cast<String, dynamic>() ?? const {});
+    } catch (error, stack) {
+      Log.d("[$id] catalog probe failed: $error\n$stack");
+    } finally {
+      await probe.dispose();
+    }
+  }
+
+  @override
+  Future<List<PluginAgent>> getAgents({required String projectId}) async {
+    final modelId = eventMapper.currentModelId;
+    return [
+      PluginAgent(
+        name: id,
+        description: "$agentDisplayName session",
+        model: modelId == null
+            ? null
+            : PluginAgentModel(
+                modelID: modelId,
+                providerID: eventMapper.currentProviderId ?? id,
+                variant: null,
+              ),
+        mode: PluginAgentMode.primary,
+        hidden: false,
+      ),
+    ];
+  }
+
+  @override
+  Future<PluginProvidersResult> getProviders({required String projectId}) async {
+    final modelId = eventMapper.currentModelId;
+    if (modelId == null) return const PluginProvidersResult(providers: []);
+    final providerId = eventMapper.currentProviderId ?? id;
+    return PluginProvidersResult(
+      providers: [
+        PluginProvider.custom(
+          id: providerId,
+          name: agentDisplayName,
+          authType: PluginProviderAuthType.unknown,
+          models: [
+            PluginModel(
+              id: modelId,
+              name: modelId,
+              variants: const [],
+              family: null,
+              isAvailable: true,
+              releaseDate: null,
+            ),
+          ],
+          defaultModelID: modelId,
+        ),
+      ],
+    );
+  }
+
+  @override
+  Future<List<PluginPendingQuestion>> getPendingQuestions({
+    required String sessionId,
+  }) async =>
+      _approvalRegistry?.pendingForSession(sessionId) ?? const [];
+
+  @override
+  Future<List<PluginPendingQuestion>> getProjectQuestions({
+    required String projectId,
+  }) async {
+    final registry = _approvalRegistry;
+    if (registry == null) return const [];
+    return registry.pendingForProject(_sessionStatuses.keys);
+  }
+
+  @override
+  Future<void> replyToQuestion({
+    required String questionId,
+    required String sessionId,
+    required List<List<String>> answers,
+  }) async {
+    _approvalRegistry?.replyQuestion(questionId, answers);
+  }
+
+  @override
+  Future<void> rejectQuestion({required String questionId, required String? sessionId}) async {
+    // The registry is keyed by the bridge question id; it already knows the
+    // session (and clears the pending entry, so awaiting-input drops), so the
+    // sessionId argument is not needed here.
+    _approvalRegistry?.rejectQuestion(questionId);
+  }
+
+  @override
+  Future<void> replyToPermission({
+    required String requestId,
+    required String sessionId,
+    required PluginPermissionReply reply,
+  }) async {
+    _approvalRegistry?.replyPermission(requestId, reply);
+  }
+
+  @override
+  List<PluginProjectActivitySummary> getActiveSessionsSummary() {
+    final registry = _approvalRegistry;
+
+    // Surface a session only when it has live activity: the agent is running
+    // (a `session/prompt` turn is in flight) or it is blocked awaiting a user
+    // answer/permission. Idle sessions are not "active" and are dropped, which
+    // also means a fully idle agent yields an empty summary (no project row) —
+    // matching the OpenCode plugin's "only active worktrees" contract.
+    //
+    // ACP sessions are flat: this plugin tracks no parent/child relationships,
+    // so `childSessionIds` is always empty, and it has no retry concept, so
+    // `isRetrying` is always false.
+    // Group active sessions under the project (directory) each belongs to, so
+    // the per-project activity badge lands on the right project — sessions can
+    // live in different opened directories, not just the launch CWD.
+    final byProject = <String, List<PluginActiveSession>>{};
+    for (final sessionId in _sessionStatuses.keys) {
+      final running = _activeSessions.contains(sessionId);
+      final awaiting = registry?.hasPendingInput(sessionId) ?? false;
+      if (!running && !awaiting) continue;
+      (byProject[_sessionCwd(sessionId)] ??= []).add(
+        PluginActiveSession(
+          id: sessionId,
+          mainAgentRunning: running,
+          awaitingInput: awaiting,
+          isRetrying: false,
+          childSessionIds: const [],
+        ),
+      );
+    }
+    if (byProject.isEmpty) return const [];
+
+    return [
+      for (final entry in byProject.entries)
+        PluginProjectActivitySummary(id: entry.key, activeSessions: entry.value),
+    ];
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _notificationSubscription?.cancel();
+    _notificationSubscription = null;
+    await _approvalRegistry?.dispose();
+    _approvalRegistry = null;
+    await _client?.dispose();
+    _client = null;
+    await _eventBuffer.close();
+  }
+}

--- a/bridge/sesori_plugin_acp/lib/src/acp_process_factory.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_process_factory.dart
@@ -1,0 +1,84 @@
+import "dart:io" as io;
+
+/// How to spawn an ACP agent subprocess.
+///
+/// ACP agents (e.g. `cursor-agent acp`, `gemini --experimental-acp`) speak
+/// JSON-RPC over their own stdin/stdout. The bridge resolves the binary and
+/// hands this spec to the plugin, which spawns the process and owns its
+/// lifecycle.
+class AcpLaunchSpec {
+  const AcpLaunchSpec({
+    required this.command,
+    required this.args,
+    this.cwd,
+    this.environment = const {},
+  });
+
+  /// Executable to run (absolute path or a name resolved on PATH).
+  final String command;
+
+  /// Arguments — typically ends with the ACP subcommand, e.g. `["acp"]`.
+  final List<String> args;
+
+  /// Working directory for the agent process. `null` inherits the bridge's.
+  final String? cwd;
+
+  /// Extra environment entries merged over the inherited environment
+  /// (e.g. `CURSOR_API_KEY`).
+  final Map<String, String> environment;
+}
+
+/// The slice of `dart:io`'s [io.Process] the ACP transport actually uses.
+///
+/// Kept narrow so tests can supply an in-memory fake without implementing the
+/// full [io.Process] surface (analogous to codex's injected
+/// `CodexWebSocketChannelFactory`).
+abstract class AcpProcessHandle {
+  Stream<List<int>> get stdout;
+  Stream<List<int>> get stderr;
+  io.IOSink get stdin;
+  Future<int> get exitCode;
+  bool kill([io.ProcessSignal signal = io.ProcessSignal.sigterm]);
+}
+
+/// Spawns an [AcpProcessHandle] for the given [AcpLaunchSpec]. Injected into
+/// [AcpStdioClient] so tests can substitute a fake process.
+typedef AcpProcessFactory = Future<AcpProcessHandle> Function(AcpLaunchSpec spec);
+
+/// Default factory: spawns a real OS process via [io.Process.start].
+Future<AcpProcessHandle> defaultAcpProcessFactory(AcpLaunchSpec spec) async {
+  final env = <String, String>{
+    ...io.Platform.environment,
+    ...spec.environment,
+  };
+  final process = await io.Process.start(
+    spec.command,
+    spec.args,
+    workingDirectory: spec.cwd,
+    environment: env,
+    runInShell: io.Platform.isWindows,
+  );
+  return _RealAcpProcess(process);
+}
+
+class _RealAcpProcess implements AcpProcessHandle {
+  _RealAcpProcess(this._process);
+
+  final io.Process _process;
+
+  @override
+  Stream<List<int>> get stdout => _process.stdout;
+
+  @override
+  Stream<List<int>> get stderr => _process.stderr;
+
+  @override
+  io.IOSink get stdin => _process.stdin;
+
+  @override
+  Future<int> get exitCode => _process.exitCode;
+
+  @override
+  bool kill([io.ProcessSignal signal = io.ProcessSignal.sigterm]) =>
+      _process.kill(signal);
+}

--- a/bridge/sesori_plugin_acp/lib/src/acp_process_factory.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_process_factory.dart
@@ -47,15 +47,13 @@ typedef AcpProcessFactory = Future<AcpProcessHandle> Function(AcpLaunchSpec spec
 
 /// Default factory: spawns a real OS process via [io.Process.start].
 Future<AcpProcessHandle> defaultAcpProcessFactory(AcpLaunchSpec spec) async {
-  final env = <String, String>{
-    ...io.Platform.environment,
-    ...spec.environment,
-  };
   final process = await io.Process.start(
     spec.command,
     spec.args,
     workingDirectory: spec.cwd,
-    environment: env,
+    // includeParentEnvironment defaults to true, so these entries are merged
+    // over the inherited environment — no manual Platform.environment copy.
+    environment: spec.environment,
     runInShell: io.Platform.isWindows,
   );
   return _RealAcpProcess(process);

--- a/bridge/sesori_plugin_acp/lib/src/acp_project_registry.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_project_registry.dart
@@ -1,0 +1,235 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:path/path.dart" as p;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+/// Persistent registry of the directories an ACP agent has been pointed at as
+/// projects.
+///
+/// ACP agents (Cursor, Codex, …) are single-process and have no notion of a
+/// "project list": each `session/new`/`session/load` merely carries a `cwd`.
+/// To let the app open several directories as projects — the way OpenCode's
+/// server tracks every project you have worked in — the plugin keeps the list
+/// here instead.
+///
+/// The launch [cwd] is always present (the implicit default project, so the
+/// list is never empty on a fresh install). Opening a directory ([register])
+/// adds it. Entries other than the implicit default persist across bridge
+/// restarts via the host [store] (a single JSON file in the plugin's private
+/// state directory), so a discovered project survives a restart rather than
+/// vanishing — matching the durability of OpenCode's server-tracked list.
+///
+/// All ids are canonical absolute paths ([p.normalize]d), so the same directory
+/// reached two ways (trailing slash, `.` segment) is one project.
+class AcpProjectRegistry {
+  AcpProjectRegistry({
+    required String cwd,
+    HostJsonStore? store,
+    String fileName = defaultFileName,
+    int Function()? nowMs,
+  })  : _cwd = _normalize(cwd),
+        _store = store,
+        _fileName = fileName,
+        _now = nowMs ?? _wallClockMs;
+
+  /// File name used inside the plugin's state directory.
+  static const String defaultFileName = "acp-projects.json";
+  static const int _schemaVersion = 1;
+
+  final String _cwd;
+  final HostJsonStore? _store;
+  final String _fileName;
+  final int Function() _now;
+
+  /// Canonical-id -> entry, in insertion order. Always contains the cwd seed
+  /// after [ensureLoaded].
+  final Map<String, _ProjectEntry> _entries = {};
+  Future<void>? _loading;
+
+  /// The launch CWD's canonical id (the implicit default project).
+  String get cwd => _cwd;
+
+  /// Loads the persisted registry once. Idempotent and safe to call from every
+  /// accessor — the read happens at most once per instance.
+  Future<void> ensureLoaded() => _loading ??= _load();
+
+  Future<void> _load() async {
+    // Seed the implicit default first so it is present even when the persisted
+    // file is missing or corrupt. createdAt = load time so freshly opened
+    // projects (registered later) sort above it, newest-first.
+    _entries[_cwd] = _ProjectEntry(id: _cwd, createdAt: _now(), persisted: false);
+
+    final store = _store;
+    if (store == null) return;
+
+    String? raw;
+    try {
+      raw = await store.read(name: _fileName);
+    } catch (_) {
+      return; // Unreadable store: serve the cwd seed only.
+    }
+    if (raw == null || raw.trim().isEmpty) return;
+
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(raw);
+    } catch (_) {
+      // Corrupt JSON: move it aside so a clean file can be written, keep seed.
+      unawaited(_quarantine());
+      return;
+    }
+    if (decoded is! Map) return;
+    final list = decoded["projects"];
+    if (list is! List) return;
+    for (final item in list) {
+      if (item is! Map) continue;
+      final rawId = item["id"];
+      if (rawId is! String || rawId.trim().isEmpty) continue;
+      final id = _normalize(rawId);
+      final createdAtRaw = item["createdAt"];
+      final createdAt = createdAtRaw is int
+          ? createdAtRaw
+          : (createdAtRaw is num ? createdAtRaw.round() : _now());
+      final nameRaw = item["name"];
+      final name = nameRaw is String && nameRaw.trim().isNotEmpty ? nameRaw.trim() : null;
+      _entries[id] = _ProjectEntry(
+        id: id,
+        createdAt: createdAt,
+        name: name,
+        persisted: true,
+      );
+    }
+  }
+
+  /// Registers [path] as a known project, persisting it. Returns the canonical
+  /// id. Idempotent: an already-known project is left untouched (no rewrite).
+  /// An empty/invalid path falls back to the cwd default.
+  Future<String> register(String path) async {
+    await ensureLoaded();
+    final id = _normalize(path);
+    if (id.isEmpty) return _cwd;
+    final existing = _entries[id];
+    if (existing != null && existing.persisted) return id;
+    _entries[id] = _ProjectEntry(
+      id: id,
+      createdAt: existing?.createdAt ?? _now(),
+      name: existing?.name,
+      persisted: true,
+    );
+    await _persist();
+    return id;
+  }
+
+  /// Sets a display [name] for [path] (the project's name otherwise derives from
+  /// the directory's basename), persisting it. Registers the project if unknown.
+  Future<void> rename({required String path, required String name}) async {
+    await ensureLoaded();
+    final id = _normalize(path);
+    if (id.isEmpty) return;
+    final existing = _entries[id];
+    final trimmed = name.trim();
+    _entries[id] = _ProjectEntry(
+      id: id,
+      createdAt: existing?.createdAt ?? _now(),
+      name: trimmed.isEmpty ? null : trimmed,
+      persisted: true,
+    );
+    await _persist();
+  }
+
+  /// All known projects, most-recently-registered first (the implicit default
+  /// cwd sorts oldest unless it was explicitly opened).
+  List<PluginProject> list() {
+    final entries = _entries.values.toList()
+      ..sort((a, b) {
+        final byTime = b.createdAt.compareTo(a.createdAt);
+        return byTime != 0 ? byTime : a.id.compareTo(b.id);
+      });
+    return [for (final e in entries) e.toProject()];
+  }
+
+  /// The project for [path] — the registered entry, or a synthesized one for an
+  /// unknown path (without registering it; [register] does that).
+  PluginProject projectFor(String path) {
+    final id = _normalize(path);
+    final entry = _entries[id];
+    if (entry != null) return entry.toProject();
+    final fallbackId = id.isEmpty ? _cwd : id;
+    return _ProjectEntry(id: fallbackId, createdAt: _now(), persisted: false).toProject();
+  }
+
+  Future<void> _persist() async {
+    final store = _store;
+    if (store == null) return;
+    final payload = jsonEncode({
+      "version": _schemaVersion,
+      "projects": [
+        // The implicit cwd default (persisted == false) is re-seeded on load,
+        // so it is never written — only explicitly opened/renamed projects are.
+        for (final e in _entries.values)
+          if (e.persisted)
+            {
+              "id": e.id,
+              "createdAt": e.createdAt,
+              if (e.name != null) "name": e.name,
+            },
+      ],
+    });
+    try {
+      await store.write(name: _fileName, contents: payload);
+    } catch (_) {
+      // Best-effort: the in-memory list still serves this run.
+    }
+  }
+
+  Future<void> _quarantine() async {
+    try {
+      await _store?.quarantine(
+        name: _fileName,
+        quarantinedName: "$_fileName.corrupt",
+      );
+    } catch (_) {
+      // Best-effort.
+    }
+  }
+
+  static int _wallClockMs() => DateTime.now().millisecondsSinceEpoch;
+
+  static String _normalize(String path) {
+    final trimmed = path.trim();
+    if (trimmed.isEmpty) return "";
+    return p.normalize(trimmed);
+  }
+}
+
+class _ProjectEntry {
+  _ProjectEntry({
+    required this.id,
+    required this.createdAt,
+    this.name,
+    required this.persisted,
+  });
+
+  final String id;
+  final int createdAt;
+  final String? name;
+
+  /// Whether this entry is written to disk. The implicit cwd default is not
+  /// (it is re-seeded each load); explicitly opened/renamed projects are.
+  final bool persisted;
+
+  PluginProject toProject() {
+    final display = name ?? _basename(id);
+    return PluginProject(
+      id: id,
+      name: display,
+      time: PluginProjectTime(created: createdAt, updated: createdAt),
+    );
+  }
+
+  static String _basename(String id) {
+    final base = p.basename(id);
+    return base.isEmpty ? id : base;
+  }
+}

--- a/bridge/sesori_plugin_acp/lib/src/acp_project_registry.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_project_registry.dart
@@ -1,4 +1,3 @@
-import "dart:async";
 import "dart:convert";
 
 import "package:path/path.dart" as p;
@@ -76,7 +75,10 @@ class AcpProjectRegistry {
       decoded = jsonDecode(raw);
     } catch (_) {
       // Corrupt JSON: move it aside so a clean file can be written, keep seed.
-      unawaited(_quarantine());
+      // Awaited (not fire-and-forget) so the quarantine completes before any
+      // later _persist() write — otherwise the rename can race ahead and move
+      // aside the freshly written clean file.
+      await _quarantine();
       return;
     }
     if (decoded is! Map) return;
@@ -159,7 +161,19 @@ class AcpProjectRegistry {
     return _ProjectEntry(id: fallbackId, createdAt: _now(), persisted: false).toProject();
   }
 
-  Future<void> _persist() async {
+  /// Serializes persistence so concurrent register/rename calls cannot interleave
+  /// or complete out of order and drop entries. Each link snapshots [_entries]
+  /// when it runs, so the final write reflects the latest state.
+  Future<void> _writeChain = Future.value();
+
+  Future<void> _persist() {
+    final next = _writeChain.then((_) => _write());
+    // Keep the chain alive even if a write fails so the next link still runs.
+    _writeChain = next.catchError((Object _) {});
+    return next;
+  }
+
+  Future<void> _write() async {
     final store = _store;
     if (store == null) return;
     final payload = jsonEncode({

--- a/bridge/sesori_plugin_acp/lib/src/acp_protocol.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_protocol.dart
@@ -1,0 +1,201 @@
+/// Standard ACP (Agent Client Protocol) method names, request builders and
+/// result parsers. Harness-specific extensions (e.g. Cursor's `cursor/*`
+/// methods and model `configOptions`) live in the consuming package.
+library;
+
+/// The ACP protocol version this bridge implements.
+const int acpProtocolVersion = 1;
+
+/// Standard ACP JSON-RPC method names.
+abstract final class AcpMethods {
+  static const String initialize = "initialize";
+  static const String authenticate = "authenticate";
+  static const String sessionNew = "session/new";
+  static const String sessionLoad = "session/load";
+  static const String sessionPrompt = "session/prompt";
+  static const String sessionCancel = "session/cancel";
+  static const String sessionUpdate = "session/update";
+  static const String sessionRequestPermission = "session/request_permission";
+  static const String sessionSetConfigOption = "session/set_config_option";
+}
+
+/// An auth method advertised by the agent in the `initialize` result.
+class AcpAuthMethod {
+  const AcpAuthMethod({required this.id, this.name, this.description});
+
+  final String id;
+  final String? name;
+  final String? description;
+
+  factory AcpAuthMethod.fromJson(Map<String, dynamic> json) => AcpAuthMethod(
+    id: (json["id"] ?? "") as String,
+    name: json["name"] as String?,
+    description: json["description"] as String?,
+  );
+}
+
+/// Capabilities the agent reports at `initialize`.
+class AcpAgentCapabilities {
+  const AcpAgentCapabilities({
+    required this.loadSession,
+    required this.listSessions,
+    required this.raw,
+  });
+
+  /// Whether `session/load` (history replay) is supported.
+  final bool loadSession;
+
+  /// Whether the standard `session/list` is supported.
+  final bool listSessions;
+
+  /// Full raw capabilities object for harness-specific probing.
+  final Map<String, dynamic> raw;
+
+  factory AcpAgentCapabilities.fromJson(Map<String, dynamic> json) {
+    final session =
+        (json["sessionCapabilities"] as Map<dynamic, dynamic>?)?.cast<String, dynamic>();
+    // ACP advertises an optional capability as either a bool or a nested
+    // object (Cursor sends `"list": {}` to mean "supported"); presence of a
+    // non-false value signals support.
+    final list = session?["list"];
+    return AcpAgentCapabilities(
+      loadSession: json["loadSession"] == true,
+      listSessions: list != null && list != false,
+      raw: json,
+    );
+  }
+}
+
+/// Parsed result of the `initialize` handshake.
+class AcpInitializeResult {
+  const AcpInitializeResult({
+    required this.protocolVersion,
+    required this.agentCapabilities,
+    required this.authMethods,
+    required this.raw,
+  });
+
+  final int protocolVersion;
+  final AcpAgentCapabilities agentCapabilities;
+  final List<AcpAuthMethod> authMethods;
+  final Map<String, dynamic> raw;
+
+  /// True when the agent requires authentication before sessions can start.
+  bool get requiresAuth => authMethods.isNotEmpty;
+
+  factory AcpInitializeResult.fromJson(Map<String, dynamic> json) {
+    final caps = (json["agentCapabilities"] as Map?)?.cast<String, dynamic>() ?? {};
+    final methods = (json["authMethods"] as List?) ?? const [];
+    return AcpInitializeResult(
+      protocolVersion: (json["protocolVersion"] ?? acpProtocolVersion) as int,
+      agentCapabilities: AcpAgentCapabilities.fromJson(caps),
+      authMethods: methods
+          .whereType<Map<dynamic, dynamic>>()
+          .map((m) => AcpAuthMethod.fromJson(m.cast<String, dynamic>()))
+          .toList(growable: false),
+      raw: json,
+    );
+  }
+}
+
+/// Result of `session/new`.
+class AcpNewSessionResult {
+  const AcpNewSessionResult({
+    required this.sessionId,
+    required this.modes,
+    required this.configOptions,
+    required this.raw,
+  });
+
+  final String sessionId;
+
+  /// Optional session modes (plan/ask/agent) — raw, harness-specific.
+  final List<Map<String, dynamic>> modes;
+
+  /// Optional config options (e.g. Cursor's model selector) — raw.
+  final List<Map<String, dynamic>> configOptions;
+
+  final Map<String, dynamic> raw;
+
+  factory AcpNewSessionResult.fromJson(Map<String, dynamic> json) {
+    return AcpNewSessionResult(
+      sessionId: (json["sessionId"] ?? "") as String,
+      modes: _mapList(json["modes"]),
+      configOptions: _mapList(json["configOptions"]),
+      raw: json,
+    );
+  }
+}
+
+/// Why a `session/prompt` turn ended.
+enum AcpStopReason {
+  endTurn,
+  maxTokens,
+  maxTurnRequests,
+  refusal,
+  cancelled,
+  unknown;
+
+  static AcpStopReason parse(Object? raw) {
+    return switch (raw) {
+      "end_turn" => AcpStopReason.endTurn,
+      "max_tokens" => AcpStopReason.maxTokens,
+      "max_turn_requests" => AcpStopReason.maxTurnRequests,
+      "refusal" => AcpStopReason.refusal,
+      "cancelled" => AcpStopReason.cancelled,
+      _ => AcpStopReason.unknown,
+    };
+  }
+}
+
+/// Result of `session/prompt`.
+class AcpPromptResult {
+  const AcpPromptResult({required this.stopReason});
+
+  final AcpStopReason stopReason;
+
+  factory AcpPromptResult.fromJson(Map<String, dynamic> json) =>
+      AcpPromptResult(stopReason: AcpStopReason.parse(json["stopReason"]));
+}
+
+/// Builds the `clientCapabilities` object sent at `initialize`.
+///
+/// [meta] carries non-standard capability hints under `_meta` (e.g. Cursor's
+/// `parameterizedModelPicker`).
+Map<String, dynamic> buildClientCapabilities({Map<String, dynamic>? meta}) {
+  return <String, dynamic>{
+    "fs": {"readTextFile": false, "writeTextFile": false},
+    "terminal": false,
+    "_meta": ?meta,
+  };
+}
+
+/// Builds `initialize` params.
+Map<String, dynamic> buildInitializeParams({
+  required String clientName,
+  required String clientVersion,
+  String? clientTitle,
+  Map<String, dynamic>? capabilityMeta,
+}) {
+  return <String, dynamic>{
+    "protocolVersion": acpProtocolVersion,
+    "clientCapabilities": buildClientCapabilities(meta: capabilityMeta),
+    "clientInfo": {
+      "name": clientName,
+      "title": clientTitle,
+      "version": clientVersion,
+    },
+  };
+}
+
+/// Builds a single text [ContentBlock] for a prompt.
+Map<String, dynamic> textContentBlock(String text) =>
+    <String, dynamic>{"type": "text", "text": text};
+
+List<Map<String, dynamic>> _mapList(Object? raw) {
+  if (raw is! List) return const [];
+  return raw
+      .whereType<Map<dynamic, dynamic>>()
+      .map((m) => m.cast<String, dynamic>())
+      .toList(growable: false);
+}

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -1,5 +1,7 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
+import "acp_content.dart";
+
 /// Accumulates the `session/update` notifications replayed by `session/load`
 /// into ordered [PluginMessageWithParts] for `getSessionMessages`.
 ///
@@ -31,13 +33,13 @@ class AcpReplayCollector {
     if (update == null) return;
     switch (update["sessionUpdate"] as String?) {
       case "agent_message_chunk":
-        final t = _contentText(update["content"]);
+        final t = acpContentText(update["content"]);
         if (t != null) _assistant().text.write(t);
       case "agent_thought_chunk":
-        final t = _contentText(update["content"]);
+        final t = acpContentText(update["content"]);
         if (t != null) _assistant().reasoning.write(t);
       case "user_message_chunk":
-        final t = _contentText(update["content"]);
+        final t = acpContentText(update["content"]);
         if (t != null) _user().text.write(t);
       case "tool_call":
         final id = update["toolCallId"] as String?;
@@ -45,16 +47,16 @@ class AcpReplayCollector {
         _assistant().tools[id] = _ToolDraft(
           tool: (update["kind"] ?? update["title"] ?? "tool") as String,
           title: update["title"] as String?,
-          status: _status(update["status"]),
-          output: _toolOutput(update),
+          status: acpToolStatus(update["status"]),
+          output: acpToolOutputText(update),
         );
       case "tool_call_update":
         final id = update["toolCallId"] as String?;
         if (id == null) return;
         final draft = _findTool(id);
         if (draft == null) return;
-        draft.status = _status(update["status"]);
-        final out = _toolOutput(update);
+        draft.status = acpToolStatus(update["status"]);
+        final out = acpToolOutputText(update);
         if (out != null) draft.output = out;
     }
   }
@@ -156,65 +158,6 @@ class AcpReplayCollector {
     for (final draft in _drafts.reversed) {
       final tool = draft.tools[toolId];
       if (tool != null) return tool;
-    }
-    return null;
-  }
-
-  PluginToolStatus _status(Object? raw) {
-    return switch (raw) {
-      "pending" => PluginToolStatus.pending,
-      "in_progress" => PluginToolStatus.running,
-      "completed" => PluginToolStatus.completed,
-      "failed" => PluginToolStatus.error,
-      _ => PluginToolStatus.pending,
-    };
-  }
-
-  /// Tool output for replayed `tool_call`/`tool_call_update`: ACP `content`
-  /// block first, else the harness `rawOutput` (cursor's exec stdout/stderr),
-  /// truncated to [maxToolOutputLength].
-  String? _toolOutput(Map<String, dynamic> update) {
-    final text = _contentText(update["content"]) ?? _rawOutputText(update["rawOutput"]);
-    if (text == null || text.isEmpty) return null;
-    return text.length > maxToolOutputLength
-        ? "${text.substring(0, maxToolOutputLength)}…"
-        : text;
-  }
-
-  String? _rawOutputText(Object? raw) {
-    if (raw is String) return raw.isEmpty ? null : raw;
-    if (raw is! Map) return null;
-    final map = raw.cast<String, dynamic>();
-    final out = (map["stdout"] as String?)?.trimRight() ?? "";
-    final err = (map["stderr"] as String?)?.trimRight() ?? "";
-    if (out.isNotEmpty || err.isNotEmpty) {
-      final buffer = StringBuffer(out);
-      if (err.isNotEmpty) {
-        if (buffer.isNotEmpty) buffer.write("\n");
-        buffer.write(err);
-      }
-      return buffer.toString();
-    }
-    final content = _contentText(map["content"])?.trimRight();
-    return (content == null || content.isEmpty) ? null : content;
-  }
-
-  String? _contentText(Object? content) {
-    if (content is String) return content.isEmpty ? null : content;
-    if (content is Map) {
-      final text = content["text"];
-      return text is String && text.isNotEmpty ? text : null;
-    }
-    if (content is List) {
-      final buffer = StringBuffer();
-      for (final entry in content) {
-        if (entry is Map) {
-          final text = entry["text"];
-          if (text is String) buffer.write(text);
-        }
-      }
-      final result = buffer.toString();
-      return result.isEmpty ? null : result;
     }
     return null;
   }

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -1,0 +1,251 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+/// Accumulates the `session/update` notifications replayed by `session/load`
+/// into ordered [PluginMessageWithParts] for `getSessionMessages`.
+///
+/// ACP replays a thread as a stream of chunk notifications in conversational
+/// order; consecutive same-role chunks belong to one message, and a role
+/// switch starts a new message.
+class AcpReplayCollector {
+  AcpReplayCollector({
+    required this.sessionId,
+    required this.agentId,
+    this.modelId,
+    this.providerId,
+  });
+
+  final String sessionId;
+  final String agentId;
+
+  /// Model/provider stamped on replayed assistant messages. Mutable so the
+  /// plugin can set the loaded session's real model after `session/load`
+  /// returns its catalog (the collector is created before the load runs).
+  String? modelId;
+  String? providerId;
+
+  final List<_Draft> _drafts = [];
+  int _seq = 0;
+
+  void consume(Map<String, dynamic> params) {
+    final update = _asMap(params["update"]);
+    if (update == null) return;
+    switch (update["sessionUpdate"] as String?) {
+      case "agent_message_chunk":
+        final t = _contentText(update["content"]);
+        if (t != null) _assistant().text.write(t);
+      case "agent_thought_chunk":
+        final t = _contentText(update["content"]);
+        if (t != null) _assistant().reasoning.write(t);
+      case "user_message_chunk":
+        final t = _contentText(update["content"]);
+        if (t != null) _user().text.write(t);
+      case "tool_call":
+        final id = update["toolCallId"] as String?;
+        if (id == null) return;
+        _assistant().tools[id] = _ToolDraft(
+          tool: (update["kind"] ?? update["title"] ?? "tool") as String,
+          title: update["title"] as String?,
+          status: _status(update["status"]),
+          output: _toolOutput(update),
+        );
+      case "tool_call_update":
+        final id = update["toolCallId"] as String?;
+        if (id == null) return;
+        final draft = _findTool(id);
+        if (draft == null) return;
+        draft.status = _status(update["status"]);
+        final out = _toolOutput(update);
+        if (out != null) draft.output = out;
+    }
+  }
+
+  List<PluginMessageWithParts> build() {
+    return [
+      for (final draft in _drafts) _buildMessage(draft),
+    ];
+  }
+
+  PluginMessageWithParts _buildMessage(_Draft draft) {
+    final parts = <PluginMessagePart>[];
+    if (draft.reasoning.isNotEmpty) {
+      parts.add(_textPart(draft, "reasoning", PluginMessagePartType.reasoning, draft.reasoning.toString()));
+    }
+    if (draft.text.isNotEmpty) {
+      parts.add(_textPart(draft, "text", PluginMessagePartType.text, draft.text.toString()));
+    }
+    draft.tools.forEach((toolId, tool) {
+      parts.add(
+        PluginMessagePart(
+          id: "${draft.id}-tool-$toolId",
+          sessionID: sessionId,
+          messageID: draft.id,
+          type: PluginMessagePartType.tool,
+          text: null,
+          tool: tool.tool,
+          state: PluginToolState(
+            status: tool.status,
+            title: tool.title,
+            output: tool.output,
+            error: tool.status == PluginToolStatus.error ? tool.output : null,
+          ),
+          prompt: null,
+          description: null,
+          agent: null,
+          agentName: null,
+          attempt: null,
+          retryError: null,
+        ),
+      );
+    });
+    return PluginMessageWithParts(info: _message(draft), parts: parts);
+  }
+
+  PluginMessage _message(_Draft draft) {
+    if (draft.role == "user") {
+      return PluginMessage.user(
+        id: draft.id,
+        sessionID: sessionId,
+        agent: null,
+        time: null,
+      );
+    }
+    return PluginMessage.assistant(
+      id: draft.id,
+      sessionID: sessionId,
+      agent: agentId,
+      modelID: modelId,
+      providerID: providerId,
+      time: null,
+    );
+  }
+
+  PluginMessagePart _textPart(
+    _Draft draft,
+    String suffix,
+    PluginMessagePartType type,
+    String text,
+  ) {
+    return PluginMessagePart(
+      id: "${draft.id}-$suffix",
+      sessionID: sessionId,
+      messageID: draft.id,
+      type: type,
+      text: text,
+      tool: null,
+      state: null,
+      prompt: null,
+      description: null,
+      agent: null,
+      agentName: null,
+      attempt: null,
+      retryError: null,
+    );
+  }
+
+  _Draft _assistant() => _ensureRole("assistant");
+  _Draft _user() => _ensureRole("user");
+
+  _Draft _ensureRole(String role) {
+    if (_drafts.isNotEmpty && _drafts.last.role == role) return _drafts.last;
+    final draft = _Draft(role: role, id: "$sessionId-h${_seq++}-$role");
+    _drafts.add(draft);
+    return draft;
+  }
+
+  _ToolDraft? _findTool(String toolId) {
+    for (final draft in _drafts.reversed) {
+      final tool = draft.tools[toolId];
+      if (tool != null) return tool;
+    }
+    return null;
+  }
+
+  PluginToolStatus _status(Object? raw) {
+    return switch (raw) {
+      "pending" => PluginToolStatus.pending,
+      "in_progress" => PluginToolStatus.running,
+      "completed" => PluginToolStatus.completed,
+      "failed" => PluginToolStatus.error,
+      _ => PluginToolStatus.pending,
+    };
+  }
+
+  /// Tool output for replayed `tool_call`/`tool_call_update`: ACP `content`
+  /// block first, else the harness `rawOutput` (cursor's exec stdout/stderr),
+  /// truncated to [maxToolOutputLength].
+  String? _toolOutput(Map<String, dynamic> update) {
+    final text = _contentText(update["content"]) ?? _rawOutputText(update["rawOutput"]);
+    if (text == null || text.isEmpty) return null;
+    return text.length > maxToolOutputLength
+        ? "${text.substring(0, maxToolOutputLength)}…"
+        : text;
+  }
+
+  String? _rawOutputText(Object? raw) {
+    if (raw is String) return raw.isEmpty ? null : raw;
+    if (raw is! Map) return null;
+    final map = raw.cast<String, dynamic>();
+    final out = (map["stdout"] as String?)?.trimRight() ?? "";
+    final err = (map["stderr"] as String?)?.trimRight() ?? "";
+    if (out.isNotEmpty || err.isNotEmpty) {
+      final buffer = StringBuffer(out);
+      if (err.isNotEmpty) {
+        if (buffer.isNotEmpty) buffer.write("\n");
+        buffer.write(err);
+      }
+      return buffer.toString();
+    }
+    final content = _contentText(map["content"])?.trimRight();
+    return (content == null || content.isEmpty) ? null : content;
+  }
+
+  String? _contentText(Object? content) {
+    if (content is String) return content.isEmpty ? null : content;
+    if (content is Map) {
+      final text = content["text"];
+      return text is String && text.isNotEmpty ? text : null;
+    }
+    if (content is List) {
+      final buffer = StringBuffer();
+      for (final entry in content) {
+        if (entry is Map) {
+          final text = entry["text"];
+          if (text is String) buffer.write(text);
+        }
+      }
+      final result = buffer.toString();
+      return result.isEmpty ? null : result;
+    }
+    return null;
+  }
+
+  Map<String, dynamic>? _asMap(Object? value) {
+    if (value is Map) return value.cast<String, dynamic>();
+    return null;
+  }
+}
+
+class _Draft {
+  _Draft({required this.role, required this.id});
+
+  final String role;
+  final String id;
+  final StringBuffer text = StringBuffer();
+  final StringBuffer reasoning = StringBuffer();
+  final Map<String, _ToolDraft> tools = {};
+}
+
+class _ToolDraft {
+  _ToolDraft({
+    required this.tool,
+    required this.title,
+    required this.status,
+    required this.output,
+  });
+
+  final String tool;
+  final String? title;
+  // Reassigned as later tool_call_update notifications arrive during replay.
+  PluginToolStatus status;
+  String? output;
+}

--- a/bridge/sesori_plugin_acp/lib/src/acp_stdio_client.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_stdio_client.dart
@@ -127,6 +127,8 @@ class AcpStdioClient {
         .transform(const LineSplitter())
         .listen(
           (line) => Log.d("[$_logTag][stderr] $line"),
+          onError: (Object error, StackTrace stack) =>
+              Log.w("[$_logTag] stderr stream error: $error", error, stack),
           cancelOnError: false,
         );
 
@@ -151,7 +153,7 @@ class AcpStdioClient {
   /// Send a JSON-RPC request and await its response.
   ///
   /// Throws [AcpRpcException] on error responses, [TimeoutException] on
-  /// timeout, [StateError] if not connected.
+  /// timeout, [StateError] if not connected or the agent process has exited.
   Future<dynamic> request({
     required String method,
     Object? params,
@@ -160,6 +162,13 @@ class AcpStdioClient {
     final process = _process;
     if (process == null) {
       throw StateError("AcpStdioClient not connected");
+    }
+    // The exit handler does not clear _process, so without this a request issued
+    // after the agent died would write to a dead pipe and then block for the
+    // full timeout (up to 30 min for a prompt) waiting for a reply that can
+    // never come. Fail fast instead.
+    if (_exited.isCompleted) {
+      throw StateError("AcpStdioClient agent process has exited");
     }
     final id = _nextId++;
     final completer = Completer<dynamic>();
@@ -238,13 +247,19 @@ class AcpStdioClient {
           return;
         }
         if (map.containsKey("error")) {
-          final err = (map["error"] as Map).cast<String, dynamic>();
+          // Parse defensively: a malformed `error` member (not a map, or a
+          // non-int code / non-string message) must still complete the pending
+          // completer, or the awaiting request orphans until it times out.
+          final rawErr = map["error"];
+          final err = rawErr is Map ? rawErr.cast<String, dynamic>() : null;
+          final code = err?["code"];
+          final message = err?["message"];
           completer.completeError(
             AcpRpcException(
               method: "<response>",
-              code: (err["code"] ?? -32603) as int,
-              message: (err["message"] ?? "unknown error") as String,
-              data: err["data"],
+              code: code is int ? code : -32603,
+              message: message is String ? message : "unknown error",
+              data: err?["data"],
             ),
           );
         } else {
@@ -314,13 +329,32 @@ class AcpStdioClient {
       }
     }
 
-    await _stdoutSubscription?.cancel();
-    await _stderrSubscription?.cancel();
+    // Isolate each teardown step so a failure in one does not skip the rest
+    // (notably _failPending, which unblocks callers awaiting in-flight
+    // requests). dispose() must not throw — log and continue.
+    try {
+      await _stdoutSubscription?.cancel();
+    } on Object catch (e, st) {
+      Log.w("[$_logTag] failed to cancel stdout subscription", e, st);
+    }
+    try {
+      await _stderrSubscription?.cancel();
+    } on Object catch (e, st) {
+      Log.w("[$_logTag] failed to cancel stderr subscription", e, st);
+    }
     _failPending(
       StateError("AcpStdioClient disposed"),
       StackTrace.current,
     );
-    await _notifications.close();
-    await _serverRequests.close();
+    try {
+      await _notifications.close();
+    } on Object catch (e, st) {
+      Log.w("[$_logTag] failed to close notifications stream", e, st);
+    }
+    try {
+      await _serverRequests.close();
+    } on Object catch (e, st) {
+      Log.w("[$_logTag] failed to close server-requests stream", e, st);
+    }
   }
 }

--- a/bridge/sesori_plugin_acp/lib/src/acp_stdio_client.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_stdio_client.dart
@@ -1,0 +1,326 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io" as io;
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
+import "acp_process_factory.dart";
+
+/// A JSON-RPC error returned by an ACP agent.
+class AcpRpcException implements Exception {
+  AcpRpcException({
+    required this.method,
+    required this.code,
+    required this.message,
+    this.data,
+  });
+
+  final String method;
+  final int code;
+  final String message;
+  final Object? data;
+
+  @override
+  String toString() => "AcpRpcException($method, code=$code, $message)";
+}
+
+/// A server-originated notification (no `id`), e.g. `session/update`.
+class AcpNotification {
+  const AcpNotification({required this.method, required this.params});
+
+  final String method;
+  final Map<String, dynamic> params;
+
+  @override
+  String toString() => "AcpNotification($method)";
+}
+
+/// A server-originated request that expects a response, e.g.
+/// `session/request_permission` or Cursor's `cursor/ask_question`.
+class AcpServerRequest {
+  const AcpServerRequest({
+    required this.id,
+    required this.method,
+    required this.params,
+  });
+
+  /// JSON-RPC `id` — echo this when responding.
+  final Object id;
+  final String method;
+  final Map<String, dynamic> params;
+}
+
+/// JSON-RPC 2.0 client for an ACP agent spoken over the agent process's
+/// stdin/stdout, framed as newline-delimited JSON (ndjson): one JSON-RPC
+/// message per `\n`, no embedded newlines (ACP transport spec).
+///
+/// Mirrors the public surface of codex's `CodexAppServerClient` (WebSocket)
+/// so the event mapper, approval registry and plugin port across with minimal
+/// change. The differences are that this client owns a real subprocess: it
+/// spawns on [connect], reaps on [dispose], and can send id-less
+/// notifications ([notify], e.g. `session/cancel`) which the WebSocket client
+/// never needed.
+class AcpStdioClient {
+  AcpStdioClient({
+    required AcpLaunchSpec launchSpec,
+    AcpProcessFactory? processFactory,
+    String logTag = "acp",
+  }) : _launchSpec = launchSpec,
+       _processFactory = processFactory ?? defaultAcpProcessFactory,
+       _logTag = logTag;
+
+  final AcpLaunchSpec _launchSpec;
+  final AcpProcessFactory _processFactory;
+  final String _logTag;
+
+  AcpProcessHandle? _process;
+  StreamSubscription<String>? _stdoutSubscription;
+  StreamSubscription<String>? _stderrSubscription;
+  bool _disposed = false;
+  int _nextId = 1;
+
+  final Map<Object, Completer<dynamic>> _pending = {};
+  final StreamController<AcpNotification> _notifications =
+      StreamController.broadcast();
+  final StreamController<AcpServerRequest> _serverRequests =
+      StreamController.broadcast();
+  final Completer<int> _exited = Completer<int>();
+
+  /// Server-originated notifications (broadcast).
+  Stream<AcpNotification> get notifications => _notifications.stream;
+
+  /// Server-originated requests that expect a response (broadcast).
+  Stream<AcpServerRequest> get serverRequests => _serverRequests.stream;
+
+  /// Completes with the agent process's exit code when it terminates.
+  Future<int> get processExit => _exited.future;
+
+  bool get isConnected => _process != null && !_disposed;
+
+  /// Spawns the agent process and wires the stdio framing.
+  ///
+  /// Does NOT perform the ACP `initialize` handshake — that is protocol-level
+  /// and carries harness-specific capabilities, so the plugin issues it via
+  /// [request] after `connect`. Idempotent only in the failure path.
+  Future<void> connect() async {
+    if (_process != null) {
+      throw StateError("AcpStdioClient already connected");
+    }
+    if (_disposed) {
+      throw StateError("AcpStdioClient is disposed");
+    }
+
+    final process = await _processFactory(_launchSpec);
+    _process = process;
+
+    _stdoutSubscription = process.stdout
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen(
+          _handleLine,
+          onError: _handleStreamError,
+          cancelOnError: false,
+        );
+
+    _stderrSubscription = process.stderr
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen(
+          (line) => Log.d("[$_logTag][stderr] $line"),
+          cancelOnError: false,
+        );
+
+    unawaited(
+      process.exitCode.then((code) {
+        if (!_exited.isCompleted) _exited.complete(code);
+        if (!_disposed) {
+          Log.w("[$_logTag] agent process exited with code $code");
+        }
+        _failPending(
+          AcpRpcException(
+            method: "<process>",
+            code: -32000,
+            message: "agent process exited with code $code",
+          ),
+          StackTrace.current,
+        );
+      }),
+    );
+  }
+
+  /// Send a JSON-RPC request and await its response.
+  ///
+  /// Throws [AcpRpcException] on error responses, [TimeoutException] on
+  /// timeout, [StateError] if not connected.
+  Future<dynamic> request({
+    required String method,
+    Object? params,
+    Duration timeout = const Duration(seconds: 60),
+  }) async {
+    final process = _process;
+    if (process == null) {
+      throw StateError("AcpStdioClient not connected");
+    }
+    final id = _nextId++;
+    final completer = Completer<dynamic>();
+    _pending[id] = completer;
+
+    final envelope = <String, dynamic>{
+      "jsonrpc": "2.0",
+      "id": id,
+      "method": method,
+    };
+    if (params != null) envelope["params"] = params;
+    _writeFrame(process, envelope);
+
+    try {
+      return await completer.future.timeout(timeout);
+    } on TimeoutException {
+      _pending.remove(id);
+      rethrow;
+    }
+  }
+
+  /// Send a JSON-RPC notification (no `id`, no response), e.g.
+  /// `session/cancel`.
+  void notify({required String method, Object? params}) {
+    final process = _process;
+    if (process == null) return;
+    final envelope = <String, dynamic>{"jsonrpc": "2.0", "method": method};
+    if (params != null) envelope["params"] = params;
+    _writeFrame(process, envelope);
+  }
+
+  /// Reply to an [AcpServerRequest] with a result payload.
+  void respondToServerRequest({required Object id, required Object? result}) {
+    final process = _process;
+    if (process == null) return;
+    _writeFrame(process, {"jsonrpc": "2.0", "id": id, "result": result});
+  }
+
+  /// Reply to an [AcpServerRequest] with a JSON-RPC error.
+  void respondToServerRequestWithError({
+    required Object id,
+    required int code,
+    required String message,
+  }) {
+    final process = _process;
+    if (process == null) return;
+    _writeFrame(process, {
+      "jsonrpc": "2.0",
+      "id": id,
+      "error": {"code": code, "message": message},
+    });
+  }
+
+  void _writeFrame(AcpProcessHandle process, Map<String, dynamic> envelope) {
+    try {
+      process.stdin.add(utf8.encode("${jsonEncode(envelope)}\n"));
+    } catch (error, stack) {
+      Log.w("[$_logTag] failed to write frame: $error\n$stack");
+    }
+  }
+
+  void _handleLine(String line) {
+    if (line.trim().isEmpty) return;
+    try {
+      final decoded = jsonDecode(line);
+      if (decoded is! Map) return;
+      final map = decoded.cast<String, dynamic>();
+      final id = map["id"];
+      final method = map["method"] as String?;
+
+      if (id != null && method == null) {
+        // Response to one of our requests.
+        final completer = _pending.remove(id);
+        if (completer == null) {
+          Log.d("[$_logTag] response for unknown id=$id");
+          return;
+        }
+        if (map.containsKey("error")) {
+          final err = (map["error"] as Map).cast<String, dynamic>();
+          completer.completeError(
+            AcpRpcException(
+              method: "<response>",
+              code: (err["code"] ?? -32603) as int,
+              message: (err["message"] ?? "unknown error") as String,
+              data: err["data"],
+            ),
+          );
+        } else {
+          completer.complete(map["result"]);
+        }
+        return;
+      }
+
+      if (id != null && method != null) {
+        // Server-originated request.
+        final params = (map["params"] as Map?)?.cast<String, dynamic>() ?? {};
+        _serverRequests.add(
+          AcpServerRequest(id: id as Object, method: method, params: params),
+        );
+        return;
+      }
+
+      if (method != null) {
+        // Notification.
+        final params = (map["params"] as Map?)?.cast<String, dynamic>() ?? {};
+        _notifications.add(AcpNotification(method: method, params: params));
+        return;
+      }
+
+      Log.d("[$_logTag] unrecognised frame: $line");
+    } catch (error, stack) {
+      Log.w("[$_logTag] failed to parse frame: $error\n$stack");
+    }
+  }
+
+  void _handleStreamError(Object error, StackTrace stack) {
+    Log.w("[$_logTag] stdout stream error: $error");
+    _failPending(error, stack);
+  }
+
+  void _failPending(Object error, StackTrace stack) {
+    final inflight = List<Completer<dynamic>>.from(_pending.values);
+    _pending.clear();
+    for (final completer in inflight) {
+      if (!completer.isCompleted) completer.completeError(error, stack);
+    }
+  }
+
+  /// Kills the agent process, fails in-flight requests, and closes streams.
+  Future<void> dispose({
+    Duration gracefulTimeout = const Duration(seconds: 5),
+  }) async {
+    if (_disposed) return;
+    _disposed = true;
+
+    final process = _process;
+    _process = null;
+    if (process != null) {
+      try {
+        if (io.Platform.isWindows) {
+          process.kill(io.ProcessSignal.sigkill);
+        } else {
+          process.kill(io.ProcessSignal.sigterm);
+          try {
+            await process.exitCode.timeout(gracefulTimeout);
+          } on TimeoutException {
+            process.kill(io.ProcessSignal.sigkill);
+          }
+        }
+      } catch (_) {
+        // Process may already be dead.
+      }
+    }
+
+    await _stdoutSubscription?.cancel();
+    await _stderrSubscription?.cancel();
+    _failPending(
+      StateError("AcpStdioClient disposed"),
+      StackTrace.current,
+    );
+    await _notifications.close();
+    await _serverRequests.close();
+  }
+}

--- a/bridge/sesori_plugin_acp/lib/src/runtime/acp_bridge_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/runtime/acp_bridge_plugin.dart
@@ -101,7 +101,12 @@ class AcpBridgePlugin with SteadyPluginLifecycle implements BridgePlugin {
       if (_stopping) {
         return;
       }
-      Log.w("[${_plugin.id}] agent process exited (code $code); marking degraded");
+      Log.w("[${_plugin.id}] agent process exited (code $code); resetting connection and marking degraded");
+      // Drop the cached client/connection so the next request re-spawns a fresh
+      // agent instead of writing to the dead process. resetConnectionAfterExit()
+      // clears the cached state synchronously before its first await and never
+      // throws, so the degraded path is genuinely recoverable.
+      unawaited(_plugin.resetConnectionAfterExit());
       markDegraded(recoverable: true, requiresUserAction: false, userActionHint: null);
     });
   }
@@ -109,10 +114,17 @@ class AcpBridgePlugin with SteadyPluginLifecycle implements BridgePlugin {
   @override
   Future<void> onShutdown({required Duration? budget}) async {
     _stopping = true;
-    await _exitSubscription?.cancel();
-    _exitSubscription = null;
+    // Isolated so a failed cancel cannot skip the dispose() below.
+    try {
+      await _exitSubscription?.cancel();
+    } on Object catch (e, st) {
+      Log.w("[${_plugin.id}] failed to cancel exit subscription", e, st);
+    } finally {
+      _exitSubscription = null;
+    }
     // AcpPlugin.dispose() reaps the agent subprocess (SIGTERM, wait, SIGKILL),
     // cancels the notification subscription, and closes the event channel.
+    // It isolates and swallows its own teardown failures, so it never throws.
     await _plugin.dispose();
   }
 }

--- a/bridge/sesori_plugin_acp/lib/src/runtime/acp_bridge_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/runtime/acp_bridge_plugin.dart
@@ -1,0 +1,118 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../acp_plugin.dart";
+
+/// Live-plugin wrapper for an stdio ACP backend.
+///
+/// ACP agents have no managed runtime in the `sesori_plugin_runtime` sense:
+/// there is no listening port to reclaim, no ownership file, no cross-restart
+/// resident server — just one long-lived child whose stdin/stdout *is* the
+/// transport. So this uses the [SteadyPluginLifecycle] archetype (the one the
+/// interface docs call out for "direct-CLI / remote-server / ACP" plugins)
+/// rather than the managed-process supervisor OpenCode needs.
+///
+/// The wrapped [AcpPlugin] is the stable [api] object for the plugin's whole
+/// lifetime; it owns the agent subprocess (spawned lazily, or eagerly via
+/// [connect]) and reaps it on [dispose]. This wrapper adds the lifecycle
+/// surface: it drives the status state machine off the ACP connection and the
+/// child's exit, and owns the ordered, idempotent [shutdown].
+class AcpBridgePlugin with SteadyPluginLifecycle implements BridgePlugin {
+  AcpBridgePlugin({
+    required AcpPlugin plugin,
+    required ServerClock clock,
+    String? endpoint,
+  }) : _plugin = plugin,
+       _clock = clock,
+       _endpoint = endpoint;
+
+  final AcpPlugin _plugin;
+  final ServerClock _clock;
+  final String? _endpoint;
+
+  StreamSubscription<int>? _exitSubscription;
+  var _stopping = false;
+
+  @override
+  BridgePluginApi get api => _plugin;
+
+  @override
+  ServerClock get statusClock => _clock;
+
+  @override
+  PluginDiagnostics describe() {
+    return PluginDiagnostics(
+      pluginId: _plugin.id,
+      endpoint: _endpoint,
+      details: {
+        "transport": "acp-stdio",
+        "agent": _plugin.agentDisplayName,
+      },
+    );
+  }
+
+  /// Eagerly establishes the ACP connection within [budget] so the agent is
+  /// spawned and the `initialize` handshake done before the first mobile
+  /// request, and the reported status reflects reality.
+  ///
+  /// A failure or timeout leaves the plugin [PluginDegraded] (recoverable: a
+  /// later request re-drives [AcpPlugin.ensureConnected]) rather than failing
+  /// the whole bridge — the descriptor's `checkAvailability` already verified
+  /// the binary, so an agent that does not answer the handshake right now is a
+  /// transient condition, not a fatal one. Never throws.
+  Future<void> connect({
+    required Duration budget,
+    required StartAbortSignal startAborted,
+  }) async {
+    bool connected;
+    try {
+      connected = await _plugin.ensureConnected().timeout(
+        budget,
+        onTimeout: () => false,
+      );
+    } on Object catch (error, stackTrace) {
+      Log.w("[${_plugin.id}] eager connect failed; starting degraded", error, stackTrace);
+      connected = false;
+    }
+    // An abort observed here is handled by the caller (descriptor), which rolls
+    // back via shutdown() and throws PluginStartAbortedException.
+    if (startAborted.isAborted) {
+      return;
+    }
+    if (connected) {
+      _armExitWatch();
+      markReady();
+    } else {
+      markDegraded(recoverable: true, requiresUserAction: false, userActionHint: null);
+    }
+  }
+
+  /// Surfaces an unexpected agent exit as [PluginDegraded] (recoverable: the
+  /// next request re-spawns via [AcpPlugin.ensureConnected]). A deliberate exit
+  /// during [shutdown] is suppressed via [_stopping] so it never reports a
+  /// crash over a clean stop.
+  void _armExitWatch() {
+    final exit = _plugin.client?.processExit;
+    if (exit == null) {
+      return;
+    }
+    _exitSubscription = exit.asStream().listen((code) {
+      if (_stopping) {
+        return;
+      }
+      Log.w("[${_plugin.id}] agent process exited (code $code); marking degraded");
+      markDegraded(recoverable: true, requiresUserAction: false, userActionHint: null);
+    });
+  }
+
+  @override
+  Future<void> onShutdown({required Duration? budget}) async {
+    _stopping = true;
+    await _exitSubscription?.cancel();
+    _exitSubscription = null;
+    // AcpPlugin.dispose() reaps the agent subprocess (SIGTERM, wait, SIGKILL),
+    // cancels the notification subscription, and closes the event channel.
+    await _plugin.dispose();
+  }
+}

--- a/bridge/sesori_plugin_acp/lib/src/runtime/acp_bridge_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/runtime/acp_bridge_plugin.dart
@@ -32,6 +32,7 @@ class AcpBridgePlugin with SteadyPluginLifecycle implements BridgePlugin {
   final String? _endpoint;
 
   StreamSubscription<int>? _exitSubscription;
+  StreamSubscription<void>? _connectedSubscription;
   var _stopping = false;
 
   @override
@@ -80,6 +81,18 @@ class AcpBridgePlugin with SteadyPluginLifecycle implements BridgePlugin {
     if (startAborted.isAborted) {
       return;
     }
+    // Re-arm the exit watch and recover to ready on every later (re)connect — a
+    // lazy reconnect after a crash+reset, or a first success following a
+    // degraded start. Subscribed after the initial ensureConnected above, whose
+    // emit (a broadcast with no subscriber yet) is dropped, so the connected
+    // branch below is not double-handled.
+    _connectedSubscription ??= _plugin.onConnected.listen((_) {
+      if (_stopping) {
+        return;
+      }
+      _armExitWatch();
+      markReady();
+    });
     if (connected) {
       _armExitWatch();
       markReady();
@@ -97,6 +110,9 @@ class AcpBridgePlugin with SteadyPluginLifecycle implements BridgePlugin {
     if (exit == null) {
       return;
     }
+    // Drop any prior watch (e.g. from the previous, now-exited client) before
+    // arming on the current client, so reconnects do not leak subscriptions.
+    unawaited(_exitSubscription?.cancel());
     _exitSubscription = exit.asStream().listen((code) {
       if (_stopping) {
         return;
@@ -115,6 +131,13 @@ class AcpBridgePlugin with SteadyPluginLifecycle implements BridgePlugin {
   Future<void> onShutdown({required Duration? budget}) async {
     _stopping = true;
     // Isolated so a failed cancel cannot skip the dispose() below.
+    try {
+      await _connectedSubscription?.cancel();
+    } on Object catch (e, st) {
+      Log.w("[${_plugin.id}] failed to cancel connected subscription", e, st);
+    } finally {
+      _connectedSubscription = null;
+    }
     try {
       await _exitSubscription?.cancel();
     } on Object catch (e, st) {

--- a/bridge/sesori_plugin_acp/lib/src/runtime/host_process_acp_factory.dart
+++ b/bridge/sesori_plugin_acp/lib/src/runtime/host_process_acp_factory.dart
@@ -1,0 +1,75 @@
+import "dart:async";
+import "dart:io" as io;
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../acp_process_factory.dart";
+
+/// Builds an [AcpProcessFactory] that spawns the agent through the bridge's
+/// [HostProcessService] instead of calling `io.Process.start` directly.
+///
+/// The plugin-lifecycle contract requires plugins to route process spawning
+/// through the [PluginHost] seams (so the bridge owns identity capture and
+/// platform-aware signalling) rather than reaching around the host. This is
+/// the ACP equivalent of the default [defaultAcpProcessFactory]: it merges the
+/// host [environment] under the launch spec's own entries and hands back an
+/// [AcpProcessHandle] backed by the spawned child.
+AcpProcessFactory hostProcessAcpFactory({
+  required HostProcessService processes,
+  required Map<String, String> environment,
+}) {
+  return (AcpLaunchSpec spec) async {
+    final spawned = await processes.spawn(
+      executable: spec.command,
+      arguments: spec.args,
+      environment: {...environment, ...spec.environment},
+      workingDirectory: spec.cwd,
+      // ACP shims on Windows (e.g. `cursor-agent.cmd`) only resolve through a
+      // shell — mirror the default factory's platform handling.
+      runInShell: io.Platform.isWindows,
+    );
+    return HostProcessAcpHandle(process: spawned, processes: processes);
+  };
+}
+
+/// Adapts a [SpawnedProcess] (from [HostProcessService.spawn]) to the narrow
+/// [AcpProcessHandle] the ACP stdio transport drives.
+///
+/// stdio passes straight through. [kill] maps onto the host's platform-aware
+/// signalling: `SIGKILL` → [HostProcessService.signalForce], everything else →
+/// [HostProcessService.signalGraceful]. The host calls are fire-and-forget —
+/// the transport observes the actual termination through [exitCode], exactly as
+/// it does with a real `io.Process`.
+class HostProcessAcpHandle implements AcpProcessHandle {
+  HostProcessAcpHandle({
+    required SpawnedProcess process,
+    required HostProcessService processes,
+  }) : _process = process,
+       _processes = processes;
+
+  final SpawnedProcess _process;
+  final HostProcessService _processes;
+
+  @override
+  Stream<List<int>> get stdout => _process.stdout;
+
+  @override
+  Stream<List<int>> get stderr => _process.stderr;
+
+  @override
+  io.IOSink get stdin => _process.stdin;
+
+  @override
+  Future<int> get exitCode => _process.exitCode;
+
+  @override
+  bool kill([io.ProcessSignal signal = io.ProcessSignal.sigterm]) {
+    final pid = _process.pid;
+    if (signal == io.ProcessSignal.sigkill) {
+      unawaited(_processes.signalForce(pid: pid));
+    } else {
+      unawaited(_processes.signalGraceful(pid: pid));
+    }
+    return true;
+  }
+}

--- a/bridge/sesori_plugin_acp/lib/src/testing/fake_acp_process.dart
+++ b/bridge/sesori_plugin_acp/lib/src/testing/fake_acp_process.dart
@@ -1,0 +1,118 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+
+import "../acp_process_factory.dart";
+
+/// In-memory [AcpProcessHandle] for transport/plugin tests — the stdio
+/// analogue of codex's injected fake WebSocket channel. Shared across ACP
+/// harness packages via `package:acp_plugin/acp_testing.dart`.
+class FakeAcpProcess implements AcpProcessHandle {
+  final StreamController<List<int>> _stdout = StreamController<List<int>>();
+  final StreamController<List<int>> _stderr = StreamController<List<int>>();
+  final Completer<int> _exit = Completer<int>();
+  final CapturingIOSink _stdin = CapturingIOSink();
+
+  bool _stdoutTapped = false;
+  bool _stderrTapped = false;
+
+  @override
+  Stream<List<int>> get stdout {
+    _stdoutTapped = true;
+    return _stdout.stream;
+  }
+
+  @override
+  Stream<List<int>> get stderr {
+    _stderrTapped = true;
+    return _stderr.stream;
+  }
+
+  @override
+  IOSink get stdin => _stdin;
+
+  @override
+  Future<int> get exitCode => _exit.future;
+
+  @override
+  bool kill([ProcessSignal signal = ProcessSignal.sigterm]) {
+    if (!_exit.isCompleted) _exit.complete(-15);
+    return true;
+  }
+
+  /// Frames the client wrote to stdin, decoded from ndjson.
+  List<Map<String, dynamic>> get written => _stdin.frames;
+
+  /// Pushes a server->client JSON-RPC message as one ndjson line.
+  void emit(Map<String, dynamic> message) {
+    _stdout.add(utf8.encode("${jsonEncode(message)}\n"));
+  }
+
+  /// Completes the process with [code], simulating an early exit.
+  void exit(int code) {
+    if (!_exit.isCompleted) _exit.complete(code);
+  }
+
+  Future<void> close() async {
+    // A single-subscription controller's `close()` future only completes once
+    // its stream has been listened to. Drain any never-tapped stream first so
+    // closing a fake the plugin never connected to does not hang. (A stream
+    // tapped then cancelled already completes close() and rejects a re-listen,
+    // so the tapped flag — not `hasListener` — is the right guard.)
+    if (!_stdoutTapped) _stdout.stream.listen(null);
+    if (!_stderrTapped) _stderr.stream.listen(null);
+    await _stdout.close();
+    await _stderr.close();
+  }
+}
+
+/// Minimal [IOSink] that captures `add`-ed bytes and decodes complete ndjson
+/// lines into [frames]. Only [add] is exercised by the transport.
+class CapturingIOSink implements IOSink {
+  final List<int> _buffer = [];
+  final List<Map<String, dynamic>> frames = [];
+
+  @override
+  Encoding encoding = utf8;
+
+  @override
+  void add(List<int> data) {
+    _buffer.addAll(data);
+    while (true) {
+      final idx = _buffer.indexOf(10);
+      if (idx < 0) break;
+      final line = utf8.decode(_buffer.sublist(0, idx));
+      _buffer.removeRange(0, idx + 1);
+      if (line.trim().isNotEmpty) {
+        frames.add((jsonDecode(line) as Map).cast<String, dynamic>());
+      }
+    }
+  }
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future<void> addStream(Stream<List<int>> stream) async {}
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  Future<void> get done => Future<void>.value();
+
+  @override
+  Future<void> flush() async {}
+
+  @override
+  void write(Object? object) {}
+
+  @override
+  void writeAll(Iterable<dynamic> objects, [String separator = ""]) {}
+
+  @override
+  void writeCharCode(int charCode) {}
+
+  @override
+  void writeln([Object? object = ""]) {}
+}

--- a/bridge/sesori_plugin_acp/pubspec.yaml
+++ b/bridge/sesori_plugin_acp/pubspec.yaml
@@ -1,0 +1,23 @@
+name: acp_plugin
+version: 0.1.0
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.12.2
+
+dependencies:
+  sesori_plugin_interface:
+    path: ../sesori_plugin_interface
+  sesori_shared:
+    path: ../../shared/sesori_shared
+  path: ^1.9.0
+  freezed_annotation: ^3.1.0
+  json_annotation: ^4.11.0
+
+dev_dependencies:
+  build_runner: any
+  freezed: ^3.2.5
+  json_serializable: ^6.13.0
+  test: ^1.25.0
+  lints: ^6.1.0

--- a/bridge/sesori_plugin_acp/test/acp_approval_registry_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_approval_registry_test.dart
@@ -1,0 +1,137 @@
+import "dart:async";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("AcpApprovalRegistry", () {
+    late StreamController<AcpServerRequest> requests;
+    late List<BridgeSseEvent> emitted;
+    late List<(Object, Object?)> responds;
+    late List<(Object, int, String)> errors;
+    late AcpApprovalRegistry registry;
+
+    setUp(() {
+      requests = StreamController<AcpServerRequest>.broadcast();
+      emitted = [];
+      responds = [];
+      errors = [];
+      registry = AcpApprovalRegistry(
+        emit: emitted.add,
+        respond: (id, result) => responds.add((id, result)),
+        respondError: (id, code, message) => errors.add((id, code, message)),
+      );
+      registry.attach(requests.stream);
+    });
+
+    tearDown(() async {
+      await registry.dispose();
+      await requests.close();
+    });
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+    AcpServerRequest permission() => const AcpServerRequest(
+      id: 7,
+      method: "session/request_permission",
+      params: {
+        "sessionId": "s1",
+        "toolCall": {"toolCallId": "tc-1", "title": "Run rm", "kind": "execute"},
+        "options": [
+          {"optionId": "opt-allow-once", "name": "Allow", "kind": "allow_once"},
+          {"optionId": "opt-allow-always", "name": "Always", "kind": "allow_always"},
+          {"optionId": "opt-reject", "name": "Reject", "kind": "reject_once"},
+        ],
+      },
+    );
+
+    test("permission request surfaces as BridgeSsePermissionAsked", () async {
+      requests.add(permission());
+      await pump();
+      final asked = emitted.single as BridgeSsePermissionAsked;
+      expect(asked.sessionID, "s1");
+      expect(asked.tool, "execute");
+      expect(asked.description, "Run rm");
+      expect(asked.requestID, isNotEmpty);
+    });
+
+    test("reply 'once' echoes the allow_once optionId", () async {
+      requests.add(permission());
+      await pump();
+      final id = (emitted.single as BridgeSsePermissionAsked).requestID;
+
+      expect(registry.replyPermission(id, PluginPermissionReply.once), isTrue);
+      final (_, result) = responds.single;
+      expect((result! as Map)["outcome"], {"outcome": "selected", "optionId": "opt-allow-once"});
+      expect(emitted.whereType<BridgeSsePermissionReplied>(), hasLength(1));
+    });
+
+    test("reply 'always' echoes the allow_always optionId", () async {
+      requests.add(permission());
+      await pump();
+      final id = (emitted.single as BridgeSsePermissionAsked).requestID;
+      registry.replyPermission(id, PluginPermissionReply.always);
+      final (_, result) = responds.single;
+      expect(((result! as Map)["outcome"] as Map)["optionId"], "opt-allow-always");
+    });
+
+    test("reply 'reject' echoes the reject optionId", () async {
+      requests.add(permission());
+      await pump();
+      final id = (emitted.single as BridgeSsePermissionAsked).requestID;
+      registry.replyPermission(id, PluginPermissionReply.reject);
+      final (_, result) = responds.single;
+      expect(((result! as Map)["outcome"] as Map)["optionId"], "opt-reject");
+    });
+
+    test("missing matching option falls back to cancelled", () async {
+      requests.add(const AcpServerRequest(
+        id: 9,
+        method: "session/request_permission",
+        params: {
+          "sessionId": "s1",
+          "toolCall": {"kind": "execute"},
+          "options": [
+            {"optionId": "opt-allow-once", "kind": "allow_once"},
+          ],
+        },
+      ));
+      await pump();
+      final id = (emitted.single as BridgeSsePermissionAsked).requestID;
+      registry.replyPermission(id, PluginPermissionReply.reject);
+      final (_, result) = responds.single;
+      expect((result! as Map)["outcome"], {"outcome": "cancelled"});
+    });
+
+    test("unknown server methods get a soft -32601 error", () async {
+      requests.add(const AcpServerRequest(id: 11, method: "cursor/mystery", params: {}));
+      await pump();
+      expect(errors.single.$2, -32601);
+    });
+
+    test("registered questions reply via the builder and surface as pending", () {
+      registry.addPendingQuestion(
+        bridgeRequestId: "q-1",
+        acpId: 5,
+        sessionId: "s1",
+        questions: [
+          const PluginQuestionInfo(
+            question: "Pick one",
+            header: "Choice",
+            options: [],
+            multiple: false,
+            custom: false,
+          ),
+        ],
+        replyBuilder: (answers) => {"selected": answers.first.first},
+      );
+
+      expect(registry.pendingForSession("s1"), hasLength(1));
+      expect(registry.replyQuestion("q-1", [["yes"]]), isTrue);
+      final (_, result) = responds.single;
+      expect((result! as Map)["selected"], "yes");
+      expect(emitted.whereType<BridgeSseQuestionReplied>(), hasLength(1));
+    });
+  });
+}

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -1,0 +1,190 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" as shared;
+import "package:test/test.dart";
+
+/// Asserts the mapper emits sesori-schema payloads — message envelopes must
+/// round-trip through `Message.fromJson`, exactly like the codex mapper.
+void main() {
+  group("AcpEventMapper", () {
+    late AcpEventMapper mapper;
+
+    setUp(() {
+      mapper = AcpEventMapper(projectCwd: "/repo", agentId: "cursor")
+        ..currentModelId = "gpt-5.4"
+        ..currentProviderId = "cursor";
+    });
+
+    AcpNotification update(Map<String, dynamic> body) => AcpNotification(
+      method: "session/update",
+      params: {"sessionId": "s1", "update": body},
+    );
+
+    test("agent_message_chunk emits envelope + part + delta on first chunk", () {
+      mapper.beginTurn("s1");
+      final events = mapper.map(
+        update({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "Hello"},
+        }),
+      );
+
+      final updated = events.whereType<BridgeSseMessageUpdated>().single;
+      final message = shared.Message.fromJson(updated.info);
+      expect(message, isA<shared.MessageAssistant>());
+
+      expect(events.whereType<BridgeSseMessagePartUpdated>(), hasLength(1));
+      final delta = events.whereType<BridgeSseMessagePartDelta>().single;
+      expect(delta.delta, "Hello");
+      expect(delta.field, "text");
+    });
+
+    test("subsequent chunks emit only a delta on the same part", () {
+      mapper.beginTurn("s1");
+      mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "Hel"},
+      }));
+      final second = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "lo"},
+      }));
+      expect(second.whereType<BridgeSseMessageUpdated>(), isEmpty);
+      expect(second.whereType<BridgeSseMessagePartDelta>().single.delta, "lo");
+    });
+
+    test("agent_thought_chunk maps to a reasoning part", () {
+      mapper.beginTurn("s1");
+      final events = mapper.map(update({
+        "sessionUpdate": "agent_thought_chunk",
+        "content": {"type": "text", "text": "thinking"},
+      }));
+      final part = events.whereType<BridgeSseMessagePartUpdated>().single.part;
+      expect(part.type, PluginMessagePartType.reasoning);
+    });
+
+    test("tool_call maps to an assistant message with a tool part", () {
+      final events = mapper.map(update({
+        "sessionUpdate": "tool_call",
+        "toolCallId": "tc-1",
+        "title": "Read file",
+        "kind": "read",
+        "status": "pending",
+      }));
+      final updated = events.whereType<BridgeSseMessageUpdated>().single;
+      expect(shared.Message.fromJson(updated.info), isA<shared.MessageAssistant>());
+      final part = events.whereType<BridgeSseMessagePartUpdated>().single.part;
+      expect(part.type, PluginMessagePartType.tool);
+      expect(part.tool, "read");
+      expect(part.state?.status, PluginToolStatus.pending);
+    });
+
+    test("tool_call_update on an edit emits a session diff", () {
+      final events = mapper.map(update({
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "tc-2",
+        "kind": "edit",
+        "status": "completed",
+      }));
+      expect(events.whereType<BridgeSseSessionDiff>(), hasLength(1));
+    });
+
+    test("plan maps to a todo update, commands to a project update", () {
+      expect(
+        mapper.map(update({"sessionUpdate": "plan", "entries": const <Object?>[]})).single,
+        isA<BridgeSseTodoUpdated>(),
+      );
+      expect(
+        mapper.map(update({"sessionUpdate": "available_commands_update"})).single,
+        isA<BridgeSseProjectUpdated>(),
+      );
+    });
+
+    test("tool_call_update surfaces rawOutput stdout/stderr as the part output", () {
+      final events = mapper.map(update({
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "tc-3",
+        "kind": "execute",
+        "title": "ls",
+        "status": "completed",
+        "rawOutput": {"exitCode": 0, "stdout": "a.dart\nb.dart\n", "stderr": ""},
+      }));
+      final part = events.whereType<BridgeSseMessagePartUpdated>().single.part;
+      expect(part.state?.status, PluginToolStatus.completed);
+      expect(part.state?.output, "a.dart\nb.dart");
+      expect(part.state?.error, isNull);
+    });
+
+    test("read-style tool surfaces rawOutput.content", () {
+      final events = mapper.map(update({
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "tc-read",
+        "kind": "read",
+        "title": "Read notes.txt",
+        "status": "completed",
+        "rawOutput": {"content": "hello from cursor e2e\n"},
+      }));
+      final part = events.whereType<BridgeSseMessagePartUpdated>().single.part;
+      expect(part.state?.output, "hello from cursor e2e");
+    });
+
+    test("failed tool_call_update mirrors output into error", () {
+      final events = mapper.map(update({
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "tc-4",
+        "kind": "execute",
+        "status": "failed",
+        "rawOutput": {"exitCode": 1, "stdout": "", "stderr": "boom"},
+      }));
+      final part = events.whereType<BridgeSseMessagePartUpdated>().single.part;
+      expect(part.state?.status, PluginToolStatus.error);
+      expect(part.state?.output, "boom");
+      expect(part.state?.error, "boom");
+    });
+
+    test("oversized tool output is truncated", () {
+      final big = "x" * (maxToolOutputLength + 50);
+      final events = mapper.map(update({
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "tc-5",
+        "kind": "execute",
+        "status": "completed",
+        "rawOutput": {"stdout": big, "stderr": ""},
+      }));
+      final output = events.whereType<BridgeSseMessagePartUpdated>().single.part.state?.output;
+      expect(output, hasLength(maxToolOutputLength + 1)); // 500 chars + ellipsis
+      expect(output, endsWith("…"));
+    });
+
+    test("session_info_update surfaces the title as a session update", () {
+      final events = mapper.map(update({
+        "sessionUpdate": "session_info_update",
+        "title": "Fix the parser",
+      }));
+      final updated = events.whereType<BridgeSseSessionUpdated>().single;
+      final session = shared.Session.fromJson(updated.info);
+      expect(session.id, "s1");
+      expect(session.title, "Fix the parser");
+    });
+
+    test("a per-session model overrides the global stamp", () {
+      mapper
+        ..currentModelId = "composer-2.5"
+        ..setSessionModel("s1", "claude-opus-4-8", providerId: "cursor");
+      mapper.beginTurn("s1");
+      final events = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "hi"},
+      }));
+      final message =
+          shared.Message.fromJson(events.whereType<BridgeSseMessageUpdated>().single.info)
+              as shared.MessageAssistant;
+      expect(message.modelID, "claude-opus-4-8");
+      expect(message.providerID, "cursor");
+    });
+
+    test("unknown variants are dropped", () {
+      expect(mapper.map(update({"sessionUpdate": "current_mode_update"})), isEmpty);
+    });
+  });
+}

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -165,6 +165,36 @@ void main() {
       final session = shared.Session.fromJson(updated.info);
       expect(session.id, "s1");
       expect(session.title, "Fix the parser");
+      // No per-session project recorded -> falls back to the launch cwd.
+      expect(session.projectID, "/repo");
+      expect(session.directory, "/repo");
+    });
+
+    test("session_info_update files the title under the session's own project", () {
+      // A session opened outside the launch cwd: its title update must carry
+      // that project's id, or the mobile session list (which drops updates whose
+      // projectID != the active project) ignores it.
+      mapper.setSessionProject("s1", "/repo/opened-elsewhere");
+      final events = mapper.map(update({
+        "sessionUpdate": "session_info_update",
+        "title": "Title in opened project",
+      }));
+      final session =
+          shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
+      expect(session.projectID, "/repo/opened-elsewhere");
+      expect(session.directory, "/repo/opened-elsewhere");
+    });
+
+    test("clearing a session's project reverts to the launch cwd", () {
+      mapper.setSessionProject("s1", "/repo/opened-elsewhere");
+      mapper.setSessionProject("s1", null);
+      final events = mapper.map(update({
+        "sessionUpdate": "session_info_update",
+        "title": "Back to default",
+      }));
+      final session =
+          shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
+      expect(session.projectID, "/repo");
     });
 
     test("a per-session model overrides the global stamp", () {

--- a/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
@@ -1,0 +1,134 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+/// Exercises [AcpPlugin.getActiveSessionsSummary] — the activity feed the
+/// mobile app renders as the per-project "running"/"needs you" badge. The
+/// stub used to return `const []`, so Cursor sessions never appeared.
+void main() {
+  group("AcpPlugin.getActiveSessionsSummary", () {
+    late FakeAcpProcess fake;
+    late AcpPlugin plugin;
+    const cwd = "/repo";
+
+    setUp(() {
+      fake = FakeAcpProcess();
+      plugin = AcpPlugin(
+        id: "acp",
+        agentDisplayName: "ACP",
+        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+        projectCwd: cwd,
+        eventMapper: AcpEventMapper(projectCwd: cwd, agentId: "acp"),
+        processFactory: (_) async => fake,
+      );
+    });
+
+    tearDown(() async {
+      await plugin.dispose();
+      await fake.close();
+    });
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+    // Polls written frames until one with [method] appears (the handshake is
+    // several awaits deep, so a single pump can race the first frame).
+    Future<Map<String, dynamic>> waitForFrame(String method) async {
+      for (var i = 0; i < 50; i++) {
+        final matches = fake.written.where((f) => f["method"] == method);
+        if (matches.isNotEmpty) return matches.last;
+        await pump();
+      }
+      throw StateError("agent never wrote a '$method' frame");
+    }
+
+    Future<void> respond(String method, Map<String, dynamic> result) async {
+      final frame = await waitForFrame(method);
+      fake.emit({"jsonrpc": "2.0", "id": frame["id"], "result": result});
+      await pump();
+    }
+
+    Future<String> connectAndCreateSession() async {
+      final connecting = plugin.ensureConnected();
+      await respond("initialize", {
+        "protocolVersion": 1,
+        "agentCapabilities": <String, dynamic>{},
+        "authMethods": <Object?>[],
+      });
+      expect(await connecting, isTrue);
+
+      final creating = plugin.createSession(
+        directory: cwd,
+        parentSessionId: null,
+        parts: const [],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond("session/new", {"sessionId": "s1"});
+      final session = await creating;
+      return session.id;
+    }
+
+    test("idle session is not surfaced; a running turn is, then clears", () async {
+      final sessionId = await connectAndCreateSession();
+      expect(sessionId, "s1");
+
+      // Created but idle -> no activity row.
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+
+      // Dispatch a prompt and withhold the session/prompt response so the turn
+      // stays in flight (ACP has no turn-complete event: busy == future pending).
+      await plugin.sendPrompt(
+        sessionId: sessionId,
+        parts: const [PluginPromptPart.text(text: "hi")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await waitForFrame("session/prompt");
+
+      final running = plugin.getActiveSessionsSummary();
+      expect(running, hasLength(1));
+      expect(running.single.id, cwd, reason: "the single synthesized project");
+      final active = running.single.activeSessions.single;
+      expect(active.id, sessionId);
+      expect(active.mainAgentRunning, isTrue);
+      expect(active.awaitingInput, isFalse);
+      expect(active.isRetrying, isFalse);
+      expect(active.childSessionIds, isEmpty, reason: "ACP sessions are flat");
+
+      // Resolve the turn -> session goes idle -> summary clears.
+      await respond("session/prompt", {"stopReason": "end_turn"});
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+    });
+
+    test("a session awaiting a permission is surfaced with awaitingInput", () async {
+      final sessionId = await connectAndCreateSession();
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+
+      // A permission ask arrives for the session (the agent is blocked on the
+      // user). The base registry tracks it as pending input.
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 99,
+        "method": "session/request_permission",
+        "params": {
+          "sessionId": sessionId,
+          "toolCall": {"toolCallId": "tc-1", "title": "Run", "kind": "execute"},
+          "options": [
+            {"optionId": "opt-allow-once", "name": "Allow", "kind": "allow_once"},
+          ],
+        },
+      });
+      await pump();
+
+      final summary = plugin.getActiveSessionsSummary();
+      expect(summary, hasLength(1));
+      final active = summary.single.activeSessions.single;
+      expect(active.id, sessionId);
+      expect(active.awaitingInput, isTrue);
+      expect(active.mainAgentRunning, isFalse, reason: "no prompt turn in flight");
+    });
+  });
+}

--- a/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
@@ -1,0 +1,159 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+/// Multi-project behaviour: an ACP agent is a single process with no project
+/// list of its own, so the plugin tracks every directory opened as a project.
+/// Before this, `getProjects` returned only the launch CWD, so a discovered
+/// directory never appeared in the app's project list.
+void main() {
+  group("AcpPlugin projects", () {
+    late FakeAcpProcess fake;
+    late AcpPlugin plugin;
+    const cwd = "/repo";
+
+    setUp(() {
+      fake = FakeAcpProcess();
+      plugin = AcpPlugin(
+        id: "acp",
+        agentDisplayName: "ACP",
+        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+        projectCwd: cwd,
+        eventMapper: AcpEventMapper(projectCwd: cwd, agentId: "acp"),
+        processFactory: (_) async => fake,
+      );
+    });
+
+    tearDown(() async {
+      await plugin.dispose();
+      await fake.close();
+    });
+
+    test("getProjects starts with just the launch CWD", () async {
+      final projects = await plugin.getProjects();
+      expect(projects.map((p) => p.id), [cwd]);
+    });
+
+    test("getProject registers a newly opened directory; getProjects then lists it", () async {
+      const opened = "/Users/x/kustos";
+      final project = await plugin.getProject(opened);
+      expect(project.id, opened);
+      expect(project.name, "kustos");
+
+      final ids = (await plugin.getProjects()).map((p) => p.id).toSet();
+      expect(ids, {cwd, opened}, reason: "the opened directory must appear in the list");
+    });
+
+    test("getProject normalizes a trailing slash to the same project", () async {
+      await plugin.getProject("/Users/x/kustos/");
+      final ids = (await plugin.getProjects()).map((p) => p.id).toList();
+      expect(ids, contains("/Users/x/kustos"));
+      expect(ids.where((id) => id.startsWith("/Users/x/kustos")), hasLength(1));
+    });
+
+    // ── Session attribution across projects ───────────────────────────────────
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+    Future<Map<String, dynamic>> waitForFrame(String method) async {
+      for (var i = 0; i < 50; i++) {
+        final matches = fake.written.where((f) => f["method"] == method);
+        if (matches.isNotEmpty) return matches.last;
+        await pump();
+      }
+      throw StateError("agent never wrote a '$method' frame");
+    }
+
+    Future<void> respond(String method, Map<String, dynamic> result) async {
+      final frame = await waitForFrame(method);
+      fake.emit({"jsonrpc": "2.0", "id": frame["id"], "result": result});
+      await pump();
+    }
+
+    Future<void> connect({bool sessionCapabilities = false}) async {
+      final connecting = plugin.ensureConnected();
+      await respond("initialize", {
+        "protocolVersion": 1,
+        "agentCapabilities": <String, dynamic>{
+          if (sessionCapabilities) ...{
+            "loadSession": true,
+            "sessionCapabilities": {"list": <String, dynamic>{}},
+          },
+        },
+        "authMethods": <Object?>[],
+      });
+      expect(await connecting, isTrue);
+    }
+
+    test("a session created in an opened directory is attributed to that project", () async {
+      await connect();
+      const opened = "/Users/x/kustos";
+
+      final creating = plugin.createSession(
+        directory: opened,
+        parentSessionId: null,
+        parts: const [],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond("session/new", {"sessionId": "s1"});
+      final session = await creating;
+
+      expect(session.projectID, opened, reason: "session belongs to the opened directory, not the launch CWD");
+      expect(session.directory, opened);
+
+      // Opening a session in a directory implicitly registers it as a project.
+      final ids = (await plugin.getProjects()).map((p) => p.id).toSet();
+      expect(ids, containsAll(<String>[cwd, opened]));
+
+      // A running turn surfaces under that project's activity row, not the CWD.
+      await plugin.sendPrompt(
+        sessionId: session.id,
+        parts: const [PluginPromptPart.text(text: "hi")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await waitForFrame("session/prompt");
+      final running = plugin.getActiveSessionsSummary();
+      expect(running, hasLength(1));
+      expect(running.single.id, opened);
+      expect(running.single.activeSessions.single.id, session.id);
+    });
+
+    test("session/load for a prior-run session uses its project's cwd", () async {
+      await connect(sessionCapabilities: true);
+      const opened = "/Users/x/kustos";
+
+      // Teach the plugin the session->project mapping the way getSessions would
+      // (the app lists a project's sessions before opening one), then prompt a
+      // session this process never created so a resume-load is forced.
+      final listing = plugin.getSessions(opened);
+      await respond("session/list", {
+        "sessions": [
+          {"sessionId": "old-s", "cwd": opened, "title": "Prior"},
+        ],
+      });
+      final sessions = await listing;
+      expect(sessions.single.projectID, opened);
+
+      final sending = plugin.sendPrompt(
+        sessionId: "old-s",
+        parts: const [PluginPromptPart.text(text: "again")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final loadFrame = await waitForFrame("session/load");
+      expect((loadFrame["params"] as Map)["cwd"], opened, reason: "resume-load must use the session's own project cwd");
+      fake.emit({"jsonrpc": "2.0", "id": loadFrame["id"], "result": const <String, dynamic>{}});
+
+      // sendPrompt drains the (empty) suppressed replay, then dispatches the
+      // prompt; await it so the prompt frame exists before we resolve the turn.
+      await sending;
+      await respond("session/prompt", {"stopReason": "end_turn"});
+    });
+  });
+}

--- a/bridge/sesori_plugin_acp/test/acp_project_registry_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_project_registry_test.dart
@@ -45,8 +45,45 @@ class _FakeStore implements HostJsonStore {
   }
 }
 
+/// A store whose `write` completions are gated, so a test can hold a write in
+/// flight and observe whether a second write is (wrongly) issued concurrently.
+class _GatedStore implements HostJsonStore {
+  final List<String> writes = [];
+  final List<Completer<void>> _gates = [];
+  String? current;
+
+  @override
+  Future<String?> read({required String name}) async => current;
+
+  @override
+  Future<void> write({required String name, required String contents}) {
+    writes.add(contents);
+    final gate = Completer<void>();
+    _gates.add(gate);
+    return gate.future.then((_) => current = contents);
+  }
+
+  /// Completes the oldest in-flight write.
+  void releaseNext() => _gates.removeAt(0).complete();
+
+  @override
+  Future<void> delete({required String name}) async => current = null;
+
+  @override
+  Future<void> quarantine({required String name, required String quarantinedName}) async {}
+
+  @override
+  Future<String?> update({
+    required String name,
+    required FutureOr<String?> Function(String? current) transform,
+  }) async =>
+      current = await transform(current);
+}
+
 void main() {
   group("AcpProjectRegistry", () {
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+
     // Monotonic clock so createdAt ordering is deterministic per call sequence.
     int Function() monotonic() {
       var t = 1000;
@@ -138,6 +175,31 @@ void main() {
       expect(project.id, "/Users/x/unknown");
       expect(project.name, "unknown");
       expect(reg.list().map((p) => p.id), ["/repo"], reason: "projectFor must not register");
+    });
+
+    test("concurrent registers serialize writes and lose no entries", () async {
+      final store = _GatedStore();
+      final reg = AcpProjectRegistry(cwd: "/repo", store: store, nowMs: monotonic());
+      await reg.ensureLoaded();
+
+      final a = reg.register("/Users/x/alpha");
+      final b = reg.register("/Users/x/beta");
+      await pump();
+
+      // The second write must be queued behind the first, not issued in
+      // parallel (which could complete out of order and drop an entry).
+      expect(store.writes, hasLength(1), reason: "writes are serialized");
+
+      store.releaseNext();
+      await pump();
+      expect(store.writes, hasLength(2), reason: "the queued write runs once the first completes");
+
+      store.releaseNext();
+      await Future.wait([a, b]);
+
+      final decoded = jsonDecode(store.current!) as Map<String, dynamic>;
+      final ids = (decoded["projects"] as List).map((e) => (e as Map)["id"]).toSet();
+      expect(ids, {"/Users/x/alpha", "/Users/x/beta"});
     });
 
     test("re-registering an existing project does not rewrite the store", () async {

--- a/bridge/sesori_plugin_acp/test/acp_project_registry_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_project_registry_test.dart
@@ -1,0 +1,152 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+/// In-memory [HostJsonStore] so registry persistence is exercised without
+/// touching disk. Mirrors the real store's plain-string contract.
+class _FakeStore implements HostJsonStore {
+  final Map<String, String> files = {};
+  final Map<String, String> quarantined = {};
+
+  @override
+  Future<String?> read({required String name}) async => files[name];
+
+  @override
+  Future<void> write({required String name, required String contents}) async {
+    files[name] = contents;
+  }
+
+  @override
+  Future<void> delete({required String name}) async {
+    files.remove(name);
+  }
+
+  @override
+  Future<void> quarantine({required String name, required String quarantinedName}) async {
+    final value = files.remove(name);
+    if (value != null) quarantined[quarantinedName] = value;
+  }
+
+  @override
+  Future<String?> update({
+    required String name,
+    required FutureOr<String?> Function(String? current) transform,
+  }) async {
+    final next = await transform(files[name]);
+    if (next == null) {
+      files.remove(name);
+      return null;
+    }
+    files[name] = next;
+    return next;
+  }
+}
+
+void main() {
+  group("AcpProjectRegistry", () {
+    // Monotonic clock so createdAt ordering is deterministic per call sequence.
+    int Function() monotonic() {
+      var t = 1000;
+      return () => ++t;
+    }
+
+    test("seeds the launch cwd as the only project", () async {
+      final reg = AcpProjectRegistry(cwd: "/repo", nowMs: monotonic());
+      await reg.ensureLoaded();
+      final projects = reg.list();
+      expect(projects, hasLength(1));
+      expect(projects.single.id, "/repo");
+      expect(projects.single.name, "repo");
+    });
+
+    test("register adds a project and getProjects includes it, newest first", () async {
+      final reg = AcpProjectRegistry(cwd: "/repo", nowMs: monotonic());
+      await reg.register("/Users/x/alpha");
+      await reg.register("/Users/x/beta");
+      final ids = reg.list().map((p) => p.id).toList();
+      // Newest registration first, launch cwd (seeded oldest) last.
+      expect(ids, ["/Users/x/beta", "/Users/x/alpha", "/repo"]);
+      expect(reg.list().firstWhere((p) => p.id == "/Users/x/beta").name, "beta");
+    });
+
+    test("normalizes trailing slashes and . segments to one id", () async {
+      final reg = AcpProjectRegistry(cwd: "/repo", nowMs: monotonic());
+      final a = await reg.register("/Users/x/proj/");
+      final b = await reg.register("/Users/x/./proj");
+      expect(a, b);
+      expect(reg.list().where((p) => p.id == "/Users/x/proj"), hasLength(1));
+    });
+
+    test("empty/blank path falls back to cwd, does not create a row", () async {
+      final reg = AcpProjectRegistry(cwd: "/repo", nowMs: monotonic());
+      final id = await reg.register("   ");
+      expect(id, "/repo");
+      expect(reg.list(), hasLength(1));
+    });
+
+    test("persists opened projects (not the cwd seed) to the store", () async {
+      final store = _FakeStore();
+      final reg = AcpProjectRegistry(cwd: "/repo", store: store, nowMs: monotonic());
+      await reg.register("/Users/x/alpha");
+
+      final raw = store.files[AcpProjectRegistry.defaultFileName];
+      expect(raw, isNotNull);
+      final decoded = jsonDecode(raw!) as Map<String, dynamic>;
+      final persistedIds = (decoded["projects"] as List).map((e) => (e as Map)["id"]).toList();
+      expect(persistedIds, ["/Users/x/alpha"], reason: "launch cwd is re-seeded, never written");
+    });
+
+    test("a fresh registry instance loads persisted projects", () async {
+      final store = _FakeStore();
+      final first = AcpProjectRegistry(cwd: "/repo", store: store, nowMs: monotonic());
+      await first.register("/Users/x/alpha");
+
+      // Simulate a bridge restart: a brand-new registry over the same store.
+      final second = AcpProjectRegistry(cwd: "/repo", store: store, nowMs: monotonic());
+      await second.ensureLoaded();
+      final ids = second.list().map((p) => p.id).toSet();
+      expect(ids, {"/repo", "/Users/x/alpha"});
+    });
+
+    test("rename sets a custom display name and persists it across reloads", () async {
+      final store = _FakeStore();
+      final first = AcpProjectRegistry(cwd: "/repo", store: store, nowMs: monotonic());
+      await first.register("/Users/x/alpha");
+      await first.rename(path: "/Users/x/alpha", name: "My Alpha");
+      expect(first.projectFor("/Users/x/alpha").name, "My Alpha");
+
+      final second = AcpProjectRegistry(cwd: "/repo", store: store, nowMs: monotonic());
+      await second.ensureLoaded();
+      expect(second.projectFor("/Users/x/alpha").name, "My Alpha");
+    });
+
+    test("corrupt persisted JSON is quarantined and the cwd seed survives", () async {
+      final store = _FakeStore()..files[AcpProjectRegistry.defaultFileName] = "{not json";
+      final reg = AcpProjectRegistry(cwd: "/repo", store: store, nowMs: monotonic());
+      await reg.ensureLoaded();
+      expect(reg.list().map((p) => p.id), ["/repo"]);
+      expect(store.quarantined, isNotEmpty);
+    });
+
+    test("projectFor returns a synthesized project for an unknown path without registering it", () async {
+      final reg = AcpProjectRegistry(cwd: "/repo", nowMs: monotonic());
+      await reg.ensureLoaded();
+      final project = reg.projectFor("/Users/x/unknown");
+      expect(project.id, "/Users/x/unknown");
+      expect(project.name, "unknown");
+      expect(reg.list().map((p) => p.id), ["/repo"], reason: "projectFor must not register");
+    });
+
+    test("re-registering an existing project does not rewrite the store", () async {
+      final store = _FakeStore();
+      final reg = AcpProjectRegistry(cwd: "/repo", store: store, nowMs: monotonic());
+      await reg.register("/Users/x/alpha");
+      final firstWrite = store.files[AcpProjectRegistry.defaultFileName];
+      await reg.register("/Users/x/alpha");
+      expect(store.files[AcpProjectRegistry.defaultFileName], firstWrite);
+    });
+  });
+}

--- a/bridge/sesori_plugin_acp/test/acp_protocol_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_protocol_test.dart
@@ -1,0 +1,64 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("AcpInitializeResult", () {
+    test("parses Cursor's real initialize result", () {
+      // Captured from a live `cursor-agent acp` (2026.05.28). Note
+      // sessionCapabilities.list is an object `{}`, not a bool.
+      final init = AcpInitializeResult.fromJson(const {
+        "protocolVersion": 1,
+        "agentCapabilities": {
+          "loadSession": true,
+          "sessionCapabilities": {"list": <String, dynamic>{}},
+        },
+        "authMethods": [
+          {"id": "cursor_login", "name": "Cursor Login"},
+        ],
+      });
+      expect(init.protocolVersion, 1);
+      expect(init.agentCapabilities.loadSession, isTrue);
+      expect(init.agentCapabilities.listSessions, isTrue);
+      expect(init.requiresAuth, isTrue);
+      expect(init.authMethods.single.id, "cursor_login");
+    });
+
+    test("absent capabilities default to false", () {
+      final init = AcpInitializeResult.fromJson(const {"protocolVersion": 1});
+      expect(init.agentCapabilities.loadSession, isFalse);
+      expect(init.agentCapabilities.listSessions, isFalse);
+      expect(init.requiresAuth, isFalse);
+    });
+  });
+
+  group("AcpNewSessionResult", () {
+    test("parses sessionId and configOptions from Cursor's session/new", () {
+      final result = AcpNewSessionResult.fromJson(const {
+        "sessionId": "s-1",
+        // modes is an object (not a list) — must not break parsing.
+        "modes": {"currentModeId": "agent"},
+        "configOptions": [
+          {
+            "id": "model",
+            "category": "model",
+            "currentValue": "composer-2.5",
+            "options": [
+              {"value": "composer-2.5", "name": "Composer 2.5"},
+              {"value": "claude-opus-4-7", "name": "Opus 4.7"},
+            ],
+          },
+        ],
+      });
+      expect(result.sessionId, "s-1");
+      expect(result.configOptions, hasLength(1));
+      expect(result.configOptions.single["category"], "model");
+    });
+  });
+
+  test("AcpStopReason parses ACP values", () {
+    expect(AcpStopReason.parse("end_turn"), AcpStopReason.endTurn);
+    expect(AcpStopReason.parse("cancelled"), AcpStopReason.cancelled);
+    expect(AcpStopReason.parse("refusal"), AcpStopReason.refusal);
+    expect(AcpStopReason.parse("???"), AcpStopReason.unknown);
+  });
+}

--- a/bridge/sesori_plugin_acp/test/acp_reconnect_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_reconnect_test.dart
@@ -1,0 +1,82 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:test/test.dart";
+
+/// After the agent subprocess exits, the cached ACP connection must be torn
+/// down so the next request spawns a fresh agent instead of writing to the dead
+/// process (the "recoverable" degraded path the lifecycle wrapper advertises).
+void main() {
+  group("AcpPlugin reconnect after exit", () {
+    final fakes = <FakeAcpProcess>[];
+    late AcpPlugin plugin;
+    const cwd = "/repo";
+
+    setUp(() {
+      fakes.clear();
+      plugin = AcpPlugin(
+        id: "acp",
+        agentDisplayName: "ACP",
+        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+        projectCwd: cwd,
+        eventMapper: AcpEventMapper(projectCwd: cwd, agentId: "acp"),
+        processFactory: (_) async {
+          final fake = FakeAcpProcess();
+          fakes.add(fake);
+          return fake;
+        },
+      );
+    });
+
+    tearDown(() async {
+      await plugin.dispose();
+      for (final fake in fakes) {
+        await fake.close();
+      }
+    });
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+    Future<void> respondInitialize(FakeAcpProcess fake) async {
+      for (var i = 0; i < 80; i++) {
+        final init = fake.written.where((f) => f["method"] == "initialize");
+        if (init.isNotEmpty) {
+          fake.emit({
+            "jsonrpc": "2.0",
+            "id": init.last["id"],
+            "result": {
+              "protocolVersion": 1,
+              "agentCapabilities": <String, dynamic>{},
+              "authMethods": <Object?>[],
+            },
+          });
+          await pump();
+          return;
+        }
+        await pump();
+      }
+      throw StateError("agent never wrote an 'initialize' frame");
+    }
+
+    test("resetConnectionAfterExit drops the cached client so the next request reconnects", () async {
+      final connecting = plugin.ensureConnected();
+      await respondInitialize(fakes.single);
+      expect(await connecting, isTrue);
+      expect(fakes, hasLength(1));
+      final first = plugin.client;
+      expect(first, isNotNull);
+
+      // The agent process dies, then the lifecycle resets the connection.
+      fakes.single.exit(1);
+      await pump();
+      await plugin.resetConnectionAfterExit();
+      expect(plugin.client, isNull);
+
+      // The next ensureConnected must spawn a brand-new agent process rather
+      // than hand back the stale cached success.
+      final reconnecting = plugin.ensureConnected();
+      await respondInitialize(fakes.last);
+      expect(await reconnecting, isTrue);
+      expect(fakes, hasLength(2), reason: "a fresh agent process was spawned");
+      expect(identical(plugin.client, first), isFalse);
+    });
+  });
+}

--- a/bridge/sesori_plugin_acp/test/acp_reconnect_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_reconnect_test.dart
@@ -57,12 +57,19 @@ void main() {
     }
 
     test("resetConnectionAfterExit drops the cached client so the next request reconnects", () async {
+      // onConnected must fire on every successful (re)connect so the lifecycle
+      // wrapper can re-arm its exit watch on the new client.
+      var connects = 0;
+      plugin.onConnected.listen((_) => connects++);
+
       final connecting = plugin.ensureConnected();
       await respondInitialize(fakes.single);
       expect(await connecting, isTrue);
       expect(fakes, hasLength(1));
       final first = plugin.client;
       expect(first, isNotNull);
+      await pump();
+      expect(connects, 1);
 
       // The agent process dies, then the lifecycle resets the connection.
       fakes.single.exit(1);
@@ -77,6 +84,8 @@ void main() {
       expect(await reconnecting, isTrue);
       expect(fakes, hasLength(2), reason: "a fresh agent process was spawned");
       expect(identical(plugin.client, first), isFalse);
+      await pump();
+      expect(connects, 2, reason: "onConnected fires again on reconnect");
     });
   });
 }

--- a/bridge/sesori_plugin_acp/test/acp_resume_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_test.dart
@@ -1,0 +1,116 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+/// A turn on a session not created this run must first re-load it (ACP agents
+/// hold sessions per-process, so a prior-run session is otherwise rejected with
+/// "session not found"). The resume `session/load` precedes the `session/prompt`
+/// and its history replay is suppressed from the live stream.
+void main() {
+  group("AcpPlugin resume-on-demand", () {
+    late FakeAcpProcess fake;
+    late AcpPlugin plugin;
+    final emitted = <BridgeSseEvent>[];
+    const cwd = "/repo";
+
+    setUp(() {
+      fake = FakeAcpProcess();
+      plugin = AcpPlugin(
+        id: "acp",
+        agentDisplayName: "ACP",
+        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+        projectCwd: cwd,
+        eventMapper: AcpEventMapper(projectCwd: cwd, agentId: "acp"),
+        processFactory: (_) async => fake,
+      );
+      emitted.clear();
+      plugin.events.listen(emitted.add);
+    });
+
+    tearDown(() async {
+      await plugin.dispose();
+      await fake.close();
+    });
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+    Future<Map<String, dynamic>> waitForFrame(String method) async {
+      for (var i = 0; i < 80; i++) {
+        final matches = fake.written.where((f) => f["method"] == method);
+        if (matches.isNotEmpty) return matches.last;
+        await pump();
+      }
+      throw StateError("agent never wrote a '$method' frame");
+    }
+
+    Future<void> respond(String method, Map<String, dynamic> result) async {
+      final frame = await waitForFrame(method);
+      fake.emit({"jsonrpc": "2.0", "id": frame["id"], "result": result});
+      await pump();
+    }
+
+    test("a prior-run session is loaded before the prompt, replay suppressed", () async {
+      final connecting = plugin.ensureConnected();
+      await respond("initialize", {
+        "protocolVersion": 1,
+        "agentCapabilities": {"loadSession": true},
+        "authMethods": <Object?>[],
+      });
+      expect(await connecting, isTrue);
+
+      // Prompt a session this process never created.
+      final sending = plugin.sendPrompt(
+        sessionId: "old-session",
+        parts: const [PluginPromptPart.text(text: "hi")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+
+      // The resume-load goes out first; while it is in flight, simulate the
+      // agent replaying old history — it must NOT reach the live stream.
+      final loadFrame = await waitForFrame("session/load");
+      expect((loadFrame["params"] as Map)["sessionId"], "old-session");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": "old-session",
+          "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "OLD HISTORY"},
+          },
+        },
+      });
+      await pump();
+      fake.emit({"jsonrpc": "2.0", "id": loadFrame["id"], "result": const <String, dynamic>{}});
+
+      await sending;
+
+      // session/load was sent before session/prompt.
+      final methods = fake.written.map((f) => f["method"]).toList();
+      expect(
+        methods.indexOf("session/load") < methods.indexOf("session/prompt"),
+        isTrue,
+        reason: "resume-load must precede the prompt",
+      );
+      await waitForFrame("session/prompt");
+
+      // The suppressed replay produced no message events on the live stream.
+      expect(emitted.whereType<BridgeSseMessagePartDelta>(), isEmpty);
+
+      // A second prompt on the now-resident session does NOT re-load.
+      final loadsBefore = fake.written.where((f) => f["method"] == "session/load").length;
+      final again = plugin.sendPrompt(
+        sessionId: "old-session",
+        parts: const [PluginPromptPart.text(text: "again")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await again;
+      final loadsAfter = fake.written.where((f) => f["method"] == "session/load").length;
+      expect(loadsAfter, loadsBefore, reason: "resident session is not re-loaded");
+    });
+  });
+}

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -1,0 +1,71 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+/// Exercises [AcpReplayCollector] — the `session/load` history reconstruction
+/// that the bridge serves to the mobile chat screen.
+void main() {
+  group("AcpReplayCollector", () {
+    Map<String, dynamic> upd(Map<String, dynamic> body) => {"update": body};
+
+    test("reconstructs a user/tool/assistant exchange in order", () {
+      final collector = AcpReplayCollector(
+        sessionId: "s1",
+        agentId: "Cursor",
+        modelId: "gpt-5.5",
+        providerId: "cursor",
+      )
+        ..consume(upd({
+          "sessionUpdate": "user_message_chunk",
+          "content": {"type": "text", "text": "list md files"},
+        }))
+        ..consume(upd({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "t1",
+          "kind": "execute",
+          "title": "find . -name '*.md'",
+          "status": "pending",
+        }))
+        ..consume(upd({
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "t1",
+          "status": "completed",
+          "rawOutput": {"exitCode": 0, "stdout": "README.md\n", "stderr": ""},
+        }))
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "There is 1 file."},
+        }));
+
+      final messages = collector.build();
+      expect(messages, hasLength(2));
+
+      final user = messages.first;
+      expect(user.info, isA<PluginMessageUser>());
+      expect(user.parts.single.text, "list md files");
+
+      final assistant = messages.last;
+      expect(assistant.info, isA<PluginMessageAssistant>());
+      final toolPart = assistant.parts.firstWhere((p) => p.type == PluginMessagePartType.tool);
+      expect(toolPart.state?.status, PluginToolStatus.completed);
+      expect(toolPart.state?.output, "README.md");
+      final textPart = assistant.parts.firstWhere((p) => p.type == PluginMessagePartType.text);
+      expect(textPart.text, "There is 1 file.");
+    });
+
+    test("stamps replayed assistant messages with the loaded session model", () {
+      final collector = AcpReplayCollector(
+        sessionId: "s1",
+        agentId: "Cursor",
+        modelId: "claude-opus-4-8",
+        providerId: "cursor",
+      )..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "hi"},
+        }));
+      final assistant = collector.build().single.info as PluginMessageAssistant;
+      expect(assistant.modelID, "claude-opus-4-8");
+      expect(assistant.providerID, "cursor");
+    });
+  });
+}

--- a/bridge/sesori_plugin_acp/test/acp_stdio_client_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_stdio_client_test.dart
@@ -92,5 +92,41 @@ void main() {
       fake.exit(1);
       await expectLater(future, throwsA(isA<AcpRpcException>()));
     });
+
+    test("a request after the process exited fails fast instead of timing out", () async {
+      fake.exit(1);
+      await pump();
+      // Without the post-exit guard this would write to a dead pipe and block
+      // for the full timeout; it must throw synchronously-ish instead.
+      await expectLater(
+        client.request(method: "session/prompt"),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test("a malformed error payload still completes the pending request", () async {
+      // `error` is not a map: the old `as Map` cast threw inside the line
+      // handler (caught + logged) and orphaned the completer until timeout.
+      final future = client.request(method: "session/new");
+      final id = fake.written.single["id"];
+      fake.emit({"jsonrpc": "2.0", "id": id, "error": "totally malformed"});
+      await expectLater(future, throwsA(isA<AcpRpcException>()));
+    });
+
+    test("an error payload with a non-int code falls back to a generic code", () async {
+      final future = client.request(method: "session/new");
+      final id = fake.written.single["id"];
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {"code": "nope", "message": 123},
+      });
+      await expectLater(
+        future,
+        throwsA(isA<AcpRpcException>()
+            .having((e) => e.code, "code", -32603)
+            .having((e) => e.message, "message", "unknown error")),
+      );
+    });
   });
 }

--- a/bridge/sesori_plugin_acp/test/acp_stdio_client_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_stdio_client_test.dart
@@ -1,0 +1,96 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("AcpStdioClient", () {
+    late FakeAcpProcess fake;
+    late AcpStdioClient client;
+
+    setUp(() async {
+      fake = FakeAcpProcess();
+      client = AcpStdioClient(
+        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+        processFactory: (_) async => fake,
+      );
+      await client.connect();
+    });
+
+    tearDown(() async {
+      await client.dispose();
+      await fake.close();
+    });
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+    test("request writes an ndjson frame and correlates the response by id", () async {
+      final future = client.request(method: "initialize", params: {"a": 1});
+
+      expect(fake.written, hasLength(1));
+      final frame = fake.written.single;
+      expect(frame["method"], "initialize");
+      expect(frame["jsonrpc"], "2.0");
+      final id = frame["id"];
+
+      fake.emit({"jsonrpc": "2.0", "id": id, "result": {"ok": true}});
+      final result = await future;
+      expect((result as Map)["ok"], true);
+    });
+
+    test("error responses surface as AcpRpcException", () async {
+      final future = client.request(method: "session/new");
+      final id = fake.written.single["id"];
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {"code": -32000, "message": "boom"},
+      });
+      await expectLater(future, throwsA(isA<AcpRpcException>()));
+    });
+
+    test("notifications route to the notifications stream", () async {
+      final seen = <AcpNotification>[];
+      client.notifications.listen(seen.add);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {"sessionId": "s1"},
+      });
+      await pump();
+      expect(seen, hasLength(1));
+      expect(seen.single.method, "session/update");
+      expect(seen.single.params["sessionId"], "s1");
+    });
+
+    test("server requests route to serverRequests and can be answered", () async {
+      final reqs = <AcpServerRequest>[];
+      client.serverRequests.listen(reqs.add);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 42,
+        "method": "session/request_permission",
+        "params": {"sessionId": "s1"},
+      });
+      await pump();
+      expect(reqs.single.id, 42);
+
+      client.respondToServerRequest(id: 42, result: {"outcome": "ok"});
+      final reply = fake.written.last;
+      expect(reply["id"], 42);
+      expect((reply["result"] as Map)["outcome"], "ok");
+    });
+
+    test("notify sends an id-less frame", () {
+      client.notify(method: "session/cancel", params: {"sessionId": "s1"});
+      final frame = fake.written.single;
+      expect(frame["method"], "session/cancel");
+      expect(frame.containsKey("id"), isFalse);
+    });
+
+    test("early process exit fails in-flight requests", () async {
+      final future = client.request(method: "session/prompt");
+      fake.exit(1);
+      await expectLater(future, throwsA(isA<AcpRpcException>()));
+    });
+  });
+}

--- a/bridge/sesori_plugin_cursor/analysis_options.yaml
+++ b/bridge/sesori_plugin_cursor/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../app/analysis_options.yaml

--- a/bridge/sesori_plugin_cursor/build.yaml
+++ b/bridge/sesori_plugin_cursor/build.yaml
@@ -1,0 +1,12 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          any_map: true
+          explicit_to_json: true
+      freezed:
+        options:
+          format: false
+          map: false
+          when: false

--- a/bridge/sesori_plugin_cursor/lib/cursor_plugin.dart
+++ b/bridge/sesori_plugin_cursor/lib/cursor_plugin.dart
@@ -1,0 +1,11 @@
+// Cursor backend for the Sesori bridge.
+//
+// Drives `cursor-agent acp` over the generic ACP machinery (acp_plugin),
+// adding Cursor's `cursor/*` extensions and its configOptions model picker.
+export "src/cursor_approval_registry.dart";
+export "src/cursor_binary.dart";
+export "src/cursor_event_mapper.dart";
+export "src/cursor_model_probe.dart";
+export "src/cursor_plugin_impl.dart";
+// Plugin-lifecycle entry point: the const descriptor the bridge registers.
+export "src/runtime/cursor_plugin_descriptor.dart";

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_approval_registry.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_approval_registry.dart
@@ -1,0 +1,175 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" as shared;
+
+/// Adds Cursor's question extensions on top of the standard ACP permission
+/// handling: `cursor/ask_question` (multiple-choice) and `cursor/create_plan`
+/// (accept/reject), both blocking requests that the bridge surfaces as
+/// questions.
+///
+/// NOTE: Cursor's exact reply payload shapes are not formally documented; the
+/// builders below are best-effort and should be confirmed against a real
+/// `cursor-agent acp` trace during end-to-end verification.
+class CursorApprovalRegistry extends AcpApprovalRegistry {
+  CursorApprovalRegistry({
+    required AcpStdioClient client,
+    required super.emit,
+    super.idGenerator,
+  }) : super(
+         respond: (id, result) =>
+             client.respondToServerRequest(id: id, result: result),
+         respondError: (id, code, message) => client
+             .respondToServerRequestWithError(id: id, code: code, message: message),
+       );
+
+  @override
+  bool handleExtensionRequest(AcpServerRequest request) {
+    switch (request.method) {
+      case "cursor/ask_question":
+        _handleAskQuestion(request);
+        return true;
+      case "cursor/create_plan":
+        _handleCreatePlan(request);
+        return true;
+    }
+    return false;
+  }
+
+  void _handleAskQuestion(AcpServerRequest request) {
+    final params = request.params;
+    final sessionId = (params["sessionId"] as String?) ?? "";
+    final title = (params["title"] as String?) ?? "Question";
+    final rawQuestions = (params["questions"] as List?) ?? const [];
+
+    final sharedQuestions = <Map<String, dynamic>>[];
+    final pluginQuestions = <PluginQuestionInfo>[];
+    final metas = <_QuestionMeta>[];
+
+    for (final raw in rawQuestions.whereType<Map<dynamic, dynamic>>()) {
+      final q = raw.cast<String, dynamic>();
+      final prompt = (q["prompt"] ?? q["question"] ?? "") as String;
+      final multiple = (q["allowMultiple"] ?? false) as bool;
+      final options = ((q["options"] as List?) ?? const [])
+          .whereType<Map<dynamic, dynamic>>()
+          .map((o) => o.cast<String, dynamic>())
+          .toList(growable: false);
+
+      final labelToId = <String, String>{};
+      final sharedOptions = <shared.QuestionOption>[];
+      final pluginOptions = <PluginQuestionOption>[];
+      for (final option in options) {
+        final id = (option["id"] ?? option["value"] ?? "") as String;
+        final label = (option["label"] ?? id) as String;
+        labelToId[label] = id;
+        sharedOptions.add(shared.QuestionOption(label: label, description: ""));
+        pluginOptions.add(PluginQuestionOption(label: label, description: ""));
+      }
+
+      sharedQuestions.add(
+        shared.QuestionInfo(
+          question: prompt,
+          header: title,
+          options: sharedOptions,
+          multiple: multiple,
+          custom: false,
+        ).toJson(),
+      );
+      pluginQuestions.add(
+        PluginQuestionInfo(
+          question: prompt,
+          header: title,
+          options: pluginOptions,
+          multiple: multiple,
+          custom: false,
+        ),
+      );
+      metas.add(_QuestionMeta(id: q["id"] as String?, labelToId: labelToId));
+    }
+
+    final bridgeId = generateBridgeId();
+    addPendingQuestion(
+      bridgeRequestId: bridgeId,
+      acpId: request.id,
+      sessionId: sessionId,
+      questions: pluginQuestions,
+      replyBuilder: (answers) => _buildAskReply(metas, answers),
+    );
+    emit(
+      BridgeSseQuestionAsked(
+        id: bridgeId,
+        sessionID: sessionId,
+        questions: sharedQuestions,
+      ),
+    );
+  }
+
+  Object _buildAskReply(List<_QuestionMeta> metas, List<List<String>> answers) {
+    final out = <Map<String, dynamic>>[];
+    for (var i = 0; i < metas.length; i++) {
+      final selectedLabels = i < answers.length ? answers[i] : const <String>[];
+      final ids = selectedLabels
+          .map((label) => metas[i].labelToId[label] ?? label)
+          .toList(growable: false);
+      out.add({"id": metas[i].id, "selectedOptionIds": ids});
+    }
+    return {"questions": out};
+  }
+
+  void _handleCreatePlan(AcpServerRequest request) {
+    final params = request.params;
+    final sessionId = (params["sessionId"] as String?) ?? "";
+    final name = (params["name"] as String?) ?? "Plan";
+    final overview = (params["overview"] as String?) ??
+        (params["plan"] as String?) ??
+        "Review the proposed plan.";
+
+    final bridgeId = generateBridgeId();
+    addPendingQuestion(
+      bridgeRequestId: bridgeId,
+      acpId: request.id,
+      sessionId: sessionId,
+      questions: [
+        PluginQuestionInfo(
+          question: overview,
+          header: name,
+          options: const [
+            PluginQuestionOption(label: "Accept", description: ""),
+            PluginQuestionOption(label: "Reject", description: ""),
+          ],
+          multiple: false,
+          custom: false,
+        ),
+      ],
+      replyBuilder: (answers) {
+        final accepted = answers.isNotEmpty &&
+            answers.first.any((a) => a.toLowerCase() == "accept");
+        return {"accepted": accepted};
+      },
+    );
+    emit(
+      BridgeSseQuestionAsked(
+        id: bridgeId,
+        sessionID: sessionId,
+        questions: [
+          shared.QuestionInfo(
+            question: overview,
+            header: name,
+            options: const [
+              shared.QuestionOption(label: "Accept", description: ""),
+              shared.QuestionOption(label: "Reject", description: ""),
+            ],
+            multiple: false,
+            custom: false,
+          ).toJson(),
+        ],
+      ),
+    );
+  }
+}
+
+class _QuestionMeta {
+  _QuestionMeta({required this.id, required this.labelToId});
+
+  final String? id;
+  final Map<String, String> labelToId;
+}

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_approval_registry.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_approval_registry.dart
@@ -47,8 +47,12 @@ class CursorApprovalRegistry extends AcpApprovalRegistry {
 
     for (final raw in rawQuestions.whereType<Map<dynamic, dynamic>>()) {
       final q = raw.cast<String, dynamic>();
-      final prompt = (q["prompt"] ?? q["question"] ?? "") as String;
-      final multiple = (q["allowMultiple"] ?? false) as bool;
+      // Parse defensively: Cursor's payload shapes are not formally documented,
+      // so a field arriving with an unexpected type (e.g. allowMultiple as a
+      // string) must not crash the whole request handler.
+      final prompt = _str(q["prompt"]) ?? _str(q["question"]);
+      if (prompt == null || prompt.isEmpty) continue; // skip a question with no text
+      final multiple = q["allowMultiple"] == true;
       final options = ((q["options"] as List?) ?? const [])
           .whereType<Map<dynamic, dynamic>>()
           .map((o) => o.cast<String, dynamic>())
@@ -58,8 +62,8 @@ class CursorApprovalRegistry extends AcpApprovalRegistry {
       final sharedOptions = <shared.QuestionOption>[];
       final pluginOptions = <PluginQuestionOption>[];
       for (final option in options) {
-        final id = (option["id"] ?? option["value"] ?? "") as String;
-        final label = (option["label"] ?? id) as String;
+        final id = _str(option["id"]) ?? _str(option["value"]) ?? "";
+        final label = _str(option["label"]) ?? id;
         labelToId[label] = id;
         sharedOptions.add(shared.QuestionOption(label: label, description: ""));
         pluginOptions.add(PluginQuestionOption(label: label, description: ""));
@@ -83,7 +87,16 @@ class CursorApprovalRegistry extends AcpApprovalRegistry {
           custom: false,
         ),
       );
-      metas.add(_QuestionMeta(id: q["id"] as String?, labelToId: labelToId));
+      metas.add(_QuestionMeta(id: _str(q["id"]), labelToId: labelToId));
+    }
+
+    // A malformed/empty question list must not register a pending question: it
+    // would block the session awaiting input that can never be answered. Reject
+    // the request so the agent can proceed instead of hanging.
+    if (pluginQuestions.isEmpty) {
+      Log.w("[cursor] cursor/ask_question had no valid questions; rejecting");
+      respondError(request.id, -32602, "cursor/ask_question: no valid questions");
+      return;
     }
 
     final bridgeId = generateBridgeId();
@@ -102,6 +115,10 @@ class CursorApprovalRegistry extends AcpApprovalRegistry {
       ),
     );
   }
+
+  /// A field as a non-empty String, or null if absent/another type. Cursor's
+  /// reply shapes are not formally documented, so casts here are fail-soft.
+  static String? _str(Object? value) => value is String ? value : null;
 
   Object _buildAskReply(List<_QuestionMeta> metas, List<List<String>> answers) {
     final out = <Map<String, dynamic>>[];

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_binary.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_binary.dart
@@ -1,0 +1,27 @@
+import "package:acp_plugin/acp_plugin.dart";
+
+/// Builds the launch spec for `cursor-agent acp`.
+///
+/// Auth is out of band: the default process factory inherits the bridge's
+/// environment, so `CURSOR_API_KEY` / `CURSOR_AUTH_TOKEN` (or a prior
+/// `cursor-agent login`) are passed through automatically.
+abstract final class CursorBinary {
+  static const String defaultBinary = "cursor-agent";
+
+  static AcpLaunchSpec launchSpec({
+    String binary = defaultBinary,
+    String? cwd,
+    String? apiEndpoint,
+    Map<String, String> environment = const {},
+  }) {
+    return AcpLaunchSpec(
+      command: binary,
+      args: [
+        if (apiEndpoint != null) ...["-e", apiEndpoint],
+        "acp",
+      ],
+      cwd: cwd,
+      environment: environment,
+    );
+  }
+}

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
@@ -1,0 +1,21 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+/// Cursor's event mapper: the standard ACP `session/update` handling from
+/// [AcpEventMapper] plus Cursor's `cursor/*` notification extensions.
+class CursorEventMapper extends AcpEventMapper {
+  CursorEventMapper({required super.projectCwd}) : super(agentId: "cursor");
+
+  @override
+  List<BridgeSseEvent> mapExtension(AcpNotification notification) {
+    switch (notification.method) {
+      case "cursor/update_todos":
+        final sessionId = notification.params["sessionId"] as String?;
+        if (sessionId == null || sessionId.isEmpty) return const [];
+        return [BridgeSseTodoUpdated(sessionID: sessionId)];
+    }
+    // cursor/task, cursor/generate_image and other extension notifications
+    // have no sesori analog — dropped.
+    return const [];
+  }
+}

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_model_probe.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_model_probe.dart
@@ -1,0 +1,61 @@
+import "package:acp_plugin/acp_plugin.dart";
+
+/// Helpers for Cursor's `configOptions` selectors returned by `session/new`
+/// and `session/load`.
+///
+/// Cursor does not take a model in `session/new`; instead it returns config
+/// options whose `category` identifies the dimension (`"model"`, `"mode"`,
+/// `"model_config"`). The option id is NOT hardcoded to the category. Selecting
+/// a value is a `session/set_config_option` call echoing a value from that
+/// option's `options[]`. See T3 Code's mismatch probe for the finicky details
+/// this guards against.
+abstract final class CursorModelProbe {
+  /// The configOption with the given [category] (e.g. `"model"`, `"mode"`), or
+  /// null if absent.
+  static Map<String, dynamic>? findConfig(
+    AcpNewSessionResult session,
+    String category,
+  ) {
+    for (final option in session.configOptions) {
+      if (option["category"] == category) return option;
+    }
+    return null;
+  }
+
+  /// The configOption whose category is `model`, or null if absent.
+  static Map<String, dynamic>? findModelConfig(AcpNewSessionResult session) =>
+      findConfig(session, "model");
+
+  /// The selectable `{value, name}` entries for a config option.
+  static List<Map<String, dynamic>> options(Map<String, dynamic> config) {
+    final raw = config["options"];
+    if (raw is! List) return const [];
+    return raw
+        .whereType<Map<dynamic, dynamic>>()
+        .map((m) => m.cast<String, dynamic>())
+        .toList(growable: false);
+  }
+
+  /// Alias of [options] for the model config (reads more clearly at the model
+  /// call site).
+  static List<Map<String, dynamic>> models(Map<String, dynamic> config) =>
+      options(config);
+
+  /// The currently selected value, if any.
+  static String? currentValue(Map<String, dynamic> config) {
+    final value = config["currentValue"] ?? config["value"];
+    return value is String ? value : null;
+  }
+
+  /// Whether [options] contains an entry with the given `value`.
+  static bool hasOption(List<Map<String, dynamic>> options, String value) {
+    for (final option in options) {
+      if (option["value"] == value) return true;
+    }
+    return false;
+  }
+
+  /// Alias of [hasOption] for the model list.
+  static bool hasModel(List<Map<String, dynamic>> models, String value) =>
+      hasOption(models, value);
+}

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
@@ -206,6 +206,18 @@ class CursorPlugin extends AcpPlugin {
     }
   }
 
+  /// The first model with a usable String `value`, or null. Used as the
+  /// default-model fallback so a malformed agent payload (a non-string value on
+  /// the first entry) cannot crash [getProviders].
+  String? _firstModelValue() {
+    for (final model in _models) {
+      if (model["value"] case final String value when value.isNotEmpty) {
+        return value;
+      }
+    }
+    return null;
+  }
+
   /// Cursor's modes as sesori variant ids, default mode first (the mobile
   /// picker auto-selects the first on a model switch).
   List<String> _modeVariants() {
@@ -267,8 +279,7 @@ class CursorPlugin extends AcpPlugin {
                   releaseDate: null,
                 ),
           ],
-          defaultModelID:
-              _currentModelId ?? (_models.first["value"] as String?),
+          defaultModelID: _currentModelId ?? _firstModelValue(),
         ),
       ],
     );

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
@@ -1,0 +1,262 @@
+import "dart:io" show Directory;
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "cursor_approval_registry.dart";
+import "cursor_binary.dart";
+import "cursor_event_mapper.dart";
+import "cursor_model_probe.dart";
+
+/// Cursor backend: drives `cursor-agent acp` over the generic ACP machinery,
+/// layering on Cursor's `cursor/*` extensions and its `configOptions` picker
+/// (model + mode + fast).
+///
+/// Selection model:
+///  - **Model** maps onto the `model` config option (`session/set_config_option
+///    {configId, value}`).
+///  - **Mode** (`agent`/`plan`/`ask`) is the sesori "variant": Cursor has no
+///    reasoning-effort knob, and the mode is the per-session "how the agent
+///    works" control, so it is exposed as each model's [PluginModel.variants]
+///    and driven by the same `set_config_option` call.
+///
+/// Cursor's `set_config_option` is honoured per `session/prompt` and *persists*
+/// across turns, but a model/mode set leaks to other sessions in the same
+/// agent process (it tracks a process-wide "current" selection). So selection
+/// is (re)applied before every turn and only when the requested value differs
+/// from what was last pushed to the agent ([_appliedModelId]/[_appliedModeId]),
+/// which both avoids redundant calls and self-corrects interleaved sessions.
+class CursorPlugin extends AcpPlugin {
+  factory CursorPlugin({
+    String binaryPath = CursorBinary.defaultBinary,
+    String? projectCwd,
+    String? apiEndpoint,
+    AcpProcessFactory? processFactory,
+    HostJsonStore? projectStore,
+  }) {
+    final cwd = projectCwd ?? Directory.current.path;
+    return CursorPlugin._(
+      launchSpec: CursorBinary.launchSpec(
+        binary: binaryPath,
+        cwd: cwd,
+        apiEndpoint: apiEndpoint,
+      ),
+      projectCwd: cwd,
+      mapper: CursorEventMapper(projectCwd: cwd),
+      processFactory: processFactory,
+      projectStore: projectStore,
+    );
+  }
+
+  CursorPlugin._({
+    required super.launchSpec,
+    required super.projectCwd,
+    required CursorEventMapper mapper,
+    super.processFactory,
+    super.projectStore,
+  }) : super(id: "cursor", agentDisplayName: "Cursor", eventMapper: mapper);
+
+  static const String _providerId = "cursor";
+
+  /// Cached model config: the option id and its `{value, name}` entries.
+  String? _modelConfigId;
+  List<Map<String, dynamic>> _models = const [];
+
+  /// Cached mode config (Cursor's `agent`/`plan`/`ask`).
+  String? _modeConfigId;
+  List<Map<String, dynamic>> _modes = const [];
+  String? _defaultModeId;
+
+  /// The model a freshly created session defaults to (used for `defaultModelID`
+  /// and as the fallback stamp when no model is explicitly selected).
+  String? _currentModelId;
+
+  /// Last model/mode actually pushed to the agent process (process-global, see
+  /// the class doc) — guards against redundant `set_config_option` calls.
+  String? _appliedModelId;
+  String? _appliedModeId;
+
+  @override
+  String? get authMethodId => "cursor_login";
+
+  @override
+  Map<String, dynamic>? get initializeCapabilityMeta =>
+      const {"parameterizedModelPicker": true};
+
+  @override
+  AcpApprovalRegistry buildApprovalRegistry(AcpStdioClient client) {
+    return CursorApprovalRegistry(client: client, emit: emitEvent);
+  }
+
+  @override
+  void captureSessionConfig(Map<String, dynamic> result, {String? sessionId}) {
+    final session = AcpNewSessionResult.fromJson(result);
+
+    final modelConfig = CursorModelProbe.findConfig(session, "model");
+    if (modelConfig != null) {
+      _modelConfigId = modelConfig["id"] as String? ?? _modelConfigId;
+      final models = CursorModelProbe.options(modelConfig);
+      if (models.isNotEmpty) _models = models;
+      _currentModelId = CursorModelProbe.currentValue(modelConfig) ?? _currentModelId;
+    }
+
+    final modeConfig = CursorModelProbe.findConfig(session, "mode");
+    if (modeConfig != null) {
+      _modeConfigId = modeConfig["id"] as String? ?? _modeConfigId;
+      final modes = CursorModelProbe.options(modeConfig);
+      if (modes.isNotEmpty) _modes = modes;
+      _defaultModeId = CursorModelProbe.currentValue(modeConfig) ?? _defaultModeId;
+    }
+
+    eventMapper.currentProviderId = _providerId;
+    eventMapper.currentModelId = _currentModelId;
+    if (sessionId != null) {
+      eventMapper.setSessionModel(sessionId, _currentModelId, providerId: _providerId);
+    }
+  }
+
+  @override
+  Future<void> applyTurnSelection({
+    required AcpStdioClient client,
+    required String sessionId,
+    required ({String providerID, String modelID})? model,
+    required PluginSessionVariant? variant,
+  }) async {
+    // Model selection.
+    final requestedModel = model?.modelID;
+    if (requestedModel != null &&
+        requestedModel.isNotEmpty &&
+        _modelConfigId != null &&
+        CursorModelProbe.hasOption(_models, requestedModel)) {
+      if (requestedModel != _appliedModelId) {
+        if (await _setConfig(client, sessionId, _modelConfigId!, requestedModel)) {
+          _appliedModelId = requestedModel;
+        }
+      }
+      eventMapper.setSessionModel(sessionId, requestedModel, providerId: _providerId);
+    } else {
+      // No explicit/valid model — stamp messages with the session's default.
+      eventMapper.setSessionModel(sessionId, _currentModelId, providerId: _providerId);
+    }
+
+    // Mode selection (the sesori "variant"). A null/empty variant uses the
+    // agent's default mode so "Default" is deterministic.
+    final requestedMode = (variant != null && variant.id.isNotEmpty)
+        ? variant.id
+        : _defaultModeId;
+    if (requestedMode != null &&
+        _modeConfigId != null &&
+        CursorModelProbe.hasOption(_modes, requestedMode) &&
+        requestedMode != _appliedModeId) {
+      if (await _setConfig(client, sessionId, _modeConfigId!, requestedMode)) {
+        _appliedModeId = requestedMode;
+      }
+    }
+  }
+
+  /// Issues a `session/set_config_option`, returning whether it succeeded.
+  /// Fail-soft: a rejected selection keeps the agent's current value rather
+  /// than failing the turn.
+  Future<bool> _setConfig(
+    AcpStdioClient client,
+    String sessionId,
+    String configId,
+    String value,
+  ) async {
+    try {
+      await client.request(
+        method: AcpMethods.sessionSetConfigOption,
+        params: {"sessionId": sessionId, "configId": configId, "value": value},
+      );
+      return true;
+    } catch (error, stack) {
+      Log.w("[cursor] set_config_option($configId=$value) rejected", error, stack);
+      return false;
+    }
+  }
+
+  /// Loads the catalog from an existing session if it has not been captured yet
+  /// this connection (so the new-session model picker is populated even before
+  /// any session is created this run).
+  Future<void> _ensureCatalog() async {
+    if (_models.isNotEmpty) return;
+    if (!await ensureConnected()) return;
+    await probeCatalogFromExistingSession();
+  }
+
+  /// Eagerly populates the catalog right after the bridge connects, so the
+  /// FIRST `getProviders`/`getAgents` the mobile issues already returns the full
+  /// model list. The mobile caches that first providers result, so an initially
+  /// empty list would otherwise leave the model/variant pickers blank until the
+  /// app refetches. Best-effort and bounded; never throws. Call after the ACP
+  /// connection is established (the descriptor does, post-`connect`).
+  Future<void> warmCatalog() async {
+    try {
+      await _ensureCatalog();
+    } on Object catch (error, stack) {
+      Log.d("[cursor] warmCatalog failed (will populate lazily): $error\n$stack");
+    }
+  }
+
+  /// Cursor's modes as sesori variant ids, default mode first (the mobile
+  /// picker auto-selects the first on a model switch).
+  List<String> _modeVariants() {
+    final ids = <String>[
+      for (final mode in _modes)
+        if (mode["value"] case final String value when value.isNotEmpty) value,
+    ];
+    final defaultMode = _defaultModeId;
+    if (defaultMode != null && ids.remove(defaultMode)) ids.insert(0, defaultMode);
+    return ids;
+  }
+
+  @override
+  Future<List<PluginAgent>> getAgents({required String projectId}) async {
+    await _ensureCatalog();
+    final modelId = eventMapper.currentModelId ?? _currentModelId;
+    return [
+      PluginAgent(
+        name: "cursor",
+        description: "Cursor CLI session",
+        model: modelId == null
+            ? null
+            : PluginAgentModel(
+                modelID: modelId,
+                providerID: _providerId,
+                variant: null,
+              ),
+        mode: PluginAgentMode.primary,
+        hidden: false,
+      ),
+    ];
+  }
+
+  @override
+  Future<PluginProvidersResult> getProviders({required String projectId}) async {
+    await _ensureCatalog();
+    if (_models.isEmpty) return const PluginProvidersResult(providers: []);
+    final variants = _modeVariants();
+    return PluginProvidersResult(
+      providers: [
+        PluginProvider.custom(
+          id: _providerId,
+          name: "Cursor",
+          authType: PluginProviderAuthType.unknown,
+          models: [
+            for (final model in _models)
+              PluginModel(
+                id: (model["value"] ?? "") as String,
+                name: (model["name"] ?? model["value"] ?? "") as String,
+                variants: variants,
+                family: null,
+                isAvailable: true,
+                releaseDate: null,
+              ),
+          ],
+          defaultModelID:
+              _currentModelId ?? (_models.first["value"] as String?),
+        ),
+      ],
+    );
+  }
+}

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
@@ -122,20 +122,28 @@ class CursorPlugin extends AcpPlugin {
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
   }) async {
-    // Model selection.
+    // Model selection. Cursor's selection is process-global, so even a turn that
+    // uses the *default* model must push it when it differs from what was last
+    // applied — otherwise the turn silently runs on whatever model another
+    // session left selected while we stamp it as the default. A null/empty model
+    // means "use the default" (_currentModelId); an explicit-but-unknown model
+    // stays fail-soft (the agent keeps its current value, see [_setConfig]).
     final requestedModel = model?.modelID;
-    if (requestedModel != null &&
-        requestedModel.isNotEmpty &&
+    final useDefault = requestedModel == null || requestedModel.isEmpty;
+    final targetModel = useDefault ? _currentModelId : requestedModel;
+    if (targetModel != null &&
+        targetModel.isNotEmpty &&
         _modelConfigId != null &&
-        CursorModelProbe.hasOption(_models, requestedModel)) {
-      if (requestedModel != _appliedModelId) {
-        if (await _setConfig(client, sessionId, _modelConfigId!, requestedModel)) {
-          _appliedModelId = requestedModel;
+        CursorModelProbe.hasOption(_models, targetModel)) {
+      if (targetModel != _appliedModelId) {
+        if (await _setConfig(client, sessionId, _modelConfigId!, targetModel)) {
+          _appliedModelId = targetModel;
         }
       }
-      eventMapper.setSessionModel(sessionId, requestedModel, providerId: _providerId);
+      eventMapper.setSessionModel(sessionId, targetModel, providerId: _providerId);
     } else {
-      // No explicit/valid model — stamp messages with the session's default.
+      // Unknown explicit model (fail-soft) or no default resolved yet — stamp
+      // messages with the session's default.
       eventMapper.setSessionModel(sessionId, _currentModelId, providerId: _providerId);
     }
 
@@ -243,15 +251,21 @@ class CursorPlugin extends AcpPlugin {
           name: "Cursor",
           authType: PluginProviderAuthType.unknown,
           models: [
+            // Parse defensively: a malformed/changed agent payload (a non-string
+            // value/name) must not crash the whole provider listing. Skip an
+            // entry without a usable value, mirroring [_modeVariants].
             for (final model in _models)
-              PluginModel(
-                id: (model["value"] ?? "") as String,
-                name: (model["name"] ?? model["value"] ?? "") as String,
-                variants: variants,
-                family: null,
-                isAvailable: true,
-                releaseDate: null,
-              ),
+              if (model["value"] case final String value when value.isNotEmpty)
+                PluginModel(
+                  id: value,
+                  name: model["name"] is String && (model["name"] as String).isNotEmpty
+                      ? model["name"] as String
+                      : value,
+                  variants: variants,
+                  family: null,
+                  isAvailable: true,
+                  releaseDate: null,
+                ),
           ],
           defaultModelID:
               _currentModelId ?? (_models.first["value"] as String?),

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
@@ -1,0 +1,304 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io" as io;
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../cursor_binary.dart";
+import "../cursor_plugin_impl.dart";
+
+/// Builds the [CursorPlugin] (the live [BridgePluginApi]) for a resolved
+/// binary. The production default constructs the real plugin wired to the
+/// host-backed process factory; tests inject a fake to avoid spawning
+/// `cursor-agent`.
+typedef CursorPluginFactory =
+    CursorPlugin Function({
+      required String binaryPath,
+      required String projectCwd,
+      required String? apiEndpoint,
+      required AcpProcessFactory processFactory,
+      required HostJsonStore? projectStore,
+    });
+
+CursorPlugin _defaultBuildPlugin({
+  required String binaryPath,
+  required String projectCwd,
+  required String? apiEndpoint,
+  required AcpProcessFactory processFactory,
+  required HostJsonStore? projectStore,
+}) {
+  return CursorPlugin(
+    binaryPath: binaryPath,
+    projectCwd: projectCwd,
+    apiEndpoint: apiEndpoint,
+    processFactory: processFactory,
+    projectStore: projectStore,
+  );
+}
+
+/// The const Cursor plugin descriptor.
+///
+/// Cursor drives a `cursor-agent acp` stdio subprocess over the generic ACP
+/// machinery, so it needs no managed-runtime supervisor (no listening port to
+/// reclaim, no ownership file). It declares its CLI surface, probes the
+/// `cursor-agent` binary for availability, and on [start] spawns the agent
+/// through the [PluginHost] process seam and returns an [AcpBridgePlugin].
+///
+/// The optional constructor parameters are test seams; the registered instance
+/// is `const CursorPluginDescriptor()`.
+class CursorPluginDescriptor extends BridgePluginDescriptor {
+  const CursorPluginDescriptor({
+    CursorPluginFactory? buildPlugin,
+    Duration connectBudget = const Duration(seconds: 15),
+    Duration versionProbeTimeout = const Duration(seconds: 10),
+  }) : _buildPlugin = buildPlugin,
+       _connectBudget = connectBudget,
+       _versionProbeTimeout = versionProbeTimeout;
+
+  final CursorPluginFactory? _buildPlugin;
+  final Duration _connectBudget;
+  final Duration _versionProbeTimeout;
+
+  /// Minimum `cursor-agent` build the bridge supports. Earlier builds (e.g.
+  /// `2026.05.28`) advertise the `acp` model picker and `session/load` but
+  /// silently no-op model switching and history replay, so the experience is
+  /// broken in ways the user can't see. `2026.06.15` is the verified-good
+  /// build where both work end-to-end.
+  static const String minVersion = "2026.06.15";
+
+  /// CLI option naming the `cursor-agent` binary (path or PATH name).
+  static const String binOption = "cursor-bin";
+
+  /// CLI option overriding the Cursor API endpoint (passed as `-e <endpoint>`).
+  static const String apiEndpointOption = "cursor-api-endpoint";
+
+  static const List<PluginOption> cliOptions = [
+    PluginValueOption(
+      name: binOption,
+      help: "Path to the cursor-agent binary",
+      defaultsTo: CursorBinary.defaultBinary,
+      allowedValues: null,
+      valueHelp: "path",
+      validate: null,
+    ),
+    PluginValueOption(
+      name: apiEndpointOption,
+      help: "Override the Cursor API endpoint (passed to cursor-agent as -e <endpoint>)",
+      defaultsTo: null,
+      allowedValues: null,
+      valueHelp: "url",
+      validate: null,
+    ),
+  ];
+
+  @override
+  String get id => "cursor";
+
+  @override
+  String get displayName => "Cursor";
+
+  @override
+  List<PluginOption> get options => cliOptions;
+
+  /// Confirms the `cursor-agent` CLI is installed and runnable before the
+  /// bridge commits to startup. Runs `<bin> --version`: exit 0 within
+  /// [versionProbeTimeout] is available; a failed launch (not installed / not
+  /// on PATH), a non-zero exit, or a timeout are unavailable. Never throws.
+  @override
+  Future<PluginAvailability> checkAvailability({
+    required PluginConfig config,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+  }) async {
+    final executablePath = config.value(binOption) ?? CursorBinary.defaultBinary;
+    return _probeCursorBinary(
+      executablePath: executablePath,
+      processes: processes,
+      environment: environment,
+    );
+  }
+
+  Future<PluginAvailability> _probeCursorBinary({
+    required String executablePath,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+  }) async {
+    final SpawnedProcess process;
+    try {
+      process = await processes.spawn(
+        executable: executablePath,
+        arguments: const ["--version"],
+        environment: environment,
+        workingDirectory: null,
+        runInShell: io.Platform.isWindows,
+      );
+    } on Object catch (error) {
+      Log.d("[cursor] availability probe could not launch '$executablePath --version': $error");
+      return PluginUnavailable(message: _notInstalledMessage(executablePath: executablePath));
+    }
+
+    final stdoutBuffer = StringBuffer();
+    final stdoutSubscription =
+        process.stdout.transform(utf8.decoder).listen(stdoutBuffer.write, onError: (Object _) {});
+    final stderrSubscription = process.stderr.listen((_) {}, onError: (Object _) {});
+    try {
+      final exitCode = await process.exitCode.timeout(_versionProbeTimeout);
+      if (exitCode == 0) {
+        final version = stdoutBuffer.toString().trim();
+        final parsed = _CalVer.tryParse(version);
+        final minimum = _CalVer.tryParse(minVersion);
+        if (parsed != null && minimum != null && parsed.compareTo(minimum) < 0) {
+          Log.w("[cursor] cursor-agent $version is below the supported minimum $minVersion");
+          return PluginUnavailable(
+            message: _outdatedMessage(executablePath: executablePath, version: version),
+          );
+        }
+        Log.d("[cursor] available: '$executablePath --version' -> ${version.isEmpty ? "exit 0 (no output)" : version}");
+        return const PluginAvailable();
+      }
+      Log.d("[cursor] availability probe '$executablePath --version' exited with code $exitCode");
+      return PluginUnavailable(message: _notWorkingMessage(executablePath: executablePath));
+    } on TimeoutException {
+      Log.d(
+        "[cursor] availability probe '$executablePath --version' did not exit within "
+        "${_versionProbeTimeout.inSeconds}s",
+      );
+      try {
+        await processes.signalForce(pid: process.pid);
+      } on Object {
+        // Best-effort: reap the hung probe.
+      }
+      return PluginUnavailable(message: _notWorkingMessage(executablePath: executablePath));
+    } on Object catch (error) {
+      Log.d("[cursor] availability probe '$executablePath --version' failed with error: $error");
+      return PluginUnavailable(message: _notWorkingMessage(executablePath: executablePath));
+    } finally {
+      await stdoutSubscription.cancel();
+      await stderrSubscription.cancel();
+    }
+  }
+
+  String _notInstalledMessage({required String executablePath}) {
+    return [
+      "Cursor was not found — the Sesori bridge needs the cursor-agent CLI to run.",
+      "",
+      "Verify it is installed:  $executablePath --version",
+      "Install the Cursor CLI:  curl https://cursor.com/install -fsS | bash",
+    ].join("\n");
+  }
+
+  String _notWorkingMessage({required String executablePath}) {
+    return [
+      'cursor-agent is installed but did not respond to "$executablePath --version".',
+      "",
+      "Re-check your install:   $executablePath --version",
+      "Update the Cursor CLI:   cursor-agent update",
+    ].join("\n");
+  }
+
+  String _outdatedMessage({required String executablePath, required String version}) {
+    final headline = "cursor-agent $version is too old for the Sesori bridge — "
+        "model switching and chat history need $minVersion or newer.";
+    return [
+      headline,
+      "",
+      "Update the Cursor CLI:   cursor-agent update",
+      "Then re-check:           $executablePath --version",
+    ].join("\n");
+  }
+
+  @override
+  Future<BridgePlugin> start(PluginHost host) async {
+    if (host.startAborted.isAborted) {
+      throw const PluginStartAbortedException();
+    }
+
+    final config = host.config;
+    final binaryPath = config.value(binOption) ?? CursorBinary.defaultBinary;
+    final rawEndpoint = config.value(apiEndpointOption)?.trim();
+    final apiEndpoint = (rawEndpoint == null || rawEndpoint.isEmpty) ? null : rawEndpoint;
+
+    // Route the agent subprocess through the host process seam rather than
+    // io.Process.start, so the bridge owns identity capture and signalling.
+    final processFactory = hostProcessAcpFactory(
+      processes: host.processes,
+      environment: host.environment,
+    );
+
+    final cursor = (_buildPlugin ?? _defaultBuildPlugin)(
+      binaryPath: binaryPath,
+      // The implicit default Cursor project is the bridge's launch directory;
+      // directories opened from the app are added to (and persisted by) the
+      // plugin's project registry via host.store.
+      projectCwd: io.Directory.current.path,
+      apiEndpoint: apiEndpoint,
+      processFactory: processFactory,
+      projectStore: host.store,
+    );
+
+    final plugin = AcpBridgePlugin(
+      plugin: cursor,
+      clock: host.clock,
+      endpoint: "$binaryPath acp",
+    );
+
+    // Eagerly spawn the agent and run the ACP handshake (bounded), so the first
+    // mobile request is fast and the status reflects reality. A timeout/failure
+    // leaves the plugin degraded rather than failing the bridge.
+    await plugin.connect(budget: _connectBudget, startAborted: host.startAborted);
+
+    // The connect above is a phase boundary: an abort observed here must roll
+    // back the spawned agent before surfacing.
+    if (host.startAborted.isAborted) {
+      try {
+        await plugin.shutdown(budget: null);
+      } on Object catch (error) {
+        Log.e("[cursor] rollback after aborted start failed: $error");
+      }
+      throw const PluginStartAbortedException();
+    }
+
+    // Eagerly warm the model/mode catalog so the mobile's first providers fetch
+    // (which it caches) already has the full list. Bounded so a slow probe never
+    // stalls startup; the lazy path in getProviders/getAgents is the fallback.
+    await cursor.warmCatalog().timeout(
+      const Duration(seconds: 12),
+      onTimeout: () => Log.d("[cursor] catalog warm-up timed out; will populate lazily"),
+    );
+
+    return plugin;
+  }
+}
+
+/// A cursor-agent calendar version (`YYYY.MM.DD`, the leading component of a
+/// build string like `2026.06.15-18-00-12-6f5a2cf`). Parsed once into a typed
+/// [Comparable] rather than comparing version strings ad hoc.
+class _CalVer implements Comparable<_CalVer> {
+  const _CalVer(this.year, this.month, this.day);
+
+  final int year;
+  final int month;
+  final int day;
+
+  /// Parses the leading `YYYY.MM.DD` from a cursor-agent version/build string,
+  /// or null if it does not start with that shape (caller fails open).
+  static _CalVer? tryParse(String raw) {
+    final match = RegExp(r"^\s*(\d{4})\.(\d{1,2})\.(\d{1,2})").firstMatch(raw);
+    if (match == null) return null;
+    return _CalVer(
+      int.parse(match.group(1)!),
+      int.parse(match.group(2)!),
+      int.parse(match.group(3)!),
+    );
+  }
+
+  @override
+  int compareTo(_CalVer other) {
+    final byYear = year.compareTo(other.year);
+    if (byYear != 0) return byYear;
+    final byMonth = month.compareTo(other.month);
+    if (byMonth != 0) return byMonth;
+    return day.compareTo(other.day);
+  }
+}

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
@@ -174,8 +174,16 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
       Log.d("[cursor] availability probe '$executablePath --version' failed with error: $error");
       return PluginUnavailable(message: _notWorkingMessage(executablePath: executablePath));
     } finally {
-      await stdoutSubscription.cancel();
-      await stderrSubscription.cancel();
+      try {
+        await stdoutSubscription.cancel();
+      } on Object catch (e, st) {
+        Log.w("[cursor] failed to cancel stdout subscription", e, st);
+      }
+      try {
+        await stderrSubscription.cancel();
+      } on Object catch (e, st) {
+        Log.w("[cursor] failed to cancel stderr subscription", e, st);
+      }
     }
   }
 
@@ -243,20 +251,25 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
       endpoint: "$binaryPath acp",
     );
 
-    // Eagerly spawn the agent and run the ACP handshake (bounded), so the first
-    // mobile request is fast and the status reflects reality. A timeout/failure
-    // leaves the plugin degraded rather than failing the bridge.
-    await plugin.connect(budget: _connectBudget, startAborted: host.startAborted);
-
-    // The connect above is a phase boundary: an abort observed here must roll
-    // back the spawned agent before surfacing.
-    if (host.startAborted.isAborted) {
+    // Rolls back the spawned agent and surfaces the abort. Each eager phase
+    // below (connect, catalog warm-up) is a boundary where an abort that arrived
+    // meanwhile must undo the partial start rather than return a live plugin.
+    Future<Never> rollbackAborted() async {
       try {
         await plugin.shutdown(budget: null);
       } on Object catch (error) {
         Log.e("[cursor] rollback after aborted start failed: $error");
       }
       throw const PluginStartAbortedException();
+    }
+
+    // Eagerly spawn the agent and run the ACP handshake (bounded), so the first
+    // mobile request is fast and the status reflects reality. A timeout/failure
+    // leaves the plugin degraded rather than failing the bridge.
+    await plugin.connect(budget: _connectBudget, startAborted: host.startAborted);
+
+    if (host.startAborted.isAborted) {
+      await rollbackAborted();
     }
 
     // Eagerly warm the model/mode catalog so the mobile's first providers fetch
@@ -266,6 +279,12 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
       const Duration(seconds: 12),
       onTimeout: () => Log.d("[cursor] catalog warm-up timed out; will populate lazily"),
     );
+
+    // Warm-up can run for seconds: re-check so an abort observed during it still
+    // rolls back instead of returning a started plugin.
+    if (host.startAborted.isAborted) {
+      await rollbackAborted();
+    }
 
     return plugin;
   }

--- a/bridge/sesori_plugin_cursor/pubspec.yaml
+++ b/bridge/sesori_plugin_cursor/pubspec.yaml
@@ -1,0 +1,25 @@
+name: cursor_plugin
+version: 0.1.0
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.12.2
+
+dependencies:
+  sesori_plugin_interface:
+    path: ../sesori_plugin_interface
+  sesori_shared:
+    path: ../../shared/sesori_shared
+  acp_plugin:
+    path: ../sesori_plugin_acp
+  path: ^1.9.0
+  freezed_annotation: ^3.1.0
+  json_annotation: ^4.11.0
+
+dev_dependencies:
+  build_runner: any
+  freezed: ^3.2.5
+  json_serializable: ^6.13.0
+  test: ^1.25.0
+  lints: ^6.1.0

--- a/bridge/sesori_plugin_cursor/test/cursor_approval_registry_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_approval_registry_test.dart
@@ -1,0 +1,105 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:cursor_plugin/cursor_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("CursorApprovalRegistry", () {
+    late FakeAcpProcess fake;
+    late AcpStdioClient client;
+    late List<BridgeSseEvent> emitted;
+    late CursorApprovalRegistry registry;
+
+    setUp(() async {
+      fake = FakeAcpProcess();
+      client = AcpStdioClient(
+        launchSpec: const AcpLaunchSpec(command: "cursor-agent", args: ["acp"]),
+        processFactory: (_) async => fake,
+      );
+      await client.connect();
+      emitted = [];
+      registry = CursorApprovalRegistry(client: client, emit: emitted.add);
+      registry.attach(client.serverRequests);
+    });
+
+    tearDown(() async {
+      await registry.dispose();
+      await client.dispose();
+      await fake.close();
+    });
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+    test("cursor/ask_question surfaces as a question with options", () async {
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "cursor/ask_question",
+        "params": {
+          "sessionId": "s1",
+          "title": "Choose",
+          "questions": [
+            {
+              "id": "q1",
+              "prompt": "Pick one",
+              "allowMultiple": false,
+              "options": [
+                {"id": "o1", "label": "Yes"},
+                {"id": "o2", "label": "No"},
+              ],
+            },
+          ],
+        },
+      });
+      await pump();
+
+      final asked = emitted.single as BridgeSseQuestionAsked;
+      expect(asked.sessionID, "s1");
+      expect(asked.questions.single["question"], "Pick one");
+      expect(asked.questions.single["header"], "Choose");
+
+      expect(registry.pendingForSession("s1"), hasLength(1));
+
+      registry.replyQuestion(asked.id, [["Yes"]]);
+      final reply = fake.written.last;
+      expect(reply["id"], 1);
+      final questions = (reply["result"] as Map)["questions"] as List;
+      expect((questions.single as Map)["selectedOptionIds"], ["o1"]);
+    });
+
+    test("cursor/create_plan surfaces as an accept/reject question", () async {
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "cursor/create_plan",
+        "params": {"sessionId": "s1", "name": "Plan A", "overview": "Do things"},
+      });
+      await pump();
+
+      final asked = emitted.single as BridgeSseQuestionAsked;
+      expect(asked.questions.single["header"], "Plan A");
+
+      registry.replyQuestion(asked.id, [["Accept"]]);
+      final reply = fake.written.last;
+      expect((reply["result"] as Map)["accepted"], true);
+    });
+
+    test("standard permission requests still work via the base", () async {
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "session/request_permission",
+        "params": {
+          "sessionId": "s1",
+          "toolCall": {"kind": "execute", "title": "Run"},
+          "options": [
+            {"optionId": "ok", "kind": "allow_once"},
+          ],
+        },
+      });
+      await pump();
+      expect(emitted.single, isA<BridgeSsePermissionAsked>());
+    });
+  });
+}

--- a/bridge/sesori_plugin_cursor/test/cursor_approval_registry_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_approval_registry_test.dart
@@ -85,6 +85,65 @@ void main() {
       expect((reply["result"] as Map)["accepted"], true);
     });
 
+    test("a non-bool allowMultiple does not crash the handler", () async {
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 4,
+        "method": "cursor/ask_question",
+        "params": {
+          "sessionId": "s1",
+          "questions": [
+            {
+              "id": "q1",
+              "prompt": "Pick",
+              "allowMultiple": "yes", // wrong type — must be treated as false
+              "options": [
+                {"id": "o1", "label": "A"},
+              ],
+            },
+          ],
+        },
+      });
+      await pump();
+      final asked = emitted.single as BridgeSseQuestionAsked;
+      expect(asked.questions.single["multiple"], false);
+      expect(registry.pendingForSession("s1"), hasLength(1));
+    });
+
+    test("an empty question list is rejected, not registered as blocking", () async {
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 5,
+        "method": "cursor/ask_question",
+        "params": {"sessionId": "s1", "questions": <Object?>[]},
+      });
+      await pump();
+      // No pending question is created, and the agent gets an error reply so it
+      // is not left blocked on input that can never be answered.
+      expect(emitted, isEmpty);
+      expect(registry.pendingForSession("s1"), isEmpty);
+      final reply = fake.written.last;
+      expect(reply["id"], 5);
+      expect(reply.containsKey("error"), isTrue);
+    });
+
+    test("questions with no usable text are dropped", () async {
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": 6,
+        "method": "cursor/ask_question",
+        "params": {
+          "sessionId": "s1",
+          "questions": [
+            {"id": "q1", "prompt": 123}, // non-string prompt -> dropped
+          ],
+        },
+      });
+      await pump();
+      expect(registry.pendingForSession("s1"), isEmpty);
+      expect(fake.written.last.containsKey("error"), isTrue);
+    });
+
     test("standard permission requests still work via the base", () async {
       fake.emit({
         "jsonrpc": "2.0",

--- a/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
@@ -1,0 +1,45 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:cursor_plugin/cursor_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("CursorEventMapper", () {
+    final mapper = CursorEventMapper(projectCwd: "/repo");
+
+    test("cursor/update_todos maps to a todo update", () {
+      final events = mapper.map(
+        const AcpNotification(
+          method: "cursor/update_todos",
+          params: {"sessionId": "s1", "todos": <Object?>[]},
+        ),
+      );
+      expect(events.single, isA<BridgeSseTodoUpdated>());
+      expect((events.single as BridgeSseTodoUpdated).sessionID, "s1");
+    });
+
+    test("other cursor extensions are dropped", () {
+      expect(
+        mapper.map(const AcpNotification(method: "cursor/task", params: {})),
+        isEmpty,
+      );
+    });
+
+    test("standard session/update still works via the base mapper", () {
+      mapper.beginTurn("s1");
+      final events = mapper.map(
+        const AcpNotification(
+          method: "session/update",
+          params: {
+            "sessionId": "s1",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              "content": {"type": "text", "text": "hi"},
+            },
+          },
+        ),
+      );
+      expect(events.whereType<BridgeSseMessagePartDelta>().single.delta, "hi");
+    });
+  });
+}

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
@@ -1,0 +1,224 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:cursor_plugin/cursor_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("CursorModelProbe", () {
+    final session = AcpNewSessionResult.fromJson({
+      "sessionId": "s1",
+      "configOptions": [
+        {"id": "verbosity", "category": "other"},
+        {
+          "id": "mode-picker",
+          "category": "mode",
+          "currentValue": "agent",
+          "options": [
+            {"value": "agent", "name": "Agent"},
+            {"value": "plan", "name": "Plan"},
+          ],
+        },
+        {
+          "id": "model-picker",
+          "category": "model",
+          "currentValue": "gpt-5.4",
+          "options": [
+            {"value": "gpt-5.4", "name": "GPT-5.4"},
+            {"value": "sonnet-4.6", "name": "Sonnet 4.6"},
+          ],
+        },
+      ],
+    });
+
+    test("finds a config by category, not by id", () {
+      final model = CursorModelProbe.findConfig(session, "model");
+      expect(model, isNotNull);
+      expect(model!["id"], "model-picker");
+      expect(CursorModelProbe.currentValue(model), "gpt-5.4");
+      expect(CursorModelProbe.options(model), hasLength(2));
+
+      final mode = CursorModelProbe.findConfig(session, "mode");
+      expect(mode!["id"], "mode-picker");
+      expect(CursorModelProbe.currentValue(mode), "agent");
+    });
+
+    test("findModelConfig + hasModel back-compat helpers", () {
+      final config = CursorModelProbe.findModelConfig(session)!;
+      expect(CursorModelProbe.models(config), hasLength(2));
+      expect(CursorModelProbe.hasModel(CursorModelProbe.models(config), "sonnet-4.6"), isTrue);
+      expect(CursorModelProbe.hasModel(CursorModelProbe.models(config), "nope"), isFalse);
+    });
+
+    test("returns null when the category is absent", () {
+      final none = AcpNewSessionResult.fromJson({"sessionId": "s", "configOptions": <Object?>[]});
+      expect(CursorModelProbe.findModelConfig(none), isNull);
+      expect(CursorModelProbe.findConfig(none, "mode"), isNull);
+    });
+  });
+
+  group("CursorPlugin", () {
+    late FakeAcpProcess fake;
+    late CursorPlugin plugin;
+
+    Map<String, dynamic> catalogResult() => {
+      "sessionId": "s1",
+      "configOptions": [
+        {
+          "id": "mode",
+          "category": "mode",
+          "currentValue": "agent",
+          "options": [
+            {"value": "agent", "name": "Agent"},
+            {"value": "plan", "name": "Plan"},
+            {"value": "ask", "name": "Ask"},
+          ],
+        },
+        {
+          "id": "model",
+          "category": "model",
+          "currentValue": "gpt-5.4",
+          "options": [
+            {"value": "gpt-5.4", "name": "GPT-5.4"},
+            {"value": "sonnet-4.6", "name": "Sonnet 4.6"},
+          ],
+        },
+      ],
+    };
+
+    setUp(() {
+      fake = FakeAcpProcess();
+      plugin = CursorPlugin(
+        projectCwd: "/repo",
+        processFactory: (_) async => fake,
+      );
+    });
+
+    tearDown(() async {
+      await plugin.dispose();
+      await fake.close();
+    });
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+    Future<Map<String, dynamic>> waitForFrame(String method) async {
+      for (var i = 0; i < 50; i++) {
+        final matches = fake.written.where((f) => f["method"] == method);
+        if (matches.isNotEmpty) return matches.last;
+        await pump();
+      }
+      throw StateError("agent never wrote a '$method' frame");
+    }
+
+    Future<void> respond(String method, Map<String, dynamic> result) async {
+      final frame = await waitForFrame(method);
+      fake.emit({"jsonrpc": "2.0", "id": frame["id"], "result": result});
+      await pump();
+    }
+
+    test("id is cursor", () {
+      expect(plugin.id, "cursor");
+    });
+
+    test("captureSessionConfig populates providers, mode variants, and agents", () async {
+      plugin.captureSessionConfig(catalogResult());
+
+      final providers = await plugin.getProviders(projectId: "/repo");
+      expect(providers.providers, hasLength(1));
+      final provider = providers.providers.single;
+      expect(provider.id, "cursor");
+      expect(provider.models, hasLength(2));
+      expect(provider.defaultModelID, "gpt-5.4");
+      // Every model exposes Cursor's modes as variants, default mode first.
+      expect(provider.models.first.variants, ["agent", "plan", "ask"]);
+
+      final agents = await plugin.getAgents(projectId: "/repo");
+      expect(agents.single.model?.modelID, "gpt-5.4");
+      expect(agents.single.model?.providerID, "cursor");
+    });
+
+    test("applyTurnSelection drives model + mode set_config_option calls", () async {
+      plugin.captureSessionConfig(catalogResult());
+
+      final client = AcpStdioClient(
+        launchSpec: const AcpLaunchSpec(command: "cursor-agent", args: ["acp"]),
+        processFactory: (_) async => fake,
+      );
+      await client.connect();
+
+      final applying = plugin.applyTurnSelection(
+        client: client,
+        sessionId: "s1",
+        model: (providerID: "cursor", modelID: "sonnet-4.6"),
+        variant: const PluginSessionVariant(id: "plan"),
+      );
+      await respond("session/set_config_option", const {}); // model
+      await respond("session/set_config_option", const {}); // mode
+      await applying;
+
+      final sets = fake.written
+          .where((f) => f["method"] == "session/set_config_option")
+          .map((f) => (f["params"] as Map).cast<String, dynamic>())
+          .toList();
+      expect(sets, hasLength(2));
+      expect(sets[0]["configId"], "model");
+      expect(sets[0]["value"], "sonnet-4.6");
+      expect(sets[1]["configId"], "mode");
+      expect(sets[1]["value"], "plan");
+
+      // The same model on a follow-up turn is not re-pushed (cursor persists it).
+      final again = plugin.applyTurnSelection(
+        client: client,
+        sessionId: "s1",
+        model: (providerID: "cursor", modelID: "sonnet-4.6"),
+        variant: const PluginSessionVariant(id: "plan"),
+      );
+      await again;
+      final setsAfter = fake.written.where((f) => f["method"] == "session/set_config_option");
+      expect(setsAfter, hasLength(2), reason: "unchanged model+mode are not re-applied");
+
+      await client.dispose();
+    });
+
+    test("applyTurnSelection never pushes an unknown model", () async {
+      plugin.captureSessionConfig(catalogResult());
+      final client = AcpStdioClient(
+        launchSpec: const AcpLaunchSpec(command: "cursor-agent", args: ["acp"]),
+        processFactory: (_) async => fake,
+      );
+      await client.connect();
+
+      final applying = plugin.applyTurnSelection(
+        client: client,
+        sessionId: "s1",
+        model: (providerID: "cursor", modelID: "not-a-real-model"),
+        variant: null,
+      );
+      // A null variant resolves to the default mode (agent) and is asserted, so
+      // the session is guaranteed in a known mode; the unknown model is dropped.
+      await respond("session/set_config_option", const {}); // mode=agent
+      await applying;
+
+      final sets = fake.written
+          .where((f) => f["method"] == "session/set_config_option")
+          .map((f) => (f["params"] as Map).cast<String, dynamic>())
+          .toList();
+      expect(sets.where((s) => s["configId"] == "model"), isEmpty,
+          reason: "unknown model is never pushed");
+      expect(sets.where((s) => s["configId"] == "mode" && s["value"] == "agent"), hasLength(1));
+
+      await client.dispose();
+    });
+
+    test("getProviders is empty before any session/catalog", () async {
+      final providers = plugin.getProviders(projectId: "/repo");
+      // _ensureCatalog connects and probes; the agent reports no list capability
+      // and no sessions, so the catalog stays empty.
+      await respond("initialize", {
+        "protocolVersion": 1,
+        "agentCapabilities": <String, dynamic>{},
+        "authMethods": <Object?>[],
+      });
+      expect((await providers).providers, isEmpty);
+    });
+  });
+}

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
@@ -209,6 +209,51 @@ void main() {
       await client.dispose();
     });
 
+    test("a default (null) model is re-applied when another model is active", () async {
+      // Cursor's model selection is process-global: if one session selects a
+      // non-default model, a later turn that uses the default must push it back,
+      // or it silently runs on the other session's model.
+      plugin.captureSessionConfig(catalogResult()); // default gpt-5.4
+      final client = AcpStdioClient(
+        launchSpec: const AcpLaunchSpec(command: "cursor-agent", args: ["acp"]),
+        processFactory: (_) async => fake,
+      );
+      await client.connect();
+
+      // Session A explicitly selects sonnet-4.6 (and the default mode).
+      final selecting = plugin.applyTurnSelection(
+        client: client,
+        sessionId: "sA",
+        model: (providerID: "cursor", modelID: "sonnet-4.6"),
+        variant: null,
+      );
+      await respond("session/set_config_option", const {}); // model=sonnet-4.6
+      await respond("session/set_config_option", const {}); // mode=agent
+      await selecting;
+
+      // Session B uses the default (null) model — must reset the process-global
+      // selection back to gpt-5.4 rather than inherit sonnet-4.6.
+      final defaulting = plugin.applyTurnSelection(
+        client: client,
+        sessionId: "sB",
+        model: null,
+        variant: null,
+      );
+      await respond("session/set_config_option", const {}); // model=gpt-5.4 (reapplied)
+      await defaulting;
+
+      final modelSets = fake.written
+          .where((f) => f["method"] == "session/set_config_option")
+          .map((f) => (f["params"] as Map).cast<String, dynamic>())
+          .where((p) => p["configId"] == "model")
+          .map((p) => p["value"])
+          .toList();
+      expect(modelSets, ["sonnet-4.6", "gpt-5.4"],
+          reason: "the default model is re-pushed when a different one was left active");
+
+      await client.dispose();
+    });
+
     test("getProviders is empty before any session/catalog", () async {
       final providers = plugin.getProviders(projectId: "/repo");
       // _ensureCatalog connects and probes; the agent reports no list capability

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
@@ -254,6 +254,29 @@ void main() {
       await client.dispose();
     });
 
+    test("getProviders tolerates a malformed model option and derives a safe default", () async {
+      // No currentValue, and the first option has a non-string value: the old
+      // `_models.first["value"] as String?` default would have thrown.
+      plugin.captureSessionConfig({
+        "sessionId": "s1",
+        "configOptions": [
+          {
+            "id": "model",
+            "category": "model",
+            "options": [
+              {"value": 123, "name": "Bad"},
+              {"value": "gpt-5.4", "name": "GPT-5.4"},
+            ],
+          },
+        ],
+      });
+      final providers = await plugin.getProviders(projectId: "/repo");
+      final provider = providers.providers.single;
+      expect(provider.models.map((m) => m.id), ["gpt-5.4"],
+          reason: "the malformed entry is dropped, not force-cast");
+      expect(provider.defaultModelID, "gpt-5.4");
+    });
+
     test("getProviders is empty before any session/catalog", () async {
       final providers = plugin.getProviders(projectId: "/repo");
       // _ensureCatalog connects and probes; the agent reports no list capability


### PR DESCRIPTION
## Summary

Adds **Cursor** as a bridge backend, driving `cursor-agent acp` (>= 2026.06.15) over a new generic **ACP** layer, built on main's `BridgePluginDescriptor` lifecycle. Selectable via `--plugin cursor`. OpenCode stays the default; Codex is intentionally out of this pass.

## Packages

- **`sesori_plugin_acp`** — generic ACP stdio JSON-RPC machinery (protocol, event mapper, approval registry, session loader, stdio client) plus lifecycle housing: `AcpBridgePlugin` (a `SteadyPluginLifecycle` `BridgePlugin` owning connect/status/shutdown) and `host_process_acp_factory` (spawns the agent through `PluginHost.processes` so the bridge owns identity + signalling).
- **`sesori_plugin_cursor`** — const `CursorPluginDescriptor` (id `cursor`): `--cursor-bin` / `--cursor-api-endpoint` options, a `cursor-agent --version` availability probe with a minimum-version gate, and `start()` that spawns `cursor-agent acp`, wraps `CursorPlugin`, and reports Ready once the ACP handshake completes.
- **app** — register `CursorPluginDescriptor` in `knownPlugins`; add acp/cursor path-deps + workspace members.

## Functionality (verified against a live cursor-agent)

- **Tool output**: read `rawOutput` (exec `{stdout,stderr}`, read/other `{content}`), truncated — previously dropped (only `content` was read).
- **Autotitle**: map `session_info_update {title}` → `BridgeSseSessionUpdated`.
- **Model/mode switching**: `captureSessionConfig` + `applyTurnSelection` hooks on createSession AND every sendPrompt/sendCommand so mid-chat switches take effect; mode (agent/plan/ask) exposed as the sesori variant; applied only on change (cursor's set leaks process-globally). Per-session model stamping.
- **History**: drain replay until the stream goes quiet before building (cursor streams later turns after the session/load response resolves).
- **Cross-restart resume**: re-load prior-run sessions via session/load before a turn (replay suppressed) — they were rejected "session not found" on a fresh agent process.
- **Catalog**: `warmCatalog()` probes an existing session's load result at connect so pickers are populated before the app's first (cached) getProviders. Minimum cursor-agent version (2026.06.15) gated in `checkAvailability`.

## Multi-project support

ACP-backed plugins were hard single-project (getProjects returned only launch CWD; getProject ignored its argument). Adds `AcpProjectRegistry` (launch CWD always present, opened dirs persisted to `acp-projects.json`) and per-session attribution via `_sessionProjects` so a session is filed under its real directory, not the launch CWD.

## Integration with main

- `PluginToolState.status` is the `PluginToolStatus` enum, not a String (#195).
- `rejectQuestion` takes `{questionId, sessionId}` (#279).
- `getActiveSessionsSummary()` surfaces running + awaiting-input sessions (was a stub).
- `BridgeCliOptions` no longer reads OpenCode-owned `--port`/`--password` (dead fields, absent + crashing under `--plugin cursor`).
- Add both new packages to the Makefile `MODULES` (were excluded from CI analyze/test).

## Tests

ACP machinery, rawOutput mapping (both shapes), title, model+mode switching, per-session model, history reconstruction, resume-on-demand, activity summary, and the project registry + cross-project session attribution. Full suite green (acp 50, cursor 14, app 1370); changed packages clean under analyze `--fatal-infos`.

Live-verified on the iPhone 17 Pro Max simulator: send/receive, multi-turn history with tool cards, model switch, mode switch, autotitle, cross-restart resume, and discovering/opening a new project that persists across a bridge restart + app cold start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Cursor backend powered by a new ACP layer, enabling `--plugin cursor` to drive `cursor-agent acp` with model/mode switching, multi-project support, history, and session resume. OpenCode remains the default; requires `cursor-agent` ≥ 2026.06.15.

- **New Features**
  - Add `acp_plugin` (stdio JSON‑RPC client, protocol helpers, event mapper, approval registry, session loader, lifecycle/process factory) and `cursor_plugin` (descriptor with `--cursor-bin`/`--cursor-api-endpoint`, version probe; spawns `cursor-agent acp`).
  - Register `CursorPluginDescriptor` in `knownPlugins`; add `tool/cursor_smoke.dart`; update workspace/Makefile/deps.
  - Chat: raw tool output, autotitle, per‑session model + mode (agent/plan/ask), history replay, cross‑restart resume; catalog warmed on connect.
  - Multi‑project registry with persistence; sessions attributed to their real project; activity summary shows running and awaiting‑input.
  - CLI: remove OpenCode‑only `--port`/`--password`.

- **Bug Fixes**
  - ACP: reset connection on agent exit; fail fast after exit; always complete malformed JSON‑RPC errors; guard stderr; re‑arm exit watch on every reconnect and recover to ready.
  - Serialize project‑registry persistence and await quarantine; apply per‑session project on `session_info_update` (title) events.
  - Cursor: reapply default model per turn; defensively parse model options and `ask_question`; reject invalid/empty questions; add post‑`warmCatalog` abort; derive `defaultModelID` safely.
  - Cleanup/hardening: isolate teardown paths, drop redundant env copy; unify tool‑output parsing for live and replay.

<sup>Written for commit 79409d804dcea38e7cc607a47a39e0ed4f24e012. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

