### PR TITLE
feat(mobile): add inline bridge-offline banner and refactor Prego alerts

### DIFF
--- a/mobile/app/lib/core/widgets/connection_overlay.dart
+++ b/mobile/app/lib/core/widgets/connection_overlay.dart
@@ -123,15 +123,17 @@ class _BridgeOfflineBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     final loc = context.loc;
 
+    // No reconnect action here: while the bridge is offline the relay
+    // connection is still alive and ConnectionService keeps a bridge-status
+    // watcher that auto-reconnects when the bridge comes back. Forcing a
+    // reconnect now can't complete the E2E handshake and would tear that
+    // watcher down, dropping into the blocking ConnectionLost state — the exact
+    // case ConnectionService deliberately avoids (see the resume path in
+    // connection_service.dart). The banner is purely informational.
     return PregoInlineAlertsNotifications(
       type: PregoInlineAlertsNotificationsType.warning,
       title: loc.bridgeDisconnectedTitle,
       icon: TablerRegular.broadcast_off,
-      primaryAction: PregoInlineAlertsNotificationsAction(
-        label: loc.connectionLostReconnect,
-        icon: TablerRegular.rotate_clockwise,
-        onPressed: () => context.read<ConnectionOverlayCubit>().reconnect(),
-      ),
     );
   }
 }

--- a/mobile/app/lib/core/widgets/connection_overlay.dart
+++ b/mobile/app/lib/core/widgets/connection_overlay.dart
@@ -121,41 +121,16 @@ class _BridgeOfflineBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final prego = context.prego;
     final loc = context.loc;
 
-    return Material(
-      elevation: 2,
-      color: Colors.orange.shade800,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-        child: Row(
-          children: [
-            const Icon(Icons.cloud_off_rounded, color: Colors.white, size: 20),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: .start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    loc.bridgeOfflineTitle,
-                    style: prego.textTheme.textXs.medium.copyWith(
-                      color: Colors.white,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  Text(
-                    loc.bridgeOfflineMessage,
-                    style: prego.textTheme.textXs.regular.copyWith(
-                      color: Colors.white70,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
-        ),
+    return PregoInlineAlertsNotifications(
+      type: PregoInlineAlertsNotificationsType.warning,
+      title: loc.bridgeDisconnectedTitle,
+      icon: TablerRegular.broadcast_off,
+      primaryAction: PregoInlineAlertsNotificationsAction(
+        label: loc.connectionLostReconnect,
+        icon: TablerRegular.rotate_clockwise,
+        onPressed: () => context.read<ConnectionOverlayCubit>().reconnect(),
       ),
     );
   }

--- a/mobile/app/lib/features/login/login_screen.dart
+++ b/mobile/app/lib/features/login/login_screen.dart
@@ -128,75 +128,108 @@ class _LoginScreenBodyState extends State<_LoginScreenBody> {
             LayoutBuilder(
               builder: (context, constraints) {
                 return SingleChildScrollView(
-                    child: ConstrainedBox(
-                      constraints: BoxConstraints(minHeight: constraints.maxHeight),
-                      child: Column(
-                        mainAxisSize: .min,
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: [
-                          Material(
-                            type: MaterialType.transparency,
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(minHeight: constraints.maxHeight),
+                    child: Column(
+                      mainAxisSize: .min,
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        Material(
+                          type: MaterialType.transparency,
+                          child: Column(
+                            mainAxisSize: .min,
+                            children: [
+                              const Hero(tag: SesoriLogo.heroTag, child: SesoriLogo()),
+                              Text(
+                                loc.loginTitle,
+                                style: prego.textTheme.textSm.regular,
+                              ),
+                              const SizedBox(height: 4),
+                              Text(
+                                loc.loginSubtitle,
+                                style: prego.textTheme.displaySm.bold,
+                              ),
+                            ],
+                          ),
+                        ),
+                        SafeArea(
+                          top: false,
+                          child: Padding(
+                            padding: const EdgeInsetsDirectional.fromSTEB(32, 86, 32, 24),
                             child: Column(
                               mainAxisSize: .min,
                               children: [
-                                const Hero(tag: SesoriLogo.heroTag, child: SesoriLogo()),
-                                Text(
-                                  loc.loginTitle,
-                                  style: prego.textTheme.textSm.regular,
+                                const SizedBox(height: 24),
+                                LoginProviderButtons(
+                                  isLoading: isLoading,
+                                  showEmailForm: _showEmailForm,
+                                  showApple: !kIsWeb && defaultTargetPlatform == TargetPlatform.iOS,
+                                  onGithubSelected: () => _loginWithProvider(AuthProvider.github),
+                                  onAppleSelected: _loginWithApple,
+                                  onGoogleSelected: () => _loginWithProvider(AuthProvider.google),
+                                  onShowEmailForm: _showEmailLogin,
                                 ),
-                                const SizedBox(height: 4),
-                                Text(
-                                  loc.loginSubtitle,
-                                  style: prego.textTheme.displaySm.bold,
-                                ),
-                              ],
-                            ),
-                          ),
-                          SafeArea(
-                            top: false,
-                            child: Padding(
-                              padding: const EdgeInsetsDirectional.fromSTEB(32, 86, 32, 24),
-                              child: Column(
-                                mainAxisSize: .min,
-                                children: [
-                                  const SizedBox(height: 24),
-                                  LoginProviderButtons(
-                                    isLoading: isLoading,
-                                    showEmailForm: _showEmailForm,
-                                    showApple: !kIsWeb && defaultTargetPlatform == TargetPlatform.iOS,
-                                    onGithubSelected: () => _loginWithProvider(AuthProvider.github),
-                                    onAppleSelected: _loginWithApple,
-                                    onGoogleSelected: () => _loginWithProvider(AuthProvider.google),
-                                    onShowEmailForm: _showEmailLogin,
+                                if (_showEmailForm) ...[
+                                  const SizedBox(height: 8),
+                                  EmailLoginForm(
+                                    key: ValueKey(_showEmailForm),
                                   ),
-                                  if (_showEmailForm) ...[
-                                    const SizedBox(height: 8),
-                                    EmailLoginForm(
-                                      key: ValueKey(_showEmailForm),
-                                    ),
-                                  ],
-                                  switch (state) {
-                                    LoginAuthenticating() => Padding(
-                                      padding: const EdgeInsetsDirectional.only(top: 16),
-                                      child: Text(
-                                        loc.loginAuthenticating,
-                                        style: prego.textTheme.textSm.regular.copyWith(
-                                          color: prego.colors.textSecondary,
-                                        ),
-                                        textAlign: TextAlign.center,
+                                ],
+                                switch (state) {
+                                  LoginAuthenticating() => Padding(
+                                    padding: const EdgeInsetsDirectional.only(top: 16),
+                                    child: Text(
+                                      loc.loginAuthenticating,
+                                      style: prego.textTheme.textSm.regular.copyWith(
+                                        color: prego.colors.textSecondary,
                                       ),
+                                      textAlign: TextAlign.center,
                                     ),
-                                    LoginAwaitingConfirmation(:final userCode) => Padding(
-                                      padding: const EdgeInsetsDirectional.only(top: 16),
-                                      child: Column(
-                                        children: [
-                                          Text(
-                                            loc.loginAwaitingConfirmation(userCode),
-                                            style: prego.textTheme.textSm.regular.copyWith(
-                                              color: prego.colors.textSecondary,
-                                            ),
-                                            textAlign: TextAlign.center,
+                                  ),
+                                  LoginAwaitingConfirmation(:final userCode) => Padding(
+                                    padding: const EdgeInsetsDirectional.only(top: 16),
+                                    child: Column(
+                                      children: [
+                                        Text(
+                                          loc.loginAwaitingConfirmation(userCode),
+                                          style: prego.textTheme.textSm.regular.copyWith(
+                                            color: prego.colors.textSecondary,
                                           ),
+                                          textAlign: TextAlign.center,
+                                        ),
+                                        const SizedBox(height: 8),
+                                        Container(
+                                          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                                          decoration: BoxDecoration(
+                                            color: prego.colors.bgBrandSolid.withAlpha(26),
+                                            borderRadius: BorderRadius.circular(8),
+                                            border: Border.all(
+                                              color: prego.colors.bgBrandSolid.withAlpha(77),
+                                            ),
+                                          ),
+                                          child: Text(
+                                            userCode,
+                                            style: prego.textTheme.textXl.bold.copyWith(
+                                              color: prego.colors.bgBrandSolid,
+                                              letterSpacing: 4,
+                                            ),
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                  LoginPolling(:final userCode) => Padding(
+                                    padding: const EdgeInsetsDirectional.only(top: 16),
+                                    child: Column(
+                                      children: [
+                                        Text(
+                                          loc.loginPolling,
+                                          style: prego.textTheme.textSm.regular.copyWith(
+                                            color: prego.colors.textSecondary,
+                                          ),
+                                          textAlign: TextAlign.center,
+                                        ),
+                                        if (userCode != null) ...[
                                           const SizedBox(height: 8),
                                           Container(
                                             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -216,106 +249,73 @@ class _LoginScreenBodyState extends State<_LoginScreenBody> {
                                             ),
                                           ),
                                         ],
-                                      ),
+                                      ],
                                     ),
-                                    LoginPolling(:final userCode) => Padding(
-                                      padding: const EdgeInsetsDirectional.only(top: 16),
-                                      child: Column(
-                                        children: [
-                                          Text(
-                                            loc.loginPolling,
-                                            style: prego.textTheme.textSm.regular.copyWith(
-                                              color: prego.colors.textSecondary,
+                                  ),
+                                  LoginTimeout() => Padding(
+                                    padding: const EdgeInsetsDirectional.only(top: 16),
+                                    child: Text(
+                                      loc.loginTimeout,
+                                      style: prego.textTheme.textSm.regular.copyWith(
+                                        color: prego.colors.textSecondary,
+                                      ),
+                                      textAlign: TextAlign.center,
+                                    ),
+                                  ),
+                                  LoginIdle() => const SizedBox.shrink(),
+                                  LoginFailed() => const SizedBox.shrink(),
+                                  LoginSuccess() => const SizedBox.shrink(),
+                                },
+                                switch (state) {
+                                  LoginFailed() => const SizedBox.shrink(),
+                                  LoginTimeout() => Padding(
+                                    padding: const EdgeInsetsDirectional.only(top: 24),
+                                    child: Card(
+                                      color: prego.colors.bgErrorPrimary,
+                                      child: Padding(
+                                        padding: const EdgeInsets.all(16),
+                                        child: Row(
+                                          children: [
+                                            Icon(
+                                              Icons.error_outline,
+                                              color: prego.colors.fgErrorPrimary,
                                             ),
-                                            textAlign: TextAlign.center,
-                                          ),
-                                          if (userCode != null) ...[
-                                            const SizedBox(height: 8),
-                                            Container(
-                                              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                                              decoration: BoxDecoration(
-                                                color: prego.colors.bgBrandSolid.withAlpha(26),
-                                                borderRadius: BorderRadius.circular(8),
-                                                border: Border.all(
-                                                  color: prego.colors.bgBrandSolid.withAlpha(77),
-                                                ),
-                                              ),
+                                            const SizedBox(width: 12),
+                                            Expanded(
                                               child: Text(
-                                                userCode,
-                                                style: prego.textTheme.textXl.bold.copyWith(
-                                                  color: prego.colors.bgBrandSolid,
-                                                  letterSpacing: 4,
+                                                loc.loginTimeout,
+                                                style: prego.textTheme.textSm.regular.copyWith(
+                                                  color: prego.colors.fgErrorPrimary,
                                                 ),
                                               ),
                                             ),
                                           ],
-                                        ],
-                                      ),
-                                    ),
-                                    LoginTimeout() => Padding(
-                                      padding: const EdgeInsetsDirectional.only(top: 16),
-                                      child: Text(
-                                        loc.loginTimeout,
-                                        style: prego.textTheme.textSm.regular.copyWith(
-                                          color: prego.colors.textSecondary,
-                                        ),
-                                        textAlign: TextAlign.center,
-                                      ),
-                                    ),
-                                    LoginIdle() => const SizedBox.shrink(),
-                                    LoginFailed() => const SizedBox.shrink(),
-                                    LoginSuccess() => const SizedBox.shrink(),
-                                  },
-                                  switch (state) {
-                                    LoginFailed() => const SizedBox.shrink(),
-                                    LoginTimeout() => Padding(
-                                      padding: const EdgeInsetsDirectional.only(top: 24),
-                                      child: Card(
-                                        color: prego.colors.bgErrorPrimary,
-                                        child: Padding(
-                                          padding: const EdgeInsets.all(16),
-                                          child: Row(
-                                            children: [
-                                              Icon(
-                                                Icons.error_outline,
-                                                color: prego.colors.fgErrorPrimary,
-                                              ),
-                                              const SizedBox(width: 12),
-                                              Expanded(
-                                                child: Text(
-                                                  loc.loginTimeout,
-                                                  style: prego.textTheme.textSm.regular.copyWith(
-                                                    color: prego.colors.fgErrorPrimary,
-                                                  ),
-                                                ),
-                                              ),
-                                            ],
-                                          ),
                                         ),
                                       ),
                                     ),
-                                    LoginIdle() => const SizedBox.shrink(),
-                                    LoginAuthenticating() => const SizedBox.shrink(),
-                                    LoginAwaitingConfirmation() => const SizedBox.shrink(),
-                                    LoginPolling() => const SizedBox.shrink(),
-                                    LoginSuccess() => const SizedBox.shrink(),
-                                  },
-                                  const SizedBox(height: 22),
-                                  MarkdownBody(
-                                    data: loc.loginAgreementText,
-                                    onTapLink: handleMarkdownLinkTap,
-                                    styleSheet: buildAgreementMarkdownStyleSheet(prego: prego),
                                   ),
-                                ],
-                              ),
+                                  LoginIdle() => const SizedBox.shrink(),
+                                  LoginAuthenticating() => const SizedBox.shrink(),
+                                  LoginAwaitingConfirmation() => const SizedBox.shrink(),
+                                  LoginPolling() => const SizedBox.shrink(),
+                                  LoginSuccess() => const SizedBox.shrink(),
+                                },
+                                const SizedBox(height: 22),
+                                MarkdownBody(
+                                  data: loc.loginAgreementText,
+                                  onTapLink: handleMarkdownLinkTap,
+                                  styleSheet: buildAgreementMarkdownStyleSheet(prego: prego),
+                                ),
+                              ],
                             ),
                           ),
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
-                  );
-                },
-              ),
+                  ),
+                );
+              },
+            ),
             PositionedDirectional(
               top: 0,
               start: 0,
@@ -390,11 +390,10 @@ class _LoginErrorBannerState extends State<_LoginErrorBanner> {
               opacity: isVisible ? 1 : 0,
               child: reason == null
                   ? const SizedBox.shrink()
-                  : PregoAlertsNotification(
+                  : PregoPopupAlertsNotifications(
                       title: loc.loginAuthenticationFailedTitle,
                       message: _getErrorMessage(loc: loc, reason: reason),
-                      onClose: () =>
-                          context.read<LoginCubit>().onDismissedLoginFailureError(),
+                      onClose: () => context.read<LoginCubit>().onDismissedLoginFailureError(),
                     ),
             ),
           ),

--- a/mobile/app/lib/l10n/app_en.arb
+++ b/mobile/app/lib/l10n/app_en.arb
@@ -61,8 +61,7 @@
   "connectionLostDisconnect": "Disconnect",
   "relayConnectionLost": "Bridge went offline",
   "relayReconnecting": "Reconnecting to bridge...",
-  "bridgeOfflineTitle": "Bridge Offline",
-  "bridgeOfflineMessage": "Start sesori-bridge on your laptop",
+  "bridgeDisconnectedTitle": "Bridge disconnected",
   "settingsTitle": "Settings",
   "settingsAccountSignedInWith": "Signed in with {provider}",
   "@settingsAccountSignedInWith": {

--- a/mobile/app/lib/l10n/app_localizations.dart
+++ b/mobile/app/lib/l10n/app_localizations.dart
@@ -331,17 +331,11 @@ abstract class AppLocalizations {
   /// **'Reconnecting to bridge...'**
   String get relayReconnecting;
 
-  /// No description provided for @bridgeOfflineTitle.
+  /// No description provided for @bridgeDisconnectedTitle.
   ///
   /// In en, this message translates to:
-  /// **'Bridge Offline'**
-  String get bridgeOfflineTitle;
-
-  /// No description provided for @bridgeOfflineMessage.
-  ///
-  /// In en, this message translates to:
-  /// **'Start sesori-bridge on your laptop'**
-  String get bridgeOfflineMessage;
+  /// **'Bridge disconnected'**
+  String get bridgeDisconnectedTitle;
 
   /// No description provided for @settingsTitle.
   ///

--- a/mobile/app/lib/l10n/app_localizations_en.dart
+++ b/mobile/app/lib/l10n/app_localizations_en.dart
@@ -141,10 +141,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get relayReconnecting => 'Reconnecting to bridge...';
 
   @override
-  String get bridgeOfflineTitle => 'Bridge Offline';
-
-  @override
-  String get bridgeOfflineMessage => 'Start sesori-bridge on your laptop';
+  String get bridgeDisconnectedTitle => 'Bridge disconnected';
 
   @override
   String get settingsTitle => 'Settings';

--- a/mobile/module_prego/lib/components/alerts/prego_inline_alerts_notifications.dart
+++ b/mobile/module_prego/lib/components/alerts/prego_inline_alerts_notifications.dart
@@ -200,7 +200,14 @@ class PregoInlineAlertsNotifications extends StatelessWidget {
         ),
         if (_buildActions(colors) case final actions?) ...[
           const SizedBox(width: PregoSpacing.md),
-          actions,
+          // The card surface is `fgPrimary` — the inverse of the page
+          // background — so action buttons that resolve their foreground from
+          // semantic page tokens (a tertiary [PregoButtonsSolid]'s
+          // `textTertiary` label, the loading `primaryAlt` fill) would be
+          // mis-toned against it. Render the cluster under the opposite-
+          // brightness palette so those tokens land on the right side of the
+          // surface in both themes.
+          _InvertedSurfaceTheme(child: actions),
         ],
       ],
     );
@@ -385,6 +392,35 @@ class PregoInlineAlertsNotifications extends StatelessWidget {
     PregoInlineAlertsNotificationsType.warning => colors.fgWarningSecondary,
     PregoInlineAlertsNotificationsType.error => colors.fgErrorSecondary,
   };
+}
+
+/// Re-themes [child] with the opposite-brightness [PregoDesignSystem].
+///
+/// The alert card paints its surface with `fgPrimary`, which is the inverse of
+/// the page background in each theme (a dark surface in light mode, a light
+/// surface in dark mode). Controls that resolve colours from semantic page
+/// tokens — e.g. a tertiary [PregoButtonsSolid] using `textTertiary`, or the
+/// loading-type `primaryAlt` fill — are tuned for the page background, so they
+/// sit on the wrong side of this inverted surface. Wrapping them in the
+/// opposite-brightness palette puts every token back on the correct side.
+class _InvertedSurfaceTheme extends StatelessWidget {
+  const _InvertedSurfaceTheme({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final inverted = theme.brightness == Brightness.light
+        ? PregoDesignSystem.dark
+        : PregoDesignSystem.light;
+    // Append after the existing extensions so the inverted PregoDesignSystem
+    // wins by type; all other theme extensions are preserved.
+    return Theme(
+      data: theme.copyWith(extensions: [...theme.extensions.values, inverted]),
+      child: child,
+    );
+  }
 }
 
 /// Stretches a [RadialGradient] horizontally into a wide, shallow ellipse.

--- a/mobile/module_prego/lib/components/alerts/prego_inline_alerts_notifications.dart
+++ b/mobile/module_prego/lib/components/alerts/prego_inline_alerts_notifications.dart
@@ -1,0 +1,427 @@
+import "package:flutter/material.dart";
+
+import "../../icons/tabler_icons.g.dart";
+import "../../theme/prego_theme.dart";
+import "../buttons/prego_buttons_solid.dart";
+
+/// Visual type for [PregoInlineAlertsNotifications] — the Figma component's
+/// `Type` property.
+///
+/// Each value selects the leading status icon, the warm accent gradient, and
+/// the fill of the primary action button.
+enum PregoInlineAlertsNotificationsType {
+  /// Neutral / informational — `circle-info` icon, brand-blue action button,
+  /// neutral (dark→white) accent glow.
+  info,
+
+  /// Success / confirmation — green `circle-check` icon, success-green action
+  /// button, green accent glow.
+  success,
+
+  /// Warning / attention — amber `triangle-exclamation` icon, warning-amber
+  /// action button, amber accent glow.
+  warning,
+
+  /// Error / failure — red `circle-exclamation` icon, error-red action button,
+  /// red accent glow.
+  error,
+
+  /// In-progress — a spinner replaces the leading icon, the primary action
+  /// renders in the inverted ("primary alt") style, and the accent glow is
+  /// neutral (as for [info]).
+  loading,
+}
+
+/// Configuration for one of [PregoInlineAlertsNotifications]'s action buttons.
+///
+/// Used for both the primary ("Learn more") and secondary buttons. Pass `null`
+/// for the corresponding [PregoInlineAlertsNotifications] field to omit a
+/// button.
+class PregoInlineAlertsNotificationsAction {
+  const PregoInlineAlertsNotificationsAction({
+    required this.label,
+    required this.onPressed,
+    this.icon,
+  });
+
+  /// Button label.
+  final String label;
+
+  /// Called when the button is tapped.
+  final VoidCallback onPressed;
+
+  /// Optional icon placed before the [label].
+  final IconData? icon;
+}
+
+/// An inline alert / notification card — a faithful port of the Figma
+/// `pregoInlineAletsNotifications` component (sic).
+///
+/// Anatomy (left → right, top → bottom):
+/// - a leading status icon (or a spinner for
+///   [PregoInlineAlertsNotificationsType.loading]),
+/// - a bold [title],
+/// - an optional [secondaryAction] (a tertiary, label-only button),
+/// - an optional [primaryAction] (a solid, accent-coloured button),
+/// - an optional close button (shown when [onClose] is non-null),
+/// - optional [supportingText] and/or [additionalContent] below the title.
+/// Usage:
+/// ```dart
+/// PregoInlineAlertsNotifications(
+///   type: PregoInlineAlertsNotificationsType.warning,
+///   title: 'Bridge offline',
+///   supportingText: 'Reconnect to keep your session in sync.',
+///   primaryAction: PregoInlineAlertsNotificationsAction(
+///     label: 'Reconnect',
+///     icon: TablerRegular.rotate_clockwise,
+///     onPressed: _reconnect,
+///   ),
+///   secondaryAction: PregoInlineAlertsNotificationsAction(
+///     label: 'Dismiss',
+///     onPressed: _dismiss,
+///   ),
+///   onClose: _dismiss,
+/// )
+/// ```
+class PregoInlineAlertsNotifications extends StatelessWidget {
+  const PregoInlineAlertsNotifications({
+    super.key,
+    required this.title,
+    this.type = PregoInlineAlertsNotificationsType.info,
+    this.supportingText,
+    this.icon,
+    this.primaryAction,
+    this.secondaryAction,
+    this.onClose,
+    this.additionalContent,
+  });
+
+  /// Bold headline text shown on the first row. Long titles ellipsize on a
+  /// single line so the actions stay aligned to the trailing edge.
+  final String title;
+
+  /// Selects the leading icon, accent gradient, and primary-action fill.
+  final PregoInlineAlertsNotificationsType type;
+
+  /// Optional supporting text shown below the title. When `null`, no supporting
+  /// text row is rendered.
+  final String? supportingText;
+
+  /// Overrides the leading icon. When `null`, the [type]'s default icon is
+  /// used. Ignored for [PregoInlineAlertsNotificationsType.loading], which
+  /// always shows a spinner.
+  final IconData? icon;
+
+  /// Optional primary (solid, accent-coloured) action button. When `null`, no
+  /// primary button is rendered.
+  final PregoInlineAlertsNotificationsAction? primaryAction;
+
+  /// Optional secondary (tertiary, label-only) action button, placed before
+  /// the [primaryAction]. When `null`, no secondary button is rendered.
+  final PregoInlineAlertsNotificationsAction? secondaryAction;
+
+  /// Called when the close button is tapped. When `null`, the close button is
+  /// not rendered.
+  final VoidCallback? onClose;
+
+  /// Optional custom widget rendered in the content column, below the
+  /// [supportingText]. Use for richer content (links, inline controls, etc.).
+  final Widget? additionalContent;
+
+  // Gap between the leading icon and the content column. Figma uses 10px —
+  // between spacing-md (8) and spacing-lg (12) — so it has no named token.
+  static const double _leadingGap = 10.0;
+
+  // Leading icon glyph size (Figma: 22px). The loading spinner is 20px.
+  static const double _iconSize = 22.0;
+  static const double _spinnerSize = 20.0;
+
+  bool get _isLoading => type == PregoInlineAlertsNotificationsType.loading;
+
+  @override
+  Widget build(BuildContext context) {
+    return Builder(builder: _buildCard);
+  }
+
+  Widget _buildCard(BuildContext context) {
+    final prego = context.prego;
+    final colors = prego.colors;
+
+    // Transparent [Material] so the title/supporting [Text] inherit a proper
+    // default text style even when the banner is placed outside a
+    // [Scaffold]/[Material] — e.g. directly in an overlay [Stack]. Without it,
+    // the text falls back to Flutter's debug style (yellow double underline).
+    return Material(
+      type: MaterialType.transparency,
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: ColoredBox(
+              color: colors.fgPrimary,
+            ),
+          ),
+          // Warm accent glow: a wide, shallow ellipse emanating from the
+          // top-centre, fading out to the type's accent colour at the rim.
+          Positioned.fill(
+            child: IgnorePointer(child: _accentGradient(colors)),
+          ),
+          Padding(
+            padding: const EdgeInsetsDirectional.fromSTEB(
+              PregoSpacing.xl, // 16
+              PregoSpacing.lg, // 12
+              PregoSpacing.lg, // 12
+              PregoSpacing.lg, // 12
+            ),
+            child: _buildBody(prego),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody(PregoDesignSystem prego) {
+    final colors = prego.colors;
+    final hasBelow = supportingText != null || additionalContent != null;
+
+    // First row: leading icon centred against the title row (which is as tall
+    // as its tallest action button), then the title + trailing actions.
+    final titleRow = Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        _buildLeading(colors),
+        const SizedBox(width: _leadingGap),
+        Expanded(
+          child: Text(
+            title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: prego.textTheme.textSm.bold.copyWith(color: colors.alphaWhite100),
+          ),
+        ),
+        if (_buildActions(colors) case final actions?) ...[
+          const SizedBox(width: PregoSpacing.md),
+          actions,
+        ],
+      ],
+    );
+
+    if (!hasBelow) return titleRow;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        titleRow,
+        // Content below the title is indented to align under the title text
+        // (past the leading icon), matching Figma's icon + text-column layout.
+        Padding(
+          padding: const EdgeInsetsDirectional.only(
+            start: _iconSize + _leadingGap,
+            top: PregoSpacing.lg,
+          ),
+          child: _buildBelow(prego),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildBelow(PregoDesignSystem prego) {
+    final colors = prego.colors;
+    final supporting = supportingText;
+    final extra = additionalContent;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (supporting != null)
+          Text(
+            supporting,
+            style: prego.textTheme.textSm.medium.copyWith(color: colors.alphaWhite70),
+          ),
+        if (supporting != null && extra != null) const SizedBox(height: PregoSpacing.lg),
+        ?extra,
+      ],
+    );
+  }
+
+  Widget _buildLeading(PregoColors colors) {
+    if (_isLoading) {
+      return SizedBox.square(
+        dimension: _spinnerSize,
+        child: CircularProgressIndicator(
+          strokeWidth: 2,
+          valueColor: AlwaysStoppedAnimation<Color>(colors.buttonPrimaryIcon),
+        ),
+      );
+    }
+    return Icon(icon ?? _defaultIcon, size: _iconSize, color: _iconColor(colors));
+  }
+
+  /// Builds the trailing action cluster (secondary + primary + close), or
+  /// `null` when none of the three are present.
+  Widget? _buildActions(PregoColors colors) {
+    final primary = primaryAction;
+    final secondary = secondaryAction;
+    final close = onClose;
+    if (primary == null && secondary == null && close == null) return null;
+
+    final (hierarchy, tone) = _primaryButtonStyle;
+
+    final children = <Widget>[
+      if (secondary != null)
+        PregoButtonsSolid(
+          label: secondary.label,
+          leadingIcon: secondary.icon,
+          hierarchy: PregoButtonsSolidHierarchy.tertiary,
+          size: PregoButtonsSolidSize.sm,
+          onPressed: secondary.onPressed,
+        ),
+      if (primary != null)
+        PregoButtonsSolid(
+          label: primary.label,
+          leadingIcon: primary.icon,
+          hierarchy: hierarchy,
+          size: PregoButtonsSolidSize.sm,
+          type: tone,
+          onPressed: primary.onPressed,
+        ),
+      if (close != null)
+        PregoButtonsSolid.iconOnly(
+          leadingIcon: TablerRegular.x,
+          hierarchy: PregoButtonsSolidHierarchy.tertiary,
+          size: PregoButtonsSolidSize.sm,
+          onPressed: close,
+        ),
+    ];
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (var i = 0; i < children.length; i++) ...[
+          if (i > 0) const SizedBox(width: PregoSpacing.lg),
+          children[i],
+        ],
+      ],
+    );
+  }
+
+  Widget _accentGradient(PregoColors colors) {
+    // (centre, rim) colours with Figma's master opacity already baked in.
+    // info/loading: gray-950 @ ~12% fading to white @ ~18% (a faint top-centre
+    // vignette). success/warning/error: ~3% white fading to the accent @ 30%.
+    final (Color center, Color rim) = switch (type) {
+      PregoInlineAlertsNotificationsType.info || PregoInlineAlertsNotificationsType.loading => (
+        const Color(0x1F0C0E12),
+        const Color(0x2EFFFFFF),
+      ),
+      PregoInlineAlertsNotificationsType.success => (
+        const Color(0x08FFFFFF),
+        colors.fgSuccessSecondary.withValues(alpha: 0.30),
+      ),
+      PregoInlineAlertsNotificationsType.warning => (
+        const Color(0x08FFFFFF),
+        colors.fgWarningPrimary.withValues(alpha: 0.30),
+      ),
+      PregoInlineAlertsNotificationsType.error => (
+        const Color(0x08FFFFFF),
+        colors.fgErrorPrimary.withValues(alpha: 0.30),
+      ),
+    };
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: RadialGradient(
+          // Just below the top edge — matches Figma's gradient origin.
+          center: const Alignment(0, -0.885),
+          // Vertical reach lands the rim colour on the bottom edge.
+          radius: 0.94,
+          // Flutter has no native elliptical radial gradient, so the circle is
+          // stretched horizontally into a wide, shallow glow (~6.7x).
+          transform: const _WideEllipseGradientTransform(6.7),
+          colors: [center, rim],
+        ),
+      ),
+    );
+  }
+
+  /// Hierarchy + tone for the primary action button, per [type].
+  (PregoButtonsSolidHierarchy, PregoButtonsSolidType) get _primaryButtonStyle => switch (type) {
+    PregoInlineAlertsNotificationsType.info => (
+      PregoButtonsSolidHierarchy.primary,
+      PregoButtonsSolidType.regular,
+    ),
+    PregoInlineAlertsNotificationsType.success => (
+      PregoButtonsSolidHierarchy.primary,
+      PregoButtonsSolidType.success,
+    ),
+    PregoInlineAlertsNotificationsType.warning => (
+      PregoButtonsSolidHierarchy.primary,
+      PregoButtonsSolidType.warning,
+    ),
+    PregoInlineAlertsNotificationsType.error => (
+      PregoButtonsSolidHierarchy.primary,
+      PregoButtonsSolidType.destructive,
+    ),
+    // Loading: inverted white fill with dark text (Figma: fg-primary fill).
+    PregoInlineAlertsNotificationsType.loading => (
+      PregoButtonsSolidHierarchy.primaryAlt,
+      PregoButtonsSolidType.regular,
+    ),
+  };
+
+  IconData get _defaultIcon => switch (type) {
+    PregoInlineAlertsNotificationsType.info ||
+    // Unused for loading (a spinner is shown), but the switch is exhaustive.
+    PregoInlineAlertsNotificationsType.loading => TablerRegular.info_circle,
+    PregoInlineAlertsNotificationsType.success => TablerRegular.circle_check,
+    PregoInlineAlertsNotificationsType.warning => TablerRegular.alert_triangle,
+    PregoInlineAlertsNotificationsType.error => TablerRegular.alert_circle,
+  };
+
+  Color _iconColor(PregoColors colors) => switch (type) {
+    // Info icon is near-black (Figma: alpha-white-100). Loading is unused.
+    PregoInlineAlertsNotificationsType.info || PregoInlineAlertsNotificationsType.loading => colors.alphaWhite100,
+    PregoInlineAlertsNotificationsType.success => colors.fgSuccessSecondary,
+    PregoInlineAlertsNotificationsType.warning => colors.fgWarningSecondary,
+    PregoInlineAlertsNotificationsType.error => colors.fgErrorSecondary,
+  };
+}
+
+/// Stretches a [RadialGradient] horizontally into a wide, shallow ellipse.
+///
+/// Flutter's [RadialGradient] only draws circles; scaling the shader's local
+/// matrix about the gradient centre (the card's horizontal midpoint) turns the
+/// circular iso-colour rings into ellipses [scaleX] times wider than they are
+/// tall. The warm overlay then fans out almost horizontally, as if its centre
+/// sat far above the card — matching the Figma radial.
+class _WideEllipseGradientTransform extends GradientTransform {
+  const _WideEllipseGradientTransform(this.scaleX);
+
+  /// How many times wider than tall each iso-colour ring is drawn.
+  final double scaleX;
+
+  @override
+  Matrix4 transform(Rect bounds, {TextDirection? textDirection}) {
+    // Scale x by [scaleX] about the gradient centre (the card's mid-x). The
+    // translation term keeps that centre fixed: x' = scaleX·x + cx·(1 - scaleX).
+    final centerX = bounds.center.dx;
+    return Matrix4(
+      scaleX,
+      0,
+      0,
+      0, // column 0
+      0,
+      1,
+      0,
+      0, // column 1
+      0,
+      0,
+      1,
+      0, // column 2
+      centerX * (1 - scaleX),
+      0,
+      0,
+      1, // column 3 (translation)
+    );
+  }
+}

--- a/mobile/module_prego/lib/components/alerts/prego_popup_alerts_notifications.dart
+++ b/mobile/module_prego/lib/components/alerts/prego_popup_alerts_notifications.dart
@@ -4,17 +4,17 @@ import "../../icons/tabler_icons.g.dart";
 import "../../interactions/prego_tappable.dart";
 import "../../theme/prego_theme.dart";
 
-/// Visual variant for [PregoAlertsNotification].
+/// Visual variant for [PregoPopupAlertsNotifications].
 ///
 /// Each variant pairs a leading icon with an accent colour used for the
 /// radial gradient overlay and the icon tint.
-enum PregoAlertsNotificationVariant {
+enum PregoPopupAlertsNotificationsVariant {
   /// Error / failure — red circle-exclamation icon, error-red gradient.
   error,
 }
 
 /// A dark, gradient-tinted alert notification matching the Figma
-/// `pregoAlertsNotifications` component.
+/// `pregoPopupAlertsNotifications` component.
 ///
 /// The component renders with a fixed dark background regardless of the
 /// app's brightness — the gradient overlay and white-alpha text colours
@@ -22,7 +22,7 @@ enum PregoAlertsNotificationVariant {
 ///
 /// Usage:
 /// ```dart
-/// PregoAlertsNotification(
+/// PregoPopupAlertsNotifications(
 ///   title: 'Authentication failed',
 ///   message: 'The credentials returned by Google could not be verified. '
 ///       'Please try again.',
@@ -31,13 +31,13 @@ enum PregoAlertsNotificationVariant {
 /// ```
 ///
 /// Passing `onClose: null` hides the close button.
-class PregoAlertsNotification extends StatelessWidget {
-  const PregoAlertsNotification({
+class PregoPopupAlertsNotifications extends StatelessWidget {
+  const PregoPopupAlertsNotifications({
     super.key,
     required this.title,
     this.message,
     this.onClose,
-    this.variant = PregoAlertsNotificationVariant.error,
+    this.variant = PregoPopupAlertsNotificationsVariant.error,
   });
 
   /// Bold headline text shown on the first line.
@@ -52,8 +52,8 @@ class PregoAlertsNotification extends StatelessWidget {
   final VoidCallback? onClose;
 
   /// Controls the leading icon and accent colour. Currently only
-  /// [PregoAlertsNotificationVariant.error] is defined.
-  final PregoAlertsNotificationVariant variant;
+  /// [PregoPopupAlertsNotificationsVariant.error] is defined.
+  final PregoPopupAlertsNotificationsVariant variant;
 
   // Solid background fill — `rgb(24, 25, 27)`. Not a semantic token because
   // the alert is always rendered on a dark surface regardless of theme.
@@ -151,11 +151,11 @@ class PregoAlertsNotification extends StatelessWidget {
   }
 
   Color _resolveAccentColor({required PregoColors colors}) => switch (variant) {
-    PregoAlertsNotificationVariant.error => colors.fgErrorSecondary,
+    PregoPopupAlertsNotificationsVariant.error => colors.fgErrorSecondary,
   };
 
   IconData _resolveIcon() => switch (variant) {
-    PregoAlertsNotificationVariant.error => TablerRegular.alert_circle,
+    PregoPopupAlertsNotificationsVariant.error => TablerRegular.alert_circle,
   };
 }
 

--- a/mobile/module_prego/lib/components/buttons/prego_buttons_solid.dart
+++ b/mobile/module_prego/lib/components/buttons/prego_buttons_solid.dart
@@ -48,15 +48,39 @@ enum PregoButtonsSolidHierarchy {
   link,
 }
 
+/// Colour tone for [PregoButtonsSolid] — the colour family applied within the
+/// chosen [PregoButtonsSolidHierarchy].
+enum PregoButtonsSolidType {
+  /// Brand blue — the default.
+  regular,
+
+  /// Error red — maps to the Figma `pregoButtonsDestructiveSolid` component.
+  destructive,
+
+  /// Warning amber. Only valid with [PregoButtonsSolidHierarchy.primary] — the
+  /// only warning solid the Figma library exposes (an instance fill override on
+  /// `pregoButtonsSolid`). Mirrors the destructive primary treatment with
+  /// `bg-warning-solid` as the fill.
+  warning,
+
+  /// Success green. Only valid with [PregoButtonsSolidHierarchy.primary] — a
+  /// `bg-success-solid` instance fill override on `pregoButtonsSolid` (used by
+  /// the success `pregoInlineAlertsNotifications`). Mirrors the warning
+  /// treatment: white text + neutral darken overlays + the neutral focus ring.
+  success,
+}
+
 /// A solid-style button matching the Figma `pregoButtonsSolid` component.
 ///
 /// Supports all four [PregoButtonsSolidHierarchy] values, all four
-/// [PregoButtonsSolidSize] values, a `destructive` flag, icon-only mode,
-/// loading state, and disabled state.
+/// [PregoButtonsSolidSize] values, the [PregoButtonsSolidType] colour families,
+/// icon-only mode, loading state, and disabled state.
 ///
-/// The `destructive` flag maps to the Figma `pregoButtonsDestructiveSolid`
-/// component — it is identical to the regular solid button except that
-/// error colour tokens replace brand colour tokens.
+/// [PregoButtonsSolidType.destructive] maps to the Figma
+/// `pregoButtonsDestructiveSolid` component — identical to the brand solid button
+/// except that error colour tokens replace brand colour tokens.
+/// [PregoButtonsSolidType.warning] keeps that treatment with the warning fill and
+/// is only valid for the [PregoButtonsSolidHierarchy.primary] hierarchy.
 ///
 /// Hover and press overlays are handled by [PregoTappable] using alpha-blended
 /// tokens (`bgPrimaryHover`, `bgPrimaryPressed`, etc.) that layer on top of
@@ -77,7 +101,7 @@ enum PregoButtonsSolidHierarchy {
 ///   label: 'Delete',
 ///   hierarchy: PregoButtonsSolidHierarchy.primary,
 ///   size: PregoButtonsSolidSize.md,
-///   destructive: true,
+///   tone: PregoButtonsSolidTone.destructive,
 ///   onPressed: () {},
 /// )
 /// ```
@@ -91,11 +115,19 @@ class PregoButtonsSolid extends StatefulWidget {
     this.leadingIcon,
     this.trailingIcon,
     this.isLoading = false,
-    this.destructive = false,
+    this.type = PregoButtonsSolidType.regular,
     this.fullWidth = false,
   }) : assert(
-         hierarchy != PregoButtonsSolidHierarchy.primaryAlt || !destructive,
-         'destructive=true is not supported for primaryAlt — Figma does not define this variant.',
+         hierarchy != PregoButtonsSolidHierarchy.primaryAlt || type == PregoButtonsSolidType.regular,
+         'primaryAlt only supports the brand tone — Figma defines no destructive/warning variant for it.',
+       ),
+       assert(
+         type != PregoButtonsSolidType.warning || hierarchy == PregoButtonsSolidHierarchy.primary,
+         'The warning tone is only defined for the primary hierarchy.',
+       ),
+       assert(
+         type != PregoButtonsSolidType.success || hierarchy == PregoButtonsSolidHierarchy.primary,
+         'The success tone is only defined for the primary hierarchy.',
        ),
        iconOnly = false;
 
@@ -107,10 +139,18 @@ class PregoButtonsSolid extends StatefulWidget {
     required this.size,
     required this.onPressed,
     this.isLoading = false,
-    this.destructive = false,
+    this.type = PregoButtonsSolidType.regular,
   }) : assert(
-         hierarchy != PregoButtonsSolidHierarchy.primaryAlt || !destructive,
-         'destructive=true is not supported for primaryAlt — Figma does not define this variant.',
+         hierarchy != PregoButtonsSolidHierarchy.primaryAlt || type == PregoButtonsSolidType.regular,
+         'primaryAlt only supports the brand tone — Figma defines no destructive/warning variant for it.',
+       ),
+       assert(
+         type != PregoButtonsSolidType.warning || hierarchy == PregoButtonsSolidHierarchy.primary,
+         'The warning tone is only defined for the primary hierarchy.',
+       ),
+       assert(
+         type != PregoButtonsSolidType.success || hierarchy == PregoButtonsSolidHierarchy.primary,
+         'The success tone is only defined for the primary hierarchy.',
        ),
        iconOnly = true,
        fullWidth = false,
@@ -141,9 +181,13 @@ class PregoButtonsSolid extends StatefulWidget {
   /// even if [onPressed] is non-null.
   final bool isLoading;
 
-  /// When `true`, error colour tokens are used instead of brand colour tokens,
-  /// matching the Figma `pregoButtonsDestructiveSolid` component.
-  final bool destructive;
+  /// Colour family for the button. Defaults to [PregoButtonsSolidType.regular].
+  ///
+  /// [PregoButtonsSolidType.destructive] swaps brand tokens for error tokens (the
+  /// Figma `pregoButtonsDestructiveSolid` component); [PregoButtonsSolidType.warning]
+  /// keeps that treatment with the warning fill and is only valid with the
+  /// [PregoButtonsSolidHierarchy.primary] hierarchy.
+  final PregoButtonsSolidType type;
 
   /// Whether the button renders in icon-only mode (square, no label).
   final bool iconOnly;
@@ -161,6 +205,10 @@ class PregoButtonsSolid extends StatefulWidget {
 
 class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
   bool _isFocused = false;
+
+  bool get _isDestructive => widget.type == PregoButtonsSolidType.destructive;
+  bool get _isWarning => widget.type == PregoButtonsSolidType.warning;
+  bool get _isSuccess => widget.type == PregoButtonsSolidType.success;
 
   @override
   Widget build(BuildContext context) {
@@ -206,8 +254,7 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
           final showSkeuomorphicOverlay = switch (widget.hierarchy) {
             PregoButtonsSolidHierarchy.primary ||
             PregoButtonsSolidHierarchy.primaryAlt => !_isFocused && (!isDisabled || widget.isLoading),
-            PregoButtonsSolidHierarchy.secondary =>
-              widget.destructive ? ((!isHovered && !isPressed) || isDisabled) : true,
+            PregoButtonsSolidHierarchy.secondary => _isDestructive ? ((!isHovered && !isPressed) || isDisabled) : true,
             PregoButtonsSolidHierarchy.tertiary || PregoButtonsSolidHierarchy.link => false,
           };
           final skeuomorphicBottomColor = _isFocused && widget.hierarchy == PregoButtonsSolidHierarchy.secondary
@@ -331,12 +378,14 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
   /// Link: transparent — no hover background.
   Color _resolveHoverOverlayColor({required PregoColors colors}) {
     return switch (widget.hierarchy) {
-      PregoButtonsSolidHierarchy.primary => widget.destructive ? colors.bgDestructiveHover : colors.bgBrandHover,
+      // Warning and success reuse the destructive darken overlay (gray-alpha, tone-neutral).
+      PregoButtonsSolidHierarchy.primary =>
+        (_isDestructive || _isWarning || _isSuccess) ? colors.bgDestructiveHover : colors.bgBrandHover,
       // Primary Alt uses a translucent alpha overlay (alpha-white-10) that darkens
       // in light mode and lightens in dark mode — Figma does not define dedicated
       // hover/press background tokens for this hierarchy.
       PregoButtonsSolidHierarchy.primaryAlt => colors.alphaWhite10,
-      PregoButtonsSolidHierarchy.secondary => widget.destructive ? Colors.transparent : colors.bgGrayHover,
+      PregoButtonsSolidHierarchy.secondary => _isDestructive ? Colors.transparent : colors.bgGrayHover,
       PregoButtonsSolidHierarchy.tertiary || PregoButtonsSolidHierarchy.link => Colors.transparent,
     };
   }
@@ -350,10 +399,11 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
   /// Link: transparent — no press background.
   Color _resolvePressOverlayColor({required PregoColors colors}) {
     return switch (widget.hierarchy) {
-      PregoButtonsSolidHierarchy.primary => widget.destructive ? colors.bgDestructivePressed : colors.bgBrandPressed,
+      PregoButtonsSolidHierarchy.primary =>
+        (_isDestructive || _isWarning || _isSuccess) ? colors.bgDestructivePressed : colors.bgBrandPressed,
       // Stronger alpha overlay on press for Primary Alt (alpha-white-20).
       PregoButtonsSolidHierarchy.primaryAlt => colors.alphaWhite20,
-      PregoButtonsSolidHierarchy.secondary => widget.destructive ? Colors.transparent : colors.bgGrayPressed,
+      PregoButtonsSolidHierarchy.secondary => _isDestructive ? Colors.transparent : colors.bgGrayPressed,
       // Tertiary: bg handles pressed state directly (no overlay needed).
       PregoButtonsSolidHierarchy.tertiary || PregoButtonsSolidHierarchy.link => Colors.transparent,
     };
@@ -415,11 +465,16 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
   }
 
   Color _primaryBgColor({required PregoColors colors, required bool isEnabled}) {
-    // Disabled: bg-disabled (same for both regular and destructive).
+    // Disabled: bg-disabled (shared across all tones).
     if (!isEnabled) return colors.bgDisabled;
     // Enabled, hover, and loading all use the same base bg.
-    // Hover/press darkening is handled by PregoTappable overlay.
-    return widget.destructive ? colors.bgErrorSolid : colors.bgBrandSolid;
+    // Hover/press darkening is handled by the PregoTappable overlay.
+    return switch (widget.type) {
+      PregoButtonsSolidType.regular => colors.bgBrandSolid,
+      PregoButtonsSolidType.destructive => colors.bgErrorSolid,
+      PregoButtonsSolidType.warning => colors.bgWarningSolid,
+      PregoButtonsSolidType.success => colors.bgSuccessSolid,
+    };
   }
 
   Color _primaryAltBgColor({required PregoColors colors, required bool isEnabled}) {
@@ -444,7 +499,7 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
       return colors.bgDisabled;
     }
 
-    if (widget.destructive) {
+    if (_isDestructive) {
       // Destructive secondary: pressed and hover use opaque bg colours directly
       // (no overlay). isPressed takes priority over isHovered.
       if (isPressed) return colors.bgDestructivePressedAlt;
@@ -469,7 +524,7 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
     // Focused tertiary uses bg-primary (white) as a base.
     if (_isFocused) return colors.bgPrimary;
 
-    if (widget.destructive) {
+    if (_isDestructive) {
       // Destructive tertiary: pressed and hover use opaque bg colours directly
       // (no overlay). isPressed takes priority over isHovered.
       if (isPressed) return colors.bgDestructivePressedAlt;
@@ -493,7 +548,7 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
     // Link has no bg at rest or on hover. On press, use the same bg as tertiary
     // for consistent tap feedback across platforms (especially Android).
     if (!isPressed || !isEnabled) return Colors.transparent;
-    return widget.destructive ? colors.bgDestructivePressedAlt : colors.bgGrayPressed;
+    return _isDestructive ? colors.bgDestructivePressedAlt : colors.bgGrayPressed;
   }
 
   Border? _resolveBorder({required PregoColors colors, required Set<WidgetState> state}) {
@@ -502,7 +557,7 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
     if (isDisabled && !widget.isLoading) {
       return switch (widget.hierarchy) {
         PregoButtonsSolidHierarchy.primary =>
-          widget.destructive
+          _isDestructive
               // Destructive primary disabled: fg-disabled_subtle border.
               ? Border.all(color: colors.fgDisabledSubtle, width: 1)
               // Regular primary disabled: border-disabled.
@@ -511,7 +566,7 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
         // No destructive variant exists for primaryAlt.
         PregoButtonsSolidHierarchy.primaryAlt => Border.all(color: colors.borderDisabled, width: 1),
         PregoButtonsSolidHierarchy.secondary =>
-          widget.destructive
+          _isDestructive
               // Destructive secondary disabled: border-disabled_subtle.
               ? Border.all(color: colors.borderDisabledSubtle, width: 1)
               // Regular secondary disabled: border-disabled_subtle.
@@ -530,7 +585,7 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
         width: 2,
       ),
       PregoButtonsSolidHierarchy.secondary =>
-        widget.destructive
+        _isDestructive
             // Destructive secondary: border-error_subtle for all active states.
             ? Border.all(color: colors.borderErrorSubtle, width: 1)
             // Regular secondary: border-primary on hover/focused; border-secondary at rest.
@@ -545,10 +600,13 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
   }
 
   List<BoxShadow>? _resolveBoxShadows({required PregoColors colors, required Set<WidgetState> state}) {
-    final focusRingColor = widget.destructive ? colors.focusRingError : colors.focusRing;
+    // Warning has no dedicated focus-ring token, so it uses the neutral brand
+    // ring (the ring conveys keyboard focus, not semantic colour).
+    final focusRingColor = _isDestructive ? colors.focusRingError : colors.focusRing;
 
     // Tertiary and link: 2-layer focus ring only when focused; no drop shadow ever.
-    if (widget.hierarchy == PregoButtonsSolidHierarchy.tertiary || widget.hierarchy == PregoButtonsSolidHierarchy.link) {
+    if (widget.hierarchy == PregoButtonsSolidHierarchy.tertiary ||
+        widget.hierarchy == PregoButtonsSolidHierarchy.link) {
       if (!_isFocused) return null;
       return [
         BoxShadow(color: focusRingColor, blurRadius: 0, spreadRadius: 4),
@@ -611,7 +669,7 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
       };
     }
 
-    if (widget.destructive) {
+    if (_isDestructive) {
       return switch (widget.hierarchy) {
         // Destructive primary: always text-white.
         PregoButtonsSolidHierarchy.primary => colors.textWhite,
@@ -652,7 +710,7 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
       };
     }
 
-    if (widget.destructive) {
+    if (_isDestructive) {
       return switch (widget.hierarchy) {
         PregoButtonsSolidHierarchy.primary => colors.textWhite,
         // Unreachable — assertion in constructor blocks primaryAlt + destructive.

--- a/mobile/module_prego/lib/components/buttons/prego_buttons_solid.dart
+++ b/mobile/module_prego/lib/components/buttons/prego_buttons_solid.dart
@@ -101,7 +101,7 @@ enum PregoButtonsSolidType {
 ///   label: 'Delete',
 ///   hierarchy: PregoButtonsSolidHierarchy.primary,
 ///   size: PregoButtonsSolidSize.md,
-///   tone: PregoButtonsSolidTone.destructive,
+///   type: PregoButtonsSolidType.destructive,
 ///   onPressed: () {},
 /// )
 /// ```

--- a/mobile/module_prego/lib/module_prego.dart
+++ b/mobile/module_prego/lib/module_prego.dart
@@ -1,7 +1,8 @@
 /// Prego design system public entry point.
 library;
 
-export 'components/alerts/prego_alerts_notification.dart';
+export 'components/alerts/prego_inline_alerts_notifications.dart';
+export 'components/alerts/prego_popup_alerts_notifications.dart';
 export 'components/buttons/prego_buttons_icon_glass.dart';
 export 'icons/tabler_icons.g.dart';
 export 'icons/vespr_icons.g.dart';


### PR DESCRIPTION
## Summary

Replaces the hand-rolled bridge-offline banner with a reusable Prego inline-alert component, and reworks the Prego alert/button APIs to support it.

- **New `PregoInlineAlertsNotifications` component** — a faithful port of the Figma `pregoInlineAlertsNotifications` component. Inline alert card with `info` / `success` / `warning` / `error` / `loading` types, a leading status icon (or spinner), bold title, optional supporting text and custom content, optional primary/secondary actions and close button, and the warm radial accent glow (drawn via a custom `GradientTransform` since Flutter has no native elliptical radial gradient).
- **Bridge-offline banner refactor** (`connection_overlay.dart`) — `_BridgeOfflineBanner` now renders a `warning`-type `PregoInlineAlertsNotifications` with a **Reconnect** primary action wired to `ConnectionOverlayCubit.reconnect()`, replacing the ad-hoc `Material`/`Row` banner.
- **`PregoAlertsNotification` → `PregoPopupAlertsNotifications`** — renamed (file + class + variant enum) to disambiguate the popup alert from the new inline alert. Login screen updated to the new name.
- **`PregoButtonsSolid`: `destructive` bool → `PregoButtonsSolidType` enum** — `regular` / `destructive` / `warning` / `success` colour tones. `warning`/`success` are `primary`-hierarchy only (enforced by constructor asserts); the new inline alert uses them for its primary action fill.
- **l10n** — dropped `bridgeOfflineTitle` / `bridgeOfflineMessage` in favour of a single `bridgeDisconnectedTitle` ("Bridge disconnected"); regenerated `app_localizations*`.
- **`login_screen.dart`** — mostly re-indentation from the rename; behaviour unchanged.

## Test plan

- [ ] Bridge-offline banner renders as a warning inline alert and the **Reconnect** button triggers a reconnect.
- [ ] Login authentication-failure popup still renders (now via `PregoPopupAlertsNotifications`).
- [ ] `flutter analyze` / build is clean across `module_prego` and `app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable `PregoInlineAlertsNotifications` component and replaces the bridge‑offline overlay with a non‑blocking inline banner with no action. Renames the popup alert and updates `PregoButtonsSolid` to use typed tones.

- **New Features**
  - Added `PregoInlineAlertsNotifications` (info/success/warning/error/loading) with icon/spinner, title, optional supporting text, primary/secondary actions, close, and a soft radial glow; action buttons auto‑invert palette for legibility on the dark card.
  - Bridge‑offline banner now shows a warning inline alert with no action; reconnect is automatic when the bridge returns.

- **Migration**
  - Rename `PregoAlertsNotification` → `PregoPopupAlertsNotifications` and `PregoAlertsNotificationVariant` → `PregoPopupAlertsNotificationsVariant`; update imports/exports.
  - Update `PregoButtonsSolid`: replace `destructive: true/false` with `type: PregoButtonsSolidType.{regular|destructive|warning|success}`; `warning`/`success` only with `primary`; `primaryAlt` supports only `regular`.
  - l10n: replace `bridgeOfflineTitle`/`bridgeOfflineMessage` with `bridgeDisconnectedTitle`.

<sup>Written for commit cf276fe95dba48f4897ce45897487ee3123e08e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


<img width="439" height="213" alt="CleanShot 2026-06-18 at 19 56 11" src="https://github.com/user-attachments/assets/d4814f07-2165-451b-bee7-4506450bfd58" />
<img width="457" height="246" alt="CleanShot 2026-06-18 at 19 56 27" src="https://github.com/user-attachments/assets/4c429139-484b-4d0d-9abc-b34a7f8ae153" />

