### PR TITLE
fix(mobile): scope registered-bridges latch by account

### DIFF
--- a/mobile/module_core/lib/src/services/registered_bridges_store.dart
+++ b/mobile/module_core/lib/src/services/registered_bridges_store.dart
@@ -60,12 +60,13 @@ class RegisteredBridgesStore {
     _accountId = _accountIdOf(authSession.authStateStream.valueOrNull);
     _authSubscription = authSession.authStateStream.listen((state) {
       switch (state) {
-        case AuthAuthenticated(:final user):
-          if (user.id == _accountId) return;
+        case AuthAuthenticated(:final user) when user.id != _accountId:
           // A different account signed in: drop the previous account's
           // in-memory latch and bind to the new one.
           _accountId = user.id;
           _knownRegistered = false;
+        case AuthAuthenticated():
+          break; // same account re-emitted (e.g. token refresh) — no change
         case AuthUnauthenticated():
           // Logout: drop the in-memory latch and best-effort delete the
           // persisted one. clear() handles its own errors, so fire-and-forget.
@@ -91,7 +92,11 @@ class RegisteredBridgesStore {
     final accountId = _accountId;
     if (accountId == null) return false;
     try {
-      if (await _storage.read(key: _storageKeyFor(accountId)) == _storedValue) {
+      final hasBridges = await _storage.read(key: _storageKeyFor(accountId)) == _storedValue;
+      // The signed-in account can change while the read is in flight; only
+      // cache the result if it still applies to the current account, so a late
+      // completion can't latch one account's answer onto another.
+      if (hasBridges && accountId == _accountId) {
         _knownRegistered = true;
       }
     } catch (error, stackTrace) {

--- a/mobile/module_core/lib/src/services/registered_bridges_store.dart
+++ b/mobile/module_core/lib/src/services/registered_bridges_store.dart
@@ -25,73 +25,106 @@ import "../logging/logging.dart";
 /// bridges yet) keeps looking up until it first succeeds — at which point it
 /// latches and moves to the "turn your bridge on" flow for good.
 ///
-/// Both the in-memory flag and the persisted flag are cleared on logout (this
-/// store listens to [AuthSession.authStateStream]) so a different account
-/// signing in on the same device never inherits this one's answer.
+/// ## Per-account isolation
+///
+/// The persisted latch is keyed by the signed-in account's id, and the
+/// in-memory flag is dropped whenever the signed-in account changes (logout, or
+/// a different account signing in — the store listens to
+/// [AuthSession.authStateStream]). Scoping the key by account means one account
+/// can never read another's answer, so even a logout `delete` that fails to
+/// land cannot leak across accounts: the stale key belongs to the account that
+/// owned it, and only that account would ever read it back (correctly — it
+/// really does have a registered bridge).
 @lazySingleton
 class RegisteredBridgesStore {
-  static const _storageKey = "has_registered_bridges";
+  static const _keyPrefix = "has_registered_bridges";
   static const _storedValue = "true";
 
   final SecureStorage _storage;
   StreamSubscription<AuthState>? _authSubscription;
 
-  /// In-memory mirror of the latch. `true` once the account is known to have a
-  /// registered bridge; `false` means "not yet known" — never "no bridges".
+  /// Id of the signed-in account, or null when signed out. Seeded from the
+  /// current auth state and kept current by the auth-state subscription so the
+  /// first lookup after construction is already correctly scoped.
+  String? _accountId;
+
+  /// In-memory mirror of the latch for [_accountId]. `true` once that account
+  /// is known to have a registered bridge; `false` means "not yet known" —
+  /// never "no bridges".
   bool _knownRegistered = false;
 
   RegisteredBridgesStore({
     required SecureStorage secureStorage,
     required AuthSession authSession,
   }) : _storage = secureStorage {
+    _accountId = _accountIdOf(authSession.authStateStream.valueOrNull);
     _authSubscription = authSession.authStateStream.listen((state) {
-      // Logout: drop the latch so the next account starts from scratch.
-      // clear() handles its own errors, so this stays fire-and-forget.
-      if (state is AuthUnauthenticated) unawaited(clear());
+      switch (state) {
+        case AuthAuthenticated(:final user):
+          if (user.id == _accountId) return;
+          // A different account signed in: drop the previous account's
+          // in-memory latch and bind to the new one.
+          _accountId = user.id;
+          _knownRegistered = false;
+        case AuthUnauthenticated():
+          // Logout: drop the in-memory latch and best-effort delete the
+          // persisted one. clear() handles its own errors, so fire-and-forget.
+          unawaited(clear());
+        case AuthInitial():
+        case AuthAuthenticating():
+        case AuthFailed():
+          break;
+      }
     });
   }
 
-  /// Whether the account is already known to have a registered bridge, from the
-  /// in-memory flag or persisted storage. Reads storage at most once per app
-  /// run for the positive answer; the in-memory flag short-circuits after that.
+  static String? _accountIdOf(AuthState? state) => state is AuthAuthenticated ? state.user.id : null;
+
+  String _storageKeyFor(String accountId) => "$_keyPrefix.$accountId";
+
+  /// Whether the current account is already known to have a registered bridge,
+  /// from the in-memory flag or persisted storage. Reads storage at most once
+  /// per app run for the positive answer; the in-memory flag short-circuits
+  /// after that. Returns `false` while signed out.
   Future<bool> hasRegisteredBridges() async {
     if (_knownRegistered) return true;
+    final accountId = _accountId;
+    if (accountId == null) return false;
     try {
-      if (await _storage.read(key: _storageKey) == _storedValue) {
+      if (await _storage.read(key: _storageKeyFor(accountId)) == _storedValue) {
         _knownRegistered = true;
       }
     } catch (error, stackTrace) {
-      loge("Failed to read registered-bridges latch", error, stackTrace);
+      loge("Failed to read the registered-bridges latch", error, stackTrace);
     }
     return _knownRegistered;
   }
 
-  /// Latches the positive answer in memory and in persistent storage. A no-op
-  /// once already latched, so repeat calls cost nothing.
+  /// Latches the positive answer in memory and under the current account's key.
+  /// A no-op once already latched, or while signed out.
   Future<void> markRegistered() async {
     if (_knownRegistered) return;
+    final accountId = _accountId;
+    if (accountId == null) return;
     _knownRegistered = true;
     try {
-      await _storage.write(key: _storageKey, value: _storedValue);
+      await _storage.write(key: _storageKeyFor(accountId), value: _storedValue);
     } catch (error, stackTrace) {
-      loge("Failed to persist registered-bridges latch", error, stackTrace);
+      loge("Failed to persist the registered-bridges latch", error, stackTrace);
     }
   }
 
-  /// Clears both the persisted latch and the in-memory flag. Invoked on logout
-  /// so a different account signing in on the same device never inherits this
-  /// one's answer.
-  ///
-  /// The persisted flag is deleted first, and the in-memory flag is dropped
-  /// only after that succeeds: clearing memory first would let a concurrent
-  /// [hasRegisteredBridges] read re-hydrate the in-memory flag from the
-  /// not-yet-deleted storage value. A storage failure is logged and leaves the
-  /// flags untouched (consistent with each other) rather than throwing into the
-  /// logout listener.
+  /// Drops the in-memory flag and best-effort deletes the signing-out account's
+  /// persisted key. Invoked on logout. Because keys are account-scoped, a delete
+  /// that fails here is harmless — the lingering key can only ever be read back
+  /// by the same account, for which the answer is still correct.
   Future<void> clear() async {
+    _knownRegistered = false;
+    final accountId = _accountId;
+    _accountId = null;
+    if (accountId == null) return;
     try {
-      await _storage.delete(key: _storageKey);
-      _knownRegistered = false;
+      await _storage.delete(key: _storageKeyFor(accountId));
     } catch (error, stackTrace) {
       loge("Failed to clear the registered-bridges latch", error, stackTrace);
     }

--- a/mobile/module_core/test/services/registered_bridges_store_test.dart
+++ b/mobile/module_core/test/services/registered_bridges_store_test.dart
@@ -6,15 +6,14 @@ import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_dart_core/src/services/registered_bridges_store.dart";
 import "package:test/test.dart";
 
-/// In-memory [SecureStorage] that also records how often each operation runs,
-/// so tests can assert the in-memory cache avoids redundant storage reads.
+/// In-memory [SecureStorage] that records how often each operation runs (so
+/// tests can assert the in-memory cache avoids redundant reads) and can be told
+/// to throw, simulating a keychain failure.
 class _InMemorySecureStorage implements SecureStorage {
-  final Map<String, String> _data = {};
+  final Map<String, String> data = {};
   int reads = 0;
   int writes = 0;
   int deletes = 0;
-
-  /// When set, the matching operation throws, simulating a keychain failure.
   bool throwOnRead = false;
   bool throwOnWrite = false;
   bool throwOnDelete = false;
@@ -23,27 +22,34 @@ class _InMemorySecureStorage implements SecureStorage {
   Future<String?> read({required String key}) async {
     reads++;
     if (throwOnRead) throw Exception("read failed");
-    return _data[key];
+    return data[key];
   }
 
   @override
   Future<void> write({required String key, required String value}) async {
     writes++;
     if (throwOnWrite) throw Exception("write failed");
-    _data[key] = value;
+    data[key] = value;
   }
 
   @override
   Future<void> delete({required String key}) async {
     deletes++;
     if (throwOnDelete) throw Exception("delete failed");
-    _data.remove(key);
+    data.remove(key);
   }
 }
 
 class _MockAuthSession extends Mock implements AuthSession {}
 
-/// Lets pending microtasks (the store's unawaited clear-on-logout) settle.
+AuthUser _user(String id) => AuthUser(
+  id: id,
+  provider: AuthProvider.github,
+  providerUserId: "pid-$id",
+  providerUsername: "user-$id",
+);
+
+/// Lets pending microtasks (the store's auth-state listener) settle.
 Future<void> _settle() async {
   await Future<void>.delayed(Duration.zero);
   await Future<void>.delayed(Duration.zero);
@@ -56,7 +62,8 @@ void main() {
 
   setUp(() {
     storage = _InMemorySecureStorage();
-    authState = BehaviorSubject<AuthState>.seeded(const AuthState.initial());
+    // Default: acct-1 is signed in.
+    authState = BehaviorSubject<AuthState>.seeded(AuthState.authenticated(user: _user("acct-1")));
     authSession = _MockAuthSession();
     when(() => authSession.authStateStream).thenAnswer((_) => authState);
   });
@@ -70,17 +77,20 @@ void main() {
     authSession: authSession,
   );
 
+  String keyFor(String accountId) => "has_registered_bridges.$accountId";
+
   test("reports no registered bridges for a fresh account", () async {
     final store = buildStore();
     expect(await store.hasRegisteredBridges(), isFalse);
   });
 
-  test("markRegistered latches the answer in memory and in storage", () async {
+  test("markRegistered latches in memory and under the account's key", () async {
     final store = buildStore();
 
     await store.markRegistered();
 
     expect(await store.hasRegisteredBridges(), isTrue);
+    expect(storage.data[keyFor("acct-1")], "true");
     expect(storage.writes, 1);
   });
 
@@ -91,19 +101,18 @@ void main() {
     await store.markRegistered();
 
     expect(storage.writes, 1);
+    expect(await store.hasRegisteredBridges(), isTrue);
   });
 
   test("a persisted latch is honoured after a restart (new store instance)", () async {
-    // First run: latch the positive answer.
     await buildStore().markRegistered();
 
-    // Simulate an app restart: a brand-new store reading the same storage.
     final restarted = buildStore();
     expect(await restarted.hasRegisteredBridges(), isTrue);
   });
 
   test("the in-memory cache serves the positive answer without re-reading storage", () async {
-    storage._data["has_registered_bridges"] = "true";
+    storage.data[keyFor("acct-1")] = "true";
     final store = buildStore();
 
     expect(await store.hasRegisteredBridges(), isTrue);
@@ -113,7 +122,7 @@ void main() {
     expect(storage.reads, 1, reason: "subsequent calls are served from memory");
   });
 
-  test("logout clears both the in-memory flag and the persisted latch", () async {
+  test("logout clears the in-memory flag and the account's persisted key", () async {
     final store = buildStore();
     await store.markRegistered();
     expect(await store.hasRegisteredBridges(), isTrue);
@@ -121,9 +130,8 @@ void main() {
     authState.add(const AuthState.unauthenticated());
     await _settle();
 
-    expect(storage._data.containsKey("has_registered_bridges"), isFalse);
-    expect(storage.deletes, greaterThanOrEqualTo(1));
-    expect(await store.hasRegisteredBridges(), isFalse);
+    expect(storage.data.containsKey(keyFor("acct-1")), isFalse);
+    expect(await store.hasRegisteredBridges(), isFalse, reason: "signed out -> no account");
   });
 
   test("non-logout auth states leave the latch untouched", () async {
@@ -139,8 +147,64 @@ void main() {
     expect(await store.hasRegisteredBridges(), isTrue);
   });
 
+  // ---------------------------------------------------------------------------
+  // Per-account isolation — the heart of the review feedback.
+  // ---------------------------------------------------------------------------
+
+  test("a different account does not inherit the previous account's latch", () async {
+    final store = buildStore();
+    await store.markRegistered(); // acct-1 latched
+    expect(storage.data[keyFor("acct-1")], "true");
+
+    authState.add(AuthState.authenticated(user: _user("acct-2")));
+    await _settle();
+
+    expect(await store.hasRegisteredBridges(), isFalse, reason: "acct-2 reads its own (empty) key");
+  });
+
+  test("a failed logout delete cannot leak the latch to a different account", () async {
+    final store = buildStore();
+    await store.markRegistered(); // acct-1 latched + persisted
+    storage.throwOnDelete = true;
+
+    // Logout: the delete throws and is swallowed, so acct-1's key lingers.
+    authState.add(const AuthState.unauthenticated());
+    await _settle();
+    expect(storage.data[keyFor("acct-1")], "true", reason: "delete failed, the key remains");
+
+    // A different account signs in on the same device, same app session.
+    authState.add(AuthState.authenticated(user: _user("acct-2")));
+    await _settle();
+
+    expect(
+      await store.hasRegisteredBridges(),
+      isFalse,
+      reason: "acct-2 reads has_registered_bridges.acct-2, never acct-1's stale key",
+    );
+  });
+
+  test("the same account keeps its latch after a failed logout delete and re-login", () async {
+    final store = buildStore();
+    await store.markRegistered();
+    storage.throwOnDelete = true;
+
+    authState.add(const AuthState.unauthenticated());
+    await _settle();
+
+    // acct-1 signs back in; its key survived the failed delete, which is
+    // correct — acct-1 really does have a registered bridge.
+    authState.add(AuthState.authenticated(user: _user("acct-1")));
+    await _settle();
+
+    expect(await store.hasRegisteredBridges(), isTrue);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Storage failure paths.
+  // ---------------------------------------------------------------------------
+
   test("a storage read failure fails soft to false", () async {
-    storage._data["has_registered_bridges"] = "true";
+    storage.data[keyFor("acct-1")] = "true";
     storage.throwOnRead = true;
     final store = buildStore();
 
@@ -153,20 +217,7 @@ void main() {
 
     await store.markRegistered(); // must not throw
     expect(await store.hasRegisteredBridges(), isTrue, reason: "in-memory latch holds");
-    expect(storage._data.containsKey("has_registered_bridges"), isFalse, reason: "nothing persisted");
-  });
-
-  test("a storage delete failure on logout is swallowed and leaves the flags consistent", () async {
-    final store = buildStore();
-    await store.markRegistered();
-    storage.throwOnDelete = true;
-
-    // Direct call must not throw…
-    await store.clear();
-    // …and, since the delete failed, the in-memory flag is not cleared ahead of
-    // storage — both still report the (un-deleted) positive latch.
-    expect(await store.hasRegisteredBridges(), isTrue);
-    expect(storage._data["has_registered_bridges"], "true");
+    expect(storage.data.containsKey(keyFor("acct-1")), isFalse, reason: "nothing persisted");
   });
 
   test("a delete failure routed through the logout listener does not throw", () async {
@@ -174,22 +225,10 @@ void main() {
     await store.markRegistered();
     storage.throwOnDelete = true;
 
-    // The listener calls clear() fire-and-forget; a throwing delete must be
-    // caught inside clear() rather than surfacing as an uncaught async error.
     authState.add(const AuthState.unauthenticated());
     await _settle();
 
-    expect(await store.hasRegisteredBridges(), isTrue);
-  });
-
-  test("a new account can latch again after a logout cleared the previous one", () async {
-    final store = buildStore();
-    await store.markRegistered();
-    authState.add(const AuthState.unauthenticated());
-    await _settle();
+    // No uncaught async error; signed out, so there is no account to report.
     expect(await store.hasRegisteredBridges(), isFalse);
-
-    await store.markRegistered();
-    expect(await store.hasRegisteredBridges(), isTrue);
   });
 }

--- a/mobile/module_core/test/services/registered_bridges_store_test.dart
+++ b/mobile/module_core/test/services/registered_bridges_store_test.dart
@@ -18,10 +18,15 @@ class _InMemorySecureStorage implements SecureStorage {
   bool throwOnWrite = false;
   bool throwOnDelete = false;
 
+  /// When set, `read` blocks on this until completed — lets a test interleave
+  /// an account switch with an in-flight read.
+  Completer<void>? readGate;
+
   @override
   Future<String?> read({required String key}) async {
     reads++;
     if (throwOnRead) throw Exception("read failed");
+    if (readGate != null) await readGate!.future;
     return data[key];
   }
 
@@ -181,6 +186,28 @@ void main() {
       isFalse,
       reason: "acct-2 reads has_registered_bridges.acct-2, never acct-1's stale key",
     );
+  });
+
+  test("an account switch during an in-flight read does not cache for the new account", () async {
+    storage.data[keyFor("acct-1")] = "true";
+    final gate = Completer<void>();
+    storage.readGate = gate;
+    final store = buildStore(); // acct-1 signed in
+
+    // Start the read for acct-1; it suspends on the gate.
+    final pending = store.hasRegisteredBridges();
+
+    // acct-2 signs in while acct-1's read is still in flight.
+    authState.add(AuthState.authenticated(user: _user("acct-2")));
+    await _settle();
+
+    // acct-1's read now completes with "true".
+    gate.complete();
+    expect(await pending, isFalse, reason: "acct-1's late result must not latch onto acct-2");
+
+    // acct-2's own lookup reads its own (empty) key — not a stale cached flag.
+    storage.readGate = null;
+    expect(await store.hasRegisteredBridges(), isFalse);
   });
 
   test("the same account keeps its latch after a failed logout delete and re-login", () async {


### PR DESCRIPTION
Follow-up to #291, addressing a per-account isolation issue flagged by the `cubic-dev-ai` review on the merged store.

## Problem
`RegisteredBridgesStore` persisted its "has registered bridges" latch under a **single global key** and deleted it on logout only on a best-effort basis. On the failure path this broke per-account isolation:

- If the logout `SecureStorage.delete()` threw, the persisted `"true"` survived.
- The latch short-circuits the network, so it **never self-heals**.
- A *different* account signing in on the same device (same app session, or after a restart) would then read that stale `"true"` and be shown the **"turn your bridge on"** view instead of the **setup onboarding** — indefinitely.

Low likelihood (keychain `delete` rarely throws + multi-account-same-device), but persistent and confusing when it happens.

## Fix
- Scope the persisted key by the signed-in account id: `has_registered_bridges.<accountId>`.
- Drop the in-memory flag whenever the signed-in account changes (logout, or a different account signing in — the store already listens to `AuthSession.authStateStream`).
- Seed the account id from the current auth state in the constructor so the first lookup is already correctly scoped.

A different account now always reads its own key, so a failed logout delete can no longer leak across accounts: the lingering key belongs to the account that owned it, and only that account would read it back — for which the answer is still correct (it really does have a registered bridge).

## Tests
Adds coverage for:
- cross-account isolation (a different account doesn't inherit the latch),
- isolation that holds even across a **failed** logout delete,
- same-account re-login after a failed delete (latch correctly preserved),
- storage read / write / delete failure paths (fail soft, no uncaught errors).

All 401 `module_core` tests pass; analyzer clean. No app-side changes — the store's public API and constructor signature are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes per-account isolation for the registered-bridges latch on mobile. Prevents cross-account leakage and guards against mid-read account switches that could skip onboarding after a logout delete failure.

- **Bug Fixes**
  - Persist latch under an account-scoped key: `has_registered_bridges.<accountId>`.
  - Reset the in-memory latch when the signed-in account changes; best-effort delete the persisted key on logout.
  - Seed the current account id from auth state so the first read is scoped; return false while signed out.
  - Do not cache a read result if the account changes while the storage read is in flight.

<sup>Written for commit a7aee94952cacfe0da7ab8552cbcea826f6bc8e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

