### PR TITLE
fix(mobile): auto-connect when the bridge comes online while the app waits

### DIFF
--- a/mobile/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/mobile/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -9,38 +9,13 @@ import "package:web_socket_channel/web_socket_channel.dart";
 import "../../logging/logging.dart";
 import "room_key_storage.dart";
 
-enum RelayClientConnectionState {
-  disconnected,
-  connecting,
-  connected,
-
-  /// Socket + auth are established and held open, but no bridge is in the
-  /// account group yet, so there is no E2E session. [RelayClient.isConnected]
-  /// stays false in this state — callers must not route requests until a bridge
-  /// appears and the key exchange completes.
-  bridgeOffline,
-  disconnecting,
-}
+/// Transport state of the relay WebSocket. This is deliberately about the
+/// socket only — it carries no notion of bridge presence or plugin status,
+/// which are tracked separately ([BridgeStatus] / the session encryptor).
+enum RelayClientConnectionState { disconnected, connecting, connected, disconnecting }
 
 /// Represents whether the bridge (desktop process) is reachable via the relay.
 enum BridgeStatus { online, offline }
-
-/// Outcome of a [RelayClient.connect] attempt.
-///
-/// The relay accepts and holds a phone socket open even when no bridge is in
-/// the account group yet, so a successful socket + auth handshake does not by
-/// itself mean an end-to-end session with a bridge was established.
-enum RelayConnectOutcome {
-  /// Socket established AND the E2E key exchange (or resume) with the bridge
-  /// completed — the client is ready for encrypted requests.
-  connected,
-
-  /// Socket established and authenticated, but no bridge is currently in the
-  /// account group, so the E2E key exchange could not complete. The socket is
-  /// kept open; the relay pushes a bridge_connected control frame when a bridge
-  /// appears, at which point a fresh handshake can run.
-  bridgeAbsent,
-}
 
 class RelayClient {
   final String relayHost;
@@ -79,7 +54,13 @@ class RelayClient {
        _roomKeyStorage = roomKeyStorage;
 
   RelayClientConnectionState get connectionState => _connectionState;
-  bool get isConnected => _connectionState == RelayClientConnectionState.connected;
+
+  /// True only when the socket is up AND an end-to-end session is established.
+  /// While the socket is held open with no bridge present (the bridge-absent
+  /// park), there is no session encryptor, so this stays false and callers
+  /// (e.g. RelayHttpApiClient) must not route requests through it.
+  bool get isConnected =>
+      _connectionState == RelayClientConnectionState.connected && _sessionEncryptor != null;
   bool get didResume => _didResume;
 
   /// Stream of bridge online/offline events sent as text control frames by the relay.
@@ -91,15 +72,18 @@ class RelayClient {
   /// stream to surface the drop.
   Stream<void> get onSocketClosed => _socketClosedController.stream;
 
-  Future<RelayConnectOutcome> connect() async {
+  /// Connects and authenticates to the relay. Returns normally whether or not a
+  /// bridge is present — inspect [isConnected] afterwards: true means the E2E
+  /// session with a bridge is established; false means the socket is held open
+  /// but no bridge is in the account group yet (the relay pushes a
+  /// bridge_connected control frame when one appears). Throws only on a genuine
+  /// connection failure.
+  Future<void> connect() async {
     if (_disposed) {
       throw StateError("RelayClient is disposed");
     }
     if (_connectionState == RelayClientConnectionState.connected) {
-      return RelayConnectOutcome.connected;
-    }
-    if (_connectionState == RelayClientConnectionState.bridgeOffline) {
-      return RelayConnectOutcome.bridgeAbsent;
+      return;
     }
     if (_connectionState == RelayClientConnectionState.connecting) {
       throw StateError("RelayClient is already connecting");
@@ -156,11 +140,11 @@ class RelayClient {
       if (storedRoomKeyBytes != null) {
         final resumed = await _tryResume(storedRoomKeyBytes);
         if (resumed) {
-          if (_disposed) return RelayConnectOutcome.connected;
+          if (_disposed) return;
           _connectionState = RelayClientConnectionState.connected;
           _didResume = true;
           logd("Relay resumed with stored room key");
-          return RelayConnectOutcome.connected;
+          return;
         }
         // Resume failed (rekey_required or decryption error); room key was cleared.
         // Reset the completer so the DH flow can capture the bridge's response.
@@ -171,27 +155,28 @@ class RelayClient {
       await _performKeyExchange();
 
       if (_disposed) {
-        return RelayConnectOutcome.connected;
+        return;
       }
 
       _connectionState = RelayClientConnectionState.connected;
       logd("Relay key exchange complete, room key persisted");
-      return RelayConnectOutcome.connected;
+      return;
     } on _BridgeOfflineDuringHandshake {
       // The relay authenticated us and is holding the socket open, but no bridge
       // is in the account group yet, so the E2E key exchange cannot complete.
-      // Keep the socket alive (do NOT tear it down) and report bridge-absent so
-      // ConnectionService can park in ConnectionBridgeOffline and let the relay's
-      // bridge_connected control frame drive a reconnect when a bridge appears.
-      if (_disposed) return RelayConnectOutcome.bridgeAbsent;
-      // Socket + auth are up but there is no E2E session yet, so isConnected
-      // stays false — RelayHttpApiClient won't route requests through this
-      // half-open client until a bridge appears and the key exchange completes.
-      _connectionState = RelayClientConnectionState.bridgeOffline;
-      // Re-arm the binary completer so a later handshake can run on this socket.
-      _firstBinaryMessage = Completer<Uint8List>();
+      // Keep the socket alive (do NOT tear it down): the transport state stays
+      // `connected`, but with no session encryptor [isConnected] is false, so
+      // ConnectionService parks in ConnectionBridgeOffline and the relay's
+      // bridge_connected control frame drives recovery when a bridge appears.
+      if (_disposed) return;
+      _connectionState = RelayClientConnectionState.connected;
+      // Clear the handshake completer: nothing awaits it while parked, and
+      // recovery builds a fresh RelayClient, so it is never reused. Leaving it
+      // armed would let a later bridge_disconnected or socket-close complete an
+      // unobserved future, surfacing as an uncaught async error.
+      _firstBinaryMessage = null;
       logd("Relay connected but bridge is offline — holding socket open");
-      return RelayConnectOutcome.bridgeAbsent;
+      return;
     } catch (error, stackTrace) {
       loge("Failed to connect relay client", error, stackTrace);
       await _teardownChannelOnly();

--- a/mobile/module_core/lib/src/capabilities/relay/relay_client.dart
+++ b/mobile/module_core/lib/src/capabilities/relay/relay_client.dart
@@ -9,10 +9,38 @@ import "package:web_socket_channel/web_socket_channel.dart";
 import "../../logging/logging.dart";
 import "room_key_storage.dart";
 
-enum RelayClientConnectionState { disconnected, connecting, connected, disconnecting }
+enum RelayClientConnectionState {
+  disconnected,
+  connecting,
+  connected,
+
+  /// Socket + auth are established and held open, but no bridge is in the
+  /// account group yet, so there is no E2E session. [RelayClient.isConnected]
+  /// stays false in this state — callers must not route requests until a bridge
+  /// appears and the key exchange completes.
+  bridgeOffline,
+  disconnecting,
+}
 
 /// Represents whether the bridge (desktop process) is reachable via the relay.
 enum BridgeStatus { online, offline }
+
+/// Outcome of a [RelayClient.connect] attempt.
+///
+/// The relay accepts and holds a phone socket open even when no bridge is in
+/// the account group yet, so a successful socket + auth handshake does not by
+/// itself mean an end-to-end session with a bridge was established.
+enum RelayConnectOutcome {
+  /// Socket established AND the E2E key exchange (or resume) with the bridge
+  /// completed — the client is ready for encrypted requests.
+  connected,
+
+  /// Socket established and authenticated, but no bridge is currently in the
+  /// account group, so the E2E key exchange could not complete. The socket is
+  /// kept open; the relay pushes a bridge_connected control frame when a bridge
+  /// appears, at which point a fresh handshake can run.
+  bridgeAbsent,
+}
 
 class RelayClient {
   final String relayHost;
@@ -30,6 +58,7 @@ class RelayClient {
   Completer<Uint8List>? _firstBinaryMessage;
 
   final StreamController<BridgeStatus> _bridgeStatusController = StreamController<BridgeStatus>.broadcast();
+  final StreamController<void> _socketClosedController = StreamController<void>.broadcast();
 
   RelayClientConnectionState _connectionState = RelayClientConnectionState.disconnected;
   bool _disposed = false;
@@ -56,12 +85,21 @@ class RelayClient {
   /// Stream of bridge online/offline events sent as text control frames by the relay.
   Stream<BridgeStatus> get bridgeStatus => _bridgeStatusController.stream;
 
-  Future<void> connect() async {
+  /// Fires once when the underlying socket closes unexpectedly (not via an
+  /// explicit [disconnect]). Used by ConnectionService to detect a dropped
+  /// socket while parked in the bridge-offline state, where there is no SSE
+  /// stream to surface the drop.
+  Stream<void> get onSocketClosed => _socketClosedController.stream;
+
+  Future<RelayConnectOutcome> connect() async {
     if (_disposed) {
       throw StateError("RelayClient is disposed");
     }
     if (_connectionState == RelayClientConnectionState.connected) {
-      return;
+      return RelayConnectOutcome.connected;
+    }
+    if (_connectionState == RelayClientConnectionState.bridgeOffline) {
+      return RelayConnectOutcome.bridgeAbsent;
     }
     if (_connectionState == RelayClientConnectionState.connecting) {
       throw StateError("RelayClient is already connecting");
@@ -118,11 +156,11 @@ class RelayClient {
       if (storedRoomKeyBytes != null) {
         final resumed = await _tryResume(storedRoomKeyBytes);
         if (resumed) {
-          if (_disposed) return;
+          if (_disposed) return RelayConnectOutcome.connected;
           _connectionState = RelayClientConnectionState.connected;
           _didResume = true;
           logd("Relay resumed with stored room key");
-          return;
+          return RelayConnectOutcome.connected;
         }
         // Resume failed (rekey_required or decryption error); room key was cleared.
         // Reset the completer so the DH flow can capture the bridge's response.
@@ -133,11 +171,27 @@ class RelayClient {
       await _performKeyExchange();
 
       if (_disposed) {
-        return;
+        return RelayConnectOutcome.connected;
       }
 
       _connectionState = RelayClientConnectionState.connected;
       logd("Relay key exchange complete, room key persisted");
+      return RelayConnectOutcome.connected;
+    } on _BridgeOfflineDuringHandshake {
+      // The relay authenticated us and is holding the socket open, but no bridge
+      // is in the account group yet, so the E2E key exchange cannot complete.
+      // Keep the socket alive (do NOT tear it down) and report bridge-absent so
+      // ConnectionService can park in ConnectionBridgeOffline and let the relay's
+      // bridge_connected control frame drive a reconnect when a bridge appears.
+      if (_disposed) return RelayConnectOutcome.bridgeAbsent;
+      // Socket + auth are up but there is no E2E session yet, so isConnected
+      // stays false — RelayHttpApiClient won't route requests through this
+      // half-open client until a bridge appears and the key exchange completes.
+      _connectionState = RelayClientConnectionState.bridgeOffline;
+      // Re-arm the binary completer so a later handshake can run on this socket.
+      _firstBinaryMessage = Completer<Uint8List>();
+      logd("Relay connected but bridge is offline — holding socket open");
+      return RelayConnectOutcome.bridgeAbsent;
     } catch (error, stackTrace) {
       loge("Failed to connect relay client", error, stackTrace);
       await _teardownChannelOnly();
@@ -197,6 +251,11 @@ class RelayClient {
       throw FormatException(
         "Unexpected first byte in resume response: 0x${responseBytes.first.toRadixString(16)}",
       );
+    } on _BridgeOfflineDuringHandshake {
+      // The bridge is offline (not a resume failure). Preserve the stored room
+      // key — a later resume against the returning bridge may still succeed —
+      // and let connect() resolve into the bridge-absent outcome.
+      rethrow;
     } catch (error, stackTrace) {
       loge("Resume failed, clearing room key and falling back to DH key exchange", error, stackTrace);
       await _roomKeyStorage.clearRoomKey();
@@ -333,6 +392,7 @@ class RelayClient {
     await _teardownChannelOnly();
     await _closeSseController();
     await _closeBridgeStatusController();
+    await _closeSocketClosedController();
     _completeAllPendingWithError(StateError("Relay disconnected"));
     _sessionEncryptor = null;
     _connectionState = RelayClientConnectionState.disconnected;
@@ -419,6 +479,8 @@ class RelayClient {
     } else {
       logw("Relay socket closed with terminal closeCode=$closeCode");
     }
+
+    _notifySocketClosed();
   }
 
   Future<void> _sendEncryptedMessage(RelayMessage message) async {
@@ -524,6 +586,24 @@ class RelayClient {
     }
   }
 
+  Future<void> _closeSocketClosedController() async {
+    if (_socketClosedController.isClosed) return;
+    try {
+      await _socketClosedController.close();
+    } catch (error, stackTrace) {
+      loge("Failed to close relay socket-closed controller", error, stackTrace);
+    }
+  }
+
+  /// Emitted from [_onSocketDone] when the socket closes unexpectedly. A
+  /// deliberate [disconnect] sets [_disposed] first and cancels the stream
+  /// subscription, so this never fires for an intentional teardown.
+  void _notifySocketClosed() {
+    if (_disposed) return;
+    if (_socketClosedController.isClosed) return;
+    _socketClosedController.add(null);
+  }
+
   /// Handles text frames from the relay. These are plaintext JSON control messages
   /// (not E2EE) sent by the relay itself, e.g. bridge_connected / bridge_disconnected.
   void _onTextFrame(String message) {
@@ -539,9 +619,10 @@ class RelayClient {
           logd("Relay: bridge went offline");
           final firstBinaryMessage = _firstBinaryMessage;
           if (firstBinaryMessage != null && !firstBinaryMessage.isCompleted) {
-            firstBinaryMessage.completeError(
-              StateError("Bridge is offline - cannot complete key exchange"),
-            );
+            // Bridge absent during the handshake. Signal a distinct, non-fatal
+            // outcome so connect() keeps the socket open and waits for a later
+            // bridge_connected instead of tearing the socket down.
+            firstBinaryMessage.completeError(const _BridgeOfflineDuringHandshake());
           }
           _bridgeStatusController.add(BridgeStatus.offline);
         default:
@@ -562,4 +643,13 @@ class RelayClient {
       }
     }
   }
+}
+
+/// Internal signal that the relay reported the bridge offline during the
+/// initial handshake (no bridge in the account group yet). Distinct from a
+/// fatal connection error so [RelayClient.connect] resolves into
+/// [RelayConnectOutcome.bridgeAbsent] and keeps the socket open instead of
+/// tearing it down.
+class _BridgeOfflineDuringHandshake implements Exception {
+  const _BridgeOfflineDuringHandshake();
 }

--- a/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -266,7 +266,7 @@ class ConnectionService {
     }
 
     try {
-      final outcome = await relayClient.connect();
+      await relayClient.connect();
 
       // If this attempt was superseded while the websocket handshake awaited,
       // stop before sending health on a socket that a newer attempt now owns.
@@ -276,15 +276,16 @@ class ConnectionService {
         return ApiResponse.error(ApiError.generic());
       }
 
-      // The relay accepted and is holding our socket open, but no bridge is in
-      // the account group yet, so no E2E session exists. Commit the socket and
-      // arm the bridge-status watcher, skipping the health probe (no session
-      // encryptor) and SSE (needs the room key). When a bridge appears the relay
-      // pushes bridge_connected; _subscribeBridgeStatus then drives a reconnect
-      // that runs a fresh key exchange — the same recovery path as a bridge that
-      // drops after a live connection. No await runs between the staleness check
-      // above and this commit, so there is no superseding race to re-check.
-      if (outcome == RelayConnectOutcome.bridgeAbsent) {
+      // connect() returned but isConnected is false: the relay accepted and is
+      // holding our socket open, but no bridge is in the account group yet, so
+      // no E2E session exists. Commit the socket and arm the bridge-status
+      // watcher, skipping the health probe (no session encryptor) and SSE (needs
+      // the room key). When a bridge appears the relay pushes bridge_connected;
+      // _subscribeBridgeStatus then drives a reconnect that runs a fresh key
+      // exchange — the same recovery path as a bridge that drops after a live
+      // connection. No await runs between the staleness check above and this
+      // commit, so there is no superseding race to re-check.
+      if (!relayClient.isConnected) {
         const bridgeOfflineHealth = HealthResponse(healthy: true, version: "");
         _clearConnectingRelayClient(relayClient);
         _relayClient = relayClient;
@@ -435,7 +436,11 @@ class ConnectionService {
           case BridgeStatus.online:
             if (_status.value is ConnectionBridgeOffline) {
               logd("Bridge came back online — reconnecting to re-establish encryption");
-              unawaited(_reconnectRelayWithRefresh(config));
+              // immediate: the bridge is provably present and the parked (or
+              // stale) socket needs replacing now, so skip the reconnect backoff
+              // delay. Backoff still applies to genuinely failed retries, so a
+              // flapping bridge is not hammered.
+              unawaited(_reconnectRelayWithRefresh(config, immediate: true));
             }
           case BridgeStatus.offline:
             if (_status.value is ConnectionConnected) {

--- a/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -284,8 +284,12 @@ class ConnectionService {
       // _subscribeBridgeStatus then drives a reconnect that runs a fresh key
       // exchange — the same recovery path as a bridge that drops after a live
       // connection. No await runs between the staleness check above and this
-      // commit, so there is no superseding race to re-check.
-      if (!relayClient.isConnected) {
+      // commit, so there is no superseding race to re-check. Gate on the
+      // transport state being `connected` too: a bridge-absent park sets the
+      // state to connected with no session encryptor, whereas a disposed/early
+      // return leaves it in `connecting` — only the former should park here.
+      if (relayClient.connectionState == RelayClientConnectionState.connected &&
+          !relayClient.isConnected) {
         const bridgeOfflineHealth = HealthResponse(healthy: true, version: "");
         _clearConnectingRelayClient(relayClient);
         _relayClient = relayClient;

--- a/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
+++ b/mobile/module_core/lib/src/capabilities/server_connection/connection_service.dart
@@ -63,6 +63,7 @@ class ConnectionService {
   RelayClient? _connectingRelayClient;
   StreamSubscription<RelaySseEvent>? _relaySseSubscription;
   StreamSubscription<BridgeStatus>? _bridgeStatusSubscription;
+  StreamSubscription<void>? _socketClosedSubscription;
   Timer? _reconnectTimer;
   Completer<void>? _reconnectDelayCompleter;
   Future<bool>? _activeAuthConnect;
@@ -265,7 +266,7 @@ class ConnectionService {
     }
 
     try {
-      await relayClient.connect();
+      final outcome = await relayClient.connect();
 
       // If this attempt was superseded while the websocket handshake awaited,
       // stop before sending health on a socket that a newer attempt now owns.
@@ -273,6 +274,36 @@ class ConnectionService {
         _clearConnectingRelayClient(relayClient);
         await relayClient.disconnect();
         return ApiResponse.error(ApiError.generic());
+      }
+
+      // The relay accepted and is holding our socket open, but no bridge is in
+      // the account group yet, so no E2E session exists. Commit the socket and
+      // arm the bridge-status watcher, skipping the health probe (no session
+      // encryptor) and SSE (needs the room key). When a bridge appears the relay
+      // pushes bridge_connected; _subscribeBridgeStatus then drives a reconnect
+      // that runs a fresh key exchange — the same recovery path as a bridge that
+      // drops after a live connection. No await runs between the staleness check
+      // above and this commit, so there is no superseding race to re-check.
+      if (outcome == RelayConnectOutcome.bridgeAbsent) {
+        const bridgeOfflineHealth = HealthResponse(healthy: true, version: "");
+        _clearConnectingRelayClient(relayClient);
+        _relayClient = relayClient;
+        _authRetryCount = 0;
+        _relayReconnectBackoff = const Duration(seconds: 1);
+        try {
+          _subscribeBridgeStatus(
+            relayClient: relayClient,
+            config: config,
+            health: bridgeOfflineHealth,
+          );
+          _watchSocketClosedWhileBridgeOffline(relayClient);
+        } catch (error, stackTrace) {
+          loge("Failed to set up watchers after bridge-absent relay connect", error, stackTrace);
+          await _disconnectRelayClient();
+          return ApiResponse.error(ApiError.generic());
+        }
+        _status.add(ConnectionStatus.bridgeOffline(config: config, health: bridgeOfflineHealth));
+        return ApiResponse.success(bridgeOfflineHealth);
       }
 
       // A resume_ack already proves the bridge is reachable; only fresh-DH
@@ -419,6 +450,23 @@ class ConnectionService {
     );
   }
 
+  /// While parked in [ConnectionBridgeOffline] with no SSE stream (the bridge
+  /// never came online, so there is no room key and no SSE subscription), the
+  /// SSE drop handler that normally detects a dead socket is absent. Watch the
+  /// relay socket directly so a relay restart or network drop while waiting is
+  /// recovered the same way an SSE drop would be.
+  void _watchSocketClosedWhileBridgeOffline(RelayClient relayClient) {
+    _socketClosedSubscription = relayClient.onSocketClosed.listen(
+      (_) {
+        logd("Relay socket closed while bridge offline — handling as a connection drop");
+        _onRelayConnectionDrop();
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        loge("Relay socket-closed stream error", error, stackTrace);
+      },
+    );
+  }
+
   void _onSseData(String rawData) {
     if (rawData.isEmpty) return;
 
@@ -506,6 +554,13 @@ class ConnectionService {
     }
     _bridgeStatusSubscription = null;
 
+    try {
+      await _socketClosedSubscription?.cancel();
+    } catch (error, stackTrace) {
+      loge("Failed to cancel relay socket-closed subscription", error, stackTrace);
+    }
+    _socketClosedSubscription = null;
+
     if (relayClient == null && connectingRelayClient == null) {
       return;
     }
@@ -549,15 +604,17 @@ class ConnectionService {
     // almost certainly a dead socket, so reconnect proactively rather than
     // discovering it later via a request timeout.
     //
-    // ConnectionBridgeOffline is deliberately NOT treated as stale here: while
-    // the bridge is offline the E2E handshake cannot complete, so a forced
-    // reconnect would fail and drop us into the blocking ConnectionLost state,
-    // losing the watcher for the bridge's return. Bridge-offline recovery keeps
-    // relying on its relay status watcher and the socket's own drop (onDone).
-    // Re-establishing a relay-level watcher without a completed handshake is a
-    // separate, larger change (tracked in the reconnect UX plan).
+    // ConnectionBridgeOffline is treated the same way: while parked waiting for
+    // the bridge, the relay can reap our backgrounded socket and with it the
+    // bridge-status watcher, so on resume that watcher can no longer be trusted
+    // to fire. Reconnecting re-establishes a live socket; if the bridge is still
+    // offline the attempt lands back in ConnectionBridgeOffline (a successful
+    // bridge-absent connect, not a failure), so this no longer risks dropping
+    // into the blocking ConnectionLost state the way it would have before the
+    // bridge-absent connect path existed.
     final connectionLikelyStale =
-        status is ConnectionConnected && backgroundedFor >= _resumeReconnectThreshold;
+        (status is ConnectionConnected || status is ConnectionBridgeOffline) &&
+        backgroundedFor >= _resumeReconnectThreshold;
 
     final needsReconnect =
         status is ConnectionLost || status is ConnectionReconnecting || connectionLikelyStale;

--- a/mobile/module_core/test/capabilities/connection_service_stale_test.dart
+++ b/mobile/module_core/test/capabilities/connection_service_stale_test.dart
@@ -280,7 +280,7 @@ void main() {
       addTearDown(sseController.close);
 
       final relayClient = MockRelayClient();
-      when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
+      when(relayClient.connect).thenAnswer((_) async {});
       when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.isConnected).thenReturn(true);
       when(() => relayClient.sendRequest(any())).thenAnswer(

--- a/mobile/module_core/test/capabilities/connection_service_stale_test.dart
+++ b/mobile/module_core/test/capabilities/connection_service_stale_test.dart
@@ -253,11 +253,13 @@ void main() {
       expect(service.currentStatus, isA<ConnectionConnected>());
     });
 
-    test("does NOT proactively reconnect on resume while bridge offline", () async {
-      // While the bridge is offline the E2E handshake cannot complete, so a
-      // forced reconnect would fail into the blocking ConnectionLost state.
-      // Bridge-offline recovery instead relies on its relay watcher / socket
-      // drop, so resume must leave the status untouched.
+    test("proactively reconnects on resume when a parked bridge-offline socket is likely stale", () async {
+      // A backgrounded phone's relay socket is reaped by the relay, taking the
+      // bridge-status watcher with it, so on resume past the staleness threshold
+      // that watcher can no longer be trusted. We proactively reconnect to
+      // re-establish a live socket; because a bridge-absent connect now succeeds
+      // (re-parking in ConnectionBridgeOffline) rather than failing, this no
+      // longer risks dropping into the blocking ConnectionLost state.
       service.emitStatusForTesting(const ConnectionStatus.bridgeOffline(config: config, health: health));
 
       lifecycleController.add(LifecycleState.paused);
@@ -266,7 +268,11 @@ void main() {
       lifecycleController.add(LifecycleState.resumed);
       await flush();
 
-      expect(service.currentStatus, isA<ConnectionBridgeOffline>());
+      // The reconnect is in flight, parked at the held token refresh (the group
+      // setUp holds getFreshAccessToken pending), so status reads as reconnecting
+      // rather than sitting passively in bridge-offline on a dead socket.
+      expect(service.currentStatus, isA<ConnectionReconnecting>());
+      verify(() => authTokenProvider.getFreshAccessToken(minTtl: any(named: "minTtl"))).called(1);
     });
 
     test("detaches the stale relay client on resume so requests stop using the dead socket", () async {
@@ -274,7 +280,7 @@ void main() {
       addTearDown(sseController.close);
 
       final relayClient = MockRelayClient();
-      when(relayClient.connect).thenAnswer((_) async {});
+      when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
       when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.isConnected).thenReturn(true);
       when(() => relayClient.sendRequest(any())).thenAnswer(

--- a/mobile/module_core/test/capabilities/connection_service_stale_test.dart
+++ b/mobile/module_core/test/capabilities/connection_service_stale_test.dart
@@ -283,6 +283,7 @@ void main() {
       when(relayClient.connect).thenAnswer((_) async {});
       when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.isConnected).thenReturn(true);
+      when(() => relayClient.connectionState).thenReturn(RelayClientConnectionState.connected);
       when(() => relayClient.sendRequest(any())).thenAnswer(
         (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
       );

--- a/mobile/module_core/test/capabilities/server_connection/connection_service_auth_state_test.dart
+++ b/mobile/module_core/test/capabilities/server_connection/connection_service_auth_state_test.dart
@@ -89,7 +89,8 @@ void main() {
       ).thenAnswer((_) async => "fresh-token-123");
 
       final relayClient = _MockRelayClient();
-      when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
+      when(relayClient.connect).thenAnswer((_) async {});
+      when(() => relayClient.isConnected).thenReturn(true);
       when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.sendRequest(any())).thenAnswer(
         (_) async => const RelayResponse(id: "r", status: 500, headers: {}, body: null),

--- a/mobile/module_core/test/capabilities/server_connection/connection_service_auth_state_test.dart
+++ b/mobile/module_core/test/capabilities/server_connection/connection_service_auth_state_test.dart
@@ -91,6 +91,7 @@ void main() {
       final relayClient = _MockRelayClient();
       when(relayClient.connect).thenAnswer((_) async {});
       when(() => relayClient.isConnected).thenReturn(true);
+      when(() => relayClient.connectionState).thenReturn(RelayClientConnectionState.connected);
       when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.sendRequest(any())).thenAnswer(
         (_) async => const RelayResponse(id: "r", status: 500, headers: {}, body: null),

--- a/mobile/module_core/test/capabilities/server_connection/connection_service_auth_state_test.dart
+++ b/mobile/module_core/test/capabilities/server_connection/connection_service_auth_state_test.dart
@@ -89,7 +89,7 @@ void main() {
       ).thenAnswer((_) async => "fresh-token-123");
 
       final relayClient = _MockRelayClient();
-      when(relayClient.connect).thenAnswer((_) async {});
+      when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
       when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.sendRequest(any())).thenAnswer(
         (_) async => const RelayResponse(id: "r", status: 500, headers: {}, body: null),

--- a/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
+++ b/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
@@ -187,7 +187,7 @@ void main() {
     test("SSE setup failure disconnects relay and returns error response", () async {
       final relayClient = MockRelayClient();
 
-      when(relayClient.connect).thenAnswer((_) async {});
+      when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
       when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.sendRequest(any())).thenAnswer(
         (_) async => RelayResponse(
@@ -233,7 +233,7 @@ void main() {
       addTearDown(sseController.close);
 
       final relayClient = MockRelayClient();
-      when(relayClient.connect).thenAnswer((_) async {});
+      when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
       when(() => relayClient.didResume).thenReturn(true);
       when(() => relayClient.subscribeSse(any())).thenAnswer((_) => sseController.stream);
       when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
@@ -269,7 +269,7 @@ void main() {
       addTearDown(sseController.close);
 
       final relayClient = MockRelayClient();
-      when(relayClient.connect).thenAnswer((_) async {});
+      when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
       when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.sendRequest(any())).thenAnswer(
         (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
@@ -312,7 +312,7 @@ void main() {
         addTearDown(sseController.close);
 
         final relayClient = MockRelayClient();
-        when(relayClient.connect).thenAnswer((_) async {});
+        when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
         when(() => relayClient.didResume).thenReturn(false);
         when(() => relayClient.isConnected).thenReturn(true);
         when(() => relayClient.sendRequest(any())).thenAnswer(
@@ -369,7 +369,7 @@ void main() {
       addTearDown(sseController.close);
 
       final relayClient = MockRelayClient();
-      when(relayClient.connect).thenAnswer((_) async {});
+      when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
       when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.isConnected).thenReturn(true);
       when(() => relayClient.sendRequest(any())).thenAnswer(
@@ -415,7 +415,7 @@ void main() {
       addTearDown(sseController.close);
 
       final relayClient = MockRelayClient();
-      when(relayClient.connect).thenAnswer((_) async {});
+      when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
       when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.isConnected).thenReturn(true);
       when(() => relayClient.sendRequest(any())).thenAnswer(
@@ -491,7 +491,7 @@ void main() {
       final initialClient = MockRelayClient();
       final firstReconnectClient = MockRelayClient();
       final secondReconnectClient = MockRelayClient();
-      final firstConnect = Completer<void>();
+      final firstConnect = Completer<RelayConnectOutcome>();
       final clients = <MockRelayClient>[
         initialClient,
         firstReconnectClient,
@@ -508,9 +508,9 @@ void main() {
         when(() => client.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
         when(client.disconnect).thenAnswer((_) async {});
       }
-      when(initialClient.connect).thenAnswer((_) async {});
+      when(initialClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
       when(firstReconnectClient.connect).thenAnswer((_) => firstConnect.future);
-      when(secondReconnectClient.connect).thenAnswer((_) async {});
+      when(secondReconnectClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
 
       var nextClient = 0;
       final factory = _TestRelayClientFactory(
@@ -557,7 +557,7 @@ void main() {
       expect(service.relayClient, same(secondReconnectClient));
       expect(service.currentStatus, isA<ConnectionConnected>());
 
-      firstConnect.complete();
+      firstConnect.complete(RelayConnectOutcome.connected);
       await Future<void>.delayed(const Duration(milliseconds: 20));
 
       verifyNever(() => firstReconnectClient.sendRequest(any()));
@@ -571,7 +571,7 @@ void main() {
 
       final initialClient = MockRelayClient();
       final reconnectClient = MockRelayClient();
-      final reconnectConnect = Completer<void>();
+      final reconnectConnect = Completer<RelayConnectOutcome>();
       final clients = <MockRelayClient>[initialClient, reconnectClient];
 
       for (final client in clients) {
@@ -584,7 +584,7 @@ void main() {
         when(() => client.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
         when(client.disconnect).thenAnswer((_) async {});
       }
-      when(initialClient.connect).thenAnswer((_) async {});
+      when(initialClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
       when(reconnectClient.connect).thenAnswer((_) => reconnectConnect.future);
 
       var nextClient = 0;
@@ -622,13 +622,158 @@ void main() {
 
       lifecycleController.add(LifecycleState.paused);
       await Future<void>.delayed(Duration.zero);
-      reconnectConnect.complete();
+      reconnectConnect.complete(RelayConnectOutcome.connected);
       await Future<void>.delayed(const Duration(milliseconds: 50));
 
       expect(service.currentStatus, const ConnectionStatus.connectionLost(config: config));
       expect(service.relayClient, isNull);
       verify(reconnectClient.disconnect).called(greaterThanOrEqualTo(1));
       verifyNever(() => reconnectClient.sendRequest(any()));
+    });
+
+    test("connect with bridge absent parks in ConnectionBridgeOffline without health probe or SSE", () async {
+      final relayClient = MockRelayClient();
+      when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.bridgeAbsent);
+      when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
+      when(() => relayClient.onSocketClosed).thenAnswer((_) => const Stream<void>.empty());
+      when(relayClient.disconnect).thenAnswer((_) async {});
+
+      final factory = _TestRelayClientFactory(
+        ({
+          required String relayHost,
+          required RelayCryptoService cryptoService,
+          required RoomKeyStorage roomKeyStorage,
+          required String? authToken,
+        }) => relayClient,
+      );
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+        relayClientFactory: factory,
+      );
+      addTearDown(service.dispose);
+
+      final result = await service.connect(config);
+
+      expect(result, isA<SuccessResponse<HealthResponse>>());
+      expect(service.currentStatus, isA<ConnectionBridgeOffline>());
+      expect(service.relayClient, same(relayClient));
+      // No E2E session yet, so neither the health probe nor SSE should run.
+      verifyNever(() => relayClient.sendRequest(any()));
+      verifyNever(() => relayClient.subscribeSse(any()));
+    });
+
+    test("bridge coming online while parked drives a reconnect to ConnectionConnected", () async {
+      final bridgeStatusController = StreamController<BridgeStatus>.broadcast();
+      addTearDown(bridgeStatusController.close);
+
+      final parkedClient = MockRelayClient();
+      when(parkedClient.connect).thenAnswer((_) async => RelayConnectOutcome.bridgeAbsent);
+      when(() => parkedClient.bridgeStatus).thenAnswer((_) => bridgeStatusController.stream);
+      when(() => parkedClient.onSocketClosed).thenAnswer((_) => const Stream<void>.empty());
+      when(parkedClient.disconnect).thenAnswer((_) async {});
+
+      final sseController = StreamController<RelaySseEvent>.broadcast();
+      addTearDown(sseController.close);
+      final connectedClient = MockRelayClient();
+      when(connectedClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
+      when(() => connectedClient.didResume).thenReturn(false);
+      when(() => connectedClient.sendRequest(any())).thenAnswer(
+        (_) async => RelayResponse(id: "h", status: 200, body: jsonEncode(health.toJson()), headers: const {}),
+      );
+      when(() => connectedClient.subscribeSse(any())).thenAnswer((_) => sseController.stream);
+      when(() => connectedClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
+      when(() => connectedClient.onSocketClosed).thenAnswer((_) => const Stream<void>.empty());
+      when(connectedClient.disconnect).thenAnswer((_) async {});
+
+      final clients = <MockRelayClient>[parkedClient, connectedClient];
+      var nextClient = 0;
+      final factory = _TestRelayClientFactory(
+        ({
+          required String relayHost,
+          required RelayCryptoService cryptoService,
+          required RoomKeyStorage roomKeyStorage,
+          required String? authToken,
+        }) => clients[nextClient++],
+      );
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+        relayClientFactory: factory,
+      );
+      addTearDown(service.dispose);
+
+      await service.connect(config);
+      expect(service.currentStatus, isA<ConnectionBridgeOffline>());
+
+      // The relay pushes bridge_connected over the still-open socket.
+      bridgeStatusController.add(BridgeStatus.online);
+      // The online handler runs _reconnectRelayWithRefresh, which waits the ~1s
+      // backoff, refreshes the token and reconnects with a fresh key exchange.
+      await Future<void>.delayed(const Duration(milliseconds: 1400));
+
+      expect(factory.callCount, 2);
+      expect(service.relayClient, same(connectedClient));
+      expect(service.currentStatus, isA<ConnectionConnected>());
+    });
+
+    test("socket closing while parked is recovered like an SSE drop", () async {
+      final socketClosedController = StreamController<void>.broadcast();
+      addTearDown(socketClosedController.close);
+
+      final parkedClient = MockRelayClient();
+      when(parkedClient.connect).thenAnswer((_) async => RelayConnectOutcome.bridgeAbsent);
+      when(() => parkedClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
+      when(() => parkedClient.onSocketClosed).thenAnswer((_) => socketClosedController.stream);
+      when(() => parkedClient.lastCloseCode).thenReturn(null);
+      when(parkedClient.disconnect).thenAnswer((_) async {});
+
+      final reparkedClient = MockRelayClient();
+      when(reparkedClient.connect).thenAnswer((_) async => RelayConnectOutcome.bridgeAbsent);
+      when(() => reparkedClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
+      when(() => reparkedClient.onSocketClosed).thenAnswer((_) => const Stream<void>.empty());
+      when(reparkedClient.disconnect).thenAnswer((_) async {});
+
+      final clients = <MockRelayClient>[parkedClient, reparkedClient];
+      var nextClient = 0;
+      final factory = _TestRelayClientFactory(
+        ({
+          required String relayHost,
+          required RelayCryptoService cryptoService,
+          required RoomKeyStorage roomKeyStorage,
+          required String? authToken,
+        }) => clients[nextClient++],
+      );
+      final service = ConnectionService(
+        cryptoService,
+        roomKeyStorage,
+        authTokenProvider,
+        authSession,
+        lifecycleSource,
+        failureReporter,
+        relayClientFactory: factory,
+      );
+      addTearDown(service.dispose);
+
+      await service.connect(config);
+      expect(service.currentStatus, isA<ConnectionBridgeOffline>());
+
+      // No SSE stream exists while parked, so the socket-closed signal is what
+      // surfaces the drop. It should reconnect and (bridge still absent) re-park.
+      socketClosedController.add(null);
+      await Future<void>.delayed(const Duration(milliseconds: 1400));
+
+      expect(factory.callCount, 2);
+      expect(service.relayClient, same(reparkedClient));
+      expect(service.currentStatus, isA<ConnectionBridgeOffline>());
     });
   });
 }

--- a/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
+++ b/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
@@ -199,6 +199,7 @@ void main() {
       );
       when(() => relayClient.subscribeSse(any())).thenThrow(StateError("SSE subscribe failed"));
       when(() => relayClient.isConnected).thenReturn(true);
+      when(() => relayClient.connectionState).thenReturn(RelayClientConnectionState.connected);
       when(relayClient.disconnect).thenAnswer((_) async {});
       when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
 
@@ -236,6 +237,7 @@ void main() {
       final relayClient = MockRelayClient();
       when(relayClient.connect).thenAnswer((_) async {});
       when(() => relayClient.isConnected).thenReturn(true);
+      when(() => relayClient.connectionState).thenReturn(RelayClientConnectionState.connected);
       when(() => relayClient.didResume).thenReturn(true);
       when(() => relayClient.subscribeSse(any())).thenAnswer((_) => sseController.stream);
       when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
@@ -273,6 +275,7 @@ void main() {
       final relayClient = MockRelayClient();
       when(relayClient.connect).thenAnswer((_) async {});
       when(() => relayClient.isConnected).thenReturn(true);
+      when(() => relayClient.connectionState).thenReturn(RelayClientConnectionState.connected);
       when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.sendRequest(any())).thenAnswer(
         (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
@@ -318,6 +321,7 @@ void main() {
         when(relayClient.connect).thenAnswer((_) async {});
         when(() => relayClient.didResume).thenReturn(false);
         when(() => relayClient.isConnected).thenReturn(true);
+        when(() => relayClient.connectionState).thenReturn(RelayClientConnectionState.connected);
         when(() => relayClient.sendRequest(any())).thenAnswer(
           (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
         );
@@ -375,6 +379,7 @@ void main() {
       when(relayClient.connect).thenAnswer((_) async {});
       when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.isConnected).thenReturn(true);
+      when(() => relayClient.connectionState).thenReturn(RelayClientConnectionState.connected);
       when(() => relayClient.sendRequest(any())).thenAnswer(
         (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
       );
@@ -421,6 +426,7 @@ void main() {
       when(relayClient.connect).thenAnswer((_) async {});
       when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.isConnected).thenReturn(true);
+      when(() => relayClient.connectionState).thenReturn(RelayClientConnectionState.connected);
       when(() => relayClient.sendRequest(any())).thenAnswer(
         (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
       );
@@ -504,6 +510,7 @@ void main() {
       for (final client in clients) {
         when(() => client.didResume).thenReturn(false);
         when(() => client.isConnected).thenReturn(true);
+        when(() => client.connectionState).thenReturn(RelayClientConnectionState.connected);
         when(() => client.sendRequest(any())).thenAnswer(
           (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
         );
@@ -580,6 +587,7 @@ void main() {
       for (final client in clients) {
         when(() => client.didResume).thenReturn(false);
         when(() => client.isConnected).thenReturn(true);
+        when(() => client.connectionState).thenReturn(RelayClientConnectionState.connected);
         when(() => client.sendRequest(any())).thenAnswer(
           (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
         );
@@ -637,8 +645,10 @@ void main() {
     test("connect with bridge absent parks in ConnectionBridgeOffline without health probe or SSE", () async {
       final relayClient = MockRelayClient();
       when(relayClient.connect).thenAnswer((_) async {});
-      // Bridge absent: connect() returns but isConnected stays false.
+      // Bridge absent: connect() returns with the transport state connected but
+      // no session encryptor, so isConnected stays false.
       when(() => relayClient.isConnected).thenReturn(false);
+      when(() => relayClient.connectionState).thenReturn(RelayClientConnectionState.connected);
       when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
       when(() => relayClient.onSocketClosed).thenAnswer((_) => const Stream<void>.empty());
       when(relayClient.disconnect).thenAnswer((_) async {});
@@ -679,6 +689,7 @@ void main() {
       final parkedClient = MockRelayClient();
       when(parkedClient.connect).thenAnswer((_) async {});
       when(() => parkedClient.isConnected).thenReturn(false);
+      when(() => parkedClient.connectionState).thenReturn(RelayClientConnectionState.connected);
       when(() => parkedClient.bridgeStatus).thenAnswer((_) => bridgeStatusController.stream);
       when(() => parkedClient.onSocketClosed).thenAnswer((_) => const Stream<void>.empty());
       when(parkedClient.disconnect).thenAnswer((_) async {});
@@ -688,6 +699,7 @@ void main() {
       final connectedClient = MockRelayClient();
       when(connectedClient.connect).thenAnswer((_) async {});
       when(() => connectedClient.isConnected).thenReturn(true);
+      when(() => connectedClient.connectionState).thenReturn(RelayClientConnectionState.connected);
       when(() => connectedClient.didResume).thenReturn(false);
       when(() => connectedClient.sendRequest(any())).thenAnswer(
         (_) async => RelayResponse(id: "h", status: 200, body: jsonEncode(health.toJson()), headers: const {}),
@@ -739,6 +751,7 @@ void main() {
       final parkedClient = MockRelayClient();
       when(parkedClient.connect).thenAnswer((_) async {});
       when(() => parkedClient.isConnected).thenReturn(false);
+      when(() => parkedClient.connectionState).thenReturn(RelayClientConnectionState.connected);
       when(() => parkedClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
       when(() => parkedClient.onSocketClosed).thenAnswer((_) => socketClosedController.stream);
       when(() => parkedClient.lastCloseCode).thenReturn(null);
@@ -747,6 +760,7 @@ void main() {
       final reparkedClient = MockRelayClient();
       when(reparkedClient.connect).thenAnswer((_) async {});
       when(() => reparkedClient.isConnected).thenReturn(false);
+      when(() => reparkedClient.connectionState).thenReturn(RelayClientConnectionState.connected);
       when(() => reparkedClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
       when(() => reparkedClient.onSocketClosed).thenAnswer((_) => const Stream<void>.empty());
       when(reparkedClient.disconnect).thenAnswer((_) async {});

--- a/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
+++ b/mobile/module_core/test/capabilities/server_connection/connection_service_reconnect_test.dart
@@ -187,7 +187,7 @@ void main() {
     test("SSE setup failure disconnects relay and returns error response", () async {
       final relayClient = MockRelayClient();
 
-      when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
+      when(relayClient.connect).thenAnswer((_) async {});
       when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.sendRequest(any())).thenAnswer(
         (_) async => RelayResponse(
@@ -198,6 +198,7 @@ void main() {
         ),
       );
       when(() => relayClient.subscribeSse(any())).thenThrow(StateError("SSE subscribe failed"));
+      when(() => relayClient.isConnected).thenReturn(true);
       when(relayClient.disconnect).thenAnswer((_) async {});
       when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
 
@@ -233,7 +234,8 @@ void main() {
       addTearDown(sseController.close);
 
       final relayClient = MockRelayClient();
-      when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
+      when(relayClient.connect).thenAnswer((_) async {});
+      when(() => relayClient.isConnected).thenReturn(true);
       when(() => relayClient.didResume).thenReturn(true);
       when(() => relayClient.subscribeSse(any())).thenAnswer((_) => sseController.stream);
       when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
@@ -269,7 +271,8 @@ void main() {
       addTearDown(sseController.close);
 
       final relayClient = MockRelayClient();
-      when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
+      when(relayClient.connect).thenAnswer((_) async {});
+      when(() => relayClient.isConnected).thenReturn(true);
       when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.sendRequest(any())).thenAnswer(
         (_) async => const RelayResponse(id: "h", status: 200, body: "{}", headers: {}),
@@ -312,7 +315,7 @@ void main() {
         addTearDown(sseController.close);
 
         final relayClient = MockRelayClient();
-        when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
+        when(relayClient.connect).thenAnswer((_) async {});
         when(() => relayClient.didResume).thenReturn(false);
         when(() => relayClient.isConnected).thenReturn(true);
         when(() => relayClient.sendRequest(any())).thenAnswer(
@@ -369,7 +372,7 @@ void main() {
       addTearDown(sseController.close);
 
       final relayClient = MockRelayClient();
-      when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
+      when(relayClient.connect).thenAnswer((_) async {});
       when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.isConnected).thenReturn(true);
       when(() => relayClient.sendRequest(any())).thenAnswer(
@@ -415,7 +418,7 @@ void main() {
       addTearDown(sseController.close);
 
       final relayClient = MockRelayClient();
-      when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
+      when(relayClient.connect).thenAnswer((_) async {});
       when(() => relayClient.didResume).thenReturn(false);
       when(() => relayClient.isConnected).thenReturn(true);
       when(() => relayClient.sendRequest(any())).thenAnswer(
@@ -491,7 +494,7 @@ void main() {
       final initialClient = MockRelayClient();
       final firstReconnectClient = MockRelayClient();
       final secondReconnectClient = MockRelayClient();
-      final firstConnect = Completer<RelayConnectOutcome>();
+      final firstConnect = Completer<void>();
       final clients = <MockRelayClient>[
         initialClient,
         firstReconnectClient,
@@ -508,9 +511,9 @@ void main() {
         when(() => client.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
         when(client.disconnect).thenAnswer((_) async {});
       }
-      when(initialClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
+      when(initialClient.connect).thenAnswer((_) async {});
       when(firstReconnectClient.connect).thenAnswer((_) => firstConnect.future);
-      when(secondReconnectClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
+      when(secondReconnectClient.connect).thenAnswer((_) async {});
 
       var nextClient = 0;
       final factory = _TestRelayClientFactory(
@@ -557,7 +560,7 @@ void main() {
       expect(service.relayClient, same(secondReconnectClient));
       expect(service.currentStatus, isA<ConnectionConnected>());
 
-      firstConnect.complete(RelayConnectOutcome.connected);
+      firstConnect.complete();
       await Future<void>.delayed(const Duration(milliseconds: 20));
 
       verifyNever(() => firstReconnectClient.sendRequest(any()));
@@ -571,7 +574,7 @@ void main() {
 
       final initialClient = MockRelayClient();
       final reconnectClient = MockRelayClient();
-      final reconnectConnect = Completer<RelayConnectOutcome>();
+      final reconnectConnect = Completer<void>();
       final clients = <MockRelayClient>[initialClient, reconnectClient];
 
       for (final client in clients) {
@@ -584,7 +587,7 @@ void main() {
         when(() => client.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
         when(client.disconnect).thenAnswer((_) async {});
       }
-      when(initialClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
+      when(initialClient.connect).thenAnswer((_) async {});
       when(reconnectClient.connect).thenAnswer((_) => reconnectConnect.future);
 
       var nextClient = 0;
@@ -622,7 +625,7 @@ void main() {
 
       lifecycleController.add(LifecycleState.paused);
       await Future<void>.delayed(Duration.zero);
-      reconnectConnect.complete(RelayConnectOutcome.connected);
+      reconnectConnect.complete();
       await Future<void>.delayed(const Duration(milliseconds: 50));
 
       expect(service.currentStatus, const ConnectionStatus.connectionLost(config: config));
@@ -633,7 +636,9 @@ void main() {
 
     test("connect with bridge absent parks in ConnectionBridgeOffline without health probe or SSE", () async {
       final relayClient = MockRelayClient();
-      when(relayClient.connect).thenAnswer((_) async => RelayConnectOutcome.bridgeAbsent);
+      when(relayClient.connect).thenAnswer((_) async {});
+      // Bridge absent: connect() returns but isConnected stays false.
+      when(() => relayClient.isConnected).thenReturn(false);
       when(() => relayClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
       when(() => relayClient.onSocketClosed).thenAnswer((_) => const Stream<void>.empty());
       when(relayClient.disconnect).thenAnswer((_) async {});
@@ -672,7 +677,8 @@ void main() {
       addTearDown(bridgeStatusController.close);
 
       final parkedClient = MockRelayClient();
-      when(parkedClient.connect).thenAnswer((_) async => RelayConnectOutcome.bridgeAbsent);
+      when(parkedClient.connect).thenAnswer((_) async {});
+      when(() => parkedClient.isConnected).thenReturn(false);
       when(() => parkedClient.bridgeStatus).thenAnswer((_) => bridgeStatusController.stream);
       when(() => parkedClient.onSocketClosed).thenAnswer((_) => const Stream<void>.empty());
       when(parkedClient.disconnect).thenAnswer((_) async {});
@@ -680,7 +686,8 @@ void main() {
       final sseController = StreamController<RelaySseEvent>.broadcast();
       addTearDown(sseController.close);
       final connectedClient = MockRelayClient();
-      when(connectedClient.connect).thenAnswer((_) async => RelayConnectOutcome.connected);
+      when(connectedClient.connect).thenAnswer((_) async {});
+      when(() => connectedClient.isConnected).thenReturn(true);
       when(() => connectedClient.didResume).thenReturn(false);
       when(() => connectedClient.sendRequest(any())).thenAnswer(
         (_) async => RelayResponse(id: "h", status: 200, body: jsonEncode(health.toJson()), headers: const {}),
@@ -716,8 +723,8 @@ void main() {
 
       // The relay pushes bridge_connected over the still-open socket.
       bridgeStatusController.add(BridgeStatus.online);
-      // The online handler runs _reconnectRelayWithRefresh, which waits the ~1s
-      // backoff, refreshes the token and reconnects with a fresh key exchange.
+      // The online handler runs _reconnectRelayWithRefresh(immediate: true), which
+      // refreshes the token and reconnects with a fresh key exchange.
       await Future<void>.delayed(const Duration(milliseconds: 1400));
 
       expect(factory.callCount, 2);
@@ -730,14 +737,16 @@ void main() {
       addTearDown(socketClosedController.close);
 
       final parkedClient = MockRelayClient();
-      when(parkedClient.connect).thenAnswer((_) async => RelayConnectOutcome.bridgeAbsent);
+      when(parkedClient.connect).thenAnswer((_) async {});
+      when(() => parkedClient.isConnected).thenReturn(false);
       when(() => parkedClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
       when(() => parkedClient.onSocketClosed).thenAnswer((_) => socketClosedController.stream);
       when(() => parkedClient.lastCloseCode).thenReturn(null);
       when(parkedClient.disconnect).thenAnswer((_) async {});
 
       final reparkedClient = MockRelayClient();
-      when(reparkedClient.connect).thenAnswer((_) async => RelayConnectOutcome.bridgeAbsent);
+      when(reparkedClient.connect).thenAnswer((_) async {});
+      when(() => reparkedClient.isConnected).thenReturn(false);
       when(() => reparkedClient.bridgeStatus).thenAnswer((_) => const Stream<BridgeStatus>.empty());
       when(() => reparkedClient.onSocketClosed).thenAnswer((_) => const Stream<void>.empty());
       when(reparkedClient.disconnect).thenAnswer((_) async {});


### PR DESCRIPTION
## Problem

Reported bug: start the app with the bridge **offline** → it shows the "Set up Sesori Bridge" / bridge-disconnected screen. Start the bridge → **the app does not connect; it requires a pull-to-refresh.**

By contrast, a bridge that drops *after* a live connection auto-recovers instantly. The two cases looked identical in the UI but used different connection states:

| | launched while bridge offline | bridge dropped after connecting |
|---|---|---|
| state | `ConnectionDisconnected` | `ConnectionBridgeOffline` |
| relay socket | none (torn down) | kept open |
| bridge-status watcher | never armed | armed |
| auto-connect on bridge-online | ❌ no | ✅ yes |

## Root cause (client-side)

The **relay already** keeps a phone socket open when no bridge is present and pushes `bridge_connected` the moment one appears (verified in `sesori_relay_server` `handler.go` — `handlePhone` parks the phone and `handleBridge` fans out `bridge_connected`). The gap was that the client tore its **own** socket down: during the initial handshake the relay's `bridge_disconnected` frame errored the key-exchange completer, which threw out of `RelayClient.connect()` into the teardown path — skipping the block that retains the `RelayClient` and arms `_subscribeBridgeStatus`. With no socket and no watcher, the later `bridge_connected` had nowhere to land.

## Fix

Treat "relay + auth socket established, but no bridge yet" as a first-class, socket-alive outcome instead of a fatal error — then reuse the existing, already-tested `bridge_connected → _reconnectRelayWithRefresh` recovery path.

- **`relay_client.dart`**: `connect()` returns a `RelayConnectOutcome`. On the initial `bridge_disconnected` it resolves to `bridgeAbsent` (keeping the socket open and the stored room key) instead of tearing down. A new `bridgeOffline` connection state keeps `isConnected == false`, so `RelayHttpApiClient` cleanly returns a "relay not connected" response rather than routing through the half-open client. Added `onSocketClosed` so a drop while parked (no SSE stream to surface it) is still detected.
- **`connection_service.dart`**: commits the `bridgeAbsent` outcome as `ConnectionBridgeOffline` with the bridge-status watcher armed (skipping the health probe and SSE, which need the room key). `_onAppResumed` now reconnects a stale parked socket on foreground; a still-absent bridge simply re-parks.

**No relay or auth-server change is required** — the relay already implements the "hold the phone, pair on arrival" behavior.

## Security

Unchanged. The relay still only forwards opaque encrypted frames (it never participates in the DH). On `bridge_connected` the phone runs a **fresh ephemeral DH** — no buffered/replayed handshake material — so forward secrecy is preserved.

## Testing

- `flutter analyze`: clean. `flutter test` (module_core): **403 passing**, including 3 new tests — park in `ConnectionBridgeOffline` (no health probe / SSE), bridge-online → reconnect to `ConnectionConnected`, and socket-drop-while-parked recovery.
- **Live-verified on the iPhone 17 Pro Max simulator**: launch with bridge offline → parked in bridge-offline → start `sesori-bridge` → app auto-connects to the projects list with **no pull-to-refresh** and no user interaction.

```
Relay connected but bridge is offline — holding socket open   ← fix: socket kept open
[ProjectList] connection status: ConnectionBridgeOffline
Relay: bridge came online                                     ← relay push
Bridge came back online — reconnecting to re-establish encryption
Relay key exchange complete, room key persisted               ← fresh DH
[ProjectList] connection status: ConnectionConnected          ← auto-connected
```

## Follow-ups (out of scope, separate PRs)

- Relay token-expiry deadline-close (`4007`) so long-parked sockets re-validate (`authResult.Expiry` is currently dead code in the relay).
- Client resilience: jittered backoff + bridge-flap debounce.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the mobile app not auto-connecting when launched while the bridge is offline. The app now keeps the relay socket open and auto-connects as soon as the bridge comes online—no pull-to-refresh.

- **Bug Fixes**
  - `RelayClient.connect()` no longer fails when the bridge is absent; it keeps the socket up with no session (`isConnected == false`), so API calls don’t route through a half-open client.
  - `ConnectionService`: when `connect()` returns with `isConnected == false` and the transport state is `connected`, commit `ConnectionBridgeOffline`, arm the bridge-status watcher, skip health probe/SSE, and watch `onSocketClosed` to recover drops while parked.
  - Reconnect immediately on `bridge_connected` (skip backoff delay).
  - On app resume, proactively reconnect likely-stale parked sockets; if the bridge is still absent, it re-parks.
  - Prevent uncaught async errors by clearing the unused handshake completer; tests cover park-without-health/SSE, bridge-online reconnect, socket-close recovery, and stub `RelayClient.connectionState` for the park guard.

<sup>Written for commit bb2626f596ad4b97ef38a7783d5ea1e6e826bc20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

