### PR TITLE
fix(fastlane): release build directly to target track instead of promoting from internal

### DIFF
--- a/mobile/app/android/fastlane/Fastfile
+++ b/mobile/app/android/fastlane/Fastfile
@@ -245,7 +245,22 @@ platform :android do
       # Verify the version code exists in the 'internal' track before attempting promotion.
       # This provides a clearer error message if the 'internal' track is empty or the version is missing,
       # instead of letting `supply` fail with a generic "Track 'internal' doesn't have any releases" error.
-      internal_version_codes = google_play_track_version_codes(track: "internal")
+      #
+      # Only the API call is wrapped in a rescue so that the user_error! validation
+      # failures below are not accidentally caught and reshaped by it.
+      begin
+        internal_version_codes = google_play_track_version_codes(track: "internal")
+      rescue StandardError => e
+        # A 404 or the specific "no releases" error from supply means the track is
+        # empty or doesn't exist. Surface a friendlier message; re-raise anything
+        # else (e.g. network or authentication failures).
+        if e.message.include?("404") || e.message.include?("Track 'internal' doesn't have any releases")
+          UI.user_error!("The 'internal' track on Google Play is empty or inaccessible. Error: #{e.message}")
+        else
+          raise e
+        end
+      end
+
       if internal_version_codes.nil? || internal_version_codes.empty?
         UI.user_error!("The 'internal' track on Google Play is empty. There are no releases to promote.")
       end
@@ -257,18 +272,7 @@ platform :android do
           "Ensure the 'deploy_internal' lane has run successfully for this version."
         )
       end
-    rescue StandardError => e
-      # If it's a 404 or the specific "no releases" error from supply, it means the track is empty or doesn't exist.
-      # We catch this to provide a more user-friendly error message.
-      if e.message.include?("404") || e.message.include?("Track 'internal' doesn't have any releases")
-         UI.user_error!("The 'internal' track on Google Play is empty or inaccessible. Error: #{e.message}")
-      else
-         # Re-raise other errors (e.g., network issues, authentication failure)
-         raise e
-      end
-    end
 
-    begin
       target_track = track == "beta" ? "beta" : "production"
       version_name = _read_version_name
 

--- a/mobile/app/android/fastlane/Fastfile
+++ b/mobile/app/android/fastlane/Fastfile
@@ -229,8 +229,8 @@ platform :android do
     end
   end
 
-  desc "Promote an existing internal-track build to beta or production. " \
-       "Does NOT build — runs on Linux."
+  desc "Release an already-uploaded build (by version code) directly to beta " \
+       "or production. Does NOT build — runs on Linux."
   lane :submit_android do |options|
     version_code = (options[:version_code] || ENV["VERSION_CODE"]).to_s.strip
     UI.user_error!("VERSION_CODE is required") if version_code.empty?
@@ -242,68 +242,52 @@ platform :android do
     _materialize_secret_files
 
     begin
-      # Verify the version code exists in the 'internal' track before attempting promotion.
-      # This provides a clearer error message if the 'internal' track is empty or the version is missing,
-      # instead of letting `supply` fail with a generic "Track 'internal' doesn't have any releases" error.
-      #
-      # Only the API call is wrapped in a rescue so that the user_error! validation
-      # failures below are not accidentally caught and reshaped by it.
-      begin
-        internal_version_codes = google_play_track_version_codes(track: "internal")
-      rescue StandardError => e
-        # A 404 or the specific "no releases" error from supply means the track is
-        # empty or doesn't exist. Surface a friendlier message; re-raise anything
-        # else (e.g. network or authentication failures).
-        if e.message.include?("404") || e.message.include?("Track 'internal' doesn't have any releases")
-          UI.user_error!("The 'internal' track on Google Play is empty or inaccessible. Error: #{e.message}")
-        else
-          raise e
-        end
-      end
-
-      if internal_version_codes.nil? || internal_version_codes.empty?
-        UI.user_error!("The 'internal' track on Google Play is empty. There are no releases to promote.")
-      end
-
-      unless internal_version_codes.include?(version_code.to_i)
-        UI.user_error!(
-          "Version code #{version_code} not found in the 'internal' track on Google Play. " \
-          "Available versions: #{internal_version_codes.join(', ')}. " \
-          "Ensure the 'deploy_internal' lane has run successfully for this version."
-        )
-      end
-
       target_track = track == "beta" ? "beta" : "production"
       version_name = _read_version_name
 
-      UI.message("Promoting Android version code #{version_code} (v#{version_name}) " \
-                 "from internal → #{target_track}")
+      # Create a release for the requested version code DIRECTLY on the target
+      # track, rather than promoting from internal.
+      #
+      # Why not `track_promote_to`? supply's promotion only operates on releases
+      # that are still ACTIVE on the source ("internal") track. Google Play now
+      # auto-supersedes/deactivates older releases when a newer build is added to
+      # a track (the behaviour behind the now-deprecated `check_superseded_tracks`
+      # and `deactivate_on_promote` options). So once a newer internal build (e.g.
+      # 119) lands, an older-but-still-present build (e.g. 118) is no longer an
+      # active release on internal and cannot be promoted — supply fails with
+      # "Track 'internal' doesn't have any releases". Targeting the destination
+      # track directly with the already-uploaded version code sidesteps this: the
+      # uploaded AAB is permanent, so Play can create a fresh release referencing
+      # it regardless of its status on internal.
+      UI.message("Releasing Android version code #{version_code} (v#{version_name}) " \
+                 "to #{target_track}")
 
       # Optional Play Store listing metadata from the private metadata repo. CI
       # populates this path only when that repo's latest commit has no `v*` tag
       # (unpublished listing changes — see submit-release.yml). Unlike iOS, supply
-      # runs the promotion and the metadata upload inside a SINGLE Play Edit, so a
-      # metadata error aborts the whole edit and the promotion does not half-land
+      # runs the release and the metadata upload inside a SINGLE Play Edit, so a
+      # metadata error aborts the whole edit and the release does not half-land
       # — no two-pass split needed. nil when the path is unset, making this a
-      # pure promotion (pre-feature behavior).
+      # pure release (pre-feature behavior).
       metadata_dir = metadata_dir_from_env("ANDROID_METADATA_PATH")
       have_meta = !metadata_dir.nil?
       UI.message(
-        have_meta ? "Uploading Play listing from #{metadata_dir}" : "No metadata path — promotion only"
+        have_meta ? "Uploading Play listing from #{metadata_dir}" : "No metadata path — release only"
       )
 
       # package_name comes from Appfile (matches deploy_internal).
       # `release_status: "completed"` implies 100% rollout — no `rollout:` needed.
+      # `skip_upload_aab/apk: true` means we do NOT re-upload a binary; supply
+      # creates the target-track release from the version code already uploaded by
+      # deploy_internal.
       # When a metadata dir is present we upload everything in it (listing text,
       # changelogs, images, screenshots); supply no-ops on categories that have
       # no files, so a text-only repo just uploads text. Release notes come from
       # <metadata_dir>/<locale>/changelogs/<versionCode>.txt with a default.txt
-      # fallback — keep a default.txt in the repo so a promotion never ships
+      # fallback — keep a default.txt in the repo so a release never ships
       # blank "What's new" (supply does so silently).
       play_opts = {
-        track: "internal",
-        track_promote_to: target_track,
-        track_promote_release_status: "completed",
+        track: target_track,
         version_code: version_code.to_i,
         skip_upload_apk: true,
         skip_upload_aab: true,
@@ -316,7 +300,7 @@ platform :android do
       play_opts[:metadata_path] = metadata_dir if metadata_dir
       upload_to_play_store(play_opts)
 
-      UI.success("Promoted Android version code #{version_code} (v#{version_name}) " \
+      UI.success("Released Android version code #{version_code} (v#{version_name}) " \
                  "to #{target_track}")
     ensure
       _cleanup_secret_files

--- a/mobile/app/android/fastlane/Fastfile
+++ b/mobile/app/android/fastlane/Fastfile
@@ -242,6 +242,33 @@ platform :android do
     _materialize_secret_files
 
     begin
+      # Verify the version code exists in the 'internal' track before attempting promotion.
+      # This provides a clearer error message if the 'internal' track is empty or the version is missing,
+      # instead of letting `supply` fail with a generic "Track 'internal' doesn't have any releases" error.
+      internal_version_codes = google_play_track_version_codes(track: "internal")
+      if internal_version_codes.nil? || internal_version_codes.empty?
+        UI.user_error!("The 'internal' track on Google Play is empty. There are no releases to promote.")
+      end
+
+      unless internal_version_codes.include?(version_code.to_i)
+        UI.user_error!(
+          "Version code #{version_code} not found in the 'internal' track on Google Play. " \
+          "Available versions: #{internal_version_codes.join(', ')}. " \
+          "Ensure the 'deploy_internal' lane has run successfully for this version."
+        )
+      end
+    rescue StandardError => e
+      # If it's a 404 or the specific "no releases" error from supply, it means the track is empty or doesn't exist.
+      # We catch this to provide a more user-friendly error message.
+      if e.message.include?("404") || e.message.include?("Track 'internal' doesn't have any releases")
+         UI.user_error!("The 'internal' track on Google Play is empty or inaccessible. Error: #{e.message}")
+      else
+         # Re-raise other errors (e.g., network issues, authentication failure)
+         raise e
+      end
+    end
+
+    begin
       target_track = track == "beta" ? "beta" : "production"
       version_name = _read_version_name
 


### PR DESCRIPTION
## Problem

The Android `submit_android` lane failed with:

```
[!] Track 'internal' doesn't have any releases
```

when promoting an older-but-still-present build (e.g. version code 118) to production after a newer build (119) had landed on the internal track.

## Root cause

`supply`'s `track_promote_to` only promotes releases that are still **active** on the source track. Google Play now auto-supersedes/deactivates older releases when a newer build is added to a track — this is the behaviour behind the now-deprecated `check_superseded_tracks` and `deactivate_on_promote` options (per the fastlane docs). Once build 119 landed on internal, build 118 was no longer an active release there and could not be promoted, producing the misleading "doesn't have any releases" error.

This is a genuine bug: requesting a specific, already-uploaded build for release should work even when a newer build exists on internal.

## Fix

`submit_android` now creates the release **directly on the target track** (`beta`/`production`) from the already-uploaded version code, instead of promoting from internal:

- Drops `track: "internal"` + `track_promote_to`.
- Sets `track: target_track` with the requested `version_code`, `skip_upload_aab/apk: true` (references the existing uploaded bundle — no rebuild/re-upload), `release_status: "completed"`.

Because the uploaded AAB is permanent, Play can create a fresh release referencing it regardless of the build's status on internal. Metadata/changelog handling and secret-file cleanup are unchanged.

## Notes

An earlier iteration of this PR added a pre-check against the internal track's version codes. That approach was removed because it could not fix this case — a superseded build is no longer reported as an active release, so the promote would fail identically. The direct-release approach addresses the root cause.