### PR TITLE
fix(ci): submit from latest Fastfile + promote Android from internal

### DIFF
--- a/.github/workflows/submit-release.yml
+++ b/.github/workflows/submit-release.yml
@@ -162,9 +162,14 @@ jobs:
       run:
         working-directory: mobile/app/ios
     steps:
+      # Deliberately NOT the resolved build commit: the submit lane needs only
+      # the fastlane config + the already-uploaded build number (passed via env),
+      # never the build's source tree. Checking out the workflow's own revision
+      # means submit always runs the LATEST Fastfile, so fixes to the submit
+      # logic apply even to builds cut from older commits (the build's binary is
+      # permanent on TestFlight). The version NAME that must match the binary is
+      # injected via VERSION_NAME below, not read from this tree's pubspec.
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.resolve.outputs.commit_sha }}
 
       # Clone the private metadata repo so we can both read its listing and decide
       # whether it needs publishing. Only for production submits with
@@ -224,6 +229,10 @@ jobs:
           APPLE_TEAM_ID:                     ${{ secrets.APPLE_TEAM_ID }}
           ITC_TEAM_ID:                       ${{ secrets.ITC_TEAM_ID }}
           BUILD_NUMBER:                      ${{ needs.resolve.outputs.build_number }}
+          # Version NAME of the resolved build (matches the uploaded binary).
+          # Injected because the job no longer checks out the build's commit, so
+          # the local pubspec may belong to a newer version.
+          VERSION_NAME:                      ${{ needs.resolve.outputs.version }}
           TRACK:                             ${{ inputs.track }}
           # Absolute paths: fastlane runs from mobile/app/ios but the metadata
           # clone lives at the workspace root. Set ONLY when the gate decided to
@@ -271,9 +280,14 @@ jobs:
       run:
         working-directory: mobile/app/android
     steps:
+      # Deliberately NOT the resolved build commit: the submit lane needs only
+      # the fastlane config + the already-uploaded version code (passed via env),
+      # never the build's source tree. Checking out the workflow's own revision
+      # means submit always runs the LATEST Fastfile, so fixes to the submit
+      # logic apply even to builds cut from older commits (the build's binary is
+      # permanent on Play). The version NAME that must match the binary is
+      # injected via VERSION_NAME below, not read from this tree's pubspec.
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.resolve.outputs.commit_sha }}
 
       # Clone the private metadata repo (production + STORE_METADATA_REPO only) to
       # read the listing and run the same tag-driven gate as iOS. See the iOS job
@@ -322,6 +336,10 @@ jobs:
         env:
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           VERSION_CODE:                     ${{ needs.resolve.outputs.build_number }}
+          # Version NAME of the resolved build (matches the uploaded binary).
+          # Injected because the job no longer checks out the build's commit, so
+          # the local pubspec may belong to a newer version.
+          VERSION_NAME:                     ${{ needs.resolve.outputs.version }}
           TRACK:                            ${{ inputs.track }}
           # Absolute path to the cloned metadata repo's Android listing dir (locale
           # folders live directly under it). Set ONLY when the gate decided to

--- a/mobile/app/android/fastlane/Fastfile
+++ b/mobile/app/android/fastlane/Fastfile
@@ -246,8 +246,8 @@ platform :android do
     end
   end
 
-  desc "Release an already-uploaded build (by version code) directly to beta " \
-       "or production. Does NOT build — runs on Linux."
+  desc "Promote an existing internal-track build to beta or production. " \
+       "Does NOT build — runs on Linux."
   lane :submit_android do |options|
     version_code = (options[:version_code] || ENV["VERSION_CODE"]).to_s.strip
     UI.user_error!("VERSION_CODE is required") if version_code.empty?
@@ -262,49 +262,63 @@ platform :android do
       target_track = track == "beta" ? "beta" : "production"
       version_name = _read_version_name
 
-      # Create a release for the requested version code DIRECTLY on the target
-      # track, rather than promoting from internal.
+      # Promotion is the ONLY supply-supported way to ship an already-uploaded
+      # build: `upload_to_play_store` can either upload a NEW binary or promote a
+      # release that currently exists on a source track to another track
+      # (`track_promote_to`). There is no API to "create a release from an
+      # arbitrary historical version code" — passing `version_code:` without
+      # `track_promote_to` and without an AAB fails with "No local metadata,
+      # apks, aab, or track to promote were found", and re-uploading the AAB is
+      # rejected because version codes must be globally unique. So we promote
+      # from internal.
       #
-      # Why not `track_promote_to`? supply's promotion only operates on releases
-      # that are still ACTIVE on the source ("internal") track. Google Play now
-      # auto-supersedes/deactivates older releases when a newer build is added to
-      # a track (the behaviour behind the now-deprecated `check_superseded_tracks`
-      # and `deactivate_on_promote` options). So once a newer internal build (e.g.
-      # 119) lands, an older-but-still-present build (e.g. 118) is no longer an
-      # active release on internal and cannot be promoted — supply fails with
-      # "Track 'internal' doesn't have any releases". Targeting the destination
-      # track directly with the already-uploaded version code sidesteps this: the
-      # uploaded AAB is permanent, so Play can create a fresh release referencing
-      # it regardless of its status on internal.
-      UI.message("Releasing Android version code #{version_code} (v#{version_name}) " \
-                 "to #{target_track}")
+      # IMPORTANT — only the LATEST internal build is promotable. `deploy_internal`
+      # sets `internal.releases = [<new build>]`, which OVERWRITES the internal
+      # track's release list with just the newest build, evicting any prior build.
+      # So once build N+1 lands on internal, build N can no longer be promoted.
+      # We guard for this explicitly below so the failure is a clear message
+      # rather than supply's cryptic "Track 'internal' doesn't have any releases".
+      internal_codes = google_play_track_version_codes(track: "internal").map(&:to_s)
+      unless internal_codes.include?(version_code)
+        UI.user_error!(
+          "Version code #{version_code} is not a release on the internal track " \
+          "(internal currently has: #{internal_codes.empty? ? 'none' : internal_codes.join(', ')}). " \
+          "Only the latest internal build can be promoted — deploying a newer build to " \
+          "internal evicts older ones. Re-deploy this build to internal, or submit the " \
+          "latest one."
+        )
+      end
+
+      UI.message("Promoting Android version code #{version_code} (v#{version_name}) " \
+                 "from internal → #{target_track}")
 
       # Optional Play Store listing metadata from the private metadata repo. CI
       # populates this path only when that repo's latest commit has no `v*` tag
       # (unpublished listing changes — see submit-release.yml). Unlike iOS, supply
-      # runs the release and the metadata upload inside a SINGLE Play Edit, so a
-      # metadata error aborts the whole edit and the release does not half-land
+      # runs the promotion and the metadata upload inside a SINGLE Play Edit, so a
+      # metadata error aborts the whole edit and the promotion does not half-land
       # — no two-pass split needed. nil when the path is unset, making this a
-      # pure release (pre-feature behavior).
+      # pure promotion (pre-feature behavior).
       metadata_dir = metadata_dir_from_env("ANDROID_METADATA_PATH")
       have_meta = !metadata_dir.nil?
       UI.message(
-        have_meta ? "Uploading Play listing from #{metadata_dir}" : "No metadata path — release only"
+        have_meta ? "Uploading Play listing from #{metadata_dir}" : "No metadata path — promotion only"
       )
 
       # package_name comes from Appfile (matches deploy_internal).
-      # `release_status: "completed"` implies 100% rollout — no `rollout:` needed.
-      # `skip_upload_aab/apk: true` means we do NOT re-upload a binary; supply
-      # creates the target-track release from the version code already uploaded by
-      # deploy_internal.
+      # `track_promote_release_status: "completed"` implies 100% rollout — no
+      # `rollout:` needed. `skip_upload_aab/apk: true` means we do NOT re-upload a
+      # binary; supply promotes the version code already on the internal track.
       # When a metadata dir is present we upload everything in it (listing text,
       # changelogs, images, screenshots); supply no-ops on categories that have
       # no files, so a text-only repo just uploads text. Release notes come from
       # <metadata_dir>/<locale>/changelogs/<versionCode>.txt with a default.txt
-      # fallback — keep a default.txt in the repo so a release never ships
+      # fallback — keep a default.txt in the repo so a promotion never ships
       # blank "What's new" (supply does so silently).
       play_opts = {
-        track: target_track,
+        track: "internal",
+        track_promote_to: target_track,
+        track_promote_release_status: "completed",
         version_code: version_code.to_i,
         skip_upload_apk: true,
         skip_upload_aab: true,
@@ -317,7 +331,7 @@ platform :android do
       play_opts[:metadata_path] = metadata_dir if metadata_dir
       upload_to_play_store(play_opts)
 
-      UI.success("Released Android version code #{version_code} (v#{version_name}) " \
+      UI.success("Promoted Android version code #{version_code} (v#{version_name}) " \
                  "to #{target_track}")
     ensure
       _cleanup_secret_files

--- a/mobile/app/android/fastlane/Fastfile
+++ b/mobile/app/android/fastlane/Fastfile
@@ -120,14 +120,28 @@ platform :android do
     version_codes
   end
 
-  # Reads the marketing version (e.g. "1.0.6") from pubspec.yaml two dirs up.
+  # Resolves the marketing version (e.g. "1.0.6"). Prefers an injected
+  # VERSION_NAME env so the submit workflow can run the LATEST Fastfile while
+  # still stamping the version that matches the already-uploaded binary (the
+  # submit job checks out the workflow's own ref, not the build's commit, so the
+  # local pubspec may belong to a newer version — see submit-release.yml). Falls
+  # back to reading pubspec.yaml two dirs up for build/standalone invocations.
   # The build-number suffix after `+` is intentionally ignored — Play decides
-  # the version code, pubspec only owns the version name.
+  # the version code, pubspec only owns the version name. Fails hard if the
+  # version cannot be determined: defaulting would stamp a wrong version onto a
+  # store release, which is worse than aborting.
   private_lane :_read_version_name do
-    pubspec_path = File.join(Dir.pwd, "..", "..", "pubspec.yaml")
-    pubspec_content = File.read(pubspec_path)
-    version_match = pubspec_content.match(/version:\s*(\d+\.\d+\.\d+)/)
-    version_match ? version_match[1] : "1.0.0"
+    injected = ENV["VERSION_NAME"].to_s.strip
+    if injected.empty?
+      pubspec_path = File.join(Dir.pwd, "..", "..", "pubspec.yaml")
+      pubspec_content = File.read(pubspec_path)
+      version_match = pubspec_content.match(/version:\s*(\d+\.\d+\.\d+)/)
+      UI.user_error!("Could not determine version name: VERSION_NAME is unset and no " \
+                     "'version: X.Y.Z' was found in #{pubspec_path}") unless version_match
+      version_match[1]
+    else
+      injected
+    end
   end
 
   desc "Print the next Google Play version code without building or uploading"

--- a/mobile/app/android/fastlane/Fastfile
+++ b/mobile/app/android/fastlane/Fastfile
@@ -278,7 +278,20 @@ platform :android do
       # So once build N+1 lands on internal, build N can no longer be promoted.
       # We guard for this explicitly below so the failure is a clear message
       # rather than supply's cryptic "Track 'internal' doesn't have any releases".
-      internal_codes = google_play_track_version_codes(track: "internal").map(&:to_s)
+      #
+      # The read itself can fail: the Play API raises (e.g. auth/network) or
+      # returns nil when the track has no releases yet. Translate both into the
+      # same actionable error rather than letting a raw exception or a NoMethodError
+      # on nil escape — otherwise the user-facing mismatch guard is bypassed.
+      begin
+        internal_codes = (google_play_track_version_codes(track: "internal") || []).map(&:to_s)
+      rescue StandardError => e
+        UI.user_error!(
+          "Could not read the internal track to verify version code #{version_code} is " \
+          "promotable (#{e.class}: #{e.message}). Check the Play service account " \
+          "credentials and that the internal track exists."
+        )
+      end
       unless internal_codes.include?(version_code)
         UI.user_error!(
           "Version code #{version_code} is not a release on the internal track " \

--- a/mobile/app/android/fastlane/Fastfile
+++ b/mobile/app/android/fastlane/Fastfile
@@ -133,7 +133,10 @@ platform :android do
   private_lane :_read_version_name do
     injected = ENV["VERSION_NAME"].to_s.strip
     if injected.empty?
-      pubspec_path = File.join(Dir.pwd, "..", "..", "pubspec.yaml")
+      # Anchor to __dir__ (the fastlane folder) rather than Dir.pwd so the path
+      # is correct regardless of the cwd fastlane resolves relative paths
+      # against — matches the AAB path resolution below.
+      pubspec_path = File.expand_path("../../pubspec.yaml", __dir__)
       pubspec_content = File.read(pubspec_path)
       version_match = pubspec_content.match(/version:\s*(\d+\.\d+\.\d+)/)
       UI.user_error!("Could not determine version name: VERSION_NAME is unset and no " \

--- a/mobile/app/ios/fastlane/Fastfile
+++ b/mobile/app/ios/fastlane/Fastfile
@@ -118,7 +118,9 @@ platform :ios do
   private_lane :_read_marketing_version do
     injected = ENV["VERSION_NAME"].to_s.strip
     if injected.empty?
-      pubspec_path = File.join(Dir.pwd, "..", "..", "pubspec.yaml")
+      # Anchor to __dir__ (the fastlane folder) rather than Dir.pwd so the path
+      # is correct regardless of the cwd fastlane resolves relative paths against.
+      pubspec_path = File.expand_path("../../pubspec.yaml", __dir__)
       pubspec_content = File.read(pubspec_path)
       version_match = pubspec_content.match(/version:\s*(\d+\.\d+\.\d+)/)
       UI.user_error!("Could not determine version name: VERSION_NAME is unset and no " \

--- a/mobile/app/ios/fastlane/Fastfile
+++ b/mobile/app/ios/fastlane/Fastfile
@@ -105,14 +105,28 @@ def release_notes_by_locale(dir)
 end
 
 platform :ios do
-  # Reads the marketing version (e.g. "1.0.6") from pubspec.yaml two dirs up.
+  # Resolves the marketing version (e.g. "1.0.6"). Prefers an injected
+  # VERSION_NAME env so the submit workflow can run the LATEST Fastfile while
+  # still stamping the version that matches the already-uploaded binary (the
+  # submit job checks out the workflow's own ref, not the build's commit, so the
+  # local pubspec may belong to a newer version — see submit-release.yml). Falls
+  # back to reading pubspec.yaml two dirs up for build/standalone invocations.
   # The build-number suffix after `+` is intentionally ignored — store APIs
-  # own the build number, pubspec only owns the version name.
+  # own the build number, pubspec only owns the version name. Fails hard if the
+  # version cannot be determined: defaulting would stamp a wrong version onto a
+  # store release, which is worse than aborting.
   private_lane :_read_marketing_version do
-    pubspec_path = File.join(Dir.pwd, "..", "..", "pubspec.yaml")
-    pubspec_content = File.read(pubspec_path)
-    version_match = pubspec_content.match(/version:\s*(\d+\.\d+\.\d+)/)
-    version_match ? version_match[1] : "1.0.0"
+    injected = ENV["VERSION_NAME"].to_s.strip
+    if injected.empty?
+      pubspec_path = File.join(Dir.pwd, "..", "..", "pubspec.yaml")
+      pubspec_content = File.read(pubspec_path)
+      version_match = pubspec_content.match(/version:\s*(\d+\.\d+\.\d+)/)
+      UI.user_error!("Could not determine version name: VERSION_NAME is unset and no " \
+                     "'version: X.Y.Z' was found in #{pubspec_path}") unless version_match
+      version_match[1]
+    else
+      injected
+    end
   end
 
   desc "Print the next TestFlight build number without building or uploading"


### PR DESCRIPTION
## Problem

The v1.1.0 production release kept failing. Two independent root causes, plus a path-resolution robustness issue surfaced in review:

### 1. Submit ran the wrong (stale) Fastfile

`submit-release.yml` checked out **the build's originating commit** before running fastlane. A build cut from a commit that predates a submit-logic change re-ran the **old** submit lane. This is why build 119 (built from a commit before #298) still hit the old promote-from-internal path and failed.

### 2. The #298 Android approach is not supported by `supply`

#298 switched `submit_android` to a "direct target-track release" using `skip_upload_aab: true` + `version_code:` (no `track_promote_to`). `supply` has **no such operation** — confirmed in its `uploader.rb`:

- With no AAB and no `track_promote_to`, `verify_config!` fails with `No local metadata, apks, aab, or track to promote were found` (build 120's failure).
- Re-uploading the AAB is also impossible: Google Play version codes must be **globally unique**.

The only supported way to ship an already-uploaded build is `track_promote_to`. The original `"Track 'internal' doesn't have any releases"` failure was **not** Google auto-supersession (as #298 assumed) — it was `deploy_internal` doing `internal.releases = [<new build>]`, which **overwrites** the internal track with only the newest build, evicting older ones. So only the **latest** internal build is ever promotable.

## Changes

**`submit-release.yml`**
- Run `submit-ios` / `submit-android` from the workflow's own revision (drop `ref: commit_sha`). The submit lanes need only fastlane config + the already-uploaded build number/version code (via env), never the build's source tree — same reasoning the `release` job already uses. Submit-logic fixes now apply even to builds cut from older commits.
- Inject `VERSION_NAME` from the `resolve` job so the stamped version still matches the uploaded binary (the job no longer checks out the build's pubspec).

**`mobile/app/android/fastlane/Fastfile`**
- Restore `track_promote_to` promotion from internal (revert #298's unsupported direct-release call).
- Add a guard: query `google_play_track_version_codes(track: internal)` and fail with a clear message if the requested version code isn't on internal — making the "only the latest internal build is promotable" constraint explicit instead of supply's cryptic error.
- `_read_version_name`: prefer injected `VERSION_NAME`, fall back to pubspec; **hard-fail** if the version can't be determined (previously silently defaulted to `1.0.0`).
- Anchor the pubspec path to `__dir__` instead of `Dir.pwd` (review feedback).

**`mobile/app/ios/fastlane/Fastfile`**
- `_read_marketing_version`: same `VERSION_NAME` injection, hard-fail, and `__dir__` anchoring as Android.

## Not in scope (already correct / pre-existing state)

- **iOS build 120's failure** (`The specified pre-release build could not be added`) is **not** a lane bug: the earlier run already submitted iOS build 119 for review, so App Store version v1.1.0 is in "Waiting For Review" and Apple won't allow swapping the attached build. iOS is already done for v1.1.0.

## Scope

CI / fastlane config only — no Dart source changes.

## Verification

- `ruby -c` passes on both Fastfiles
- workflow YAML validates
- `VERSION_NAME` is set only in the two submit jobs; build/deploy jobs keep the pubspec fallback
