### PR TITLE
docs: add npm package READMEs and update PR comment workflow

### DIFF
--- a/.opencode/skills/address-pr-comments/SKILL.md
+++ b/.opencode/skills/address-pr-comments/SKILL.md
@@ -11,7 +11,7 @@ Addresses unresolved inline PR review comments by assessing their validity, impl
 
 1. **Unresolved comments only**: Unless explicitly told otherwise, only fetch and address comments where `is_resolved == false`. Use the `--unresolved` flag.
 2. **Every thread gets a reply**: After assessing and acting on a comment, you MUST post a reply to that comment thread. No thread should be left without a response.
-3. **Do not reply twice**: Before posting a reply, check the thread's `comments[]` for an existing body starting with `[Sesori reply]`. If the last comment in the thread is already a `[Sesori reply]`, skip the thread unless there is a new follow-up request from a reviewer. If the last comment is an acknowledgment like "Acknowledged" or similar that does not require action, skip it.
+3. **Do not reply twice**: Before posting a reply, inspect the comments after the most recent `[Sesori reply]`. If the last comment is already a `[Sesori reply]` and there are no later reviewer comments, skip the thread. If the only later comments are acknowledgment-only bot comments (for example "Acknowledged", "Thanks", "Looks good", or "Accepted") with no new request, objection, question, or requested change, skip the thread. Do not skip if a later comment raises a follow-up, pushback, asks for clarification, or requests additional changes; handle that as a new actionable comment.
 4. **Reply prefix**: Every reply must start with `[Sesori reply]` so it is clear the response comes from the agent, not the human user.
 5. **All comments are assessed**: Every comment must be evaluated for validity. Do not automatically assume any comment is correct.
 6. **Extra scrutiny for AI/bot comments**: Comments from AI reviewers or bots require more careful assessment. They are more likely to be incorrect, irrelevant, or based on stale context.
@@ -76,6 +76,19 @@ For AI/bot comments:
 - Verify the claim by reading the actual code
 - Check if the suggestion aligns with existing codebase patterns
 - Do not implement blindly — apply the same critical thinking you would use on your own code
+
+#### Acknowledgment-only bot follow-ups
+
+Some bots post a short acknowledgment after the `[Sesori reply]` instead of resolving the thread. Treat the thread as already addressed when every comment after the most recent `[Sesori reply]` is acknowledgment-only, such as "Acknowledged", "Thanks", "Looks good", "Accepted", or equivalent non-actionable wording.
+
+Do not treat a bot follow-up as acknowledgment-only if it contains any of the following:
+- a new requested change or clarification
+- a question about the fix
+- a pushback or objection
+- a statement that the previous reply did not address the original concern
+- a new link, suggestion, or actionable review note
+
+For human follow-ups, assume the follow-up is actionable unless it is explicitly just an acknowledgment.
 
 For human comments:
 - Assume the comment is correct unless you have strong evidence otherwise

--- a/bridge/app/npm/sesori-bridge-darwin-arm64/README.md
+++ b/bridge/app/npm/sesori-bridge-darwin-arm64/README.md
@@ -1,0 +1,37 @@
+# @sesori/bridge-darwin-arm64
+
+Platform payload for [`@sesori/bridge`](../sesori-bridge/README.md) on **macOS (Apple Silicon)**.
+
+This package contains the native Sesori Bridge runtime archive for `darwin/arm64`. It is consumed automatically by the bootstrap launcher — you do not need to install it directly. If `npx @sesori/bridge` detects `darwin arm64`, this package provides the native binary payload that gets unpacked into the managed runtime under `~/.local/share/sesori/`.
+
+## Install (indirect)
+
+```bash
+npx @sesori/bridge --version
+```
+
+If you somehow need the payload directly (not recommended for normal use):
+
+```bash
+npm install @sesori/bridge-darwin-arm64
+```
+
+## What it contains
+
+- `lib/runtime/` — native Sesori Bridge binary archive for macOS ARM64, sourced from the matching GitHub Release asset (`sesori-bridge-macos-arm64.tar.gz`).
+
+## Supported platform
+
+| Field | Value |
+| --- | --- |
+| `os` | `darwin` |
+| `cpu` | `arm64` |
+
+## Documentation
+
+- [Sesori Bridge install guide](https://github.com/sesori-ai/sesori_apps_monorepo/blob/main/bridge/INSTALL.md)
+- [Project README](https://github.com/sesori-ai/sesori_apps_monorepo#readme)
+
+## License
+
+Source-available under the Functional Source License, Version 1.1, Apache 2.0 Future License (`FSL-1.1-ALv2`). See [LICENSE](./LICENSE).

--- a/bridge/app/npm/sesori-bridge-darwin-arm64/README.md
+++ b/bridge/app/npm/sesori-bridge-darwin-arm64/README.md
@@ -1,13 +1,13 @@
 # @sesori/bridge-darwin-arm64
 
-Platform payload for [`@sesori/bridge`](../sesori-bridge/README.md) on **macOS (Apple Silicon)**.
+Platform payload for [`@sesori/bridge`](https://www.npmjs.com/package/@sesori/bridge) on **macOS (Apple Silicon)**.
 
 This package contains the native Sesori Bridge runtime archive for `darwin/arm64`. It is consumed automatically by the bootstrap launcher — you do not need to install it directly. If `npx @sesori/bridge` detects `darwin arm64`, this package provides the native binary payload that gets unpacked into the managed runtime under `~/.local/share/sesori/`.
 
 ## Install (indirect)
 
 ```bash
-npx @sesori/bridge --version
+npx @sesori/bridge
 ```
 
 If you somehow need the payload directly (not recommended for normal use):

--- a/bridge/app/npm/sesori-bridge-darwin-x64/README.md
+++ b/bridge/app/npm/sesori-bridge-darwin-x64/README.md
@@ -1,0 +1,37 @@
+# @sesori/bridge-darwin-x64
+
+Platform payload for [`@sesori/bridge`](../sesori-bridge/README.md) on **macOS (Intel)**.
+
+This package contains the native Sesori Bridge runtime archive for `darwin/x64`. It is consumed automatically by the bootstrap launcher — you do not need to install it directly. If `npx @sesori/bridge` detects `darwin x64`, this package provides the native binary payload that gets unpacked into the managed runtime under `~/.local/share/sesori/`.
+
+## Install (indirect)
+
+```bash
+npx @sesori/bridge --version
+```
+
+If you somehow need the payload directly (not recommended for normal use):
+
+```bash
+npm install @sesori/bridge-darwin-x64
+```
+
+## What it contains
+
+- `lib/runtime/` — native Sesori Bridge binary archive for macOS x64, sourced from the matching GitHub Release asset (`sesori-bridge-macos-x64.tar.gz`).
+
+## Supported platform
+
+| Field | Value |
+| --- | --- |
+| `os` | `darwin` |
+| `cpu` | `x64` |
+
+## Documentation
+
+- [Sesori Bridge install guide](https://github.com/sesori-ai/sesori_apps_monorepo/blob/main/bridge/INSTALL.md)
+- [Project README](https://github.com/sesori-ai/sesori_apps_monorepo#readme)
+
+## License
+
+Source-available under the Functional Source License, Version 1.1, Apache 2.0 Future License (`FSL-1.1-ALv2`). See [LICENSE](./LICENSE).

--- a/bridge/app/npm/sesori-bridge-darwin-x64/README.md
+++ b/bridge/app/npm/sesori-bridge-darwin-x64/README.md
@@ -1,13 +1,13 @@
 # @sesori/bridge-darwin-x64
 
-Platform payload for [`@sesori/bridge`](../sesori-bridge/README.md) on **macOS (Intel)**.
+Platform payload for [`@sesori/bridge`](https://www.npmjs.com/package/@sesori/bridge) on **macOS (Intel)**.
 
 This package contains the native Sesori Bridge runtime archive for `darwin/x64`. It is consumed automatically by the bootstrap launcher — you do not need to install it directly. If `npx @sesori/bridge` detects `darwin x64`, this package provides the native binary payload that gets unpacked into the managed runtime under `~/.local/share/sesori/`.
 
 ## Install (indirect)
 
 ```bash
-npx @sesori/bridge --version
+npx @sesori/bridge
 ```
 
 If you somehow need the payload directly (not recommended for normal use):

--- a/bridge/app/npm/sesori-bridge-linux-arm64/README.md
+++ b/bridge/app/npm/sesori-bridge-linux-arm64/README.md
@@ -1,0 +1,37 @@
+# @sesori/bridge-linux-arm64
+
+Platform payload for [`@sesori/bridge`](../sesori-bridge/README.md) on **Linux (ARM64)**.
+
+This package contains the native Sesori Bridge runtime archive for `linux/arm64`. It is consumed automatically by the bootstrap launcher — you do not need to install it directly. If `npx @sesori/bridge` detects `linux arm64`, this package provides the native binary payload that gets unpacked into the managed runtime under `~/.local/share/sesori/`.
+
+## Install (indirect)
+
+```bash
+npx @sesori/bridge --version
+```
+
+If you somehow need the payload directly (not recommended for normal use):
+
+```bash
+npm install @sesori/bridge-linux-arm64
+```
+
+## What it contains
+
+- `lib/runtime/` — native Sesori Bridge binary archive for Linux ARM64, sourced from the matching GitHub Release asset (`sesori-bridge-linux-arm64.tar.gz`).
+
+## Supported platform
+
+| Field | Value |
+| --- | --- |
+| `os` | `linux` |
+| `cpu` | `arm64` |
+
+## Documentation
+
+- [Sesori Bridge install guide](https://github.com/sesori-ai/sesori_apps_monorepo/blob/main/bridge/INSTALL.md)
+- [Project README](https://github.com/sesori-ai/sesori_apps_monorepo#readme)
+
+## License
+
+Source-available under the Functional Source License, Version 1.1, Apache 2.0 Future License (`FSL-1.1-ALv2`). See [LICENSE](./LICENSE).

--- a/bridge/app/npm/sesori-bridge-linux-arm64/README.md
+++ b/bridge/app/npm/sesori-bridge-linux-arm64/README.md
@@ -1,13 +1,13 @@
 # @sesori/bridge-linux-arm64
 
-Platform payload for [`@sesori/bridge`](../sesori-bridge/README.md) on **Linux (ARM64)**.
+Platform payload for [`@sesori/bridge`](https://www.npmjs.com/package/@sesori/bridge) on **Linux (ARM64)**.
 
 This package contains the native Sesori Bridge runtime archive for `linux/arm64`. It is consumed automatically by the bootstrap launcher — you do not need to install it directly. If `npx @sesori/bridge` detects `linux arm64`, this package provides the native binary payload that gets unpacked into the managed runtime under `~/.local/share/sesori/`.
 
 ## Install (indirect)
 
 ```bash
-npx @sesori/bridge --version
+npx @sesori/bridge
 ```
 
 If you somehow need the payload directly (not recommended for normal use):

--- a/bridge/app/npm/sesori-bridge-linux-x64/README.md
+++ b/bridge/app/npm/sesori-bridge-linux-x64/README.md
@@ -1,0 +1,37 @@
+# @sesori/bridge-linux-x64
+
+Platform payload for [`@sesori/bridge`](../sesori-bridge/README.md) on **Linux (x86_64)**.
+
+This package contains the native Sesori Bridge runtime archive for `linux/x64`. It is consumed automatically by the bootstrap launcher — you do not need to install it directly. If `npx @sesori/bridge` detects `linux x64`, this package provides the native binary payload that gets unpacked into the managed runtime under `~/.local/share/sesori/`.
+
+## Install (indirect)
+
+```bash
+npx @sesori/bridge --version
+```
+
+If you somehow need the payload directly (not recommended for normal use):
+
+```bash
+npm install @sesori/bridge-linux-x64
+```
+
+## What it contains
+
+- `lib/runtime/` — native Sesori Bridge binary archive for Linux x64, sourced from the matching GitHub Release asset (`sesori-bridge-linux-x64.tar.gz`).
+
+## Supported platform
+
+| Field | Value |
+| --- | --- |
+| `os` | `linux` |
+| `cpu` | `x64` |
+
+## Documentation
+
+- [Sesori Bridge install guide](https://github.com/sesori-ai/sesori_apps_monorepo/blob/main/bridge/INSTALL.md)
+- [Project README](https://github.com/sesori-ai/sesori_apps_monorepo#readme)
+
+## License
+
+Source-available under the Functional Source License, Version 1.1, Apache 2.0 Future License (`FSL-1.1-ALv2`). See [LICENSE](./LICENSE).

--- a/bridge/app/npm/sesori-bridge-linux-x64/README.md
+++ b/bridge/app/npm/sesori-bridge-linux-x64/README.md
@@ -1,13 +1,13 @@
 # @sesori/bridge-linux-x64
 
-Platform payload for [`@sesori/bridge`](../sesori-bridge/README.md) on **Linux (x86_64)**.
+Platform payload for [`@sesori/bridge`](https://www.npmjs.com/package/@sesori/bridge) on **Linux (x86_64)**.
 
 This package contains the native Sesori Bridge runtime archive for `linux/x64`. It is consumed automatically by the bootstrap launcher — you do not need to install it directly. If `npx @sesori/bridge` detects `linux x64`, this package provides the native binary payload that gets unpacked into the managed runtime under `~/.local/share/sesori/`.
 
 ## Install (indirect)
 
 ```bash
-npx @sesori/bridge --version
+npx @sesori/bridge
 ```
 
 If you somehow need the payload directly (not recommended for normal use):

--- a/bridge/app/npm/sesori-bridge-win32-arm64/LICENSE
+++ b/bridge/app/npm/sesori-bridge-win32-arm64/LICENSE
@@ -1,0 +1,75 @@
+# Functional Source License, Version 1.1, ALv2 Future License
+
+## Abbreviation
+
+FSL-1.1-ALv2
+
+## Notice
+
+Copyright 2026 Sesori.com
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under these Terms and Conditions, as indicated by our inclusion of these Terms and Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents, Redistribution and Trademark clauses below, we hereby grant you the right to use, copy, modify, create derivative works, publicly perform, publicly display and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use means making the Software available to others in a commercial product or service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our patents, the license grant above includes a license under our patents. If you make a claim against any party that the Software infringes or contributes to the infringement of any patent, then your patent license to the Software ends immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software, you must include a copy of or a link to these Terms and Conditions and not remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of the Software, you have no right under these Terms and Conditions to use our trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under the Apache License, Version 2.0 that is effective on the second anniversary of the date we make the Software available. On or after that date, you may use the Software under the Apache License, Version 2.0, in which case the following will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/bridge/app/npm/sesori-bridge-win32-arm64/README.md
+++ b/bridge/app/npm/sesori-bridge-win32-arm64/README.md
@@ -34,4 +34,4 @@ npm install @sesori/bridge-win32-arm64
 
 ## License
 
-Source-available under the Functional Source License, Version 1.1, Apache 2.0 Future License (`FSL-1.1-ALv2`). See the [repository LICENSE](https://github.com/sesori-ai/sesori_apps_monorepo/blob/main/LICENSE).
+Source-available under the Functional Source License, Version 1.1, Apache 2.0 Future License (`FSL-1.1-ALv2`). See [LICENSE](./LICENSE).

--- a/bridge/app/npm/sesori-bridge-win32-arm64/README.md
+++ b/bridge/app/npm/sesori-bridge-win32-arm64/README.md
@@ -1,0 +1,37 @@
+# @sesori/bridge-win32-arm64
+
+Platform payload for [`@sesori/bridge`](../sesori-bridge/README.md) on **Windows (ARM64)**.
+
+This package contains the native Sesori Bridge runtime archive for `win32/arm64`. It is consumed automatically by the bootstrap launcher — you do not need to install it directly. If `npx @sesori/bridge` detects `win32 arm64`, this package provides the native binary payload that gets unpacked into the managed runtime under `%LOCALAPPDATA%\sesori\`.
+
+## Install (indirect)
+
+```bash
+npx @sesori/bridge --version
+```
+
+If you somehow need the payload directly (not recommended for normal use):
+
+```bash
+npm install @sesori/bridge-win32-arm64
+```
+
+## What it contains
+
+- `lib/runtime/` — native Sesori Bridge binary archive for Windows ARM64, sourced from the matching GitHub Release asset (`sesori-bridge-windows-arm64.zip`).
+
+## Supported platform
+
+| Field | Value |
+| --- | --- |
+| `os` | `win32` |
+| `cpu` | `arm64` |
+
+## Documentation
+
+- [Sesori Bridge install guide](https://github.com/sesori-ai/sesori_apps_monorepo/blob/main/bridge/INSTALL.md)
+- [Project README](https://github.com/sesori-ai/sesori_apps_monorepo#readme)
+
+## License
+
+Source-available under the Functional Source License, Version 1.1, Apache 2.0 Future License (`FSL-1.1-ALv2`). See the [repository LICENSE](https://github.com/sesori-ai/sesori_apps_monorepo/blob/main/LICENSE).

--- a/bridge/app/npm/sesori-bridge-win32-arm64/README.md
+++ b/bridge/app/npm/sesori-bridge-win32-arm64/README.md
@@ -1,13 +1,13 @@
 # @sesori/bridge-win32-arm64
 
-Platform payload for [`@sesori/bridge`](../sesori-bridge/README.md) on **Windows (ARM64)**.
+Platform payload for [`@sesori/bridge`](https://www.npmjs.com/package/@sesori/bridge) on **Windows (ARM64)**.
 
 This package contains the native Sesori Bridge runtime archive for `win32/arm64`. It is consumed automatically by the bootstrap launcher — you do not need to install it directly. If `npx @sesori/bridge` detects `win32 arm64`, this package provides the native binary payload that gets unpacked into the managed runtime under `%LOCALAPPDATA%\sesori\`.
 
 ## Install (indirect)
 
 ```bash
-npx @sesori/bridge --version
+npx @sesori/bridge
 ```
 
 If you somehow need the payload directly (not recommended for normal use):

--- a/bridge/app/npm/sesori-bridge-win32-x64/README.md
+++ b/bridge/app/npm/sesori-bridge-win32-x64/README.md
@@ -1,13 +1,13 @@
 # @sesori/bridge-win32-x64
 
-Platform payload for [`@sesori/bridge`](../sesori-bridge/README.md) on **Windows (x86_64)**.
+Platform payload for [`@sesori/bridge`](https://www.npmjs.com/package/@sesori/bridge) on **Windows (x86_64)**.
 
 This package contains the native Sesori Bridge runtime archive for `win32/x64`. It is consumed automatically by the bootstrap launcher — you do not need to install it directly. If `npx @sesori/bridge` detects `win32 x64`, this package provides the native binary payload that gets unpacked into the managed runtime under `%LOCALAPPDATA%\sesori\`.
 
 ## Install (indirect)
 
 ```bash
-npx @sesori/bridge --version
+npx @sesori/bridge
 ```
 
 If you somehow need the payload directly (not recommended for normal use):

--- a/bridge/app/npm/sesori-bridge-win32-x64/README.md
+++ b/bridge/app/npm/sesori-bridge-win32-x64/README.md
@@ -1,0 +1,37 @@
+# @sesori/bridge-win32-x64
+
+Platform payload for [`@sesori/bridge`](../sesori-bridge/README.md) on **Windows (x86_64)**.
+
+This package contains the native Sesori Bridge runtime archive for `win32/x64`. It is consumed automatically by the bootstrap launcher — you do not need to install it directly. If `npx @sesori/bridge` detects `win32 x64`, this package provides the native binary payload that gets unpacked into the managed runtime under `%LOCALAPPDATA%\sesori\`.
+
+## Install (indirect)
+
+```bash
+npx @sesori/bridge --version
+```
+
+If you somehow need the payload directly (not recommended for normal use):
+
+```bash
+npm install @sesori/bridge-win32-x64
+```
+
+## What it contains
+
+- `lib/runtime/` — native Sesori Bridge binary archive for Windows x64, sourced from the matching GitHub Release asset (`sesori-bridge-windows-x64.zip`).
+
+## Supported platform
+
+| Field | Value |
+| --- | --- |
+| `os` | `win32` |
+| `cpu` | `x64` |
+
+## Documentation
+
+- [Sesori Bridge install guide](https://github.com/sesori-ai/sesori_apps_monorepo/blob/main/bridge/INSTALL.md)
+- [Project README](https://github.com/sesori-ai/sesori_apps_monorepo#readme)
+
+## License
+
+Source-available under the Functional Source License, Version 1.1, Apache 2.0 Future License (`FSL-1.1-ALv2`). See [LICENSE](./LICENSE).

--- a/bridge/app/npm/sesori-bridge/README.md
+++ b/bridge/app/npm/sesori-bridge/README.md
@@ -13,10 +13,14 @@ The platform-specific native binary is pulled from the matching optional depende
 
 ```bash
 # macOS / Linux / Windows (Node.js required)
-npx @sesori/bridge --version
+npx @sesori/bridge
 ```
 
-After the first run, use `sesori-bridge` directly (open a new terminal on macOS/Linux if `~/.local/bin` was just added to your PATH).
+After the first run, the managed `sesori-bridge` command is installed. Open a new terminal on macOS/Linux if `~/.local/bin` was just added to your PATH, then verify:
+
+```bash
+sesori-bridge --version
+```
 
 Prefer a shell installer with no Node.js dependency?
 

--- a/bridge/app/npm/sesori-bridge/README.md
+++ b/bridge/app/npm/sesori-bridge/README.md
@@ -1,0 +1,53 @@
+# @sesori/bridge
+
+Bootstrap launcher for the [Sesori Bridge](https://github.com/sesori-ai/sesori_apps_monorepo) — a lightweight CLI that connects an AI coding assistant running on your laptop to the Sesori mobile app via an encrypted relay.
+
+This npm package is a **bootstrap launcher**, not the runtime itself. When you run `sesori-bridge` (or `npx @sesori/bridge`), it installs and updates a managed native binary under your home directory:
+
+- macOS / Linux: `~/.local/share/sesori/`
+- Windows: `%LOCALAPPDATA%\sesori\`
+
+The platform-specific native binary is pulled from the matching optional dependency (`@sesori/bridge-<os>-<arch>`), with a fallback to the tagged GitHub Release asset if the npm payload is unavailable. After install, the `sesori-bridge` command runs the managed runtime, which keeps itself up to date.
+
+## Install
+
+```bash
+# macOS / Linux / Windows (Node.js required)
+npx @sesori/bridge --version
+```
+
+After the first run, use `sesori-bridge` directly (open a new terminal on macOS/Linux if `~/.local/bin` was just added to your PATH).
+
+Prefer a shell installer with no Node.js dependency?
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/sesori-ai/sesori_apps_monorepo/main/install.sh | bash
+
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/sesori-ai/sesori_apps_monorepo/main/install.ps1 | iex
+```
+
+Both paths install the same managed runtime.
+
+## Supported platforms
+
+| OS     | Architecture | Optional dependency            |
+| ------ | ------------ | ------------------------------ |
+| macOS  | arm64, x64   | `@sesori/bridge-darwin-*`       |
+| Linux  | arm64, x64   | `@sesori/bridge-linux-*`        |
+| Windows| arm64, x64   | `@sesori/bridge-win32-*`        |
+
+## Uninstall
+
+`npm uninstall @sesori/bridge` only removes this npm package. To remove the managed runtime, delete the install directory listed above (and the `~/.local/bin/sesori-bridge` symlink on macOS/Linux).
+
+## Documentation
+
+- [Sesori Bridge install guide](https://github.com/sesori-ai/sesori_apps_monorepo/blob/main/bridge/INSTALL.md)
+- [Sesori Bridge architecture](https://github.com/sesori-ai/sesori_apps_monorepo/blob/main/bridge/ARCHITECTURE.md)
+- [Project README](https://github.com/sesori-ai/sesori_apps_monorepo#readme)
+
+## License
+
+Source-available under the Functional Source License, Version 1.1, Apache 2.0 Future License (`FSL-1.1-ALv2`). See [LICENSE](./LICENSE).

--- a/bridge/app/npm/sesori-bridge/README.md
+++ b/bridge/app/npm/sesori-bridge/README.md
@@ -16,11 +16,13 @@ The platform-specific native binary is pulled from the matching optional depende
 npx @sesori/bridge
 ```
 
-After the first run, the managed `sesori-bridge` command is installed. Open a new terminal on macOS/Linux if `~/.local/bin` was just added to your PATH, then verify:
+After the first run, the managed `sesori-bridge` command is installed. On all platforms, open a new terminal so the new PATH entry is picked up (macOS/Linux: `~/.local/bin`; Windows: `%LOCALAPPDATA%\sesori\bin`), then verify:
 
 ```bash
 sesori-bridge --version
 ```
+
+On Windows, the bootstrap persists the User PATH via a child PowerShell process that cannot refresh the current terminal — a new terminal is required before `sesori-bridge` is available. Alternatively, run the binary directly: `& "$env:LOCALAPPDATA\sesori\bin\sesori-bridge.exe" --version`.
 
 Prefer a shell installer with no Node.js dependency?
 


### PR DESCRIPTION
## Summary

The npm packages under `bridge/app/npm/` had no README files, so their pages on npmjs.com would show empty descriptions. This adds a focused README for each of the 7 published packages.

## What's included

- **`@sesori/bridge`** — the bootstrap launcher. Documents the install flow (`npx @sesori/bridge`), the shell-installer alternative, supported platforms, managed runtime install locations, and uninstall behavior.
- **`@sesori/bridge-{darwin,linux,win32}-{arm64,x64}`** (6 packages) — platform payload packages. Each README documents that the package is consumed automatically by the bootstrap launcher, lists the matching GitHub Release artifact name, and shows the `os`/`cpu` fields.

All READMEs cross-link to the [install guide](https://github.com/sesori-ai/sesori_apps_monorepo/blob/main/bridge/INSTALL.md), the architecture doc, and the repo README, and reference the FSL-1.1-ALv2 license.

## PR review workflow update

Also updates the `address-pr-comments` skill so unresolved threads that already have a `[Sesori reply]` and only receive acknowledgment-only bot follow-ups are treated as already addressed. The skill still keeps follow-ups actionable when a bot or human raises a new request, question, pushback, or clarification.

## Verification

- No code changes — README files and opencode skill docs only.
- Artifact names cross-checked against each package's `package.json` `sesoriBridge.releaseArtifact` field.
- Package list matches the optional dependencies declared in `@sesori/bridge`'s `package.json`.

## Notes

- The `@sesori/bridge-win32-arm64` package now ships a local `LICENSE` file for consistency with the other packages.

Generated with [opencode](https://opencode.ai).