### PR TITLE
feat(make): add root pub-get target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,15 @@ TOOL_VERSIONS := $(shell git rev-parse --show-toplevel)/.tool-versions
 FLUTTER_VERSION := $(shell grep '^flutter' $(TOOL_VERSIONS) | awk '{print $$2}')
 DART ?= $(HOME)/.asdf/installs/flutter/$(FLUTTER_VERSION)/bin/cache/dart-sdk/bin/dart
 
-.PHONY: bump-version bump-version-check
+.PHONY: pub-get bump-version bump-version-check
+
+DART_WORKSPACES := shared bridge mobile
+
+pub-get:
+	@for dir in $(DART_WORKSPACES); do \
+		printf '=== pub-get: %s ===\n' "$$dir"; \
+		$(MAKE) --no-print-directory -C "$$dir" pub-get || exit 1; \
+	done
 
 define run_sync_versions
 	@set -eu; \


### PR DESCRIPTION
Adds a root-level `make pub-get` target that runs pub get across the shared, bridge, and mobile Dart workspaces.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a root `make pub-get` target that runs `pub get` across the `shared`, `bridge`, and `mobile` Dart workspaces. This lets you fetch dependencies for all Dart projects with one command.

<sup>Written for commit 48ac2dce91315b08d86a19b4444d38483fe1d765. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

