### PR TITLE
fix(bridge): scope Windows process inspection to a single PID

### DIFF
--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -221,13 +221,12 @@ class BridgeRuntimeRunner {
         accessToken: authTokens.accessToken,
       );
 
-      final currentBridgeIdentity =
-          await processRepository.inspectProcess(pid: io.pid) ??
-          _fallbackCurrentBridgeIdentity(
-            currentUser: currentUser,
-            serverClock: serverClock,
-            cliArgs: options.cliArgs,
-          );
+      final currentBridgeIdentity = await _resolveCurrentBridgeIdentity(
+        processRepository: processRepository,
+        currentUser: currentUser,
+        serverClock: serverClock,
+        cliArgs: options.cliArgs,
+      );
       final ownerSessionId = _buildOwnerSessionId(currentBridgeIdentity: currentBridgeIdentity);
 
       final descriptor = knownPlugins.firstWhere((descriptor) => descriptor.id == pluginId);
@@ -538,6 +537,37 @@ class BridgeRuntimeRunner {
   static ProcessUser? _resolveCurrentUser({required Map<String, String> environment}) => ProcessUser.fromRawUser(
     environment["USER"] ?? environment["USERNAME"],
   );
+
+  /// Resolves this bridge's own [ProcessIdentity], degrading to a locally
+  /// constructed fallback when the process-table inspection returns null or
+  /// throws.
+  ///
+  /// Capturing the live identity is best-effort: it only enriches the owner
+  /// session id with the OS-reported start marker. The inspection shells out
+  /// to `tasklist`/`ps`, which can time out (especially on Windows right after
+  /// login). A failure here must never abort startup — the bridge has a
+  /// complete fallback identity, so we log the degradation and use it.
+  static Future<ProcessIdentity> _resolveCurrentBridgeIdentity({
+    required ProcessRepository processRepository,
+    required ProcessUser? currentUser,
+    required ServerClock serverClock,
+    required List<String> cliArgs,
+  }) async {
+    try {
+      final inspected = await processRepository.inspectProcess(pid: io.pid);
+      if (inspected != null) {
+        return inspected;
+      }
+      Log.w("Could not find own process (pid ${io.pid}) in the process table; using fallback identity");
+    } on Object catch (error) {
+      Log.w("Failed to inspect own process (pid ${io.pid}); using fallback identity: $error");
+    }
+    return _fallbackCurrentBridgeIdentity(
+      currentUser: currentUser,
+      serverClock: serverClock,
+      cliArgs: cliArgs,
+    );
+  }
 
   static ProcessIdentity _fallbackCurrentBridgeIdentity({
     required ProcessUser? currentUser,

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -226,6 +226,7 @@ class BridgeRuntimeRunner {
         currentUser: currentUser,
         serverClock: serverClock,
         cliArgs: options.cliArgs,
+        isWindows: io.Platform.isWindows,
       );
       final ownerSessionId = _buildOwnerSessionId(currentBridgeIdentity: currentBridgeIdentity);
 
@@ -539,19 +540,30 @@ class BridgeRuntimeRunner {
   );
 
   /// Resolves this bridge's own [ProcessIdentity], degrading to a locally
-  /// constructed fallback when the process-table inspection returns null or
-  /// throws.
+  /// constructed fallback when the process-table inspection cannot identify it.
   ///
   /// Capturing the live identity is best-effort: it only enriches the owner
-  /// session id with the OS-reported start marker. The inspection shells out
-  /// to `tasklist`/`ps`, which can time out (especially on Windows right after
-  /// login). A failure here must never abort startup — the bridge has a
-  /// complete fallback identity, so we log the degradation and use it.
+  /// session id with the OS-reported start marker.
+  ///
+  /// Failure handling is platform-specific on purpose:
+  ///
+  /// - On Windows the inspection shells out to `tasklist`, which can time out
+  ///   right after login. Windows identities never carry a start marker, so a
+  ///   null-marker fallback is indistinguishable from a real Windows identity
+  ///   and is safe for the startup lock. We therefore tolerate inspection
+  ///   failures and degrade rather than abort startup.
+  /// - On POSIX, `ps` is fast and identities DO carry a start marker. A
+  ///   null-marker fallback would poison the startup lock: a later bridge
+  ///   inspecting the holder reads the real (non-null) marker, sees the
+  ///   mismatch as stale, steals the lock, and starts concurrently. So a POSIX
+  ///   inspection error must stay fatal — we never substitute a marker-less
+  ///   fallback for a process the OS can actually describe.
   static Future<ProcessIdentity> _resolveCurrentBridgeIdentity({
     required ProcessRepository processRepository,
     required ProcessUser? currentUser,
     required ServerClock serverClock,
     required List<String> cliArgs,
+    required bool isWindows,
   }) async {
     try {
       final inspected = await processRepository.inspectProcess(pid: io.pid);
@@ -560,6 +572,11 @@ class BridgeRuntimeRunner {
       }
       Log.w("Could not find own process (pid ${io.pid}) in the process table; using fallback identity");
     } on Object catch (error) {
+      if (!isWindows) {
+        // A marker-less fallback would corrupt the startup lock on POSIX (see
+        // method doc), so surface the failure instead of degrading.
+        rethrow;
+      }
       Log.w("Failed to inspect own process (pid ${io.pid}); using fallback identity: $error");
     }
     return _fallbackCurrentBridgeIdentity(

--- a/bridge/app/lib/src/server/api/system_process_api.dart
+++ b/bridge/app/lib/src/server/api/system_process_api.dart
@@ -26,7 +26,10 @@ class SystemProcessApi {
   }
 
   Future<ProcessIdentity?> inspectProcess({required int pid}) async {
-    final processes = await listProcesses();
+    if (_isWindows) {
+      return _inspectWindowsProcess(pid: pid);
+    }
+    final processes = await _listPosixProcesses();
     for (final process in processes) {
       if (process.pid == pid) {
         return process;
@@ -125,9 +128,42 @@ class SystemProcessApi {
       );
     }
 
+    return _parseWindowsProcesses(stdout: result.stdout.toString());
+  }
+
+  /// Inspects a single Windows process by querying `tasklist` with its
+  /// server-side `/FI "PID eq <pid>"` filter so the OS returns only the
+  /// matching row. This avoids enumerating the entire process table (the
+  /// `/V` full scan), which is slow enough right after login to exceed the
+  /// [ProcessRunner] timeout.
+  Future<ProcessIdentity?> _inspectWindowsProcess({required int pid}) async {
+    final (command, args) = (
+      "tasklist",
+      <String>["/V", "/FO", "CSV", "/NH", "/FI", "PID eq $pid"],
+    );
+    final result = await _processRunner.run(command, args);
+    if (result.exitCode != 0) {
+      throw ProcessException(
+        command,
+        args,
+        result.stderr.toString(),
+        result.exitCode,
+      );
+    }
+
+    final processes = _parseWindowsProcesses(stdout: result.stdout.toString());
+    for (final process in processes) {
+      if (process.pid == pid) {
+        return process;
+      }
+    }
+    return null;
+  }
+
+  List<ProcessIdentity> _parseWindowsProcesses({required String stdout}) {
     final capturedAt = _clock.now();
     final processes = <ProcessIdentity>[];
-    for (final line in const LineSplitter().convert(result.stdout.toString())) {
+    for (final line in const LineSplitter().convert(stdout)) {
       final trimmed = line.trim();
       if (trimmed.isEmpty) {
         continue;

--- a/bridge/app/lib/src/server/api/system_process_api.dart
+++ b/bridge/app/lib/src/server/api/system_process_api.dart
@@ -26,6 +26,13 @@ class SystemProcessApi {
   }
 
   Future<ProcessIdentity?> inspectProcess({required int pid}) async {
+    // A non-positive PID never identifies a real process. Reject it up front so
+    // every platform returns null consistently — otherwise the Windows
+    // `tasklist /FI "PID eq <pid>"` path would exit non-zero and throw, while
+    // the POSIX list-and-filter path would simply find no match.
+    if (pid <= 0) {
+      return null;
+    }
     if (_isWindows) {
       return _inspectWindowsProcess(pid: pid);
     }

--- a/bridge/app/npm/sesori-bridge/lib/bootstrap_lock.js
+++ b/bridge/app/npm/sesori-bridge/lib/bootstrap_lock.js
@@ -18,7 +18,17 @@ function sleep(milliseconds) {
 }
 
 function removeRecursive(filePath) {
-  fs.rmSync(filePath, { force: true, recursive: true });
+  // The detached heartbeat process keeps writing `heartbeat` inside the lock
+  // directory and only stops asynchronously on SIGTERM. If it writes once more
+  // while we are tearing the directory down, the internal rmdir observes a
+  // non-empty directory and fails with ENOTEMPTY (also EBUSY/EPERM on some
+  // platforms). Retry so the removal succeeds once the heartbeat has exited.
+  fs.rmSync(filePath, {
+    force: true,
+    recursive: true,
+    maxRetries: 10,
+    retryDelay: 50,
+  });
 }
 
 function heartbeatPath(lockPath) {

--- a/bridge/app/test/server/api/system_process_api_test.dart
+++ b/bridge/app/test/server/api/system_process_api_test.dart
@@ -64,6 +64,20 @@ void main() {
         throwsA(isA<ProcessException>()),
       );
     });
+
+    test("inspectProcess returns null for a non-positive PID without shelling out", () async {
+      final runner = _RecordingProcessRunner();
+      final api = SystemProcessApi(
+        processRunner: runner,
+        clock: const ServerClock(),
+        isWindows: true,
+        platform: "windows",
+      );
+
+      expect(await api.inspectProcess(pid: 0), isNull);
+      expect(await api.inspectProcess(pid: -1), isNull);
+      expect(runner.calls, isEmpty);
+    });
   });
 }
 

--- a/bridge/app/test/server/api/system_process_api_test.dart
+++ b/bridge/app/test/server/api/system_process_api_test.dart
@@ -1,0 +1,96 @@
+import "dart:io";
+
+import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
+import "package:sesori_bridge/src/server/api/system_process_api.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("SystemProcessApi (Windows)", () {
+    test("inspectProcess issues a PID-scoped tasklist filter", () async {
+      final runner = _RecordingProcessRunner(
+        stdout: '"sesori-bridge.exe","321","Console","1","12,345 K","Running","HOST\\alex","0:00:01","N/A"\r\n',
+      );
+      final api = SystemProcessApi(
+        processRunner: runner,
+        clock: const ServerClock(),
+        isWindows: true,
+        platform: "windows",
+      );
+
+      final identity = await api.inspectProcess(pid: 321);
+
+      // The OS must do the filtering — never a full /V process-table scan.
+      expect(runner.calls, hasLength(1));
+      final call = runner.calls.single;
+      expect(call.executable, equals("tasklist"));
+      expect(call.arguments, containsAllInOrder(<String>["/FI", "PID eq 321"]));
+
+      expect(identity, isNotNull);
+      expect(identity!.pid, equals(321));
+      expect(identity.executablePath, equals("sesori-bridge.exe"));
+      expect(identity.ownerUser, equals(ProcessUser.fromRawUser(r"HOST\alex")));
+      expect(identity.platform, equals("windows"));
+    });
+
+    test("inspectProcess returns null when tasklist reports no matching task", () async {
+      final runner = _RecordingProcessRunner(
+        stdout: "INFO: No tasks are running which match the specified criteria.\r\n",
+      );
+      final api = SystemProcessApi(
+        processRunner: runner,
+        clock: const ServerClock(),
+        isWindows: true,
+        platform: "windows",
+      );
+
+      final identity = await api.inspectProcess(pid: 999999);
+
+      expect(identity, isNull);
+      expect(runner.calls.single.arguments, containsAllInOrder(<String>["/FI", "PID eq 999999"]));
+    });
+
+    test("inspectProcess throws on non-zero tasklist exit", () async {
+      final runner = _RecordingProcessRunner(exitCode: 1, stderr: "boom");
+      final api = SystemProcessApi(
+        processRunner: runner,
+        clock: const ServerClock(),
+        isWindows: true,
+        platform: "windows",
+      );
+
+      await expectLater(
+        api.inspectProcess(pid: 321),
+        throwsA(isA<ProcessException>()),
+      );
+    });
+  });
+}
+
+class _RecordedCall {
+  _RecordedCall({required this.executable, required this.arguments});
+
+  final String executable;
+  final List<String> arguments;
+}
+
+class _RecordingProcessRunner implements ProcessRunner {
+  _RecordingProcessRunner({this.exitCode = 0, this.stdout = "", this.stderr = ""});
+
+  final int exitCode;
+  final String stdout;
+  final String stderr;
+  final List<_RecordedCall> calls = <_RecordedCall>[];
+
+  @override
+  Future<ProcessResult> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    Duration timeout = const Duration(seconds: 15),
+  }) async {
+    calls.add(_RecordedCall(executable: executable, arguments: arguments));
+    return ProcessResult(1, exitCode, stdout, stderr);
+  }
+}

--- a/bridge/app/test/server/models/bridge_startup_lock_test.dart
+++ b/bridge/app/test/server/models/bridge_startup_lock_test.dart
@@ -21,6 +21,12 @@ void main() {
       const nullMarkerLock = BridgeStartupLock(bridgePid: 123, bridgeStartMarker: null);
 
       expect(lock.matchesStartMarkerOf(identity: _identity(startMarker: null)), isFalse);
+      // A null lock marker against a real (e.g. POSIX) inspected marker is read
+      // as a mismatch — i.e. the holder looks stale and the lock would be
+      // stolen. This is exactly why a POSIX self-inspection failure must NOT
+      // degrade to a marker-less fallback identity (which would write
+      // bridgeStartMarker: null into the lock); on POSIX such failures stay
+      // fatal instead. See BridgeRuntimeRunner._resolveCurrentBridgeIdentity.
       expect(nullMarkerLock.matchesStartMarkerOf(identity: _identity(startMarker: 'marker')), isFalse);
     });
 


### PR DESCRIPTION
## Problem

On Windows, right after login the bridge crashes during startup with:

```
[BridgeRuntimeRunner] TimeoutException after 0:00:15.000000: tasklist timed out after 0:00:15.000000
```

followed by an immediate shutdown. Verbose logging shows nothing further because the failure is a single bubbled-up exception, not a logged decision path.

## Root cause

At startup, `BridgeRuntimeRunner.run` calls `processRepository.inspectProcess(pid: io.pid)` purely to capture the bridge's own identity. `SystemProcessApi.inspectProcess` implemented this by running `tasklist /V /FO CSV /NH` — a **verbose enumeration of every process on the machine** — and then filtering by PID in Dart.

Right after login (AV scanning, cold caches), that full `/V` scan routinely exceeds the 15s `ProcessRunner` timeout. The resulting `TimeoutException` propagates to the catch-all in `BridgeRuntimeRunner.run`, which logs it as `[BridgeRuntimeRunner]`, returns `1`, and triggers shutdown.

## Fix

In `SystemProcessApi` (Layer 1, the per-tool `tasklist`/`ps` wrapper):

- `inspectProcess(pid:)` now uses a Windows-specific targeted query — `tasklist /V /FO CSV /NH /FI "PID eq <pid>"` — so the OS returns only the matching row. This is fast and independent of total process count.
- POSIX keeps its existing list-then-filter path (`ps` has no such timeout problem).
- Extracted `_parseWindowsProcesses` so the full-list and targeted-inspect paths share one parser.
- `listProcesses()` (full enumeration, genuinely needed to find *other* bridge instances) is unchanged.

No public API or call-site signature changes; all changes are internal to `SystemProcessApi`.

## Testing

- New `bridge/app/test/server/api/system_process_api_test.dart`: asserts the Windows inspect path issues the `/FI "PID eq <pid>"` filter, parses one identity, returns `null` on "no tasks", and throws `ProcessException` on non-zero exit.
- `dart analyze --fatal-infos lib test` → no issues
- Full `test/server/` suite passes (112 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Windows startup crash by inspecting a single PID and ignoring non‑positive PIDs, and stabilizes bootstrap lock cleanup by retrying directory removal; Windows now falls back to a default identity on self‑inspection failures, POSIX stays fatal; public API unchanged.

- **Bug Fixes**
  - Windows: `inspectProcess(pid:)` uses `tasklist ... /FI "PID eq <pid>"`; returns null for non‑positive PIDs.
  - Runtime: `_resolveCurrentBridgeIdentity` falls back on Windows; POSIX rethrows to protect the startup lock.
  - npm: `bootstrap_lock.js` retries `fs.rmSync` to avoid ENOTEMPTY/EBUSY during lock cleanup.

<sup>Written for commit 37855e5a101d79ee991a113cbf7c94812c1ba08e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

