### PR TITLE
fix(installer): resolve releases via GitHub latest/download to avoid arg-length failure

### DIFF
--- a/bridge/app/test/tool/installers_test.dart
+++ b/bridge/app/test/tool/installers_test.dart
@@ -91,41 +91,93 @@ void main() {
       expect(result.stderr, contains('Sesori Bridge supports macOS and Linux only.'));
     });
 
-    test('resolves the newest stable bridge release with matching asset and checksums', () async {
+    test('parses the version from a release-download redirect Location header', () async {
       final libraryPath = await _createInstallShLibrary();
-      final tempDir = await Directory.systemTemp.createTemp('install-sh-release-');
+      final tempDir = await Directory.systemTemp.createTemp('install-sh-parse-');
+      addTearDown(() => tempDir.delete(recursive: true));
+
+      final result = await _runBashSnippet(
+        script:
+            '''
+source ${jsonEncode(libraryPath)}
+printf '%s\n' 'HTTP/2 302' 'location: https://github.com/sesori-ai/sesori_apps_monorepo/releases/download/v1.2.3/sesori-bridge-linux-x64.tar.gz' | parse_version_from_headers
+''',
+        environment: {
+          'PATH': Platform.environment['PATH'] ?? '',
+          'HOME': tempDir.path,
+        },
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      expect((result.stdout as String).trim(), equals('1.2.3'));
+    });
+
+    test('resolves the latest release via the static latest/download redirect (no API, no Python)', () async {
+      final libraryPath = await _createInstallShLibrary();
+      final tempDir = await Directory.systemTemp.createTemp('install-sh-latest-');
+      addTearDown(() => tempDir.delete(recursive: true));
+      final binDir = await Directory(p.join(tempDir.path, 'bin')).create();
+      // A python3 that always fails proves the primary path never invokes it.
+      await _createExecutable(
+        binDir: binDir,
+        name: 'python3',
+        body: '#!/bin/sh\nexit 1\n',
+      );
+
+      final result = await _runBashSnippet(
+        script:
+            '''
+source ${jsonEncode(libraryPath)}
+fetch_redirect_headers() {
+  printf '%s\n' 'location: https://github.com/sesori-ai/sesori_apps_monorepo/releases/download/v4.5.6/sesori-bridge-macos-arm64.tar.gz'
+}
+resolve_release sesori-bridge-macos-arm64.tar.gz
+printf '%s\n%s\n%s\n' "\$RESOLVED_VERSION" "\$RESOLVED_ARCHIVE_URL" "\$RESOLVED_CHECKSUMS_URL"
+''',
+        environment: {
+          'PATH': '${binDir.path}:${Platform.environment['PATH'] ?? ''}',
+          'HOME': tempDir.path,
+        },
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      expect(
+        (result.stdout as String).trim(),
+        equals(
+          [
+            '4.5.6',
+            'https://github.com/sesori-ai/sesori_apps_monorepo/releases/download/v4.5.6/sesori-bridge-macos-arm64.tar.gz',
+            'https://github.com/sesori-ai/sesori_apps_monorepo/releases/download/v4.5.6/checksums.txt',
+          ].join('\n'),
+        ),
+      );
+    });
+
+    test('falls back to scanning older releases when latest/download lacks the asset', () async {
+      final libraryPath = await _createInstallShLibrary();
+      final tempDir = await Directory.systemTemp.createTemp('install-sh-fallback-');
       addTearDown(() => tempDir.delete(recursive: true));
       final releasesPath = p.join(tempDir.path, 'releases.json');
       await File(releasesPath).writeAsString(
         jsonEncode([
+          // Non-"v" tag: ignored.
           {
             'tag_name': 'repo-v9.9.9',
             'draft': false,
             'prerelease': false,
             'assets': [
-              {
-                'name': 'sesori-bridge-macos-arm64.tar.gz',
-                'browser_download_url': 'https://example.com/repo-v9.9.9/sesori-bridge-macos-arm64.tar.gz',
-              },
-              {
-                'name': 'checksums.txt',
-                'browser_download_url': 'https://example.com/repo-v9.9.9/checksums.txt',
-              },
+              {'name': 'sesori-bridge-macos-arm64.tar.gz'},
+              {'name': 'checksums.txt'},
             ],
           },
+          // Prerelease: ignored even though it is the newest.
           {
             'tag_name': 'v0.4.0-beta.1',
             'draft': false,
             'prerelease': true,
             'assets': [
-              {
-                'name': 'sesori-bridge-macos-arm64.tar.gz',
-                'browser_download_url': 'https://example.com/v0.4.0-beta.1/sesori-bridge-macos-arm64.tar.gz',
-              },
-              {
-                'name': 'checksums.txt',
-                'browser_download_url': 'https://example.com/v0.4.0-beta.1/checksums.txt',
-              },
+              {'name': 'sesori-bridge-macos-arm64.tar.gz'},
+              {'name': 'checksums.txt'},
             ],
           },
           {
@@ -133,14 +185,8 @@ void main() {
             'draft': false,
             'prerelease': false,
             'assets': [
-              {
-                'name': 'sesori-bridge-macos-arm64.tar.gz',
-                'browser_download_url': 'https://example.com/v0.3.1/sesori-bridge-macos-arm64.tar.gz',
-              },
-              {
-                'name': 'checksums.txt',
-                'browser_download_url': 'https://example.com/v0.3.1/checksums.txt',
-              },
+              {'name': 'sesori-bridge-macos-arm64.tar.gz'},
+              {'name': 'checksums.txt'},
             ],
           },
           {
@@ -148,14 +194,8 @@ void main() {
             'draft': false,
             'prerelease': false,
             'assets': [
-              {
-                'name': 'sesori-bridge-macos-arm64.tar.gz',
-                'browser_download_url': 'https://example.com/v0.4.0/sesori-bridge-macos-arm64.tar.gz',
-              },
-              {
-                'name': 'checksums.txt',
-                'browser_download_url': 'https://example.com/v0.4.0/checksums.txt',
-              },
+              {'name': 'sesori-bridge-macos-arm64.tar.gz'},
+              {'name': 'checksums.txt'},
             ],
           },
         ]),
@@ -165,9 +205,10 @@ void main() {
         script:
             '''
 source ${jsonEncode(libraryPath)}
+fetch_redirect_headers() { return 1; }
 fetch_text() { cat ${jsonEncode(releasesPath)}; }
-resolve_release_contract sesori-bridge-macos-arm64.tar.gz
-printf '%s\n%s\n%s\n' "\$RESOLVED_RELEASE_TAG" "\$RESOLVED_ARCHIVE_URL" "\$RESOLVED_CHECKSUMS_URL"
+resolve_release sesori-bridge-macos-arm64.tar.gz
+printf '%s\n%s\n%s\n' "\$RESOLVED_VERSION" "\$RESOLVED_ARCHIVE_URL" "\$RESOLVED_CHECKSUMS_URL"
 ''',
         environment: {
           'PATH': Platform.environment['PATH'] ?? '',
@@ -180,37 +221,32 @@ printf '%s\n%s\n%s\n' "\$RESOLVED_RELEASE_TAG" "\$RESOLVED_ARCHIVE_URL" "\$RESOL
         (result.stdout as String).trim(),
         equals(
           [
-            'v0.4.0',
-            'https://example.com/v0.4.0/sesori-bridge-macos-arm64.tar.gz',
-            'https://example.com/v0.4.0/checksums.txt',
+            '0.4.0',
+            'https://github.com/sesori-ai/sesori_apps_monorepo/releases/download/v0.4.0/sesori-bridge-macos-arm64.tar.gz',
+            'https://github.com/sesori-ai/sesori_apps_monorepo/releases/download/v0.4.0/checksums.txt',
           ].join('\n'),
         ),
       );
     });
 
-    test('paginates release resolution until a later page contains the highest eligible stable release', () async {
+    test('paginates the fallback scan until a later page contains the highest eligible stable release', () async {
       final libraryPath = await _createInstallShLibrary();
       final tempDir = await Directory.systemTemp.createTemp('install-sh-pagination-');
       addTearDown(() => tempDir.delete(recursive: true));
       final pageOnePath = p.join(tempDir.path, 'page-1.json');
       final pageTwoPath = p.join(tempDir.path, 'page-2.json');
+      // A full page (per_page=30) forces the scan to fetch a second page.
       await File(pageOnePath).writeAsString(
         jsonEncode(
-          List.generate(100, (index) {
+          List.generate(30, (index) {
             final version = '0.3.${index + 1}';
             return {
               'tag_name': 'v$version',
               'draft': false,
               'prerelease': false,
               'assets': [
-                {
-                  'name': 'sesori-bridge-linux-x64.tar.gz',
-                    'browser_download_url': 'https://example.com/v$version/sesori-bridge-linux-x64.tar.gz',
-                },
-                {
-                  'name': 'checksums.txt',
-                    'browser_download_url': 'https://example.com/v$version/checksums.txt',
-                },
+                {'name': 'sesori-bridge-macos-arm64.tar.gz'},
+                {'name': 'checksums.txt'},
               ],
             };
           }),
@@ -223,14 +259,8 @@ printf '%s\n%s\n%s\n' "\$RESOLVED_RELEASE_TAG" "\$RESOLVED_ARCHIVE_URL" "\$RESOL
             'draft': false,
             'prerelease': false,
             'assets': [
-              {
-                'name': 'sesori-bridge-macos-arm64.tar.gz',
-                'browser_download_url': 'https://example.com/v0.4.0/sesori-bridge-macos-arm64.tar.gz',
-              },
-              {
-                'name': 'checksums.txt',
-                'browser_download_url': 'https://example.com/v0.4.0/checksums.txt',
-              },
+              {'name': 'sesori-bridge-macos-arm64.tar.gz'},
+              {'name': 'checksums.txt'},
             ],
           },
         ]),
@@ -240,6 +270,7 @@ printf '%s\n%s\n%s\n' "\$RESOLVED_RELEASE_TAG" "\$RESOLVED_ARCHIVE_URL" "\$RESOL
         script:
             '''
 source ${jsonEncode(libraryPath)}
+fetch_redirect_headers() { return 1; }
 fetch_text() {
   case "\$1" in
     *page=1) cat ${jsonEncode(pageOnePath)} ;;
@@ -247,8 +278,8 @@ fetch_text() {
     *) printf '[]' ;;
   esac
 }
-resolve_release_contract sesori-bridge-macos-arm64.tar.gz
-printf '%s\n%s\n%s\n' "\$RESOLVED_RELEASE_TAG" "\$RESOLVED_ARCHIVE_URL" "\$RESOLVED_CHECKSUMS_URL"
+resolve_release sesori-bridge-macos-arm64.tar.gz
+printf '%s\n' "\$RESOLVED_VERSION"
 ''',
         environment: {
           'PATH': Platform.environment['PATH'] ?? '',
@@ -257,16 +288,50 @@ printf '%s\n%s\n%s\n' "\$RESOLVED_RELEASE_TAG" "\$RESOLVED_ARCHIVE_URL" "\$RESOL
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
-      expect(
-        (result.stdout as String).trim(),
-        equals(
-          [
-            'v0.4.0',
-            'https://example.com/v0.4.0/sesori-bridge-macos-arm64.tar.gz',
-            'https://example.com/v0.4.0/checksums.txt',
-          ].join('\n'),
-        ),
+      expect((result.stdout as String).trim(), equals('0.4.0'));
+    });
+
+    test('resolves a >128KB release page through the fallback without an argument-length failure', () async {
+      final libraryPath = await _createInstallShLibrary();
+      final tempDir = await Directory.systemTemp.createTemp('install-sh-bigpage-');
+      addTearDown(() => tempDir.delete(recursive: true));
+      final releasesPath = p.join(tempDir.path, 'releases.json');
+      // A single release whose body alone exceeds Linux MAX_ARG_STRLEN (128KB).
+      // The previous implementation passed this JSON through an env var and
+      // failed with "Argument list too long"; reading from a file must not.
+      await File(releasesPath).writeAsString(
+        jsonEncode([
+          {
+            'tag_name': 'v0.9.9',
+            'draft': false,
+            'prerelease': false,
+            'body': 'x' * 200000,
+            'assets': [
+              {'name': 'sesori-bridge-linux-x64.tar.gz'},
+              {'name': 'checksums.txt'},
+            ],
+          },
+        ]),
       );
+      expect(await File(releasesPath).length(), greaterThan(131072));
+
+      final result = await _runBashSnippet(
+        script:
+            '''
+source ${jsonEncode(libraryPath)}
+fetch_redirect_headers() { return 1; }
+fetch_text() { cat ${jsonEncode(releasesPath)}; }
+resolve_release sesori-bridge-linux-x64.tar.gz
+printf '%s\n' "\$RESOLVED_VERSION"
+''',
+        environment: {
+          'PATH': Platform.environment['PATH'] ?? '',
+          'HOME': tempDir.path,
+        },
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      expect((result.stdout as String).trim(), equals('0.9.9'));
     });
 
     test('verifies checksum manifests by asset basename', () async {
@@ -353,22 +418,36 @@ cat "\$HOME/.zprofile"
       );
     });
 
-    test('writes managed runtime manifest with resolved version', () {
+    test('writes managed runtime manifest with the resolved version', () {
       final script = File(_installShPath()).readAsStringSync();
 
       expect(script, contains(r'MANAGED_MANIFEST="${INSTALL_DIR}/.managed-runtime.json"'));
-      expect(script, contains(r'resolved_version="${RESOLVED_RELEASE_TAG#v}"'));
+      expect(script, contains(r'local resolved_version="${RESOLVED_VERSION}"'));
+      expect(script, contains(r'"${BINARY}" --version'));
       expect(script, contains('printf'));
       expect(script, contains('"%s"'));
       expect(script, contains(r'"${resolved_version}" > "${MANAGED_MANIFEST}"'));
     });
 
-    test('accepts only v release tags', () {
+    test('the fallback scan accepts only stable v release tags', () {
       final script = File(_installShPath()).readAsStringSync();
 
       expect(script, contains('if tag_name.startswith("v"):'));
       expect(script, contains('version = tag_name.replace("v", "", 1)'));
       expect(script, isNot(contains('bridge-v')));
+    });
+
+    test('never passes release JSON through argv/env and uses static latest/download', () {
+      final script = File(_installShPath()).readAsStringSync();
+
+      // The original "Argument list too long" failure came from passing the
+      // release JSON to python3 via RELEASES_JSON/PAGE_JSON environment vars.
+      expect(script, isNot(contains('RELEASES_JSON=')));
+      expect(script, isNot(contains('PAGE_JSON=')));
+      // Primary path is GitHub's native always-latest static download.
+      expect(script, contains(r'releases/latest/download/${filename}'));
+      // The fallback scan streams each page to a file (paths-as-args only).
+      expect(script, contains(r'> "${page_file}"'));
     });
   });
 
@@ -395,7 +474,19 @@ cat "\$HOME/.zprofile"
       expect(script, contains('falling back to the x64 build'));
     });
 
-    test('resolves stable bridge-tagged release assets and checksum basenames', () {
+    test('resolves via latest/download with a retained scan fallback', () {
+      // Coordinator dispatches to two peer resolvers.
+      expect(script, contains('function Resolve-BridgeRelease {'));
+      expect(script, contains('function Resolve-BridgeReleaseViaLatest {'));
+      expect(script, contains('function Resolve-BridgeReleaseViaScan {'));
+
+      // Primary: GitHub-native always-latest static asset; version from redirect.
+      expect(script, contains(r'releases/latest/download/$ArchiveName'));
+      expect(script, contains('Get-RedirectLocation'));
+      expect(script, contains(r'releases/download/(v[0-9]+\.[0-9]+\.[0-9]+)/'));
+      expect(script, contains('Test-RemoteAssetExists'));
+
+      // Fallback scan retained: pagination + client-side filtering + version sort.
       expect(script, contains(r"$tagName.StartsWith('v')"));
       expect(script, contains(r'''$release.draft -or $release.prerelease'''));
       expect(script, contains(r'[version]::TryParse($versionText, [ref]$parsedVersion)'));
@@ -404,6 +495,8 @@ cat "\$HOME/.zprofile"
       expect(script, contains('Sort-Object Version -Descending'));
       expect(script, contains(r'''Where-Object { $_.name -eq $ArchiveName }'''));
       expect(script, contains(r'''Where-Object { $_.name -eq 'checksums.txt' }'''));
+
+      // Checksum entries are still matched by asset basename (unchanged).
       expect(script, contains(r'''if ($line -match '^([a-fA-F0-9]{64})\s+\*?(.+)$')'''));
       expect(script, contains(r'''if ($filePart -eq $ArchiveName) {'''));
     });

--- a/bridge/app/test/tool/installers_test.dart
+++ b/bridge/app/test/tool/installers_test.dart
@@ -128,8 +128,10 @@ printf '%s\n' 'HTTP/2 302' 'location: https://github.com/sesori-ai/sesori_apps_m
         script:
             '''
 source ${jsonEncode(libraryPath)}
+# Both the archive probe and the checksums probe go through fetch_redirect_headers;
+# a 2xx status line is required so the resolver accepts the latest release.
 fetch_redirect_headers() {
-  printf '%s\n' 'location: https://github.com/sesori-ai/sesori_apps_monorepo/releases/download/v4.5.6/sesori-bridge-macos-arm64.tar.gz'
+  printf '%s\n' 'HTTP/2 200' 'location: https://github.com/sesori-ai/sesori_apps_monorepo/releases/download/v4.5.6/sesori-bridge-macos-arm64.tar.gz'
 }
 resolve_release sesori-bridge-macos-arm64.tar.gz
 printf '%s\n%s\n%s\n' "\$RESOLVED_VERSION" "\$RESOLVED_ARCHIVE_URL" "\$RESOLVED_CHECKSUMS_URL"
@@ -151,6 +153,94 @@ printf '%s\n%s\n%s\n' "\$RESOLVED_VERSION" "\$RESOLVED_ARCHIVE_URL" "\$RESOLVED_
           ].join('\n'),
         ),
       );
+    });
+
+    test('falls back to a scan when the latest release is missing checksums.txt', () async {
+      final libraryPath = await _createInstallShLibrary();
+      final tempDir = await Directory.systemTemp.createTemp('install-sh-partial-');
+      addTearDown(() => tempDir.delete(recursive: true));
+      final releasesPath = p.join(tempDir.path, 'releases.json');
+      await File(releasesPath).writeAsString(
+        jsonEncode([
+          {
+            'tag_name': 'v0.4.0',
+            'draft': false,
+            'prerelease': false,
+            'assets': [
+              {'name': 'sesori-bridge-macos-arm64.tar.gz'},
+              {'name': 'checksums.txt'},
+            ],
+          },
+        ]),
+      );
+
+      // Latest has the archive (200) but checksums.txt is still missing (404),
+      // e.g. a partial publish window. The resolver must reject it and scan.
+      final result = await _runBashSnippet(
+        script:
+            '''
+source ${jsonEncode(libraryPath)}
+fetch_redirect_headers() {
+  case "\$1" in
+    *checksums.txt) printf '%s\n' 'HTTP/2 404' ;;
+    *) printf '%s\n' 'HTTP/2 200' 'location: https://github.com/sesori-ai/sesori_apps_monorepo/releases/download/v9.9.9/sesori-bridge-macos-arm64.tar.gz' ;;
+  esac
+}
+fetch_text() { cat ${jsonEncode(releasesPath)}; }
+resolve_release sesori-bridge-macos-arm64.tar.gz
+printf '%s\n' "\$RESOLVED_VERSION"
+''',
+        environment: {
+          'PATH': Platform.environment['PATH'] ?? '',
+          'HOME': tempDir.path,
+        },
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      expect((result.stdout as String).trim(), equals('0.4.0'));
+    });
+
+    test('falls back when a stale curl returns exit 0 for a 404 archive HEAD', () async {
+      final libraryPath = await _createInstallShLibrary();
+      final tempDir = await Directory.systemTemp.createTemp('install-sh-oldcurl-');
+      addTearDown(() => tempDir.delete(recursive: true));
+      final releasesPath = p.join(tempDir.path, 'releases.json');
+      await File(releasesPath).writeAsString(
+        jsonEncode([
+          {
+            'tag_name': 'v0.4.0',
+            'draft': false,
+            'prerelease': false,
+            'assets': [
+              {'name': 'sesori-bridge-macos-arm64.tar.gz'},
+              {'name': 'checksums.txt'},
+            ],
+          },
+        ]),
+      );
+
+      // Simulate old curl: exit 0 even though the final hop is 404 (only 3xx +
+      // 4xx, no 2xx). The version is still parseable from the redirect, so the
+      // 2xx guard is what prevents wrongly accepting the missing asset.
+      final result = await _runBashSnippet(
+        script:
+            '''
+source ${jsonEncode(libraryPath)}
+fetch_redirect_headers() {
+  printf '%s\n' 'HTTP/2 302' 'location: https://github.com/sesori-ai/sesori_apps_monorepo/releases/download/v9.9.9/sesori-bridge-macos-arm64.tar.gz' 'HTTP/2 404'
+}
+fetch_text() { cat ${jsonEncode(releasesPath)}; }
+resolve_release sesori-bridge-macos-arm64.tar.gz
+printf '%s\n' "\$RESOLVED_VERSION"
+''',
+        environment: {
+          'PATH': Platform.environment['PATH'] ?? '',
+          'HOME': tempDir.path,
+        },
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      expect((result.stdout as String).trim(), equals('0.4.0'));
     });
 
     test('falls back to scanning older releases when latest/download lacks the asset', () async {
@@ -445,7 +535,8 @@ cat "\$HOME/.zprofile"
       expect(script, isNot(contains('RELEASES_JSON=')));
       expect(script, isNot(contains('PAGE_JSON=')));
       // Primary path is GitHub's native always-latest static download.
-      expect(script, contains(r'releases/latest/download/${filename}'));
+      expect(script, contains('releases/latest/download'));
+      expect(script, contains(r'${latest_base}/${filename}'));
       // The fallback scan streams each page to a file (paths-as-args only).
       expect(script, contains(r'> "${page_file}"'));
     });

--- a/bridge/app/test/tool/installers_test.dart
+++ b/bridge/app/test/tool/installers_test.dart
@@ -243,6 +243,49 @@ printf '%s\n' "\$RESOLVED_VERSION"
       expect((result.stdout as String).trim(), equals('0.4.0'));
     });
 
+    test('treats only the final HTTP status as success, ignoring an intermediate proxy 200', () async {
+      final libraryPath = await _createInstallShLibrary();
+      final tempDir = await Directory.systemTemp.createTemp('install-sh-proxy-');
+      addTearDown(() => tempDir.delete(recursive: true));
+      final releasesPath = p.join(tempDir.path, 'releases.json');
+      await File(releasesPath).writeAsString(
+        jsonEncode([
+          {
+            'tag_name': 'v0.4.0',
+            'draft': false,
+            'prerelease': false,
+            'assets': [
+              {'name': 'sesori-bridge-macos-arm64.tar.gz'},
+              {'name': 'checksums.txt'},
+            ],
+          },
+        ]),
+      );
+
+      // An HTTP proxy emits "200 Connection established" before the real
+      // response. The final status is 404, so the asset must be treated as
+      // missing (matching any 2xx line would wrongly accept it).
+      final result = await _runBashSnippet(
+        script:
+            '''
+source ${jsonEncode(libraryPath)}
+fetch_redirect_headers() {
+  printf '%s\n' 'HTTP/1.1 200 Connection established' 'location: https://github.com/sesori-ai/sesori_apps_monorepo/releases/download/v9.9.9/sesori-bridge-macos-arm64.tar.gz' 'HTTP/2 404'
+}
+fetch_text() { cat ${jsonEncode(releasesPath)}; }
+resolve_release sesori-bridge-macos-arm64.tar.gz
+printf '%s\n' "\$RESOLVED_VERSION"
+''',
+        environment: {
+          'PATH': Platform.environment['PATH'] ?? '',
+          'HOME': tempDir.path,
+        },
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      expect((result.stdout as String).trim(), equals('0.4.0'));
+    });
+
     test('falls back to scanning older releases when latest/download lacks the asset', () async {
       final libraryPath = await _createInstallShLibrary();
       final tempDir = await Directory.systemTemp.createTemp('install-sh-fallback-');

--- a/bridge/app/test/updater/release_contract_test.dart
+++ b/bridge/app/test/updater/release_contract_test.dart
@@ -146,30 +146,49 @@ void main() {
       );
     });
 
-    test('install.sh encodes the v-tagged asset and basename checksum contract', () async {
+    test('install.sh encodes the latest/download contract with a v-tagged scan fallback', () async {
       final script = await _readRepoFile(relativePath: 'install.sh');
 
-      expect(script, contains(r'GITHUB_RELEASES_API_URL="https://api.github.com/repos/${GITHUB_REPO}/releases"'));
-      expect(script, contains('GITHUB_RELEASES_PER_PAGE=100'));
-      expect(script, contains('GITHUB_RELEASES_MAX_PAGES=10'));
+      // Primary path: GitHub-native always-latest static download; the version is
+      // read from the versioned download redirect, and both the archive and
+      // checksums.txt are required before the latest release is accepted.
+      expect(script, contains(r'GITHUB="${GITHUB:-https://github.com}"'));
+      expect(script, contains('releases/latest/download'));
+      expect(script, contains(r'${latest_base}/${filename}'));
+      expect(script, contains(r'${latest_base}/checksums.txt'));
+      expect(script, contains('parse_version_from_headers'));
+      expect(script, contains('headers_indicate_success'));
+
+      // Fallback scan: still the REST API, but small and reading pages from
+      // files (paths-as-args only), never env vars.
+      expect(script, contains(r'GITHUB_API="${GITHUB_API:-https://api.github.com}"'));
+      expect(script, contains('GITHUB_RELEASES_PER_PAGE=30'));
+      expect(script, contains('GITHUB_RELEASES_MAX_PAGES=3'));
       expect(script, contains(r'?per_page=${GITHUB_RELEASES_PER_PAGE}&page=${page}'));
       expect(script, contains('if tag_name.startswith("v"):'));
       expect(script, contains('release.get("draft") or release.get("prerelease")'));
       expect(script, contains('eligible.sort('));
-      expect(script, contains('asset_url = assets.get(filename)'));
-      expect(script, contains('checksums_url = assets.get("checksums.txt")'));
+      expect(script, contains('if filename in asset_names and "checksums.txt" in asset_names:'));
       expect(
         script,
         contains(r'''awk -v name="${filename}" '$2 == name || $2 == "*" name { print $1; exit }' '''),
       );
     });
 
-    test('install.ps1 encodes the v-tagged asset and basename checksum contract', () async {
+    test('install.ps1 encodes the latest/download contract with a v-tagged scan fallback', () async {
       final script = await _readRepoFile(relativePath: 'install.ps1');
 
+      // Primary path: latest/download static asset + redirect-derived version,
+      // requiring the archive and checksums before accepting the latest release.
+      expect(script, contains(r'releases/latest/download/$ArchiveName'));
+      expect(script, contains('Get-RedirectLocation'));
+      expect(script, contains(r'releases/download/(v[0-9]+\.[0-9]+\.[0-9]+)/'));
+      expect(script, contains('Test-RemoteAssetExists'));
+
+      // Fallback scan retained, with the smaller paging contract.
       expect(script, contains(r'$ReleasesApiUrl = "https://api.github.com/repos/$RepoOwner/$RepoName/releases"'));
-      expect(script, contains(r'$ReleasesPerPage = 100'));
-      expect(script, contains(r'$ReleasesMaxPages = 10'));
+      expect(script, contains(r'$ReleasesPerPage = 30'));
+      expect(script, contains(r'$ReleasesMaxPages = 3'));
       expect(script, contains(r'"${ReleasesApiUrl}?per_page=$ReleasesPerPage&page=$page"'));
       expect(script, contains("StartsWith('v')"));
       expect(script, contains(r'''$release.draft -or $release.prerelease'''));

--- a/install.ps1
+++ b/install.ps1
@@ -6,9 +6,13 @@ $ErrorActionPreference = 'Stop'
 
 $RepoOwner  = 'sesori-ai'
 $RepoName   = 'sesori_apps_monorepo'
+$RepoBase   = "https://github.com/$RepoOwner/$RepoName"
 $ReleasesApiUrl = "https://api.github.com/repos/$RepoOwner/$RepoName/releases"
-$ReleasesPerPage = 100
-$ReleasesMaxPages = 10
+# Fallback-only knobs: scanning recent releases is a cold path used only when the
+# latest release lacks this platform's asset. Kept small because the release
+# pipeline prunes internal pre-releases to a single rolling object.
+$ReleasesPerPage = 30
+$ReleasesMaxPages = 3
 $BinaryName = 'sesori-bridge.exe'
 $InstallRoot = Join-Path $env:LOCALAPPDATA 'sesori'
 $BinDir      = Join-Path $InstallRoot 'bin'
@@ -57,7 +61,90 @@ if ($arch -notin @('x64', 'arm64')) {
 }
 
 $ArchiveName   = "sesori-bridge-windows-$arch.zip"
-function Resolve-BridgeRelease {
+# Returns the Location header of the first (non-followed) redirect for $Url, or
+# $null. Used to learn the version from GitHub's latest -> versioned-download
+# redirect without downloading the asset body.
+function Get-RedirectLocation {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Url
+    )
+
+    $request = [System.Net.WebRequest]::Create($Url)
+    $request.Method = 'HEAD'
+    $request.AllowAutoRedirect = $false
+    $request.UserAgent = 'sesori-bridge-installer'
+    try {
+        $response = $request.GetResponse()
+        try {
+            return $response.Headers['Location']
+        } finally {
+            $response.Close()
+        }
+    } catch [System.Net.WebException] {
+        $errorResponse = $_.Exception.Response
+        if ($errorResponse) {
+            try {
+                return $errorResponse.Headers['Location']
+            } finally {
+                $errorResponse.Close()
+            }
+        }
+        return $null
+    }
+}
+
+# Returns $true when a HEAD request to $Url (following redirects) resolves to 200.
+function Test-RemoteAssetExists {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Url
+    )
+
+    try {
+        $response = Invoke-WebRequest -Uri $Url -Method Head -UseBasicParsing -Headers @{ 'User-Agent' = 'sesori-bridge-installer' }
+        return $response.StatusCode -eq 200
+    } catch {
+        return $null
+    }
+}
+
+# Resolver (primary): GitHub serves an always-latest static asset at
+# releases/latest/download/<file>, redirecting through the versioned download
+# path. Read the version from that redirect, confirm the asset exists, and
+# publish the resolution contract. Returns $null when the latest release does not
+# carry this platform's asset, so the coordinator can fall back to a scan.
+function Resolve-BridgeReleaseViaLatest {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ArchiveName
+    )
+
+    $latestAssetUrl = "$RepoBase/releases/latest/download/$ArchiveName"
+    $location = Get-RedirectLocation -Url $latestAssetUrl
+    if (-not $location -or $location -notmatch 'releases/download/(v[0-9]+\.[0-9]+\.[0-9]+)/') {
+        return $null
+    }
+
+    $tagName = $Matches[1]
+    $assetUrl = "$RepoBase/releases/download/$tagName/$ArchiveName"
+    $checksumsUrl = "$RepoBase/releases/download/$tagName/checksums.txt"
+    if (-not (Test-RemoteAssetExists -Url $assetUrl)) {
+        return $null
+    }
+
+    return [pscustomobject]@{
+        Version = $tagName.Substring(1)
+        TagName = $tagName
+        AssetUrl = $assetUrl
+        ChecksumsUrl = $checksumsUrl
+    }
+}
+
+# Resolver (fallback): used only when the latest release lacks this platform's
+# asset. Scans recent releases and selects the newest stable one carrying both
+# the asset and checksums.txt. Returns $null when none qualifies.
+function Resolve-BridgeReleaseViaScan {
     param(
         [Parameter(Mandatory = $true)]
         [string]$ArchiveName
@@ -107,21 +194,35 @@ function Resolve-BridgeRelease {
         return $eligible | Sort-Object Version -Descending | Select-Object -First 1
     }
 
-    throw "Could not resolve a published bridge release for $ArchiveName."
+    return $null
 }
 
-try {
-    $Release = Resolve-BridgeRelease -ArchiveName $ArchiveName
-} catch {
-    $noReleaseFound = $_.Exception.Message -like '*Could not resolve a published bridge release*'
-    if ($arch -eq 'arm64' -and $noReleaseFound) {
-        Write-Warning "No native arm64 bridge release found yet; falling back to the x64 build (runs under emulation on Windows arm64). Re-run this installer after a native arm64 release to switch to the native build."
-        $arch = 'x64'
-        $ArchiveName = "sesori-bridge-windows-$arch.zip"
-        $Release = Resolve-BridgeRelease -ArchiveName $ArchiveName
-    } else {
-        throw
+# Coordinator: resolves the release to install via two peer strategies that
+# return the same shape (Version/TagName/AssetUrl/ChecksumsUrl). The
+# always-latest path is tried first; the older-release scan is the fallback.
+function Resolve-BridgeRelease {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ArchiveName
+    )
+
+    $release = Resolve-BridgeReleaseViaLatest -ArchiveName $ArchiveName
+    if (-not $release) {
+        $release = Resolve-BridgeReleaseViaScan -ArchiveName $ArchiveName
     }
+    return $release
+}
+
+$Release = Resolve-BridgeRelease -ArchiveName $ArchiveName
+if (-not $Release -and $arch -eq 'arm64') {
+    Write-Warning "No native arm64 bridge release found yet; falling back to the x64 build (runs under emulation on Windows arm64). Re-run this installer after a native arm64 release to switch to the native build."
+    $arch = 'x64'
+    $ArchiveName = "sesori-bridge-windows-$arch.zip"
+    $Release = Resolve-BridgeRelease -ArchiveName $ArchiveName
+}
+if (-not $Release) {
+    Write-Error "Could not resolve a published bridge release for $ArchiveName."
+    exit 1
 }
 $AssetUrl = $Release.AssetUrl
 $ChecksumsUrl = $Release.ChecksumsUrl

--- a/install.ps1
+++ b/install.ps1
@@ -105,7 +105,7 @@ function Test-RemoteAssetExists {
         $response = Invoke-WebRequest -Uri $Url -Method Head -UseBasicParsing -Headers @{ 'User-Agent' = 'sesori-bridge-installer' }
         return $response.StatusCode -eq 200
     } catch {
-        return $null
+        return $false
     }
 }
 
@@ -129,7 +129,10 @@ function Resolve-BridgeReleaseViaLatest {
     $tagName = $Matches[1]
     $assetUrl = "$RepoBase/releases/download/$tagName/$ArchiveName"
     $checksumsUrl = "$RepoBase/releases/download/$tagName/checksums.txt"
-    if (-not (Test-RemoteAssetExists -Url $assetUrl)) {
+    # Require both the archive and checksums.txt. During a partial publish the
+    # archive can exist without checksums; without this the installer would fail
+    # the later checksum download instead of falling back to an older release.
+    if (-not (Test-RemoteAssetExists -Url $assetUrl) -or -not (Test-RemoteAssetExists -Url $checksumsUrl)) {
         return $null
     }
 

--- a/install.sh
+++ b/install.sh
@@ -10,14 +10,30 @@ SYMLINK_DIR="${HOME}/.local/bin"
 SYMLINK="${SYMLINK_DIR}/sesori-bridge"
 MANAGED_MANIFEST="${INSTALL_DIR}/.managed-runtime.json"
 GITHUB_REPO="sesori-ai/sesori_apps_monorepo"
-GITHUB_RELEASES_API_URL="https://api.github.com/repos/${GITHUB_REPO}/releases"
-GITHUB_RELEASES_PER_PAGE=100
-GITHUB_RELEASES_MAX_PAGES=10
+# Base hosts are overridable for GitHub Enterprise or testing (see Bun/uv installers).
+GITHUB="${GITHUB:-https://github.com}"
+GITHUB_API="${GITHUB_API:-https://api.github.com}"
+# Fallback-only knobs: scanning recent releases is a cold path used only when the
+# latest release is missing this platform's asset. Kept small because the release
+# pipeline prunes internal pre-releases to a single rolling object.
+GITHUB_RELEASES_API_URL="${GITHUB_API}/repos/${GITHUB_REPO}/releases"
+GITHUB_RELEASES_PER_PAGE=30
+GITHUB_RELEASES_MAX_PAGES=3
+
+# Populated by resolve_release(): the version (without leading "v") and the
+# archive/checksums download URLs for the release being installed.
+RESOLVED_VERSION=""
+RESOLVED_ARCHIVE_URL=""
+RESOLVED_CHECKSUMS_URL=""
 
 TMPDIR_WORK=""
+TMPDIR_RELEASES=""
 cleanup() {
     if [ -n "${TMPDIR_WORK}" ] && [ -d "${TMPDIR_WORK}" ]; then
         rm -rf "${TMPDIR_WORK}"
+    fi
+    if [ -n "${TMPDIR_RELEASES}" ] && [ -d "${TMPDIR_RELEASES}" ]; then
+        rm -rf "${TMPDIR_RELEASES}"
     fi
 }
 trap cleanup EXIT
@@ -75,77 +91,124 @@ fetch_text() {
     fi
 }
 
-resolve_release_contract() {
-    local filename="${1}"
-    if ! command -v python3 > /dev/null 2>&1; then
-        echo "python3 is required to resolve the latest bridge release." >&2
+# Emits the HTTP response headers (including any redirect hops) for a HEAD
+# request to ${url}, and returns non-zero if the URL ultimately 404s/errors.
+# Used to learn the resolved version from GitHub's latest -> versioned-download
+# redirect without downloading the asset body.
+fetch_redirect_headers() {
+    local url="${1}"
+    if command -v curl > /dev/null 2>&1; then
+        curl -fsSL -I -H "User-Agent: sesori-bridge-installer" "${url}"
+    elif command -v wget > /dev/null 2>&1; then
+        wget -S --spider --header="User-Agent: sesori-bridge-installer" "${url}" 2>&1
+    else
+        echo "Neither curl nor wget found. Please install one and retry." >&2
         exit 1
     fi
-    local releases_json='[]'
-    local page_json
-    local page
-    for page in $(seq 1 "${GITHUB_RELEASES_MAX_PAGES}"); do
-        page_json="$(fetch_text "${GITHUB_RELEASES_API_URL}?per_page=${GITHUB_RELEASES_PER_PAGE}&page=${page}")"
-        releases_json="$(RELEASES_JSON="${releases_json}" PAGE_JSON="${page_json}" python3 -c '
-import json, os
+}
 
-releases = json.loads(os.environ["RELEASES_JSON"])
-page = json.loads(os.environ["PAGE_JSON"])
-if not isinstance(releases, list) or not isinstance(page, list):
+# Pure transformation: reads HTTP header text on stdin and prints the X.Y.Z
+# version embedded in a GitHub "releases/download/vX.Y.Z/" redirect Location.
+parse_version_from_headers() {
+    sed -nE 's#.*/releases/download/v([0-9]+\.[0-9]+\.[0-9]+)/.*#\1#p' | head -n 1
+}
+
+# Resolver (primary): GitHub serves an always-latest static asset at
+# releases/latest/download/<file>, redirecting through the versioned download
+# path. Probe it to confirm the asset exists and to learn the version, then
+# publish the resolution contract. Returns non-zero when the latest release does
+# not carry this platform's asset, so the caller can fall back to a scan.
+resolve_release_via_latest() {
+    local filename="${1}"
+    local latest_archive_url="${GITHUB}/${GITHUB_REPO}/releases/latest/download/${filename}"
+
+    local headers
+    headers="$(fetch_redirect_headers "${latest_archive_url}")" || return 1
+
+    local version
+    version="$(printf '%s\n' "${headers}" | parse_version_from_headers)"
+
+    if [ -n "${version}" ]; then
+        RESOLVED_VERSION="${version}"
+        RESOLVED_ARCHIVE_URL="${GITHUB}/${GITHUB_REPO}/releases/download/v${version}/${filename}"
+        RESOLVED_CHECKSUMS_URL="${GITHUB}/${GITHUB_REPO}/releases/download/v${version}/checksums.txt"
+    else
+        # The asset exists but the version was not parseable from the redirect;
+        # download via the always-latest URLs and resolve the version from the
+        # installed binary after extraction.
+        RESOLVED_VERSION=""
+        RESOLVED_ARCHIVE_URL="${latest_archive_url}"
+        RESOLVED_CHECKSUMS_URL="${GITHUB}/${GITHUB_REPO}/releases/latest/download/checksums.txt"
+    fi
+    return 0
+}
+
+# Resolver (fallback): used only when the latest release lacks this platform's
+# asset. Pages recent releases into temp FILES (never argv/env, to avoid the
+# Linux MAX_ARG_STRLEN limit that broke the previous implementation) and selects
+# the newest stable release that carries both the asset and checksums.txt.
+resolve_release_via_scan() {
+    local filename="${1}"
+    if ! command -v python3 > /dev/null 2>&1; then
+        echo "The latest release is missing ${filename}, and resolving an older release requires python3, which was not found." >&2
+        echo "Install python3 and retry, or report this at https://github.com/${GITHUB_REPO}/issues." >&2
+        exit 1
+    fi
+
+    TMPDIR_RELEASES="$(mktemp -d)"
+    local page page_file page_count
+    local page_files=()
+    for page in $(seq 1 "${GITHUB_RELEASES_MAX_PAGES}"); do
+        page_file="${TMPDIR_RELEASES}/releases-page-${page}.json"
+        if ! fetch_text "${GITHUB_RELEASES_API_URL}?per_page=${GITHUB_RELEASES_PER_PAGE}&page=${page}" > "${page_file}"; then
+            echo "Unexpected release metadata returned by GitHub." >&2
+            exit 1
+        fi
+        page_count="$(python3 -c '
+import json, sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    page = json.load(handle)
+if not isinstance(page, list):
     raise SystemExit(1)
-print(json.dumps(releases + page))
-')" || {
+print(len(page))
+' "${page_file}")" || {
             echo "Unexpected release metadata returned by GitHub." >&2
             exit 1
         }
-        if [ "$(PAGE_JSON="${page_json}" python3 -c 'import json, os; page = json.loads(os.environ["PAGE_JSON"]); print(len(page))')" -lt "${GITHUB_RELEASES_PER_PAGE}" ]; then
+        page_files+=("${page_file}")
+        if [ "${page_count}" -lt "${GITHUB_RELEASES_PER_PAGE}" ]; then
             break
         fi
     done
-    local resolved
-resolved="$(RELEASES_JSON="${releases_json}" python3 -c '
-import json, os, sys
+
+    local tag
+    tag="$(python3 -c '
+import json, sys
 from functools import cmp_to_key
 import re
 
 STABLE_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
 
 def compare_versions(a: str, b: str) -> int:
-    def split_pre(v: str):
-        if "-" in v:
-            core, pre = v.split("-", 1)
-        else:
-            core, pre = v, None
-        return core, pre
-
-    def parse_core(v: str):
-        return [int(part) for part in v.split(".")]
-
-    a_core, a_pre = split_pre(a)
-    b_core, b_pre = split_pre(b)
-    a_parts = parse_core(a_core)
-    b_parts = parse_core(b_core)
-
+    a_parts = [int(part) for part in a.split(".")]
+    b_parts = [int(part) for part in b.split(".")]
     for left, right in zip(a_parts, b_parts):
         if left != right:
             return 1 if left > right else -1
-
     if len(a_parts) != len(b_parts):
         return 1 if len(a_parts) > len(b_parts) else -1
-
-    if a_pre is None and b_pre is None:
-        return 0
-    if a_pre is None:
-        return 1
-    if b_pre is None:
-        return -1
     return 0
 
 def is_valid_stable_version(v: str) -> bool:
     return bool(STABLE_VERSION_RE.match(v))
 
 filename = sys.argv[1]
-releases = json.loads(os.environ["RELEASES_JSON"])
+releases = []
+for path in sys.argv[2:]:
+    with open(path, encoding="utf-8") as handle:
+        releases.extend(json.load(handle))
+
 eligible = []
 for release in releases:
     tag_name = release.get("tag_name", "")
@@ -157,35 +220,36 @@ for release in releases:
         continue
     if not is_valid_stable_version(version):
         continue
-    assets = {
-        asset.get("name"): asset.get("browser_download_url")
-        for asset in release.get("assets", [])
-    }
-    asset_url = assets.get(filename)
-    checksums_url = assets.get("checksums.txt")
-    if asset_url and checksums_url:
-        eligible.append((version, tag_name, asset_url, checksums_url))
+    asset_names = {asset.get("name") for asset in release.get("assets", [])}
+    if filename in asset_names and "checksums.txt" in asset_names:
+        eligible.append((version, tag_name))
 
 if eligible:
     eligible.sort(key=cmp_to_key(lambda left, right: compare_versions(left[0], right[0])), reverse=True)
-    _, tag_name, asset_url, checksums_url = eligible[0]
-    print(tag_name)
-    print(asset_url)
-    print(checksums_url)
+    print(eligible[0][1])
     sys.exit(0)
 sys.exit(1)
-' "${filename}")" || {
+' "${filename}" "${page_files[@]}")" || {
         echo "Could not resolve a published bridge release for ${filename}." >&2
         exit 1
     }
-    set -- ${resolved}
-    if [ "$#" -ne 3 ]; then
-        echo "Unexpected release metadata returned by GitHub." >&2
-        exit 1
+
+    RESOLVED_VERSION="${tag#v}"
+    RESOLVED_ARCHIVE_URL="${GITHUB}/${GITHUB_REPO}/releases/download/${tag}/${filename}"
+    RESOLVED_CHECKSUMS_URL="${GITHUB}/${GITHUB_REPO}/releases/download/${tag}/checksums.txt"
+    return 0
+}
+
+# Coordinator: resolves the release to install via two peer strategies that
+# publish the same contract (RESOLVED_VERSION / RESOLVED_ARCHIVE_URL /
+# RESOLVED_CHECKSUMS_URL). The always-latest path is tried first; the
+# older-release scan is the fallback.
+resolve_release() {
+    local filename="${1}"
+    if resolve_release_via_latest "${filename}"; then
+        return 0
     fi
-    RESOLVED_RELEASE_TAG="${1}"
-    RESOLVED_ARCHIVE_URL="${2}"
-    RESOLVED_CHECKSUMS_URL="${3}"
+    resolve_release_via_scan "${filename}"
 }
 
 sha256_file() {
@@ -317,19 +381,24 @@ check_conflicts() {
 }
 
 main() {
-    local os arch filename archive_url checksums_url
+    local os arch filename
 
     os="$(detect_os)"
     arch="$(detect_arch)"
     filename="sesori-bridge-${os}-${arch}.tar.gz"
-    resolve_release_contract "${filename}"
-    archive_url="${RESOLVED_ARCHIVE_URL}"
-    checksums_url="${RESOLVED_CHECKSUMS_URL}"
+    resolve_release "${filename}"
+
+    local release_label
+    if [ -n "${RESOLVED_VERSION}" ]; then
+        release_label="v${RESOLVED_VERSION}"
+    else
+        release_label="latest"
+    fi
 
     echo "Sesori Bridge installer"
     echo "======================="
     echo "Platform     : ${os}/${arch}"
-    echo "Release      : ${RESOLVED_RELEASE_TAG}"
+    echo "Release      : ${release_label}"
     echo "Install root : ${INSTALL_DIR}"
     echo "Symlink      : ${SYMLINK}"
     echo ""
@@ -339,8 +408,8 @@ main() {
     local archive="${TMPDIR_WORK}/${filename}"
     local checksums="${TMPDIR_WORK}/checksums.txt"
 
-    download "${archive_url}" "${archive}"
-    download "${checksums_url}" "${checksums}"
+    download "${RESOLVED_ARCHIVE_URL}" "${archive}"
+    download "${RESOLVED_CHECKSUMS_URL}" "${checksums}"
 
     echo "[2/4] Verifying checksum..."
     verify_checksum "${archive}" "${checksums}" "${filename}" "${os}"
@@ -351,13 +420,24 @@ main() {
     tar -xzf "${archive}" -C "${INSTALL_DIR}"
 
     chmod +x "${BINARY}"
-    resolved_version="${RESOLVED_RELEASE_TAG#v}"
-    printf '{"version":"%s"}\n' "${resolved_version}" > "${MANAGED_MANIFEST}"
 
     if [ "${os}" = "macos" ]; then
         xattr -dr com.apple.quarantine "${INSTALL_DIR}" 2>/dev/null || true
         xattr -dr com.apple.provenance "${INSTALL_DIR}" 2>/dev/null || true
     fi
+
+    # The version comes from the resolved release; if the redirect could not be
+    # parsed (rare), fall back to the freshly installed binary. Quarantine xattrs
+    # are stripped above first so the binary can run on macOS.
+    local resolved_version="${RESOLVED_VERSION}"
+    if [ -z "${resolved_version}" ]; then
+        resolved_version="$("${BINARY}" --version 2>/dev/null | head -n 1 | tr -d '[:space:]')"
+    fi
+    if [ -z "${resolved_version}" ]; then
+        echo "Could not determine the installed bridge version." >&2
+        exit 1
+    fi
+    printf '{"version":"%s"}\n' "${resolved_version}" > "${MANAGED_MANIFEST}"
 
     echo "[4/4] Creating symlink..."
     create_symlink "${BINARY}" "${SYMLINK}"

--- a/install.sh
+++ b/install.sh
@@ -113,17 +113,40 @@ parse_version_from_headers() {
     sed -nE 's#.*/releases/download/v([0-9]+\.[0-9]+\.[0-9]+)/.*#\1#p' | head -n 1
 }
 
+# Reads HTTP header text on stdin; succeeds only if a final 2xx status is present.
+# Some older curl builds (< 7.76.0) exit 0 on a 404 HEAD when combining -I with
+# -f, so the exit code alone cannot confirm an asset exists — the redirect hops
+# are 3xx and only a present asset yields a 2xx, so require a 2xx status line.
+headers_indicate_success() {
+    grep -qiE '^[[:space:]]*HTTP/[0-9.]+[[:space:]]+2[0-9][0-9]'
+}
+
+# Returns 0 when a HEAD to ${1} ultimately resolves to a 2xx response.
+remote_asset_exists() {
+    local headers
+    headers="$(fetch_redirect_headers "${1}")" || return 1
+    printf '%s\n' "${headers}" | headers_indicate_success
+}
+
 # Resolver (primary): GitHub serves an always-latest static asset at
 # releases/latest/download/<file>, redirecting through the versioned download
-# path. Probe it to confirm the asset exists and to learn the version, then
-# publish the resolution contract. Returns non-zero when the latest release does
-# not carry this platform's asset, so the caller can fall back to a scan.
+# path. Probe it to confirm the archive AND checksums.txt both exist and to learn
+# the version, then publish the resolution contract. Returns non-zero when the
+# latest release does not carry a complete asset set for this platform, so the
+# caller can fall back to a scan of older releases.
 resolve_release_via_latest() {
     local filename="${1}"
-    local latest_archive_url="${GITHUB}/${GITHUB_REPO}/releases/latest/download/${filename}"
+    local latest_base="${GITHUB}/${GITHUB_REPO}/releases/latest/download"
 
     local headers
-    headers="$(fetch_redirect_headers "${latest_archive_url}")" || return 1
+    headers="$(fetch_redirect_headers "${latest_base}/${filename}")" || return 1
+    # Confirm the archive itself resolved (not just an intermediate redirect).
+    printf '%s\n' "${headers}" | headers_indicate_success || return 1
+
+    # checksums.txt is a separate release asset; during a partial publish the
+    # archive can exist without it. Require both so we fall back to a complete
+    # older release instead of failing the later checksum download.
+    remote_asset_exists "${latest_base}/checksums.txt" || return 1
 
     local version
     version="$(printf '%s\n' "${headers}" | parse_version_from_headers)"
@@ -137,8 +160,8 @@ resolve_release_via_latest() {
         # download via the always-latest URLs and resolve the version from the
         # installed binary after extraction.
         RESOLVED_VERSION=""
-        RESOLVED_ARCHIVE_URL="${latest_archive_url}"
-        RESOLVED_CHECKSUMS_URL="${GITHUB}/${GITHUB_REPO}/releases/latest/download/checksums.txt"
+        RESOLVED_ARCHIVE_URL="${latest_base}/${filename}"
+        RESOLVED_CHECKSUMS_URL="${latest_base}/checksums.txt"
     fi
     return 0
 }

--- a/install.sh
+++ b/install.sh
@@ -113,12 +113,14 @@ parse_version_from_headers() {
     sed -nE 's#.*/releases/download/v([0-9]+\.[0-9]+\.[0-9]+)/.*#\1#p' | head -n 1
 }
 
-# Reads HTTP header text on stdin; succeeds only if a final 2xx status is present.
+# Reads HTTP header text on stdin; succeeds only if the FINAL HTTP status is 2xx.
 # Some older curl builds (< 7.76.0) exit 0 on a 404 HEAD when combining -I with
-# -f, so the exit code alone cannot confirm an asset exists — the redirect hops
-# are 3xx and only a present asset yields a 2xx, so require a 2xx status line.
+# -f, so the exit code alone cannot confirm an asset exists. We inspect the last
+# status line specifically (not any 2xx line) so an intermediate 2xx — e.g. an
+# HTTP proxy's "200 Connection established" before a final 404 — is not misread
+# as success. POSIX awk keeps this portable across BSD (macOS) and GNU awk.
 headers_indicate_success() {
-    grep -qiE '^[[:space:]]*HTTP/[0-9.]+[[:space:]]+2[0-9][0-9]'
+    awk 'toupper($1) ~ /^HTTP\// { status = $2 } END { exit (status ~ /^2[0-9][0-9]$/) ? 0 : 1 }'
 }
 
 # Returns 0 when a HEAD to ${1} ultimately resolves to a 2xx response.


### PR DESCRIPTION
## Problem

The `curl … | bash` installer (`install.sh`) fails on Linux with **`Argument list too long`** when installing Sesori Bridge (reported on Ubuntu 24.04, v1.1.0).

Root cause: `resolve_release_contract()` passed GitHub release metadata to `python3` through **environment variables**. A single `/releases?per_page=100` page is ~**206 KB**, which exceeds Linux's per‑arg/env limit `MAX_ARG_STRLEN` (**131072 bytes**), so `execve` returns `E2BIG`. macOS limits are far higher, so it wasn't caught locally.

## Approach

Replace the multi‑page GitHub **API scan** with GitHub's native always‑latest static URLs (`releases/latest/download/<file>`):

- **Primary path** (`resolve_release_via_latest`): probe `releases/latest/download/<asset>`, parse the version from the versioned download **redirect**, and construct the archive + `checksums.txt` URLs. No API call, no JSON, **no Python**, nothing passed through argv/env.
- **Coordinator** `resolve_release()` dispatches to two **peer** resolvers publishing the same contract.
- **Fallback** (`resolve_release_via_scan`, rare): only if the latest release lacks this platform's asset. It pages `/releases` into **temp files** (never env vars) and passes only file *paths* to `python3`, so it can't hit the arg‑length limit either. Paging reduced to `per_page=30, max_pages=3`.
- The version for `.managed-runtime.json` comes from the redirect (falls back to `sesori-bridge --version` post‑extract).
- `install.ps1` is mirrored to the same coordinator + `latest/download` shape, keeping the existing `Invoke-RestMethod` scan as the fallback.

Note: GitHub's `/releases/latest` is *defined* as the latest non‑prerelease/non‑draft release, so the primary path is prerelease‑free by construction. (The list API has no server‑side prerelease filter; that filtering is client‑side in the fallback only.)

## Validation

- 18/18 `installers_test.dart` tests pass; `dart analyze --fatal-infos` clean.
- New tests: pure header‑parser unit test, primary‑path test that proves `python3` is never invoked (failing `python3` placed on `PATH`), fallback scan selection (ignores prerelease/non‑`v` tags), fallback pagination, a **>128 KB regression test**, and a guard asserting no `RELEASES_JSON=`/`PAGE_JSON=` env passing remains.
- **Real end‑to‑end install** against live GitHub resolved `v1.1.0`, verified checksum, and wrote `{"version":"1.1.0"}` matching the binary's `--version`.
- `aristotle-plan-review` and `aristotle-impl-review`: both APPROVED.

## Test plan

- [ ] Linux x86_64 (Ubuntu 24.04): `curl … | bash` installs the latest stable build without `Argument list too long`.
- [ ] macOS arm64/x64 and Linux arm64 install via the primary path.
- [ ] Windows `install.ps1` installs via `latest/download` (arm64 → x64 fallback intact).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Linux installer crash (“Argument list too long”) by resolving releases via GitHub’s `releases/latest/download` redirect, removing large JSON from argv/env. Also tightens HTTP checks to accept only the final 2xx status and require `checksums.txt`, with a safe scan fallback.

- **Bug Fixes**
  - Primary path: use `releases/latest/download/<asset>`, parse the version from the redirect, and require a final 2xx plus `checksums.txt`; ignores proxy “200 Connection established” lines and guards old `curl` 404s; no API calls, no JSON piping, no `python3`.
  - Fallback scan: only when latest lacks the asset or checksums; pages `/releases` into temp files and passes only file paths to `python3` (no env bloat). Pagination reduced to `per_page=30`, `max_pages=3`.
  - Writes `.managed-runtime.json` using the parsed version, falling back to `sesori-bridge --version` if the redirect isn’t parseable.
  - Windows `install.ps1`: mirrors the coordinator + `latest/download` flow with `Get-RedirectLocation` and `Test-RemoteAssetExists`, including checksums gating; arm64→x64 fallback unchanged.

<sup>Written for commit 822edf5a9327b62bc7ab85446f1c1b75dca7a062. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

