### PR TITLE
feat(opencode): add --no-password flag to disable OpenCode auth

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/open_code_raw_http_client.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/open_code_raw_http_client.dart
@@ -65,7 +65,7 @@ class OpenCodeRawHttpClient {
 
   Map<String, String> get _authHeaders {
     final password = _password;
-    if (password == null) return const {};
+    if (password == null || password.isEmpty) return const {};
     final creds = base64.encode(utf8.encode("opencode:$password"));
     return {"Authorization": "Basic $creds"};
   }

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
@@ -131,6 +131,12 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
       valueHelp: null,
       validate: null,
     ),
+    PluginFlagOption(
+      name: "no-password",
+      help: "Disable OpenCode server authentication",
+      defaultsTo: false,
+      negatable: true,
+    ),
     PluginValueOption(
       name: "opencode-bin",
       help: "Path to opencode binary",
@@ -145,6 +151,9 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
   static void validateConfigValues(PluginConfig config) {
     if (config.flag("no-auto-start") && config.intValue("port") == null) {
       throw const PluginConfigException("The --no-auto-start flag requires --port to be set.");
+    }
+    if (config.flag("no-password") && (config.value("password")?.isNotEmpty ?? false)) {
+      throw const PluginConfigException("The --no-password flag cannot be used with --password.");
     }
   }
 
@@ -289,6 +298,7 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
 
     final config = host.config;
     final requestedPort = config.intValue("port");
+    final noPassword = config.flag("no-password");
     // Mirror the legacy flow's `password.normalize()`: trim, and map a blank
     // value to "no password supplied" — otherwise the same CLI input would
     // select a different password (or demand auth the user never set) after
@@ -329,11 +339,11 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
       final attachPort = requestedPort!;
       port = attachPort;
       serverUrl = "http://$openCodeLoopbackHost:$attachPort";
-      apiPassword = providedPassword;
+      apiPassword = noPassword ? null : providedPassword;
       spec = buildOpenCodeManagedRuntimeSpec(
         host: host,
         executablePath: "",
-        password: providedPassword ?? "",
+        password: noPassword ? null : (providedPassword ?? ""),
         portPolicy: ExplicitPortPolicy(port: attachPort),
         probeClientFactory: probeClientFactory,
       );
@@ -351,7 +361,7 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
       }
     } else {
       // Managed mode: spawn and own a new server.
-      final serverPassword = providedPassword ?? generateOpenCodePassword(random: _random);
+      final serverPassword = noPassword ? null : (providedPassword ?? generateOpenCodePassword(random: _random));
       apiPassword = serverPassword;
       final executablePath = config.value("opencode-bin")!;
 

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
@@ -108,8 +108,8 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
   final Duration _versionProbeTimeout;
   final OpenCodeDbOptimizer? _optimizeDb;
 
-  /// The four OpenCode CLI options, names/help/defaults identical to the flags
-  /// the bridge has always declared.
+  /// The OpenCode CLI options: the four historical flags plus the
+  /// authentication-disabling flag.
   static const List<PluginOption> cliOptions = [
     PluginValueOption.integer(
       name: "port",
@@ -343,7 +343,7 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
       spec = buildOpenCodeManagedRuntimeSpec(
         host: host,
         executablePath: "",
-        password: noPassword ? null : (providedPassword ?? ""),
+        password: noPassword ? null : providedPassword,
         portPolicy: ExplicitPortPolicy(port: attachPort),
         probeClientFactory: probeClientFactory,
       );

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
@@ -135,7 +135,7 @@ class OpenCodePluginDescriptor extends BridgePluginDescriptor {
       name: "no-password",
       help: "Disable OpenCode server authentication",
       defaultsTo: false,
-      negatable: true,
+      negatable: false,
     ),
     PluginValueOption(
       name: "opencode-bin",

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_policy.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_policy.dart
@@ -165,8 +165,12 @@ Future<SpawnedProcess> spawnOpenCodeProcess({
 }) async {
   final environment = <String, String>{
     ...host.environment,
-    if (password != null && password.isNotEmpty) "OPENCODE_SERVER_PASSWORD": password,
   };
+  if (password == null || password.isEmpty) {
+    environment.remove("OPENCODE_SERVER_PASSWORD");
+  } else {
+    environment["OPENCODE_SERVER_PASSWORD"] = password;
+  }
   final process = await host.processes.spawn(
     executable: executablePath,
     arguments: <String>["serve", "--port", "$port", "--hostname", openCodeLoopbackHost],

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_policy.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_policy.dart
@@ -167,7 +167,9 @@ Future<SpawnedProcess> spawnOpenCodeProcess({
     ...host.environment,
   };
   if (password == null || password.isEmpty) {
-    environment.remove("OPENCODE_SERVER_PASSWORD");
+    environment.removeWhere(
+      (key, _) => key.toUpperCase() == "OPENCODE_SERVER_PASSWORD",
+    );
   } else {
     environment["OPENCODE_SERVER_PASSWORD"] = password;
   }

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_policy.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_policy.dart
@@ -161,11 +161,11 @@ Future<SpawnedProcess> spawnOpenCodeProcess({
   required PluginHost host,
   required String executablePath,
   required int port,
-  required String password,
+  required String? password,
 }) async {
   final environment = <String, String>{
     ...host.environment,
-    "OPENCODE_SERVER_PASSWORD": password,
+    if (password != null && password.isNotEmpty) "OPENCODE_SERVER_PASSWORD": password,
   };
   final process = await host.processes.spawn(
     executable: executablePath,
@@ -231,11 +231,12 @@ class _DrainingOpenCodeProcess implements SpawnedProcess {
 }
 
 /// Probes OpenCode health on [port]: `GET /global/health` with Basic auth
-/// `opencode:<password>`, healthy iff the response is HTTP 200 (matching the
-/// legacy probe). Reports unhealthy rather than throwing on any error.
+/// `opencode:<password>` when a password is supplied, or with no auth when
+/// [password] is null or empty. Healthy iff the response is HTTP 200 (matching
+/// the legacy probe). Reports unhealthy rather than throwing on any error.
 Future<RuntimeHealthProbe> probeOpenCodeHealth({
   required int port,
-  required String password,
+  required String? password,
   required http.Client Function() clientFactory,
   Duration timeout = const Duration(seconds: 5),
 }) async {
@@ -243,7 +244,9 @@ Future<RuntimeHealthProbe> probeOpenCodeHealth({
   try {
     final uri = Uri.parse("http://$openCodeLoopbackHost:$port/global/health");
     final request = http.Request("GET", uri);
-    request.headers["Authorization"] = "Basic ${base64Encode(utf8.encode("opencode:$password"))}";
+    if (password != null && password.isNotEmpty) {
+      request.headers["Authorization"] = "Basic ${base64Encode(utf8.encode("opencode:$password"))}";
+    }
     // One timeout bounds the send AND the body drain together (mirroring the
     // legacy probe): a service that returns headers but never closes the body
     // must fail the attempt, not hang the supervisor under the startup mutex.
@@ -293,7 +296,7 @@ OpenCodeOwnershipRecord buildOpenCodeOwnershipRecord(RuntimeRecordDraft draft) {
 ManagedRuntimeSpec<OpenCodeOwnershipRecord> buildOpenCodeManagedRuntimeSpec({
   required PluginHost host,
   required String executablePath,
-  required String password,
+  required String? password,
   required RuntimePortPolicy portPolicy,
   required http.Client Function() probeClientFactory,
 }) {

--- a/bridge/sesori_plugin_opencode/test/open_code_raw_http_client_test.dart
+++ b/bridge/sesori_plugin_opencode/test/open_code_raw_http_client_test.dart
@@ -54,6 +54,24 @@ void main() {
       expect(captured.headers.containsKey("authorization"), isFalse);
     });
 
+    test("omits the auth header when password is empty", () async {
+      late http.BaseRequest captured;
+      final mockClient = MockClient((request) async {
+        captured = request;
+        return http.Response("{}", 200);
+      });
+
+      final client = OpenCodeRawHttpClient(
+        serverURL: "http://localhost:1234",
+        password: "",
+        client: mockClient,
+      );
+
+      await client.get(path: "/project");
+
+      expect(captured.headers.containsKey("authorization"), isFalse);
+    });
+
     test("forwards the body on POST", () async {
       late String capturedBody;
       final mockClient = MockClient((request) async {

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_availability_test.dart
@@ -9,7 +9,7 @@ import "package:test/test.dart";
 void main() {
   group("OpenCodePluginDescriptor.checkAvailability", () {
     const managedConfig = PluginConfig(
-      values: {"no-auto-start": false, "port": null, "password": "", "opencode-bin": "opencode"},
+      values: {"no-auto-start": false, "port": null, "password": "", "opencode-bin": "opencode", "no-password": false},
     );
 
     test("attach mode (--no-auto-start) reports available without spawning a probe", () async {
@@ -19,7 +19,7 @@ void main() {
 
       final result = await const OpenCodePluginDescriptor().checkAvailability(
         config: const PluginConfig(
-          values: {"no-auto-start": true, "port": "4096", "password": "", "opencode-bin": "opencode"},
+          values: {"no-auto-start": true, "port": "4096", "password": "", "opencode-bin": "opencode", "no-password": false},
         ),
         processes: processes,
         environment: const <String, String>{},
@@ -107,7 +107,7 @@ void main() {
 
       final result = await const OpenCodePluginDescriptor().checkAvailability(
         config: const PluginConfig(
-          values: {"no-auto-start": false, "port": null, "password": "", "opencode-bin": null},
+          values: {"no-auto-start": false, "port": null, "password": "", "opencode-bin": null, "no-password": false},
         ),
         processes: processes,
         environment: const <String, String>{},
@@ -148,7 +148,7 @@ void main() {
 
       final result = await const OpenCodePluginDescriptor().checkAvailability(
         config: const PluginConfig(
-          values: {"no-auto-start": false, "port": null, "password": "", "opencode-bin": "/custom/opencode"},
+          values: {"no-auto-start": false, "port": null, "password": "", "opencode-bin": "/custom/opencode", "no-password": false},
         ),
         processes: processes,
         environment: const <String, String>{},

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_test.dart
@@ -15,31 +15,52 @@ void main() {
   group("OpenCodePluginDescriptor static surface", () {
     const descriptor = OpenCodePluginDescriptor();
 
-    test("declares the four OpenCode CLI options with the legacy names", () {
+    test("declares the OpenCode CLI options with the legacy names plus --no-password", () {
       expect(descriptor.id, equals("opencode"));
       expect(descriptor.displayName, equals("OpenCode"));
       expect(
         descriptor.options.map((o) => o.name).toList(),
-        equals(<String>["port", "no-auto-start", "password", "opencode-bin"]),
+        equals(<String>["port", "no-auto-start", "password", "no-password", "opencode-bin"]),
       );
     });
 
     test("validateConfig requires --port when --no-auto-start is set", () {
       expect(
         () => descriptor.validateConfig(
-          const PluginConfig(values: {"no-auto-start": true, "port": null, "password": "", "opencode-bin": "opencode"}),
+          const PluginConfig(values: {"no-auto-start": true, "port": null, "password": "", "opencode-bin": "opencode", "no-password": false}),
         ),
         throwsA(isA<PluginConfigException>()),
       );
       expect(
         () => descriptor.validateConfig(
-          const PluginConfig(values: {"no-auto-start": true, "port": "4096", "password": "", "opencode-bin": "opencode"}),
+          const PluginConfig(values: {"no-auto-start": true, "port": "4096", "password": "", "opencode-bin": "opencode", "no-password": false}),
         ),
         returnsNormally,
       );
       expect(
         () => descriptor.validateConfig(
-          const PluginConfig(values: {"no-auto-start": false, "port": null, "password": "", "opencode-bin": "opencode"}),
+          const PluginConfig(values: {"no-auto-start": false, "port": null, "password": "", "opencode-bin": "opencode", "no-password": false}),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test("validateConfig rejects --no-password together with --password", () {
+      expect(
+        () => descriptor.validateConfig(
+          const PluginConfig(values: {"no-auto-start": true, "port": "4096", "password": "secret", "opencode-bin": "opencode", "no-password": true}),
+        ),
+        throwsA(isA<PluginConfigException>()),
+      );
+      expect(
+        () => descriptor.validateConfig(
+          const PluginConfig(values: {"no-auto-start": true, "port": "4096", "password": "", "opencode-bin": "opencode", "no-password": true}),
+        ),
+        returnsNormally,
+      );
+      expect(
+        () => descriptor.validateConfig(
+          const PluginConfig(values: {"no-auto-start": true, "port": "4096", "password": "secret", "opencode-bin": "opencode", "no-password": false}),
         ),
         returnsNormally,
       );
@@ -54,7 +75,7 @@ void main() {
     setUp(() {
       host = _FakeHost(
         config: const PluginConfig(
-          values: {"port": null, "no-auto-start": false, "password": "", "opencode-bin": "/bin/opencode"},
+          values: {"port": null, "no-auto-start": false, "password": "", "opencode-bin": "/bin/opencode", "no-password": false},
         ),
       );
       apiRecorder = _FakeApiRecorder();
@@ -91,6 +112,25 @@ void main() {
       expect(record!["status"], equals("ready"));
       expect(record["port"], equals(51000));
       expect(record["openCodePid"], equals(4242));
+
+      await plugin.shutdown(budget: null);
+    });
+
+    test("--no-password spawns without OPENCODE_SERVER_PASSWORD", () async {
+      host = _FakeHost(
+        config: const PluginConfig(
+          values: {"port": null, "no-auto-start": false, "password": "", "opencode-bin": "/bin/opencode", "no-password": true},
+        ),
+      );
+      host.ports.defaultBindable = true;
+      final plugin = await descriptor().start(host);
+
+      expect(plugin.currentStatus, isA<PluginReady>());
+      expect(apiRecorder.last!.password, isNull);
+      expect(host.processes.spawnedProcesses, hasLength(1));
+      final environment = host.processes.spawnEnvironments.single;
+      expect(environment, isNotNull);
+      expect(environment!.containsKey("OPENCODE_SERVER_PASSWORD"), isFalse);
 
       await plugin.shutdown(budget: null);
     });
@@ -282,7 +322,7 @@ void main() {
 
     _FakeHost attachHost() => _FakeHost(
       config: const PluginConfig(
-        values: {"port": "4096", "no-auto-start": true, "password": "", "opencode-bin": "opencode"},
+        values: {"port": "4096", "no-auto-start": true, "password": "", "opencode-bin": "opencode", "no-password": false},
       ),
     );
 
@@ -301,6 +341,26 @@ void main() {
       expect(plugin.describe().details["mode"], equals("attached"));
       expect(host.ownershipRecord("owner-current"), isNull);
       expect(host.processes.spawnedProcesses, isEmpty);
+
+      await plugin.shutdown(budget: null);
+    });
+
+    test("--no-password attaches with a null password", () async {
+      final host = _FakeHost(
+        config: const PluginConfig(
+          values: {"port": "4096", "no-auto-start": true, "password": "", "opencode-bin": "opencode", "no-password": true},
+        ),
+      );
+      final descriptor = OpenCodePluginDescriptor(
+        buildApi: apiRecorder.build,
+        optimizeDb: _noopOptimizeDb,
+        probeClientFactory: () => MockClient((_) async => http.Response("", 200)),
+      );
+
+      final plugin = await descriptor.start(host);
+
+      expect(plugin.currentStatus, isA<PluginReady>());
+      expect(apiRecorder.last!.password, isNull);
 
       await plugin.shutdown(budget: null);
     });
@@ -332,7 +392,7 @@ void main() {
 
       final trimmedHost = _FakeHost(
         config: const PluginConfig(
-          values: {"port": "4096", "no-auto-start": true, "password": "  secret  ", "opencode-bin": "opencode"},
+          values: {"port": "4096", "no-auto-start": true, "password": "  secret  ", "opencode-bin": "opencode", "no-password": false},
         ),
       );
       final trimmedPlugin = await descriptor.start(trimmedHost);
@@ -341,7 +401,7 @@ void main() {
 
       final blankHost = _FakeHost(
         config: const PluginConfig(
-          values: {"port": "4096", "no-auto-start": true, "password": "   ", "opencode-bin": "opencode"},
+          values: {"port": "4096", "no-auto-start": true, "password": "   ", "opencode-bin": "opencode", "no-password": false},
         ),
       );
       final blankPlugin = await descriptor.start(blankHost);
@@ -590,6 +650,7 @@ class _FakePortService implements HostPortService {
 
 class _FakeHostProcessService implements HostProcessService {
   final List<_FakeSpawnedProcess> spawnedProcesses = <_FakeSpawnedProcess>[];
+  final List<Map<String, String>?> spawnEnvironments = <Map<String, String>?>[];
   final List<String> signals = <String>[];
   final Map<int, ProcessIdentity> inspectResults = <int, ProcessIdentity>{};
   void Function()? onSpawn;
@@ -604,6 +665,7 @@ class _FakeHostProcessService implements HostProcessService {
     required bool runInShell,
   }) async {
     onSpawn?.call();
+    spawnEnvironments.add(environment);
     final process = _FakeSpawnedProcess(pid: nextPid++, executablePath: executable);
     spawnedProcesses.add(process);
     return process;

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_policy_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_policy_test.dart
@@ -233,11 +233,16 @@ void main() {
       expect(recording.environment!.containsKey("OPENCODE_SERVER_PASSWORD"), isFalse);
     });
 
-    test("omits the password env var when password is empty", () async {
+    test("removes password env vars case-insensitively when password is empty", () async {
       final recording = _RecordingHostProcessService();
       final host = _SpawnFakeHost(
         processes: recording,
-        environment: const <String, String>{"PATH": "/usr/bin"},
+        environment: const <String, String>{
+          "PATH": "/usr/bin",
+          "Opencode_Server_Password": "leak",
+          "opencode_server_password": "leak2",
+          "OPENCODE_SERVER_PASSWORD": "leak3",
+        },
       );
 
       await spawnOpenCodeProcess(
@@ -248,7 +253,10 @@ void main() {
       );
 
       expect(recording.environment, isNotNull);
+      expect(recording.environment!.containsKey("Opencode_Server_Password"), isFalse);
+      expect(recording.environment!.containsKey("opencode_server_password"), isFalse);
       expect(recording.environment!.containsKey("OPENCODE_SERVER_PASSWORD"), isFalse);
+      expect(recording.environment!["PATH"], equals("/usr/bin"));
     });
   });
 

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_policy_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_policy_test.dart
@@ -126,6 +126,36 @@ void main() {
       );
     });
 
+    test("omits the Authorization header when password is null", () async {
+      late http.BaseRequest captured;
+      final probe = await probeOpenCodeHealth(
+        port: 51000,
+        password: null,
+        clientFactory: () => MockClient((request) async {
+          captured = request;
+          return http.Response("", 200);
+        }),
+      );
+
+      expect(probe.healthy, isTrue);
+      expect(captured.headers.containsKey("Authorization"), isFalse);
+    });
+
+    test("omits the Authorization header when password is empty", () async {
+      late http.BaseRequest captured;
+      final probe = await probeOpenCodeHealth(
+        port: 51000,
+        password: "",
+        clientFactory: () => MockClient((request) async {
+          captured = request;
+          return http.Response("", 200);
+        }),
+      );
+
+      expect(probe.healthy, isTrue);
+      expect(captured.headers.containsKey("Authorization"), isFalse);
+    });
+
     test("reports unhealthy with an error on a non-200 status", () async {
       final probe = await probeOpenCodeHealth(
         port: 51000,
@@ -183,6 +213,42 @@ void main() {
       expect(recording.environment?["PATH"], equals("/usr/bin"));
       expect(recording.environment?["HOME"], equals("/home/alex"));
       expect(recording.workingDirectory, isNull);
+    });
+
+    test("omits the password env var when password is null", () async {
+      final recording = _RecordingHostProcessService();
+      final host = _SpawnFakeHost(
+        processes: recording,
+        environment: const <String, String>{"PATH": "/usr/bin"},
+      );
+
+      await spawnOpenCodeProcess(
+        host: host,
+        executablePath: "/bin/opencode",
+        port: 51000,
+        password: null,
+      );
+
+      expect(recording.environment, isNotNull);
+      expect(recording.environment!.containsKey("OPENCODE_SERVER_PASSWORD"), isFalse);
+    });
+
+    test("omits the password env var when password is empty", () async {
+      final recording = _RecordingHostProcessService();
+      final host = _SpawnFakeHost(
+        processes: recording,
+        environment: const <String, String>{"PATH": "/usr/bin"},
+      );
+
+      await spawnOpenCodeProcess(
+        host: host,
+        executablePath: "/bin/opencode",
+        port: 51000,
+        password: "",
+      );
+
+      expect(recording.environment, isNotNull);
+      expect(recording.environment!.containsKey("OPENCODE_SERVER_PASSWORD"), isFalse);
     });
   });
 


### PR DESCRIPTION
Adds an explicit `--no-password` flag to the OpenCode bridge plugin.

When set, the bridge does not generate, pass, or require an OpenCode server password:
- Managed mode spawns `opencode serve` without setting `OPENCODE_SERVER_PASSWORD`.
- Attach mode probes and connects without sending an `Authorization` header.
- `OpenCodeRawHttpClient` now treats an empty password the same as a missing password.

Validation rejects using `--no-password` together with `--password`.

All bridge tests and analysis pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--no-password` flag to the OpenCode bridge to disable server auth in managed and attach modes. When set or when the password is empty, we omit `OPENCODE_SERVER_PASSWORD` and the `Authorization` header, and treat it as no password.

- **New Features**
  - Added `--no-password` (non-negatable); cannot be used with `--password`.
  - Managed mode: spawns `opencode serve` without `OPENCODE_SERVER_PASSWORD`.
  - Attach mode: probes/connects without an `Authorization` header.
  - Empty or null passwords skip auth across the HTTP client, health probe, and spawn env.

- **Bug Fixes**
  - Case-insensitive removal of any inherited `OPENCODE_SERVER_PASSWORD` from the environment when auth is disabled or the password is empty.

<sup>Written for commit b57fc84329f031ac3482461ce7a6de4dc05c9484. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

