### PR TITLE
feat(installer): polished, branded output across all install paths

### DIFF
--- a/bridge/app/npm/sesori-bridge/bin/bridge.js
+++ b/bridge/app/npm/sesori-bridge/bin/bridge.js
@@ -3,6 +3,7 @@
 "use strict";
 
 var bootstrap = require("../lib/bootstrap");
+var uiModule = require("../lib/ui");
 
 var PLATFORM_PACKAGES = bootstrap.PLATFORM_PACKAGES;
 
@@ -10,12 +11,16 @@ var key = process.platform + " " + process.arch;
 var pkgName = PLATFORM_PACKAGES[key];
 
 if (!pkgName) {
-  console.error(
-    "sesori-bridge: Unsupported platform: " + process.platform + " " + process.arch + "\n" +
-    "Supported platforms: " + Object.keys(PLATFORM_PACKAGES).join(", ") + "\n" +
-    "You can install the correct package manually:\n" +
-    "  npm install " + Object.values(PLATFORM_PACKAGES).join("\n  npm install ")
-  );
+  // Pass the current process streams/env explicitly so the message is emitted
+  // through the same process object the caller sees (matters under test sandboxes
+  // that intercept process.stderr/stdout).
+  var ui = new uiModule.Ui({ stream: process.stdout, errStream: process.stderr, env: process.env });
+  ui.error("Unsupported platform: " + process.platform + " " + process.arch);
+  ui.hint("Supported platforms: " + Object.keys(PLATFORM_PACKAGES).join(", "));
+  ui.hint("You can install the correct package manually:");
+  Object.values(PLATFORM_PACKAGES).forEach(function(name) {
+    ui.hint("  npm install " + name);
+  });
   process.exit(1);
 }
 

--- a/bridge/app/npm/sesori-bridge/bin/bridge.js
+++ b/bridge/app/npm/sesori-bridge/bin/bridge.js
@@ -17,10 +17,8 @@ if (!pkgName) {
   var ui = new uiModule.Ui({ stream: process.stdout, errStream: process.stderr, env: process.env });
   ui.error("Unsupported platform: " + process.platform + " " + process.arch);
   ui.hint("Supported platforms: " + Object.keys(PLATFORM_PACKAGES).join(", "));
-  ui.hint("You can install the correct package manually:");
-  Object.values(PLATFORM_PACKAGES).forEach(function(name) {
-    ui.hint("  npm install " + name);
-  });
+  ui.hint("Install on a supported platform with:");
+  ui.hint("  npx @sesori/bridge");
   process.exit(1);
 }
 

--- a/bridge/app/npm/sesori-bridge/lib/bootstrap.js
+++ b/bridge/app/npm/sesori-bridge/lib/bootstrap.js
@@ -92,14 +92,21 @@ function isManagedSymlinkReady(installRoot) {
   }
 }
 
+// Whether the bare `sesori-bridge` command resolves in a fresh shell. On Windows
+// there is no ~/.local/bin symlink, so PATH being configured is the only signal;
+// on Unix both the PATH entry and the managed symlink must hold.
+function isCommandReady(installRoot) {
+  var pathConfigured = launcher.isLocalBinInPath();
+  if (process.platform === "win32") {
+    return pathConfigured;
+  }
+  return pathConfigured && isManagedSymlinkReady(installRoot);
+}
+
 function printInstallSummary(options) {
   var commands = nextCommand(options.binaryPath, options.args);
-  var pathConfigured = launcher.isLocalBinInPath();
   var symlinkReady = isManagedSymlinkReady(options.installRoot);
-
-  // On Windows there is no ~/.local/bin symlink; PATH being configured is the
-  // signal that the bare command resolves. On Unix, both must hold.
-  var commandReady = process.platform === "win32" ? pathConfigured : (pathConfigured && symlinkReady);
+  var commandReady = isCommandReady(options.installRoot);
 
   if (commandReady) {
     ui.completion({
@@ -246,6 +253,7 @@ async function runMain(options) {
   var bootstrapResult = await bootstrapManagedRuntime(options && options.pkgName);
   var launcherResult = null;
   var pathStatus = "already configured";
+  var pathChanged = false;
   try {
     launcherResult = launcher.ensureManagedCommandPath({
       binDir: managedBinDir(bootstrapResult.installRoot),
@@ -254,6 +262,7 @@ async function runMain(options) {
       shellPath: process.env.SHELL || "",
     });
     pathStatus = launcherResult && launcherResult.message ? launcherResult.message : "already configured";
+    pathChanged = !!(launcherResult && launcherResult.changed);
   } catch (error) {
     pathStatus = "manual action required";
     ui.error("Failed to persist the managed command path.");
@@ -261,9 +270,14 @@ async function runMain(options) {
     ui.hint("The managed runtime is installed, but you may need to add it to PATH manually.");
   }
 
-  // Stay quiet on a no-op re-bootstrap (runtime already current); only show the
-  // completion panel when an install actually happened.
-  if (bootstrapResult.installed) {
+  // Show the completion panel when there is something actionable to tell the
+  // user: a real install happened, the bootstrap just changed the PATH, or the
+  // command isn't usable yet (PATH not configured / symlink missing) so the
+  // user still needs the "open a new terminal" / direct-binary guidance. Only a
+  // pure no-op — runtime current AND command already usable AND nothing changed
+  // — stays quiet, so repeated launches aren't noisy.
+  var commandReady = isCommandReady(bootstrapResult.installRoot);
+  if (bootstrapResult.installed || pathChanged || !commandReady) {
     printInstallSummary({
       installRoot: bootstrapResult.installRoot,
       binaryPath: bootstrapResult.binaryPath,

--- a/bridge/app/npm/sesori-bridge/lib/bootstrap.js
+++ b/bridge/app/npm/sesori-bridge/lib/bootstrap.js
@@ -65,9 +65,9 @@ function nextCommand(binaryPath, args) {
   }
   return {
     managed: managedCommand,
+    // Bare-command form used both as the runnable next step and as the
+    // completion panel's highlighted call-to-action.
     pathCommand: ["sesori-bridge"].concat(commandArgs).map(shellQuote).join(" "),
-    // Display form for the completion panel's highlighted call-to-action.
-    pathDisplay: ["sesori-bridge"].concat(commandArgs).map(shellQuote).join(" "),
   };
 }
 
@@ -106,7 +106,7 @@ function printInstallSummary(options) {
       version: options.version,
       location: options.installRoot,
       onPath: true,
-      command: commands.pathDisplay,
+      command: commands.pathCommand,
     });
   } else if (!symlinkReady && process.platform !== "win32") {
     // The managed symlink is missing/blocked: instruct the user to run the
@@ -122,7 +122,7 @@ function printInstallSummary(options) {
       version: options.version,
       location: options.installRoot,
       onPath: false,
-      command: commands.pathDisplay,
+      command: commands.pathCommand,
     });
   }
 }

--- a/bridge/app/npm/sesori-bridge/lib/bootstrap.js
+++ b/bridge/app/npm/sesori-bridge/lib/bootstrap.js
@@ -6,6 +6,11 @@ var launcher = require("./launcher");
 var bootstrapLock = require("./bootstrap_lock");
 var releaseAssetRuntime = require("./release_asset_runtime");
 var runtimeInstall = require("./runtime_install");
+var uiModule = require("./ui");
+
+// Single shared UI instance for the bootstrap's user-facing output. Matches the
+// visual spec of install.sh / install.ps1.
+var ui = new uiModule.Ui({});
 
 var PLATFORM_PACKAGES = {
   "darwin arm64": "@sesori/bridge-darwin-arm64",
@@ -17,7 +22,15 @@ var PLATFORM_PACKAGES = {
 };
 
 function fail(message) {
-  console.error(message);
+  // Render each line of a multi-line error through the styled prefix: the first
+  // line as the Error, subsequent lines as muted Notes (remediation guidance).
+  var lines = String(message).split("\n");
+  ui.error(lines[0].replace(/^sesori-bridge:\s*/, ""));
+  for (var i = 1; i < lines.length; i++) {
+    if (lines[i].length > 0) {
+      ui.hint(lines[i]);
+    }
+  }
   process.exit(1);
 }
 
@@ -53,6 +66,8 @@ function nextCommand(binaryPath, args) {
   return {
     managed: managedCommand,
     pathCommand: ["sesori-bridge"].concat(commandArgs).map(shellQuote).join(" "),
+    // Display form for the completion panel's highlighted call-to-action.
+    pathDisplay: ["sesori-bridge"].concat(commandArgs).map(shellQuote).join(" "),
   };
 }
 
@@ -81,26 +96,34 @@ function printInstallSummary(options) {
   var commands = nextCommand(options.binaryPath, options.args);
   var pathConfigured = launcher.isLocalBinInPath();
   var symlinkReady = isManagedSymlinkReady(options.installRoot);
-  console.log("");
-  console.log("Sesori Bridge install complete");
-  console.log("============================");
-  console.log("Managed install: " + options.installRoot);
-  console.log("Managed binary : " + options.binaryPath);
-  console.log("PATH update    : " + options.pathStatus);
-  console.log("");
-  console.log("Next steps");
-  console.log("----------");
-  if (pathConfigured && symlinkReady) {
-    console.log("Start the bridge:");
-    console.log("   " + commands.pathCommand);
-  } else if (!pathConfigured) {
-    console.log("1. Open a new terminal");
-    console.log("2. Run the bridge:");
-    console.log("   " + commands.pathCommand);
+
+  // On Windows there is no ~/.local/bin symlink; PATH being configured is the
+  // signal that the bare command resolves. On Unix, both must hold.
+  var commandReady = process.platform === "win32" ? pathConfigured : (pathConfigured && symlinkReady);
+
+  if (commandReady) {
+    ui.completion({
+      version: options.version,
+      location: options.installRoot,
+      onPath: true,
+      command: commands.pathDisplay,
+    });
+  } else if (!symlinkReady && process.platform !== "win32") {
+    // The managed symlink is missing/blocked: instruct the user to run the
+    // managed binary directly rather than the bare command.
+    ui.completion({
+      version: options.version,
+      location: options.installRoot,
+      onPath: true,
+      command: commands.managed,
+    });
   } else {
-    console.log("The symlink at ~/.local/bin/sesori-bridge is missing or blocked.");
-    console.log("Run the bridge directly:");
-    console.log("   " + commands.managed);
+    ui.completion({
+      version: options.version,
+      location: options.installRoot,
+      onPath: false,
+      command: commands.pathDisplay,
+    });
   }
 }
 
@@ -136,7 +159,7 @@ async function bootstrapManagedRuntime(pkgName) {
     return await bootstrapLock.withBootstrapLock({
       installRoot: installRoot,
       onWait: function() {
-        console.error("sesori-bridge: Another bootstrap is already in progress. Waiting for the managed install lock...");
+        ui.noteErr("Another bootstrap is already in progress. Waiting for the managed install lock...");
       },
     }, async function() {
       var currentVersion = runtimeInstall.readManagedVersion(installRoot);
@@ -151,17 +174,38 @@ async function bootstrapManagedRuntime(pkgName) {
             );
           }
           runtimeInstall.createManagedSymlink(installRoot);
-          return { binaryPath: runtimeInstall.managedBinaryPath(installRoot), installRoot: installRoot };
+          // Already up to date: nothing to install, so stay quiet (no banner).
+          return { binaryPath: runtimeInstall.managedBinaryPath(installRoot), installRoot: installRoot, version: currentVersion, installed: false };
         }
         if (comparison === 0 && runtimeReady) {
           runtimeInstall.createManagedSymlink(installRoot);
-          return { binaryPath: runtimeInstall.managedBinaryPath(installRoot), installRoot: installRoot };
+          return { binaryPath: runtimeInstall.managedBinaryPath(installRoot), installRoot: installRoot, version: currentVersion, installed: false };
         }
       }
+
+      // A real install is happening — show the full branded flow. Steps mirror
+      // the shell installers (Download, Verify, Install, Link) so the experience
+      // is consistent across runtimes; resolvePayload performs the download +
+      // checksum verification for the GitHub-fallback path internally.
+      ui.banner();
+      ui.summary(process.platform + "/" + process.arch, "v" + preferredVersion);
+
       payload = localPayload;
+      ui.step(1, "Downloading release");
       if (!payload) {
+        // No bundled npm payload; download the matching GitHub release asset.
         payload = await releaseAssetRuntime.resolvePayload();
+        ui.ok("Downloaded release v" + (payload && payload.version ? payload.version : preferredVersion));
+      } else {
+        ui.ok("Using bundled runtime payload");
       }
+
+      ui.step(2, "Verifying checksum");
+      // resolvePayload verifies the SHA256 of downloaded assets; bundled npm
+      // payloads are trusted via the npm tarball integrity check.
+      ui.ok("Checksum verified");
+
+      ui.step(3, "Installing managed runtime");
       try {
         runtimeInstall.installManagedRuntime(payload, installRoot, {
           beforeInstallSwap: function() {
@@ -179,8 +223,17 @@ async function bootstrapManagedRuntime(pkgName) {
           "Refusing to run runtime binaries from npm-owned paths. Delete the managed install directory and rerun npx @sesori/bridge if you need a clean bootstrap."
         );
       }
+      ui.ok("Installed to " + installRoot);
+
+      ui.step(4, "Linking command");
       runtimeInstall.createManagedSymlink(installRoot);
-      return { binaryPath: runtimeInstall.managedBinaryPath(installRoot), installRoot: installRoot };
+      if (process.platform === "win32") {
+        ui.ok("Linked sesori-bridge");
+      } else {
+        ui.ok("Linked ~/.local/bin/sesori-bridge");
+      }
+      var installedVersion = runtimeInstall.readManagedVersion(installRoot) || preferredVersion;
+      return { binaryPath: runtimeInstall.managedBinaryPath(installRoot), installRoot: installRoot, version: installedVersion, installed: true };
     });
   } finally {
     if (payload && typeof payload.cleanup === "function") {
@@ -203,18 +256,22 @@ async function runMain(options) {
     pathStatus = launcherResult && launcherResult.message ? launcherResult.message : "already configured";
   } catch (error) {
     pathStatus = "manual action required";
-    console.error(
-      "sesori-bridge: Failed to persist the managed command path.\n" +
-      errorMessage(error) + "\n" +
-      "The managed runtime is installed, but you may need to add it to PATH manually."
-    );
+    ui.error("Failed to persist the managed command path.");
+    ui.hint(errorMessage(error));
+    ui.hint("The managed runtime is installed, but you may need to add it to PATH manually.");
   }
-  printInstallSummary({
-    installRoot: bootstrapResult.installRoot,
-    binaryPath: bootstrapResult.binaryPath,
-    pathStatus: pathStatus,
-    args: process.argv.slice(2),
-  });
+
+  // Stay quiet on a no-op re-bootstrap (runtime already current); only show the
+  // completion panel when an install actually happened.
+  if (bootstrapResult.installed) {
+    printInstallSummary({
+      installRoot: bootstrapResult.installRoot,
+      binaryPath: bootstrapResult.binaryPath,
+      version: bootstrapResult.version,
+      pathStatus: pathStatus,
+      args: process.argv.slice(2),
+    });
+  }
 }
 
 function main(options) {

--- a/bridge/app/npm/sesori-bridge/lib/runtime_install.js
+++ b/bridge/app/npm/sesori-bridge/lib/runtime_install.js
@@ -4,6 +4,7 @@ var child_process = require("child_process");
 var fs = require("fs");
 var os = require("os");
 var path = require("path");
+var ui = require("./ui").shared();
 
 function fail(message) {
   console.error(message);
@@ -171,7 +172,8 @@ function createManagedSymlink(installRoot) {
     }
     fs.symlinkSync(binaryPath, symlinkPath);
   } catch (error) {
-    console.warn("sesori-bridge: Failed to create symlink at " + symlinkPath + ". You may need to add " + path.dirname(binaryPath) + " to PATH manually.");
+    ui.warn("Failed to create symlink at " + symlinkPath + ".");
+    ui.hint("You may need to add " + path.dirname(binaryPath) + " to PATH manually.");
   }
 }
 
@@ -184,7 +186,7 @@ function stripMacOSAttributes(installRoot) {
     try {
       child_process.execFileSync("xattr", ["-dr", attr, installRoot], { stdio: "pipe" });
     } catch (error) {
-      console.warn("sesori-bridge: Failed to strip " + attr + " from " + installRoot + ": " + error.message);
+      ui.warn("Failed to strip " + attr + " from " + installRoot + ": " + error.message);
     }
   });
 }

--- a/bridge/app/npm/sesori-bridge/lib/ui.js
+++ b/bridge/app/npm/sesori-bridge/lib/ui.js
@@ -10,7 +10,7 @@
 // TERM=dumb, non-UTF-8 locale). FORCE_COLOR forces color on.
 
 var TOTAL_STEPS = 4;
-var PANEL_WIDTH = 52;
+var PANEL_WIDTH = 56;
 var ESC = "\u001b";
 
 // ┌─ PALETTE ───────────────────────────────────────────────────────────────────
@@ -273,18 +273,32 @@ Ui.prototype.panelRow = function(content, contentColor, border) {
 };
 
 // A panel row highlighting a runnable command plus a muted inline comment. Width
-// is computed from the plain text so colored escapes don't skew alignment.
+// is computed from the plain text so colored escapes don't skew alignment. If the
+// command alone exceeds the panel width the comment is dropped (and the command
+// truncated as a last resort) so the right border stays aligned.
 Ui.prototype.panelCommandRow = function(command, comment, border) {
   var c = this._panelChars();
   var gap = "   ";
-  var plain = command + gap + comment;
   var inner = PANEL_WIDTH - 2;
+  var ellipsis = this._useUnicode ? "\u2026" : "...";
+
+  // Drop the comment if command + gap + comment overflows.
+  if (command.length + gap.length + comment.length > inner) {
+    comment = "";
+  }
+  // Truncate the command itself if it still overflows on its own.
+  if (command.length > inner) {
+    command = command.slice(0, inner - ellipsis.length) + ellipsis;
+  }
+
+  var plain = comment ? command + gap + comment : command;
   var pad = inner - plain.length;
   if (pad < 0) {
     pad = 0;
   }
-  var painted =
-    this.paint(this._c.brand + this._c.bold, command) + gap + this.paint(this._c.dim, comment);
+  var painted = comment
+    ? this.paint(this._c.brand + this._c.bold, command) + gap + this.paint(this._c.dim, comment)
+    : this.paint(this._c.brand + this._c.bold, command);
   this._write(
     "  " + border + c.v + this._c.reset + " " + painted + repeat(" ", pad) + " " + border + c.v + this._c.reset
   );

--- a/bridge/app/npm/sesori-bridge/lib/ui.js
+++ b/bridge/app/npm/sesori-bridge/lib/ui.js
@@ -1,0 +1,381 @@
+"use strict";
+
+// Presentation layer for the npm bootstrap. This is the Node.js implementation of
+// the SAME visual spec used by install.sh and install.ps1 — banner, colored
+// steps, progress bar, completion panel, and labeled error/warning prefixes are
+// kept byte-for-byte equivalent across the three runtimes.
+//
+// Color and Unicode are opt-out: we degrade to plain ASCII whenever the
+// environment can't be trusted to render them (NO_COLOR, redirected output,
+// TERM=dumb, non-UTF-8 locale). FORCE_COLOR forces color on.
+
+var TOTAL_STEPS = 4;
+var PANEL_WIDTH = 52;
+var ESC = "\u001b";
+
+// ┌─ PALETTE ───────────────────────────────────────────────────────────────────
+// │ Edit these ANSI codes in ONE place to retheme the installer. They map into the
+// │ active palette only when color is enabled.
+// │ 256-color codes: brand blue #1472FF ≈ 39 (bright) / 25 (deep).
+// └──────────────────────────────────────────────────────────────────────────────
+var PALETTE = {
+  reset: ESC + "[0m",
+  banner: ESC + "[0;2m", // SESORI wordmark — faded grey
+  brand: ESC + "[38;5;39m", // accents: step counter, command, progress bar
+  brandDim: ESC + "[38;5;25m",
+  green: ESC + "[38;5;42m", // success
+  yellow: ESC + "[38;5;214m", // warning
+  red: ESC + "[38;5;203m", // error
+  dim: ESC + "[0;2m", // secondary / muted text
+  bold: ESC + "[1m",
+};
+
+var BANNER_UNICODE = [
+  " \u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2557\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2557\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2557 \u2588\u2588\u2588\u2588\u2588\u2588\u2557 \u2588\u2588\u2588\u2588\u2588\u2588\u2557 \u2588\u2588\u2557",
+  " \u2588\u2588\u2554\u2550\u2550\u2550\u2550\u255d\u2588\u2588\u2554\u2550\u2550\u2550\u2550\u255d\u2588\u2588\u2554\u2550\u2550\u2550\u2550\u255d\u2588\u2588\u2554\u2550\u2550\u2550\u2588\u2588\u2557\u2588\u2588\u2554\u2550\u2550\u2588\u2588\u2557\u2588\u2588\u2551",
+  " \u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2557\u2588\u2588\u2588\u2588\u2588\u2557  \u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2557\u2588\u2588\u2551   \u2588\u2588\u2551\u2588\u2588\u2588\u2588\u2588\u2588\u2554\u255d\u2588\u2588\u2551",
+  " \u255a\u2550\u2550\u2550\u2550\u2588\u2588\u2551\u2588\u2588\u2554\u2550\u2550\u255d  \u255a\u2550\u2550\u2550\u2550\u2588\u2588\u2551\u2588\u2588\u2551   \u2588\u2588\u2551\u2588\u2588\u2554\u2550\u2550\u2588\u2588\u2557\u2588\u2588\u2551",
+  " \u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2551\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2557\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2551\u255a\u2588\u2588\u2588\u2588\u2588\u2588\u2554\u255d\u2588\u2588\u2551  \u2588\u2588\u2551\u2588\u2588\u2551",
+  " \u255a\u2550\u2550\u2550\u2550\u2550\u2550\u255d\u255a\u2550\u2550\u2550\u2550\u2550\u2550\u255d\u255a\u2550\u2550\u2550\u2550\u2550\u2550\u255d \u255a\u2550\u2550\u2550\u2550\u2550\u255d \u255a\u2550\u255d  \u255a\u2550\u255d\u255a\u2550\u255d",
+];
+
+var BANNER_ASCII = [
+  "  ____  _____ ____   ___  ____  ___ ",
+  " / ___|| ____/ ___| / _ \\|  _ \\|_ _|",
+  " \\___ \\|  _| \\___ \\| | | | |_) || | ",
+  "  ___) | |___ ___) | |_| |  _ < | | ",
+  " |____/|_____|____/ \\___/|_| \\_\\___|",
+];
+
+function Ui(options) {
+  options = options || {};
+  var stream = options.stream || process.stdout;
+  var errStream = options.errStream || process.stderr;
+
+  this._stream = stream;
+  this._errStream = errStream;
+  this._useColor = detectColor(stream, options.env || process.env);
+  this._useUnicode = detectUnicode(options.env || process.env);
+
+  // Active palette: real codes when color is on, empty strings otherwise.
+  var p = this._useColor ? PALETTE : emptyPalette();
+  this._c = p;
+
+  this._glyphs = this._useUnicode
+    ? {
+        check: "\u2713", // ✓
+        warn: "\u26a0", // ⚠
+        cross: "\u2717", // ✗
+        arrow: "\u279c", // ➜
+        barFull: "\u25a0", // ■
+        barEmpty: "\uff65", // ･
+      }
+    : {
+        check: "[OK]",
+        warn: "!",
+        cross: "x",
+        arrow: ">",
+        barFull: "#",
+        barEmpty: ".",
+      };
+}
+
+function emptyPalette() {
+  return {
+    reset: "",
+    banner: "",
+    brand: "",
+    brandDim: "",
+    green: "",
+    yellow: "",
+    red: "",
+    dim: "",
+    bold: "",
+  };
+}
+
+// Color is emitted unless NO_COLOR is set, output is not a TTY, or TERM=dumb.
+// FORCE_COLOR forces it on.
+function detectColor(stream, env) {
+  if (env.FORCE_COLOR) {
+    return true;
+  }
+  if (env.NO_COLOR) {
+    return false;
+  }
+  if (!stream || !stream.isTTY) {
+    return false;
+  }
+  if (!env.TERM || env.TERM === "dumb") {
+    return false;
+  }
+  return true;
+}
+
+// Unicode glyphs are safe in a UTF-8 locale; otherwise fall back to ASCII. On
+// Windows, Node's console is UTF-8-capable, so default to Unicode unless the
+// locale clearly says otherwise.
+function detectUnicode(env) {
+  if (env.TERM === "dumb") {
+    return false;
+  }
+  var locale = env.LC_ALL || env.LC_CTYPE || env.LANG || "";
+  if (/utf-?8/i.test(locale)) {
+    return true;
+  }
+  if (process.platform === "win32" && !locale) {
+    return true;
+  }
+  return false;
+}
+
+Ui.prototype.useColor = function() {
+  return this._useColor;
+};
+
+Ui.prototype.useUnicode = function() {
+  return this._useUnicode;
+};
+
+Ui.prototype.glyphs = function() {
+  return this._glyphs;
+};
+
+Ui.prototype._write = function(line) {
+  this._stream.write(line + "\n");
+};
+
+Ui.prototype._writeErr = function(line) {
+  this._errStream.write(line + "\n");
+};
+
+// Wrap text in a color (and reset), or pass it through when color is off.
+Ui.prototype.paint = function(color, text) {
+  if (this._useColor && color) {
+    return color + text + this._c.reset;
+  }
+  return text;
+};
+
+// The SESORI wordmark, faded grey, printed as the header.
+Ui.prototype.banner = function() {
+  var b = this._useColor ? this._c.banner : "";
+  var r = this._useColor ? this._c.reset : "";
+  var lines = this._useUnicode ? BANNER_UNICODE : BANNER_ASCII;
+  this._write("");
+  for (var i = 0; i < lines.length; i++) {
+    this._write(b + lines[i] + r);
+  }
+  this._write("");
+  this._write(
+    "  " +
+      this.paint(
+        this._c.dim,
+        "Installing the Sesori Bridge \u2014 connect AI coding sessions to your phone"
+      )
+  );
+  this._write("");
+};
+
+// Two muted summary lines under the banner.
+Ui.prototype.summary = function(platform, version) {
+  this._write(
+    "  " + this.paint(this._c.dim, "Platform") + " " + this.paint(this._c.bold, platform)
+  );
+  this._write(
+    "  " + this.paint(this._c.dim, "Version ") + " " + this.paint(this._c.bold, version)
+  );
+  this._write("");
+};
+
+// A "[n/N] message" step header in brand blue.
+Ui.prototype.step = function(number, message) {
+  this._write(this.paint(this._c.brand, "[" + number + "/" + TOTAL_STEPS + "]") + " " + message);
+};
+
+// A green success line with a check glyph, confirming a completed step.
+Ui.prototype.ok = function(message) {
+  this._write(
+    "      " + this.paint(this._c.green, this._glyphs.check) + " " + this.paint(this._c.dim, message)
+  );
+};
+
+// A muted, indented note under a step.
+Ui.prototype.note = function(message) {
+  this._write("      " + this.paint(this._c.dim, message));
+};
+
+// A muted note emitted to stderr (for diagnostics like lock-wait that should not
+// pollute stdout but must remain visible when stdout is redirected).
+Ui.prototype.noteErr = function(message) {
+  this._writeErr(this.paint(this._c.dim, message));
+};
+
+// Error / warning / note prefixes. All go to stderr so they remain visible when
+// stdout is redirected.
+Ui.prototype.error = function(message) {
+  this._writeErr(this.paint(this._c.red, this._glyphs.cross + " Error:") + " " + message);
+};
+
+Ui.prototype.warn = function(message) {
+  this._writeErr(this.paint(this._c.yellow, this._glyphs.warn + " Warning:") + " " + message);
+};
+
+Ui.prototype.hint = function(message) {
+  this._writeErr(this.paint(this._c.brand, this._glyphs.arrow + " Note:") + " " + message);
+};
+
+function repeat(ch, count) {
+  if (count <= 0) {
+    return "";
+  }
+  return new Array(count + 1).join(ch);
+}
+
+Ui.prototype._panelChars = function() {
+  if (this._useUnicode) {
+    return { tl: "\u250c", tr: "\u2510", bl: "\u2514", br: "\u2518", h: "\u2500", v: "\u2502" };
+  }
+  return { tl: "+", tr: "+", bl: "+", br: "+", h: "-", v: "|" };
+};
+
+Ui.prototype.panelTop = function(border) {
+  var c = this._panelChars();
+  this._write("  " + border + c.tl + repeat(c.h, PANEL_WIDTH) + c.tr + this._c.reset);
+};
+
+Ui.prototype.panelBottom = function(border) {
+  var c = this._panelChars();
+  this._write("  " + border + c.bl + repeat(c.h, PANEL_WIDTH) + c.br + this._c.reset);
+};
+
+// A single panel row. Content longer than the inner width is truncated with an
+// ellipsis so the right border stays aligned.
+Ui.prototype.panelRow = function(content, contentColor, border) {
+  content = content || "";
+  var c = this._panelChars();
+  var inner = PANEL_WIDTH - 2;
+  if (content.length > inner) {
+    if (this._useUnicode) {
+      content = content.slice(0, inner - 1) + "\u2026";
+    } else {
+      content = content.slice(0, inner - 3) + "...";
+    }
+  }
+  var pad = inner - content.length;
+  if (pad < 0) {
+    pad = 0;
+  }
+  var painted = contentColor ? this.paint(contentColor, content) : content;
+  this._write(
+    "  " + border + c.v + this._c.reset + " " + painted + repeat(" ", pad) + " " + border + c.v + this._c.reset
+  );
+};
+
+// A panel row highlighting a runnable command plus a muted inline comment. Width
+// is computed from the plain text so colored escapes don't skew alignment.
+Ui.prototype.panelCommandRow = function(command, comment, border) {
+  var c = this._panelChars();
+  var gap = "   ";
+  var plain = command + gap + comment;
+  var inner = PANEL_WIDTH - 2;
+  var pad = inner - plain.length;
+  if (pad < 0) {
+    pad = 0;
+  }
+  var painted =
+    this.paint(this._c.brand + this._c.bold, command) + gap + this.paint(this._c.dim, comment);
+  this._write(
+    "  " + border + c.v + this._c.reset + " " + painted + repeat(" ", pad) + " " + border + c.v + this._c.reset
+  );
+};
+
+// A panel row with an emphasized middle segment: prefix + bold(emphasis) + suffix.
+Ui.prototype.panelEmphasisRow = function(prefix, emphasis, suffix, border) {
+  var c = this._panelChars();
+  var plain = prefix + emphasis + suffix;
+  var inner = PANEL_WIDTH - 2;
+  var pad = inner - plain.length;
+  if (pad < 0) {
+    pad = 0;
+  }
+  var painted = prefix + this.paint(this._c.brand + this._c.bold, emphasis) + suffix;
+  this._write(
+    "  " + border + c.v + this._c.reset + " " + painted + repeat(" ", pad) + " " + border + c.v + this._c.reset
+  );
+};
+
+// Quiet success confirmation + boxed "Next steps" call-to-action. onPath controls
+// whether the "open a new terminal" instruction is shown.
+Ui.prototype.completion = function(options) {
+  var version = options.version;
+  var location = options.location;
+  var onPath = options.onPath;
+  var command = options.command || "sesori-bridge";
+
+  this._write("");
+  this._write(this.paint(this._c.green, this._glyphs.check) + " Sesori Bridge v" + version + " installed");
+  this._write(this.paint(this._c.dim, "Location") + " " + this.paint(this._c.dim, location));
+  this._write("");
+
+  var border = this._c.brand;
+  this.panelTop(border);
+  this.panelRow("Next steps", this._c.bold, border);
+  this.panelRow("", "", border);
+  if (!onPath) {
+    this.panelEmphasisRow("In a ", "new terminal", " window, run:", border);
+    this.panelRow("", "", border);
+  }
+  this.panelCommandRow(command, "# Start the bridge", border);
+  this.panelBottom(border);
+  this._write("");
+};
+
+// Render an in-place download progress bar (brand-blue ■/･ + percentage). No-op
+// when color is off or output is not a TTY, so logs stay clean.
+Ui.prototype.progress = function(received, total) {
+  if (!this._useColor || !this._stream.isTTY || !total || total <= 0) {
+    return;
+  }
+  var width = 32;
+  var percent = Math.floor((received * 100) / total);
+  if (percent > 100) {
+    percent = 100;
+  }
+  var on = Math.floor((percent * width) / 100);
+  var off = width - on;
+  var bar =
+    this._c.brand +
+    repeat(this._glyphs.barFull, on) +
+    this._c.dim +
+    repeat(this._glyphs.barEmpty, off) +
+    this._c.reset;
+  var pct = ("   " + percent).slice(-3);
+  this._stream.write("\r      " + bar + " " + pct + "%");
+};
+
+// Finish the progress line (newline) if a bar was being drawn.
+Ui.prototype.progressDone = function() {
+  if (this._useColor && this._stream.isTTY) {
+    this._stream.write("\n");
+  }
+};
+
+// Process-wide shared instance, so low-level modules can emit styled
+// warnings/notes without each constructing their own (and re-detecting).
+var sharedInstance = null;
+function shared() {
+  if (!sharedInstance) {
+    sharedInstance = new Ui({});
+  }
+  return sharedInstance;
+}
+
+module.exports = {
+  Ui: Ui,
+  shared: shared,
+  TOTAL_STEPS: TOTAL_STEPS,
+  PANEL_WIDTH: PANEL_WIDTH,
+  detectColor: detectColor,
+  detectUnicode: detectUnicode,
+};

--- a/bridge/app/test/tool/installers_test.dart
+++ b/bridge/app/test/tool/installers_test.dart
@@ -513,7 +513,9 @@ printf '%s\n' "\$RESOLVED_VERSION"
       );
 
       expect(result.exitCode, equals(0));
-      expect(result.stderr, contains('Warning: another sesori-bridge found at $shadowPath'));
+      // Styled warning/note prefixes vary (glyph/color depend on the terminal);
+      // assert on the stable message text only.
+      expect(result.stderr, contains('Another sesori-bridge was found at $shadowPath'));
       expect(result.stderr, contains('It may shadow the newly installed version.'));
     });
 
@@ -543,11 +545,17 @@ cat "\$HOME/.zprofile"
         RegExp(r'export PATH="\$HOME/.local/bin:\$PATH"').allMatches(result.stdout as String).length,
         equals(2),
       );
+      // Styled confirmation: the rc files are named in the "Added ... to your
+      // PATH" line, with the source hint on the following note line.
       expect(
         result.stdout,
         contains(
-          "PATH: persisted ~/.local/bin in ${p.join(tempDir.path, '.zshrc')} and ${p.join(tempDir.path, '.zprofile')}. Run 'source ${p.join(tempDir.path, '.zshrc')}' or open a new terminal.",
+          'Added ~/.local/bin to your PATH in ${p.join(tempDir.path, '.zshrc')} and ${p.join(tempDir.path, '.zprofile')}',
         ),
+      );
+      expect(
+        result.stdout,
+        contains("Run 'source ${p.join(tempDir.path, '.zshrc')}' or open a new terminal to use it."),
       );
     });
 
@@ -560,6 +568,74 @@ cat "\$HOME/.zprofile"
       expect(script, contains('printf'));
       expect(script, contains('"%s"'));
       expect(script, contains(r'"${resolved_version}" > "${MANAGED_MANIFEST}"'));
+    });
+
+    test('emits ANSI color and the SESORI banner when FORCE_COLOR is set', () async {
+      final libraryPath = await _createInstallShLibrary();
+
+      final result = await _runBashSnippet(
+        script: 'source ${jsonEncode(libraryPath)}; init_style; print_banner; step 1 "Downloading release"; ok "done"',
+        environment: {
+          'PATH': Platform.environment['PATH'] ?? '',
+          'FORCE_COLOR': '1',
+          'LANG': 'en_US.UTF-8',
+        },
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      final out = result.stdout as String;
+      // Brand-blue step counter + green check escapes are present.
+      expect(out, contains('\u001b[38;5;39m[1/4]'));
+      expect(out, contains('\u001b[38;5;42m'));
+      // The tagline accompanies the banner.
+      expect(out, contains('Installing the Sesori Bridge'));
+      // Unicode glyph + wordmark block char in a UTF-8 locale.
+      expect(out, contains('\u2713'));
+      expect(out, contains('\u2588'));
+    });
+
+    test('suppresses all ANSI escapes when NO_COLOR is set', () async {
+      final libraryPath = await _createInstallShLibrary();
+
+      final result = await _runBashSnippet(
+        script: 'source ${jsonEncode(libraryPath)}; init_style; print_banner; step 1 "Downloading release"; ok "done"',
+        environment: {
+          'PATH': Platform.environment['PATH'] ?? '',
+          'NO_COLOR': '1',
+          'LANG': 'en_US.UTF-8',
+        },
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      final out = result.stdout as String;
+      // No escape sequences at all.
+      expect(out, isNot(contains('\u001b[')));
+      // Copy still present, just unstyled.
+      expect(out, contains('[1/4] Downloading release'));
+      expect(out, contains('Installing the Sesori Bridge'));
+    });
+
+    test('falls back to ASCII glyphs in a non-UTF-8 locale', () async {
+      final libraryPath = await _createInstallShLibrary();
+
+      final result = await _runBashSnippet(
+        script: 'source ${jsonEncode(libraryPath)}; init_style; print_banner; ok "done"',
+        environment: {
+          'PATH': Platform.environment['PATH'] ?? '',
+          'FORCE_COLOR': '1',
+          'LANG': 'C',
+          'LC_ALL': 'C',
+        },
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      final out = result.stdout as String;
+      // ASCII success marker instead of the ✓ glyph.
+      expect(out, contains('[OK]'));
+      expect(out, isNot(contains('\u2713')));
+      // ASCII wordmark instead of block-char Unicode.
+      expect(out, isNot(contains('\u2588')));
+      expect(out, contains('____'));
     });
 
     test('the fallback scan accepts only stable v release tags', () {
@@ -637,14 +713,44 @@ cat "\$HOME/.zprofile"
 
     test('warns about PATH conflicts and only appends the managed bin dir once', () {
       expect(script, contains("Get-Command 'sesori-bridge' -ErrorAction SilentlyContinue"));
-      expect(script, contains("Write-Warning \"Another sesori-bridge was found at '"));
+      // Conflict is surfaced via the styled warning helper.
+      expect(script, contains("Write-Warn \"Another sesori-bridge was found at '"));
       expect(script, contains(r'''$pathEntries | Where-Object { $_.TrimEnd('\') -ieq $BinDir.TrimEnd('\') }'''));
       expect(script, contains(r"[Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')"));
-      expect(script, contains(r'PATH: persisted $BinDir in the user PATH.'));
-      expect(script, contains('Write-Host "Start the bridge:"'));
-      expect(script, contains('Write-Host "   sesori-bridge"'));
-      expect(script, contains('Write-Host "1. Open a new terminal"'));
-      expect(script, contains('Write-Host "2. Run the bridge:"'));
+      // PATH persistence is confirmed via the styled success helper.
+      expect(script, contains(r'Write-Ok "Added $BinDir to your PATH"'));
+    });
+
+    test('renders the styled banner, steps, and next-steps panel', () {
+      // Banner + tagline header.
+      expect(script, contains('function Write-Banner'));
+      expect(script, contains('Installing the Sesori Bridge'));
+      // Numbered steps use the shared [n/4] helper.
+      expect(script, contains("Write-Step 1 'Downloading release'"));
+      expect(script, contains("Write-Step 2 'Verifying checksum'"));
+      expect(script, contains("Write-Step 3 'Installing managed runtime'"));
+      expect(script, contains("Write-Step 4 'Linking command'"));
+      // Completion: quiet success line + boxed "Next steps" with highlighted cmd.
+      expect(script, contains(r'Sesori Bridge v$resolvedVersionLabel installed'));
+      expect(script, contains("Write-PanelRow 'Next steps'"));
+      expect(script, contains("Write-PanelEmphasisRow 'In a ' 'new terminal' ' window, run:'"));
+      expect(script, contains("Write-PanelCommandRow 'sesori-bridge' '# Start the bridge'"));
+    });
+
+    test('degrades gracefully: color/unicode detection and ASCII fallback', () {
+      // Honors NO_COLOR / FORCE_COLOR / TERM=dumb / redirected output.
+      expect(script, contains('function Test-ShouldUseColor'));
+      expect(script, contains(r'if ($env:FORCE_COLOR)'));
+      expect(script, contains(r'if ($env:NO_COLOR)'));
+      expect(script, contains(r"if ($env:TERM -eq 'dumb')"));
+      expect(script, contains('IsOutputRedirected'));
+      // UTF-8 output + Unicode capability detection, with ASCII glyph fallback.
+      expect(script, contains('function Test-ShouldUseUnicode'));
+      expect(script, contains(r'[System.Text.UTF8Encoding]::new($false)'));
+      expect(script, contains(r"$Script:G_CHECK = '[OK]'"));
+      // Palette is centralized for easy retheming.
+      expect(script, contains('PALETTE_BANNER'));
+      expect(script, contains('PALETTE_BRAND'));
     });
 
     test('writes managed runtime manifest with resolved version', () {

--- a/bridge/app/test/tool/npm_wrapper_test.dart
+++ b/bridge/app/test/tool/npm_wrapper_test.dart
@@ -376,11 +376,14 @@ void _expectInstallSummary({
   required List<String> args,
 }) {
   final nextStep = ['sesori-bridge', ...args].join(' ');
-  expect(result.stdout, contains('Sesori Bridge install complete'));
-  expect(result.stdout, contains('Managed binary : ${_managedBinaryPath(homePath: homePath)}'));
+  // The completion output is styled (banner + boxed "Next steps"). Assert on
+  // stable substrings rather than full styled lines so cosmetic tweaks to the
+  // panel don't break behavior tests. Color is off here (piped, no FORCE_COLOR).
+  expect(result.stdout, contains('Sesori Bridge v'));
+  expect(result.stdout, contains('installed'));
   expect(result.stdout, contains('Next steps'));
-  expect(result.stdout, contains('Run the bridge:'));
-  expect(result.stdout, contains('   $nextStep'));
+  expect(result.stdout, contains('# Start the bridge'));
+  expect(result.stdout, contains(nextStep));
 }
 
 Future<({int exitCode, String stdout, String stderr})> _waitForProcess(Process process) async {
@@ -396,6 +399,7 @@ Future<void> main() async {
     test('fails with a clear message for unsupported platforms', () async {
       final scriptPath = p.join(_wrapperPackageRoot(), 'bin', 'bridge.js');
       final bootstrapPath = p.join(_wrapperPackageRoot(), 'lib', 'bootstrap.js');
+      final uiPath = p.join(_wrapperPackageRoot(), 'lib', 'ui.js');
       final result = await _runNodeHarness(
         source:
             '''
@@ -410,12 +414,19 @@ const sandbox = {
     if (name === '../lib/bootstrap') {
       return require(${jsonEncode(bootstrapPath)});
     }
+    if (name === '../lib/ui') {
+      return require(${jsonEncode(uiPath)});
+    }
     throw new Error('unexpected require: ' + name);
   },
   process: {
     platform: 'sunos',
     arch: 'sparc',
     argv: ['node', 'bridge.js'],
+    env: {},
+    // The styled UI writes through process.stderr; capture it here.
+    stderr: { write(chunk) { stderr.push(String(chunk)); } },
+    stdout: { write() {} },
     exit(code) { exitCode = code; throw new Error('__EXIT__'); },
   },
   console: { error(message) { stderr.push(String(message)); } },
@@ -425,7 +436,7 @@ try {
 } catch (error) {
   if (error.message !== '__EXIT__') throw error;
 }
-console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
+console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
 ''',
       );
 
@@ -433,7 +444,7 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       final decoded = jsonDecode((result.stdout as String).trim()) as Map<String, dynamic>;
       expect(decoded['exitCode'], equals(1));
       final stderr = decoded['stderr'] as String;
-      expect(stderr, contains('sesori-bridge: Unsupported platform: sunos sparc'));
+      expect(stderr, contains('Unsupported platform: sunos sparc'));
       expect(stderr, contains('Supported platforms: darwin arm64, darwin x64, linux x64, linux arm64, win32 x64, win32 arm64'));
       expect(stderr, contains('npm install @sesori/bridge-darwin-arm64'));
     });
@@ -603,12 +614,8 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
 
       expect(bootstrapResult.exitCode, equals(0), reason: '${bootstrapResult.stdout}\n${bootstrapResult.stderr}');
       _expectInstallSummary(result: bootstrapResult, homePath: homeDir.path, args: ['serve']);
-      expect(
-        bootstrapResult.stdout,
-        contains(
-          'PATH update    : Persisted ~/.local/bin in ${p.join(homeDir.path, '.bashrc')} and ${p.join(homeDir.path, '.profile')}. Run `source ${p.join(homeDir.path, '.bashrc')}` or open a new terminal.',
-        ),
-      );
+      // The styled completion no longer echoes a "PATH update" status line; the
+      // PATH persistence is asserted directly against the shell rc files below.
       expect(
         File(p.join(homeDir.path, '.bashrc')).readAsStringSync(),
         contains(r'export PATH="$HOME/.local/bin:$PATH"'),
@@ -975,8 +982,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
       expect(result.stderr, contains('Failed to persist the managed command path'));
       expect(result.stderr, contains('The managed runtime is installed, but you may need to add it to PATH manually.'));
-      expect(result.stdout, contains('PATH update    : manual action required'));
-      expect(result.stdout, isNot(contains('PATH update    : already configured')));
       final directRun = await _runManagedBinary(
         homePath: homeDir.path,
         args: ['status'],
@@ -1209,6 +1214,64 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('\\n') }));
       expect(recorded['marker'], equals('payload-runtime'));
       expect(recorded['executedPath'], equals(_managedBinaryPath(homePath: homeDir.path)));
       expect(lockDir.existsSync(), isFalse);
+    });
+  });
+
+  group('ui.js', () {
+    // Drives lib/ui.js directly with an in-memory capture stream and an explicit
+    // env, so we can assert the shared visual spec's degradation behavior without
+    // a real terminal. Matches the install.sh color/no-color/ASCII tests.
+    final uiPath = p.join(_wrapperPackageRoot(), 'lib', 'ui.js');
+
+    Future<String> renderUi({required Map<String, String> env}) async {
+      final result = await _runNodeHarness(
+        source:
+            '''
+const ui = require(${jsonEncode(uiPath)});
+const chunks = [];
+const stream = { isTTY: true, write(s) { chunks.push(String(s)); } };
+const env = ${jsonEncode(env)};
+const u = new ui.Ui({ stream, errStream: stream, env });
+u.banner();
+u.summary("darwin/arm64", "v1.2.3");
+u.step(1, "Downloading release");
+u.ok("Downloaded sesori-bridge-macos-arm64.tar.gz");
+u.completion({ version: "1.2.3", location: "~/.local/share/sesori", onPath: false });
+process.stdout.write(JSON.stringify({ out: chunks.join("") }));
+''',
+      );
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      final decoded = jsonDecode((result.stdout as String).trim()) as Map<String, dynamic>;
+      return decoded['out'] as String;
+    }
+
+    test('emits ANSI color and Unicode glyphs under FORCE_COLOR + UTF-8', () async {
+      final out = await renderUi(env: {'FORCE_COLOR': '1', 'LANG': 'en_US.UTF-8'});
+      // Brand-blue step counter and green check escapes.
+      expect(out, contains('\u001b[38;5;39m[1/4]'));
+      expect(out, contains('\u001b[38;5;42m'));
+      // Unicode wordmark + check glyph + box-drawing.
+      expect(out, contains('\u2588'));
+      expect(out, contains('\u2713'));
+      expect(out, contains('\u250c'));
+      expect(out, contains('Installing the Sesori Bridge'));
+      expect(out, contains('# Start the bridge'));
+    });
+
+    test('suppresses ANSI escapes under NO_COLOR', () async {
+      final out = await renderUi(env: {'NO_COLOR': '1', 'LANG': 'en_US.UTF-8'});
+      expect(out, isNot(contains('\u001b[')));
+      expect(out, contains('[1/4] Downloading release'));
+      expect(out, contains('Next steps'));
+    });
+
+    test('falls back to ASCII glyphs in a non-UTF-8 locale', () async {
+      final out = await renderUi(env: {'FORCE_COLOR': '1', 'LANG': 'C', 'LC_ALL': 'C'});
+      // ASCII success marker + ASCII box, no Unicode block/check chars.
+      expect(out, contains('[OK]'));
+      expect(out, contains('+--'));
+      expect(out, isNot(contains('\u2713')));
+      expect(out, isNot(contains('\u2588')));
     });
   });
 }

--- a/bridge/app/test/tool/npm_wrapper_test.dart
+++ b/bridge/app/test/tool/npm_wrapper_test.dart
@@ -446,7 +446,9 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final stderr = decoded['stderr'] as String;
       expect(stderr, contains('Unsupported platform: sunos sparc'));
       expect(stderr, contains('Supported platforms: darwin arm64, darwin x64, linux x64, linux arm64, win32 x64, win32 arm64'));
-      expect(stderr, contains('npm install @sesori/bridge-darwin-arm64'));
+      // The hint points at the bootstrap entry point (npx), not direct installs
+      // of the internal per-platform payload packages.
+      expect(stderr, contains('npx @sesori/bridge'));
     });
 
     test('bootstrap source renders Windows managed fallback commands via PowerShell invocation', () async {

--- a/bridge/app/test/tool/npm_wrapper_test.dart
+++ b/bridge/app/test/tool/npm_wrapper_test.dart
@@ -689,6 +689,46 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       expect(recorded['libMarker'], equals('existing-lib'));
     });
 
+    test('no-op bootstrap still shows next-steps when the command is not yet usable', () async {
+      // The runtime is already current (no reinstall), but the bare command is
+      // not resolvable in this shell (~/.local/bin is not on PATH). The bootstrap
+      // recreates the symlink / may persist PATH, so the user must still be told
+      // to open a new terminal — the completion panel must not be suppressed.
+      final wrapperRoot = await _createWrapperFixture();
+      final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
+      addTearDown(() => homeDir.delete(recursive: true));
+
+      await _createPlatformPayload(
+        wrapperRoot: wrapperRoot,
+        version: '1.2.3',
+        binaryMarker: 'payload-runtime',
+        libMarker: 'payload-lib',
+      );
+      await _seedManagedRuntime(
+        homePath: homeDir.path,
+        version: '1.2.3',
+        binaryMarker: 'existing-managed',
+        libMarker: 'existing-lib',
+        includeBinary: true,
+        includeLib: true,
+      );
+
+      // The temp HOME's ~/.local/bin is never on the inherited PATH, so the bare
+      // command is not yet usable — exactly the "no-op but not ready" scenario.
+      final result = await _runWrapperProcess(
+        packageRoot: wrapperRoot,
+        homePath: homeDir.path,
+        args: ['status'],
+        environment: {
+          'SHELL': '/bin/bash',
+        },
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      expect(result.stdout, contains('Next steps'));
+      expect(result.stdout, contains('new terminal'));
+    });
+
     test('same-version managed runtime does not require release download fallback', () async {
       final wrapperRoot = await _createWrapperFixture();
       final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');

--- a/install.ps1
+++ b/install.ps1
@@ -4,6 +4,311 @@ $ErrorActionPreference = 'Stop'
 # Sesori Bridge CLI - Windows Installer
 # Usage: irm https://raw.githubusercontent.com/sesori-ai/sesori_apps_monorepo/main/install.ps1 | iex
 
+# ── Presentation layer ────────────────────────────────────────────────────────
+# Shared visual spec, kept byte-for-byte equivalent with install.sh and the npm
+# bootstrap. Color and Unicode are opt-out: we degrade to plain ASCII whenever
+# the environment can't be trusted to render them.
+$Script:TotalSteps = 4
+$ESC = [char]27
+
+# ┌─ PALETTE ────────────────────────────────────────────────────────────────────
+# │ Edit these ANSI codes in ONE place to retheme the installer. Init-Style copies
+# │ them into the $C_* variables only when color is enabled (otherwise the $C_*
+# │ variables stay empty for plain output).
+# │ 256-color codes: brand blue #1472FF ≈ 39 (bright) / 25 (deep).
+# └──────────────────────────────────────────────────────────────────────────────
+$PALETTE_RESET     = "$ESC[0m"
+$PALETTE_BANNER    = "$ESC[0;2m"        # SESORI wordmark — faded grey
+$PALETTE_BRAND     = "$ESC[38;5;39m"    # accents: step counter, command, progress
+$PALETTE_BRAND_DIM = "$ESC[38;5;25m"
+$PALETTE_GREEN     = "$ESC[38;5;42m"    # success
+$PALETTE_YELLOW    = "$ESC[38;5;214m"   # warning
+$PALETTE_RED       = "$ESC[38;5;203m"   # error
+$PALETTE_DIM       = "$ESC[0;2m"        # secondary / muted text
+$PALETTE_BOLD      = "$ESC[1m"
+
+# Active palette (empty unless color is enabled). Assigned by Init-Style.
+$Script:C_RESET = ''
+$Script:C_BANNER = ''
+$Script:C_BRAND = ''
+$Script:C_BRAND_DIM = ''
+$Script:C_GREEN = ''
+$Script:C_YELLOW = ''
+$Script:C_RED = ''
+$Script:C_DIM = ''
+$Script:C_BOLD = ''
+
+# Glyphs. Unicode where safe, ASCII otherwise. Populated by Init-Style.
+$Script:G_CHECK = ''
+$Script:G_WARN = ''
+$Script:G_CROSS = ''
+$Script:G_ARROW = ''
+$Script:G_BAR_FULL = ''
+$Script:G_BAR_EMPTY = ''
+
+$Script:UseColor = $false
+$Script:UseUnicode = $false
+$Script:PanelWidth = 52
+
+# Color is emitted unless NO_COLOR is set, output is redirected, or TERM=dumb.
+# FORCE_COLOR forces it on. On Windows a console host generally supports ANSI
+# (Windows Terminal, PowerShell 5.1+, conhost on Win10+), so a TTY is the signal.
+function Test-ShouldUseColor {
+    if ($env:FORCE_COLOR) { return $true }
+    if ($env:NO_COLOR) { return $false }
+    if ($env:TERM -eq 'dumb') { return $false }
+    try {
+        if ([System.Console]::IsOutputRedirected) { return $false }
+    } catch {
+        # IsOutputRedirected unavailable (rare hosts); fall through to enabled.
+    }
+    return $true
+}
+
+# Unicode glyphs are safe once the console output encoding is UTF-8, which we set
+# in Init-Style. Legacy code pages (e.g. 437/1252) fall back to ASCII.
+function Test-ShouldUseUnicode {
+    if ($env:TERM -eq 'dumb') { return $false }
+    try {
+        if ([System.Console]::OutputEncoding.CodePage -eq 65001) { return $true }
+    } catch {
+        return $false
+    }
+    return $false
+}
+
+# Enable virtual-terminal (ANSI) processing on the console host. PowerShell 7 and
+# Windows Terminal handle ANSI natively, but Windows PowerShell 5.1 on legacy
+# conhost needs ENABLE_VIRTUAL_TERMINAL_PROCESSING (0x0004) set on the output
+# handle, otherwise escape sequences print literally. Best-effort: failures fall
+# back to plain output via the detection below.
+function Enable-VirtualTerminal {
+    if ($PSVersionTable.PSVersion.Major -ge 6) { return }  # PS7+ handles VT itself
+    try {
+        if (-not ('Sesori.NativeConsole' -as [type])) {
+            Add-Type -Namespace 'Sesori' -Name 'NativeConsole' -MemberDefinition @'
+[DllImport("kernel32.dll", SetLastError = true)]
+public static extern IntPtr GetStdHandle(int nStdHandle);
+[DllImport("kernel32.dll", SetLastError = true)]
+public static extern bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
+[DllImport("kernel32.dll", SetLastError = true)]
+public static extern bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
+'@ -ErrorAction Stop
+        }
+        $handle = [Sesori.NativeConsole]::GetStdHandle(-11)  # STD_OUTPUT_HANDLE
+        $mode = 0
+        if ([Sesori.NativeConsole]::GetConsoleMode($handle, [ref]$mode)) {
+            [void][Sesori.NativeConsole]::SetConsoleMode($handle, $mode -bor 0x0004)
+        }
+    } catch {
+        # No console / unsupported host; detection below will disable color.
+    }
+}
+
+function Init-Style {
+    Enable-VirtualTerminal
+
+    # Prefer UTF-8 output so the box-drawing/glyphs render on modern consoles.
+    try {
+        [System.Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+    } catch {
+        # Some hosts (ISE, redirected) reject this; we detect and fall back below.
+    }
+
+    if (Test-ShouldUseColor) {
+        $Script:UseColor = $true
+        $Script:C_RESET = $PALETTE_RESET
+        $Script:C_BANNER = $PALETTE_BANNER
+        $Script:C_BRAND = $PALETTE_BRAND
+        $Script:C_BRAND_DIM = $PALETTE_BRAND_DIM
+        $Script:C_GREEN = $PALETTE_GREEN
+        $Script:C_YELLOW = $PALETTE_YELLOW
+        $Script:C_RED = $PALETTE_RED
+        $Script:C_DIM = $PALETTE_DIM
+        $Script:C_BOLD = $PALETTE_BOLD
+    }
+
+    if (Test-ShouldUseUnicode) {
+        $Script:UseUnicode = $true
+        $Script:G_CHECK = [char]0x2713      # ✓
+        $Script:G_WARN = [char]0x26A0       # ⚠
+        $Script:G_CROSS = [char]0x2717      # ✗
+        $Script:G_ARROW = [char]0x279C      # ➜
+        $Script:G_BAR_FULL = [char]0x25A0   # ■
+        $Script:G_BAR_EMPTY = [char]0xFF65  # ･
+    } else {
+        $Script:G_CHECK = '[OK]'
+        $Script:G_WARN = '!'
+        $Script:G_CROSS = 'x'
+        $Script:G_ARROW = '>'
+        $Script:G_BAR_FULL = '#'
+        $Script:G_BAR_EMPTY = '.'
+    }
+}
+
+# Wrap text in a color (and the reset), or pass it through when color is off.
+function Use-Paint {
+    param([string]$Color, [string]$Text)
+    if ($Script:UseColor) { return "$Color$Text$($Script:C_RESET)" }
+    return $Text
+}
+
+# Emit raw text honoring embedded ANSI. Write-Host keeps it on the console only
+# (never the pipeline), matching the shell installers' stdout behavior.
+function Write-Line {
+    param([string]$Text = '')
+    Write-Host $Text
+}
+
+# The SESORI wordmark, faded grey, printed as the header.
+function Write-Banner {
+    $b = $Script:C_BANNER
+    $r = $Script:C_RESET
+    if (-not $Script:UseColor) { $b = ''; $r = '' }
+
+    Write-Line ''
+    if ($Script:UseUnicode) {
+        $lines = @(
+            ' ███████╗███████╗███████╗ ██████╗ ██████╗ ██╗',
+            ' ██╔════╝██╔════╝██╔════╝██╔═══██╗██╔══██╗██║',
+            ' ███████╗█████╗  ███████╗██║   ██║██████╔╝██║',
+            ' ╚════██║██╔══╝  ╚════██║██║   ██║██╔══██╗██║',
+            ' ███████║███████╗███████║╚██████╔╝██║  ██║██║',
+            ' ╚══════╝╚══════╝╚══════╝ ╚═════╝ ╚═╝  ╚═╝╚═╝'
+        )
+    } else {
+        $lines = @(
+            '  ____  _____ ____   ___  ____  ___ ',
+            ' / ___|| ____/ ___| / _ \|  _ \|_ _|',
+            ' \___ \|  _| \___ \| | | | |_) || | ',
+            '  ___) | |___ ___) | |_| |  _ < | | ',
+            ' |____/|_____|____/ \___/|_| \_\___|'
+        )
+    }
+    foreach ($line in $lines) {
+        Write-Line "$b$line$r"
+    }
+    Write-Line ''
+    Write-Line ('  ' + (Use-Paint $Script:C_DIM 'Installing the Sesori Bridge — connect AI coding sessions to your phone'))
+    Write-Line ''
+}
+
+# A "[n/N] message" step header in brand blue.
+function Write-Step {
+    param([int]$Number, [string]$Message)
+    Write-Line ((Use-Paint $Script:C_BRAND "[$Number/$($Script:TotalSteps)]") + " $Message")
+}
+
+# A green success line with a check glyph, confirming a completed step.
+function Write-Ok {
+    param([string]$Message)
+    Write-Line ('      ' + (Use-Paint $Script:C_GREEN $Script:G_CHECK) + ' ' + (Use-Paint $Script:C_DIM $Message))
+}
+
+# A muted, indented note under a step.
+function Write-Note {
+    param([string]$Message)
+    Write-Line ('      ' + (Use-Paint $Script:C_DIM $Message))
+}
+
+# Error / warning / note prefixes. Errors and warnings go to stderr so they are
+# visible even when stdout is redirected.
+function Write-Err {
+    param([string]$Message)
+    [Console]::Error.WriteLine((Use-Paint $Script:C_RED "$($Script:G_CROSS) Error:") + " $Message")
+}
+
+function Write-Warn {
+    param([string]$Message)
+    [Console]::Error.WriteLine((Use-Paint $Script:C_YELLOW "$($Script:G_WARN) Warning:") + " $Message")
+}
+
+function Write-Hint {
+    param([string]$Message)
+    [Console]::Error.WriteLine((Use-Paint $Script:C_BRAND "$($Script:G_ARROW) Note:") + " $Message")
+}
+
+function Get-RepeatedChar {
+    param([string]$Char, [int]$Count)
+    if ($Count -le 0) { return '' }
+    return ($Char * $Count)
+}
+
+# Box-drawing helpers for the "Next steps" panel. PanelWidth is the inner width
+# (between the borders). Border color is passed in so the same panel can frame
+# different kinds of content.
+function Write-PanelTop {
+    param([string]$Border = $Script:C_BRAND)
+    if ($Script:UseUnicode) {
+        $bar = [char]0x2500
+        Write-Line ('  ' + $Border + [char]0x250C + (Get-RepeatedChar $bar $Script:PanelWidth) + [char]0x2510 + $Script:C_RESET)
+    } else {
+        Write-Line ('  ' + $Border + '+' + (Get-RepeatedChar '-' $Script:PanelWidth) + '+' + $Script:C_RESET)
+    }
+}
+
+function Write-PanelBottom {
+    param([string]$Border = $Script:C_BRAND)
+    if ($Script:UseUnicode) {
+        $bar = [char]0x2500
+        Write-Line ('  ' + $Border + [char]0x2514 + (Get-RepeatedChar $bar $Script:PanelWidth) + [char]0x2518 + $Script:C_RESET)
+    } else {
+        Write-Line ('  ' + $Border + '+' + (Get-RepeatedChar '-' $Script:PanelWidth) + '+' + $Script:C_RESET)
+    }
+}
+
+# A single panel row. Content longer than the inner width is truncated with an
+# ellipsis so the right border stays aligned.
+function Write-PanelRow {
+    param([string]$Content = '', [string]$ContentColor = '', [string]$Border = $Script:C_BRAND)
+    $bar = if ($Script:UseUnicode) { [char]0x2502 } else { '|' }
+    $inner = $Script:PanelWidth - 2
+    if ($Content.Length -gt $inner) {
+        if ($Script:UseUnicode) {
+            $Content = $Content.Substring(0, $inner - 1) + [char]0x2026
+        } else {
+            $Content = $Content.Substring(0, $inner - 3) + '...'
+        }
+    }
+    $pad = $inner - $Content.Length
+    if ($pad -lt 0) { $pad = 0 }
+    $spaces = ' ' * $pad
+    $painted = if ($ContentColor) { Use-Paint $ContentColor $Content } else { $Content }
+    Write-Line ('  ' + $Border + $bar + $Script:C_RESET + ' ' + $painted + $spaces + ' ' + $Border + $bar + $Script:C_RESET)
+}
+
+# A panel row highlighting a runnable command plus a muted inline comment. Width
+# is computed from the plain text so the colored escapes don't skew alignment.
+function Write-PanelCommandRow {
+    param([string]$Command, [string]$Comment, [string]$Border = $Script:C_BRAND)
+    $bar = if ($Script:UseUnicode) { [char]0x2502 } else { '|' }
+    $gap = '   '
+    $plain = "$Command$gap$Comment"
+    $inner = $Script:PanelWidth - 2
+    $pad = $inner - $plain.Length
+    if ($pad -lt 0) { $pad = 0 }
+    $spaces = ' ' * $pad
+    $painted = (Use-Paint ($Script:C_BRAND + $Script:C_BOLD) $Command) + $gap + (Use-Paint $Script:C_DIM $Comment)
+    Write-Line ('  ' + $Border + $bar + $Script:C_RESET + ' ' + $painted + $spaces + ' ' + $Border + $bar + $Script:C_RESET)
+}
+
+# A panel row with an emphasized middle segment: "<prefix><bold emphasis><suffix>".
+# The prefix/suffix render default-colored; the middle is brand-blue/bold so a
+# hard-requirement phrase (e.g. "new terminal") stands out.
+function Write-PanelEmphasisRow {
+    param([string]$Prefix, [string]$Emphasis, [string]$Suffix, [string]$Border = $Script:C_BRAND)
+    $bar = if ($Script:UseUnicode) { [char]0x2502 } else { '|' }
+    $plain = "$Prefix$Emphasis$Suffix"
+    $inner = $Script:PanelWidth - 2
+    $pad = $inner - $plain.Length
+    if ($pad -lt 0) { $pad = 0 }
+    $spaces = ' ' * $pad
+    $painted = $Prefix + (Use-Paint ($Script:C_BRAND + $Script:C_BOLD) $Emphasis) + $Suffix
+    Write-Line ('  ' + $Border + $bar + $Script:C_RESET + ' ' + $painted + $spaces + ' ' + $Border + $bar + $Script:C_RESET)
+}
+
+Init-Style
+
 $RepoOwner  = 'sesori-ai'
 $RepoName   = 'sesori_apps_monorepo'
 $RepoBase   = "https://github.com/$RepoOwner/$RepoName"
@@ -56,7 +361,8 @@ switch ($detectedOsArchitecture) {
 }
 
 if ($arch -notin @('x64', 'arm64')) {
-    Write-Error "Unsupported architecture '$detectedOsArchitecture'. Only x64 (AMD64) and arm64 are supported on Windows."
+    Write-Err "Unsupported architecture '$detectedOsArchitecture'."
+    Write-Hint "Only x64 (AMD64) and arm64 are supported on Windows."
     exit 1
 }
 
@@ -218,13 +524,13 @@ function Resolve-BridgeRelease {
 
 $Release = Resolve-BridgeRelease -ArchiveName $ArchiveName
 if (-not $Release -and $arch -eq 'arm64') {
-    Write-Warning "No native arm64 bridge release found yet; falling back to the x64 build (runs under emulation on Windows arm64). Re-run this installer after a native arm64 release to switch to the native build."
+    Write-Warn "No native arm64 bridge release found yet; falling back to the x64 build (runs under emulation on Windows arm64). Re-run this installer after a native arm64 release to switch to the native build."
     $arch = 'x64'
     $ArchiveName = "sesori-bridge-windows-$arch.zip"
     $Release = Resolve-BridgeRelease -ArchiveName $ArchiveName
 }
 if (-not $Release) {
-    Write-Error "Could not resolve a published bridge release for $ArchiveName."
+    Write-Err "Could not resolve a published bridge release for $ArchiveName."
     exit 1
 }
 $AssetUrl = $Release.AssetUrl
@@ -235,26 +541,26 @@ $TempDir       = Join-Path ([System.IO.Path]::GetTempPath()) "sesori-install-$([
 $TempZip       = Join-Path $TempDir $ArchiveName
 $TempChecksums = Join-Path $TempDir 'checksums.txt'
 
-Write-Host "Sesori Bridge installer" -ForegroundColor Cyan
-Write-Host "=======================" -ForegroundColor Cyan
-Write-Host "Platform     : windows/$arch"
-Write-Host "Release      : $($Release.TagName)"
-Write-Host "Install root : $InstallRoot"
-Write-Host ""
+Write-Banner
+Write-Line ('  ' + (Use-Paint $Script:C_DIM 'Platform') + ' ' + (Use-Paint $Script:C_BOLD "windows/$arch"))
+Write-Line ('  ' + (Use-Paint $Script:C_DIM 'Version ') + ' ' + (Use-Paint $Script:C_BOLD "$($Release.TagName)"))
+Write-Line ''
 
 try {
     # ── Create temp directory ─────────────────────────────────────────────────
     New-Item -ItemType Directory -Force -Path $TempDir | Out-Null
 
     # ── Download archive ──────────────────────────────────────────────────────
-    Write-Host "[1/3] Downloading release assets..." -ForegroundColor Yellow
+    # Invoke-WebRequest renders its own native progress bar in the console host.
+    Write-Step 1 'Downloading release'
     Invoke-WebRequest -Uri $AssetUrl -OutFile $TempZip -UseBasicParsing
 
     # ── Download checksums ────────────────────────────────────────────────────
     Invoke-WebRequest -Uri $ChecksumsUrl -OutFile $TempChecksums -UseBasicParsing
+    Write-Ok "Downloaded $ArchiveName"
 
     # ── Verify SHA256 ─────────────────────────────────────────────────────────
-    Write-Host "[2/3] Verifying checksum..." -ForegroundColor Yellow
+    Write-Step 2 'Verifying checksum'
 
     $actualHash = (Get-FileHash -Path $TempZip -Algorithm SHA256).Hash.ToLower()
 
@@ -271,28 +577,31 @@ try {
     }
 
     if ($null -eq $expectedHash) {
-        Write-Error "Could not find checksum entry for '$ArchiveName' in checksums.txt."
+        Write-Err "Could not find checksum entry for '$ArchiveName' in checksums.txt."
         exit 1
     }
 
     if ($actualHash -ne $expectedHash) {
-        Write-Error "SHA256 mismatch!`n  Expected : $expectedHash`n  Actual   : $actualHash`nAborting install."
+        Write-Err "SHA256 checksum mismatch for $ArchiveName"
+        [Console]::Error.WriteLine('        ' + (Use-Paint $Script:C_DIM 'Expected:') + " $expectedHash")
+        [Console]::Error.WriteLine('        ' + (Use-Paint $Script:C_DIM 'Got:     ') + " $actualHash")
+        Write-Hint 'Download may be corrupted. Aborting.'
         exit 1
     }
 
-    Write-Host "Checksum OK ($actualHash)" -ForegroundColor Green
+    Write-Ok 'Checksum verified'
 
     # ── Create install directories ────────────────────────────────────────────
     New-Item -ItemType Directory -Force -Path $BinDir | Out-Null
 
     # ── Extract archive ───────────────────────────────────────────────────────
-    Write-Host "[3/3] Installing managed runtime..." -ForegroundColor Yellow
+    Write-Step 3 'Installing managed runtime'
     Expand-Archive -Path $TempZip -DestinationPath $InstallRoot -Force
 
     # ── Verify binary ─────────────────────────────────────────────────────────
     $BinaryPath = Join-Path $BinDir $BinaryName
     if (-not (Test-Path $BinaryPath)) {
-        Write-Error "Expected binary not found at '$BinaryPath' after extraction. Check archive structure."
+        Write-Err "Expected binary not found at '$BinaryPath' after extraction. Check archive structure."
         exit 1
     }
 
@@ -306,14 +615,17 @@ try {
         $managedManifestJson,
         [System.Text.UTF8Encoding]::new($false)
     )
+    Write-Ok "Installed to $InstallRoot"
 
     # ── Check for conflicts in existing PATH ──────────────────────────────────
     $existingOnPath = Get-Command 'sesori-bridge' -ErrorAction SilentlyContinue
     if ($existingOnPath -and ($existingOnPath.Source -ne $BinaryPath)) {
-        Write-Warning "Another sesori-bridge was found at '$($existingOnPath.Source)'. It may conflict with this install."
+        Write-Warn "Another sesori-bridge was found at '$($existingOnPath.Source)'."
+        Write-Hint "It may shadow the newly installed version."
     }
 
     # ── Update user PATH ──────────────────────────────────────────────────────
+    Write-Step 4 'Linking command'
     $currentPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
     $pathEntries = $currentPath -split ';' | Where-Object { $_ -ne '' }
 
@@ -322,9 +634,9 @@ try {
     if (-not $alreadyInPath) {
         $newPath = ($BinDir + ';' + ($pathEntries -join ';'))
         [Environment]::SetEnvironmentVariable('PATH', $newPath, 'User')
-        Write-Host "PATH: persisted $BinDir in the user PATH." -ForegroundColor Green
+        Write-Ok "Added $BinDir to your PATH"
     } else {
-        Write-Host "PATH: already configured." -ForegroundColor Green
+        Write-Ok "$BinDir is already in your PATH"
     }
 
     # Also update the current session PATH so --version works immediately
@@ -332,11 +644,7 @@ try {
         $env:PATH = "$BinDir;$env:PATH"
     }
 
-    Write-Host ""
-    Write-Host "Sesori Bridge install complete" -ForegroundColor Green
-    Write-Host "============================" -ForegroundColor Green
-    Write-Host "Managed binary : $BinaryPath"
-    Write-Host ""
+    $resolvedVersionLabel = $resolvedVersion
 
     $sesoriAvailable = $null
     try {
@@ -344,21 +652,24 @@ try {
     } catch {
         # Ignore
     }
+    $onPath = ($sesoriAvailable -and ($sesoriAvailable.Source -ieq $BinaryPath))
 
-    if ($sesoriAvailable -and ($sesoriAvailable.Source -ieq $BinaryPath)) {
-        Write-Host "sesori-bridge is available in this terminal." -ForegroundColor Green
-        Write-Host ""
-        Write-Host "Next steps" -ForegroundColor Cyan
-        Write-Host "----------" -ForegroundColor Cyan
-        Write-Host "Start the bridge:"
-        Write-Host "   sesori-bridge"
-    } else {
-        Write-Host "Next steps" -ForegroundColor Cyan
-        Write-Host "----------" -ForegroundColor Cyan
-        Write-Host "1. Open a new terminal"
-        Write-Host "2. Run the bridge:"
-        Write-Host "   sesori-bridge"
+    # ── Completion: quiet success line + boxed "Next steps" call-to-action ─────
+    Write-Line ''
+    Write-Line ((Use-Paint $Script:C_GREEN $Script:G_CHECK) + " Sesori Bridge v$resolvedVersionLabel installed")
+    Write-Line ((Use-Paint $Script:C_DIM 'Location') + ' ' + (Use-Paint $Script:C_DIM $InstallRoot))
+    Write-Line ''
+
+    Write-PanelTop $Script:C_BRAND
+    Write-PanelRow 'Next steps' $Script:C_BOLD $Script:C_BRAND
+    Write-PanelRow '' '' $Script:C_BRAND
+    if (-not $onPath) {
+        Write-PanelEmphasisRow 'In a ' 'new terminal' ' window, run:' $Script:C_BRAND
+        Write-PanelRow '' '' $Script:C_BRAND
     }
+    Write-PanelCommandRow 'sesori-bridge' '# Start the bridge' $Script:C_BRAND
+    Write-PanelBottom $Script:C_BRAND
+    Write-Line ''
 
 } finally {
     # ── Cleanup temp files ────────────────────────────────────────────────────

--- a/install.ps1
+++ b/install.ps1
@@ -48,7 +48,7 @@ $Script:G_BAR_EMPTY = ''
 
 $Script:UseColor = $false
 $Script:UseUnicode = $false
-$Script:PanelWidth = 52
+$Script:PanelWidth = 56
 
 # Color is emitted unless NO_COLOR is set, output is redirected, or TERM=dumb.
 # FORCE_COLOR forces it on. On Windows a console host generally supports ANSI
@@ -203,12 +203,6 @@ function Write-Step {
 function Write-Ok {
     param([string]$Message)
     Write-Line ('      ' + (Use-Paint $Script:C_GREEN $Script:G_CHECK) + ' ' + (Use-Paint $Script:C_DIM $Message))
-}
-
-# A muted, indented note under a step.
-function Write-Note {
-    param([string]$Message)
-    Write-Line ('      ' + (Use-Paint $Script:C_DIM $Message))
 }
 
 # Error / warning / note prefixes. Errors and warnings go to stderr so they are

--- a/install.sh
+++ b/install.sh
@@ -204,7 +204,7 @@ hint() {
 # Box-drawing helpers for a panel. Unicode by default, ASCII when Unicode is
 # unsafe. PANEL_WIDTH is the inner width (between the borders). The border color
 # is passed in (${1}) so the same panel can frame different kinds of content.
-PANEL_WIDTH=52
+PANEL_WIDTH=56
 
 panel_top() {
     local border="${1:-${C_BRAND}}"
@@ -262,20 +262,41 @@ panel_command_row() {
     [ "${USE_UNICODE}" = true ] && bar="│"
 
     local gap="   "
-    local plain="${command}${gap}${comment}"
     local inner=$(( PANEL_WIDTH - 2 ))
+    local ellipsis="..."
+    [ "${USE_UNICODE}" = true ] && ellipsis="…"
+
+    # Drop the comment if command + gap + comment overflows; truncate the command
+    # itself only as a last resort, so the right border stays aligned.
+    if [ $(( ${#command} + ${#gap} + ${#comment} )) -gt "${inner}" ]; then
+        comment=""
+    fi
+    if [ "${#command}" -gt "${inner}" ]; then
+        command="${command:0:$(( inner - ${#ellipsis} ))}${ellipsis}"
+    fi
+
+    local plain="${command}"
+    [ -n "${comment}" ] && plain="${command}${gap}${comment}"
     local pad=$(( inner - ${#plain} ))
     [ "${pad}" -lt 0 ] && pad=0
     local spaces
     spaces="$(printf '%*s' "${pad}" '')"
 
-    printf '  %s%s%s %s%s%s%s %s%s%s\n' \
-        "${border}" "${bar}" "${C_RESET}" \
-        "$(paint "${C_BRAND}${C_BOLD}" "${command}")" \
-        "${gap}" \
-        "$(paint "${C_DIM}" "${comment}")" \
-        "${spaces}" \
-        "${border}" "${bar}" "${C_RESET}"
+    if [ -n "${comment}" ]; then
+        printf '  %s%s%s %s%s%s%s %s%s%s\n' \
+            "${border}" "${bar}" "${C_RESET}" \
+            "$(paint "${C_BRAND}${C_BOLD}" "${command}")" \
+            "${gap}" \
+            "$(paint "${C_DIM}" "${comment}")" \
+            "${spaces}" \
+            "${border}" "${bar}" "${C_RESET}"
+    else
+        printf '  %s%s%s %s%s %s%s%s\n' \
+            "${border}" "${bar}" "${C_RESET}" \
+            "$(paint "${C_BRAND}${C_BOLD}" "${command}")" \
+            "${spaces}" \
+            "${border}" "${bar}" "${C_RESET}"
+    fi
 }
 
 # A panel row with an emphasized middle segment: "${1}<bold ${2}>${3}". The
@@ -446,27 +467,30 @@ download_with_progress_curl() {
     curl --trace-ascii "${tracefile}" -fsSL -o "${dest}" "${url}" &
     local curl_pid=$!
 
-    local total=0 bytes=0 size lower
+    # --trace-ascii emits a hex/ASCII dump of the WHOLE payload (millions of lines
+    # for a binary). Pre-filter with grep so the bash loop only sees the handful of
+    # content-length / recv-data lines, and parse with bash's built-in regex so we
+    # never fork tr/sed per line.
+    local total=0 bytes=0
     while IFS= read -r line; do
-        lower="$(printf '%s' "${line}" | tr '[:upper:]' '[:lower:]')"
-        case "${lower}" in
-            "0000: content-length:"*)
-                total="$(printf '%s' "${lower}" | sed -nE 's/^0000: content-length: *([0-9]+).*/\1/p')"
-                [ -n "${total}" ] || total=0
-                bytes=0
-                ;;
-            "<= recv data"*)
-                size="$(printf '%s' "${lower}" | sed -nE 's/^<= recv data, ([0-9]+) bytes.*/\1/p')"
-                if [ -n "${size}" ] && [ "${total}" -gt 0 ]; then
-                    bytes=$(( bytes + size ))
-                    render_progress "${bytes}" "${total}"
-                fi
-                ;;
-        esac
-    done < "${tracefile}"
+        if [[ "${line}" =~ [Cc]ontent-[Ll]ength:[[:space:]]*([0-9]+) ]]; then
+            total="${BASH_REMATCH[1]}"
+            bytes=0
+        elif [[ "${line}" =~ [Rr]ecv[[:space:]]data,[[:space:]]*([0-9]+)[[:space:]]bytes ]]; then
+            if [ "${total}" -gt 0 ]; then
+                bytes=$(( bytes + BASH_REMATCH[1] ))
+                render_progress "${bytes}" "${total}"
+            fi
+        fi
+    done < <(grep -E -i '^0000: content-length:|^<= recv data' "${tracefile}" 2>/dev/null || true)
 
-    wait "${curl_pid}"
-    local status=$?
+    # Capture curl's exit status WITHOUT tripping errexit, so the terminal-state
+    # cleanup below always runs even when the download fails (network error, 404,
+    # interrupted transfer). Otherwise a failed install would leave the cursor
+    # hidden and fd 4 open.
+    local status=0
+    wait "${curl_pid}" || status=$?
+
     rm -f "${tracefile}"
     # Restore cursor, end the bar line, and release fd 4.
     printf '\n' >&4

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,294 @@ RESOLVED_VERSION=""
 RESOLVED_ARCHIVE_URL=""
 RESOLVED_CHECKSUMS_URL=""
 
+# ── Presentation layer ───────────────────────────────────────────────────────
+# Shared visual spec (kept byte-for-byte equivalent across install.sh,
+# install.ps1, and the npm bootstrap). Color and Unicode are opt-out: we degrade
+# to plain ASCII whenever the environment can't be trusted to render them.
+TOTAL_STEPS=4
+
+# ┌─ PALETTE ───────────────────────────────────────────────────────────────────
+# │ Edit these ANSI codes in ONE place to retheme the installer. They are the raw
+# │ escape sequences; init_style() copies them into the C_* variables only when
+# │ color is enabled (otherwise the C_* variables stay empty for plain output).
+# │ 256-color codes: brand blue #1472FF ≈ 39 (bright) / 25 (deep).
+# └──────────────────────────────────────────────────────────────────────────────
+PALETTE_RESET=$'\033[0m'
+PALETTE_BANNER=$'\033[0;2m'       # SESORI wordmark — faded grey; large enough to read without color
+PALETTE_BRAND=$'\033[38;5;39m'    # accents: step counter, command, progress bar
+PALETTE_BRAND_DIM=$'\033[38;5;25m'
+PALETTE_GREEN=$'\033[38;5;42m'    # success
+PALETTE_YELLOW=$'\033[38;5;214m'  # warning
+PALETTE_RED=$'\033[38;5;203m'     # error
+PALETTE_DIM=$'\033[0;2m'          # secondary / muted text
+PALETTE_BOLD=$'\033[1m'
+
+# Active palette (empty unless color is enabled). Assigned by init_style().
+C_RESET=""
+C_BANNER=""
+C_BRAND=""
+C_BRAND_DIM=""
+C_GREEN=""
+C_YELLOW=""
+C_RED=""
+C_DIM=""
+C_BOLD=""
+
+# Glyphs. Unicode where safe, ASCII otherwise. Populated by init_style().
+G_CHECK=""
+G_WARN=""
+G_CROSS=""
+G_ARROW=""
+G_BAR_FULL=""
+G_BAR_EMPTY=""
+
+USE_COLOR=false
+USE_UNICODE=false
+
+# Detect whether color should be emitted. Honors NO_COLOR (disable), FORCE_COLOR
+# (force on), a non-TTY stdout (disable), and TERM=dumb/unset (disable).
+should_use_color() {
+    if [ -n "${FORCE_COLOR:-}" ]; then
+        return 0
+    fi
+    if [ -n "${NO_COLOR:-}" ]; then
+        return 1
+    fi
+    if [ ! -t 1 ]; then
+        return 1
+    fi
+    case "${TERM:-}" in
+        "" | dumb) return 1 ;;
+    esac
+    return 0
+}
+
+# Detect whether Unicode glyphs are safe to emit. Requires a UTF-8 locale; falls
+# back to ASCII for C/POSIX/unset locales and dumb terminals.
+should_use_unicode() {
+    case "${TERM:-}" in
+        dumb) return 1 ;;
+    esac
+    case "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" in
+        *[Uu][Tt][Ff]-8* | *[Uu][Tt][Ff]8*) return 0 ;;
+    esac
+    return 1
+}
+
+init_style() {
+    if should_use_color; then
+        USE_COLOR=true
+        C_RESET="${PALETTE_RESET}"
+        C_BANNER="${PALETTE_BANNER}"
+        C_BRAND="${PALETTE_BRAND}"
+        C_BRAND_DIM="${PALETTE_BRAND_DIM}"
+        C_GREEN="${PALETTE_GREEN}"
+        C_YELLOW="${PALETTE_YELLOW}"
+        C_RED="${PALETTE_RED}"
+        C_DIM="${PALETTE_DIM}"
+        C_BOLD="${PALETTE_BOLD}"
+    fi
+
+    if should_use_unicode; then
+        USE_UNICODE=true
+        G_CHECK="✓"
+        G_WARN="⚠"
+        G_CROSS="✗"
+        G_ARROW="➜"
+        G_BAR_FULL="■"
+        G_BAR_EMPTY="･"
+    else
+        G_CHECK="[OK]"
+        G_WARN="!"
+        G_CROSS="x"
+        G_ARROW=">"
+        G_BAR_FULL="#"
+        G_BAR_EMPTY="."
+    fi
+}
+
+# Wrap ${2} in color ${1} (and the reset), or pass it through when color is off.
+paint() {
+    if [ "${USE_COLOR}" = true ]; then
+        printf '%s%s%s' "${1}" "${2}" "${C_RESET}"
+    else
+        printf '%s' "${2}"
+    fi
+}
+
+# The SESORI wordmark, in deep brand blue, printed as the header. Kept calm
+# (deep blue, not the bright accent) so it frames the install without shouting.
+print_banner() {
+    local b="${C_BANNER}"
+    local r="${C_RESET}"
+    if [ "${USE_COLOR}" != true ]; then
+        b=""
+        r=""
+    fi
+    printf '\n'
+    if [ "${USE_UNICODE}" = true ]; then
+        printf '%s ███████╗███████╗███████╗ ██████╗ ██████╗ ██╗%s\n' "${b}" "${r}"
+        printf '%s ██╔════╝██╔════╝██╔════╝██╔═══██╗██╔══██╗██║%s\n' "${b}" "${r}"
+        printf '%s ███████╗█████╗  ███████╗██║   ██║██████╔╝██║%s\n' "${b}" "${r}"
+        printf '%s ╚════██║██╔══╝  ╚════██║██║   ██║██╔══██╗██║%s\n' "${b}" "${r}"
+        printf '%s ███████║███████╗███████║╚██████╔╝██║  ██║██║%s\n' "${b}" "${r}"
+        printf '%s ╚══════╝╚══════╝╚══════╝ ╚═════╝ ╚═╝  ╚═╝╚═╝%s\n' "${b}" "${r}"
+    else
+        printf '%s  ____  _____ ____   ___  ____  ___ %s\n' "${b}" "${r}"
+        printf '%s / ___|| ____/ ___| / _ \\|  _ \\|_ _|%s\n' "${b}" "${r}"
+        printf '%s \\___ \\|  _| \\___ \\| | | | |_) || | %s\n' "${b}" "${r}"
+        printf '%s  ___) | |___ ___) | |_| |  _ < | | %s\n' "${b}" "${r}"
+        printf '%s |____/|_____|____/ \\___/|_| \\_\\___|%s\n' "${b}" "${r}"
+    fi
+    printf '\n'
+    printf '  %s\n' "$(paint "${C_DIM}" "Installing the Sesori Bridge — connect AI coding sessions to your phone")"
+    printf '\n'
+}
+
+# A "[n/N] message" step header in brand blue.
+step() {
+    local n="${1}"
+    local message="${2}"
+    printf '%s %s\n' "$(paint "${C_BRAND}" "[${n}/${TOTAL_STEPS}]")" "${message}"
+}
+
+# A green success line with a check glyph, used to confirm a completed step.
+ok() {
+    printf '      %s %s\n' "$(paint "${C_GREEN}" "${G_CHECK}")" "$(paint "${C_DIM}" "${1}")"
+}
+
+# A muted, indented note under a step.
+note() {
+    printf '      %s\n' "$(paint "${C_DIM}" "${1}")"
+}
+
+# Error / warning / note prefixes. Errors go to stderr; warnings too, since they
+# accompany a degraded outcome the user must see even when stdout is redirected.
+err() {
+    printf '%s %s\n' "$(paint "${C_RED}" "${G_CROSS} Error:")" "${1}" >&2
+}
+
+warn() {
+    printf '%s %s\n' "$(paint "${C_YELLOW}" "${G_WARN} Warning:")" "${1}" >&2
+}
+
+hint() {
+    printf '%s %s\n' "$(paint "${C_BRAND}" "${G_ARROW} Note:")" "${1}" >&2
+}
+
+# Box-drawing helpers for a panel. Unicode by default, ASCII when Unicode is
+# unsafe. PANEL_WIDTH is the inner width (between the borders). The border color
+# is passed in (${1}) so the same panel can frame different kinds of content.
+PANEL_WIDTH=52
+
+panel_top() {
+    local border="${1:-${C_BRAND}}"
+    if [ "${USE_UNICODE}" = true ]; then
+        printf '  %s┌%s┐%s\n' "${border}" "$(repeat_char '─' "${PANEL_WIDTH}")" "${C_RESET}"
+    else
+        printf '  %s+%s+%s\n' "${border}" "$(repeat_char '-' "${PANEL_WIDTH}")" "${C_RESET}"
+    fi
+}
+
+panel_bottom() {
+    local border="${1:-${C_BRAND}}"
+    if [ "${USE_UNICODE}" = true ]; then
+        printf '  %s└%s┘%s\n' "${border}" "$(repeat_char '─' "${PANEL_WIDTH}")" "${C_RESET}"
+    else
+        printf '  %s+%s+%s\n' "${border}" "$(repeat_char '-' "${PANEL_WIDTH}")" "${C_RESET}"
+    fi
+}
+
+# A single panel row. ${1} is the content, ${2} (optional) a color applied to the
+# content, ${3} (optional) the border color. Content longer than the inner width
+# is truncated with an ellipsis so the right border stays aligned.
+panel_row() {
+    local content="${1}"
+    local content_color="${2:-}"
+    local border="${3:-${C_BRAND}}"
+    local bar="|"
+    [ "${USE_UNICODE}" = true ] && bar="│"
+
+    local inner=$(( PANEL_WIDTH - 2 ))
+    if [ "${#content}" -gt "${inner}" ]; then
+        content="${content:0:$(( inner - 1 ))}…"
+        [ "${USE_UNICODE}" = true ] || content="${content:0:$(( inner - 3 ))}..."
+    fi
+    local pad=$(( inner - ${#content} ))
+    [ "${pad}" -lt 0 ] && pad=0
+    local spaces
+    spaces="$(printf '%*s' "${pad}" '')"
+    printf '  %s%s%s %s%s %s%s%s\n' \
+        "${border}" "${bar}" "${C_RESET}" \
+        "$(paint "${content_color}" "${content}")" \
+        "${spaces}" \
+        "${border}" "${bar}" "${C_RESET}"
+}
+
+# A panel row that highlights a runnable command plus a muted inline comment,
+# e.g. "sesori-bridge   # Start the bridge". Width/padding are computed from the
+# PLAIN text (command + gap + comment) so the colored escapes don't skew the
+# border alignment. ${3} is the border color.
+panel_command_row() {
+    local command="${1}"
+    local comment="${2}"
+    local border="${3:-${C_BRAND}}"
+    local bar="|"
+    [ "${USE_UNICODE}" = true ] && bar="│"
+
+    local gap="   "
+    local plain="${command}${gap}${comment}"
+    local inner=$(( PANEL_WIDTH - 2 ))
+    local pad=$(( inner - ${#plain} ))
+    [ "${pad}" -lt 0 ] && pad=0
+    local spaces
+    spaces="$(printf '%*s' "${pad}" '')"
+
+    printf '  %s%s%s %s%s%s%s %s%s%s\n' \
+        "${border}" "${bar}" "${C_RESET}" \
+        "$(paint "${C_BRAND}${C_BOLD}" "${command}")" \
+        "${gap}" \
+        "$(paint "${C_DIM}" "${comment}")" \
+        "${spaces}" \
+        "${border}" "${bar}" "${C_RESET}"
+}
+
+# A panel row with an emphasized middle segment: "${1}<bold ${2}>${3}". The
+# prefix and suffix render in the default color; the middle is brand-blue/bold so
+# a hard-requirement phrase (e.g. "new terminal") stands out. Width is computed
+# from the plain concatenation so the border stays aligned. ${4} is border color.
+panel_emphasis_row() {
+    local prefix="${1}"
+    local emphasis="${2}"
+    local suffix="${3}"
+    local border="${4:-${C_BRAND}}"
+    local bar="|"
+    [ "${USE_UNICODE}" = true ] && bar="│"
+
+    local plain="${prefix}${emphasis}${suffix}"
+    local inner=$(( PANEL_WIDTH - 2 ))
+    local pad=$(( inner - ${#plain} ))
+    [ "${pad}" -lt 0 ] && pad=0
+    local spaces
+    spaces="$(printf '%*s' "${pad}" '')"
+
+    printf '  %s%s%s %s%s%s%s %s%s%s\n' \
+        "${border}" "${bar}" "${C_RESET}" \
+        "${prefix}" \
+        "$(paint "${C_BRAND}${C_BOLD}" "${emphasis}")" \
+        "${suffix}" \
+        "${spaces}" \
+        "${border}" "${bar}" "${C_RESET}"
+}
+
+repeat_char() {
+    local ch="${1}"
+    local count="${2}"
+    local out
+    out="$(printf '%*s' "${count}" '')"
+    printf '%s' "${out// /${ch}}"
+}
+
 TMPDIR_WORK=""
 TMPDIR_RELEASES=""
 cleanup() {
@@ -45,8 +333,8 @@ detect_os() {
         Darwin) echo "macos" ;;
         Linux)  echo "linux" ;;
         *)
-            echo "Unsupported operating system: ${raw_os}" >&2
-            echo "Sesori Bridge supports macOS and Linux only." >&2
+            err "Unsupported operating system: ${raw_os}"
+            hint "Sesori Bridge supports macOS and Linux only."
             exit 1
             ;;
     esac
@@ -59,8 +347,8 @@ detect_arch() {
         x86_64)          echo "x64" ;;
         aarch64 | arm64) echo "arm64" ;;
         *)
-            echo "Unsupported architecture: ${raw_arch}" >&2
-            echo "Sesori Bridge supports x86_64 and arm64 only." >&2
+            err "Unsupported architecture: ${raw_arch}"
+            hint "Sesori Bridge supports x86_64 and arm64 only."
             exit 1
             ;;
     esac
@@ -74,9 +362,117 @@ download() {
     elif command -v wget > /dev/null 2>&1; then
         wget -qO "${dest}" "${url}"
     else
-        echo "Neither curl nor wget found. Please install one and retry." >&2
+        err "Neither curl nor wget found. Please install one and retry."
         exit 1
     fi
+}
+
+# Render a single progress-bar frame: a brand-blue ■/･ bar plus a percentage.
+# Drawn in place (carriage return, no newline) on the controlling terminal.
+render_progress() {
+    local bytes="${1}"
+    local total="${2}"
+    [ "${total}" -gt 0 ] || return 0
+
+    local width=32
+    local percent=$(( bytes * 100 / total ))
+    [ "${percent}" -gt 100 ] && percent=100
+    local on=$(( percent * width / 100 ))
+    local off=$(( width - on ))
+
+    local filled empty
+    filled="$(printf '%*s' "${on}" '')"
+    filled="${filled// /${G_BAR_FULL}}"
+    empty="$(printf '%*s' "${off}" '')"
+    empty="${empty// /${G_BAR_EMPTY}}"
+
+    if [ "${USE_COLOR}" = true ]; then
+        printf '\r      %s%s%s%s %3d%%' "${C_BRAND}" "${filled}" "${C_DIM}" "${empty}" "${percent}" >&4
+        printf '%s' "${C_RESET}" >&4
+    else
+        printf '\r      %s%s %3d%%' "${filled}" "${empty}" "${percent}" >&4
+    fi
+}
+
+# Download with a live progress bar. Prefers curl (trace-parsed byte counts for a
+# branded bar); falls back to wget's native --show-progress; and to a plain
+# download with a static note when neither a TTY nor curl is available.
+download_with_progress() {
+    local url="${1}"
+    local dest="${2}"
+
+    # Only animate on an interactive terminal; otherwise keep logs clean.
+    if [ ! -t 1 ] || [ "${USE_COLOR}" != true ]; then
+        note "Downloading release..."
+        download "${url}" "${dest}"
+        return $?
+    fi
+
+    if command -v curl > /dev/null 2>&1; then
+        download_with_progress_curl "${url}" "${dest}"
+        return $?
+    fi
+
+    if command -v wget > /dev/null 2>&1; then
+        # wget renders its own progress bar on stderr; let it through.
+        wget --show-progress -qO "${dest}" "${url}"
+        return $?
+    fi
+
+    err "Neither curl nor wget found. Please install one and retry."
+    exit 1
+}
+
+# curl-backed progress: parse curl's --trace-ascii stream for content-length and
+# received-data events, accumulate bytes, and redraw the bar. Mirrors the
+# approach used by the opencode installer.
+download_with_progress_curl() {
+    local url="${1}"
+    local dest="${2}"
+
+    local tmp_dir="${TMPDIR:-/tmp}"
+    local tracefile="${tmp_dir}/sesori_install_$$.trace"
+    rm -f "${tracefile}"
+    if ! mkfifo "${tracefile}" 2>/dev/null; then
+        # No FIFO support — fall back to a plain download.
+        download "${url}" "${dest}"
+        return $?
+    fi
+
+    # fd 4 mirrors stdout for the in-place bar; hide the cursor while it animates.
+    exec 4>&1
+    printf '\033[?25l' >&4
+
+    curl --trace-ascii "${tracefile}" -fsSL -o "${dest}" "${url}" &
+    local curl_pid=$!
+
+    local total=0 bytes=0 size lower
+    while IFS= read -r line; do
+        lower="$(printf '%s' "${line}" | tr '[:upper:]' '[:lower:]')"
+        case "${lower}" in
+            "0000: content-length:"*)
+                total="$(printf '%s' "${lower}" | sed -nE 's/^0000: content-length: *([0-9]+).*/\1/p')"
+                [ -n "${total}" ] || total=0
+                bytes=0
+                ;;
+            "<= recv data"*)
+                size="$(printf '%s' "${lower}" | sed -nE 's/^<= recv data, ([0-9]+) bytes.*/\1/p')"
+                if [ -n "${size}" ] && [ "${total}" -gt 0 ]; then
+                    bytes=$(( bytes + size ))
+                    render_progress "${bytes}" "${total}"
+                fi
+                ;;
+        esac
+    done < "${tracefile}"
+
+    wait "${curl_pid}"
+    local status=$?
+    rm -f "${tracefile}"
+    # Restore cursor, end the bar line, and release fd 4.
+    printf '\n' >&4
+    printf '\033[?25h' >&4
+    exec 4>&-
+    return ${status}
 }
 
 fetch_text() {
@@ -86,7 +482,7 @@ fetch_text() {
     elif command -v wget > /dev/null 2>&1; then
         wget -qO - --header="Accept: application/vnd.github+json" --header="User-Agent: sesori-bridge-installer" "${url}"
     else
-        echo "Neither curl nor wget found. Please install one and retry." >&2
+        err "Neither curl nor wget found. Please install one and retry."
         exit 1
     fi
 }
@@ -102,7 +498,7 @@ fetch_redirect_headers() {
     elif command -v wget > /dev/null 2>&1; then
         wget -S --spider --header="User-Agent: sesori-bridge-installer" "${url}" 2>&1
     else
-        echo "Neither curl nor wget found. Please install one and retry." >&2
+        err "Neither curl nor wget found. Please install one and retry."
         exit 1
     fi
 }
@@ -175,8 +571,8 @@ resolve_release_via_latest() {
 resolve_release_via_scan() {
     local filename="${1}"
     if ! command -v python3 > /dev/null 2>&1; then
-        echo "The latest release is missing ${filename}, and resolving an older release requires python3, which was not found." >&2
-        echo "Install python3 and retry, or report this at https://github.com/${GITHUB_REPO}/issues." >&2
+        err "The latest release is missing ${filename}, and resolving an older release requires python3, which was not found."
+        hint "Install python3 and retry, or report this at https://github.com/${GITHUB_REPO}/issues."
         exit 1
     fi
 
@@ -186,7 +582,7 @@ resolve_release_via_scan() {
     for page in $(seq 1 "${GITHUB_RELEASES_MAX_PAGES}"); do
         page_file="${TMPDIR_RELEASES}/releases-page-${page}.json"
         if ! fetch_text "${GITHUB_RELEASES_API_URL}?per_page=${GITHUB_RELEASES_PER_PAGE}&page=${page}" > "${page_file}"; then
-            echo "Unexpected release metadata returned by GitHub." >&2
+            err "Unexpected release metadata returned by GitHub."
             exit 1
         fi
         page_count="$(python3 -c '
@@ -198,7 +594,7 @@ if not isinstance(page, list):
     raise SystemExit(1)
 print(len(page))
 ' "${page_file}")" || {
-            echo "Unexpected release metadata returned by GitHub." >&2
+            err "Unexpected release metadata returned by GitHub."
             exit 1
         }
         page_files+=("${page_file}")
@@ -255,7 +651,7 @@ if eligible:
     sys.exit(0)
 sys.exit(1)
 ' "${filename}" "${page_files[@]}")" || {
-        echo "Could not resolve a published bridge release for ${filename}." >&2
+        err "Could not resolve a published bridge release for ${filename}."
         exit 1
     }
 
@@ -297,7 +693,7 @@ verify_checksum() {
     expected_digest="$(awk -v name="${filename}" '$2 == name || $2 == "*" name { print $1; exit }' "${checksums_file}")"
 
     if [ -z "${expected_digest}" ]; then
-        echo "Could not find checksum for ${filename} in checksums.txt" >&2
+        err "Could not find checksum for ${filename} in checksums.txt"
         exit 1
     fi
 
@@ -305,10 +701,10 @@ verify_checksum() {
     actual_digest="$(sha256_file "${archive}" "${os}")"
 
     if [ "${actual_digest}" != "${expected_digest}" ]; then
-        echo "SHA256 checksum mismatch for ${filename}" >&2
-        echo "  Expected: ${expected_digest}" >&2
-        echo "  Got:      ${actual_digest}" >&2
-        echo "Download may be corrupted. Aborting." >&2
+        err "SHA256 checksum mismatch for ${filename}"
+        printf '        %s %s\n' "$(paint "${C_DIM}" "Expected:")" "${expected_digest}" >&2
+        printf '        %s %s\n' "$(paint "${C_DIM}" "Got:     ")" "${actual_digest}" >&2
+        hint "Download may be corrupted. Aborting."
         exit 1
     fi
 }
@@ -326,7 +722,7 @@ add_to_path() {
     local bin_dir="${1}"
 
     if is_local_bin_in_path; then
-        echo "PATH: ~/.local/bin is already in your PATH."
+        ok "~/.local/bin is already in your PATH"
         return 0
     fi
 
@@ -342,7 +738,7 @@ add_to_path() {
             mkdir -p "$(dirname "${rc_file}")"
             if ! grep -qF 'fish_add_path "$HOME/.local/bin"' "${rc_file}" 2>/dev/null; then
                 echo 'fish_add_path "$HOME/.local/bin"' >> "${rc_file}"
-                echo "PATH: persisted ~/.local/bin in ${rc_file}."
+                ok "Added ~/.local/bin to your PATH in ${rc_file}"
             fi
             return 0
             ;;
@@ -369,7 +765,8 @@ add_to_path() {
                 joined_files+=", ${updated_files[index]}"
             fi
         done
-        echo "PATH: persisted ~/.local/bin in ${joined_files}. Run 'source ${updated_files[0]}' or open a new terminal."
+        ok "Added ~/.local/bin to your PATH in ${joined_files}"
+        note "Run 'source ${updated_files[0]}' or open a new terminal to use it."
     fi
 }
 
@@ -386,7 +783,7 @@ create_symlink() {
     fi
 
     ln -s "${target}" "${link}"
-    echo "Symlink: ${link} -> ${target}"
+    ok "Linked ${link}"
     return 0
 }
 
@@ -398,14 +795,16 @@ check_conflicts() {
             "${INSTALL_DIR}"/*) : ;;
             "${SYMLINK}") : ;;
             *)
-                echo "Warning: another sesori-bridge found at ${existing}" >&2
-                echo "It may shadow the newly installed version." >&2
+                warn "Another sesori-bridge was found at ${existing}"
+                hint "It may shadow the newly installed version."
                 ;;
         esac
     fi
 }
 
 main() {
+    init_style
+
     local os arch filename
 
     os="$(detect_os)"
@@ -420,27 +819,26 @@ main() {
         release_label="latest"
     fi
 
-    echo "Sesori Bridge installer"
-    echo "======================="
-    echo "Platform     : ${os}/${arch}"
-    echo "Release      : ${release_label}"
-    echo "Install root : ${INSTALL_DIR}"
-    echo "Symlink      : ${SYMLINK}"
-    echo ""
-    echo "[1/4] Downloading release assets..."
+    print_banner
+    printf '  %s %s\n' "$(paint "${C_DIM}" "Platform")" "$(paint "${C_BOLD}" "${os}/${arch}")"
+    printf '  %s  %s\n' "$(paint "${C_DIM}" "Version")" "$(paint "${C_BOLD}" "${release_label}")"
+    printf '\n'
+
+    step 1 "Downloading release"
 
     TMPDIR_WORK="$(mktemp -d)"
     local archive="${TMPDIR_WORK}/${filename}"
     local checksums="${TMPDIR_WORK}/checksums.txt"
 
-    download "${RESOLVED_ARCHIVE_URL}" "${archive}"
+    download_with_progress "${RESOLVED_ARCHIVE_URL}" "${archive}"
     download "${RESOLVED_CHECKSUMS_URL}" "${checksums}"
+    ok "Downloaded ${filename}"
 
-    echo "[2/4] Verifying checksum..."
+    step 2 "Verifying checksum"
     verify_checksum "${archive}" "${checksums}" "${filename}" "${os}"
-    echo "Checksum OK."
+    ok "Checksum verified"
 
-    echo "[3/4] Installing managed runtime..."
+    step 3 "Installing managed runtime"
     mkdir -p "${INSTALL_DIR}"
     tar -xzf "${archive}" -C "${INSTALL_DIR}"
 
@@ -459,40 +857,66 @@ main() {
         resolved_version="$("${BINARY}" --version 2>/dev/null | head -n 1 | tr -d '[:space:]')"
     fi
     if [ -z "${resolved_version}" ]; then
-        echo "Could not determine the installed bridge version." >&2
+        err "Could not determine the installed bridge version."
         exit 1
     fi
     printf '{"version":"%s"}\n' "${resolved_version}" > "${MANAGED_MANIFEST}"
+    ok "Installed to ${INSTALL_DIR}"
 
-    echo "[4/4] Creating symlink..."
+    step 4 "Linking command"
     create_symlink "${BINARY}" "${SYMLINK}"
 
     check_conflicts
     add_to_path "${SYMLINK_DIR}"
 
-    echo ""
-    echo "Sesori Bridge install complete"
-    echo "============================"
-    echo "Managed binary : ${BINARY}"
-    echo "Symlink        : ${SYMLINK}"
-    echo ""
+    print_completion "${resolved_version}"
+}
+
+# Completion output: a quiet, plain success confirmation followed by a boxed
+# "Next steps" call-to-action. The box is intentionally on the NEXT STEPS (not the
+# success line), so the user's attention lands on what to do next. The runnable
+# command is highlighted; the inline hint is muted.
+print_completion() {
+    local installed_version="${1}"
+
+    # Prefer a ~-relative path so the location reads cleanly.
+    local short_dir="${INSTALL_DIR}"
+    case "${INSTALL_DIR}" in
+        "${HOME}"/*) short_dir="~${INSTALL_DIR#"${HOME}"}" ;;
+    esac
+
+    # Plain (unboxed) success confirmation — present but understated. Only the
+    # tick is green; the text stays default-colored so it doesn't compete with
+    # the boxed call-to-action below.
+    printf '\n'
+    printf '%s %s\n' \
+        "$(paint "${C_GREEN}" "${G_CHECK}")" \
+        "Sesori Bridge v${installed_version} installed"
+    printf '%s %s\n' \
+        "$(paint "${C_DIM}" "Location")" \
+        "$(paint "${C_DIM}" "${short_dir}")"
+    printf '\n'
 
     local resolved_binary
     resolved_binary="$(command -v sesori-bridge 2>/dev/null || true)"
+    local on_path=false
     if [ -n "${resolved_binary}" ] && { [ "${resolved_binary}" = "${BINARY}" ] || [ "${resolved_binary}" = "${SYMLINK}" ]; }; then
-        echo "sesori-bridge is available in this terminal."
-        echo ""
-        echo "Next steps"
-        echo "----------"
-        echo "Start the bridge:"
-        echo "   sesori-bridge"
-    else
-        echo "Next steps"
-        echo "----------"
-        echo "1. Open a new terminal"
-        echo "2. Run the bridge:"
-        echo "   sesori-bridge"
+        on_path=true
     fi
+
+    # Boxed "Next steps" call-to-action, framed in brand blue.
+    panel_top "${C_BRAND}"
+    panel_row "Next steps" "${C_BOLD}" "${C_BRAND}"
+    panel_row "" "" "${C_BRAND}"
+    if [ "${on_path}" != true ]; then
+        # "new terminal" is a hard requirement, so emphasize it rather than mute
+        # the whole line — a faded instruction gets skipped.
+        panel_emphasis_row "In a " "new terminal" " window, run:" "${C_BRAND}"
+        panel_row "" "" "${C_BRAND}"
+    fi
+    panel_command_row "sesori-bridge" "# Start the bridge" "${C_BRAND}"
+    panel_bottom "${C_BRAND}"
+    printf '\n'
 }
 
 main


### PR DESCRIPTION
## What

Gives the three Sesori Bridge install paths — `install.sh` (macOS/Linux), `install.ps1` (Windows), and the `@sesori/bridge` npm bootstrap — a consistent, premium first-impression experience, matching the quality bar of the opencode installer. First impressions matter, and the previous installers were plain `echo`/`Write-Host`/`console.log` with `===` underlines and `[1/4]` steps.

## The experience (full color + Unicode)

```
 ███████╗███████╗███████╗ ██████╗ ██████╗ ██╗      (faded grey wordmark)
 ██╔════╝██╔════╝██╔════╝██╔═══██╗██╔══██╗██║
 ███████╗█████╗  ███████╗██║   ██║██████╔╝██║
 ╚════██║██╔══╝  ╚════██║██║   ██║██╔══██╗██║
 ███████║███████╗███████║╚██████╔╝██║  ██║██║
 ╚══════╝╚══════╝╚══════╝ ╚═════╝ ╚═╝  ╚═╝╚═╝

  Installing the Sesori Bridge — connect AI coding sessions to your phone

  Platform macos/arm64
  Version  v1.2.3

[1/4] Downloading release
      ■■■■■■■■■■■■■■■■････････････････  50%        (brand-blue progress bar)
      ✓ Downloaded sesori-bridge-macos-arm64.tar.gz
[2/4] Verifying checksum
      ✓ Checksum verified
[3/4] Installing managed runtime
      ✓ Installed to ~/.local/share/sesori
[4/4] Linking command
      ✓ Linked ~/.local/bin/sesori-bridge

✓ Sesori Bridge v1.2.3 installed
Location ~/.local/share/sesori

  ┌────────────────────────────────────────────────────┐  (brand-blue box)
  │ Next steps                                         │
  │                                                    │
  │ In a new terminal window, run:                     │  ("new terminal" bold/blue)
  │                                                    │
  │ sesori-bridge   # Start the bridge                 │  (command highlighted)
  └────────────────────────────────────────────────────┘
```

## Design decisions

- **SESORI wordmark** in faded grey (large enough to read without color, doesn't shout).
- **Brand blue (#1472FF ≈ 256-color 39)** for active accents: step counter, the runnable command, progress bar, the "Next steps" box, and the emphasized "new terminal".
- **The box frames "Next steps"** (the call-to-action), not the success line — attention lands on what to do next. The success line is a quiet green-tick + default-color text.
- **Centralized `PALETTE` block** at the top of each script: retheming is a one-line change.

## Cross-runtime consistency

One visual spec, implemented per-runtime via local helpers (the three languages can't share a library), so all three render equivalent output:
- **bash**: trace-parsed `■/･` progress bar (curl), `wget --show-progress` fallback, plain fallback.
- **PowerShell**: native `Invoke-WebRequest` progress; enables VT processing for ANSI on legacy conhost (PS 5.1) and sets UTF-8 output.
- **npm**: new `lib/ui.js` presentation module; banner/steps/completion on a genuine install, quiet on no-op re-bootstraps; progress bar on the GitHub-fallback download path.

## Graceful degradation

- Honors **NO_COLOR**, **FORCE_COLOR**, **TERM=dumb**, and non-TTY/redirected output (no ANSI, no animations).
- Falls back to **ASCII glyphs** (`+--+` box, `[OK]`, `#`/`.` bar, `!`/`>` prefixes) outside a UTF-8 locale / on legacy code pages — no mojibake.

## Out of scope

The bridge auto-updater output (`update_service.dart`) is intentionally **not** touched — concurrent work is in progress there. A separate restyling handoff note will be provided.

## Tests

- Rewrote brittle exact-string assertions to stable substrings.
- Added behavior tests: bash (FORCE_COLOR color+banner, NO_COLOR suppression, ASCII fallback), npm `ui.js` (color / no-color / ASCII), and PowerShell static-contract checks for the banner/steps/panel + detection.
- `dart test test/tool/installers_test.dart test/tool/npm_wrapper_test.dart` → 50 passing. `dart analyze --fatal-infos` clean.

Install/resolve/checksum **logic is unchanged** — this is presentation-only.

Reviewed by `aristotle-plan-review` (plan) and `aristotle-impl-review` (implementation): both APPROVED.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the installers across `install.sh`, `install.ps1`, and the `@sesori/bridge` npm bootstrap with a consistent, branded UI. Also updated unsupported‑platform guidance to use styled output and direct users to `npx @sesori/bridge`.

- **New Features**
  - Unified visual spec: SESORI wordmark, brand‑blue accents, `[n/4]` steps with green checks, and a boxed “Next steps” highlighting `sesori-bridge`.
  - Live progress bars: curl‑trace bar (bash), native `Invoke-WebRequest` bar (PowerShell), and a content‑length bar in the npm GitHub‑fallback path.
  - Centralized palette and UI helpers; new Node module `lib/ui.js` with labeled Error/Warning/Note prefixes to stderr. Unsupported‑platform errors in the npm bin now use the styled UI and point to `npx @sesori/bridge`.
  - Graceful degradation: honors `NO_COLOR`, `FORCE_COLOR`, `TERM=dumb`, non‑TTY, and non‑UTF‑8 locales with ASCII fallbacks. PowerShell enables VT processing and sets UTF‑8.
  - npm bootstrap shows the full flow on real installs and now shows the completion panel when PATH was changed or the command isn’t ready; it stays quiet only on pure no‑ops.

- **Bug Fixes**
  - Bash progress: pre‑filters curl `--trace-ascii` output and parses with bash regex (no per‑line forks), and always restores the cursor/FDs even on failure.
  - Completion panel: truncates long command rows (drops the hint if needed, then ellipsizes) and widens `PANEL_WIDTH` to 56 in `install.sh` and `lib/ui.js` to keep borders aligned.
  - PowerShell: removed unused helper; PATH updates and warnings flow through styled helpers.
  - npm bootstrap: routes symlink/`xattr` warnings via shared UI; shows “Next steps” when a no‑op bootstrap leaves the command unusable; unsupported‑platform hint fixed to use `npx @sesori/bridge`.

<sup>Written for commit fac914510a429a3c8ac31a78844f41225becd467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

