### PR TITLE
fix: use theme-aware status-bar icons

### DIFF
--- a/mobile/app/lib/main.dart
+++ b/mobile/app/lib/main.dart
@@ -191,21 +191,10 @@ class SesoriApp extends StatelessWidget {
         fontFamily: PregoTextTheme.fontFamily,
         fontFamilyFallback: PregoTextTheme.fontFamilyFallback,
         extensions: [PregoDesignSystem.light],
-        // Status bar: dark icons for the light theme's light backgrounds.
-        // Without this, transparent AppBars (e.g. ProjectListScreen) default to
-        // light/white icons that vanish against a light background. Bars are
-        // kept transparent so the edge-to-edge layout set up in main() survives
-        // — the bare SystemUiOverlayStyle.dark constant would force a black
-        // Android navigation bar.
-        appBarTheme: const AppBarTheme(
-          systemOverlayStyle: SystemUiOverlayStyle(
-            statusBarColor: Colors.transparent,
-            statusBarIconBrightness: Brightness.dark,
-            statusBarBrightness: Brightness.light,
-            systemNavigationBarColor: Colors.transparent,
-            systemNavigationBarIconBrightness: Brightness.dark,
-          ),
-        ),
+        // Dark status-bar icons for the light theme's light backgrounds.
+        // Without this, transparent AppBars (e.g. ProjectListScreen) default
+        // to light/white icons that vanish against a light background.
+        appBarTheme: const AppBarTheme(systemOverlayStyle: SystemUiOverlayStyle.dark),
       ),
       darkTheme: ThemeData(
         colorScheme: PregoColors.dark.toFlutterColorScheme(),
@@ -213,19 +202,8 @@ class SesoriApp extends StatelessWidget {
         fontFamily: PregoTextTheme.fontFamily,
         fontFamilyFallback: PregoTextTheme.fontFamilyFallback,
         extensions: [PregoDesignSystem.dark],
-        // Status bar: light icons for the dark theme's dark backgrounds. Bars
-        // kept transparent to preserve edge-to-edge — the bare
-        // SystemUiOverlayStyle.light constant would force a black Android
-        // navigation bar.
-        appBarTheme: const AppBarTheme(
-          systemOverlayStyle: SystemUiOverlayStyle(
-            statusBarColor: Colors.transparent,
-            statusBarIconBrightness: Brightness.light,
-            statusBarBrightness: Brightness.dark,
-            systemNavigationBarColor: Colors.transparent,
-            systemNavigationBarIconBrightness: Brightness.light,
-          ),
-        ),
+        // Light status-bar icons for the dark theme's dark backgrounds.
+        appBarTheme: const AppBarTheme(systemOverlayStyle: SystemUiOverlayStyle.light),
       ),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,

--- a/mobile/app/lib/main.dart
+++ b/mobile/app/lib/main.dart
@@ -191,6 +191,10 @@ class SesoriApp extends StatelessWidget {
         fontFamily: PregoTextTheme.fontFamily,
         fontFamilyFallback: PregoTextTheme.fontFamilyFallback,
         extensions: [PregoDesignSystem.light],
+        // Dark status-bar icons for the light theme's light backgrounds.
+        // Without this, transparent AppBars (e.g. ProjectListScreen) default
+        // to light/white icons that vanish against a light background.
+        appBarTheme: const AppBarTheme(systemOverlayStyle: SystemUiOverlayStyle.dark),
       ),
       darkTheme: ThemeData(
         colorScheme: PregoColors.dark.toFlutterColorScheme(),
@@ -198,6 +202,8 @@ class SesoriApp extends StatelessWidget {
         fontFamily: PregoTextTheme.fontFamily,
         fontFamilyFallback: PregoTextTheme.fontFamilyFallback,
         extensions: [PregoDesignSystem.dark],
+        // Light status-bar icons for the dark theme's dark backgrounds.
+        appBarTheme: const AppBarTheme(systemOverlayStyle: SystemUiOverlayStyle.light),
       ),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,

--- a/mobile/app/lib/main.dart
+++ b/mobile/app/lib/main.dart
@@ -191,10 +191,21 @@ class SesoriApp extends StatelessWidget {
         fontFamily: PregoTextTheme.fontFamily,
         fontFamilyFallback: PregoTextTheme.fontFamilyFallback,
         extensions: [PregoDesignSystem.light],
-        // Dark status-bar icons for the light theme's light backgrounds.
-        // Without this, transparent AppBars (e.g. ProjectListScreen) default
-        // to light/white icons that vanish against a light background.
-        appBarTheme: const AppBarTheme(systemOverlayStyle: SystemUiOverlayStyle.dark),
+        // Status bar: dark icons for the light theme's light backgrounds.
+        // Without this, transparent AppBars (e.g. ProjectListScreen) default to
+        // light/white icons that vanish against a light background. Bars are
+        // kept transparent so the edge-to-edge layout set up in main() survives
+        // — the bare SystemUiOverlayStyle.dark constant would force a black
+        // Android navigation bar.
+        appBarTheme: const AppBarTheme(
+          systemOverlayStyle: SystemUiOverlayStyle(
+            statusBarColor: Colors.transparent,
+            statusBarIconBrightness: Brightness.dark,
+            statusBarBrightness: Brightness.light,
+            systemNavigationBarColor: Colors.transparent,
+            systemNavigationBarIconBrightness: Brightness.dark,
+          ),
+        ),
       ),
       darkTheme: ThemeData(
         colorScheme: PregoColors.dark.toFlutterColorScheme(),
@@ -202,8 +213,19 @@ class SesoriApp extends StatelessWidget {
         fontFamily: PregoTextTheme.fontFamily,
         fontFamilyFallback: PregoTextTheme.fontFamilyFallback,
         extensions: [PregoDesignSystem.dark],
-        // Light status-bar icons for the dark theme's dark backgrounds.
-        appBarTheme: const AppBarTheme(systemOverlayStyle: SystemUiOverlayStyle.light),
+        // Status bar: light icons for the dark theme's dark backgrounds. Bars
+        // kept transparent to preserve edge-to-edge — the bare
+        // SystemUiOverlayStyle.light constant would force a black Android
+        // navigation bar.
+        appBarTheme: const AppBarTheme(
+          systemOverlayStyle: SystemUiOverlayStyle(
+            statusBarColor: Colors.transparent,
+            statusBarIconBrightness: Brightness.light,
+            statusBarBrightness: Brightness.dark,
+            systemNavigationBarColor: Colors.transparent,
+            systemNavigationBarIconBrightness: Brightness.light,
+          ),
+        ),
       ),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,


### PR DESCRIPTION
## Problem

On the projects list screen, the OS status bar icons are **white in light mode** — barely visible against the light background. In dark mode they're fine.

## Root cause

`ProjectListScreen`'s `AppBar` uses `backgroundColor: Colors.transparent`. When an AppBar has no explicit `systemOverlayStyle`, Flutter infers the status-bar icon brightness from the AppBar's own background color via `ThemeData.estimateBrightnessForColor`.

`Colors.transparent` is `0x00000000`; `Color.computeLuminance()` ignores alpha and sees pure black → estimates `Brightness.dark` → AppBar forces `SystemUiOverlayStyle.light` (**white icons**) in *both* themes.

- Dark mode: white icons on the dark background → visible (works by accident).
- Light mode: white icons on the light background → invisible (the bug).

No `AppBarTheme`, `systemOverlayStyle`, or `SystemChrome.setSystemUIOverlayStyle` existed anywhere, so this AppBar was the sole — and broken — driver.

## Fix

Set `appBarTheme.systemOverlayStyle` per theme in `main.dart`, so it no longer depends on the transparent AppBar's background guess:

- Light theme → `SystemUiOverlayStyle.dark` (dark icons on light backgrounds)
- Dark theme → `SystemUiOverlayStyle.light` (light icons on dark backgrounds)

App-wide, so any other transparent-background AppBar benefits too.

## Test plan

- [ ] Light mode: status-bar icons are dark / clearly visible on the projects list screen.
- [ ] Dark mode: status-bar icons remain light / visible (no regression).

Note: status-bar styling only renders at runtime, so it isn't covered by widget tests — needs a manual look on device/simulator. `flutter analyze` is clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invisible status bar icons in light mode by making AppBar system overlay styling theme-aware. Icons are dark in light theme and light in dark theme across screens, including those with transparent app bars.

- **Bug Fixes**
  - Set `appBarTheme.systemOverlayStyle` in `main.dart` per theme: light → `SystemUiOverlayStyle.dark`, dark → `SystemUiOverlayStyle.light`.
  - Avoid brightness misinference from transparent `AppBar` backgrounds so icons stay readable on the projects list and similar screens.

<sup>Written for commit dbf38d9f993e6ab8d89f484a603338dc303c0ea4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

