### PR TITLE
chore(prego): regenerate Figma color tokens & fix color usages

### DIFF
--- a/mobile/app/lib/features/project_list/onboarding/onboarding_hero.dart
+++ b/mobile/app/lib/features/project_list/onboarding/onboarding_hero.dart
@@ -101,7 +101,7 @@ class _OnboardingHero extends StatelessWidget {
         children: [
           // Aurora landscape: a centred panel (sized by the factors below)
           // whose edges fade out via the foreground vignette. The fade colour
-          // (auroraEdge) matches the Scaffold's bgPrimaryAlt background, so the
+          // (auroraEdge) matches the Scaffold's bgSecondary background, so the
           // panel blends in seamlessly even though it doesn't span full width —
           // keep those two colours in sync. Image -> background decoration;
           // radial gradient -> foreground vignette painted on top.

--- a/mobile/app/lib/features/project_list/onboarding/onboarding_hero.dart
+++ b/mobile/app/lib/features/project_list/onboarding/onboarding_hero.dart
@@ -86,7 +86,7 @@ class _OnboardingHero extends StatelessWidget {
     // Read brightness off the same PregoColors instance that supplies the
     // vignette edge below, so the artwork and the fade colour can't disagree.
     final colors = context.prego.colors;
-    final auroraEdge = colors.bgPrimaryAlt;
+    final auroraEdge = colors.bgSecondary;
     final isDark = colors.brightness == Brightness.dark;
     final auroraAsset = isDark ? _kAuroraDarkAsset : _kAuroraLightAsset;
     final laptopAsset = isDark ? _kLaptopDarkAsset : _kLaptopLightAsset;

--- a/mobile/app/lib/features/project_list/project_list_screen.dart
+++ b/mobile/app/lib/features/project_list/project_list_screen.dart
@@ -126,7 +126,7 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
     final prego = context.prego;
 
     return Scaffold(
-      backgroundColor: prego.colors.bgSecondary,
+      backgroundColor: prego.colors.bgPrimary,
       // TODO: we need to have app wide navigation bar component
       appBar: AppBar(
         backgroundColor: Colors.transparent,

--- a/mobile/app/lib/features/project_list/project_list_screen.dart
+++ b/mobile/app/lib/features/project_list/project_list_screen.dart
@@ -126,7 +126,7 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
     final prego = context.prego;
 
     return Scaffold(
-      backgroundColor: prego.colors.bgPrimary,
+      backgroundColor: prego.colors.bgSecondary,
       // TODO: we need to have app wide navigation bar component
       appBar: AppBar(
         backgroundColor: Colors.transparent,

--- a/mobile/app/lib/features/project_list/project_list_screen.dart
+++ b/mobile/app/lib/features/project_list/project_list_screen.dart
@@ -126,7 +126,7 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
     final prego = context.prego;
 
     return Scaffold(
-      backgroundColor: prego.colors.bgPrimaryAlt,
+      backgroundColor: prego.colors.bgPrimary,
       // TODO: we need to have app wide navigation bar component
       appBar: AppBar(
         backgroundColor: Colors.transparent,

--- a/mobile/module_prego/lib/components/buttons/prego_buttons_icon_glass.dart
+++ b/mobile/module_prego/lib/components/buttons/prego_buttons_icon_glass.dart
@@ -140,7 +140,7 @@ class PregoButtonsIconGlass extends StatelessWidget {
           return colors.buttonGlassPrimaryHover;
         }
 
-        return colors.buttonGlassPrimaryBackground;
+        return null;
       }),
       containerBuilder: ({required Widget child, required Set<WidgetState> state}) {
         // iOS: real frosted glass via the liquid_glass_plus shader. The icon

--- a/mobile/module_prego/lib/components/buttons/prego_buttons_solid.dart
+++ b/mobile/module_prego/lib/components/buttons/prego_buttons_solid.dart
@@ -512,7 +512,7 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
     // the PregoTappable overlay (bgPrimaryHover = rgba(0,0,0,0.16) composited
     // on top of bg-primary_alt).
     if (_isFocused) return colors.bgPrimary;
-    return colors.bgPrimaryAlt;
+    return colors.bgSecondary;
   }
 
   Color _tertiaryBgColor({

--- a/mobile/module_prego/lib/components/buttons/prego_buttons_solid.dart
+++ b/mobile/module_prego/lib/components/buttons/prego_buttons_solid.dart
@@ -508,9 +508,9 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
       return colors.bgPrimary;
     }
 
-    // Regular secondary: bg-primary_alt at rest. Hover darkening is handled by
+    // Regular secondary: bgSecondary at rest. Hover darkening is handled by
     // the PregoTappable overlay (bgPrimaryHover = rgba(0,0,0,0.16) composited
-    // on top of bg-primary_alt).
+    // on top of bgSecondary).
     if (_isFocused) return colors.bgPrimary;
     return colors.bgSecondary;
   }

--- a/mobile/module_prego/lib/components/main_screens/prego_quick_action_button.dart
+++ b/mobile/module_prego/lib/components/main_screens/prego_quick_action_button.dart
@@ -180,7 +180,7 @@ class _PregoQuickActionButtonCore extends StatelessWidget {
     required bool isEnabled,
     required BorderSide borderSide,
   }) => ShapeDecoration(
-    color: isEnabled ? prego.colors.bgPrimaryAlt : prego.colors.bgDisabled,
+    color: isEnabled ? prego.colors.bgSecondary : prego.colors.bgDisabled,
     shape: RoundedSuperellipseBorder(
       side: borderSide,
       borderRadius: BorderRadius.circular(PregoRadius.x4l),

--- a/mobile/module_prego/lib/theme/primitives/prego_color_primitives.g.dart
+++ b/mobile/module_prego/lib/theme/primitives/prego_color_primitives.g.dart
@@ -24,211 +24,226 @@ abstract final class PregoColorPrimitives {
   /// Figma: Base/black
   static const Color baseBlack = Color(0xFF000000);
 
-  /// Figma: Base/transparent
-  static const Color baseTransparent = Color(0x00FFFFFF);
+  /// Figma: Base/transparent white
+  static const Color baseTransparentWhite = Color(0x00FFFFFF);
 
   /// Figma: Base/transparent black
   static const Color baseTransparentBlack = Color(0x00000000);
 
   // ===========================================================================
-  // Gray (light mode)
+  // Gray
   // ===========================================================================
 
-  /// Figma: Gray (light mode)/25
-  static const Color grayLight25 = Color(0xFFFDFDFD);
+  /// Figma: Gray/25
+  static const Color gray25 = Color(0xFFFDFDFD);
 
-  /// Figma: Gray (light mode)/50
-  static const Color grayLight50 = Color(0xFFFAFAFA);
+  /// Figma: Gray/50
+  static const Color gray50 = Color(0xFFFCFCFC);
 
-  /// Figma: Gray (light mode)/100
-  static const Color grayLight100 = Color(0xFFF5F5F5);
+  /// Figma: Gray/100
+  static const Color gray100 = Color(0xFFF5F5F5);
 
-  /// Figma: Gray (light mode)/200
-  static const Color grayLight200 = Color(0xFFE9EAEB);
+  /// Figma: Gray/200
+  static const Color gray200 = Color(0xFFF0F0F0);
 
-  /// Figma: Gray (light mode)/300
-  static const Color grayLight300 = Color(0xFFD5D7DA);
+  /// Figma: Gray/300
+  static const Color gray300 = Color(0xFFE6E6E6);
 
-  /// Figma: Gray (light mode)/400
-  static const Color grayLight400 = Color(0xFFA4A7AE);
+  /// Figma: Gray/350
+  static const Color gray350 = Color(0xFFDBDBDB);
 
-  /// Figma: Gray (light mode)/500
-  static const Color grayLight500 = Color(0xFF717680);
+  /// Figma: Gray/400
+  static const Color gray400 = Color(0xFFAEAEAE);
 
-  /// Figma: Gray (light mode)/600
-  static const Color grayLight600 = Color(0xFF535862);
+  /// Figma: Gray/425
+  static const Color gray425 = Color(0xFF999999);
 
-  /// Figma: Gray (light mode)/700
-  static const Color grayLight700 = Color(0xFF414651);
+  /// Figma: Gray/450
+  static const Color gray450 = Color(0xFF8C8C8C);
 
-  /// Figma: Gray (light mode)/800
-  static const Color grayLight800 = Color(0xFF272C35);
+  /// Figma: Gray/525
+  static const Color gray525 = Color(0xFF6E6E6E);
 
-  /// Figma: Gray (light mode)/900
-  static const Color grayLight900 = Color(0xFF191D26);
+  /// Figma: Gray/500
+  static const Color gray500 = Color(0xFF3D3D3D);
 
-  /// Figma: Gray (light mode)/950
-  static const Color grayLight950 = Color(0xFF0B0D11);
+  /// Figma: Gray/600
+  static const Color gray600 = Color(0xFF2D2D2D);
 
-  // ===========================================================================
-  // Gray (dark mode)
-  // ===========================================================================
+  /// Figma: Gray/700
+  static const Color gray700 = Color(0xFF242424);
 
-  /// Figma: Gray (dark mode)/25
-  static const Color grayDark25 = Color(0xFFF2F2F2);
+  /// Figma: Gray/800
+  static const Color gray800 = Color(0xFF242424);
 
-  /// Figma: Gray (dark mode)/50
-  static const Color grayDark50 = Color(0xFFE2E3E4);
+  /// Figma: Gray/900
+  static const Color gray900 = Color(0xFF181818);
 
-  /// Figma: Gray (dark mode)/100
-  static const Color grayDark100 = Color(0xFFCFD1D4);
-
-  /// Figma: Gray (dark mode)/200
-  static const Color grayDark200 = Color(0xFFBFC1C5);
-
-  /// Figma: Gray (dark mode)/300
-  static const Color grayDark300 = Color(0xFFAEB2B7);
-
-  /// Figma: Gray (dark mode)/400
-  static const Color grayDark400 = Color(0xFF999DA3);
-
-  /// Figma: Gray (dark mode)/500
-  static const Color grayDark500 = Color(0xFF7E838B);
-
-  /// Figma: Gray (dark mode)/600
-  static const Color grayDark600 = Color(0xFF656A71);
-
-  /// Figma: Gray (dark mode)/700
-  static const Color grayDark700 = Color(0xFF4D5156);
-
-  /// Figma: Gray (dark mode)/800
-  static const Color grayDark800 = Color(0xFF303236);
-
-  /// Figma: Gray (dark mode)/900
-  static const Color grayDark900 = Color(0xFF18191B);
-
-  /// Figma: Gray (dark mode)/950
-  static const Color grayDark950 = Color(0xFF030405);
+  /// Figma: Gray/950
+  static const Color gray950 = Color(0xFF0C0C0C);
 
   // ===========================================================================
-  // Gray (dark mode alpha)
+  // Alpha White
   // ===========================================================================
 
-  /// Figma: Gray (dark mode alpha)/25
-  static const Color grayDarkAlpha25 = Color(0xFAFFFFFF);
+  /// Figma: Alpha White/25
+  static const Color alphaWhite25 = Color(0xFAFFFFFF);
 
-  /// Figma: Gray (dark mode alpha)/50
-  static const Color grayDarkAlpha50 = Color(0xF5FFFFFF);
+  /// Figma: Alpha White/50
+  static const Color alphaWhite50 = Color(0xF5FFFFFF);
 
-  /// Figma: Gray (dark mode alpha)/100
-  static const Color grayDarkAlpha100 = Color(0xF0FFFFFF);
+  /// Figma: Alpha White/100
+  static const Color alphaWhite100 = Color(0xF0FFFFFF);
 
-  /// Figma: Gray (dark mode alpha)/200
-  static const Color grayDarkAlpha200 = Color(0xEBFFFFFF);
+  /// Figma: Alpha White/200
+  static const Color alphaWhite200 = Color(0xEBFFFFFF);
 
-  /// Figma: Gray (dark mode alpha)/300
-  static const Color grayDarkAlpha300 = Color(0xCCFFFFFF);
+  /// Figma: Alpha White/300
+  static const Color alphaWhite300 = Color(0xCCFFFFFF);
 
-  /// Figma: Gray (dark mode alpha)/400
-  static const Color grayDarkAlpha400 = Color(0x8FFFFFFF);
+  /// Figma: Alpha White/400
+  static const Color alphaWhite400 = Color(0x8FFFFFFF);
 
-  /// Figma: Gray (dark mode alpha)/500
-  static const Color grayDarkAlpha500 = Color(0x80FFFFFF);
+  /// Figma: Alpha White/500
+  static const Color alphaWhite500 = Color(0x80FFFFFF);
 
-  /// Figma: Gray (dark mode alpha)/600
-  static const Color grayDarkAlpha600 = Color(0x40FFFFFF);
+  /// Figma: Alpha White/600
+  static const Color alphaWhite600 = Color(0x40FFFFFF);
 
-  /// Figma: Gray (dark mode alpha)/700
-  static const Color grayDarkAlpha700 = Color(0x29FFFFFF);
+  /// Figma: Alpha White/700
+  static const Color alphaWhite700 = Color(0x29FFFFFF);
 
-  /// Figma: Gray (dark mode alpha)/800
-  static const Color grayDarkAlpha800 = Color(0x14FFFFFF);
+  /// Figma: Alpha White/800
+  static const Color alphaWhite800 = Color(0x14FFFFFF);
 
-  /// Figma: Gray (dark mode alpha)/900
-  static const Color grayDarkAlpha900 = Color(0x0AFFFFFF);
+  /// Figma: Alpha White/900
+  static const Color alphaWhite900 = Color(0x0AFFFFFF);
 
-  /// Figma: Gray (dark mode alpha)/950
-  static const Color grayDarkAlpha950 = Color(0x00FFFFFF);
-
-  // ===========================================================================
-  // Gray (light mode alpha)
-  // ===========================================================================
-
-  /// Figma: Gray (light mode alpha)/25
-  static const Color grayLightAlpha25 = Color(0x00000000);
-
-  /// Figma: Gray (light mode alpha)/50
-  static const Color grayLightAlpha50 = Color(0x0A000000);
-
-  /// Figma: Gray (light mode alpha)/100
-  static const Color grayLightAlpha100 = Color(0x14000000);
-
-  /// Figma: Gray (light mode alpha)/200
-  static const Color grayLightAlpha200 = Color(0x29000000);
-
-  /// Figma: Gray (light mode alpha)/300
-  static const Color grayLightAlpha300 = Color(0x59000000);
-
-  /// Figma: Gray (light mode alpha)/400
-  static const Color grayLightAlpha400 = Color(0x80000000);
-
-  /// Figma: Gray (light mode alpha)/500
-  static const Color grayLightAlpha500 = Color(0x8F000000);
-
-  /// Figma: Gray (light mode alpha)/600
-  static const Color grayLightAlpha600 = Color(0xCC000000);
-
-  /// Figma: Gray (light mode alpha)/700
-  static const Color grayLightAlpha700 = Color(0xEB000000);
-
-  /// Figma: Gray (light mode alpha)/800
-  static const Color grayLightAlpha800 = Color(0xF0000000);
-
-  /// Figma: Gray (light mode alpha)/900
-  static const Color grayLightAlpha900 = Color(0xF5000000);
-
-  /// Figma: Gray (light mode alpha)/950
-  static const Color grayLightAlpha950 = Color(0xFA000000);
+  /// Figma: Alpha White/950
+  static const Color alphaWhite950 = Color(0x00FFFFFF);
 
   // ===========================================================================
-  // Brand Blue
+  // Alpha Black
   // ===========================================================================
 
-  /// Figma: Brand Blue/25
-  static const Color brandBlue25 = Color(0xFFEBF3FF);
+  /// Figma: Alpha Black/25
+  static const Color alphaBlack25 = Color(0x00000000);
 
-  /// Figma: Brand Blue/50
-  static const Color brandBlue50 = Color(0xFFE0EDFF);
+  /// Figma: Alpha Black/50
+  static const Color alphaBlack50 = Color(0x0A000000);
 
-  /// Figma: Brand Blue/100
-  static const Color brandBlue100 = Color(0xFFD1E3FF);
+  /// Figma: Alpha Black/100
+  static const Color alphaBlack100 = Color(0x14000000);
 
-  /// Figma: Brand Blue/200
-  static const Color brandBlue200 = Color(0xFFB2D1FF);
+  /// Figma: Alpha Black/200
+  static const Color alphaBlack200 = Color(0x29000000);
 
-  /// Figma: Brand Blue/300
-  static const Color brandBlue300 = Color(0xFF80B2FF);
+  /// Figma: Alpha Black/300
+  static const Color alphaBlack300 = Color(0x59000000);
 
-  /// Figma: Brand Blue/400
-  static const Color brandBlue400 = Color(0xFF4D94FF);
+  /// Figma: Alpha Black/400
+  static const Color alphaBlack400 = Color(0x80000000);
 
-  /// Figma: Brand Blue/500
-  static const Color brandBlue500 = Color(0xFF1472FF);
+  /// Figma: Alpha Black/500
+  static const Color alphaBlack500 = Color(0x8F000000);
 
-  /// Figma: Brand Blue/600
-  static const Color brandBlue600 = Color(0xFF005CE5);
+  /// Figma: Alpha Black/600
+  static const Color alphaBlack600 = Color(0xCC000000);
 
-  /// Figma: Brand Blue/700
-  static const Color brandBlue700 = Color(0xFF0047B2);
+  /// Figma: Alpha Black/700
+  static const Color alphaBlack700 = Color(0xEB000000);
 
-  /// Figma: Brand Blue/800
-  static const Color brandBlue800 = Color(0xFF00317A);
+  /// Figma: Alpha Black/800
+  static const Color alphaBlack800 = Color(0xF0000000);
 
-  /// Figma: Brand Blue/900
-  static const Color brandBlue900 = Color(0xFF001F4D);
+  /// Figma: Alpha Black/900
+  static const Color alphaBlack900 = Color(0xF5000000);
 
-  /// Figma: Brand Blue/950
-  static const Color brandBlue950 = Color(0xFF000A1A);
+  /// Figma: Alpha Black/950
+  static const Color alphaBlack950 = Color(0xFA000000);
+
+  // ===========================================================================
+  // Alpha Gray
+  // ===========================================================================
+
+  /// Figma: Alpha Gray/25
+  static const Color alphaGray25 = Color(0x00FDFDFD);
+
+  /// Figma: Alpha Gray/50
+  static const Color alphaGray50 = Color(0x00FCFCFC);
+
+  /// Figma: Alpha Gray/100
+  static const Color alphaGray100 = Color(0x00F5F5F5);
+
+  /// Figma: Alpha Gray/200
+  static const Color alphaGray200 = Color(0x00F0F0F0);
+
+  /// Figma: Alpha Gray/300
+  static const Color alphaGray300 = Color(0x00E6E6E6);
+
+  /// Figma: Alpha Gray/350
+  static const Color alphaGray350 = Color(0x00DBDBDB);
+
+  /// Figma: Alpha Gray/400
+  static const Color alphaGray400 = Color(0x00AEAEAE);
+
+  /// Figma: Alpha Gray/500
+  static const Color alphaGray500 = Color(0x003D3D3D);
+
+  /// Figma: Alpha Gray/600
+  static const Color alphaGray600 = Color(0x002D2D2D);
+
+  /// Figma: Alpha Gray/700
+  static const Color alphaGray700 = Color(0x00242424);
+
+  /// Figma: Alpha Gray/800
+  static const Color alphaGray800 = Color(0x00242424);
+
+  /// Figma: Alpha Gray/900
+  static const Color alphaGray900 = Color(0x00181818);
+
+  /// Figma: Alpha Gray/950
+  static const Color alphaGray950 = Color(0x000C0C0C);
+
+  // ===========================================================================
+  // Blue
+  // ===========================================================================
+
+  /// Figma: Blue/25
+  static const Color blue25 = Color(0xFFEBF3FF);
+
+  /// Figma: Blue/50
+  static const Color blue50 = Color(0xFFE0EDFF);
+
+  /// Figma: Blue/100
+  static const Color blue100 = Color(0xFFD1E3FF);
+
+  /// Figma: Blue/200
+  static const Color blue200 = Color(0xFFB2D1FF);
+
+  /// Figma: Blue/300
+  static const Color blue300 = Color(0xFF80B2FF);
+
+  /// Figma: Blue/400
+  static const Color blue400 = Color(0xFF4D94FF);
+
+  /// Figma: Blue/500
+  static const Color blue500 = Color(0xFF1472FF);
+
+  /// Figma: Blue/600
+  static const Color blue600 = Color(0xFF005CE5);
+
+  /// Figma: Blue/700
+  static const Color blue700 = Color(0xFF0047B2);
+
+  /// Figma: Blue/800
+  static const Color blue800 = Color(0xFF00317A);
+
+  /// Figma: Blue/900
+  static const Color blue900 = Color(0xFF001F4D);
+
+  /// Figma: Blue/950
+  static const Color blue950 = Color(0xFF000A1A);
 
   // ===========================================================================
   // Error

--- a/mobile/module_prego/lib/theme/primitives/prego_colors.g.dart
+++ b/mobile/module_prego/lib/theme/primitives/prego_colors.g.dart
@@ -5,7 +5,7 @@
 
 import "package:flutter/material.dart";
 
-import "../../../../utils/lerp_utils.dart";
+import "../../utils/lerp_utils.dart";
 import "prego_color_primitives.g.dart";
 
 /// Dark mode color tokens matching Figma specifications.
@@ -18,23 +18,23 @@ abstract final class PregoColorsDark {
   // Text Colors - Figma: Colors/Text/*
   // ===========================================================================
 
-  /// Figma: Colors/Text/text-brand-primary (900) → Gray (dark mode)/50
-  static const Color textBrandPrimary = PregoColorPrimitives.grayDark50;
+  /// Figma: Colors/Text/text-brand-primary (900) → Blue/200
+  static const Color textBrandPrimary = PregoColorPrimitives.blue200;
 
-  /// Figma: Colors/Text/text-brand-secondary (700) → Gray (dark mode)/300
-  static const Color textBrandSecondary = PregoColorPrimitives.grayDark300;
+  /// Figma: Colors/Text/text-brand-secondary (700) → Blue/300
+  static const Color textBrandSecondary = PregoColorPrimitives.blue300;
 
-  /// Figma: Colors/Text/text-brand-secondary_hover → Gray (dark mode)/200
-  static const Color textBrandSecondaryHover = PregoColorPrimitives.grayDark200;
+  /// Figma: Colors/Text/text-brand-secondary_hover → Blue/600
+  static const Color textBrandSecondaryHover = PregoColorPrimitives.blue600;
 
-  /// Figma: Colors/Text/text-brand-tertiary (600) → Gray (dark mode)/400
-  static const Color textBrandTertiary = PregoColorPrimitives.grayDark400;
+  /// Figma: Colors/Text/text-brand-tertiary (600) → Blue/800
+  static const Color textBrandTertiary = PregoColorPrimitives.blue800;
 
-  /// Figma: Colors/Text/text-brand-tertiary_alt → Brand Blue/200
-  static const Color textBrandTertiaryAlt = PregoColorPrimitives.brandBlue200;
+  /// Figma: Colors/Text/text-brand-tertiary_alt → Blue/200
+  static const Color textBrandTertiaryAlt = PregoColorPrimitives.blue200;
 
-  /// Figma: Colors/Text/text-disabled → Gray (dark mode)/500
-  static const Color textDisabled = PregoColorPrimitives.grayDark500;
+  /// Figma: Colors/Text/text-disabled → Gray/500
+  static const Color textDisabled = PregoColorPrimitives.gray500;
 
   /// Figma: Colors/Text/text-error-primary (600) → Error/400
   static const Color textErrorPrimary = PregoColorPrimitives.error400;
@@ -42,32 +42,29 @@ abstract final class PregoColorsDark {
   /// Figma: Colors/Text/text-error-primary_hover → Error/300
   static const Color textErrorPrimaryHover = PregoColorPrimitives.error300;
 
-  /// Figma: Colors/Text/text-placeholder → Gray (dark mode)/600
-  static const Color textPlaceholder = PregoColorPrimitives.grayDark600;
+  /// Figma: Colors/Text/text-placeholder → Gray/600
+  static const Color textPlaceholder = PregoColorPrimitives.gray600;
 
-  /// Figma: Colors/Text/text-placeholder_subtle → Gray (dark mode)/700
-  static const Color textPlaceholderSubtle = PregoColorPrimitives.grayDark700;
+  /// Figma: Colors/Text/text-placeholder_subtle → Gray/700
+  static const Color textPlaceholderSubtle = PregoColorPrimitives.gray700;
 
-  /// Figma: Colors/Text/text-primary (900) → Gray (dark mode)/25
-  static const Color textPrimary = PregoColorPrimitives.grayDark25;
+  /// Figma: Colors/Text/text-primary (950) → Gray/25
+  static const Color textPrimary = PregoColorPrimitives.gray25;
 
-  /// Figma: Colors/Text/text-primary_on-brand → Gray (dark mode)/50
-  static const Color textPrimaryOnBrand = PregoColorPrimitives.grayDark50;
+  /// Figma: Colors/Text/text-primary_on-brand → Blue/300
+  static const Color textPrimaryOnBrand = PregoColorPrimitives.blue300;
 
   /// Figma: Colors/Text/text-primary_on-white → Base/black
   static const Color textPrimaryOnWhite = PregoColorPrimitives.baseBlack;
 
-  /// Figma: Colors/Text/text-quaternary (500) → Gray (dark mode)/400
-  static const Color textQuaternary = PregoColorPrimitives.grayDark400;
+  /// Figma: Colors/Text/text-quaternary (500) → Gray/500
+  static const Color textQuaternary = PregoColorPrimitives.gray500;
 
-  /// Figma: Colors/Text/text-quaternary_on-brand → Gray (dark mode)/400
-  static const Color textQuaternaryOnBrand = PregoColorPrimitives.grayDark400;
+  /// Figma: Colors/Text/text-secondary (600) → Gray/400
+  static const Color textSecondary = PregoColorPrimitives.gray400;
 
-  /// Figma: Colors/Text/text-secondary (600) → Gray (dark mode)/400
-  static const Color textSecondary = PregoColorPrimitives.grayDark400;
-
-  /// Figma: Colors/Text/text-secondary_hover → Gray (dark mode)/200
-  static const Color textSecondaryHover = PregoColorPrimitives.grayDark200;
+  /// Figma: Colors/Text/text-secondary_hover → Gray/450
+  static const Color textSecondaryHover = PregoColorPrimitives.gray450;
 
   /// Figma: Colors/Text/text-secondary_on-brand → Base/white
   static const Color textSecondaryOnBrand = PregoColorPrimitives.baseWhite;
@@ -75,14 +72,14 @@ abstract final class PregoColorsDark {
   /// Figma: Colors/Text/text-success-primary (600) → Success/400
   static const Color textSuccessPrimary = PregoColorPrimitives.success400;
 
-  /// Figma: Colors/Text/text-tertiary (600) → Gray (light mode)/400
-  static const Color textTertiary = PregoColorPrimitives.grayLight400;
+  /// Figma: Colors/Text/text-tertiary (450) → Gray/450
+  static const Color textTertiary = PregoColorPrimitives.gray450;
 
-  /// Figma: Colors/Text/text-tertiary_hover → Gray (dark mode)/300
-  static const Color textTertiaryHover = PregoColorPrimitives.grayDark300;
+  /// Figma: Colors/Text/text-tertiary_hover → Gray/425
+  static const Color textTertiaryHover = PregoColorPrimitives.gray425;
 
-  /// Figma: Colors/Text/text-tertiary_on-brand → Gray (dark mode)/400
-  static const Color textTertiaryOnBrand = PregoColorPrimitives.grayDark400;
+  /// Figma: Colors/Text/text-tertiary_on-brand → Blue/400
+  static const Color textTertiaryOnBrand = PregoColorPrimitives.blue400;
 
   /// Figma: Colors/Text/text-warning-primary (600) → Warning/400
   static const Color textWarningPrimary = PregoColorPrimitives.warning400;
@@ -94,17 +91,14 @@ abstract final class PregoColorsDark {
   // Border Colors - Figma: Colors/Border/*
   // ===========================================================================
 
-  /// Figma: Colors/Border/border-brand → Brand Blue/400
-  static const Color borderBrand = PregoColorPrimitives.brandBlue400;
+  /// Figma: Colors/Border/border-brand → Blue/400
+  static const Color borderBrand = PregoColorPrimitives.blue400;
 
-  /// Figma: Colors/Border/border-brand_alt → Gray (dark mode)/700
-  static const Color borderBrandAlt = PregoColorPrimitives.grayDark700;
+  /// Figma: Colors/Border/border-disabled → Gray/500
+  static const Color borderDisabled = PregoColorPrimitives.gray500;
 
-  /// Figma: Colors/Border/border-disabled → Gray (dark mode)/700
-  static const Color borderDisabled = PregoColorPrimitives.grayDark700;
-
-  /// Figma: Colors/Border/border-disabled_subtle → Gray (dark mode)/800
-  static const Color borderDisabledSubtle = PregoColorPrimitives.grayDark800;
+  /// Figma: Colors/Border/border-disabled_subtle → Gray/800
+  static const Color borderDisabledSubtle = PregoColorPrimitives.gray800;
 
   /// Figma: Colors/Border/border-error → Error/400
   static const Color borderError = PregoColorPrimitives.error400;
@@ -118,45 +112,48 @@ abstract final class PregoColorsDark {
   /// Figma: Colors/Border/border-inside-reversed-top
   static const Color borderInsideReversedTop = Color(0xFF303236);
 
-  /// Figma: Colors/Border/border-primary → Gray (dark mode)/700
-  static const Color borderPrimary = PregoColorPrimitives.grayDark700;
+  /// Figma: Colors/Border/border-primary → Gray/500
+  static const Color borderPrimary = PregoColorPrimitives.gray500;
 
-  /// Figma: Colors/Border/border-reversed → Gray (dark mode)/800
-  static const Color borderReversed = PregoColorPrimitives.grayDark800;
+  /// Figma: Colors/Border/border-reversed → Base/black
+  static const Color borderReversed = PregoColorPrimitives.baseBlack;
 
-  /// Figma: Colors/Border/border-secondary → Gray (dark mode)/800
-  static const Color borderSecondary = PregoColorPrimitives.grayDark800;
+  /// Figma: Colors/Border/border-secondary → Gray/600
+  static const Color borderSecondary = PregoColorPrimitives.gray600;
 
-  /// Figma: Colors/Border/border-secondary_alt → Base/black
-  static const Color borderSecondaryAlt = PregoColorPrimitives.baseBlack;
+  /// Figma: Colors/Border/border-secondary_alt → Alpha Gray/25
+  static const Color borderSecondaryAlt = PregoColorPrimitives.alphaGray25;
 
-  /// Figma: Colors/Border/border-tertiary → Gray (dark mode)/800
-  static const Color borderTertiary = PregoColorPrimitives.grayDark800;
+  /// Figma: Colors/Border/border-selected → Base/white
+  static const Color borderSelected = PregoColorPrimitives.baseWhite;
+
+  /// Figma: Colors/Border/border-tertiary → Alpha White/900
+  static const Color borderTertiary = PregoColorPrimitives.alphaWhite900;
 
   // ===========================================================================
   // Foreground Colors - Figma: Colors/Foreground/*
   // ===========================================================================
 
-  /// Figma: Colors/Foreground/fg-brand-primary (600) → Brand Blue/500
-  static const Color fgBrandPrimary = PregoColorPrimitives.brandBlue500;
+  /// Figma: Colors/Foreground/fg-brand-primary (600) → Blue/500
+  static const Color fgBrandPrimary = PregoColorPrimitives.blue500;
 
   /// Figma: Colors/Foreground/fg-brand-primary_alt → Gray (dark mode)/300
-  static const Color fgBrandPrimaryAlt = PregoColorPrimitives.grayDark300;
+  static const Color fgBrandPrimaryAlt = Color(0xFFAEB2B7);
 
   /// Figma: Colors/Foreground/fg-brand-secondary (500) → Gray (dark mode)/500
-  static const Color fgBrandSecondary = PregoColorPrimitives.grayDark500;
+  static const Color fgBrandSecondary = Color(0xFF7E838B);
 
   /// Figma: Colors/Foreground/fg-brand-secondary_alt → Gray (dark mode)/600
-  static const Color fgBrandSecondaryAlt = PregoColorPrimitives.grayDark600;
+  static const Color fgBrandSecondaryAlt = Color(0xFF656A71);
 
   /// Figma: Colors/Foreground/fg-brand-secondary_hover → Gray (dark mode)/500
-  static const Color fgBrandSecondaryHover = PregoColorPrimitives.grayDark500;
+  static const Color fgBrandSecondaryHover = Color(0xFF7E838B);
 
   /// Figma: Colors/Foreground/fg-disabled → Gray (dark mode)/500
-  static const Color fgDisabled = PregoColorPrimitives.grayDark500;
+  static const Color fgDisabled = Color(0xFF7E838B);
 
   /// Figma: Colors/Foreground/fg-disabled_subtle → Gray (dark mode)/600
-  static const Color fgDisabledSubtle = PregoColorPrimitives.grayDark600;
+  static const Color fgDisabledSubtle = Color(0xFF656A71);
 
   /// Figma: Colors/Foreground/fg-error-primary → Error/500
   static const Color fgErrorPrimary = PregoColorPrimitives.error500;
@@ -168,16 +165,16 @@ abstract final class PregoColorsDark {
   static const Color fgPrimary = PregoColorPrimitives.baseWhite;
 
   /// Figma: Colors/Foreground/fg-quaternary (400) → Gray (dark mode)/600
-  static const Color fgQuaternary = PregoColorPrimitives.grayDark600;
+  static const Color fgQuaternary = Color(0xFF656A71);
 
   /// Figma: Colors/Foreground/fg-quaternary_hover → Gray (dark mode)/500
-  static const Color fgQuaternaryHover = PregoColorPrimitives.grayDark500;
+  static const Color fgQuaternaryHover = Color(0xFF7E838B);
 
   /// Figma: Colors/Foreground/fg-secondary (700) → Gray (dark mode)/300
-  static const Color fgSecondary = PregoColorPrimitives.grayDark300;
+  static const Color fgSecondary = Color(0xFFAEB2B7);
 
   /// Figma: Colors/Foreground/fg-secondary_hover → Gray (dark mode)/200
-  static const Color fgSecondaryHover = PregoColorPrimitives.grayDark200;
+  static const Color fgSecondaryHover = Color(0xFFBFC1C5);
 
   /// Figma: Colors/Foreground/fg-success-primary → Success/500
   static const Color fgSuccessPrimary = PregoColorPrimitives.success500;
@@ -186,10 +183,10 @@ abstract final class PregoColorsDark {
   static const Color fgSuccessSecondary = PregoColorPrimitives.success400;
 
   /// Figma: Colors/Foreground/fg-tertiary (600) → Gray (dark mode)/400
-  static const Color fgTertiary = PregoColorPrimitives.grayDark400;
+  static const Color fgTertiary = Color(0xFF999DA3);
 
   /// Figma: Colors/Foreground/fg-tertiary_hover → Gray (dark mode)/300
-  static const Color fgTertiaryHover = PregoColorPrimitives.grayDark300;
+  static const Color fgTertiaryHover = Color(0xFFAEB2B7);
 
   /// Figma: Colors/Foreground/fg-warning-primary → Warning/500
   static const Color fgWarningPrimary = PregoColorPrimitives.warning500;
@@ -204,50 +201,50 @@ abstract final class PregoColorsDark {
   // Background Colors - Figma: Colors/Background/*
   // ===========================================================================
 
-  /// Figma: Colors/Background/Black-white-inversed (alpha) → Base/transparent black
-  static const Color blackWhiteInversed = PregoColorPrimitives.baseTransparentBlack;
+  /// Figma: Colors/Background/Black-white-inversed (alpha) → Alpha Gray/950
+  static const Color blackWhiteInversed = PregoColorPrimitives.alphaGray950;
 
   /// Figma: Colors/Background/bg-active → Gray (dark mode)/800
-  static const Color bgActive = PregoColorPrimitives.grayDark800;
+  static const Color bgActive = Color(0xFF303236);
 
-  /// Figma: Colors/Background/bg-brand-primary → Brand Blue/500
-  static const Color bgBrandPrimary = PregoColorPrimitives.brandBlue500;
+  /// Figma: Colors/Background/bg-brand-primary → Blue/500
+  static const Color bgBrandPrimary = PregoColorPrimitives.blue500;
 
   /// Figma: Colors/Background/bg-brand-primary_alt → Background/bg-secondary
   static const Color bgBrandPrimaryAlt = PregoColorsDark.bgSecondary;
 
-  /// Figma: Colors/Background/bg-brand-secondary → Brand Blue/600
-  static const Color bgBrandSecondary = PregoColorPrimitives.brandBlue600;
+  /// Figma: Colors/Background/bg-brand-secondary → Blue/600
+  static const Color bgBrandSecondary = PregoColorPrimitives.blue600;
 
   /// Figma: Colors/Background/bg-brand-section → Background/bg-secondary
   static const Color bgBrandSection = PregoColorsDark.bgSecondary;
 
   /// Figma: Colors/Background/bg-brand-section_subtle → Gray (dark mode)/950
-  static const Color bgBrandSectionSubtle = PregoColorPrimitives.grayDark950;
+  static const Color bgBrandSectionSubtle = Color(0xFF030405);
 
-  /// Figma: Colors/Background/bg-brand-solid → Brand Blue/600
-  static const Color bgBrandSolid = PregoColorPrimitives.brandBlue600;
+  /// Figma: Colors/Background/bg-brand-solid → Blue/600
+  static const Color bgBrandSolid = PregoColorPrimitives.blue600;
 
-  /// Figma: Colors/Background/bg-brand-solid_hover → Brand Blue/500
-  static const Color bgBrandSolidHover = PregoColorPrimitives.brandBlue500;
+  /// Figma: Colors/Background/bg-brand-solid_hover → Blue/500
+  static const Color bgBrandSolidHover = PregoColorPrimitives.blue500;
 
-  /// Figma: Colors/Background/bg-brand_hover → Gray (dark mode alpha)/700
-  static const Color bgBrandHover = PregoColorPrimitives.grayDarkAlpha700;
+  /// Figma: Colors/Background/bg-brand_hover → Alpha White/700
+  static const Color bgBrandHover = PregoColorPrimitives.alphaWhite700;
 
-  /// Figma: Colors/Background/bg-brand_pressed → Gray (dark mode alpha)/500
-  static const Color bgBrandPressed = PregoColorPrimitives.grayDarkAlpha500;
+  /// Figma: Colors/Background/bg-brand_pressed → Alpha White/500
+  static const Color bgBrandPressed = PregoColorPrimitives.alphaWhite500;
 
-  /// Figma: Colors/Background/bg-destructive_hover → Gray (dark mode alpha)/900
-  static const Color bgDestructiveHover = PregoColorPrimitives.grayDarkAlpha900;
+  /// Figma: Colors/Background/bg-destructive_hover → Alpha White/900
+  static const Color bgDestructiveHover = PregoColorPrimitives.alphaWhite900;
 
-  /// Figma: Colors/Background/bg-destructive_pressed → Gray (dark mode alpha)/700
-  static const Color bgDestructivePressed = PregoColorPrimitives.grayDarkAlpha700;
+  /// Figma: Colors/Background/bg-destructive_pressed → Alpha White/700
+  static const Color bgDestructivePressed = PregoColorPrimitives.alphaWhite700;
 
-  /// Figma: Colors/Background/bg-disabled → Gray (dark mode)/800
-  static const Color bgDisabled = PregoColorPrimitives.grayDark800;
+  /// Figma: Colors/Background/bg-disabled → Gray/800
+  static const Color bgDisabled = PregoColorPrimitives.gray800;
 
   /// Figma: Colors/Background/bg-disabled_subtle → Gray (dark mode)/900
-  static const Color bgDisabledSubtle = PregoColorPrimitives.grayDark900;
+  static const Color bgDisabledSubtle = Color(0xFF18191B);
 
   /// Figma: Colors/Background/bg-error-primary → Error/950
   static const Color bgErrorPrimary = PregoColorPrimitives.error950;
@@ -261,41 +258,38 @@ abstract final class PregoColorsDark {
   /// Figma: Colors/Background/bg-error-solid_hover → Error/500
   static const Color bgErrorSolidHover = PregoColorPrimitives.error500;
 
-  /// Figma: Colors/Background/bg-gray_hover → Gray (dark mode alpha)/800
-  static const Color bgGrayHover = PregoColorPrimitives.grayDarkAlpha800;
+  /// Figma: Colors/Background/bg-gray_hover → Alpha White/800
+  static const Color bgGrayHover = PregoColorPrimitives.alphaWhite800;
 
-  /// Figma: Colors/Background/bg-gray_pressed → Gray (dark mode alpha)/600
-  static const Color bgGrayPressed = PregoColorPrimitives.grayDarkAlpha600;
+  /// Figma: Colors/Background/bg-gray_pressed → Alpha White/600
+  static const Color bgGrayPressed = PregoColorPrimitives.alphaWhite600;
 
-  /// Figma: Colors/Background/bg-overlay → Gray (dark mode)/800
-  static const Color bgOverlay = PregoColorPrimitives.grayDark800;
+  /// Figma: Colors/Background/bg-overlay → Gray/500
+  static const Color bgOverlay = PregoColorPrimitives.gray500;
 
-  /// Figma: Colors/Background/bg-primary → Gray (dark mode)/950
-  static const Color bgPrimary = PregoColorPrimitives.grayDark950;
+  /// Figma: Colors/Background/bg-primary → Gray/950
+  static const Color bgPrimary = PregoColorPrimitives.gray950;
 
   /// Figma: Colors/Background/bg-primary-solid → Background/bg-secondary
   static const Color bgPrimarySolid = PregoColorsDark.bgSecondary;
 
-  /// Figma: Colors/Background/bg-primary_alt → Background/bg-secondary
-  static const Color bgPrimaryAlt = PregoColorsDark.bgSecondary;
-
   /// Figma: Colors/Background/bg-quaternary → Gray (dark mode)/700
-  static const Color bgQuaternary = PregoColorPrimitives.grayDark700;
+  static const Color bgQuaternary = Color(0xFF4D5156);
 
   /// Figma: Colors/Background/bg-secondary → Gray (dark mode)/900
-  static const Color bgSecondary = PregoColorPrimitives.grayDark900;
+  static const Color bgSecondary = Color(0xFF18191B);
 
   /// Figma: Colors/Background/bg-secondary-solid → Gray (dark mode)/600
-  static const Color bgSecondarySolid = PregoColorPrimitives.grayDark600;
+  static const Color bgSecondarySolid = Color(0xFF656A71);
 
   /// Figma: Colors/Background/bg-secondary_alt → Background/bg-primary
   static const Color bgSecondaryAlt = PregoColorsDark.bgPrimary;
 
   /// Figma: Colors/Background/bg-secondary_hover → Gray (dark mode)/800
-  static const Color bgSecondaryHover = PregoColorPrimitives.grayDark800;
+  static const Color bgSecondaryHover = Color(0xFF303236);
 
   /// Figma: Colors/Background/bg-secondary_subtle → Gray (dark mode)/900
-  static const Color bgSecondarySubtle = PregoColorPrimitives.grayDark900;
+  static const Color bgSecondarySubtle = Color(0xFF18191B);
 
   /// Figma: Colors/Background/bg-success-primary → Success/950
   static const Color bgSuccessPrimary = PregoColorPrimitives.success950;
@@ -306,8 +300,17 @@ abstract final class PregoColorsDark {
   /// Figma: Colors/Background/bg-success-solid → Success/600
   static const Color bgSuccessSolid = PregoColorPrimitives.success600;
 
+  /// Figma: Colors/Background/bg-surface_1 → Gray/900
+  static const Color bgSurface1 = PregoColorPrimitives.gray900;
+
+  /// Figma: Colors/Background/bg-surface_2 → Gray/700
+  static const Color bgSurface2 = PregoColorPrimitives.gray700;
+
+  /// Figma: Colors/Background/bg-surface_3 → Gray/600
+  static const Color bgSurface3 = PregoColorPrimitives.gray600;
+
   /// Figma: Colors/Background/bg-tertiary → Gray (dark mode)/800
-  static const Color bgTertiary = PregoColorPrimitives.grayDark800;
+  static const Color bgTertiary = Color(0xFF303236);
 
   /// Figma: Colors/Background/bg-warning-primary → Warning/950
   static const Color bgWarningPrimary = PregoColorPrimitives.warning950;
@@ -328,8 +331,8 @@ abstract final class PregoColorsDark {
   // Effects - Figma: Colors/Effects/*
   // ===========================================================================
 
-  /// Figma: Colors/Effects/Focus rings/focus-ring → Brand Blue/500
-  static const Color focusRing = PregoColorPrimitives.brandBlue500;
+  /// Figma: Colors/Effects/Focus rings/focus-ring → Blue/500
+  static const Color focusRing = PregoColorPrimitives.blue500;
 
   /// Figma: Colors/Effects/Focus rings/focus-ring-error → Error/500
   static const Color focusRingError = PregoColorPrimitives.error500;
@@ -338,35 +341,35 @@ abstract final class PregoColorsDark {
   // Effects - Figma: Colors/Effects/Shadows/*
   // ===========================================================================
 
-  /// Figma: Colors/Effects/Shadows/shadow-2xl_01 → Base/transparent
-  static const Color shadow2xl01 = PregoColorPrimitives.baseTransparent;
+  /// Figma: Colors/Effects/Shadows/shadow-2xl_01 → Base/transparent white
+  static const Color shadow2xl01 = PregoColorPrimitives.baseTransparentWhite;
 
-  /// Figma: Colors/Effects/Shadows/shadow-2xl_02 → Base/transparent
-  static const Color shadow2xl02 = PregoColorPrimitives.baseTransparent;
+  /// Figma: Colors/Effects/Shadows/shadow-2xl_02 → Base/transparent white
+  static const Color shadow2xl02 = PregoColorPrimitives.baseTransparentWhite;
 
-  /// Figma: Colors/Effects/Shadows/shadow-3xl_01 → Base/transparent
-  static const Color shadow3xl01 = PregoColorPrimitives.baseTransparent;
+  /// Figma: Colors/Effects/Shadows/shadow-3xl_01 → Base/transparent white
+  static const Color shadow3xl01 = PregoColorPrimitives.baseTransparentWhite;
 
-  /// Figma: Colors/Effects/Shadows/shadow-3xl_02 → Base/transparent
-  static const Color shadow3xl02 = PregoColorPrimitives.baseTransparent;
+  /// Figma: Colors/Effects/Shadows/shadow-3xl_02 → Base/transparent white
+  static const Color shadow3xl02 = PregoColorPrimitives.baseTransparentWhite;
 
-  /// Figma: Colors/Effects/Shadows/shadow-inversed → Gray (light mode alpha)/200
-  static const Color shadowInversed = PregoColorPrimitives.grayLightAlpha200;
+  /// Figma: Colors/Effects/Shadows/shadow-inversed → Alpha Black/200
+  static const Color shadowInversed = PregoColorPrimitives.alphaBlack200;
 
-  /// Figma: Colors/Effects/Shadows/shadow-lg_01 → Base/transparent
-  static const Color shadowLg01 = PregoColorPrimitives.baseTransparent;
+  /// Figma: Colors/Effects/Shadows/shadow-lg_01 → Base/transparent white
+  static const Color shadowLg01 = PregoColorPrimitives.baseTransparentWhite;
 
-  /// Figma: Colors/Effects/Shadows/shadow-lg_02 → Base/transparent
-  static const Color shadowLg02 = PregoColorPrimitives.baseTransparent;
+  /// Figma: Colors/Effects/Shadows/shadow-lg_02 → Base/transparent white
+  static const Color shadowLg02 = PregoColorPrimitives.baseTransparentWhite;
 
-  /// Figma: Colors/Effects/Shadows/shadow-lg_03 → Base/transparent
-  static const Color shadowLg03 = PregoColorPrimitives.baseTransparent;
+  /// Figma: Colors/Effects/Shadows/shadow-lg_03 → Base/transparent white
+  static const Color shadowLg03 = PregoColorPrimitives.baseTransparentWhite;
 
-  /// Figma: Colors/Effects/Shadows/shadow-md_01 → Base/transparent
-  static const Color shadowMd01 = PregoColorPrimitives.baseTransparent;
+  /// Figma: Colors/Effects/Shadows/shadow-md_01 → Base/transparent white
+  static const Color shadowMd01 = PregoColorPrimitives.baseTransparentWhite;
 
-  /// Figma: Colors/Effects/Shadows/shadow-md_02 → Base/transparent
-  static const Color shadowMd02 = PregoColorPrimitives.baseTransparent;
+  /// Figma: Colors/Effects/Shadows/shadow-md_02 → Base/transparent white
+  static const Color shadowMd02 = PregoColorPrimitives.baseTransparentWhite;
 
   /// Figma: Colors/Effects/Shadows/shadow-skeumorphic
   static const Color skeuomorphicShadow = Color(0x0D0C0E12);
@@ -374,23 +377,23 @@ abstract final class PregoColorsDark {
   /// Figma: Colors/Effects/Shadows/shadow-skeumorphic-inner-border
   static const Color skeuomorphicInnerBorder = Color(0x2E0C0E12);
 
-  /// Figma: Colors/Effects/Shadows/shadow-sm_01 → Base/transparent
-  static const Color shadowSm01 = PregoColorPrimitives.baseTransparent;
+  /// Figma: Colors/Effects/Shadows/shadow-sm_01 → Base/transparent white
+  static const Color shadowSm01 = PregoColorPrimitives.baseTransparentWhite;
 
-  /// Figma: Colors/Effects/Shadows/shadow-sm_02 → Base/transparent
-  static const Color shadowSm02 = PregoColorPrimitives.baseTransparent;
+  /// Figma: Colors/Effects/Shadows/shadow-sm_02 → Base/transparent white
+  static const Color shadowSm02 = PregoColorPrimitives.baseTransparentWhite;
 
-  /// Figma: Colors/Effects/Shadows/shadow-xl_01 → Base/transparent
-  static const Color shadowXl01 = PregoColorPrimitives.baseTransparent;
+  /// Figma: Colors/Effects/Shadows/shadow-xl_01 → Base/transparent white
+  static const Color shadowXl01 = PregoColorPrimitives.baseTransparentWhite;
 
-  /// Figma: Colors/Effects/Shadows/shadow-xl_02 → Base/transparent
-  static const Color shadowXl02 = PregoColorPrimitives.baseTransparent;
+  /// Figma: Colors/Effects/Shadows/shadow-xl_02 → Base/transparent white
+  static const Color shadowXl02 = PregoColorPrimitives.baseTransparentWhite;
 
-  /// Figma: Colors/Effects/Shadows/shadow-xl_03 → Base/transparent
-  static const Color shadowXl03 = PregoColorPrimitives.baseTransparent;
+  /// Figma: Colors/Effects/Shadows/shadow-xl_03 → Base/transparent white
+  static const Color shadowXl03 = PregoColorPrimitives.baseTransparentWhite;
 
-  /// Figma: Colors/Effects/Shadows/shadow-xs → Base/transparent
-  static const Color shadowXs = PregoColorPrimitives.baseTransparent;
+  /// Figma: Colors/Effects/Shadows/shadow-xs → Base/transparent white
+  static const Color shadowXs = PregoColorPrimitives.baseTransparentWhite;
 
   // ===========================================================================
   // Component Colors - Buttons
@@ -402,27 +405,27 @@ abstract final class PregoColorsDark {
   /// Figma: Component colors/Components/Buttons/button-destructive-primary-icon_hover → Error/200
   static const Color buttonDestructivePrimaryIconHover = PregoColorPrimitives.error200;
 
-  /// Figma: Component colors/Components/Buttons/button-glass- primary-background → Gray (dark mode alpha)/900
-  static const Color buttonGlassPrimaryBackground = PregoColorPrimitives.grayDarkAlpha900;
+  /// Figma: Component colors/Components/Buttons/button-glass- primary-background → Alpha White/900
+  static const Color buttonGlassPrimaryBackground = PregoColorPrimitives.alphaWhite900;
 
-  /// Figma: Component colors/Components/Buttons/button-glass- primary-hover → Gray (dark mode alpha)/800
-  static const Color buttonGlassPrimaryHover = PregoColorPrimitives.grayDarkAlpha800;
+  /// Figma: Component colors/Components/Buttons/button-glass- primary-hover → Alpha White/800
+  static const Color buttonGlassPrimaryHover = PregoColorPrimitives.alphaWhite800;
 
-  /// Figma: Component colors/Components/Buttons/button-primary-icon → Brand Blue/300
-  static const Color buttonPrimaryIcon = PregoColorPrimitives.brandBlue300;
+  /// Figma: Component colors/Components/Buttons/button-primary-icon → Blue/300
+  static const Color buttonPrimaryIcon = PregoColorPrimitives.blue300;
 
-  /// Figma: Component colors/Components/Buttons/button-primary-icon_hover → Brand Blue/200
-  static const Color buttonPrimaryIconHover = PregoColorPrimitives.brandBlue200;
+  /// Figma: Component colors/Components/Buttons/button-primary-icon_hover → Blue/200
+  static const Color buttonPrimaryIconHover = PregoColorPrimitives.blue200;
 
   // ===========================================================================
   // Component Colors - Icons
   // ===========================================================================
 
   /// Figma: Component colors/Components/Icons/Icons/icon-fg-brand → Gray (dark mode)/400
-  static const Color iconFgBrand = PregoColorPrimitives.grayDark400;
+  static const Color iconFgBrand = Color(0xFF999DA3);
 
   /// Figma: Component colors/Components/Icons/Icons/icon-fg-brand_on-brand → Gray (dark mode)/400
-  static const Color iconFgBrandOnBrand = PregoColorPrimitives.grayDark400;
+  static const Color iconFgBrandOnBrand = Color(0xFF999DA3);
 
   // ===========================================================================
   // Component Colors - Alpha (mode-invariant)
@@ -486,35 +489,35 @@ abstract final class PregoColorsDark {
   static const Color alphaWhite90 = Color(0xE50C0E12);
 
   /// Figma: Component colors/Alpha/alpha-white-100 → Gray (dark mode)/950
-  static const Color alphaWhite100 = PregoColorPrimitives.grayDark950;
+  static const Color alphaWhite100 = Color(0xFF030405);
 
   // ===========================================================================
   // Utility Colors
   // ===========================================================================
 
-  /// Figma: Component colors/Utility/Blue/utility-blue-50 → Brand Blue/900
-  static const Color utilityBlue50 = PregoColorPrimitives.brandBlue900;
+  /// Figma: Component colors/Utility/Blue/utility-blue-50 → Blue/900
+  static const Color utilityBlue50 = PregoColorPrimitives.blue900;
 
-  /// Figma: Component colors/Utility/Blue/utility-blue-100 → Brand Blue/800
-  static const Color utilityBlue100 = PregoColorPrimitives.brandBlue800;
+  /// Figma: Component colors/Utility/Blue/utility-blue-100 → Blue/800
+  static const Color utilityBlue100 = PregoColorPrimitives.blue800;
 
-  /// Figma: Component colors/Utility/Blue/utility-blue-200 → Brand Blue/700
-  static const Color utilityBlue200 = PregoColorPrimitives.brandBlue700;
+  /// Figma: Component colors/Utility/Blue/utility-blue-200 → Blue/700
+  static const Color utilityBlue200 = PregoColorPrimitives.blue700;
 
-  /// Figma: Component colors/Utility/Blue/utility-blue-300 → Brand Blue/600
-  static const Color utilityBlue300 = PregoColorPrimitives.brandBlue600;
+  /// Figma: Component colors/Utility/Blue/utility-blue-300 → Blue/600
+  static const Color utilityBlue300 = PregoColorPrimitives.blue600;
 
-  /// Figma: Component colors/Utility/Blue/utility-blue-400 → Brand Blue/500
-  static const Color utilityBlue400 = PregoColorPrimitives.brandBlue500;
+  /// Figma: Component colors/Utility/Blue/utility-blue-400 → Blue/500
+  static const Color utilityBlue400 = PregoColorPrimitives.blue500;
 
-  /// Figma: Component colors/Utility/Blue/utility-blue-500 → Brand Blue/400
-  static const Color utilityBlue500 = PregoColorPrimitives.brandBlue400;
+  /// Figma: Component colors/Utility/Blue/utility-blue-500 → Blue/400
+  static const Color utilityBlue500 = PregoColorPrimitives.blue400;
 
-  /// Figma: Component colors/Utility/Blue/utility-blue-600 → Brand Blue/300
-  static const Color utilityBlue600 = PregoColorPrimitives.brandBlue300;
+  /// Figma: Component colors/Utility/Blue/utility-blue-600 → Blue/300
+  static const Color utilityBlue600 = PregoColorPrimitives.blue300;
 
-  /// Figma: Component colors/Utility/Blue/utility-blue-700 → Brand Blue/200
-  static const Color utilityBlue700 = PregoColorPrimitives.brandBlue200;
+  /// Figma: Component colors/Utility/Blue/utility-blue-700 → Blue/200
+  static const Color utilityBlue700 = PregoColorPrimitives.blue200;
 
   /// Figma: Component colors/Utility/Error/utility-error-50 → Error/950
   static const Color utilityError50 = PregoColorPrimitives.error950;
@@ -595,20 +598,20 @@ abstract final class PregoColorsDark {
   /// Figma: Component colors/Components/Avatars/avatar-styles-bg-neutral
   static const Color avatarStylesBgNeutral = Color(0xFFE0E0E0);
 
-  /// Figma: Component colors/Components/Icons/Hero Avatar/brand-gradient-bottom → Brand Blue/300
-  static const Color brandGradientBottom = PregoColorPrimitives.brandBlue300;
+  /// Figma: Component colors/Components/Icons/Hero Avatar/brand-gradient-bottom → Blue/300
+  static const Color brandGradientBottom = PregoColorPrimitives.blue300;
 
   /// Figma: Component colors/Components/Icons/Hero Avatar/brand-gradient-top → Base/white
   static const Color brandGradientTop = PregoColorPrimitives.baseWhite;
 
-  /// Figma: Component colors/Components/Icons/Featured icons/featured-icon-light-fg-brand → Brand Blue/200
-  static const Color featuredIconLightFgBrand = PregoColorPrimitives.brandBlue200;
+  /// Figma: Component colors/Components/Icons/Featured icons/featured-icon-light-fg-brand → Blue/200
+  static const Color featuredIconLightFgBrand = PregoColorPrimitives.blue200;
 
   /// Figma: Component colors/Components/Icons/Featured icons/featured-icon-light-fg-error → Error/200
   static const Color featuredIconLightFgError = PregoColorPrimitives.error200;
 
-  /// Figma: Component colors/Components/Icons/Featured icons/featured-icon-light-fg-gray → Gray (dark mode alpha)/200
-  static const Color featuredIconLightFgGray = PregoColorPrimitives.grayDarkAlpha200;
+  /// Figma: Component colors/Components/Icons/Featured icons/featured-icon-light-fg-gray → Alpha White/200
+  static const Color featuredIconLightFgGray = PregoColorPrimitives.alphaWhite200;
 
   /// Figma: Component colors/Components/Icons/Featured icons/featured-icon-light-fg-success → Success/200
   static const Color featuredIconLightFgSuccess = PregoColorPrimitives.success200;
@@ -634,17 +637,17 @@ abstract final class PregoColorsDark {
   /// Figma: Component colors/Components/Icons/Hero Avatar/purple-gradient-top → Base/white
   static const Color purpleGradientTop = PregoColorPrimitives.baseWhite;
 
-  /// Figma: Component colors/Components/Toggles/toggle-border → Base/transparent
-  static const Color toggleBorder = PregoColorPrimitives.baseTransparent;
+  /// Figma: Component colors/Components/Toggles/toggle-border → Base/transparent white
+  static const Color toggleBorder = PregoColorPrimitives.baseTransparentWhite;
 
   /// Figma: Component colors/Components/Toggles/toggle-button-fg_disabled → Gray (dark mode)/600
-  static const Color toggleButtonFgDisabled = PregoColorPrimitives.grayDark600;
+  static const Color toggleButtonFgDisabled = Color(0xFF656A71);
 
-  /// Figma: Component colors/Components/Toggles/toggle-slim-border_pressed → Base/transparent
-  static const Color toggleSlimBorderPressed = PregoColorPrimitives.baseTransparent;
+  /// Figma: Component colors/Components/Toggles/toggle-slim-border_pressed → Base/transparent white
+  static const Color toggleSlimBorderPressed = PregoColorPrimitives.baseTransparentWhite;
 
-  /// Figma: Component colors/Components/Toggles/toggle-slim-border_pressed-hover → Base/transparent
-  static const Color toggleSlimBorderPressedHover = PregoColorPrimitives.baseTransparent;
+  /// Figma: Component colors/Components/Toggles/toggle-slim-border_pressed-hover → Base/transparent white
+  static const Color toggleSlimBorderPressedHover = PregoColorPrimitives.baseTransparentWhite;
 }
 
 /// Light mode color tokens matching Figma specifications.
@@ -657,23 +660,23 @@ abstract final class PregoColorsLight {
   // Text Colors - Figma: Colors/Text/*
   // ===========================================================================
 
-  /// Figma: Colors/Text/text-brand-primary (900) → Brand Blue/900
-  static const Color textBrandPrimary = PregoColorPrimitives.brandBlue900;
+  /// Figma: Colors/Text/text-brand-primary (900) → Blue/900
+  static const Color textBrandPrimary = PregoColorPrimitives.blue900;
 
-  /// Figma: Colors/Text/text-brand-secondary (700) → Brand Blue/700
-  static const Color textBrandSecondary = PregoColorPrimitives.brandBlue700;
+  /// Figma: Colors/Text/text-brand-secondary (700) → Blue/700
+  static const Color textBrandSecondary = PregoColorPrimitives.blue700;
 
-  /// Figma: Colors/Text/text-brand-secondary_hover → Brand Blue/800
-  static const Color textBrandSecondaryHover = PregoColorPrimitives.brandBlue800;
+  /// Figma: Colors/Text/text-brand-secondary_hover → Blue/800
+  static const Color textBrandSecondaryHover = PregoColorPrimitives.blue800;
 
-  /// Figma: Colors/Text/text-brand-tertiary (600) → Brand Blue/600
-  static const Color textBrandTertiary = PregoColorPrimitives.brandBlue600;
+  /// Figma: Colors/Text/text-brand-tertiary (600) → Blue/600
+  static const Color textBrandTertiary = PregoColorPrimitives.blue600;
 
-  /// Figma: Colors/Text/text-brand-tertiary_alt → Brand Blue/600
-  static const Color textBrandTertiaryAlt = PregoColorPrimitives.brandBlue600;
+  /// Figma: Colors/Text/text-brand-tertiary_alt → Blue/600
+  static const Color textBrandTertiaryAlt = PregoColorPrimitives.blue600;
 
-  /// Figma: Colors/Text/text-disabled → Gray (light mode)/500
-  static const Color textDisabled = PregoColorPrimitives.grayLight500;
+  /// Figma: Colors/Text/text-disabled → Gray/400
+  static const Color textDisabled = PregoColorPrimitives.gray400;
 
   /// Figma: Colors/Text/text-error-primary (600) → Error/600
   static const Color textErrorPrimary = PregoColorPrimitives.error600;
@@ -681,47 +684,44 @@ abstract final class PregoColorsLight {
   /// Figma: Colors/Text/text-error-primary_hover → Error/700
   static const Color textErrorPrimaryHover = PregoColorPrimitives.error700;
 
-  /// Figma: Colors/Text/text-placeholder → Gray (light mode)/400
-  static const Color textPlaceholder = PregoColorPrimitives.grayLight400;
+  /// Figma: Colors/Text/text-placeholder → Gray/400
+  static const Color textPlaceholder = PregoColorPrimitives.gray400;
 
-  /// Figma: Colors/Text/text-placeholder_subtle → Gray (light mode)/300
-  static const Color textPlaceholderSubtle = PregoColorPrimitives.grayLight300;
+  /// Figma: Colors/Text/text-placeholder_subtle → Gray/300
+  static const Color textPlaceholderSubtle = PregoColorPrimitives.gray300;
 
-  /// Figma: Colors/Text/text-primary (900) → Gray (light mode)/950
-  static const Color textPrimary = PregoColorPrimitives.grayLight950;
+  /// Figma: Colors/Text/text-primary (950) → Gray/950
+  static const Color textPrimary = PregoColorPrimitives.gray950;
 
-  /// Figma: Colors/Text/text-primary_on-brand → Base/white
-  static const Color textPrimaryOnBrand = PregoColorPrimitives.baseWhite;
+  /// Figma: Colors/Text/text-primary_on-brand → Blue/500
+  static const Color textPrimaryOnBrand = PregoColorPrimitives.blue500;
 
   /// Figma: Colors/Text/text-primary_on-white → Base/white
   static const Color textPrimaryOnWhite = PregoColorPrimitives.baseWhite;
 
   /// Figma: Colors/Text/text-quaternary (500) → Gray (light mode)/400
-  static const Color textQuaternary = PregoColorPrimitives.grayLight400;
+  static const Color textQuaternary = Color(0xFFA4A7AE);
 
-  /// Figma: Colors/Text/text-quaternary_on-brand → Brand Blue/300
-  static const Color textQuaternaryOnBrand = PregoColorPrimitives.brandBlue300;
-
-  /// Figma: Colors/Text/text-secondary (600) → Gray (light mode)/700
-  static const Color textSecondary = PregoColorPrimitives.grayLight700;
+  /// Figma: Colors/Text/text-secondary (600) → Gray/500
+  static const Color textSecondary = PregoColorPrimitives.gray500;
 
   /// Figma: Colors/Text/text-secondary_hover → Gray (light mode)/800
-  static const Color textSecondaryHover = PregoColorPrimitives.grayLight800;
+  static const Color textSecondaryHover = Color(0xFF252B37);
 
-  /// Figma: Colors/Text/text-secondary_on-brand → Brand Blue/400
-  static const Color textSecondaryOnBrand = PregoColorPrimitives.brandBlue400;
+  /// Figma: Colors/Text/text-secondary_on-brand → Blue/400
+  static const Color textSecondaryOnBrand = PregoColorPrimitives.blue400;
 
   /// Figma: Colors/Text/text-success-primary (600) → Success/600
   static const Color textSuccessPrimary = PregoColorPrimitives.success600;
 
-  /// Figma: Colors/Text/text-tertiary (600) → Gray (light mode)/600
-  static const Color textTertiary = PregoColorPrimitives.grayLight600;
+  /// Figma: Colors/Text/text-tertiary (450) → Gray/525
+  static const Color textTertiary = PregoColorPrimitives.gray525;
 
-  /// Figma: Colors/Text/text-tertiary_hover → Gray (light mode)/700
-  static const Color textTertiaryHover = PregoColorPrimitives.grayLight700;
+  /// Figma: Colors/Text/text-tertiary_hover → Gray/700
+  static const Color textTertiaryHover = PregoColorPrimitives.gray700;
 
-  /// Figma: Colors/Text/text-tertiary_on-brand → Brand Blue/200
-  static const Color textTertiaryOnBrand = PregoColorPrimitives.brandBlue200;
+  /// Figma: Colors/Text/text-tertiary_on-brand → Blue/200
+  static const Color textTertiaryOnBrand = PregoColorPrimitives.blue200;
 
   /// Figma: Colors/Text/text-warning-primary (600) → Warning/600
   static const Color textWarningPrimary = PregoColorPrimitives.warning600;
@@ -733,17 +733,14 @@ abstract final class PregoColorsLight {
   // Border Colors - Figma: Colors/Border/*
   // ===========================================================================
 
-  /// Figma: Colors/Border/border-brand → Brand Blue/500
-  static const Color borderBrand = PregoColorPrimitives.brandBlue500;
+  /// Figma: Colors/Border/border-brand → Blue/500
+  static const Color borderBrand = PregoColorPrimitives.blue500;
 
-  /// Figma: Colors/Border/border-brand_alt → Brand Blue/600
-  static const Color borderBrandAlt = PregoColorPrimitives.brandBlue600;
+  /// Figma: Colors/Border/border-disabled → Gray/350
+  static const Color borderDisabled = PregoColorPrimitives.gray350;
 
-  /// Figma: Colors/Border/border-disabled → Gray (light mode)/300
-  static const Color borderDisabled = PregoColorPrimitives.grayLight300;
-
-  /// Figma: Colors/Border/border-disabled_subtle → Gray (light mode)/200
-  static const Color borderDisabledSubtle = PregoColorPrimitives.grayLight200;
+  /// Figma: Colors/Border/border-disabled_subtle → Gray/200
+  static const Color borderDisabledSubtle = PregoColorPrimitives.gray200;
 
   /// Figma: Colors/Border/border-error → Error/500
   static const Color borderError = PregoColorPrimitives.error500;
@@ -757,45 +754,48 @@ abstract final class PregoColorsLight {
   /// Figma: Colors/Border/border-inside-reversed-top
   static const Color borderInsideReversedTop = Color(0x00FFFFFF);
 
-  /// Figma: Colors/Border/border-primary → Gray (light mode)/300
-  static const Color borderPrimary = PregoColorPrimitives.grayLight300;
+  /// Figma: Colors/Border/border-primary → Alpha Black/200
+  static const Color borderPrimary = PregoColorPrimitives.alphaBlack200;
 
   /// Figma: Colors/Border/border-reversed → Base/white
   static const Color borderReversed = PregoColorPrimitives.baseWhite;
 
-  /// Figma: Colors/Border/border-secondary → Gray (light mode)/200
-  static const Color borderSecondary = PregoColorPrimitives.grayLight200;
+  /// Figma: Colors/Border/border-secondary → Alpha Black/100
+  static const Color borderSecondary = PregoColorPrimitives.alphaBlack100;
 
   /// Figma: Colors/Border/border-secondary_alt
   static const Color borderSecondaryAlt = Color(0x0D000000);
 
-  /// Figma: Colors/Border/border-tertiary → Gray (light mode)/100
-  static const Color borderTertiary = PregoColorPrimitives.grayLight100;
+  /// Figma: Colors/Border/border-selected → Gray/900
+  static const Color borderSelected = PregoColorPrimitives.gray900;
+
+  /// Figma: Colors/Border/border-tertiary → Alpha Black/50
+  static const Color borderTertiary = PregoColorPrimitives.alphaBlack50;
 
   // ===========================================================================
   // Foreground Colors - Figma: Colors/Foreground/*
   // ===========================================================================
 
-  /// Figma: Colors/Foreground/fg-brand-primary (600) → Brand Blue/600
-  static const Color fgBrandPrimary = PregoColorPrimitives.brandBlue600;
+  /// Figma: Colors/Foreground/fg-brand-primary (600) → Blue/600
+  static const Color fgBrandPrimary = PregoColorPrimitives.blue600;
 
-  /// Figma: Colors/Foreground/fg-brand-primary_alt → Brand Blue/600
-  static const Color fgBrandPrimaryAlt = PregoColorPrimitives.brandBlue600;
+  /// Figma: Colors/Foreground/fg-brand-primary_alt → Blue/600
+  static const Color fgBrandPrimaryAlt = PregoColorPrimitives.blue600;
 
-  /// Figma: Colors/Foreground/fg-brand-secondary (500) → Brand Blue/500
-  static const Color fgBrandSecondary = PregoColorPrimitives.brandBlue500;
+  /// Figma: Colors/Foreground/fg-brand-secondary (500) → Blue/500
+  static const Color fgBrandSecondary = PregoColorPrimitives.blue500;
 
-  /// Figma: Colors/Foreground/fg-brand-secondary_alt → Brand Blue/500
-  static const Color fgBrandSecondaryAlt = PregoColorPrimitives.brandBlue500;
+  /// Figma: Colors/Foreground/fg-brand-secondary_alt → Blue/500
+  static const Color fgBrandSecondaryAlt = PregoColorPrimitives.blue500;
 
-  /// Figma: Colors/Foreground/fg-brand-secondary_hover → Brand Blue/500
-  static const Color fgBrandSecondaryHover = PregoColorPrimitives.brandBlue500;
+  /// Figma: Colors/Foreground/fg-brand-secondary_hover → Blue/500
+  static const Color fgBrandSecondaryHover = PregoColorPrimitives.blue500;
 
-  /// Figma: Colors/Foreground/fg-disabled → Gray (light mode)/400
-  static const Color fgDisabled = PregoColorPrimitives.grayLight400;
+  /// Figma: Colors/Foreground/fg-disabled → Gray/400
+  static const Color fgDisabled = PregoColorPrimitives.gray400;
 
-  /// Figma: Colors/Foreground/fg-disabled_subtle → Gray (light mode)/300
-  static const Color fgDisabledSubtle = PregoColorPrimitives.grayLight300;
+  /// Figma: Colors/Foreground/fg-disabled_subtle → Gray/300
+  static const Color fgDisabledSubtle = PregoColorPrimitives.gray300;
 
   /// Figma: Colors/Foreground/fg-error-primary → Error/600
   static const Color fgErrorPrimary = PregoColorPrimitives.error600;
@@ -804,19 +804,19 @@ abstract final class PregoColorsLight {
   static const Color fgErrorSecondary = PregoColorPrimitives.error500;
 
   /// Figma: Colors/Foreground/fg-primary (900) → Gray (dark mode)/900
-  static const Color fgPrimary = PregoColorPrimitives.grayDark900;
+  static const Color fgPrimary = Color(0xFF18191B);
 
-  /// Figma: Colors/Foreground/fg-quaternary (400) → Gray (light mode)/400
-  static const Color fgQuaternary = PregoColorPrimitives.grayLight400;
+  /// Figma: Colors/Foreground/fg-quaternary (400) → Gray/400
+  static const Color fgQuaternary = PregoColorPrimitives.gray400;
 
-  /// Figma: Colors/Foreground/fg-quaternary_hover → Gray (light mode)/500
-  static const Color fgQuaternaryHover = PregoColorPrimitives.grayLight500;
+  /// Figma: Colors/Foreground/fg-quaternary_hover → Gray/500
+  static const Color fgQuaternaryHover = PregoColorPrimitives.gray500;
 
-  /// Figma: Colors/Foreground/fg-secondary (700) → Gray (light mode)/700
-  static const Color fgSecondary = PregoColorPrimitives.grayLight700;
+  /// Figma: Colors/Foreground/fg-secondary (700) → Gray/700
+  static const Color fgSecondary = PregoColorPrimitives.gray700;
 
-  /// Figma: Colors/Foreground/fg-secondary_hover → Gray (light mode)/800
-  static const Color fgSecondaryHover = PregoColorPrimitives.grayLight800;
+  /// Figma: Colors/Foreground/fg-secondary_hover → Gray/800
+  static const Color fgSecondaryHover = PregoColorPrimitives.gray800;
 
   /// Figma: Colors/Foreground/fg-success-primary → Success/600
   static const Color fgSuccessPrimary = PregoColorPrimitives.success600;
@@ -824,11 +824,11 @@ abstract final class PregoColorsLight {
   /// Figma: Colors/Foreground/fg-success-secondary → Success/500
   static const Color fgSuccessSecondary = PregoColorPrimitives.success500;
 
-  /// Figma: Colors/Foreground/fg-tertiary (600) → Gray (light mode)/600
-  static const Color fgTertiary = PregoColorPrimitives.grayLight600;
+  /// Figma: Colors/Foreground/fg-tertiary (600) → Gray/600
+  static const Color fgTertiary = PregoColorPrimitives.gray600;
 
-  /// Figma: Colors/Foreground/fg-tertiary_hover → Gray (light mode)/700
-  static const Color fgTertiaryHover = PregoColorPrimitives.grayLight700;
+  /// Figma: Colors/Foreground/fg-tertiary_hover → Gray/700
+  static const Color fgTertiaryHover = PregoColorPrimitives.gray700;
 
   /// Figma: Colors/Foreground/fg-warning-primary → Warning/600
   static const Color fgWarningPrimary = PregoColorPrimitives.warning600;
@@ -843,50 +843,50 @@ abstract final class PregoColorsLight {
   // Background Colors - Figma: Colors/Background/*
   // ===========================================================================
 
-  /// Figma: Colors/Background/Black-white-inversed (alpha) → Base/transparent
-  static const Color blackWhiteInversed = PregoColorPrimitives.baseTransparent;
+  /// Figma: Colors/Background/Black-white-inversed (alpha) → Alpha Gray/300
+  static const Color blackWhiteInversed = PregoColorPrimitives.alphaGray300;
 
-  /// Figma: Colors/Background/bg-active → Gray (light mode)/50
-  static const Color bgActive = PregoColorPrimitives.grayLight50;
+  /// Figma: Colors/Background/bg-active → Gray/50
+  static const Color bgActive = PregoColorPrimitives.gray50;
 
-  /// Figma: Colors/Background/bg-brand-primary → Brand Blue/50
-  static const Color bgBrandPrimary = PregoColorPrimitives.brandBlue50;
+  /// Figma: Colors/Background/bg-brand-primary → Blue/50
+  static const Color bgBrandPrimary = PregoColorPrimitives.blue50;
 
-  /// Figma: Colors/Background/bg-brand-primary_alt → Brand Blue/50
-  static const Color bgBrandPrimaryAlt = PregoColorPrimitives.brandBlue50;
+  /// Figma: Colors/Background/bg-brand-primary_alt → Blue/50
+  static const Color bgBrandPrimaryAlt = PregoColorPrimitives.blue50;
 
-  /// Figma: Colors/Background/bg-brand-secondary → Brand Blue/100
-  static const Color bgBrandSecondary = PregoColorPrimitives.brandBlue100;
+  /// Figma: Colors/Background/bg-brand-secondary → Blue/100
+  static const Color bgBrandSecondary = PregoColorPrimitives.blue100;
 
-  /// Figma: Colors/Background/bg-brand-section → Brand Blue/800
-  static const Color bgBrandSection = PregoColorPrimitives.brandBlue800;
+  /// Figma: Colors/Background/bg-brand-section → Blue/800
+  static const Color bgBrandSection = PregoColorPrimitives.blue800;
 
-  /// Figma: Colors/Background/bg-brand-section_subtle → Gray (light mode)/100
-  static const Color bgBrandSectionSubtle = PregoColorPrimitives.grayLight100;
+  /// Figma: Colors/Background/bg-brand-section_subtle → Gray/100
+  static const Color bgBrandSectionSubtle = PregoColorPrimitives.gray100;
 
-  /// Figma: Colors/Background/bg-brand-solid → Brand Blue/600
-  static const Color bgBrandSolid = PregoColorPrimitives.brandBlue600;
+  /// Figma: Colors/Background/bg-brand-solid → Blue/600
+  static const Color bgBrandSolid = PregoColorPrimitives.blue600;
 
-  /// Figma: Colors/Background/bg-brand-solid_hover → Brand Blue/700
-  static const Color bgBrandSolidHover = PregoColorPrimitives.brandBlue700;
+  /// Figma: Colors/Background/bg-brand-solid_hover → Blue/700
+  static const Color bgBrandSolidHover = PregoColorPrimitives.blue700;
 
-  /// Figma: Colors/Background/bg-brand_hover → Gray (light mode alpha)/200
-  static const Color bgBrandHover = PregoColorPrimitives.grayLightAlpha200;
+  /// Figma: Colors/Background/bg-brand_hover → Alpha Black/200
+  static const Color bgBrandHover = PregoColorPrimitives.alphaBlack200;
 
-  /// Figma: Colors/Background/bg-brand_pressed → Gray (light mode alpha)/300
-  static const Color bgBrandPressed = PregoColorPrimitives.grayLightAlpha300;
+  /// Figma: Colors/Background/bg-brand_pressed → Alpha Black/300
+  static const Color bgBrandPressed = PregoColorPrimitives.alphaBlack300;
 
-  /// Figma: Colors/Background/bg-destructive_hover → Gray (light mode alpha)/200
-  static const Color bgDestructiveHover = PregoColorPrimitives.grayLightAlpha200;
+  /// Figma: Colors/Background/bg-destructive_hover → Alpha Black/200
+  static const Color bgDestructiveHover = PregoColorPrimitives.alphaBlack200;
 
-  /// Figma: Colors/Background/bg-destructive_pressed → Gray (light mode alpha)/400
-  static const Color bgDestructivePressed = PregoColorPrimitives.grayLightAlpha400;
+  /// Figma: Colors/Background/bg-destructive_pressed → Alpha Black/300
+  static const Color bgDestructivePressed = PregoColorPrimitives.alphaBlack300;
 
-  /// Figma: Colors/Background/bg-disabled → Gray (light mode)/100
-  static const Color bgDisabled = PregoColorPrimitives.grayLight100;
+  /// Figma: Colors/Background/bg-disabled → Gray/200
+  static const Color bgDisabled = PregoColorPrimitives.gray200;
 
-  /// Figma: Colors/Background/bg-disabled_subtle → Gray (light mode)/50
-  static const Color bgDisabledSubtle = PregoColorPrimitives.grayLight50;
+  /// Figma: Colors/Background/bg-disabled_subtle → Gray/50
+  static const Color bgDisabledSubtle = PregoColorPrimitives.gray50;
 
   /// Figma: Colors/Background/bg-error-primary → Error/50
   static const Color bgErrorPrimary = PregoColorPrimitives.error50;
@@ -900,41 +900,38 @@ abstract final class PregoColorsLight {
   /// Figma: Colors/Background/bg-error-solid_hover → Error/700
   static const Color bgErrorSolidHover = PregoColorPrimitives.error700;
 
-  /// Figma: Colors/Background/bg-gray_hover → Gray (light mode alpha)/50
-  static const Color bgGrayHover = PregoColorPrimitives.grayLightAlpha50;
+  /// Figma: Colors/Background/bg-gray_hover → Alpha Black/50
+  static const Color bgGrayHover = PregoColorPrimitives.alphaBlack50;
 
-  /// Figma: Colors/Background/bg-gray_pressed → Gray (light mode alpha)/200
-  static const Color bgGrayPressed = PregoColorPrimitives.grayLightAlpha200;
+  /// Figma: Colors/Background/bg-gray_pressed → Alpha Black/200
+  static const Color bgGrayPressed = PregoColorPrimitives.alphaBlack200;
 
-  /// Figma: Colors/Background/bg-overlay → Gray (light mode)/950
-  static const Color bgOverlay = PregoColorPrimitives.grayLight950;
+  /// Figma: Colors/Background/bg-overlay → Base/white
+  static const Color bgOverlay = PregoColorPrimitives.baseWhite;
 
-  /// Figma: Colors/Background/bg-primary → Base/white
-  static const Color bgPrimary = PregoColorPrimitives.baseWhite;
+  /// Figma: Colors/Background/bg-primary → Gray/300
+  static const Color bgPrimary = PregoColorPrimitives.gray300;
 
-  /// Figma: Colors/Background/bg-primary-solid → Gray (light mode)/950
-  static const Color bgPrimarySolid = PregoColorPrimitives.grayLight950;
+  /// Figma: Colors/Background/bg-primary-solid → Gray/950
+  static const Color bgPrimarySolid = PregoColorPrimitives.gray950;
 
-  /// Figma: Colors/Background/bg-primary_alt → Gray (light mode)/25
-  static const Color bgPrimaryAlt = PregoColorPrimitives.grayLight25;
+  /// Figma: Colors/Background/bg-quaternary → Gray/200
+  static const Color bgQuaternary = PregoColorPrimitives.gray200;
 
-  /// Figma: Colors/Background/bg-quaternary → Gray (light mode)/200
-  static const Color bgQuaternary = PregoColorPrimitives.grayLight200;
+  /// Figma: Colors/Background/bg-secondary → Gray/50
+  static const Color bgSecondary = PregoColorPrimitives.gray50;
 
-  /// Figma: Colors/Background/bg-secondary → Gray (light mode)/50
-  static const Color bgSecondary = PregoColorPrimitives.grayLight50;
+  /// Figma: Colors/Background/bg-secondary-solid → Gray/600
+  static const Color bgSecondarySolid = PregoColorPrimitives.gray600;
 
-  /// Figma: Colors/Background/bg-secondary-solid → Gray (light mode)/600
-  static const Color bgSecondarySolid = PregoColorPrimitives.grayLight600;
+  /// Figma: Colors/Background/bg-secondary_alt → Gray/50
+  static const Color bgSecondaryAlt = PregoColorPrimitives.gray50;
 
-  /// Figma: Colors/Background/bg-secondary_alt → Gray (light mode)/50
-  static const Color bgSecondaryAlt = PregoColorPrimitives.grayLight50;
+  /// Figma: Colors/Background/bg-secondary_hover → Gray/100
+  static const Color bgSecondaryHover = PregoColorPrimitives.gray100;
 
-  /// Figma: Colors/Background/bg-secondary_hover → Gray (light mode)/100
-  static const Color bgSecondaryHover = PregoColorPrimitives.grayLight100;
-
-  /// Figma: Colors/Background/bg-secondary_subtle → Gray (light mode)/25
-  static const Color bgSecondarySubtle = PregoColorPrimitives.grayLight25;
+  /// Figma: Colors/Background/bg-secondary_subtle → Gray (light mode)/5
+  static const Color bgSecondarySubtle = Color(0xFFFDFDFD);
 
   /// Figma: Colors/Background/bg-success-primary → Success/50
   static const Color bgSuccessPrimary = PregoColorPrimitives.success50;
@@ -945,8 +942,17 @@ abstract final class PregoColorsLight {
   /// Figma: Colors/Background/bg-success-solid → Success/600
   static const Color bgSuccessSolid = PregoColorPrimitives.success600;
 
-  /// Figma: Colors/Background/bg-tertiary → Gray (light mode)/100
-  static const Color bgTertiary = PregoColorPrimitives.grayLight100;
+  /// Figma: Colors/Background/bg-surface_1 → Gray/200
+  static const Color bgSurface1 = PregoColorPrimitives.gray200;
+
+  /// Figma: Colors/Background/bg-surface_2 → Gray/100
+  static const Color bgSurface2 = PregoColorPrimitives.gray100;
+
+  /// Figma: Colors/Background/bg-surface_3 → Gray/50
+  static const Color bgSurface3 = PregoColorPrimitives.gray50;
+
+  /// Figma: Colors/Background/bg-tertiary → Gray/100
+  static const Color bgTertiary = PregoColorPrimitives.gray100;
 
   /// Figma: Colors/Background/bg-warning-primary → Warning/50
   static const Color bgWarningPrimary = PregoColorPrimitives.warning50;
@@ -967,8 +973,8 @@ abstract final class PregoColorsLight {
   // Effects - Figma: Colors/Effects/*
   // ===========================================================================
 
-  /// Figma: Colors/Effects/Focus rings/focus-ring → Brand Blue/500
-  static const Color focusRing = PregoColorPrimitives.brandBlue500;
+  /// Figma: Colors/Effects/Focus rings/focus-ring → Blue/500
+  static const Color focusRing = PregoColorPrimitives.blue500;
 
   /// Figma: Colors/Effects/Focus rings/focus-ring-error → Error/500
   static const Color focusRingError = PregoColorPrimitives.error500;
@@ -1041,27 +1047,27 @@ abstract final class PregoColorsLight {
   /// Figma: Component colors/Components/Buttons/button-destructive-primary-icon_hover → Error/200
   static const Color buttonDestructivePrimaryIconHover = PregoColorPrimitives.error200;
 
-  /// Figma: Component colors/Components/Buttons/button-glass- primary-background → Gray (light mode alpha)/50
-  static const Color buttonGlassPrimaryBackground = PregoColorPrimitives.grayLightAlpha50;
+  /// Figma: Component colors/Components/Buttons/button-glass- primary-background → Alpha White/400
+  static const Color buttonGlassPrimaryBackground = PregoColorPrimitives.alphaWhite400;
 
-  /// Figma: Component colors/Components/Buttons/button-glass- primary-hover → Gray (light mode alpha)/100
-  static const Color buttonGlassPrimaryHover = PregoColorPrimitives.grayLightAlpha100;
+  /// Figma: Component colors/Components/Buttons/button-glass- primary-hover → Alpha Black/25
+  static const Color buttonGlassPrimaryHover = PregoColorPrimitives.alphaBlack25;
 
-  /// Figma: Component colors/Components/Buttons/button-primary-icon → Brand Blue/300
-  static const Color buttonPrimaryIcon = PregoColorPrimitives.brandBlue300;
+  /// Figma: Component colors/Components/Buttons/button-primary-icon → Blue/300
+  static const Color buttonPrimaryIcon = PregoColorPrimitives.blue300;
 
-  /// Figma: Component colors/Components/Buttons/button-primary-icon_hover → Brand Blue/200
-  static const Color buttonPrimaryIconHover = PregoColorPrimitives.brandBlue200;
+  /// Figma: Component colors/Components/Buttons/button-primary-icon_hover → Blue/200
+  static const Color buttonPrimaryIconHover = PregoColorPrimitives.blue200;
 
   // ===========================================================================
   // Component Colors - Icons
   // ===========================================================================
 
-  /// Figma: Component colors/Components/Icons/Icons/icon-fg-brand → Brand Blue/600
-  static const Color iconFgBrand = PregoColorPrimitives.brandBlue600;
+  /// Figma: Component colors/Components/Icons/Icons/icon-fg-brand → Blue/600
+  static const Color iconFgBrand = PregoColorPrimitives.blue600;
 
-  /// Figma: Component colors/Components/Icons/Icons/icon-fg-brand_on-brand → Brand Blue/200
-  static const Color iconFgBrandOnBrand = PregoColorPrimitives.brandBlue200;
+  /// Figma: Component colors/Components/Icons/Icons/icon-fg-brand_on-brand → Blue/200
+  static const Color iconFgBrandOnBrand = PregoColorPrimitives.blue200;
 
   // ===========================================================================
   // Component Colors - Alpha (mode-invariant)
@@ -1131,29 +1137,29 @@ abstract final class PregoColorsLight {
   // Utility Colors
   // ===========================================================================
 
-  /// Figma: Component colors/Utility/Blue/utility-blue-50 → Brand Blue/50
-  static const Color utilityBlue50 = PregoColorPrimitives.brandBlue50;
+  /// Figma: Component colors/Utility/Blue/utility-blue-50 → Blue/50
+  static const Color utilityBlue50 = PregoColorPrimitives.blue50;
 
-  /// Figma: Component colors/Utility/Blue/utility-blue-100 → Brand Blue/100
-  static const Color utilityBlue100 = PregoColorPrimitives.brandBlue100;
+  /// Figma: Component colors/Utility/Blue/utility-blue-100 → Blue/100
+  static const Color utilityBlue100 = PregoColorPrimitives.blue100;
 
-  /// Figma: Component colors/Utility/Blue/utility-blue-200 → Brand Blue/200
-  static const Color utilityBlue200 = PregoColorPrimitives.brandBlue200;
+  /// Figma: Component colors/Utility/Blue/utility-blue-200 → Blue/200
+  static const Color utilityBlue200 = PregoColorPrimitives.blue200;
 
-  /// Figma: Component colors/Utility/Blue/utility-blue-300 → Brand Blue/300
-  static const Color utilityBlue300 = PregoColorPrimitives.brandBlue300;
+  /// Figma: Component colors/Utility/Blue/utility-blue-300 → Blue/300
+  static const Color utilityBlue300 = PregoColorPrimitives.blue300;
 
-  /// Figma: Component colors/Utility/Blue/utility-blue-400 → Brand Blue/400
-  static const Color utilityBlue400 = PregoColorPrimitives.brandBlue400;
+  /// Figma: Component colors/Utility/Blue/utility-blue-400 → Blue/400
+  static const Color utilityBlue400 = PregoColorPrimitives.blue400;
 
-  /// Figma: Component colors/Utility/Blue/utility-blue-500 → Brand Blue/500
-  static const Color utilityBlue500 = PregoColorPrimitives.brandBlue500;
+  /// Figma: Component colors/Utility/Blue/utility-blue-500 → Blue/500
+  static const Color utilityBlue500 = PregoColorPrimitives.blue500;
 
-  /// Figma: Component colors/Utility/Blue/utility-blue-600 → Brand Blue/600
-  static const Color utilityBlue600 = PregoColorPrimitives.brandBlue600;
+  /// Figma: Component colors/Utility/Blue/utility-blue-600 → Blue/600
+  static const Color utilityBlue600 = PregoColorPrimitives.blue600;
 
-  /// Figma: Component colors/Utility/Blue/utility-blue-700 → Brand Blue/700
-  static const Color utilityBlue700 = PregoColorPrimitives.brandBlue700;
+  /// Figma: Component colors/Utility/Blue/utility-blue-700 → Blue/700
+  static const Color utilityBlue700 = PregoColorPrimitives.blue700;
 
   /// Figma: Component colors/Utility/Error/utility-error-50 → Error/50
   static const Color utilityError50 = PregoColorPrimitives.error50;
@@ -1234,20 +1240,20 @@ abstract final class PregoColorsLight {
   /// Figma: Component colors/Components/Avatars/avatar-styles-bg-neutral
   static const Color avatarStylesBgNeutral = Color(0xFFE0E0E0);
 
-  /// Figma: Component colors/Components/Icons/Hero Avatar/brand-gradient-bottom → Brand Blue/700
-  static const Color brandGradientBottom = PregoColorPrimitives.brandBlue700;
+  /// Figma: Component colors/Components/Icons/Hero Avatar/brand-gradient-bottom → Blue/700
+  static const Color brandGradientBottom = PregoColorPrimitives.blue700;
 
-  /// Figma: Component colors/Components/Icons/Hero Avatar/brand-gradient-top → Brand Blue/400
-  static const Color brandGradientTop = PregoColorPrimitives.brandBlue400;
+  /// Figma: Component colors/Components/Icons/Hero Avatar/brand-gradient-top → Blue/400
+  static const Color brandGradientTop = PregoColorPrimitives.blue400;
 
-  /// Figma: Component colors/Components/Icons/Featured icons/featured-icon-light-fg-brand → Brand Blue/600
-  static const Color featuredIconLightFgBrand = PregoColorPrimitives.brandBlue600;
+  /// Figma: Component colors/Components/Icons/Featured icons/featured-icon-light-fg-brand → Blue/600
+  static const Color featuredIconLightFgBrand = PregoColorPrimitives.blue600;
 
   /// Figma: Component colors/Components/Icons/Featured icons/featured-icon-light-fg-error → Error/600
   static const Color featuredIconLightFgError = PregoColorPrimitives.error600;
 
-  /// Figma: Component colors/Components/Icons/Featured icons/featured-icon-light-fg-gray → Gray (light mode)/500
-  static const Color featuredIconLightFgGray = PregoColorPrimitives.grayLight500;
+  /// Figma: Component colors/Components/Icons/Featured icons/featured-icon-light-fg-gray → Gray/500
+  static const Color featuredIconLightFgGray = PregoColorPrimitives.gray500;
 
   /// Figma: Component colors/Components/Icons/Featured icons/featured-icon-light-fg-success → Success/600
   static const Color featuredIconLightFgSuccess = PregoColorPrimitives.success600;
@@ -1273,11 +1279,11 @@ abstract final class PregoColorsLight {
   /// Figma: Component colors/Components/Icons/Hero Avatar/purple-gradient-top → Purple/300
   static const Color purpleGradientTop = PregoColorPrimitives.purple300;
 
-  /// Figma: Component colors/Components/Toggles/toggle-border → Gray (light mode)/300
-  static const Color toggleBorder = PregoColorPrimitives.grayLight300;
+  /// Figma: Component colors/Components/Toggles/toggle-border → Gray/950
+  static const Color toggleBorder = PregoColorPrimitives.gray950;
 
-  /// Figma: Component colors/Components/Toggles/toggle-button-fg_disabled → Gray (light mode)/50
-  static const Color toggleButtonFgDisabled = PregoColorPrimitives.grayLight50;
+  /// Figma: Component colors/Components/Toggles/toggle-button-fg_disabled → Gray/50
+  static const Color toggleButtonFgDisabled = PregoColorPrimitives.gray50;
 
   /// Figma: Component colors/Components/Toggles/toggle-slim-border_pressed → Background/bg-brand-solid
   static const Color toggleSlimBorderPressed = PregoColorsLight.bgBrandSolid;
@@ -1302,7 +1308,7 @@ abstract final class PregoColorsLight {
 /// )
 /// ```
 @immutable
-// ignore: use_enums
+// ignore: use_enums, theme token containers need class semantics and static dark/light singletons
 final class PregoColors {
   // ===========================================================================
   // Dark Mode - Figma: Color mode = Dark
@@ -1325,7 +1331,6 @@ final class PregoColors {
     textPrimaryOnBrand: PregoColorsDark.textPrimaryOnBrand,
     textPrimaryOnWhite: PregoColorsDark.textPrimaryOnWhite,
     textQuaternary: PregoColorsDark.textQuaternary,
-    textQuaternaryOnBrand: PregoColorsDark.textQuaternaryOnBrand,
     textSecondary: PregoColorsDark.textSecondary,
     textSecondaryHover: PregoColorsDark.textSecondaryHover,
     textSecondaryOnBrand: PregoColorsDark.textSecondaryOnBrand,
@@ -1337,7 +1342,6 @@ final class PregoColors {
     textWhite: PregoColorsDark.textWhite,
     // Border
     borderBrand: PregoColorsDark.borderBrand,
-    borderBrandAlt: PregoColorsDark.borderBrandAlt,
     borderDisabled: PregoColorsDark.borderDisabled,
     borderDisabledSubtle: PregoColorsDark.borderDisabledSubtle,
     borderError: PregoColorsDark.borderError,
@@ -1348,6 +1352,7 @@ final class PregoColors {
     borderReversed: PregoColorsDark.borderReversed,
     borderSecondary: PregoColorsDark.borderSecondary,
     borderSecondaryAlt: PregoColorsDark.borderSecondaryAlt,
+    borderSelected: PregoColorsDark.borderSelected,
     borderTertiary: PregoColorsDark.borderTertiary,
     // Foreground
     fgBrandPrimary: PregoColorsDark.fgBrandPrimary,
@@ -1396,7 +1401,6 @@ final class PregoColors {
     bgOverlay: PregoColorsDark.bgOverlay,
     bgPrimary: PregoColorsDark.bgPrimary,
     bgPrimarySolid: PregoColorsDark.bgPrimarySolid,
-    bgPrimaryAlt: PregoColorsDark.bgPrimaryAlt,
     bgQuaternary: PregoColorsDark.bgQuaternary,
     bgSecondary: PregoColorsDark.bgSecondary,
     bgSecondarySolid: PregoColorsDark.bgSecondarySolid,
@@ -1406,6 +1410,9 @@ final class PregoColors {
     bgSuccessPrimary: PregoColorsDark.bgSuccessPrimary,
     bgSuccessSecondary: PregoColorsDark.bgSuccessSecondary,
     bgSuccessSolid: PregoColorsDark.bgSuccessSolid,
+    bgSurface1: PregoColorsDark.bgSurface1,
+    bgSurface2: PregoColorsDark.bgSurface2,
+    bgSurface3: PregoColorsDark.bgSurface3,
     bgTertiary: PregoColorsDark.bgTertiary,
     bgWarningPrimary: PregoColorsDark.bgWarningPrimary,
     bgWarningSecondary: PregoColorsDark.bgWarningSecondary,
@@ -1536,7 +1543,6 @@ final class PregoColors {
     required this.textPrimaryOnBrand,
     required this.textPrimaryOnWhite,
     required this.textQuaternary,
-    required this.textQuaternaryOnBrand,
     required this.textSecondary,
     required this.textSecondaryHover,
     required this.textSecondaryOnBrand,
@@ -1548,7 +1554,6 @@ final class PregoColors {
     required this.textWhite,
     // Border
     required this.borderBrand,
-    required this.borderBrandAlt,
     required this.borderDisabled,
     required this.borderDisabledSubtle,
     required this.borderError,
@@ -1559,6 +1564,7 @@ final class PregoColors {
     required this.borderReversed,
     required this.borderSecondary,
     required this.borderSecondaryAlt,
+    required this.borderSelected,
     required this.borderTertiary,
     // Foreground
     required this.fgBrandPrimary,
@@ -1607,7 +1613,6 @@ final class PregoColors {
     required this.bgOverlay,
     required this.bgPrimary,
     required this.bgPrimarySolid,
-    required this.bgPrimaryAlt,
     required this.bgQuaternary,
     required this.bgSecondary,
     required this.bgSecondarySolid,
@@ -1617,6 +1622,9 @@ final class PregoColors {
     required this.bgSuccessPrimary,
     required this.bgSuccessSecondary,
     required this.bgSuccessSolid,
+    required this.bgSurface1,
+    required this.bgSurface2,
+    required this.bgSurface3,
     required this.bgTertiary,
     required this.bgWarningPrimary,
     required this.bgWarningSecondary,
@@ -1767,7 +1775,7 @@ final class PregoColors {
   /// Figma: Colors/Text/text-placeholder_subtle
   final Color textPlaceholderSubtle;
 
-  /// Figma: Colors/Text/text-primary (900)
+  /// Figma: Colors/Text/text-primary (950)
   final Color textPrimary;
 
   /// Figma: Colors/Text/text-primary_on-brand
@@ -1778,9 +1786,6 @@ final class PregoColors {
 
   /// Figma: Colors/Text/text-quaternary (500)
   final Color textQuaternary;
-
-  /// Figma: Colors/Text/text-quaternary_on-brand
-  final Color textQuaternaryOnBrand;
 
   /// Figma: Colors/Text/text-secondary (600)
   final Color textSecondary;
@@ -1794,7 +1799,7 @@ final class PregoColors {
   /// Figma: Colors/Text/text-success-primary (600)
   final Color textSuccessPrimary;
 
-  /// Figma: Colors/Text/text-tertiary (600)
+  /// Figma: Colors/Text/text-tertiary (450)
   final Color textTertiary;
 
   /// Figma: Colors/Text/text-tertiary_hover
@@ -1815,9 +1820,6 @@ final class PregoColors {
 
   /// Figma: Colors/Border/border-brand
   final Color borderBrand;
-
-  /// Figma: Colors/Border/border-brand_alt
-  final Color borderBrandAlt;
 
   /// Figma: Colors/Border/border-disabled
   final Color borderDisabled;
@@ -1848,6 +1850,9 @@ final class PregoColors {
 
   /// Figma: Colors/Border/border-secondary_alt
   final Color borderSecondaryAlt;
+
+  /// Figma: Colors/Border/border-selected
+  final Color borderSelected;
 
   /// Figma: Colors/Border/border-tertiary
   final Color borderTertiary;
@@ -1995,9 +2000,6 @@ final class PregoColors {
   /// Figma: Colors/Background/bg-primary-solid
   final Color bgPrimarySolid;
 
-  /// Figma: Colors/Background/bg-primary_alt
-  final Color bgPrimaryAlt;
-
   /// Figma: Colors/Background/bg-quaternary
   final Color bgQuaternary;
 
@@ -2024,6 +2026,15 @@ final class PregoColors {
 
   /// Figma: Colors/Background/bg-success-solid
   final Color bgSuccessSolid;
+
+  /// Figma: Colors/Background/bg-surface_1
+  final Color bgSurface1;
+
+  /// Figma: Colors/Background/bg-surface_2
+  final Color bgSurface2;
+
+  /// Figma: Colors/Background/bg-surface_3
+  final Color bgSurface3;
 
   /// Figma: Colors/Background/bg-tertiary
   final Color bgTertiary;
@@ -2386,7 +2397,6 @@ final class PregoColors {
     textPrimaryOnBrand: PregoColorsLight.textPrimaryOnBrand,
     textPrimaryOnWhite: PregoColorsLight.textPrimaryOnWhite,
     textQuaternary: PregoColorsLight.textQuaternary,
-    textQuaternaryOnBrand: PregoColorsLight.textQuaternaryOnBrand,
     textSecondary: PregoColorsLight.textSecondary,
     textSecondaryHover: PregoColorsLight.textSecondaryHover,
     textSecondaryOnBrand: PregoColorsLight.textSecondaryOnBrand,
@@ -2398,7 +2408,6 @@ final class PregoColors {
     textWhite: PregoColorsLight.textWhite,
     // Border
     borderBrand: PregoColorsLight.borderBrand,
-    borderBrandAlt: PregoColorsLight.borderBrandAlt,
     borderDisabled: PregoColorsLight.borderDisabled,
     borderDisabledSubtle: PregoColorsLight.borderDisabledSubtle,
     borderError: PregoColorsLight.borderError,
@@ -2409,6 +2418,7 @@ final class PregoColors {
     borderReversed: PregoColorsLight.borderReversed,
     borderSecondary: PregoColorsLight.borderSecondary,
     borderSecondaryAlt: PregoColorsLight.borderSecondaryAlt,
+    borderSelected: PregoColorsLight.borderSelected,
     borderTertiary: PregoColorsLight.borderTertiary,
     // Foreground
     fgBrandPrimary: PregoColorsLight.fgBrandPrimary,
@@ -2457,7 +2467,6 @@ final class PregoColors {
     bgOverlay: PregoColorsLight.bgOverlay,
     bgPrimary: PregoColorsLight.bgPrimary,
     bgPrimarySolid: PregoColorsLight.bgPrimarySolid,
-    bgPrimaryAlt: PregoColorsLight.bgPrimaryAlt,
     bgQuaternary: PregoColorsLight.bgQuaternary,
     bgSecondary: PregoColorsLight.bgSecondary,
     bgSecondarySolid: PregoColorsLight.bgSecondarySolid,
@@ -2467,6 +2476,9 @@ final class PregoColors {
     bgSuccessPrimary: PregoColorsLight.bgSuccessPrimary,
     bgSuccessSecondary: PregoColorsLight.bgSuccessSecondary,
     bgSuccessSolid: PregoColorsLight.bgSuccessSolid,
+    bgSurface1: PregoColorsLight.bgSurface1,
+    bgSurface2: PregoColorsLight.bgSurface2,
+    bgSurface3: PregoColorsLight.bgSurface3,
     bgTertiary: PregoColorsLight.bgTertiary,
     bgWarningPrimary: PregoColorsLight.bgWarningPrimary,
     bgWarningSecondary: PregoColorsLight.bgWarningSecondary,
@@ -2597,7 +2609,6 @@ final class PregoColors {
     textPrimaryOnBrand: lerpColorNonNull(a.textPrimaryOnBrand, b.textPrimaryOnBrand, t),
     textPrimaryOnWhite: lerpColorNonNull(a.textPrimaryOnWhite, b.textPrimaryOnWhite, t),
     textQuaternary: lerpColorNonNull(a.textQuaternary, b.textQuaternary, t),
-    textQuaternaryOnBrand: lerpColorNonNull(a.textQuaternaryOnBrand, b.textQuaternaryOnBrand, t),
     textSecondary: lerpColorNonNull(a.textSecondary, b.textSecondary, t),
     textSecondaryHover: lerpColorNonNull(a.textSecondaryHover, b.textSecondaryHover, t),
     textSecondaryOnBrand: lerpColorNonNull(a.textSecondaryOnBrand, b.textSecondaryOnBrand, t),
@@ -2609,7 +2620,6 @@ final class PregoColors {
     textWhite: lerpColorNonNull(a.textWhite, b.textWhite, t),
     // Border
     borderBrand: lerpColorNonNull(a.borderBrand, b.borderBrand, t),
-    borderBrandAlt: lerpColorNonNull(a.borderBrandAlt, b.borderBrandAlt, t),
     borderDisabled: lerpColorNonNull(a.borderDisabled, b.borderDisabled, t),
     borderDisabledSubtle: lerpColorNonNull(a.borderDisabledSubtle, b.borderDisabledSubtle, t),
     borderError: lerpColorNonNull(a.borderError, b.borderError, t),
@@ -2620,6 +2630,7 @@ final class PregoColors {
     borderReversed: lerpColorNonNull(a.borderReversed, b.borderReversed, t),
     borderSecondary: lerpColorNonNull(a.borderSecondary, b.borderSecondary, t),
     borderSecondaryAlt: lerpColorNonNull(a.borderSecondaryAlt, b.borderSecondaryAlt, t),
+    borderSelected: lerpColorNonNull(a.borderSelected, b.borderSelected, t),
     borderTertiary: lerpColorNonNull(a.borderTertiary, b.borderTertiary, t),
     // Foreground
     fgBrandPrimary: lerpColorNonNull(a.fgBrandPrimary, b.fgBrandPrimary, t),
@@ -2668,7 +2679,6 @@ final class PregoColors {
     bgOverlay: lerpColorNonNull(a.bgOverlay, b.bgOverlay, t),
     bgPrimary: lerpColorNonNull(a.bgPrimary, b.bgPrimary, t),
     bgPrimarySolid: lerpColorNonNull(a.bgPrimarySolid, b.bgPrimarySolid, t),
-    bgPrimaryAlt: lerpColorNonNull(a.bgPrimaryAlt, b.bgPrimaryAlt, t),
     bgQuaternary: lerpColorNonNull(a.bgQuaternary, b.bgQuaternary, t),
     bgSecondary: lerpColorNonNull(a.bgSecondary, b.bgSecondary, t),
     bgSecondarySolid: lerpColorNonNull(a.bgSecondarySolid, b.bgSecondarySolid, t),
@@ -2678,6 +2688,9 @@ final class PregoColors {
     bgSuccessPrimary: lerpColorNonNull(a.bgSuccessPrimary, b.bgSuccessPrimary, t),
     bgSuccessSecondary: lerpColorNonNull(a.bgSuccessSecondary, b.bgSuccessSecondary, t),
     bgSuccessSolid: lerpColorNonNull(a.bgSuccessSolid, b.bgSuccessSolid, t),
+    bgSurface1: lerpColorNonNull(a.bgSurface1, b.bgSurface1, t),
+    bgSurface2: lerpColorNonNull(a.bgSurface2, b.bgSurface2, t),
+    bgSurface3: lerpColorNonNull(a.bgSurface3, b.bgSurface3, t),
     bgTertiary: lerpColorNonNull(a.bgTertiary, b.bgTertiary, t),
     bgWarningPrimary: lerpColorNonNull(a.bgWarningPrimary, b.bgWarningPrimary, t),
     bgWarningSecondary: lerpColorNonNull(a.bgWarningSecondary, b.bgWarningSecondary, t),
@@ -2708,7 +2721,11 @@ final class PregoColors {
     shadowXs: lerpColorNonNull(a.shadowXs, b.shadowXs, t),
     // Buttons
     buttonDestructivePrimaryIcon: lerpColorNonNull(a.buttonDestructivePrimaryIcon, b.buttonDestructivePrimaryIcon, t),
-    buttonDestructivePrimaryIconHover: lerpColorNonNull(a.buttonDestructivePrimaryIconHover, b.buttonDestructivePrimaryIconHover, t),
+    buttonDestructivePrimaryIconHover: lerpColorNonNull(
+      a.buttonDestructivePrimaryIconHover,
+      b.buttonDestructivePrimaryIconHover,
+      t,
+    ),
     buttonGlassPrimaryBackground: lerpColorNonNull(a.buttonGlassPrimaryBackground, b.buttonGlassPrimaryBackground, t),
     buttonGlassPrimaryHover: lerpColorNonNull(a.buttonGlassPrimaryHover, b.buttonGlassPrimaryHover, t),
     buttonPrimaryIcon: lerpColorNonNull(a.buttonPrimaryIcon, b.buttonPrimaryIcon, t),

--- a/mobile/module_prego/lib/theme/primitives/prego_colors_x.dart
+++ b/mobile/module_prego/lib/theme/primitives/prego_colors_x.dart
@@ -35,7 +35,7 @@ extension PregoColorsX on PregoColors {
     onError: brightness == .light ? fgWhite : bgErrorPrimary,
     onErrorContainer: brightness == .light ? fgWhite : textErrorPrimaryHover,
     surface: bgPrimary,
-    surfaceContainer: brightness == .light ? bgSecondary : bgPrimaryAlt,
+    surfaceContainer: bgSecondary,
     surfaceContainerHighest: brightness == .light ? bgQuaternary : bgTertiary,
     onSurface: textPrimary,
     onSurfaceVariant: brightness == .light ? textTertiary : textSecondary,

--- a/mobile/module_prego/scripts/figma_tokens/FIGMA_TOKEN_SYNC.md
+++ b/mobile/module_prego/scripts/figma_tokens/FIGMA_TOKEN_SYNC.md
@@ -4,7 +4,7 @@ Extracts design token variables (colors, spacing, radius, dimensions) from the F
 
 ## Prerequisites
 
-- Access to the VESPR Figma Design System file (file key: `8CQtJDHrN4nxfTPlmCxK9B`)
+- Access to the VESPR Figma Design System file (file key: `DTKWZawsS3zfA7TPA4OlGr`)
 - Figma Desktop app (for plugin console access)
 
 ## Step 1: Export variables from Figma
@@ -12,7 +12,7 @@ Extracts design token variables (colors, spacing, radius, dimensions) from the F
 The Figma REST API's `/variables/local` endpoint requires an Enterprise plan. Since we're on Pro, we use the Figma Plugin API via the console instead.
 
 1. Open the Design System file in **Figma Desktop**
-2. Go to **Plugins > Development > Open console**
+2. Go to **Plugins > Development > Show/Hide console**
 3. Paste and run the following script:
 
 ```js

--- a/mobile/module_prego/scripts/figma_tokens/figma_tokens.json
+++ b/mobile/module_prego/scripts/figma_tokens/figma_tokens.json
@@ -32,7 +32,7 @@
         }
       },
       {
-        "name": "Colors/Base/transparent",
+        "name": "Colors/Base/transparent white",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -56,7 +56,7 @@
         }
       },
       {
-        "name": "Colors/Gray (light mode)/25",
+        "name": "Colors/Gray/25",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -68,19 +68,19 @@
         }
       },
       {
-        "name": "Colors/Gray (light mode)/50",
+        "name": "Colors/Gray/50",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
-            "r": 0.9801960587501526,
-            "g": 0.9803071618080139,
-            "b": 0.9805882573127747,
+            "r": 0.9900000095367432,
+            "g": 0.9900000095367432,
+            "b": 0.9900000095367432,
             "a": 1
           }
         }
       },
       {
-        "name": "Colors/Gray (light mode)/100",
+        "name": "Colors/Gray/100",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -92,259 +92,163 @@
         }
       },
       {
-        "name": "Colors/Gray (light mode)/200",
+        "name": "Colors/Gray/200",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
-            "r": 0.9137254953384399,
-            "g": 0.9163398742675781,
-            "b": 0.9215686321258545,
+            "r": 0.9411764740943909,
+            "g": 0.9411764740943909,
+            "b": 0.9411764740943909,
             "a": 1
           }
         }
       },
       {
-        "name": "Colors/Gray (light mode)/300",
+        "name": "Colors/Gray/300",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
-            "r": 0.8358039259910583,
-            "g": 0.8420000076293945,
-            "b": 0.8543921709060669,
+            "r": 0.9038461446762085,
+            "g": 0.9038461446762085,
+            "b": 0.9038461446762085,
             "a": 1
           }
         }
       },
       {
-        "name": "Colors/Gray (light mode)/400",
+        "name": "Colors/Gray/350",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
-            "r": 0.6425098180770874,
-            "g": 0.656000018119812,
+            "r": 0.8600000143051147,
+            "g": 0.8600000143051147,
+            "b": 0.8600000143051147,
+            "a": 1
+          }
+        }
+      },
+      {
+        "name": "Colors/Gray/400",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:0": {
+            "r": 0.6829804182052612,
+            "g": 0.6829804182052612,
             "b": 0.6829804182052612,
             "a": 1
           }
         }
       },
       {
-        "name": "Colors/Gray (light mode)/500",
+        "name": "Colors/Gray/425",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
-            "r": 0.4431372582912445,
-            "g": 0.4627451002597809,
-            "b": 0.501960813999176,
+            "r": 0.6000000238418579,
+            "g": 0.6000000238418579,
+            "b": 0.6000000238418579,
             "a": 1
           }
         }
       },
       {
-        "name": "Colors/Gray (light mode)/600",
+        "name": "Colors/Gray/450",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
-            "r": 0.3265098035335541,
-            "g": 0.3454379141330719,
-            "b": 0.38329413533210754,
+            "r": 0.550000011920929,
+            "g": 0.550000011920929,
+            "b": 0.550000011920929,
             "a": 1
           }
         }
       },
       {
-        "name": "Colors/Gray (light mode)/700",
+        "name": "Colors/Gray/525",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
-            "r": 0.2549019753932953,
-            "g": 0.27581700682640076,
-            "b": 0.3176470696926117,
+            "r": 0.4313725531101227,
+            "g": 0.4313725531101227,
+            "b": 0.4313725531101227,
             "a": 1
           }
         }
       },
       {
-        "name": "Colors/Gray (light mode)/800",
+        "name": "Colors/Gray/500",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
-            "r": 0.15333333611488342,
-            "g": 0.17137254774570465,
-            "b": 0.2074509859085083,
+            "r": 0.23999999463558197,
+            "g": 0.23999999463558197,
+            "b": 0.23999999463558197,
             "a": 1
           }
         }
       },
       {
-        "name": "Colors/Gray (light mode)/900",
+        "name": "Colors/Gray/600",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
-            "r": 0.09882353246212006,
-            "g": 0.11529411375522614,
-            "b": 0.14823530614376068,
+            "r": 0.1764705926179886,
+            "g": 0.1764705926179886,
+            "b": 0.1764705926179886,
             "a": 1
           }
         }
       },
       {
-        "name": "Colors/Gray (light mode)/950",
+        "name": "Colors/Gray/700",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
-            "r": 0.04172549024224281,
-            "g": 0.05050980672240257,
-            "b": 0.0680784359574318,
+            "r": 0.1411764770746231,
+            "g": 0.1411764770746231,
+            "b": 0.1411764770746231,
             "a": 1
           }
         }
       },
       {
-        "name": "Colors/Gray (dark mode)/25",
+        "name": "Colors/Gray/800",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
-            "r": 0.9495000243186951,
-            "g": 0.9498999714851379,
-            "b": 0.9505000114440918,
+            "r": 0.1411764770746231,
+            "g": 0.1411764770746231,
+            "b": 0.1411764770746231,
             "a": 1
           }
         }
       },
       {
-        "name": "Colors/Gray (dark mode)/50",
+        "name": "Colors/Gray/900",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
-            "r": 0.8867000341415405,
-            "g": 0.8893397450447083,
-            "b": 0.8932999968528748,
+            "r": 0.0941176488995552,
+            "g": 0.0941176488995552,
+            "b": 0.0941176488995552,
             "a": 1
           }
         }
       },
       {
-        "name": "Colors/Gray (dark mode)/100",
+        "name": "Colors/Gray/950",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
-            "r": 0.8104490041732788,
-            "g": 0.8180897831916809,
-            "b": 0.8295510411262512,
+            "r": 0.048114482313394547,
+            "g": 0.048114482313394547,
+            "b": 0.048114482313394547,
             "a": 1
           }
         }
       },
       {
-        "name": "Colors/Gray (dark mode)/200",
-        "resolvedType": "COLOR",
-        "valuesByMode": {
-          "75:0": {
-            "r": 0.7472652792930603,
-            "g": 0.7574530243873596,
-            "b": 0.7727347016334534,
-            "a": 1
-          }
-        }
-      },
-      {
-        "name": "Colors/Gray (dark mode)/300",
-        "resolvedType": "COLOR",
-        "valuesByMode": {
-          "75:0": {
-            "r": 0.6840816736221313,
-            "g": 0.6968162655830383,
-            "b": 0.7159183621406555,
-            "a": 1
-          }
-        }
-      },
-      {
-        "name": "Colors/Gray (dark mode)/400",
-        "resolvedType": "COLOR",
-        "valuesByMode": {
-          "75:0": {
-            "r": 0.5998367071151733,
-            "g": 0.615967333316803,
-            "b": 0.6401633024215698,
-            "a": 1
-          }
-        }
-      },
-      {
-        "name": "Colors/Gray (dark mode)/500",
-        "resolvedType": "COLOR",
-        "valuesByMode": {
-          "75:0": {
-            "r": 0.4930841028690338,
-            "g": 0.514616847038269,
-            "b": 0.5469158887863159,
-            "a": 1
-          }
-        }
-      },
-      {
-        "name": "Colors/Gray (dark mode)/600",
-        "resolvedType": "COLOR",
-        "valuesByMode": {
-          "75:0": {
-            "r": 0.39680981636047363,
-            "g": 0.4153619706630707,
-            "b": 0.44319018721580505,
-            "a": 1
-          }
-        }
-      },
-      {
-        "name": "Colors/Gray (dark mode)/700",
-        "resolvedType": "COLOR",
-        "valuesByMode": {
-          "75:0": {
-            "r": 0.3028571307659149,
-            "g": 0.316571444272995,
-            "b": 0.33714285492897034,
-            "a": 1
-          }
-        }
-      },
-      {
-        "name": "Colors/Gray (dark mode)/800",
-        "resolvedType": "COLOR",
-        "valuesByMode": {
-          "75:0": {
-            "r": 0.19016394019126892,
-            "g": 0.19803278148174286,
-            "b": 0.20983606576919556,
-            "a": 1
-          }
-        }
-      },
-      {
-        "name": "Colors/Gray (dark mode)/900",
-        "resolvedType": "COLOR",
-        "valuesByMode": {
-          "75:0": {
-            "r": 0.09400000423192978,
-            "g": 0.09879999607801437,
-            "b": 0.10599999874830246,
-            "a": 1
-          }
-        }
-      },
-      {
-        "name": "Colors/Gray (dark mode)/950",
-        "resolvedType": "COLOR",
-        "valuesByMode": {
-          "75:0": {
-            "r": 0.0117647061124444,
-            "g": 0.01568627543747425,
-            "b": 0.019607843831181526,
-            "a": 1
-          }
-        }
-      },
-      {
-        "name": "Colors/Gray (dark mode alpha)/25",
+        "name": "Colors/Alpha White/25",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -356,7 +260,7 @@
         }
       },
       {
-        "name": "Colors/Gray (dark mode alpha)/50",
+        "name": "Colors/Alpha White/50",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -368,7 +272,7 @@
         }
       },
       {
-        "name": "Colors/Gray (dark mode alpha)/100",
+        "name": "Colors/Alpha White/100",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -380,7 +284,7 @@
         }
       },
       {
-        "name": "Colors/Gray (dark mode alpha)/200",
+        "name": "Colors/Alpha White/200",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -392,7 +296,7 @@
         }
       },
       {
-        "name": "Colors/Gray (dark mode alpha)/300",
+        "name": "Colors/Alpha White/300",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -404,7 +308,7 @@
         }
       },
       {
-        "name": "Colors/Gray (dark mode alpha)/400",
+        "name": "Colors/Alpha White/400",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -416,7 +320,7 @@
         }
       },
       {
-        "name": "Colors/Gray (dark mode alpha)/500",
+        "name": "Colors/Alpha White/500",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -428,7 +332,7 @@
         }
       },
       {
-        "name": "Colors/Gray (dark mode alpha)/600",
+        "name": "Colors/Alpha White/600",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -440,7 +344,7 @@
         }
       },
       {
-        "name": "Colors/Gray (dark mode alpha)/700",
+        "name": "Colors/Alpha White/700",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -452,7 +356,7 @@
         }
       },
       {
-        "name": "Colors/Gray (dark mode alpha)/800",
+        "name": "Colors/Alpha White/800",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -464,7 +368,7 @@
         }
       },
       {
-        "name": "Colors/Gray (dark mode alpha)/900",
+        "name": "Colors/Alpha White/900",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -476,7 +380,7 @@
         }
       },
       {
-        "name": "Colors/Gray (dark mode alpha)/950",
+        "name": "Colors/Alpha White/950",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -488,7 +392,7 @@
         }
       },
       {
-        "name": "Colors/Gray (light mode alpha)/25",
+        "name": "Colors/Alpha Black/25",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -500,7 +404,7 @@
         }
       },
       {
-        "name": "Colors/Gray (light mode alpha)/50",
+        "name": "Colors/Alpha Black/50",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -512,7 +416,7 @@
         }
       },
       {
-        "name": "Colors/Gray (light mode alpha)/100",
+        "name": "Colors/Alpha Black/100",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -524,7 +428,7 @@
         }
       },
       {
-        "name": "Colors/Gray (light mode alpha)/200",
+        "name": "Colors/Alpha Black/200",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -536,7 +440,7 @@
         }
       },
       {
-        "name": "Colors/Gray (light mode alpha)/300",
+        "name": "Colors/Alpha Black/300",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -548,7 +452,7 @@
         }
       },
       {
-        "name": "Colors/Gray (light mode alpha)/400",
+        "name": "Colors/Alpha Black/400",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -560,7 +464,7 @@
         }
       },
       {
-        "name": "Colors/Gray (light mode alpha)/500",
+        "name": "Colors/Alpha Black/500",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -572,7 +476,7 @@
         }
       },
       {
-        "name": "Colors/Gray (light mode alpha)/600",
+        "name": "Colors/Alpha Black/600",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -584,7 +488,7 @@
         }
       },
       {
-        "name": "Colors/Gray (light mode alpha)/700",
+        "name": "Colors/Alpha Black/700",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -596,7 +500,7 @@
         }
       },
       {
-        "name": "Colors/Gray (light mode alpha)/800",
+        "name": "Colors/Alpha Black/800",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -608,7 +512,7 @@
         }
       },
       {
-        "name": "Colors/Gray (light mode alpha)/900",
+        "name": "Colors/Alpha Black/900",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -620,7 +524,7 @@
         }
       },
       {
-        "name": "Colors/Gray (light mode alpha)/950",
+        "name": "Colors/Alpha Black/950",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -632,7 +536,163 @@
         }
       },
       {
-        "name": "Colors/Brand Blue/25",
+        "name": "Colors/Alpha Gray/25",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:0": {
+            "r": 0.9901961088180542,
+            "g": 0.9901961088180542,
+            "b": 0.9901961088180542,
+            "a": 0
+          }
+        }
+      },
+      {
+        "name": "Colors/Alpha Gray/50",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:0": {
+            "r": 0.9900000095367432,
+            "g": 0.9900000095367432,
+            "b": 0.9900000095367432,
+            "a": 0
+          }
+        }
+      },
+      {
+        "name": "Colors/Alpha Gray/100",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:0": {
+            "r": 0.96039217710495,
+            "g": 0.9606797695159912,
+            "b": 0.9611764550209045,
+            "a": 0
+          }
+        }
+      },
+      {
+        "name": "Colors/Alpha Gray/200",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:0": {
+            "r": 0.9411764740943909,
+            "g": 0.9411764740943909,
+            "b": 0.9411764740943909,
+            "a": 0
+          }
+        }
+      },
+      {
+        "name": "Colors/Alpha Gray/300",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:0": {
+            "r": 0.9038461446762085,
+            "g": 0.9038461446762085,
+            "b": 0.9038461446762085,
+            "a": 0
+          }
+        }
+      },
+      {
+        "name": "Colors/Alpha Gray/350",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:0": {
+            "r": 0.8600000143051147,
+            "g": 0.8600000143051147,
+            "b": 0.8600000143051147,
+            "a": 0
+          }
+        }
+      },
+      {
+        "name": "Colors/Alpha Gray/400",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:0": {
+            "r": 0.6829804182052612,
+            "g": 0.6829804182052612,
+            "b": 0.6829804182052612,
+            "a": 0
+          }
+        }
+      },
+      {
+        "name": "Colors/Alpha Gray/500",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:0": {
+            "r": 0.23999999463558197,
+            "g": 0.23999999463558197,
+            "b": 0.23999999463558197,
+            "a": 0
+          }
+        }
+      },
+      {
+        "name": "Colors/Alpha Gray/600",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:0": {
+            "r": 0.1764705926179886,
+            "g": 0.1764705926179886,
+            "b": 0.1764705926179886,
+            "a": 0
+          }
+        }
+      },
+      {
+        "name": "Colors/Alpha Gray/700",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:0": {
+            "r": 0.1411764770746231,
+            "g": 0.1411764770746231,
+            "b": 0.1411764770746231,
+            "a": 0
+          }
+        }
+      },
+      {
+        "name": "Colors/Alpha Gray/800",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:0": {
+            "r": 0.1411764770746231,
+            "g": 0.1411764770746231,
+            "b": 0.1411764770746231,
+            "a": 0
+          }
+        }
+      },
+      {
+        "name": "Colors/Alpha Gray/900",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:0": {
+            "r": 0.0941176488995552,
+            "g": 0.0941176488995552,
+            "b": 0.0941176488995552,
+            "a": 0
+          }
+        }
+      },
+      {
+        "name": "Colors/Alpha Gray/950",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:0": {
+            "r": 0.048114482313394547,
+            "g": 0.048114482313394547,
+            "b": 0.048114482313394547,
+            "a": 0
+          }
+        }
+      },
+      {
+        "name": "Colors/Blue/25",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -644,7 +704,7 @@
         }
       },
       {
-        "name": "Colors/Brand Blue/50",
+        "name": "Colors/Blue/50",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -656,7 +716,7 @@
         }
       },
       {
-        "name": "Colors/Brand Blue/100",
+        "name": "Colors/Blue/100",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -668,7 +728,7 @@
         }
       },
       {
-        "name": "Colors/Brand Blue/200",
+        "name": "Colors/Blue/200",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -680,7 +740,7 @@
         }
       },
       {
-        "name": "Colors/Brand Blue/300",
+        "name": "Colors/Blue/300",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -692,7 +752,7 @@
         }
       },
       {
-        "name": "Colors/Brand Blue/400",
+        "name": "Colors/Blue/400",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -704,7 +764,7 @@
         }
       },
       {
-        "name": "Colors/Brand Blue/500",
+        "name": "Colors/Blue/500",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -716,7 +776,7 @@
         }
       },
       {
-        "name": "Colors/Brand Blue/600",
+        "name": "Colors/Blue/600",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -728,7 +788,7 @@
         }
       },
       {
-        "name": "Colors/Brand Blue/700",
+        "name": "Colors/Blue/700",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -740,7 +800,7 @@
         }
       },
       {
-        "name": "Colors/Brand Blue/800",
+        "name": "Colors/Blue/800",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -752,7 +812,7 @@
         }
       },
       {
-        "name": "Colors/Brand Blue/900",
+        "name": "Colors/Blue/900",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -764,7 +824,7 @@
         }
       },
       {
-        "name": "Colors/Brand Blue/950",
+        "name": "Colors/Blue/950",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:0": {
@@ -1590,27 +1650,87 @@
     ],
     "variables": [
       {
-        "name": "Colors/Text/text-primary (900)",
+        "name": "Colors/Text/text-primary (950)",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.04172549024224281,
-            "g": 0.05050980672240257,
-            "b": 0.0680784359574318,
+            "r": 0.048114482313394547,
+            "g": 0.048114482313394547,
+            "b": 0.048114482313394547,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/950"
+            "_alias": "Colors/Gray/950"
           },
           "75:4": {
-            "r": 0.9495000243186951,
-            "g": 0.9498999714851379,
-            "b": 0.9505000114440918,
+            "r": 0.9901961088180542,
+            "g": 0.9901961088180542,
+            "b": 0.9901961088180542,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/25"
+            "_alias": "Colors/Gray/25"
+          }
+        }
+      },
+      {
+        "name": "Colors/Text/text-secondary (600)",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:2": {
+            "r": 0.23999999463558197,
+            "g": 0.23999999463558197,
+            "b": 0.23999999463558197,
+            "a": 1,
+            "_alias": "Colors/Gray/500"
+          },
+          "75:4": {
+            "r": 0.6829804182052612,
+            "g": 0.6829804182052612,
+            "b": 0.6829804182052612,
+            "a": 1,
+            "_alias": "Colors/Gray/400"
+          }
+        }
+      },
+      {
+        "name": "Colors/Text/text-tertiary (450)",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:2": {
+            "r": 0.4313725531101227,
+            "g": 0.4313725531101227,
+            "b": 0.4313725531101227,
+            "a": 1,
+            "_alias": "Colors/Gray/525"
+          },
+          "75:4": {
+            "r": 0.550000011920929,
+            "g": 0.550000011920929,
+            "b": 0.550000011920929,
+            "a": 1,
+            "_alias": "Colors/Gray/450"
           }
         }
       },
       {
         "name": "Colors/Text/text-primary_on-brand",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:2": {
+            "r": 0.07999999821186066,
+            "g": 0.44799986481666565,
+            "b": 1,
+            "a": 1,
+            "_alias": "Colors/Blue/500"
+          },
+          "75:4": {
+            "r": 0.5,
+            "g": 0.6999999284744263,
+            "b": 1,
+            "a": 1,
+            "_alias": "Colors/Blue/300"
+          }
+        }
+      },
+      {
+        "name": "Colors/Text/text-primary_on-white",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
@@ -1621,49 +1741,11 @@
             "_alias": "Colors/Base/white"
           },
           "75:4": {
-            "r": 0.8867000341415405,
-            "g": 0.8893397450447083,
-            "b": 0.8932999968528748,
+            "r": 0,
+            "g": 0,
+            "b": 0,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/50"
-          }
-        }
-      },
-      {
-        "name": "Colors/Text/text-primary_on-white",
-        "resolvedType": "COLOR",
-        "valuesByMode": {
-          "75:2": {
-            "r": 0.03921568766236305,
-            "g": 0.04967320337891579,
-            "b": 0.07058823853731155,
-            "a": 1
-          },
-          "75:4": {
-            "r": 0.03921568766236305,
-            "g": 0.05098039284348488,
-            "b": 0.07058823853731155,
-            "a": 1
-          }
-        }
-      },
-      {
-        "name": "Colors/Text/text-secondary (600)",
-        "resolvedType": "COLOR",
-        "valuesByMode": {
-          "75:2": {
-            "r": 0.2549019753932953,
-            "g": 0.27581700682640076,
-            "b": 0.3176470696926117,
-            "a": 1,
-            "_alias": "Colors/Gray (light mode)/700"
-          },
-          "75:4": {
-            "r": 0.5998367071151733,
-            "g": 0.615967333316803,
-            "b": 0.6401633024215698,
-            "a": 1,
-            "_alias": "Colors/Gray (dark mode)/400"
+            "_alias": "Colors/Base/black"
           }
         }
       },
@@ -1679,11 +1761,11 @@
             "_alias": "Colors/Gray (light mode)/800"
           },
           "75:4": {
-            "r": 0.7472652792930603,
-            "g": 0.7574530243873596,
-            "b": 0.7727347016334534,
+            "r": 0.550000011920929,
+            "g": 0.550000011920929,
+            "b": 0.550000011920929,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/200"
+            "_alias": "Colors/Gray/450"
           }
         }
       },
@@ -1696,7 +1778,7 @@
             "g": 0.5799999237060547,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/400"
+            "_alias": "Colors/Blue/400"
           },
           "75:4": {
             "r": 1,
@@ -1708,42 +1790,22 @@
         }
       },
       {
-        "name": "Colors/Text/text-tertiary (600)",
-        "resolvedType": "COLOR",
-        "valuesByMode": {
-          "75:2": {
-            "r": 0.3265098035335541,
-            "g": 0.3454379141330719,
-            "b": 0.38329413533210754,
-            "a": 1,
-            "_alias": "Colors/Gray (light mode)/600"
-          },
-          "75:4": {
-            "r": 0.6425098180770874,
-            "g": 0.656000018119812,
-            "b": 0.6829804182052612,
-            "a": 1,
-            "_alias": "Colors/Gray (light mode)/400"
-          }
-        }
-      },
-      {
         "name": "Colors/Text/text-tertiary_hover",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.2549019753932953,
-            "g": 0.27581700682640076,
-            "b": 0.3176470696926117,
+            "r": 0.1411764770746231,
+            "g": 0.1411764770746231,
+            "b": 0.1411764770746231,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/700"
+            "_alias": "Colors/Gray/700"
           },
           "75:4": {
-            "r": 0.6840816736221313,
-            "g": 0.6968162655830383,
-            "b": 0.7159183621406555,
+            "r": 0.6000000238418579,
+            "g": 0.6000000238418579,
+            "b": 0.6000000238418579,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/300"
+            "_alias": "Colors/Gray/425"
           }
         }
       },
@@ -1756,14 +1818,14 @@
             "g": 0.8199999332427979,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/200"
+            "_alias": "Colors/Blue/200"
           },
           "75:4": {
-            "r": 0.5998367071151733,
-            "g": 0.615967333316803,
-            "b": 0.6401633024215698,
+            "r": 0.30000001192092896,
+            "g": 0.5799999237060547,
+            "b": 1,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/400"
+            "_alias": "Colors/Blue/400"
           }
         }
       },
@@ -1779,31 +1841,11 @@
             "_alias": "Colors/Gray (light mode)/400"
           },
           "75:4": {
-            "r": 0.5998367071151733,
-            "g": 0.615967333316803,
-            "b": 0.6401633024215698,
+            "r": 0.23999999463558197,
+            "g": 0.23999999463558197,
+            "b": 0.23999999463558197,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/400"
-          }
-        }
-      },
-      {
-        "name": "Colors/Text/text-quaternary_on-brand",
-        "resolvedType": "COLOR",
-        "valuesByMode": {
-          "75:2": {
-            "r": 0.5,
-            "g": 0.6999999284744263,
-            "b": 1,
-            "a": 1,
-            "_alias": "Colors/Brand Blue/300"
-          },
-          "75:4": {
-            "r": 0.5998367071151733,
-            "g": 0.615967333316803,
-            "b": 0.6401633024215698,
-            "a": 1,
-            "_alias": "Colors/Gray (dark mode)/400"
+            "_alias": "Colors/Gray/500"
           }
         }
       },
@@ -1832,18 +1874,18 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.4431372582912445,
-            "g": 0.4627451002597809,
-            "b": 0.501960813999176,
+            "r": 0.6829804182052612,
+            "g": 0.6829804182052612,
+            "b": 0.6829804182052612,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/500"
+            "_alias": "Colors/Gray/400"
           },
           "75:4": {
-            "r": 0.4930841028690338,
-            "g": 0.514616847038269,
-            "b": 0.5469158887863159,
+            "r": 0.23999999463558197,
+            "g": 0.23999999463558197,
+            "b": 0.23999999463558197,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/500"
+            "_alias": "Colors/Gray/500"
           }
         }
       },
@@ -1852,18 +1894,18 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.6425098180770874,
-            "g": 0.656000018119812,
+            "r": 0.6829804182052612,
+            "g": 0.6829804182052612,
             "b": 0.6829804182052612,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/400"
+            "_alias": "Colors/Gray/400"
           },
           "75:4": {
-            "r": 0.39680981636047363,
-            "g": 0.4153619706630707,
-            "b": 0.44319018721580505,
+            "r": 0.1764705926179886,
+            "g": 0.1764705926179886,
+            "b": 0.1764705926179886,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/600"
+            "_alias": "Colors/Gray/600"
           }
         }
       },
@@ -1872,18 +1914,18 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.8358039259910583,
-            "g": 0.8420000076293945,
-            "b": 0.8543921709060669,
+            "r": 0.9038461446762085,
+            "g": 0.9038461446762085,
+            "b": 0.9038461446762085,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/300"
+            "_alias": "Colors/Gray/300"
           },
           "75:4": {
-            "r": 0.3028571307659149,
-            "g": 0.316571444272995,
-            "b": 0.33714285492897034,
+            "r": 0.1411764770746231,
+            "g": 0.1411764770746231,
+            "b": 0.1411764770746231,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/700"
+            "_alias": "Colors/Gray/700"
           }
         }
       },
@@ -1896,14 +1938,14 @@
             "g": 0.1199999675154686,
             "b": 0.30000001192092896,
             "a": 1,
-            "_alias": "Colors/Brand Blue/900"
+            "_alias": "Colors/Blue/900"
           },
           "75:4": {
-            "r": 0.8867000341415405,
-            "g": 0.8893397450447083,
-            "b": 0.8932999968528748,
+            "r": 0.699999988079071,
+            "g": 0.8199999332427979,
+            "b": 1,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/50"
+            "_alias": "Colors/Blue/200"
           }
         }
       },
@@ -1916,14 +1958,14 @@
             "g": 0.27999991178512573,
             "b": 0.699999988079071,
             "a": 1,
-            "_alias": "Colors/Brand Blue/700"
+            "_alias": "Colors/Blue/700"
           },
           "75:4": {
-            "r": 0.6840816736221313,
-            "g": 0.6968162655830383,
-            "b": 0.7159183621406555,
+            "r": 0.5,
+            "g": 0.6999999284744263,
+            "b": 1,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/300"
+            "_alias": "Colors/Blue/300"
           }
         }
       },
@@ -1936,14 +1978,14 @@
             "g": 0.19199994206428528,
             "b": 0.47999998927116394,
             "a": 1,
-            "_alias": "Colors/Brand Blue/800"
+            "_alias": "Colors/Blue/800"
           },
           "75:4": {
-            "r": 0.7472652792930603,
-            "g": 0.7574530243873596,
-            "b": 0.7727347016334534,
+            "r": 0,
+            "g": 0.3599998652935028,
+            "b": 0.8999999761581421,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/200"
+            "_alias": "Colors/Blue/600"
           }
         }
       },
@@ -1956,14 +1998,14 @@
             "g": 0.3599998652935028,
             "b": 0.8999999761581421,
             "a": 1,
-            "_alias": "Colors/Brand Blue/600"
+            "_alias": "Colors/Blue/600"
           },
           "75:4": {
-            "r": 0.5998367071151733,
-            "g": 0.615967333316803,
-            "b": 0.6401633024215698,
+            "r": 0,
+            "g": 0.19199994206428528,
+            "b": 0.47999998927116394,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/400"
+            "_alias": "Colors/Blue/800"
           }
         }
       },
@@ -1976,14 +2018,14 @@
             "g": 0.3599998652935028,
             "b": 0.8999999761581421,
             "a": 1,
-            "_alias": "Colors/Brand Blue/600"
+            "_alias": "Colors/Blue/600"
           },
           "75:4": {
             "r": 0.699999988079071,
             "g": 0.8199999332427979,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/200"
+            "_alias": "Colors/Blue/200"
           }
         }
       },
@@ -2072,18 +2114,18 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.8358039259910583,
-            "g": 0.8420000076293945,
-            "b": 0.8543921709060669,
-            "a": 1,
-            "_alias": "Colors/Gray (light mode)/300"
+            "r": 0,
+            "g": 0,
+            "b": 0,
+            "a": 0.1599999964237213,
+            "_alias": "Colors/Alpha Black/200"
           },
           "75:4": {
-            "r": 0.3028571307659149,
-            "g": 0.316571444272995,
-            "b": 0.33714285492897034,
+            "r": 0.23999999463558197,
+            "g": 0.23999999463558197,
+            "b": 0.23999999463558197,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/700"
+            "_alias": "Colors/Gray/500"
           }
         }
       },
@@ -2092,18 +2134,18 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.9137254953384399,
-            "g": 0.9163398742675781,
-            "b": 0.9215686321258545,
-            "a": 1,
-            "_alias": "Colors/Gray (light mode)/200"
+            "r": 0,
+            "g": 0,
+            "b": 0,
+            "a": 0.07999999821186066,
+            "_alias": "Colors/Alpha Black/100"
           },
           "75:4": {
-            "r": 0.19016394019126892,
-            "g": 0.19803278148174286,
-            "b": 0.20983606576919556,
+            "r": 0.1764705926179886,
+            "g": 0.1764705926179886,
+            "b": 0.1764705926179886,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/800"
+            "_alias": "Colors/Gray/600"
           }
         }
       },
@@ -2118,11 +2160,11 @@
             "a": 0.05000000074505806
           },
           "75:4": {
-            "r": 0,
-            "g": 0,
-            "b": 0,
-            "a": 1,
-            "_alias": "Colors/Base/black"
+            "r": 0.9901961088180542,
+            "g": 0.9901961088180542,
+            "b": 0.9901961088180542,
+            "a": 0,
+            "_alias": "Colors/Alpha Gray/25"
           }
         }
       },
@@ -2131,18 +2173,18 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.96039217710495,
-            "g": 0.9606797695159912,
-            "b": 0.9611764550209045,
-            "a": 1,
-            "_alias": "Colors/Gray (light mode)/100"
+            "r": 0,
+            "g": 0,
+            "b": 0,
+            "a": 0.03999999910593033,
+            "_alias": "Colors/Alpha Black/50"
           },
           "75:4": {
-            "r": 0.19016394019126892,
-            "g": 0.19803278148174286,
-            "b": 0.20983606576919556,
-            "a": 1,
-            "_alias": "Colors/Gray (dark mode)/800"
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 0.03999999910593033,
+            "_alias": "Colors/Alpha White/900"
           }
         }
       },
@@ -2151,18 +2193,18 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.8358039259910583,
-            "g": 0.8420000076293945,
-            "b": 0.8543921709060669,
+            "r": 0.8600000143051147,
+            "g": 0.8600000143051147,
+            "b": 0.8600000143051147,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/300"
+            "_alias": "Colors/Gray/350"
           },
           "75:4": {
-            "r": 0.3028571307659149,
-            "g": 0.316571444272995,
-            "b": 0.33714285492897034,
+            "r": 0.23999999463558197,
+            "g": 0.23999999463558197,
+            "b": 0.23999999463558197,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/700"
+            "_alias": "Colors/Gray/500"
           }
         }
       },
@@ -2171,18 +2213,18 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.9137254953384399,
-            "g": 0.9163398742675781,
-            "b": 0.9215686321258545,
+            "r": 0.9411764740943909,
+            "g": 0.9411764740943909,
+            "b": 0.9411764740943909,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/200"
+            "_alias": "Colors/Gray/200"
           },
           "75:4": {
-            "r": 0.19016394019126892,
-            "g": 0.19803278148174286,
-            "b": 0.20983606576919556,
+            "r": 0.1411764770746231,
+            "g": 0.1411764770746231,
+            "b": 0.1411764770746231,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/800"
+            "_alias": "Colors/Gray/800"
           }
         }
       },
@@ -2198,11 +2240,11 @@
             "_alias": "Colors/Base/white"
           },
           "75:4": {
-            "r": 0.19016394019126892,
-            "g": 0.19803278148174286,
-            "b": 0.20983606576919556,
+            "r": 0,
+            "g": 0,
+            "b": 0,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/800"
+            "_alias": "Colors/Base/black"
           }
         }
       },
@@ -2215,34 +2257,14 @@
             "g": 0.44799986481666565,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/500"
+            "_alias": "Colors/Blue/500"
           },
           "75:4": {
             "r": 0.30000001192092896,
             "g": 0.5799999237060547,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/400"
-          }
-        }
-      },
-      {
-        "name": "Colors/Border/border-brand_alt",
-        "resolvedType": "COLOR",
-        "valuesByMode": {
-          "75:2": {
-            "r": 0,
-            "g": 0.3599998652935028,
-            "b": 0.8999999761581421,
-            "a": 1,
-            "_alias": "Colors/Brand Blue/600"
-          },
-          "75:4": {
-            "r": 0.3028571307659149,
-            "g": 0.316571444272995,
-            "b": 0.33714285492897034,
-            "a": 1,
-            "_alias": "Colors/Gray (dark mode)/700"
+            "_alias": "Colors/Blue/400"
           }
         }
       },
@@ -2323,15 +2345,35 @@
         }
       },
       {
+        "name": "Colors/Border/border-selected",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:2": {
+            "r": 0.0941176488995552,
+            "g": 0.0941176488995552,
+            "b": 0.0941176488995552,
+            "a": 1,
+            "_alias": "Colors/Gray/900"
+          },
+          "75:4": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1,
+            "_alias": "Colors/Base/white"
+          }
+        }
+      },
+      {
         "name": "Colors/Foreground/fg-primary (900)",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.09882353246212006,
-            "g": 0.11529411375522614,
-            "b": 0.14823530614376068,
+            "r": 0.09400000423192978,
+            "g": 0.09879999607801437,
+            "b": 0.10599999874830246,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/900"
+            "_alias": "Colors/Gray (dark mode)/900"
           },
           "75:4": {
             "r": 1,
@@ -2347,11 +2389,11 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.2549019753932953,
-            "g": 0.27581700682640076,
-            "b": 0.3176470696926117,
+            "r": 0.1411764770746231,
+            "g": 0.1411764770746231,
+            "b": 0.1411764770746231,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/700"
+            "_alias": "Colors/Gray/700"
           },
           "75:4": {
             "r": 0.6840816736221313,
@@ -2367,11 +2409,11 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.15333333611488342,
-            "g": 0.17137254774570465,
-            "b": 0.2074509859085083,
+            "r": 0.1411764770746231,
+            "g": 0.1411764770746231,
+            "b": 0.1411764770746231,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/800"
+            "_alias": "Colors/Gray/800"
           },
           "75:4": {
             "r": 0.7472652792930603,
@@ -2387,11 +2429,11 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.3265098035335541,
-            "g": 0.3454379141330719,
-            "b": 0.38329413533210754,
+            "r": 0.1764705926179886,
+            "g": 0.1764705926179886,
+            "b": 0.1764705926179886,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/600"
+            "_alias": "Colors/Gray/600"
           },
           "75:4": {
             "r": 0.5998367071151733,
@@ -2407,11 +2449,11 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.2549019753932953,
-            "g": 0.27581700682640076,
-            "b": 0.3176470696926117,
+            "r": 0.1411764770746231,
+            "g": 0.1411764770746231,
+            "b": 0.1411764770746231,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/700"
+            "_alias": "Colors/Gray/700"
           },
           "75:4": {
             "r": 0.6840816736221313,
@@ -2427,11 +2469,11 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.6425098180770874,
-            "g": 0.656000018119812,
+            "r": 0.6829804182052612,
+            "g": 0.6829804182052612,
             "b": 0.6829804182052612,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/400"
+            "_alias": "Colors/Gray/400"
           },
           "75:4": {
             "r": 0.39680981636047363,
@@ -2447,11 +2489,11 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.4431372582912445,
-            "g": 0.4627451002597809,
-            "b": 0.501960813999176,
+            "r": 0.23999999463558197,
+            "g": 0.23999999463558197,
+            "b": 0.23999999463558197,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/500"
+            "_alias": "Colors/Gray/500"
           },
           "75:4": {
             "r": 0.4930841028690338,
@@ -2487,11 +2529,11 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.6425098180770874,
-            "g": 0.656000018119812,
+            "r": 0.6829804182052612,
+            "g": 0.6829804182052612,
             "b": 0.6829804182052612,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/400"
+            "_alias": "Colors/Gray/400"
           },
           "75:4": {
             "r": 0.4930841028690338,
@@ -2507,11 +2549,11 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.8358039259910583,
-            "g": 0.8420000076293945,
-            "b": 0.8543921709060669,
+            "r": 0.9038461446762085,
+            "g": 0.9038461446762085,
+            "b": 0.9038461446762085,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/300"
+            "_alias": "Colors/Gray/300"
           },
           "75:4": {
             "r": 0.39680981636047363,
@@ -2531,14 +2573,14 @@
             "g": 0.3599998652935028,
             "b": 0.8999999761581421,
             "a": 1,
-            "_alias": "Colors/Brand Blue/600"
+            "_alias": "Colors/Blue/600"
           },
           "75:4": {
             "r": 0.07999999821186066,
             "g": 0.44799986481666565,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/500"
+            "_alias": "Colors/Blue/500"
           }
         }
       },
@@ -2551,7 +2593,7 @@
             "g": 0.3599998652935028,
             "b": 0.8999999761581421,
             "a": 1,
-            "_alias": "Colors/Brand Blue/600"
+            "_alias": "Colors/Blue/600"
           },
           "75:4": {
             "r": 0.6840816736221313,
@@ -2571,7 +2613,7 @@
             "g": 0.44799986481666565,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/500"
+            "_alias": "Colors/Blue/500"
           },
           "75:4": {
             "r": 0.4930841028690338,
@@ -2591,7 +2633,7 @@
             "g": 0.44799986481666565,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/500"
+            "_alias": "Colors/Blue/500"
           },
           "75:4": {
             "r": 0.39680981636047363,
@@ -2611,7 +2653,7 @@
             "g": 0.44799986481666565,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/500"
+            "_alias": "Colors/Blue/500"
           },
           "75:4": {
             "r": 0.4930841028690338,
@@ -2747,18 +2789,18 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 1,
-            "g": 1,
-            "b": 1,
+            "r": 0.9038461446762085,
+            "g": 0.9038461446762085,
+            "b": 0.9038461446762085,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Alpha Gray/300"
           },
           "75:4": {
-            "r": 0,
-            "g": 0,
-            "b": 0,
+            "r": 0.048114482313394547,
+            "g": 0.048114482313394547,
+            "b": 0.048114482313394547,
             "a": 0,
-            "_alias": "Colors/Base/transparent black"
+            "_alias": "Colors/Alpha Gray/950"
           }
         }
       },
@@ -2767,23 +2809,83 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 1,
-            "g": 1,
-            "b": 1,
+            "r": 0.9038461446762085,
+            "g": 0.9038461446762085,
+            "b": 0.9038461446762085,
             "a": 1,
-            "_alias": "Colors/Base/white"
+            "_alias": "Colors/Gray/300"
           },
           "75:4": {
-            "r": 0.0117647061124444,
-            "g": 0.01568627543747425,
-            "b": 0.019607843831181526,
+            "r": 0.048114482313394547,
+            "g": 0.048114482313394547,
+            "b": 0.048114482313394547,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/950"
+            "_alias": "Colors/Gray/950"
           }
         }
       },
       {
-        "name": "Colors/Background/bg-primary_alt",
+        "name": "Colors/Background/bg-surface_1",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:2": {
+            "r": 0.9411764740943909,
+            "g": 0.9411764740943909,
+            "b": 0.9411764740943909,
+            "a": 1,
+            "_alias": "Colors/Gray/200"
+          },
+          "75:4": {
+            "r": 0.0941176488995552,
+            "g": 0.0941176488995552,
+            "b": 0.0941176488995552,
+            "a": 1,
+            "_alias": "Colors/Gray/900"
+          }
+        }
+      },
+      {
+        "name": "Colors/Background/bg-surface_2",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:2": {
+            "r": 0.96039217710495,
+            "g": 0.9606797695159912,
+            "b": 0.9611764550209045,
+            "a": 1,
+            "_alias": "Colors/Gray/100"
+          },
+          "75:4": {
+            "r": 0.1411764770746231,
+            "g": 0.1411764770746231,
+            "b": 0.1411764770746231,
+            "a": 1,
+            "_alias": "Colors/Gray/700"
+          }
+        }
+      },
+      {
+        "name": "Colors/Background/bg-surface_3",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:2": {
+            "r": 0.9900000095367432,
+            "g": 0.9900000095367432,
+            "b": 0.9900000095367432,
+            "a": 1,
+            "_alias": "Colors/Gray/50"
+          },
+          "75:4": {
+            "r": 0.1764705926179886,
+            "g": 0.1764705926179886,
+            "b": 0.1764705926179886,
+            "a": 1,
+            "_alias": "Colors/Gray/600"
+          }
+        }
+      },
+      {
+        "name": "Colors/Background/bg-overlay",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
@@ -2794,11 +2896,11 @@
             "_alias": "Colors/Base/white"
           },
           "75:4": {
-            "r": 0.09400000423192978,
-            "g": 0.09879999607801437,
-            "b": 0.10599999874830246,
+            "r": 0.23999999463558197,
+            "g": 0.23999999463558197,
+            "b": 0.23999999463558197,
             "a": 1,
-            "_alias": "Colors/Background/bg-secondary"
+            "_alias": "Colors/Gray/500"
           }
         }
       },
@@ -2811,14 +2913,14 @@
             "g": 0,
             "b": 0,
             "a": 0.1599999964237213,
-            "_alias": "Colors/Gray (light mode alpha)/200"
+            "_alias": "Colors/Alpha Black/200"
           },
           "75:4": {
             "r": 1,
             "g": 1,
             "b": 1,
             "a": 0.1599999964237213,
-            "_alias": "Colors/Gray (dark mode alpha)/700"
+            "_alias": "Colors/Alpha White/700"
           }
         }
       },
@@ -2831,14 +2933,14 @@
             "g": 0,
             "b": 0,
             "a": 0.3499999940395355,
-            "_alias": "Colors/Gray (light mode alpha)/300"
+            "_alias": "Colors/Alpha Black/300"
           },
           "75:4": {
             "r": 1,
             "g": 1,
             "b": 1,
             "a": 0.5,
-            "_alias": "Colors/Gray (dark mode alpha)/500"
+            "_alias": "Colors/Alpha White/500"
           }
         }
       },
@@ -2851,14 +2953,14 @@
             "g": 0,
             "b": 0,
             "a": 0.03999999910593033,
-            "_alias": "Colors/Gray (light mode alpha)/50"
+            "_alias": "Colors/Alpha Black/50"
           },
           "75:4": {
             "r": 1,
             "g": 1,
             "b": 1,
             "a": 0.07999999821186066,
-            "_alias": "Colors/Gray (dark mode alpha)/800"
+            "_alias": "Colors/Alpha White/800"
           }
         }
       },
@@ -2871,14 +2973,14 @@
             "g": 0,
             "b": 0,
             "a": 0.1599999964237213,
-            "_alias": "Colors/Gray (light mode alpha)/200"
+            "_alias": "Colors/Alpha Black/200"
           },
           "75:4": {
             "r": 1,
             "g": 1,
             "b": 1,
             "a": 0.25,
-            "_alias": "Colors/Gray (dark mode alpha)/600"
+            "_alias": "Colors/Alpha White/600"
           }
         }
       },
@@ -2891,14 +2993,14 @@
             "g": 0,
             "b": 0,
             "a": 0.1599999964237213,
-            "_alias": "Colors/Gray (light mode alpha)/200"
+            "_alias": "Colors/Alpha Black/200"
           },
           "75:4": {
             "r": 1,
             "g": 1,
             "b": 1,
             "a": 0.03999999910593033,
-            "_alias": "Colors/Gray (dark mode alpha)/900"
+            "_alias": "Colors/Alpha White/900"
           }
         }
       },
@@ -2910,15 +3012,15 @@
             "r": 0,
             "g": 0,
             "b": 0,
-            "a": 0.5,
-            "_alias": "Colors/Gray (light mode alpha)/400"
+            "a": 0.3499999940395355,
+            "_alias": "Colors/Alpha Black/300"
           },
           "75:4": {
             "r": 1,
             "g": 1,
             "b": 1,
             "a": 0.1599999964237213,
-            "_alias": "Colors/Gray (dark mode alpha)/700"
+            "_alias": "Colors/Alpha White/700"
           }
         }
       },
@@ -2967,11 +3069,11 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.04172549024224281,
-            "g": 0.05050980672240257,
-            "b": 0.0680784359574318,
+            "r": 0.048114482313394547,
+            "g": 0.048114482313394547,
+            "b": 0.048114482313394547,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/950"
+            "_alias": "Colors/Gray/950"
           },
           "75:4": {
             "r": 0.09400000423192978,
@@ -2987,11 +3089,11 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.9801960587501526,
-            "g": 0.9803071618080139,
-            "b": 0.9805882573127747,
+            "r": 0.9900000095367432,
+            "g": 0.9900000095367432,
+            "b": 0.9900000095367432,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/50"
+            "_alias": "Colors/Gray/50"
           },
           "75:4": {
             "r": 0.09400000423192978,
@@ -3007,16 +3109,16 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.9801960587501526,
-            "g": 0.9803071618080139,
-            "b": 0.9805882573127747,
+            "r": 0.9900000095367432,
+            "g": 0.9900000095367432,
+            "b": 0.9900000095367432,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/50"
+            "_alias": "Colors/Gray/50"
           },
           "75:4": {
-            "r": 0.0117647061124444,
-            "g": 0.01568627543747425,
-            "b": 0.019607843831181526,
+            "r": 0.048114482313394547,
+            "g": 0.048114482313394547,
+            "b": 0.048114482313394547,
             "a": 1,
             "_alias": "Colors/Background/bg-primary"
           }
@@ -3031,7 +3133,7 @@
             "g": 0.9606797695159912,
             "b": 0.9611764550209045,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/100"
+            "_alias": "Colors/Gray/100"
           },
           "75:4": {
             "r": 0.19016394019126892,
@@ -3051,7 +3153,7 @@
             "g": 0.9901961088180542,
             "b": 0.9901961088180542,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/25"
+            "_alias": "Colors/Gray (light mode)/5"
           },
           "75:4": {
             "r": 0.09400000423192978,
@@ -3067,11 +3169,11 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.3265098035335541,
-            "g": 0.3454379141330719,
-            "b": 0.38329413533210754,
+            "r": 0.1764705926179886,
+            "g": 0.1764705926179886,
+            "b": 0.1764705926179886,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/600"
+            "_alias": "Colors/Gray/600"
           },
           "75:4": {
             "r": 0.39680981636047363,
@@ -3091,7 +3193,7 @@
             "g": 0.9606797695159912,
             "b": 0.9611764550209045,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/100"
+            "_alias": "Colors/Gray/100"
           },
           "75:4": {
             "r": 0.19016394019126892,
@@ -3107,11 +3209,11 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.9137254953384399,
-            "g": 0.9163398742675781,
-            "b": 0.9215686321258545,
+            "r": 0.9411764740943909,
+            "g": 0.9411764740943909,
+            "b": 0.9411764740943909,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/200"
+            "_alias": "Colors/Gray/200"
           },
           "75:4": {
             "r": 0.3028571307659149,
@@ -3127,11 +3229,11 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.9801960587501526,
-            "g": 0.9803071618080139,
-            "b": 0.9805882573127747,
+            "r": 0.9900000095367432,
+            "g": 0.9900000095367432,
+            "b": 0.9900000095367432,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/50"
+            "_alias": "Colors/Gray/50"
           },
           "75:4": {
             "r": 0.19016394019126892,
@@ -3147,18 +3249,18 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.96039217710495,
-            "g": 0.9606797695159912,
-            "b": 0.9611764550209045,
+            "r": 0.9411764740943909,
+            "g": 0.9411764740943909,
+            "b": 0.9411764740943909,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/100"
+            "_alias": "Colors/Gray/200"
           },
           "75:4": {
-            "r": 0.19016394019126892,
-            "g": 0.19803278148174286,
-            "b": 0.20983606576919556,
+            "r": 0.1411764770746231,
+            "g": 0.1411764770746231,
+            "b": 0.1411764770746231,
             "a": 1,
-            "_alias": "Colors/Gray (dark mode)/800"
+            "_alias": "Colors/Gray/800"
           }
         }
       },
@@ -3167,11 +3269,11 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.9801960587501526,
-            "g": 0.9803071618080139,
-            "b": 0.9805882573127747,
+            "r": 0.9900000095367432,
+            "g": 0.9900000095367432,
+            "b": 0.9900000095367432,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/50"
+            "_alias": "Colors/Gray/50"
           },
           "75:4": {
             "r": 0.09400000423192978,
@@ -3179,26 +3281,6 @@
             "b": 0.10599999874830246,
             "a": 1,
             "_alias": "Colors/Gray (dark mode)/900"
-          }
-        }
-      },
-      {
-        "name": "Colors/Background/bg-overlay",
-        "resolvedType": "COLOR",
-        "valuesByMode": {
-          "75:2": {
-            "r": 0.04172549024224281,
-            "g": 0.05050980672240257,
-            "b": 0.0680784359574318,
-            "a": 1,
-            "_alias": "Colors/Gray (light mode)/950"
-          },
-          "75:4": {
-            "r": 0.19016394019126892,
-            "g": 0.19803278148174286,
-            "b": 0.20983606576919556,
-            "a": 1,
-            "_alias": "Colors/Gray (dark mode)/800"
           }
         }
       },
@@ -3211,14 +3293,14 @@
             "g": 0.9280000329017639,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/50"
+            "_alias": "Colors/Blue/50"
           },
           "75:4": {
             "r": 0.07999999821186066,
             "g": 0.44799986481666565,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/500"
+            "_alias": "Colors/Blue/500"
           }
         }
       },
@@ -3231,7 +3313,7 @@
             "g": 0.9280000329017639,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/50"
+            "_alias": "Colors/Blue/50"
           },
           "75:4": {
             "r": 0.09400000423192978,
@@ -3251,14 +3333,14 @@
             "g": 0.8920000791549683,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/100"
+            "_alias": "Colors/Blue/100"
           },
           "75:4": {
             "r": 0,
             "g": 0.3599998652935028,
             "b": 0.8999999761581421,
             "a": 1,
-            "_alias": "Colors/Brand Blue/600"
+            "_alias": "Colors/Blue/600"
           }
         }
       },
@@ -3271,14 +3353,14 @@
             "g": 0.3599998652935028,
             "b": 0.8999999761581421,
             "a": 1,
-            "_alias": "Colors/Brand Blue/600"
+            "_alias": "Colors/Blue/600"
           },
           "75:4": {
             "r": 0,
             "g": 0.3599998652935028,
             "b": 0.8999999761581421,
             "a": 1,
-            "_alias": "Colors/Brand Blue/600"
+            "_alias": "Colors/Blue/600"
           }
         }
       },
@@ -3291,14 +3373,14 @@
             "g": 0.27999991178512573,
             "b": 0.699999988079071,
             "a": 1,
-            "_alias": "Colors/Brand Blue/700"
+            "_alias": "Colors/Blue/700"
           },
           "75:4": {
             "r": 0.07999999821186066,
             "g": 0.44799986481666565,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/500"
+            "_alias": "Colors/Blue/500"
           }
         }
       },
@@ -3311,7 +3393,7 @@
             "g": 0.19199994206428528,
             "b": 0.47999998927116394,
             "a": 1,
-            "_alias": "Colors/Brand Blue/800"
+            "_alias": "Colors/Blue/800"
           },
           "75:4": {
             "r": 0.09400000423192978,
@@ -3331,7 +3413,7 @@
             "g": 0.9606797695159912,
             "b": 0.9611764550209045,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/100"
+            "_alias": "Colors/Gray/100"
           },
           "75:4": {
             "r": 0.0117647061124444,
@@ -3551,14 +3633,14 @@
             "g": 0.44799986481666565,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/500"
+            "_alias": "Colors/Blue/500"
           },
           "75:4": {
             "r": 0.07999999821186066,
             "g": 0.44799986481666565,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/500"
+            "_alias": "Colors/Blue/500"
           }
         }
       },
@@ -3597,7 +3679,7 @@
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
@@ -3616,7 +3698,7 @@
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
@@ -3635,7 +3717,7 @@
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
@@ -3654,7 +3736,7 @@
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
@@ -3673,7 +3755,7 @@
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
@@ -3692,7 +3774,7 @@
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
@@ -3711,7 +3793,7 @@
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
@@ -3730,7 +3812,7 @@
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
@@ -3749,7 +3831,7 @@
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
@@ -3768,7 +3850,7 @@
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
@@ -3787,7 +3869,7 @@
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
@@ -3806,7 +3888,7 @@
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
@@ -3825,7 +3907,7 @@
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
@@ -3844,7 +3926,7 @@
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
@@ -3863,7 +3945,7 @@
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
@@ -3882,7 +3964,7 @@
             "g": 0,
             "b": 0,
             "a": 0.1599999964237213,
-            "_alias": "Colors/Gray (light mode alpha)/200"
+            "_alias": "Colors/Alpha Black/200"
           }
         }
       },
@@ -4790,14 +4872,14 @@
             "g": 0.6999999284744263,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/300"
+            "_alias": "Colors/Blue/300"
           },
           "75:4": {
             "r": 0.5,
             "g": 0.6999999284744263,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/300"
+            "_alias": "Colors/Blue/300"
           }
         }
       },
@@ -4810,14 +4892,14 @@
             "g": 0.8199999332427979,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/200"
+            "_alias": "Colors/Blue/200"
           },
           "75:4": {
             "r": 0.699999988079071,
             "g": 0.8199999332427979,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/200"
+            "_alias": "Colors/Blue/200"
           }
         }
       },
@@ -4866,18 +4948,18 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0,
-            "g": 0,
-            "b": 0,
-            "a": 0.03999999910593033,
-            "_alias": "Colors/Gray (light mode alpha)/50"
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 0.5600000023841858,
+            "_alias": "Colors/Alpha White/400"
           },
           "75:4": {
             "r": 1,
             "g": 1,
             "b": 1,
             "a": 0.03999999910593033,
-            "_alias": "Colors/Gray (dark mode alpha)/900"
+            "_alias": "Colors/Alpha White/900"
           }
         }
       },
@@ -4889,15 +4971,15 @@
             "r": 0,
             "g": 0,
             "b": 0,
-            "a": 0.07999999821186066,
-            "_alias": "Colors/Gray (light mode alpha)/100"
+            "a": 0,
+            "_alias": "Colors/Alpha Black/25"
           },
           "75:4": {
             "r": 1,
             "g": 1,
             "b": 1,
             "a": 0.07999999821186066,
-            "_alias": "Colors/Gray (dark mode alpha)/800"
+            "_alias": "Colors/Alpha White/800"
           }
         }
       },
@@ -4910,7 +4992,7 @@
             "g": 0.3599998652935028,
             "b": 0.8999999761581421,
             "a": 1,
-            "_alias": "Colors/Brand Blue/600"
+            "_alias": "Colors/Blue/600"
           },
           "75:4": {
             "r": 0.5998367071151733,
@@ -4930,7 +5012,7 @@
             "g": 0.8199999332427979,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/200"
+            "_alias": "Colors/Blue/200"
           },
           "75:4": {
             "r": 0.5998367071151733,
@@ -4950,14 +5032,14 @@
             "g": 0.3599998652935028,
             "b": 0.8999999761581421,
             "a": 1,
-            "_alias": "Colors/Brand Blue/600"
+            "_alias": "Colors/Blue/600"
           },
           "75:4": {
             "r": 0.699999988079071,
             "g": 0.8199999332427979,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/200"
+            "_alias": "Colors/Blue/200"
           }
         }
       },
@@ -4966,18 +5048,18 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.4431372582912445,
-            "g": 0.4627451002597809,
-            "b": 0.501960813999176,
+            "r": 0.23999999463558197,
+            "g": 0.23999999463558197,
+            "b": 0.23999999463558197,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/500"
+            "_alias": "Colors/Gray/500"
           },
           "75:4": {
             "r": 1,
             "g": 1,
             "b": 1,
             "a": 0.9200000166893005,
-            "_alias": "Colors/Gray (dark mode alpha)/200"
+            "_alias": "Colors/Alpha White/200"
           }
         }
       },
@@ -5046,11 +5128,11 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.9801960587501526,
-            "g": 0.9803071618080139,
-            "b": 0.9805882573127747,
+            "r": 0.9900000095367432,
+            "g": 0.9900000095367432,
+            "b": 0.9900000095367432,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/50"
+            "_alias": "Colors/Gray/50"
           },
           "75:4": {
             "r": 0.39680981636047363,
@@ -5066,18 +5148,18 @@
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
-            "r": 0.8358039259910583,
-            "g": 0.8420000076293945,
-            "b": 0.8543921709060669,
+            "r": 0.048114482313394547,
+            "g": 0.048114482313394547,
+            "b": 0.048114482313394547,
             "a": 1,
-            "_alias": "Colors/Gray (light mode)/300"
+            "_alias": "Colors/Gray/950"
           },
           "75:4": {
             "r": 1,
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
@@ -5097,7 +5179,7 @@
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
@@ -5117,12 +5199,12 @@
             "g": 1,
             "b": 1,
             "a": 0,
-            "_alias": "Colors/Base/transparent"
+            "_alias": "Colors/Base/transparent white"
           }
         }
       },
       {
-        "name": "Component colors/Components/Icons/Main Avatar/gradient-top",
+        "name": "Component colors/Components/Icons/Hero Avatar/brand-gradient-top",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
@@ -5130,7 +5212,7 @@
             "g": 0.5799999237060547,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/400"
+            "_alias": "Colors/Blue/400"
           },
           "75:4": {
             "r": 1,
@@ -5142,7 +5224,7 @@
         }
       },
       {
-        "name": "Component colors/Components/Icons/Main Avatar/gradient-bottom",
+        "name": "Component colors/Components/Icons/Hero Avatar/brand-gradient-bottom",
         "resolvedType": "COLOR",
         "valuesByMode": {
           "75:2": {
@@ -5150,14 +5232,134 @@
             "g": 0.27999991178512573,
             "b": 0.699999988079071,
             "a": 1,
-            "_alias": "Colors/Brand Blue/700"
+            "_alias": "Colors/Blue/700"
           },
           "75:4": {
             "r": 0.5,
             "g": 0.6999999284744263,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/300"
+            "_alias": "Colors/Blue/300"
+          }
+        }
+      },
+      {
+        "name": "Component colors/Components/Icons/Hero Avatar/purple-gradient-top",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:2": {
+            "r": 0.8352941274642944,
+            "g": 0.6745098233222961,
+            "b": 1,
+            "a": 1,
+            "_alias": "Colors/Purple/300"
+          },
+          "75:4": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1,
+            "_alias": "Colors/Base/white"
+          }
+        }
+      },
+      {
+        "name": "Component colors/Components/Icons/Hero Avatar/purple-gradient-bottom",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:2": {
+            "r": 0.3294117748737335,
+            "g": 0.062745101749897,
+            "b": 0.5764706134796143,
+            "a": 1,
+            "_alias": "Colors/Purple/900"
+          },
+          "75:4": {
+            "r": 0.8352941274642944,
+            "g": 0.6745098233222961,
+            "b": 1,
+            "a": 1,
+            "_alias": "Colors/Purple/300"
+          }
+        }
+      },
+      {
+        "name": "Component colors/Components/Icons/Hero Avatar/orange-gradient-top",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:2": {
+            "r": 0.8613921999931335,
+            "g": 0.4089790880680084,
+            "b": 0.013117611408233643,
+            "a": 1,
+            "_alias": "Colors/Warning/600"
+          },
+          "75:4": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1,
+            "_alias": "Colors/Base/white"
+          }
+        }
+      },
+      {
+        "name": "Component colors/Components/Icons/Hero Avatar/orange-gradient-bottom",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:2": {
+            "r": 0.8526000380516052,
+            "g": 0.17574664950370789,
+            "b": 0.1273999810218811,
+            "a": 1,
+            "_alias": "Colors/Error/600"
+          },
+          "75:4": {
+            "r": 0.9919999837875366,
+            "g": 0.6336000561714172,
+            "b": 0.6080000400543213,
+            "a": 1,
+            "_alias": "Colors/Error/300"
+          }
+        }
+      },
+      {
+        "name": "Component colors/Components/Icons/Hero Avatar/green-gradient-top 2",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:2": {
+            "r": 0.4598628282546997,
+            "g": 0.877392053604126,
+            "b": 0.6547098159790039,
+            "a": 1,
+            "_alias": "Colors/Success/300"
+          },
+          "75:4": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1,
+            "_alias": "Colors/Base/white"
+          }
+        }
+      },
+      {
+        "name": "Component colors/Components/Icons/Hero Avatar/green-gradient-bottom",
+        "resolvedType": "COLOR",
+        "valuesByMode": {
+          "75:2": {
+            "r": 0.02800002694129944,
+            "g": 0.3014117479324341,
+            "b": 0.19204704463481903,
+            "a": 1,
+            "_alias": "Colors/Success/900"
+          },
+          "75:4": {
+            "r": 0.6686275601387024,
+            "g": 0.9392156004905701,
+            "b": 0.776862621307373,
+            "a": 1,
+            "_alias": "Colors/Success/200"
           }
         }
       },
@@ -5170,14 +5372,14 @@
             "g": 0.9280000329017639,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/50"
+            "_alias": "Colors/Blue/50"
           },
           "75:4": {
             "r": 0,
             "g": 0.1199999675154686,
             "b": 0.30000001192092896,
             "a": 1,
-            "_alias": "Colors/Brand Blue/900"
+            "_alias": "Colors/Blue/900"
           }
         }
       },
@@ -5190,14 +5392,14 @@
             "g": 0.8920000791549683,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/100"
+            "_alias": "Colors/Blue/100"
           },
           "75:4": {
             "r": 0,
             "g": 0.19199994206428528,
             "b": 0.47999998927116394,
             "a": 1,
-            "_alias": "Colors/Brand Blue/800"
+            "_alias": "Colors/Blue/800"
           }
         }
       },
@@ -5210,14 +5412,14 @@
             "g": 0.8199999332427979,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/200"
+            "_alias": "Colors/Blue/200"
           },
           "75:4": {
             "r": 0,
             "g": 0.27999991178512573,
             "b": 0.699999988079071,
             "a": 1,
-            "_alias": "Colors/Brand Blue/700"
+            "_alias": "Colors/Blue/700"
           }
         }
       },
@@ -5230,14 +5432,14 @@
             "g": 0.6999999284744263,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/300"
+            "_alias": "Colors/Blue/300"
           },
           "75:4": {
             "r": 0,
             "g": 0.3599998652935028,
             "b": 0.8999999761581421,
             "a": 1,
-            "_alias": "Colors/Brand Blue/600"
+            "_alias": "Colors/Blue/600"
           }
         }
       },
@@ -5250,14 +5452,14 @@
             "g": 0.5799999237060547,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/400"
+            "_alias": "Colors/Blue/400"
           },
           "75:4": {
             "r": 0.07999999821186066,
             "g": 0.44799986481666565,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/500"
+            "_alias": "Colors/Blue/500"
           }
         }
       },
@@ -5270,14 +5472,14 @@
             "g": 0.44799986481666565,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/500"
+            "_alias": "Colors/Blue/500"
           },
           "75:4": {
             "r": 0.30000001192092896,
             "g": 0.5799999237060547,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/400"
+            "_alias": "Colors/Blue/400"
           }
         }
       },
@@ -5290,14 +5492,14 @@
             "g": 0.3599998652935028,
             "b": 0.8999999761581421,
             "a": 1,
-            "_alias": "Colors/Brand Blue/600"
+            "_alias": "Colors/Blue/600"
           },
           "75:4": {
             "r": 0.5,
             "g": 0.6999999284744263,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/300"
+            "_alias": "Colors/Blue/300"
           }
         }
       },
@@ -5310,14 +5512,14 @@
             "g": 0.27999991178512573,
             "b": 0.699999988079071,
             "a": 1,
-            "_alias": "Colors/Brand Blue/700"
+            "_alias": "Colors/Blue/700"
           },
           "75:4": {
             "r": 0.699999988079071,
             "g": 0.8199999332427979,
             "b": 1,
             "a": 1,
-            "_alias": "Colors/Brand Blue/200"
+            "_alias": "Colors/Blue/200"
           }
         }
       }


### PR DESCRIPTION
## Summary

Regenerates the Prego design-token set from the current VESPR Figma Design System file and fixes the color usages that the regeneration changed.

- **Regenerated Figma tokens** — `prego_colors.g.dart`, `prego_color_primitives.g.dart`, and `figma_tokens.json` re-exported from Figma.
- **New Figma source file** — token sync now points at file key `DTKWZawsS3zfA7TPA4OlGr` (was `8CQtJDHrN4nxfTPlmCxK9B`); `FIGMA_TOKEN_SYNC.md` updated accordingly (also corrects the console menu path to **Plugins > Development > Show/Hide console**).
- **Color-usage fixes** following the token changes:
  - `onboarding_hero.dart`, `project_list_screen.dart`, `prego_buttons_solid.dart`, `prego_quick_action_button.dart`: `bgPrimaryAlt` → `bgSecondary` / `bgPrimary`.
  - `prego_colors_x.dart`: `surfaceContainer` now resolves to `bgSecondary` in both brightnesses.
  - `prego_buttons_icon_glass.dart`: default glass icon-button background → `null` (let the frosted-glass shader show through instead of painting `buttonGlassPrimaryBackground`).

## Notes

The bulk of the diff is generated token output (`*.g.dart`, `figma_tokens.json`); the hand-written changes are the six widget/theme files above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerated Prego color tokens from the latest VESPR Figma file and aligned color usages with the new palette. Restores the frosted-glass icon button and updates hero and project list backgrounds per the new mapping.

- **Refactors**
  - Token sync now uses Figma file key `DTKWZawsS3zfA7TPA4OlGr`; re-exported `prego_colors.g.dart`, `prego_color_primitives.g.dart`, and `figma_tokens.json`; updated `FIGMA_TOKEN_SYNC.md` console path.
  - Replaced `bgPrimaryAlt` with `bgSecondary`/`bgPrimary` across the onboarding hero (vignette edge now `bgSecondary`), solid buttons, and quick-action buttons; `surfaceContainer` now maps to `bgSecondary` in all modes; project list Scaffold uses `bgPrimary`.
  - Glass icon button background set to null so the frosted-glass shader shows through.

<sup>Written for commit 80ed3f29db4c3e0720e95a1ad8f05bfdbfac8005. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

