### PR TITLE
feat(installer): npx --force/--help, always-confirm, un-truncated commands, lock-flake fix; bump v1.1.2

### DIFF
--- a/bridge/app/lib/src/version.dart
+++ b/bridge/app/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '1.1.1';
+const String appVersion = '1.1.2';

--- a/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-arm64",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS ARM64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.1.1",
+    "releaseTag": "v1.1.2",
     "releaseArtifact": "sesori-bridge-macos-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-darwin-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-x64",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS x64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.1.1",
+    "releaseTag": "v1.1.2",
     "releaseArtifact": "sesori-bridge-macos-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-arm64",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux ARM64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.1.1",
+    "releaseTag": "v1.1.2",
     "releaseArtifact": "sesori-bridge-linux-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-x64",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux x64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.1.1",
+    "releaseTag": "v1.1.2",
     "releaseArtifact": "sesori-bridge-linux-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-arm64",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows ARM64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.1.1",
+    "releaseTag": "v1.1.2",
     "releaseArtifact": "sesori-bridge-windows-arm64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-x64",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows x64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.1.1",
+    "releaseTag": "v1.1.2",
     "releaseArtifact": "sesori-bridge-windows-x64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge/README.md
+++ b/bridge/app/npm/sesori-bridge/README.md
@@ -2,12 +2,12 @@
 
 Bootstrap launcher for the [Sesori Bridge](https://github.com/sesori-ai/sesori_apps_monorepo) — a lightweight CLI that connects an AI coding assistant running on your laptop to the Sesori mobile app via an encrypted relay.
 
-This npm package is a **bootstrap launcher**, not the runtime itself. When you run `sesori-bridge` (or `npx @sesori/bridge`), it installs and updates a managed native binary under your home directory:
+This npm package is a **bootstrap launcher**, not the runtime itself. Running `npx @sesori/bridge` installs (or refreshes) a managed native binary under your home directory and tells you how to start it — it does **not** start the bridge:
 
 - macOS / Linux: `~/.local/share/sesori/`
 - Windows: `%LOCALAPPDATA%\sesori\`
 
-The platform-specific native binary is pulled from the matching optional dependency (`@sesori/bridge-<os>-<arch>`), with a fallback to the tagged GitHub Release asset if the npm payload is unavailable. After install, the `sesori-bridge` command runs the managed runtime, which keeps itself up to date.
+The platform-specific native binary is pulled from the matching optional dependency (`@sesori/bridge-<os>-<arch>`), with a fallback to the tagged GitHub Release asset if the npm payload is unavailable. After install, you run the managed `sesori-bridge` command yourself; the runtime keeps itself up to date from then on.
 
 ## Install
 
@@ -16,13 +16,25 @@ The platform-specific native binary is pulled from the matching optional depende
 npx @sesori/bridge
 ```
 
-After the first run, the managed `sesori-bridge` command is installed. On all platforms, open a new terminal so the new PATH entry is picked up (macOS/Linux: `~/.local/bin`; Windows: `%LOCALAPPDATA%\sesori\bin`), then verify:
+This installs the managed runtime and prints the next step. The bootstrap only installs — it never starts the bridge, and it forwards no arguments to it. On all platforms, open a new terminal so the new PATH entry is picked up (macOS/Linux: `~/.local/bin`; Windows: `%LOCALAPPDATA%\sesori\bin`), then start the bridge and check the version:
 
 ```bash
-sesori-bridge --version
+sesori-bridge            # start the bridge
+sesori-bridge --version  # check the installed version
 ```
 
 On Windows, the bootstrap persists the User PATH via a child PowerShell process that cannot refresh the current terminal — a new terminal is required before `sesori-bridge` is available. Alternatively, run the binary directly: `& "$env:LOCALAPPDATA\sesori\bin\sesori-bridge.exe" --version`.
+
+### Options
+
+```bash
+npx @sesori/bridge --force   # -f: reinstall the bundled version, overwriting
+                             #     whatever is installed (even a newer or
+                             #     incomplete/corrupt runtime)
+npx @sesori/bridge --help    # -h: show usage
+```
+
+By default the bootstrap leaves an already-current or newer healthy runtime in place, and refuses to overwrite a newer-but-incomplete runtime with an older payload. Use `--force` to override all of that and (re)install the bundled version unconditionally — useful for repairing a wedged install.
 
 Prefer a shell installer with no Node.js dependency?
 

--- a/bridge/app/npm/sesori-bridge/lib/bootstrap.js
+++ b/bridge/app/npm/sesori-bridge/lib/bootstrap.js
@@ -253,7 +253,6 @@ async function runMain(options) {
   var bootstrapResult = await bootstrapManagedRuntime(options && options.pkgName);
   var launcherResult = null;
   var pathStatus = "already configured";
-  var pathChanged = false;
   try {
     launcherResult = launcher.ensureManagedCommandPath({
       binDir: managedBinDir(bootstrapResult.installRoot),
@@ -262,7 +261,6 @@ async function runMain(options) {
       shellPath: process.env.SHELL || "",
     });
     pathStatus = launcherResult && launcherResult.message ? launcherResult.message : "already configured";
-    pathChanged = !!(launcherResult && launcherResult.changed);
   } catch (error) {
     pathStatus = "manual action required";
     ui.error("Failed to persist the managed command path.");
@@ -270,26 +268,21 @@ async function runMain(options) {
     ui.hint("The managed runtime is installed, but you may need to add it to PATH manually.");
   }
 
-  // Show the completion panel when there is something actionable to tell the
-  // user: a real install happened, the bootstrap just changed the PATH, the
-  // command isn't usable yet (PATH not configured / symlink missing) so the user
-  // still needs the "open a new terminal" / direct-binary guidance, OR the user
-  // passed args. The npm bootstrap never executes the managed binary, so an
-  // invocation like `npx @sesori/bridge --version` must not exit silently — we
-  // surface the `sesori-bridge <args>` command for the user to run. Only a pure
-  // no-op — runtime current, command usable, nothing changed, no args — stays
-  // quiet so repeated bare launches aren't noisy.
+  // Always show the completion panel. `npx @sesori/bridge` is an explicit,
+  // user-initiated request to set up the bridge, so it must never exit silently
+  // — even when the runtime is already current and the command is already on
+  // PATH, the user expects confirmation ("already installed") plus how to start
+  // it. The npm bootstrap never execs the managed binary, so the panel is the
+  // only feedback the user gets. (The managed binary is launched directly from
+  // PATH, not through this entry point, so this is never on a hot launch path.)
   var forwardedArgs = process.argv.slice(2);
-  var commandReady = isCommandReady(bootstrapResult.installRoot);
-  if (bootstrapResult.installed || pathChanged || !commandReady || forwardedArgs.length > 0) {
-    printInstallSummary({
-      installRoot: bootstrapResult.installRoot,
-      binaryPath: bootstrapResult.binaryPath,
-      version: bootstrapResult.version,
-      pathStatus: pathStatus,
-      args: forwardedArgs,
-    });
-  }
+  printInstallSummary({
+    installRoot: bootstrapResult.installRoot,
+    binaryPath: bootstrapResult.binaryPath,
+    version: bootstrapResult.version,
+    pathStatus: pathStatus,
+    args: forwardedArgs,
+  });
 }
 
 function main(options) {

--- a/bridge/app/npm/sesori-bridge/lib/bootstrap.js
+++ b/bridge/app/npm/sesori-bridge/lib/bootstrap.js
@@ -271,19 +271,23 @@ async function runMain(options) {
   }
 
   // Show the completion panel when there is something actionable to tell the
-  // user: a real install happened, the bootstrap just changed the PATH, or the
-  // command isn't usable yet (PATH not configured / symlink missing) so the
-  // user still needs the "open a new terminal" / direct-binary guidance. Only a
-  // pure no-op — runtime current AND command already usable AND nothing changed
-  // — stays quiet, so repeated launches aren't noisy.
+  // user: a real install happened, the bootstrap just changed the PATH, the
+  // command isn't usable yet (PATH not configured / symlink missing) so the user
+  // still needs the "open a new terminal" / direct-binary guidance, OR the user
+  // passed args. The npm bootstrap never executes the managed binary, so an
+  // invocation like `npx @sesori/bridge --version` must not exit silently — we
+  // surface the `sesori-bridge <args>` command for the user to run. Only a pure
+  // no-op — runtime current, command usable, nothing changed, no args — stays
+  // quiet so repeated bare launches aren't noisy.
+  var forwardedArgs = process.argv.slice(2);
   var commandReady = isCommandReady(bootstrapResult.installRoot);
-  if (bootstrapResult.installed || pathChanged || !commandReady) {
+  if (bootstrapResult.installed || pathChanged || !commandReady || forwardedArgs.length > 0) {
     printInstallSummary({
       installRoot: bootstrapResult.installRoot,
       binaryPath: bootstrapResult.binaryPath,
       version: bootstrapResult.version,
       pathStatus: pathStatus,
-      args: process.argv.slice(2),
+      args: forwardedArgs,
     });
   }
 }

--- a/bridge/app/npm/sesori-bridge/lib/bootstrap.js
+++ b/bridge/app/npm/sesori-bridge/lib/bootstrap.js
@@ -38,6 +38,43 @@ function errorMessage(error) {
   return String(error && error.message ? error.message : error);
 }
 
+// Print bootstrap usage. The bootstrap ONLY installs/refreshes the managed
+// runtime; it never starts the bridge, so it forwards no arguments. When shown
+// after a usage error, route it to stderr so it accompanies the error.
+function printUsage(toStderr) {
+  ui.usage([
+    "Usage: npx @sesori/bridge [options]",
+    "",
+    "Installs or refreshes the managed Sesori Bridge runtime, then tells you how",
+    "to start it. It does not start the bridge itself.",
+    "",
+    "Options:",
+    "  -f, --force    Reinstall the bundled runtime version, overwriting whatever",
+    "                 is currently installed (even a newer or corrupt runtime).",
+    "  -h, --help     Show this help.",
+  ], toStderr);
+}
+
+// Parse the bootstrap's own arguments. The bootstrap consumes ALL arguments —
+// none are forwarded to the bridge — so anything other than the known flags is a
+// usage error. Returns { force } on success, or throws _UsageError / signals help.
+function parseArgs(argv) {
+  var result = { force: false, help: false };
+  for (var i = 0; i < argv.length; i++) {
+    var arg = argv[i];
+    if (arg === "-f" || arg === "--force") {
+      result.force = true;
+    } else if (arg === "-h" || arg === "--help") {
+      result.help = true;
+    } else {
+      var err = new Error("Unknown option: " + arg);
+      err.isUsageError = true;
+      throw err;
+    }
+  }
+  return result;
+}
+
 function shellQuote(value) {
   if (!value) {
     return "''";
@@ -55,19 +92,20 @@ function powershellQuote(value) {
   return "'" + String(value).replace(/'/g, "''") + "'";
 }
 
-function nextCommand(binaryPath, args) {
-  var commandArgs = Array.isArray(args) ? args : [];
+// Build the "start the bridge" commands shown in the completion panel. The
+// bootstrap forwards no arguments — it only installs — so these are the bare
+// command (resolved via PATH) and the direct managed-binary path (fallback when
+// the symlink is missing/blocked).
+function nextCommand(binaryPath) {
   var managedCommand;
   if (process.platform === "win32") {
-    managedCommand = "& " + [binaryPath].concat(commandArgs).map(powershellQuote).join(" ");
+    managedCommand = "& " + powershellQuote(binaryPath);
   } else {
-    managedCommand = [binaryPath].concat(commandArgs).map(shellQuote).join(" ");
+    managedCommand = shellQuote(binaryPath);
   }
   return {
     managed: managedCommand,
-    // Bare-command form used both as the runnable next step and as the
-    // completion panel's highlighted call-to-action.
-    pathCommand: ["sesori-bridge"].concat(commandArgs).map(shellQuote).join(" "),
+    pathCommand: "sesori-bridge",
   };
 }
 
@@ -104,7 +142,7 @@ function isCommandReady(installRoot) {
 }
 
 function printInstallSummary(options) {
-  var commands = nextCommand(options.binaryPath, options.args);
+  var commands = nextCommand(options.binaryPath);
   var symlinkReady = isManagedSymlinkReady(options.installRoot);
   var commandReady = isCommandReady(options.installRoot);
 
@@ -157,7 +195,8 @@ function recordInstallAttempt() {
   fs.writeFileSync(counterPath, String(currentValue + 1), "utf8");
 }
 
-async function bootstrapManagedRuntime(pkgName) {
+async function bootstrapManagedRuntime(pkgName, parsedOptions) {
+  var force = !!(parsedOptions && parsedOptions.force);
   var installRoot = runtimeInstall.managedInstallRoot();
   var localPayload = runtimeInstall.tryResolvePayload(pkgName);
   var preferredVersion = localPayload ? localPayload.version : releaseAssetRuntime.wrapperVersion();
@@ -171,13 +210,16 @@ async function bootstrapManagedRuntime(pkgName) {
     }, async function() {
       var currentVersion = runtimeInstall.readManagedVersion(installRoot);
       var runtimeReady = runtimeInstall.isManagedRuntimeReady(installRoot);
-      if (currentVersion !== null) {
+      // --force bypasses all version/readiness gating: reinstall the payload
+      // version unconditionally, overwriting whatever exists (newer, corrupt, or
+      // same) via the atomic staged swap below.
+      if (!force && currentVersion !== null) {
         var comparison = runtimeInstall.compareVersions(currentVersion, preferredVersion);
         if (comparison > 0) {
           if (!runtimeReady) {
             throw new Error(
               "sesori-bridge: Managed runtime " + currentVersion + " is incomplete/corrupt and newer than npm payload " + preferredVersion + ".\n" +
-              "Refusing to repair it with an older npm payload. Reinstall the managed runtime explicitly, or delete the managed install directory and bootstrap again with npx."
+              "Refusing to repair it with an older npm payload. Reinstall it explicitly with `npx @sesori/bridge --force`, or delete the managed install directory and bootstrap again."
             );
           }
           runtimeInstall.createManagedSymlink(installRoot);
@@ -250,7 +292,8 @@ async function bootstrapManagedRuntime(pkgName) {
 }
 
 async function runMain(options) {
-  var bootstrapResult = await bootstrapManagedRuntime(options && options.pkgName);
+  var parsed = (options && options.parsed) || { force: false };
+  var bootstrapResult = await bootstrapManagedRuntime(options && options.pkgName, parsed);
   var launcherResult = null;
   var pathStatus = "already configured";
   try {
@@ -273,20 +316,33 @@ async function runMain(options) {
   // — even when the runtime is already current and the command is already on
   // PATH, the user expects confirmation ("already installed") plus how to start
   // it. The npm bootstrap never execs the managed binary, so the panel is the
-  // only feedback the user gets. (The managed binary is launched directly from
-  // PATH, not through this entry point, so this is never on a hot launch path.)
-  var forwardedArgs = process.argv.slice(2);
+  // only feedback the user gets, and it always suggests the bare `sesori-bridge`
+  // command (the bootstrap forwards no arguments to the bridge).
   printInstallSummary({
     installRoot: bootstrapResult.installRoot,
     binaryPath: bootstrapResult.binaryPath,
     version: bootstrapResult.version,
     pathStatus: pathStatus,
-    args: forwardedArgs,
   });
 }
 
 function main(options) {
-  runMain(options).catch(function(error) {
+  var parsed;
+  try {
+    parsed = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    // Unknown option: show the error and usage on stderr, then exit non-zero.
+    ui.error(errorMessage(error));
+    printUsage(true);
+    process.exit(1);
+    return;
+  }
+  if (parsed.help) {
+    printUsage();
+    return;
+  }
+  var runOptions = Object.assign({}, options, { parsed: parsed });
+  runMain(runOptions).catch(function(error) {
     fail(errorMessage(error));
   });
 }

--- a/bridge/app/npm/sesori-bridge/lib/bootstrap_lock.js
+++ b/bridge/app/npm/sesori-bridge/lib/bootstrap_lock.js
@@ -10,6 +10,10 @@ var LOCK_STALE_MS = Number(process.env.SESORI_BRIDGE_TEST_BOOTSTRAP_LOCK_STALE_M
 var HEARTBEAT_INTERVAL_MS = Math.max(100, Math.floor(LOCK_STALE_MS / 4));
 var HEARTBEAT_FILE_NAME = "heartbeat";
 var OWNER_FILE_NAME = "owner.json";
+// Bounded wait for the detached heartbeat to exit on SIGTERM before the lock
+// directory is removed, so it can't re-create files mid-teardown (ENOTEMPTY).
+var HEARTBEAT_STOP_TIMEOUT_MS = 2000;
+var HEARTBEAT_STOP_POLL_MS = 25;
 
 function sleep(milliseconds) {
   var buffer = new SharedArrayBuffer(4);
@@ -26,9 +30,23 @@ function removeRecursive(filePath) {
   fs.rmSync(filePath, {
     force: true,
     recursive: true,
-    maxRetries: 10,
+    maxRetries: 25,
     retryDelay: 50,
   });
+}
+
+// Tear down the lock directory after the heartbeat has been signalled. We first
+// delete the heartbeat file so a last-gasp heartbeat write has nothing to
+// re-create the directory around, then remove the directory recursively with
+// retries. This closes the ENOTEMPTY race where the detached heartbeat process
+// re-populates the directory between rmSync retries.
+function removeLockDirectory(lockPath) {
+  try {
+    fs.rmSync(heartbeatPath(lockPath), { force: true, maxRetries: 25, retryDelay: 50 });
+  } catch (_) {
+    // Best effort; the recursive removal below still retries.
+  }
+  removeRecursive(lockPath);
 }
 
 function heartbeatPath(lockPath) {
@@ -62,13 +80,35 @@ function startHeartbeat(lockPath) {
   return heartbeatProcess;
 }
 
+function processIsAlive(pid) {
+  try {
+    // Signal 0 performs existence/permission checks without delivering a signal.
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // ESRCH = no such process (it exited). EPERM = exists but not ours to signal.
+    return !!(error && error.code === "EPERM");
+  }
+}
+
 function stopHeartbeat(heartbeatProcess) {
   if (!heartbeatProcess || typeof heartbeatProcess.pid !== "number") {
     return;
   }
+  var pid = heartbeatProcess.pid;
   try {
-    process.kill(heartbeatProcess.pid, "SIGTERM");
-  } catch (_) {}
+    process.kill(pid, "SIGTERM");
+  } catch (_) {
+    return;
+  }
+  // Wait (briefly, synchronously) for the detached heartbeat to actually exit
+  // before the caller tears down the lock directory. Otherwise a last-gasp
+  // heartbeat write can re-create the directory between rmSync retries and
+  // surface as ENOTEMPTY. Bounded so a wedged heartbeat can't hang the bootstrap.
+  var deadline = Date.now() + HEARTBEAT_STOP_TIMEOUT_MS;
+  while (Date.now() < deadline && processIsAlive(pid)) {
+    sleep(HEARTBEAT_STOP_POLL_MS);
+  }
 }
 
 function lockIsStale(lockPath) {
@@ -128,13 +168,13 @@ function withBootstrapLock(options, callback) {
   } finally {
     if (!callbackResult || typeof callbackResult.then !== "function") {
       stopHeartbeat(heartbeatProcess);
-      removeRecursive(lockPath);
+      removeLockDirectory(lockPath);
     }
   }
   if (callbackResult && typeof callbackResult.then === "function") {
     return Promise.resolve(callbackResult).finally(function() {
       stopHeartbeat(heartbeatProcess);
-      removeRecursive(lockPath);
+      removeLockDirectory(lockPath);
     });
   }
   return callbackResult;

--- a/bridge/app/npm/sesori-bridge/lib/ui.js
+++ b/bridge/app/npm/sesori-bridge/lib/ui.js
@@ -333,15 +333,34 @@ Ui.prototype.completion = function(options) {
   this._write("");
 
   var border = this._c.brand;
+  var comment = "# Start the bridge";
+  var gap = "   ";
+  var inner = PANEL_WIDTH - 2;
+  // A runnable command must stay intact (copy/paste-able). If it fits a panel
+  // row inside the box, keep the polished boxed layout; otherwise render the
+  // full, un-truncated command on its own line BELOW the box so a long managed
+  // path or long forwarded args are never ellipsized.
+  var fitsInBox = command.length + gap.length + comment.length <= inner;
+
   this.panelTop(border);
   this.panelRow("Next steps", this._c.bold, border);
   this.panelRow("", "", border);
   if (!onPath) {
     this.panelEmphasisRow("In a ", "new terminal", " window, run:", border);
-    this.panelRow("", "", border);
+    if (fitsInBox) {
+      this.panelRow("", "", border);
+    }
   }
-  this.panelCommandRow(command, "# Start the bridge", border);
+  if (fitsInBox) {
+    this.panelCommandRow(command, comment, border);
+  }
   this.panelBottom(border);
+
+  if (!fitsInBox) {
+    // Full command on its own line, never truncated.
+    this._write("");
+    this._write("    " + this.paint(this._c.brand + this._c.bold, command));
+  }
   this._write("");
 };
 

--- a/bridge/app/npm/sesori-bridge/lib/ui.js
+++ b/bridge/app/npm/sesori-bridge/lib/ui.js
@@ -188,6 +188,19 @@ Ui.prototype.summary = function(platform, version) {
   this._write("");
 };
 
+// Print help/usage text verbatim (no styling beyond the caller's formatting).
+// Goes to stdout for an explicit --help, or to stderr when shown alongside a
+// usage error (so it accompanies the error and doesn't pollute stdout).
+Ui.prototype.usage = function(lines, toStderr) {
+  for (var i = 0; i < lines.length; i++) {
+    if (toStderr) {
+      this._writeErr(lines[i]);
+    } else {
+      this._write(lines[i]);
+    }
+  }
+};
+
 // A "[n/N] message" step header in brand blue.
 Ui.prototype.step = function(number, message) {
   this._write(this.paint(this._c.brand, "[" + number + "/" + TOTAL_STEPS + "]") + " " + message);

--- a/bridge/app/npm/sesori-bridge/package.json
+++ b/bridge/app/npm/sesori-bridge/package.json
@@ -1,22 +1,22 @@
 {
   "name": "@sesori/bridge",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Bootstrap launcher for the managed Sesori Bridge runtime",
   "bin": {
     "sesori-bridge": "bin/bridge.js"
   },
   "optionalDependencies": {
-    "@sesori/bridge-darwin-arm64": "1.1.1",
-    "@sesori/bridge-darwin-x64": "1.1.1",
-    "@sesori/bridge-linux-x64": "1.1.1",
-    "@sesori/bridge-linux-arm64": "1.1.1",
-    "@sesori/bridge-win32-x64": "1.1.1",
-    "@sesori/bridge-win32-arm64": "1.1.1"
+    "@sesori/bridge-darwin-arm64": "1.1.2",
+    "@sesori/bridge-darwin-x64": "1.1.2",
+    "@sesori/bridge-linux-x64": "1.1.2",
+    "@sesori/bridge-linux-arm64": "1.1.2",
+    "@sesori/bridge-win32-x64": "1.1.2",
+    "@sesori/bridge-win32-arm64": "1.1.2"
   },
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.1.1",
+    "releaseTag": "v1.1.2",
     "runtimeBundleSource": "github-release-assets"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sesori_bridge
 description: Dart implementation of the Sesori Bridge CLI for WebSocket communication.
-version: 1.1.1
+version: 1.1.2
 publish_to: none
 resolution: workspace
 

--- a/bridge/app/test/tool/installers_test.dart
+++ b/bridge/app/test/tool/installers_test.dart
@@ -734,7 +734,11 @@ cat "\$HOME/.zprofile"
       expect(script, contains(r'Sesori Bridge v$resolvedVersionLabel installed'));
       expect(script, contains("Write-PanelRow 'Next steps'"));
       expect(script, contains("Write-PanelEmphasisRow 'In a ' 'new terminal' ' window, run:'"));
-      expect(script, contains("Write-PanelCommandRow 'sesori-bridge' '# Start the bridge'"));
+      // The runnable command is kept intact: boxed when it fits, otherwise
+      // printed in full below the box (never ellipsized).
+      expect(script, contains(r"$nextCommand = 'sesori-bridge'"));
+      expect(script, contains(r'Write-PanelCommandRow $nextCommand $nextComment'));
+      expect(script, contains(r'if (-not $fitsInBox)'));
     });
 
     test('degrades gracefully: color/unicode detection and ASCII fallback', () {

--- a/bridge/app/test/tool/npm_wrapper_test.dart
+++ b/bridge/app/test/tool/npm_wrapper_test.dart
@@ -82,7 +82,7 @@ Future<ProcessResult> _runNodeHarness({required String source}) async {
 Future<ProcessResult> _runWrapperProcess({
   required Directory packageRoot,
   required String homePath,
-  required List<String> args,
+  List<String> args = const [],
   Map<String, String> environment = const {},
 }) {
   return Process.run(
@@ -115,7 +115,7 @@ Future<ProcessResult> _runManagedBinary({
 Future<Process> _startWrapperProcess({
   required Directory packageRoot,
   required String homePath,
-  required List<String> args,
+  List<String> args = const [],
   Map<String, String> environment = const {},
 }) {
   return Process.start(
@@ -373,17 +373,16 @@ Future<String> _readWrapperVersion() async {
 void _expectInstallSummary({
   required ProcessResult result,
   required String homePath,
-  required List<String> args,
 }) {
-  final nextStep = ['sesori-bridge', ...args].join(' ');
-  // The completion output is styled (banner + boxed "Next steps"). Assert on
-  // stable substrings rather than full styled lines so cosmetic tweaks to the
-  // panel don't break behavior tests. Color is off here (piped, no FORCE_COLOR).
+  // The bootstrap only installs; it never forwards arguments to the bridge, so
+  // the next-step command is always the bare `sesori-bridge`. The completion
+  // output is styled (banner + boxed "Next steps"); assert on stable substrings
+  // rather than full styled lines. Color is off here (piped, no FORCE_COLOR).
   expect(result.stdout, contains('Sesori Bridge v'));
   expect(result.stdout, contains('installed'));
   expect(result.stdout, contains('Next steps'));
   expect(result.stdout, contains('# Start the bridge'));
-  expect(result.stdout, contains(nextStep));
+  expect(result.stdout, contains('sesori-bridge'));
 }
 
 Future<({int exitCode, String stdout, String stderr})> _waitForProcess(Process process) async {
@@ -455,9 +454,11 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final source = await File(p.join(_wrapperPackageRoot(), 'lib', 'bootstrap.js')).readAsString();
 
       expect(source, contains('function powershellQuote(value)'));
+      // The bootstrap forwards no arguments, so the managed fallback command is
+      // just the quoted binary path invoked via PowerShell's call operator.
       expect(
         source,
-        contains('managedCommand = "& " + [binaryPath].concat(commandArgs).map(powershellQuote).join(" ")'),
+        contains('managedCommand = "& " + powershellQuote(binaryPath)'),
       );
     });
 
@@ -481,7 +482,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final result = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['doctor'],
         environment: {
           'SESORI_BRIDGE_RECORD_PATH': bootstrapRecordPath,
           'SESORI_BRIDGE_RELEASES_BASE_URL': releasesBaseUrl,
@@ -489,7 +489,7 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
-      _expectInstallSummary(result: result, homePath: homeDir.path, args: ['doctor']);
+      _expectInstallSummary(result: result, homePath: homeDir.path);
       expect(File(bootstrapRecordPath).existsSync(), isFalse);
       final directRun = await _runManagedBinary(
         homePath: homeDir.path,
@@ -522,7 +522,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final result = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['--version'],
         environment: {'SESORI_BRIDGE_RELEASES_BASE_URL': releasesBaseUrl},
       );
 
@@ -543,7 +542,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final result = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['doctor'],
         environment: {'SESORI_BRIDGE_RELEASES_BASE_URL': releasesBaseUrl},
       );
 
@@ -571,11 +569,10 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final result = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['serve', '--port', '4096'],
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
-      _expectInstallSummary(result: result, homePath: homeDir.path, args: ['serve', '--port', '4096']);
+      _expectInstallSummary(result: result, homePath: homeDir.path);
       expect(File(recordPath).existsSync(), isFalse);
       final managedBinary = _managedBinaryPath(homePath: homeDir.path);
       final directRun = await _runManagedBinary(
@@ -608,14 +605,13 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final bootstrapResult = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['serve'],
         environment: {
           'SHELL': '/bin/bash',
         },
       );
 
       expect(bootstrapResult.exitCode, equals(0), reason: '${bootstrapResult.stdout}\n${bootstrapResult.stderr}');
-      _expectInstallSummary(result: bootstrapResult, homePath: homeDir.path, args: ['serve']);
+      _expectInstallSummary(result: bootstrapResult, homePath: homeDir.path);
       // The styled completion no longer echoes a "PATH update" status line; the
       // PATH persistence is asserted directly against the shell rc files below.
       expect(
@@ -676,7 +672,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final result = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['status'],
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
@@ -720,7 +715,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final result = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['status'],
         environment: {
           'SHELL': '/bin/bash',
         },
@@ -806,7 +800,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final result = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['status'],
         environment: {
           'SESORI_BRIDGE_RELEASES_BASE_URL': 'http://127.0.0.1:1/releases/download',
         },
@@ -848,7 +841,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final result = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['doctor'],
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
@@ -887,7 +879,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final result = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['doctor'],
         environment: {
           'SESORI_BRIDGE_RELEASES_BASE_URL': 'http://127.0.0.1:1/releases/download',
         },
@@ -929,7 +920,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final result = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['status'],
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
@@ -974,7 +964,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final result = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['status'],
       );
 
       expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
@@ -1013,16 +1002,147 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final result = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['status'],
         environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
       );
 
       expect(result.exitCode, equals(1));
       expect(result.stderr, contains('Managed runtime 9.9.9 is incomplete/corrupt and newer than npm payload 1.2.3'));
       expect(result.stderr, contains('Refusing to repair it with an older npm payload'));
-      expect(result.stderr, contains('bootstrap again with npx'));
+      // The remediation now points at --force (and the manual-delete fallback).
+      expect(result.stderr, contains('npx @sesori/bridge --force'));
       expect(Directory(_bootstrapLockPath(homePath: homeDir.path)).existsSync(), isFalse);
       expect(File(recordPath).existsSync(), isFalse);
+    });
+
+    test('--force overwrites a newer incomplete managed runtime with the payload', () async {
+      // Same setup as "fails closed when a newer managed runtime is incomplete",
+      // but --force bypasses the guard and reinstalls the bundled version.
+      final wrapperRoot = await _createWrapperFixture();
+      final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
+      addTearDown(() => homeDir.delete(recursive: true));
+      final recordPath = p.join(homeDir.path, 'record.json');
+
+      await _createPlatformPayload(
+        wrapperRoot: wrapperRoot,
+        version: '1.2.3',
+        binaryMarker: 'payload-runtime',
+        libMarker: 'payload-lib',
+      );
+      await _seedManagedRuntime(
+        homePath: homeDir.path,
+        version: '9.9.9',
+        binaryMarker: 'broken-newer-managed',
+        libMarker: 'broken-lib',
+        includeBinary: true,
+        includeLib: false,
+      );
+
+      final result = await _runWrapperProcess(
+        packageRoot: wrapperRoot,
+        homePath: homeDir.path,
+        args: const ['--force'],
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      // The newer-but-broken 9.9.9 runtime is overwritten by the 1.2.3 payload.
+      final directRun = await _runManagedBinary(
+        homePath: homeDir.path,
+        args: const ['status'],
+        environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
+      );
+      expect(directRun.exitCode, equals(0), reason: '${directRun.stdout}\n${directRun.stderr}');
+      final recorded = await _readRecordedInvocation(recordPath: recordPath);
+      expect(recorded['marker'], equals('payload-runtime'));
+      expect(recorded['libMarker'], equals('payload-lib'));
+    });
+
+    test('--force reinstalls even when the same version is already healthy', () async {
+      final wrapperRoot = await _createWrapperFixture();
+      final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
+      addTearDown(() => homeDir.delete(recursive: true));
+
+      await _createPlatformPayload(
+        wrapperRoot: wrapperRoot,
+        version: '1.2.3',
+        binaryMarker: 'payload-runtime',
+        libMarker: 'payload-lib',
+      );
+      await _seedManagedRuntime(
+        homePath: homeDir.path,
+        version: '1.2.3',
+        binaryMarker: 'existing-managed',
+        libMarker: 'existing-lib',
+        includeBinary: true,
+        includeLib: true,
+      );
+
+      final result = await _runWrapperProcess(
+        packageRoot: wrapperRoot,
+        homePath: homeDir.path,
+        args: const ['-f'],
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      // A no-op would have kept 'existing-managed'; --force reinstalls the payload.
+      final recordPath = p.join(homeDir.path, 'record.json');
+      final directRun = await _runManagedBinary(
+        homePath: homeDir.path,
+        args: const ['status'],
+        environment: {'SESORI_BRIDGE_RECORD_PATH': recordPath},
+      );
+      expect(directRun.exitCode, equals(0), reason: '${directRun.stdout}\n${directRun.stderr}');
+      final recorded = await _readRecordedInvocation(recordPath: recordPath);
+      expect(recorded['marker'], equals('payload-runtime'));
+    });
+
+    test('--help prints usage and exits 0 without installing', () async {
+      final wrapperRoot = await _createWrapperFixture();
+      final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
+      addTearDown(() => homeDir.delete(recursive: true));
+
+      await _createPlatformPayload(
+        wrapperRoot: wrapperRoot,
+        version: '1.2.3',
+        binaryMarker: 'payload-runtime',
+        libMarker: 'payload-lib',
+      );
+
+      final result = await _runWrapperProcess(
+        packageRoot: wrapperRoot,
+        homePath: homeDir.path,
+        args: const ['--help'],
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      expect(result.stdout, contains('Usage: npx @sesori/bridge'));
+      expect(result.stdout, contains('--force'));
+      // No install happened: the managed runtime was never created.
+      expect(File(_managedBinaryPath(homePath: homeDir.path)).existsSync(), isFalse);
+    });
+
+    test('rejects unknown options with usage and a non-zero exit', () async {
+      final wrapperRoot = await _createWrapperFixture();
+      final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
+      addTearDown(() => homeDir.delete(recursive: true));
+
+      await _createPlatformPayload(
+        wrapperRoot: wrapperRoot,
+        version: '1.2.3',
+        binaryMarker: 'payload-runtime',
+        libMarker: 'payload-lib',
+      );
+
+      final result = await _runWrapperProcess(
+        packageRoot: wrapperRoot,
+        homePath: homeDir.path,
+        args: const ['--bogus'],
+      );
+
+      expect(result.exitCode, equals(1));
+      expect(result.stderr, contains('Unknown option: --bogus'));
+      expect(result.stderr, contains('Usage: npx @sesori/bridge'));
+      // Nothing was installed.
+      expect(File(_managedBinaryPath(homePath: homeDir.path)).existsSync(), isFalse);
     });
 
     test('fails closed on managed install write failure', () async {
@@ -1041,7 +1161,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final result = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['status'],
         environment: {
           'SESORI_BRIDGE_TEST_WRITE_FAIL': '1',
         },
@@ -1072,7 +1191,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final result = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['status'],
         environment: {
           'SHELL': '/usr/bin/fish',
         },
@@ -1107,7 +1225,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final bootstrapResult = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['serve'],
       );
       expect(bootstrapResult.exitCode, equals(0), reason: '${bootstrapResult.stdout}\n${bootstrapResult.stderr}');
 
@@ -1188,7 +1305,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final firstProcess = await _startWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['serve', 'first'],
         environment: {
           'SESORI_BRIDGE_TEST_BOOTSTRAP_HOLD_MS': '800',
           'SESORI_BRIDGE_TEST_INSTALL_COUNTER_PATH': installCounterPath,
@@ -1200,7 +1316,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final secondProcess = await _startWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['serve', 'second'],
         environment: {
           'SESORI_BRIDGE_TEST_INSTALL_COUNTER_PATH': installCounterPath,
         },
@@ -1235,7 +1350,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final firstProcess = await _startWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['serve', 'first'],
         environment: {
           'SESORI_BRIDGE_TEST_BOOTSTRAP_HOLD_MS': '1200',
           'SESORI_BRIDGE_TEST_BOOTSTRAP_LOCK_STALE_MS': '300',
@@ -1249,7 +1363,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final secondProcess = await _startWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['serve', 'second'],
         environment: {
           'SESORI_BRIDGE_TEST_BOOTSTRAP_LOCK_STALE_MS': '300',
           'SESORI_BRIDGE_TEST_BOOTSTRAP_LOCK_TIMEOUT_MS': '4000',
@@ -1295,7 +1408,6 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       final result = await _runWrapperProcess(
         packageRoot: wrapperRoot,
         homePath: homeDir.path,
-        args: ['status'],
         environment: {
           'SESORI_BRIDGE_TEST_BOOTSTRAP_LOCK_STALE_MS': '200',
           'SESORI_BRIDGE_TEST_BOOTSTRAP_LOCK_TIMEOUT_MS': '2000',

--- a/bridge/app/test/tool/npm_wrapper_test.dart
+++ b/bridge/app/test/tool/npm_wrapper_test.dart
@@ -1315,5 +1315,27 @@ process.stdout.write(JSON.stringify({ out: chunks.join("") }));
       expect(out, isNot(contains('\u2713')));
       expect(out, isNot(contains('\u2588')));
     });
+
+    test('keeps a long runnable command intact (printed below the box, not truncated)', () async {
+      const longCommand =
+          '/var/folders/very/long/managed/path/.local/share/sesori/bin/sesori-bridge status --verbose';
+      final result = await _runNodeHarness(
+        source:
+            '''
+const ui = require(${jsonEncode(uiPath)});
+const chunks = [];
+const stream = { isTTY: true, write(s) { chunks.push(String(s)); } };
+const u = new ui.Ui({ stream, errStream: stream, env: { FORCE_COLOR: '1', LANG: 'en_US.UTF-8' } });
+u.completion({ version: "1.2.3", location: "x", onPath: true, command: ${jsonEncode(longCommand)} });
+process.stdout.write(JSON.stringify({ out: chunks.join("") }));
+''',
+      );
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      final out =
+          (jsonDecode((result.stdout as String).trim()) as Map<String, dynamic>)['out'] as String;
+      // The full command appears verbatim (copy/paste-able) and is never ellipsized.
+      expect(out, contains(longCommand));
+      expect(out, isNot(contains('\u2026')));
+    });
   });
 }

--- a/bridge/app/test/tool/npm_wrapper_test.dart
+++ b/bridge/app/test/tool/npm_wrapper_test.dart
@@ -731,6 +731,63 @@ console.log(JSON.stringify({ exitCode, stderr: stderr.join('') }));
       expect(result.stdout, contains('new terminal'));
     });
 
+    test('bare no-op still confirms install and next-steps when already set up', () async {
+      // The exact `npx @sesori/bridge` (no args) scenario after a prior install:
+      // runtime current, command already on PATH, nothing changes. The bootstrap
+      // never execs the managed binary, so it must still print confirmation +
+      // next-steps rather than exiting silently.
+      final wrapperRoot = await _createWrapperFixture();
+      final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');
+      addTearDown(() => homeDir.delete(recursive: true));
+
+      await _createPlatformPayload(
+        wrapperRoot: wrapperRoot,
+        version: '1.2.3',
+        binaryMarker: 'payload-runtime',
+        libMarker: 'payload-lib',
+      );
+      await _seedManagedRuntime(
+        homePath: homeDir.path,
+        version: '1.2.3',
+        binaryMarker: 'existing-managed',
+        libMarker: 'existing-lib',
+        includeBinary: true,
+        includeLib: true,
+      );
+
+      // First run creates the ~/.local/bin/sesori-bridge symlink.
+      await _runWrapperProcess(
+        packageRoot: wrapperRoot,
+        homePath: homeDir.path,
+        args: const [],
+        environment: const {'SHELL': '/bin/bash'},
+      );
+
+      // Second run: put ~/.local/bin on PATH so the command is "ready". Keep the
+      // node binary resolvable by appending the inherited PATH.
+      final localBin = p.join(homeDir.path, '.local', 'bin');
+      final inheritedPath = Platform.environment['PATH'] ?? '';
+      final result = await _runWrapperProcess(
+        packageRoot: wrapperRoot,
+        homePath: homeDir.path,
+        args: const [],
+        environment: {
+          'SHELL': '/bin/bash',
+          'PATH': '$localBin:$inheritedPath',
+        },
+      );
+
+      expect(result.exitCode, equals(0), reason: '${result.stdout}\n${result.stderr}');
+      // Confirmation + next-steps are shown even though nothing was installed and
+      // the command is already usable; the "open a new terminal" line is omitted
+      // because the command already resolves.
+      expect(result.stdout, contains('Sesori Bridge v'));
+      expect(result.stdout, contains('installed'));
+      expect(result.stdout, contains('Next steps'));
+      expect(result.stdout, contains('# Start the bridge'));
+      expect(result.stdout, isNot(contains('new terminal')));
+    });
+
     test('same-version managed runtime does not require release download fallback', () async {
       final wrapperRoot = await _createWrapperFixture();
       final homeDir = await Directory.systemTemp.createTemp('npm-wrapper-home-');

--- a/install.ps1
+++ b/install.ps1
@@ -654,15 +654,30 @@ try {
     Write-Line ((Use-Paint $Script:C_DIM 'Location') + ' ' + (Use-Paint $Script:C_DIM $InstallRoot))
     Write-Line ''
 
+    # A runnable command must stay intact (copy/paste-able): if it fits a panel
+    # row we keep the boxed layout, otherwise we print the full, un-truncated
+    # command on its own line below the box rather than ellipsizing it.
+    $nextCommand = 'sesori-bridge'
+    $nextComment = '# Start the bridge'
+    $gap = '   '
+    $inner = $Script:PanelWidth - 2
+    $fitsInBox = ($nextCommand.Length + $gap.Length + $nextComment.Length) -le $inner
+
     Write-PanelTop $Script:C_BRAND
     Write-PanelRow 'Next steps' $Script:C_BOLD $Script:C_BRAND
     Write-PanelRow '' '' $Script:C_BRAND
     if (-not $onPath) {
         Write-PanelEmphasisRow 'In a ' 'new terminal' ' window, run:' $Script:C_BRAND
-        Write-PanelRow '' '' $Script:C_BRAND
+        if ($fitsInBox) { Write-PanelRow '' '' $Script:C_BRAND }
     }
-    Write-PanelCommandRow 'sesori-bridge' '# Start the bridge' $Script:C_BRAND
+    if ($fitsInBox) {
+        Write-PanelCommandRow $nextCommand $nextComment $Script:C_BRAND
+    }
     Write-PanelBottom $Script:C_BRAND
+    if (-not $fitsInBox) {
+        Write-Line ''
+        Write-Line ('    ' + (Use-Paint ($Script:C_BRAND + $Script:C_BOLD) $nextCommand))
+    }
     Write-Line ''
 
 } finally {

--- a/install.sh
+++ b/install.sh
@@ -928,7 +928,17 @@ print_completion() {
         on_path=true
     fi
 
-    # Boxed "Next steps" call-to-action, framed in brand blue.
+    # Boxed "Next steps" call-to-action, framed in brand blue. A runnable command
+    # must stay intact (copy/paste-able): if it fits a panel row we keep the boxed
+    # layout, otherwise we print the full, un-truncated command on its own line
+    # below the box rather than ellipsizing it.
+    local command="sesori-bridge"
+    local comment="# Start the bridge"
+    local gap="   "
+    local inner=$(( PANEL_WIDTH - 2 ))
+    local fits_in_box=true
+    [ $(( ${#command} + ${#gap} + ${#comment} )) -gt "${inner}" ] && fits_in_box=false
+
     panel_top "${C_BRAND}"
     panel_row "Next steps" "${C_BOLD}" "${C_BRAND}"
     panel_row "" "" "${C_BRAND}"
@@ -936,10 +946,17 @@ print_completion() {
         # "new terminal" is a hard requirement, so emphasize it rather than mute
         # the whole line — a faded instruction gets skipped.
         panel_emphasis_row "In a " "new terminal" " window, run:" "${C_BRAND}"
-        panel_row "" "" "${C_BRAND}"
+        [ "${fits_in_box}" = true ] && panel_row "" "" "${C_BRAND}"
     fi
-    panel_command_row "sesori-bridge" "# Start the bridge" "${C_BRAND}"
+    if [ "${fits_in_box}" = true ]; then
+        panel_command_row "${command}" "${comment}" "${C_BRAND}"
+    fi
     panel_bottom "${C_BRAND}"
+
+    if [ "${fits_in_box}" != true ]; then
+        printf '\n'
+        printf '    %s\n' "$(paint "${C_BRAND}${C_BOLD}" "${command}")"
+    fi
     printf '\n'
 }
 

--- a/install.sh
+++ b/install.sh
@@ -937,7 +937,9 @@ print_completion() {
     local gap="   "
     local inner=$(( PANEL_WIDTH - 2 ))
     local fits_in_box=true
-    [ $(( ${#command} + ${#gap} + ${#comment} )) -gt "${inner}" ] && fits_in_box=false
+    if [ $(( ${#command} + ${#gap} + ${#comment} )) -gt "${inner}" ]; then
+        fits_in_box=false
+    fi
 
     panel_top "${C_BRAND}"
     panel_row "Next steps" "${C_BOLD}" "${C_BRAND}"
@@ -946,7 +948,9 @@ print_completion() {
         # "new terminal" is a hard requirement, so emphasize it rather than mute
         # the whole line — a faded instruction gets skipped.
         panel_emphasis_row "In a " "new terminal" " window, run:" "${C_BRAND}"
-        [ "${fits_in_box}" = true ] && panel_row "" "" "${C_BRAND}"
+        if [ "${fits_in_box}" = true ]; then
+            panel_row "" "" "${C_BRAND}"
+        fi
     fi
     if [ "${fits_in_box}" = true ]; then
         panel_command_row "${command}" "${comment}" "${C_BRAND}"

--- a/mobile/app/pubspec.yaml
+++ b/mobile/app/pubspec.yaml
@@ -17,7 +17,7 @@ resolution: workspace
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.1+1
+version: 1.1.2+1
 environment:
   sdk: ^3.12.2
 


### PR DESCRIPTION
## What

Follow-up to #310 (installer UX restyling). Started from two post-merge review comments, then grew to fix the npm bootstrap's silent-no-op behavior, clarify the bootstrap-vs-runtime boundary, add `--force`/`--help`, fix a pre-existing lock-teardown flake, and bump the shared version to **v1.1.2**.

## npm bootstrap behavior

The npm package is a **bootstrap launcher** — it installs/refreshes the managed runtime and never starts the bridge.

- **Consumes its own args, forwards none.** Previously, non-flag args were cosmetically interpolated into the displayed "next steps" command (e.g. `npx @sesori/bridge serve` → `sesori-bridge serve`), even though the bootstrap never runs the bridge. That was misleading, so the bootstrap now consumes all its arguments and the next step always shows the bare `sesori-bridge` (or the direct managed path when the symlink is missing/blocked).
- **`--force` / `-f`** — bypass all version/readiness gating and unconditionally (re)install the bundled runtime version, overwriting whatever is installed (a newer, same, or incomplete/corrupt runtime). Reuses the existing atomic staged-swap install and still runs under the bootstrap lock. The "newer-but-incomplete" hard error now points the user at `npx @sesori/bridge --force` as the remedy.
- **`--help` / `-h`** — print usage and exit 0. Unknown options print a styled error + usage to stderr and exit 1.
- **Always confirms.** `npx @sesori/bridge` is an explicit user action and the bootstrap never execs the managed binary, so it no longer exits silently on a no-op. Even when the runtime is already current and on PATH, it prints `✓ Sesori Bridge vX installed` + the boxed **Next steps** (the "open a new terminal" line is omitted when the command already resolves).

## Completion panel: never ellipsize a runnable command

The panel previously truncated long commands with `…`, which makes them un-pasteable when the panel is the only place showing the command (long managed path on a missing symlink, etc.). Now the command stays boxed when it fits, and otherwise the **full, un-truncated command is printed on its own line below the box**. Applied consistently across `install.sh`, `install.ps1`, and the npm `ui.js`.

```
  ┌────────────────────────────────────────────────────────┐
  │ Next steps                                             │
  │                                                        │
  └────────────────────────────────────────────────────────┘

    /var/folders/very/long/managed/path/.local/share/sesori/bin/sesori-bridge
```

## Bootstrap lock teardown flake (pre-existing)

Fixed an `ENOTEMPTY` race that intermittently failed the lock-directory cleanup on CI. `stopHeartbeat` now waits (bounded) for the detached heartbeat process to actually exit after SIGTERM, the heartbeat file is deleted before the directory, and removal retries were increased — so a last-gasp heartbeat write can no longer re-create the directory mid-teardown.

## install.sh

- Same "print the command below the box if it doesn't fit" treatment as the npm path.
- Converted two `[ cond ] && cmd` shorthands in the completion block to standard `if` blocks (safer/clearer under `set -e`), per review feedback.

## Version bump to v1.1.2

Bumped the shared bridge + mobile version via the canonical `make bump-version VERSION=1.1.2` (not hand-edited):
- 7 npm `package.json` files (version + `optionalDependencies` + `sesoriBridge.releaseTag` → `v1.1.2`)
- `bridge/app/pubspec.yaml`, `bridge/app/lib/src/version.dart`
- `mobile/app/pubspec.yaml` (mobile build number preserved at `+1`)

## Docs

- npm package `README.md`: clarified the bootstrap-vs-runtime distinction (installs only, never starts the bridge, forwards no args), documented `--force`/`--help`, and fixed the verify step.

## Tests

- New: `--force` overwrites a newer-incomplete runtime and reinstalls an already-healthy same version; `--help` prints usage and installs nothing; unknown options are rejected; bare no-op still confirms + shows next steps; long command printed in full below the box.
- Updated the tests that relied on the old arg-forwarding, the PowerShell completion contract, and the newer-incomplete error copy.
- `dart test test/tool/installers_test.dart test/tool/npm_wrapper_test.dart` → 57 passing. `dart analyze` clean.

Reviewed by `aristotle-impl-review` (plan + each implementation round): APPROVED.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show the completion panel for `npx @sesori/bridge` and keep runnable commands intact. Adds `--force`/`--help`, fixes a bootstrap lock teardown flake, and bumps Bridge and Mobile to v1.1.2.

- **New Features**
  - npm bootstrap now consumes its own args and forwards none; next steps always suggest the bare `sesori-bridge` (or the direct managed path).  
  - `--force`/`-f` reinstalls the bundled runtime unconditionally; `--help`/`-h` prints usage; unknown options print usage to stderr and exit 1.

- **Bug Fixes**
  - Always print confirmation and next steps; omit the “new terminal” hint when the command already resolves.
  - Runnable commands are never ellipsized: boxed when they fit, otherwise the full command is printed below the box (`install.sh`, `install.ps1`, npm `ui.js`).
  - Bootstrap lock teardown is more robust: wait for the heartbeat to exit after SIGTERM, delete the heartbeat file first, and increase removal retries to avoid ENOTEMPTY flakes.

<sup>Written for commit 88ad6f7159e21dba5da0977189cf8eb8d976ded9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
