### PR TITLE
fix(opencode): probe both bind and connect hosts before claiming a port

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_policy.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_policy.dart
@@ -96,6 +96,15 @@ String resolveOpenCodeConnectHost({required String bindHost}) {
 /// connect-host probe catches a specific-address squatter and the bind-host
 /// probe catches a wildcard squatter. When the two hosts are equal (loopback or
 /// a concrete interface address) this collapses to a single probe.
+///
+/// The distinct hosts are probed **sequentially**, not concurrently. Each probe
+/// opens a real `ServerSocket` for the duration of the bind check, and on
+/// platforms where a wildcard bind and a same-port specific-address bind are
+/// mutually exclusive (notably Linux, a bridge build target) a concurrent probe
+/// would have one host's open socket make the other host's probe report `false`
+/// — falsely rejecting a genuinely free port. Probing one host at a time means
+/// no probe is ever live while another runs, so only a real foreign listener
+/// (never our own probe) can fail a bind.
 Future<bool> probeOpenCodePortBindable({
   required HostPortService ports,
   required int port,
@@ -103,10 +112,12 @@ Future<bool> probeOpenCodePortBindable({
   required String connectHost,
 }) async {
   final hosts = <String>{bindHost, connectHost};
-  final results = await Future.wait<bool>(
-    hosts.map((host) => ports.isBindable(host: host, port: port)),
-  );
-  return results.every((bindable) => bindable);
+  for (final host in hosts) {
+    if (!await ports.isBindable(host: host, port: port)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /// Maximum crash-restarts attempted within one failure episode before the

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_policy.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_policy.dart
@@ -4,7 +4,8 @@ import "dart:io" as io;
 import "dart:math";
 
 import "package:http/http.dart" as http;
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginHost, ProcessIdentity, SpawnedProcess;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
+    show HostPortService, PluginHost, ProcessIdentity, SpawnedProcess;
 import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 
 import "open_code_ownership_record.dart";
@@ -76,6 +77,36 @@ String resolveOpenCodeConnectHost({required String bindHost}) {
     return "::1";
   }
   return bindHost;
+}
+
+/// Whether [port] is free for a managed OpenCode start, probed across both the
+/// host OpenCode will bind and the host the bridge will dial.
+///
+/// A single-address bind probe is not enough when the two differ. With a
+/// wildcard bind (`0.0.0.0`/`::`) the connect host is a specific loopback
+/// (`127.0.0.1`/`::1`), and the OS lets a wildcard bind and a specific-address
+/// listener on the same port coexist: a `ServerSocket.bind("0.0.0.0", port)`
+/// probe succeeds even though something already holds `127.0.0.1:port`, and the
+/// reverse is also true. Probing only one host therefore lets a foreign server
+/// already listening on the *other* address slip through pre-start, after which
+/// the spawned child co-binds the wildcard, never exits, and the health probe —
+/// dialing the connect host — is answered by that foreign listener.
+///
+/// Requiring **every** distinct host to be bindable closes both gaps: the
+/// connect-host probe catches a specific-address squatter and the bind-host
+/// probe catches a wildcard squatter. When the two hosts are equal (loopback or
+/// a concrete interface address) this collapses to a single probe.
+Future<bool> probeOpenCodePortBindable({
+  required HostPortService ports,
+  required int port,
+  required String bindHost,
+  required String connectHost,
+}) async {
+  final hosts = <String>{bindHost, connectHost};
+  final results = await Future.wait<bool>(
+    hosts.map((host) => ports.isBindable(host: host, port: port)),
+  );
+  return results.every((bindable) => bindable);
 }
 
 /// Maximum crash-restarts attempted within one failure episode before the
@@ -341,7 +372,8 @@ ManagedRuntimeSpec<OpenCodeOwnershipRecord> buildOpenCodeManagedRuntimeSpec({
     ),
     probeHealth: ({required int port}) =>
         probeOpenCodeHealth(port: port, password: password, clientFactory: probeClientFactory, host: connectHost),
-    probePortBindable: ({required int port}) => host.ports.isBindable(host: bindHost, port: port),
+    probePortBindable: ({required int port}) =>
+        probeOpenCodePortBindable(ports: host.ports, port: port, bindHost: bindHost, connectHost: connectHost),
     buildRecord: (draft) => buildOpenCodeOwnershipRecord(draft: draft, bindHost: bindHost),
     portPolicy: portPolicy,
     healthPolicy: RuntimeHealthPolicy.deadline(

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_policy_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_policy_test.dart
@@ -394,6 +394,67 @@ void main() {
     });
   });
 
+  group("probeOpenCodePortBindable", () {
+    test("probes a single host once when bind and connect hosts are equal", () async {
+      final ports = _RecordingHostPortService(unbindableHosts: const <String>{});
+
+      final bindable = await probeOpenCodePortBindable(
+        ports: ports,
+        port: 4096,
+        bindHost: "127.0.0.1",
+        connectHost: "127.0.0.1",
+      );
+
+      expect(bindable, isTrue);
+      expect(ports.probedHosts, equals(<String>["127.0.0.1"]));
+    });
+
+    test("rejects a specific-address squatter the wildcard bind probe alone would miss", () async {
+      // The bug scenario: --opencode-host 0.0.0.0 while another opencode holds
+      // 127.0.0.1. Binding 0.0.0.0 would succeed, but the connect host probe
+      // catches the squatter.
+      final ports = _RecordingHostPortService(unbindableHosts: const <String>{"127.0.0.1"});
+
+      final bindable = await probeOpenCodePortBindable(
+        ports: ports,
+        port: 4096,
+        bindHost: "0.0.0.0",
+        connectHost: "127.0.0.1",
+      );
+
+      expect(bindable, isFalse);
+      expect(ports.probedHosts, containsAll(<String>["0.0.0.0", "127.0.0.1"]));
+    });
+
+    test("rejects a wildcard squatter the connect-host probe alone would miss", () async {
+      final ports = _RecordingHostPortService(unbindableHosts: const <String>{"0.0.0.0"});
+
+      final bindable = await probeOpenCodePortBindable(
+        ports: ports,
+        port: 4096,
+        bindHost: "0.0.0.0",
+        connectHost: "127.0.0.1",
+      );
+
+      expect(bindable, isFalse);
+      expect(ports.probedHosts, containsAll(<String>["0.0.0.0", "127.0.0.1"]));
+    });
+
+    test("reports free only when both hosts are bindable", () async {
+      final ports = _RecordingHostPortService(unbindableHosts: const <String>{});
+
+      final bindable = await probeOpenCodePortBindable(
+        ports: ports,
+        port: 4096,
+        bindHost: "0.0.0.0",
+        connectHost: "127.0.0.1",
+      );
+
+      expect(bindable, isTrue);
+      expect(ports.probedHosts.toSet(), equals(<String>{"0.0.0.0", "127.0.0.1"}));
+    });
+  });
+
   group("buildOpenCodeRestartPolicy", () {
     test("builds the bounded pinned-port restart pacing", () {
       final policy = buildOpenCodeRestartPolicy();
@@ -513,4 +574,20 @@ class _FakeSpawnedProcess implements SpawnedProcess {
 
   @override
   Stream<List<int>> get stderr => Stream<List<int>>.value(const <int>[]);
+}
+
+/// Records every host probed and reports any host in [unbindableHosts] as
+/// occupied — a stand-in for a foreign listener already holding the port on
+/// that specific address.
+class _RecordingHostPortService implements HostPortService {
+  _RecordingHostPortService({required Set<String> unbindableHosts}) : _unbindableHosts = unbindableHosts;
+
+  final Set<String> _unbindableHosts;
+  final List<String> probedHosts = <String>[];
+
+  @override
+  Future<bool> isBindable({required String host, required int port}) async {
+    probedHosts.add(host);
+    return !_unbindableHosts.contains(host);
+  }
 }

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_policy_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_policy_test.dart
@@ -423,7 +423,8 @@ void main() {
       );
 
       expect(bindable, isFalse);
-      expect(ports.probedHosts, containsAll(<String>["0.0.0.0", "127.0.0.1"]));
+      // 0.0.0.0 probes bindable first, then the 127.0.0.1 squatter is detected.
+      expect(ports.probedHosts, equals(<String>["0.0.0.0", "127.0.0.1"]));
     });
 
     test("rejects a wildcard squatter the connect-host probe alone would miss", () async {
@@ -437,7 +438,9 @@ void main() {
       );
 
       expect(bindable, isFalse);
-      expect(ports.probedHosts, containsAll(<String>["0.0.0.0", "127.0.0.1"]));
+      // The bind host (0.0.0.0) is probed first and fails, so the probe
+      // short-circuits before dialing the connect host.
+      expect(ports.probedHosts, equals(<String>["0.0.0.0"]));
     });
 
     test("reports free only when both hosts are bindable", () async {
@@ -452,6 +455,24 @@ void main() {
 
       expect(bindable, isTrue);
       expect(ports.probedHosts.toSet(), equals(<String>{"0.0.0.0", "127.0.0.1"}));
+    });
+
+    test("probes the distinct hosts sequentially, never holding two probes at once", () async {
+      // A concurrent probe would let one host's open ServerSocket make the
+      // other host's bind probe fail on platforms where wildcard and
+      // specific-address binds are mutually exclusive (e.g. Linux). Asserting
+      // that no two probes overlap pins the sequential contract.
+      final ports = _RecordingHostPortService(unbindableHosts: const <String>{});
+
+      final bindable = await probeOpenCodePortBindable(
+        ports: ports,
+        port: 4096,
+        bindHost: "0.0.0.0",
+        connectHost: "127.0.0.1",
+      );
+
+      expect(bindable, isTrue);
+      expect(ports.maxConcurrentProbes, equals(1));
     });
   });
 
@@ -579,15 +600,31 @@ class _FakeSpawnedProcess implements SpawnedProcess {
 /// Records every host probed and reports any host in [unbindableHosts] as
 /// occupied — a stand-in for a foreign listener already holding the port on
 /// that specific address.
+///
+/// Tracks the peak number of overlapping `isBindable` calls so a test can
+/// assert the caller never runs two probes concurrently. Each probe yields to
+/// the event loop while "in flight", so any concurrent caller would observe an
+/// overlap.
 class _RecordingHostPortService implements HostPortService {
   _RecordingHostPortService({required Set<String> unbindableHosts}) : _unbindableHosts = unbindableHosts;
 
   final Set<String> _unbindableHosts;
   final List<String> probedHosts = <String>[];
+  int _inFlight = 0;
+  int maxConcurrentProbes = 0;
 
   @override
   Future<bool> isBindable({required String host, required int port}) async {
     probedHosts.add(host);
-    return !_unbindableHosts.contains(host);
+    _inFlight += 1;
+    maxConcurrentProbes = _inFlight > maxConcurrentProbes ? _inFlight : maxConcurrentProbes;
+    try {
+      // Yield so an overlapping probe (if the caller raced them) would be
+      // observed while this one is still counted as in flight.
+      await Future<void>.delayed(Duration.zero);
+      return !_unbindableHosts.contains(host);
+    } finally {
+      _inFlight -= 1;
+    }
   }
 }


### PR DESCRIPTION
## Problem

When the bridge is launched with a wildcard bind host while a *different* opencode instance already holds the connect host, the bridge falsely reports the port as started and silently proxies the foreign opencode.

Repro (clean `main`):

```
dart run bin/bridge.dart --opencode-host 0.0.0.0 --opencode-port 4096
# ... another opencode already listens on 127.0.0.1:4096
[OpenCodePluginDescriptor][opencode] starting on port 4096
[OpenCodePluginDescriptor][opencode] started on port 4096   <-- false: 4096 is held by a foreign opencode
Target: http://127.0.0.1:4096                                <-- bridge proxies the wrong server
```

## Root cause

A `bindHost` vs `connectHost` asymmetry defeats all three managed-runtime startup defenses:

1. **Pre-start bindability probe** bound only on `bindHost` (`0.0.0.0`). A wildcard bind does **not** collide with an existing specific-address (`127.0.0.1`) listener at the OS level, so `ServerSocket.bind("0.0.0.0", 4096)` succeeds even while `127.0.0.1:4096` is held — the probe reports the port free.
2. **Early-child-exit guard** never fires: the spawned child runs `serve --hostname 0.0.0.0`, co-binds the wildcard alongside the specific-address squatter, and does not exit.
3. **Health probe** dials `connectHost` (`127.0.0.1:4096`), which is answered by the pre-existing (passwordless) opencode → 200 → "started".

Verified empirically that a wildcard bind and a specific-address listener coexist on the same port in both directions, so neither a single wildcard probe nor a single loopback probe is sufficient on its own.

## Fix

`probePortBindable` now probes **every distinct host** (`bindHost` and `connectHost`, deduped) in parallel and treats the port as free only when all are bindable:

- the connect-host probe catches a specific-address squatter (the bug above);
- the bind-host probe catches a wildcard squatter;
- when the two hosts are equal (loopback or a concrete interface IP) it collapses to a single probe — unchanged behavior.

New `probeOpenCodePortBindable(...)` helper in `open_code_runtime_policy.dart`, following the file's existing top-level policy-function pattern (`resolveOpenCodeConnectHost`, `probeOpenCodeHealth`, `spawnOpenCodeProcess`, ...).

## Tests

Added a `probeOpenCodePortBindable` group (4 cases) covering: single probe when hosts are equal, specific-address squatter rejection, wildcard squatter rejection, and the all-free case.

- `dart analyze --fatal-infos` clean (sesori_plugin_opencode)
- `dart test` — all module tests pass (353)
- aristotle-impl-review: APPROVED

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Probe both the bind and connect hosts, sequentially, before claiming an OpenCode port to prevent false “started” states and accidental proxying of a foreign server. Fixes cases like `--opencode-host 0.0.0.0` with another instance on `127.0.0.1:4096`.

- **Bug Fixes**
  - Added `probeOpenCodePortBindable(...)` to check `bindHost` and `connectHost` (deduped) sequentially and require all to be bindable, avoiding self-interference on platforms where wildcard and specific binds conflict.
  - Updated managed runtime `probePortBindable` to use the new helper.
  - Tests: equal-host collapse, specific-address squatter rejection, wildcard squatter rejection, all-free success, and a sequential non-overlap regression.

<sup>Written for commit 9a4b74b8f3448cc0f7c93e68b8c8b6249a2cc082. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

