### PR TITLE
fix(bridge): implement startDetached in SystemProcessApi test fake

### DIFF
--- a/bridge/app/test/server/api/system_process_api_test.dart
+++ b/bridge/app/test/server/api/system_process_api_test.dart
@@ -107,4 +107,13 @@ class _RecordingProcessRunner implements ProcessRunner {
     calls.add(_RecordedCall(executable: executable, arguments: arguments));
     return ProcessResult(1, exitCode, stdout, stderr);
   }
+
+  @override
+  Future<int> startDetached({
+    required String executable,
+    required List<String> arguments,
+    Map<String, String>? environment,
+  }) {
+    throw UnimplementedError();
+  }
 }


### PR DESCRIPTION
## Problem

Bridge CI on `main` is failing after #288 (`feat(bridge): stage-and-apply updates in place...`). That PR added a `startDetached` method to the concrete `ProcessRunner` class, but the `_RecordingProcessRunner` test fake in `system_process_api_test.dart` (which `implements ProcessRunner`) was not updated.

`dart analyze --fatal-infos` fails with:

```
error - test/server/api/system_process_api_test.dart:91:7 - Missing concrete implementation of 'ProcessRunner.startDetached'. - non_abstract_class_inherits_abstract_member
```

## Fix

Implement `startDetached` on the test fake. The fake is only used for `inspectProcess`/`run` assertions, so the method throws `UnimplementedError` — consistent with it never being exercised by these tests.

## Verification

- `make analyze` — clean across all bridge modules
- `dart test test/server/api/system_process_api_test.dart` — all 4 tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix failing Bridge CI by implementing `startDetached` in the `SystemProcessApi` test fake (`_RecordingProcessRunner`) to match the updated `ProcessRunner` interface. The method throws `UnimplementedError` since tests don't use it, restoring a clean `dart analyze` and passing tests.

<sup>Written for commit c791da3b54e99b036dd4ecd41e9777f3ef8bf949. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

