### PR TITLE
feat(bridge): targeted POSIX inspectProcess via ps -p

### DIFF
--- a/bridge/app/lib/src/server/api/system_process_api.dart
+++ b/bridge/app/lib/src/server/api/system_process_api.dart
@@ -99,19 +99,33 @@ class SystemProcessApi {
   /// returns only the matching row. This mirrors [_inspectWindowsProcess] and
   /// avoids enumerating the whole process table just to look up one pid.
   ///
-  /// Unlike [_listPosixProcesses], a non-zero exit here means "no such process"
-  /// (`ps -p` exits non-zero when the pid is gone), so it returns `null` instead
-  /// of throwing. The targeted form drops the `a`/`x` list selectors but keeps
-  /// `-ww` so long command lines are never truncated, and reuses the same
-  /// `-o` column spec so [_parsePosixProcesses]'s 24-char `lstart` regex matches.
+  /// `ps -p` exits non-zero both when the pid is simply gone AND when the
+  /// invocation genuinely fails (e.g. a usage/format error or `ps` itself
+  /// failing), and on BSD `ps` the exit code is `1` in every case — so the exit
+  /// code alone cannot distinguish them. We disambiguate via stderr: a vanished
+  /// pid produces empty stdout and empty stderr, so we treat non-zero + empty
+  /// stderr as "no such process" and return `null`. A non-zero exit with stderr
+  /// content is a real failure and is rethrown as a [ProcessException] — never
+  /// swallowed — because callers such as `BridgeRuntimeRunner` rely on POSIX
+  /// self-inspection errors staying fatal (a marker-less fallback would corrupt
+  /// the startup lock).
+  ///
+  /// The targeted form drops the `a`/`x` list selectors but keeps `-ww` so long
+  /// command lines are never truncated, and reuses the same `-o` column spec so
+  /// [_parsePosixProcesses]'s 24-char `lstart` regex matches.
   Future<ProcessIdentity?> _inspectPosixProcess({required int pid}) async {
+    final (command, args) = ("ps", <String>["-p", "$pid", "-wwo", "pid=,user=,lstart=,command="]);
     final result = await _processRunner.run(
-      "ps",
-      <String>["-p", "$pid", "-wwo", "pid=,user=,lstart=,command="],
+      command,
+      args,
       environment: {"LC_ALL": "C"},
     );
     if (result.exitCode != 0) {
-      return null;
+      final stderr = result.stderr.toString().trim();
+      if (stderr.isEmpty) {
+        return null;
+      }
+      throw ProcessException(command, args, stderr, result.exitCode);
     }
 
     final processes = _parsePosixProcesses(stdout: result.stdout.toString());

--- a/bridge/app/lib/src/server/api/system_process_api.dart
+++ b/bridge/app/lib/src/server/api/system_process_api.dart
@@ -46,13 +46,7 @@ class SystemProcessApi {
     if (_isWindows) {
       return _inspectWindowsProcess(pid: pid);
     }
-    final processes = await _listPosixProcesses();
-    for (final process in processes) {
-      if (process.pid == pid) {
-        return process;
-      }
-    }
-    return null;
+    return _inspectPosixProcess(pid: pid);
   }
 
   Future<SignalResult> sendGracefulSignal({required int pid}) => _sendSignal(
@@ -98,9 +92,41 @@ class SystemProcessApi {
       );
     }
 
+    return _parsePosixProcesses(stdout: result.stdout.toString());
+  }
+
+  /// Inspects a single POSIX process by querying `ps -p <pid>` so the OS
+  /// returns only the matching row. This mirrors [_inspectWindowsProcess] and
+  /// avoids enumerating the whole process table just to look up one pid.
+  ///
+  /// Unlike [_listPosixProcesses], a non-zero exit here means "no such process"
+  /// (`ps -p` exits non-zero when the pid is gone), so it returns `null` instead
+  /// of throwing. The targeted form drops the `a`/`x` list selectors but keeps
+  /// `-ww` so long command lines are never truncated, and reuses the same
+  /// `-o` column spec so [_parsePosixProcesses]'s 24-char `lstart` regex matches.
+  Future<ProcessIdentity?> _inspectPosixProcess({required int pid}) async {
+    final result = await _processRunner.run(
+      "ps",
+      <String>["-p", "$pid", "-wwo", "pid=,user=,lstart=,command="],
+      environment: {"LC_ALL": "C"},
+    );
+    if (result.exitCode != 0) {
+      return null;
+    }
+
+    final processes = _parsePosixProcesses(stdout: result.stdout.toString());
+    for (final process in processes) {
+      if (process.pid == pid) {
+        return process;
+      }
+    }
+    return null;
+  }
+
+  List<ProcessIdentity> _parsePosixProcesses({required String stdout}) {
     final capturedAt = _clock.now();
     final processes = <ProcessIdentity>[];
-    for (final line in const LineSplitter().convert(result.stdout.toString())) {
+    for (final line in const LineSplitter().convert(stdout)) {
       final trimmed = line.trim();
       if (trimmed.isEmpty) {
         continue;

--- a/bridge/app/test/server/api/system_process_api_test.dart
+++ b/bridge/app/test/server/api/system_process_api_test.dart
@@ -113,8 +113,10 @@ void main() {
       expect(identity.platform, equals("macos"));
     });
 
-    test("inspectProcess returns null (without throwing) when ps exits non-zero", () async {
-      final runner = _RecordingProcessRunner(exitCode: 1, stdout: "");
+    test("inspectProcess returns null (without throwing) when ps exits non-zero with no stderr", () async {
+      // A vanished pid: `ps -p` exits non-zero with empty stdout AND empty
+      // stderr. That is the legitimate "no such process" signal.
+      final runner = _RecordingProcessRunner(exitCode: 1, stdout: "", stderr: "");
       final api = SystemProcessApi(
         processRunner: runner,
         clock: const ServerClock(),
@@ -126,6 +128,25 @@ void main() {
 
       expect(identity, isNull);
       expect(runner.calls.single.arguments, containsAllInOrder(<String>["-p", "999999"]));
+    });
+
+    test("inspectProcess throws (not null) when ps exits non-zero with stderr", () async {
+      // A genuine invocation/format failure writes to stderr. It must NOT be
+      // collapsed to null — callers rely on POSIX self-inspection errors
+      // staying fatal so the startup lock is never poisoned with a
+      // marker-less fallback identity.
+      final runner = _RecordingProcessRunner(exitCode: 1, stdout: "", stderr: "ps: unknown option");
+      final api = SystemProcessApi(
+        processRunner: runner,
+        clock: const ServerClock(),
+        isWindows: false,
+        platform: "macos",
+      );
+
+      await expectLater(
+        api.inspectProcess(pid: 321),
+        throwsA(isA<ProcessException>()),
+      );
     });
 
     test("inspectProcess returns null when ps yields no matching row", () async {

--- a/bridge/app/test/server/api/system_process_api_test.dart
+++ b/bridge/app/test/server/api/system_process_api_test.dart
@@ -79,13 +79,89 @@ void main() {
       expect(runner.calls, isEmpty);
     });
   });
+
+  group("SystemProcessApi (POSIX)", () {
+    test("inspectProcess issues a PID-scoped ps query and parses one identity", () async {
+      final runner = _RecordingProcessRunner(
+        stdout: "  321 alex     Mon Jun 22 09:15:01 2026 /usr/local/bin/sesori-bridge --relay wss://relay\n",
+      );
+      final api = SystemProcessApi(
+        processRunner: runner,
+        clock: const ServerClock(),
+        isWindows: false,
+        platform: "macos",
+      );
+
+      final identity = await api.inspectProcess(pid: 321);
+
+      // The OS must do the filtering — never a full process-table scan.
+      expect(runner.calls, hasLength(1));
+      final call = runner.calls.single;
+      expect(call.executable, equals("ps"));
+      expect(call.arguments, containsAllInOrder(<String>["-p", "321"]));
+      expect(call.arguments, contains("-wwo"));
+      // The list selectors `a`/`x` must be dropped for the targeted lookup.
+      expect(call.arguments, isNot(contains("-axwwo")));
+      expect(call.environment, equals(<String, String>{"LC_ALL": "C"}));
+
+      expect(identity, isNotNull);
+      expect(identity!.pid, equals(321));
+      expect(identity.startMarker, equals("Mon Jun 22 09:15:01 2026"));
+      expect(identity.executablePath, equals("/usr/local/bin/sesori-bridge"));
+      expect(identity.commandLine, equals("/usr/local/bin/sesori-bridge --relay wss://relay"));
+      expect(identity.ownerUser, equals(ProcessUser.fromRawUser("alex")));
+      expect(identity.platform, equals("macos"));
+    });
+
+    test("inspectProcess returns null (without throwing) when ps exits non-zero", () async {
+      final runner = _RecordingProcessRunner(exitCode: 1, stdout: "");
+      final api = SystemProcessApi(
+        processRunner: runner,
+        clock: const ServerClock(),
+        isWindows: false,
+        platform: "macos",
+      );
+
+      final identity = await api.inspectProcess(pid: 999999);
+
+      expect(identity, isNull);
+      expect(runner.calls.single.arguments, containsAllInOrder(<String>["-p", "999999"]));
+    });
+
+    test("inspectProcess returns null when ps yields no matching row", () async {
+      final runner = _RecordingProcessRunner(stdout: "\n");
+      final api = SystemProcessApi(
+        processRunner: runner,
+        clock: const ServerClock(),
+        isWindows: false,
+        platform: "macos",
+      );
+
+      expect(await api.inspectProcess(pid: 321), isNull);
+    });
+
+    test("inspectProcess returns null for a non-positive PID without shelling out", () async {
+      final runner = _RecordingProcessRunner();
+      final api = SystemProcessApi(
+        processRunner: runner,
+        clock: const ServerClock(),
+        isWindows: false,
+        platform: "macos",
+      );
+
+      expect(await api.inspectProcess(pid: 0), isNull);
+      expect(await api.inspectProcess(pid: -1), isNull);
+      expect(runner.calls, isEmpty);
+    });
+  });
 }
 
 class _RecordedCall {
-  _RecordedCall({required this.executable, required this.arguments});
+  _RecordedCall({required this.executable, required this.arguments, required this.environment});
 
   final String executable;
   final List<String> arguments;
+  final Map<String, String>? environment;
 }
 
 class _RecordingProcessRunner implements ProcessRunner {
@@ -104,7 +180,16 @@ class _RecordingProcessRunner implements ProcessRunner {
     Map<String, String>? environment,
     Duration timeout = const Duration(seconds: 15),
   }) async {
-    calls.add(_RecordedCall(executable: executable, arguments: arguments));
+    calls.add(_RecordedCall(executable: executable, arguments: arguments, environment: environment));
     return ProcessResult(1, exitCode, stdout, stderr);
+  }
+
+  @override
+  Future<int> startDetached({
+    required String executable,
+    required List<String> arguments,
+    Map<String, String>? environment,
+  }) {
+    throw UnsupportedError("startDetached is not used by SystemProcessApi process-inspection tests");
   }
 }


### PR DESCRIPTION
## Summary

Makes `SystemProcessApi.inspectProcess(pid:)` on POSIX query **one** process by PID via `ps -p <pid>` instead of listing the entire process table and filtering — closing the asymmetry with the Windows path, which already uses a server-side PID filter (`tasklist /FI "PID eq <pid>"`, added in #305).

On Unix there is no need to enumerate all tasks just to inspect one.

## Changes

`bridge/app/lib/src/server/api/system_process_api.dart`:
- Add `_inspectPosixProcess(pid:)` — runs `ps -p <pid> -wwo "pid=,user=,lstart=,command="` with `LC_ALL=C`. A non-zero exit here means "no such process", so it returns `null` (does **not** throw, unlike `_listPosixProcesses`).
- Extract the line→`ProcessIdentity` parsing loop into a shared `_parsePosixProcesses(stdout:)` (mirrors `_parseWindowsProcesses`); used by both the list and targeted paths. Preserves the existing throw when the regex matches but the pid group is null.
- Point the `inspectProcess` POSIX branch at `_inspectPosixProcess(pid:)`.
- Keep `listProcesses()` / `_listPosixProcesses()` unchanged for full enumeration (still used by `bridge_instance_repository`).
- `pid <= 0` guard unchanged.

The targeted form drops the `a`/`x` list selectors but keeps `-ww` (no command-line truncation) and reuses the same `-o` column spec, so the 24-char `lstart` regex still matches.

## Tests

`bridge/app/test/server/api/system_process_api_test.dart` (fake `ProcessRunner`):
- POSIX inspect issues `ps -p <pid> ...`, drops `-axwwo`, passes `LC_ALL=C`, and parses one identity including `startMarker`.
- Returns `null` without throwing on non-zero exit, and on empty/no-match stdout.
- `pid <= 0` returns `null` without shelling out (`isWindows: false`).

## Verification

- `dart analyze --fatal-infos lib/src/server test/server/api/system_process_api_test.dart` → no issues
- `dart test test/server/api/system_process_api_test.dart` → 8/8 pass
- `dart test test/server/` → 127/127 pass

Builds on #305. Reviewed by `aristotle-plan-review` and `aristotle-impl-review` (both approved).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
POSIX `inspectProcess(pid)` now queries a single process via `ps -p <pid>`, matching Windows. It returns `null` when the PID is gone and throws on real `ps` errors.

- **Refactors**
  - Added `_inspectPosixProcess(pid)` that runs `ps -p <pid> -wwo "pid=,user=,lstart=,command="` with `LC_ALL=C`.
  - Extracted `_parsePosixProcesses(stdout)` shared by list and targeted paths.
  - Left `listProcesses()`/`_listPosixProcesses()` unchanged for full enumeration.

- **Bug Fixes**
  - Preserve genuine `ps` errors: non-zero exit with empty stderr ⇒ `null`; non-zero with stderr ⇒ rethrow `ProcessException`.

<sup>Written for commit 93b24c0f7f75ca6801308acd1eef458870283a8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

