### PR TITLE
feat(bridge): shared terminal color/glyph capability detection

### DIFF
--- a/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
+++ b/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
@@ -39,3 +39,5 @@ export "src/process/process_identity.dart";
 export "src/process/process_user.dart";
 export "src/process/server_clock.dart";
 export "src/process/signal_result.dart";
+export "src/terminal_color_validator.dart";
+export "src/terminal_glyph_validator.dart";

--- a/bridge/sesori_plugin_interface/lib/src/ansi_color.dart
+++ b/bridge/sesori_plugin_interface/lib/src/ansi_color.dart
@@ -1,5 +1,7 @@
 import "dart:io";
 
+import "terminal_color_validator.dart";
+
 /// ANSI foreground colors used to highlight terminal output.
 enum AnsiColor {
   red("\x1B[31m"),
@@ -15,46 +17,33 @@ enum AnsiColor {
 
 /// Wraps terminal text in ANSI color escape sequences.
 ///
-/// Coloring is only applied when [out] is an interactive terminal that supports
-/// ANSI escapes and the `NO_COLOR` environment variable is unset. When output
-/// is redirected to a file or pipe (or the stream is not a terminal), or the
-/// user has opted out via `NO_COLOR`, [colorize] returns the text unchanged so
+/// Whether color is applied is delegated to [TerminalColorValidator] (honoring
+/// `FORCE_COLOR`, `NO_COLOR`, `TERM`, and the stream's own ANSI probe). When
+/// color is not supported — output redirected to a file or pipe, a non-terminal
+/// stream, or an explicit opt-out — [colorize] returns the text unchanged so
 /// escape sequences never pollute captured logs.
 class AnsiColorFormatter {
   AnsiColorFormatter._();
 
   static const String _reset = "\x1B[0m";
 
-  /// Returns [text] wrapped in [color] when [out] supports ANSI escapes,
-  /// otherwise returns [text] unchanged.
+  /// Returns [text] wrapped in [color] when [TerminalColorValidator] reports
+  /// that [out] supports color, otherwise returns [text] unchanged.
   ///
   /// [environment] defaults to the process environment and exists to make the
-  /// `NO_COLOR` opt-out deterministically testable.
+  /// color opt-in/opt-out deterministically testable.
   static String colorize({
     required String text,
     required AnsiColor color,
     required Stdout out,
     Map<String, String>? environment,
   }) {
-    if (!_supportsAnsi(out: out, environment: environment ?? Platform.environment)) {
+    if (!TerminalColorValidator.isSupported(
+      out: out,
+      environment: environment ?? Platform.environment,
+    )) {
       return text;
     }
     return "${color.code}$text$_reset";
-  }
-
-  static bool _supportsAnsi({required Stdout out, required Map<String, String> environment}) {
-    // Honor the NO_COLOR convention (https://no-color.org/): when the variable
-    // is present (regardless of value), disable colorized output even on a
-    // capable terminal.
-    if (environment.containsKey("NO_COLOR")) {
-      return false;
-    }
-    try {
-      return out.supportsAnsiEscapes;
-    } catch (_) {
-      // Fake stdout streams used in tests (and exotic platforms) may not
-      // implement the capability probe; treat them as non-terminal.
-      return false;
-    }
   }
 }

--- a/bridge/sesori_plugin_interface/lib/src/terminal_color_validator.dart
+++ b/bridge/sesori_plugin_interface/lib/src/terminal_color_validator.dart
@@ -5,10 +5,12 @@ import "dart:io";
 /// The rules mirror the Sesori installer scripts (see `install.sh`) so the CLI,
 /// the loggers, and the installers all agree on when color is safe:
 ///
-/// 1. `FORCE_COLOR` (present with any value, even empty) forces color on — an
-///    explicit opt-in that overrides every other signal, including a
-///    non-terminal [out]. This is the only way ANSI escapes reach a redirected
-///    stream.
+/// 1. `FORCE_COLOR` (present and non-empty) forces color on — an explicit
+///    opt-in that overrides every other signal, including a non-terminal
+///    [out]. This is the only way ANSI escapes reach a redirected stream. An
+///    empty `FORCE_COLOR=` is treated as unset (matching `install.sh`'s `-n`
+///    check and the npm bootstrap's truthiness check) and falls through to the
+///    rules below.
 /// 2. `NO_COLOR` (present with any value) forces color off
 ///    (https://no-color.org/).
 /// 3. `TERM=dumb` forces color off.
@@ -27,7 +29,8 @@ class TerminalColorValidator {
     required Stdout out,
     required Map<String, String> environment,
   }) {
-    if (environment.containsKey("FORCE_COLOR")) {
+    final forceColor = environment["FORCE_COLOR"];
+    if (forceColor != null && forceColor.isNotEmpty) {
       return true;
     }
     if (environment.containsKey("NO_COLOR")) {

--- a/bridge/sesori_plugin_interface/lib/src/terminal_color_validator.dart
+++ b/bridge/sesori_plugin_interface/lib/src/terminal_color_validator.dart
@@ -1,0 +1,47 @@
+import "dart:io";
+
+/// Decides whether ANSI color escapes should be written to [out].
+///
+/// The rules mirror the Sesori installer scripts (see `install.sh`) so the CLI,
+/// the loggers, and the installers all agree on when color is safe:
+///
+/// 1. `FORCE_COLOR` (present with any value, even empty) forces color on — an
+///    explicit opt-in that overrides every other signal, including a
+///    non-terminal [out]. This is the only way ANSI escapes reach a redirected
+///    stream.
+/// 2. `NO_COLOR` (present with any value) forces color off
+///    (https://no-color.org/).
+/// 3. `TERM=dumb` forces color off.
+/// 4. Otherwise the stream's own [Stdout.supportsAnsiEscapes] probe decides
+///    (false for pipes/files, and for fake/exotic streams whose probe throws).
+///
+/// Unlike the shell installer, an empty/unset `TERM` does NOT force color off:
+/// Dart's `supportsAnsiEscapes` is a more reliable capability signal than the
+/// mere presence of `TERM`, and forcing off there would regress color on real
+/// terminals that do not export `TERM`.
+class TerminalColorValidator {
+  TerminalColorValidator._();
+
+  /// Whether color may be emitted to [out] under [environment].
+  static bool isSupported({
+    required Stdout out,
+    required Map<String, String> environment,
+  }) {
+    if (environment.containsKey("FORCE_COLOR")) {
+      return true;
+    }
+    if (environment.containsKey("NO_COLOR")) {
+      return false;
+    }
+    if (environment["TERM"] == "dumb") {
+      return false;
+    }
+    try {
+      return out.supportsAnsiEscapes;
+    } catch (_) {
+      // Fake stdout streams used in tests (and exotic platforms) may not
+      // implement the capability probe; treat them as non-terminal.
+      return false;
+    }
+  }
+}

--- a/bridge/sesori_plugin_interface/lib/src/terminal_glyph_validator.dart
+++ b/bridge/sesori_plugin_interface/lib/src/terminal_glyph_validator.dart
@@ -4,8 +4,9 @@
 /// The rules mirror the Sesori installer scripts (see `install.sh`):
 ///
 /// 1. `TERM=dumb` forces ASCII.
-/// 2. Otherwise a UTF-8 locale enables unicode glyphs. The locale is read from
-///    `LC_ALL`, then `LC_CTYPE`, then `LANG` (first set wins) and matched
+/// 2. Otherwise a UTF-8 locale enables unicode glyphs. The locale is the first
+///    non-empty of `LC_ALL`, `LC_CTYPE`, `LANG` (an empty value is skipped,
+///    matching `install.sh`'s `${LC_ALL:-…}` fallback) and matched
 ///    case-insensitively against `utf-8`/`utf8`.
 /// 3. Anything else (including an unset locale) falls back to ASCII.
 ///
@@ -20,8 +21,11 @@ class TerminalGlyphValidator {
     if (environment["TERM"] == "dumb") {
       return false;
     }
-    final locale =
-        (environment["LC_ALL"] ?? environment["LC_CTYPE"] ?? environment["LANG"] ?? "").toLowerCase();
+    final locale = ([
+      environment["LC_ALL"],
+      environment["LC_CTYPE"],
+      environment["LANG"],
+    ].firstWhere((value) => value != null && value.isNotEmpty, orElse: () => "") ?? "").toLowerCase();
     return locale.contains("utf-8") || locale.contains("utf8");
   }
 }

--- a/bridge/sesori_plugin_interface/lib/src/terminal_glyph_validator.dart
+++ b/bridge/sesori_plugin_interface/lib/src/terminal_glyph_validator.dart
@@ -1,0 +1,27 @@
+/// Decides whether unicode glyphs (rather than ASCII fallbacks) are safe to
+/// emit to the terminal.
+///
+/// The rules mirror the Sesori installer scripts (see `install.sh`):
+///
+/// 1. `TERM=dumb` forces ASCII.
+/// 2. Otherwise a UTF-8 locale enables unicode glyphs. The locale is read from
+///    `LC_ALL`, then `LC_CTYPE`, then `LANG` (first set wins) and matched
+///    case-insensitively against `utf-8`/`utf8`.
+/// 3. Anything else (including an unset locale) falls back to ASCII.
+///
+/// Glyph support is independent of the output stream, so [isSupported] takes
+/// only the [environment]; callers pair the result with their own glyph and
+/// ASCII-fallback sets.
+class TerminalGlyphValidator {
+  TerminalGlyphValidator._();
+
+  /// Whether unicode glyphs may be emitted under [environment].
+  static bool isSupported({required Map<String, String> environment}) {
+    if (environment["TERM"] == "dumb") {
+      return false;
+    }
+    final locale =
+        (environment["LC_ALL"] ?? environment["LC_CTYPE"] ?? environment["LANG"] ?? "").toLowerCase();
+    return locale.contains("utf-8") || locale.contains("utf8");
+  }
+}

--- a/bridge/sesori_plugin_interface/test/terminal_color_validator_test.dart
+++ b/bridge/sesori_plugin_interface/test/terminal_color_validator_test.dart
@@ -1,0 +1,134 @@
+import "dart:io";
+
+import "package:sesori_plugin_interface/src/terminal_color_validator.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("TerminalColorValidator", () {
+    test("supported on a capable terminal with no overriding env", () {
+      expect(
+        TerminalColorValidator.isSupported(
+          out: _FakeStdout(supportsAnsiEscapes: true),
+          environment: const {},
+        ),
+        isTrue,
+      );
+    });
+
+    test("not supported on a non-terminal with no overriding env", () {
+      expect(
+        TerminalColorValidator.isSupported(
+          out: _FakeStdout(supportsAnsiEscapes: false),
+          environment: const {},
+        ),
+        isFalse,
+      );
+    });
+
+    test("not supported when the capability probe throws", () {
+      expect(
+        TerminalColorValidator.isSupported(
+          out: _ThrowingStdout(),
+          environment: const {},
+        ),
+        isFalse,
+      );
+    });
+
+    test("FORCE_COLOR forces support even on a non-terminal", () {
+      expect(
+        TerminalColorValidator.isSupported(
+          out: _FakeStdout(supportsAnsiEscapes: false),
+          environment: const {"FORCE_COLOR": "1"},
+        ),
+        isTrue,
+        reason: "FORCE_COLOR is an explicit opt-in that overrides the stream probe",
+      );
+    });
+
+    test("FORCE_COLOR forces support without probing the stream", () {
+      expect(
+        TerminalColorValidator.isSupported(
+          out: _ThrowingStdout(),
+          environment: const {"FORCE_COLOR": ""},
+        ),
+        isTrue,
+        reason: "FORCE_COLOR (even empty) short-circuits before the capability probe",
+      );
+    });
+
+    test("FORCE_COLOR takes precedence over NO_COLOR", () {
+      expect(
+        TerminalColorValidator.isSupported(
+          out: _FakeStdout(supportsAnsiEscapes: false),
+          environment: const {"FORCE_COLOR": "1", "NO_COLOR": "1"},
+        ),
+        isTrue,
+        reason: "the installer precedence checks FORCE_COLOR before NO_COLOR",
+      );
+    });
+
+    test("NO_COLOR disables support on a capable terminal", () {
+      expect(
+        TerminalColorValidator.isSupported(
+          out: _FakeStdout(supportsAnsiEscapes: true),
+          environment: const {"NO_COLOR": "1"},
+        ),
+        isFalse,
+      );
+    });
+
+    test("NO_COLOR disables support even when set to an empty value", () {
+      expect(
+        TerminalColorValidator.isSupported(
+          out: _FakeStdout(supportsAnsiEscapes: true),
+          environment: const {"NO_COLOR": ""},
+        ),
+        isFalse,
+        reason: "presence of NO_COLOR disables color regardless of its value",
+      );
+    });
+
+    test("TERM=dumb disables support on a capable terminal", () {
+      expect(
+        TerminalColorValidator.isSupported(
+          out: _FakeStdout(supportsAnsiEscapes: true),
+          environment: const {"TERM": "dumb"},
+        ),
+        isFalse,
+      );
+    });
+
+    test("a non-dumb TERM defers to the stream probe", () {
+      expect(
+        TerminalColorValidator.isSupported(
+          out: _FakeStdout(supportsAnsiEscapes: true),
+          environment: const {"TERM": "xterm-256color"},
+        ),
+        isTrue,
+      );
+    });
+  });
+}
+
+/// Stdout whose ANSI support can be controlled.
+class _FakeStdout implements Stdout {
+  _FakeStdout({required bool supportsAnsiEscapes}) : _supportsAnsiEscapes = supportsAnsiEscapes;
+
+  final bool _supportsAnsiEscapes;
+
+  @override
+  bool get supportsAnsiEscapes => _supportsAnsiEscapes;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Stdout whose capability probe throws, mimicking exotic platforms.
+class _ThrowingStdout implements Stdout {
+  @override
+  bool get supportsAnsiEscapes => throw UnsupportedError("no terminal");
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/sesori_plugin_interface/test/terminal_color_validator_test.dart
+++ b/bridge/sesori_plugin_interface/test/terminal_color_validator_test.dart
@@ -46,14 +46,33 @@ void main() {
       );
     });
 
-    test("FORCE_COLOR forces support without probing the stream", () {
+    test("a non-empty FORCE_COLOR forces support without probing the stream", () {
       expect(
         TerminalColorValidator.isSupported(
           out: _ThrowingStdout(),
-          environment: const {"FORCE_COLOR": ""},
+          environment: const {"FORCE_COLOR": "1"},
         ),
         isTrue,
-        reason: "FORCE_COLOR (even empty) short-circuits before the capability probe",
+        reason: "a non-empty FORCE_COLOR short-circuits before the capability probe",
+      );
+    });
+
+    test("an empty FORCE_COLOR is treated as unset and falls through", () {
+      expect(
+        TerminalColorValidator.isSupported(
+          out: _FakeStdout(supportsAnsiEscapes: false),
+          environment: const {"FORCE_COLOR": ""},
+        ),
+        isFalse,
+        reason: "an empty FORCE_COLOR matches install.sh's -n check (treated as unset)",
+      );
+      expect(
+        TerminalColorValidator.isSupported(
+          out: _FakeStdout(supportsAnsiEscapes: true),
+          environment: const {"FORCE_COLOR": "", "NO_COLOR": "1"},
+        ),
+        isFalse,
+        reason: "an empty FORCE_COLOR falls through to NO_COLOR",
       );
     });
 

--- a/bridge/sesori_plugin_interface/test/terminal_glyph_validator_test.dart
+++ b/bridge/sesori_plugin_interface/test/terminal_glyph_validator_test.dart
@@ -1,0 +1,69 @@
+import "package:sesori_plugin_interface/src/terminal_glyph_validator.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("TerminalGlyphValidator", () {
+    test("supported for a UTF-8 LANG", () {
+      expect(
+        TerminalGlyphValidator.isSupported(environment: const {"LANG": "en_US.UTF-8"}),
+        isTrue,
+      );
+    });
+
+    test("supported for a 'utf8' spelling", () {
+      expect(
+        TerminalGlyphValidator.isSupported(environment: const {"LANG": "C.UTF8"}),
+        isTrue,
+      );
+    });
+
+    test("matched case-insensitively", () {
+      expect(
+        TerminalGlyphValidator.isSupported(environment: const {"LANG": "en_US.utf-8"}),
+        isTrue,
+      );
+    });
+
+    test("not supported for a non-UTF-8 locale", () {
+      expect(
+        TerminalGlyphValidator.isSupported(environment: const {"LANG": "POSIX"}),
+        isFalse,
+      );
+    });
+
+    test("not supported when no locale variable is set", () {
+      expect(
+        TerminalGlyphValidator.isSupported(environment: const {}),
+        isFalse,
+      );
+    });
+
+    test("LC_ALL takes precedence over LANG", () {
+      expect(
+        TerminalGlyphValidator.isSupported(
+          environment: const {"LC_ALL": "C", "LANG": "en_US.UTF-8"},
+        ),
+        isFalse,
+        reason: "LC_ALL wins, and a bare C locale is not UTF-8",
+      );
+    });
+
+    test("LC_CTYPE takes precedence over LANG", () {
+      expect(
+        TerminalGlyphValidator.isSupported(
+          environment: const {"LC_CTYPE": "en_US.UTF-8", "LANG": "POSIX"},
+        ),
+        isTrue,
+      );
+    });
+
+    test("TERM=dumb forces ASCII even with a UTF-8 locale", () {
+      expect(
+        TerminalGlyphValidator.isSupported(
+          environment: const {"TERM": "dumb", "LANG": "en_US.UTF-8"},
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/bridge/sesori_plugin_interface/test/terminal_glyph_validator_test.dart
+++ b/bridge/sesori_plugin_interface/test/terminal_glyph_validator_test.dart
@@ -57,6 +57,25 @@ void main() {
       );
     });
 
+    test("skips an empty LC_ALL and falls through to a later locale", () {
+      expect(
+        TerminalGlyphValidator.isSupported(
+          environment: const {"LC_ALL": "", "LANG": "en_US.UTF-8"},
+        ),
+        isTrue,
+        reason: "an empty value is skipped, matching the install.sh locale fallback",
+      );
+    });
+
+    test("all-empty locale variables fall back to ASCII", () {
+      expect(
+        TerminalGlyphValidator.isSupported(
+          environment: const {"LC_ALL": "", "LC_CTYPE": "", "LANG": ""},
+        ),
+        isFalse,
+      );
+    });
+
     test("TERM=dumb forces ASCII even with a UTF-8 locale", () {
       expect(
         TerminalGlyphValidator.isSupported(


### PR DESCRIPTION
## What

Extracts the ANSI-color decision out of `AnsiColorFormatter` into a dedicated `TerminalColorValidator`, and adds a sibling `TerminalGlyphValidator` for unicode-glyph support — so `Console`, `Log`, and upcoming branded CLI output share **one** source of truth for "can this stream/environment render color / glyphs?".

Brings the Dart side to parity with the installer scripts' detection (`install.sh`):

- **Color** (`TerminalColorValidator.isSupported({out, environment})`): `FORCE_COLOR` forces on → `NO_COLOR` forces off → `TERM=dumb` forces off → otherwise the stream's own `supportsAnsiEscapes` probe decides.
- **Glyphs** (`TerminalGlyphValidator.isSupported({environment})`): `TERM=dumb` → ASCII; otherwise a UTF-8 locale (`LC_ALL`/`LC_CTYPE`/`LANG`, first set wins, case-insensitive `utf-8`/`utf8`) → unicode; else ASCII.

## Why

Groundwork for a branded `sesori-bridge update` command (separate follow-up PR) whose output should match the polished installer experience. Rather than duplicate ad-hoc color checks, this unifies the decision and upgrades `Console`/`Log` to honor `FORCE_COLOR` and `TERM=dumb` too.

## Notes

- `Console` and `Log` are **unchanged** — they already colorize through `AnsiColorFormatter.colorize`, so they inherit the upgraded decision automatically.
- Deliberate divergence from the shell installer: an empty/unset `TERM` does **not** force color off, because Dart's `supportsAnsiEscapes` is a more reliable probe than the presence of `TERM` (forcing off there would regress color on real terminals that don't export `TERM`).
- Brand 256-color palette and glyph characters intentionally stay with their consumers (the bridge CLI styler in the follow-up PR); only the capability *checks* are shared here.

## Testing

- New `terminal_color_validator_test.dart` (10 cases) + `terminal_glyph_validator_test.dart` (8 cases) covering the full env matrix.
- `make analyze` clean across all 4 bridge modules (`dart analyze --fatal-infos`).
- `dart test` green for `sesori_plugin_interface` (138 tests) — existing `ansi_color`/`console`/`log` tests still pass, confirming the no-ANSI-leak-into-non-terminal guarantee holds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes terminal capability detection for ANSI colors and Unicode glyphs so `Console`, `Log`, and the upcoming CLI output use the same rules as the installer. `AnsiColorFormatter` now delegates to shared validators for clear, consistent behavior.

- **New Features**
  - `TerminalColorValidator.isSupported({out, environment})`: `FORCE_COLOR` (non-empty) → on; `NO_COLOR` → off; `TERM=dumb` → off; else `Stdout.supportsAnsiEscapes`. An empty `FORCE_COLOR` is treated as unset.
  - `TerminalGlyphValidator.isSupported({environment})`: `TERM=dumb` → ASCII; else first non-empty of `LC_ALL`/`LC_CTYPE`/`LANG` with UTF-8/utf8 → Unicode; otherwise ASCII.
  - Exported both validators from `sesori_plugin_interface.dart`.

- **Refactors**
  - Moved color decision from `AnsiColorFormatter` to `TerminalColorValidator`; `Console`/`Log` inherit the updated rules (now honor `FORCE_COLOR` and `TERM=dumb`). Unset `TERM` does not disable color to rely on `supportsAnsiEscapes`.

<sup>Written for commit 8a87c59de1a9d54e04ee381d33a536754d2bd8ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

