### PR TITLE
feat(bridge): add a `sesori-bridge update` command

### DIFF
--- a/.opencode/pr-monitor.json
+++ b/.opencode/pr-monitor.json
@@ -1,3 +1,6 @@
 {
-  "ignoreCommentTag": "[Sesori reply]"
+  "ignoreCommentTag": "[Sesori reply]",
+  "maxCiWaitMinutes": 30,
+  "debounceMinutes": 2,
+  "pollIntervalSeconds": 45
 }

--- a/.opencode/skills/address-pr-comments/SKILL.md
+++ b/.opencode/skills/address-pr-comments/SKILL.md
@@ -107,6 +107,7 @@ For each valid comment:
 
 Fix guidelines:
 - Fix minimally. Do not refactor unrelated code.
+- A small, safe hardening or cleanup a reviewer flags **inside a file or class your PR already modifies** is in scope — implement it rather than declining it as "pre-existing" or "out of scope." Reserve those reasons for genuinely unrelated files or large/risky refactors.
 - Follow existing codebase conventions (style, naming, patterns)
 - If a comment requests a specific approach and you disagree, use your judgment but explain in the reply
 - If you are changing logic or fixing logic bugs/edge case omissions/etc, use TDD (write a failing test first)

--- a/.opencode/skills/monitor-pr/SKILL.md
+++ b/.opencode/skills/monitor-pr/SKILL.md
@@ -38,6 +38,16 @@ act as follows, addressing everything in the report in one batch:
 | Approved + CI passing + 0 unresolved threads | Nothing to fix — summarize the PR state to the user. |
 | `— MERGED` / `— CLOSED` | The monitor already stopped itself. Nothing to do. |
 
+> **Owner-account comments are NOT your own replies.** The agent pushes commits
+> and posts review replies using the **same GitHub account as the human owner**,
+> so a report that lists new comments from that account (e.g. "1 new: 1
+> &lt;owner&gt;") may be the **human giving you an instruction**, not an echo of
+> your own reply. Agent replies always start with `[Sesori reply]` (see the
+> `address-pr-comments` skill). Treat any owner-account comment **without** that
+> prefix as a human instruction — fetch it and act on it (including when it
+> overrides a decision you already made). Never skip a reported owner-account
+> comment by assuming you wrote it.
+
 ## After handling a report — no manual flush needed
 
 A delivered `[PR Monitor]` report has **already advanced** the "new since last flush"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,6 +410,10 @@ Do not skip either step. The reviewers exist because violations compound — one
 - Never rely on users reviewing uncommitted changes. Remote PR state is the review source of truth unless the user explicitly says otherwise.
 - Never use `git commit --amend` anywhere in this repo workflow. There are no exceptions; if follow-up changes are needed, create a new commit instead.
 
+## Error Handling
+
+**Never catch and swallow.** Every `catch` block must log. Even a no-op, best-effort, or intentional-degradation handler must emit at least a `debug`/`warning` log that includes the caught error and (briefly) why continuing is safe. A silent `catch` — an empty body, or a bare comment with no log — is forbidden. If you genuinely want to ignore an error, you still log it. This applies in every workspace (bridge, mobile, shared).
+
 ## Forbidden
 
 - Don't modify `shared/sesori_shared` without considering impact on both bridge and mobile consumers.

--- a/bridge/AGENTS.md
+++ b/bridge/AGENTS.md
@@ -119,9 +119,9 @@ If a concept has a fixed set of values (PR state, mergeable status, review decis
 
 API methods must **throw** on unexpected errors. Never return empty lists, `null`, or `false` to hide failures — the caller should decide how to handle the error. A single `catch` block is fine if all errors are handled identically; don't split into multiple catches that do the same thing.
 
-### Log Unexpected Degradation Paths
+### Never Swallow Exceptions — Every `catch` Logs
 
-When a service/repository intentionally degrades on an unexpected `catch`, emit a warning/debug log with enough context to understand what failed. Silent fallback is only acceptable when the code is explicitly best-effort and the lack of logging is intentional.
+Every `catch` block must log. When a service/repository degrades on an unexpected `catch`, emit a warning/debug log (including the caught error) with enough context to understand what failed. This applies to **no-op and best-effort handlers too**: a silent `catch` — an empty body, or a bare comment with no log — is forbidden. If continuing really is safe, record that decision and the error with `Log.d`/`Log.w`; never discard an exception without a trace.
 
 ### No Redundant Model Layers
 

--- a/bridge/app/AGENTS.md
+++ b/bridge/app/AGENTS.md
@@ -81,6 +81,7 @@ bridge/ workspace modules (siblings of app/):
 
 ## ANTI-PATTERNS
 
+- **Never catch and swallow** — every `catch` must log (a `debug`/`warning` including the caught error), even no-op/best-effort/intentional-degradation handlers. A silent `catch` (empty body or a bare comment with no log) is forbidden.
 - **Never duplicate crypto** — use `sesori_shared` package for all encryption/protocol types
 - **Never hardcode URLs** — relay and auth backend are CLI-configurable. The OpenCode server defaults to loopback (`127.0.0.1`) but its host and port are CLI-configurable too (`--opencode-host`, `--opencode-port`)
 - **Never inline HTTP calls in business logic** — extract to a dedicated API class with typed return values

--- a/bridge/app/AGENTS.md
+++ b/bridge/app/AGENTS.md
@@ -74,7 +74,8 @@ bridge/ workspace modules (siblings of app/):
     fooRequest = FooRequest.fromJson(
       jsonDecodeMap(request.body),
     );
-  } catch {
+  } catch (error) {
+    Log.d("Rejecting request with an invalid JSON body: $error");
     return buildErrorResponse(request, 400, "invalid JSON body");
   }
   ```

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -464,6 +464,9 @@ class UpdateCommand extends cli.Command<void> {
             archiveExtractorApi: ArchiveExtractorApi(processRunner: processRunner),
           ),
           filesystemCleaner: filesystemCleaner,
+          // Stage into a per-process workspace so a manual update can't clobber
+          // (or be clobbered by) a resident bridge's background staging.
+          workspaceLabel: 'manual.$pid',
         ),
         updateApplyService: UpdateApplyService(
           installationRepository: installationRepository,

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -491,7 +491,7 @@ class UpdateCommand extends cli.Command<void> {
         errorStream: stderr,
         environment: environment,
       );
-      for (final line in formatter.format(outcome)) {
+      for (final line in formatter.format(outcome: outcome)) {
         if (line.isError) {
           stderr.writeln(line.text);
         } else {

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:args/args.dart' show ArgParserException;
 import 'package:args/command_runner.dart' as cli;
+import 'package:clock/clock.dart';
 import 'package:http/http.dart' as http;
 import 'package:sesori_bridge/src/api/bridge_settings_api.dart';
 import 'package:sesori_bridge/src/api/default_editor_api.dart';
@@ -30,7 +31,31 @@ import 'package:sesori_bridge/src/server/repositories/terminal_prompt_repository
 import 'package:sesori_bridge/src/server/services/bridge_instance_service.dart';
 import 'package:sesori_bridge/src/services/bridge_config_service.dart';
 import 'package:sesori_bridge/src/services/sleep_prevention_service.dart';
+import 'package:sesori_bridge/src/updater/api/archive_extractor_api.dart';
+import 'package:sesori_bridge/src/updater/api/checksum_manifest_api.dart';
+import 'package:sesori_bridge/src/updater/api/checksum_verifier_api.dart';
+import 'package:sesori_bridge/src/updater/api/github_releases_api.dart';
+import 'package:sesori_bridge/src/updater/api/managed_runtime_manifest_api.dart';
+import 'package:sesori_bridge/src/updater/api/platform_update_api.dart';
+import 'package:sesori_bridge/src/updater/api/update_attempt_api.dart';
+import 'package:sesori_bridge/src/updater/api/update_cache_api.dart';
+import 'package:sesori_bridge/src/updater/api/update_download_api.dart';
+import 'package:sesori_bridge/src/updater/api/update_log_api.dart';
+import 'package:sesori_bridge/src/updater/formatters/update_command_formatter.dart';
+import 'package:sesori_bridge/src/updater/foundation/filesystem_cleaner.dart';
 import 'package:sesori_bridge/src/updater/foundation/release_track.dart';
+import 'package:sesori_bridge/src/updater/foundation/update_lock.dart';
+import 'package:sesori_bridge/src/updater/models/distribution_target.dart';
+import 'package:sesori_bridge/src/updater/models/explicit_update_outcome.dart';
+import 'package:sesori_bridge/src/updater/repositories/release_repository.dart';
+import 'package:sesori_bridge/src/updater/repositories/update_artifact_repository.dart';
+import 'package:sesori_bridge/src/updater/repositories/update_attempt_repository.dart';
+import 'package:sesori_bridge/src/updater/repositories/update_installation_repository.dart';
+import 'package:sesori_bridge/src/updater/repositories/update_log_repository.dart';
+import 'package:sesori_bridge/src/updater/services/managed_runtime_path_service.dart';
+import 'package:sesori_bridge/src/updater/services/manual_update_service.dart';
+import 'package:sesori_bridge/src/updater/services/update_apply_service.dart';
+import 'package:sesori_bridge/src/updater/services/update_install_service.dart';
 import 'package:sesori_bridge/src/version.dart';
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart'
     show BridgePluginDescriptor, Console, Log, LogLevel, PluginConfig, PluginConfigException, ProcessUser, ServerClock;
@@ -369,6 +394,139 @@ class ConfigTrackCommand extends cli.Command<void> {
   }
 }
 
+class UpdateCommand extends cli.Command<void> {
+  @override
+  final name = 'update';
+
+  @override
+  final description = 'Update the bridge to the latest release on your track, then exit';
+
+  UpdateCommand() {
+    argParser.addFlag(
+      'force',
+      abbr: 'f',
+      negatable: false,
+      help:
+          'Reinstall the latest release for your track even if you are already on it, '
+          'and switch from an internal build back to stable when the track is stable.',
+    );
+  }
+
+  @override
+  Future<void> run() async {
+    final bool force = argResults!['force'] as bool;
+    final environment = Platform.environment;
+    final managedRuntimePaths = const ManagedRuntimePathService().currentPaths(environment: environment);
+    final installRoot = managedRuntimePaths.installRoot;
+    const clock = Clock();
+    const filesystemCleaner = FilesystemCleaner();
+    final releaseTrack = await _resolveReleaseTrack();
+
+    // Opportunistically authenticate GitHub release checks; the first non-empty
+    // of GITHUB_TOKEN / GH_TOKEN lifts the 60/hour anonymous limit to 5000/hour.
+    final githubToken =
+        [
+              environment['GITHUB_TOKEN'],
+              environment['GH_TOKEN'],
+            ]
+            .map((token) => token?.trim())
+            .firstWhere(
+              (token) => token != null && token.isNotEmpty,
+              orElse: () => null,
+            );
+
+    final httpClient = http.Client();
+    try {
+      final processRunner = ProcessRunner();
+      final logRepository = UpdateLogRepository(
+        api: UpdateLogApi(installRoot: installRoot, clock: clock),
+      );
+      final attemptRepository = UpdateAttemptRepository(api: UpdateAttemptApi(installRoot: installRoot));
+      final installationRepository = UpdateInstallationRepository(
+        platformUpdateApi: PlatformUpdateApi.forPlatform(processRunner: processRunner),
+        manifestApi: const ManagedRuntimeManifestApi(),
+      );
+      final updateLock = UpdateLock(currentPid: pid, processRunner: processRunner, clock: clock);
+
+      final manualUpdateService = ManualUpdateService(
+        releaseRepository: ReleaseRepository(
+          api: GitHubReleasesApi(httpClient: httpClient, authToken: githubToken),
+          cache: UpdateCacheApi(cacheDirectory: managedRuntimePaths.cacheDirectory, clock: clock),
+          currentVersion: appVersion,
+          target: currentDistributionTarget(),
+          track: releaseTrack,
+        ),
+        updateInstallService: UpdateInstallService(
+          updateArtifactRepository: UpdateArtifactRepository(
+            downloadApi: UpdateDownloadApi(httpClient: httpClient),
+            checksumManifestApi: ChecksumManifestApi(httpClient: httpClient),
+            checksumVerifierApi: ChecksumVerifierApi(),
+            archiveExtractorApi: ArchiveExtractorApi(processRunner: processRunner),
+          ),
+          filesystemCleaner: filesystemCleaner,
+        ),
+        updateApplyService: UpdateApplyService(
+          installationRepository: installationRepository,
+          attemptRepository: attemptRepository,
+          logRepository: logRepository,
+          updateLock: updateLock,
+          filesystemCleaner: filesystemCleaner,
+          clock: clock,
+          currentVersion: appVersion,
+          installRoot: installRoot,
+        ),
+        track: releaseTrack,
+        installRoot: installRoot,
+        executablePath: Platform.resolvedExecutable,
+        managedExecutablePath: managedRuntimePaths.binaryPath,
+      );
+
+      final outcome = await manualUpdateService.runUpdate(force: force);
+
+      final formatter = UpdateCommandFormatter(
+        outStream: stdout,
+        errorStream: stderr,
+        environment: environment,
+      );
+      for (final line in formatter.format(outcome)) {
+        if (line.isError) {
+          stderr.writeln(line.text);
+        } else {
+          stdout.writeln(line.text);
+        }
+      }
+      exitCode = _exitCodeFor(outcome);
+    } finally {
+      httpClient.close();
+    }
+  }
+
+  Future<ReleaseTrack> _resolveReleaseTrack() async {
+    try {
+      final settings = await BridgeSettingsRepository(api: BridgeSettingsApi()).loadSettings();
+      return settings.releaseTrack;
+    } on Object catch (error) {
+      Log.w('Failed to resolve release track; defaulting to stable: $error');
+      return ReleaseTrack.stable;
+    }
+  }
+
+  int _exitCodeFor(ExplicitUpdateOutcome outcome) {
+    switch (outcome) {
+      case ExplicitUpdateApplied():
+      case ExplicitUpdateAlreadyLatest():
+      case ExplicitUpdateTrackMismatch():
+        return 0;
+      case ExplicitUpdateNoEligibleRelease():
+      case ExplicitUpdateNotManaged():
+      case ExplicitUpdateNpmDirect():
+      case ExplicitUpdateLockBusy():
+      case ExplicitUpdateFailed():
+        return 1;
+    }
+  }
+}
+
 /// Best-effort `enabledPlugins` read for plugin selection. Selection also
 /// runs for `--help` and `logout`, so it must never crash on (or create)
 /// a missing/broken config — failures resolve to "unset". Diagnostics go
@@ -411,7 +569,8 @@ Future<void> main(List<String> args) async {
   final runner = cli.CommandRunner<void>('sesori-bridge', 'Sesori Bridge CLI')
     ..addCommand(RunCommand(selectedPlugin: selectedPlugin, selectionError: pluginSelectionError))
     ..addCommand(LogoutCommand())
-    ..addCommand(ConfigCommand());
+    ..addCommand(ConfigCommand())
+    ..addCommand(UpdateCommand());
 
   try {
     await runner.run(effectiveCliArgs(args));

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -609,6 +609,8 @@ class BridgeRuntimeRunner {
           archiveExtractorApi: ArchiveExtractorApi(processRunner: processRunner),
         ),
         filesystemCleaner: filesystemCleaner,
+        // The background updater uses the shared, fixed staging paths.
+        workspaceLabel: null,
       ),
       updateApplyService: updateApplyService,
       logRepository: logRepository,

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -578,13 +578,12 @@ class BridgeRuntimeRunner {
       platformUpdateApi: PlatformUpdateApi.forPlatform(processRunner: processRunner),
       manifestApi: const ManagedRuntimeManifestApi(),
     );
-    final updateLock = UpdateLock(currentPid: io.pid, processRunner: processRunner);
+    final updateLock = UpdateLock(currentPid: io.pid, processRunner: processRunner, clock: clock);
     final updateApplyService = UpdateApplyService(
       installationRepository: installationRepository,
       attemptRepository: attemptRepository,
       logRepository: logRepository,
       updateLock: updateLock,
-      messageFormatter: messageFormatter,
       filesystemCleaner: filesystemCleaner,
       clock: clock,
       currentVersion: appVersion,

--- a/bridge/app/lib/src/updater/formatters/update_command_formatter.dart
+++ b/bridge/app/lib/src/updater/formatters/update_command_formatter.dart
@@ -47,7 +47,7 @@ class UpdateCommandFormatter {
   static const String _dim = '\x1B[2m';
   static const String _bold = '\x1B[1m';
 
-  List<RenderedLine> format(ExplicitUpdateOutcome outcome) {
+  List<RenderedLine> format({required ExplicitUpdateOutcome outcome}) {
     switch (outcome) {
       case ExplicitUpdateApplied():
         return _applied(outcome);

--- a/bridge/app/lib/src/updater/formatters/update_command_formatter.dart
+++ b/bridge/app/lib/src/updater/formatters/update_command_formatter.dart
@@ -1,0 +1,151 @@
+import 'dart:io';
+
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart'
+    show TerminalColorValidator, TerminalGlyphValidator;
+
+import '../models/explicit_update_outcome.dart';
+
+/// A single rendered output line and where it belongs. [isError] lines go to
+/// stderr; the rest go to stdout. The [text] is already styled (color/glyphs
+/// applied or stripped) for its destination, so the command only writes it.
+class RenderedLine {
+  final bool isError;
+  final String text;
+
+  const RenderedLine({required this.isError, required this.text});
+}
+
+/// Renders an [ExplicitUpdateOutcome] into branded, capability-gated output
+/// lines for the `sesori-bridge update` command.
+///
+/// Self-contained on purpose: it owns the brand palette + glyph set (kept
+/// visually consistent with the installer scripts) and decides color/glyph
+/// support per output stream via [TerminalColorValidator] / [TerminalGlyphValidator].
+/// Pure: given the streams + environment, [format] returns strings and performs
+/// no IO — the command does the writing.
+class UpdateCommandFormatter {
+  UpdateCommandFormatter({
+    required Stdout outStream,
+    required Stdout errorStream,
+    required Map<String, String> environment,
+  }) : _colorOut = TerminalColorValidator.isSupported(out: outStream, environment: environment),
+       _colorErr = TerminalColorValidator.isSupported(out: errorStream, environment: environment),
+       _unicode = TerminalGlyphValidator.isSupported(environment: environment);
+
+  final bool _colorOut;
+  final bool _colorErr;
+  final bool _unicode;
+
+  /// Where users are sent to reinstall manually after a failure.
+  static const String installScriptUrl = 'https://sesori.com/';
+
+  static const String _reset = '\x1B[0m';
+  static const String _brand = '\x1B[38;5;39m';
+  static const String _green = '\x1B[38;5;42m';
+  static const String _yellow = '\x1B[38;5;214m';
+  static const String _red = '\x1B[38;5;203m';
+  static const String _dim = '\x1B[2m';
+  static const String _bold = '\x1B[1m';
+
+  List<RenderedLine> format(ExplicitUpdateOutcome outcome) {
+    switch (outcome) {
+      case ExplicitUpdateApplied():
+        return _applied(outcome);
+      case ExplicitUpdateAlreadyLatest():
+        return [
+          _success("You're on the latest ${outcome.track.wireValue} build (v${outcome.version}).", isError: false),
+        ];
+      case ExplicitUpdateTrackMismatch():
+        final track = outcome.track.wireValue;
+        return [
+          _warn("Running v${outcome.currentVersion}, which isn't on the $track track.", isError: false),
+          _dimLine('  Latest $track is v${outcome.latestVersion}.', isError: false),
+          _note(
+            'Run  ${_command('sesori-bridge update --force', isError: false)}  to switch to $track.',
+            isError: false,
+          ),
+        ];
+      case ExplicitUpdateNoEligibleRelease():
+        return [_error('No ${outcome.track.wireValue} release is available to install.', isError: true)];
+      case ExplicitUpdateNotManaged():
+        return [
+          _error('sesori-bridge update only updates the managed install.', isError: true),
+          _dimLine("  You're running from ${outcome.executablePath}.", isError: true),
+          _note('Install with the Sesori install script, or run via npx @sesori/bridge.', isError: true),
+        ];
+      case ExplicitUpdateNpmDirect():
+        return [_error(outcome.message, isError: true)];
+      case ExplicitUpdateLockBusy():
+        return [_warn('Another update is already in progress. Try again shortly.', isError: true)];
+      case ExplicitUpdateFailed():
+        return _failed(outcome);
+    }
+  }
+
+  List<RenderedLine> _applied(ExplicitUpdateApplied outcome) {
+    final track = outcome.track.wireValue;
+    final String headline;
+    switch (outcome.kind) {
+      case UpdateAppliedKind.upgrade:
+        final from = outcome.fromVersion;
+        headline = from == null ? 'Updated to v${outcome.toVersion}.' : 'Updated v$from $_arrow v${outcome.toVersion}';
+      case UpdateAppliedKind.reinstall:
+        headline = 'Reinstalled v${outcome.toVersion} ($track).';
+      case UpdateAppliedKind.downgrade:
+        headline = 'Switched to $track v${outcome.toVersion}.';
+    }
+    return [
+      _success(headline, isError: false),
+      _dimLine('  Takes effect on next launch; restart a running bridge to apply now.', isError: false),
+    ];
+  }
+
+  List<RenderedLine> _failed(ExplicitUpdateFailed outcome) {
+    final lines = <RenderedLine>[
+      _error('Update failed: ${outcome.reason}.', isError: true),
+      _note('Re-run the install script to update manually: $installScriptUrl', isError: true),
+    ];
+    final logPath = outcome.logPath;
+    if (logPath != null) {
+      lines.add(_dimLine('  Details in $logPath', isError: true));
+    }
+    return lines;
+  }
+
+  String get _arrow => _unicode ? '\u2192' : '->';
+
+  RenderedLine _success(String text, {required bool isError}) => RenderedLine(
+    isError: isError,
+    text: '${_glyph(_green, '\u2713', '[OK]', isError: isError)} $text',
+  );
+
+  RenderedLine _warn(String text, {required bool isError}) => RenderedLine(
+    isError: isError,
+    text: '${_glyph(_yellow, '\u26a0', '!', isError: isError)} $text',
+  );
+
+  RenderedLine _error(String text, {required bool isError}) => RenderedLine(
+    isError: isError,
+    text: '${_glyph(_red, '\u2717', 'x', isError: isError)} $text',
+  );
+
+  RenderedLine _note(String text, {required bool isError}) => RenderedLine(
+    isError: isError,
+    text: '${_glyph(_brand, '\u279c', '>', isError: isError)} $text',
+  );
+
+  RenderedLine _dimLine(String text, {required bool isError}) => RenderedLine(
+    isError: isError,
+    text: _paint(_dim, text, isError: isError),
+  );
+
+  String _command(String text, {required bool isError}) => _paint('$_brand$_bold', text, isError: isError);
+
+  String _glyph(String code, String unicode, String ascii, {required bool isError}) =>
+      _paint(code, _unicode ? unicode : ascii, isError: isError);
+
+  String _paint(String code, String text, {required bool isError}) {
+    final bool color = isError ? _colorErr : _colorOut;
+    return color ? '$code$text$_reset' : text;
+  }
+}

--- a/bridge/app/lib/src/updater/formatters/update_command_formatter.dart
+++ b/bridge/app/lib/src/updater/formatters/update_command_formatter.dart
@@ -58,10 +58,10 @@ class UpdateCommandFormatter {
       case ExplicitUpdateTrackMismatch():
         final track = outcome.track.wireValue;
         return [
-          _warn("Running v${outcome.currentVersion}, which isn't on the $track track.", isError: false),
+          _warn("You're on v${outcome.currentVersion}, not the latest $track build.", isError: false),
           _dimLine('  Latest $track is v${outcome.latestVersion}.', isError: false),
           _note(
-            'Run  ${_command('sesori-bridge update --force', isError: false)}  to switch to $track.',
+            'Run  ${_command('sesori-bridge update --force', isError: false)}  to install it.',
             isError: false,
           ),
         ];

--- a/bridge/app/lib/src/updater/foundation/update_lock.dart
+++ b/bridge/app/lib/src/updater/foundation/update_lock.dart
@@ -77,8 +77,7 @@ class UpdateLock {
     );
 
     try {
-      await lockFile.create(exclusive: true);
-      await lockFile.writeAsString(ownerJson, flush: true);
+      await _createAndWriteLock(lockFile: lockFile, ownerJson: ownerJson);
       return LockAcquireResult.acquired;
     } on PathExistsException {
       final LockAcquireResult staleLockResult = await _removeStaleLockIfNeeded(
@@ -90,8 +89,7 @@ class UpdateLock {
       }
 
       try {
-        await lockFile.create(exclusive: true);
-        await lockFile.writeAsString(ownerJson, flush: true);
+        await _createAndWriteLock(lockFile: lockFile, ownerJson: ownerJson);
         return LockAcquireResult.acquired;
       } on PathExistsException {
         return LockAcquireResult.alreadyLocked;
@@ -104,6 +102,26 @@ class UpdateLock {
     } on FileSystemException catch (error) {
       if (_isPermissionDenied(error: error)) {
         return LockAcquireResult.permissionDenied;
+      }
+      rethrow;
+    }
+  }
+
+  /// Creates [lockFile] exclusively and writes the owner record. If the write
+  /// fails after the file was created, the empty/partial lock file is removed
+  /// before the error propagates — a transient write failure must not leave a
+  /// lock file that blocks other acquirers until the stale-lock grace period
+  /// reclaims it.
+  Future<void> _createAndWriteLock({required File lockFile, required String ownerJson}) async {
+    await lockFile.create(exclusive: true);
+    try {
+      await lockFile.writeAsString(ownerJson, flush: true);
+    } on Object {
+      try {
+        await lockFile.delete();
+      } on Object {
+        // Best-effort: if the cleanup delete also fails, the stale-lock grace
+        // period still reclaims the empty file on a later attempt.
       }
       rethrow;
     }

--- a/bridge/app/lib/src/updater/foundation/update_lock.dart
+++ b/bridge/app/lib/src/updater/foundation/update_lock.dart
@@ -123,21 +123,22 @@ class UpdateLock {
   }
 
   /// Removes the lock file [_createAndWriteLock] just created when its
-  /// owner-record write failed — but only while it is still the empty file we
-  /// created.
+  /// owner-record write failed — but only while it is still ours.
   ///
-  /// If a slow write let the empty lock age past [_invalidLockGracePeriod],
-  /// another acquirer may have already reaped it and created its own
-  /// owner-stamped lock at the same path; deleting that would break mutual
-  /// exclusion, so a non-empty file is left untouched. Best-effort, but never
-  /// silent — a cleanup failure is logged rather than swallowed.
+  /// "Ours" is an empty, partial, or otherwise unparseable write, or a record
+  /// stamped with our own pid. If a slow write let the file age past
+  /// [_invalidLockGracePeriod], another acquirer may have reaped it and written
+  /// its own owner-stamped lock at the same path; deleting that would break
+  /// mutual exclusion, so a record owned by a different pid is left untouched.
+  /// Best-effort, but never silent — a cleanup failure is logged.
   Future<void> _cleanupUnwrittenLock({required File lockFile}) async {
     try {
-      if ((await lockFile.readAsString()).isEmpty) {
+      final _LockOwner? owner = _parseOwner(content: await lockFile.readAsString());
+      if (owner == null || owner.pid == _currentPid) {
         await lockFile.delete();
       }
     } on Object catch (error, stackTrace) {
-      Log.w('Failed to clean up the empty lock file after a write failure: $error', error, stackTrace);
+      Log.w('Failed to clean up the lock file after a write failure: $error', error, stackTrace);
     }
   }
 

--- a/bridge/app/lib/src/updater/foundation/update_lock.dart
+++ b/bridge/app/lib/src/updater/foundation/update_lock.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:sesori_shared/sesori_shared.dart';
 
 import '../../bridge/foundation/process_runner.dart';
@@ -14,22 +15,39 @@ enum LockAcquireResult {
 }
 
 class UpdateLock {
+  /// Default age after which a still-"held" `.update.lock` is reaped as stale,
+  /// even when the holder PID still appears alive.
+  ///
+  /// Liveness (PID + process start marker) is the primary, precise check; this
+  /// is a last-resort guard against the rare wedge where a crashed holder's PID
+  /// is reused by an unrelated long-lived process while the recorded marker was
+  /// unavailable. Generous on purpose: a real in-place swap holds the lock for
+  /// well under a second, so this never trips a legitimate update.
+  static const Duration updateStaleLockMaxAge = Duration(minutes: 15);
+
   final int _currentPid;
   final ProcessRunner _processRunner;
+  final Clock _clock;
 
   UpdateLock({
     required int currentPid,
     required ProcessRunner processRunner,
+    required Clock clock,
   }) : _currentPid = currentPid,
-       _processRunner = processRunner;
+       _processRunner = processRunner,
+       _clock = clock;
 
   Future<T> locked<T>({
     required File lockFile,
     required Future<T> Function() onLockAcquired,
     required Future<T> Function(LockAcquireResult result) onLockRejected,
     required bool Function(T value) shouldReleaseLock,
+    Duration? staleLockMaxAge,
   }) async {
-    final LockAcquireResult lockResult = await _acquireLock(lockFile: lockFile);
+    final LockAcquireResult lockResult = await _acquireLock(
+      lockFile: lockFile,
+      staleLockMaxAge: staleLockMaxAge,
+    );
     if (lockResult != LockAcquireResult.acquired) {
       return onLockRejected(lockResult);
     }
@@ -47,7 +65,10 @@ class UpdateLock {
     }
   }
 
-  Future<LockAcquireResult> _acquireLock({required File lockFile}) async {
+  Future<LockAcquireResult> _acquireLock({
+    required File lockFile,
+    required Duration? staleLockMaxAge,
+  }) async {
     final String ownerJson = jsonEncode(
       _LockOwner(
         pid: _currentPid,
@@ -60,7 +81,10 @@ class UpdateLock {
       await lockFile.writeAsString(ownerJson, flush: true);
       return LockAcquireResult.acquired;
     } on PathExistsException {
-      final LockAcquireResult staleLockResult = await _removeStaleLockIfNeeded(lockFile: lockFile);
+      final LockAcquireResult staleLockResult = await _removeStaleLockIfNeeded(
+        lockFile: lockFile,
+        staleLockMaxAge: staleLockMaxAge,
+      );
       if (staleLockResult != LockAcquireResult.acquired) {
         return staleLockResult;
       }
@@ -85,7 +109,10 @@ class UpdateLock {
     }
   }
 
-  Future<LockAcquireResult> _removeStaleLockIfNeeded({required File lockFile}) async {
+  Future<LockAcquireResult> _removeStaleLockIfNeeded({
+    required File lockFile,
+    required Duration? staleLockMaxAge,
+  }) async {
     final String content;
     try {
       content = await lockFile.readAsString();
@@ -101,10 +128,7 @@ class UpdateLock {
 
     final _LockOwner? owner = _parseOwner(content: content);
     if (owner == null) {
-      final FileStat stat = lockFile.statSync();
-      final DateTime lastModified = stat.modified;
-      final Duration age = DateTime.now().difference(lastModified);
-      if (age < _invalidLockGracePeriod) {
+      if (_lockAge(lockFile: lockFile) < _invalidLockGracePeriod) {
         return LockAcquireResult.alreadyLocked;
       }
       return _deleteStaleLock(lockFile: lockFile);
@@ -121,10 +145,22 @@ class UpdateLock {
 
     final bool isAlive = await isProcessAlive(pidToCheck: owner.pid);
     if (isAlive) {
+      // Liveness says the holder is still running. As a last resort, reap a
+      // lock held far longer than any real swap takes (which is sub-second);
+      // this only ever clears the rare wedge of a crashed holder whose PID was
+      // reused by an unrelated long-lived process.
+      if (staleLockMaxAge != null && _lockAge(lockFile: lockFile) > staleLockMaxAge) {
+        return _deleteStaleLock(lockFile: lockFile);
+      }
       return LockAcquireResult.alreadyLocked;
     }
 
     return _deleteStaleLock(lockFile: lockFile);
+  }
+
+  Duration _lockAge({required File lockFile}) {
+    final FileStat stat = lockFile.statSync();
+    return _clock.now().difference(stat.modified);
   }
 
   Future<String?> _currentProcessMarker() {

--- a/bridge/app/lib/src/updater/foundation/update_lock.dart
+++ b/bridge/app/lib/src/updater/foundation/update_lock.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:clock/clock.dart';
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Log;
 import 'package:sesori_shared/sesori_shared.dart';
 
 import '../../bridge/foundation/process_runner.dart';
@@ -108,22 +109,35 @@ class UpdateLock {
   }
 
   /// Creates [lockFile] exclusively and writes the owner record. If the write
-  /// fails after the file was created, the empty/partial lock file is removed
-  /// before the error propagates — a transient write failure must not leave a
-  /// lock file that blocks other acquirers until the stale-lock grace period
-  /// reclaims it.
+  /// fails after the file was created, the empty lock file is cleaned up before
+  /// the error propagates — a transient write failure must not leave a lock file
+  /// that blocks other acquirers until the stale-lock grace period reclaims it.
   Future<void> _createAndWriteLock({required File lockFile, required String ownerJson}) async {
     await lockFile.create(exclusive: true);
     try {
       await lockFile.writeAsString(ownerJson, flush: true);
     } on Object {
-      try {
-        await lockFile.delete();
-      } on Object {
-        // Best-effort: if the cleanup delete also fails, the stale-lock grace
-        // period still reclaims the empty file on a later attempt.
-      }
+      await _cleanupUnwrittenLock(lockFile: lockFile);
       rethrow;
+    }
+  }
+
+  /// Removes the lock file [_createAndWriteLock] just created when its
+  /// owner-record write failed — but only while it is still the empty file we
+  /// created.
+  ///
+  /// If a slow write let the empty lock age past [_invalidLockGracePeriod],
+  /// another acquirer may have already reaped it and created its own
+  /// owner-stamped lock at the same path; deleting that would break mutual
+  /// exclusion, so a non-empty file is left untouched. Best-effort, but never
+  /// silent — a cleanup failure is logged rather than swallowed.
+  Future<void> _cleanupUnwrittenLock({required File lockFile}) async {
+    try {
+      if ((await lockFile.readAsString()).isEmpty) {
+        await lockFile.delete();
+      }
+    } on Object catch (error, stackTrace) {
+      Log.w('Failed to clean up the empty lock file after a write failure: $error', error, stackTrace);
     }
   }
 

--- a/bridge/app/lib/src/updater/models/explicit_update_outcome.dart
+++ b/bridge/app/lib/src/updater/models/explicit_update_outcome.dart
@@ -1,0 +1,95 @@
+import '../foundation/release_track.dart';
+
+/// The result of an explicit `sesori-bridge update` invocation, returned by
+/// [ManualUpdateService] as pure data. The command derives its rendered output
+/// and exit code from this; no `Console`/IO happens in the service.
+sealed class ExplicitUpdateOutcome {
+  const ExplicitUpdateOutcome();
+}
+
+/// How an applied release relates to the version that was running.
+enum UpdateAppliedKind {
+  /// The installed release is newer than the running version.
+  upgrade,
+
+  /// The installed release equals the running version (a repair reinstall).
+  reinstall,
+
+  /// The installed release is older than the running version (e.g. forcing the
+  /// latest stable while an `-internal.*` build was running).
+  downgrade,
+}
+
+/// A release was staged and applied; it activates on the next launch.
+final class ExplicitUpdateApplied extends ExplicitUpdateOutcome {
+  final String? fromVersion;
+  final String toVersion;
+  final UpdateAppliedKind kind;
+  final ReleaseTrack track;
+
+  const ExplicitUpdateApplied({
+    required this.fromVersion,
+    required this.toVersion,
+    required this.kind,
+    required this.track,
+  });
+}
+
+/// Already on the latest eligible release for the active track.
+final class ExplicitUpdateAlreadyLatest extends ExplicitUpdateOutcome {
+  final String version;
+  final ReleaseTrack track;
+
+  const ExplicitUpdateAlreadyLatest({required this.version, required this.track});
+}
+
+/// The running binary is not eligible for the active track and the latest
+/// eligible release is not newer, so a plain update can't help — suggests
+/// `--force` to switch onto the track.
+final class ExplicitUpdateTrackMismatch extends ExplicitUpdateOutcome {
+  final String currentVersion;
+  final String latestVersion;
+  final ReleaseTrack track;
+
+  const ExplicitUpdateTrackMismatch({
+    required this.currentVersion,
+    required this.latestVersion,
+    required this.track,
+  });
+}
+
+/// No release eligible for the active track was found to install.
+final class ExplicitUpdateNoEligibleRelease extends ExplicitUpdateOutcome {
+  final ReleaseTrack track;
+
+  const ExplicitUpdateNoEligibleRelease({required this.track});
+}
+
+/// The command was run from a binary that is not the managed install (e.g. a
+/// dev build or an arbitrary path), so there is nothing to update in place.
+final class ExplicitUpdateNotManaged extends ExplicitUpdateOutcome {
+  final String executablePath;
+
+  const ExplicitUpdateNotManaged({required this.executablePath});
+}
+
+/// The command was run directly from an npm-owned package payload.
+final class ExplicitUpdateNpmDirect extends ExplicitUpdateOutcome {
+  final String message;
+
+  const ExplicitUpdateNpmDirect({required this.message});
+}
+
+/// Another update is already in progress (the update lock is held).
+final class ExplicitUpdateLockBusy extends ExplicitUpdateOutcome {
+  const ExplicitUpdateLockBusy();
+}
+
+/// The update failed (network, rate limit, checksum, permission, swap, …).
+/// [logPath] points at the durable update log when one is available.
+final class ExplicitUpdateFailed extends ExplicitUpdateOutcome {
+  final String reason;
+  final String? logPath;
+
+  const ExplicitUpdateFailed({required this.reason, required this.logPath});
+}

--- a/bridge/app/lib/src/updater/models/update_apply_outcome.dart
+++ b/bridge/app/lib/src/updater/models/update_apply_outcome.dart
@@ -1,0 +1,31 @@
+/// The result of [UpdateApplyService.apply]: what happened during the in-place
+/// swap, returned as data for the caller to present.
+///
+/// Persistence (the durable [UpdateAttempt] and the append-only update log) is
+/// handled inside the service. This type carries only what a caller needs to
+/// message the user and decide flow — the apply service itself never writes to
+/// `Console`.
+sealed class UpdateApplyOutcome {
+  const UpdateApplyOutcome();
+}
+
+/// The staged release was swapped in and is pending activation on next launch.
+final class UpdateApplied extends UpdateApplyOutcome {
+  final String version;
+
+  const UpdateApplied({required this.version});
+}
+
+/// Another process holds the update lock; the swap was skipped (benign).
+final class UpdateApplyLockBusy extends UpdateApplyOutcome {
+  const UpdateApplyLockBusy();
+}
+
+/// The swap failed. [reason] is a human-readable cause; [logPath] points at the
+/// durable update log with full detail.
+final class UpdateApplyFailed extends UpdateApplyOutcome {
+  final String reason;
+  final String logPath;
+
+  const UpdateApplyFailed({required this.reason, required this.logPath});
+}

--- a/bridge/app/lib/src/updater/models/update_resolution.dart
+++ b/bridge/app/lib/src/updater/models/update_resolution.dart
@@ -1,0 +1,31 @@
+import 'bridge_version.dart';
+import 'release_info.dart';
+
+/// A snapshot for deciding an explicit update.
+///
+/// Carries the running version, whether it is eligible for the active release
+/// track, and the latest eligible release (if any) with its typed version.
+/// Version parsing/typing lives in the repository that builds this; consumers
+/// only compare the already-typed values.
+class UpdateResolution {
+  /// The version of the currently running binary.
+  final BridgeVersion currentVersion;
+
+  /// Whether [currentVersion] is eligible for the active track (e.g. an
+  /// `-internal.*` build is not eligible while the track is `stable`).
+  final bool currentEligible;
+
+  /// The latest release eligible for the active track, or `null` when none was
+  /// found (empty/unreachable release set is surfaced as an error upstream).
+  final ReleaseInfo? latestEligible;
+
+  /// The typed version of [latestEligible], or `null` when there is none.
+  final BridgeVersion? latestVersion;
+
+  const UpdateResolution({
+    required this.currentVersion,
+    required this.currentEligible,
+    required this.latestEligible,
+    required this.latestVersion,
+  });
+}

--- a/bridge/app/lib/src/updater/repositories/release_repository.dart
+++ b/bridge/app/lib/src/updater/repositories/release_repository.dart
@@ -9,6 +9,7 @@ import '../models/cached_release.dart';
 import '../models/distribution_target.dart';
 import '../models/github_release_dto.dart';
 import '../models/release_info.dart';
+import '../models/update_resolution.dart';
 
 class ReleaseRepository {
   final GitHubReleasesApi _api;
@@ -52,6 +53,37 @@ class ReleaseRepository {
     }
 
     return _fetchAndEvaluate();
+  }
+
+  /// Resolves the latest release eligible for the active track, regardless of
+  /// the current version, for an explicit `update`.
+  ///
+  /// Always fetches fresh: it bypasses the read cache so the result reflects
+  /// what is published right now (a just-cut release is never missed, and a
+  /// repair reinstall sees current truth). It still writes the cache as a side
+  /// effect, so the background updater benefits. The returned [UpdateResolution]
+  /// also reports the current version and whether it is eligible for the track,
+  /// so the caller can detect a track/version mismatch.
+  Future<UpdateResolution> resolveUpdate() async {
+    final releases = await _api.fetchReleases();
+    final selected = _selectLatestBridgeRelease(releases: releases);
+
+    ReleaseInfo? latestEligible;
+    BridgeVersion? latestVersion;
+    if (selected != null) {
+      final extracted = await _extractReleaseInfo(release: selected);
+      if (extracted != null) {
+        latestEligible = extracted.info;
+        latestVersion = extracted.version;
+      }
+    }
+
+    return UpdateResolution(
+      currentVersion: _currentVersion,
+      currentEligible: _isEligible(_currentVersion),
+      latestEligible: latestEligible,
+      latestVersion: latestVersion,
+    );
   }
 
   ReleaseInfo? _evaluateCached({required CachedRelease cached}) {
@@ -122,16 +154,34 @@ class ReleaseRepository {
   }
 
   Future<ReleaseInfo?> _evaluateRelease({required GitHubReleaseDto release}) async {
+    final extracted = await _extractReleaseInfo(release: release);
+    if (extracted == null) {
+      return null;
+    }
+    if (!_isEligible(extracted.version)) {
+      return null;
+    }
+    if (extracted.version.compareTo(_currentVersion) <= 0) {
+      return null;
+    }
+    return extracted.info;
+  }
+
+  /// Parses [release] into a typed [ReleaseInfo] (version + asset/checksums
+  /// URLs + published date) and writes the metadata cache as a side effect.
+  /// Returns `null` when the tag/version is unparseable or the required assets
+  /// are missing. Applies NO eligibility or "is newer" gating — callers decide.
+  Future<({ReleaseInfo info, BridgeVersion version})?> _extractReleaseInfo({
+    required GitHubReleaseDto release,
+  }) async {
     final tagName = release.tagName;
     if (!tagName.startsWith('v')) {
       return null;
     }
 
     final versionString = tagName.replaceFirst('v', '');
-    final BridgeVersion? latestVersion = BridgeVersion.tryParse(
-      value: versionString,
-    );
-    if (latestVersion == null) {
+    final BridgeVersion? version = BridgeVersion.tryParse(value: versionString);
+    if (version == null) {
       return null;
     }
 
@@ -163,14 +213,13 @@ class ReleaseRepository {
 
     if (assetUrl != null && checksumsUrl != null) {
       // Best-effort: the cache is a 10-minute TTL optimization to avoid
-      // re-hitting GitHub every cycle. It is written before the "is this newer?"
-      // comparison below, so a write failure (e.g. a full/unwritable cache dir)
-      // must not turn an otherwise-successful check — including "no newer
-      // release" — into a genuine update failure with reinstall guidance.
+      // re-hitting GitHub every cycle. A write failure (e.g. a full/unwritable
+      // cache dir) must not turn an otherwise-successful check or resolution
+      // into a genuine update failure with reinstall guidance.
       try {
         await _cache.write(
           release: CachedRelease(
-            latestVersion: latestVersion.toString(),
+            latestVersion: version.toString(),
             downloadUrl: assetUrl,
             checksumsUrl: checksumsUrl,
             assetName: assetName,
@@ -184,21 +233,18 @@ class ReleaseRepository {
       }
     }
 
-    if (!_isEligible(latestVersion)) {
-      return null;
-    }
-    if (latestVersion.compareTo(_currentVersion) <= 0) {
-      return null;
-    }
     if (assetUrl == null || checksumsUrl == null) {
       return null;
     }
 
-    return ReleaseInfo(
-      version: latestVersion.toString(),
-      assetUrl: assetUrl,
-      checksumsUrl: checksumsUrl,
-      publishedAt: publishedAt,
+    return (
+      info: ReleaseInfo(
+        version: version.toString(),
+        assetUrl: assetUrl,
+        checksumsUrl: checksumsUrl,
+        publishedAt: publishedAt,
+      ),
+      version: version,
     );
   }
 }

--- a/bridge/app/lib/src/updater/services/manual_update_service.dart
+++ b/bridge/app/lib/src/updater/services/manual_update_service.dart
@@ -1,0 +1,202 @@
+import 'dart:async';
+import 'dart:io' show HttpException, SocketException;
+
+import 'package:http/http.dart' show ClientException;
+
+import '../foundation/github_rate_limit_exception.dart';
+import '../foundation/release_track.dart';
+import '../foundation/update_policy.dart';
+import '../models/bridge_version.dart';
+import '../models/explicit_update_outcome.dart';
+import '../models/release_info.dart';
+import '../models/update_apply_outcome.dart';
+import '../models/update_install_result.dart';
+import '../models/update_resolution.dart';
+import '../models/update_result.dart';
+import '../repositories/release_repository.dart';
+import 'update_apply_service.dart';
+import 'update_install_service.dart';
+
+/// Coordinates an explicit, one-shot `sesori-bridge update`.
+///
+/// Unlike the background [UpdateService], this is a user-initiated action: it
+/// overrides the background-only suppressors (`SESORI_NO_UPDATE`, CI) but still
+/// requires the managed install. It resolves the latest release eligible for
+/// the active track, decides what to do (plain vs `--force`, including the
+/// internal→stable switch), then reuses [UpdateInstallService.stageUpdate] +
+/// [UpdateApplyService.apply] to install it. It returns an
+/// [ExplicitUpdateOutcome] as pure data — the command renders it and never the
+/// service.
+class ManualUpdateService {
+  ManualUpdateService({
+    required ReleaseRepository releaseRepository,
+    required UpdateInstallService updateInstallService,
+    required UpdateApplyService updateApplyService,
+    required ReleaseTrack track,
+    required String installRoot,
+    required String executablePath,
+    required String managedExecutablePath,
+  }) : _releaseRepository = releaseRepository,
+       _updateInstallService = updateInstallService,
+       _updateApplyService = updateApplyService,
+       _track = track,
+       _installRoot = installRoot,
+       _executablePath = executablePath,
+       _managedExecutablePath = managedExecutablePath;
+
+  final ReleaseRepository _releaseRepository;
+  final UpdateInstallService _updateInstallService;
+  final UpdateApplyService _updateApplyService;
+  final ReleaseTrack _track;
+  final String _installRoot;
+  final String _executablePath;
+  final String _managedExecutablePath;
+
+  /// Runs the update once. When [force] is true, installs the latest eligible
+  /// release for the active track regardless of the current version (a repair
+  /// reinstall, or a downgrade onto the track); otherwise installs only a
+  /// strictly-newer release and reports "already latest" or a track mismatch.
+  Future<ExplicitUpdateOutcome> runUpdate({required bool force}) async {
+    final ExplicitUpdateOutcome? gated = _gate();
+    if (gated != null) {
+      return gated;
+    }
+
+    final UpdateResolution resolution;
+    try {
+      resolution = await _releaseRepository.resolveUpdate();
+    } on GitHubRateLimitException catch (error) {
+      return ExplicitUpdateFailed(reason: _rateLimitReason(error), logPath: null);
+    } on SocketException catch (error) {
+      return ExplicitUpdateFailed(reason: "couldn't reach GitHub: $error", logPath: null);
+    } on TimeoutException catch (error) {
+      return ExplicitUpdateFailed(reason: 'the release check timed out: $error', logPath: null);
+    } on HttpException catch (error) {
+      return ExplicitUpdateFailed(reason: 'a network error occurred: $error', logPath: null);
+    } on ClientException catch (error) {
+      return ExplicitUpdateFailed(reason: 'a network error occurred: $error', logPath: null);
+    } on Object catch (error) {
+      return ExplicitUpdateFailed(reason: error.toString(), logPath: null);
+    }
+
+    final ReleaseInfo? latest = resolution.latestEligible;
+    final BridgeVersion? latestVersion = resolution.latestVersion;
+    if (latest == null || latestVersion == null) {
+      return ExplicitUpdateNoEligibleRelease(track: _track);
+    }
+
+    final BridgeVersion current = resolution.currentVersion;
+    final int comparison = latestVersion.compareTo(current);
+
+    if (!force) {
+      if (comparison > 0) {
+        return _stageAndApply(release: latest, fromVersion: current, kind: UpdateAppliedKind.upgrade);
+      }
+      if (resolution.currentEligible) {
+        return ExplicitUpdateAlreadyLatest(version: current.toString(), track: _track);
+      }
+      // The running binary is not on the active track and the latest eligible
+      // release is not newer (e.g. an `-internal.*` build while track=stable),
+      // so a plain update can't help — point the user at `--force`.
+      return ExplicitUpdateTrackMismatch(
+        currentVersion: current.toString(),
+        latestVersion: latestVersion.toString(),
+        track: _track,
+      );
+    }
+
+    return _stageAndApply(
+      release: latest,
+      fromVersion: current,
+      kind: comparison > 0
+          ? UpdateAppliedKind.upgrade
+          : comparison == 0
+          ? UpdateAppliedKind.reinstall
+          : UpdateAppliedKind.downgrade,
+    );
+  }
+
+  /// Refuses to run anywhere but the managed install. An explicit command
+  /// overrides the background-only suppressors, but it cannot update an npm
+  /// payload run directly or a non-managed binary.
+  ExplicitUpdateOutcome? _gate() {
+    final String? npmMessage = unsupportedPackageRuntimeMessage(
+      executablePath: _executablePath,
+      managedExecutablePath: _managedExecutablePath,
+    );
+    if (npmMessage != null) {
+      return ExplicitUpdateNpmDirect(message: npmMessage);
+    }
+    if (!isManagedInstall(
+      executablePath: _executablePath,
+      managedExecutablePath: _managedExecutablePath,
+    )) {
+      return ExplicitUpdateNotManaged(executablePath: _executablePath);
+    }
+    return null;
+  }
+
+  Future<ExplicitUpdateOutcome> _stageAndApply({
+    required ReleaseInfo release,
+    required BridgeVersion fromVersion,
+    required UpdateAppliedKind kind,
+  }) async {
+    final UpdateInstallResult staged;
+    try {
+      staged = await _updateInstallService.stageUpdate(release: release, installRoot: _installRoot);
+    } on Object catch (error) {
+      return ExplicitUpdateFailed(reason: error.toString(), logPath: null);
+    }
+
+    final String? stagingPath = staged.stagingPath;
+    if (staged.result != UpdateResult.success || stagingPath == null) {
+      return ExplicitUpdateFailed(reason: _stageFailureReason(staged.result), logPath: null);
+    }
+
+    final UpdateApplyOutcome applyOutcome;
+    try {
+      applyOutcome = await _updateApplyService.apply(release: release, stagingPath: stagingPath);
+    } on Object catch (error) {
+      return ExplicitUpdateFailed(reason: error.toString(), logPath: null);
+    }
+
+    switch (applyOutcome) {
+      case UpdateApplied(:final version):
+        return ExplicitUpdateApplied(
+          fromVersion: fromVersion.toString(),
+          toVersion: version,
+          kind: kind,
+          track: _track,
+        );
+      case UpdateApplyLockBusy():
+        return const ExplicitUpdateLockBusy();
+      case UpdateApplyFailed(:final reason, :final logPath):
+        return ExplicitUpdateFailed(reason: reason, logPath: logPath);
+    }
+  }
+
+  String _stageFailureReason(UpdateResult result) {
+    switch (result) {
+      case UpdateResult.permissionDenied:
+        return "can't write to the install directory (permission denied)";
+      case UpdateResult.checksumFailed:
+        return 'the downloaded archive failed checksum verification';
+      case UpdateResult.downloadFailed:
+        return 'the release archive could not be downloaded or extracted';
+      case UpdateResult.networkError:
+        return "couldn't reach GitHub";
+      case UpdateResult.alreadyLocked:
+        return 'another update is already in progress';
+      case UpdateResult.success:
+        return 'an unexpected error occurred';
+    }
+  }
+
+  String _rateLimitReason(GitHubRateLimitException error) {
+    if (error.authenticated) {
+      return 'GitHub API rate limit reached for the authenticated token; try again shortly';
+    }
+    return 'GitHub API rate limit reached; set GITHUB_TOKEN (or GH_TOKEN) to raise the '
+        '60/hour limit to 5000/hour, or try again later';
+  }
+}

--- a/bridge/app/lib/src/updater/services/manual_update_service.dart
+++ b/bridge/app/lib/src/updater/services/manual_update_service.dart
@@ -92,12 +92,15 @@ class ManualUpdateService {
       if (comparison > 0) {
         return _stageAndApply(release: latest, fromVersion: current, kind: UpdateAppliedKind.upgrade);
       }
-      if (resolution.currentEligible) {
+      if (comparison == 0) {
         return ExplicitUpdateAlreadyLatest(version: current.toString(), track: _track);
       }
-      // The running binary is not on the active track and the latest eligible
-      // release is not newer (e.g. an `-internal.*` build while track=stable),
-      // so a plain update can't help — point the user at `--force`.
+      // comparison < 0: the running build is not the latest published build for
+      // the track. Either it is off-track (e.g. an `-internal.*` build while the
+      // track is stable), or it is "ahead" of the latest published release (a
+      // copied dev/QA build, or a release that was yanked). A plain update can't
+      // reach the published latest — only `--force` can — so point the user at
+      // it rather than misreporting "already latest".
       return ExplicitUpdateTrackMismatch(
         currentVersion: current.toString(),
         latestVersion: latestVersion.toString(),

--- a/bridge/app/lib/src/updater/services/update_apply_service.dart
+++ b/bridge/app/lib/src/updater/services/update_apply_service.dart
@@ -61,20 +61,28 @@ class UpdateApplyService {
       staleLockMaxAge: UpdateLock.updateStaleLockMaxAge,
       onLockAcquired: () => _applyLocked(release: release, stagingPath: stagingPath),
       onLockRejected: (LockAcquireResult result) async {
+        final UpdateApplyOutcome outcome;
         switch (result) {
           case LockAcquireResult.alreadyLocked:
             // Another bridge is applying — benign; the next cycle retries.
             logWarning('Skipping in-place update to ${release.version}: another update is in progress');
-            return const UpdateApplyLockBusy();
+            outcome = const UpdateApplyLockBusy();
           case LockAcquireResult.permissionDenied:
             // A stale/root-owned `.update.lock` the user can't read or delete
             // blocks every future update — surface it instead of silently
             // re-downloading and warning forever.
-            return _recordLockPermissionFailure(release: release);
+            outcome = await _recordLockPermissionFailure(release: release);
           case LockAcquireResult.acquired:
             // Never delivered to onLockRejected.
-            return const UpdateApplyLockBusy();
+            outcome = const UpdateApplyLockBusy();
         }
+        // The swap never ran, so the staged payload we were handed is ours to
+        // remove. Staging paths are per-stager, so this never deletes the
+        // payload the lock-holding applier is consuming. Without it, a manual
+        // update's per-process staging dir would accumulate on every attempt
+        // made during a resident update or a stale lock.
+        await _cleanupStaging(stagingPath: stagingPath);
+        return outcome;
       },
       shouldReleaseLock: (_) => true,
     );

--- a/bridge/app/lib/src/updater/services/update_apply_service.dart
+++ b/bridge/app/lib/src/updater/services/update_apply_service.dart
@@ -3,29 +3,29 @@ import 'dart:io';
 import 'package:clock/clock.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
-import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Console, Log;
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Log;
 
 import '../foundation/filesystem_cleaner.dart';
 import '../foundation/update_lock.dart';
-import '../foundation/update_message_formatter.dart';
 import '../models/release_info.dart';
+import '../models/update_apply_outcome.dart';
 import '../models/update_attempt.dart';
 import '../repositories/update_attempt_repository.dart';
 import '../repositories/update_installation_repository.dart';
 import '../repositories/update_log_repository.dart';
 
-/// The shared in-place apply/rollback decision boundary.
+/// The shared in-place apply/rollback boundary for a staged release.
 ///
-/// Used by the periodic [UpdateService] to apply a freshly staged release. It
-/// records a durable [UpdateAttempt] and an append-only log around the swap so a
-/// failure is never silent, and surfaces user-facing messaging.
+/// It records a durable [UpdateAttempt] and an append-only log around the swap
+/// so a failure is never silent, then returns an [UpdateApplyOutcome] describing
+/// what happened. Presentation lives with the caller — this service never writes
+/// to `Console`.
 class UpdateApplyService {
   UpdateApplyService({
     required UpdateInstallationRepository installationRepository,
     required UpdateAttemptRepository attemptRepository,
     required UpdateLogRepository logRepository,
     required UpdateLock updateLock,
-    required UpdateMessageFormatter messageFormatter,
     required FilesystemCleaner filesystemCleaner,
     required Clock clock,
     required String currentVersion,
@@ -34,7 +34,6 @@ class UpdateApplyService {
        _attemptRepository = attemptRepository,
        _logRepository = logRepository,
        _updateLock = updateLock,
-       _messageFormatter = messageFormatter,
        _filesystemCleaner = filesystemCleaner,
        _clock = clock,
        _currentVersion = currentVersion,
@@ -44,48 +43,44 @@ class UpdateApplyService {
   final UpdateAttemptRepository _attemptRepository;
   final UpdateLogRepository _logRepository;
   final UpdateLock _updateLock;
-  final UpdateMessageFormatter _messageFormatter;
   final FilesystemCleaner _filesystemCleaner;
   final Clock _clock;
   final String _currentVersion;
   final String _installRoot;
 
   @visibleForTesting
-  void Function(String message) emitMessage = Console.message;
-
-  @visibleForTesting
-  void Function(String message) emitError = Console.error;
-
-  @visibleForTesting
   void Function(String message) logWarning = Log.w;
 
   /// Applies the staged payload at [stagingPath] in place, under the
-  /// cross-process update lock. Returns `true` when the swap is staged for
-  /// activation, `false` on any benign skip or genuine failure (both reported).
-  Future<bool> apply({required ReleaseInfo release, required String stagingPath}) {
-    return _updateLock.locked<bool>(
+  /// cross-process update lock. Returns an [UpdateApplyOutcome] describing the
+  /// result. The durable attempt record and the update log are written here, but
+  /// no user-facing message is emitted — the caller presents the outcome.
+  Future<UpdateApplyOutcome> apply({required ReleaseInfo release, required String stagingPath}) {
+    return _updateLock.locked<UpdateApplyOutcome>(
       lockFile: File(p.join(_installRoot, '.update.lock')),
+      staleLockMaxAge: UpdateLock.updateStaleLockMaxAge,
       onLockAcquired: () => _applyLocked(release: release, stagingPath: stagingPath),
       onLockRejected: (LockAcquireResult result) async {
         switch (result) {
           case LockAcquireResult.alreadyLocked:
             // Another bridge is applying — benign; the next cycle retries.
             logWarning('Skipping in-place update to ${release.version}: another update is in progress');
+            return const UpdateApplyLockBusy();
           case LockAcquireResult.permissionDenied:
             // A stale/root-owned `.update.lock` the user can't read or delete
             // blocks every future update — surface it instead of silently
             // re-downloading and warning forever.
-            await _reportLockPermissionFailure(release: release);
+            return _recordLockPermissionFailure(release: release);
           case LockAcquireResult.acquired:
-            break; // never delivered to onLockRejected
+            // Never delivered to onLockRejected.
+            return const UpdateApplyLockBusy();
         }
-        return false;
       },
       shouldReleaseLock: (_) => true,
     );
   }
 
-  Future<void> _reportLockPermissionFailure({required ReleaseInfo release}) async {
+  Future<UpdateApplyOutcome> _recordLockPermissionFailure({required ReleaseInfo release}) async {
     try {
       await _logRepository.log(
         message: 'Update lock permission denied applying ${release.version} (check ownership of .update.lock)',
@@ -93,16 +88,13 @@ class UpdateApplyService {
     } on Object catch (error) {
       logWarning('Failed to log update lock failure: $error');
     }
-    emitError(
-      _messageFormatter.failureGuidance(
-        toVersion: release.version,
-        reason: 'the update lock could not be acquired (permission denied on .update.lock)',
-        logPath: _logRepository.logPath,
-      ),
+    return UpdateApplyFailed(
+      reason: 'the update lock could not be acquired (permission denied on .update.lock)',
+      logPath: _logRepository.logPath,
     );
   }
 
-  Future<bool> _applyLocked({required ReleaseInfo release, required String stagingPath}) async {
+  Future<UpdateApplyOutcome> _applyLocked({required ReleaseInfo release, required String stagingPath}) async {
     final UpdateAttempt attempt = UpdateAttempt(
       fromVersion: _currentVersion,
       toVersion: release.version,
@@ -114,32 +106,38 @@ class UpdateApplyService {
 
     // The pre-apply record/log writes are guarded together with the swap: an
     // I/O failure there (e.g. an unwritable install root) is itself a genuine
-    // apply failure and must surface to the user + durable log, never throw out
-    // of apply() into the caller's onError path.
+    // apply failure and must be recorded and returned, never thrown out of
+    // apply() into the caller's onError path.
     try {
       await _logRepository.logAttemptHeader(fromVersion: _currentVersion, toVersion: release.version);
       await _attemptRepository.saveAttempt(attempt: attempt);
       await _logRepository.log(message: 'Applying in-place swap from staging: $stagingPath');
       await _installationRepository.applyInPlace(installRoot: _installRoot, stagingPath: stagingPath);
     } on Object catch (error, stackTrace) {
-      await _reportSwapFailure(attempt: attempt, release: release, error: error, stackTrace: stackTrace);
+      final UpdateApplyOutcome outcome = await _recordSwapFailure(
+        attempt: attempt,
+        release: release,
+        error: error,
+        stackTrace: stackTrace,
+      );
       await _cleanupStaging(stagingPath: stagingPath);
-      return false;
+      return outcome;
     }
 
     await _recordPendingActivation(attempt: attempt, release: release);
     await _cleanupStaging(stagingPath: stagingPath);
-    return true;
+    return UpdateApplied(version: release.version);
   }
 
-  Future<void> _reportSwapFailure({
+  Future<UpdateApplyOutcome> _recordSwapFailure({
     required UpdateAttempt attempt,
     required ReleaseInfo release,
     required Object error,
     required StackTrace stackTrace,
   }) async {
     // Recording the failure is itself best-effort — the repository whose write
-    // just failed may fail again — but the user-facing guidance always runs.
+    // just failed may fail again — but the returned outcome always carries the
+    // cause for the caller to surface.
     try {
       await _attemptRepository.saveAttempt(
         attempt: attempt.copyWith(status: UpdateAttemptStatus.failed, reason: error.toString()),
@@ -148,13 +146,7 @@ class UpdateApplyService {
     } on Object catch (recordError) {
       logWarning('Failed to record the update failure: $recordError');
     }
-    emitError(
-      _messageFormatter.failureGuidance(
-        toVersion: release.version,
-        reason: error.toString(),
-        logPath: _logRepository.logPath,
-      ),
-    );
+    return UpdateApplyFailed(reason: error.toString(), logPath: _logRepository.logPath);
   }
 
   Future<void> _recordPendingActivation({
@@ -166,7 +158,7 @@ class UpdateApplyService {
     // durable attempt record is NEVER left at `inFlight` after a successful
     // swap: the next-launch reconciliation would otherwise treat a successful
     // update as interrupted and emit reinstall guidance, contradicting the
-    // success we report below.
+    // success the caller reports.
     var pendingActivationRecorded = false;
     try {
       await _attemptRepository.saveAttempt(
@@ -204,8 +196,6 @@ class UpdateApplyService {
     } on Object catch (manifestError) {
       logWarning('Failed to update the managed runtime manifest: $manifestError');
     }
-
-    emitMessage(_messageFormatter.installedPendingActivation(toVersion: release.version));
   }
 
   Future<void> _cleanupStaging({required String stagingPath}) {

--- a/bridge/app/lib/src/updater/services/update_install_service.dart
+++ b/bridge/app/lib/src/updater/services/update_install_service.dart
@@ -15,35 +15,35 @@ import '../repositories/update_artifact_repository.dart';
 /// returns the [UpdateInstallResult.stagingPath] for the apply step to consume.
 ///
 /// The archive + staging paths live under the install root (they must share a
-/// filesystem with it so the apply step can rename rather than copy). They are
-/// shared, fixed paths by default. A separate, concurrent stager — e.g. an
-/// explicit `update` process running while a resident bridge's background
-/// updater is mid-stage — must pass a distinct [workspaceLabel] so the two do
-/// not clobber each other's archive/staging on the way to the lock-guarded swap.
+/// filesystem with it so the apply step can rename rather than copy). Pass a
+/// `null` [workspaceLabel] to use the shared, fixed paths. A separate,
+/// concurrent stager — e.g. an explicit `update` process running while a
+/// resident bridge's background updater is mid-stage — passes a distinct
+/// [workspaceLabel] so the two do not clobber each other's archive/staging on
+/// the way to the lock-guarded swap.
 class UpdateInstallService {
   UpdateInstallService({
     required UpdateArtifactRepository updateArtifactRepository,
     required FilesystemCleaner filesystemCleaner,
-    String workspaceLabel = '',
+    required String? workspaceLabel,
   }) : _updateArtifactRepository = updateArtifactRepository,
        _filesystemCleaner = filesystemCleaner,
-       _workspaceSuffix = workspaceLabel.isEmpty ? '' : '.$workspaceLabel';
+       _workspaceLabel = workspaceLabel;
 
   final UpdateArtifactRepository _updateArtifactRepository;
   final FilesystemCleaner _filesystemCleaner;
-  final String _workspaceSuffix;
+  final String? _workspaceLabel;
 
   Future<UpdateInstallResult> stageUpdate({
     required ReleaseInfo release,
     required String installRoot,
   }) async {
+    final String suffix = _workspaceLabel == null ? '' : '.$_workspaceLabel';
     final String archivePath = p.join(
       installRoot,
-      Platform.isWindows
-          ? '.sesori-bridge-update$_workspaceSuffix.zip'
-          : '.sesori-bridge-update$_workspaceSuffix.tar.gz',
+      Platform.isWindows ? '.sesori-bridge-update$suffix.zip' : '.sesori-bridge-update$suffix.tar.gz',
     );
-    final String stagingPath = p.join(installRoot, '.sesori-bridge-staging$_workspaceSuffix');
+    final String stagingPath = p.join(installRoot, '.sesori-bridge-staging$suffix');
     var staged = false;
 
     try {

--- a/bridge/app/lib/src/updater/services/update_install_service.dart
+++ b/bridge/app/lib/src/updater/services/update_install_service.dart
@@ -13,15 +13,25 @@ import '../repositories/update_artifact_repository.dart';
 /// Stages an update payload: download → checksum-verify → extract into a staging
 /// directory. It performs no swap and makes no apply decisions — on success it
 /// returns the [UpdateInstallResult.stagingPath] for the apply step to consume.
+///
+/// The archive + staging paths live under the install root (they must share a
+/// filesystem with it so the apply step can rename rather than copy). They are
+/// shared, fixed paths by default. A separate, concurrent stager — e.g. an
+/// explicit `update` process running while a resident bridge's background
+/// updater is mid-stage — must pass a distinct [workspaceLabel] so the two do
+/// not clobber each other's archive/staging on the way to the lock-guarded swap.
 class UpdateInstallService {
   UpdateInstallService({
     required UpdateArtifactRepository updateArtifactRepository,
     required FilesystemCleaner filesystemCleaner,
+    String workspaceLabel = '',
   }) : _updateArtifactRepository = updateArtifactRepository,
-       _filesystemCleaner = filesystemCleaner;
+       _filesystemCleaner = filesystemCleaner,
+       _workspaceSuffix = workspaceLabel.isEmpty ? '' : '.$workspaceLabel';
 
   final UpdateArtifactRepository _updateArtifactRepository;
   final FilesystemCleaner _filesystemCleaner;
+  final String _workspaceSuffix;
 
   Future<UpdateInstallResult> stageUpdate({
     required ReleaseInfo release,
@@ -29,9 +39,11 @@ class UpdateInstallService {
   }) async {
     final String archivePath = p.join(
       installRoot,
-      Platform.isWindows ? '.sesori-bridge-update.zip' : '.sesori-bridge-update.tar.gz',
+      Platform.isWindows
+          ? '.sesori-bridge-update$_workspaceSuffix.zip'
+          : '.sesori-bridge-update$_workspaceSuffix.tar.gz',
     );
-    final String stagingPath = p.join(installRoot, '.sesori-bridge-staging');
+    final String stagingPath = p.join(installRoot, '.sesori-bridge-staging$_workspaceSuffix');
     var staged = false;
 
     try {

--- a/bridge/app/lib/src/updater/services/update_reconciliation_service.dart
+++ b/bridge/app/lib/src/updater/services/update_reconciliation_service.dart
@@ -62,6 +62,7 @@ class UpdateReconciliationService {
     try {
       await _updateLock.locked<void>(
         lockFile: File(p.join(_installRoot, '.update.lock')),
+        staleLockMaxAge: UpdateLock.updateStaleLockMaxAge,
         onLockAcquired: _reconcileLocked,
         onLockRejected: (LockAcquireResult result) async {
           switch (result) {

--- a/bridge/app/lib/src/updater/services/update_service.dart
+++ b/bridge/app/lib/src/updater/services/update_service.dart
@@ -10,6 +10,7 @@ import '../foundation/github_rate_limit_exception.dart';
 import '../foundation/update_message_formatter.dart';
 import '../foundation/update_policy.dart';
 import '../models/release_info.dart';
+import '../models/update_apply_outcome.dart';
 import '../models/update_result.dart';
 import '../repositories/release_repository.dart';
 import '../repositories/update_log_repository.dart';
@@ -57,6 +58,9 @@ class UpdateService {
 
   StreamSubscription<void>? _subscription;
   bool _disposed = false;
+
+  @visibleForTesting
+  void Function(String message) emitMessage = Console.message;
 
   @visibleForTesting
   void Function(String message) emitError = Console.error;
@@ -164,13 +168,30 @@ class UpdateService {
       if (_disposed) {
         return;
       }
-      final applied = await _updateApplyService.apply(release: release, stagingPath: stagingPath);
-      if (applied) {
-        // The release is now staged for activation on the next launch. This
-        // process still reports the old appVersion, so left running it would
-        // keep "finding" and re-applying the same release every interval —
-        // stop the cycle until a restart.
-        _stopPolling();
+      final UpdateApplyOutcome outcome = await _updateApplyService.apply(
+        release: release,
+        stagingPath: stagingPath,
+      );
+      switch (outcome) {
+        case UpdateApplied(:final version):
+          emitMessage(_messageFormatter.installedPendingActivation(toVersion: version));
+          // The release is now staged for activation on the next launch. This
+          // process still reports the old appVersion, so left running it would
+          // keep "finding" and re-applying the same release every interval —
+          // stop the cycle until a restart.
+          _stopPolling();
+        case UpdateApplyLockBusy():
+          // Another update is in progress — benign; apply logged a diagnostic.
+          // The next cycle retries.
+          break;
+        case UpdateApplyFailed(:final reason, :final logPath):
+          emitError(
+            _messageFormatter.failureGuidance(
+              toVersion: release.version,
+              reason: reason,
+              logPath: logPath,
+            ),
+          );
       }
     } on Object catch (error, stackTrace) {
       await _reportGenuineFailure(

--- a/bridge/app/test/updater/manual_update_service_test.dart
+++ b/bridge/app/test/updater/manual_update_service_test.dart
@@ -1,0 +1,257 @@
+import 'dart:io';
+
+import 'package:sesori_bridge/src/updater/foundation/release_track.dart';
+import 'package:sesori_bridge/src/updater/models/bridge_version.dart';
+import 'package:sesori_bridge/src/updater/models/explicit_update_outcome.dart';
+import 'package:sesori_bridge/src/updater/models/release_info.dart';
+import 'package:sesori_bridge/src/updater/models/update_apply_outcome.dart';
+import 'package:sesori_bridge/src/updater/models/update_install_result.dart';
+import 'package:sesori_bridge/src/updater/models/update_resolution.dart';
+import 'package:sesori_bridge/src/updater/models/update_result.dart';
+import 'package:sesori_bridge/src/updater/repositories/release_repository.dart';
+import 'package:sesori_bridge/src/updater/services/manual_update_service.dart';
+import 'package:sesori_bridge/src/updater/services/update_apply_service.dart';
+import 'package:sesori_bridge/src/updater/services/update_install_service.dart';
+import 'package:test/test.dart';
+
+const String _managed = '/usr/local/bin/sesori-bridge';
+
+ReleaseInfo _release(String version) => ReleaseInfo(
+  version: version,
+  assetUrl: 'https://example.com/bridge.tar.gz',
+  checksumsUrl: 'https://example.com/checksums.txt',
+  publishedAt: DateTime.utc(2026),
+);
+
+UpdateResolution _resolution({
+  required String current,
+  required bool currentEligible,
+  String? latest,
+}) => UpdateResolution(
+  currentVersion: BridgeVersion.parse(value: current),
+  currentEligible: currentEligible,
+  latestEligible: latest == null ? null : _release(latest),
+  latestVersion: latest == null ? null : BridgeVersion.parse(value: latest),
+);
+
+class _FakeReleaseRepository implements ReleaseRepository {
+  UpdateResolution Function()? onResolve;
+  Object? resolveError;
+
+  @override
+  Future<UpdateResolution> resolveUpdate() async {
+    if (resolveError != null) {
+      throw resolveError!;
+    }
+    return onResolve!();
+  }
+
+  @override
+  Future<ReleaseInfo?> checkForNewerRelease() => throw UnimplementedError();
+}
+
+class _FakeInstallService implements UpdateInstallService {
+  UpdateInstallResult result = const UpdateInstallResult.staged(stagingPath: '/tmp/staging');
+  int stageCount = 0;
+
+  @override
+  Future<UpdateInstallResult> stageUpdate({required ReleaseInfo release, required String installRoot}) async {
+    stageCount++;
+    return result;
+  }
+}
+
+class _FakeApplyService implements UpdateApplyService {
+  UpdateApplyOutcome Function(ReleaseInfo release)? onApply;
+  int applyCount = 0;
+
+  @override
+  void Function(String message) logWarning = (_) {};
+
+  @override
+  Future<UpdateApplyOutcome> apply({required ReleaseInfo release, required String stagingPath}) async {
+    applyCount++;
+    return onApply?.call(release) ?? UpdateApplied(version: release.version);
+  }
+}
+
+void main() {
+  late _FakeReleaseRepository release;
+  late _FakeInstallService install;
+  late _FakeApplyService apply;
+
+  ManualUpdateService buildService({
+    ReleaseTrack track = ReleaseTrack.stable,
+    String executablePath = _managed,
+  }) => ManualUpdateService(
+    releaseRepository: release,
+    updateInstallService: install,
+    updateApplyService: apply,
+    track: track,
+    installRoot: '/tmp/install',
+    executablePath: executablePath,
+    managedExecutablePath: _managed,
+  );
+
+  setUp(() {
+    release = _FakeReleaseRepository();
+    install = _FakeInstallService();
+    apply = _FakeApplyService();
+  });
+
+  group('plain update', () {
+    test('installs a strictly-newer release as an upgrade', () async {
+      release.onResolve = () => _resolution(current: '1.0.0', currentEligible: true, latest: '2.0.0');
+
+      final outcome = await buildService().runUpdate(force: false);
+
+      expect(
+        outcome,
+        isA<ExplicitUpdateApplied>()
+            .having((o) => o.kind, 'kind', UpdateAppliedKind.upgrade)
+            .having((o) => o.fromVersion, 'from', '1.0.0')
+            .having((o) => o.toVersion, 'to', '2.0.0'),
+      );
+      expect(install.stageCount, 1);
+      expect(apply.applyCount, 1);
+    });
+
+    test('reports already-latest without staging when nothing newer exists', () async {
+      release.onResolve = () => _resolution(current: '2.0.0', currentEligible: true, latest: '2.0.0');
+
+      final outcome = await buildService().runUpdate(force: false);
+
+      expect(
+        outcome,
+        isA<ExplicitUpdateAlreadyLatest>().having((o) => o.version, 'version', '2.0.0'),
+      );
+      expect(install.stageCount, 0);
+      expect(apply.applyCount, 0);
+    });
+
+    test('reports a track mismatch when the running build is off-track', () async {
+      // Running an internal build while track=stable; latest stable is older.
+      release.onResolve = () => _resolution(current: '2.0.0-internal.3', currentEligible: false, latest: '1.5.0');
+
+      final outcome = await buildService().runUpdate(force: false);
+
+      expect(
+        outcome,
+        isA<ExplicitUpdateTrackMismatch>()
+            .having((o) => o.currentVersion, 'current', '2.0.0-internal.3')
+            .having((o) => o.latestVersion, 'latest', '1.5.0')
+            .having((o) => o.track, 'track', ReleaseTrack.stable),
+      );
+      expect(install.stageCount, 0);
+    });
+
+    test('reports no eligible release when none is found', () async {
+      release.onResolve = () => _resolution(current: '1.0.0', currentEligible: true, latest: null);
+
+      final outcome = await buildService().runUpdate(force: false);
+
+      expect(outcome, isA<ExplicitUpdateNoEligibleRelease>());
+      expect(install.stageCount, 0);
+    });
+  });
+
+  group('force update', () {
+    test('reinstalls the same version', () async {
+      release.onResolve = () => _resolution(current: '2.0.0', currentEligible: true, latest: '2.0.0');
+
+      final outcome = await buildService().runUpdate(force: true);
+
+      expect(
+        outcome,
+        isA<ExplicitUpdateApplied>().having((o) => o.kind, 'kind', UpdateAppliedKind.reinstall),
+      );
+      expect(apply.applyCount, 1);
+    });
+
+    test('downgrades from an internal build to the latest stable', () async {
+      release.onResolve = () => _resolution(current: '2.0.0-internal.3', currentEligible: false, latest: '1.5.0');
+
+      final outcome = await buildService().runUpdate(force: true);
+
+      expect(
+        outcome,
+        isA<ExplicitUpdateApplied>()
+            .having((o) => o.kind, 'kind', UpdateAppliedKind.downgrade)
+            .having((o) => o.toVersion, 'to', '1.5.0'),
+      );
+      expect(apply.applyCount, 1);
+    });
+
+    test('upgrades when a newer release exists', () async {
+      release.onResolve = () => _resolution(current: '1.0.0', currentEligible: true, latest: '2.0.0');
+
+      final outcome = await buildService().runUpdate(force: true);
+
+      expect(outcome, isA<ExplicitUpdateApplied>().having((o) => o.kind, 'kind', UpdateAppliedKind.upgrade));
+    });
+  });
+
+  group('gating', () {
+    test('refuses a non-managed install without resolving', () async {
+      final outcome = await buildService(executablePath: '/somewhere/else/sesori-bridge').runUpdate(force: false);
+
+      expect(
+        outcome,
+        isA<ExplicitUpdateNotManaged>().having((o) => o.executablePath, 'path', '/somewhere/else/sesori-bridge'),
+      );
+      expect(install.stageCount, 0);
+    });
+
+    test('refuses an npm-payload run directly', () async {
+      final outcome = await buildService(
+        executablePath: '/x/node_modules/sesori-bridge-darwin-arm64/lib/runtime/bin/sesori-bridge',
+      ).runUpdate(force: false);
+
+      expect(outcome, isA<ExplicitUpdateNpmDirect>());
+      expect(install.stageCount, 0);
+    });
+  });
+
+  group('failures', () {
+    test('a network error during resolution is a failure', () async {
+      release.resolveError = const SocketException('offline');
+
+      final outcome = await buildService().runUpdate(force: false);
+
+      expect(outcome, isA<ExplicitUpdateFailed>().having((o) => o.reason, 'reason', contains('GitHub')));
+    });
+
+    test('a stage failure is surfaced with a reason', () async {
+      release.onResolve = () => _resolution(current: '1.0.0', currentEligible: true, latest: '2.0.0');
+      install.result = const UpdateInstallResult.failed(result: UpdateResult.checksumFailed);
+
+      final outcome = await buildService().runUpdate(force: false);
+
+      expect(outcome, isA<ExplicitUpdateFailed>().having((o) => o.reason, 'reason', contains('checksum')));
+      expect(apply.applyCount, 0);
+    });
+
+    test('an apply failure carries the reason and log path', () async {
+      release.onResolve = () => _resolution(current: '1.0.0', currentEligible: true, latest: '2.0.0');
+      apply.onApply = (_) => const UpdateApplyFailed(reason: 'disk full', logPath: '/tmp/update.log');
+
+      final outcome = await buildService().runUpdate(force: false);
+
+      expect(
+        outcome,
+        isA<ExplicitUpdateFailed>()
+            .having((o) => o.reason, 'reason', 'disk full')
+            .having((o) => o.logPath, 'logPath', '/tmp/update.log'),
+      );
+    });
+
+    test('apply lock contention maps to a lock-busy outcome', () async {
+      release.onResolve = () => _resolution(current: '1.0.0', currentEligible: true, latest: '2.0.0');
+      apply.onApply = (_) => const UpdateApplyLockBusy();
+
+      final outcome = await buildService().runUpdate(force: false);
+
+      expect(outcome, isA<ExplicitUpdateLockBusy>());
+    });
+  });
+}

--- a/bridge/app/test/updater/manual_update_service_test.dart
+++ b/bridge/app/test/updater/manual_update_service_test.dart
@@ -145,6 +145,24 @@ void main() {
       expect(install.stageCount, 0);
     });
 
+    test('reports a mismatch (force hint) when ahead of the latest published build', () async {
+      // A stable-looking build that is ahead of the latest published release —
+      // a copied dev/QA build, or a release that was yanked. This must NOT
+      // report "already latest"; --force is the only path back to the latest
+      // published build.
+      release.onResolve = () => _resolution(current: '9.9.9', currentEligible: true, latest: '1.5.0');
+
+      final outcome = await buildService().runUpdate(force: false);
+
+      expect(
+        outcome,
+        isA<ExplicitUpdateTrackMismatch>()
+            .having((o) => o.currentVersion, 'current', '9.9.9')
+            .having((o) => o.latestVersion, 'latest', '1.5.0'),
+      );
+      expect(install.stageCount, 0);
+    });
+
     test('reports no eligible release when none is found', () async {
       release.onResolve = () => _resolution(current: '1.0.0', currentEligible: true, latest: null);
 

--- a/bridge/app/test/updater/release_repository_test.dart
+++ b/bridge/app/test/updater/release_repository_test.dart
@@ -810,6 +810,106 @@ void main() {
         expect(httpCallCount, equals(1), reason: 'a stable cache must not satisfy an internal-track check');
       });
     });
+
+    // -----------------------------------------------------------------------
+    group('resolveUpdate', () {
+      test('returns the latest eligible release and current eligibility', () async {
+        final repository = _makeRepository(
+          httpClient: _mockOk(
+            body: [
+              _releaseJson(version: '0.4.0'),
+              _releaseJson(version: '0.3.1'),
+            ],
+          ),
+          currentVersion: '0.2.0',
+        );
+
+        final resolution = await repository.resolveUpdate();
+
+        expect(resolution.latestEligible?.version, equals('0.4.0'));
+        expect(resolution.latestVersion?.toString(), equals('0.4.0'));
+        expect(resolution.currentVersion.toString(), equals('0.2.0'));
+        expect(resolution.currentEligible, isTrue);
+      });
+
+      test('returns the latest eligible release even when it is not newer (for --force)', () async {
+        final repository = _makeRepository(
+          httpClient: _mockOk(body: [_releaseJson(version: '0.3.0')]),
+          currentVersion: '0.5.0',
+        );
+
+        final resolution = await repository.resolveUpdate();
+
+        // checkForNewerRelease() would return null here; resolveUpdate must not.
+        expect(resolution.latestEligible?.version, equals('0.3.0'));
+        expect(resolution.latestVersion?.toString(), equals('0.3.0'));
+      });
+
+      test('reports an off-track running build as ineligible', () async {
+        final repository = _makeRepository(
+          httpClient: _mockOk(body: [_releaseJson(version: '0.3.0')]),
+          currentVersion: '0.5.0-internal.3',
+        );
+
+        final resolution = await repository.resolveUpdate();
+
+        expect(resolution.currentEligible, isFalse);
+        expect(resolution.latestEligible?.version, equals('0.3.0'));
+      });
+
+      test('always fetches fresh, ignoring a fresh cache', () async {
+        var httpCallCount = 0;
+        final client = MockClient((_) async {
+          httpCallCount++;
+          return http.Response(jsonEncode([_releaseJson(version: '0.4.0')]), 200);
+        });
+        final cached = CachedRelease(
+          latestVersion: '9.9.9',
+          downloadUrl: 'https://example.com/dl/asset.tar.gz',
+          checksumsUrl: 'https://example.com/dl/checksums.txt',
+          assetName: _defaultTarget.assetName,
+          track: 'stable',
+          publishedAt: DateTime.parse('2024-06-01T00:00:00Z'),
+          checkedAt: DateTime.now(),
+        );
+        final repository = _makeRepository(
+          httpClient: client,
+          cache: _FakeCache(readResult: cached),
+          currentVersion: '0.2.0',
+        );
+
+        final resolution = await repository.resolveUpdate();
+
+        expect(httpCallCount, equals(1), reason: 'resolveUpdate bypasses the read cache');
+        expect(resolution.latestEligible?.version, equals('0.4.0'));
+      });
+
+      test('returns a null latest when no eligible release exists', () async {
+        final repository = _makeRepository(
+          httpClient: _mockOk(body: <Map<String, dynamic>>[]),
+          currentVersion: '0.2.0',
+        );
+
+        final resolution = await repository.resolveUpdate();
+
+        expect(resolution.latestEligible, isNull);
+        expect(resolution.latestVersion, isNull);
+      });
+
+      test('writes the resolved release to the cache as a side effect', () async {
+        final cache = _FakeCache();
+        final repository = _makeRepository(
+          httpClient: _mockOk(body: [_releaseJson(version: '0.4.0')]),
+          cache: cache,
+          currentVersion: '0.2.0',
+        );
+
+        await repository.resolveUpdate();
+
+        expect(cache.writtenReleases, hasLength(1));
+        expect(cache.writtenReleases.first.latestVersion, equals('0.4.0'));
+      });
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/bridge/app/test/updater/update_apply_service_test.dart
+++ b/bridge/app/test/updater/update_apply_service_test.dart
@@ -4,8 +4,8 @@ import 'package:clock/clock.dart';
 import 'package:path/path.dart' as p;
 import 'package:sesori_bridge/src/updater/foundation/filesystem_cleaner.dart';
 import 'package:sesori_bridge/src/updater/foundation/update_lock.dart';
-import 'package:sesori_bridge/src/updater/foundation/update_message_formatter.dart';
 import 'package:sesori_bridge/src/updater/models/release_info.dart';
+import 'package:sesori_bridge/src/updater/models/update_apply_outcome.dart';
 import 'package:sesori_bridge/src/updater/models/update_attempt.dart';
 import 'package:sesori_bridge/src/updater/repositories/update_attempt_repository.dart';
 import 'package:sesori_bridge/src/updater/repositories/update_installation_repository.dart';
@@ -95,6 +95,7 @@ class _FakeUpdateLock implements UpdateLock {
     required Future<T> Function() onLockAcquired,
     required Future<T> Function(LockAcquireResult result) onLockRejected,
     required bool Function(T value) shouldReleaseLock,
+    Duration? staleLockMaxAge,
   }) {
     if (outcome == LockAcquireResult.acquired) {
       return onLockAcquired();
@@ -120,8 +121,6 @@ void main() {
   late _FakeAttemptRepository attempts;
   late _FakeLogRepository logs;
   late _FakeUpdateLock lock;
-  late List<String> infoMessages;
-  late List<String> errorMessages;
   late List<String> warnings;
 
   UpdateApplyService buildService() {
@@ -130,14 +129,11 @@ void main() {
       attemptRepository: attempts,
       logRepository: logs,
       updateLock: lock,
-      messageFormatter: const UpdateMessageFormatter(),
       filesystemCleaner: const FilesystemCleaner(),
       clock: Clock.fixed(DateTime.utc(2026, 6, 17)),
       currentVersion: '1.0.0',
       installRoot: installRoot.path,
     );
-    service.emitMessage = infoMessages.add;
-    service.emitError = errorMessages.add;
     service.logWarning = warnings.add;
     return service;
   }
@@ -150,8 +146,6 @@ void main() {
     attempts = _FakeAttemptRepository();
     logs = _FakeLogRepository();
     lock = _FakeUpdateLock();
-    infoMessages = <String>[];
-    errorMessages = <String>[];
     warnings = <String>[];
   });
 
@@ -161,12 +155,12 @@ void main() {
     }
   });
 
-  test('successful apply records pending activation and reports it', () async {
+  test('successful apply records pending activation and returns applied', () async {
     final service = buildService();
 
-    final applied = await service.apply(release: _release(), stagingPath: stagingPath);
+    final outcome = await service.apply(release: _release(), stagingPath: stagingPath);
 
-    expect(applied, isTrue);
+    expect(outcome, isA<UpdateApplied>().having((o) => o.version, 'version', '2.0.0'));
     expect(installation.applyCount, 1);
     // The managed-runtime manifest is bumped so the npm bootstrap won't clobber
     // the freshly swapped binary.
@@ -174,8 +168,6 @@ void main() {
     expect(attempts.saved.first.status, UpdateAttemptStatus.inFlight);
     expect(attempts.saved.last.status, UpdateAttemptStatus.appliedPendingActivation);
     expect(attempts.saved.last.stage, UpdateStage.activated);
-    expect(infoMessages.single, contains('2.0.0'));
-    expect(errorMessages, isEmpty);
     // The staging directory is cleaned after a successful apply.
     expect(Directory(stagingPath).existsSync(), isFalse);
   });
@@ -184,11 +176,11 @@ void main() {
     attempts.throwOnSaveStatus = UpdateAttemptStatus.appliedPendingActivation;
     final service = buildService();
 
-    final applied = await service.apply(release: _release(), stagingPath: stagingPath);
+    final outcome = await service.apply(release: _release(), stagingPath: stagingPath);
 
     // The swap landed, so apply still succeeds; recording activation is
     // best-effort.
-    expect(applied, isTrue);
+    expect(outcome, isA<UpdateApplied>());
     expect(installation.applyCount, 1);
     // The inFlight record could not be advanced to appliedPendingActivation, so
     // it is cleared — the next launch must not reconcile this successful update
@@ -206,38 +198,53 @@ void main() {
     logs.throwOnMessageContaining = 'pending activation on next launch';
     final service = buildService();
 
-    final applied = await service.apply(release: _release(), stagingPath: stagingPath);
+    final outcome = await service.apply(release: _release(), stagingPath: stagingPath);
 
-    expect(applied, isTrue);
+    expect(outcome, isA<UpdateApplied>());
     expect(attempts.saved.last.status, UpdateAttemptStatus.appliedPendingActivation);
     expect(installation.recordedVersion, '2.0.0');
     expect(warnings, contains(predicate<String>((w) => w.contains('pending activation'))));
   });
 
-  test('failed swap records a failure and surfaces guidance', () async {
+  test('failed swap records a failure and returns it with the log path', () async {
     installation.applyError = StateError('disk full');
     final service = buildService();
 
-    final applied = await service.apply(release: _release(), stagingPath: stagingPath);
+    final outcome = await service.apply(release: _release(), stagingPath: stagingPath);
 
-    expect(applied, isFalse);
+    expect(
+      outcome,
+      isA<UpdateApplyFailed>()
+          .having((o) => o.reason, 'reason', contains('disk full'))
+          .having((o) => o.logPath, 'logPath', logs.logPath),
+    );
     expect(attempts.saved.first.status, UpdateAttemptStatus.inFlight);
     expect(attempts.saved.last.status, UpdateAttemptStatus.failed);
     expect(attempts.saved.last.reason, contains('disk full'));
-    expect(errorMessages.single, contains('https://sesori.com/'));
-    expect(infoMessages, isEmpty);
   });
 
   test('lock contention is benign: no apply, a warning, no attempt record', () async {
     lock.outcome = LockAcquireResult.alreadyLocked;
     final service = buildService();
 
-    final applied = await service.apply(release: _release(), stagingPath: stagingPath);
+    final outcome = await service.apply(release: _release(), stagingPath: stagingPath);
 
-    expect(applied, isFalse);
+    expect(outcome, isA<UpdateApplyLockBusy>());
     expect(installation.applyCount, 0);
     expect(attempts.saved, isEmpty);
     expect(warnings, hasLength(1));
-    expect(errorMessages, isEmpty);
+  });
+
+  test('lock permission denied surfaces a failure', () async {
+    lock.outcome = LockAcquireResult.permissionDenied;
+    final service = buildService();
+
+    final outcome = await service.apply(release: _release(), stagingPath: stagingPath);
+
+    expect(
+      outcome,
+      isA<UpdateApplyFailed>().having((o) => o.reason, 'reason', contains('permission denied')),
+    );
+    expect(installation.applyCount, 0);
   });
 }

--- a/bridge/app/test/updater/update_apply_service_test.dart
+++ b/bridge/app/test/updater/update_apply_service_test.dart
@@ -233,6 +233,9 @@ void main() {
     expect(installation.applyCount, 0);
     expect(attempts.saved, isEmpty);
     expect(warnings, hasLength(1));
+    // The swap never ran, so the staged payload is cleaned up rather than left
+    // to accumulate (important for the per-process manual staging dirs).
+    expect(Directory(stagingPath).existsSync(), isFalse);
   });
 
   test('lock permission denied surfaces a failure', () async {
@@ -246,5 +249,6 @@ void main() {
       isA<UpdateApplyFailed>().having((o) => o.reason, 'reason', contains('permission denied')),
     );
     expect(installation.applyCount, 0);
+    expect(Directory(stagingPath).existsSync(), isFalse);
   });
 }

--- a/bridge/app/test/updater/update_command_formatter_test.dart
+++ b/bridge/app/test/updater/update_command_formatter_test.dart
@@ -25,7 +25,7 @@ void main() {
   group('UpdateCommandFormatter', () {
     test('renders a plain ASCII upgrade with no color', () {
       final lines = _formatter().format(
-        const ExplicitUpdateApplied(
+        outcome: const ExplicitUpdateApplied(
           fromVersion: '1.0.0',
           toVersion: '2.0.0',
           kind: UpdateAppliedKind.upgrade,
@@ -43,7 +43,7 @@ void main() {
 
     test('uses unicode glyphs and ANSI when supported', () {
       final lines = _formatter(color: true, unicode: true).format(
-        const ExplicitUpdateApplied(
+        outcome: const ExplicitUpdateApplied(
           fromVersion: '1.0.0',
           toVersion: '2.0.0',
           kind: UpdateAppliedKind.upgrade,
@@ -58,7 +58,7 @@ void main() {
 
     test('reinstall and downgrade headlines read naturally', () {
       final reinstall = _formatter().format(
-        const ExplicitUpdateApplied(
+        outcome: const ExplicitUpdateApplied(
           fromVersion: '2.0.0',
           toVersion: '2.0.0',
           kind: UpdateAppliedKind.reinstall,
@@ -68,7 +68,7 @@ void main() {
       expect(reinstall.first.text, '[OK] Reinstalled v2.0.0 (stable).');
 
       final downgrade = _formatter().format(
-        const ExplicitUpdateApplied(
+        outcome: const ExplicitUpdateApplied(
           fromVersion: '2.0.0-internal.3',
           toVersion: '1.5.0',
           kind: UpdateAppliedKind.downgrade,
@@ -80,7 +80,7 @@ void main() {
 
     test('already-latest is a single stdout line', () {
       final lines = _formatter().format(
-        const ExplicitUpdateAlreadyLatest(version: '2.0.0', track: ReleaseTrack.stable),
+        outcome: const ExplicitUpdateAlreadyLatest(version: '2.0.0', track: ReleaseTrack.stable),
       );
 
       expect(lines, hasLength(1));
@@ -90,7 +90,7 @@ void main() {
 
     test('track mismatch is informational on stdout with a force hint', () {
       final lines = _formatter().format(
-        const ExplicitUpdateTrackMismatch(
+        outcome: const ExplicitUpdateTrackMismatch(
           currentVersion: '2.0.0-internal.3',
           latestVersion: '1.5.0',
           track: ReleaseTrack.stable,
@@ -104,20 +104,22 @@ void main() {
 
     test('failures and refusals go to stderr', () {
       expect(
-        _formatter().format(const ExplicitUpdateNotManaged(executablePath: '/x')).first.isError,
+        _formatter().format(outcome: const ExplicitUpdateNotManaged(executablePath: '/x')).first.isError,
         isTrue,
       );
       expect(
-        _formatter().format(const ExplicitUpdateNpmDirect(message: 'use npx @sesori/bridge')).first.isError,
+        _formatter().format(outcome: const ExplicitUpdateNpmDirect(message: 'use npx @sesori/bridge')).first.isError,
         isTrue,
       );
-      expect(_formatter().format(const ExplicitUpdateLockBusy()).first.isError, isTrue);
+      expect(_formatter().format(outcome: const ExplicitUpdateLockBusy()).first.isError, isTrue);
       expect(
-        _formatter().format(const ExplicitUpdateNoEligibleRelease(track: ReleaseTrack.stable)).first.isError,
+        _formatter().format(outcome: const ExplicitUpdateNoEligibleRelease(track: ReleaseTrack.stable)).first.isError,
         isTrue,
       );
 
-      final failed = _formatter().format(const ExplicitUpdateFailed(reason: 'boom', logPath: '/tmp/log'));
+      final failed = _formatter().format(
+        outcome: const ExplicitUpdateFailed(reason: 'boom', logPath: '/tmp/log'),
+      );
       expect(failed.every((line) => line.isError), isTrue);
       expect(failed.any((line) => line.text.contains('boom')), isTrue);
       expect(failed.any((line) => line.text.contains('/tmp/log')), isTrue);
@@ -131,7 +133,7 @@ void main() {
       );
 
       final lines = formatter.format(
-        const ExplicitUpdateAlreadyLatest(version: '2.0.0', track: ReleaseTrack.stable),
+        outcome: const ExplicitUpdateAlreadyLatest(version: '2.0.0', track: ReleaseTrack.stable),
       );
 
       expect(lines.first.text, isNot(contains('\x1B')));

--- a/bridge/app/test/updater/update_command_formatter_test.dart
+++ b/bridge/app/test/updater/update_command_formatter_test.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+
+import 'package:sesori_bridge/src/updater/formatters/update_command_formatter.dart';
+import 'package:sesori_bridge/src/updater/foundation/release_track.dart';
+import 'package:sesori_bridge/src/updater/models/explicit_update_outcome.dart';
+import 'package:test/test.dart';
+
+class _FakeStdout implements Stdout {
+  _FakeStdout({required this.supportsAnsiEscapes});
+
+  @override
+  final bool supportsAnsiEscapes;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+UpdateCommandFormatter _formatter({bool color = false, bool unicode = false}) => UpdateCommandFormatter(
+  outStream: _FakeStdout(supportsAnsiEscapes: color),
+  errorStream: _FakeStdout(supportsAnsiEscapes: color),
+  environment: unicode ? const {'LANG': 'en_US.UTF-8'} : const {},
+);
+
+void main() {
+  group('UpdateCommandFormatter', () {
+    test('renders a plain ASCII upgrade with no color', () {
+      final lines = _formatter().format(
+        const ExplicitUpdateApplied(
+          fromVersion: '1.0.0',
+          toVersion: '2.0.0',
+          kind: UpdateAppliedKind.upgrade,
+          track: ReleaseTrack.stable,
+        ),
+      );
+
+      expect(lines, hasLength(2));
+      expect(lines.first.isError, isFalse);
+      expect(lines.first.text, '[OK] Updated v1.0.0 -> v2.0.0');
+      expect(lines.first.text, isNot(contains('\x1B')));
+      expect(lines[1].isError, isFalse);
+      expect(lines[1].text, contains('Takes effect on next launch'));
+    });
+
+    test('uses unicode glyphs and ANSI when supported', () {
+      final lines = _formatter(color: true, unicode: true).format(
+        const ExplicitUpdateApplied(
+          fromVersion: '1.0.0',
+          toVersion: '2.0.0',
+          kind: UpdateAppliedKind.upgrade,
+          track: ReleaseTrack.stable,
+        ),
+      );
+
+      expect(lines.first.text, contains('\u2713')); // ✓
+      expect(lines.first.text, contains('\u2192')); // →
+      expect(lines.first.text, contains('\x1B['));
+    });
+
+    test('reinstall and downgrade headlines read naturally', () {
+      final reinstall = _formatter().format(
+        const ExplicitUpdateApplied(
+          fromVersion: '2.0.0',
+          toVersion: '2.0.0',
+          kind: UpdateAppliedKind.reinstall,
+          track: ReleaseTrack.stable,
+        ),
+      );
+      expect(reinstall.first.text, '[OK] Reinstalled v2.0.0 (stable).');
+
+      final downgrade = _formatter().format(
+        const ExplicitUpdateApplied(
+          fromVersion: '2.0.0-internal.3',
+          toVersion: '1.5.0',
+          kind: UpdateAppliedKind.downgrade,
+          track: ReleaseTrack.stable,
+        ),
+      );
+      expect(downgrade.first.text, '[OK] Switched to stable v1.5.0.');
+    });
+
+    test('already-latest is a single stdout line', () {
+      final lines = _formatter().format(
+        const ExplicitUpdateAlreadyLatest(version: '2.0.0', track: ReleaseTrack.stable),
+      );
+
+      expect(lines, hasLength(1));
+      expect(lines.first.isError, isFalse);
+      expect(lines.first.text, "[OK] You're on the latest stable build (v2.0.0).");
+    });
+
+    test('track mismatch is informational on stdout with a force hint', () {
+      final lines = _formatter().format(
+        const ExplicitUpdateTrackMismatch(
+          currentVersion: '2.0.0-internal.3',
+          latestVersion: '1.5.0',
+          track: ReleaseTrack.stable,
+        ),
+      );
+
+      expect(lines.every((line) => !line.isError), isTrue);
+      expect(lines.any((line) => line.text.contains('update --force')), isTrue);
+      expect(lines.any((line) => line.text.contains('1.5.0')), isTrue);
+    });
+
+    test('failures and refusals go to stderr', () {
+      expect(
+        _formatter().format(const ExplicitUpdateNotManaged(executablePath: '/x')).first.isError,
+        isTrue,
+      );
+      expect(
+        _formatter().format(const ExplicitUpdateNpmDirect(message: 'use npx @sesori/bridge')).first.isError,
+        isTrue,
+      );
+      expect(_formatter().format(const ExplicitUpdateLockBusy()).first.isError, isTrue);
+      expect(
+        _formatter().format(const ExplicitUpdateNoEligibleRelease(track: ReleaseTrack.stable)).first.isError,
+        isTrue,
+      );
+
+      final failed = _formatter().format(const ExplicitUpdateFailed(reason: 'boom', logPath: '/tmp/log'));
+      expect(failed.every((line) => line.isError), isTrue);
+      expect(failed.any((line) => line.text.contains('boom')), isTrue);
+      expect(failed.any((line) => line.text.contains('/tmp/log')), isTrue);
+    });
+
+    test('NO_COLOR strips ANSI even on a capable terminal', () {
+      final formatter = UpdateCommandFormatter(
+        outStream: _FakeStdout(supportsAnsiEscapes: true),
+        errorStream: _FakeStdout(supportsAnsiEscapes: true),
+        environment: const {'NO_COLOR': '1', 'LANG': 'en_US.UTF-8'},
+      );
+
+      final lines = formatter.format(
+        const ExplicitUpdateAlreadyLatest(version: '2.0.0', track: ReleaseTrack.stable),
+      );
+
+      expect(lines.first.text, isNot(contains('\x1B')));
+      expect(lines.first.text, contains('\u2713')); // glyph still unicode; only color is gated off
+    });
+  });
+}

--- a/bridge/app/test/updater/update_install_service_test.dart
+++ b/bridge/app/test/updater/update_install_service_test.dart
@@ -127,4 +127,26 @@ void main() {
     expect(result.stagingPath, isNull);
     expect(Directory(p.join(installRoot.path, '.sesori-bridge-staging')).existsSync(), isFalse);
   });
+
+  test('a workspace label isolates the archive and staging paths from the default', () async {
+    final service = UpdateInstallService(
+      updateArtifactRepository: _FakeArtifactRepository(),
+      filesystemCleaner: const FilesystemCleaner(),
+      workspaceLabel: 'manual.4242',
+    );
+
+    final result = await service.stageUpdate(release: _release(), installRoot: installRoot.path);
+
+    expect(result.result, UpdateResult.success);
+    expect(result.stagingPath, p.join(installRoot.path, '.sesori-bridge-staging.manual.4242'));
+    expect(Directory(result.stagingPath!).existsSync(), isTrue);
+    // The shared default staging path is never touched, so a concurrent default
+    // stager (a resident bridge's background updater) cannot collide with it.
+    expect(Directory(p.join(installRoot.path, '.sesori-bridge-staging')).existsSync(), isFalse);
+    expect(
+      File(p.join(installRoot.path, '.sesori-bridge-update.manual.4242.tar.gz')).existsSync(),
+      isFalse,
+      reason: 'the suffixed archive is cleaned after extraction',
+    );
+  });
 }

--- a/bridge/app/test/updater/update_install_service_test.dart
+++ b/bridge/app/test/updater/update_install_service_test.dart
@@ -59,6 +59,7 @@ void main() {
     final service = UpdateInstallService(
       updateArtifactRepository: _FakeArtifactRepository(),
       filesystemCleaner: const FilesystemCleaner(),
+      workspaceLabel: null,
     );
 
     final result = await service.stageUpdate(release: _release(), installRoot: installRoot.path);
@@ -77,6 +78,7 @@ void main() {
     final service = UpdateInstallService(
       updateArtifactRepository: _FakeArtifactRepository()..downloadResult = UpdateResult.networkError,
       filesystemCleaner: const FilesystemCleaner(),
+      workspaceLabel: null,
     );
 
     final result = await service.stageUpdate(release: _release(), installRoot: installRoot.path);
@@ -89,6 +91,7 @@ void main() {
     final service = UpdateInstallService(
       updateArtifactRepository: _FakeArtifactRepository()..checksumValid = false,
       filesystemCleaner: const FilesystemCleaner(),
+      workspaceLabel: null,
     );
 
     final result = await service.stageUpdate(release: _release(), installRoot: installRoot.path);
@@ -107,6 +110,7 @@ void main() {
     final service = UpdateInstallService(
       updateArtifactRepository: _FakeArtifactRepository(),
       filesystemCleaner: const FilesystemCleaner(),
+      workspaceLabel: null,
     );
 
     final result = await service.stageUpdate(release: _release(), installRoot: installRoot.path);
@@ -119,6 +123,7 @@ void main() {
     final service = UpdateInstallService(
       updateArtifactRepository: _FakeArtifactRepository()..extracted = false,
       filesystemCleaner: const FilesystemCleaner(),
+      workspaceLabel: null,
     );
 
     final result = await service.stageUpdate(release: _release(), installRoot: installRoot.path);

--- a/bridge/app/test/updater/update_lock_test.dart
+++ b/bridge/app/test/updater/update_lock_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:clock/clock.dart';
@@ -34,6 +35,38 @@ class _RecordingProcessRunner implements ProcessRunner {
     lastArguments = arguments;
     return ProcessResult(1, exitCode, stdout, '');
   }
+}
+
+/// A lock file whose exclusive `create` succeeds but whose `writeAsString`
+/// fails, so the owner record is never written. Records whether `delete` was
+/// called, to verify the empty lock file is cleaned up on a write failure.
+class _WriteFailingFile implements File {
+  bool deleted = false;
+
+  @override
+  Future<File> create({bool recursive = false, bool exclusive = false}) async => this;
+
+  @override
+  Future<File> writeAsString(
+    String contents, {
+    FileMode mode = FileMode.write,
+    Encoding encoding = utf8,
+    bool flush = false,
+  }) async {
+    throw const FileSystemException('simulated write failure');
+  }
+
+  @override
+  Future<FileSystemEntity> delete({bool recursive = false}) async {
+    deleted = true;
+    return this;
+  }
+
+  @override
+  String get path => '/tmp/.update.lock';
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 void main() {
@@ -302,6 +335,28 @@ void main() {
 
       expect(result, equals(LockAcquireResult.alreadyLocked));
       expect(lockFile.existsSync(), isTrue);
+    });
+
+    test('a write failure after create deletes the empty lock file', () async {
+      final lockFile = _WriteFailingFile();
+      final lock = UpdateLock(
+        currentPid: pid,
+        processRunner: _RecordingProcessRunner(exitCode: 1),
+        clock: const Clock(),
+      );
+
+      await expectLater(
+        lock.locked<int>(
+          lockFile: lockFile,
+          onLockAcquired: () async => 1,
+          onLockRejected: (_) async => -1,
+          shouldReleaseLock: (_) => true,
+        ),
+        throwsA(isA<FileSystemException>()),
+      );
+      // The empty lock file is removed rather than left to block other
+      // acquirers until the grace period reclaims it.
+      expect(lockFile.deleted, isTrue);
     });
   });
 }

--- a/bridge/app/test/updater/update_lock_test.dart
+++ b/bridge/app/test/updater/update_lock_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:clock/clock.dart';
 import 'package:sesori_bridge/src/bridge/foundation/process_runner.dart';
 import 'package:sesori_bridge/src/updater/foundation/update_lock.dart';
 import 'package:test/test.dart';
@@ -56,6 +57,7 @@ void main() {
       final lock = UpdateLock(
         currentPid: pid,
         processRunner: _RecordingProcessRunner(exitCode: 1),
+        clock: const Clock(),
       );
 
       var acquired = false;
@@ -83,6 +85,7 @@ void main() {
       final lock = UpdateLock(
         currentPid: pid,
         processRunner: _RecordingProcessRunner(exitCode: 1),
+        clock: const Clock(),
       );
 
       final result = await lock.locked<int>(
@@ -101,6 +104,7 @@ void main() {
       final lock = UpdateLock(
         currentPid: pid,
         processRunner: runner,
+        clock: const Clock(),
       );
 
       final result = await lock.isProcessAlive(pidToCheck: 999999);
@@ -120,6 +124,7 @@ void main() {
       final lock = UpdateLock(
         currentPid: pid,
         processRunner: _RecordingProcessRunner(exitCode: 1),
+        clock: const Clock(),
       );
 
       final result = await lock.locked<int>(
@@ -152,6 +157,7 @@ void main() {
       final lock = UpdateLock(
         currentPid: pid,
         processRunner: _RecordingProcessRunner(exitCode: 1),
+        clock: const Clock(),
       );
 
       final result = await lock.locked<LockAcquireResult>(
@@ -169,6 +175,7 @@ void main() {
       final lock = UpdateLock(
         currentPid: pid,
         processRunner: _RecordingProcessRunner(exitCode: 1),
+        clock: const Clock(),
       );
 
       final result = await lock.locked<int>(
@@ -195,6 +202,7 @@ void main() {
           exitCode: 0,
           stdout: 'new-process-marker\n',
         ),
+        clock: const Clock(),
       );
 
       final result = await lock.locked<int>(
@@ -226,6 +234,7 @@ void main() {
       final lock = UpdateLock(
         currentPid: pid,
         processRunner: _RecordingProcessRunner(exitCode: 1),
+        clock: const Clock(),
       );
 
       final result = await lock.locked<LockAcquireResult>(
@@ -236,6 +245,63 @@ void main() {
       );
 
       expect(result, equals(LockAcquireResult.permissionDenied));
+    });
+
+    test('a held lock older than staleLockMaxAge is reaped as a last resort', () async {
+      if (Platform.isWindows) {
+        return;
+      }
+
+      final lockFile = File('${tempDir.path}/.update.lock');
+      await lockFile.writeAsString('{"pid":999999,"processMarker":"marker"}', flush: true);
+      // Make the lock look far older than any real swap would take.
+      await lockFile.setLastModified(DateTime.now().subtract(const Duration(minutes: 20)));
+
+      final lock = UpdateLock(
+        currentPid: pid,
+        // exitCode 0 makes the recorded-marker read match and the liveness
+        // (kill -0) probe report the holder as alive, so only the age guard can
+        // reclaim the lock.
+        processRunner: _RecordingProcessRunner(exitCode: 0, stdout: 'marker\n'),
+        clock: Clock.fixed(DateTime.now()),
+      );
+
+      final result = await lock.locked<int>(
+        lockFile: lockFile,
+        onLockAcquired: () async => 1,
+        onLockRejected: (_) async => -1,
+        shouldReleaseLock: (_) => true,
+        staleLockMaxAge: const Duration(minutes: 15),
+      );
+
+      expect(result, equals(1));
+      expect(lockFile.existsSync(), isFalse);
+    });
+
+    test('a held lock within staleLockMaxAge stays locked', () async {
+      if (Platform.isWindows) {
+        return;
+      }
+
+      final lockFile = File('${tempDir.path}/.update.lock');
+      await lockFile.writeAsString('{"pid":999999,"processMarker":"marker"}', flush: true);
+
+      final lock = UpdateLock(
+        currentPid: pid,
+        processRunner: _RecordingProcessRunner(exitCode: 0, stdout: 'marker\n'),
+        clock: Clock.fixed(DateTime.now()),
+      );
+
+      final result = await lock.locked<LockAcquireResult>(
+        lockFile: lockFile,
+        onLockAcquired: () async => LockAcquireResult.acquired,
+        onLockRejected: (reason) async => reason,
+        shouldReleaseLock: (_) => true,
+        staleLockMaxAge: const Duration(minutes: 15),
+      );
+
+      expect(result, equals(LockAcquireResult.alreadyLocked));
+      expect(lockFile.existsSync(), isTrue);
     });
   });
 }

--- a/bridge/app/test/updater/update_lock_test.dart
+++ b/bridge/app/test/updater/update_lock_test.dart
@@ -41,6 +41,12 @@ class _RecordingProcessRunner implements ProcessRunner {
 /// fails, so the owner record is never written. Records whether `delete` was
 /// called, to verify the empty lock file is cleaned up on a write failure.
 class _WriteFailingFile implements File {
+  _WriteFailingFile({this.contentAfterFailedWrite = ''});
+
+  /// What `readAsString` returns during cleanup. Empty means the empty file we
+  /// created is still there; non-empty simulates another acquirer having reaped
+  /// it and written its own owner-stamped lock at the same path.
+  final String contentAfterFailedWrite;
   bool deleted = false;
 
   @override
@@ -55,6 +61,9 @@ class _WriteFailingFile implements File {
   }) async {
     throw const FileSystemException('simulated write failure');
   }
+
+  @override
+  Future<String> readAsString({Encoding encoding = utf8}) async => contentAfterFailedWrite;
 
   @override
   Future<FileSystemEntity> delete({bool recursive = false}) async {
@@ -357,6 +366,29 @@ void main() {
       // The empty lock file is removed rather than left to block other
       // acquirers until the grace period reclaims it.
       expect(lockFile.deleted, isTrue);
+    });
+
+    test('a write failure does not delete a lock another process recreated', () async {
+      // Simulate a slow write: by the time cleanup runs, another acquirer has
+      // reaped the empty lock and written its own owner-stamped lock at the
+      // same path. We must not delete that one.
+      final lockFile = _WriteFailingFile(contentAfterFailedWrite: '{"pid":4242,"processMarker":"other"}');
+      final lock = UpdateLock(
+        currentPid: pid,
+        processRunner: _RecordingProcessRunner(exitCode: 1),
+        clock: const Clock(),
+      );
+
+      await expectLater(
+        lock.locked<int>(
+          lockFile: lockFile,
+          onLockAcquired: () async => 1,
+          onLockRejected: (_) async => -1,
+          shouldReleaseLock: (_) => true,
+        ),
+        throwsA(isA<FileSystemException>()),
+      );
+      expect(lockFile.deleted, isFalse);
     });
   });
 }

--- a/bridge/app/test/updater/update_lock_test.dart
+++ b/bridge/app/test/updater/update_lock_test.dart
@@ -390,5 +390,45 @@ void main() {
       );
       expect(lockFile.deleted, isFalse);
     });
+
+    test('a write failure deletes a partially written (unparseable) lock file', () async {
+      final lockFile = _WriteFailingFile(contentAfterFailedWrite: '{"pid":12');
+      final lock = UpdateLock(
+        currentPid: pid,
+        processRunner: _RecordingProcessRunner(exitCode: 1),
+        clock: const Clock(),
+      );
+
+      await expectLater(
+        lock.locked<int>(
+          lockFile: lockFile,
+          onLockAcquired: () async => 1,
+          onLockRejected: (_) async => -1,
+          shouldReleaseLock: (_) => true,
+        ),
+        throwsA(isA<FileSystemException>()),
+      );
+      expect(lockFile.deleted, isTrue);
+    });
+
+    test('a write failure deletes a lock still stamped with our own pid', () async {
+      final lockFile = _WriteFailingFile(contentAfterFailedWrite: '{"pid":$pid,"processMarker":"self"}');
+      final lock = UpdateLock(
+        currentPid: pid,
+        processRunner: _RecordingProcessRunner(exitCode: 1),
+        clock: const Clock(),
+      );
+
+      await expectLater(
+        lock.locked<int>(
+          lockFile: lockFile,
+          onLockAcquired: () async => 1,
+          onLockRejected: (_) async => -1,
+          shouldReleaseLock: (_) => true,
+        ),
+        throwsA(isA<FileSystemException>()),
+      );
+      expect(lockFile.deleted, isTrue);
+    });
   });
 }

--- a/bridge/app/test/updater/update_reconciliation_service_test.dart
+++ b/bridge/app/test/updater/update_reconciliation_service_test.dart
@@ -63,6 +63,7 @@ class _FakeUpdateLock implements UpdateLock {
     required Future<T> Function() onLockAcquired,
     required Future<T> Function(LockAcquireResult result) onLockRejected,
     required bool Function(T value) shouldReleaseLock,
+    Duration? staleLockMaxAge,
   }) {
     if (outcome == LockAcquireResult.acquired) {
       return onLockAcquired();

--- a/bridge/app/test/updater/update_service_test.dart
+++ b/bridge/app/test/updater/update_service_test.dart
@@ -2,7 +2,9 @@ import 'package:fake_async/fake_async.dart';
 import 'package:sesori_bridge/src/updater/foundation/github_rate_limit_exception.dart';
 import 'package:sesori_bridge/src/updater/foundation/update_message_formatter.dart';
 import 'package:sesori_bridge/src/updater/models/release_info.dart';
+import 'package:sesori_bridge/src/updater/models/update_apply_outcome.dart';
 import 'package:sesori_bridge/src/updater/models/update_install_result.dart';
+import 'package:sesori_bridge/src/updater/models/update_resolution.dart';
 import 'package:sesori_bridge/src/updater/models/update_result.dart';
 import 'package:sesori_bridge/src/updater/repositories/release_repository.dart';
 import 'package:sesori_bridge/src/updater/repositories/update_log_repository.dart';
@@ -22,6 +24,9 @@ class _FakeReleaseRepository implements ReleaseRepository {
     checkCount++;
     return onCheck == null ? null : onCheck!();
   }
+
+  @override
+  Future<UpdateResolution> resolveUpdate() => throw UnimplementedError();
 }
 
 class _FakeInstallService implements UpdateInstallService {
@@ -37,20 +42,15 @@ class _FakeInstallService implements UpdateInstallService {
 
 class _FakeApplyService implements UpdateApplyService {
   final List<String> appliedVersions = <String>[];
-
-  @override
-  void Function(String message) emitMessage = (_) {};
-
-  @override
-  void Function(String message) emitError = (_) {};
+  UpdateApplyOutcome Function(ReleaseInfo release)? onApply;
 
   @override
   void Function(String message) logWarning = (_) {};
 
   @override
-  Future<bool> apply({required ReleaseInfo release, required String stagingPath}) async {
+  Future<UpdateApplyOutcome> apply({required ReleaseInfo release, required String stagingPath}) async {
     appliedVersions.add(release.version);
-    return true;
+    return onApply?.call(release) ?? UpdateApplied(version: release.version);
   }
 }
 
@@ -79,6 +79,7 @@ void main() {
   late _FakeInstallService install;
   late _FakeApplyService apply;
   late _FakeLogRepository logs;
+  late List<String> infoMessages;
   late List<String> errors;
   late List<String> warnings;
 
@@ -97,6 +98,7 @@ void main() {
       managedExecutablePath: _managedPath,
       environment: environment,
     );
+    service.emitMessage = infoMessages.add;
     service.emitError = errors.add;
     service.logWarning = warnings.add;
     return service;
@@ -107,6 +109,7 @@ void main() {
     install = _FakeInstallService();
     apply = _FakeApplyService();
     logs = _FakeLogRepository();
+    infoMessages = <String>[];
     errors = <String>[];
     warnings = <String>[];
   });
@@ -128,7 +131,32 @@ void main() {
       expect(release.checkCount, 1);
       expect(install.stageCount, 1);
       expect(apply.appliedVersions, equals(['2.0.0']));
+      expect(infoMessages.single, contains('2.0.0'));
       expect(errors, isEmpty);
+    });
+  });
+
+  test('an apply failure surfaces an error and stays quiet on success output', () {
+    release.onCheck = () async => _release(version: '2.0.0');
+    apply.onApply = (_) => const UpdateApplyFailed(reason: 'disk full', logPath: '/tmp/.sesori-bridge-update.log');
+
+    runStarted(buildService(), (async) {
+      expect(apply.appliedVersions, equals(['2.0.0']));
+      expect(errors, hasLength(1));
+      expect(errors.single, contains('disk full'));
+      expect(errors.single, contains('https://sesori.com/'));
+      expect(infoMessages, isEmpty);
+    });
+  });
+
+  test('apply lock contention stays quiet', () {
+    release.onCheck = () async => _release(version: '2.0.0');
+    apply.onApply = (_) => const UpdateApplyLockBusy();
+
+    runStarted(buildService(), (async) {
+      expect(apply.appliedVersions, equals(['2.0.0']));
+      expect(errors, isEmpty);
+      expect(infoMessages, isEmpty);
     });
   });
 

--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -91,6 +91,10 @@ If a feature needs a platform capability not already abstracted:
 
 There is ONE production implementation per interface. Do not add factories, alternatives, or abstract factories unless there is a real second implementor (e.g., a test fake is NOT a second implementor — see "No Pointless Interfaces" philosophy in the bridge AGENTS.md; `implements` works on any class in Dart 3).
 
+## Error Handling
+
+**Never catch and swallow.** Every `catch` must log — even a no-op, best-effort, or intentional-degradation handler must emit at least a `debug`/`warning` log that includes the caught error and why continuing is safe. A silent `catch` (empty body or a bare comment with no log) is forbidden.
+
 ## Forbidden
 
 - `module_core` MUST NOT import `package:flutter`. It is pure Dart and must remain testable without Flutter.

--- a/mobile/app/AGENTS.md
+++ b/mobile/app/AGENTS.md
@@ -4,6 +4,10 @@ Thin UI shell for the Sesori mobile client. All business logic, state management
 
 See [`../AGENTS.md`](../AGENTS.md) for shared conventions (architecture layering, DI, testing, error handling).
 
+## Error Handling
+
+**Never catch and swallow** (see the repo-root `AGENTS.md`): every `catch` must log — even a no-op or best-effort handler emits at least a `debug`/`warning` that includes the caught error. A silent `catch` is forbidden.
+
 ## Flutter-Specific Conventions
 
 - `flutter_bloc` for widget integration (`BlocProvider`, `context.watch`, `context.read`)

--- a/mobile/module_auth/AGENTS.md
+++ b/mobile/module_auth/AGENTS.md
@@ -4,6 +4,10 @@ Standalone pure Dart package encapsulating all authentication concerns: token li
 
 See [`../AGENTS.md`](../AGENTS.md) for shared conventions (architecture layering, DI, testing, error handling).
 
+## Error Handling
+
+**Never catch and swallow** (see the repo-root `AGENTS.md`): every `catch` must log — even a no-op or best-effort handler emits at least a `debug`/`warning` that includes the caught error. A silent `catch` is forbidden.
+
 ## Public API (exported from barrel file)
 
 Only these types are exported. Everything else is internal (`lib/src/`).

--- a/mobile/module_core/AGENTS.md
+++ b/mobile/module_core/AGENTS.md
@@ -2,6 +2,10 @@
 
 Business logic, state management, services, and models for the Sesori ecosystem. Zero Flutter SDK dependency — usable from both the Flutter app and a future CLI/TUI tool.
 
+## Error Handling
+
+**Never catch and swallow** (see the repo-root `AGENTS.md`): every `catch` must log — even a no-op or best-effort handler emits at least a `debug`/`warning` that includes the caught error. A silent `catch` is forbidden.
+
 ## Package Structure
 
 ```

--- a/shared/sesori_shared/AGENTS.md
+++ b/shared/sesori_shared/AGENTS.md
@@ -2,6 +2,10 @@
 
 Pure Dart library — crypto primitives + protocol types shared by `sesori_bridge_dart` and `sesori_mobile`. No Flutter dependency. Works in native binaries and Flutter apps.
 
+## Error Handling
+
+**Never catch and swallow.** Every `catch` must log — even a no-op, best-effort, or intentional-degradation handler must emit at least a `debug`/`warning` log that includes the caught error and why continuing is safe. A silent `catch` (empty body or a bare comment with no log) is forbidden.
+
 ## STRUCTURE
 
 ```


### PR DESCRIPTION
## What

Adds an explicit, one-shot `sesori-bridge update` command. It installs the latest release on the active track and **exits** — it never relaunches or starts a bridge; the swapped binary activates on the next launch (a running bridge picks it up when it restarts).

- **`sesori-bridge update`** — installs a strictly-newer release on the track; otherwise reports you're already on the latest, or (if you're on an off-track build, e.g. an internal build while the track is `stable`) hints `--force`.
- **`sesori-bridge update --force`** — installs the latest eligible release for the track **regardless of the current version**: a repair reinstall when you're already current, and the way to switch an internal build back to the latest stable.

Output is **branded** — brand-blue accents, ✓/✗/⚠/➜ glyphs, dim secondary text — built on the terminal capability validators from #317, with full ASCII/no-color degradation (`NO_COLOR`/`FORCE_COLOR`/`TERM`/locale).

## Behavior notes

- **Explicit overrides background suppressors:** ignores `SESORI_NO_UPDATE` and CI detection (those gate the *automatic* updater), but still requires the managed install — it refuses an npm-payload run directly or a non-managed/dev binary.
- **Activation is on next launch** (consistent with the post-#288 stage-and-apply model); the command prints that, and that a running bridge must restart to pick it up.
- **Exit codes:** `0` for applied / already-latest / track-mismatch-hint; `1` for failures and refusals.

## How it's built (scoped-down)

This deliberately avoids re-architecting the freshly-merged #288 background updater. The minimal structural change is that `UpdateApplyService.apply()` now returns a typed `UpdateApplyOutcome` (instead of `bool`) and no longer emits `Console` or depends on `UpdateMessageFormatter` — its two callers present the outcome at their own edge (the background cycle keeps its existing messages; the command renders branded output).

- **`ManualUpdateService`** (Layer 3) — coordinates gating → release resolution → stage → apply, returning a typed `ExplicitUpdateOutcome`. Pure data out; no IO.
- **`ReleaseRepository.resolveUpdate()`** — latest eligible release for the track regardless of current version (always fresh; still writes the cache), plus current-version eligibility for mismatch detection.
- **`UpdateLock`** — injects a clock and adds a generous **15-minute stale-age guard** (liveness-first; only reaps a still-"held" lock older than the threshold) so a wedged lock can't block updates forever. Applied to the apply + reconcile paths.
- **`UpdateCommandFormatter`** (`updater/formatters/`) — self-contained `Formatter` that renders outcomes to branded, capability-gated lines.
- **`UpdateCommand`** in `bin/bridge.dart` — wires the service subset inline (same pattern as `LogoutCommand`/`ConfigEditCommand`) and renders.

## Reviews / testing

- Plan-reviewed and code-reviewed via the repo's architecture agents (both approved after applying required fixes).
- `make analyze` clean across all 4 bridge modules; `make test` green (1507 app tests + the other modules).
- New tests: `ManualUpdateService` (every outcome branch incl. force reinstall/downgrade, gating, network/stage/apply failures), `UpdateCommandFormatter` (color/glyph gating, stdout/stderr routing, `NO_COLOR`), `ReleaseRepository.resolveUpdate`, plus `UpdateLock` stale-age tests; updated apply/service/reconciliation tests for the new outcome contract.

## Depends on

Builds on #317 (terminal color/glyph capability detection), already merged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one‑shot `sesori-bridge update` command that installs the latest track release and exits. It never relaunches, uses per‑process staging, and prints clear, branded output.

- **New Features**
  - One‑shot update; activates on next launch.
  - Plain `update` installs only newer; equal prints already latest; ahead‑of‑latest or off‑track hints `--force`. `--force` reinstalls the latest for your track (repair or switch back to stable).
  - Branded output (color/glyph‑gated) with ASCII/no‑color fallback.
  - Only managed installs: ignores auto‑update suppressors but refuses npm‑payload runs and non‑managed binaries, with guidance.
  - Per‑process staging to avoid background collisions.
  - Uses `GITHUB_TOKEN`/`GH_TOKEN` when set; exit codes: 0 (applied/already‑latest/force‑hint), 1 (failures/refusals).

- **Refactors**
  - `UpdateApplyService.apply()` returns `UpdateApplyOutcome`, does no console IO, and cleans staged payloads when the lock is rejected; the background updater now renders outcomes and messages.
  - Added `ManualUpdateService` and `UpdateCommandFormatter` (format({required outcome})) to coordinate explicit updates and render branded messages.
  - `ReleaseRepository.resolveUpdate()` always fetches fresh and returns `UpdateResolution` (latest eligible + current eligibility).
  - `UpdateLock` injects a `Clock`, reaps 15‑minute stale locks, revalidates ownership, and cleans up our own failed‑write locks (empty/partial/unparseable or stamped with our pid); logs cleanup errors. Used by apply and reconciliation.
  - `UpdateInstallService` now takes `required String? workspaceLabel`: `null` uses the shared background paths; the command passes `manual.<pid>` for per‑process staging.
  - Docs/monitor: require logging in every `catch` (no silent handlers); clarified owner‑vs‑agent replies and tuned PR monitor config (max CI wait, debounce, poll interval).

<sup>Written for commit 7c8b2b59511072716cae855f7d2250b24178d10c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

