### PR TITLE
chore: harden update-dependencies skill and expose it as a Claude Code slash command

### DIFF
--- a/.ai/skills/update-dependencies/SKILL.md
+++ b/.ai/skills/update-dependencies/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-dependencies
-description: Weekly dependency update workflow for Sesori Apps Monorepo. Updates all pubspec.yaml files across bridge and mobile workspaces plus standalone packages, handles conflicts, manages iOS/Android native dependencies, and updates Fastlane/Gemfile versions.
+description: Weekly dependency update workflow for Sesori Apps Monorepo. Updates every pubspec.yaml across the bridge and mobile workspaces plus standalone packages, regenerates all lockfiles, re-resolves iOS/macOS SwiftPM native dependencies (Package.resolved), updates Fastlane/Gemfile versions, handles conflicts, and verifies via analyze/test/codegen.
 ---
 
 <objective>
@@ -23,6 +23,7 @@ The repo has two Dart workspaces and two standalone packages. Workspace members 
 
 - `bridge/pubspec.yaml` — workspace root, env only
 - `bridge/sesori_plugin_interface/pubspec.yaml`
+- `bridge/sesori_plugin_runtime/pubspec.yaml` (depends on `sesori_plugin_interface`)
 - `bridge/sesori_plugin_opencode/pubspec.yaml`
 - `bridge/app/pubspec.yaml` (CLI relay server)
 
@@ -48,9 +49,48 @@ Sesori iOS is **Swift Package Manager only** — there is no Podfile, and CocoaP
 - `mobile/app/android/Gemfile` (fastlane gem)
 - `mobile/app/android/Gemfile.lock`
 </android_files>
+
+<swiftpm_files>
+iOS and macOS pull native dependencies (Firebase, Google SDKs, leveldb, gRPC, etc.) via Swift Package Manager. The resolved native versions are pinned in `Package.resolved` lockfiles. The **build-authoritative** copies — the ones `flutter build` actually uses — are:
+
+- `mobile/app/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved`
+- `mobile/app/macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved`
+
+There are also secondary `Runner.xcodeproj/project.xcworkspace/.../Package.resolved` copies that Xcode maintains only when the bare project is opened. They are not build-critical and are not reliably kept in sync (iOS already differs from its workspace copy) — do not hand-edit or force them.
+
+These lockfiles change on most weekly runs because native SDK patch releases land continuously, **independent of pubspec.yaml**. They MUST be re-resolved every run (Phase 5). Skipping this is a silent, recurring miss — e.g. one past run bumped firebase-ios-sdk but left GoogleUtilities/nanopb/promises stale.
+</swiftpm_files>
 </project_structure>
 
 <process>
+<phase name="0. Preflight Discovery">
+<description>Enumerate the ACTUAL dependency surface and reconcile it against the documented lists in `<project_structure>`. The hardcoded lists below WILL go stale as packages are added — a package missing from the tables is the single most common failure of this workflow (e.g. `bridge/sesori_plugin_runtime` was missed for weeks). Treat what you discover here as authoritative; the tables are only the expected reference.</description>
+
+<step name="0.1">List every source pubspec (excludes build artifacts, codegen output, and worktrees):
+
+```bash
+find . -name pubspec.yaml -not -path '*/build/*' -not -path '*/.dart_tool/*' -not -path './.worktrees/*' | sort
+```
+
+Cross-check the output against the package inventory in `<project_structure>`. If a pubspec appears that is NOT listed there (a newly added workspace member), treat it as in-scope for THIS run — add it to every per-file step below (env constraints in 1.2, outdated check in 2.1, constraint bumps in 3.1) — AND update the inventory + env table in this skill so future runs inherit it. The ONLY pubspec excluded from edits is `shared/no_slop_linter/pubspec.yaml`.
+</step>
+
+<step name="0.2">List the authoritative workspace members straight from the workspace roots — every member here MUST be processed in Phases 1–3:
+
+```bash
+sed -n '/^workspace:/,$p' bridge/pubspec.yaml
+sed -n '/^workspace:/,$p' mobile/pubspec.yaml
+```
+</step>
+
+<step name="0.3">List the iOS/macOS SwiftPM lockfiles that Phase 5 will refresh (expect exactly two — these are native deps and are in scope):
+
+```bash
+find mobile/app -path '*Runner.xcworkspace*Package.resolved' -not -path '*/build/*' | sort
+```
+</step>
+</phase>
+
 <phase name="1. Environment Setup">
 <description>Ensure Flutter/Dart is at latest stable version, align environment constraints, and clean lock files</description>
 
@@ -90,6 +130,7 @@ For each pubspec.yaml below, read its `environment` section and update only the 
 | `bridge/pubspec.yaml` | ✅ | — | caret |
 | `bridge/app/pubspec.yaml` | ✅ | — | caret |
 | `bridge/sesori_plugin_interface/pubspec.yaml` | ✅ | — | caret |
+| `bridge/sesori_plugin_runtime/pubspec.yaml` | ✅ | — | caret |
 | `bridge/sesori_plugin_opencode/pubspec.yaml` | ✅ | — | caret |
 | `shared/sesori_shared/pubspec.yaml` | ✅ | — | caret |
 
@@ -158,6 +199,7 @@ set -e
 set -e
 (cd bridge && dart pub get)
 (cd bridge/sesori_plugin_interface && dart pub outdated)
+(cd bridge/sesori_plugin_runtime && dart pub outdated)
 (cd bridge/sesori_plugin_opencode && dart pub outdated)
 (cd bridge/app && dart pub outdated)
 ```
@@ -186,7 +228,7 @@ set -e
 <step name="3.1">For each pubspec.yaml, in this order:
 
 1. `shared/sesori_shared/pubspec.yaml` (consumed by both workspaces)
-2. Bridge workspace members: `bridge/sesori_plugin_interface`, `bridge/sesori_plugin_opencode`, `bridge/app`
+2. Bridge workspace members (dependency order): `bridge/sesori_plugin_interface`, `bridge/sesori_plugin_runtime`, `bridge/sesori_plugin_opencode`, `bridge/app`
 3. Mobile workspace members: `mobile/module_auth`, `mobile/module_core`, `mobile/module_prego`, `mobile/app`
 
 **SKIP** `shared/no_slop_linter/pubspec.yaml` — analyzer-plugin constraints are bumped manually (see the project structure note). Do not edit it here even if `pub outdated` reports newer versions.
@@ -223,13 +265,21 @@ set -e
 - Re-run pub get
 </step>
 
-<step name="3.4">Verify that pubspec.yaml files were actually modified:
+<step name="3.4">Verify that constraints were actually bumped — **per workspace, not globally**. The most common silent failure is updating one workspace (usually mobile) and skipping the others.
 
 ```bash
-git diff --name-only -- '*.yaml'
+git diff --name-only -- '*.yaml' | sort
 ```
 
-**HALT** if no pubspec.yaml files show changes but outdated packages exist. Do not proceed without having bumped version constraints. Revisit step 3.1.
+Account for EACH of the three resolution units independently:
+
+- **shared** — `shared/sesori_shared/pubspec.yaml`
+- **bridge** — `bridge/**/pubspec.yaml` (all members, including `sesori_plugin_runtime`)
+- **mobile** — `mobile/**/pubspec.yaml`
+
+For each, confirm one of two outcomes: either (a) its pubspec(s) appear in the diff because you bumped constraints, OR (b) you can point to the Phase 2 `outdated` output showing it genuinely had no upgradable direct/dev deps.
+
+**HALT** if any workspace is neither changed nor provably already-current. A workspace that had outdated packages but shows no diff means you skipped it — revisit step 3.1 for that specific workspace. Do not continue until all three are accounted for.
 </step>
 </phase>
 
@@ -241,7 +291,7 @@ git diff --name-only -- '*.yaml'
 ```bash
 set -e
 (cd shared && make analyze)   # sesori_shared + no_slop_linter
-(cd bridge && make analyze)   # sesori_plugin_interface, sesori_plugin_opencode, app
+(cd bridge && make analyze)   # sesori_plugin_interface, sesori_plugin_runtime, sesori_plugin_opencode, app
 (cd mobile && make analyze)   # module_auth, module_core, module_prego, app (with --fatal-infos)
 ```
 
@@ -271,7 +321,7 @@ set -e
 ```bash
 set -e
 (cd shared && make codegen)   # sesori_shared
-(cd bridge && make codegen)   # sesori_plugin_interface, sesori_plugin_opencode, app
+(cd bridge && make codegen)   # sesori_plugin_interface, sesori_plugin_runtime, sesori_plugin_opencode, app
 (cd mobile && make codegen)   # module_auth, module_core, module_prego, app
 ```
 
@@ -279,10 +329,35 @@ If a generator dependency is later added to a currently-skipped package, update 
 </step>
 </phase>
 
-<phase name="5. Fastlane and Gemfile Dependencies">
-<description>Update Fastlane and Ruby gem dependencies for iOS and Android. Sesori iOS is SPM-only — there is no `cocoapods` gem step.</description>
+<phase name="5. Native Dependencies (SwiftPM + Fastlane/Gemfile)">
+<description>Refresh the iOS/macOS SwiftPM native dependency graph and the Ruby/Fastlane gems. Sesori iOS is SPM-only — there is no Podfile and no `cocoapods` gem step.</description>
 
-<step name="5.1">Check the latest fastlane version:
+<step name="5.1">Re-resolve SwiftPM native dependencies (`Package.resolved`) for iOS and macOS.
+
+These lockfiles pin the native Firebase / Google / gRPC / leveldb versions pulled in transitively by the Flutter native plugins. They drift independently of pubspec.yaml (new native patch releases land continuously), so they MUST be re-resolved every run — skipping this leaves native deps stale even when Dart deps are current.
+
+**Order matters.** `flutter pub get` regenerates the `FlutterGeneratedPluginSwiftPackage` from the (already-bumped, post-Phase-3) plugin versions FIRST; the Xcode resolve then picks the newest versions allowed by those constraints. Running the resolve against a stale generated package can **downgrade** dependencies — always `flutter pub get` immediately before resolving.
+
+```bash
+set -e
+(cd mobile && flutter pub get)   # regenerate the SwiftPM package from current plugin versions
+(cd mobile/app/ios && xcodebuild -resolvePackageDependencies -workspace Runner.xcworkspace -scheme Runner)
+(cd mobile/app/macos && xcodebuild -resolvePackageDependencies -workspace Runner.xcworkspace -scheme Runner)
+```
+
+This updates only the two build-authoritative `Runner.xcworkspace/.../Package.resolved` files (see `<swiftpm_files>`). Note: this uses `flutter pub get`, not the Makefile `dart pub get` — only the Flutter tool regenerates the SwiftPM package. Requires Xcode + the iOS/macOS toolchain on the machine; if unavailable, record SwiftPM as deferred in the conflict list rather than silently skipping.
+</step>
+
+<step name="5.2">Verify the SwiftPM lockfiles resolved (changes here are expected on most weekly runs):
+
+```bash
+git diff --stat -- '*Package.resolved'
+```
+
+If there are NO changes, confirm that's genuine (the native graph really was current) and not a resolve that silently failed — re-check the `xcodebuild` exit codes from 5.1.
+</step>
+
+<step name="5.3">Check the latest fastlane version:
 
 ```bash
 gem search fastlane --remote --versions | head -3
@@ -296,7 +371,7 @@ Update the `fastlane` gem constraint in both Gemfiles if a newer minor version i
 Do NOT touch any `cocoapods` gem entry — Sesori does not use CocoaPods. If a `cocoapods` line is still present in `mobile/app/ios/Gemfile`, leave it alone (it's an inert holdover); do not bump it.
 </step>
 
-<step name="5.2">Update Gemfile.lock for iOS:
+<step name="5.4">Update Gemfile.lock for iOS:
 
 ```bash
 cd mobile/app/ios && bundle update && cd ../../..
@@ -304,7 +379,7 @@ cd mobile/app/ios && bundle update && cd ../../..
 
 </step>
 
-<step name="5.3">Update Gemfile.lock for Android:
+<step name="5.5">Update Gemfile.lock for Android:
 
 ```bash
 cd mobile/app/android && bundle update && cd ../../..
@@ -312,7 +387,7 @@ cd mobile/app/android && bundle update && cd ../../..
 
 </step>
 
-<step name="5.4">Verify fastlane still works:
+<step name="5.6">Verify fastlane still works:
 
 ```bash
 cd mobile/app/ios && bundle exec fastlane --version && cd ../../..
@@ -323,24 +398,9 @@ cd mobile/app/android && bundle exec fastlane --version && cd ../../..
 </phase>
 
 <phase name="6. Final Commits">
-<description>Commit all remaining changes with proper categorization</description>
+<description>Commit all remaining changes with proper categorization. Commit the narrowly-scoped Fastlane change FIRST, then a catch-all for everything else — a leading `git add -A` would swallow the Gemfile changes and make a separate Fastlane commit impossible.</description>
 
-<step name="6.1">Commit dependency updates (pubspec.yaml changes, lock files, generated code):
-
-```bash
-git add -A
-git commit -m "chore: update project dependencies
-
-- Update {list key dependencies bumped}
-- Regenerate lock files and generated code
-
-Conflicts/Deferred:
-- {dependency}: blocked by {reason}"
-```
-
-</step>
-
-<step name="6.2">If Fastlane/Gemfile had changes, commit separately:
+<step name="6.1">If Fastlane/Gemfile changed, commit those specific files first:
 
 ```bash
 git add mobile/app/ios/Gemfile mobile/app/ios/Gemfile.lock mobile/app/android/Gemfile mobile/app/android/Gemfile.lock
@@ -348,6 +408,23 @@ git commit -m "chore: update Fastlane gem dependencies
 
 - Update fastlane to X.Y.Z
 - Regenerate Gemfile.lock for iOS and Android"
+```
+
+Skip this commit if the Gemfiles/Gemfile.lock are unchanged.
+</step>
+
+<step name="6.2">Commit everything else — pubspec.yaml bumps, regenerated `pubspec.lock` files, iOS/macOS SwiftPM `Package.resolved`, generated code, and any `.tool-versions`/env changes not already committed in Phase 1:
+
+```bash
+git add -A
+git commit -m "chore: update project dependencies
+
+- Update {list key dependencies bumped, per workspace}
+- Re-resolve iOS/macOS SwiftPM native deps (Package.resolved)
+- Regenerate lock files and generated code
+
+Conflicts/Deferred:
+- {dependency}: blocked by {reason}"
 ```
 
 </step>
@@ -366,9 +443,12 @@ Report this list at the end of the update process for visibility.
 
 <success_criteria>
 
-- Environment constraints (sdk, flutter) updated in 10 pubspec.yaml files (every pubspec EXCEPT `shared/no_slop_linter/pubspec.yaml`, which is excluded entirely)
+- Preflight discovery (Phase 0) ran; every discovered source pubspec and workspace member is accounted for, with none silently skipped
+- Environment constraints (sdk, flutter) updated in 11 pubspec.yaml files (every pubspec EXCEPT `shared/no_slop_linter/pubspec.yaml`, which is excluded entirely — the count INCLUDES `bridge/sesori_plugin_runtime`)
 - Version constraints bumped to latest resolvable versions in every pubspec EXCEPT `shared/no_slop_linter/pubspec.yaml`
+- All three workspaces (shared, bridge, mobile) are individually accounted for: each either has bumped constraints or provably had no upgradable deps (Phase 3.4)
 - All pubspec.lock files regenerated (workspace roots + 2 standalone packages = 4 lockfiles)
+- iOS + macOS SwiftPM `Package.resolved` re-resolved (the 2 authoritative `Runner.xcworkspace` lockfiles), or recorded as deferred if no Xcode toolchain
 - `(cd shared && make analyze)`, `(cd bridge && make analyze)`, `(cd mobile && make analyze)` all pass
 - `(cd shared && make test)`, `(cd bridge && make test)`, `(cd mobile && make test)` all pass
 - `(cd shared && make codegen)`, `(cd bridge && make codegen)`, `(cd mobile && make codegen)` all complete cleanly

--- a/.ai/skills/update-dependencies/SKILL.md
+++ b/.ai/skills/update-dependencies/SKILL.md
@@ -340,12 +340,19 @@ These lockfiles pin the native Firebase / Google / gRPC / leveldb versions pulle
 
 ```bash
 set -e
-(cd mobile && flutter pub get)   # regenerate the SwiftPM package from current plugin versions
-(cd mobile/app/ios && xcodebuild -resolvePackageDependencies -workspace Runner.xcworkspace -scheme Runner)
-(cd mobile/app/macos && xcodebuild -resolvePackageDependencies -workspace Runner.xcworkspace -scheme Runner)
+(cd mobile/app && flutter pub get)   # regenerate the SwiftPM package; run in mobile/app (it owns ios/ + macos/), not the workspace root
+if command -v xcodebuild >/dev/null 2>&1; then
+  (cd mobile/app/ios && xcodebuild -resolvePackageDependencies -workspace Runner.xcworkspace -scheme Runner)
+  (cd mobile/app/macos && xcodebuild -resolvePackageDependencies -workspace Runner.xcworkspace -scheme Runner)
+else
+  echo "xcodebuild unavailable (non-macOS host) — record SwiftPM resolution as deferred in the conflict list"
+fi
 ```
 
-This updates only the two build-authoritative `Runner.xcworkspace/.../Package.resolved` files (see `<swiftpm_files>`). Note: this uses `flutter pub get`, not the Makefile `dart pub get` — only the Flutter tool regenerates the SwiftPM package. Requires Xcode + the iOS/macOS toolchain on the machine; if unavailable, record SwiftPM as deferred in the conflict list rather than silently skipping.
+This updates only the two build-authoritative `Runner.xcworkspace/.../Package.resolved` files (see `<swiftpm_files>`). Notes:
+
+- Run `flutter pub get` from `mobile/app`, not the `mobile` workspace root — `mobile/app` is the package that owns the `ios/`/`macos/` dirs, so it is what regenerates their `FlutterGeneratedPluginSwiftPackage` (running from a pub-workspace member still resolves the whole workspace). Use `flutter pub get`, not the Makefile `dart pub get` — only the Flutter tool regenerates the SwiftPM package.
+- `xcodebuild` is macOS-only, and under `set -e` a bare call would abort the whole run on a non-macOS host; the `command -v` guard lets the workflow continue and record SwiftPM as deferred instead of silently skipping.
 </step>
 
 <step name="5.2">Verify the SwiftPM lockfiles resolved (changes here are expected on most weekly runs):

--- a/.claude/skills/update-dependencies/SKILL.md
+++ b/.claude/skills/update-dependencies/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: update-dependencies
+description: Weekly dependency update workflow for Sesori Apps Monorepo. Updates every pubspec.yaml across the bridge and mobile workspaces plus standalone packages, regenerates all lockfiles, re-resolves iOS/macOS SwiftPM native dependencies (Package.resolved), updates Fastlane/Gemfile versions, handles conflicts, and verifies via analyze/test/codegen.
+---
+
+# update-dependencies (Claude Code shim)
+
+This is the Claude Code entry point for the shared `update-dependencies` skill. The full procedure — preflight discovery, environment-constraint alignment, per-workspace dependency bumps, build verification, SwiftPM native-dependency resolution, Fastlane/Gemfile updates, and commit hygiene — is **not duplicated here**. It lives in one canonical file.
+
+**Read `.ai/skills/update-dependencies/SKILL.md` now and follow it in full.** (Path is relative to the repository root, which is the Claude Code working directory.)
+
+## Path resolution
+
+No remapping is needed. Every command in the canonical file already uses paths relative to the repository root (e.g. `find . -name pubspec.yaml`, `cd shared && make pub-get`, `cd mobile/app/ios`), which is exactly where Claude Code runs `bash`. Run them as written. There are no skill-local scripts to resolve.


### PR DESCRIPTION
## Summary

Hardens the weekly `update-dependencies` skill so it actually updates **all** packages/modules, and exposes it as a Claude Code slash command (`/update-dependencies`).

The skill was reviewed against the real repo (workspace roots, Makefiles, and the last four weekly-update PRs) rather than its own description. Two of the findings were causing **recurring silent misses**.

## Why

- **`bridge/sesori_plugin_runtime` was never updated.** It's a real workspace member (in `bridge/pubspec.yaml`'s `workspace:` and `bridge/Makefile`'s `MODULES`, added in #236) but was absent from the skill entirely. History confirms it: #268 bumped `interface`/`opencode`/`app` and skipped `runtime`.
- **iOS/macOS SwiftPM `Package.resolved` was never re-resolved.** The frontmatter promised "manages iOS/Android native dependencies," but there was no SwiftPM step. Verified live that the correct flow upgrades `GoogleUtilities 8.1.0→8.1.1`, `nanopb→2.30910.1`, `promises→2.4.1` — native bumps #319 left stale. Also found the order trap: resolving *without* a preceding `flutter pub get` **downgrades** deps against a stale generated package.
- **Whole workspaces were silently skipped** in some runs (#319 and #204 touched only `mobile/`). The only guard was a single global "did any pubspec change?" check, which passes when just one workspace is updated.
- **Latent bug:** Phase 6's `git add -A` swallowed the Gemfiles before the separate Fastlane commit could be made.

## Changes

**`74f5ae29` — harden the canonical skill (`.ai/skills/update-dependencies/SKILL.md`)**

*Completeness*
- Add `bridge/sesori_plugin_runtime` to the inventory, env-constraints table, Phase 2 outdated checks, Phase 3 bump ordering, Phase 4 comments, and success criteria (10 → 11 pubspecs).
- Add a **Phase 5 SwiftPM resolution** step (`flutter pub get` → `xcodebuild -resolvePackageDependencies` for iOS + macOS) plus a `<swiftpm_files>` reference block documenting the two build-authoritative `Runner.xcworkspace` lockfiles and the order trap.

*Reliability*
- Add **Phase 0 preflight discovery** that enumerates the real dependency surface (`find` pubspecs, workspace `sed`, Package.resolved) and reconciles it against the documented lists — self-heals drift so a future-added package can't be silently missed.
- Make **Phase 3.4 a per-workspace HALT gate** (shared / bridge / mobile each accounted for) instead of one global check.
- Fix **Phase 6 commit ordering** so the scoped Fastlane commit precedes the `git add -A` catch-all.

**`6b3d4b5f` — expose it to Claude Code**
- Add a thin shim at `.claude/skills/update-dependencies/SKILL.md` (Claude Code only discovers skills under `.claude/skills/` and `~/.claude/skills/`). It carries valid frontmatter for discovery and delegates to the single canonical `.ai/` file — no procedure duplicated, no path remapping needed (canonical commands are already repo-root relative). Mirrors the existing `address-pr-comments` shim pattern.

## Verification

- Ran the new preflight commands (`find`, `sed -n '/^workspace:/,$p'`) — output matches the documented inventory.
- Ran the SwiftPM flow live and confirmed both the correct upgrade behavior and the downgrade-without-`pub get` failure mode; reverted all working-tree resolution changes (this PR touches only the two SKILL.md files).
- `/update-dependencies` registers as a slash command (confirmed in-session after adding the shim).

## Scope

Docs/tooling only — two `SKILL.md` files. No application code, no dependency versions, and no lockfiles are changed by this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the weekly `update-dependencies` skill to cover all packages and native deps, eliminating silent misses. Also exposed it as a Claude Code slash command: `/update-dependencies`.

- **Bug Fixes**
  - Added `bridge/sesori_plugin_runtime` across inventory, checks, bump order, and success criteria (now 11 pubspecs).
  - Added SwiftPM re-resolve for iOS/macOS with `flutter pub get` → `xcodebuild`, updating the two authoritative `Runner.xcworkspace/.../Package.resolved` files and documenting the order trap.
  - Guarded `xcodebuild` behind `command -v` so runs continue on non‑macOS hosts (records SwiftPM resolution as deferred).
  - Run `flutter pub get` from `mobile/app` to correctly regenerate the SwiftPM package before resolving.
  - Added Phase 0 preflight to enumerate all pubspecs and workspace members; changed Phase 3.4 to a per‑workspace HALT (shared, bridge, mobile) to prevent partial updates.
  - Fixed commit ordering so Fastlane/Gemfile changes land before the catch‑all commit.

- **New Features**
  - Exposed the skill as a Claude Code command via `.claude/skills/update-dependencies/SKILL.md`, delegating to the canonical `.ai/skills/update-dependencies/SKILL.md`.

<sup>Written for commit b6d46ea567ff87e8b1f5fd063cc43d6dac506361. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

