### PR TITLE
fix: surface archive extraction failure cause on Windows

### DIFF
--- a/bridge/app/lib/src/updater/repositories/update_artifact_repository.dart
+++ b/bridge/app/lib/src/updater/repositories/update_artifact_repository.dart
@@ -104,12 +104,18 @@ class UpdateArtifactRepository {
   Future<bool> extractArchive({
     required String archivePath,
     required String stagingPath,
-  }) {
-    return _archiveExtractor.extract(
+  }) async {
+    final ArchiveExtractionResult result = await _archiveExtractor.extract(
       archivePath: archivePath,
       stagingPath: stagingPath,
       format: _archiveFormat,
     );
+    if (!result.succeeded) {
+      // The caller maps a false result onto a generic UpdateResult that drops
+      // the cause, so log the extractor's reason here to keep it observable.
+      Log.w('extractArchive: failed to extract release archive: ${result.failureReason}');
+    }
+    return result.succeeded;
   }
 
   String _publishedAssetFileName({required String assetUrl}) {

--- a/bridge/sesori_bridge_foundation/lib/src/archive_extractor.dart
+++ b/bridge/sesori_bridge_foundation/lib/src/archive_extractor.dart
@@ -22,7 +22,7 @@ enum ArchiveFormat { tarGz, zip }
 /// permission denied, PowerShell constrained-language mode, …).
 class ArchiveExtractionResult {
   const ArchiveExtractionResult.success() : succeeded = true, failureReason = null;
-  const ArchiveExtractionResult.failure(String reason) : succeeded = false, failureReason = reason;
+  const ArchiveExtractionResult.failure({required String reason}) : succeeded = false, failureReason = reason;
 
   final bool succeeded;
   final String? failureReason;
@@ -55,12 +55,25 @@ class ArchiveExtractor {
     }
     stagingDir.createSync(recursive: true);
 
-    final ArchiveExtractionResult extracted = switch (format) {
-      ArchiveFormat.tarGz => await _extractTarGz(archivePath: archivePath, stagingPath: stagingPath),
-      ArchiveFormat.zip => Platform.isWindows
-          ? await _extractZipWindows(archivePath: archivePath, stagingPath: stagingPath)
-          : await _extractZipPosix(archivePath: archivePath, stagingPath: stagingPath),
-    };
+    // The helpers shell out via the command executor, which can throw rather
+    // than return a non-zero result (e.g. the tool is missing/not executable —
+    // ProcessException — or a hung command is force-killed past its timeout —
+    // TimeoutException). Convert those into a structured failure so callers
+    // always observe the cause instead of an unhandled async error.
+    final ArchiveExtractionResult extracted;
+    try {
+      extracted = await switch (format) {
+        ArchiveFormat.tarGz => _extractTarGz(archivePath: archivePath, stagingPath: stagingPath),
+        ArchiveFormat.zip => Platform.isWindows
+            ? _extractZipWindows(archivePath: archivePath, stagingPath: stagingPath)
+            : _extractZipPosix(archivePath: archivePath, stagingPath: stagingPath),
+      };
+    } on Object catch (error, stackTrace) {
+      final String reason = "extraction command failed to run: $error";
+      Log.w("Archive extraction command threw", error, stackTrace);
+      _deleteQuietly(stagingDir);
+      return ArchiveExtractionResult.failure(reason: reason);
+    }
     if (!extracted.succeeded) {
       return extracted;
     }
@@ -73,7 +86,7 @@ class ArchiveExtractor {
       const String reason = "the archive contains symlink entries";
       Log.w("Rejecting archive payload: $reason.");
       _deleteQuietly(stagingDir);
-      return const ArchiveExtractionResult.failure(reason);
+      return const ArchiveExtractionResult.failure(reason: reason);
     }
     return const ArchiveExtractionResult.success();
   }
@@ -87,11 +100,11 @@ class ArchiveExtractor {
     // before writing anything.
     final CommandResult listing = await _commandExecutor.run("tar", ["-tzf", archivePath], timeout: _listTimeout);
     if (listing.exitCode != 0) {
-      return ArchiveExtractionResult.failure(_toolFailure(tool: "tar -tzf", result: listing));
+      return ArchiveExtractionResult.failure(reason: _toolFailure(tool: "tar -tzf", result: listing));
     }
     final String? escapeReason = _firstEscapingMember(stagingPath: stagingPath, listing: listing.stdout);
     if (escapeReason != null) {
-      return ArchiveExtractionResult.failure(escapeReason);
+      return ArchiveExtractionResult.failure(reason: escapeReason);
     }
 
     final CommandResult result = await _commandExecutor.run(
@@ -100,7 +113,7 @@ class ArchiveExtractor {
       timeout: _extractTimeout,
     );
     if (result.exitCode != 0) {
-      return ArchiveExtractionResult.failure(_toolFailure(tool: "tar -xzf", result: result));
+      return ArchiveExtractionResult.failure(reason: _toolFailure(tool: "tar -xzf", result: result));
     }
     return const ArchiveExtractionResult.success();
   }
@@ -113,11 +126,11 @@ class ArchiveExtractor {
     // would escape before extracting.
     final CommandResult listing = await _commandExecutor.run("unzip", ["-Z1", archivePath], timeout: _listTimeout);
     if (listing.exitCode != 0) {
-      return ArchiveExtractionResult.failure(_toolFailure(tool: "unzip -Z1", result: listing));
+      return ArchiveExtractionResult.failure(reason: _toolFailure(tool: "unzip -Z1", result: listing));
     }
     final String? escapeReason = _firstEscapingMember(stagingPath: stagingPath, listing: listing.stdout);
     if (escapeReason != null) {
-      return ArchiveExtractionResult.failure(escapeReason);
+      return ArchiveExtractionResult.failure(reason: escapeReason);
     }
 
     final CommandResult result = await _commandExecutor.run(
@@ -126,7 +139,7 @@ class ArchiveExtractor {
       timeout: _extractTimeout,
     );
     if (result.exitCode != 0) {
-      return ArchiveExtractionResult.failure(_toolFailure(tool: "unzip", result: result));
+      return ArchiveExtractionResult.failure(reason: _toolFailure(tool: "unzip", result: result));
     }
     return const ArchiveExtractionResult.success();
   }
@@ -148,7 +161,7 @@ class ArchiveExtractor {
       timeout: _extractTimeout,
     );
     if (result.exitCode != 0) {
-      return ArchiveExtractionResult.failure(_toolFailure(tool: "powershell Expand-Archive", result: result));
+      return ArchiveExtractionResult.failure(reason: _toolFailure(tool: "powershell Expand-Archive", result: result));
     }
     return const ArchiveExtractionResult.success();
   }

--- a/bridge/sesori_bridge_foundation/lib/src/archive_extractor.dart
+++ b/bridge/sesori_bridge_foundation/lib/src/archive_extractor.dart
@@ -12,6 +12,22 @@ import "command_executor.dart";
 /// `.tar.gz` on Linux).
 enum ArchiveFormat { tarGz, zip }
 
+/// The outcome of an [ArchiveExtractor.extract] attempt.
+///
+/// On failure, [failureReason] carries the underlying cause (the failing tool's
+/// exit code + stderr, or which hardening check rejected the payload) so the
+/// caller can surface it instead of a bare "extraction failed". A swallowed
+/// extractor error is otherwise invisible — the platform tool's stderr is the
+/// only signal of what actually went wrong (corrupt archive, missing tool,
+/// permission denied, PowerShell constrained-language mode, …).
+class ArchiveExtractionResult {
+  const ArchiveExtractionResult.success() : succeeded = true, failureReason = null;
+  const ArchiveExtractionResult.failure(String reason) : succeeded = false, failureReason = reason;
+
+  final bool succeeded;
+  final String? failureReason;
+}
+
 /// Extracts a downloaded runtime archive into a staging directory.
 ///
 /// The archive has already been checksum-verified, but extraction is still
@@ -28,7 +44,7 @@ class ArchiveExtractor {
   static const Duration _listTimeout = Duration(seconds: 30);
   static const Duration _extractTimeout = Duration(minutes: 2);
 
-  Future<bool> extract({
+  Future<ArchiveExtractionResult> extract({
     required String archivePath,
     required String stagingPath,
     required ArchiveFormat format,
@@ -39,14 +55,14 @@ class ArchiveExtractor {
     }
     stagingDir.createSync(recursive: true);
 
-    final bool extracted = switch (format) {
+    final ArchiveExtractionResult extracted = switch (format) {
       ArchiveFormat.tarGz => await _extractTarGz(archivePath: archivePath, stagingPath: stagingPath),
       ArchiveFormat.zip => Platform.isWindows
           ? await _extractZipWindows(archivePath: archivePath, stagingPath: stagingPath)
           : await _extractZipPosix(archivePath: archivePath, stagingPath: stagingPath),
     };
-    if (!extracted) {
-      return false;
+    if (!extracted.succeeded) {
+      return extracted;
     }
 
     // A symlink could point outside the install root and be followed when the
@@ -54,14 +70,15 @@ class ArchiveExtractor {
     // on a later launch — escaping the sandbox. Payloads never ship symlinks, so
     // reject the whole staged tree if any are present.
     if (_containsSymlink(stagingDir)) {
-      Log.w("Rejecting archive payload: the archive contains symlink entries.");
+      const String reason = "the archive contains symlink entries";
+      Log.w("Rejecting archive payload: $reason.");
       _deleteQuietly(stagingDir);
-      return false;
+      return const ArchiveExtractionResult.failure(reason);
     }
-    return true;
+    return const ArchiveExtractionResult.success();
   }
 
-  Future<bool> _extractTarGz({
+  Future<ArchiveExtractionResult> _extractTarGz({
     required String archivePath,
     required String stagingPath,
   }) async {
@@ -70,10 +87,11 @@ class ArchiveExtractor {
     // before writing anything.
     final CommandResult listing = await _commandExecutor.run("tar", ["-tzf", archivePath], timeout: _listTimeout);
     if (listing.exitCode != 0) {
-      return false;
+      return ArchiveExtractionResult.failure(_toolFailure(tool: "tar -tzf", result: listing));
     }
-    if (_anyMemberEscapes(stagingPath: stagingPath, listing: listing.stdout)) {
-      return false;
+    final String? escapeReason = _firstEscapingMember(stagingPath: stagingPath, listing: listing.stdout);
+    if (escapeReason != null) {
+      return ArchiveExtractionResult.failure(escapeReason);
     }
 
     final CommandResult result = await _commandExecutor.run(
@@ -81,10 +99,13 @@ class ArchiveExtractor {
       ["-xzf", archivePath, "-C", stagingPath],
       timeout: _extractTimeout,
     );
-    return result.exitCode == 0;
+    if (result.exitCode != 0) {
+      return ArchiveExtractionResult.failure(_toolFailure(tool: "tar -xzf", result: result));
+    }
+    return const ArchiveExtractionResult.success();
   }
 
-  Future<bool> _extractZipPosix({
+  Future<ArchiveExtractionResult> _extractZipPosix({
     required String archivePath,
     required String stagingPath,
   }) async {
@@ -92,10 +113,11 @@ class ArchiveExtractor {
     // would escape before extracting.
     final CommandResult listing = await _commandExecutor.run("unzip", ["-Z1", archivePath], timeout: _listTimeout);
     if (listing.exitCode != 0) {
-      return false;
+      return ArchiveExtractionResult.failure(_toolFailure(tool: "unzip -Z1", result: listing));
     }
-    if (_anyMemberEscapes(stagingPath: stagingPath, listing: listing.stdout)) {
-      return false;
+    final String? escapeReason = _firstEscapingMember(stagingPath: stagingPath, listing: listing.stdout);
+    if (escapeReason != null) {
+      return ArchiveExtractionResult.failure(escapeReason);
     }
 
     final CommandResult result = await _commandExecutor.run(
@@ -103,10 +125,13 @@ class ArchiveExtractor {
       ["-o", "-q", archivePath, "-d", stagingPath],
       timeout: _extractTimeout,
     );
-    return result.exitCode == 0;
+    if (result.exitCode != 0) {
+      return ArchiveExtractionResult.failure(_toolFailure(tool: "unzip", result: result));
+    }
+    return const ArchiveExtractionResult.success();
   }
 
-  Future<bool> _extractZipWindows({
+  Future<ArchiveExtractionResult> _extractZipWindows({
     required String archivePath,
     required String stagingPath,
   }) async {
@@ -116,26 +141,43 @@ class ArchiveExtractor {
     final CommandResult result = await _commandExecutor.run(
       "powershell",
       [
+        "-NoProfile",
         "-Command",
-        "Expand-Archive -LiteralPath '$psArchive' -DestinationPath '$psStaging' -Force",
+        "\$ProgressPreference = 'SilentlyContinue'; Expand-Archive -LiteralPath '$psArchive' -DestinationPath '$psStaging' -Force",
       ],
       timeout: _extractTimeout,
     );
-    return result.exitCode == 0;
+    if (result.exitCode != 0) {
+      return ArchiveExtractionResult.failure(_toolFailure(tool: "powershell Expand-Archive", result: result));
+    }
+    return const ArchiveExtractionResult.success();
   }
 
-  bool _anyMemberEscapes({required String stagingPath, required String listing}) {
+  /// A one-line description of a failed helper command, including its exit code
+  /// and the tail of its stderr (or stdout, if stderr is empty) so the real
+  /// cause is visible rather than swallowed.
+  String _toolFailure({required String tool, required CommandResult result}) {
+    String detail = result.stderr.trim();
+    if (detail.isEmpty) {
+      detail = result.stdout.trim();
+    }
+    final String suffix = detail.isEmpty ? "" : ": $detail";
+    return "$tool exited with code ${result.exitCode}$suffix";
+  }
+
+  String? _firstEscapingMember({required String stagingPath, required String listing}) {
     for (final String line in const LineSplitter().convert(listing)) {
       final String member = line.trim();
       if (member.isEmpty) {
         continue;
       }
       if (_escapesStaging(stagingPath: stagingPath, member: member)) {
-        Log.w("Rejecting archive payload: archive member escapes staging: $member");
-        return true;
+        final String reason = "archive member escapes staging: $member";
+        Log.w("Rejecting archive payload: $reason");
+        return reason;
       }
     }
-    return false;
+    return null;
   }
 
   /// Whether [member] (an archive entry path) would resolve outside [stagingPath]

--- a/bridge/sesori_bridge_foundation/test/archive_extractor_test.dart
+++ b/bridge/sesori_bridge_foundation/test/archive_extractor_test.dart
@@ -29,6 +29,25 @@ class _RealCommandExecutor implements CommandExecutor {
   }
 }
 
+/// A [CommandExecutor] that always throws, modelling a missing/unexecutable tool
+/// (`ProcessException`) or a force-killed timeout (`TimeoutException`).
+class _ThrowingCommandExecutor implements CommandExecutor {
+  _ThrowingCommandExecutor({required this.error});
+
+  final Object error;
+
+  @override
+  Future<CommandResult> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+    Map<String, String>? environment,
+    Duration? timeout,
+  }) async {
+    throw error;
+  }
+}
+
 void main() {
   late Directory tempDir;
   late String payloadDir;
@@ -125,6 +144,27 @@ void main() {
       expect(result.succeeded, isTrue);
       expect(File(p.join(stagingPath, "bin", "opencode")).readAsStringSync(), "BIN");
       expect(File(p.join(stagingPath, "lib", "a.txt")).readAsStringSync(), "A");
+    });
+  });
+
+  group("command failures", () {
+    test("converts a thrown command-execution error into a structured failure", () async {
+      final extractor = ArchiveExtractor(
+        commandExecutor: _ThrowingCommandExecutor(
+          error: const ProcessException("tar", [], "tar: command not found", 127),
+        ),
+      );
+
+      final result = await extractor.extract(
+        archivePath: p.join(tempDir.path, "missing.tar.gz"),
+        stagingPath: stagingPath,
+        format: ArchiveFormat.tarGz,
+      );
+
+      expect(result.succeeded, isFalse);
+      expect(result.failureReason, contains("extraction command failed to run"));
+      // Fail-closed: a thrown command leaves no partial staging behind.
+      expect(Directory(stagingPath).existsSync(), isFalse);
     });
   });
 }

--- a/bridge/sesori_bridge_foundation/test/archive_extractor_test.dart
+++ b/bridge/sesori_bridge_foundation/test/archive_extractor_test.dart
@@ -69,13 +69,13 @@ void main() {
       writeFile(p.join("lib", "a.dll"), "A");
       final archive = await tarPayload();
 
-      final ok = await extractor().extract(
+      final result = await extractor().extract(
         archivePath: archive,
         stagingPath: stagingPath,
         format: ArchiveFormat.tarGz,
       );
 
-      expect(ok, isTrue);
+      expect(result.succeeded, isTrue);
       expect(File(p.join(stagingPath, "bin", "sesori-bridge")).readAsStringSync(), "BIN");
       expect(File(p.join(stagingPath, "lib", "a.dll")).readAsStringSync(), "A");
     });
@@ -87,13 +87,14 @@ void main() {
       Link(p.join(payloadDir, "lib", "evil")).createSync("/etc/passwd");
       final archive = await tarPayload();
 
-      final ok = await extractor().extract(
+      final result = await extractor().extract(
         archivePath: archive,
         stagingPath: stagingPath,
         format: ArchiveFormat.tarGz,
       );
 
-      expect(ok, isFalse);
+      expect(result.succeeded, isFalse);
+      expect(result.failureReason, contains("symlink"));
       // Fail-closed: nothing is left staged for the placement step.
       expect(Directory(stagingPath).existsSync(), isFalse);
     });
@@ -115,13 +116,13 @@ void main() {
       }
       expect(zipResult.exitCode, 0, reason: "zip failed: ${zipResult.stderr}");
 
-      final ok = await extractor().extract(
+      final result = await extractor().extract(
         archivePath: archive,
         stagingPath: stagingPath,
         format: ArchiveFormat.zip,
       );
 
-      expect(ok, isTrue);
+      expect(result.succeeded, isTrue);
       expect(File(p.join(stagingPath, "bin", "opencode")).readAsStringSync(), "BIN");
       expect(File(p.join(stagingPath, "lib", "a.txt")).readAsStringSync(), "A");
     });

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_install_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_install_service.dart
@@ -100,13 +100,13 @@ class OpenCodeRuntimeInstallService {
       _throwIfAborted(startAborted);
 
       yield const ProvisionExtracting();
-      final bool extracted = await _archiveExtractor.extract(
+      final ArchiveExtractionResult extracted = await _archiveExtractor.extract(
         archivePath: downloadPath,
         stagingPath: stagingPath,
         format: asset.format,
       );
-      if (!extracted) {
-        throw OpenCodeRuntimeInstallException("failed to extract ${asset.assetName}");
+      if (!extracted.succeeded) {
+        throw OpenCodeRuntimeInstallException("failed to extract ${asset.assetName} (${extracted.failureReason})");
       }
       _throwIfAborted(startAborted);
 

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_install_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_install_service_test.dart
@@ -49,7 +49,7 @@ class _FakeArchiveExtractor implements ArchiveExtractor {
     required ArchiveFormat format,
   }) async {
     if (!success) {
-      return const ArchiveExtractionResult.failure("powershell Expand-Archive exited with code 1: boom");
+      return const ArchiveExtractionResult.failure(reason: "powershell Expand-Archive exited with code 1: boom");
     }
     Directory(stagingPath).createSync(recursive: true);
     File(p.join(stagingPath, "opencode")).writeAsStringSync("BINARY");

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_install_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_install_service_test.dart
@@ -43,13 +43,17 @@ class _FakeArchiveExtractor implements ArchiveExtractor {
   final bool success;
 
   @override
-  Future<bool> extract({required String archivePath, required String stagingPath, required ArchiveFormat format}) async {
+  Future<ArchiveExtractionResult> extract({
+    required String archivePath,
+    required String stagingPath,
+    required ArchiveFormat format,
+  }) async {
     if (!success) {
-      return false;
+      return const ArchiveExtractionResult.failure("powershell Expand-Archive exited with code 1: boom");
     }
     Directory(stagingPath).createSync(recursive: true);
     File(p.join(stagingPath, "opencode")).writeAsStringSync("BINARY");
-    return true;
+    return const ArchiveExtractionResult.success();
   }
 }
 
@@ -155,10 +159,16 @@ void main() {
     expect(File(p.join(versionDir(), "opencode")).existsSync(), isFalse);
   });
 
-  test("throws when extraction fails", () async {
+  test("throws when extraction fails, surfacing the underlying reason", () async {
     await expectLater(
       install(build(extractSuccess: false)).drain<void>(),
-      throwsA(isA<OpenCodeRuntimeInstallException>()),
+      throwsA(
+        isA<OpenCodeRuntimeInstallException>().having(
+          (e) => e.message,
+          "message",
+          allOf(contains("failed to extract"), contains("Expand-Archive exited with code 1: boom")),
+        ),
+      ),
     );
   });
 


### PR DESCRIPTION
## Problem

On Windows, the new startup OpenCode runtime provisioning failed with only a generic message:

```
OpenCode runtime setup failed: Could not install the OpenCode runtime: failed to extract opencode-windows-x64.zip
```

The user re-ran with `--log-level verbose` and got no extra detail. Root cause: `ArchiveExtractor.extract` returned a bare `bool`, so when PowerShell's `Expand-Archive` exited non-zero the actual error (`result.stderr` + exit code) was **discarded before it could reach any logger**. The download had passed its SHA-256 check, so the failure was purely in extraction — but nothing told us *why*.

This is also a "never silently swallow" violation: a degrade path dropped the real error with no trace.

## Fix

- `ArchiveExtractor.extract` now returns an `ArchiveExtractionResult` (`succeeded` + `failureReason`). Each path (`tar`, `unzip`, PowerShell `Expand-Archive`) captures the failing tool's **exit code and stderr** (stdout fallback) into the reason. The two hardening rejections (symlink, path traversal) carry their own reasons.
- `OpenCodeRuntimeInstallException` now includes the reason, so the user-visible `ProvisionFailed` message reads e.g. `failed to extract opencode-windows-x64.zip (powershell Expand-Archive exited with code N: <stderr>)`.
- `UpdateArtifactRepository.extractArchive` (the bridge self-updater, the other consumer) keeps its `bool` contract but now `Log.w`s the extractor's reason instead of dropping it.
- Hardened the Windows invocation with `-NoProfile` and `$ProgressPreference = 'SilentlyContinue'` so a noisy/broken PowerShell profile or progress-stream rendering on PowerShell 5.1 can't derail `Expand-Archive`.

Behavior is unchanged on success and still fails-closed on the security checks. `ProvisionFailed` remains non-fatal (bridge degrades, stays connected, retries on restart).

## Why this is the right first step

The extraction failure cause was invisible. This surfaces the true root cause (corrupt/zero-byte download, constrained-language mode, locked destination from AV, path issue, etc.) so the underlying Windows fix can be confirmed from the actual error rather than guessed.

## Testing

- `make analyze` clean across all bridge modules
- `make test` passes (1486 tests)
- Added: extractor symlink rejection now asserts the reason; install-service test asserts the underlying reason is surfaced in the exception message

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the real cause of Windows archive extraction failures by returning and surfacing the failing tool’s exit code and stderr, instead of a generic “failed to extract” message. Also harden PowerShell and convert thrown command-execution errors into clear, structured failures.

- **Bug Fixes**
  - `ArchiveExtractor.extract` now returns `ArchiveExtractionResult` (success + `failureReason`), capturing exit code and stderr for `tar`, `unzip`, and PowerShell `Expand-Archive`.
  - Wrap extraction dispatch in try/catch to convert `ProcessException`/`TimeoutException` into `failureReason` (“extraction command failed to run: …”) and clean up partial staging; added a test for this path.
  - Propagate reasons: install errors include the cause, and the updater logs it instead of dropping it.
  - Security checks still fail-closed; rejections (symlink, path traversal) now include clear reasons.
  - Windows: run PowerShell with `-NoProfile` and `$ProgressPreference='SilentlyContinue'`. Behavior is unchanged on success.

<sup>Written for commit e72f486700c5bd7e1f03b2bb71d748c68a0c8e9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

