### PR TITLE
docs(desktop): desktop app implementation plan

### DIFF
--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -159,7 +159,7 @@ internal `new`).
 | Component | Layer | Role |
 |---|---|---|
 | `ControlChannelServer` | Layer 0 | GUI-hosted loopback WS host + per-spawn secret; inbound-as-stream + `send` (precedent: `DebugServer`) |
-| `ControlMessageDispatcher` | Layer 3 | routes inbound: token req → `AuthTokenProvider`; status/progress → `BridgeStatusTracker`; **prompts → a lower-layer prompt store/tracker** (NOT the cubit directly — Layer 4↔4 same-level deps are forbidden) |
+| `ControlMessageDispatcher` | Layer 3 | routes inbound: token req → `AuthTokenProvider`; status/progress → `BridgeStatusTracker`; **prompts → a Layer-3 prompt store/tracker** (NOT upward into the Layer-4 cubit/UI — deps must point downward) |
 | prompt state (e.g. on `BridgeStatusTracker` or a `BridgePromptTracker`) | Layer 3 | holds pending prompts as state/stream; the cubit consumes it |
 | process API (mirrors `HostProcessCommandExecutor`) | Layer 1 | spawn/kill/monitor a long-lived child |
 | `BridgeProcessRepository` | Layer 2 | wraps the process API |
@@ -190,7 +190,7 @@ and consumes only the exported interfaces (`AuthTokenProvider`/`OAuthFlowProvide
 | A11 | GUI login opens the browser via a **desktop `UrlLauncher` adapter** | the bridge's `openOAuthBrowser` is bridge-workspace-only; `client/desktop` must not import bridge internals |
 | A12 | Token push must drive **RelayClient re-auth/reconnect**, not just emit on a stream | `RelayClient` reads the token once in `connect()`; an open socket stays on the old JWT until reconnect |
 | A13 | GUI keeps a **readable copy of `bridgeId`** + a GUI-side unregister fallback | logout can happen with the helper off/crashed/unreachable; otherwise the registration leaks |
-| A14 | Control prompts flow dispatcher → **Layer-3 prompt state** → cubit | dispatcher and cubit are both Layer 4; same-level deps are forbidden |
+| A14 | Control prompts flow dispatcher → **Layer-3 prompt state** → cubit | the `ControlMessageDispatcher` (Layer 3) must not depend upward on `BridgeControlCubit` (Layer 4); it writes prompts to a Layer-3 store/tracker that the cubit reads, keeping dependencies pointing downward |
 | A15 | All module_core platform prerequisites registered in the **first DI slice** | `LoginCubit`/`ConnectionService` need `LifecycleSource`/`RelayCryptoService`/`FailureReporter`; deferring them breaks `get_it` resolution in early PRs |
 
 ## 8. Open risks & lead-time register

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -236,6 +236,7 @@ Legend: ☐ pending · ◐ in-progress · ☑ done. Sizes: **S** ≤150 LOC · *
 - ☐ 2.2 Desktop platform adapters (SecureStorage, UrlLauncher) — Low-Med / S-M
 - ☐ 2.3 Login reuse (`AuthManager` browser-poll OAuth) — Med / M
 - ☐ 2.4 Relay connection + bridge online/offline — Low-Med / S-M
+- ☐ 2.5a Re-export `AuthTokenProvider` from `module_core` (seam) — Low / S
 - ☐ 2.5 `ControlChannelServer` + `ControlMessageDispatcher` + token responder — Med / M
 - ☐ 2.6 `BridgeProcessService`: spawn/kill/path + control flags — High / M
 - ☐ 2.7 Exit-code state machine (86/0/other + backoff) — High / M
@@ -256,7 +257,7 @@ Legend: ☐ pending · ◐ in-progress · ☑ done. Sizes: **S** ≤150 LOC · *
 - ☐ 3.2 macOS codesign + notarize + staple — High / M
 - ☐ 3.3 Windows leg: build + bundle + installer (unsigned) — High / M
 - ☐ 3.4 Windows code signing (needs cert) — Med / S-M
-- ☐ 3.5 Linux AppImage + bundle (+ optional GPG) — Med-High / M
+- ☐ 3.5 Linux AppImage + bundle + **mandatory** GPG signing — Med-High / M
 - ☐ 3.6 macOS self-update (Sparkle) + EdDSA + appcast — High / M
 - ☐ 3.7 Windows self-update (WinSparkle) + appcast — High / M
 - ☐ 3.8 Linux self-update (zsync/AppImageUpdate) — Med-High / M

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -1,0 +1,258 @@
+# Sesori Desktop App — Master Plan
+
+> Living document. This is the map: architecture, decisions, invariants, risk
+> register, and the PR status index. Per-phase detail lives in `phase-N-*.md`.
+> Each PR updates its phase doc's **Findings log** and, if needed, the
+> **Plan-deltas** and this index. Keep the **Current pointer** below accurate so
+> any session can resume cleanly.
+
+## Current pointer
+
+- **Active phase:** Phase 0 (not started)
+- **In-flight PR:** none
+- **Branch:** `design-discussion-session` (this plan PR) → feature branches per PR thereafter
+- **Next action:** land the plan PR, then start PR 0.1 (workspace rename)
+
+---
+
+## 1. Goal
+
+Ship a downloadable desktop app that installs, runs, and controls the existing
+`sesori-bridge` from the OS tray/menu-bar and self-starts at boot — replacing
+the terminal/npm install for desktop users. The same app eventually bakes in the
+accessory UI (projects/sessions/chat). The headless/VM path (standalone CLI +
+systemd) is preserved unchanged.
+
+## 2. Architecture
+
+One installable app per OS contains **two binaries** built from the monorepo at
+the **same commit/version**:
+
+```
+Sesori.app (.dmg) / Sesori installer (.exe) / Sesori.AppImage
+├── Binary B — Flutter GUI ("client" app)         ← tray + window + supervisor + control server
+└── Binary A — sesori-bridge (pure Dart)           ← spawned & supervised as a child ("helper")
+```
+
+- **Binary A** is the existing `sesori-bridge`, in **two run modes** from one
+  library: **standalone** (terminal/systemd, unchanged) and **supervised**
+  (launched by the GUI with `--control-url`/`--control-secret`).
+- **GUI ↔ helper** talk over a **GUI-hosted loopback WebSocket control channel**
+  (per-spawn secret). It carries ONLY: fresh-token requests, token-stream
+  pushes, status pushes, runtime-provisioning progress, and prompts
+  (replace-bridge, unregister-and-exit). **No project data.**
+- **Project data** flows phone-style over the relay (`relay.sesori.com`). The
+  desktop UI (v1.x) is a relay client like the phone, reusing `module_core`
+  transport unchanged.
+- This mirrors Tailscale (`Tailscale.app` supervises `tailscaled`; the same
+  daemon also runs headless on a server).
+
+### Data flow
+
+- **Login:** GUI owns login+refresh via `module_auth` (sole token authority).
+  Poll-based OAuth (browser open + server-side session-token poll) — **no
+  localhost redirect / deep link**. `openOAuthBrowser` already covers all 3 OSes.
+- **Token:** helper never runs OAuth/refresh. It pulls access tokens from the GUI
+  over the control channel (and receives pushed updates), implementing the
+  bridge's existing `AccessTokenProvider`/`TokenRefresher` seams.
+- **Registration:** helper self-registers its `bridgeId` (using the GUI-supplied
+  token) and persists it in a helper-owned store (not `token.json`).
+- **Runtime provisioning:** on first run the bridge's `ensureRuntime` phase
+  downloads/installs OpenCode, emitting `RuntimeProvisionProgress`. In supervised
+  mode these events are teed onto the control channel → GUI shows first-run
+  progress. `ProvisionFailed` is non-fatal → **degraded** plugin.
+- **Restart:** phone-triggered restart makes the supervised bridge `exit(86)`;
+  the GUI respawns. Crash (other non-zero) → backoff respawn. Clean stop → exit 0,
+  no respawn.
+- **Logout:** GUI sends `unregister-and-exit`; the bridge unregisters its
+  `bridgeId` using the current token, exits; the GUI then invalidates tokens.
+
+## 3. Decisions (locked)
+
+| # | Decision |
+|---|----------|
+| 1 | **Hybrid library**: one bridge library → one binary, two run modes (standalone / supervised). |
+| 2 | Desktop UI **reuses the relay** like the phone (v1); loopback data path is a later optimization. |
+| 3 | GUI **supervises the bridge binary** as a child process. |
+| 4 | **GUI is the sole token authority**; helper is token-provided (no helper OAuth/refresh → no rotation race). |
+| 5 | Control channel = **GUI-hosted loopback WebSocket** + per-spawn secret. |
+| 6 | **Native tray menu + single main window** for v1; control logic in a reusable cubit/service. |
+| 7 | GUI **autostarts tray-only** (`--hidden`) and **respawns the bridge if last-on**. |
+| 8 | Restart via **exit-code sentinel `86`**; crash→backoff respawn; **self-update off** when bundled; **GUI single-instance**. |
+| 9 | **Dev ID/notarized .dmg + signed Windows installer + Linux AppImage**, self-update via **Sparkle/WinSparkle/zsync**, GitHub-fed. |
+| 10 | **Separate desktop package + extract a shared UI library.** |
+| 11 | Both new packages live in the (renamed) **`client/`** workspace. |
+| 12 | **Unified shared version**; desktop bundles the same-commit bridge. |
+| 13 | **Fully signed** on all three OSes (procure a Windows code-signing cert). |
+| 14 | **Lean v1**: install + control + login + signed + self-update + first-run provisioning UI. Baked-in accessory UI deferred to v1.x. |
+
+## 4. Release-safety invariants (MUST hold at every merged PR)
+
+**Every merged PR must leave `main` able to cut a CLI (bridge) release and a
+mobile release.**
+
+1. **Bridge/CLI stays releasable** — all supervised-mode work is **additive and
+   gated by `--control-url`**, and **never touches the relay protocol or
+   standalone defaults**. Each Phase 1 PR asserts standalone behaviour is
+   unchanged.
+2. **Mobile stays releasable** — Phase 0 (rename) acceptance includes a **mobile
+   release-pipeline dry-run**; each Phase 4 extraction PR keeps `mobile/app`
+   building, tests green, and a release dry-run passing.
+3. **Desktop CI is non-blocking** for CLI/mobile releases until desktop is
+   stable. The existing all-or-nothing release `finalize` must **not** gate on
+   desktop legs (a desktop build failure can never abort a CLI/mobile release).
+   Folding desktop into the release gate is a later, deliberate decision.
+4. **Workspace integrity** — after each desktop PR, `dart pub get` +
+   `mobile/app` build/test stay green (desktop-only deps are platform-scoped).
+5. **`make bump-version` stays backward-compatible** — bumps CLI+mobile even
+   while desktop is mid-development; before Phase 3, releases ship no desktop
+   artifact.
+
+## 5. Coding conventions for new code
+
+- Follow the strict layered architecture (see root + workspace `AGENTS.md`).
+- **Error handling (per updated repo rule):** swallow-and-continue must log;
+  catch-all should generally log; **do NOT double-log a failure already
+  surfaced** (rethrow / typed throw / explicit failure return like
+  `ProvisionFailed`); pass the error as the logger argument
+  (`Log.w("msg", error, stackTrace)`), never string-interpolated.
+- **Naming alignment with `sesori_bridge_foundation`** (landed on main): mirror
+  `CommandExecutor`/`HostProcessCommandExecutor`, `PlatformTarget`,
+  `SemanticVersion`, `BinaryDownloadClient`, `ChecksumValidator`,
+  `ArchiveExtractor` for analogous desktop primitives (separate workspace → mirror
+  the pattern, don't import bridge foundation).
+- Every PR runs through `aristotle-impl-review` before opening; the first
+  implementation plan per phase runs through `aristotle-plan-review`.
+
+## 6. Component design (Aristotle-aligned)
+
+### Bridge side (supervised mode; gated by `--control-url`)
+
+| Component | Layer / dir | Role |
+|---|---|---|
+| `ControlChannelClient` | Layer 0 `bridge/foundation/` | loopback WS client; connect/reconnect; send/receive |
+| Control-protocol Freezed DTOs | `shared/sesori_shared` | pure wire types (incl. provision-progress mirror) |
+| `ControlChannelTokenService` | Layer 3 `auth/` | implements `AccessTokenProvider`/`TokenRefresher`; pull + push token stream |
+| `BridgeControlMessageDispatcher` | Layer 4 | routes inbound control msgs (token push → token service, restart → handoff, logout → unregister-and-exit) |
+| `BridgeIdentityFileApi` (L1) + `BridgeIdentityRepository` (L2) | `api/` + `repositories/` | persist `bridgeId` separately from `token.json` |
+| supervised auth bootstrap | composition root | short-circuit `BridgeRuntimeAuthService.ensureAuthenticated` (no stdin); keep an equivalent `logAuthenticatedUser` |
+| restart change | `orchestrator`/runner seam | `handleRestartHandoff()` → `exit(86)` instead of `spawnSuccessor()` |
+
+Supervised-vs-standalone is chosen **once at the composition root**
+(`bridge_runtime_runner.dart`), which wires either `TokenManager` (+ interactive
+auth) or the control-channel service (+ bootstrap). `ControlChannelClient` is
+constructed at the root and **injected** into `ControlChannelTokenService` (no
+internal `new`).
+
+### Desktop GUI side (`client/desktop`, reusing `module_core`/`module_auth`/`module_prego`/`module_app_ui`)
+
+| Component | Layer | Role |
+|---|---|---|
+| `ControlChannelServer` | Layer 0 | GUI-hosted loopback WS host + per-spawn secret; inbound-as-stream + `send` (precedent: `DebugServer`) |
+| `ControlMessageDispatcher` | Layer 4 | routes inbound: token req → `AuthTokenProvider`; status/progress → `BridgeStatusTracker`; prompts → cubit/UI |
+| process API (mirrors `HostProcessCommandExecutor`) | Layer 1 | spawn/kill/monitor a long-lived child |
+| `BridgeProcessRepository` | Layer 2 | wraps the process API |
+| `BridgeProcessService` | Layer 3 | bridge child lifecycle: spawn (control flags), exit-code state machine (86/0/other + backoff), single supervised-bridge guard |
+| `BridgeStatusTracker` | Layer 3 | status (relay/plugin health, provisioning, degraded, active sessions) from control events; stream/snapshot |
+| `BridgeControlCubit` | Layer 4 | toggle on/off (→ service), expose status (← tracker) for tray + window |
+| `DesktopInstanceService` | Layer 3 | GUI single-instance lock (separate from process supervision) |
+| `SystemTray` / `WindowHost` / `LaunchAtLogin` / `AppUpdater` | Layer 0 capability interfaces + desktop impls | wrap `tray_manager` / `window_manager` / `launch_at_startup` / `auto_updater` |
+| desktop `SecureStorage` / `UrlLauncher` / `FailureReporter` impls | Layer 0 adapters | platform adapters for the desktop shell |
+
+Auth: `client/desktop` registers `module_auth` via `configureAuthDependencies(getIt)`
+and consumes only the exported interfaces (`AuthTokenProvider`/`OAuthFlowProvider`/`AuthSession`) — **no direct `AuthManager` import**.
+
+## 7. Architecture decision records (ADR)
+
+| ADR | Decision | Rationale |
+|---|---|---|
+| A1 | Out-of-process supervised child (not in-process isolate) | crash isolation; reuse bridge lifecycle; sandbox boundary |
+| A2 | macOS **not** sandboxed (Developer ID, not MAS) | the bridge spawns `git`/`opencode`/`ps` |
+| A3 | Single token authority (GUI), helper token-provided | eliminates cross-process refresh-rotation race |
+| A4 | Control-protocol DTOs in `sesori_shared` | only shared point between bridge + client workspaces; pure data |
+| A5 | `ControlChannelServer` name kept (vs Aristotle's `Listener`) | `Listener` implies one-way subscription; this is a duplex socket host; `DebugServer` precedent |
+| A6 | `bridgeId` persistence = file API + thin repo (no Dao) | one string; no DB/migration needed |
+| A7 | First-run provisioning UI is **v1** | first launch downloads OpenCode; user must see progress |
+
+## 8. Open risks & lead-time register
+
+| Item | Status | Owner | Notes |
+|---|---|---|---|
+| Windows code-signing cert | **OPEN — lead time** | TBD | blocks PR 3.4 (signed Windows); EV clears SmartScreen faster |
+| CI secrets (Dev ID, notarization key, EdDSA appcast, GPG) | OPEN | TBD | PR 3.0b |
+| Flutter multi-window viability (v2 popover) | OPEN | TBD | de-risk with a spike before Phase 5 popover |
+| macOS login-item arg detection (`--hidden`) | OPEN | TBD | `SMAppService` may need a shim |
+| OpenCode presence | **RESOLVED** | — | bridge now auto-provisions via `ensureRuntime`; residual = first-run progress UX + degraded handling (PRs 1.13, 2.16) |
+| `bundled bridge` runtime-ownership guard | OPEN | TBD | spike in PR 2.8 (avoid discovering at notarization) |
+
+## 9. PR status index
+
+Legend: ☐ pending · ◐ in-progress · ☑ done. Sizes: **S** ≤150 LOC · **M** 150–350 · **L** (rename only, mechanical).
+
+### Phase 0 — Rename → `phase-0-rename.md`
+- ☐ 0.1 `mobile/`→`client/` everywhere (atomic) — **Med-High / L**
+
+### Phase 1 — Bridge supervised mode → `phase-1-bridge-supervised.md`
+- ☐ 1.1 `--control-url`/`--control-secret` + `ControlChannelClient` skeleton — Low / M
+- ☐ 1.2 Control-protocol Freezed DTOs (incl. provision-progress mirror) — Low / S-M
+- ☐ 1.3 Supervised auth bootstrap (short-circuit `ensureAuthenticated`) — Med / M
+- ☐ 1.4 Token provider **pull** over channel (+ timeout/GUI-down) — Med / M
+- ☐ 1.5 Token-stream **push** → relay client — Med / S-M
+- ☐ 1.6 Supervised registration + `bridgeId` out of `token.json` — Med / M
+- ☐ 1.7 Exit-code restart (`86`) + bypass successor-spawn — Med / S-M
+- ☐ 1.8 Disable self-update + reconcile when supervised — Low / S
+- ☐ 1.9 Re-home prompts/Console → control events — Med / M
+- ☐ 1.10 Status push (relay/plugin/active sessions) — Low / S-M
+- ☐ 1.11 `unregister-and-exit` control command — Low / S-M
+- ☐ 1.12 Single-live precedence under supervised `--hidden` — Med / M
+- ☐ 1.13 Tee `RuntimeProvisionProgress` → control channel — Low / S-M
+
+### Phase 2 — Desktop shell + supervisor → `phase-2-desktop-shell.md`
+- ☐ 2.1 `client/desktop` package + builds on 3 OSes — Med / M
+- ☐ 2.2 Desktop platform adapters (SecureStorage, UrlLauncher) — Low-Med / S-M
+- ☐ 2.3 Login reuse (`AuthManager` browser-poll OAuth) — Med / M
+- ☐ 2.4 Relay connection + bridge online/offline — Low-Med / S-M
+- ☐ 2.5 `ControlChannelServer` + `ControlMessageDispatcher` + token responder — Med / M
+- ☐ 2.6 `BridgeProcessService`: spawn/kill/path + control flags — High / M
+- ☐ 2.7 Exit-code state machine (86/0/other + backoff) — High / M
+- ☐ 2.8 Spike: bundled bridge runtime-ownership + `--hidden` contention — Med / S-M
+- ☐ 2.9 Tray menu + reusable control cubit — Med / M
+- ☐ 2.10 `WindowHost` single window + v1 window contents — Med / M
+- ☐ 2.11 Autostart + `--hidden` boot + macOS login-item detection — Med / M
+- ☐ 2.12 GUI single-instance + persist on/off & last-state — Low-Med / S-M
+- ☐ 2.13 Logout coordination (GUI: unregister→kill→invalidate) — Med / S-M
+- ☐ 2.14 Desktop `FailureReporter` impl — Low-Med / S-M
+- ☐ 2.15 E2E integration (spawn→handshake→token→relay→restart→logout) — Med / M
+- ☐ 2.16 First-run provisioning progress UI + degraded state — Med / M
+
+### Phase 3 — Packaging / signing / self-update (= v1) → `phase-3-packaging.md`
+- ☐ 3.0a macOS no-sandbox + hardened-runtime + spawn-child entitlements — Med / S-M
+- ☐ 3.0b CI secrets provisioning (config + docs) — Low / S
+- ☐ 3.1 `_reusable-desktop-build.yml` macOS leg (unsigned) — High / M
+- ☐ 3.2 macOS codesign + notarize + staple — High / M
+- ☐ 3.3 Windows leg: build + bundle + installer (unsigned) — High / M
+- ☐ 3.4 Windows code signing (needs cert) — Med / S-M
+- ☐ 3.5 Linux AppImage + bundle (+ optional GPG) — Med-High / M
+- ☐ 3.6 macOS self-update (Sparkle) + EdDSA + appcast — High / M
+- ☐ 3.7 Windows self-update (WinSparkle) + appcast — High / M
+- ☐ 3.8 Linux self-update (zsync/AppImageUpdate) — Med-High / M
+- ☐ 3.9 Failed-update/rollback handling + update UX — Med / M
+- ☐ 3.10 Release-pipeline integration (non-blocking) + `make bump-version` + changelog — Med / M
+- ☐ 3.11 Uninstall + login-item/token cleanup — Low-Med / S-M
+
+### Phase 4 — Accessory UI (v1.x) → `phase-4-accessory-ui.md`
+- ☐ 4.1 Create `client/module_app_ui` + move shared widgets/extensions/l10n — Med / M
+- ☐ 4.2 Move voice capture UI — Med / M
+- ☐ 4.3 Move login/splash — Med / M
+- ☐ 4.4 Move project_list + session_list — Med / M
+- ☐ 4.5 Move session_detail + session_diffs + new_session (split if needed) — Med / M
+- ☐ 4.6 Move settings — Low-Med / S-M
+- ☐ 4.7 Desktop router composition + wire accessory UI into window — Med / M
+
+### Phase 5 — Polish (v2) → `phase-5-polish.md`
+- ☐ 5.1 Multi-window spike (throwaway) — Med / S-M
+- ☐ 5.2 Frameless popover window (sliced during planning) — Med / M+
+- ☐ 5.3 Richer settings — Low-Med / M
+
+> Note: OpenCode onboarding/detection was REMOVED from Phase 5 — the bridge now
+> auto-provisions OpenCode at startup (main #322).

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -56,7 +56,9 @@ Sesori.app (.dmg) / Sesori installer (.exe) / Sesori.AppImage
 
 - **Login:** GUI owns login+refresh via `module_auth` (sole token authority).
   Poll-based OAuth (browser open + server-side session-token poll) — **no
-  localhost redirect / deep link**. `openOAuthBrowser` already covers all 3 OSes.
+  localhost redirect / deep link**. The browser is opened through a **desktop
+  `UrlLauncher` adapter** (the bridge's `openOAuthBrowser` lives in the bridge
+  workspace and must NOT be imported by `client/desktop`).
 - **Token:** helper never runs OAuth/refresh. It pulls access tokens from the GUI
   over the control channel (and receives pushed updates), implementing the
   bridge's existing `AccessTokenProvider`/`TokenRefresher` seams.
@@ -128,8 +130,9 @@ mobile release.**
   `SemanticVersion`, `BinaryDownloadClient`, `ChecksumValidator`,
   `ArchiveExtractor` for analogous desktop primitives (separate workspace → mirror
   the pattern, don't import bridge foundation).
-- Every PR runs through `aristotle-impl-review` before opening; the first
-  implementation plan per phase runs through `aristotle-plan-review`.
+- **Every implementation PR** runs through `aristotle-plan-review` before coding
+  **and** `aristotle-impl-review` before opening — the architecture gate is
+  per-PR, never per-phase (a later PR in a phase must not bypass it).
 
 ## 6. Component design (Aristotle-aligned)
 
@@ -141,7 +144,7 @@ mobile release.**
 | Control-protocol Freezed DTOs | `shared/sesori_shared` | pure wire types (incl. provision-progress mirror) |
 | `ControlChannelTokenService` | Layer 3 `auth/` | implements `AccessTokenProvider`/`TokenRefresher`; pull + push token stream |
 | `BridgeControlMessageDispatcher` | Layer 4 | routes inbound control msgs (token push → token service, restart → handoff, logout → unregister-and-exit) |
-| `BridgeIdentityFileApi` (L1) + `BridgeIdentityRepository` (L2) | `api/` + `repositories/` | persist `bridgeId` separately from `token.json` |
+| `BridgeIdentityStore` (file API + reader) | **inside the `auth/` subsystem** | persist `bridgeId` separately from `token.json`; kept within `auth/` (which is self-contained, outside the core layer hierarchy) so auth code doesn't depend back on top-level `repositories/`. Injected from the composition root. |
 | supervised auth bootstrap | composition root | short-circuit `BridgeRuntimeAuthService.ensureAuthenticated` (no stdin); keep an equivalent `logAuthenticatedUser` |
 | restart change | `orchestrator`/runner seam | `handleRestartHandoff()` → `exit(86)` instead of `spawnSuccessor()` |
 
@@ -156,12 +159,13 @@ internal `new`).
 | Component | Layer | Role |
 |---|---|---|
 | `ControlChannelServer` | Layer 0 | GUI-hosted loopback WS host + per-spawn secret; inbound-as-stream + `send` (precedent: `DebugServer`) |
-| `ControlMessageDispatcher` | Layer 4 | routes inbound: token req → `AuthTokenProvider`; status/progress → `BridgeStatusTracker`; prompts → cubit/UI |
+| `ControlMessageDispatcher` | Layer 3 | routes inbound: token req → `AuthTokenProvider`; status/progress → `BridgeStatusTracker`; **prompts → a lower-layer prompt store/tracker** (NOT the cubit directly — Layer 4↔4 same-level deps are forbidden) |
+| prompt state (e.g. on `BridgeStatusTracker` or a `BridgePromptTracker`) | Layer 3 | holds pending prompts as state/stream; the cubit consumes it |
 | process API (mirrors `HostProcessCommandExecutor`) | Layer 1 | spawn/kill/monitor a long-lived child |
 | `BridgeProcessRepository` | Layer 2 | wraps the process API |
 | `BridgeProcessService` | Layer 3 | bridge child lifecycle: spawn (control flags), exit-code state machine (86/0/other + backoff), single supervised-bridge guard |
 | `BridgeStatusTracker` | Layer 3 | status (relay/plugin health, provisioning, degraded, active sessions) from control events; stream/snapshot |
-| `BridgeControlCubit` | Layer 4 | toggle on/off (→ service), expose status (← tracker) for tray + window |
+| `BridgeControlCubit` | Layer 4 | toggle on/off (→ service), expose status + prompts (← trackers) for tray + window |
 | `DesktopInstanceService` | Layer 3 | GUI single-instance lock (separate from process supervision) |
 | `SystemTray` / `WindowHost` / `LaunchAtLogin` / `AppUpdater` | Layer 0 capability interfaces + desktop impls | wrap `tray_manager` / `window_manager` / `launch_at_startup` / `auto_updater` |
 | desktop `SecureStorage` / `UrlLauncher` / `FailureReporter` impls | Layer 0 adapters | platform adapters for the desktop shell |
@@ -178,20 +182,27 @@ and consumes only the exported interfaces (`AuthTokenProvider`/`OAuthFlowProvide
 | A3 | Single token authority (GUI), helper token-provided | eliminates cross-process refresh-rotation race |
 | A4 | Control-protocol DTOs in `sesori_shared` | only shared point between bridge + client workspaces; pure data |
 | A5 | `ControlChannelServer` name kept (vs Aristotle's `Listener`) | `Listener` implies one-way subscription; this is a duplex socket host; `DebugServer` precedent |
-| A6 | `bridgeId` persistence = file API + thin repo (no Dao) | one string; no DB/migration needed |
+| A6 | `bridgeId` persistence = a small file-backed store **inside `auth/`** (no Dao) | one string; no DB/migration; keeps it within the self-contained auth subsystem so auth code doesn't depend on top-level `repositories/` |
 | A7 | First-run provisioning UI is **v1** | first launch downloads OpenCode; user must see progress |
 | A8 | Control-channel secret delivered **off-argv** (inherited FD/pipe or stdin handshake), not `--control-secret` | argv is readable by other local processes/users; this channel issues bearer tokens, so an argv-leaked secret = token theft |
 | A9 | Helper exits on **control-channel loss** after a short grace period | if the GUI crashes/force-quits, the OS does not reliably kill the child; the helper must not linger invisibly with a live token |
 | A10 | Desktop uninstall touches **only desktop-owned state** | `token.json` + managed runtime live under the shared Sesori data root used by the standalone CLI; deleting them would break/log-out the terminal bridge |
+| A11 | GUI login opens the browser via a **desktop `UrlLauncher` adapter** | the bridge's `openOAuthBrowser` is bridge-workspace-only; `client/desktop` must not import bridge internals |
+| A12 | Token push must drive **RelayClient re-auth/reconnect**, not just emit on a stream | `RelayClient` reads the token once in `connect()`; an open socket stays on the old JWT until reconnect |
+| A13 | GUI keeps a **readable copy of `bridgeId`** + a GUI-side unregister fallback | logout can happen with the helper off/crashed/unreachable; otherwise the registration leaks |
+| A14 | Control prompts flow dispatcher → **Layer-3 prompt state** → cubit | dispatcher and cubit are both Layer 4; same-level deps are forbidden |
+| A15 | All module_core platform prerequisites registered in the **first DI slice** | `LoginCubit`/`ConnectionService` need `LifecycleSource`/`RelayCryptoService`/`FailureReporter`; deferring them breaks `get_it` resolution in early PRs |
 
 ## 8. Open risks & lead-time register
 
 | Item | Status | Owner | Notes |
 |---|---|---|---|
 | Windows code-signing cert | **OPEN — lead time** | TBD | blocks PR 3.4 (signed Windows); EV clears SmartScreen faster |
-| Control-channel secret bootstrap (off-argv) | OPEN | TBD | ADR A8; designed in PR 1.1 / PR 2.5 |
+| Control-channel secret bootstrap (off-argv) | OPEN | TBD | ADR A8; designed in PR 1.1 / PR 2.6 |
 | Orphaned helper on GUI crash | OPEN | TBD | ADR A9; parent-loss policy in PR 1.1 |
 | Uninstall vs shared CLI state | OPEN | TBD | ADR A10; scope cleanup in PR 3.11 |
+| RelayClient live re-auth on token push | OPEN | TBD | ADR A12; PR 1.5 must add the subscription/reconnect path + live-connection test |
+| `core/widgets` not pure leaf UI | OPEN | TBD | `connection_overlay.dart` imports app DI/routing/go_router; PR 4.1 must refactor + declare deps first |
 | CI secrets (Dev ID, notarization key, EdDSA appcast, GPG) | OPEN | TBD | PR 3.0b |
 | Flutter multi-window viability (v2 popover) | OPEN | TBD | de-risk with a spike before Phase 5 popover |
 | macOS login-item arg detection (`--hidden`) | OPEN | TBD | `SMAppService` may need a shim |

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -36,11 +36,16 @@ Sesori.app (.dmg) / Sesori installer (.exe) / Sesori.AppImage
 
 - **Binary A** is the existing `sesori-bridge`, in **two run modes** from one
   library: **standalone** (terminal/systemd, unchanged) and **supervised**
-  (launched by the GUI with `--control-url`/`--control-secret`).
-- **GUI ↔ helper** talk over a **GUI-hosted loopback WebSocket control channel**
-  (per-spawn secret). It carries ONLY: fresh-token requests, token-stream
-  pushes, status pushes, runtime-provisioning progress, and prompts
-  (replace-bridge, unregister-and-exit). **No project data.**
+  (launched by the GUI; supervised mode is selected by a `--control-url` flag).
+- **GUI ↔ helper** talk over a **GUI-hosted loopback WebSocket control channel**.
+  The channel carries ONLY: fresh-token requests, token-stream pushes, status
+  pushes, runtime-provisioning progress, and prompts (replace-bridge,
+  unregister-and-exit). **No project data.**
+- **Control-channel secret is NOT passed in argv.** Command-line arguments are
+  inspectable by any other local process/user, and this channel issues bearer
+  tokens — so a leaked secret = token theft. The per-spawn secret is delivered
+  off-argv (inherited pipe/FD or a stdin handshake at spawn); only the
+  loopback URL may be a flag. See ADR A8.
 - **Project data** flows phone-style over the relay (`relay.sesori.com`). The
   desktop UI (v1.x) is a relay client like the phone, reusing `module_core`
   transport unchanged.
@@ -96,14 +101,16 @@ mobile release.**
    standalone defaults**. Each Phase 1 PR asserts standalone behaviour is
    unchanged.
 2. **Mobile stays releasable** — Phase 0 (rename) acceptance includes a **mobile
-   release-pipeline dry-run**; each Phase 4 extraction PR keeps `mobile/app`
-   building, tests green, and a release dry-run passing.
+   release-pipeline dry-run**. After the rename the mobile app lives at
+   `client/app`, so every later gate is phrased against the **mobile product**
+   (path `client/app`, NOT `mobile/app`); each Phase 4 extraction PR keeps
+   `client/app` building, tests green, and a release dry-run passing.
 3. **Desktop CI is non-blocking** for CLI/mobile releases until desktop is
    stable. The existing all-or-nothing release `finalize` must **not** gate on
    desktop legs (a desktop build failure can never abort a CLI/mobile release).
    Folding desktop into the release gate is a later, deliberate decision.
 4. **Workspace integrity** — after each desktop PR, `dart pub get` +
-   `mobile/app` build/test stay green (desktop-only deps are platform-scoped).
+   `client/app` (the mobile product) build/test stay green (desktop-only deps are platform-scoped).
 5. **`make bump-version` stays backward-compatible** — bumps CLI+mobile even
    while desktop is mid-development; before Phase 3, releases ship no desktop
    artifact.
@@ -130,7 +137,7 @@ mobile release.**
 
 | Component | Layer / dir | Role |
 |---|---|---|
-| `ControlChannelClient` | Layer 0 `bridge/foundation/` | loopback WS client; connect/reconnect; send/receive |
+| `ControlChannelClient` | Layer 0 `bridge/app/lib/src/.../foundation/` (target layer, not the legacy nested tree) | loopback WS client; connect/reconnect; send/receive |
 | Control-protocol Freezed DTOs | `shared/sesori_shared` | pure wire types (incl. provision-progress mirror) |
 | `ControlChannelTokenService` | Layer 3 `auth/` | implements `AccessTokenProvider`/`TokenRefresher`; pull + push token stream |
 | `BridgeControlMessageDispatcher` | Layer 4 | routes inbound control msgs (token push → token service, restart → handoff, logout → unregister-and-exit) |
@@ -173,12 +180,18 @@ and consumes only the exported interfaces (`AuthTokenProvider`/`OAuthFlowProvide
 | A5 | `ControlChannelServer` name kept (vs Aristotle's `Listener`) | `Listener` implies one-way subscription; this is a duplex socket host; `DebugServer` precedent |
 | A6 | `bridgeId` persistence = file API + thin repo (no Dao) | one string; no DB/migration needed |
 | A7 | First-run provisioning UI is **v1** | first launch downloads OpenCode; user must see progress |
+| A8 | Control-channel secret delivered **off-argv** (inherited FD/pipe or stdin handshake), not `--control-secret` | argv is readable by other local processes/users; this channel issues bearer tokens, so an argv-leaked secret = token theft |
+| A9 | Helper exits on **control-channel loss** after a short grace period | if the GUI crashes/force-quits, the OS does not reliably kill the child; the helper must not linger invisibly with a live token |
+| A10 | Desktop uninstall touches **only desktop-owned state** | `token.json` + managed runtime live under the shared Sesori data root used by the standalone CLI; deleting them would break/log-out the terminal bridge |
 
 ## 8. Open risks & lead-time register
 
 | Item | Status | Owner | Notes |
 |---|---|---|---|
 | Windows code-signing cert | **OPEN — lead time** | TBD | blocks PR 3.4 (signed Windows); EV clears SmartScreen faster |
+| Control-channel secret bootstrap (off-argv) | OPEN | TBD | ADR A8; designed in PR 1.1 / PR 2.5 |
+| Orphaned helper on GUI crash | OPEN | TBD | ADR A9; parent-loss policy in PR 1.1 |
+| Uninstall vs shared CLI state | OPEN | TBD | ADR A10; scope cleanup in PR 3.11 |
 | CI secrets (Dev ID, notarization key, EdDSA appcast, GPG) | OPEN | TBD | PR 3.0b |
 | Flutter multi-window viability (v2 popover) | OPEN | TBD | de-risk with a spike before Phase 5 popover |
 | macOS login-item arg detection (`--hidden`) | OPEN | TBD | `SMAppService` may need a shim |
@@ -193,7 +206,7 @@ Legend: ☐ pending · ◐ in-progress · ☑ done. Sizes: **S** ≤150 LOC · *
 - ☐ 0.1 `mobile/`→`client/` everywhere (atomic) — **Med-High / L**
 
 ### Phase 1 — Bridge supervised mode → `phase-1-bridge-supervised.md`
-- ☐ 1.1 `--control-url`/`--control-secret` + `ControlChannelClient` skeleton — Low / M
+- ☐ 1.1 `--control-url` + off-argv secret bootstrap + `ControlChannelClient` skeleton — Low-Med / M
 - ☐ 1.2 Control-protocol Freezed DTOs (incl. provision-progress mirror) — Low / S-M
 - ☐ 1.3 Supervised auth bootstrap (short-circuit `ensureAuthenticated`) — Med / M
 - ☐ 1.4 Token provider **pull** over channel (+ timeout/GUI-down) — Med / M

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -159,8 +159,8 @@ internal `new`).
 | Component | Layer | Role |
 |---|---|---|
 | `ControlChannelServer` | Layer 0 | GUI-hosted loopback WS host + per-spawn secret; inbound-as-stream + `send` (precedent: `DebugServer`) |
-| `ControlMessageDispatcher` | Layer 3 | routes inbound: token req → `AuthTokenProvider`; status/progress → `BridgeStatusTracker`; **prompts → a Layer-3 prompt store/tracker** (NOT upward into the Layer-4 cubit/UI — deps must point downward) |
-| prompt state (e.g. on `BridgeStatusTracker` or a `BridgePromptTracker`) | Layer 3 | holds pending prompts as state/stream; the cubit consumes it |
+| `ControlMessageDispatcher` | Layer 4 (consumer/orchestrator) | subscribes to `ControlChannelServer`'s inbound stream and writes **down** into Layer-3 sinks: token req → `AuthTokenProvider`; status/progress → `BridgeStatusTracker`; prompts → `BridgePromptTracker`. It depends only downward; it does NOT touch the cubit/UI. |
+| `BridgeStatusTracker` / `BridgePromptTracker` | Layer 3 | hold status/pending-prompt state as stream/snapshot; written by the dispatcher, read by the cubit |
 | process API (mirrors `HostProcessCommandExecutor`) | Layer 1 | spawn/kill/monitor a long-lived child |
 | `BridgeProcessRepository` | Layer 2 | wraps the process API |
 | `BridgeProcessService` | Layer 3 | bridge child lifecycle: spawn (control flags), exit-code state machine (86/0/other + backoff), single supervised-bridge guard |
@@ -190,8 +190,12 @@ and consumes only the exported interfaces (`AuthTokenProvider`/`OAuthFlowProvide
 | A11 | GUI login opens the browser via a **desktop `UrlLauncher` adapter** | the bridge's `openOAuthBrowser` is bridge-workspace-only; `client/desktop` must not import bridge internals |
 | A12 | Token push must drive **RelayClient re-auth/reconnect**, not just emit on a stream | `RelayClient` reads the token once in `connect()`; an open socket stays on the old JWT until reconnect |
 | A13 | GUI keeps a **readable copy of `bridgeId`** + a GUI-side unregister fallback | logout can happen with the helper off/crashed/unreachable; otherwise the registration leaks |
-| A14 | Control prompts flow dispatcher → **Layer-3 prompt state** → cubit | the `ControlMessageDispatcher` (Layer 3) must not depend upward on `BridgeControlCubit` (Layer 4); it writes prompts to a Layer-3 store/tracker that the cubit reads, keeping dependencies pointing downward |
+| A14 | `ControlMessageDispatcher` is **Layer 4** and depends only **downward** on Layer-3 sinks (`BridgeStatusTracker`, `BridgePromptTracker`, `AuthTokenProvider`); the cubit reads those same trackers | avoids both a same-level (L3↔L3 dispatcher↔tracker, or L4↔L4 dispatcher↔cubit) dependency and an upward dependency — the dispatcher writes trackers, the cubit reads trackers, so all edges point downward |
 | A15 | All module_core platform prerequisites registered in the **first DI slice** | `LoginCubit`/`ConnectionService` need `LifecycleSource`/`RelayCryptoService`/`FailureReporter`; deferring them breaks `get_it` resolution in early PRs |
+| A16 | `SystemTray` stays a **dumb Layer-0 adapter**; the Layer-4 cubit drives it and consumes the service/tracker | a platform adapter must not depend on Layer-3 lifecycle/status — that reverses dependency direction |
+| A17 | The helper emits a **`registered` control event with `bridgeId`**; the GUI persists it on receipt | gives the GUI a readable id for the offline-unregister fallback (A13) before any crash/stop |
+| A18 | Updater **stops the helper (expected-exit, suppress respawn) before staging/apply**, restores last-on after relaunch | a running child can't be replaced (Windows) and respawn-during-apply risks mixed-version/failed updates |
+| A19 | Desktop offline/onboarding uses a **desktop seam** that starts the supervised helper, not mobile `reconnectBridge()`/`BridgeInstall` CLI prompts | on desktop the app *is* the bridge; the shared mobile actions don't start the helper |
 
 ## 8. Open risks & lead-time register
 
@@ -261,13 +265,13 @@ Legend: ☐ pending · ◐ in-progress · ☑ done. Sizes: **S** ≤150 LOC · *
 - ☐ 3.6 macOS self-update (Sparkle) + EdDSA + appcast — High / M
 - ☐ 3.7 Windows self-update (WinSparkle) + appcast — High / M
 - ☐ 3.8 Linux self-update (zsync/AppImageUpdate) — Med-High / M
-- ☐ 3.9 Failed-update/rollback handling + update UX — Med / M
+- ☐ 3.9 Update-apply policy (stop helper first) + rollback + update UX — Med / M
 - ☐ 3.10 Release-pipeline integration (non-blocking) + `make bump-version` + changelog — Med / M
 - ☐ 3.11 Uninstall + login-item/token cleanup — Low-Med / S-M
 
 ### Phase 4 — Accessory UI (v1.x) → `phase-4-accessory-ui.md`
 - ☐ 4.1 Create `client/module_app_ui` + move shared widgets/extensions/l10n — Med / M
-- ☐ 4.2 Move voice capture UI — Med / M
+- ☐ 4.2 Voice: move only real UI; keep services behind module_core seams — Med / M
 - ☐ 4.3 Move login/splash — Med / M
 - ☐ 4.4 Move project_list + session_list — Med / M
 - ☐ 4.5 Move session_detail + session_diffs + new_session (split if needed) — Med / M

--- a/docs/desktop/phase-0-rename.md
+++ b/docs/desktop/phase-0-rename.md
@@ -35,6 +35,11 @@ DoD · Aristotle verdicts · Findings log · Plan-deltas.
       `client/analysis_options.yaml`, `client/Makefile`) — **excluding**
       `client/desktop/**`. (Omitting the workspace-root files would let a
       dependency/lockfile change merge without the mobile CI/release gates.)
+    - **This mobile-product narrowing applies ONLY to the release / TestFlight /
+      Play / bridge-release workflows.** Quality-gate workflows that protect *all*
+      Dart workspaces — notably `lint-suppressions.yml` (newly-added `// ignore`
+      detection) — must **keep covering `client/desktop/**`** (and every package),
+      so desktop PRs can't add unjustified suppressions unchecked.
   - `.github/actions/setup-flutter/action.yml` (`default: 'mobile'`).
   - `tool/sync_versions.dart` (path joins **and** hardcoded `'mobile'` error
     strings) and `tool/generate_release_notes.dart:364`

--- a/docs/desktop/phase-0-rename.md
+++ b/docs/desktop/phase-0-rename.md
@@ -23,10 +23,21 @@ DoD · Aristotle verdicts · Findings log · Plan-deltas.
     `_reusable-next-build-number.yml`, `_reusable-ios-testflight.yml`,
     `_reusable-android-internal.yml`, `submit-release.yml`,
     `release-all-platforms.yml`, `lint-suppressions.yml`).
+    - **Scope path filters to the mobile *product*, not all of `client/`.** A
+      mechanical `mobile/**` → `client/**` would make future `client/desktop`
+      PRs trigger TestFlight/Play and bridge release jobs, violating
+      release-safety invariant #3 (desktop is non-blocking, ships no artifact
+      before Phase 3). Use explicit mobile-product paths instead:
+      `client/app/**` + shared mobile modules (`client/module_core/**`,
+      `client/module_auth/**`, `client/module_prego/**`) and later
+      `client/module_app_ui/**` — **excluding** `client/desktop/**`.
   - `.github/actions/setup-flutter/action.yml` (`default: 'mobile'`).
   - `tool/sync_versions.dart` (path joins **and** hardcoded `'mobile'` error
     strings) and `tool/generate_release_notes.dart:364`
-    (`path.startsWith('mobile/')` PR classification).
+    (`path.startsWith('mobile/')` PR classification) — re-scope the classifier
+    to the mobile-product paths (not blanket `client/`) so later
+    `client/desktop` PRs aren't mislabeled as **App** changes; desktop gets its
+    own classification when the Desktop section lands (Phase 3 / PR 3.10).
   - Fastlane references; `.gitignore` (`!mobile/pubspec.lock`).
   - `AGENTS.md` files + `README.md` references.
 - **Risk:** **Med-High.** Hazards: silent breakage of release-note

--- a/docs/desktop/phase-0-rename.md
+++ b/docs/desktop/phase-0-rename.md
@@ -30,7 +30,11 @@ DoD · Aristotle verdicts · Findings log · Plan-deltas.
       before Phase 3). Use explicit mobile-product paths instead:
       `client/app/**` + shared mobile modules (`client/module_core/**`,
       `client/module_auth/**`, `client/module_prego/**`) and later
-      `client/module_app_ui/**` — **excluding** `client/desktop/**`.
+      `client/module_app_ui/**`, **plus the workspace-root files** that drive
+      mobile dependency resolution (`client/pubspec.yaml`, `client/pubspec.lock`,
+      `client/analysis_options.yaml`, `client/Makefile`) — **excluding**
+      `client/desktop/**`. (Omitting the workspace-root files would let a
+      dependency/lockfile change merge without the mobile CI/release gates.)
   - `.github/actions/setup-flutter/action.yml` (`default: 'mobile'`).
   - `tool/sync_versions.dart` (path joins **and** hardcoded `'mobile'` error
     strings) and `tool/generate_release_notes.dart:364`

--- a/docs/desktop/phase-0-rename.md
+++ b/docs/desktop/phase-0-rename.md
@@ -1,0 +1,49 @@
+# Phase 0 — Workspace Rename (`mobile/` → `client/`)
+
+> Goal: rename the `mobile/` workspace to `client/` so it can house both the
+> mobile store app and the new desktop app. Dedicated, mechanical, atomic — done
+> first so it never muddies feature diffs.
+
+**Per-PR template:** Goal · Scope · Risk (+hazards) · Review-size · Acceptance ·
+DoD · Aristotle verdicts · Findings log · Plan-deltas.
+
+---
+
+## PR 0.1 — Rename `mobile/` → `client/` (atomic)
+
+- **Goal:** Rename the directory `mobile/` → `client/` and the pub workspace
+  `sesori_mobile_workspace` → `sesori_client_workspace`, updating every
+  reference so CI, tooling, and both mobile platforms keep working.
+- **Scope (files/areas):**
+  - Directory move `mobile/` → `client/` (use `git mv` so renames are visible).
+  - Intra-workspace `pubspec.yaml` names/paths; root pub workspace name.
+  - Root `Makefile` (`cd mobile` → `cd client`).
+  - **All** `.github/workflows/*` referencing `mobile/` (`mobile-ci.yml`,
+    `_reusable-next-build-number.yml`, `_reusable-ios-testflight.yml`,
+    `_reusable-android-internal.yml`, `submit-release.yml`,
+    `release-all-platforms.yml`, `lint-suppressions.yml`).
+  - `.github/actions/setup-flutter/action.yml` (`default: 'mobile'`).
+  - `tool/sync_versions.dart` (path joins **and** hardcoded `'mobile'` error
+    strings) and `tool/generate_release_notes.dart:364`
+    (`path.startsWith('mobile/')` PR classification).
+  - Fastlane references; `.gitignore` (`!mobile/pubspec.lock`).
+  - `AGENTS.md` files + `README.md` references.
+- **Risk:** **Med-High.** Hazards: silent breakage of release-note
+  classification and version-sync error strings (don't fail loudly); CI default
+  working-dir breakage; missing a reference.
+- **Review-size:** **L** — large but mechanical (a move + finite string updates).
+  Reviewed via a **grep-proof**, not line-by-line.
+- **Acceptance:**
+  - `dart pub get` (workspace), `dart analyze`, and tests pass under `client/`.
+  - `flutter build` works for iOS + Android.
+  - **Mobile release-pipeline dry-run succeeds** (release-safety invariant #2):
+    the TestFlight/Play workflows resolve all paths under `client/`.
+  - Grep gate: `rg "mobile/" ` and `rg "'mobile'"` return only intentional
+    matches (none in build/CI/tooling paths).
+- **DoD:** pub get / analyze / test exit 0 · codegen unaffected ·
+  release-safety invariant #2 verified · `aristotle-impl-review` clear.
+- **Aristotle verdicts:** plan ☐ · impl ☐.
+- **Findings log:** _(fill in as the PR lands)_
+- **Plan-deltas:** _(record any discovered references not listed above)_
+
+> Must stay atomic — splitting the rename across PRs breaks `main` between them.

--- a/docs/desktop/phase-0-rename.md
+++ b/docs/desktop/phase-0-rename.md
@@ -17,7 +17,8 @@ DoD · Aristotle verdicts · Findings log · Plan-deltas.
 - **Scope (files/areas):**
   - Directory move `mobile/` → `client/` (use `git mv` so renames are visible).
   - Intra-workspace `pubspec.yaml` names/paths; root pub workspace name.
-  - Root `Makefile` (`cd mobile` → `cd client`).
+  - Root `Makefile` — both `cd mobile` paths **and** the bare workspace token
+    `DART_WORKSPACES := shared bridge mobile` (line 7) → `... bridge client`.
   - **All** `.github/workflows/*` referencing `mobile/` (`mobile-ci.yml`,
     `_reusable-next-build-number.yml`, `_reusable-ios-testflight.yml`,
     `_reusable-android-internal.yml`, `submit-release.yml`,
@@ -38,8 +39,11 @@ DoD · Aristotle verdicts · Findings log · Plan-deltas.
   - `flutter build` works for iOS + Android.
   - **Mobile release-pipeline dry-run succeeds** (release-safety invariant #2):
     the TestFlight/Play workflows resolve all paths under `client/`.
-  - Grep gate: `rg "mobile/" ` and `rg "'mobile'"` return only intentional
-    matches (none in build/CI/tooling paths).
+  - Grep gate (three searches, since path/quoted searches miss bare tokens like
+    `Makefile:7`'s `DART_WORKSPACES := shared bridge mobile`):
+    `rg "mobile/"`, `rg "'mobile'"`, and a **bare-token** `rg "\bmobile\b"` —
+    each returns only intentional matches (product prose on an allowlist; none in
+    build/CI/tooling).
 - **DoD:** pub get / analyze / test exit 0 · codegen unaffected ·
   release-safety invariant #2 verified · `aristotle-impl-review` clear.
 - **Aristotle verdicts:** plan ☐ · impl ☐.

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -51,7 +51,9 @@ runs **under the startup mutex**, which reinforces PR 1.12.
 ## PR 1.2 — Control-protocol Freezed DTOs (incl. provision-progress mirror)
 - **Goal:** Define wire DTOs in `shared/sesori_shared`: `token_request`,
   `token_response`, `token_update`, `status`, `prompt_request`/`prompt_response`,
-  `restart`, `unregister_and_exit`, and **provision-progress** variants mirroring
+  `restart`, `unregister_and_exit`, a **`registered` event carrying the
+  `bridgeId`** (so the GUI can persist a readable copy for the offline-unregister
+  fallback, ADR A13), and **provision-progress** variants mirroring
   `RuntimeProvisionProgress` (resolving/downloading{received,total}/extracting/
   verifying/notice/ready/failed). Pure data + (de)serialization + tests.
   Optional/new fields use Freezed `@Default` (not throw/catch) for forward/back
@@ -136,12 +138,16 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   structured events.
 - **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
 
-## PR 1.10 — Status push
+## PR 1.10 — Status push (incl. registered `bridgeId`)
 - **Goal:** Bridge pushes `status` (relay connection state, plugin health,
-  active-session summary) over the channel.
+  active-session summary) over the channel, **and emits the `registered` event
+  with its `bridgeId` as soon as registration succeeds** — so the GUI persists a
+  readable copy *before* any crash/stop and can run the offline-unregister
+  fallback (ADR A13, pairs with PR 2.13).
 - **Risk:** Low. **Size:** S-M.
-- **Acceptance:** status events received by a fake server; reflects live changes
-  (reactive, no polling).
+- **Acceptance:** status events received by a fake server; the `registered`
+  event carries `bridgeId` and is emitted right after registration; reflects
+  live changes (reactive, no polling).
 - **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
 
 ## PR 1.11 — `unregister-and-exit` control command

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -1,7 +1,7 @@
 # Phase 1 — Bridge Supervised Mode
 
 > Goal: teach the existing `sesori-bridge` a **supervised mode** (gated by
-> `--control-url`/`--control-secret`) where the GUI is its token authority and
+> `--control-url` + an off-argv secret) where the GUI is its token authority and
 > lifecycle owner. **Every PR is additive and gated** so the standalone CLI is
 > provably unchanged and the relay protocol is untouched (release-safety
 > invariant #1). All PRs target the bridge workspace and can proceed in parallel
@@ -14,19 +14,38 @@ Aristotle verdicts · Findings log · Plan-deltas.
 (asserted by test) · relay protocol untouched · `--control-url` absent ⇒ exact
 current behaviour.
 
+> **Exception — PR 1.2** writes shared wire DTOs into `sesori_shared`, which is
+> consumed by **both** the bridge and the mobile/client. That PR additionally
+> requires shared codegen/tests to pass **and** a `client/app` (mobile product)
+> compatibility check — the bridge-only gate is not sufficient for it.
+
 **Rebase note:** main #322 added `_ensurePluginRuntime` + foundation imports to
 `bridge_runtime_runner.dart`; supervised wiring layers on top. `ensureRuntime`
 runs **under the startup mutex**, which reinforces PR 1.12.
 
 ---
 
-## PR 1.1 — `--control-url`/`--control-secret` + `ControlChannelClient` skeleton
-- **Goal:** Parse the new flags in `RunCommand`; add `ControlChannelClient`
-  (Layer 0 `bridge/foundation/`, `web_socket_channel`) that connects/reconnects
-  to the GUI; no message semantics yet.
-- **Risk:** Low. **Size:** M.
-- **Acceptance:** standalone unchanged; with flags, client connects to a fake
-  server in tests; reconnect on drop.
+## PR 1.1 — `--control-url` + control-secret bootstrap + `ControlChannelClient` skeleton
+- **Goal:** Add supervised-mode detection via `--control-url`; receive the
+  per-spawn **secret off-argv** (inherited FD/pipe or stdin handshake — NOT a
+  `--control-secret` flag, per ADR A8). Add `ControlChannelClient` (Layer 0
+  target `foundation/` layer — NOT the legacy nested `bridge/foundation/` tree;
+  `web_socket_channel`) that connects/reconnects to the GUI; no message
+  semantics yet.
+- **Scope notes (implementation):**
+  - Do **not** enforce strict parse-time validation on the supervised-only
+    option; validate/trim only when supervised mode is active (avoids false
+    fails in standalone).
+  - **Completer hygiene:** don't leave temporary `Completer`s armed after a
+    handshake completes/parks; null them out so a later `completeError` can't
+    raise an uncaught zone error.
+  - **Parent-loss policy (ADR A9):** if the control channel is lost (GUI crash/
+    force-quit), the helper exits after a short grace period rather than
+    lingering with a live token.
+- **Risk:** Low-Med. **Size:** M.
+- **Acceptance:** standalone unchanged; with supervised bootstrap the client
+  connects to a fake server in tests; reconnect on drop; the secret never
+  appears in `ps`/argv; control-channel loss triggers grace-period exit.
 - **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
 
 ## PR 1.2 — Control-protocol Freezed DTOs (incl. provision-progress mirror)
@@ -35,8 +54,13 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   `restart`, `unregister_and_exit`, and **provision-progress** variants mirroring
   `RuntimeProvisionProgress` (resolving/downloading{received,total}/extracting/
   verifying/notice/ready/failed). Pure data + (de)serialization + tests.
+  Optional/new fields use Freezed `@Default` (not throw/catch) for forward/back
+  compatibility across protocol versions.
 - **Risk:** Low. **Size:** S-M.
-- **Acceptance:** round-trip serialization tests; no logic in shared.
+- **Acceptance (note — `sesori_shared` is consumed by mobile too, so this PR is
+  the exception to the "Phase 1 = bridge only" standing text):** round-trip
+  serialization tests; no logic in shared; **`sesori_shared` codegen + tests
+  pass AND `client/app` (mobile product) still builds** (no consumer break).
 - **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
 
 ## PR 1.3 — Supervised auth bootstrap
@@ -71,7 +95,9 @@ runs **under the startup mutex**, which reinforces PR 1.12.
 ## PR 1.6 — Supervised registration + `bridgeId` out of `token.json`
 - **Goal:** Persist `bridgeId` via `BridgeIdentityFileApi` (L1) +
   `BridgeIdentityRepository` (L2), separate from `token.json`; supervised
-  registration uses the supplied token; preserve carry-over semantics.
+  registration uses the supplied token; preserve carry-over semantics. Use
+  **synchronous** filesystem checks (`existsSync`/`statSync`) for the
+  `avoid_slow_async_io` lint.
 - **Risk:** Med (touches `TokenData` persistence). **Size:** M.
 - **Acceptance:** supervised registers + persists bridgeId; standalone token.json
   path unchanged.

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -1,0 +1,138 @@
+# Phase 1 — Bridge Supervised Mode
+
+> Goal: teach the existing `sesori-bridge` a **supervised mode** (gated by
+> `--control-url`/`--control-secret`) where the GUI is its token authority and
+> lifecycle owner. **Every PR is additive and gated** so the standalone CLI is
+> provably unchanged and the relay protocol is untouched (release-safety
+> invariant #1). All PRs target the bridge workspace and can proceed in parallel
+> with Phase 0/2 prep.
+
+**Per-PR template:** Goal · Scope · Risk · Review-size · Acceptance · DoD ·
+Aristotle verdicts · Findings log · Plan-deltas.
+
+**Standing acceptance (all Phase 1 PRs):** standalone behaviour byte-identical
+(asserted by test) · relay protocol untouched · `--control-url` absent ⇒ exact
+current behaviour.
+
+**Rebase note:** main #322 added `_ensurePluginRuntime` + foundation imports to
+`bridge_runtime_runner.dart`; supervised wiring layers on top. `ensureRuntime`
+runs **under the startup mutex**, which reinforces PR 1.12.
+
+---
+
+## PR 1.1 — `--control-url`/`--control-secret` + `ControlChannelClient` skeleton
+- **Goal:** Parse the new flags in `RunCommand`; add `ControlChannelClient`
+  (Layer 0 `bridge/foundation/`, `web_socket_channel`) that connects/reconnects
+  to the GUI; no message semantics yet.
+- **Risk:** Low. **Size:** M.
+- **Acceptance:** standalone unchanged; with flags, client connects to a fake
+  server in tests; reconnect on drop.
+- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+
+## PR 1.2 — Control-protocol Freezed DTOs (incl. provision-progress mirror)
+- **Goal:** Define wire DTOs in `shared/sesori_shared`: `token_request`,
+  `token_response`, `token_update`, `status`, `prompt_request`/`prompt_response`,
+  `restart`, `unregister_and_exit`, and **provision-progress** variants mirroring
+  `RuntimeProvisionProgress` (resolving/downloading{received,total}/extracting/
+  verifying/notice/ready/failed). Pure data + (de)serialization + tests.
+- **Risk:** Low. **Size:** S-M.
+- **Acceptance:** round-trip serialization tests; no logic in shared.
+- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+
+## PR 1.3 — Supervised auth bootstrap
+- **Goal:** In supervised mode, short-circuit
+  `BridgeRuntimeAuthService.ensureAuthenticated`/`promptForProvider` (no stdin);
+  obtain the initial token from the control channel; keep an equivalent
+  `logAuthenticatedUser` after the token arrives.
+- **Risk:** Med (auth path). **Size:** M.
+- **Acceptance:** supervised start never reads stdin; standalone interactive flow
+  untouched.
+- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+
+## PR 1.4 — Token provider **pull** over channel
+- **Goal:** `ControlChannelTokenService` (Layer 3 `auth/`) implements
+  `AccessTokenProvider`/`TokenRefresher`; `getAccessToken({forceRefresh})`
+  requests a token over the channel and blocks with a timeout; define behaviour
+  when the GUI is mid-login/down. Client injected from composition root (no
+  internal `new`).
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** force-refresh requests a fresh token; timeout + GUI-down paths
+  yield a typed failure (logged once at the surfacing point, not double-logged).
+- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+
+## PR 1.5 — Token-stream **push** → relay client
+- **Goal:** Bridge `tokenStream` so GUI-pushed `token_update`s emit on the
+  `ValueStream<String>` the `RelayClient` consumes; relay never uses a stale
+  token after a GUI refresh.
+- **Risk:** Med (silent-auth-failure if wrong). **Size:** S-M.
+- **Acceptance:** a pushed update propagates to the relay client in tests.
+- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+
+## PR 1.6 — Supervised registration + `bridgeId` out of `token.json`
+- **Goal:** Persist `bridgeId` via `BridgeIdentityFileApi` (L1) +
+  `BridgeIdentityRepository` (L2), separate from `token.json`; supervised
+  registration uses the supplied token; preserve carry-over semantics.
+- **Risk:** Med (touches `TokenData` persistence). **Size:** M.
+- **Acceptance:** supervised registers + persists bridgeId; standalone token.json
+  path unchanged.
+- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+
+## PR 1.7 — Exit-code restart (`86`) + bypass successor-spawn
+- **Goal:** In supervised mode `handleRestartHandoff()` flushes the
+  `{restarting:true}` response then `exit(86)` instead of
+  `BridgeRestartService.spawnSuccessor()`. Name the exact bypass call site.
+- **Risk:** Med. **Size:** S-M.
+- **Acceptance:** phone-triggered restart → exit 86 in supervised mode; standalone
+  successor handoff unchanged.
+- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+
+## PR 1.8 — Disable self-update + reconcile when supervised
+- **Goal:** Pass `SESORI_NO_UPDATE`/skip policy; assert reconcile is skipped so a
+  bundled bridge never rewrites itself.
+- **Risk:** Low. **Size:** S.
+- **Acceptance:** no update/reconcile attempt in supervised mode; standalone
+  self-update intact.
+- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+
+## PR 1.9 — Re-home prompts/Console → control events
+- **Goal:** Replace-bridge prompt + login-needed + essential `Console` output
+  become structured control events in supervised mode.
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** standalone Console output **byte-identical**; supervised emits
+  structured events.
+- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+
+## PR 1.10 — Status push
+- **Goal:** Bridge pushes `status` (relay connection state, plugin health,
+  active-session summary) over the channel.
+- **Risk:** Low. **Size:** S-M.
+- **Acceptance:** status events received by a fake server; reflects live changes
+  (reactive, no polling).
+- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+
+## PR 1.11 — `unregister-and-exit` control command
+- **Goal:** Handle a control command that unregisters the `bridgeId` (current
+  token) then exits 0, for GUI logout ordering.
+- **Risk:** Low. **Size:** S-M.
+- **Acceptance:** command unregisters then exits 0; routed via
+  `BridgeControlMessageDispatcher`.
+- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+
+## PR 1.12 — Single-live precedence under supervised `--hidden`
+- **Goal:** Define/implement contention behaviour when no stdin: a supervised
+  bridge surfaces replace-prompt via the control channel; define precedence vs a
+  standalone terminal bridge on the same machine (avoid `nonInteractive` abort
+  surprises). `ensureRuntime` already runs under the mutex.
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** documented + tested precedence; no silent abort.
+- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+
+## PR 1.13 — Tee `RuntimeProvisionProgress` → control channel
+- **Goal:** In supervised mode, tee the typed `RuntimeProvisionProgress` stream
+  from `_ensurePluginRuntime` onto the control channel (mapped to the PR-1.2
+  DTOs) so the GUI can render first-run progress; keep stderr rendering for
+  standalone.
+- **Risk:** Low. **Size:** S-M.
+- **Acceptance:** provision events reach a fake server; `ProvisionReady`/`Failed`
+  terminal events conveyed; standalone formatter output unchanged.
+- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -84,12 +84,17 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   yield a typed failure (logged once at the surfacing point, not double-logged).
 - **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
 
-## PR 1.5 — Token-stream **push** → relay client
-- **Goal:** Bridge `tokenStream` so GUI-pushed `token_update`s emit on the
-  `ValueStream<String>` the `RelayClient` consumes; relay never uses a stale
-  token after a GUI refresh.
-- **Risk:** Med (silent-auth-failure if wrong). **Size:** S-M.
-- **Acceptance:** a pushed update propagates to the relay client in tests.
+## PR 1.5 — Token-stream **push** → relay re-auth
+- **Goal:** Make a GUI-pushed `token_update` actually re-authenticate the live
+  relay connection. Today `RelayClient` reads `accessToken` only once in
+  `connect()` and `tokenStream` is otherwise unused, so merely emitting on a
+  stream leaves an **open** WebSocket on the old JWT until reconnect. This PR
+  wires the `RelayClient` subscription → re-auth/reconnect path so a refresh
+  while connected takes effect (ADR A12).
+- **Risk:** Med (silent-auth-failure if wrong). **Size:** M.
+- **Acceptance:** with a **live** relay connection (not just stream
+  propagation), a pushed token update re-authenticates without losing the
+  session; covered by a connection-level test.
 - **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
 
 ## PR 1.6 — Supervised registration + `bridgeId` out of `token.json`

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -65,11 +65,13 @@ runs **under the startup mutex**, which reinforces PR 1.12.
 
 ## PR 1.3 — Supervised auth bootstrap
 - **Goal:** In supervised mode, short-circuit
-  `BridgeRuntimeAuthService.ensureAuthenticated`/`promptForProvider` (no stdin);
-  obtain the initial token from the control channel; keep an equivalent
-  `logAuthenticatedUser` after the token arrives.
+  `BridgeRuntimeAuthService.ensureAuthenticated`/`promptForProvider` (no
+  interactive **auth/prompt** input); obtain the initial token from the control
+  channel; keep an equivalent `logAuthenticatedUser` after the token arrives.
 - **Risk:** Med (auth path). **Size:** M.
-- **Acceptance:** supervised start never reads stdin; standalone interactive flow
+- **Acceptance:** supervised start performs **no interactive auth/prompt stdin
+  reads** (this is distinct from PR 1.1's optional one-shot secret-bootstrap
+  stdin handshake, which is not an auth prompt); standalone interactive flow
   untouched.
 - **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
 
@@ -98,11 +100,12 @@ runs **under the startup mutex**, which reinforces PR 1.12.
 - **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
 
 ## PR 1.6 — Supervised registration + `bridgeId` out of `token.json`
-- **Goal:** Persist `bridgeId` via `BridgeIdentityFileApi` (L1) +
-  `BridgeIdentityRepository` (L2), separate from `token.json`; supervised
-  registration uses the supplied token; preserve carry-over semantics. Use
-  **synchronous** filesystem checks (`existsSync`/`statSync`) for the
-  `avoid_slow_async_io` lint.
+- **Goal:** Persist `bridgeId` separately from `token.json` in a small
+  file-backed store that lives **inside the `auth/` subsystem** (NOT new
+  top-level `api/`+`repositories/` classes — that would make `auth/` depend back
+  on the core repository layer; see ADR A6). Supervised registration uses the
+  supplied token; preserve carry-over semantics. Use **synchronous** filesystem
+  checks (`existsSync`/`statSync`) for the `avoid_slow_async_io` lint.
 - **Risk:** Med (touches `TokenData` persistence). **Size:** M.
 - **Acceptance:** supervised registers + persists bridgeId; standalone token.json
   path unchanged.

--- a/docs/desktop/phase-2-desktop-shell.md
+++ b/docs/desktop/phase-2-desktop-shell.md
@@ -6,7 +6,7 @@
 > bridge, the phone connects.
 
 **Standing acceptance (all Phase 2 PRs):** after merge `dart pub get` +
-`mobile/app` build/test stay green (release-safety invariant #4); desktop-only
+`client/app` (the mobile product) build/test stay green (release-safety invariant #4); desktop-only
 deps are platform-scoped and don't enter mobile builds.
 
 **Per-PR template:** Goal · Scope · Risk · Review-size · Acceptance · DoD ·
@@ -49,11 +49,15 @@ Aristotle verdicts · Findings log · Plan-deltas.
 
 ## PR 2.6 — `BridgeProcessService`: spawn/kill/path + control flags
 - **Goal:** Spawn the bridge binary (path resolution dev + packaged) passing
-  `--control-url`/`--control-secret`; kill; monitor exit. Layer-3 service over a
-  Layer-2 `BridgeProcessRepository` over a Layer-1 process API (mirrors
-  `HostProcessCommandExecutor`). No exit-code state machine yet.
+  `--control-url` + the **off-argv** control secret (ADR A8); kill; monitor exit.
+  Layer-3 service over a Layer-2 `BridgeProcessRepository` over a Layer-1 process
+  API (mirrors `HostProcessCommandExecutor`). No exit-code state machine yet.
+- **Scope note:** guard against invalid/non-positive PIDs (`pid <= 0`) at the
+  process-API entry point so platform tools (e.g. Windows `tasklist` PID filter)
+  don't throw on bad input — consistent cross-platform behaviour.
 - **Risk:** High (process lifecycle, cross-platform spawn). **Size:** M.
-- **Acceptance:** spawns + connects to the control server; clean kill.
+- **Acceptance:** spawns + connects to the control server; clean kill; secret
+  not visible in `ps`/argv; non-positive PIDs handled gracefully.
 
 ## PR 2.7 — Exit-code state machine
 - **Goal:** 86→respawn (no backoff), 0→stop (no respawn), other→crash backoff +

--- a/docs/desktop/phase-2-desktop-shell.md
+++ b/docs/desktop/phase-2-desktop-shell.md
@@ -1,0 +1,126 @@
+# Phase 2 — Desktop Shell + Supervisor (functional internal MVP)
+
+> Goal: build `client/desktop` — the Flutter GUI that logs in, supervises the
+> bridge helper, shows tray control + status, autostarts, and renders first-run
+> provisioning progress. End state: download-and-run app that logs in, runs the
+> bridge, the phone connects.
+
+**Standing acceptance (all Phase 2 PRs):** after merge `dart pub get` +
+`mobile/app` build/test stay green (release-safety invariant #4); desktop-only
+deps are platform-scoped and don't enter mobile builds.
+
+**Per-PR template:** Goal · Scope · Risk · Review-size · Acceptance · DoD ·
+Aristotle verdicts · Findings log · Plan-deltas.
+
+---
+
+## PR 2.1 — `client/desktop` package + builds on 3 OSes
+- **Goal:** New package; `main_desktop.dart`; empty window; DI bootstrap reusing
+  `module_core`/`module_auth` (3-phase order). Builds on macOS/Windows/Linux.
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** `flutter build macos/windows/linux` succeeds; app launches to a
+  placeholder; mobile build unaffected.
+
+## PR 2.2 — Desktop platform adapters
+- **Goal:** Desktop `SecureStorage` + `UrlLauncher` adapters + DI registration.
+- **Risk:** Low-Med. **Size:** S-M.
+- **Acceptance:** secure storage read/write works on each desktop OS.
+
+## PR 2.3 — Login reuse (`AuthManager` browser-poll OAuth)
+- **Goal:** Wire login via `configureAuthDependencies` + exported interfaces
+  (`OAuthFlowProvider`/`AuthSession`); browser-open + server poll (no deep link).
+  **No direct `AuthManager` import.**
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** can log in via browser; auth state observed via interfaces.
+
+## PR 2.4 — Relay connection + bridge online/offline
+- **Goal:** Connect to the relay as a client; show bridge online/offline.
+- **Risk:** Low-Med. **Size:** S-M.
+- **Acceptance:** relay connects with the auth token; status reflects bridge
+  presence.
+
+## PR 2.5 — `ControlChannelServer` + `ControlMessageDispatcher` + token responder
+- **Goal:** GUI-hosted loopback WS host + per-spawn secret; dispatcher routes
+  inbound (token req → `AuthTokenProvider`, status/progress → tracker, prompts →
+  cubit). Tested against a fake helper client.
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** a fake helper connects with the secret, requests + receives a
+  token; bad secret rejected.
+
+## PR 2.6 — `BridgeProcessService`: spawn/kill/path + control flags
+- **Goal:** Spawn the bridge binary (path resolution dev + packaged) passing
+  `--control-url`/`--control-secret`; kill; monitor exit. Layer-3 service over a
+  Layer-2 `BridgeProcessRepository` over a Layer-1 process API (mirrors
+  `HostProcessCommandExecutor`). No exit-code state machine yet.
+- **Risk:** High (process lifecycle, cross-platform spawn). **Size:** M.
+- **Acceptance:** spawns + connects to the control server; clean kill.
+
+## PR 2.7 — Exit-code state machine
+- **Goal:** 86→respawn (no backoff), 0→stop (no respawn), other→crash backoff +
+  give-up + tray surfacing; GUI "expected exit" flag for GUI-initiated kills.
+  Isolated state-machine tests.
+- **Risk:** High. **Size:** M.
+- **Acceptance:** each exit class drives the correct action; give-up after N rapid
+  crashes surfaces an error.
+
+## PR 2.8 — Spike: bundled bridge runtime-ownership + `--hidden` contention
+- **Goal:** Run the bridge from a **fake bundle layout**; confirm it does NOT trip
+  its runtime-ownership guard (`unsupportedPackageRuntimeMessage`) and that
+  single-live contention under `--hidden` is handled (pairs with PR 1.12). Pulled
+  forward to avoid discovering this at notarization (Phase 3).
+- **Risk:** Med. **Size:** S-M.
+- **Acceptance:** bundled-path launch succeeds; contention resolved without silent
+  abort.
+
+## PR 2.9 — Tray menu + reusable control cubit
+- **Goal:** `SystemTray` (`tray_manager`) menu: On/Off toggle (→
+  `BridgeProcessService`), status line (← `BridgeStatusTracker`), Open/Quit.
+  `BridgeControlCubit` holds the toggle/status logic (reused later by the popover).
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** tray works on 3 OSes; toggle starts/stops the bridge; status
+  updates live.
+
+## PR 2.10 — `WindowHost` single window + v1 window contents
+- **Goal:** `window_manager` single window (show/hide/focus). v1 window contents:
+  connection/account status, login/logout, on/off, check-for-update, quit.
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** window opens/focuses from tray; contents reflect live state.
+
+## PR 2.11 — Autostart + `--hidden` boot + macOS login-item detection
+- **Goal:** `LaunchAtLogin` (`launch_at_startup`) registration with `--hidden`;
+  detect hidden launch → tray-only (macOS may need a `SMAppService` shim).
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** reboot → tray returns hidden (no window).
+
+## PR 2.12 — GUI single-instance + persist on/off & last-state
+- **Goal:** `DesktopInstanceService` single-instance lock (second launch focuses
+  first); persist on/off + last-state; respawn bridge if last-on.
+- **Risk:** Low-Med. **Size:** S-M.
+- **Acceptance:** second launch focuses first; last-on respawns bridge on boot.
+
+## PR 2.13 — Logout coordination (GUI side)
+- **Goal:** On logout: send `unregister-and-exit` → wait for helper exit → kill if
+  needed → invalidate tokens. Pairs with PR 1.11.
+- **Risk:** Med. **Size:** S-M.
+- **Acceptance:** logout unregisters the bridge before token invalidation.
+
+## PR 2.14 — Desktop `FailureReporter` impl
+- **Goal:** Crash/error reporting for the tray app (decide Crashlytics vs other
+  vs no-op).
+- **Risk:** Low-Med. **Size:** S-M.
+- **Acceptance:** errors are reported/recorded per the chosen impl.
+
+## PR 2.15 — E2E integration
+- **Goal:** Run GUI+helper together: spawn → control handshake → token push/pull →
+  relay connect → trigger 86 → respawn → logout → unregister.
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** the full happy path passes as an automated/scripted test.
+
+## PR 2.16 — First-run provisioning progress UI + degraded state
+- **Goal:** Render `RuntimeProvisionProgress` (download bar/status) from the
+  control channel on first run; show a **degraded** state when `ProvisionFailed`
+  (relay/phone still up). Status model in `BridgeStatusTracker` gains
+  `provisioning`/`degraded`.
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** first run shows download progress; provision failure shows a
+  degraded-but-running state.

--- a/docs/desktop/phase-2-desktop-shell.md
+++ b/docs/desktop/phase-2-desktop-shell.md
@@ -60,17 +60,20 @@ Aristotle verdicts · Findings log · Plan-deltas.
   green.
 
 ## PR 2.5 — `ControlChannelServer` + `ControlMessageDispatcher` + token responder
-- **Goal:** GUI-hosted loopback WS host + off-argv per-spawn secret;
-  `ControlMessageDispatcher` (Layer 3) routes inbound: token req →
+- **Goal:** GUI-hosted loopback WS host + off-argv per-spawn secret.
+  `ControlChannelServer` (Layer 0) exposes an inbound message stream + `send`.
+  `ControlMessageDispatcher` (**Layer 4** consumer/orchestrator) subscribes to
+  that stream and writes **down** into Layer-3 sinks: token req →
   `AuthTokenProvider` (via the `module_core` re-export from PR 2.5a — **not** a
   direct `module_auth` import in source), status/progress → `BridgeStatusTracker`,
-  **prompts → a Layer-3 prompt store/tracker** that the cubit consumes (the
-  Layer-3 dispatcher must NOT depend upward on the Layer-4 `BridgeControlCubit`/UI
-  — deps point downward, ADR A14). Tested against a fake helper client.
+  prompts → `BridgePromptTracker`. The cubit reads those trackers. All deps point
+  downward — the dispatcher touches neither the cubit (no L4↔L4) nor a peer
+  Layer-3 service as a same-level dep (ADR A14). Tested against a fake helper.
 - **Risk:** Med. **Size:** M.
 - **Acceptance:** a fake helper connects with the secret, requests + receives a
-  token; bad secret rejected; prompts surface as state/stream with no
-  dispatcher→cubit dependency; no direct `module_auth` import in non-DI source.
+  token; bad secret rejected; prompts/status surface via trackers; no
+  dispatcher→cubit dependency and no same-level dispatcher↔service edge; no direct
+  `module_auth` import in non-DI source.
 
 ## PR 2.6 — `BridgeProcessService`: spawn/kill/path + control flags
 - **Goal:** Spawn the bridge binary (path resolution dev + packaged) passing
@@ -102,12 +105,17 @@ Aristotle verdicts · Findings log · Plan-deltas.
   abort.
 
 ## PR 2.9 — Tray menu + reusable control cubit
-- **Goal:** `SystemTray` (`tray_manager`) menu: On/Off toggle (→
-  `BridgeProcessService`), status line (← `BridgeStatusTracker`), Open/Quit.
-  `BridgeControlCubit` holds the toggle/status logic (reused later by the popover).
+- **Goal:** Keep `SystemTray` (`tray_manager`) a **dumb Layer-0 adapter**: it
+  renders menu items + exposes click events through its interface; it knows
+  **nothing** about `BridgeProcessService`/`BridgeStatusTracker` (a Layer-0
+  adapter must not depend on Layer-3 — that reverses dependency direction). The
+  **Layer-4 `BridgeControlCubit`** owns the wiring: it consumes the service +
+  tracker, builds the menu model, pushes it to `SystemTray`, and handles tray
+  click events (On/Off → `BridgeProcessService`, Open/Quit). Reused later by the
+  popover.
 - **Risk:** Med. **Size:** M.
 - **Acceptance:** tray works on 3 OSes; toggle starts/stops the bridge; status
-  updates live.
+  updates live; `SystemTray` has no dependency on Layer-3 classes.
 
 ## PR 2.10 — `WindowHost` single window + v1 window contents
 - **Goal:** `window_manager` single window (show/hide/focus). v1 window contents:
@@ -133,7 +141,9 @@ Aristotle verdicts · Findings log · Plan-deltas.
   can also happen with the **bridge off, crashed, or the control channel
   unreachable** — and `bridgeId` is helper-owned, so the GUI would otherwise have
   nothing to unregister and the registration would leak. So the GUI keeps a
-  **readable copy of `bridgeId`** (exposed/persisted on the GUI side) and a
+  **readable copy of `bridgeId`** — persisted on the GUI side from the
+  `registered` control event (PR 1.2/1.10) as soon as the helper registers, so a
+  later crash/stop can't leave the GUI with nothing to delete — and a
   **GUI-side unregister fallback** **before** invalidating tokens (ADR A13).
   The DELETE must go **through a `module_core` seam, not a direct auth-API call**:
   `module_core`'s `BridgeApi`/`BridgeRepository` currently cover only

--- a/docs/desktop/phase-2-desktop-shell.md
+++ b/docs/desktop/phase-2-desktop-shell.md
@@ -29,9 +29,14 @@ Aristotle verdicts · Findings log · Plan-deltas.
   these, so deferring `FailureReporter` to PR 2.14 would let the package build but
   fail at `get_it` resolution. Use no-op/desktop impls where a full one isn't
   ready yet (PR 2.14 later replaces the `FailureReporter` no-op with the real one).
+  Also register a desktop **`http.Client`** here — `module_auth` DI resolves
+  `package:http`'s `Client` when `AuthManager`/`HttpApiClient` are first used, so
+  it must exist before `configureAuthDependencies` runs (else PR 2.3 login builds
+  but fails at `get_it` resolution).
 - **Risk:** Low-Med. **Size:** S-M.
 - **Acceptance:** secure storage read/write works per OS; `get_it` resolves
-  `LoginCubit` + `ConnectionService` with no missing-registration errors.
+  `LoginCubit` + `ConnectionService` (and the auth `http.Client`) with no
+  missing-registration errors.
 
 ## PR 2.3 — Login reuse (browser-poll OAuth)
 - **Goal:** Wire login via `configureAuthDependencies` + exported interfaces

--- a/docs/desktop/phase-2-desktop-shell.md
+++ b/docs/desktop/phase-2-desktop-shell.md
@@ -21,17 +21,27 @@ Aristotle verdicts · Findings log · Plan-deltas.
 - **Acceptance:** `flutter build macos/windows/linux` succeeds; app launches to a
   placeholder; mobile build unaffected.
 
-## PR 2.2 — Desktop platform adapters
-- **Goal:** Desktop `SecureStorage` + `UrlLauncher` adapters + DI registration.
+## PR 2.2 — Desktop platform adapters (ALL module_core prerequisites)
+- **Goal:** Register desktop implementations for **every** `module_core` platform
+  prerequisite the early login/relay slices need — not just `SecureStorage` +
+  `UrlLauncher`, but also `LifecycleSource` (login) and `RelayCryptoService` +
+  `FailureReporter` (relay). `LoginCubit`/`ConnectionService` constructors require
+  these, so deferring `FailureReporter` to PR 2.14 would let the package build but
+  fail at `get_it` resolution. Use no-op/desktop impls where a full one isn't
+  ready yet (PR 2.14 later replaces the `FailureReporter` no-op with the real one).
 - **Risk:** Low-Med. **Size:** S-M.
-- **Acceptance:** secure storage read/write works on each desktop OS.
+- **Acceptance:** secure storage read/write works per OS; `get_it` resolves
+  `LoginCubit` + `ConnectionService` with no missing-registration errors.
 
-## PR 2.3 — Login reuse (`AuthManager` browser-poll OAuth)
+## PR 2.3 — Login reuse (browser-poll OAuth)
 - **Goal:** Wire login via `configureAuthDependencies` + exported interfaces
-  (`OAuthFlowProvider`/`AuthSession`); browser-open + server poll (no deep link).
-  **No direct `AuthManager` import.**
+  (`OAuthFlowProvider`/`AuthSession`); server-poll OAuth (no deep link). The
+  browser is opened via the **desktop `UrlLauncher` adapter** (PR 2.2) — the
+  bridge's `openOAuthBrowser` is bridge-workspace-only and must NOT be imported
+  (ADR A11). **No direct `AuthManager` import.**
 - **Risk:** Med. **Size:** M.
-- **Acceptance:** can log in via browser; auth state observed via interfaces.
+- **Acceptance:** can log in via the system browser; auth state observed via
+  interfaces; no import of bridge internals.
 
 ## PR 2.4 — Relay connection + bridge online/offline
 - **Goal:** Connect to the relay as a client; show bridge online/offline.
@@ -40,12 +50,16 @@ Aristotle verdicts · Findings log · Plan-deltas.
   presence.
 
 ## PR 2.5 — `ControlChannelServer` + `ControlMessageDispatcher` + token responder
-- **Goal:** GUI-hosted loopback WS host + per-spawn secret; dispatcher routes
-  inbound (token req → `AuthTokenProvider`, status/progress → tracker, prompts →
-  cubit). Tested against a fake helper client.
+- **Goal:** GUI-hosted loopback WS host + off-argv per-spawn secret;
+  `ControlMessageDispatcher` (Layer 3) routes inbound: token req →
+  `AuthTokenProvider`, status/progress → `BridgeStatusTracker`, **prompts → a
+  Layer-3 prompt store/tracker** that the cubit consumes (the dispatcher must NOT
+  depend on `BridgeControlCubit`/UI — both are Layer 4; same-level deps are
+  forbidden, ADR A14). Tested against a fake helper client.
 - **Risk:** Med. **Size:** M.
 - **Acceptance:** a fake helper connects with the secret, requests + receives a
-  token; bad secret rejected.
+  token; bad secret rejected; prompts surface as state/stream with no
+  dispatcher→cubit dependency.
 
 ## PR 2.6 — `BridgeProcessService`: spawn/kill/path + control flags
 - **Goal:** Spawn the bridge binary (path resolution dev + packaged) passing
@@ -102,11 +116,19 @@ Aristotle verdicts · Findings log · Plan-deltas.
 - **Risk:** Low-Med. **Size:** S-M.
 - **Acceptance:** second launch focuses first; last-on respawns bridge on boot.
 
-## PR 2.13 — Logout coordination (GUI side)
-- **Goal:** On logout: send `unregister-and-exit` → wait for helper exit → kill if
-  needed → invalidate tokens. Pairs with PR 1.11.
-- **Risk:** Med. **Size:** S-M.
-- **Acceptance:** logout unregisters the bridge before token invalidation.
+## PR 2.13 — Logout coordination (GUI side) + offline unregister fallback
+- **Goal:** On logout with a **live** helper: send `unregister-and-exit` → wait
+  for exit → kill if needed → invalidate tokens (pairs with PR 1.11). But logout
+  can also happen with the **bridge off, crashed, or the control channel
+  unreachable** — and `bridgeId` is helper-owned, so the GUI would otherwise have
+  nothing to unregister and the registration would leak. So the GUI keeps a
+  **readable copy of `bridgeId`** (exposed/persisted on the GUI side) and a
+  **GUI-side unregister fallback** (call `DELETE /auth/bridges/{id}` with the
+  still-valid token) **before** invalidating tokens (ADR A13).
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** logout unregisters the bridge before token invalidation in
+  **both** the live-helper and helper-absent/crashed paths; no leaked
+  registration.
 
 ## PR 2.14 — Desktop `FailureReporter` impl
 - **Goal:** Crash/error reporting for the tray app (decide Crashlytics vs other

--- a/docs/desktop/phase-2-desktop-shell.md
+++ b/docs/desktop/phase-2-desktop-shell.md
@@ -53,9 +53,9 @@ Aristotle verdicts · Findings log · Plan-deltas.
 - **Goal:** GUI-hosted loopback WS host + off-argv per-spawn secret;
   `ControlMessageDispatcher` (Layer 3) routes inbound: token req →
   `AuthTokenProvider`, status/progress → `BridgeStatusTracker`, **prompts → a
-  Layer-3 prompt store/tracker** that the cubit consumes (the dispatcher must NOT
-  depend on `BridgeControlCubit`/UI — both are Layer 4; same-level deps are
-  forbidden, ADR A14). Tested against a fake helper client.
+  Layer-3 prompt store/tracker** that the cubit consumes (the Layer-3 dispatcher
+  must NOT depend upward on the Layer-4 `BridgeControlCubit`/UI — deps point
+  downward, ADR A14). Tested against a fake helper client.
 - **Risk:** Med. **Size:** M.
 - **Acceptance:** a fake helper connects with the secret, requests + receives a
   token; bad secret rejected; prompts surface as state/stream with no

--- a/docs/desktop/phase-2-desktop-shell.md
+++ b/docs/desktop/phase-2-desktop-shell.md
@@ -49,17 +49,28 @@ Aristotle verdicts · Findings log · Plan-deltas.
 - **Acceptance:** relay connects with the auth token; status reflects bridge
   presence.
 
+## PR 2.5a — Re-export `AuthTokenProvider` from `module_core` (seam, precursor)
+- **Goal:** `sesori_dart_core` re-exports `AuthSession`/`OAuthFlowProvider` but
+  **not** `AuthTokenProvider` (verified). The desktop dispatcher is app-level and
+  may only import `sesori_auth` for the `configureAuthDependencies` DI call, so it
+  needs a `module_core` seam to consume the token provider with typed DI. Add the
+  `AuthTokenProvider` re-export to the `module_core` barrel.
+- **Risk:** Low. **Size:** S. (Mobile-product change — keep `client/app` green.)
+- **Acceptance:** `module_core` exposes `AuthTokenProvider`; mobile build + tests
+  green.
+
 ## PR 2.5 — `ControlChannelServer` + `ControlMessageDispatcher` + token responder
 - **Goal:** GUI-hosted loopback WS host + off-argv per-spawn secret;
   `ControlMessageDispatcher` (Layer 3) routes inbound: token req →
-  `AuthTokenProvider`, status/progress → `BridgeStatusTracker`, **prompts → a
-  Layer-3 prompt store/tracker** that the cubit consumes (the Layer-3 dispatcher
-  must NOT depend upward on the Layer-4 `BridgeControlCubit`/UI — deps point
-  downward, ADR A14). Tested against a fake helper client.
+  `AuthTokenProvider` (via the `module_core` re-export from PR 2.5a — **not** a
+  direct `module_auth` import in source), status/progress → `BridgeStatusTracker`,
+  **prompts → a Layer-3 prompt store/tracker** that the cubit consumes (the
+  Layer-3 dispatcher must NOT depend upward on the Layer-4 `BridgeControlCubit`/UI
+  — deps point downward, ADR A14). Tested against a fake helper client.
 - **Risk:** Med. **Size:** M.
 - **Acceptance:** a fake helper connects with the secret, requests + receives a
   token; bad secret rejected; prompts surface as state/stream with no
-  dispatcher→cubit dependency.
+  dispatcher→cubit dependency; no direct `module_auth` import in non-DI source.
 
 ## PR 2.6 — `BridgeProcessService`: spawn/kill/path + control flags
 - **Goal:** Spawn the bridge binary (path resolution dev + packaged) passing
@@ -123,12 +134,18 @@ Aristotle verdicts · Findings log · Plan-deltas.
   unreachable** — and `bridgeId` is helper-owned, so the GUI would otherwise have
   nothing to unregister and the registration would leak. So the GUI keeps a
   **readable copy of `bridgeId`** (exposed/persisted on the GUI side) and a
-  **GUI-side unregister fallback** (call `DELETE /auth/bridges/{id}` with the
-  still-valid token) **before** invalidating tokens (ADR A13).
+  **GUI-side unregister fallback** **before** invalidating tokens (ADR A13).
+  The DELETE must go **through a `module_core` seam, not a direct auth-API call**:
+  `module_core`'s `BridgeApi`/`BridgeRepository` currently cover only
+  `GET /auth/bridges`, so add a `deleteBridge(id)` method on `BridgeApi` +
+  `BridgeRepository` and have the GUI call that (app code must not call auth APIs
+  or import the auth HTTP client directly). This `module_core` addition is a
+  precursor sub-step of this PR.
 - **Risk:** Med. **Size:** M.
 - **Acceptance:** logout unregisters the bridge before token invalidation in
-  **both** the live-helper and helper-absent/crashed paths; no leaked
-  registration.
+  **both** the live-helper and helper-absent/crashed paths; the GUI calls the
+  `module_core` `BridgeRepository.deleteBridge` seam (no direct auth-API/HTTP
+  import in app code); no leaked registration; mobile build stays green.
 
 ## PR 2.14 — Desktop `FailureReporter` impl
 - **Goal:** Crash/error reporting for the tray app (decide Crashlytics vs other

--- a/docs/desktop/phase-3-packaging.md
+++ b/docs/desktop/phase-3-packaging.md
@@ -51,11 +51,15 @@ Aristotle verdicts · Findings log · Plan-deltas.
 - **Risk:** Med. **Size:** S-M.
 - **Acceptance:** signed installer runs without SmartScreen "unknown publisher".
 
-## PR 3.5 — Linux AppImage + bundle (+ optional GPG)
-- **Goal:** Build Flutter Linux (x64 + arm64), bundle the bridge, produce AppImage
-  (+ optional GPG sign) with zsync metadata.
+## PR 3.5 — Linux AppImage + bundle + GPG signing
+- **Goal:** Build Flutter Linux (x64 + arm64), bundle the bridge, produce a
+  **GPG-signed** AppImage with zsync metadata. Decision #13 locks "fully signed
+  on all three OSes," so Linux signing is **mandatory**, not optional (an
+  unsigned AppImage + unauthenticated zsync update path would contradict the
+  locked release-security decision).
 - **Risk:** Med-High. **Size:** M.
-- **Acceptance:** AppImage runs on a clean distro; bridge spawns.
+- **Acceptance:** AppImage runs on a clean distro; bridge spawns; the AppImage +
+  zsync update path is GPG-signed and verified.
 
 ## PR 3.6 — macOS self-update (Sparkle)
 - **Goal:** `auto_updater`/Sparkle + EdDSA keys + appcast generation from GitHub

--- a/docs/desktop/phase-3-packaging.md
+++ b/docs/desktop/phase-3-packaging.md
@@ -1,0 +1,96 @@
+# Phase 3 — Packaging / Signing / Self-Update (= v1)
+
+> Goal: produce signed, notarized, self-updating, downloadable installers on all
+> three OSes, each bundling the same-commit bridge binary. End state: **v1
+> shipped.**
+
+**Release-safety (critical):** desktop build/sign legs are **separate,
+non-blocking** CI jobs. The existing all-or-nothing release `finalize` must NOT
+gate on desktop — a desktop failure can never abort a CLI/mobile release
+(invariant #3). Folding desktop into the gate is a later, deliberate decision.
+
+**Per-PR template:** Goal · Scope · Risk · Review-size · Acceptance · DoD ·
+Aristotle verdicts · Findings log · Plan-deltas.
+
+---
+
+## PR 3.0a — macOS entitlements (no-sandbox + hardened runtime + spawn-child)
+- **Goal:** Non-sandboxed Developer ID entitlements + hardened runtime + network
+  client; ensure a notarized GUI may spawn the bundled bridge child.
+- **Risk:** Med. **Size:** S-M.
+- **Acceptance:** a locally-signed build launches and spawns the bridge under
+  hardened runtime.
+
+## PR 3.0b — CI secrets provisioning (config + docs)
+- **Goal:** Wire GitHub secrets: Dev ID cert + notarization API key, Windows cert
+  placeholder, Sparkle EdDSA keys, GPG. Docs only; no secrets in repo.
+- **Risk:** Low. **Size:** S.
+- **Acceptance:** workflow references resolve; documented setup.
+
+## PR 3.1 — `_reusable-desktop-build.yml` macOS leg (unsigned)
+- **Goal:** New reusable workflow (mirrors `_reusable-bridge-build.yml`): `needs:`
+  the bridge-build job, download the signed bridge artifact, `lipo` → universal,
+  build universal Flutter app, bundle the bridge, produce an unsigned `.app`/`.dmg`.
+- **Risk:** High. **Size:** M.
+- **Acceptance:** unsigned `.dmg` artifact produced in CI.
+
+## PR 3.2 — macOS codesign + notarize + staple
+- **Goal:** Codesign (Dev ID), submit to notarytool, staple.
+- **Risk:** High. **Size:** M.
+- **Acceptance:** notarized `.dmg` installs + runs + spawns the bridge on a clean
+  mac.
+
+## PR 3.3 — Windows leg: build + bundle + installer (unsigned)
+- **Goal:** Build Flutter Windows (x64 + arm64), bundle the matching bridge,
+  Inno/NSIS installer.
+- **Risk:** High. **Size:** M.
+- **Acceptance:** unsigned installer installs + runs on a clean Windows.
+
+## PR 3.4 — Windows code signing *(needs cert — lead-time)*
+- **Goal:** Sign the installer + binaries with the code-signing cert.
+- **Risk:** Med. **Size:** S-M.
+- **Acceptance:** signed installer runs without SmartScreen "unknown publisher".
+
+## PR 3.5 — Linux AppImage + bundle (+ optional GPG)
+- **Goal:** Build Flutter Linux (x64 + arm64), bundle the bridge, produce AppImage
+  (+ optional GPG sign) with zsync metadata.
+- **Risk:** Med-High. **Size:** M.
+- **Acceptance:** AppImage runs on a clean distro; bridge spawns.
+
+## PR 3.6 — macOS self-update (Sparkle)
+- **Goal:** `auto_updater`/Sparkle + EdDSA keys + appcast generation from GitHub
+  releases.
+- **Risk:** High. **Size:** M.
+- **Acceptance:** vN→vN+1 update succeeds on macOS.
+
+## PR 3.7 — Windows self-update (WinSparkle)
+- **Goal:** WinSparkle + appcast.
+- **Risk:** High. **Size:** M.
+- **Acceptance:** vN→vN+1 update succeeds on Windows.
+
+## PR 3.8 — Linux self-update (zsync/AppImageUpdate)
+- **Goal:** zsync feed + AppImageUpdate integration.
+- **Risk:** Med-High. **Size:** M.
+- **Acceptance:** vN→vN+1 update succeeds on Linux.
+
+## PR 3.9 — Failed-update / rollback handling + update UX
+- **Goal:** Surface update-available/failed in the window; handle a failed
+  staging/apply gracefully (no bricking).
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** an injected failed update leaves the app runnable + reports it.
+
+## PR 3.10 — Release-pipeline integration (non-blocking) + versioning
+- **Goal:** Hook the desktop build into `release-all-platforms.yml` +
+  `submit-release.yml` as **non-blocking** legs; extend `make bump-version` to
+  bump the desktop package; add a **Desktop** section to `CHANGELOG.md`; publish
+  appcast/zsync to releases keyed to the shared version.
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** an internal release dry-run produces signed, self-update-ready
+  desktop artifacts; a forced desktop-leg failure does **not** block the
+  CLI/mobile release.
+
+## PR 3.11 — Uninstall + login-item/token cleanup
+- **Goal:** Per-OS uninstall removes the login item and cleans
+  `token.json`/bridge runtime dirs.
+- **Risk:** Low-Med. **Size:** S-M.
+- **Acceptance:** uninstall leaves no login item or stale credentials.

--- a/docs/desktop/phase-3-packaging.md
+++ b/docs/desktop/phase-3-packaging.md
@@ -89,8 +89,18 @@ Aristotle verdicts · Findings log · Plan-deltas.
   desktop artifacts; a forced desktop-leg failure does **not** block the
   CLI/mobile release.
 
-## PR 3.11 — Uninstall + login-item/token cleanup
-- **Goal:** Per-OS uninstall removes the login item and cleans
-  `token.json`/bridge runtime dirs.
+## PR 3.11 — Uninstall + login-item cleanup (desktop-owned state only)
+- **Goal:** Per-OS uninstall removes the **login item** and **GUI-owned** state
+  (GUI secure storage, any explicitly desktop-namespaced helper state). It must
+  **NOT** delete `token.json` or the managed bridge runtime: those live under the
+  **shared** Sesori data root (`tokenPath()`, `ManagedRuntimePathService`) used by
+  the standalone CLI, and removing them would log out / break the terminal bridge
+  the master plan preserves (ADR A10). If shared helper state must be cleaned,
+  namespace/migrate it to a desktop-owned location first.
+- **Scope note:** wrap each cleanup step in its own `on Object catch` so one
+  failure (permissions/missing file) doesn't block the rest; capture the first
+  meaningful error and rethrow after all steps run.
 - **Risk:** Low-Med. **Size:** S-M.
-- **Acceptance:** uninstall leaves no login item or stale credentials.
+- **Acceptance:** uninstall removes the login item + GUI state; a co-installed
+  standalone CLI remains logged in and runnable; a forced mid-step failure still
+  runs remaining steps.

--- a/docs/desktop/phase-3-packaging.md
+++ b/docs/desktop/phase-3-packaging.md
@@ -122,11 +122,15 @@ Aristotle verdicts · Findings log · Plan-deltas.
   module_core seam from PR 2.13) using the still-available token + GUI-persisted
   `bridgeId` **before** clearing GUI-owned credentials/state — otherwise a stale
   offline bridge is orphaned on the account and deleting the local copy first
-  makes later cleanup impossible. Failure is non-fatal (logged), since the server
-  record can also be removed from the account UI.
+  makes later cleanup impossible. This step is **best-effort and exempt from the
+  capture-and-rethrow policy below**: its failure is logged and swallowed (the
+  server record can also be removed from the account UI), so a network/unregister
+  error never aborts the uninstall or gets rethrown.
 - **Scope note:** wrap each cleanup step in its own `on Object catch` so one
   failure (permissions/missing file) doesn't block the rest; capture the first
-  meaningful error and rethrow after all steps run.
+  meaningful error and rethrow after all steps run — **except** the best-effort
+  server-unregister step above, which is logged-and-swallowed and never
+  contributes to the rethrown error.
 - **Risk:** Low-Med. **Size:** S-M.
 - **Acceptance:** uninstall removes the login item + GUI state; a co-installed
   standalone CLI remains logged in and runnable; a forced mid-step failure still

--- a/docs/desktop/phase-3-packaging.md
+++ b/docs/desktop/phase-3-packaging.md
@@ -77,11 +77,21 @@ Aristotle verdicts · Findings log · Plan-deltas.
 - **Risk:** Med-High. **Size:** M.
 - **Acceptance:** vN→vN+1 update succeeds on Linux.
 
-## PR 3.9 — Failed-update / rollback handling + update UX
-- **Goal:** Surface update-available/failed in the window; handle a failed
-  staging/apply gracefully (no bricking).
+## PR 3.9 — Update-apply policy (stop helper first) + failed-update/rollback + UX
+- **Goal:** Two parts.
+  1. **Stop the helper before staging/apply.** The bundled bridge is a running
+     child of the app install; on Windows a running executable can't be replaced,
+     and on any OS applying a bundle update while the supervisor respawns the old
+     child risks a failed or mixed-version update. The updater must mark the stop
+     as **expected** (suppress respawn — reuse the PR 2.7 "expected exit" flag),
+     stop the helper, stage/apply, relaunch, then **restore last-on**.
+  2. Surface update-available/failed in the window; handle a failed staging/apply
+     gracefully (no bricking).
 - **Risk:** Med. **Size:** M.
-- **Acceptance:** an injected failed update leaves the app runnable + reports it.
+- **Acceptance:** with the bridge **on**, an update stops the helper (no respawn
+  thrash), applies, relaunches, and restores last-on; a Windows
+  running-executable replace doesn't fail; an injected failed update leaves the
+  app runnable + reports it.
 
 ## PR 3.10 — Release-pipeline integration (non-blocking) + versioning
 - **Goal:** Hook the desktop build into `release-all-platforms.yml` +

--- a/docs/desktop/phase-3-packaging.md
+++ b/docs/desktop/phase-3-packaging.md
@@ -98,10 +98,16 @@ Aristotle verdicts · Findings log · Plan-deltas.
   `submit-release.yml` as **non-blocking** legs; extend `make bump-version` to
   bump the desktop package; add a **Desktop** section to `CHANGELOG.md`; publish
   appcast/zsync to releases keyed to the shared version.
+- **Trigger paths:** PR 0.1 excluded `client/desktop/**` from the (mobile-product)
+  release triggers, so this PR must **add `client/desktop/**` (and any
+  desktop-owned UI package paths) to the desktop release jobs' triggers** —
+  otherwise a desktop-only fix never starts the internal release / appcast-zsync
+  publish and the self-update channel silently misses releases. The desktop jobs
+  stay **non-blocking** for the CLI/mobile legs (invariant #3).
 - **Risk:** Med. **Size:** M.
 - **Acceptance:** an internal release dry-run produces signed, self-update-ready
-  desktop artifacts; a forced desktop-leg failure does **not** block the
-  CLI/mobile release.
+  desktop artifacts; a **desktop-only** change triggers the desktop release/appcast
+  publish; a forced desktop-leg failure does **not** block the CLI/mobile release.
 
 ## PR 3.11 — Uninstall + login-item cleanup (desktop-owned state only)
 - **Goal:** Per-OS uninstall removes the **login item** and **GUI-owned** state
@@ -111,6 +117,13 @@ Aristotle verdicts · Findings log · Plan-deltas.
   the standalone CLI, and removing them would log out / break the terminal bridge
   the master plan preserves (ADR A10). If shared helper state must be cleaned,
   namespace/migrate it to a desktop-owned location first.
+- **Best-effort server unregister first:** for users who uninstall **without**
+  going through logout, do a best-effort `BridgeRepository.deleteBridge` (the
+  module_core seam from PR 2.13) using the still-available token + GUI-persisted
+  `bridgeId` **before** clearing GUI-owned credentials/state — otherwise a stale
+  offline bridge is orphaned on the account and deleting the local copy first
+  makes later cleanup impossible. Failure is non-fatal (logged), since the server
+  record can also be removed from the account UI.
 - **Scope note:** wrap each cleanup step in its own `on Object catch` so one
   failure (permissions/missing file) doesn't block the rest; capture the first
   meaningful error and rethrow after all steps run.

--- a/docs/desktop/phase-4-accessory-ui.md
+++ b/docs/desktop/phase-4-accessory-ui.md
@@ -31,27 +31,42 @@ Aristotle verdicts · Findings log · Plan-deltas.
 - **Acceptance:** `client/app` consumes the moved code via the package, builds +
   tests pass, **no dependency cycle** `module_app_ui` → `client/app`.
 
+> **Standing rule for every move PR (4.2–4.6):** the package-boundary hazard
+> from PR 4.1 applies to **screens too** — current screens (e.g.
+> `splash_screen.dart`, `settings_screen.dart`, session-detail widgets) import
+> app DI / routing / app-owned widgets directly. **Each move PR must first push
+> those couplings out** (DI/routing behind constructor params or callbacks;
+> depend on the shared widgets already in `module_app_ui`) and declare the
+> screen's legitimate direct package deps, so no move creates a cycle back to
+> `client/app` or leaves unresolved relative imports. Every move PR's acceptance
+> includes **"no `module_app_ui` → `client/app` cycle."**
+
 ## PR 4.2 — Move voice capture UI
-- **Goal:** Move `capabilities/voice/` UI (plugin deps: `record`, `wakelock_plus`).
+- **Goal:** Refactor app-coupling out, then move `capabilities/voice/` UI (plugin
+  deps: `record`, `wakelock_plus`).
 - **Risk:** Med. **Size:** M.
-- **Acceptance:** voice capture works on mobile via the package.
+- **Acceptance:** voice capture works on mobile via the package; no cycle.
 
 ## PR 4.3 — Move login/splash
+- **Goal:** Push DI/routing out of `splash_screen.dart`/login screens, then move.
 - **Risk:** Med. **Size:** M.
-- **Acceptance:** mobile login/splash unchanged.
+- **Acceptance:** mobile login/splash unchanged; no cycle.
 
 ## PR 4.4 — Move project_list + session_list
+- **Goal:** Decouple app DI/routing, then move.
 - **Risk:** Med. **Size:** M.
-- **Acceptance:** mobile lists unchanged.
+- **Acceptance:** mobile lists unchanged; no cycle.
 
 ## PR 4.5 — Move session_detail + session_diffs + new_session
-- **Goal:** Move the heavier session screens. **Split further if >size cap.**
+- **Goal:** Decouple app DI/routing/app-owned widgets, then move the heavier
+  session screens. **Split further if >size cap.**
 - **Risk:** Med. **Size:** M (split if needed).
-- **Acceptance:** mobile session screens unchanged.
+- **Acceptance:** mobile session screens unchanged; no cycle.
 
 ## PR 4.6 — Move settings
+- **Goal:** Decouple app DI/routing out of `settings_screen.dart`, then move.
 - **Risk:** Low-Med. **Size:** S-M.
-- **Acceptance:** mobile settings unchanged.
+- **Acceptance:** mobile settings unchanged; no cycle.
 
 ## PR 4.7 — Desktop router composition + wire accessory UI into window
 - **Goal:** Compose the desktop GoRouter from the shared screens; render the full

--- a/docs/desktop/phase-4-accessory-ui.md
+++ b/docs/desktop/phase-4-accessory-ui.md
@@ -1,11 +1,11 @@
 # Phase 4 — Accessory UI (v1.x)
 
-> Goal: extract the accessory screens out of `mobile/app` into a shared
-> `client/module_app_ui` Flutter library, then wire that full UI
-> (projects/sessions/chat) into the desktop window. Per-feature moves keep the
-> diffs reviewable and keep `mobile/app` green.
+> Goal: extract the accessory screens out of `client/app` (the renamed mobile
+> app) into a shared `client/module_app_ui` Flutter library, then wire that full
+> UI (projects/sessions/chat) into the desktop window. Per-feature moves keep the
+> diffs reviewable and keep `client/app` green.
 
-**Standing acceptance (all Phase 4 PRs):** `mobile/app` builds + tests pass + a
+**Standing acceptance (all Phase 4 PRs):** `client/app` (the mobile product) builds + tests pass + a
 mobile release dry-run passes after each PR (release-safety invariant #2). No UI
 behaviour change for mobile.
 

--- a/docs/desktop/phase-4-accessory-ui.md
+++ b/docs/desktop/phase-4-accessory-ui.md
@@ -41,11 +41,20 @@ Aristotle verdicts · Findings log · Plan-deltas.
 > `client/app` or leaves unresolved relative imports. Every move PR's acceptance
 > includes **"no `module_app_ui` → `client/app` cycle."**
 
-## PR 4.2 — Move voice capture UI
-- **Goal:** Refactor app-coupling out, then move `capabilities/voice/` UI (plugin
-  deps: `record`, `wakelock_plus`).
+## PR 4.2 — Voice: move only real UI; keep services behind module_core seams
+- **Goal:** Note that `mobile/app/lib/capabilities/voice/` is **not UI** — it's
+  injectable services/config (`VoiceTranscriptionService` (which calls the
+  Layer-1 `VoiceApi` directly), `WakeLockService`, `RecordingFileProvider`,
+  `audio_format_config`). So this PR must **not** move that directory into the
+  shared UI package (it would drag app/service/platform logic + direct API access
+  across the boundary). Instead: identify the actual **voice widgets** (if any)
+  to move into `module_app_ui`, and first relocate the voice **lifecycle** behind
+  proper `module_core` service/repository + platform seams (recording stays a
+  Flutter platform adapter). If there are no shared voice widgets, this PR is just
+  the seam relocation.
 - **Risk:** Med. **Size:** M.
-- **Acceptance:** voice capture works on mobile via the package; no cycle.
+- **Acceptance:** voice capture works on mobile via the seams; no service/API
+  logic lands in `module_app_ui`; no cycle.
 
 ## PR 4.3 — Move login/splash
 - **Goal:** Push DI/routing out of `splash_screen.dart`/login screens, then move.
@@ -71,5 +80,16 @@ Aristotle verdicts · Findings log · Plan-deltas.
 ## PR 4.7 — Desktop router composition + wire accessory UI into window
 - **Goal:** Compose the desktop GoRouter from the shared screens; render the full
   accessory UI in the desktop window via the relay.
+- **Desktop offline/onboarding seam:** the shared screens' bridge-offline flow
+  calls `ProjectListCubit.reconnectBridge()` (relay reconnect only) and shows
+  `BridgeInstall` CLI commands (install `sesori-bridge` in a terminal) — both
+  **wrong for desktop**, where the app *is* the bridge and should start the
+  supervised helper. Introduce a desktop-specific seam/callback for
+  offline/onboarding states so the desktop UI drives `BridgeProcessService` /
+  control status (turn the bridge on) instead of showing mobile install/reconnect
+  actions. (The shared screens accept this behaviour via injected
+  callback/strategy so mobile keeps its current actions.)
 - **Risk:** Med. **Size:** M.
-- **Acceptance:** desktop shows projects/sessions/chat through the relay.
+- **Acceptance:** desktop shows projects/sessions/chat through the relay; the
+  bridge-offline state offers "start the bridge" (drives `BridgeProcessService`),
+  not a CLI-install/reconnect prompt; mobile offline UX unchanged.

--- a/docs/desktop/phase-4-accessory-ui.md
+++ b/docs/desktop/phase-4-accessory-ui.md
@@ -15,11 +15,21 @@ Aristotle verdicts · Findings log · Plan-deltas.
 ---
 
 ## PR 4.1 — Create `client/module_app_ui` + move shared leaf UI
-- **Goal:** New Flutter library package; move shared widgets
-  (`core/widgets/`), `core/extensions/`, `l10n/`, `status_colors`/`constants`.
-  Depends only on `module_core` + `module_prego` + Flutter.
-- **Risk:** Med. **Size:** M.
-- **Acceptance:** mobile consumes the moved code via the new package; mobile green.
+- **Goal:** New Flutter library package; move genuinely-shared leaf UI
+  (`core/extensions/`, `l10n/`, `status_colors`/`constants`, and the truly
+  leaf widgets).
+- **Important — `core/widgets/` is NOT all leaf UI.** Verified: e.g.
+  `connection_overlay.dart` imports app DI (`../di/injection.dart`) and routing
+  (`../routing/app_router.dart`) + `go_router`; several widgets import
+  `flutter_markdown_plus`/`flutter_svg`/`vector_graphics`/`sesori_shared`. Moving
+  the directory wholesale would create a **package cycle back into `client/app`**
+  or fail to resolve imports. So this PR (or a precursor split PR) must first
+  **refactor app-coupled widgets** (push DI/routing dependencies out via
+  params/callbacks) and **declare the legitimate direct package deps**
+  (`go_router`, `flutter_svg`, etc.) in `module_app_ui`'s pubspec.
+- **Risk:** Med-High. **Size:** M (split the refactor out if it grows).
+- **Acceptance:** `client/app` consumes the moved code via the package, builds +
+  tests pass, **no dependency cycle** `module_app_ui` → `client/app`.
 
 ## PR 4.2 — Move voice capture UI
 - **Goal:** Move `capabilities/voice/` UI (plugin deps: `record`, `wakelock_plus`).

--- a/docs/desktop/phase-4-accessory-ui.md
+++ b/docs/desktop/phase-4-accessory-ui.md
@@ -1,0 +1,50 @@
+# Phase 4 — Accessory UI (v1.x)
+
+> Goal: extract the accessory screens out of `mobile/app` into a shared
+> `client/module_app_ui` Flutter library, then wire that full UI
+> (projects/sessions/chat) into the desktop window. Per-feature moves keep the
+> diffs reviewable and keep `mobile/app` green.
+
+**Standing acceptance (all Phase 4 PRs):** `mobile/app` builds + tests pass + a
+mobile release dry-run passes after each PR (release-safety invariant #2). No UI
+behaviour change for mobile.
+
+**Per-PR template:** Goal · Scope · Risk · Review-size · Acceptance · DoD ·
+Aristotle verdicts · Findings log · Plan-deltas.
+
+---
+
+## PR 4.1 — Create `client/module_app_ui` + move shared leaf UI
+- **Goal:** New Flutter library package; move shared widgets
+  (`core/widgets/`), `core/extensions/`, `l10n/`, `status_colors`/`constants`.
+  Depends only on `module_core` + `module_prego` + Flutter.
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** mobile consumes the moved code via the new package; mobile green.
+
+## PR 4.2 — Move voice capture UI
+- **Goal:** Move `capabilities/voice/` UI (plugin deps: `record`, `wakelock_plus`).
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** voice capture works on mobile via the package.
+
+## PR 4.3 — Move login/splash
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** mobile login/splash unchanged.
+
+## PR 4.4 — Move project_list + session_list
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** mobile lists unchanged.
+
+## PR 4.5 — Move session_detail + session_diffs + new_session
+- **Goal:** Move the heavier session screens. **Split further if >size cap.**
+- **Risk:** Med. **Size:** M (split if needed).
+- **Acceptance:** mobile session screens unchanged.
+
+## PR 4.6 — Move settings
+- **Risk:** Low-Med. **Size:** S-M.
+- **Acceptance:** mobile settings unchanged.
+
+## PR 4.7 — Desktop router composition + wire accessory UI into window
+- **Goal:** Compose the desktop GoRouter from the shared screens; render the full
+  accessory UI in the desktop window via the relay.
+- **Risk:** Med. **Size:** M.
+- **Acceptance:** desktop shows projects/sessions/chat through the relay.

--- a/docs/desktop/phase-5-polish.md
+++ b/docs/desktop/phase-5-polish.md
@@ -1,0 +1,30 @@
+# Phase 5 — Polish (v2)
+
+> Goal: post-v1 polish. Detailed slicing happens when we reach it.
+
+**Per-PR template:** Goal · Scope · Risk · Review-size · Acceptance · DoD ·
+Aristotle verdicts · Findings log · Plan-deltas.
+
+> **Removed from this phase:** OpenCode detection/onboarding — the bridge now
+> auto-provisions OpenCode at startup via `ensureRuntime` (main #322). First-run
+> progress + degraded handling already land in v1 (PRs 1.13, 2.16).
+
+---
+
+## PR 5.1 — Multi-window spike (throwaway)
+- **Goal:** Validate Flutter multi-window viability (official or
+  `desktop_multi_window`) before committing to the popover.
+- **Risk:** Med. **Size:** S-M.
+- **Acceptance:** a documented go/no-go with a working two-window proof.
+
+## PR 5.2 — Frameless popover window
+- **Goal:** VPN-style frameless popover anchored to the tray with hide-on-blur,
+  reusing the existing `BridgeControlCubit` state (control logic already shared
+  from Phase 2). Sliced into smaller PRs during planning.
+- **Risk:** Med. **Size:** M+ (slice).
+- **Acceptance:** popover shows status + on/off, anchored + blur-dismiss on 3 OSes.
+
+## PR 5.3 — Richer settings
+- **Goal:** Plugin/relay/log-level config, update track, etc.
+- **Risk:** Low-Med. **Size:** M.
+- **Acceptance:** settings persist + apply.

--- a/opencode.json
+++ b/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["github:sesori-ai/opencode-pr-monitor#v0.1.2"],
+  "plugin": ["github:sesori-ai/opencode-pr-monitor#v0.1.3"],
   "mcp": {
     "mobile-mcp": {
       "type": "local",


### PR DESCRIPTION
## Summary

Adds `docs/desktop/` — a living, PR-by-PR implementation plan for the **Sesori desktop app**: a tray/menu-bar app that installs, runs, and controls the existing `sesori-bridge` (supervised as a child process) and self-starts at boot, replacing the terminal install for desktop users. Same app eventually bakes in the accessory UI.

This PR is **plan/docs only** (plus a small `opencode-pr-monitor` bump to `v0.1.3`). No product code.

## What's here

- **`PLAN.md`** — architecture (two binaries: Flutter GUI supervising the bridge helper; control via a GUI-hosted loopback WebSocket; data via the relay), the 14 locked decisions, **release-safety invariants**, an Aristotle-aligned component design, an ADR log, and a risk/lead-time register with a **PR status index + current pointer**.
- **`phase-0..5-*.md`** — ~55 **human-reviewable** PRs (hard ~350-LOC cap; rename is the one mechanical exception), each with goal/scope/risk/acceptance/DoD/Aristotle-verdict/findings-log slots so each work session is scoped to one phase doc.

## Key properties

- **Release-safety invariant:** every PR keeps `main` able to release the CLI and mobile. Supervised-bridge changes are additive and gated by `--control-url`; desktop CI legs are non-blocking for CLI/mobile releases.
- **Auth:** GUI is the sole token authority; the helper is token-provided over the control channel (no cross-process refresh race).
- **Lifecycle:** exit-code-driven restart (`86`), crash-respawn, self-update off for the bundled bridge; the app self-updates on all 3 OSes (Sparkle/WinSparkle/AppImage-zsync).
- **Reflects latest `main`:** OpenCode now auto-provisions at startup (#322), so onboarding is dropped from v2 and first-run provisioning progress is surfaced over the control channel in v1; naming aligned with the new `sesori_bridge_foundation` primitives.

## Reviewed

Plan reviewed by `aristotle-plan-review`; rulings incorporated, with two documented exceptions in the ADR log (`ControlChannelServer` naming; minimal `bridgeId` persistence).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `docs/desktop/` with a living, PR-by-PR implementation plan for the Sesori desktop app (tray/menu-bar GUI supervising `sesori-bridge`, bundles the bridge, auto-starts). Updates include review feedback on release triggers, auth DI, desktop release jobs, and a PR 3.11 clarification that uninstall’s best-effort server unregister is logged-and-swallowed and never aborts uninstall. No product code changes.

- **New Features**
  - Added `docs/desktop/PLAN.md` and phase docs with architecture, decisions, invariants, ADRs, risks, and a PR index.
  - Review updates:
    - ADRs: A8–A15 retained; A16 (keep `SystemTray` a dumb Layer-0 adapter), A17 (`registered` event carries `bridgeId` for GUI persistence), A18 (stop helper before update; restore last-on), A19 (desktop offline/onboarding seam starts the supervised helper).
    - Phase 0: narrow release-workflow path filters and release-notes classifier to the mobile product paths and `client` workspace-root files; keep `lint-suppressions.yml` covering all workspaces including `client/desktop/**`; exclude `client/desktop/**` from mobile release triggers.
    - PR 2.2: also register a desktop `http.Client` before `configureAuthDependencies` so `module_auth` DI resolves cleanly.
    - PR 2.13: route offline unregister via a new `module_core` `BridgeApi/BridgeRepository.deleteBridge` seam.
    - PR 3.10: add `client/desktop/**` (and desktop UI paths) to desktop release-job triggers, kept non-blocking for CLI/mobile.
    - PR 3.11: best-effort server unregister via `BridgeRepository.deleteBridge` before clearing local creds when uninstalling without logout; explicitly exempt this step from the capture-and-rethrow policy — failures are logged and swallowed and never abort uninstall.

- **Dependencies**
  - Bumped `opencode-pr-monitor` to `v0.1.3`.

<sup>Written for commit 12a101511d1eee75fbb29618454ca44a6f0e9c36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

