### PR TITLE
feat(mobile): enable Impeller on macOS + tune adaptive glass quality

### DIFF
--- a/mobile/app/lib/main.dart
+++ b/mobile/app/lib/main.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:ui" as ui;
 
 import "package:firebase_analytics/firebase_analytics.dart";
 import "package:firebase_core/firebase_core.dart";
@@ -121,13 +122,29 @@ Future<void> bootstrapSesoriApp({
       }),
     );
   }
+
+  final isImpeller = ui.ImageFilter.isShaderFilterSupported;
+
+  if (isImpeller) {
+    logd("🚀 Running on Impeller Rendering Engine");
+  } else {
+    logd("🎨 Running on Skia Rendering Engine (or fallback)");
+  }
+
   runAppFn(
     LiquidGlassWidgets.wrap(
       child: const SesoriApp(),
       adaptiveQuality: true,
       // ignore: experimental_member_use
-      adaptiveConfig: const GlassAdaptiveScopeConfig(
-        initialQuality: GlassQuality.standard,
+      adaptiveConfig: GlassAdaptiveScopeConfig(
+        targetFrameMs: 8,
+        minQuality: .minimal,
+        initialQuality: .standard,
+        maxQuality: .standard,
+        allowStepUp: false,
+        onQualityChanged: (oldQuality, newQuality) {
+          logd("Quality changed for liquid glass: ${oldQuality.name} -> ${newQuality.name}");
+        },
       ),
     ),
   );

--- a/mobile/app/macos/Runner/Info.plist
+++ b/mobile/app/macos/Runner/Info.plist
@@ -30,6 +30,8 @@
 		<string>MainMenu</string>
 		<key>NSPrincipalClass</key>
 		<string>NSApplication</string>
+		<key>FLTEnableImpeller</key>
+  		<true />
 		<key>GOOGLE_ANALYTICS_DEFAULT_ALLOW_ANALYTICS_STORAGE</key>
 		<true />
 		<key>GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_STORAGE</key>

--- a/mobile/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/mobile/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -4,6 +4,7 @@ import "package:flutter/material.dart";
 import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 
 import "../../module_prego.dart";
+import "../../utils/color_extensions.dart";
 
 /// A page scaffold with a glass top navigation bar and the iOS-style
 /// large-title collapse from the `liquid_glass_widgets` navigation showcase
@@ -12,10 +13,9 @@ import "../../module_prego.dart";
 /// Built on the package's [GlassScaffold] with its bar provided by
 /// [PregoTopNavigation]: the bar surface is transparent and glass is reserved
 /// for the buttons ([PregoButtonsIconGlass]), and the body scrolls behind the
-/// bar. As content approaches the bar it both dissolves into the [GlassScaffold]
-/// colour fade and softens under a graduated [PregoScrollEdgeBlur], frosting the
-/// content behind the transparent bar and releasing it smoothly just below —
-/// the iOS-26 scroll-edge look. A large [title] sits below the bar; as the body
+/// bar. As content approaches the bar it dissolves into the [GlassScaffold]
+/// colour fade, releasing it smoothly just below — the iOS-26 scroll-edge look.
+/// A large [title] sits below the bar; as the body
 /// scrolls it fades out while the same title fades in, centred, inside the bar.
 ///
 /// This scaffold owns the whole page around the bar. The collapse couples the
@@ -123,9 +123,9 @@ class PregoGlassScaffold extends StatefulWidget {
 class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
   final ScrollController _scrollController = ScrollController();
 
-  /// How far past the bar the scroll-edge effects (the package colour fade and
-  /// the [PregoScrollEdgeBlur]) ramp out. A little longer than the package
-  /// default (20) for a softer, smoother release of content below the bar.
+  /// How far past the bar the scroll-edge colour fade ramps out. A little longer
+  /// than the package default (20) for a softer, smoother release of content
+  /// below the bar.
   static const double _scrollEdgeFadeExtent = 80;
 
   /// Page glass-layer settings replicated from the showcase's
@@ -149,12 +149,6 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
     _scrollController.dispose();
     super.dispose();
   }
-
-  /// 0 while the large title is fully shown, 1 once it has collapsed into the
-  /// bar. Delegates to [PregoTopNavigation.collapseProgressOf] — the single
-  /// source of truth for the collapse — so the large-title sliver fades out in
-  /// lockstep with the bar title fading in.
-  double get _collapseProgress => PregoTopNavigation.collapseProgressOf(_scrollController);
 
   @override
   Widget build(BuildContext context) {
@@ -185,7 +179,8 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
         if (extendBehind) SliverToBoxAdapter(child: SizedBox(height: topPad + topNav.preferredSize.height)),
         // Inline mode shows a fixed title in the bar, so there is no large
         // title sliver to scroll away.
-        if (!inline) _buildLargeTitleSliver(),
+        if (!inline)
+          _LargeTitleSliver(title: widget.title, subtitle: widget.subtitle, scrollController: _scrollController),
         ...widget.slivers,
       ],
     );
@@ -227,10 +222,7 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
                   end: Alignment.bottomCenter,
                 ),
               ),
-              // Extend past the bar by the scroll-edge fade extent so the
-              // gradient releases in lockstep with the package colour fade
-              // ([topEdgeFadeExtent]) instead of stopping at the bar edge.
-              height: topPad + topNav.preferredSize.height + _scrollEdgeFadeExtent,
+              height: topPad + topNav.preferredSize.height,
             ),
           ),
         ),
@@ -254,36 +246,59 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
 
   /// The large title below the bar — scrolls away with the body and fades out
   /// as it collapses into the bar.
-  Widget _buildLargeTitleSliver() {
-    final subtitle = widget.subtitle;
+}
+
+class _LargeTitleSliver extends StatelessWidget {
+  final String title;
+  final String? subtitle;
+  final ScrollController scrollController;
+  const _LargeTitleSliver({
+    required this.title,
+    required this.subtitle,
+    required this.scrollController,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    final subtitle = this.subtitle;
+
     return SliverToBoxAdapter(
       child: Padding(
         padding: const EdgeInsetsDirectional.fromSTEB(PregoSpacing.x3l, 0, PregoSpacing.x3l, PregoSpacing.xl),
         child: ListenableBuilder(
-          listenable: _scrollController,
+          listenable: scrollController,
           builder: (context, _) {
-            final prego = context.prego;
-            return Opacity(
-              opacity: (1 - _collapseProgress).clamp(0.0, 1.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
+            /// 0 while the large title is fully shown, 1 once it has collapsed into the
+            /// bar. Delegates to [PregoTopNavigation.collapseProgressOf] — the single
+            /// source of truth for the collapse — so the large-title sliver fades out in
+            /// lockstep with the bar title fading in.
+            final collapseProgress = PregoTopNavigation.collapseProgressOf(scrollController);
+            // Fade via text alpha instead of an Opacity layer — no saveLayer per frame.
+            final opacity = (1 - collapseProgress).clamp(0.0, 1.0);
+
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  title,
+                  style: prego.textTheme.displayMd.medium.copyWith(
+                    color: prego.colors.textPrimary.withMultipliedOpacity(opacity),
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (subtitle != null && subtitle.isNotEmpty)
                   Text(
-                    widget.title,
-                    style: prego.textTheme.displayMd.medium.copyWith(color: prego.colors.textPrimary),
+                    subtitle,
+                    style: prego.textTheme.textMd.regular.copyWith(
+                      color: prego.colors.textSecondary.withMultipliedOpacity(opacity),
+                    ),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
-                  if (subtitle != null && subtitle.isNotEmpty)
-                    Text(
-                      subtitle,
-                      style: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textSecondary),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                ],
-              ),
+              ],
             );
           },
         ),

--- a/mobile/module_prego/lib/components/navigation/prego_top_navigation.dart
+++ b/mobile/module_prego/lib/components/navigation/prego_top_navigation.dart
@@ -7,8 +7,8 @@ import "../../module_prego.dart";
 /// `liquid_glass_widgets` [GlassAppBar].
 ///
 /// The bar surface is transparent and glass is reserved for the buttons
-/// ([PregoButtonsIconGlass]); the iOS-style scroll-edge fade and blur are owned
-/// by the enclosing [GlassScaffold] (via [PregoScrollEdgeBlur]), not painted
+/// ([PregoButtonsIconGlass]); the iOS-style scroll-edge fade is owned
+/// by the enclosing [GlassScaffold], not painted
 /// here. This follows the package's navigation showcase, which fades content
 /// with the scaffold edge effect and reserves the glass (frost) effect for
 /// buttons rather than frosting the bar surface itself.

--- a/mobile/module_prego/lib/components/navigation/prego_top_navigation.dart
+++ b/mobile/module_prego/lib/components/navigation/prego_top_navigation.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 
 import "../../module_prego.dart";
+import "../../utils/color_extensions.dart";
 
 /// The app's glass top navigation bar — a [PreferredSizeWidget] wrapping the
 /// `liquid_glass_widgets` [GlassAppBar].
@@ -168,14 +169,12 @@ class PregoTopNavigation extends StatelessWidget implements PreferredSizeWidget 
         final progress = collapseProgressOf(controller);
         if (progress == 0) return const SizedBox.shrink();
         final prego = context.prego;
-        return Opacity(
-          opacity: progress,
-          child: Text(
-            title,
-            style: prego.textTheme.textXl.bold.copyWith(color: prego.colors.textPrimary),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
+        // Fade via text alpha instead of an Opacity layer — no saveLayer per frame.
+        return Text(
+          title,
+          style: prego.textTheme.textXl.bold.copyWith(color: prego.colors.textPrimary.withMultipliedOpacity(progress)),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
         );
       },
     );


### PR DESCRIPTION
## What

- **Impeller on macOS** — enabled by default via `FLTEnableImpeller` in `Info.plist`; bootstrap now logs whether Impeller or Skia/fallback is active.
- **Adaptive glass quality** — constrained the `GlassAdaptiveScopeConfig`: cap at `standard`, allow step-down to `minimal`, disable step-up, target 8ms frames, and log quality transitions.
- **Fade extent fix** — large-title scroll-edge fade now drives text alpha instead of wrapping in `Opacity`, dropping the per-frame `saveLayer`; corrected the fade-extent doc.
- **Cleanup** — removed dead `PregoScrollEdgeBlur` references from doc comments.

## Test

`flutter analyze` on `module_prego` / `app`. Verify glass rendering on macOS (Impeller) and scroll-edge fade on a collapsing large-title screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables Impeller by default on macOS and tightens `liquid_glass_widgets` adaptive glass for steadier 8ms frames. Also switches both large-title and collapsed bar title fades to text alpha (no saveLayer) and cleans up docs.

- **New Features**
  - macOS Impeller on by default via `FLTEnableImpeller` in `Info.plist`; bootstrap logs Impeller vs Skia.
  - Adaptive glass: targetFrameMs 8; cap `maxQuality` at standard; allow step-down to minimal; disable step-up; log quality changes.

- **Bug Fixes**
  - Large-title and collapsed bar title fades now use text color alpha instead of `Opacity` to avoid per-frame saveLayer.
  - Corrected fade-extent doc and removed dead `PregoScrollEdgeBlur` references.

<sup>Written for commit 6bc336aa6c9285cc38d5caf40031df3aad71f116. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

