### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/.opencode/skills/release/SKILL.md
+++ b/.opencode/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Automates the synchronized Sesori App + Bridge release workflow — bumps versions together, generates changelog entries, and creates a PR
+description: Automates the synchronized Sesori App + Bridge release workflow — bumps versions together and creates a PR
 compatibility: opencode
 metadata:
   audience: maintainers
@@ -68,43 +68,24 @@ git diff <previous-tag>..HEAD -- client/
 git log --oneline --name-only <previous-tag>..HEAD
 ```
 
-Categorize commits based on their prefixes:
+Categorize commits based on their prefixes (used to summarize the PR body):
 - `feat:` or `feat(` → Added
 - `fix:` or `fix(` → Fixed
 - `chore:` → Changed (or skip unless significant)
 - `docs:` → Changed
 - `refactor:` → Changed
 
-### Step 5: Update Root CHANGELOG.md
+This repo does NOT use changelog files. Do not create or update any `CHANGELOG.md`. The categorized commits above are only used to write the PR body in the next step.
 
-Read the existing `CHANGELOG.md` and add a new section below `## [Unreleased]`:
+### Step 5: Commit the version bump
 
-```markdown
-## [<version>] - <YYYY-MM-DD>
-
-### App
-- <list of app changes, or "No changes">
-
-### Bridge
-- <list of bridge changes, or "No changes">
-```
-
-Use the actual categorized commits. Be specific about what each commit does, not just the commit message subject. When one side has no changes for this release, write exactly `- No changes`.
-
-### Step 6: Stage CHANGELOG.md
+Stage the version-bumped files and commit on the current release branch:
 
 ```bash
-git add CHANGELOG.md
-```
-
-### Step 7: Create Release Branch and Commit
-
-```bash
-git checkout -b release/v<version>
 git commit -m "chore(release): v<version>"
 ```
 
-### Step 8: Create GitHub Pull Request
+### Step 6: Create GitHub Pull Request
 
 Use `gh` to create the PR:
 
@@ -114,10 +95,9 @@ gh pr create \
   --body "$(cat <<'EOF'
 ## Summary
 - Bump shared version to v<version>
-- Update CHANGELOG.md with App and Bridge changes since v<previous>
 
 ## Changes
-<list the key changes>
+<list the key changes since v<previous>, or "No changes">
 EOF
 )" \
   --base main

--- a/bridge/app/lib/src/version.dart
+++ b/bridge/app/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '1.1.2';
+const String appVersion = '1.2.0';

--- a/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-arm64",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS ARM64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.1.2",
+    "releaseTag": "v1.2.0",
     "releaseArtifact": "sesori-bridge-macos-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-darwin-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-x64",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS x64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.1.2",
+    "releaseTag": "v1.2.0",
     "releaseArtifact": "sesori-bridge-macos-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-arm64",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux ARM64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.1.2",
+    "releaseTag": "v1.2.0",
     "releaseArtifact": "sesori-bridge-linux-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-x64",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux x64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.1.2",
+    "releaseTag": "v1.2.0",
     "releaseArtifact": "sesori-bridge-linux-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-arm64",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows ARM64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.1.2",
+    "releaseTag": "v1.2.0",
     "releaseArtifact": "sesori-bridge-windows-arm64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-x64",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows x64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.1.2",
+    "releaseTag": "v1.2.0",
     "releaseArtifact": "sesori-bridge-windows-x64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge/package.json
+++ b/bridge/app/npm/sesori-bridge/package.json
@@ -1,22 +1,22 @@
 {
   "name": "@sesori/bridge",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Bootstrap launcher for the managed Sesori Bridge runtime",
   "bin": {
     "sesori-bridge": "bin/bridge.js"
   },
   "optionalDependencies": {
-    "@sesori/bridge-darwin-arm64": "1.1.2",
-    "@sesori/bridge-darwin-x64": "1.1.2",
-    "@sesori/bridge-linux-x64": "1.1.2",
-    "@sesori/bridge-linux-arm64": "1.1.2",
-    "@sesori/bridge-win32-x64": "1.1.2",
-    "@sesori/bridge-win32-arm64": "1.1.2"
+    "@sesori/bridge-darwin-arm64": "1.2.0",
+    "@sesori/bridge-darwin-x64": "1.2.0",
+    "@sesori/bridge-linux-x64": "1.2.0",
+    "@sesori/bridge-linux-arm64": "1.2.0",
+    "@sesori/bridge-win32-x64": "1.2.0",
+    "@sesori/bridge-win32-arm64": "1.2.0"
   },
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.1.2",
+    "releaseTag": "v1.2.0",
     "runtimeBundleSource": "github-release-assets"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sesori_bridge
 description: Dart implementation of the Sesori Bridge CLI for WebSocket communication.
-version: 1.1.2
+version: 1.2.0
 publish_to: none
 resolution: workspace
 

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -17,7 +17,7 @@ resolution: workspace
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.1.2+1
+version: 1.2.0+1
 environment:
   sdk: ^3.12.2
 


### PR DESCRIPTION
## Summary
- Bump shared version to v1.2.0 (bridge + mobile)
- No functional changes since v1.1.2 on this branch's base

## Changes

### App
- No changes

### Bridge
- No changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped shared version to v1.2.0 across Bridge and Client. No functional changes; aligns versions and `releaseTag`s, and updates the release skill to drop changelog steps and commit on the release branch.

- **Dependencies**
  - Set `@sesori/bridge` and all platform packages to `1.2.0`; `releaseTag` to `v1.2.0`.
  - Updated `@sesori/bridge` optional deps to `1.2.0`.
  - Bumped app versions in `bridge/app/lib/src/version.dart`, `bridge/app/pubspec.yaml`, and `client/app/pubspec.yaml`.

<sup>Written for commit ba4988d75c864ad30f998a480a8ec5436a7cb758. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

