### PR TITLE
fix(mobile): don't permanently cache an empty provider catalog

### DIFF
--- a/client/module_core/lib/src/repositories/session_repository.dart
+++ b/client/module_core/lib/src/repositories/session_repository.dart
@@ -104,15 +104,20 @@ class SessionRepository {
 
     final response = await _api.listProviders(projectId: projectId);
 
-    // Only cache a response that actually carries models. Some backends build
-    // their model catalog asynchronously (e.g. the Cursor/ACP plugin warms it
-    // from an existing session after the agent connects), so an early fetch can
-    // succeed with an empty list. Caching that empty result — permanently, since
-    // this repository is a lazy singleton — would leave the model picker blank
-    // forever for that project. Skipping the cache lets the next open retry and
-    // pick up the catalog once it is ready.
+    // Only cache once every provider in the response actually carries models.
+    // Some backends build their model catalog asynchronously (e.g. the
+    // Cursor/ACP plugin warms it from an existing session after the agent
+    // connects), so an early fetch can succeed with an empty list — and in a
+    // multi-provider project one provider can still be warming up (empty
+    // `models`) while another is already populated. Caching such a partial
+    // result — permanently, since this repository is a lazy singleton — would
+    // leave the warming provider's picker blank forever. Requiring all providers
+    // to be populated (and the list to be non-empty, since `every` is vacuously
+    // true on an empty list) lets the next open retry until the full catalog is
+    // ready.
     if (response is SuccessResponse<ProviderListResponse> &&
-        response.data.items.any((provider) => provider.models.isNotEmpty)) {
+        response.data.items.isNotEmpty &&
+        response.data.items.every((provider) => provider.models.isNotEmpty)) {
       _providerCache[projectId] = response.data;
     }
 

--- a/client/module_core/lib/src/repositories/session_repository.dart
+++ b/client/module_core/lib/src/repositories/session_repository.dart
@@ -104,7 +104,15 @@ class SessionRepository {
 
     final response = await _api.listProviders(projectId: projectId);
 
-    if (response is SuccessResponse<ProviderListResponse>) {
+    // Only cache a response that actually carries models. Some backends build
+    // their model catalog asynchronously (e.g. the Cursor/ACP plugin warms it
+    // from an existing session after the agent connects), so an early fetch can
+    // succeed with an empty list. Caching that empty result — permanently, since
+    // this repository is a lazy singleton — would leave the model picker blank
+    // forever for that project. Skipping the cache lets the next open retry and
+    // pick up the catalog once it is ready.
+    if (response is SuccessResponse<ProviderListResponse> &&
+        response.data.items.any((provider) => provider.models.isNotEmpty)) {
       _providerCache[projectId] = response.data;
     }
 

--- a/client/module_core/test/repositories/session_repository_test.dart
+++ b/client/module_core/test/repositories/session_repository_test.dart
@@ -117,4 +117,53 @@ void main() {
     ).called(1);
     verify(() => api.rejectQuestion(requestId: "question-1", sessionId: "session-1")).called(1);
   });
+
+  test("listProviders does not cache an empty response but caches one with models", () async {
+    final api = MockSessionApi();
+    final repository = SessionRepository(api: api);
+
+    const emptyProviders = ProviderListResponse(connectedOnly: false, items: <ProviderInfo>[]);
+    const populatedProviders = ProviderListResponse(
+      connectedOnly: false,
+      items: [
+        ProviderInfo(
+          id: "cursor",
+          name: "Cursor",
+          defaultModelID: "auto",
+          models: {
+            "auto": ProviderModel(
+              id: "auto",
+              providerID: "cursor",
+              name: "Auto",
+              variants: <String>[],
+              family: null,
+              releaseDate: null,
+            ),
+          },
+        ),
+      ],
+    );
+
+    // First fetch returns an empty catalog (e.g. the ACP backend has not warmed
+    // its model list yet); later fetches return the populated catalog.
+    var calls = 0;
+    when(() => api.listProviders(projectId: "p1")).thenAnswer((_) async {
+      calls++;
+      return ApiResponse.success(calls == 1 ? emptyProviders : populatedProviders);
+    });
+
+    final first = await repository.listProviders(projectId: "p1");
+    expect((first as SuccessResponse<ProviderListResponse>).data.items, isEmpty);
+
+    // The empty result must NOT be cached: the second fetch hits the API again
+    // and returns the now-populated catalog (the regression being guarded).
+    final second = await repository.listProviders(projectId: "p1");
+    expect((second as SuccessResponse<ProviderListResponse>).data.items, isNotEmpty);
+    verify(() => api.listProviders(projectId: "p1")).called(2);
+
+    // The populated result IS cached: the third fetch is served without the API.
+    final third = await repository.listProviders(projectId: "p1");
+    expect((third as SuccessResponse<ProviderListResponse>).data.items, isNotEmpty);
+    verifyNever(() => api.listProviders(projectId: "p1"));
+  });
 }

--- a/client/module_core/test/repositories/session_repository_test.dart
+++ b/client/module_core/test/repositories/session_repository_test.dart
@@ -166,4 +166,61 @@ void main() {
     expect((third as SuccessResponse<ProviderListResponse>).data.items, isNotEmpty);
     verifyNever(() => api.listProviders(projectId: "p1"));
   });
+
+  test("listProviders does not cache a partially populated multi-provider response", () async {
+    final api = MockSessionApi();
+    final repository = SessionRepository(api: api);
+
+    ProviderInfo provider({required String id, required bool withModels}) => ProviderInfo(
+          id: id,
+          name: id,
+          defaultModelID: withModels ? "$id-default" : null,
+          models: withModels
+              ? {
+                  "$id-default": ProviderModel(
+                    id: "$id-default",
+                    providerID: id,
+                    name: "$id default",
+                    variants: <String>[],
+                    family: null,
+                    releaseDate: null,
+                  ),
+                }
+              : const <String, ProviderModel>{},
+        );
+
+    // A fast provider is already populated while a slow one (e.g. Cursor/ACP) is
+    // still warming up with an empty models map; once warmed, both are populated.
+    const connectedOnly = true;
+    final partialProviders = ProviderListResponse(
+      connectedOnly: connectedOnly,
+      items: [provider(id: "openai", withModels: true), provider(id: "cursor", withModels: false)],
+    );
+    final fullProviders = ProviderListResponse(
+      connectedOnly: connectedOnly,
+      items: [provider(id: "openai", withModels: true), provider(id: "cursor", withModels: true)],
+    );
+
+    var calls = 0;
+    when(() => api.listProviders(projectId: "p1")).thenAnswer((_) async {
+      calls++;
+      return ApiResponse.success(calls == 1 ? partialProviders : fullProviders);
+    });
+
+    // The partial response must NOT be cached, even though one provider has
+    // models — otherwise the warming provider's picker would stay blank forever.
+    final first = await repository.listProviders(projectId: "p1");
+    final firstItems = (first as SuccessResponse<ProviderListResponse>).data.items;
+    expect(firstItems.firstWhere((p) => p.id == "cursor").models, isEmpty);
+
+    // Next fetch hits the API again and returns the now-fully-populated catalog.
+    final second = await repository.listProviders(projectId: "p1");
+    final secondItems = (second as SuccessResponse<ProviderListResponse>).data.items;
+    expect(secondItems.firstWhere((p) => p.id == "cursor").models, isNotEmpty);
+    verify(() => api.listProviders(projectId: "p1")).called(2);
+
+    // The fully-populated result IS cached: the third fetch is served from cache.
+    await repository.listProviders(projectId: "p1");
+    verifyNever(() => api.listProviders(projectId: "p1"));
+  });
 }


### PR DESCRIPTION
## Summary

`SessionRepository` is a lazy singleton, so caching a provider-list response that carries no models would leave the model picker **blank forever** for that project.

Some backends build their model catalog asynchronously — the Cursor/ACP plugin warms it from an existing session only after the agent connects — so an early `listProviders` fetch can succeed with an empty `items`/`models` list. This change only caches a response when at least one provider actually has models, letting the next open retry and pick up the catalog once it's ready.

## Changes

- `session_repository.dart`: only populate `_providerCache` when the response contains at least one provider with a non-empty `models` map.
- `session_repository_test.dart`: regression test covering empty-then-populated fetches — the empty result is re-fetched (not cached), and the populated result is served from cache.

## Testing

- `dart test module_core` — all 408 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops permanently caching empty or partial provider catalogs so the model picker doesn’t stay blank. `SessionRepository` now caches provider lists only when the list is non-empty and every provider has models, allowing retries until the catalog is ready.

- **Bug Fixes**
  - Cache provider list only when non-empty and all providers have non-empty `models` in `session_repository.dart`.
  - Add tests to ensure empty and partially populated results aren’t cached, and fully populated results are.

<sup>Written for commit 7f7889f16f492c7aec1f32e41575907e333514f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

