### PR TITLE
ui: glass styling for chat screen and quick fixes

### DIFF
--- a/client/app/lib/core/widgets/agent_model_buttons.dart
+++ b/client/app/lib/core/widgets/agent_model_buttons.dart
@@ -1,90 +1,370 @@
+import "dart:async";
+
 import "package:flutter/material.dart";
+import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart" show ModelPickerSection, ModelPickerSectionBuilder;
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
 
 import "../extensions/build_context_x.dart";
+import "model_picker_sheet.dart";
 
-class AgentModelButtons extends StatelessWidget {
-  final List<SessionVariant> availableVariants;
-  final String modelName;
+/// Composer header exposing the agent / model / variant selection as three
+/// liquid-glass pill buttons. Tapping a pill morphs it into a [GlassMenu]
+/// popup listing the pickable values (instead of a modal bottom sheet).
+///
+/// The widget owns the menu contents, so it receives the selectable data and
+/// the selection callbacks directly rather than a "open picker" callback.
+class AgentModelButtons extends StatefulWidget {
+  final List<AgentInfo> agents;
   final String selectedAgent;
+  final ValueChanged<String> onAgentSelected;
+
+  final List<ProviderInfo> providers;
   final AgentModel? selectedAgentModel;
-  final VoidCallback onAgentTap;
-  final VoidCallback onModelTap;
-  final VoidCallback onVariantTap;
+  final void Function({required String providerID, required String modelID}) onModelSelected;
+
+  final List<SessionVariant> availableVariants;
+  final ValueChanged<SessionVariant?> onVariantSelected;
 
   const AgentModelButtons({
     super.key,
-    required this.availableVariants,
-    required this.modelName,
+    required this.agents,
     required this.selectedAgent,
+    required this.onAgentSelected,
+    required this.providers,
     required this.selectedAgentModel,
-    required this.onAgentTap,
-    required this.onModelTap,
-    required this.onVariantTap,
+    required this.onModelSelected,
+    required this.availableVariants,
+    required this.onVariantSelected,
   });
+
+  @override
+  State<AgentModelButtons> createState() => _AgentModelButtonsState();
+}
+
+class _AgentModelButtonsState extends State<AgentModelButtons> {
+  /// Pre-sorted, provider-grouped model sections for the model menu. Grouping/
+  /// sorting a large catalog is non-trivial (the bottom sheet ran it in an
+  /// isolate), so it is memoized here and only rebuilt when the provider
+  /// catalog or selection changes — never on the frequent composer rebuilds
+  /// that streaming triggers. Filtering by [_modelQuery] is a cheap per-build
+  /// `contains` pass over these precomputed sections.
+  List<ModelPickerSection> _modelSections = const [];
+
+  /// Drives the model menu imperatively so the in-popup search affordance can
+  /// dismiss the glass popup before the full-screen search sheet rises.
+  final GlassMenuController _modelMenuController = GlassMenuController();
+
+  @override
+  void initState() {
+    super.initState();
+    _rebuildModelSections();
+  }
+
+  @override
+  void didUpdateWidget(AgentModelButtons oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.providers, widget.providers) ||
+        oldWidget.selectedAgentModel?.providerID != widget.selectedAgentModel?.providerID ||
+        oldWidget.selectedAgentModel?.modelID != widget.selectedAgentModel?.modelID) {
+      _rebuildModelSections();
+    }
+  }
+
+  void _rebuildModelSections() {
+    final selected = widget.selectedAgentModel;
+    _modelSections = const ModelPickerSectionBuilder().build(
+      providers: widget.providers,
+      selectedProviderID: selected?.providerID ?? "",
+      selectedModelID: selected?.modelID ?? "",
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(top: 6, bottom: 2),
+      child: Row(
+        children: [
+          Expanded(child: _buildAgentMenu(context)),
+          const SizedBox(width: 8),
+          Expanded(child: _buildModelMenu(context)),
+          if (widget.availableVariants.isNotEmpty) ...[
+            const SizedBox(width: 8),
+            Expanded(child: _buildVariantMenu(context)),
+          ],
+        ],
+      ),
+    );
+  }
+
+  // ── Menus ──────────────────────────────────────────────────────────────────
+
+  Widget _buildAgentMenu(BuildContext context) {
+    final loc = context.loc;
+    return GlassMenu(
+      menuWidth: 240,
+      menuHeight: widget.agents.length > 6 ? 320 : null,
+      menuBorderRadius: 24,
+      autoAdjustToScreen: true,
+      menuPadding: const EdgeInsets.all(12),
+      settings: _menuGlass(context),
+      triggerBuilder: (context, toggle) => _Trigger(
+        icon: Icons.smart_toy_outlined,
+        label: widget.selectedAgent,
+        onTap: toggle,
+      ),
+      items: [
+        _menuLabel(context, text: loc.sessionDetailPickerAgent),
+        for (final agent in widget.agents)
+          _menuItem(
+            context,
+            title: agent.name,
+            subtitle: agent.description,
+            isSelected: agent.name == widget.selectedAgent,
+            onTap: () => widget.onAgentSelected(agent.name),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildModelMenu(BuildContext context) {
+    final selected = widget.selectedAgentModel;
+
+    // The compact popup is a quick-pick list: a search affordance pinned at the
+    // top, then each provider's representative models. Tapping the affordance
+    // escalates into the full-screen search sheet (see [_openModelSearchSheet]).
+    final items = <Widget>[_buildModelSearchAffordance(context)];
+    var modelRows = 0;
+    var headerRows = 0;
+    for (final section in _modelSections) {
+      final models = section.models.where((model) => model.visibleByDefault).toList();
+      if (models.isEmpty) continue;
+      headerRows++;
+      items.add(_menuLabel(context, text: section.providerName));
+      for (final model in models) {
+        modelRows++;
+        items.add(
+          _menuItem(
+            context,
+            title: model.displayName,
+            subtitle: model.family,
+            isSelected: section.providerID == selected?.providerID && model.modelID == selected?.modelID,
+            onTap: () => widget.onModelSelected(providerID: section.providerID, modelID: model.modelID),
+          ),
+        );
+      }
+    }
+
+    return GlassMenu(
+      controller: _modelMenuController,
+      menuWidth: 320,
+      menuHeight: _modelMenuHeight(modelRows: modelRows, headerRows: headerRows),
+      menuBorderRadius: 24,
+      autoAdjustToScreen: true,
+      menuPadding: const EdgeInsets.all(12),
+      settings: _menuGlass(context),
+      triggerBuilder: (context, toggle) => _Trigger(
+        icon: Icons.memory_outlined,
+        label: _resolveModelName(context),
+        onTap: toggle,
+      ),
+      items: items,
+    );
+  }
+
+  /// A search-bar-styled tap target pinned at the top of the model popup.
+  /// Tapping it enters "search mode": the compact glass popup collapses and the
+  /// roomy, keyboard-friendly full-screen search sheet rises in its place. The
+  /// popup itself does not filter — searching happens in that sheet.
+  Widget _buildModelSearchAffordance(BuildContext context) {
+    final prego = context.prego;
+    final loc = context.loc;
+    return Padding(
+      padding: const EdgeInsetsDirectional.fromSTEB(4, 0, 4, 8),
+      child: GestureDetector(
+        onTap: _openModelSearchSheet,
+        behavior: HitTestBehavior.opaque,
+        child: Container(
+          height: 40,
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          decoration: BoxDecoration(
+            color: prego.colors.bgPrimary,
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Row(
+            children: [
+              Icon(Icons.search, size: 18, color: prego.colors.textSecondary),
+              const SizedBox(width: 8),
+              Text(
+                loc.sessionDetailModelSearch,
+                style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textSecondary),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Collapses the glass popup and opens the full-screen, autofocused model
+  /// search sheet. Selecting there flows back through [onModelSelected].
+  void _openModelSearchSheet() {
+    _modelMenuController.close();
+    final selected = widget.selectedAgentModel;
+    unawaited(
+      ModelPickerSheet.show(
+        context,
+        providers: widget.providers,
+        selectedProviderID: selected?.providerID ?? "",
+        selectedModelID: selected?.modelID ?? "",
+        fullScreen: true,
+        autofocusSearch: true,
+        onModelChanged: ({required String providerID, required String modelID}) =>
+            widget.onModelSelected(providerID: providerID, modelID: modelID),
+      ),
+    );
+  }
+
+  /// Fixed (always-scrollable) model-menu height that fits the quick-pick rows
+  /// but caps so the popup never fills the screen; results scroll inside.
+  double _modelMenuHeight({required int modelRows, required int headerRows}) {
+    const searchHeight = 52.0;
+    const itemHeight = 48.0;
+    const headerHeight = 30.0;
+    const verticalPadding = 36.0;
+    final natural = searchHeight + modelRows * itemHeight + headerRows * headerHeight + verticalPadding;
+    return natural.clamp(120.0, 380.0);
+  }
+
+  Widget _buildVariantMenu(BuildContext context) {
+    final loc = context.loc;
+    final selectedVariant = widget.selectedAgentModel?.variant;
+    return GlassMenu(
+      menuWidth: 220,
+      menuHeight: widget.availableVariants.length > 6 ? 320 : null,
+      menuBorderRadius: 24,
+      autoAdjustToScreen: true,
+      menuPadding: const EdgeInsets.all(12),
+      settings: _menuGlass(context),
+      triggerBuilder: (context, toggle) => _Trigger(
+        icon: Icons.speed_outlined,
+        label: selectedVariant ?? loc.sessionDetailVariantDefault,
+        onTap: toggle,
+      ),
+      items: [
+        _menuLabel(context, text: loc.sessionDetailPickerVariant),
+        _menuItem(
+          context,
+          title: loc.sessionDetailVariantDefault,
+          subtitle: null,
+          isSelected: selectedVariant == null,
+          onTap: () => widget.onVariantSelected(null),
+        ),
+        for (final variant in widget.availableVariants)
+          _menuItem(
+            context,
+            title: variant.id,
+            subtitle: null,
+            isSelected: variant.id == selectedVariant,
+            onTap: () => widget.onVariantSelected(variant),
+          ),
+      ],
+    );
+  }
+
+  // ── Shared menu pieces ───────────────────────────────────────────────────
+
+  Widget _menuLabel(BuildContext context, {required String text}) {
+    final prego = context.prego;
+    return GlassMenuLabel(
+      title: text,
+      style: prego.textTheme.textXs.medium.copyWith(
+        color: prego.colors.textSecondary,
+        letterSpacing: 0.8,
+      ),
+    );
+  }
+
+  GlassMenuItem _menuItem(
+    BuildContext context, {
+    required String title,
+    required String? subtitle,
+    required bool isSelected,
+    required VoidCallback onTap,
+  }) {
+    final prego = context.prego;
+    return GlassMenuItem(
+      title: title,
+      subtitle: subtitle,
+      titleStyle: prego.textTheme.textSm.medium.copyWith(color: prego.colors.textPrimary),
+      subtitleStyle: prego.textTheme.textXs.regular.copyWith(color: prego.colors.textSecondary),
+      trailing: isSelected ? Icon(Icons.check, size: 16, color: prego.colors.bgBrandSolid) : null,
+      onTap: onTap,
+    );
+  }
+
+  LiquidGlassSettings _menuGlass(BuildContext context) {
+    final colors = context.prego.colors;
+    return LiquidGlassSettings(
+      glassColor: colors.buttonGlassPrimaryBackground,
+    );
+  }
+
+  String _resolveModelName(BuildContext context) {
+    final providerID = widget.selectedAgentModel?.providerID;
+    final modelID = widget.selectedAgentModel?.modelID;
+    final fallback = context.loc.sessionDetailModelFallback;
+    if (providerID == null || modelID == null) return fallback;
+    for (final provider in widget.providers) {
+      if (provider.id == providerID) {
+        final model = provider.models[modelID];
+        if (model != null) return model.name;
+      }
+    }
+    return modelID.isNotEmpty ? modelID : fallback;
+  }
+}
+
+/// A single glass pill that triggers one of the menus. Fills its [Expanded]
+/// slot (so long labels ellipsize) and shows a caret to signal it opens a menu.
+class _Trigger extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  const _Trigger({required this.icon, required this.label, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
-    final loc = context.loc;
-    final buttonStyle = OutlinedButton.styleFrom(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-      minimumSize: .zero,
-      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-      textStyle: prego.textTheme.textXs.medium,
-      side: BorderSide(color: prego.colors.borderPrimary),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-    );
-
-    return Padding(
-      padding: const EdgeInsetsDirectional.fromSTEB(12, 6, 12, 2),
-      child: Row(
-        children: [
-          Flexible(
-            child: OutlinedButton.icon(
-              onPressed: onAgentTap,
-              icon: Icon(Icons.smart_toy_outlined, size: 14, color: prego.colors.textSecondary),
-              label: Text(
-                selectedAgent,
-                style: TextStyle(color: prego.colors.textSecondary),
-                overflow: .ellipsis,
+    final foreground = prego.colors.textSecondary;
+    return GlassButton.custom(
+      onTap: onTap,
+      width: double.infinity,
+      height: 36,
+      shape: const LiquidRoundedRectangle(borderRadius: 18),
+      useOwnLayer: true,
+      settings: LiquidGlassSettings(glassColor: prego.colors.buttonGlassPrimaryBackground),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        child: Row(
+          children: [
+            Icon(icon, size: 14, color: foreground),
+            const SizedBox(width: 6),
+            Expanded(
+              child: Text(
+                label,
                 maxLines: 1,
-              ),
-              style: buttonStyle,
-            ),
-          ),
-          const SizedBox(width: 8),
-          Flexible(
-            child: OutlinedButton.icon(
-              onPressed: onModelTap,
-              icon: Icon(Icons.memory_outlined, size: 14, color: prego.colors.textSecondary),
-              label: Text(
-                modelName,
-                style: TextStyle(color: prego.colors.textSecondary),
-                overflow: .ellipsis,
-                maxLines: 1,
-              ),
-              style: buttonStyle,
-            ),
-          ),
-          if (availableVariants.isNotEmpty) ...[
-            const SizedBox(width: 8),
-            Flexible(
-              child: OutlinedButton.icon(
-                onPressed: onVariantTap,
-                icon: Icon(Icons.speed_outlined, size: 14, color: prego.colors.textSecondary),
-                label: Text(
-                  selectedAgentModel?.variant ?? loc.sessionDetailVariantDefault,
-                  style: TextStyle(color: prego.colors.textSecondary),
-                  overflow: .ellipsis,
-                  maxLines: 1,
-                ),
-                style: buttonStyle,
+                overflow: TextOverflow.ellipsis,
+                style: prego.textTheme.textXs.medium.copyWith(color: foreground),
               ),
             ),
+            const SizedBox(width: 4),
+            Icon(Icons.unfold_more, size: 14, color: foreground),
           ],
-        ],
+        ),
       ),
     );
   }

--- a/client/app/lib/core/widgets/agent_model_buttons.dart
+++ b/client/app/lib/core/widgets/agent_model_buttons.dart
@@ -83,62 +83,137 @@ class _AgentModelButtonsState extends State<AgentModelButtons> {
 
   @override
   Widget build(BuildContext context) {
+    final selected = widget.selectedAgentModel;
     return Padding(
       padding: const EdgeInsetsDirectional.only(top: 6, bottom: 2),
       child: Row(
         children: [
-          Expanded(child: _buildAgentMenu(context)),
+          Expanded(
+            child: _AgentMenu(
+              agents: widget.agents,
+              selectedAgent: widget.selectedAgent,
+              onAgentSelected: widget.onAgentSelected,
+            ),
+          ),
           const SizedBox(width: 8),
-          Expanded(child: _buildModelMenu(context)),
+          Expanded(
+            child: _ModelMenu(
+              controller: _modelMenuController,
+              sections: _modelSections,
+              selected: selected,
+              providers: widget.providers,
+              onModelSelected: widget.onModelSelected,
+              onSearchTap: _openModelSearchSheet,
+            ),
+          ),
           if (widget.availableVariants.isNotEmpty) ...[
             const SizedBox(width: 8),
-            Expanded(child: _buildVariantMenu(context)),
+            Expanded(
+              child: _VariantMenu(
+                availableVariants: widget.availableVariants,
+                selectedVariant: selected?.variant,
+                onVariantSelected: widget.onVariantSelected,
+              ),
+            ),
           ],
         ],
       ),
     );
   }
 
-  // ── Menus ──────────────────────────────────────────────────────────────────
+  /// Collapses the glass popup and opens the full-screen, autofocused model
+  /// search sheet. Selecting there flows back through [onModelSelected]. Lives
+  /// on the State because it drives the popup controller it owns.
+  void _openModelSearchSheet() {
+    _modelMenuController.close();
+    final selected = widget.selectedAgentModel;
+    unawaited(
+      ModelPickerSheet.show(
+        context,
+        providers: widget.providers,
+        selectedProviderID: selected?.providerID ?? "",
+        selectedModelID: selected?.modelID ?? "",
+        fullScreen: true,
+        autofocusSearch: true,
+        onModelChanged: ({required String providerID, required String modelID}) =>
+            widget.onModelSelected(providerID: providerID, modelID: modelID),
+      ),
+    );
+  }
+}
 
-  Widget _buildAgentMenu(BuildContext context) {
+// ── Menus ────────────────────────────────────────────────────────────────────
+
+/// Agent-selection pill + its popup. Extracted as a widget (rather than a build
+/// method) so it gets its own element subtree and only rebuilds with its inputs.
+class _AgentMenu extends StatelessWidget {
+  final List<AgentInfo> agents;
+  final String selectedAgent;
+  final ValueChanged<String> onAgentSelected;
+
+  const _AgentMenu({
+    required this.agents,
+    required this.selectedAgent,
+    required this.onAgentSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
     final loc = context.loc;
     return GlassMenu(
       menuWidth: 240,
-      menuHeight: widget.agents.length > 6 ? 320 : null,
+      menuHeight: agents.length > 6 ? 320 : null,
       menuBorderRadius: 24,
       autoAdjustToScreen: true,
       menuPadding: const EdgeInsets.all(12),
       settings: _menuGlass(context),
       triggerBuilder: (context, toggle) => _Trigger(
         icon: Icons.smart_toy_outlined,
-        label: widget.selectedAgent,
+        label: selectedAgent,
         onTap: toggle,
       ),
       items: [
         _menuLabel(context, text: loc.sessionDetailPickerAgent),
-        for (final agent in widget.agents)
+        for (final agent in agents)
           _menuItem(
             context,
             title: agent.name,
             subtitle: agent.description,
-            isSelected: agent.name == widget.selectedAgent,
-            onTap: () => widget.onAgentSelected(agent.name),
+            isSelected: agent.name == selectedAgent,
+            onTap: () => onAgentSelected(agent.name),
           ),
       ],
     );
   }
+}
 
-  Widget _buildModelMenu(BuildContext context) {
-    final selected = widget.selectedAgentModel;
+/// Model-selection pill + its quick-pick popup (search affordance pinned at the
+/// top, then each provider's representative models).
+class _ModelMenu extends StatelessWidget {
+  final GlassMenuController controller;
+  final List<ModelPickerSection> sections;
+  final AgentModel? selected;
+  final List<ProviderInfo> providers;
+  final void Function({required String providerID, required String modelID}) onModelSelected;
+  final VoidCallback onSearchTap;
 
-    // The compact popup is a quick-pick list: a search affordance pinned at the
-    // top, then each provider's representative models. Tapping the affordance
-    // escalates into the full-screen search sheet (see [_openModelSearchSheet]).
-    final items = <Widget>[_buildModelSearchAffordance(context)];
+  const _ModelMenu({
+    required this.controller,
+    required this.sections,
+    required this.selected,
+    required this.providers,
+    required this.onModelSelected,
+    required this.onSearchTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // Tapping the search affordance escalates into the full-screen search sheet
+    // (see [_AgentModelButtonsState._openModelSearchSheet]).
+    final items = <Widget>[_ModelSearchAffordance(onTap: onSearchTap)];
     var modelRows = 0;
     var headerRows = 0;
-    for (final section in _modelSections) {
+    for (final section in sections) {
       final models = section.models.where((model) => model.visibleByDefault).toList();
       if (models.isEmpty) continue;
       headerRows++;
@@ -151,14 +226,14 @@ class _AgentModelButtonsState extends State<AgentModelButtons> {
             title: model.displayName,
             subtitle: model.family,
             isSelected: section.providerID == selected?.providerID && model.modelID == selected?.modelID,
-            onTap: () => widget.onModelSelected(providerID: section.providerID, modelID: model.modelID),
+            onTap: () => onModelSelected(providerID: section.providerID, modelID: model.modelID),
           ),
         );
       }
     }
 
     return GlassMenu(
-      controller: _modelMenuController,
+      controller: controller,
       menuWidth: 320,
       menuHeight: _modelMenuHeight(modelRows: modelRows, headerRows: headerRows),
       menuBorderRadius: 24,
@@ -167,24 +242,80 @@ class _AgentModelButtonsState extends State<AgentModelButtons> {
       settings: _menuGlass(context),
       triggerBuilder: (context, toggle) => _Trigger(
         icon: Icons.memory_outlined,
-        label: _resolveModelName(context),
+        label: _resolveModelName(context, providers: providers, selected: selected),
         onTap: toggle,
       ),
       items: items,
     );
   }
+}
 
-  /// A search-bar-styled tap target pinned at the top of the model popup.
-  /// Tapping it enters "search mode": the compact glass popup collapses and the
-  /// roomy, keyboard-friendly full-screen search sheet rises in its place. The
-  /// popup itself does not filter — searching happens in that sheet.
-  Widget _buildModelSearchAffordance(BuildContext context) {
+/// Variant-selection pill + its popup.
+class _VariantMenu extends StatelessWidget {
+  final List<SessionVariant> availableVariants;
+  final String? selectedVariant;
+  final ValueChanged<SessionVariant?> onVariantSelected;
+
+  const _VariantMenu({
+    required this.availableVariants,
+    required this.selectedVariant,
+    required this.onVariantSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = context.loc;
+    return GlassMenu(
+      menuWidth: 220,
+      menuHeight: availableVariants.length > 6 ? 320 : null,
+      menuBorderRadius: 24,
+      autoAdjustToScreen: true,
+      menuPadding: const EdgeInsets.all(12),
+      settings: _menuGlass(context),
+      triggerBuilder: (context, toggle) => _Trigger(
+        icon: Icons.speed_outlined,
+        label: selectedVariant ?? loc.sessionDetailVariantDefault,
+        onTap: toggle,
+      ),
+      items: [
+        _menuLabel(context, text: loc.sessionDetailPickerVariant),
+        _menuItem(
+          context,
+          title: loc.sessionDetailVariantDefault,
+          subtitle: null,
+          isSelected: selectedVariant == null,
+          onTap: () => onVariantSelected(null),
+        ),
+        for (final variant in availableVariants)
+          _menuItem(
+            context,
+            title: variant.id,
+            subtitle: null,
+            isSelected: variant.id == selectedVariant,
+            onTap: () => onVariantSelected(variant),
+          ),
+      ],
+    );
+  }
+}
+
+/// A search-bar-styled tap target pinned at the top of the model popup. Tapping
+/// it enters "search mode": the compact glass popup collapses and the roomy,
+/// keyboard-friendly full-screen search sheet rises in its place. The popup
+/// itself does not filter — searching happens in that sheet.
+class _ModelSearchAffordance extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const _ModelSearchAffordance({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
     final prego = context.prego;
     final loc = context.loc;
     return Padding(
       padding: const EdgeInsetsDirectional.fromSTEB(4, 0, 4, 8),
       child: GestureDetector(
-        onTap: _openModelSearchSheet,
+        onTap: onTap,
         behavior: HitTestBehavior.opaque,
         child: Container(
           height: 40,
@@ -207,124 +338,73 @@ class _AgentModelButtonsState extends State<AgentModelButtons> {
       ),
     );
   }
+}
 
-  /// Collapses the glass popup and opens the full-screen, autofocused model
-  /// search sheet. Selecting there flows back through [onModelSelected].
-  void _openModelSearchSheet() {
-    _modelMenuController.close();
-    final selected = widget.selectedAgentModel;
-    unawaited(
-      ModelPickerSheet.show(
-        context,
-        providers: widget.providers,
-        selectedProviderID: selected?.providerID ?? "",
-        selectedModelID: selected?.modelID ?? "",
-        fullScreen: true,
-        autofocusSearch: true,
-        onModelChanged: ({required String providerID, required String modelID}) =>
-            widget.onModelSelected(providerID: providerID, modelID: modelID),
-      ),
-    );
-  }
+// ── Shared menu pieces ─────────────────────────────────────────────────────
 
-  /// Fixed (always-scrollable) model-menu height that fits the quick-pick rows
-  /// but caps so the popup never fills the screen; results scroll inside.
-  double _modelMenuHeight({required int modelRows, required int headerRows}) {
-    const searchHeight = 52.0;
-    const itemHeight = 48.0;
-    const headerHeight = 30.0;
-    const verticalPadding = 36.0;
-    final natural = searchHeight + modelRows * itemHeight + headerRows * headerHeight + verticalPadding;
-    return natural.clamp(120.0, 380.0);
-  }
+/// Fixed (always-scrollable) model-menu height that fits the quick-pick rows
+/// but caps so the popup never fills the screen; results scroll inside.
+double _modelMenuHeight({required int modelRows, required int headerRows}) {
+  const searchHeight = 52.0;
+  const itemHeight = 48.0;
+  const headerHeight = 30.0;
+  const verticalPadding = 36.0;
+  final natural = searchHeight + modelRows * itemHeight + headerRows * headerHeight + verticalPadding;
+  return natural.clamp(120.0, 380.0);
+}
 
-  Widget _buildVariantMenu(BuildContext context) {
-    final loc = context.loc;
-    final selectedVariant = widget.selectedAgentModel?.variant;
-    return GlassMenu(
-      menuWidth: 220,
-      menuHeight: widget.availableVariants.length > 6 ? 320 : null,
-      menuBorderRadius: 24,
-      autoAdjustToScreen: true,
-      menuPadding: const EdgeInsets.all(12),
-      settings: _menuGlass(context),
-      triggerBuilder: (context, toggle) => _Trigger(
-        icon: Icons.speed_outlined,
-        label: selectedVariant ?? loc.sessionDetailVariantDefault,
-        onTap: toggle,
-      ),
-      items: [
-        _menuLabel(context, text: loc.sessionDetailPickerVariant),
-        _menuItem(
-          context,
-          title: loc.sessionDetailVariantDefault,
-          subtitle: null,
-          isSelected: selectedVariant == null,
-          onTap: () => widget.onVariantSelected(null),
-        ),
-        for (final variant in widget.availableVariants)
-          _menuItem(
-            context,
-            title: variant.id,
-            subtitle: null,
-            isSelected: variant.id == selectedVariant,
-            onTap: () => widget.onVariantSelected(variant),
-          ),
-      ],
-    );
-  }
+Widget _menuLabel(BuildContext context, {required String text}) {
+  final prego = context.prego;
+  return GlassMenuLabel(
+    title: text,
+    style: prego.textTheme.textXs.medium.copyWith(
+      color: prego.colors.textSecondary,
+      letterSpacing: 0.8,
+    ),
+  );
+}
 
-  // ── Shared menu pieces ───────────────────────────────────────────────────
+GlassMenuItem _menuItem(
+  BuildContext context, {
+  required String title,
+  required String? subtitle,
+  required bool isSelected,
+  required VoidCallback onTap,
+}) {
+  final prego = context.prego;
+  return GlassMenuItem(
+    title: title,
+    subtitle: subtitle,
+    titleStyle: prego.textTheme.textSm.medium.copyWith(color: prego.colors.textPrimary),
+    subtitleStyle: prego.textTheme.textXs.regular.copyWith(color: prego.colors.textSecondary),
+    trailing: isSelected ? Icon(Icons.check, size: 16, color: prego.colors.bgBrandSolid) : null,
+    onTap: onTap,
+  );
+}
 
-  Widget _menuLabel(BuildContext context, {required String text}) {
-    final prego = context.prego;
-    return GlassMenuLabel(
-      title: text,
-      style: prego.textTheme.textXs.medium.copyWith(
-        color: prego.colors.textSecondary,
-        letterSpacing: 0.8,
-      ),
-    );
-  }
+LiquidGlassSettings _menuGlass(BuildContext context) {
+  final colors = context.prego.colors;
+  return LiquidGlassSettings(
+    glassColor: colors.buttonGlassPrimaryBackground,
+  );
+}
 
-  GlassMenuItem _menuItem(
-    BuildContext context, {
-    required String title,
-    required String? subtitle,
-    required bool isSelected,
-    required VoidCallback onTap,
-  }) {
-    final prego = context.prego;
-    return GlassMenuItem(
-      title: title,
-      subtitle: subtitle,
-      titleStyle: prego.textTheme.textSm.medium.copyWith(color: prego.colors.textPrimary),
-      subtitleStyle: prego.textTheme.textXs.regular.copyWith(color: prego.colors.textSecondary),
-      trailing: isSelected ? Icon(Icons.check, size: 16, color: prego.colors.bgBrandSolid) : null,
-      onTap: onTap,
-    );
-  }
-
-  LiquidGlassSettings _menuGlass(BuildContext context) {
-    final colors = context.prego.colors;
-    return LiquidGlassSettings(
-      glassColor: colors.buttonGlassPrimaryBackground,
-    );
-  }
-
-  String _resolveModelName(BuildContext context) {
-    final providerID = widget.selectedAgentModel?.providerID;
-    final modelID = widget.selectedAgentModel?.modelID;
-    final fallback = context.loc.sessionDetailModelFallback;
-    if (providerID == null || modelID == null) return fallback;
-    for (final provider in widget.providers) {
-      if (provider.id == providerID) {
-        final model = provider.models[modelID];
-        if (model != null) return model.name;
-      }
+String _resolveModelName(
+  BuildContext context, {
+  required List<ProviderInfo> providers,
+  required AgentModel? selected,
+}) {
+  final providerID = selected?.providerID;
+  final modelID = selected?.modelID;
+  final fallback = context.loc.sessionDetailModelFallback;
+  if (providerID == null || modelID == null) return fallback;
+  for (final provider in providers) {
+    if (provider.id == providerID) {
+      final model = provider.models[modelID];
+      if (model != null) return model.name;
     }
-    return modelID.isNotEmpty ? modelID : fallback;
   }
+  return modelID.isNotEmpty ? modelID : fallback;
 }
 
 /// A single glass pill that triggers one of the menus. Fills its [Expanded]

--- a/client/app/lib/core/widgets/command_picker_sheet.dart
+++ b/client/app/lib/core/widgets/command_picker_sheet.dart
@@ -169,7 +169,11 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
               ),
             ),
             final filtered => ListView.separated(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              // Extend the scrollable underneath the home indicator: with
+              // handleBottomSafeArea: false the sheet no longer pads for it, so
+              // the bottom inset is added as scroll padding here (mirroring the
+              // model picker) instead of clipping the last command above it.
+              padding: EdgeInsets.fromLTRB(8, 4, 8, 4 + MediaQuery.paddingOf(context).bottom),
               itemCount: filtered.length,
               separatorBuilder: (_, _) => Divider(
                 height: 1,

--- a/client/app/lib/core/widgets/command_picker_sheet.dart
+++ b/client/app/lib/core/widgets/command_picker_sheet.dart
@@ -173,7 +173,7 @@ class _CommandPickerSheetState extends State<CommandPickerSheet> {
               // handleBottomSafeArea: false the sheet no longer pads for it, so
               // the bottom inset is added as scroll padding here (mirroring the
               // model picker) instead of clipping the last command above it.
-              padding: EdgeInsets.fromLTRB(8, 4, 8, 4 + MediaQuery.paddingOf(context).bottom),
+              padding: EdgeInsetsDirectional.fromSTEB(8, 4, 8, 4 + MediaQuery.paddingOf(context).bottom),
               itemCount: filtered.length,
               separatorBuilder: (_, _) => Divider(
                 height: 1,

--- a/client/app/lib/core/widgets/command_picker_sheet.dart
+++ b/client/app/lib/core/widgets/command_picker_sheet.dart
@@ -27,6 +27,7 @@ class CommandPickerSheet extends StatefulWidget {
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
+      handleBottomSafeArea: false,
       builder: (sheetContext) {
         final height = MediaQuery.sizeOf(sheetContext).height * 0.7;
         final prego = sheetContext.prego;

--- a/client/app/lib/core/widgets/model_picker_sheet.dart
+++ b/client/app/lib/core/widgets/model_picker_sheet.dart
@@ -23,21 +23,35 @@ class ModelPickerSheet extends StatefulWidget {
   final String selectedProviderID;
   final String selectedModelID;
   final void Function({required String providerID, required String modelID}) onModelChanged;
+
+  /// Whether the search field grabs focus (and raises the keyboard) as soon as
+  /// the sheet opens. Used when the sheet is opened straight into "search mode"
+  /// from the composer's model menu.
+  final bool autofocusSearch;
+
   const ModelPickerSheet({
     super.key,
     required this.providers,
     required this.selectedProviderID,
     required this.selectedModelID,
     required this.onModelChanged,
+    this.autofocusSearch = false,
   });
 
   /// Shows the model picker as a modal bottom sheet.
+  ///
+  /// [fullScreen] makes the sheet rise to just below the top safe area instead
+  /// of the default 70 % height — used when escalating from the composer's
+  /// compact model menu into a roomy, keyboard-friendly search surface.
+  /// [autofocusSearch] opens the sheet with the search field already focused.
   static Future<void> show(
     BuildContext context, {
     required List<ProviderInfo> providers,
     required String selectedProviderID,
     required String selectedModelID,
     required void Function({required String providerID, required String modelID}) onModelChanged,
+    bool fullScreen = false,
+    bool autofocusSearch = false,
   }) {
     return showAppModalBottomSheet(
       context: context,
@@ -48,7 +62,14 @@ class ModelPickerSheet extends StatefulWidget {
       // than having the whole sheet lifted above the indicator.
       handleBottomSafeArea: false,
       builder: (sheetContext) {
-        final height = MediaQuery.sizeOf(sheetContext).height * 0.7;
+        final media = MediaQuery.of(sheetContext);
+        // Full screen: fill from just below the notch to the bottom edge. The
+        // keyboard inset is subtracted here (and re-added as bottom padding by
+        // showAppModalBottomSheet) so the content never overflows above the
+        // top safe area when the keyboard is up.
+        final height = fullScreen
+            ? media.size.height - media.viewPadding.top - media.viewInsets.bottom
+            : media.size.height * 0.7;
         final prego = sheetContext.prego;
         // Material (not a decorated Container) so the ListTiles inside can
         // paint their ink and selection effects on the sheet surface.
@@ -62,6 +83,7 @@ class ModelPickerSheet extends StatefulWidget {
               providers: providers,
               selectedProviderID: selectedProviderID,
               selectedModelID: selectedModelID,
+              autofocusSearch: autofocusSearch,
               onModelChanged: ({required String providerID, required String modelID}) {
                 onModelChanged(providerID: providerID, modelID: modelID);
                 context.pop();
@@ -175,7 +197,7 @@ class _ModelPickerSheetState extends State<ModelPickerSheet> {
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
           child: TextField(
-            autofocus: false,
+            autofocus: widget.autofocusSearch,
             decoration: InputDecoration(
               hintText: loc.sessionDetailModelSearch,
               prefixIcon: const Icon(Icons.search, size: 20),

--- a/client/app/lib/core/widgets/model_picker_sheet.dart
+++ b/client/app/lib/core/widgets/model_picker_sheet.dart
@@ -62,14 +62,19 @@ class ModelPickerSheet extends StatefulWidget {
       // than having the whole sheet lifted above the indicator.
       handleBottomSafeArea: false,
       builder: (sheetContext) {
-        final media = MediaQuery.of(sheetContext);
+        // Granular getters (not MediaQuery.of) so this builder only depends on
+        // the size/insets it actually reads, rather than rebuilding on every
+        // unrelated MediaQueryData change (text scale, brightness, …).
+        final size = MediaQuery.sizeOf(sheetContext);
+        final viewPadding = MediaQuery.viewPaddingOf(sheetContext);
+        final viewInsets = MediaQuery.viewInsetsOf(sheetContext);
         // Full screen: fill from just below the notch to the bottom edge. The
         // keyboard inset is subtracted here (and re-added as bottom padding by
         // showAppModalBottomSheet) so the content never overflows above the
         // top safe area when the keyboard is up.
         final height = fullScreen
-            ? media.size.height - media.viewPadding.top - media.viewInsets.bottom
-            : media.size.height * 0.7;
+            ? size.height - viewPadding.top - viewInsets.bottom
+            : size.height * 0.7;
         final prego = sheetContext.prego;
         // Material (not a decorated Container) so the ListTiles inside can
         // paint their ink and selection effects on the sheet surface.

--- a/client/app/lib/features/new_session/new_session_screen.dart
+++ b/client/app/lib/features/new_session/new_session_screen.dart
@@ -199,26 +199,29 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
                         ),
                       ),
                     ),
-                    PromptInput(
-                      // Persist the unsent prompt per project so it survives
-                      // leaving and returning to the new-session screen before
-                      // a session exists; cleared once the session is created.
-                      draftKey: "new-session:${widget.projectId}",
-                      isBusy: state is NewSessionSending,
-                      onSend: (String text, String? command) {
-                        context.read<NewSessionCubit>().createSession(
-                          text: text,
-                          command: command,
-                          dedicatedWorktree: _dedicatedWorktree,
-                        );
-                      },
-                      onAbort: _dismissScreen,
-                      header: _buildErrorBanner(state),
-                      composerHeader: _buildComposerHeader(state),
-                      availableCommands: state.agentModelData?.commands ?? const [],
-                      stagedCommand: state.agentModelData?.stagedCommand,
-                      onCommandSelected: context.read<NewSessionCubit>().stageCommand,
-                      onCommandCleared: context.read<NewSessionCubit>().clearStagedCommand,
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: PromptInput(
+                        // Persist the unsent prompt per project so it survives
+                        // leaving and returning to the new-session screen before
+                        // a session exists; cleared once the session is created.
+                        draftKey: "new-session:${widget.projectId}",
+                        isBusy: state is NewSessionSending,
+                        onSend: (String text, String? command) {
+                          context.read<NewSessionCubit>().createSession(
+                            text: text,
+                            command: command,
+                            dedicatedWorktree: _dedicatedWorktree,
+                          );
+                        },
+                        onAbort: _dismissScreen,
+                        header: _buildErrorBanner(state),
+                        composerHeader: _buildComposerHeader(state),
+                        availableCommands: state.agentModelData?.commands ?? const [],
+                        stagedCommand: state.agentModelData?.stagedCommand,
+                        onCommandSelected: context.read<NewSessionCubit>().stageCommand,
+                        onCommandCleared: context.read<NewSessionCubit>().clearStagedCommand,
+                      ),
                     ),
                   ],
                 ),

--- a/client/app/lib/features/new_session/new_session_screen.dart
+++ b/client/app/lib/features/new_session/new_session_screen.dart
@@ -9,9 +9,6 @@ import "../../core/extensions/build_context_x.dart";
 import "../../core/extensions/remote_failure_x.dart";
 import "../../core/routing/app_router.dart";
 import "../../core/widgets/agent_model_buttons.dart";
-import "../../core/widgets/agent_picker_sheet.dart";
-import "../../core/widgets/model_picker_sheet.dart";
-import "../../core/widgets/variant_picker_sheet.dart";
 import "../session_detail/widgets/prompt_input.dart";
 import "new_session_loading_overlay.dart";
 
@@ -56,37 +53,6 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
     context.pop();
   }
 
-  void _openAgentPicker(AgentModelData data) {
-    final cubit = context.read<NewSessionCubit>();
-    AgentPickerSheet.show(
-      context,
-      agents: data.agents,
-      selectedAgent: data.agent ?? "",
-      onAgentChanged: cubit.selectAgent,
-    );
-  }
-
-  void _openModelPicker(AgentModelData data) {
-    final cubit = context.read<NewSessionCubit>();
-    final agentModel = data.agentModel;
-    ModelPickerSheet.show(
-      context,
-      providers: data.providers,
-      selectedProviderID: agentModel?.providerID ?? "",
-      selectedModelID: agentModel?.modelID ?? "",
-      onModelChanged: cubit.selectModel,
-    );
-  }
-
-  void _openVariantPicker(AgentModelData data) {
-    VariantPickerSheet.show(
-      context,
-      selectedVariantId: data.agentModel?.variant,
-      availableVariants: data.availableVariants,
-      onVariantChanged: context.read<NewSessionCubit>().selectVariant,
-    );
-  }
-
   Widget? _buildErrorBanner(NewSessionState state) {
     final prego = context.prego;
     final loc = context.loc;
@@ -115,31 +81,17 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
     final selectedAgent = data?.agent;
     if (data == null || data.agents.isEmpty || selectedAgent == null) return null;
 
-    final modelName = _resolveModelName(data);
+    final cubit = context.read<NewSessionCubit>();
     return AgentModelButtons(
-      availableVariants: data.availableVariants,
-      modelName: modelName,
+      agents: data.agents,
       selectedAgent: selectedAgent,
+      onAgentSelected: cubit.selectAgent,
+      providers: data.providers,
       selectedAgentModel: data.agentModel,
-      onAgentTap: () => _openAgentPicker(data),
-      onModelTap: () => _openModelPicker(data),
-      onVariantTap: () => _openVariantPicker(data),
+      onModelSelected: cubit.selectModel,
+      availableVariants: data.availableVariants,
+      onVariantSelected: cubit.selectVariant,
     );
-  }
-
-  String _resolveModelName(AgentModelData data) {
-    final providerID = data.agentModel?.providerID;
-    final modelID = data.agentModel?.modelID;
-    final loc = context.loc;
-    if (providerID == null || modelID == null) return loc.sessionDetailPickerModel;
-    for (final provider in data.providers) {
-      if (provider.id == providerID) {
-        final model = provider.models[modelID];
-        if (model != null) return model.name;
-      }
-    }
-    if (modelID.isNotEmpty) return modelID;
-    return loc.sessionDetailPickerModel;
   }
 
   @override

--- a/client/app/lib/features/session_detail/widgets/jump_to_edge_pill.dart
+++ b/client/app/lib/features/session_detail/widgets/jump_to_edge_pill.dart
@@ -16,18 +16,24 @@ class JumpToEdgePill extends StatelessWidget {
   final String label;
   final VoidCallback onTap;
 
+  /// Extra distance lifted above the bottom edge so the pill clears a floating
+  /// composer overlaid on the scrollable. Zero when nothing overlays the bottom
+  /// (e.g. the read-only variant).
+  final double bottomInset;
+
   const JumpToEdgePill({
     super.key,
     required this.tapTargetKey,
     required this.label,
     required this.onTap,
+    this.bottomInset = 0,
   });
 
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
     return Positioned(
-      bottom: 12,
+      bottom: 12 + bottomInset,
       left: 0,
       right: 0,
       child: Center(

--- a/client/app/lib/features/session_detail/widgets/jump_to_edge_pill.dart
+++ b/client/app/lib/features/session_detail/widgets/jump_to_edge_pill.dart
@@ -26,7 +26,7 @@ class JumpToEdgePill extends StatelessWidget {
     required this.tapTargetKey,
     required this.label,
     required this.onTap,
-    this.bottomInset = 0,
+    required this.bottomInset,
   });
 
   @override

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -274,6 +274,7 @@ class _PromptInputState extends State<PromptInput> {
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
+    final loc = context.loc;
 
     return DecoratedBox(
       // Floating composer: no bar surface, no separator line. The scaffold
@@ -357,18 +358,25 @@ class _PromptInputState extends State<PromptInput> {
                   onTap: _handleMicTap,
                 ),
                 if (_voiceState == _VoiceState.idle) ...[
-                  GlassIconButton(
-                    onPressed: _handleSend,
-                    icon: const Icon(Icons.send),
-                    glowColor: prego.colors.bgBrandSolid,
-                    // tooltip: loc.sessionDetailSend,
+                  // GlassIconButton has no tooltip/semanticLabel, so wrap it in
+                  // a Tooltip to restore the long-press/hover label and the
+                  // screen-reader name the old IconButton carried.
+                  Tooltip(
+                    message: loc.sessionDetailSend,
+                    child: GlassIconButton(
+                      onPressed: _handleSend,
+                      icon: const Icon(Icons.send),
+                      glowColor: prego.colors.bgBrandSolid,
+                    ),
                   ),
                   if (widget.isBusy)
-                    GlassIconButton(
-                      onPressed: widget.onAbort,
-                      icon: const Icon(Icons.stop_circle),
-                      glowColor: prego.colors.fgErrorPrimary,
-                      // tooltip: loc.sessionDetailAbort,
+                    Tooltip(
+                      message: loc.sessionDetailAbort,
+                      child: GlassIconButton(
+                        onPressed: widget.onAbort,
+                        icon: const Icon(Icons.stop_circle),
+                        glowColor: prego.colors.fgErrorPrimary,
+                      ),
                     ),
                 ],
               ],
@@ -434,25 +442,35 @@ class _MicButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
+    final loc = context.loc;
 
+    // GlassIconButton exposes no tooltip/semanticLabel, so wrap each state's
+    // button in a Tooltip to keep the long-press/hover label and screen-reader
+    // name the old IconButton provided.
     return switch (voiceState) {
-      _VoiceState.idle => GlassIconButton(
-        onPressed: onTap,
-        icon: const Icon(Icons.mic_none),
-        glowColor: prego.colors.textSecondary,
-        // tooltip: loc.voiceRecord,
+      _VoiceState.idle => Tooltip(
+        message: loc.voiceRecord,
+        child: GlassIconButton(
+          onPressed: onTap,
+          icon: const Icon(Icons.mic_none),
+          glowColor: prego.colors.textSecondary,
+        ),
       ),
-      _VoiceState.recording => GlassIconButton(
-        onPressed: onTap,
-        icon: const Icon(Icons.stop_circle_outlined),
-        glowColor: prego.colors.fgErrorPrimary,
-        // tooltip: loc.voiceStopRecording,
+      _VoiceState.recording => Tooltip(
+        message: loc.voiceStopRecording,
+        child: GlassIconButton(
+          onPressed: onTap,
+          icon: const Icon(Icons.stop_circle_outlined),
+          glowColor: prego.colors.fgErrorPrimary,
+        ),
       ),
-      _VoiceState.transcribing => GlassIconButton(
-        onPressed: onTap,
-        icon: const Icon(Icons.close),
-        glowColor: prego.colors.fgErrorPrimary,
-        // tooltip: loc.voiceCancelTranscription,
+      _VoiceState.transcribing => Tooltip(
+        message: loc.voiceCancelTranscription,
+        child: GlassIconButton(
+          onPressed: onTap,
+          icon: const Icon(Icons.close),
+          glowColor: prego.colors.fgErrorPrimary,
+        ),
       ),
     };
   }

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -3,6 +3,7 @@ import "dart:math" as math;
 
 import "package:flutter/material.dart";
 import "package:flutter/services.dart";
+import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
@@ -25,8 +26,7 @@ class PromptInput extends StatefulWidget {
   final ValueChanged<CommandInfo> onCommandSelected;
   final VoidCallback onCommandCleared;
 
-  /// Optional widget rendered inside the prompt container, above the text field
-  /// but below the separator line.
+  /// Optional widget rendered inside the composer, above the text-field row.
   final Widget? header;
 
   /// Key under which the in-progress draft is persisted across navigation /
@@ -274,13 +274,24 @@ class _PromptInputState extends State<PromptInput> {
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
-    final loc = context.loc;
 
-    return Container(
+    return DecoratedBox(
+      // Floating composer: no bar surface, no separator line. The scaffold
+      // background fades up behind the floating controls so chat content
+      // dissolves as it scrolls past — the same scrim the glass top navigation
+      // bar uses (PregoGlassScaffold), mirrored to the bottom edge: opaque
+      // where the controls sit, transparent where content emerges above. The
+      // controls keep their own glass.
       decoration: BoxDecoration(
-        color: prego.colors.bgPrimary,
-        border: Border(
-          top: BorderSide(color: prego.colors.borderSecondary),
+        gradient: LinearGradient(
+          begin: Alignment.center,
+          end: Alignment.topCenter,
+          colors: [
+            prego.colors.bgPrimary.withValues(alpha: 0.9),
+            prego.colors.bgPrimary.withValues(alpha: 0.7),
+            prego.colors.bgPrimary.withValues(alpha: 0),
+          ],
+          stops: const [0, 0.8, 1.0],
         ),
       ),
       child: Column(
@@ -293,18 +304,8 @@ class _PromptInputState extends State<PromptInput> {
               padding: const EdgeInsetsDirectional.fromSTEB(12, 6, 12, 2),
               child: Align(
                 alignment: AlignmentDirectional.centerStart,
-                child: InputChip(
-                  label: Text("/${commandInfo.name}"),
-                  avatar: CircleAvatar(
-                    backgroundColor: prego.colors.bgBrandPrimary,
-                    child: Text(
-                      "/",
-                      style: prego.textTheme.textMd.bold.copyWith(
-                        color: prego.colors.textBrandPrimary,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                  ),
+                child: GlassChip(
+                  label: "/${commandInfo.name}",
                   onDeleted: widget.onCommandCleared,
                   deleteIcon: const Icon(Icons.close, size: 18),
                 ),
@@ -314,19 +315,17 @@ class _PromptInputState extends State<PromptInput> {
 
           Padding(
             padding: EdgeInsetsDirectional.only(
-              start: 12,
-              end: 8,
               top: widget.header != null ? 4 : 8,
               bottom: MediaQuery.of(context).padding.bottom + 8,
             ),
             child: Row(
+              spacing: 8,
               crossAxisAlignment: .end,
               children: [
                 _SlashButton(
                   enabled: _voiceState == _VoiceState.idle,
                   onTap: _openCommandPicker,
                 ),
-                const SizedBox(width: 8),
                 Expanded(
                   child: switch (_voiceState) {
                     _VoiceState.recording => _RecordingIndicator(amplitudeStream: _voiceService.amplitudeStream),
@@ -338,48 +337,38 @@ class _PromptInputState extends State<PromptInput> {
                         const SingleActivator(LogicalKeyboardKey.enter, meta: true): _handleSend,
                         const SingleActivator(LogicalKeyboardKey.enter, control: true): _handleSend,
                       },
-                      child: TextField(
+                      child: GlassTextField(
                         controller: _controller,
                         focusNode: _focusNode,
                         minLines: 1,
                         maxLines: 5,
                         textInputAction: TextInputAction.newline,
-                        decoration: InputDecoration(
-                          hintText: _commandHintText(context),
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(24),
-                            borderSide: BorderSide.none,
-                          ),
-                          filled: true,
-                          fillColor: prego.colors.bgQuaternary,
-                          contentPadding: const EdgeInsets.symmetric(
-                            horizontal: 16,
-                            vertical: 10,
-                          ),
-                          isDense: true,
-                        ),
+                        // Command-aware placeholder: the staged command's hint,
+                        // else the default prompt hint. The glass field supplies
+                        // its own surface/fill/border, so only the hint text
+                        // carries over from the old InputDecoration.
+                        placeholder: _commandHintText(context),
                       ),
                     ),
                   },
                 ),
-                const SizedBox(width: 8),
                 _MicButton(
                   voiceState: _voiceState,
                   onTap: _handleMicTap,
                 ),
                 if (_voiceState == _VoiceState.idle) ...[
-                  IconButton(
+                  GlassIconButton(
                     onPressed: _handleSend,
                     icon: const Icon(Icons.send),
-                    color: prego.colors.bgBrandSolid,
-                    tooltip: loc.sessionDetailSend,
+                    glowColor: prego.colors.bgBrandSolid,
+                    // tooltip: loc.sessionDetailSend,
                   ),
                   if (widget.isBusy)
-                    IconButton(
+                    GlassIconButton(
                       onPressed: widget.onAbort,
                       icon: const Icon(Icons.stop_circle),
-                    color: prego.colors.fgErrorPrimary,
-                      tooltip: loc.sessionDetailAbort,
+                      glowColor: prego.colors.fgErrorPrimary,
+                      // tooltip: loc.sessionDetailAbort,
                     ),
                 ],
               ],
@@ -409,9 +398,7 @@ class _SlashButton extends StatelessWidget {
     final prego = context.prego;
 
     return Material(
-      color: enabled
-          ? prego.colors.bgQuaternary
-          : prego.colors.bgQuaternary.withValues(alpha: 0.5),
+      color: enabled ? prego.colors.bgQuaternary : prego.colors.bgQuaternary.withValues(alpha: 0.5),
       shape: const CircleBorder(),
       child: InkWell(
         customBorder: const CircleBorder(),
@@ -447,26 +434,25 @@ class _MicButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
-    final loc = context.loc;
 
     return switch (voiceState) {
-      _VoiceState.idle => IconButton(
+      _VoiceState.idle => GlassIconButton(
         onPressed: onTap,
         icon: const Icon(Icons.mic_none),
-        color: prego.colors.textSecondary,
-        tooltip: loc.voiceRecord,
+        glowColor: prego.colors.textSecondary,
+        // tooltip: loc.voiceRecord,
       ),
-      _VoiceState.recording => IconButton(
+      _VoiceState.recording => GlassIconButton(
         onPressed: onTap,
         icon: const Icon(Icons.stop_circle_outlined),
-        color: prego.colors.fgErrorPrimary,
-        tooltip: loc.voiceStopRecording,
+        glowColor: prego.colors.fgErrorPrimary,
+        // tooltip: loc.voiceStopRecording,
       ),
-      _VoiceState.transcribing => IconButton(
+      _VoiceState.transcribing => GlassIconButton(
         onPressed: onTap,
         icon: const Icon(Icons.close),
-        color: prego.colors.fgErrorPrimary,
-        tooltip: loc.voiceCancelTranscription,
+        glowColor: prego.colors.fgErrorPrimary,
+        // tooltip: loc.voiceCancelTranscription,
       ),
     };
   }

--- a/client/app/lib/features/session_detail/widgets/reasoning_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/reasoning_modal.dart
@@ -101,6 +101,8 @@ class _ReasoningModalState extends State<ReasoningModal> {
                         tapTargetKey: _kFollowOutputKey,
                         label: loc.sessionDetailFollowOutput,
                         onTap: () => _follow.animateToEdge(),
+                        // No floating composer in the reasoning sheet.
+                        bottomInset: 0,
                       )
                   : null,
               child: ListView(

--- a/client/app/lib/features/session_detail/widgets/session_detail_body.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_body.dart
@@ -10,10 +10,7 @@ import "../../../core/constants.dart";
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/routing/app_router.dart";
 import "../../../core/routing/imperative_pane_route.dart";
-import "../../../core/widgets/agent_picker_sheet.dart";
-import "../../../core/widgets/model_picker_sheet.dart";
 import "../../../core/widgets/session_split/session_split_scope.dart";
-import "../../../core/widgets/variant_picker_sheet.dart";
 import "permission_modal.dart";
 import "question_modal.dart";
 import "session_detail_loaded_view.dart";
@@ -128,6 +125,10 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
       // scroll for a large title to collapse against. Use the fixed, centred
       // inline title (Figma "Middle Title") instead.
       inlineTitle: true,
+      // The chat owns its own scroll and insets itself, so the messages scroll
+      // behind the transparent bar like every other screen. Skip the auto top
+      // spacer that would otherwise confine the loaded view below the bar.
+      reserveBarSpace: false,
       automaticallyImplyLeading: showLeading,
       actions: actions.isEmpty ? null : actions,
       slivers: [
@@ -137,12 +138,13 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
             child: Center(child: CircularProgressIndicator()),
           ),
           // The loaded view is a Column with an Expanded chat and a pinned
-          // composer. hasScrollBody: true gives it the exact remaining height
-          // (chat flexes, composer stays anchored at the bottom and rides above
-          // the keyboard) — the same layout the previous Scaffold body had. The
-          // chat owns its own reversed scroll controller, so the large title
-          // can't collapse with it; it stays expanded, as on the new-session
-          // screen.
+          // composer. With reserveBarSpace: false there is no top spacer, so
+          // hasScrollBody: true gives it the full viewport height behind the
+          // bar — the chat scrolls behind the transparent bar and insets its
+          // own content below it (chat flexes, composer stays anchored at the
+          // bottom and rides above the keyboard). The chat owns its own
+          // reversed scroll controller, so the large title can't collapse with
+          // it; the inline title is used instead, as on the new-session screen.
           final SessionDetailLoaded loaded => SliverFillRemaining(
             hasScrollBody: true,
             child: widget.readOnly
@@ -158,9 +160,6 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
                     state: loaded,
                     onShowPendingQuestions: _showPendingQuestions,
                     onShowPendingPermissions: _showPendingPermissions,
-                    onOpenAgentPicker: _openAgentPicker,
-                    onOpenModelPicker: _openModelPicker,
-                    onOpenVariantPicker: _openVariantPicker,
                   ),
           ),
           SessionDetailFailed(:final reason) => SliverFillRemaining(
@@ -187,44 +186,6 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
     if (state case SessionDetailLoaded(:final pendingPermissions) when pendingPermissions.isNotEmpty) {
       _showPermissionModal(pendingPermissions.first);
     }
-  }
-
-  void _openAgentPicker() {
-    final cubit = context.read<SessionDetailCubit>();
-    final state = cubit.state;
-    if (state is! SessionDetailLoaded) return;
-    AgentPickerSheet.show(
-      context,
-      agents: state.availableAgents,
-      selectedAgent: state.selectedAgent,
-      onAgentChanged: cubit.selectAgent,
-    );
-  }
-
-  void _openModelPicker() {
-    final cubit = context.read<SessionDetailCubit>();
-    final state = cubit.state;
-    if (state is! SessionDetailLoaded) return;
-    final agentModel = state.selectedAgentModel;
-    ModelPickerSheet.show(
-      context,
-      providers: state.availableProviders,
-      selectedProviderID: agentModel?.providerID ?? "",
-      selectedModelID: agentModel?.modelID ?? "",
-      onModelChanged: cubit.selectModel,
-    );
-  }
-
-  void _openVariantPicker() {
-    final cubit = context.read<SessionDetailCubit>();
-    final state = cubit.state;
-    if (state is! SessionDetailLoaded) return;
-    VariantPickerSheet.show(
-      context,
-      selectedVariantId: state.selectedAgentModel?.variant,
-      availableVariants: state.availableVariants,
-      onVariantChanged: cubit.selectVariant,
-    );
   }
 
   void _showQuestionModal(SesoriQuestionAsked question) {

--- a/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
@@ -45,12 +45,13 @@ class SessionDetailLoadedView extends StatefulWidget {
 }
 
 class _SessionDetailLoadedViewState extends State<SessionDetailLoadedView> {
-  /// Measured height of the floating composer overlaying the bottom of the
-  /// chat. Fed to the message list so the newest message rests just above the
-  /// composer (and the "jump to latest" pill clears it) while older content
-  /// scrolls up behind the composer's fade. Stays 0 in the read-only variant,
-  /// which renders no composer.
-  double _composerHeight = 0;
+  /// Measured height of the floating bottom controls overlaying the bottom of
+  /// the chat — the background-tasks bar, queued messages and the composer. Fed
+  /// to the message list so the newest message rests just above them (and the
+  /// "jump to latest" pill clears them) while older content scrolls up behind
+  /// the composer's fade. Stays 0 in the read-only variant, which renders none
+  /// of these controls.
+  double _bottomControlsHeight = 0;
 
   @override
   Widget build(BuildContext context) {
@@ -80,20 +81,13 @@ class _SessionDetailLoadedViewState extends State<SessionDetailLoadedView> {
                       retryErrorMessage: state.retryErrorMessage,
                       // Pad the oldest-message edge clear of the bar it scrolls
                       // behind, and the newest-message edge clear of the floating
-                      // composer overlaid below; content in between scrolls up
-                      // behind the bar's fade and the composer's fade.
+                      // bottom controls overlaid below (background-tasks bar,
+                      // queued messages and composer); content in between scrolls
+                      // up behind the bar's fade and the composer's fade.
                       topInset: topInset,
-                      bottomInset: _composerHeight,
+                      bottomInset: _bottomControlsHeight,
                     ),
             ),
-            if (state.children.isNotEmpty && !widget.readOnly)
-              BackgroundTasksBar(
-                projectId: widget.projectId,
-                children: state.children,
-                childStatuses: state.childStatuses,
-              ),
-            if (!widget.readOnly && state.queuedMessages.isNotEmpty)
-              SessionDetailQueuedMessagesSection(messages: state.queuedMessages),
           ],
         ),
         // The refresh indicator and pending banners pin just below the
@@ -128,42 +122,64 @@ class _SessionDetailLoadedViewState extends State<SessionDetailLoadedView> {
             ],
           ),
         ),
+        // Floating bottom controls — the background-tasks bar, queued messages
+        // and the composer, stacked in that order above the composer at the
+        // bottom edge. They sit over the chat (which scrolls behind them) and
+        // are measured as one cluster so the chat insets its newest message
+        // clear of the whole stack — and so the tasks bar/queued stay tappable
+        // above the composer instead of hidden behind it.
         if (!widget.readOnly)
           Positioned(
             bottom: 0,
-            left: 16,
-            right: 16,
+            left: 0,
+            right: 0,
             child: _MeasureSize(
               onChange: (size) {
-                if (!mounted || size.height == _composerHeight) return;
-                setState(() => _composerHeight = size.height);
+                if (!mounted || size.height == _bottomControlsHeight) return;
+                setState(() => _bottomControlsHeight = size.height);
               },
-              child: PromptInput(
-                draftKey: widget.sessionId,
-                isBusy: hasActiveWork(
-                  sessionStatus: state.sessionStatus,
-                  childStatuses: state.childStatuses,
-                ),
-                onSend: (text, command) => context.read<SessionDetailCubit>().sendMessage(
-                  text: text,
-                  command: command,
-                ),
-                onAbort: () => context.read<SessionDetailCubit>().abort(),
-                header: null,
-                composerHeader: AgentModelButtons(
-                  agents: state.availableAgents,
-                  selectedAgent: state.selectedAgent,
-                  onAgentSelected: context.read<SessionDetailCubit>().selectAgent,
-                  providers: state.availableProviders,
-                  selectedAgentModel: state.selectedAgentModel,
-                  onModelSelected: context.read<SessionDetailCubit>().selectModel,
-                  availableVariants: state.availableVariants,
-                  onVariantSelected: context.read<SessionDetailCubit>().selectVariant,
-                ),
-                availableCommands: state.availableCommands,
-                stagedCommand: state.stagedCommand,
-                onCommandSelected: context.read<SessionDetailCubit>().stageCommand,
-                onCommandCleared: context.read<SessionDetailCubit>().clearStagedCommand,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (state.children.isNotEmpty)
+                    BackgroundTasksBar(
+                      projectId: widget.projectId,
+                      children: state.children,
+                      childStatuses: state.childStatuses,
+                    ),
+                  if (state.queuedMessages.isNotEmpty)
+                    SessionDetailQueuedMessagesSection(messages: state.queuedMessages),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: PromptInput(
+                      draftKey: widget.sessionId,
+                      isBusy: hasActiveWork(
+                        sessionStatus: state.sessionStatus,
+                        childStatuses: state.childStatuses,
+                      ),
+                      onSend: (text, command) => context.read<SessionDetailCubit>().sendMessage(
+                        text: text,
+                        command: command,
+                      ),
+                      onAbort: () => context.read<SessionDetailCubit>().abort(),
+                      header: null,
+                      composerHeader: AgentModelButtons(
+                        agents: state.availableAgents,
+                        selectedAgent: state.selectedAgent,
+                        onAgentSelected: context.read<SessionDetailCubit>().selectAgent,
+                        providers: state.availableProviders,
+                        selectedAgentModel: state.selectedAgentModel,
+                        onModelSelected: context.read<SessionDetailCubit>().selectModel,
+                        availableVariants: state.availableVariants,
+                        onVariantSelected: context.read<SessionDetailCubit>().selectVariant,
+                      ),
+                      availableCommands: state.availableCommands,
+                      stagedCommand: state.stagedCommand,
+                      onCommandSelected: context.read<SessionDetailCubit>().stageCommand,
+                      onCommandCleared: context.read<SessionDetailCubit>().clearStagedCommand,
+                    ),
+                  ),
+                ],
               ),
             ),
           ),

--- a/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:flutter/rendering.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -6,13 +7,12 @@ import "package:theme_prego/module_prego.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/widgets/agent_model_buttons.dart";
-import "../../../l10n/app_localizations.dart";
 import "background_tasks_bar.dart";
 import "prompt_input.dart";
 import "session_detail_message_list.dart";
 import "session_detail_scaffold_sections.dart";
 
-class SessionDetailLoadedView extends StatelessWidget {
+class SessionDetailLoadedView extends StatefulWidget {
   final String? projectId;
   // Session id, used as the composer draft key. Null in the read-only
   // variant, which renders no prompt input.
@@ -21,9 +21,6 @@ class SessionDetailLoadedView extends StatelessWidget {
   final bool readOnly;
   final VoidCallback onShowPendingQuestions;
   final VoidCallback onShowPendingPermissions;
-  final VoidCallback onOpenAgentPicker;
-  final VoidCallback onOpenModelPicker;
-  final VoidCallback onOpenVariantPicker;
 
   const SessionDetailLoadedView.readOnly({
     super.key,
@@ -32,10 +29,7 @@ class SessionDetailLoadedView extends StatelessWidget {
     required this.onShowPendingQuestions,
     required this.onShowPendingPermissions,
   }) : readOnly = true,
-       sessionId = null,
-       onOpenAgentPicker = _noopCallback,
-       onOpenModelPicker = _noopCallback,
-       onOpenVariantPicker = _noopCallback;
+       sessionId = null;
 
   const SessionDetailLoadedView.editable({
     super.key,
@@ -44,105 +38,139 @@ class SessionDetailLoadedView extends StatelessWidget {
     required this.state,
     required this.onShowPendingQuestions,
     required this.onShowPendingPermissions,
-    required this.onOpenAgentPicker,
-    required this.onOpenModelPicker,
-    required this.onOpenVariantPicker,
   }) : readOnly = false;
+
+  @override
+  State<SessionDetailLoadedView> createState() => _SessionDetailLoadedViewState();
+}
+
+class _SessionDetailLoadedViewState extends State<SessionDetailLoadedView> {
+  /// Measured height of the floating composer overlaying the bottom of the
+  /// chat. Fed to the message list so the newest message rests just above the
+  /// composer (and the "jump to latest" pill clears it) while older content
+  /// scrolls up behind the composer's fade. Stays 0 in the read-only variant,
+  /// which renders no composer.
+  double _composerHeight = 0;
 
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
+    final state = widget.state;
     final questionCount = state.pendingQuestions.fold<int>(0, (sum, q) => sum + q.questions.length);
 
-    return Column(
+    // The scaffold lets this view fill the full height behind the transparent
+    // bar (reserveBarSpace: false), so the message list scrolls behind it like
+    // every other screen. Inset the chat's content — and pin the refresh
+    // indicator / banners — by this much so they clear the bar at rest.
+    final topInset = MediaQuery.paddingOf(context).top + PregoTopNavigation.barHeight;
+
+    return Stack(
       children: [
-        if (state.isRefreshing) const LinearProgressIndicator(),
-        if (state.pendingQuestions.isNotEmpty)
-          SessionDetailPendingBanner(
-            icon: Icons.help_outline,
-            backgroundColor: context.prego.colors.bgBrandPrimary,
-            foregroundColor: context.prego.colors.textBrandPrimary,
-            label: questionCount == 1 ? loc.questionBannerSingle : loc.questionBannerMultiple(questionCount),
-            onTap: onShowPendingQuestions,
-          ),
-        if (state.pendingPermissions.isNotEmpty)
-          SessionDetailPendingBanner(
-            icon: Icons.shield_outlined,
-            backgroundColor: context.prego.colors.bgSuccessPrimary,
-            foregroundColor: context.prego.colors.textSuccessPrimary,
-            label: state.pendingPermissions.length == 1
-                ? loc.permissionBannerSingle
-                : loc.permissionBannerMultiple(state.pendingPermissions.length),
-            onTap: onShowPendingPermissions,
-          ),
-        Expanded(
-          child: state.messages.isEmpty && state.retryErrorMessage == null
-              ? Center(child: Text(loc.sessionDetailEmpty))
-              : SessionDetailMessageList(
-                  projectId: projectId,
-                  messages: state.messages,
-                  streamingText: state.streamingText,
-                  children: state.children,
-                  childStatuses: state.childStatuses,
-                  retryErrorMessage: state.retryErrorMessage,
-                ),
+        Column(
+          children: [
+            Expanded(
+              child: state.messages.isEmpty && state.retryErrorMessage == null
+                  ? Center(child: Text(loc.sessionDetailEmpty))
+                  : SessionDetailMessageList(
+                      projectId: widget.projectId,
+                      messages: state.messages,
+                      streamingText: state.streamingText,
+                      children: state.children,
+                      childStatuses: state.childStatuses,
+                      retryErrorMessage: state.retryErrorMessage,
+                      // Pad the oldest-message edge clear of the bar it scrolls
+                      // behind, and the newest-message edge clear of the floating
+                      // composer overlaid below; content in between scrolls up
+                      // behind the bar's fade and the composer's fade.
+                      topInset: topInset,
+                      bottomInset: _composerHeight,
+                    ),
+            ),
+            if (state.children.isNotEmpty && !widget.readOnly)
+              BackgroundTasksBar(
+                projectId: widget.projectId,
+                children: state.children,
+                childStatuses: state.childStatuses,
+              ),
+            if (!widget.readOnly && state.queuedMessages.isNotEmpty)
+              SessionDetailQueuedMessagesSection(messages: state.queuedMessages),
+          ],
         ),
-        if (state.children.isNotEmpty && !readOnly)
-          BackgroundTasksBar(
-            projectId: projectId,
-            children: state.children,
-            childStatuses: state.childStatuses,
+        // The refresh indicator and pending banners pin just below the
+        // transparent bar, floating over the chat that scrolls behind them —
+        // rather than pushing the chat down out of the behind-bar region.
+        Positioned(
+          top: topInset,
+          left: 0,
+          right: 0,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (state.isRefreshing) const LinearProgressIndicator(),
+              if (state.pendingQuestions.isNotEmpty)
+                SessionDetailPendingBanner(
+                  icon: Icons.help_outline,
+                  backgroundColor: context.prego.colors.bgBrandPrimary,
+                  foregroundColor: context.prego.colors.textBrandPrimary,
+                  label: questionCount == 1 ? loc.questionBannerSingle : loc.questionBannerMultiple(questionCount),
+                  onTap: widget.onShowPendingQuestions,
+                ),
+              if (state.pendingPermissions.isNotEmpty)
+                SessionDetailPendingBanner(
+                  icon: Icons.shield_outlined,
+                  backgroundColor: context.prego.colors.bgSuccessPrimary,
+                  foregroundColor: context.prego.colors.textSuccessPrimary,
+                  label: state.pendingPermissions.length == 1
+                      ? loc.permissionBannerSingle
+                      : loc.permissionBannerMultiple(state.pendingPermissions.length),
+                  onTap: widget.onShowPendingPermissions,
+                ),
+            ],
           ),
-        if (!readOnly && state.queuedMessages.isNotEmpty)
-          SessionDetailQueuedMessagesSection(messages: state.queuedMessages),
-        if (!readOnly)
-          PromptInput(
-            draftKey: sessionId,
-            isBusy: hasActiveWork(
-              sessionStatus: state.sessionStatus,
-              childStatuses: state.childStatuses,
+        ),
+        if (!widget.readOnly)
+          Positioned(
+            bottom: 0,
+            left: 16,
+            right: 16,
+            child: _MeasureSize(
+              onChange: (size) {
+                if (!mounted || size.height == _composerHeight) return;
+                setState(() => _composerHeight = size.height);
+              },
+              child: PromptInput(
+                draftKey: widget.sessionId,
+                isBusy: hasActiveWork(
+                  sessionStatus: state.sessionStatus,
+                  childStatuses: state.childStatuses,
+                ),
+                onSend: (text, command) => context.read<SessionDetailCubit>().sendMessage(
+                  text: text,
+                  command: command,
+                ),
+                onAbort: () => context.read<SessionDetailCubit>().abort(),
+                header: null,
+                composerHeader: AgentModelButtons(
+                  agents: state.availableAgents,
+                  selectedAgent: state.selectedAgent,
+                  onAgentSelected: context.read<SessionDetailCubit>().selectAgent,
+                  providers: state.availableProviders,
+                  selectedAgentModel: state.selectedAgentModel,
+                  onModelSelected: context.read<SessionDetailCubit>().selectModel,
+                  availableVariants: state.availableVariants,
+                  onVariantSelected: context.read<SessionDetailCubit>().selectVariant,
+                ),
+                availableCommands: state.availableCommands,
+                stagedCommand: state.stagedCommand,
+                onCommandSelected: context.read<SessionDetailCubit>().stageCommand,
+                onCommandCleared: context.read<SessionDetailCubit>().clearStagedCommand,
+              ),
             ),
-            onSend: (text, command) => context.read<SessionDetailCubit>().sendMessage(
-              text: text,
-              command: command,
-            ),
-            onAbort: () => context.read<SessionDetailCubit>().abort(),
-            header: null,
-            composerHeader: AgentModelButtons(
-              availableVariants: state.availableVariants,
-              modelName: _resolveModelName(state, loc: loc),
-              selectedAgent: state.selectedAgent,
-              selectedAgentModel: state.selectedAgentModel,
-              onAgentTap: onOpenAgentPicker,
-              onModelTap: onOpenModelPicker,
-              onVariantTap: onOpenVariantPicker,
-            ),
-            availableCommands: state.availableCommands,
-            stagedCommand: state.stagedCommand,
-            onCommandSelected: context.read<SessionDetailCubit>().stageCommand,
-            onCommandCleared: context.read<SessionDetailCubit>().clearStagedCommand,
           ),
       ],
     );
   }
-
-  String _resolveModelName(SessionDetailLoaded state, {required AppLocalizations loc}) {
-    final providerID = state.selectedAgentModel?.providerID;
-    final modelID = state.selectedAgentModel?.modelID;
-    final fallback = loc.sessionDetailModelFallback;
-    if (providerID == null || modelID == null) return fallback;
-    for (final provider in state.availableProviders) {
-      if (provider.id == providerID) {
-        final model = provider.models[modelID];
-        if (model != null) return model.name;
-      }
-    }
-    if (modelID.isNotEmpty) return modelID;
-    return fallback;
-  }
 }
-
-void _noopCallback() {}
 
 bool hasActiveWork({
   required SessionStatus sessionStatus,
@@ -150,4 +178,38 @@ bool hasActiveWork({
 }) {
   return sessionStatus is! SessionStatusIdle ||
       childStatuses.values.any((s) => s is SessionStatusBusy || s is SessionStatusRetry);
+}
+
+/// Reports its child's measured size via [onChange] after each layout pass.
+/// Used to feed the floating composer's height to the message list so the
+/// newest message and the "jump to latest" pill rest clear of it. [onChange]
+/// is invoked post-frame so listeners may safely call `setState`.
+class _MeasureSize extends SingleChildRenderObjectWidget {
+  const _MeasureSize({required this.onChange, required super.child});
+
+  final ValueChanged<Size> onChange;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) => _MeasureSizeRenderBox(onChange);
+
+  @override
+  void updateRenderObject(BuildContext context, _MeasureSizeRenderBox renderObject) {
+    renderObject.onChange = onChange;
+  }
+}
+
+class _MeasureSizeRenderBox extends RenderProxyBox {
+  _MeasureSizeRenderBox(this.onChange);
+
+  ValueChanged<Size> onChange;
+  Size? _lastReported;
+
+  @override
+  void performLayout() {
+    super.performLayout();
+    final size = child?.size ?? Size.zero;
+    if (size == _lastReported) return;
+    _lastReported = size;
+    WidgetsBinding.instance.addPostFrameCallback((_) => onChange(size));
+  }
 }

--- a/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_loaded_view.dart
@@ -85,7 +85,11 @@ class _SessionDetailLoadedViewState extends State<SessionDetailLoadedView> {
                       // queued messages and composer); content in between scrolls
                       // up behind the bar's fade and the composer's fade.
                       topInset: topInset,
-                      bottomInset: _bottomControlsHeight,
+                      // The read-only variant renders no floating controls, so
+                      // force the inset to 0 there — guarding against a stale
+                      // measured height lingering if a state object is reused
+                      // across an editable -> read-only transition.
+                      bottomInset: widget.readOnly ? 0 : _bottomControlsHeight,
                     ),
             ),
           ],

--- a/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -65,6 +65,19 @@ class SessionDetailMessageList extends StatefulWidget {
   final Map<String, SessionStatus> childStatuses;
   final String? retryErrorMessage;
 
+  /// Height of the floating composer overlaying the list's bottom edge. Used
+  /// both as extra bottom scroll padding — so the newest message rests clear of
+  /// the composer while older content scrolls up behind its fade — and to lift
+  /// the "jump to latest" pill above the composer. Zero in the read-only
+  /// variant, which renders no composer.
+  final double bottomInset;
+
+  /// Top inset (status bar + nav bar height) the list scrolls behind. Added as
+  /// extra top scroll padding so the oldest message rests clear of the
+  /// transparent bar at full scroll, while content in between scrolls up behind
+  /// it and dissolves into the bar's fade.
+  final double topInset;
+
   const SessionDetailMessageList({
     super.key,
     required this.projectId,
@@ -73,6 +86,8 @@ class SessionDetailMessageList extends StatefulWidget {
     required this.children,
     required this.childStatuses,
     this.retryErrorMessage,
+    this.bottomInset = 0,
+    this.topInset = 0,
   });
 
   @override
@@ -289,6 +304,8 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
         tapTargetKey: _kJumpToLatestKey,
         label: loc.sessionDetailJumpToLatest,
         onTap: () => _follow.animateToEdge(),
+        // Lift the pill clear of the floating composer overlaid below.
+        bottomInset: widget.bottomInset,
       ),
       // Horizontal "peek" gesture: slide the transcript left to reveal
       // each message's timestamp on the right. Driven by a raw [Listener]
@@ -374,8 +391,8 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
               insertAnimationDuration: Duration.zero,
               removeAnimationDuration: Duration.zero,
               shouldScrollToEndWhenSendingMessage: false,
-              topPadding: 8,
-              bottomPadding: 8,
+              topPadding: 8 + widget.topInset,
+              bottomPadding: 8 + widget.bottomInset,
               handleSafeArea: false,
               keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.manual,
               // Always allow overscroll/bounce, even when the transcript is

--- a/client/app/test/components/navigation/prego_nav_title_test.dart
+++ b/client/app/test/components/navigation/prego_nav_title_test.dart
@@ -5,7 +5,7 @@ import "package:theme_prego/module_prego.dart";
 /// Layout guard for [PregoNavTitle], the centred two-line title block of the
 /// glass top bar.
 ///
-/// The bar is a fixed 54pt (`PregoTopNavigation`'s `_appBarHeight`). With the
+/// The bar is a fixed 54pt (`PregoTopNavigation.barHeight`). With the
 /// design tokens' body-text line heights, a title + subtitle stack measured
 /// 28 + 24 = 52pt — only 2pt under the bar — so Android's slightly taller text
 /// metrics tipped the inner [Column] into a 3px bottom overflow on the

--- a/client/app/test/core/widgets/session_split/session_split_shell_test.dart
+++ b/client/app/test/core/widgets/session_split/session_split_shell_test.dart
@@ -201,7 +201,7 @@ void main() {
       // Start sending; creation is now in flight. Scope to the composer — the
       // session-detail route behind the pushed overlay also has a prompt field.
       final newSession = find.byType(NewSessionScreen);
-      await tester.enterText(find.descendant(of: newSession, matching: find.byType(TextField)), "do the thing");
+      await tester.enterText(find.descendant(of: newSession, matching: find.byType(EditableText)), "do the thing");
       await tester.tap(find.descendant(of: newSession, matching: find.byIcon(Icons.send)), warnIfMissed: false);
       await tester.pump();
       expect(find.byKey(const Key("new_session_loading_overlay")), findsOneWidget);

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -4,6 +4,7 @@ import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:get_it/get_it.dart";
 import "package:go_router/go_router.dart";
+import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:mocktail/mocktail.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/capabilities/voice/voice_transcription_service.dart";
@@ -108,19 +109,20 @@ void main() {
     await tester.pumpWidget(_buildApp());
     await tester.pumpAndSettle();
 
-    expect(find.widgetWithText(OutlinedButton, "xhigh"), findsOneWidget);
+    expect(find.widgetWithText(GlassButton, "xhigh"), findsOneWidget);
 
-    await tester.tap(find.widgetWithText(OutlinedButton, "xhigh"));
+    await tester.tap(find.widgetWithText(GlassButton, "xhigh"));
     await tester.pumpAndSettle();
 
-    expect(find.text("Variant"), findsOneWidget);
-    expect(find.text("Default"), findsWidgets);
-    expect(find.widgetWithText(ListTile, "xhigh"), findsOneWidget);
+    // The variant pill morphs into a glass popup listing the Default option
+    // plus the model's variants.
+    expect(find.widgetWithText(GlassMenuItem, "Default"), findsOneWidget);
+    expect(find.widgetWithText(GlassMenuItem, "xhigh"), findsOneWidget);
 
-    await tester.tap(find.widgetWithText(ListTile, "xhigh"));
+    await tester.tap(find.widgetWithText(GlassMenuItem, "xhigh"));
     await tester.pumpAndSettle();
 
-    expect(find.widgetWithText(OutlinedButton, "xhigh"), findsOneWidget);
+    expect(find.widgetWithText(GlassButton, "xhigh"), findsOneWidget);
   });
 
   testWidgets("selecting a different variant updates the displayed variant", (tester) async {
@@ -153,19 +155,19 @@ void main() {
     await tester.pumpAndSettle();
 
     // Initially shows the agent's default variant.
-    expect(find.widgetWithText(OutlinedButton, "xhigh"), findsOneWidget);
+    expect(find.widgetWithText(GlassButton, "xhigh"), findsOneWidget);
 
     // Open variant picker.
-    await tester.tap(find.widgetWithText(OutlinedButton, "xhigh"));
+    await tester.tap(find.widgetWithText(GlassButton, "xhigh"));
     await tester.pumpAndSettle();
 
     // Select a different variant.
-    await tester.tap(find.widgetWithText(ListTile, "low"));
+    await tester.tap(find.widgetWithText(GlassMenuItem, "low"));
     await tester.pumpAndSettle();
 
     // The UI should now reflect the newly selected variant.
-    expect(find.widgetWithText(OutlinedButton, "low"), findsOneWidget);
-    expect(find.widgetWithText(OutlinedButton, "xhigh"), findsNothing);
+    expect(find.widgetWithText(GlassButton, "low"), findsOneWidget);
+    expect(find.widgetWithText(GlassButton, "xhigh"), findsNothing);
   });
 
   testWidgets("selecting Default clears the displayed variant", (tester) async {
@@ -198,43 +200,43 @@ void main() {
     await tester.pumpAndSettle();
 
     // Initially shows the agent's default variant.
-    expect(find.widgetWithText(OutlinedButton, "xhigh"), findsOneWidget);
+    expect(find.widgetWithText(GlassButton, "xhigh"), findsOneWidget);
 
     // Open variant picker.
-    await tester.tap(find.widgetWithText(OutlinedButton, "xhigh"));
+    await tester.tap(find.widgetWithText(GlassButton, "xhigh"));
     await tester.pumpAndSettle();
 
     // Select Default (null variant).
-    await tester.tap(find.widgetWithText(ListTile, "Default"));
+    await tester.tap(find.widgetWithText(GlassMenuItem, "Default"));
     await tester.pumpAndSettle();
 
     // The UI should now show "Default".
-    expect(find.widgetWithText(OutlinedButton, "Default"), findsOneWidget);
-    expect(find.widgetWithText(OutlinedButton, "xhigh"), findsNothing);
+    expect(find.widgetWithText(GlassButton, "Default"), findsOneWidget);
+    expect(find.widgetWithText(GlassButton, "xhigh"), findsNothing);
   });
 
   testWidgets("preserves selectedAgentModel variant when changing agent", (tester) async {
     await tester.pumpWidget(_buildApp());
     await tester.pumpAndSettle();
 
-    await tester.tap(find.widgetWithText(OutlinedButton, "xhigh"));
+    await tester.tap(find.widgetWithText(GlassButton, "xhigh"));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.widgetWithText(ListTile, "xhigh"));
+    await tester.tap(find.widgetWithText(GlassMenuItem, "xhigh"));
     await tester.pumpAndSettle();
 
-    expect(find.widgetWithText(OutlinedButton, "xhigh"), findsOneWidget);
+    expect(find.widgetWithText(GlassButton, "xhigh"), findsOneWidget);
 
-    await tester.tap(find.widgetWithText(OutlinedButton, "coder"));
+    await tester.tap(find.widgetWithText(GlassButton, "coder"));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.widgetWithText(ListTile, "reviewer"));
+    await tester.tap(find.widgetWithText(GlassMenuItem, "reviewer"));
     await tester.pumpAndSettle();
 
-    expect(find.widgetWithText(OutlinedButton, "reviewer"), findsOneWidget);
+    expect(find.widgetWithText(GlassButton, "reviewer"), findsOneWidget);
     // Changing the agent seeds the variant from the agent's default.
-    // Reviewer has variant: null, so the button shows "Default".
-    expect(find.widgetWithText(OutlinedButton, "Default"), findsOneWidget);
+    // Reviewer has variant: null, so the pill shows "Default".
+    expect(find.widgetWithText(GlassButton, "Default"), findsOneWidget);
   });
 
   testWidgets("shows the loading overlay with accessible message during sending", (tester) async {
@@ -257,7 +259,7 @@ void main() {
 
     final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
 
-    await tester.enterText(find.byType(TextField), "test message");
+    await tester.enterText(find.byType(EditableText), "test message");
     await tester.tap(find.byIcon(Icons.send), warnIfMissed: false);
     await tester.pump();
 
@@ -285,7 +287,7 @@ void main() {
     await tester.pumpWidget(_buildApp());
     await tester.pumpAndSettle();
 
-    await tester.enterText(find.byType(TextField), "test message");
+    await tester.enterText(find.byType(EditableText), "test message");
     await tester.tap(find.byIcon(Icons.send), warnIfMissed: false);
     await tester.pump();
 
@@ -332,7 +334,7 @@ void main() {
 
     final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
 
-    await tester.enterText(find.byType(TextField), "test message");
+    await tester.enterText(find.byType(EditableText), "test message");
     await tester.tap(find.byIcon(Icons.send), warnIfMissed: false);
     await tester.pump();
 
@@ -375,7 +377,7 @@ void main() {
 
     final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
 
-    await tester.enterText(find.byType(TextField), "test message");
+    await tester.enterText(find.byType(EditableText), "test message");
     await tester.tap(find.byIcon(Icons.send), warnIfMissed: false);
     await tester.pump();
 
@@ -420,7 +422,7 @@ void main() {
     await tester.pumpWidget(_buildApp());
     await tester.pumpAndSettle();
 
-    await tester.enterText(find.byType(TextField), "test message");
+    await tester.enterText(find.byType(EditableText), "test message");
     await tester.tap(find.byIcon(Icons.send));
     await tester.pump();
 
@@ -435,7 +437,7 @@ void main() {
       findsOneWidget,
     );
     expect(find.byType(NewSessionScreen), findsNothing);
-    expect(find.byType(TextField), findsNothing);
+    expect(find.byType(EditableText), findsNothing);
   });
 
   testWidgets("does not show snackbar when auto-navigating after creating a session", (tester) async {
@@ -458,7 +460,7 @@ void main() {
 
     final loc = AppLocalizations.of(tester.element(find.byType(NewSessionScreen)))!;
 
-    await tester.enterText(find.byType(TextField), "test message");
+    await tester.enterText(find.byType(EditableText), "test message");
     await tester.tap(find.byIcon(Icons.send));
     await tester.pump();
 
@@ -490,7 +492,7 @@ void main() {
     await tester.pumpWidget(_buildApp());
     await tester.pumpAndSettle();
 
-    await tester.enterText(find.byType(TextField), "test message");
+    await tester.enterText(find.byType(EditableText), "test message");
     await tester.tap(find.byIcon(Icons.send));
     await tester.pump();
 
@@ -502,10 +504,10 @@ void main() {
     expect(find.byKey(const Key("new_session_loading_overlay")), findsNothing);
     // Error text now comes from the shared, localized ApiError mapping.
     expect(find.text("An unknown error occurred"), findsOneWidget);
-    expect(find.byType(TextField), findsOneWidget);
+    expect(find.byType(EditableText), findsOneWidget);
     expect(find.byIcon(Icons.send), findsOneWidget);
 
-    await tester.enterText(find.byType(TextField), "retry message");
+    await tester.enterText(find.byType(EditableText), "retry message");
     await tester.pump();
 
     expect(find.text("retry message"), findsOneWidget);
@@ -518,7 +520,7 @@ void main() {
     await tester.pumpWidget(_buildApp());
     await tester.pumpAndSettle();
 
-    await tester.enterText(find.byType(TextField), "half-written idea");
+    await tester.enterText(find.byType(EditableText), "half-written idea");
     await tester.pump();
 
     // Tear the screen down (e.g. the user navigates away) before creating a

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -6,6 +6,7 @@ import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:get_it/get_it.dart";
 import "package:go_router/go_router.dart";
+import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:mocktail/mocktail.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_mobile/capabilities/voice/voice_transcription_service.dart";
@@ -118,12 +119,12 @@ void main() {
     // the bar subtitle must collapse to empty — never a literal "null".
     expect(find.text("null"), findsNothing);
 
-    await tester.tap(find.widgetWithText(OutlinedButton, "xhigh"));
+    await tester.tap(find.widgetWithText(GlassButton, "xhigh"));
     await tester.pumpAndSettle();
 
-    expect(find.text("Variant"), findsOneWidget);
+    expect(find.widgetWithText(GlassMenuItem, "xhigh"), findsOneWidget);
 
-    await tester.tap(find.widgetWithText(ListTile, "xhigh"));
+    await tester.tap(find.widgetWithText(GlassMenuItem, "xhigh"));
     await tester.pumpAndSettle();
 
     verify(() => cubit.selectVariant(const SessionVariant(id: "xhigh"))).called(1);
@@ -168,14 +169,14 @@ void main() {
     await tester.pumpAndSettle();
 
     // Initially shows the selected variant.
-    expect(find.widgetWithText(OutlinedButton, "xhigh"), findsOneWidget);
+    expect(find.widgetWithText(GlassButton, "xhigh"), findsOneWidget);
 
     // Open variant picker.
-    await tester.tap(find.widgetWithText(OutlinedButton, "xhigh"));
+    await tester.tap(find.widgetWithText(GlassButton, "xhigh"));
     await tester.pumpAndSettle();
 
     // Select Default (null variant).
-    await tester.tap(find.widgetWithText(ListTile, "Default"));
+    await tester.tap(find.widgetWithText(GlassMenuItem, "Default"));
     await tester.pumpAndSettle();
 
     verify(() => cubit.selectVariant(null)).called(1);
@@ -186,8 +187,8 @@ void main() {
     await tester.pumpAndSettle();
 
     // The UI should now show "Default".
-    expect(find.widgetWithText(OutlinedButton, "Default"), findsOneWidget);
-    expect(find.widgetWithText(OutlinedButton, "xhigh"), findsNothing);
+    expect(find.widgetWithText(GlassButton, "Default"), findsOneWidget);
+    expect(find.widgetWithText(GlassButton, "xhigh"), findsNothing);
   });
 
   testWidgets("diff button navigates to diffs with the typed route", (tester) async {

--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -34,6 +34,15 @@ import "../../utils/color_extensions.dart";
 /// incompatible with a body scrolling behind a transparent bar. With it off,
 /// [GlassScaffold] insets the body below the bar instead.
 ///
+/// Set [reserveBarSpace] to `false` when the body owns its own scroll behind the
+/// bar (e.g. a reversed chat list) and manages the bar inset itself. The
+/// auto-injected top spacer is then skipped, so the body's first sliver fills
+/// the full height behind the bar; the body must pad its scrollable content down
+/// by `MediaQuery.paddingOf(context).top + PregoTopNavigation.barHeight` so it
+/// clears the bar at rest. Only meaningful with [extendBodyBehindBar] and, in
+/// practice, [inlineTitle] (a collapsing large title has nothing to reserve
+/// against here).
+///
 /// Set [inlineTitle] to `true` for a fixed, centred title (and [subtitle]) in
 /// the bar — the showcase's inline-title pattern (`_InlineTitleDemo`) — instead
 /// of the large title that collapses on scroll. Use it for screens whose body
@@ -65,6 +74,7 @@ class PregoGlassScaffold extends StatefulWidget {
     this.onRefresh,
     this.backgroundColor,
     this.extendBodyBehindBar = true,
+    this.reserveBarSpace = true,
   });
 
   /// Primary title — shown large below the bar and, once collapsed, inline.
@@ -115,6 +125,11 @@ class PregoGlassScaffold extends StatefulWidget {
   /// Whether the body scrolls behind the bar. Defaults to `true`. Set `false`
   /// for bodies with pinned slivers that must pin below the bar.
   final bool extendBodyBehindBar;
+
+  /// Whether to inject the top spacer that pushes the first content below the
+  /// bar. Defaults to `true`. Set `false` when the body owns its own scroll and
+  /// insets itself (see the class doc).
+  final bool reserveBarSpace;
 
   @override
   State<PregoGlassScaffold> createState() => _PregoGlassScaffoldState();
@@ -175,8 +190,10 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
       slivers: [
         // When the body scrolls behind the bar, reserve space so the title
         // clears it. When it doesn't, GlassScaffold already insets the body
-        // below the bar, so a spacer would double the gap.
-        if (extendBehind) SliverToBoxAdapter(child: SizedBox(height: topPad + topNav.preferredSize.height)),
+        // below the bar, so a spacer would double the gap. Skipped entirely when
+        // the body owns its own scroll and insets itself ([reserveBarSpace]).
+        if (extendBehind && widget.reserveBarSpace)
+          SliverToBoxAdapter(child: SizedBox(height: topPad + topNav.preferredSize.height)),
         // Inline mode shows a fixed title in the bar, so there is no large
         // title sliver to scroll away.
         if (!inline)

--- a/client/module_prego/lib/components/navigation/prego_nav_title.dart
+++ b/client/module_prego/lib/components/navigation/prego_nav_title.dart
@@ -35,8 +35,8 @@ class PregoNavTitle extends StatelessWidget {
   ///
   /// Those tokens are tuned for paragraph spacing; in this fixed-height bar they
   /// are pure dead space. With them, a title + subtitle stack measures
-  /// 28 + 24 = 52pt — only 2pt under the 54pt bar (`PregoTopNavigation`'s
-  /// `_appBarHeight`), so Android's slightly taller text metrics tip the
+  /// 28 + 24 = 52pt — only 2pt under the 54pt bar (`PregoTopNavigation.barHeight`),
+  /// so Android's slightly taller text metrics tip the
   /// [Column] into a bottom overflow. These are centred single lines, so a
   /// normal single-line leading (≈ the font's natural height) looks identical
   /// glyph-wise while bringing the stack to ~18 + 16 ×1.25 = 42.5pt, clearing

--- a/client/module_prego/lib/components/navigation/prego_top_navigation.dart
+++ b/client/module_prego/lib/components/navigation/prego_top_navigation.dart
@@ -94,8 +94,10 @@ class PregoTopNavigation extends StatelessWidget implements PreferredSizeWidget 
   /// [leading] nor [onBack] is supplied.
   final bool automaticallyImplyLeading;
 
-  /// [GlassAppBar]'s content height — matches the Figma design.
-  static const double _appBarHeight = 54;
+  /// [GlassAppBar]'s content height — matches the Figma design. Public so bodies
+  /// that own their own scroll behind the bar (see [PregoGlassScaffold] with
+  /// `reserveBarSpace: false`) can compute the top inset their content must clear.
+  static const double barHeight = 54;
 
   /// Scroll distance over which the large title collapses into the bar — the
   /// value used by the showcase's `_LargeTitleCollapseDemo`.
@@ -117,7 +119,7 @@ class PregoTopNavigation extends StatelessWidget implements PreferredSizeWidget 
   }
 
   @override
-  Size get preferredSize => const Size.fromHeight(_appBarHeight);
+  Size get preferredSize => const Size.fromHeight(barHeight);
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary

UI pass over the session detail / chat screen, applying glass styling and a set of quick fixes.

- Glass treatment for the chat screen and navigation (`prego_glass_scaffold`, `prego_top_navigation`, `prego_nav_title`)
- Reworked agent/model buttons and model picker sheet styling
- Session detail body, loaded view, message list, and prompt input layout fixes
- Scroll session detail messages behind the glass nav bar
- Fixed bottom safe area on the command picker
- Spacing/glow color tweaks on the glass chips

## Test plan

- [ ] Visually verify chat screen glass styling on device/simulator
- [ ] Confirm messages scroll correctly behind the glass nav bar
- [ ] Check command picker bottom safe area

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Glass-styled chat screen with a floating composer and inline top nav. In-place glass menus for agent/model/variant with a quick search that escalates to a full-screen picker; tightened scrolling so content flows behind the bar and above bottom controls.

- **New Features**
  - Floating composer with a soft fade; replaced TextField/buttons/chips with `GlassTextField`, `GlassIconButton`, and `GlassChip`.
  - Agent/model/variant pills open `GlassMenu` quick-picks; model search escalates to a full-screen `ModelPickerSheet` (`fullScreen`, `autofocusSearch`) backed by provider-grouped sections.
  - Messages scroll behind the transparent bar; added `reserveBarSpace` to `PregoGlassScaffold`, use `PregoTopNavigation.barHeight`, and pass `topInset`/`bottomInset` to the message list (`JumpToEdgePill.bottomInset` is now required).

- **Bug Fixes**
  - Kept the background-tasks bar and queued messages stacked above the floating composer; newest messages inset under the measured bottom cluster (read-only forces bottom inset to 0).
  - Fixed bottom safe area in the command picker by disabling sheet padding and adding home-indicator scroll padding with `EdgeInsetsDirectional`; full-screen model picker sizes correctly with the keyboard using granular `MediaQuery` getters.
  - Restored accessible labels for glass icon buttons via `Tooltip`; fixed composer padding on the new-session screen; updated widget tests to target `EditableText`, `GlassButton`, and `GlassMenuItem`.

<sup>Written for commit 8d7272dd50633f614b1c217347c13e94ed2ef333. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

