### PR TITLE
feat(bridge): supervised-mode control-channel skeleton (Phase 1, PR 1.1)

### DIFF
--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -115,7 +115,12 @@ class RunCommand extends cli.Command<void> {
         defaultsTo: 'info',
         allowed: ['verbose', 'debug', 'info', 'warning', 'error'],
         help: 'Minimum log level',
-      );
+      )
+      // Supervised mode: the desktop GUI passes the loopback control-channel
+      // URL here. Hidden because it is an internal GUI↔helper contract, not a
+      // user-facing flag. The per-spawn secret is delivered off-argv (stdin),
+      // never as a flag (ADR A8). Absent ⇒ standalone behaviour is unchanged.
+      ..addOption('control-url', hide: true, help: 'Internal: supervised-mode control channel URL');
   }
 
   @override

--- a/bridge/app/lib/src/api/control_secret_api.dart
+++ b/bridge/app/lib/src/api/control_secret_api.dart
@@ -1,0 +1,32 @@
+import "dart:async";
+import "dart:convert";
+
+/// Layer-1 data access that reads the per-spawn control-channel secret from an
+/// inherited input stream (the supervised child's stdin pipe).
+///
+/// The secret is delivered off-argv (ADR A8): argv is world-readable on common
+/// platforms and this secret authenticates the control channel that issues
+/// bearer tokens, so it must never appear on the command line. The GUI writes
+/// `<secret>\n` to the child's stdin at spawn; this reads the first line.
+class ControlSecretApi {
+  final Stream<List<int>> _input;
+
+  ControlSecretApi({required Stream<List<int>> input}) : _input = input;
+
+  /// Reads and returns the trimmed secret (the first line of the input stream).
+  ///
+  /// Throws [TimeoutException] if no line arrives within [timeout], or
+  /// [StateError] if the stream ends with no line or the line is blank.
+  Future<String> readSecret({Duration timeout = const Duration(seconds: 10)}) async {
+    final firstLine = await _input
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .first
+        .timeout(timeout);
+    final secret = firstLine.trim();
+    if (secret.isEmpty) {
+      throw StateError("Control-channel secret was empty");
+    }
+    return secret;
+  }
+}

--- a/bridge/app/lib/src/bridge/runtime/bridge_cli_options.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_cli_options.dart
@@ -7,13 +7,24 @@ class BridgeCliOptions {
   final int? debugPort;
   final String logLevelName;
 
+  /// Loopback control-channel URL supplied by a GUI supervisor via
+  /// `--control-url`. `null` in standalone mode. See [isSupervised].
+  final String? controlUrl;
+
   const BridgeCliOptions({
     required this.cliArgs,
     required this.relayUrl,
     required this.authBackendUrl,
     required this.debugPort,
     required this.logLevelName,
+    required this.controlUrl,
   });
+
+  /// Whether the bridge runs under a GUI supervisor (the desktop app). True
+  /// exactly when `--control-url` was supplied; in that mode the bridge
+  /// connects the loopback control channel and the GUI is its token authority
+  /// and lifecycle owner. Absent ⇒ unchanged standalone CLI behaviour.
+  bool get isSupervised => controlUrl != null;
 
   factory BridgeCliOptions.fromArgResults({
     required List<String> cliArgs,
@@ -29,12 +40,19 @@ class BridgeCliOptions {
     );
     final debugPortRaw = results["debug-port"] as String;
 
+    // Supervised-only option: trim and treat blank as absent. Do NOT validate
+    // it here (no URI parse) — strict parse-time validation would risk failing
+    // a standalone invocation; it is parsed only when supervised mode is active.
+    final controlUrlRaw = (results["control-url"] as String?)?.trim();
+    final controlUrl = (controlUrlRaw != null && controlUrlRaw.isNotEmpty) ? controlUrlRaw : null;
+
     return BridgeCliOptions(
       cliArgs: cliArgs,
       relayUrl: results["relay"] as String,
       authBackendUrl: authBackendUrl,
       debugPort: debugPortRaw.isNotEmpty ? int.tryParse(debugPortRaw) : null,
       logLevelName: results["log-level"] as String,
+      controlUrl: controlUrl,
     );
   }
 

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -3,6 +3,7 @@ import "dart:io" as io;
 
 import "package:clock/clock.dart";
 import "package:http/http.dart" as http;
+import "package:meta/meta.dart";
 import "package:path/path.dart" as path;
 import "package:rxdart/rxdart.dart";
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show ArchiveExtractor, BinaryDownloadClient, ChecksumValidator;
@@ -446,28 +447,50 @@ class BridgeRuntimeRunner {
     }
   }
 
-  /// Supervised-mode bootstrap: read the per-spawn secret off-argv (stdin),
-  /// open the GUI's loopback control channel, and arm the parent-loss exit
-  /// policy (ADR A9). Both the client and the loss listener are torn down via
-  /// the shutdown coordinator. Only ever called when `--control-url` is set.
+  /// Whether [url] is an acceptable supervised control-channel endpoint: a
+  /// loopback host over ws/wss. The GUI hosts the control channel on loopback,
+  /// so anything else is rejected — the bridge fails closed rather than sending
+  /// the per-spawn bearer secret to a non-loopback endpoint (defense in depth,
+  /// since `--control-url` is GUI-supplied and could be misconfigured/tampered).
+  @visibleForTesting
+  static bool isLoopbackControlUrl(Uri url) {
+    if (url.scheme != "ws" && url.scheme != "wss") return false;
+    final host = url.host.toLowerCase();
+    return host == "127.0.0.1" || host == "localhost" || host == "::1";
+  }
+
+  /// Supervised-mode bootstrap: validate the loopback control URL, read the
+  /// per-spawn secret off-argv (stdin), arm the parent-loss exit policy (ADR
+  /// A9), then connect the GUI's loopback control channel. Both the client and
+  /// the loss listener are torn down via the shutdown coordinator. Only ever
+  /// called when `--control-url` is set.
   static Future<void> _startSupervisedControlChannel({
     required BridgeCliOptions options,
     required BridgeShutdownCoordinator shutdownCoordinator,
   }) async {
+    final url = Uri.parse(options.controlUrl!);
+    if (!isLoopbackControlUrl(url)) {
+      throw StateError(
+        "Refusing supervised control URL '${options.controlUrl}': must be a loopback ws/wss endpoint",
+      );
+    }
+
     final secret = await ControlSecretApi(input: io.stdin).readSecret();
-    final controlChannelClient = ControlChannelClient(
-      url: Uri.parse(options.controlUrl!),
-      secret: secret,
-    );
-    await controlChannelClient.connect();
+    final controlChannelClient = ControlChannelClient(url: url, secret: secret);
     shutdownCoordinator.add(disposable: controlChannelClient.dispose);
 
+    // Subscribe the parent-loss policy BEFORE connecting: the first
+    // `disconnected` transition must never be missed (reconnect failures don't
+    // re-emit it), otherwise a GUI crash during this startup window would leave
+    // the ADR A9 grace timer un-armed and the helper running with no parent.
     final lossListener = ControlChannelLossListener(
       connectionState: controlChannelClient.connectionState,
       exitProcess: io.exit,
     );
     lossListener.start();
     shutdownCoordinator.add(disposable: lossListener.dispose);
+
+    await controlChannelClient.connect();
   }
 
   /// Runs the plugin's runtime-provisioning phase, rendering progress and

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -118,6 +118,14 @@ class BridgeRuntimeRunner {
   /// shutdown coordinator's backstop is sized from it (budget + slack).
   static const Duration _pluginShutdownBudget = Duration(seconds: 10);
 
+  /// How long the control-channel parent-loss exit waits for a graceful
+  /// shutdown before forcing exit with the abnormal loss code. Kept BELOW the
+  /// coordinator's backstop (ordered budget `_pluginShutdownBudget` + 10s slack)
+  /// so this path always exits non-zero — a control-channel loss must never be
+  /// reported to the supervisor as a clean (0) exit, even if the plugin stop
+  /// hangs and the backstop would otherwise fire with the neutral code 0.
+  static const Duration _controlLossShutdownBudget = Duration(seconds: 15);
+
   static Future<int> run({
     required BridgeCliOptions options,
     required PluginConfig pluginConfig,
@@ -505,10 +513,15 @@ class BridgeRuntimeRunner {
     required BridgeShutdownCoordinator shutdownCoordinator,
     required int code,
   }) async {
+    // Bound the graceful stop below the coordinator's own backstop so this path
+    // always exits with the abnormal loss `code`. If the stop hangs, our
+    // timeout fires (and we exit non-zero) before the backstop would exit with
+    // its neutral code 0. The underlying shutdown future keeps running, but the
+    // process is exiting anyway.
     try {
-      await shutdownCoordinator.shutdown();
+      await shutdownCoordinator.shutdown().timeout(_controlLossShutdownBudget);
     } catch (error, stackTrace) {
-      Log.w("[control] graceful shutdown after control-channel loss failed", error, stackTrace);
+      Log.w("[control] graceful shutdown after control-channel loss did not finish cleanly", error, stackTrace);
     }
     io.exit(code);
   }

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -25,6 +25,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
         StartAbortSignal;
 
 import "../../api/bridge_settings_api.dart";
+import "../../api/control_secret_api.dart";
 import "../../auth/bridge_registration_api.dart";
 import "../../auth/bridge_registration_repository.dart";
 import "../../auth/bridge_registration_service.dart";
@@ -34,6 +35,8 @@ import "../../auth/login_oauth_api.dart";
 import "../../auth/login_oauth_service.dart";
 import "../../auth/token.dart";
 import "../../auth/token_manager.dart";
+import "../../control/control_channel_loss_listener.dart";
+import "../../foundation/control_channel_client.dart";
 import "../../repositories/bridge_settings_repository.dart";
 import "../../server/api/loopback_port_api.dart";
 import "../../server/api/runtime_file_api.dart";
@@ -194,6 +197,16 @@ class BridgeRuntimeRunner {
     );
 
     try {
+      // Supervised mode (desktop GUI): bring up the loopback control channel
+      // before anything else so the GUI sees the helper connect promptly. Every
+      // step here is gated by `--control-url`; standalone startup is unchanged.
+      if (options.isSupervised) {
+        await _startSupervisedControlChannel(
+          options: options,
+          shutdownCoordinator: shutdownCoordinator,
+        );
+      }
+
       final runtimeOwnershipError = unsupportedPackageRuntimeMessage(
         executablePath: io.Platform.resolvedExecutable,
         managedExecutablePath: managedRuntimePaths.binaryPath,
@@ -431,6 +444,30 @@ class BridgeRuntimeRunner {
     } finally {
       await shutdownCoordinator.shutdown();
     }
+  }
+
+  /// Supervised-mode bootstrap: read the per-spawn secret off-argv (stdin),
+  /// open the GUI's loopback control channel, and arm the parent-loss exit
+  /// policy (ADR A9). Both the client and the loss listener are torn down via
+  /// the shutdown coordinator. Only ever called when `--control-url` is set.
+  static Future<void> _startSupervisedControlChannel({
+    required BridgeCliOptions options,
+    required BridgeShutdownCoordinator shutdownCoordinator,
+  }) async {
+    final secret = await ControlSecretApi(input: io.stdin).readSecret();
+    final controlChannelClient = ControlChannelClient(
+      url: Uri.parse(options.controlUrl!),
+      secret: secret,
+    );
+    await controlChannelClient.connect();
+    shutdownCoordinator.add(disposable: controlChannelClient.dispose);
+
+    final lossListener = ControlChannelLossListener(
+      connectionState: controlChannelClient.connectionState,
+      exitProcess: io.exit,
+    );
+    lossListener.start();
+    shutdownCoordinator.add(disposable: lossListener.dispose);
   }
 
   /// Runs the plugin's runtime-provisioning phase, rendering progress and

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -485,12 +485,32 @@ class BridgeRuntimeRunner {
     // the ADR A9 grace timer un-armed and the helper running with no parent.
     final lossListener = ControlChannelLossListener(
       connectionState: controlChannelClient.connectionState,
-      exitProcess: io.exit,
+      // Don't hard-exit straight from the loss timer: that bypasses the ordered
+      // plugin stop in the shutdown coordinator and could orphan an owned
+      // backend runtime (e.g. OpenCode). Shut down gracefully first, then exit.
+      exitProcess: (code) => unawaited(_shutdownThenExit(shutdownCoordinator: shutdownCoordinator, code: code)),
     );
     lossListener.start();
     shutdownCoordinator.add(disposable: lossListener.dispose);
 
     await controlChannelClient.connect();
+  }
+
+  /// Graceful termination for the control-channel parent-loss policy (ADR A9):
+  /// run the ordered shutdown (which stops the plugin and any owned runtime)
+  /// before exiting, so a hard exit from the loss timer cannot orphan the
+  /// backend process. The coordinator's own backstop bounds a hung stop. The
+  /// precise exit code the GUI observes is finalized in Phase 2 (PR 2.7).
+  static Future<void> _shutdownThenExit({
+    required BridgeShutdownCoordinator shutdownCoordinator,
+    required int code,
+  }) async {
+    try {
+      await shutdownCoordinator.shutdown();
+    } catch (error, stackTrace) {
+      Log.w("[control] graceful shutdown after control-channel loss failed", error, stackTrace);
+    }
+    io.exit(code);
   }
 
   /// Runs the plugin's runtime-provisioning phase, rendering progress and

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -118,22 +118,21 @@ class BridgeRuntimeRunner {
   /// shutdown coordinator's backstop is sized from it (budget + slack).
   static const Duration _pluginShutdownBudget = Duration(seconds: 10);
 
-  /// How long the control-channel parent-loss exit waits for a graceful
-  /// shutdown before forcing exit with the abnormal loss code. Kept BELOW the
-  /// coordinator's backstop (ordered budget `_pluginShutdownBudget` + 10s slack)
-  /// so this path always exits non-zero — a control-channel loss must never be
-  /// reported to the supervisor as a clean (0) exit, even if the plugin stop
-  /// hangs and the backstop would otherwise fire with the neutral code 0.
-  static const Duration _controlLossShutdownBudget = Duration(seconds: 15);
-
   static Future<int> run({
     required BridgeCliOptions options,
     required PluginConfig pluginConfig,
     required String pluginId,
   }) async {
     final failureLatch = PluginFailureLatch();
+    // Set when a control-channel loss triggers shutdown, so BOTH the explicit
+    // exit and the coordinator backstop report the abnormal code. A loss must
+    // never look like a clean (0) exit, even if the stop hangs — and because
+    // the backstop fires at (ordered budget + slack), its timing varies with
+    // how many ordered steps are registered (none yet before the plugin
+    // starts), so a fixed timeout race against it is not reliable.
+    int? supervisedLossExitCode;
     final shutdownCoordinator = BridgeShutdownCoordinator(
-      backstopExitCode: () => failureLatch.failure == null ? 0 : 1,
+      backstopExitCode: () => supervisedLossExitCode ?? (failureLatch.failure == null ? 0 : 1),
     );
     final subscriptions = CompositeSubscription();
     shutdownCoordinator.add(disposable: subscriptions.cancel);
@@ -213,6 +212,7 @@ class BridgeRuntimeRunner {
         await _startSupervisedControlChannel(
           options: options,
           shutdownCoordinator: shutdownCoordinator,
+          requestAbnormalExit: (code) => supervisedLossExitCode = code,
         );
       }
 
@@ -475,6 +475,7 @@ class BridgeRuntimeRunner {
   static Future<void> _startSupervisedControlChannel({
     required BridgeCliOptions options,
     required BridgeShutdownCoordinator shutdownCoordinator,
+    required void Function(int code) requestAbnormalExit,
   }) async {
     final url = Uri.parse(options.controlUrl!);
     if (!isLoopbackControlUrl(url)) {
@@ -495,8 +496,13 @@ class BridgeRuntimeRunner {
       connectionState: controlChannelClient.connectionState,
       // Don't hard-exit straight from the loss timer: that bypasses the ordered
       // plugin stop in the shutdown coordinator and could orphan an owned
-      // backend runtime (e.g. OpenCode). Shut down gracefully first, then exit.
-      exitProcess: (code) => unawaited(_shutdownThenExit(shutdownCoordinator: shutdownCoordinator, code: code)),
+      // backend runtime (e.g. OpenCode). Record the abnormal code (so the
+      // coordinator backstop reports it too if the stop hangs), then shut down
+      // gracefully before exiting.
+      exitProcess: (code) {
+        requestAbnormalExit(code);
+        unawaited(_shutdownThenExit(shutdownCoordinator: shutdownCoordinator, code: code));
+      },
     );
     lossListener.start();
     shutdownCoordinator.add(disposable: lossListener.dispose);
@@ -507,21 +513,19 @@ class BridgeRuntimeRunner {
   /// Graceful termination for the control-channel parent-loss policy (ADR A9):
   /// run the ordered shutdown (which stops the plugin and any owned runtime)
   /// before exiting, so a hard exit from the loss timer cannot orphan the
-  /// backend process. The coordinator's own backstop bounds a hung stop. The
+  /// backend process. If the stop hangs, the coordinator backstop fires — and
+  /// because the loss code was recorded via `requestAbnormalExit`, the backstop
+  /// reports that abnormal code, not the neutral 0, so a loss is never seen as a
+  /// clean exit regardless of the backstop's (step-count-dependent) timing. The
   /// precise exit code the GUI observes is finalized in Phase 2 (PR 2.7).
   static Future<void> _shutdownThenExit({
     required BridgeShutdownCoordinator shutdownCoordinator,
     required int code,
   }) async {
-    // Bound the graceful stop below the coordinator's own backstop so this path
-    // always exits with the abnormal loss `code`. If the stop hangs, our
-    // timeout fires (and we exit non-zero) before the backstop would exit with
-    // its neutral code 0. The underlying shutdown future keeps running, but the
-    // process is exiting anyway.
     try {
-      await shutdownCoordinator.shutdown().timeout(_controlLossShutdownBudget);
+      await shutdownCoordinator.shutdown();
     } catch (error, stackTrace) {
-      Log.w("[control] graceful shutdown after control-channel loss did not finish cleanly", error, stackTrace);
+      Log.w("[control] graceful shutdown after control-channel loss failed", error, stackTrace);
     }
     io.exit(code);
   }

--- a/bridge/app/lib/src/control/control_channel_loss_listener.dart
+++ b/bridge/app/lib/src/control/control_channel_loss_listener.dart
@@ -48,7 +48,12 @@ class ControlChannelLossListener {
     _disposed = true;
     _graceTimer?.cancel();
     _graceTimer = null;
-    await _subscription?.cancel();
+    // Isolate the cancel so a failure still lets teardown finish.
+    try {
+      await _subscription?.cancel();
+    } on Object catch (error, stackTrace) {
+      Log.w("[control] failed to cancel connection-state subscription", error, stackTrace);
+    }
     _subscription = null;
   }
 

--- a/bridge/app/lib/src/control/control_channel_loss_listener.dart
+++ b/bridge/app/lib/src/control/control_channel_loss_listener.dart
@@ -1,0 +1,71 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
+import "../foundation/control_channel_client.dart";
+
+/// Exit code used when the control channel stays lost past the grace period. A
+/// non-zero code marks an abnormal termination; if the GUI is still alive it
+/// treats this like a crash and may respawn the bridge. The GUI's full
+/// exit-code policy is defined later (Phase 2 / PR 1.7).
+const int controlChannelLostExitCode = 1;
+
+/// Terminates the supervised bridge if the control channel stays down past a
+/// grace period (ADR A9). When the GUI crashes or is force-quit, the OS does
+/// not reliably kill the child, so the helper must not linger invisibly with a
+/// live token.
+///
+/// It observes [ControlChannelClient.connectionState]: a `disconnected` event
+/// arms a one-shot grace timer; a `connected` event (the client reconnected in
+/// time) cancels it; if the timer elapses while still disconnected, the process
+/// exits. A clean [ControlChannelClient.dispose] closes the state stream (done)
+/// WITHOUT a `disconnected` event, so a normal shutdown never triggers an exit.
+class ControlChannelLossListener {
+  final Stream<ControlChannelConnectionState> _connectionState;
+  final void Function(int code) _exitProcess;
+  final Duration _gracePeriod;
+  final int _exitCode;
+
+  StreamSubscription<ControlChannelConnectionState>? _subscription;
+  Timer? _graceTimer;
+  bool _disposed = false;
+
+  ControlChannelLossListener({
+    required Stream<ControlChannelConnectionState> connectionState,
+    required void Function(int code) exitProcess,
+    Duration gracePeriod = const Duration(seconds: 5),
+    int exitCode = controlChannelLostExitCode,
+  }) : _connectionState = connectionState,
+       _exitProcess = exitProcess,
+       _gracePeriod = gracePeriod,
+       _exitCode = exitCode;
+
+  void start() {
+    _subscription ??= _connectionState.listen(_handleState);
+  }
+
+  Future<void> dispose() async {
+    _disposed = true;
+    _graceTimer?.cancel();
+    _graceTimer = null;
+    await _subscription?.cancel();
+    _subscription = null;
+  }
+
+  void _handleState(ControlChannelConnectionState state) {
+    if (_disposed) return;
+    switch (state) {
+      case ControlChannelConnectionState.connected:
+        _graceTimer?.cancel();
+        _graceTimer = null;
+      case ControlChannelConnectionState.disconnected:
+        _graceTimer ??= Timer(_gracePeriod, _onGraceElapsed);
+    }
+  }
+
+  void _onGraceElapsed() {
+    if (_disposed) return;
+    Log.w("[control] control channel lost for ${_gracePeriod.inSeconds}s — exiting supervised bridge");
+    _exitProcess(_exitCode);
+  }
+}

--- a/bridge/app/lib/src/foundation/control_channel_client.dart
+++ b/bridge/app/lib/src/foundation/control_channel_client.dart
@@ -73,7 +73,7 @@ class ControlChannelClient {
     _active = true;
     _generation++;
     try {
-      await _openChannel();
+      await _openChannel(_generation);
     } catch (_) {
       _active = false;
       rethrow;
@@ -94,7 +94,12 @@ class ControlChannelClient {
     _generation++;
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
-    await _socketSubscription?.cancel();
+    // Isolate every teardown step: a failure in one must not skip the rest.
+    try {
+      await _socketSubscription?.cancel();
+    } on Object catch (error, stackTrace) {
+      Log.w("[control][ws] failed to cancel subscription during dispose", error, stackTrace);
+    }
     _socketSubscription = null;
     final channel = _channel;
     _channel = null;
@@ -103,15 +108,23 @@ class ControlChannelClient {
         await channel.sink.close().timeout(const Duration(seconds: 3));
       } on TimeoutException {
         Log.w("[control][ws] close handshake timed out — connection abandoned");
-      } catch (error, stackTrace) {
+      } on Object catch (error, stackTrace) {
         Log.w("[control][ws] close failed — connection abandoned", error, stackTrace);
       }
     }
-    await _inbound.close();
-    await _connectionState.close();
+    try {
+      await _inbound.close();
+    } on Object catch (error, stackTrace) {
+      Log.w("[control][ws] failed to close inbound stream", error, stackTrace);
+    }
+    try {
+      await _connectionState.close();
+    } on Object catch (error, stackTrace) {
+      Log.w("[control][ws] failed to close connectionState stream", error, stackTrace);
+    }
   }
 
-  Future<void> _openChannel() async {
+  Future<void> _openChannel(int generation) async {
     final channel = IOWebSocketChannel.connect(
       _url,
       headers: <String, dynamic>{"Authorization": "Bearer $_secret"},
@@ -121,12 +134,16 @@ class ControlChannelClient {
     } catch (_) {
       // Clean up the half-open channel so a failed/timed-out attempt never
       // leaves a zombie connection lingering.
-      try {
-        await channel.sink.close().timeout(const Duration(seconds: 1));
-      } catch (closeError, closeStackTrace) {
-        Log.w("[control][ws] failed to clean up channel after a failed connect", closeError, closeStackTrace);
-      }
+      await _closeChannelQuietly(channel, "after a failed connect");
       rethrow;
+    }
+
+    // Liveness guard: dispose() or a newer connect generation may have run while
+    // we awaited the handshake. Never install a socket on a disposed/superseded
+    // client — that would leak a live WebSocket past dispose.
+    if (!_active || generation != _generation) {
+      await _closeChannelQuietly(channel, "on a superseded connect");
+      return;
     }
 
     _channel = channel;
@@ -140,6 +157,14 @@ class ControlChannelClient {
       onDone: () => _handleDisconnect(channel),
       cancelOnError: false,
     );
+  }
+
+  Future<void> _closeChannelQuietly(IOWebSocketChannel channel, String context) async {
+    try {
+      await channel.sink.close().timeout(const Duration(seconds: 1));
+    } catch (error, stackTrace) {
+      Log.w("[control][ws] failed to close channel $context", error, stackTrace);
+    }
   }
 
   void _handleFrame(dynamic frame) {
@@ -159,9 +184,19 @@ class ControlChannelClient {
     // already been replaced by a reconnect (onError can be followed by onDone
     // for the same socket — only the current channel may drive a reconnect).
     if (!_active || !identical(_channel, channel)) return;
-    unawaited(_socketSubscription?.cancel());
+    final subscription = _socketSubscription;
     _socketSubscription = null;
     _channel = null;
+    if (subscription != null) {
+      // unawaited alone does not consume errors; a throwing cancel would
+      // surface as an uncaught async error. Future.sync also catches a
+      // synchronous throw from cancel().
+      unawaited(
+        Future.sync(subscription.cancel).catchError((Object error, StackTrace stackTrace) {
+          Log.w("[control][ws] failed to cancel subscription on disconnect", error, stackTrace);
+        }),
+      );
+    }
     _emitConnectionState(ControlChannelConnectionState.disconnected);
     _scheduleReconnect(_initialReconnectDelay, _generation);
   }
@@ -171,7 +206,7 @@ class ControlChannelClient {
     _reconnectTimer = Timer(delay, () async {
       if (!_active || generation != _generation) return;
       try {
-        await _openChannel();
+        await _openChannel(generation);
       } catch (error, stackTrace) {
         if (!_active || generation != _generation) return;
         Log.w("[control][ws] reconnect attempt failed; backing off", error, stackTrace);

--- a/bridge/app/lib/src/foundation/control_channel_client.dart
+++ b/bridge/app/lib/src/foundation/control_channel_client.dart
@@ -1,0 +1,192 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+import "package:web_socket_channel/io.dart";
+
+/// Live connection state of the loopback control channel.
+///
+/// This is internal lifecycle state, NOT a wire-protocol type — the
+/// control-protocol DTOs live in `sesori_shared` (added in a later PR).
+enum ControlChannelConnectionState { connected, disconnected }
+
+/// Layer-0 transport for the GUI-hosted loopback control channel used in
+/// supervised mode. It is a dumb duplex WebSocket pipe: it connects,
+/// auto-reconnects with backoff while it is alive, surfaces inbound text
+/// frames, and sends outbound text frames. It performs NO message parsing or
+/// routing — higher layers interpret the frames.
+///
+/// The per-spawn secret authenticates the bridge to the GUI's control server.
+/// It travels as an `Authorization: Bearer` header on the WebSocket upgrade
+/// request — never on argv (ADR A8) and never as an application message.
+///
+/// Reconnect ownership differs from [RelayClient] (whose backoff loop lives in
+/// the orchestrator): the GUI may come and go while the bridge stays up, so the
+/// control client owns its own reconnect loop. The decision to give up after a
+/// sustained outage is NOT made here — it belongs to a separate lifecycle
+/// policy (`ControlChannelLossListener`, ADR A9) that observes
+/// [connectionState].
+class ControlChannelClient {
+  final Uri _url;
+  final String _secret;
+  final Duration _connectTimeout;
+  final Duration _initialReconnectDelay;
+  final Duration _maxReconnectDelay;
+
+  final StreamController<String> _inbound = StreamController<String>.broadcast();
+  final StreamController<ControlChannelConnectionState> _connectionState =
+      StreamController<ControlChannelConnectionState>.broadcast();
+
+  IOWebSocketChannel? _channel;
+  StreamSubscription<dynamic>? _socketSubscription;
+  Timer? _reconnectTimer;
+  bool _active = false;
+  int _generation = 0;
+
+  ControlChannelClient({
+    required Uri url,
+    required String secret,
+    Duration connectTimeout = const Duration(seconds: 15),
+    Duration initialReconnectDelay = const Duration(seconds: 1),
+    Duration maxReconnectDelay = const Duration(seconds: 30),
+  }) : _url = url,
+       _secret = secret,
+       _connectTimeout = connectTimeout,
+       _initialReconnectDelay = initialReconnectDelay,
+       _maxReconnectDelay = maxReconnectDelay;
+
+  /// Raw inbound text frames from the control server. No parsing is performed.
+  Stream<String> get inbound => _inbound.stream;
+
+  /// Live connection-state transitions (connected / disconnected). A real drop
+  /// emits [ControlChannelConnectionState.disconnected]; an intentional
+  /// [dispose] closes this stream (done) WITHOUT emitting `disconnected`, so a
+  /// loss policy can distinguish an outage from a clean shutdown.
+  Stream<ControlChannelConnectionState> get connectionState => _connectionState.stream;
+
+  /// Opens the initial connection. Throws if the first attempt fails (the GUI
+  /// control server is not listening, or the handshake times out), mirroring
+  /// [RelayClient.connect]. Once connected, subsequent drops are recovered in
+  /// the background with exponential backoff until [dispose].
+  Future<void> connect() async {
+    if (_active) return;
+    _active = true;
+    _generation++;
+    try {
+      await _openChannel();
+    } catch (_) {
+      _active = false;
+      rethrow;
+    }
+  }
+
+  /// Sends a raw text frame. Throws [StateError] if not currently connected.
+  void send(String frame) {
+    final channel = _channel;
+    if (channel == null) {
+      throw StateError("Control channel is not connected");
+    }
+    channel.sink.add(frame);
+  }
+
+  Future<void> dispose() async {
+    _active = false;
+    _generation++;
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
+    await _socketSubscription?.cancel();
+    _socketSubscription = null;
+    final channel = _channel;
+    _channel = null;
+    if (channel != null) {
+      try {
+        await channel.sink.close().timeout(const Duration(seconds: 3));
+      } on TimeoutException {
+        Log.w("[control][ws] close handshake timed out — connection abandoned");
+      } catch (error, stackTrace) {
+        Log.w("[control][ws] close failed — connection abandoned", error, stackTrace);
+      }
+    }
+    await _inbound.close();
+    await _connectionState.close();
+  }
+
+  Future<void> _openChannel() async {
+    final channel = IOWebSocketChannel.connect(
+      _url,
+      headers: <String, dynamic>{"Authorization": "Bearer $_secret"},
+    );
+    try {
+      await channel.ready.timeout(_connectTimeout);
+    } catch (_) {
+      // Clean up the half-open channel so a failed/timed-out attempt never
+      // leaves a zombie connection lingering.
+      try {
+        await channel.sink.close().timeout(const Duration(seconds: 1));
+      } catch (closeError, closeStackTrace) {
+        Log.w("[control][ws] failed to clean up channel after a failed connect", closeError, closeStackTrace);
+      }
+      rethrow;
+    }
+
+    _channel = channel;
+    _emitConnectionState(ControlChannelConnectionState.connected);
+    _socketSubscription = channel.stream.listen(
+      _handleFrame,
+      onError: (Object error, StackTrace stackTrace) {
+        Log.w("[control][ws] socket error", error, stackTrace);
+        _handleDisconnect(channel);
+      },
+      onDone: () => _handleDisconnect(channel),
+      cancelOnError: false,
+    );
+  }
+
+  void _handleFrame(dynamic frame) {
+    if (frame is String) {
+      _inbound.add(frame);
+      return;
+    }
+    if (frame is List<int>) {
+      _inbound.add(utf8.decode(frame));
+      return;
+    }
+    Log.w("[control][ws] ignoring unsupported frame type: ${frame.runtimeType}");
+  }
+
+  void _handleDisconnect(IOWebSocketChannel channel) {
+    // Ignore drops once disposed, and stale callbacks from a channel that has
+    // already been replaced by a reconnect (onError can be followed by onDone
+    // for the same socket — only the current channel may drive a reconnect).
+    if (!_active || !identical(_channel, channel)) return;
+    unawaited(_socketSubscription?.cancel());
+    _socketSubscription = null;
+    _channel = null;
+    _emitConnectionState(ControlChannelConnectionState.disconnected);
+    _scheduleReconnect(_initialReconnectDelay, _generation);
+  }
+
+  void _scheduleReconnect(Duration delay, int generation) {
+    _reconnectTimer?.cancel();
+    _reconnectTimer = Timer(delay, () async {
+      if (!_active || generation != _generation) return;
+      try {
+        await _openChannel();
+      } catch (error, stackTrace) {
+        if (!_active || generation != _generation) return;
+        Log.w("[control][ws] reconnect attempt failed; backing off", error, stackTrace);
+        _scheduleReconnect(_nextBackoff(delay), generation);
+      }
+    });
+  }
+
+  Duration _nextBackoff(Duration delay) {
+    final doubled = delay * 2;
+    return doubled > _maxReconnectDelay ? _maxReconnectDelay : doubled;
+  }
+
+  void _emitConnectionState(ControlChannelConnectionState state) {
+    if (_connectionState.isClosed) return;
+    _connectionState.add(state);
+  }
+}

--- a/bridge/app/test/api/control_secret_api_test.dart
+++ b/bridge/app/test/api/control_secret_api_test.dart
@@ -1,0 +1,41 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:sesori_bridge/src/api/control_secret_api.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ControlSecretApi", () {
+    test("reads the first line of the input stream as the secret", () async {
+      final api = ControlSecretApi(
+        input: Stream<List<int>>.fromIterable([utf8.encode("my-secret\nignored\n")]),
+      );
+      expect(await api.readSecret(), equals("my-secret"));
+    });
+
+    test("trims surrounding whitespace from the secret line", () async {
+      final api = ControlSecretApi(
+        input: Stream<List<int>>.fromIterable([utf8.encode("  spaced-secret  \n")]),
+      );
+      expect(await api.readSecret(), equals("spaced-secret"));
+    });
+
+    test("throws a StateError when the secret line is blank", () async {
+      final api = ControlSecretApi(
+        input: Stream<List<int>>.fromIterable([utf8.encode("   \n")]),
+      );
+      await expectLater(api.readSecret(), throwsA(isA<StateError>()));
+    });
+
+    test("times out when no line ever arrives", () async {
+      final controller = StreamController<List<int>>();
+      addTearDown(controller.close);
+      final api = ControlSecretApi(input: controller.stream);
+
+      await expectLater(
+        api.readSecret(timeout: const Duration(milliseconds: 50)),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
+  });
+}

--- a/bridge/app/test/bridge/runtime/bridge_cli_options_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_cli_options_test.dart
@@ -20,9 +20,49 @@ void main() {
 
     expect(options.debugPort, 8080);
   });
+
+  group("supervised mode (--control-url)", () {
+    test("is standalone when --control-url is absent", () {
+      final options = _parseOptions(args: const []);
+
+      expect(options.controlUrl, isNull);
+      expect(options.isSupervised, isFalse);
+    });
+
+    test("is supervised when --control-url is provided", () {
+      final options = _parseOptions(args: const ["--control-url", "ws://127.0.0.1:54321/control"]);
+
+      expect(options.controlUrl, equals("ws://127.0.0.1:54321/control"));
+      expect(options.isSupervised, isTrue);
+    });
+
+    test("treats a blank --control-url as standalone", () {
+      final options = _parseOptions(args: const ["--control-url", "   "]);
+
+      expect(options.controlUrl, isNull);
+      expect(options.isSupervised, isFalse);
+    });
+
+    test("trims the control URL", () {
+      final options = _parseOptions(args: const ["--control-url", "  ws://127.0.0.1:9/ctrl  "]);
+
+      expect(options.controlUrl, equals("ws://127.0.0.1:9/ctrl"));
+    });
+
+    test("leaves the standalone options unchanged", () {
+      final options = _parseOptions(args: const ["--relay", "wss://example.test/relay", "--log-level", "debug"]);
+
+      expect(options.relayUrl, equals("wss://example.test/relay"));
+      expect(options.logLevelName, equals("debug"));
+      expect(options.isSupervised, isFalse);
+    });
+  });
 }
 
 BridgeCliOptions _parseOptions({required List<String> args}) {
+  // Mirrors the bridge-core options that [BridgeCliOptions.fromArgResults]
+  // reads. Notably there is NO `--control-secret` option — the per-spawn secret
+  // is delivered off-argv (ADR A8), never on the command line.
   final parser = ArgParser()
     ..addOption("relay", defaultsTo: "wss://relay.sesori.com")
     ..addOption("auth-backend", defaultsTo: "")
@@ -31,7 +71,8 @@ BridgeCliOptions _parseOptions({required List<String> args}) {
       "log-level",
       defaultsTo: "info",
       allowed: ["verbose", "debug", "info", "warning", "error"],
-    );
+    )
+    ..addOption("control-url", hide: true);
 
   final results = parser.parse(args);
   return BridgeCliOptions.fromArgResults(

--- a/bridge/app/test/bridge/runtime/bridge_runtime_auth_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_auth_test.dart
@@ -151,6 +151,7 @@ BridgeCliOptions _options({required String authBackendUrl}) {
     authBackendUrl: authBackendUrl,
     debugPort: null,
     logLevelName: 'info',
+    controlUrl: null,
   );
 }
 

--- a/bridge/app/test/bridge/runtime/bridge_runtime_runner_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_runner_test.dart
@@ -1,0 +1,24 @@
+import "package:sesori_bridge/src/bridge/runtime/bridge_runtime_runner.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("BridgeRuntimeRunner.isLoopbackControlUrl", () {
+    test("accepts ws/wss on loopback hosts", () {
+      expect(BridgeRuntimeRunner.isLoopbackControlUrl(Uri.parse("ws://127.0.0.1:54321/control")), isTrue);
+      expect(BridgeRuntimeRunner.isLoopbackControlUrl(Uri.parse("wss://localhost:9/ctrl")), isTrue);
+      expect(BridgeRuntimeRunner.isLoopbackControlUrl(Uri.parse("ws://[::1]:8080")), isTrue);
+      expect(BridgeRuntimeRunner.isLoopbackControlUrl(Uri.parse("WS://LOCALHOST:9")), isTrue);
+    });
+
+    test("rejects non-loopback hosts", () {
+      expect(BridgeRuntimeRunner.isLoopbackControlUrl(Uri.parse("ws://evil.example.com:80/control")), isFalse);
+      expect(BridgeRuntimeRunner.isLoopbackControlUrl(Uri.parse("ws://10.0.0.5:9")), isFalse);
+      expect(BridgeRuntimeRunner.isLoopbackControlUrl(Uri.parse("wss://0.0.0.0:9")), isFalse);
+    });
+
+    test("rejects non-ws schemes even on loopback", () {
+      expect(BridgeRuntimeRunner.isLoopbackControlUrl(Uri.parse("http://127.0.0.1:9")), isFalse);
+      expect(BridgeRuntimeRunner.isLoopbackControlUrl(Uri.parse("https://localhost:9")), isFalse);
+    });
+  });
+}

--- a/bridge/app/test/control/control_channel_loss_listener_test.dart
+++ b/bridge/app/test/control/control_channel_loss_listener_test.dart
@@ -1,0 +1,108 @@
+import "dart:async";
+
+import "package:fake_async/fake_async.dart";
+import "package:sesori_bridge/src/control/control_channel_loss_listener.dart";
+import "package:sesori_bridge/src/foundation/control_channel_client.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ControlChannelLossListener", () {
+    test("exits after the grace period when the channel stays disconnected", () {
+      fakeAsync((async) {
+        final controller = StreamController<ControlChannelConnectionState>();
+        final exitCodes = <int>[];
+        ControlChannelLossListener(
+          connectionState: controller.stream,
+          exitProcess: exitCodes.add,
+          gracePeriod: const Duration(seconds: 5),
+        ).start();
+
+        controller.add(ControlChannelConnectionState.disconnected);
+        async.elapse(const Duration(seconds: 4));
+        expect(exitCodes, isEmpty, reason: "grace period has not elapsed yet");
+
+        async.elapse(const Duration(seconds: 2));
+        expect(exitCodes, equals([controlChannelLostExitCode]));
+      });
+    });
+
+    test("does not exit when the channel reconnects within the grace period", () {
+      fakeAsync((async) {
+        final controller = StreamController<ControlChannelConnectionState>();
+        final exitCodes = <int>[];
+        ControlChannelLossListener(
+          connectionState: controller.stream,
+          exitProcess: exitCodes.add,
+          gracePeriod: const Duration(seconds: 5),
+        ).start();
+
+        controller.add(ControlChannelConnectionState.disconnected);
+        async.elapse(const Duration(seconds: 2));
+        controller.add(ControlChannelConnectionState.connected);
+        async.elapse(const Duration(seconds: 10));
+
+        expect(exitCodes, isEmpty);
+      });
+    });
+
+    test("re-arms the grace timer on a subsequent disconnect", () {
+      fakeAsync((async) {
+        final controller = StreamController<ControlChannelConnectionState>();
+        final exitCodes = <int>[];
+        ControlChannelLossListener(
+          connectionState: controller.stream,
+          exitProcess: exitCodes.add,
+          gracePeriod: const Duration(seconds: 5),
+        ).start();
+
+        controller.add(ControlChannelConnectionState.disconnected);
+        async.elapse(const Duration(seconds: 2));
+        controller.add(ControlChannelConnectionState.connected);
+        async.elapse(const Duration(seconds: 10));
+        expect(exitCodes, isEmpty);
+
+        controller.add(ControlChannelConnectionState.disconnected);
+        async.elapse(const Duration(seconds: 5));
+        expect(exitCodes, equals([controlChannelLostExitCode]));
+      });
+    });
+
+    test("does not exit after dispose, even once the grace period elapses", () {
+      fakeAsync((async) {
+        final controller = StreamController<ControlChannelConnectionState>();
+        final exitCodes = <int>[];
+        final listener = ControlChannelLossListener(
+          connectionState: controller.stream,
+          exitProcess: exitCodes.add,
+          gracePeriod: const Duration(seconds: 5),
+        )..start();
+
+        controller.add(ControlChannelConnectionState.disconnected);
+        async.elapse(const Duration(seconds: 2));
+        unawaited(listener.dispose());
+        async.elapse(const Duration(seconds: 10));
+
+        expect(exitCodes, isEmpty);
+      });
+    });
+
+    test("ignores a clean stream close (client dispose) without exiting", () {
+      fakeAsync((async) {
+        final controller = StreamController<ControlChannelConnectionState>();
+        final exitCodes = <int>[];
+        ControlChannelLossListener(
+          connectionState: controller.stream,
+          exitProcess: exitCodes.add,
+          gracePeriod: const Duration(seconds: 5),
+        ).start();
+
+        // A clean ControlChannelClient.dispose() closes the stream (done)
+        // WITHOUT a disconnected event — that must never trigger an exit.
+        unawaited(controller.close());
+        async.elapse(const Duration(seconds: 10));
+
+        expect(exitCodes, isEmpty);
+      });
+    });
+  });
+}

--- a/bridge/app/test/foundation/control_channel_client_test.dart
+++ b/bridge/app/test/foundation/control_channel_client_test.dart
@@ -1,0 +1,193 @@
+import "dart:async";
+import "dart:collection";
+import "dart:io";
+
+import "package:sesori_bridge/src/foundation/control_channel_client.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ControlChannelClient", () {
+    test("connects and presents the secret as an Authorization bearer header", () async {
+      final server = await _FakeControlServer.start();
+      addTearDown(server.close);
+
+      final client = ControlChannelClient(
+        url: Uri.parse("ws://127.0.0.1:${server.port}"),
+        secret: "s3cr3t-token",
+      );
+      await client.connect();
+      addTearDown(client.dispose);
+
+      final connection = await server.nextConnection();
+      expect(connection.authorizationHeader, equals("Bearer s3cr3t-token"));
+    });
+
+    test("surfaces inbound text frames on the inbound stream", () async {
+      final server = await _FakeControlServer.start();
+      addTearDown(server.close);
+
+      final client = ControlChannelClient(
+        url: Uri.parse("ws://127.0.0.1:${server.port}"),
+        secret: "x",
+      );
+      await client.connect();
+      addTearDown(client.dispose);
+
+      final connection = await server.nextConnection();
+      final received = client.inbound.first;
+      connection.socket.add("hello-from-gui");
+
+      expect(await received.timeout(const Duration(seconds: 5)), equals("hello-from-gui"));
+    });
+
+    test("send delivers a frame to the server", () async {
+      final server = await _FakeControlServer.start();
+      addTearDown(server.close);
+
+      final client = ControlChannelClient(
+        url: Uri.parse("ws://127.0.0.1:${server.port}"),
+        secret: "x",
+      );
+      await client.connect();
+      addTearDown(client.dispose);
+
+      final connection = await server.nextConnection();
+      final serverReceived = connection.socket.cast<String>().first;
+      client.send("ping");
+
+      expect(await serverReceived.timeout(const Duration(seconds: 5)), equals("ping"));
+    });
+
+    test("auto-reconnects after the server drops the connection", () async {
+      final server = await _FakeControlServer.start();
+      addTearDown(server.close);
+
+      final client = ControlChannelClient(
+        url: Uri.parse("ws://127.0.0.1:${server.port}"),
+        secret: "x",
+        initialReconnectDelay: const Duration(milliseconds: 20),
+      );
+      final states = <ControlChannelConnectionState>[];
+      client.connectionState.listen(states.add);
+      await client.connect();
+      addTearDown(client.dispose);
+
+      final first = await server.nextConnection();
+      await first.socket.close();
+
+      // The client must dial a fresh connection (still presenting the secret).
+      final second = await server.nextConnection();
+      expect(second.authorizationHeader, equals("Bearer x"));
+      await _waitFor(() => states.contains(ControlChannelConnectionState.disconnected));
+    });
+
+    test("connect throws when the server never completes the handshake", () async {
+      // Bind but never accept/upgrade: the WebSocket handshake never resolves.
+      final rawServer = await ServerSocket.bind("127.0.0.1", 0);
+      addTearDown(rawServer.close);
+
+      final client = ControlChannelClient(
+        url: Uri.parse("ws://127.0.0.1:${rawServer.port}"),
+        secret: "x",
+        connectTimeout: const Duration(milliseconds: 300),
+      );
+
+      await expectLater(client.connect(), throwsA(isA<TimeoutException>()));
+    });
+
+    test("dispose closes the inbound and connection-state streams", () async {
+      final server = await _FakeControlServer.start();
+      addTearDown(server.close);
+
+      final client = ControlChannelClient(
+        url: Uri.parse("ws://127.0.0.1:${server.port}"),
+        secret: "x",
+      );
+      await client.connect();
+      await server.nextConnection();
+
+      await client.dispose();
+
+      expect(client.inbound, emitsDone);
+      expect(client.connectionState, emitsDone);
+    });
+  });
+}
+
+Future<void> _waitFor(
+  bool Function() condition, {
+  Duration timeout = const Duration(seconds: 5),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (!condition()) {
+    if (DateTime.now().isAfter(deadline)) {
+      fail("Timed out waiting for condition");
+    }
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+}
+
+class _FakeControlConnection {
+  final WebSocket socket;
+  final String? authorizationHeader;
+
+  const _FakeControlConnection({required this.socket, required this.authorizationHeader});
+}
+
+/// A loopback control server that records the upgrade `Authorization` header
+/// and exposes each accepted connection so a test can drive the GUI side.
+class _FakeControlServer {
+  final HttpServer _server;
+  final Queue<_FakeControlConnection> _buffered = Queue<_FakeControlConnection>();
+  final Queue<Completer<_FakeControlConnection>> _waiters = Queue<Completer<_FakeControlConnection>>();
+
+  _FakeControlServer._(this._server);
+
+  static Future<_FakeControlServer> start() async {
+    final server = await HttpServer.bind("127.0.0.1", 0);
+    final instance = _FakeControlServer._(server);
+    server.listen(instance._handleRequest);
+    return instance;
+  }
+
+  int get port => _server.port;
+
+  Future<_FakeControlConnection> nextConnection() {
+    if (_buffered.isNotEmpty) {
+      return Future.value(_buffered.removeFirst());
+    }
+    final completer = Completer<_FakeControlConnection>();
+    _waiters.add(completer);
+    return completer.future.timeout(const Duration(seconds: 5));
+  }
+
+  Future<void> close() async {
+    for (final waiter in _waiters) {
+      if (!waiter.isCompleted) {
+        waiter.completeError(StateError("server closing"));
+      }
+    }
+    _waiters.clear();
+    for (final connection in _buffered) {
+      await connection.socket.close();
+    }
+    _buffered.clear();
+    await _server.close(force: true);
+  }
+
+  Future<void> _handleRequest(HttpRequest request) async {
+    if (!WebSocketTransformer.isUpgradeRequest(request)) {
+      request.response.statusCode = HttpStatus.notFound;
+      await request.response.close();
+      return;
+    }
+    final authorization = request.headers.value("authorization");
+    final socket = await WebSocketTransformer.upgrade(request);
+    final connection = _FakeControlConnection(socket: socket, authorizationHeader: authorization);
+    if (_waiters.isNotEmpty) {
+      _waiters.removeFirst().complete(connection);
+    } else {
+      _buffered.add(connection);
+    }
+  }
+}

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -37,6 +37,13 @@
 > or ADR (§7) no longer holds — fix it in the **same PR**: record it in the phase
 > doc's **Plan-deltas** and amend the affected section above. A stale plan is
 > worse than none.
+>
+> **Track every deferral in the plan — always.** Whenever a PR defers work to a
+> later stage (a known gap, a follow-up, a reviewer point answered with "PR X
+> handles this"), record it in the **same PR** in BOTH: (a) the owning later
+> PR's **Acceptance** in its phase doc, and (b) the §8 risk register. A deferral
+> that lives only in a PR reply, commit message, or chat is **not tracked** and
+> will be lost — those are not the plan.
 
 ---
 
@@ -231,6 +238,7 @@ and consumes only the exported interfaces (`AuthTokenProvider`/`OAuthFlowProvide
 | Windows code-signing cert | **OPEN — lead time** | TBD | blocks PR 3.4 (signed Windows); EV clears SmartScreen faster |
 | Control-channel secret bootstrap (off-argv) | OPEN | TBD | ADR A8; designed in PR 1.1 / PR 2.6 |
 | Orphaned helper on GUI crash | OPEN | TBD | ADR A9; parent-loss policy in PR 1.1 |
+| Supervised restart replays `--control-url` (no stdin secret) | OPEN — until PR 1.7 | TBD | PR 1.1 gap; PR 1.7 makes supervised restart `exit(86)` not `spawnSuccessor()`. Unreachable pre-GUI; successor fails closed (`ControlSecretApi` timeout → exit 1) |
 | Uninstall vs shared CLI state | OPEN | TBD | ADR A10; scope cleanup in PR 3.11 |
 | RelayClient live re-auth on token push | OPEN | TBD | ADR A12; PR 1.5 must add the subscription/reconnect path + live-connection test |
 | `core/widgets` not pure leaf UI | OPEN | TBD | `connection_overlay.dart` imports app DI/routing/go_router; PR 4.1 must refactor + declare deps first |

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -9,7 +9,7 @@
 ## Current pointer
 
 - **Last completed phase:** Phase 0 — `mobile/`→`client/` rename (PR 0.1)
-- **In-flight PR:** none
+- **In-flight PR:** PR 1.1 — `--control-url` + off-argv secret bootstrap + `ControlChannelClient` skeleton (open, not merged)
 - **Branch:** one feature branch per PR, cut from `main`
 
 > **The pointer is backward-looking.** "Last completed phase" advances only once
@@ -17,6 +17,19 @@
 > genuinely done. Use **In-flight PR** for work in progress; the next action is
 > intentionally not tracked here — read it off the first ☐ in the PR status
 > index (§9).
+>
+> **How to resume (derive the next action — do NOT ask first).** When told to
+> "continue with the next phase/PR", resolve it deterministically:
+> 1. If **In-flight PR** above is not "none", continue that PR.
+> 2. Otherwise the next action is the **first ☐ in the PR status index (§9)**,
+>    read top-to-bottom. Phases and the PRs within them are strictly ordered and
+>    are completed in order (a later phase depends on earlier phases existing).
+> 3. **The session worktree/branch name is NOT authoritative** and may not match
+>    the plan — e.g. a branch named `…-phase-2` while the first ☐ is still in
+>    Phase 1. The plan always wins; never infer the phase/PR from the branch name.
+> 4. **Default scope = one PR per session** (matches "one feature branch per
+>    PR"). Implement the single next PR, run both Aristotle gates (§5), open it,
+>    then stop unless the user says otherwise.
 >
 > **Keep the plan true.** If a PR reveals that an assumption here was wrong — a
 > locked decision (§3), release-safety invariant (§4), component design (§6),
@@ -152,6 +165,8 @@ mobile release.**
 | Component | Layer / dir | Role |
 |---|---|---|
 | `ControlChannelClient` | Layer 0 `bridge/app/lib/src/.../foundation/` (target layer, not the legacy nested tree) | loopback WS client; connect/reconnect; send/receive |
+| `ControlSecretApi` | Layer 1 `api/` | reads the per-spawn secret off-argv (first stdin line); sent as the control-channel WS `Authorization: Bearer` upgrade header (PR 1.1) |
+| `ControlChannelLossListener` | `control/` subsystem | ADR A9 grace-period process exit on sustained control-channel loss; injected `exitProcess` (PR 1.1) |
 | Control-protocol Freezed DTOs | `shared/sesori_shared` | pure wire types (incl. provision-progress mirror) |
 | `ControlChannelTokenService` | Layer 3 `auth/` | implements `AccessTokenProvider`/`TokenRefresher`; pull + push token stream |
 | `BridgeControlMessageDispatcher` | Layer 4 | routes inbound control msgs (token push → token service, restart → handoff, logout → unregister-and-exit) |
@@ -232,7 +247,7 @@ Legend: ☐ pending · ◐ in-progress · ☑ done. Sizes: **S** ≤150 LOC · *
 - ☑ 0.1 `mobile/`→`client/` everywhere (atomic) — **Med-High / L**
 
 ### Phase 1 — Bridge supervised mode → `phase-1-bridge-supervised.md`
-- ☐ 1.1 `--control-url` + off-argv secret bootstrap + `ControlChannelClient` skeleton — Low-Med / M
+- ◐ 1.1 `--control-url` + off-argv secret bootstrap + `ControlChannelClient` skeleton — Low-Med / M
 - ☐ 1.2 Control-protocol Freezed DTOs (incl. provision-progress mirror) — Low / S-M
 - ☐ 1.3 Supervised auth bootstrap (short-circuit `ensureAuthenticated`) — Med / M
 - ☐ 1.4 Token provider **pull** over channel (+ timeout/GUI-down) — Med / M

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -8,22 +8,23 @@
 
 ## Current pointer
 
-- **Last completed phase:** Phase 0 — `mobile/`→`client/` rename (PR 0.1)
-- **In-flight PR:** PR 1.1 — `--control-url` + off-argv secret bootstrap + `ControlChannelClient` skeleton (open, not merged)
+- **Last completed phase:** Phase 1 — PR 1.1 `--control-url` + off-argv secret bootstrap + `ControlChannelClient` skeleton
 - **Branch:** one feature branch per PR, cut from `main`
 
-> **The pointer is backward-looking.** "Last completed phase" advances only once
-> a phase's PRs have all landed, so right after any merge it reflects what is
-> genuinely done. Use **In-flight PR** for work in progress; the next action is
-> intentionally not tracked here — read it off the first ☐ in the PR status
-> index (§9).
+> **Advance this pointer to the PR you just raised.** There is no separate
+> "in-flight" field: when you open a PR, set **Last completed phase** above to
+> that PR and mark its §9 row ☑. PRs squash-merge one at a time, so the pointer
+> (and the §9 index) read true the moment that PR merges. Do this for every PR
+> as you progress.
 >
 > **How to resume (derive the next action — do NOT ask first).** When told to
 > "continue with the next phase/PR", resolve it deterministically:
-> 1. If **In-flight PR** above is not "none", continue that PR.
-> 2. Otherwise the next action is the **first ☐ in the PR status index (§9)**,
->    read top-to-bottom. Phases and the PRs within them are strictly ordered and
->    are completed in order (a later phase depends on earlier phases existing).
+> 1. The next action is the **first ☐ in the PR status index (§9)**, read
+>    top-to-bottom. Phases and the PRs within them are strictly ordered and are
+>    completed in order (a later phase depends on earlier phases existing).
+> 2. **Read the prior Findings logs / Plan-deltas first** — this file plus the
+>    relevant `phase-N-*.md` — an earlier PR may have recorded a decision, delta,
+>    naming choice, or gotcha that affects the next PR.
 > 3. **The session worktree/branch name is NOT authoritative** and may not match
 >    the plan — e.g. a branch named `…-phase-2` while the first ☐ is still in
 >    Phase 1. The plan always wins; never infer the phase/PR from the branch name.
@@ -247,7 +248,7 @@ Legend: ☐ pending · ◐ in-progress · ☑ done. Sizes: **S** ≤150 LOC · *
 - ☑ 0.1 `mobile/`→`client/` everywhere (atomic) — **Med-High / L**
 
 ### Phase 1 — Bridge supervised mode → `phase-1-bridge-supervised.md`
-- ◐ 1.1 `--control-url` + off-argv secret bootstrap + `ControlChannelClient` skeleton — Low-Med / M
+- ☑ 1.1 `--control-url` + off-argv secret bootstrap + `ControlChannelClient` skeleton — Low-Med / M
 - ☐ 1.2 Control-protocol Freezed DTOs (incl. provision-progress mirror) — Low / S-M
 - ☐ 1.3 Supervised auth bootstrap (short-circuit `ensureAuthenticated`) — Med / M
 - ☐ 1.4 Token provider **pull** over channel (+ timeout/GUI-down) — Med / M

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -46,7 +46,31 @@ runs **under the startup mutex**, which reinforces PR 1.12.
 - **Acceptance:** standalone unchanged; with supervised bootstrap the client
   connects to a fake server in tests; reconnect on drop; the secret never
   appears in `ps`/argv; control-channel loss triggers grace-period exit.
-- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+- **Aristotle:** plan ☑ · impl ☑.
+- **Findings:** Shipped as three gated units + the `--control-url` option.
+  `ControlChannelClient` (Layer 0 `foundation/`) owns connect + its own
+  exp-backoff auto-reconnect (the GUI may come/go while the bridge stays up, so
+  unlike `RelayClient` the reconnect loop lives in the client, not a consumer),
+  a raw `inbound` text stream, `send`, and a `connectionState` stream. The
+  per-spawn secret is read as the first stdin line (`ControlSecretApi`) and
+  presented to the GUI as an `Authorization: Bearer` header on the WS **upgrade
+  request** — transport-level auth, off-argv, and independent of the PR-1.2 wire
+  DTOs. Parent-loss exit (ADR A9) is a separate `ControlChannelLossListener`
+  with an injected `exitProcess` (root passes `io.exit`), grace 5s, exit code
+  `1`. A real drop emits `disconnected` (arms grace); a clean `dispose` closes
+  the state stream `done` (no grace) so shutdown never self-exits. Standalone is
+  byte-identical (everything behind `isSupervised`). `make analyze` clean;
+  `make test` 1504 pass.
+- **Deltas:** §6 placed only `ControlChannelClient` (foundation, kept). Two
+  components plan-review pinned to specific layers were NOT pre-specified in §6
+  and are now added there: the off-argv secret reader is a **Layer-1
+  `ControlSecretApi`** in `api/` (mirrors `TerminalPromptApi`; a stdin reader is
+  data access, not a foundation primitive — `Reader` is not a sanctioned
+  suffix), and the ADR-A9 grace-exit is a **`ControlChannelLossListener` in a
+  new `control/` subsystem dir** (a decision-making `Listener` cannot live in
+  Layer-0 `foundation/`). Parent-loss exit code is provisionally `1`
+  (`controlChannelLostExitCode`); the GUI-side exit-code state machine (PR
+  2.7 / 1.7) may refine it.
 
 ## PR 1.2 — Control-protocol Freezed DTOs (incl. provision-progress mirror)
 - **Goal:** Define wire DTOs in `shared/sesori_shared`: `token_request`,

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -156,7 +156,8 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   this PR must ensure supervised restart never calls `spawnSuccessor()`.
 - **Risk:** Med. **Size:** S-M.
 - **Acceptance:** phone-triggered restart → exit 86 in supervised mode; standalone
-  successor handoff unchanged.
+  successor handoff unchanged; **supervised mode never calls `spawnSuccessor()`**
+  (closes the PR-1.1 `--control-url`-replay gap — asserted by test).
 - **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
 
 ## PR 1.8 — Disable self-update + reconcile when supervised

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -61,6 +61,14 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   the state stream `done` (no grace) so shutdown never self-exits. Standalone is
   byte-identical (everything behind `isSupervised`). `make analyze` clean;
   `make test` 1504 pass.
+- **Review round 2:** addressed reviewer feedback — enforce loopback ws/wss on
+  `--control-url` before dialing (fail closed, don't leak the bearer secret);
+  subscribe the loss listener *before* `connect()` (don't miss the first
+  `disconnected`); post-handshake liveness guard in `_openChannel`; isolate
+  teardown steps + handle `cancel()` errors. **Control-loss exit is graceful:**
+  it routes through `shutdownCoordinator.shutdown()` (ordered plugin stop) before
+  `io.exit`, so a hard exit from the loss timer can't orphan an owned runtime.
+  The supervised `spawnSuccessor()` flag-replay gap is tracked to **PR 1.7**.
 - **Deltas:** §6 placed only `ControlChannelClient` (foundation, kept). Two
   components plan-review pinned to specific layers were NOT pre-specified in §6
   and are now added there: the off-argv secret reader is a **Layer-1
@@ -141,6 +149,11 @@ runs **under the startup mutex**, which reinforces PR 1.12.
 - **Goal:** In supervised mode `handleRestartHandoff()` flushes the
   `{restarting:true}` response then `exit(86)` instead of
   `BridgeRestartService.spawnSuccessor()`. Name the exact bypass call site.
+  **Closes the PR-1.1 interim gap:** until this lands, a supervised
+  `spawnSuccessor()` replays `--control-url` into the detached successor with no
+  off-argv secret on stdin, so the successor fails in `ControlSecretApi` instead
+  of reconnecting. Not reachable by any shipping path pre-GUI (Phase 2), but
+  this PR must ensure supervised restart never calls `spawnSuccessor()`.
 - **Risk:** Med. **Size:** S-M.
 - **Acceptance:** phone-triggered restart → exit 86 in supervised mode; standalone
   successor handoff unchanged.


### PR DESCRIPTION
## What & why

First PR of **Phase 1 — bridge supervised mode** (desktop app implementation; see `docs/desktop/PLAN.md` + `docs/desktop/phase-1-bridge-supervised.md`).

Teaches `sesori-bridge` a **supervised mode**, gated by a new hidden `--control-url` flag. When supervised, the bridge reads a per-spawn secret **off-argv** (first stdin line — ADR A8), opens a GUI-hosted **loopback WebSocket control channel** presenting that secret as an `Authorization: Bearer` upgrade header, and **exits if the channel stays down past a grace period** (ADR A9). This is the **skeleton** — no control-message semantics yet (wire DTOs land in PR 1.2).

## Changes (all gated by `--control-url`; standalone is byte-identical)

| Unit | Layer / dir | Role |
|---|---|---|
| `ControlChannelClient` | Layer 0 `foundation/` | loopback WS transport: connect, own exp-backoff auto-reconnect, raw `inbound` text stream, `send`, `connectionState` stream, `dispose` |
| `ControlSecretApi` | Layer 1 `api/` | reads the off-argv secret (first stdin line) |
| `ControlChannelLossListener` | `control/` subsystem | ADR A9 grace-period process exit on sustained loss; injected `exitProcess` (root passes `io.exit`) |
| `BridgeCliOptions.controlUrl` / `isSupervised` + hidden `--control-url` | — | supervised-mode detection (trim, blank→null, no strict parse-time validation) |

Wired once at the composition root (`BridgeRuntimeRunner._startSupervisedControlChannel`, behind `isSupervised`); both the client and listener are torn down via `BridgeShutdownCoordinator`.

### Design notes
- **Secret never on argv.** Delivered via stdin; presented to the GUI as a WS upgrade header (transport-level auth, independent of PR-1.2 DTOs). There is deliberately no `--control-secret` flag.
- **Reconnect lives in the client** (unlike `RelayClient`, whose loop lives in the orchestrator): the GUI may come/go while the bridge stays up.
- **Clean shutdown never self-exits:** a real drop emits `disconnected` (arms grace); `dispose` closes the state stream `done` (no grace).

## Release-safety
- Bridge/CLI stays releasable: 100% additive, gated by `--control-url`; relay protocol untouched; standalone path unchanged (asserted by the retained `bridge_cli_options` standalone tests).
- No mobile/shared changes.

## Tests
New: `ControlChannelClient` (secret-as-header, inbound, send, auto-reconnect, connect-timeout, dispose), `ControlSecretApi` (first line / trim / blank / timeout), `ControlChannelLossListener` (grace exit / recover / re-arm / dispose / clean-close). Extended `bridge_cli_options` with a supervised group (kept the 3 standalone tests).

`make analyze` clean across all bridge modules; `make test` **1504 pass**.

## Architecture review
- `aristotle-plan-review`: **APPROVED** (after relocating the secret reader → Layer-1 `ControlSecretApi` and the loss listener → `control/`).
- `aristotle-impl-review`: **APPROVED**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds supervised mode to `sesori-bridge` behind a hidden `--control-url`: reads a per‑spawn secret from stdin, validates loopback ws/wss, opens a WebSocket control channel with `Authorization: Bearer`, auto-reconnects, and exits after a grace period if the channel stays down. On loss, we shut down gracefully and record a non‑zero exit code so the backstop reports the same abnormal code even if shutdown hangs.

- **New Features**
  - `ControlChannelClient`: loopback WS transport with connect/send/receive, connection-state stream, and exponential-backoff auto-reconnect; sends secret as `Authorization: Bearer`.
  - `ControlSecretApi`: reads the first stdin line as the secret (trimmed; times out if absent); never passed via argv.
  - `ControlChannelLossListener`: arms a grace timer on disconnect, cancels on reconnect, then requests a graceful shutdown and exit via injected `exitProcess` if it elapses.
  - CLI/runtime wiring: hidden `--control-url`, `BridgeCliOptions.isSupervised`, startup hook in `BridgeRuntimeRunner`, teardown via `BridgeShutdownCoordinator`; rejects non-loopback or non-ws URLs (fail closed).

- **Bug Fixes**
  - Control-channel loss exit runs through an ordered shutdown and records an abnormal exit code so the backstop exits with the same non‑zero code if the stop hangs.
  - Subscribe the loss listener before `connect()` to never miss the first disconnect on startup.
  - Guard post-handshake install to avoid attaching a socket after dispose/new generation.
  - Isolate and error-handle teardown (subscription cancel, channel close) to prevent leaks and uncaught async errors.

<sup>Written for commit 2af070c3f76dc17dd03c46e2610bcdbf2739b8c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

