### PR TITLE
feat(shared): control-protocol wire DTOs (Phase 1, PR 1.2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -391,6 +391,24 @@ int computeNotificationId(String sessionId, NotificationCategory category) { ...
 MyClass([FlutterLocalNotificationsPlugin? plugin]) : _plugin = plugin ?? FlutterLocalNotificationsPlugin();
 ```
 
+## Code Comments
+
+Comments live in the codebase forever; the implementation plan you happen to be
+executing does not. Keep them timeless.
+
+- **Never reference the implementation plan from source comments.** No PR numbers
+  (`PR 1.7`), phase IDs (`Phase 2`), ADR codes (`ADR A13`), or plan-section refs
+  (`§8`). They are tracking artifacts that rot the moment the work merges and mean
+  nothing to a future reader. This includes doc comments, inline comments, and
+  TODOs.
+- **Keep the rationale, drop the pointer.** The *reason* a thing exists is often
+  worth a comment — just state it directly. Write "carries `bridgeId` so the GUI
+  can persist a readable copy for an offline-unregister fallback", not "… fallback
+  (ADR A13)"; write "intentional restart, so the supervisor respawns instead of
+  treating it as a crash", not "… as a crash (PR 1.7)".
+- Plan/phase status, deferrals, and cross-PR sequencing belong in the plan and
+  phase docs (e.g. `docs/desktop/*.md`), never in code.
+
 ## Analysis
 
 Strict analysis is enabled across all packages. Don't add `// ignore:` comments without a written justification in the same line.

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -8,7 +8,7 @@
 
 ## Current pointer
 
-- **Last completed phase:** Phase 1 — PR 1.1 `--control-url` + off-argv secret bootstrap + `ControlChannelClient` skeleton
+- **Last completed phase:** Phase 1 — PR 1.2 Control-protocol Freezed DTOs in `sesori_shared` (`ControlMessage` + `ControlProvisionProgress` mirror)
 - **Branch:** one feature branch per PR, cut from `main`
 
 > **Advance this pointer to the PR you just raised.** There is no separate
@@ -257,7 +257,7 @@ Legend: ☐ pending · ◐ in-progress · ☑ done. Sizes: **S** ≤150 LOC · *
 
 ### Phase 1 — Bridge supervised mode → `phase-1-bridge-supervised.md`
 - ☑ 1.1 `--control-url` + off-argv secret bootstrap + `ControlChannelClient` skeleton — Low-Med / M
-- ☐ 1.2 Control-protocol Freezed DTOs (incl. provision-progress mirror) — Low / S-M
+- ☑ 1.2 Control-protocol Freezed DTOs (incl. provision-progress mirror) — Low / S-M
 - ☐ 1.3 Supervised auth bootstrap (short-circuit `ensureAuthenticated`) — Med / M
 - ☐ 1.4 Token provider **pull** over channel (+ timeout/GUI-down) — Med / M
 - ☐ 1.5 Token-stream **push** → relay client — Med / S-M

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -95,7 +95,33 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   the exception to the "Phase 1 = bridge only" standing text):** round-trip
   serialization tests; no logic in shared; **`sesori_shared` codegen + tests
   pass AND `client/app` (mobile product) still builds** (no consumer break).
-- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+- **Aristotle:** plan ☑ · impl ☑.
+- **Findings:** Shipped as two pure-data Freezed sealed unions in
+  `shared/sesori_shared/lib/src/protocol/` (alongside `messages.dart`/`RelayMessage`,
+  the precedent), not under `models/` — these are protocol wire types.
+  `ControlMessage` is a single bidirectional union keyed by `type`
+  (`unionValueCase: snake`) with 10 variants: `token_request`/`token_response`
+  (id-correlated; null `accessToken` ⇒ GUI couldn't supply), `token_update`
+  (push), `status`, `prompt_request`/`prompt_response` (id-correlated),
+  `restart` (intentional-restart heads-up), `unregister_and_exit`, `registered`
+  (carries `bridgeId`, ADR A13), and `provision_progress` (wraps the nested
+  union). `ControlProvisionProgress` is a separate union mirroring
+  `RuntimeProvisionProgress` 1:1 (resolving/downloading/extracting/verifying/
+  notice/ready/failed) — the source lives in `sesori_plugin_interface` and MUST
+  NOT be imported (dependency direction), so it is mirrored; the derived
+  `fraction` getter is intentionally dropped (pure data). Forward-compat: three
+  enums (`ControlRelayConnectionState`/`ControlPluginHealthState`/
+  `ControlPromptKind`) each carry an `unknown` `@JsonValue` fallback +
+  `@JsonKey(unknownEnumValue:)`; optional fields use `@Default`; null keys auto-
+  drop (build.yaml `include_if_null:false`). No catch-all message-type variant
+  (matches `RelayMessage`; GUI+helper are same-commit, ADR/§2). 25 round-trip/
+  discriminator/fallback tests; `sesori_shared` 265 tests + analyze clean;
+  `client/app` (mobile) `flutter analyze` clean (additive, no consumer break).
+- **Deltas:** §6 listed only "Control-protocol Freezed DTOs | `shared/sesori_shared`".
+  Concretely realized as two unions in `lib/src/protocol/` (not `models/`),
+  matching `RelayMessage`'s home. Status/prompt field shapes (the three enums +
+  `activeSessionCount`) are introduced here; their senders (PRs 1.9/1.10/1.12)
+  may extend them **additively** via `@Default` fields / new enum values.
 
 ## PR 1.3 — Supervised auth bootstrap
 - **Goal:** In supervised mode, short-circuit

--- a/shared/sesori_shared/lib/sesori_shared.dart
+++ b/shared/sesori_shared/lib/sesori_shared.dart
@@ -66,6 +66,8 @@ export "src/models/sesori/update_session_archive_request.dart";
 export "src/notifications/session_notification_id.dart";
 export "src/protocol/close_codes.dart";
 export "src/protocol/constants.dart";
+export "src/protocol/control_message.dart";
+export "src/protocol/control_provision_progress.dart";
 export "src/protocol/framing.dart";
 export "src/protocol/messages.dart";
 export "src/reporting/failure_reporter.dart";

--- a/shared/sesori_shared/lib/src/protocol/control_message.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_message.dart
@@ -5,14 +5,14 @@ import "control_provision_progress.dart";
 part "control_message.freezed.dart";
 part "control_message.g.dart";
 
-/// The GUI-hosted loopback control-channel wire protocol (ADR A5): a single
-/// sealed union carrying every message exchanged between the desktop GUI and
-/// the supervised bridge helper, in both directions. The relay-bound
-/// `RelayMessage` is the precedent for this shape.
+/// The GUI-hosted loopback control-channel wire protocol: a single sealed union
+/// carrying every message exchanged between the desktop GUI and the supervised
+/// bridge helper, in both directions. (`RelayMessage` is the analogous union for
+/// the relay protocol.)
 ///
-/// PR 1.2 defines only the wire types; senders/handlers land in later Phase-1
-/// PRs (1.3-1.13) and Phase-2 GUI PRs. New optional fields added by those PRs
-/// use `@Default` so older/newer peers stay wire-compatible.
+/// Pure wire types only — senders and handlers live in the bridge and the
+/// desktop GUI. New optional fields use `@Default` so older and newer peers stay
+/// wire-compatible.
 @Freezed(unionKey: "type", unionValueCase: FreezedUnionCase.snake, fromJson: true, toJson: true)
 sealed class ControlMessage with _$ControlMessage {
   /// helper → GUI: request a fresh access token. [id] correlates the
@@ -65,24 +65,25 @@ sealed class ControlMessage with _$ControlMessage {
   }) = ControlPromptResponse;
 
   /// helper → GUI: heads-up that this exit is an intentional restart (exit 86),
-  /// so the GUI respawns instead of treating it as a crash (PR 1.7).
+  /// so the GUI respawns it instead of treating the exit as a crash.
   @FreezedUnionValue("restart")
   const factory ControlMessage.restart() = ControlRestart;
 
   /// GUI → helper: unregister this bridge with the current token, then exit 0
-  /// (logout ordering, PR 1.11).
+  /// (logout ordering).
   @FreezedUnionValue("unregister_and_exit")
   const factory ControlMessage.unregisterAndExit() = ControlUnregisterAndExit;
 
   /// helper → GUI: registration succeeded; carries [bridgeId] so the GUI can
-  /// persist a readable copy for the offline-unregister fallback (ADR A13).
+  /// persist a readable copy for an offline-unregister fallback (logout when the
+  /// helper is unreachable).
   @FreezedUnionValue("registered")
   const factory ControlMessage.registered({
     required String bridgeId,
   }) = ControlRegistered;
 
   /// helper → GUI: a runtime-provisioning progress event (first-run download /
-  /// install), teed from the bridge's provisioning stream (PR 1.13).
+  /// install), teed from the bridge's provisioning stream.
   @FreezedUnionValue("provision_progress")
   const factory ControlMessage.provisionProgress({
     required ControlProvisionProgress progress,

--- a/shared/sesori_shared/lib/src/protocol/control_message.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_message.dart
@@ -1,0 +1,129 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+import "control_provision_progress.dart";
+
+part "control_message.freezed.dart";
+part "control_message.g.dart";
+
+/// The GUI-hosted loopback control-channel wire protocol (ADR A5): a single
+/// sealed union carrying every message exchanged between the desktop GUI and
+/// the supervised bridge helper, in both directions. The relay-bound
+/// `RelayMessage` is the precedent for this shape.
+///
+/// PR 1.2 defines only the wire types; senders/handlers land in later Phase-1
+/// PRs (1.3-1.13) and Phase-2 GUI PRs. New optional fields added by those PRs
+/// use `@Default` so older/newer peers stay wire-compatible.
+@Freezed(unionKey: "type", unionValueCase: FreezedUnionCase.snake, fromJson: true, toJson: true)
+sealed class ControlMessage with _$ControlMessage {
+  /// helper → GUI: request a fresh access token. [id] correlates the
+  /// [ControlTokenResponse]; [forceRefresh] asks the GUI to mint a new one.
+  @FreezedUnionValue("token_request")
+  const factory ControlMessage.tokenRequest({
+    required String id,
+    @Default(false) bool forceRefresh,
+  }) = ControlTokenRequest;
+
+  /// GUI → helper: reply to a [ControlTokenRequest]. A null [accessToken] means
+  /// the GUI could not supply one (mid-login / signed out); the helper treats
+  /// it as a typed failure.
+  @FreezedUnionValue("token_response")
+  const factory ControlMessage.tokenResponse({
+    required String id,
+    required String? accessToken,
+  }) = ControlTokenResponse;
+
+  /// GUI → helper (push): a refreshed access token to adopt without a request.
+  @FreezedUnionValue("token_update")
+  const factory ControlMessage.tokenUpdate({
+    required String accessToken,
+  }) = ControlTokenUpdate;
+
+  /// helper → GUI (push): current relay/plugin health + active-session summary.
+  @FreezedUnionValue("status")
+  const factory ControlMessage.status({
+    @JsonKey(unknownEnumValue: ControlRelayConnectionState.unknown)
+    required ControlRelayConnectionState relay,
+    @JsonKey(unknownEnumValue: ControlPluginHealthState.unknown)
+    required ControlPluginHealthState plugin,
+    @Default(0) int activeSessionCount,
+  }) = ControlStatus;
+
+  /// helper → GUI: surface a user prompt (e.g. replace-bridge, login-needed).
+  /// [id] correlates the [ControlPromptResponse].
+  @FreezedUnionValue("prompt_request")
+  const factory ControlMessage.promptRequest({
+    required String id,
+    @JsonKey(unknownEnumValue: ControlPromptKind.unknown) required ControlPromptKind kind,
+    required String? message,
+  }) = ControlPromptRequest;
+
+  /// GUI → helper: the user's answer to a [ControlPromptRequest].
+  @FreezedUnionValue("prompt_response")
+  const factory ControlMessage.promptResponse({
+    required String id,
+    required bool accepted,
+  }) = ControlPromptResponse;
+
+  /// helper → GUI: heads-up that this exit is an intentional restart (exit 86),
+  /// so the GUI respawns instead of treating it as a crash (PR 1.7).
+  @FreezedUnionValue("restart")
+  const factory ControlMessage.restart() = ControlRestart;
+
+  /// GUI → helper: unregister this bridge with the current token, then exit 0
+  /// (logout ordering, PR 1.11).
+  @FreezedUnionValue("unregister_and_exit")
+  const factory ControlMessage.unregisterAndExit() = ControlUnregisterAndExit;
+
+  /// helper → GUI: registration succeeded; carries [bridgeId] so the GUI can
+  /// persist a readable copy for the offline-unregister fallback (ADR A13).
+  @FreezedUnionValue("registered")
+  const factory ControlMessage.registered({
+    required String bridgeId,
+  }) = ControlRegistered;
+
+  /// helper → GUI: a runtime-provisioning progress event (first-run download /
+  /// install), teed from the bridge's provisioning stream (PR 1.13).
+  @FreezedUnionValue("provision_progress")
+  const factory ControlMessage.provisionProgress({
+    required ControlProvisionProgress progress,
+  }) = ControlProvisionProgressMessage;
+
+  factory ControlMessage.fromJson(Map<String, dynamic> json) => _$ControlMessageFromJson(json);
+}
+
+/// Relay connection state reported in a [ControlStatus]. [unknown] is the
+/// forward-compat fallback for values a newer helper might add.
+enum ControlRelayConnectionState {
+  @JsonValue("connected")
+  connected,
+  @JsonValue("connecting")
+  connecting,
+  @JsonValue("disconnected")
+  disconnected,
+  @JsonValue("unknown")
+  unknown,
+}
+
+/// Plugin (backend) health reported in a [ControlStatus]. [unknown] is the
+/// forward-compat fallback.
+enum ControlPluginHealthState {
+  @JsonValue("healthy")
+  healthy,
+  @JsonValue("degraded")
+  degraded,
+  @JsonValue("unavailable")
+  unavailable,
+  @JsonValue("unknown")
+  unknown,
+}
+
+/// The kind of prompt a [ControlPromptRequest] surfaces. [unknown] is the
+/// forward-compat fallback.
+enum ControlPromptKind {
+  @JsonValue("replace_bridge")
+  replaceBridge,
+  @JsonValue("login_needed")
+  loginNeeded,
+  @JsonValue("unknown")
+  unknown,
+}

--- a/shared/sesori_shared/lib/src/protocol/control_message.freezed.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_message.freezed.dart
@@ -1,0 +1,788 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'control_message.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+ControlMessage _$ControlMessageFromJson(
+  Map<String, dynamic> json
+) {
+        switch (json['type']) {
+                  case 'token_request':
+          return ControlTokenRequest.fromJson(
+            json
+          );
+                case 'token_response':
+          return ControlTokenResponse.fromJson(
+            json
+          );
+                case 'token_update':
+          return ControlTokenUpdate.fromJson(
+            json
+          );
+                case 'status':
+          return ControlStatus.fromJson(
+            json
+          );
+                case 'prompt_request':
+          return ControlPromptRequest.fromJson(
+            json
+          );
+                case 'prompt_response':
+          return ControlPromptResponse.fromJson(
+            json
+          );
+                case 'restart':
+          return ControlRestart.fromJson(
+            json
+          );
+                case 'unregister_and_exit':
+          return ControlUnregisterAndExit.fromJson(
+            json
+          );
+                case 'registered':
+          return ControlRegistered.fromJson(
+            json
+          );
+                case 'provision_progress':
+          return ControlProvisionProgressMessage.fromJson(
+            json
+          );
+        
+          default:
+            throw CheckedFromJsonException(
+  json,
+  'type',
+  'ControlMessage',
+  'Invalid union type "${json['type']}"!'
+);
+        }
+      
+}
+
+/// @nodoc
+mixin _$ControlMessage {
+
+
+
+  /// Serializes this ControlMessage to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlMessage);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'ControlMessage()';
+}
+
+
+}
+
+/// @nodoc
+class $ControlMessageCopyWith<$Res>  {
+$ControlMessageCopyWith(ControlMessage _, $Res Function(ControlMessage) __);
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlTokenRequest implements ControlMessage {
+  const ControlTokenRequest({required this.id, this.forceRefresh = false, final  String? $type}): $type = $type ?? 'token_request';
+  factory ControlTokenRequest.fromJson(Map<String, dynamic> json) => _$ControlTokenRequestFromJson(json);
+
+ final  String id;
+@JsonKey() final  bool forceRefresh;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ControlTokenRequestCopyWith<ControlTokenRequest> get copyWith => _$ControlTokenRequestCopyWithImpl<ControlTokenRequest>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlTokenRequestToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlTokenRequest&&(identical(other.id, id) || other.id == id)&&(identical(other.forceRefresh, forceRefresh) || other.forceRefresh == forceRefresh));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,forceRefresh);
+
+@override
+String toString() {
+  return 'ControlMessage.tokenRequest(id: $id, forceRefresh: $forceRefresh)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ControlTokenRequestCopyWith<$Res> implements $ControlMessageCopyWith<$Res> {
+  factory $ControlTokenRequestCopyWith(ControlTokenRequest value, $Res Function(ControlTokenRequest) _then) = _$ControlTokenRequestCopyWithImpl;
+@useResult
+$Res call({
+ String id, bool forceRefresh
+});
+
+
+
+
+}
+/// @nodoc
+class _$ControlTokenRequestCopyWithImpl<$Res>
+    implements $ControlTokenRequestCopyWith<$Res> {
+  _$ControlTokenRequestCopyWithImpl(this._self, this._then);
+
+  final ControlTokenRequest _self;
+  final $Res Function(ControlTokenRequest) _then;
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? id = null,Object? forceRefresh = null,}) {
+  return _then(ControlTokenRequest(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,forceRefresh: null == forceRefresh ? _self.forceRefresh : forceRefresh // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlTokenResponse implements ControlMessage {
+  const ControlTokenResponse({required this.id, required this.accessToken, final  String? $type}): $type = $type ?? 'token_response';
+  factory ControlTokenResponse.fromJson(Map<String, dynamic> json) => _$ControlTokenResponseFromJson(json);
+
+ final  String id;
+ final  String? accessToken;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ControlTokenResponseCopyWith<ControlTokenResponse> get copyWith => _$ControlTokenResponseCopyWithImpl<ControlTokenResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlTokenResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlTokenResponse&&(identical(other.id, id) || other.id == id)&&(identical(other.accessToken, accessToken) || other.accessToken == accessToken));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,accessToken);
+
+@override
+String toString() {
+  return 'ControlMessage.tokenResponse(id: $id, accessToken: $accessToken)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ControlTokenResponseCopyWith<$Res> implements $ControlMessageCopyWith<$Res> {
+  factory $ControlTokenResponseCopyWith(ControlTokenResponse value, $Res Function(ControlTokenResponse) _then) = _$ControlTokenResponseCopyWithImpl;
+@useResult
+$Res call({
+ String id, String? accessToken
+});
+
+
+
+
+}
+/// @nodoc
+class _$ControlTokenResponseCopyWithImpl<$Res>
+    implements $ControlTokenResponseCopyWith<$Res> {
+  _$ControlTokenResponseCopyWithImpl(this._self, this._then);
+
+  final ControlTokenResponse _self;
+  final $Res Function(ControlTokenResponse) _then;
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? id = null,Object? accessToken = freezed,}) {
+  return _then(ControlTokenResponse(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,accessToken: freezed == accessToken ? _self.accessToken : accessToken // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlTokenUpdate implements ControlMessage {
+  const ControlTokenUpdate({required this.accessToken, final  String? $type}): $type = $type ?? 'token_update';
+  factory ControlTokenUpdate.fromJson(Map<String, dynamic> json) => _$ControlTokenUpdateFromJson(json);
+
+ final  String accessToken;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ControlTokenUpdateCopyWith<ControlTokenUpdate> get copyWith => _$ControlTokenUpdateCopyWithImpl<ControlTokenUpdate>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlTokenUpdateToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlTokenUpdate&&(identical(other.accessToken, accessToken) || other.accessToken == accessToken));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,accessToken);
+
+@override
+String toString() {
+  return 'ControlMessage.tokenUpdate(accessToken: $accessToken)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ControlTokenUpdateCopyWith<$Res> implements $ControlMessageCopyWith<$Res> {
+  factory $ControlTokenUpdateCopyWith(ControlTokenUpdate value, $Res Function(ControlTokenUpdate) _then) = _$ControlTokenUpdateCopyWithImpl;
+@useResult
+$Res call({
+ String accessToken
+});
+
+
+
+
+}
+/// @nodoc
+class _$ControlTokenUpdateCopyWithImpl<$Res>
+    implements $ControlTokenUpdateCopyWith<$Res> {
+  _$ControlTokenUpdateCopyWithImpl(this._self, this._then);
+
+  final ControlTokenUpdate _self;
+  final $Res Function(ControlTokenUpdate) _then;
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? accessToken = null,}) {
+  return _then(ControlTokenUpdate(
+accessToken: null == accessToken ? _self.accessToken : accessToken // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlStatus implements ControlMessage {
+  const ControlStatus({@JsonKey(unknownEnumValue: ControlRelayConnectionState.unknown) required this.relay, @JsonKey(unknownEnumValue: ControlPluginHealthState.unknown) required this.plugin, this.activeSessionCount = 0, final  String? $type}): $type = $type ?? 'status';
+  factory ControlStatus.fromJson(Map<String, dynamic> json) => _$ControlStatusFromJson(json);
+
+@JsonKey(unknownEnumValue: ControlRelayConnectionState.unknown) final  ControlRelayConnectionState relay;
+@JsonKey(unknownEnumValue: ControlPluginHealthState.unknown) final  ControlPluginHealthState plugin;
+@JsonKey() final  int activeSessionCount;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ControlStatusCopyWith<ControlStatus> get copyWith => _$ControlStatusCopyWithImpl<ControlStatus>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlStatusToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlStatus&&(identical(other.relay, relay) || other.relay == relay)&&(identical(other.plugin, plugin) || other.plugin == plugin)&&(identical(other.activeSessionCount, activeSessionCount) || other.activeSessionCount == activeSessionCount));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,relay,plugin,activeSessionCount);
+
+@override
+String toString() {
+  return 'ControlMessage.status(relay: $relay, plugin: $plugin, activeSessionCount: $activeSessionCount)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ControlStatusCopyWith<$Res> implements $ControlMessageCopyWith<$Res> {
+  factory $ControlStatusCopyWith(ControlStatus value, $Res Function(ControlStatus) _then) = _$ControlStatusCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(unknownEnumValue: ControlRelayConnectionState.unknown) ControlRelayConnectionState relay,@JsonKey(unknownEnumValue: ControlPluginHealthState.unknown) ControlPluginHealthState plugin, int activeSessionCount
+});
+
+
+
+
+}
+/// @nodoc
+class _$ControlStatusCopyWithImpl<$Res>
+    implements $ControlStatusCopyWith<$Res> {
+  _$ControlStatusCopyWithImpl(this._self, this._then);
+
+  final ControlStatus _self;
+  final $Res Function(ControlStatus) _then;
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? relay = null,Object? plugin = null,Object? activeSessionCount = null,}) {
+  return _then(ControlStatus(
+relay: null == relay ? _self.relay : relay // ignore: cast_nullable_to_non_nullable
+as ControlRelayConnectionState,plugin: null == plugin ? _self.plugin : plugin // ignore: cast_nullable_to_non_nullable
+as ControlPluginHealthState,activeSessionCount: null == activeSessionCount ? _self.activeSessionCount : activeSessionCount // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlPromptRequest implements ControlMessage {
+  const ControlPromptRequest({required this.id, @JsonKey(unknownEnumValue: ControlPromptKind.unknown) required this.kind, required this.message, final  String? $type}): $type = $type ?? 'prompt_request';
+  factory ControlPromptRequest.fromJson(Map<String, dynamic> json) => _$ControlPromptRequestFromJson(json);
+
+ final  String id;
+@JsonKey(unknownEnumValue: ControlPromptKind.unknown) final  ControlPromptKind kind;
+ final  String? message;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ControlPromptRequestCopyWith<ControlPromptRequest> get copyWith => _$ControlPromptRequestCopyWithImpl<ControlPromptRequest>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlPromptRequestToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlPromptRequest&&(identical(other.id, id) || other.id == id)&&(identical(other.kind, kind) || other.kind == kind)&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,kind,message);
+
+@override
+String toString() {
+  return 'ControlMessage.promptRequest(id: $id, kind: $kind, message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ControlPromptRequestCopyWith<$Res> implements $ControlMessageCopyWith<$Res> {
+  factory $ControlPromptRequestCopyWith(ControlPromptRequest value, $Res Function(ControlPromptRequest) _then) = _$ControlPromptRequestCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(unknownEnumValue: ControlPromptKind.unknown) ControlPromptKind kind, String? message
+});
+
+
+
+
+}
+/// @nodoc
+class _$ControlPromptRequestCopyWithImpl<$Res>
+    implements $ControlPromptRequestCopyWith<$Res> {
+  _$ControlPromptRequestCopyWithImpl(this._self, this._then);
+
+  final ControlPromptRequest _self;
+  final $Res Function(ControlPromptRequest) _then;
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? id = null,Object? kind = null,Object? message = freezed,}) {
+  return _then(ControlPromptRequest(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,kind: null == kind ? _self.kind : kind // ignore: cast_nullable_to_non_nullable
+as ControlPromptKind,message: freezed == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlPromptResponse implements ControlMessage {
+  const ControlPromptResponse({required this.id, required this.accepted, final  String? $type}): $type = $type ?? 'prompt_response';
+  factory ControlPromptResponse.fromJson(Map<String, dynamic> json) => _$ControlPromptResponseFromJson(json);
+
+ final  String id;
+ final  bool accepted;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ControlPromptResponseCopyWith<ControlPromptResponse> get copyWith => _$ControlPromptResponseCopyWithImpl<ControlPromptResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlPromptResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlPromptResponse&&(identical(other.id, id) || other.id == id)&&(identical(other.accepted, accepted) || other.accepted == accepted));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,accepted);
+
+@override
+String toString() {
+  return 'ControlMessage.promptResponse(id: $id, accepted: $accepted)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ControlPromptResponseCopyWith<$Res> implements $ControlMessageCopyWith<$Res> {
+  factory $ControlPromptResponseCopyWith(ControlPromptResponse value, $Res Function(ControlPromptResponse) _then) = _$ControlPromptResponseCopyWithImpl;
+@useResult
+$Res call({
+ String id, bool accepted
+});
+
+
+
+
+}
+/// @nodoc
+class _$ControlPromptResponseCopyWithImpl<$Res>
+    implements $ControlPromptResponseCopyWith<$Res> {
+  _$ControlPromptResponseCopyWithImpl(this._self, this._then);
+
+  final ControlPromptResponse _self;
+  final $Res Function(ControlPromptResponse) _then;
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? id = null,Object? accepted = null,}) {
+  return _then(ControlPromptResponse(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,accepted: null == accepted ? _self.accepted : accepted // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlRestart implements ControlMessage {
+  const ControlRestart({final  String? $type}): $type = $type ?? 'restart';
+  factory ControlRestart.fromJson(Map<String, dynamic> json) => _$ControlRestartFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlRestartToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlRestart);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'ControlMessage.restart()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlUnregisterAndExit implements ControlMessage {
+  const ControlUnregisterAndExit({final  String? $type}): $type = $type ?? 'unregister_and_exit';
+  factory ControlUnregisterAndExit.fromJson(Map<String, dynamic> json) => _$ControlUnregisterAndExitFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlUnregisterAndExitToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlUnregisterAndExit);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'ControlMessage.unregisterAndExit()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlRegistered implements ControlMessage {
+  const ControlRegistered({required this.bridgeId, final  String? $type}): $type = $type ?? 'registered';
+  factory ControlRegistered.fromJson(Map<String, dynamic> json) => _$ControlRegisteredFromJson(json);
+
+ final  String bridgeId;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ControlRegisteredCopyWith<ControlRegistered> get copyWith => _$ControlRegisteredCopyWithImpl<ControlRegistered>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlRegisteredToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlRegistered&&(identical(other.bridgeId, bridgeId) || other.bridgeId == bridgeId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,bridgeId);
+
+@override
+String toString() {
+  return 'ControlMessage.registered(bridgeId: $bridgeId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ControlRegisteredCopyWith<$Res> implements $ControlMessageCopyWith<$Res> {
+  factory $ControlRegisteredCopyWith(ControlRegistered value, $Res Function(ControlRegistered) _then) = _$ControlRegisteredCopyWithImpl;
+@useResult
+$Res call({
+ String bridgeId
+});
+
+
+
+
+}
+/// @nodoc
+class _$ControlRegisteredCopyWithImpl<$Res>
+    implements $ControlRegisteredCopyWith<$Res> {
+  _$ControlRegisteredCopyWithImpl(this._self, this._then);
+
+  final ControlRegistered _self;
+  final $Res Function(ControlRegistered) _then;
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? bridgeId = null,}) {
+  return _then(ControlRegistered(
+bridgeId: null == bridgeId ? _self.bridgeId : bridgeId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlProvisionProgressMessage implements ControlMessage {
+  const ControlProvisionProgressMessage({required this.progress, final  String? $type}): $type = $type ?? 'provision_progress';
+  factory ControlProvisionProgressMessage.fromJson(Map<String, dynamic> json) => _$ControlProvisionProgressMessageFromJson(json);
+
+ final  ControlProvisionProgress progress;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ControlProvisionProgressMessageCopyWith<ControlProvisionProgressMessage> get copyWith => _$ControlProvisionProgressMessageCopyWithImpl<ControlProvisionProgressMessage>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlProvisionProgressMessageToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlProvisionProgressMessage&&(identical(other.progress, progress) || other.progress == progress));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,progress);
+
+@override
+String toString() {
+  return 'ControlMessage.provisionProgress(progress: $progress)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ControlProvisionProgressMessageCopyWith<$Res> implements $ControlMessageCopyWith<$Res> {
+  factory $ControlProvisionProgressMessageCopyWith(ControlProvisionProgressMessage value, $Res Function(ControlProvisionProgressMessage) _then) = _$ControlProvisionProgressMessageCopyWithImpl;
+@useResult
+$Res call({
+ ControlProvisionProgress progress
+});
+
+
+$ControlProvisionProgressCopyWith<$Res> get progress;
+
+}
+/// @nodoc
+class _$ControlProvisionProgressMessageCopyWithImpl<$Res>
+    implements $ControlProvisionProgressMessageCopyWith<$Res> {
+  _$ControlProvisionProgressMessageCopyWithImpl(this._self, this._then);
+
+  final ControlProvisionProgressMessage _self;
+  final $Res Function(ControlProvisionProgressMessage) _then;
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? progress = null,}) {
+  return _then(ControlProvisionProgressMessage(
+progress: null == progress ? _self.progress : progress // ignore: cast_nullable_to_non_nullable
+as ControlProvisionProgress,
+  ));
+}
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$ControlProvisionProgressCopyWith<$Res> get progress {
+  
+  return $ControlProvisionProgressCopyWith<$Res>(_self.progress, (value) {
+    return _then(_self.copyWith(progress: value));
+  });
+}
+}
+
+// dart format on

--- a/shared/sesori_shared/lib/src/protocol/control_message.g.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_message.g.dart
@@ -1,0 +1,164 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'control_message.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ControlTokenRequest _$ControlTokenRequestFromJson(Map json) =>
+    ControlTokenRequest(
+      id: json['id'] as String,
+      forceRefresh: json['forceRefresh'] as bool? ?? false,
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$ControlTokenRequestToJson(
+  ControlTokenRequest instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'forceRefresh': instance.forceRefresh,
+  'type': instance.$type,
+};
+
+ControlTokenResponse _$ControlTokenResponseFromJson(Map json) =>
+    ControlTokenResponse(
+      id: json['id'] as String,
+      accessToken: json['accessToken'] as String?,
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$ControlTokenResponseToJson(
+  ControlTokenResponse instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'accessToken': ?instance.accessToken,
+  'type': instance.$type,
+};
+
+ControlTokenUpdate _$ControlTokenUpdateFromJson(Map json) => ControlTokenUpdate(
+  accessToken: json['accessToken'] as String,
+  $type: json['type'] as String?,
+);
+
+Map<String, dynamic> _$ControlTokenUpdateToJson(ControlTokenUpdate instance) =>
+    <String, dynamic>{
+      'accessToken': instance.accessToken,
+      'type': instance.$type,
+    };
+
+ControlStatus _$ControlStatusFromJson(Map json) => ControlStatus(
+  relay: $enumDecode(
+    _$ControlRelayConnectionStateEnumMap,
+    json['relay'],
+    unknownValue: ControlRelayConnectionState.unknown,
+  ),
+  plugin: $enumDecode(
+    _$ControlPluginHealthStateEnumMap,
+    json['plugin'],
+    unknownValue: ControlPluginHealthState.unknown,
+  ),
+  activeSessionCount: (json['activeSessionCount'] as num?)?.toInt() ?? 0,
+  $type: json['type'] as String?,
+);
+
+Map<String, dynamic> _$ControlStatusToJson(ControlStatus instance) =>
+    <String, dynamic>{
+      'relay': _$ControlRelayConnectionStateEnumMap[instance.relay]!,
+      'plugin': _$ControlPluginHealthStateEnumMap[instance.plugin]!,
+      'activeSessionCount': instance.activeSessionCount,
+      'type': instance.$type,
+    };
+
+const _$ControlRelayConnectionStateEnumMap = {
+  ControlRelayConnectionState.connected: 'connected',
+  ControlRelayConnectionState.connecting: 'connecting',
+  ControlRelayConnectionState.disconnected: 'disconnected',
+  ControlRelayConnectionState.unknown: 'unknown',
+};
+
+const _$ControlPluginHealthStateEnumMap = {
+  ControlPluginHealthState.healthy: 'healthy',
+  ControlPluginHealthState.degraded: 'degraded',
+  ControlPluginHealthState.unavailable: 'unavailable',
+  ControlPluginHealthState.unknown: 'unknown',
+};
+
+ControlPromptRequest _$ControlPromptRequestFromJson(Map json) =>
+    ControlPromptRequest(
+      id: json['id'] as String,
+      kind: $enumDecode(
+        _$ControlPromptKindEnumMap,
+        json['kind'],
+        unknownValue: ControlPromptKind.unknown,
+      ),
+      message: json['message'] as String?,
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$ControlPromptRequestToJson(
+  ControlPromptRequest instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'kind': _$ControlPromptKindEnumMap[instance.kind]!,
+  'message': ?instance.message,
+  'type': instance.$type,
+};
+
+const _$ControlPromptKindEnumMap = {
+  ControlPromptKind.replaceBridge: 'replace_bridge',
+  ControlPromptKind.loginNeeded: 'login_needed',
+  ControlPromptKind.unknown: 'unknown',
+};
+
+ControlPromptResponse _$ControlPromptResponseFromJson(Map json) =>
+    ControlPromptResponse(
+      id: json['id'] as String,
+      accepted: json['accepted'] as bool,
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$ControlPromptResponseToJson(
+  ControlPromptResponse instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'accepted': instance.accepted,
+  'type': instance.$type,
+};
+
+ControlRestart _$ControlRestartFromJson(Map json) =>
+    ControlRestart($type: json['type'] as String?);
+
+Map<String, dynamic> _$ControlRestartToJson(ControlRestart instance) =>
+    <String, dynamic>{'type': instance.$type};
+
+ControlUnregisterAndExit _$ControlUnregisterAndExitFromJson(Map json) =>
+    ControlUnregisterAndExit($type: json['type'] as String?);
+
+Map<String, dynamic> _$ControlUnregisterAndExitToJson(
+  ControlUnregisterAndExit instance,
+) => <String, dynamic>{'type': instance.$type};
+
+ControlRegistered _$ControlRegisteredFromJson(Map json) => ControlRegistered(
+  bridgeId: json['bridgeId'] as String,
+  $type: json['type'] as String?,
+);
+
+Map<String, dynamic> _$ControlRegisteredToJson(ControlRegistered instance) =>
+    <String, dynamic>{'bridgeId': instance.bridgeId, 'type': instance.$type};
+
+ControlProvisionProgressMessage _$ControlProvisionProgressMessageFromJson(
+  Map json,
+) => ControlProvisionProgressMessage(
+  progress: ControlProvisionProgress.fromJson(
+    Map<String, dynamic>.from(json['progress'] as Map),
+  ),
+  $type: json['type'] as String?,
+);
+
+Map<String, dynamic> _$ControlProvisionProgressMessageToJson(
+  ControlProvisionProgressMessage instance,
+) => <String, dynamic>{
+  'progress': instance.progress.toJson(),
+  'type': instance.$type,
+};

--- a/shared/sesori_shared/lib/src/protocol/control_provision_progress.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_provision_progress.dart
@@ -1,0 +1,51 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "control_provision_progress.freezed.dart";
+part "control_provision_progress.g.dart";
+
+/// Wire mirror of the bridge's `RuntimeProvisionProgress` (which lives in
+/// `sesori_plugin_interface` and cannot be imported here — `sesori_shared` is
+/// the shared leaf both workspaces depend on). In supervised mode the bridge
+/// tees its provisioning stream onto the control channel as these DTOs so the
+/// GUI can render first-run download/install progress (PR 1.13).
+///
+/// Pure data only: the source type's derived `fraction` getter is intentionally
+/// omitted — consumers compute it from [ControlProvisionDownloading.totalBytes].
+@Freezed(unionKey: "type", unionValueCase: FreezedUnionCase.snake, fromJson: true, toJson: true)
+sealed class ControlProvisionProgress with _$ControlProvisionProgress {
+  /// Deciding which runtime to use; no bytes fetched yet.
+  @FreezedUnionValue("resolving")
+  const factory ControlProvisionProgress.resolving() = ControlProvisionResolving;
+
+  /// Downloading the managed runtime archive. [totalBytes] is null when the
+  /// server did not advertise a length (progress is then indeterminate).
+  @FreezedUnionValue("downloading")
+  const factory ControlProvisionProgress.downloading({
+    required int receivedBytes,
+    required int? totalBytes,
+  }) = ControlProvisionDownloading;
+
+  /// Unpacking the downloaded archive into its versioned install directory.
+  @FreezedUnionValue("extracting")
+  const factory ControlProvisionProgress.extracting() = ControlProvisionExtracting;
+
+  /// Verifying the downloaded archive against its pinned checksum.
+  @FreezedUnionValue("verifying")
+  const factory ControlProvisionProgress.verifying() = ControlProvisionVerifying;
+
+  /// A non-terminal, user-facing notice surfaced mid-provision.
+  @FreezedUnionValue("notice")
+  const factory ControlProvisionProgress.notice({required String message}) = ControlProvisionNotice;
+
+  /// Terminal success: the runtime is ready; [binaryPath] is the launch target.
+  @FreezedUnionValue("ready")
+  const factory ControlProvisionProgress.ready({required String binaryPath}) = ControlProvisionReady;
+
+  /// Terminal failure (non-fatal): the runtime could not be provisioned;
+  /// [message] explains what went wrong for logs/diagnostics.
+  @FreezedUnionValue("failed")
+  const factory ControlProvisionProgress.failed({required String message}) = ControlProvisionFailed;
+
+  factory ControlProvisionProgress.fromJson(Map<String, dynamic> json) =>
+      _$ControlProvisionProgressFromJson(json);
+}

--- a/shared/sesori_shared/lib/src/protocol/control_provision_progress.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_provision_progress.dart
@@ -7,7 +7,7 @@ part "control_provision_progress.g.dart";
 /// `sesori_plugin_interface` and cannot be imported here — `sesori_shared` is
 /// the shared leaf both workspaces depend on). In supervised mode the bridge
 /// tees its provisioning stream onto the control channel as these DTOs so the
-/// GUI can render first-run download/install progress (PR 1.13).
+/// GUI can render first-run download/install progress.
 ///
 /// Pure data only: the source type's derived `fraction` getter is intentionally
 /// omitted — consumers compute it from [ControlProvisionDownloading.totalBytes].

--- a/shared/sesori_shared/lib/src/protocol/control_provision_progress.freezed.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_provision_progress.freezed.dart
@@ -1,0 +1,502 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'control_provision_progress.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+ControlProvisionProgress _$ControlProvisionProgressFromJson(
+  Map<String, dynamic> json
+) {
+        switch (json['type']) {
+                  case 'resolving':
+          return ControlProvisionResolving.fromJson(
+            json
+          );
+                case 'downloading':
+          return ControlProvisionDownloading.fromJson(
+            json
+          );
+                case 'extracting':
+          return ControlProvisionExtracting.fromJson(
+            json
+          );
+                case 'verifying':
+          return ControlProvisionVerifying.fromJson(
+            json
+          );
+                case 'notice':
+          return ControlProvisionNotice.fromJson(
+            json
+          );
+                case 'ready':
+          return ControlProvisionReady.fromJson(
+            json
+          );
+                case 'failed':
+          return ControlProvisionFailed.fromJson(
+            json
+          );
+        
+          default:
+            throw CheckedFromJsonException(
+  json,
+  'type',
+  'ControlProvisionProgress',
+  'Invalid union type "${json['type']}"!'
+);
+        }
+      
+}
+
+/// @nodoc
+mixin _$ControlProvisionProgress {
+
+
+
+  /// Serializes this ControlProvisionProgress to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlProvisionProgress);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'ControlProvisionProgress()';
+}
+
+
+}
+
+/// @nodoc
+class $ControlProvisionProgressCopyWith<$Res>  {
+$ControlProvisionProgressCopyWith(ControlProvisionProgress _, $Res Function(ControlProvisionProgress) __);
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlProvisionResolving implements ControlProvisionProgress {
+  const ControlProvisionResolving({final  String? $type}): $type = $type ?? 'resolving';
+  factory ControlProvisionResolving.fromJson(Map<String, dynamic> json) => _$ControlProvisionResolvingFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlProvisionResolvingToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlProvisionResolving);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'ControlProvisionProgress.resolving()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlProvisionDownloading implements ControlProvisionProgress {
+  const ControlProvisionDownloading({required this.receivedBytes, required this.totalBytes, final  String? $type}): $type = $type ?? 'downloading';
+  factory ControlProvisionDownloading.fromJson(Map<String, dynamic> json) => _$ControlProvisionDownloadingFromJson(json);
+
+ final  int receivedBytes;
+ final  int? totalBytes;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of ControlProvisionProgress
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ControlProvisionDownloadingCopyWith<ControlProvisionDownloading> get copyWith => _$ControlProvisionDownloadingCopyWithImpl<ControlProvisionDownloading>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlProvisionDownloadingToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlProvisionDownloading&&(identical(other.receivedBytes, receivedBytes) || other.receivedBytes == receivedBytes)&&(identical(other.totalBytes, totalBytes) || other.totalBytes == totalBytes));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,receivedBytes,totalBytes);
+
+@override
+String toString() {
+  return 'ControlProvisionProgress.downloading(receivedBytes: $receivedBytes, totalBytes: $totalBytes)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ControlProvisionDownloadingCopyWith<$Res> implements $ControlProvisionProgressCopyWith<$Res> {
+  factory $ControlProvisionDownloadingCopyWith(ControlProvisionDownloading value, $Res Function(ControlProvisionDownloading) _then) = _$ControlProvisionDownloadingCopyWithImpl;
+@useResult
+$Res call({
+ int receivedBytes, int? totalBytes
+});
+
+
+
+
+}
+/// @nodoc
+class _$ControlProvisionDownloadingCopyWithImpl<$Res>
+    implements $ControlProvisionDownloadingCopyWith<$Res> {
+  _$ControlProvisionDownloadingCopyWithImpl(this._self, this._then);
+
+  final ControlProvisionDownloading _self;
+  final $Res Function(ControlProvisionDownloading) _then;
+
+/// Create a copy of ControlProvisionProgress
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? receivedBytes = null,Object? totalBytes = freezed,}) {
+  return _then(ControlProvisionDownloading(
+receivedBytes: null == receivedBytes ? _self.receivedBytes : receivedBytes // ignore: cast_nullable_to_non_nullable
+as int,totalBytes: freezed == totalBytes ? _self.totalBytes : totalBytes // ignore: cast_nullable_to_non_nullable
+as int?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlProvisionExtracting implements ControlProvisionProgress {
+  const ControlProvisionExtracting({final  String? $type}): $type = $type ?? 'extracting';
+  factory ControlProvisionExtracting.fromJson(Map<String, dynamic> json) => _$ControlProvisionExtractingFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlProvisionExtractingToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlProvisionExtracting);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'ControlProvisionProgress.extracting()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlProvisionVerifying implements ControlProvisionProgress {
+  const ControlProvisionVerifying({final  String? $type}): $type = $type ?? 'verifying';
+  factory ControlProvisionVerifying.fromJson(Map<String, dynamic> json) => _$ControlProvisionVerifyingFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlProvisionVerifyingToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlProvisionVerifying);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'ControlProvisionProgress.verifying()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlProvisionNotice implements ControlProvisionProgress {
+  const ControlProvisionNotice({required this.message, final  String? $type}): $type = $type ?? 'notice';
+  factory ControlProvisionNotice.fromJson(Map<String, dynamic> json) => _$ControlProvisionNoticeFromJson(json);
+
+ final  String message;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of ControlProvisionProgress
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ControlProvisionNoticeCopyWith<ControlProvisionNotice> get copyWith => _$ControlProvisionNoticeCopyWithImpl<ControlProvisionNotice>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlProvisionNoticeToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlProvisionNotice&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,message);
+
+@override
+String toString() {
+  return 'ControlProvisionProgress.notice(message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ControlProvisionNoticeCopyWith<$Res> implements $ControlProvisionProgressCopyWith<$Res> {
+  factory $ControlProvisionNoticeCopyWith(ControlProvisionNotice value, $Res Function(ControlProvisionNotice) _then) = _$ControlProvisionNoticeCopyWithImpl;
+@useResult
+$Res call({
+ String message
+});
+
+
+
+
+}
+/// @nodoc
+class _$ControlProvisionNoticeCopyWithImpl<$Res>
+    implements $ControlProvisionNoticeCopyWith<$Res> {
+  _$ControlProvisionNoticeCopyWithImpl(this._self, this._then);
+
+  final ControlProvisionNotice _self;
+  final $Res Function(ControlProvisionNotice) _then;
+
+/// Create a copy of ControlProvisionProgress
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? message = null,}) {
+  return _then(ControlProvisionNotice(
+message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlProvisionReady implements ControlProvisionProgress {
+  const ControlProvisionReady({required this.binaryPath, final  String? $type}): $type = $type ?? 'ready';
+  factory ControlProvisionReady.fromJson(Map<String, dynamic> json) => _$ControlProvisionReadyFromJson(json);
+
+ final  String binaryPath;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of ControlProvisionProgress
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ControlProvisionReadyCopyWith<ControlProvisionReady> get copyWith => _$ControlProvisionReadyCopyWithImpl<ControlProvisionReady>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlProvisionReadyToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlProvisionReady&&(identical(other.binaryPath, binaryPath) || other.binaryPath == binaryPath));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,binaryPath);
+
+@override
+String toString() {
+  return 'ControlProvisionProgress.ready(binaryPath: $binaryPath)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ControlProvisionReadyCopyWith<$Res> implements $ControlProvisionProgressCopyWith<$Res> {
+  factory $ControlProvisionReadyCopyWith(ControlProvisionReady value, $Res Function(ControlProvisionReady) _then) = _$ControlProvisionReadyCopyWithImpl;
+@useResult
+$Res call({
+ String binaryPath
+});
+
+
+
+
+}
+/// @nodoc
+class _$ControlProvisionReadyCopyWithImpl<$Res>
+    implements $ControlProvisionReadyCopyWith<$Res> {
+  _$ControlProvisionReadyCopyWithImpl(this._self, this._then);
+
+  final ControlProvisionReady _self;
+  final $Res Function(ControlProvisionReady) _then;
+
+/// Create a copy of ControlProvisionProgress
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? binaryPath = null,}) {
+  return _then(ControlProvisionReady(
+binaryPath: null == binaryPath ? _self.binaryPath : binaryPath // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class ControlProvisionFailed implements ControlProvisionProgress {
+  const ControlProvisionFailed({required this.message, final  String? $type}): $type = $type ?? 'failed';
+  factory ControlProvisionFailed.fromJson(Map<String, dynamic> json) => _$ControlProvisionFailedFromJson(json);
+
+ final  String message;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of ControlProvisionProgress
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ControlProvisionFailedCopyWith<ControlProvisionFailed> get copyWith => _$ControlProvisionFailedCopyWithImpl<ControlProvisionFailed>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlProvisionFailedToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlProvisionFailed&&(identical(other.message, message) || other.message == message));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,message);
+
+@override
+String toString() {
+  return 'ControlProvisionProgress.failed(message: $message)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ControlProvisionFailedCopyWith<$Res> implements $ControlProvisionProgressCopyWith<$Res> {
+  factory $ControlProvisionFailedCopyWith(ControlProvisionFailed value, $Res Function(ControlProvisionFailed) _then) = _$ControlProvisionFailedCopyWithImpl;
+@useResult
+$Res call({
+ String message
+});
+
+
+
+
+}
+/// @nodoc
+class _$ControlProvisionFailedCopyWithImpl<$Res>
+    implements $ControlProvisionFailedCopyWith<$Res> {
+  _$ControlProvisionFailedCopyWithImpl(this._self, this._then);
+
+  final ControlProvisionFailed _self;
+  final $Res Function(ControlProvisionFailed) _then;
+
+/// Create a copy of ControlProvisionProgress
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? message = null,}) {
+  return _then(ControlProvisionFailed(
+message: null == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/shared/sesori_shared/lib/src/protocol/control_provision_progress.g.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_provision_progress.g.dart
@@ -1,0 +1,76 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'control_provision_progress.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ControlProvisionResolving _$ControlProvisionResolvingFromJson(Map json) =>
+    ControlProvisionResolving($type: json['type'] as String?);
+
+Map<String, dynamic> _$ControlProvisionResolvingToJson(
+  ControlProvisionResolving instance,
+) => <String, dynamic>{'type': instance.$type};
+
+ControlProvisionDownloading _$ControlProvisionDownloadingFromJson(Map json) =>
+    ControlProvisionDownloading(
+      receivedBytes: (json['receivedBytes'] as num).toInt(),
+      totalBytes: (json['totalBytes'] as num?)?.toInt(),
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$ControlProvisionDownloadingToJson(
+  ControlProvisionDownloading instance,
+) => <String, dynamic>{
+  'receivedBytes': instance.receivedBytes,
+  'totalBytes': ?instance.totalBytes,
+  'type': instance.$type,
+};
+
+ControlProvisionExtracting _$ControlProvisionExtractingFromJson(Map json) =>
+    ControlProvisionExtracting($type: json['type'] as String?);
+
+Map<String, dynamic> _$ControlProvisionExtractingToJson(
+  ControlProvisionExtracting instance,
+) => <String, dynamic>{'type': instance.$type};
+
+ControlProvisionVerifying _$ControlProvisionVerifyingFromJson(Map json) =>
+    ControlProvisionVerifying($type: json['type'] as String?);
+
+Map<String, dynamic> _$ControlProvisionVerifyingToJson(
+  ControlProvisionVerifying instance,
+) => <String, dynamic>{'type': instance.$type};
+
+ControlProvisionNotice _$ControlProvisionNoticeFromJson(Map json) =>
+    ControlProvisionNotice(
+      message: json['message'] as String,
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$ControlProvisionNoticeToJson(
+  ControlProvisionNotice instance,
+) => <String, dynamic>{'message': instance.message, 'type': instance.$type};
+
+ControlProvisionReady _$ControlProvisionReadyFromJson(Map json) =>
+    ControlProvisionReady(
+      binaryPath: json['binaryPath'] as String,
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$ControlProvisionReadyToJson(
+  ControlProvisionReady instance,
+) => <String, dynamic>{
+  'binaryPath': instance.binaryPath,
+  'type': instance.$type,
+};
+
+ControlProvisionFailed _$ControlProvisionFailedFromJson(Map json) =>
+    ControlProvisionFailed(
+      message: json['message'] as String,
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$ControlProvisionFailedToJson(
+  ControlProvisionFailed instance,
+) => <String, dynamic>{'message': instance.message, 'type': instance.$type};

--- a/shared/sesori_shared/test/protocol/control_message_test.dart
+++ b/shared/sesori_shared/test/protocol/control_message_test.dart
@@ -1,0 +1,105 @@
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ControlMessage", () {
+    final variants = <String, ControlMessage>{
+      "token_request": const ControlMessage.tokenRequest(id: "req-1", forceRefresh: true),
+      "token_response": const ControlMessage.tokenResponse(id: "req-1", accessToken: "jwt"),
+      "token_update": const ControlMessage.tokenUpdate(accessToken: "jwt"),
+      "status": const ControlMessage.status(
+        relay: ControlRelayConnectionState.connected,
+        plugin: ControlPluginHealthState.degraded,
+        activeSessionCount: 3,
+      ),
+      "prompt_request": const ControlMessage.promptRequest(
+        id: "p-1",
+        kind: ControlPromptKind.replaceBridge,
+        message: "Another bridge is running",
+      ),
+      "prompt_response": const ControlMessage.promptResponse(id: "p-1", accepted: true),
+      "restart": const ControlMessage.restart(),
+      "unregister_and_exit": const ControlMessage.unregisterAndExit(),
+      "registered": const ControlMessage.registered(bridgeId: "br_abc12345"),
+      "provision_progress": const ControlMessage.provisionProgress(
+        progress: ControlProvisionProgress.downloading(receivedBytes: 10, totalBytes: 100),
+      ),
+    };
+
+    variants.forEach((type, original) {
+      test("round-trips the $type variant with its discriminator", () {
+        final json = original.toJson();
+
+        expect(json["type"], equals(type));
+        expect(ControlMessage.fromJson(json), equals(original));
+      });
+    });
+
+    test("tokenRequest defaults forceRefresh to false when absent", () {
+      final parsed = ControlMessage.fromJson({"type": "token_request", "id": "req-2"});
+
+      expect(parsed, isA<ControlTokenRequest>());
+      expect((parsed as ControlTokenRequest).forceRefresh, isFalse);
+    });
+
+    test("tokenResponse omits accessToken when the GUI cannot supply one", () {
+      const original = ControlMessage.tokenResponse(id: "req-3", accessToken: null);
+
+      final json = original.toJson();
+
+      expect(json, equals({"type": "token_response", "id": "req-3"}));
+      expect((ControlMessage.fromJson(json) as ControlTokenResponse).accessToken, isNull);
+    });
+
+    test("promptRequest omits message when null", () {
+      const original = ControlMessage.promptRequest(
+        id: "p-2",
+        kind: ControlPromptKind.loginNeeded,
+        message: null,
+      );
+
+      final json = original.toJson();
+
+      expect(json.containsKey("message"), isFalse);
+      expect(ControlMessage.fromJson(json), equals(original));
+    });
+
+    test("status nests the provision-progress discriminator independently", () {
+      const original = ControlMessage.provisionProgress(
+        progress: ControlProvisionProgress.ready(binaryPath: "/bin/opencode"),
+      );
+
+      final json = original.toJson();
+
+      expect(json["type"], equals("provision_progress"));
+      expect(json["progress"], equals({"type": "ready", "binaryPath": "/bin/opencode"}));
+      expect(ControlMessage.fromJson(json), equals(original));
+    });
+
+    group("forward-compatibility", () {
+      test("relay enum falls back to unknown for an unrecognized value", () {
+        final parsed = ControlMessage.fromJson({
+          "type": "status",
+          "relay": "rebooting",
+          "plugin": "healthy",
+        });
+
+        final status = parsed as ControlStatus;
+        expect(status.relay, equals(ControlRelayConnectionState.unknown));
+        expect(status.plugin, equals(ControlPluginHealthState.healthy));
+        expect(status.activeSessionCount, equals(0));
+      });
+
+      test("prompt-kind enum falls back to unknown for an unrecognized value", () {
+        final parsed = ControlMessage.fromJson({
+          "type": "prompt_request",
+          "id": "p-3",
+          "kind": "future_prompt",
+          "message": null,
+        });
+
+        expect((parsed as ControlPromptRequest).kind, equals(ControlPromptKind.unknown));
+      });
+    });
+  });
+}

--- a/shared/sesori_shared/test/protocol/control_provision_progress_test.dart
+++ b/shared/sesori_shared/test/protocol/control_provision_progress_test.dart
@@ -1,0 +1,48 @@
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ControlProvisionProgress", () {
+    final variants = <String, ControlProvisionProgress>{
+      "resolving": const ControlProvisionProgress.resolving(),
+      "downloading": const ControlProvisionProgress.downloading(receivedBytes: 512, totalBytes: 2048),
+      "extracting": const ControlProvisionProgress.extracting(),
+      "verifying": const ControlProvisionProgress.verifying(),
+      "notice": const ControlProvisionProgress.notice(message: "using managed runtime"),
+      "ready": const ControlProvisionProgress.ready(binaryPath: "/opt/opencode/bin/opencode"),
+      "failed": const ControlProvisionProgress.failed(message: "checksum mismatch"),
+    };
+
+    variants.forEach((type, original) {
+      test("round-trips the $type variant with its discriminator", () {
+        final json = original.toJson();
+
+        expect(json["type"], equals(type));
+        expect(ControlProvisionProgress.fromJson(json), equals(original));
+      });
+    });
+
+    test("downloading omits totalBytes when indeterminate", () {
+      const original = ControlProvisionProgress.downloading(receivedBytes: 100, totalBytes: null);
+
+      final json = original.toJson();
+
+      expect(json.containsKey("totalBytes"), isFalse);
+      expect(json, equals({"type": "downloading", "receivedBytes": 100}));
+
+      final restored = ControlProvisionProgress.fromJson(json);
+      expect(restored, equals(original));
+      expect((restored as ControlProvisionDownloading).totalBytes, isNull);
+    });
+
+    test("parses the concrete variant subtype", () {
+      final parsed = ControlProvisionProgress.fromJson({
+        "type": "ready",
+        "binaryPath": "/usr/local/bin/opencode",
+      });
+
+      expect(parsed, isA<ControlProvisionReady>());
+      expect((parsed as ControlProvisionReady).binaryPath, equals("/usr/local/bin/opencode"));
+    });
+  });
+}


### PR DESCRIPTION
## What

Phase 1, **PR 1.2** of the desktop plan (`docs/desktop/PLAN.md` §9). Adds the GUI↔supervised-helper **control-channel wire protocol** as pure-data Freezed sealed unions in `shared/sesori_shared` (ADR A4: control-protocol DTOs are pure data, the only shared point between the bridge and client workspaces).

This PR introduces **only wire types + JSON (de)serialization + tests** — zero senders/handlers/services. Later Phase-1 PRs (1.3–1.13) and Phase-2 GUI PRs consume them.

## Types (both in `lib/src/protocol/`, alongside `RelayMessage`)

- **`ControlMessage`** — single bidirectional union keyed by `type`:
  - `token_request` / `token_response` (id-correlated; null `accessToken` ⇒ GUI couldn't supply)
  - `token_update` (push), `status`, `prompt_request` / `prompt_response` (id-correlated)
  - `restart` (intentional-restart heads-up before `exit(86)`), `unregister_and_exit`
  - `registered` (carries `bridgeId`, ADR A13), `provision_progress` (wraps the nested union)
- **`ControlProvisionProgress`** — separate union mirroring the bridge's `RuntimeProvisionProgress` 1:1 (resolving / downloading / extracting / verifying / notice / ready / failed). The source lives in `sesori_plugin_interface` and **must not** be imported (dependency direction), so it is mirrored; the derived `fraction` getter is intentionally dropped (pure data).

## Forward-compatibility

- Three enums (`ControlRelayConnectionState`, `ControlPluginHealthState`, `ControlPromptKind`) each carry an `unknown` `@JsonValue` fallback + `@JsonKey(unknownEnumValue:)`.
- Optional fields use `@Default`; null keys auto-drop (build.yaml `include_if_null: false`).
- No catch-all message-type variant — matches `RelayMessage`; the GUI and helper are built from the same commit (§2).

## Release safety

Purely additive: new files + additive barrel exports, no existing type touched ⇒ standalone bridge and mobile both unaffected.

## Tests / verification

- 25 new round-trip / discriminator / null-omission / enum-fallback tests.
- `sesori_shared`: `dart analyze` clean, `dart test` 265 pass.
- `client/app` (mobile product): `flutter analyze` clean — additive change, no consumer break (the PR-1.2-specific acceptance).

## Aristotle

- Plan review: **APPROVED**
- Impl review: **APPROVED**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the GUI↔supervised-helper control-channel wire DTOs to `sesori_shared` as pure-data `Freezed` unions with JSON serialization. Also cleans up DTO comments and adds an `AGENTS.md` guideline to keep source comments timeless.

- **New Features**
  - `ControlMessage` union (`type: snake_case`): token_request, token_response, token_update, status, prompt_request, prompt_response, restart, unregister_and_exit, registered, provision_progress.
  - `ControlProvisionProgress` union mirrors bridge `RuntimeProvisionProgress` (resolving, downloading, extracting, verifying, notice, ready, failed); pure data only.
  - Forward-compat: enums include `unknown` fallbacks; optional fields use `@Default`; JSON omits nulls.
  - Barrel exports added in `sesori_shared.dart`; desktop docs updated to mark PR 1.2 done; added “timeless comments” rule in `AGENTS.md` and scrubbed DTO comments to remove plan/ADR/PR refs.
  - 25 serialization tests added; no behavior changes; other products remain unaffected.

<sup>Written for commit e2ff4be11ef0f3f377667225b5da7afe92f339da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

