### PR TITLE
feat: device descriptor on OAuth login (drop 4-char match code)

### DIFF
--- a/bridge/app/lib/src/auth/login_oauth_api.dart
+++ b/bridge/app/lib/src/auth/login_oauth_api.dart
@@ -13,11 +13,17 @@ Uri _buildUri({required String base, required String path}) {
 class LoginOAuthApi {
   final String authBackendUrl;
   final http.Client _client;
+  final String _clientType;
+  final DeviceInfo _device;
 
   LoginOAuthApi({
     required this.authBackendUrl,
     required http.Client client,
-  }) : _client = client;
+    required String clientType,
+    required DeviceInfo device,
+  })  : _client = client,
+        _clientType = clientType,
+        _device = device;
 
   Future<AuthInitResponse> initOAuthSession({
     required OAuthProvider provider,
@@ -30,7 +36,7 @@ class LoginOAuthApi {
         "Content-Type": "application/json",
         oauthSessionTokenHeader: sessionToken,
       },
-      body: jsonEncode(const AuthInitRequest(clientType: "bridge").toJson()),
+      body: jsonEncode(AuthInitRequest(clientType: _clientType, device: _device).toJson()),
     );
 
     if (response.statusCode != 200) {
@@ -44,8 +50,8 @@ class LoginOAuthApi {
       throw Exception("auth init response malformed: $e");
     }
 
-    if (initResp.authUrl.isEmpty || initResp.state.isEmpty || initResp.userCode.isEmpty) {
-      throw Exception("auth init response missing authUrl/state/userCode");
+    if (initResp.authUrl.isEmpty || initResp.state.isEmpty) {
+      throw Exception("auth init response missing authUrl/state");
     }
 
     return initResp;

--- a/bridge/app/lib/src/auth/login_oauth_service.dart
+++ b/bridge/app/lib/src/auth/login_oauth_service.dart
@@ -168,8 +168,6 @@ class LoginOAuthService {
       sessionToken: sessionToken,
     );
 
-    _printUserCode(initResp.userCode);
-
     // The URL is ALWAYS printed, on its own line, so login works even when no
     // browser can be opened: the bridge frequently runs headless (servers, SSH
     // sessions, containers), and a launcher exit code of 0 only means the OS
@@ -254,43 +252,6 @@ class LoginOAuthService {
     } finally {
       stopwatch.stop();
     }
-  }
-
-  void _printUserCode(String userCode) {
-    const line = "┌──────────────────────────────────────────┐";
-    const empty = "│                                          │";
-    const contentWidth = 42; // width inside the box borders
-
-    final codeText = "CODE:  $userCode";
-    final codePadding = " " * ((contentWidth - codeText.length) ~/ 2);
-    final codeLine = "│$codePadding$codeText${" " * (contentWidth - codePadding.length - codeText.length)}│";
-
-    const confirmText = "Confirm this code on the web page";
-    final confirmPadding = " " * ((contentWidth - confirmText.length) ~/ 2);
-    final confirmLine =
-        "│$confirmPadding$confirmText${" " * (contentWidth - confirmPadding.length - confirmText.length)}│";
-
-    const beforeText = "before approving the login request.";
-    final beforePadding = " " * ((contentWidth - beforeText.length) ~/ 2);
-    final beforeLine = "│$beforePadding$beforeText${" " * (contentWidth - beforePadding.length - beforeText.length)}│";
-
-    const bottomLine = "└──────────────────────────────────────────┘";
-
-    // Printed as a single write so the box renders atomically as one block.
-    Console.message(
-      [
-        "",
-        line,
-        empty,
-        codeLine,
-        empty,
-        confirmLine,
-        beforeLine,
-        empty,
-        bottomLine,
-        "",
-      ].join("\n"),
-    );
   }
 
   String _generateSessionToken() {

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -756,7 +756,7 @@ class BridgeRuntimeRunner {
   /// always satisfied, and clamp to the 120-char server limit. The cosmetic OS
   /// version is omitted when it can't be derived.
   static DeviceInfo _bridgeDeviceInfo() {
-    final hostname = io.Platform.localHostname.trim();
+    final hostname = _localHostname().trim();
     final name = hostname.isEmpty ? "Sesori Bridge" : hostname;
     return DeviceInfo(
       name: name.length > 120 ? name.substring(0, 120).trim() : name,
@@ -767,6 +767,18 @@ class BridgeRuntimeRunner {
       ),
       appVersion: appVersion,
     );
+  }
+
+  /// `Platform.localHostname` can throw (e.g. `SocketException` when hostname
+  /// resolution fails in restricted/containerized environments). The descriptor
+  /// is best-effort, so degrade to an empty name and let the caller fall back.
+  static String _localHostname() {
+    try {
+      return io.Platform.localHostname;
+    } on Object catch (error) {
+      Log.w("Failed to read localHostname for the device descriptor", error);
+      return "";
+    }
   }
 
   /// Reads `/etc/os-release` (Linux only) so [OsVersionFormatter] can derive the

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -5,7 +5,8 @@ import "package:clock/clock.dart";
 import "package:http/http.dart" as http;
 import "package:path/path.dart" as path;
 import "package:rxdart/rxdart.dart";
-import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show ArchiveExtractor, BinaryDownloadClient, ChecksumValidator;
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart"
+    show ArchiveExtractor, BinaryDownloadClient, ChecksumValidator, OsVersionFormatter, PlatformOs;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
     show
         BridgePlugin,
@@ -23,6 +24,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
         ServerClock,
         StartAbortController,
         StartAbortSignal;
+import "package:sesori_shared/sesori_shared.dart" show DeviceInfo;
 
 import "../../api/bridge_settings_api.dart";
 import "../../auth/bridge_registration_api.dart";
@@ -183,6 +185,8 @@ class BridgeRuntimeRunner {
         api: LoginOAuthApi(
           authBackendUrl: options.authBackendUrl,
           client: httpClient,
+          clientType: "bridge_${PlatformOs.fromOperatingSystem(operatingSystem: io.Platform.operatingSystem).value}",
+          device: _bridgeDeviceInfo(),
         ),
         browserLauncher: openOAuthBrowser,
         browserOpenability: detectBrowserOpenability,
@@ -743,5 +747,37 @@ class BridgeRuntimeRunner {
 
   static String _buildOwnerSessionId({required ProcessIdentity currentBridgeIdentity}) {
     return '${currentBridgeIdentity.pid}:${currentBridgeIdentity.startMarker ?? currentBridgeIdentity.capturedAt.toIso8601String()}';
+  }
+
+  /// Describes this bridge machine for the auth-server confirmation page.
+  ///
+  /// Best-effort: [io.Platform.localHostname] is virtually always present, but
+  /// we fall back to a constant so the server's required, non-empty `name` is
+  /// always satisfied, and clamp to the 120-char server limit. The cosmetic OS
+  /// version is omitted when it can't be derived.
+  static DeviceInfo _bridgeDeviceInfo() {
+    final hostname = io.Platform.localHostname.trim();
+    final name = hostname.isEmpty ? "Sesori Bridge" : hostname;
+    return DeviceInfo(
+      name: name.length > 120 ? name.substring(0, 120).trim() : name,
+      osVersion: const OsVersionFormatter().format(
+        operatingSystem: io.Platform.operatingSystem,
+        operatingSystemVersion: io.Platform.operatingSystemVersion,
+        osReleaseContents: _readLinuxOsRelease(),
+      ),
+      appVersion: appVersion,
+    );
+  }
+
+  /// Reads `/etc/os-release` (Linux only) so [OsVersionFormatter] can derive the
+  /// distro label; null on other platforms or when the file can't be read.
+  static String? _readLinuxOsRelease() {
+    if (!io.Platform.isLinux) return null;
+    try {
+      return io.File("/etc/os-release").readAsStringSync();
+    } on io.IOException catch (error) {
+      Log.w("Failed to read /etc/os-release for the device descriptor", error);
+      return null;
+    }
   }
 }

--- a/bridge/app/test/auth/login_test.dart
+++ b/bridge/app/test/auth/login_test.dart
@@ -55,7 +55,13 @@ void main() {
         expect(initRequest.method, equals('POST'));
         expect(initRequest.path, equals('/auth/github/init'));
         expect(initRequest.queryParameters, isEmpty);
-        expect(initRequest.body, equals({'clientType': 'bridge'}));
+        expect(
+          initRequest.body,
+          equals({
+            'clientType': 'bridge_macos',
+            'device': {'name': 'Test Mac', 'osVersion': 'macOS 14.5', 'appVersion': '1.2.0'},
+          }),
+        );
         expect(initRequest.contentType, startsWith('application/json'));
         expect(initRequest.sessionToken, matches(RegExp(r'^[0-9a-f]{64}$')));
         expect(initRequest.body!.values, isNot(contains(initRequest.sessionToken)));
@@ -272,6 +278,8 @@ void main() {
         final api = LoginOAuthApi(
           authBackendUrl: authServer.baseUrl,
           client: authServer.client,
+          clientType: 'bridge_macos',
+          device: DeviceInfo(name: 'Test Mac', osVersion: null, appVersion: null),
         );
 
         await api.ackOAuthSessionCompletion(sessionToken: 'session-token-123');
@@ -521,6 +529,8 @@ LoginOAuthService _createOAuthService({
     api: LoginOAuthApi(
       authBackendUrl: authServer.baseUrl,
       client: authServer.client,
+      clientType: 'bridge_macos',
+      device: DeviceInfo(name: 'Test Mac', osVersion: 'macOS 14.5', appVersion: '1.2.0'),
     ),
     browserLauncher: browserLauncher,
     browserOpenability: browserOpenability,

--- a/bridge/sesori_bridge_foundation/lib/sesori_bridge_foundation.dart
+++ b/bridge/sesori_bridge_foundation/lib/sesori_bridge_foundation.dart
@@ -8,6 +8,7 @@ export "src/binary_download_client.dart";
 export "src/checksum_validator.dart";
 export "src/command_executor.dart";
 export "src/host_process_command_executor.dart";
+export "src/os_version_formatter.dart";
 export "src/platform_target.dart";
 export "src/semantic_version.dart";
 export "src/sesori_data_directory.dart";

--- a/bridge/sesori_bridge_foundation/lib/src/os_version_formatter.dart
+++ b/bridge/sesori_bridge_foundation/lib/src/os_version_formatter.dart
@@ -1,0 +1,94 @@
+import "dart:convert" show LineSplitter;
+
+/// Derives a short, human-friendly OS-version label (e.g. "macOS 14.5",
+/// "Windows 11", "Ubuntu 22.04") from raw host platform facts.
+///
+/// Pure: callers supply the raw `Platform.operatingSystem` /
+/// `Platform.operatingSystemVersion` strings and, on Linux, the contents of
+/// `/etc/os-release` (the only place the distro name+version lives — the raw
+/// version string there is just the kernel). Marketing codenames ("Sonoma",
+/// "Tahoe") are intentionally NOT derived: no OS API exposes them.
+///
+/// Returns null when no meaningful version can be parsed, so the cosmetic
+/// field is simply omitted rather than echoing the OS family already conveyed
+/// by `clientType`. The result is trimmed and clamped to [maxLength].
+class OsVersionFormatter {
+  const OsVersionFormatter();
+
+  /// Hard limit matching the auth server's `device.osVersion` schema (<= 40).
+  static const int maxLength = 40;
+
+  String? format({
+    required String operatingSystem,
+    required String operatingSystemVersion,
+    required String? osReleaseContents,
+  }) {
+    final raw = switch (operatingSystem) {
+      "macos" => _macos(operatingSystemVersion),
+      "windows" => _windows(operatingSystemVersion),
+      "linux" => _linux(osReleaseContents),
+      _ => null,
+    };
+    if (raw == null) return null;
+
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty) return null;
+    return trimmed.length > maxLength ? trimmed.substring(0, maxLength).trim() : trimmed;
+  }
+
+  /// "Version 14.5 (Build 23F79)" -> "macOS 14.5".
+  String? _macos(String operatingSystemVersion) {
+    final version = RegExp(r"(\d+(?:\.\d+)*)").firstMatch(operatingSystemVersion)?.group(1);
+    return version == null ? null : "macOS $version";
+  }
+
+  /// Windows 11 still reports major 10.0; the build number is the only
+  /// discriminator (>= 22000 is Windows 11).
+  String? _windows(String operatingSystemVersion) {
+    final build = RegExp(r"Build\s+(\d+)").firstMatch(operatingSystemVersion)?.group(1) ??
+        RegExp(r"\b(\d{5,})\b").firstMatch(operatingSystemVersion)?.group(1);
+    final buildNumber = build == null ? null : int.tryParse(build);
+    if (buildNumber == null) return null;
+    return buildNumber >= 22000 ? "Windows 11" : "Windows 10";
+  }
+
+  /// Reads the distro name+version from `/etc/os-release` contents, preferring
+  /// `PRETTY_NAME` (e.g. "Ubuntu 22.04.3 LTS") and falling back to
+  /// `NAME`+`VERSION_ID`.
+  String? _linux(String? osReleaseContents) {
+    if (osReleaseContents == null) return null;
+
+    final values = _parseOsRelease(osReleaseContents);
+    final pretty = values["PRETTY_NAME"];
+    if (pretty != null && pretty.isNotEmpty) return pretty;
+
+    final name = values["NAME"];
+    if (name != null && name.isNotEmpty) {
+      final versionId = values["VERSION_ID"];
+      return (versionId != null && versionId.isNotEmpty) ? "$name $versionId" : name;
+    }
+    return null;
+  }
+
+  Map<String, String> _parseOsRelease(String contents) {
+    final result = <String, String>{};
+    for (final line in const LineSplitter().convert(contents)) {
+      final trimmed = line.trim();
+      if (trimmed.isEmpty || trimmed.startsWith("#")) continue;
+
+      final eq = trimmed.indexOf("=");
+      if (eq <= 0) continue;
+
+      final key = trimmed.substring(0, eq).trim();
+      var value = trimmed.substring(eq + 1).trim();
+      // Strip the surrounding single/double quotes os-release(5) allows.
+      if (value.length >= 2 &&
+          ((value.startsWith('"') && value.endsWith('"')) ||
+              (value.startsWith("'") && value.endsWith("'")))) {
+        value = value.substring(1, value.length - 1);
+      }
+      result[key] = value;
+    }
+    return result;
+  }
+}

--- a/bridge/sesori_bridge_foundation/test/os_version_formatter_test.dart
+++ b/bridge/sesori_bridge_foundation/test/os_version_formatter_test.dart
@@ -1,0 +1,87 @@
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:test/test.dart";
+
+void main() {
+  const formatter = OsVersionFormatter();
+
+  String? format({
+    required String os,
+    String version = "",
+    String? osRelease,
+  }) =>
+      formatter.format(
+        operatingSystem: os,
+        operatingSystemVersion: version,
+        osReleaseContents: osRelease,
+      );
+
+  group("macOS", () {
+    test("extracts the version number from the raw version string", () {
+      expect(format(os: "macos", version: "Version 14.5 (Build 23F79)"), equals("macOS 14.5"));
+      expect(format(os: "macos", version: "Version 26.0 (Build 25A100)"), equals("macOS 26.0"));
+    });
+
+    test("returns null when no version number is present", () {
+      expect(format(os: "macos", version: "Version macOS"), isNull);
+    });
+  });
+
+  group("Windows", () {
+    test("maps build >= 22000 to Windows 11", () {
+      expect(format(os: "windows", version: "10.0 (Build 22631)"), equals("Windows 11"));
+      expect(format(os: "windows", version: "10.0.26100"), equals("Windows 11"));
+    });
+
+    test("maps lower builds to Windows 10", () {
+      expect(format(os: "windows", version: "10.0 (Build 19045)"), equals("Windows 10"));
+      expect(format(os: "windows", version: "10.0.19045"), equals("Windows 10"));
+    });
+
+    test("returns null when no build number is present", () {
+      expect(format(os: "windows", version: "10.0"), isNull);
+    });
+  });
+
+  group("Linux", () {
+    test("prefers PRETTY_NAME from /etc/os-release", () {
+      const osRelease = '''
+NAME="Ubuntu"
+VERSION_ID="22.04"
+PRETTY_NAME="Ubuntu 22.04.3 LTS"
+''';
+      expect(format(os: "linux", osRelease: osRelease), equals("Ubuntu 22.04.3 LTS"));
+    });
+
+    test("falls back to NAME + VERSION_ID when PRETTY_NAME is absent", () {
+      const osRelease = '''
+NAME="Debian GNU/Linux"
+VERSION_ID="12"
+''';
+      expect(format(os: "linux", osRelease: osRelease), equals("Debian GNU/Linux 12"));
+    });
+
+    test("tolerates single quotes, comments, and blank lines", () {
+      const osRelease = '''
+# a comment
+
+PRETTY_NAME='Fedora Linux 40'
+''';
+      expect(format(os: "linux", osRelease: osRelease), equals("Fedora Linux 40"));
+    });
+
+    test("returns null when os-release contents are unavailable", () {
+      expect(format(os: "linux", osRelease: null), isNull);
+    });
+  });
+
+  test("returns null for an unknown operating system", () {
+    expect(format(os: "fuchsia", version: "1.0"), isNull);
+  });
+
+  test("clamps the label to the 40-char server limit", () {
+    const osRelease = 'PRETTY_NAME="A Very Long Distribution Name That Exceeds The Limit"';
+    final result = format(os: "linux", osRelease: osRelease);
+    expect(result, isNotNull);
+    expect(result!.length, lessThanOrEqualTo(OsVersionFormatter.maxLength));
+  });
+}

--- a/client/app/lib/core/di/injection.config.dart
+++ b/client/app/lib/core/di/injection.config.dart
@@ -9,6 +9,7 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:device_info_plus/device_info_plus.dart' as _i833;
 import 'package:firebase_crashlytics/firebase_crashlytics.dart' as _i141;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart'
     as _i163;
@@ -35,6 +36,8 @@ import 'package:sesori_mobile/core/platform/firebase_push_messaging_source.dart'
     as _i1042;
 import 'package:sesori_mobile/core/platform/flutter_local_notification_client.dart'
     as _i636;
+import 'package:sesori_mobile/core/platform/flutter_oauth_device_descriptor_provider.dart'
+    as _i363;
 import 'package:sesori_mobile/core/platform/flutter_secure_storage_adapter.dart'
     as _i816;
 import 'package:sesori_mobile/core/platform/flutter_url_launcher.dart' as _i10;
@@ -63,6 +66,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i1039.AudioRecorder>(() => registerModule.audioRecorder);
     gh.lazySingleton<_i163.FlutterLocalNotificationsPlugin>(
       () => registerModule.flutterLocalNotificationsPlugin,
+    );
+    gh.lazySingleton<_i833.DeviceInfoPlugin>(
+      () => registerModule.deviceInfoPlugin,
     );
     gh.lazySingleton<_i558.FlutterSecureStorage>(
       () => registerModule.secureStorage,
@@ -98,6 +104,11 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i816.FlutterSecureStorageAdapter(gh<_i558.FlutterSecureStorage>()),
     );
     gh.lazySingleton<_i948.UrlLauncher>(() => _i10.FlutterUrlLauncher());
+    gh.lazySingleton<_i948.OAuthDeviceDescriptorProvider>(
+      () => _i363.FlutterOAuthDeviceDescriptorProvider(
+        gh<_i833.DeviceInfoPlugin>(),
+      ),
+    );
     gh.lazySingleton<_i553.FailureReporter>(
       () => _i534.CrashlyticsFailureReporter(gh<_i141.FirebaseCrashlytics>()),
     );

--- a/client/app/lib/core/di/register_module.dart
+++ b/client/app/lib/core/di/register_module.dart
@@ -1,3 +1,4 @@
+import "package:device_info_plus/device_info_plus.dart";
 import "package:firebase_crashlytics/firebase_crashlytics.dart";
 import "package:flutter_local_notifications/flutter_local_notifications.dart";
 import "package:flutter_secure_storage/flutter_secure_storage.dart";
@@ -20,6 +21,9 @@ abstract class RegisterModule {
 
   @lazySingleton
   FlutterLocalNotificationsPlugin get flutterLocalNotificationsPlugin => FlutterLocalNotificationsPlugin();
+
+  @lazySingleton
+  DeviceInfoPlugin get deviceInfoPlugin => DeviceInfoPlugin();
 
   @lazySingleton
   NotificationCanceller notificationCanceller(LocalNotificationClient client) => client;

--- a/client/app/lib/core/platform/flutter_oauth_device_descriptor_provider.dart
+++ b/client/app/lib/core/platform/flutter_oauth_device_descriptor_provider.dart
@@ -42,20 +42,25 @@ class FlutterOAuthDeviceDescriptorProvider implements OAuthDeviceDescriptorProvi
       };
 
   Future<DeviceInfo> _device({required String? appVersion}) async {
+    // Web has no native device-info channel and the mobile getters throw an
+    // UnsupportedError there; skip them to avoid noisy stack traces.
+    if (kIsWeb) {
+      return DeviceInfo(name: _fallbackName(), osVersion: null, appVersion: appVersion);
+    }
     try {
       switch (defaultTargetPlatform) {
         case TargetPlatform.iOS:
           final info = await _deviceInfo.iosInfo;
           return DeviceInfo(
-            name: _clamp(info.name, _maxNameLength) ?? _fallbackName(),
-            osVersion: _clamp("iOS ${info.systemVersion}", _maxVersionLength),
+            name: _clamp(value: info.name, maxLength: _maxNameLength) ?? _fallbackName(),
+            osVersion: _clamp(value: "iOS ${info.systemVersion}", maxLength: _maxVersionLength),
             appVersion: appVersion,
           );
         case TargetPlatform.android:
           final info = await _deviceInfo.androidInfo;
           return DeviceInfo(
-            name: _clamp("${info.manufacturer} ${info.model}", _maxNameLength) ?? _fallbackName(),
-            osVersion: _clamp("Android ${info.version.release}", _maxVersionLength),
+            name: _clamp(value: "${info.manufacturer} ${info.model}", maxLength: _maxNameLength) ?? _fallbackName(),
+            osVersion: _clamp(value: "Android ${info.version.release}", maxLength: _maxVersionLength),
             appVersion: appVersion,
           );
         case TargetPlatform.macOS:
@@ -73,7 +78,7 @@ class FlutterOAuthDeviceDescriptorProvider implements OAuthDeviceDescriptorProvi
   Future<String?> _appVersion() async {
     try {
       final info = await PackageInfo.fromPlatform();
-      return _clamp(info.version, _maxVersionLength);
+      return _clamp(value: info.version, maxLength: _maxVersionLength);
     } catch (error, stackTrace) {
       logw("Failed to read app version for the OAuth device descriptor", error, stackTrace);
       return null;
@@ -89,7 +94,7 @@ class FlutterOAuthDeviceDescriptorProvider implements OAuthDeviceDescriptorProvi
         TargetPlatform.fuchsia => "Device",
       };
 
-  String? _clamp(String value, int maxLength) {
+  String? _clamp({required String value, required int maxLength}) {
     final trimmed = value.trim();
     if (trimmed.isEmpty) return null;
     return trimmed.length > maxLength ? trimmed.substring(0, maxLength).trim() : trimmed;

--- a/client/app/lib/core/platform/flutter_oauth_device_descriptor_provider.dart
+++ b/client/app/lib/core/platform/flutter_oauth_device_descriptor_provider.dart
@@ -1,0 +1,97 @@
+import "package:device_info_plus/device_info_plus.dart";
+import "package:flutter/foundation.dart";
+import "package:injectable/injectable.dart";
+import "package:package_info_plus/package_info_plus.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+/// Flutter implementation of [OAuthDeviceDescriptorProvider].
+///
+/// Derives the auth-server `clientType` from [defaultTargetPlatform] and reads
+/// the device name + OS version (device_info_plus) and app version
+/// (package_info_plus).
+///
+/// Never throws: the auth-init request requires a device, so device/package
+/// reads are wrapped and a failure degrades to a best-effort descriptor
+/// (platform-default name, null version fields). Values are clamped to the auth
+/// server's schema limits.
+@LazySingleton(as: OAuthDeviceDescriptorProvider)
+class FlutterOAuthDeviceDescriptorProvider implements OAuthDeviceDescriptorProvider {
+  FlutterOAuthDeviceDescriptorProvider(DeviceInfoPlugin deviceInfo) : _deviceInfo = deviceInfo;
+
+  final DeviceInfoPlugin _deviceInfo;
+
+  static const _maxNameLength = 120;
+  static const _maxVersionLength = 40;
+
+  @override
+  Future<OAuthDeviceDescriptor> describe() async {
+    final appVersion = await _appVersion();
+    final device = await _device(appVersion: appVersion);
+    return OAuthDeviceDescriptor(clientType: _clientType(), device: device);
+  }
+
+  String _clientType() => switch (defaultTargetPlatform) {
+        TargetPlatform.iOS => "app_ios",
+        TargetPlatform.android => "app_android",
+        TargetPlatform.macOS ||
+        TargetPlatform.windows ||
+        TargetPlatform.linux ||
+        TargetPlatform.fuchsia =>
+          "app",
+      };
+
+  Future<DeviceInfo> _device({required String? appVersion}) async {
+    try {
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.iOS:
+          final info = await _deviceInfo.iosInfo;
+          return DeviceInfo(
+            name: _clamp(info.name, _maxNameLength) ?? _fallbackName(),
+            osVersion: _clamp("iOS ${info.systemVersion}", _maxVersionLength),
+            appVersion: appVersion,
+          );
+        case TargetPlatform.android:
+          final info = await _deviceInfo.androidInfo;
+          return DeviceInfo(
+            name: _clamp("${info.manufacturer} ${info.model}", _maxNameLength) ?? _fallbackName(),
+            osVersion: _clamp("Android ${info.version.release}", _maxVersionLength),
+            appVersion: appVersion,
+          );
+        case TargetPlatform.macOS:
+        case TargetPlatform.windows:
+        case TargetPlatform.linux:
+        case TargetPlatform.fuchsia:
+          return DeviceInfo(name: _fallbackName(), osVersion: null, appVersion: appVersion);
+      }
+    } catch (error, stackTrace) {
+      logw("Failed to read device info for the OAuth device descriptor", error, stackTrace);
+      return DeviceInfo(name: _fallbackName(), osVersion: null, appVersion: appVersion);
+    }
+  }
+
+  Future<String?> _appVersion() async {
+    try {
+      final info = await PackageInfo.fromPlatform();
+      return _clamp(info.version, _maxVersionLength);
+    } catch (error, stackTrace) {
+      logw("Failed to read app version for the OAuth device descriptor", error, stackTrace);
+      return null;
+    }
+  }
+
+  String _fallbackName() => switch (defaultTargetPlatform) {
+        TargetPlatform.iOS => "iPhone",
+        TargetPlatform.android => "Android device",
+        TargetPlatform.macOS => "Mac",
+        TargetPlatform.windows => "Windows device",
+        TargetPlatform.linux => "Linux device",
+        TargetPlatform.fuchsia => "Device",
+      };
+
+  String? _clamp(String value, int maxLength) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) return null;
+    return trimmed.length > maxLength ? trimmed.substring(0, maxLength).trim() : trimmed;
+  }
+}

--- a/client/app/lib/features/login/login_screen.dart
+++ b/client/app/lib/features/login/login_screen.dart
@@ -111,7 +111,7 @@ class _LoginScreenBodyState extends State<_LoginScreenBody> {
     final prego = context.prego;
     final loc = context.loc;
     final state = context.watch<LoginCubit>().state;
-    final isLoading = state is LoginAuthenticating || state is LoginAwaitingConfirmation || state is LoginPolling;
+    final isLoading = state is LoginAuthenticating || state is LoginPolling;
 
     return Scaffold(
       body: BlocListener<LoginCubit, LoginState>(
@@ -186,70 +186,14 @@ class _LoginScreenBodyState extends State<_LoginScreenBody> {
                                       textAlign: TextAlign.center,
                                     ),
                                   ),
-                                  LoginAwaitingConfirmation(:final userCode) => Padding(
+                                  LoginPolling() => Padding(
                                     padding: const EdgeInsetsDirectional.only(top: 16),
-                                    child: Column(
-                                      children: [
-                                        Text(
-                                          loc.loginAwaitingConfirmation(userCode),
-                                          style: prego.textTheme.textSm.regular.copyWith(
-                                            color: prego.colors.textSecondary,
-                                          ),
-                                          textAlign: TextAlign.center,
-                                        ),
-                                        const SizedBox(height: 8),
-                                        Container(
-                                          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                                          decoration: BoxDecoration(
-                                            color: prego.colors.bgBrandSolid.withAlpha(26),
-                                            borderRadius: BorderRadius.circular(8),
-                                            border: Border.all(
-                                              color: prego.colors.bgBrandSolid.withAlpha(77),
-                                            ),
-                                          ),
-                                          child: Text(
-                                            userCode,
-                                            style: prego.textTheme.textXl.bold.copyWith(
-                                              color: prego.colors.bgBrandSolid,
-                                              letterSpacing: 4,
-                                            ),
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                  LoginPolling(:final userCode) => Padding(
-                                    padding: const EdgeInsetsDirectional.only(top: 16),
-                                    child: Column(
-                                      children: [
-                                        Text(
-                                          loc.loginPolling,
-                                          style: prego.textTheme.textSm.regular.copyWith(
-                                            color: prego.colors.textSecondary,
-                                          ),
-                                          textAlign: TextAlign.center,
-                                        ),
-                                        if (userCode != null) ...[
-                                          const SizedBox(height: 8),
-                                          Container(
-                                            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                                            decoration: BoxDecoration(
-                                              color: prego.colors.bgBrandSolid.withAlpha(26),
-                                              borderRadius: BorderRadius.circular(8),
-                                              border: Border.all(
-                                                color: prego.colors.bgBrandSolid.withAlpha(77),
-                                              ),
-                                            ),
-                                            child: Text(
-                                              userCode,
-                                              style: prego.textTheme.textXl.bold.copyWith(
-                                                color: prego.colors.bgBrandSolid,
-                                                letterSpacing: 4,
-                                              ),
-                                            ),
-                                          ),
-                                        ],
-                                      ],
+                                    child: Text(
+                                      loc.loginPolling,
+                                      style: prego.textTheme.textSm.regular.copyWith(
+                                        color: prego.colors.textSecondary,
+                                      ),
+                                      textAlign: TextAlign.center,
                                     ),
                                   ),
                                   LoginTimeout() => Padding(
@@ -296,7 +240,6 @@ class _LoginScreenBodyState extends State<_LoginScreenBody> {
                                   ),
                                   LoginIdle() => const SizedBox.shrink(),
                                   LoginAuthenticating() => const SizedBox.shrink(),
-                                  LoginAwaitingConfirmation() => const SizedBox.shrink(),
                                   LoginPolling() => const SizedBox.shrink(),
                                   LoginSuccess() => const SizedBox.shrink(),
                                 },

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -231,15 +231,7 @@
   "loginError": "Sign in failed. Please try again.",
   "loginAuthenticating": "Signing in...",
   "loginAwaitingCallback": "Waiting for authorization...",
-  "loginAwaitingConfirmation": "Confirm this code on the login page: {userCode}",
-  "@loginAwaitingConfirmation": {
-    "placeholders": {
-      "userCode": {
-        "type": "String"
-      }
-    }
-  },
-  "loginPolling": "Confirming authorization...",
+  "loginPolling": "Confirm the sign-in in your browser to continue.",
   "loginTimeout": "Authorization timed out. Please try again.",
   "loginBrowserOpenFailed": "Could not open browser",
   "loginCallbackTimeout": "Authorization timed out. Please try again.",

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -961,16 +961,10 @@ abstract class AppLocalizations {
   /// **'Waiting for authorization...'**
   String get loginAwaitingCallback;
 
-  /// No description provided for @loginAwaitingConfirmation.
-  ///
-  /// In en, this message translates to:
-  /// **'Confirm this code on the login page: {userCode}'**
-  String loginAwaitingConfirmation(String userCode);
-
   /// No description provided for @loginPolling.
   ///
   /// In en, this message translates to:
-  /// **'Confirming authorization...'**
+  /// **'Confirm the sign-in in your browser to continue.'**
   String get loginPolling;
 
   /// No description provided for @loginTimeout.

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -487,12 +487,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get loginAwaitingCallback => 'Waiting for authorization...';
 
   @override
-  String loginAwaitingConfirmation(String userCode) {
-    return 'Confirm this code on the login page: $userCode';
-  }
-
-  @override
-  String get loginPolling => 'Confirming authorization...';
+  String get loginPolling => 'Confirm the sign-in in your browser to continue.';
 
   @override
   String get loginTimeout => 'Authorization timed out. Please try again.';

--- a/client/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/client/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import app_links
 import cryptography_flutter
+import device_info_plus
 import firebase_analytics
 import firebase_core
 import firebase_crashlytics
@@ -22,6 +23,7 @@ import wakelock_plus
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   CryptographyFlutterPlugin.register(with: registry.registrar(forPlugin: "CryptographyFlutterPlugin"))
+  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FirebaseAnalyticsPlugin.register(with: registry.registrar(forPlugin: "FirebaseAnalyticsPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCrashlyticsPlugin"))

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -64,8 +64,8 @@ dependencies:
   app_links: ^7.1.2
   url_launcher: ^6.3.2
   universal_platform: ^1.1.0
-  device_info_plus: ^13.0.0
-  package_info_plus: ^10.0.0
+  device_info_plus: ^13.2.0
+  package_info_plus: ^10.2.0
   record: ^7.1.0
   path: any
   path_provider: ^2.1.6

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -64,6 +64,8 @@ dependencies:
   app_links: ^7.1.2
   url_launcher: ^6.3.2
   universal_platform: ^1.1.0
+  device_info_plus: ^13.0.0
+  package_info_plus: ^10.0.0
   record: ^7.1.0
   path: any
   path_provider: ^2.1.6

--- a/client/app/test/features/login/login_cubit_test.dart
+++ b/client/app/test/features/login/login_cubit_test.dart
@@ -42,7 +42,6 @@ void main() {
         (_) async => const AuthInitResponse(
           authUrl: "https://auth.example.com/login",
           state: "test-state",
-          userCode: "ABCD",
           expiresIn: 300,
         ),
       );
@@ -58,39 +57,13 @@ void main() {
     });
 
     blocTest<LoginCubit, LoginState>(
-      "loginWithProvider emits authenticating → awaitingConfirmation → polling → success",
+      "loginWithProvider emits authenticating → polling → success",
       build: () => LoginCubit(mockOAuthFlowProvider, mockUrlLauncher, mockAuthSession, mockLifecycleSource),
       act: (cubit) async {
         await cubit.loginWithProvider(AuthProvider.github);
       },
       expect: () => [
         isA<LoginAuthenticating>(),
-        isA<LoginAwaitingConfirmation>(),
-        isA<LoginPolling>(),
-        isA<LoginSuccess>(),
-      ],
-    );
-
-    blocTest<LoginCubit, LoginState>(
-      "loginWithProvider emits awaitingConfirmation with correct userCode",
-      build: () => LoginCubit(mockOAuthFlowProvider, mockUrlLauncher, mockAuthSession, mockLifecycleSource),
-      act: (cubit) async {
-        when(
-          () => mockOAuthFlowProvider.startOAuthFlow(provider: any(named: "provider")),
-        ).thenAnswer(
-          (_) async => const AuthInitResponse(
-            authUrl: "https://auth.example.com/login",
-            state: "test-state",
-            userCode: "XYZ9",
-            expiresIn: 300,
-          ),
-        );
-
-        await cubit.loginWithProvider(AuthProvider.github);
-      },
-      expect: () => [
-        isA<LoginAuthenticating>(),
-        isA<LoginAwaitingConfirmation>().having((s) => s.userCode, "userCode", "XYZ9"),
         isA<LoginPolling>(),
         isA<LoginSuccess>(),
       ],
@@ -148,7 +121,6 @@ void main() {
       },
       expect: () => [
         isA<LoginAuthenticating>(),
-        isA<LoginAwaitingConfirmation>(),
         isA<LoginFailed>(),
       ],
     );
@@ -165,7 +137,6 @@ void main() {
       },
       expect: () => [
         isA<LoginAuthenticating>(),
-        isA<LoginAwaitingConfirmation>(),
         isA<LoginPolling>(),
         isA<LoginTimeout>(),
       ],

--- a/client/app/test/features/login/login_cubit_test.dart
+++ b/client/app/test/features/login/login_cubit_test.dart
@@ -121,6 +121,7 @@ void main() {
       },
       expect: () => [
         isA<LoginAuthenticating>(),
+        isA<LoginPolling>(),
         isA<LoginFailed>(),
       ],
     );

--- a/client/module_auth/lib/sesori_auth.dart
+++ b/client/module_auth/lib/sesori_auth.dart
@@ -17,4 +17,5 @@ export "src/interfaces/auth_session.dart";
 export "src/interfaces/auth_token_provider.dart";
 export "src/interfaces/oauth_flow_provider.dart";
 export "src/models/auth_state.dart";
+export "src/platform/oauth_device_descriptor_provider.dart";
 export "src/platform/secure_storage.dart";

--- a/client/module_auth/lib/src/auth_manager.dart
+++ b/client/module_auth/lib/src/auth_manager.dart
@@ -14,13 +14,13 @@ import "interfaces/auth_session.dart";
 import "interfaces/auth_token_provider.dart";
 import "interfaces/oauth_flow_provider.dart";
 import "models/auth_state.dart";
+import "platform/oauth_device_descriptor_provider.dart";
 import "storage/oauth_storage_service.dart";
 import "storage/token_storage_service.dart";
 
 @lazySingleton
 class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
   static const _sessionTokenHeader = "X-Sesori-Session-Token";
-  static const _mobileClientType = "app";
   static const _defaultPollInterval = Duration(milliseconds: 250);
   static const _defaultPollTimeout = Duration(minutes: 5);
   static const _defaultRequestTimeout = Duration(seconds: 35);
@@ -29,6 +29,7 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
   final http.Client _client;
   final TokenStorageService _tokenStorage;
   final OAuthStorageService _oAuthStorage;
+  final OAuthDeviceDescriptorProvider _deviceDescriptorProvider;
   final BehaviorSubject<AuthState> _authState;
   final Duration _pollInterval;
   final Duration _pollTimeout;
@@ -38,13 +39,15 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
   AuthManager(
     http.Client client,
     TokenStorageService tokenStorage,
-    OAuthStorageService oAuthStorage, {
+    OAuthStorageService oAuthStorage,
+    OAuthDeviceDescriptorProvider deviceDescriptorProvider, {
     @visibleForTesting Duration pollInterval = _defaultPollInterval,
     @visibleForTesting Duration pollTimeout = _defaultPollTimeout,
     @visibleForTesting Future<void> Function(Duration duration)? delay,
   }) : _client = client,
        _tokenStorage = tokenStorage,
        _oAuthStorage = oAuthStorage,
+       _deviceDescriptorProvider = deviceDescriptorProvider,
        _pollInterval = pollInterval,
        _pollTimeout = pollTimeout,
        _delay = delay ?? Future<void>.delayed,
@@ -62,7 +65,8 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
     http.Client client,
     TokenStorageService tokenStorage,
     OAuthStorageService oAuthStorage,
-  ) => AuthManager(client, tokenStorage, oAuthStorage);
+    OAuthDeviceDescriptorProvider deviceDescriptorProvider,
+  ) => AuthManager(client, tokenStorage, oAuthStorage, deviceDescriptorProvider);
 
   @override
   ValueStream<AuthState> get authStateStream => _authState.stream;
@@ -98,10 +102,11 @@ class AuthManager implements AuthTokenProvider, OAuthFlowProvider, AuthSession {
     _oAuthSessionToken = sessionToken;
 
     try {
+      final descriptor = await _deviceDescriptorProvider.describe();
       final uri = Uri.parse("$authBaseUrl/auth/${provider.key}/init");
       final response = await _post(
         uri,
-        body: const AuthInitRequest(clientType: _mobileClientType).toJson(),
+        body: AuthInitRequest(clientType: descriptor.clientType, device: descriptor.device).toJson(),
         headers: {_sessionTokenHeader: sessionToken},
       );
       _ensureSuccess(response, context: "Failed to start ${provider.label} auth flow");

--- a/client/module_auth/lib/src/di/injection.config.dart
+++ b/client/module_auth/lib/src/di/injection.config.dart
@@ -20,6 +20,8 @@ import 'package:sesori_auth/src/di/auth_module.dart' as _i992;
 import 'package:sesori_auth/src/interfaces/auth_session.dart' as _i279;
 import 'package:sesori_auth/src/interfaces/auth_token_provider.dart' as _i264;
 import 'package:sesori_auth/src/interfaces/oauth_flow_provider.dart' as _i798;
+import 'package:sesori_auth/src/platform/oauth_device_descriptor_provider.dart'
+    as _i63;
 import 'package:sesori_auth/src/platform/secure_storage.dart' as _i892;
 import 'package:sesori_auth/src/storage/oauth_storage_service.dart' as _i765;
 import 'package:sesori_auth/src/storage/token_storage_service.dart' as _i164;
@@ -38,15 +40,16 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i164.TokenStorageService>(
       () => _i164.TokenStorageService(gh<_i892.SecureStorage>()),
     );
+    gh.lazySingleton<_i542.HttpApiClient>(
+      () => _i542.HttpApiClient(gh<_i519.Client>()),
+    );
     gh.lazySingleton<_i655.AuthManager>(
       () => _i655.AuthManager.create(
         gh<_i519.Client>(),
         gh<_i164.TokenStorageService>(),
         gh<_i765.OAuthStorageService>(),
+        gh<_i63.OAuthDeviceDescriptorProvider>(),
       ),
-    );
-    gh.lazySingleton<_i542.HttpApiClient>(
-      () => _i542.HttpApiClient(gh<_i519.Client>()),
     );
     gh.lazySingleton<_i264.AuthTokenProvider>(
       () => authModule.authTokenProvider(gh<_i655.AuthManager>()),

--- a/client/module_auth/lib/src/interfaces/oauth_flow_provider.dart
+++ b/client/module_auth/lib/src/interfaces/oauth_flow_provider.dart
@@ -3,8 +3,9 @@ import "package:sesori_shared/sesori_shared.dart";
 /// Drives the OAuth authorization flow through the auth-server session flow.
 ///
 /// The auth server owns provider redirects and PKCE. Callers open the returned
-/// [AuthInitResponse.authUrl], display [AuthInitResponse.userCode], then wait
-/// for [pollForResult] to complete after the browser confirmation step.
+/// [AuthInitResponse.authUrl], then wait for [pollForResult] to complete after
+/// the user confirms the sign-in on the auth-server page (which describes this
+/// device).
 abstract interface class OAuthFlowProvider {
   /// Starts an auth-server backed OAuth session for [provider].
   Future<AuthInitResponse> startOAuthFlow({required OAuthProvider provider});

--- a/client/module_auth/lib/src/platform/oauth_device_descriptor_provider.dart
+++ b/client/module_auth/lib/src/platform/oauth_device_descriptor_provider.dart
@@ -1,0 +1,24 @@
+import "package:sesori_shared/sesori_shared.dart";
+
+/// The platform-derived descriptor sent at OAuth init: the auth-server
+/// `clientType` for this build (e.g. "app_ios" / "app_android") plus the
+/// structured [DeviceInfo] describing the device that started the sign-in.
+class OAuthDeviceDescriptor {
+  const OAuthDeviceDescriptor({required this.clientType, required this.device});
+
+  final String clientType;
+  final DeviceInfo device;
+}
+
+/// Supplies the [OAuthDeviceDescriptor] for this device.
+///
+/// `module_auth` is pure Dart and cannot read Flutter/native device APIs, so
+/// the app layer provides the implementation (mirrors the `SecureStorage`
+/// platform interface). There is exactly one production implementation.
+///
+/// [describe] must never throw: the auth-init request requires a device, so the
+/// implementation degrades to a best-effort descriptor (platform-default name,
+/// null version fields) rather than failing the whole login.
+abstract interface class OAuthDeviceDescriptorProvider {
+  Future<OAuthDeviceDescriptor> describe();
+}

--- a/client/module_auth/test/auth_manager_test.dart
+++ b/client/module_auth/test/auth_manager_test.dart
@@ -6,6 +6,7 @@ import "package:mocktail/mocktail.dart";
 import "package:sesori_auth/src/auth_config.dart";
 import "package:sesori_auth/src/auth_manager.dart";
 import "package:sesori_auth/src/models/auth_state.dart";
+import "package:sesori_auth/src/platform/oauth_device_descriptor_provider.dart";
 import "package:sesori_auth/src/storage/oauth_storage_service.dart";
 import "package:sesori_auth/src/storage/token_storage_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -16,6 +17,15 @@ class MockHttpClient extends Mock implements http.Client {}
 class MockTokenStorageService extends Mock implements TokenStorageService {}
 
 class MockOAuthStorageService extends Mock implements OAuthStorageService {}
+
+/// Returns a fixed descriptor so the init body is deterministic in tests.
+class FakeOAuthDeviceDescriptorProvider implements OAuthDeviceDescriptorProvider {
+  @override
+  Future<OAuthDeviceDescriptor> describe() async => const OAuthDeviceDescriptor(
+        clientType: "app_ios",
+        device: DeviceInfo(name: "Test iPhone", osVersion: "iOS 17.5", appVersion: "1.2.0"),
+      );
+}
 
 void main() {
   setUpAll(() {
@@ -42,7 +52,7 @@ void main() {
     mockHttpClient = MockHttpClient();
     mockTokenStorage = MockTokenStorageService();
     mockOAuthStorage = MockOAuthStorageService();
-    authManager = AuthManager(mockHttpClient, mockTokenStorage, mockOAuthStorage);
+    authManager = AuthManager(mockHttpClient, mockTokenStorage, mockOAuthStorage, FakeOAuthDeviceDescriptorProvider());
     when(
       () => mockOAuthStorage.saveOAuthSession(
         sessionToken: any(named: "sessionToken"),
@@ -269,7 +279,7 @@ void main() {
   });
 
   group("OAuth flow", () {
-    test("startOAuthFlow creates header-only session token and returns user code details", () async {
+    test("startOAuthFlow creates header-only session token and sends the device descriptor", () async {
       const authUrl = "https://github.com/login/oauth/authorize?client_id=abc";
       when(
         () => mockHttpClient.post(
@@ -279,7 +289,7 @@ void main() {
         ),
       ).thenAnswer(
         (_) async => http.Response(
-          jsonEncode({"authUrl": authUrl, "state": "state-1", "userCode": "A1B2", "expiresIn": 300}),
+          jsonEncode({"authUrl": authUrl, "state": "state-1", "expiresIn": 300}),
           200,
         ),
       );
@@ -288,7 +298,6 @@ void main() {
 
       expect(result.authUrl, authUrl);
       expect(result.state, "state-1");
-      expect(result.userCode, "A1B2");
       expect(result.expiresIn, 300);
 
       final capturedPostCall = verify(
@@ -303,7 +312,10 @@ void main() {
       final sessionToken = headers["X-Sesori-Session-Token"];
       expect(sessionToken, matches(RegExp(r"^[0-9a-f]{64}$")));
       expect(headers["Content-Type"], "application/json");
-      expect(body, {"clientType": "app"});
+      expect(body, {
+        "clientType": "app_ios",
+        "device": {"name": "Test iPhone", "osVersion": "iOS 17.5", "appVersion": "1.2.0"},
+      });
       expect(body.values, isNot(contains(sessionToken)));
       verifyNever(
         () => mockOAuthStorage.saveAuthProviderAndPkceVerifier(
@@ -318,6 +330,7 @@ void main() {
         mockHttpClient,
         mockTokenStorage,
         mockOAuthStorage,
+        FakeOAuthDeviceDescriptorProvider(),
         pollInterval: Duration.zero,
         delay: (_) async {},
       );
@@ -420,6 +433,7 @@ void main() {
         mockHttpClient,
         mockTokenStorage,
         mockOAuthStorage,
+        FakeOAuthDeviceDescriptorProvider(),
         pollInterval: Duration.zero,
         delay: (_) async {},
       );
@@ -489,6 +503,7 @@ void main() {
         mockHttpClient,
         mockTokenStorage,
         mockOAuthStorage,
+        FakeOAuthDeviceDescriptorProvider(),
         pollInterval: Duration.zero,
         delay: (_) async {},
       );
@@ -555,6 +570,7 @@ void main() {
         mockHttpClient,
         mockTokenStorage,
         mockOAuthStorage,
+        FakeOAuthDeviceDescriptorProvider(),
         pollInterval: Duration.zero,
         delay: (_) async {},
       );
@@ -728,6 +744,7 @@ void main() {
         mockHttpClient,
         mockTokenStorage,
         mockOAuthStorage,
+        FakeOAuthDeviceDescriptorProvider(),
         pollInterval: Duration.zero,
         delay: (_) async {},
       );
@@ -804,7 +821,7 @@ void main() {
         mockHttpClient = MockHttpClient();
         mockTokenStorage = MockTokenStorageService();
         mockOAuthStorage = MockOAuthStorageService();
-        authManager = AuthManager(mockHttpClient, mockTokenStorage, mockOAuthStorage);
+    authManager = AuthManager(mockHttpClient, mockTokenStorage, mockOAuthStorage, FakeOAuthDeviceDescriptorProvider());
         await arrangeStartedFlow(statusResponse: statusResponse);
 
         await expectLater(authManager.pollForResult(), throwsA(isA<StateError>()));
@@ -818,6 +835,7 @@ void main() {
         mockHttpClient,
         mockTokenStorage,
         mockOAuthStorage,
+        FakeOAuthDeviceDescriptorProvider(),
         pollInterval: Duration.zero,
         pollTimeout: Duration.zero,
         delay: (_) async {},

--- a/client/module_core/lib/sesori_dart_core.dart
+++ b/client/module_core/lib/sesori_dart_core.dart
@@ -11,6 +11,8 @@ export "package:sesori_auth/sesori_auth.dart"
         AuthSession,
         AuthState,
         AuthUnauthenticated,
+        OAuthDeviceDescriptor,
+        OAuthDeviceDescriptorProvider,
         OAuthFlowProvider,
         SecureStorage;
 export "package:sesori_auth/sesori_auth.dart"

--- a/client/module_core/lib/src/cubits/login/login_cubit.dart
+++ b/client/module_core/lib/src/cubits/login/login_cubit.dart
@@ -154,6 +154,12 @@ class LoginCubit extends Cubit<LoginState> {
       final initResponse = await _oAuthFlowProvider.startOAuthFlow(provider: provider);
       if (isClosed) return false;
 
+      // Enter the resumable polling state BEFORE launching the browser. Opening
+      // the browser can suspend the app before launch() returns; the OAuth
+      // session already exists, so _onAppResumed must observe a LoginPolling
+      // state (not LoginAuthenticating) to recover and resume polling.
+      emit(const LoginState.polling());
+
       logd("Opening ${provider.label} auth URL in browser");
 
       final launched = await _urlLauncher.launch(Uri.parse(initResponse.authUrl));
@@ -167,7 +173,6 @@ class LoginCubit extends Cubit<LoginState> {
 
       _didActivePollEnterBackground = _isInBackground;
       _isPolling = true;
-      emit(const LoginState.polling());
       try {
         await _oAuthFlowProvider.pollForResult();
       } finally {

--- a/client/module_core/lib/src/cubits/login/login_cubit.dart
+++ b/client/module_core/lib/src/cubits/login/login_cubit.dart
@@ -154,26 +154,27 @@ class LoginCubit extends Cubit<LoginState> {
       final initResponse = await _oAuthFlowProvider.startOAuthFlow(provider: provider);
       if (isClosed) return false;
 
-      // Enter the resumable polling state BEFORE launching the browser. Opening
-      // the browser can suspend the app before launch() returns; the OAuth
-      // session already exists, so _onAppResumed must observe a LoginPolling
-      // state (not LoginAuthenticating) to recover and resume polling.
+      // Show the resumable polling UI and ARM the poll guard BEFORE launching
+      // the browser. Opening the browser can suspend the app before launch()
+      // returns; with _isPolling already set, a resume during that window is a
+      // no-op (it won't start a second concurrent poll) — the pollForResult()
+      // below owns the session. The finally resets the guard on every exit path
+      // (launch failure, success, or a thrown poll error), so the outer catch's
+      // _handlePollInterruption still sees _isPolling == false.
       emit(const LoginState.polling());
-
-      logd("Opening ${provider.label} auth URL in browser");
-
-      final launched = await _urlLauncher.launch(Uri.parse(initResponse.authUrl));
-
-      if (isClosed) return false;
-
-      if (!launched) {
-        emit(const LoginState.failed(reason: LoginFailedReason.browserOpenFailed));
-        return false;
-      }
-
       _didActivePollEnterBackground = _isInBackground;
       _isPolling = true;
       try {
+        logd("Opening ${provider.label} auth URL in browser");
+
+        final launched = await _urlLauncher.launch(Uri.parse(initResponse.authUrl));
+        if (isClosed) return false;
+
+        if (!launched) {
+          emit(const LoginState.failed(reason: LoginFailedReason.browserOpenFailed));
+          return false;
+        }
+
         await _oAuthFlowProvider.pollForResult();
       } finally {
         _isPolling = false;

--- a/client/module_core/lib/src/cubits/login/login_cubit.dart
+++ b/client/module_core/lib/src/cubits/login/login_cubit.dart
@@ -72,7 +72,7 @@ class LoginCubit extends Cubit<LoginState> {
 
   Future<void> _onAppResumed() async {
     if (_isPolling) return;
-    if (state is LoginAwaitingConfirmation || state is LoginPolling || state is LoginTimeout) {
+    if (state is LoginPolling || state is LoginTimeout) {
       final hasActiveSession = await _oAuthFlowProvider.hasActiveOAuthSession();
       if (!hasActiveSession) {
         // A background interruption parks the flow in LoginPolling. If the
@@ -86,19 +86,9 @@ class LoginCubit extends Cubit<LoginState> {
       }
       if (isClosed) return;
 
-      final currentUserCode = switch (state) {
-        LoginAwaitingConfirmation(:final userCode) => userCode,
-        LoginPolling(:final userCode) => userCode,
-        LoginTimeout() => null,
-        LoginIdle() => null,
-        LoginAuthenticating() => null,
-        LoginSuccess() => null,
-        LoginFailed() => null,
-      };
-
       _didActivePollEnterBackground = _isInBackground;
       _isPolling = true;
-      emit(LoginState.polling(userCode: currentUserCode));
+      emit(const LoginState.polling());
       try {
         await _oAuthFlowProvider.resumeOAuthFlow();
         if (isClosed) return;
@@ -108,7 +98,7 @@ class LoginCubit extends Cubit<LoginState> {
         if (isClosed) return;
         emit(const LoginState.timeout());
       } catch (e, st) {
-        if (_handlePollInterruption(error: e, userCode: currentUserCode)) return;
+        if (_handlePollInterruption(error: e)) return;
         loge("OAuth resumed but failed", e, st);
         if (isClosed) return;
         emit(const LoginState.failed(reason: LoginFailedReason.unknown));
@@ -126,13 +116,13 @@ class LoginCubit extends Cubit<LoginState> {
   ///
   /// Returns true when the error was handled as a recoverable interruption, in
   /// which case the caller must stop and not emit a failure state.
-  bool _handlePollInterruption({required Object error, required String? userCode}) {
+  bool _handlePollInterruption({required Object error}) {
     if (!_isRecoverablePollInterruption(error)) return false;
     if (!_isInBackground && !_didActivePollEnterBackground) return false;
     final alreadyForeground = !_isInBackground;
     _didActivePollEnterBackground = false;
     if (isClosed) return true;
-    emit(LoginState.polling(userCode: userCode));
+    emit(const LoginState.polling());
     if (alreadyForeground) {
       // The app already returned to the foreground before this abort surfaced,
       // so no further `resumed` lifecycle event will arrive to drive recovery.
@@ -160,13 +150,9 @@ class LoginCubit extends Cubit<LoginState> {
   Future<bool> loginWithProvider(OAuthProvider provider) async {
     emit(const LoginState.authenticating());
 
-    String? pollingUserCode;
     try {
       final initResponse = await _oAuthFlowProvider.startOAuthFlow(provider: provider);
       if (isClosed) return false;
-
-      pollingUserCode = initResponse.userCode;
-      emit(LoginState.awaitingConfirmation(userCode: initResponse.userCode));
 
       logd("Opening ${provider.label} auth URL in browser");
 
@@ -181,7 +167,7 @@ class LoginCubit extends Cubit<LoginState> {
 
       _didActivePollEnterBackground = _isInBackground;
       _isPolling = true;
-      emit(LoginState.polling(userCode: initResponse.userCode));
+      emit(const LoginState.polling());
       try {
         await _oAuthFlowProvider.pollForResult();
       } finally {
@@ -197,7 +183,7 @@ class LoginCubit extends Cubit<LoginState> {
       emit(const LoginState.timeout());
       return false;
     } catch (e, st) {
-      if (_handlePollInterruption(error: e, userCode: pollingUserCode)) return false;
+      if (_handlePollInterruption(error: e)) return false;
       loge("${provider.label} login failed", e, st);
       if (isClosed) return false;
       emit(const LoginState.failed(reason: LoginFailedReason.unknown));

--- a/client/module_core/lib/src/cubits/login/login_state.dart
+++ b/client/module_core/lib/src/cubits/login/login_state.dart
@@ -10,9 +10,7 @@ sealed class LoginState with _$LoginState {
 
   const factory LoginState.authenticating() = LoginAuthenticating;
 
-  const factory LoginState.awaitingConfirmation({required String userCode}) = LoginAwaitingConfirmation;
-
-  const factory LoginState.polling({String? userCode}) = LoginPolling;
+  const factory LoginState.polling() = LoginPolling;
 
   const factory LoginState.timeout() = LoginTimeout;
 

--- a/client/module_core/lib/src/cubits/login/login_state.freezed.dart
+++ b/client/module_core/lib/src/cubits/login/login_state.freezed.dart
@@ -109,134 +109,34 @@ String toString() {
 /// @nodoc
 
 
-class LoginAwaitingConfirmation implements LoginState {
-  const LoginAwaitingConfirmation({required this.userCode});
-  
-
- final  String userCode;
-
-/// Create a copy of LoginState
-/// with the given fields replaced by the non-null parameter values.
-@JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-$LoginAwaitingConfirmationCopyWith<LoginAwaitingConfirmation> get copyWith => _$LoginAwaitingConfirmationCopyWithImpl<LoginAwaitingConfirmation>(this, _$identity);
-
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginAwaitingConfirmation&&(identical(other.userCode, userCode) || other.userCode == userCode));
-}
-
-
-@override
-int get hashCode => Object.hash(runtimeType,userCode);
-
-@override
-String toString() {
-  return 'LoginState.awaitingConfirmation(userCode: $userCode)';
-}
-
-
-}
-
-/// @nodoc
-abstract mixin class $LoginAwaitingConfirmationCopyWith<$Res> implements $LoginStateCopyWith<$Res> {
-  factory $LoginAwaitingConfirmationCopyWith(LoginAwaitingConfirmation value, $Res Function(LoginAwaitingConfirmation) _then) = _$LoginAwaitingConfirmationCopyWithImpl;
-@useResult
-$Res call({
- String userCode
-});
-
-
-
-
-}
-/// @nodoc
-class _$LoginAwaitingConfirmationCopyWithImpl<$Res>
-    implements $LoginAwaitingConfirmationCopyWith<$Res> {
-  _$LoginAwaitingConfirmationCopyWithImpl(this._self, this._then);
-
-  final LoginAwaitingConfirmation _self;
-  final $Res Function(LoginAwaitingConfirmation) _then;
-
-/// Create a copy of LoginState
-/// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? userCode = null,}) {
-  return _then(LoginAwaitingConfirmation(
-userCode: null == userCode ? _self.userCode : userCode // ignore: cast_nullable_to_non_nullable
-as String,
-  ));
-}
-
-
-}
-
-/// @nodoc
-
-
 class LoginPolling implements LoginState {
-  const LoginPolling({this.userCode});
+  const LoginPolling();
   
 
- final  String? userCode;
 
-/// Create a copy of LoginState
-/// with the given fields replaced by the non-null parameter values.
-@JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-$LoginPollingCopyWith<LoginPolling> get copyWith => _$LoginPollingCopyWithImpl<LoginPolling>(this, _$identity);
+
 
 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginPolling&&(identical(other.userCode, userCode) || other.userCode == userCode));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LoginPolling);
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,userCode);
+int get hashCode => runtimeType.hashCode;
 
 @override
 String toString() {
-  return 'LoginState.polling(userCode: $userCode)';
+  return 'LoginState.polling()';
 }
 
 
 }
 
-/// @nodoc
-abstract mixin class $LoginPollingCopyWith<$Res> implements $LoginStateCopyWith<$Res> {
-  factory $LoginPollingCopyWith(LoginPolling value, $Res Function(LoginPolling) _then) = _$LoginPollingCopyWithImpl;
-@useResult
-$Res call({
- String? userCode
-});
 
 
-
-
-}
-/// @nodoc
-class _$LoginPollingCopyWithImpl<$Res>
-    implements $LoginPollingCopyWith<$Res> {
-  _$LoginPollingCopyWithImpl(this._self, this._then);
-
-  final LoginPolling _self;
-  final $Res Function(LoginPolling) _then;
-
-/// Create a copy of LoginState
-/// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? userCode = freezed,}) {
-  return _then(LoginPolling(
-userCode: freezed == userCode ? _self.userCode : userCode // ignore: cast_nullable_to_non_nullable
-as String?,
-  ));
-}
-
-
-}
 
 /// @nodoc
 

--- a/client/module_core/test/cubits/login/login_cubit_test.dart
+++ b/client/module_core/test/cubits/login/login_cubit_test.dart
@@ -25,7 +25,6 @@ class MockLifecycleSource extends Mock implements LifecycleSource {}
 const testAuthInitResponse = AuthInitResponse(
   authUrl: "https://accounts.google.com/o/oauth2/auth",
   state: "oauth-state",
-  userCode: "ABCD",
   expiresIn: 300,
 );
 
@@ -85,7 +84,6 @@ void main() {
         act: (cubit) async => cubit.loginWithProvider(AuthProvider.google),
         expect: () => [
           isA<LoginAuthenticating>(),
-          isA<LoginAwaitingConfirmation>().having((state) => state.userCode, "userCode", "ABCD"),
           isA<LoginPolling>(),
           isA<LoginSuccess>(),
         ],
@@ -98,12 +96,11 @@ void main() {
       );
 
       blocTest<LoginCubit, LoginState>(
-        "loginWithProvider(AuthProvider.google) emits user code before polling then success",
+        "loginWithProvider(AuthProvider.google) emits polling then success",
         build: buildCubit,
         act: (cubit) async => cubit.loginWithProvider(AuthProvider.google),
         expect: () => [
           isA<LoginAuthenticating>(),
-          isA<LoginAwaitingConfirmation>().having((state) => state.userCode, "userCode", "ABCD"),
           isA<LoginPolling>(),
           isA<LoginSuccess>(),
         ],
@@ -118,7 +115,6 @@ void main() {
         act: (cubit) async => cubit.loginWithProvider(AuthProvider.google),
         expect: () => [
           isA<LoginAuthenticating>(),
-          isA<LoginAwaitingConfirmation>(),
           isA<LoginPolling>(),
           isA<LoginSuccess>(),
         ],
@@ -148,7 +144,6 @@ void main() {
         },
         expect: () => [
           isA<LoginAuthenticating>(),
-          isA<LoginAwaitingConfirmation>(),
           isA<LoginFailed>(),
         ],
         verify: (_) {
@@ -165,7 +160,6 @@ void main() {
         },
         expect: () => [
           isA<LoginAuthenticating>(),
-          isA<LoginAwaitingConfirmation>(),
           isA<LoginPolling>(),
           isA<LoginTimeout>(),
         ],
@@ -335,7 +329,6 @@ void main() {
           },
           expect: () => [
             isA<LoginAuthenticating>(),
-            isA<LoginAwaitingConfirmation>(),
             isA<LoginPolling>(),
             isA<LoginFailed>().having(
               (state) => state.reason,
@@ -407,7 +400,8 @@ void main() {
         when(() => mockOAuthFlowProvider.hasActiveOAuthSession()).thenAnswer((_) async => true);
 
         final cubit = buildCubit();
-        cubit.emit(LoginState.awaitingConfirmation(userCode: testAuthInitResponse.userCode));
+        // Park the flow in a resumable state (e.g. a prior timeout) before resume.
+        cubit.emit(const LoginState.timeout());
 
         final states = <LoginState>[];
         final sub = cubit.stream.listen(states.add);
@@ -431,7 +425,8 @@ void main() {
         when(() => mockOAuthFlowProvider.hasActiveOAuthSession()).thenAnswer((_) async => false);
 
         final cubit = buildCubit();
-        cubit.emit(LoginState.awaitingConfirmation(userCode: testAuthInitResponse.userCode));
+        // A resumable, non-polling state (timeout) must not auto-reset to idle.
+        cubit.emit(const LoginState.timeout());
 
         final states = <LoginState>[];
         final sub = cubit.stream.listen(states.add);

--- a/client/module_core/test/cubits/login/login_cubit_test.dart
+++ b/client/module_core/test/cubits/login/login_cubit_test.dart
@@ -144,6 +144,7 @@ void main() {
         },
         expect: () => [
           isA<LoginAuthenticating>(),
+          isA<LoginPolling>(),
           isA<LoginFailed>(),
         ],
         verify: (_) {

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -329,6 +329,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.13"
+  device_info_plus:
+    dependency: transitive
+    description:
+      name: device_info_plus
+      sha256: "0891702f96b2e465fe567b7ec448380e6b1c14f60af552a8536d9f583b6b8442"
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.2.0"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: "04b173a92e2d9161dfead145667037c8d834db725ce2e7b942bfe18fd2f45a46"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.0"
   diff_match_patch:
     dependency: transitive
     description:
@@ -1640,6 +1656,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.3.0"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "73b1d78920a9d6e03f8b4e43e612b87bf3152a0e5c5e5150267762b7c4116904"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
   xdg_directories:
     dependency: transitive
     description:

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -1024,10 +1024,10 @@ packages:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: "4bf625947f6c7713ee242296a682e23e44823c09cf9d79e4f1238923c92db852"
+      sha256: f5c435dc0e0d461e5b32471a870f769b6a1cc46930637efe24fbc535314e78ad
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.0"
+    version: "10.2.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:

--- a/shared/sesori_shared/lib/sesori_shared.dart
+++ b/shared/sesori_shared/lib/sesori_shared.dart
@@ -19,6 +19,7 @@ export "src/models/auth/auth_url_response.dart";
 export "src/models/auth/auth_user.dart";
 export "src/models/auth/bridge_summary.dart";
 export "src/models/auth/bridges_list_response.dart";
+export "src/models/auth/device_info.dart";
 export "src/models/auth/logout_response.dart";
 export "src/models/auth/register_bridge_request.dart";
 export "src/models/auth/session_status_response.dart";

--- a/shared/sesori_shared/lib/src/models/auth/auth_init_request.dart
+++ b/shared/sesori_shared/lib/src/models/auth/auth_init_request.dart
@@ -1,5 +1,7 @@
 import "package:freezed_annotation/freezed_annotation.dart";
 
+import "device_info.dart";
+
 part "auth_init_request.freezed.dart";
 part "auth_init_request.g.dart";
 
@@ -7,6 +9,7 @@ part "auth_init_request.g.dart";
 sealed class AuthInitRequest with _$AuthInitRequest {
   const factory AuthInitRequest({
     required String clientType,
+    required DeviceInfo device,
   }) = _AuthInitRequest;
 
   factory AuthInitRequest.fromJson(Map<String, dynamic> json) => _$AuthInitRequestFromJson(json);

--- a/shared/sesori_shared/lib/src/models/auth/auth_init_request.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/auth/auth_init_request.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$AuthInitRequest {
 
- String get clientType;
+ String get clientType; DeviceInfo get device;
 /// Create a copy of AuthInitRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $AuthInitRequestCopyWith<AuthInitRequest> get copyWith => _$AuthInitRequestCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AuthInitRequest&&(identical(other.clientType, clientType) || other.clientType == clientType));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AuthInitRequest&&(identical(other.clientType, clientType) || other.clientType == clientType)&&(identical(other.device, device) || other.device == device));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,clientType);
+int get hashCode => Object.hash(runtimeType,clientType,device);
 
 @override
 String toString() {
-  return 'AuthInitRequest(clientType: $clientType)';
+  return 'AuthInitRequest(clientType: $clientType, device: $device)';
 }
 
 
@@ -48,11 +48,11 @@ abstract mixin class $AuthInitRequestCopyWith<$Res>  {
   factory $AuthInitRequestCopyWith(AuthInitRequest value, $Res Function(AuthInitRequest) _then) = _$AuthInitRequestCopyWithImpl;
 @useResult
 $Res call({
- String clientType
+ String clientType, DeviceInfo device
 });
 
 
-
+$DeviceInfoCopyWith<$Res> get device;
 
 }
 /// @nodoc
@@ -65,13 +65,23 @@ class _$AuthInitRequestCopyWithImpl<$Res>
 
 /// Create a copy of AuthInitRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? clientType = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? clientType = null,Object? device = null,}) {
   return _then(_self.copyWith(
 clientType: null == clientType ? _self.clientType : clientType // ignore: cast_nullable_to_non_nullable
-as String,
+as String,device: null == device ? _self.device : device // ignore: cast_nullable_to_non_nullable
+as DeviceInfo,
   ));
 }
-
+/// Create a copy of AuthInitRequest
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$DeviceInfoCopyWith<$Res> get device {
+  
+  return $DeviceInfoCopyWith<$Res>(_self.device, (value) {
+    return _then(_self.copyWith(device: value));
+  });
+}
 }
 
 
@@ -80,10 +90,11 @@ as String,
 @JsonSerializable()
 
 class _AuthInitRequest implements AuthInitRequest {
-  const _AuthInitRequest({required this.clientType});
+  const _AuthInitRequest({required this.clientType, required this.device});
   factory _AuthInitRequest.fromJson(Map<String, dynamic> json) => _$AuthInitRequestFromJson(json);
 
 @override final  String clientType;
+@override final  DeviceInfo device;
 
 /// Create a copy of AuthInitRequest
 /// with the given fields replaced by the non-null parameter values.
@@ -98,16 +109,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AuthInitRequest&&(identical(other.clientType, clientType) || other.clientType == clientType));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AuthInitRequest&&(identical(other.clientType, clientType) || other.clientType == clientType)&&(identical(other.device, device) || other.device == device));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,clientType);
+int get hashCode => Object.hash(runtimeType,clientType,device);
 
 @override
 String toString() {
-  return 'AuthInitRequest(clientType: $clientType)';
+  return 'AuthInitRequest(clientType: $clientType, device: $device)';
 }
 
 
@@ -118,11 +129,11 @@ abstract mixin class _$AuthInitRequestCopyWith<$Res> implements $AuthInitRequest
   factory _$AuthInitRequestCopyWith(_AuthInitRequest value, $Res Function(_AuthInitRequest) _then) = __$AuthInitRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String clientType
+ String clientType, DeviceInfo device
 });
 
 
-
+@override $DeviceInfoCopyWith<$Res> get device;
 
 }
 /// @nodoc
@@ -135,14 +146,24 @@ class __$AuthInitRequestCopyWithImpl<$Res>
 
 /// Create a copy of AuthInitRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? clientType = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? clientType = null,Object? device = null,}) {
   return _then(_AuthInitRequest(
 clientType: null == clientType ? _self.clientType : clientType // ignore: cast_nullable_to_non_nullable
-as String,
+as String,device: null == device ? _self.device : device // ignore: cast_nullable_to_non_nullable
+as DeviceInfo,
   ));
 }
 
-
+/// Create a copy of AuthInitRequest
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$DeviceInfoCopyWith<$Res> get device {
+  
+  return $DeviceInfoCopyWith<$Res>(_self.device, (value) {
+    return _then(_self.copyWith(device: value));
+  });
+}
 }
 
 // dart format on

--- a/shared/sesori_shared/lib/src/models/auth/auth_init_request.g.dart
+++ b/shared/sesori_shared/lib/src/models/auth/auth_init_request.g.dart
@@ -6,8 +6,13 @@ part of 'auth_init_request.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_AuthInitRequest _$AuthInitRequestFromJson(Map json) =>
-    _AuthInitRequest(clientType: json['clientType'] as String);
+_AuthInitRequest _$AuthInitRequestFromJson(Map json) => _AuthInitRequest(
+  clientType: json['clientType'] as String,
+  device: DeviceInfo.fromJson(Map<String, dynamic>.from(json['device'] as Map)),
+);
 
 Map<String, dynamic> _$AuthInitRequestToJson(_AuthInitRequest instance) =>
-    <String, dynamic>{'clientType': instance.clientType};
+    <String, dynamic>{
+      'clientType': instance.clientType,
+      'device': instance.device.toJson(),
+    };

--- a/shared/sesori_shared/lib/src/models/auth/auth_init_response.dart
+++ b/shared/sesori_shared/lib/src/models/auth/auth_init_response.dart
@@ -8,7 +8,6 @@ sealed class AuthInitResponse with _$AuthInitResponse {
   const factory AuthInitResponse({
     required String authUrl,
     required String state,
-    required String userCode,
     required int expiresIn,
   }) = _AuthInitResponse;
 

--- a/shared/sesori_shared/lib/src/models/auth/auth_init_response.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/auth/auth_init_response.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$AuthInitResponse {
 
- String get authUrl; String get state; String get userCode; int get expiresIn;
+ String get authUrl; String get state; int get expiresIn;
 /// Create a copy of AuthInitResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $AuthInitResponseCopyWith<AuthInitResponse> get copyWith => _$AuthInitResponseCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AuthInitResponse&&(identical(other.authUrl, authUrl) || other.authUrl == authUrl)&&(identical(other.state, state) || other.state == state)&&(identical(other.userCode, userCode) || other.userCode == userCode)&&(identical(other.expiresIn, expiresIn) || other.expiresIn == expiresIn));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AuthInitResponse&&(identical(other.authUrl, authUrl) || other.authUrl == authUrl)&&(identical(other.state, state) || other.state == state)&&(identical(other.expiresIn, expiresIn) || other.expiresIn == expiresIn));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,authUrl,state,userCode,expiresIn);
+int get hashCode => Object.hash(runtimeType,authUrl,state,expiresIn);
 
 @override
 String toString() {
-  return 'AuthInitResponse(authUrl: $authUrl, state: $state, userCode: $userCode, expiresIn: $expiresIn)';
+  return 'AuthInitResponse(authUrl: $authUrl, state: $state, expiresIn: $expiresIn)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $AuthInitResponseCopyWith<$Res>  {
   factory $AuthInitResponseCopyWith(AuthInitResponse value, $Res Function(AuthInitResponse) _then) = _$AuthInitResponseCopyWithImpl;
 @useResult
 $Res call({
- String authUrl, String state, String userCode, int expiresIn
+ String authUrl, String state, int expiresIn
 });
 
 
@@ -65,11 +65,10 @@ class _$AuthInitResponseCopyWithImpl<$Res>
 
 /// Create a copy of AuthInitResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? authUrl = null,Object? state = null,Object? userCode = null,Object? expiresIn = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? authUrl = null,Object? state = null,Object? expiresIn = null,}) {
   return _then(_self.copyWith(
 authUrl: null == authUrl ? _self.authUrl : authUrl // ignore: cast_nullable_to_non_nullable
 as String,state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
-as String,userCode: null == userCode ? _self.userCode : userCode // ignore: cast_nullable_to_non_nullable
 as String,expiresIn: null == expiresIn ? _self.expiresIn : expiresIn // ignore: cast_nullable_to_non_nullable
 as int,
   ));
@@ -83,12 +82,11 @@ as int,
 @JsonSerializable()
 
 class _AuthInitResponse implements AuthInitResponse {
-  const _AuthInitResponse({required this.authUrl, required this.state, required this.userCode, required this.expiresIn});
+  const _AuthInitResponse({required this.authUrl, required this.state, required this.expiresIn});
   factory _AuthInitResponse.fromJson(Map<String, dynamic> json) => _$AuthInitResponseFromJson(json);
 
 @override final  String authUrl;
 @override final  String state;
-@override final  String userCode;
 @override final  int expiresIn;
 
 /// Create a copy of AuthInitResponse
@@ -104,16 +102,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AuthInitResponse&&(identical(other.authUrl, authUrl) || other.authUrl == authUrl)&&(identical(other.state, state) || other.state == state)&&(identical(other.userCode, userCode) || other.userCode == userCode)&&(identical(other.expiresIn, expiresIn) || other.expiresIn == expiresIn));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AuthInitResponse&&(identical(other.authUrl, authUrl) || other.authUrl == authUrl)&&(identical(other.state, state) || other.state == state)&&(identical(other.expiresIn, expiresIn) || other.expiresIn == expiresIn));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,authUrl,state,userCode,expiresIn);
+int get hashCode => Object.hash(runtimeType,authUrl,state,expiresIn);
 
 @override
 String toString() {
-  return 'AuthInitResponse(authUrl: $authUrl, state: $state, userCode: $userCode, expiresIn: $expiresIn)';
+  return 'AuthInitResponse(authUrl: $authUrl, state: $state, expiresIn: $expiresIn)';
 }
 
 
@@ -124,7 +122,7 @@ abstract mixin class _$AuthInitResponseCopyWith<$Res> implements $AuthInitRespon
   factory _$AuthInitResponseCopyWith(_AuthInitResponse value, $Res Function(_AuthInitResponse) _then) = __$AuthInitResponseCopyWithImpl;
 @override @useResult
 $Res call({
- String authUrl, String state, String userCode, int expiresIn
+ String authUrl, String state, int expiresIn
 });
 
 
@@ -141,11 +139,10 @@ class __$AuthInitResponseCopyWithImpl<$Res>
 
 /// Create a copy of AuthInitResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? authUrl = null,Object? state = null,Object? userCode = null,Object? expiresIn = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? authUrl = null,Object? state = null,Object? expiresIn = null,}) {
   return _then(_AuthInitResponse(
 authUrl: null == authUrl ? _self.authUrl : authUrl // ignore: cast_nullable_to_non_nullable
 as String,state: null == state ? _self.state : state // ignore: cast_nullable_to_non_nullable
-as String,userCode: null == userCode ? _self.userCode : userCode // ignore: cast_nullable_to_non_nullable
 as String,expiresIn: null == expiresIn ? _self.expiresIn : expiresIn // ignore: cast_nullable_to_non_nullable
 as int,
   ));

--- a/shared/sesori_shared/lib/src/models/auth/auth_init_response.g.dart
+++ b/shared/sesori_shared/lib/src/models/auth/auth_init_response.g.dart
@@ -9,7 +9,6 @@ part of 'auth_init_response.dart';
 _AuthInitResponse _$AuthInitResponseFromJson(Map json) => _AuthInitResponse(
   authUrl: json['authUrl'] as String,
   state: json['state'] as String,
-  userCode: json['userCode'] as String,
   expiresIn: (json['expiresIn'] as num).toInt(),
 );
 
@@ -17,6 +16,5 @@ Map<String, dynamic> _$AuthInitResponseToJson(_AuthInitResponse instance) =>
     <String, dynamic>{
       'authUrl': instance.authUrl,
       'state': instance.state,
-      'userCode': instance.userCode,
       'expiresIn': instance.expiresIn,
     };

--- a/shared/sesori_shared/lib/src/models/auth/device_info.dart
+++ b/shared/sesori_shared/lib/src/models/auth/device_info.dart
@@ -1,0 +1,23 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "device_info.freezed.dart";
+part "device_info.g.dart";
+
+/// Optional structured descriptor sent at OAuth init so the auth-server
+/// confirmation page can describe the device that started the sign-in.
+///
+/// [name] is a human-recognizable machine/device name (a recognition aid only,
+/// untrusted and HTML-escaped server-side — clients must NOT pre-escape it).
+/// Type + OS family are derived server-side from `clientType`, so keep those out
+/// of [name]. [osVersion]/[appVersion] are cosmetic; null values are omitted
+/// from the wire payload (json_serializable `include_if_null: false` default).
+@Freezed(fromJson: true, toJson: true)
+sealed class DeviceInfo with _$DeviceInfo {
+  const factory DeviceInfo({
+    required String name,
+    required String? osVersion,
+    required String? appVersion,
+  }) = _DeviceInfo;
+
+  factory DeviceInfo.fromJson(Map<String, dynamic> json) => _$DeviceInfoFromJson(json);
+}

--- a/shared/sesori_shared/lib/src/models/auth/device_info.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/auth/device_info.freezed.dart
@@ -1,0 +1,154 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'device_info.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$DeviceInfo {
+
+ String get name; String? get osVersion; String? get appVersion;
+/// Create a copy of DeviceInfo
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$DeviceInfoCopyWith<DeviceInfo> get copyWith => _$DeviceInfoCopyWithImpl<DeviceInfo>(this as DeviceInfo, _$identity);
+
+  /// Serializes this DeviceInfo to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DeviceInfo&&(identical(other.name, name) || other.name == name)&&(identical(other.osVersion, osVersion) || other.osVersion == osVersion)&&(identical(other.appVersion, appVersion) || other.appVersion == appVersion));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,osVersion,appVersion);
+
+@override
+String toString() {
+  return 'DeviceInfo(name: $name, osVersion: $osVersion, appVersion: $appVersion)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $DeviceInfoCopyWith<$Res>  {
+  factory $DeviceInfoCopyWith(DeviceInfo value, $Res Function(DeviceInfo) _then) = _$DeviceInfoCopyWithImpl;
+@useResult
+$Res call({
+ String name, String? osVersion, String? appVersion
+});
+
+
+
+
+}
+/// @nodoc
+class _$DeviceInfoCopyWithImpl<$Res>
+    implements $DeviceInfoCopyWith<$Res> {
+  _$DeviceInfoCopyWithImpl(this._self, this._then);
+
+  final DeviceInfo _self;
+  final $Res Function(DeviceInfo) _then;
+
+/// Create a copy of DeviceInfo
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? osVersion = freezed,Object? appVersion = freezed,}) {
+  return _then(_self.copyWith(
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,osVersion: freezed == osVersion ? _self.osVersion : osVersion // ignore: cast_nullable_to_non_nullable
+as String?,appVersion: freezed == appVersion ? _self.appVersion : appVersion // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _DeviceInfo implements DeviceInfo {
+  const _DeviceInfo({required this.name, required this.osVersion, required this.appVersion});
+  factory _DeviceInfo.fromJson(Map<String, dynamic> json) => _$DeviceInfoFromJson(json);
+
+@override final  String name;
+@override final  String? osVersion;
+@override final  String? appVersion;
+
+/// Create a copy of DeviceInfo
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$DeviceInfoCopyWith<_DeviceInfo> get copyWith => __$DeviceInfoCopyWithImpl<_DeviceInfo>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$DeviceInfoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _DeviceInfo&&(identical(other.name, name) || other.name == name)&&(identical(other.osVersion, osVersion) || other.osVersion == osVersion)&&(identical(other.appVersion, appVersion) || other.appVersion == appVersion));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,name,osVersion,appVersion);
+
+@override
+String toString() {
+  return 'DeviceInfo(name: $name, osVersion: $osVersion, appVersion: $appVersion)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$DeviceInfoCopyWith<$Res> implements $DeviceInfoCopyWith<$Res> {
+  factory _$DeviceInfoCopyWith(_DeviceInfo value, $Res Function(_DeviceInfo) _then) = __$DeviceInfoCopyWithImpl;
+@override @useResult
+$Res call({
+ String name, String? osVersion, String? appVersion
+});
+
+
+
+
+}
+/// @nodoc
+class __$DeviceInfoCopyWithImpl<$Res>
+    implements _$DeviceInfoCopyWith<$Res> {
+  __$DeviceInfoCopyWithImpl(this._self, this._then);
+
+  final _DeviceInfo _self;
+  final $Res Function(_DeviceInfo) _then;
+
+/// Create a copy of DeviceInfo
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? osVersion = freezed,Object? appVersion = freezed,}) {
+  return _then(_DeviceInfo(
+name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,osVersion: freezed == osVersion ? _self.osVersion : osVersion // ignore: cast_nullable_to_non_nullable
+as String?,appVersion: freezed == appVersion ? _self.appVersion : appVersion // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/shared/sesori_shared/lib/src/models/auth/device_info.g.dart
+++ b/shared/sesori_shared/lib/src/models/auth/device_info.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'device_info.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_DeviceInfo _$DeviceInfoFromJson(Map json) => _DeviceInfo(
+  name: json['name'] as String,
+  osVersion: json['osVersion'] as String?,
+  appVersion: json['appVersion'] as String?,
+);
+
+Map<String, dynamic> _$DeviceInfoToJson(_DeviceInfo instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'osVersion': ?instance.osVersion,
+      'appVersion': ?instance.appVersion,
+    };

--- a/shared/sesori_shared/test/models/auth_flow_models_test.dart
+++ b/shared/sesori_shared/test/models/auth_flow_models_test.dart
@@ -3,14 +3,41 @@ import "package:test/test.dart";
 
 void main() {
   group("AuthInitRequest", () {
-    test("round-trips through JSON", () {
-      const original = AuthInitRequest(clientType: "mobile");
+    test("round-trips through JSON with a full device", () {
+      const original = AuthInitRequest(
+        clientType: "app_ios",
+        device: DeviceInfo(name: "Alex's iPhone", osVersion: "iOS 17.5", appVersion: "1.2.0"),
+      );
 
       final json = original.toJson();
       final restored = AuthInitRequest.fromJson(json);
 
       expect(restored, equals(original));
-      expect(json, equals({"clientType": "mobile"}));
+      expect(
+        json,
+        equals({
+          "clientType": "app_ios",
+          "device": {"name": "Alex's iPhone", "osVersion": "iOS 17.5", "appVersion": "1.2.0"},
+        }),
+      );
+    });
+
+    test("omits null device version fields from the wire payload", () {
+      const original = AuthInitRequest(
+        clientType: "bridge_macos",
+        device: DeviceInfo(name: "Alex's MacBook Pro", osVersion: null, appVersion: null),
+      );
+
+      final json = original.toJson();
+
+      expect(
+        json,
+        equals({
+          "clientType": "bridge_macos",
+          "device": {"name": "Alex's MacBook Pro"},
+        }),
+      );
+      expect(AuthInitRequest.fromJson(json), equals(original));
     });
   });
 
@@ -19,7 +46,6 @@ void main() {
       const original = AuthInitResponse(
         authUrl: "https://example.com/auth",
         state: "state-123",
-        userCode: "ABCD-EFGH",
         expiresIn: 600,
       );
 
@@ -32,7 +58,6 @@ void main() {
         equals({
           "authUrl": "https://example.com/auth",
           "state": "state-123",
-          "userCode": "ABCD-EFGH",
           "expiresIn": 600,
         }),
       );


### PR DESCRIPTION
## Summary

Adopts auth-server PR #37 across the monorepo. The OAuth "pending confirmation" page no longer shows a 4-char match code — it describes the device that started sign-in. Clients now send an optional structured `device { name, osVersion?, appVersion? }` plus a **per-platform `clientType`**, and the dead match-code UI is removed.

`device` is optional server-side, so bridge and apps can ship independently.

## Shared (`sesori_shared`)
- New Freezed `DeviceInfo` (`name` required; `osVersion`/`appVersion` nullable, omitted from the wire when null).
- `AuthInitRequest` now carries a required `device`.
- Dropped the now-unused `userCode` from `AuthInitResponse` (server still returns it; it's ignored).

## Bridge (desktop)
- Sends `clientType` `bridge_macos` / `bridge_windows` / `bridge_linux` (derived from foundation `PlatformOs`, not the registration service).
- `device.name` = `Platform.localHostname` (trimmed, ≤120, fallback constant); `appVersion` = build const.
- `device.osVersion` = clean label via a new pure `OsVersionFormatter` (Layer 0): `macOS 14.5` / `Windows 11` / `Ubuntu 22.04` (parses `Platform.operatingSystemVersion`; reads `/etc/os-release` on Linux; clamped ≤40; no marketing codenames — not exposed by the OS).
- Removed the CLI 4-char code box (the browser opens instantly).

## Mobile (iOS / Android)
- New `OAuthDeviceDescriptorProvider` platform interface in `module_auth` (SecureStorage-style), consumed by `AuthManager`. Flutter adapter reads `device_info_plus` / `package_info_plus` / `defaultTargetPlatform`; degrades safely (never throws — `device` is required).
- `clientType` = `app_ios` / `app_android`; `name` = `UIDevice.name` / `<manufacturer> <model>`; `osVersion` = `iOS X` / `Android Y`; `appVersion` = package version.
- Collapsed the `LoginState` match-code flow (dropped `awaitingConfirmation` + `userCode`); the login screen shows a generic "Confirm the sign-in in your browser" message.
- Adds `device_info_plus` + `package_info_plus`.

## Notes
- `device.name` is HTML-escaped server-side — clients do not pre-escape. The trusted page signal remains `clientType`; the name is a recognition aid only.

## Testing
- `dart analyze` / `flutter analyze` clean across all modules (bridge `--fatal-infos`).
- shared 241, bridge 1487, module_auth 30, module_core 409, app 524 — all pass.
- New `OsVersionFormatter` unit tests; updated auth/login tests for the new body shape and collapsed states.
- Reviewed by aristotle plan-review (before) and impl-review (after) — both approved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the OAuth 4‑char match code with a device‑described confirmation flow. Clients now send `clientType` and a structured `device`, and the app shows “confirm in your browser”; the polling guard is armed before browser launch to avoid race conditions.

- **New Features**
  - `sesori_shared`: added `DeviceInfo`; `AuthInitRequest` now requires `device`; removed `userCode` from `AuthInitResponse`.
  - Bridge: sends `clientType` `bridge_<os>` and `device { name, osVersion?, appVersion? }`; `name` uses guarded `Platform.localHostname` (clamped/fallback); `osVersion` via new `OsVersionFormatter` (parses `Platform.operatingSystemVersion`, reads `/etc/os-release` on Linux); injected into `LoginOAuthApi`; removed the CLI code box.
  - Mobile: new `OAuthDeviceDescriptorProvider` in `module_auth`; Flutter adapter derives `clientType` (`app_ios`/`app_android`) and fills `device` using platform APIs with a `kIsWeb` fast path and safe fallbacks; login drops the match code and shows a simple “confirm in your browser” message; added `device_info_plus` `^13.2.0` and bumped `package_info_plus` to `^10.2.0`.

- **Bug Fixes**
  - Hardened login by setting the poll guard before opening the browser and resetting it in a finally block, preventing concurrent resume/poll during launch.

<sup>Written for commit fea9ab880e4466667d3a0e32c2f80ea1bf8f1fe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

