### PR TITLE
feat(bridge): supervised auth bootstrap over control channel (Phase 1, PR 1.3)

### DIFF
--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -39,6 +39,7 @@ import "../../auth/login_oauth_service.dart";
 import "../../auth/token.dart";
 import "../../auth/token_manager.dart";
 import "../../control/control_channel_loss_listener.dart";
+import "../../control/control_channel_token_service.dart";
 import "../../foundation/control_channel_client.dart";
 import "../../repositories/bridge_settings_repository.dart";
 import "../../server/api/loopback_port_api.dart";
@@ -212,12 +213,18 @@ class BridgeRuntimeRunner {
       // Supervised mode (desktop GUI): bring up the loopback control channel
       // before anything else so the GUI sees the helper connect promptly. Every
       // step here is gated by `--control-url`; standalone startup is unchanged.
+      ControlChannelTokenService? controlChannelTokenService;
       if (options.isSupervised) {
-        await _startSupervisedControlChannel(
+        final controlChannelClient = await _connectSupervisedControlChannel(
           options: options,
           shutdownCoordinator: shutdownCoordinator,
           requestAbnormalExit: (code) => supervisedLossExitCode = code,
         );
+        // The GUI is the token authority in supervised mode: the bridge pulls
+        // its access token from the control channel instead of the interactive
+        // terminal login. Shares the same client the loss listener observes.
+        controlChannelTokenService = ControlChannelTokenService(client: controlChannelClient);
+        shutdownCoordinator.add(disposable: controlChannelTokenService.dispose);
       }
 
       final runtimeOwnershipError = unsupportedPackageRuntimeMessage(
@@ -273,10 +280,21 @@ class BridgeRuntimeRunner {
         }
       }
 
-      final authTokens = await runtimeAuthService.ensureAuthenticated(options: options);
+      // Supervised mode short-circuits the interactive auth bootstrap: no
+      // provider menu, no email/password prompt — the access token comes from
+      // the GUI over the control channel. Standalone runs the unchanged
+      // interactive flow. logAuthenticatedUser is identical on both paths.
+      final String authAccessToken;
+      final supervisedTokenService = controlChannelTokenService;
+      if (supervisedTokenService != null) {
+        authAccessToken = await supervisedTokenService.requestToken();
+      } else {
+        final authTokens = await runtimeAuthService.ensureAuthenticated(options: options);
+        authAccessToken = authTokens.accessToken;
+      }
       await runtimeAuthService.logAuthenticatedUser(
         authBackendUrl: options.authBackendUrl,
-        accessToken: authTokens.accessToken,
+        accessToken: authAccessToken,
       );
 
       final currentBridgeIdentity = await _resolveCurrentBridgeIdentity(
@@ -371,7 +389,7 @@ class BridgeRuntimeRunner {
           .addTo(subscriptions);
 
       final tokenManager = TokenManager(
-        initialToken: authTokens.accessToken,
+        initialToken: authAccessToken,
         authBackendUrl: options.authBackendUrl,
         loadTokens: loadTokens,
         saveTokens: saveTokens,
@@ -473,10 +491,11 @@ class BridgeRuntimeRunner {
 
   /// Supervised-mode bootstrap: validate the loopback control URL, read the
   /// per-spawn secret off-argv (stdin), arm the parent-loss exit policy (ADR
-  /// A9), then connect the GUI's loopback control channel. Both the client and
-  /// the loss listener are torn down via the shutdown coordinator. Only ever
-  /// called when `--control-url` is set.
-  static Future<void> _startSupervisedControlChannel({
+  /// A9), then connect the GUI's loopback control channel and return the
+  /// connected client so the caller can pull the initial access token over it.
+  /// Both the client and the loss listener are torn down via the shutdown
+  /// coordinator. Only ever called when `--control-url` is set.
+  static Future<ControlChannelClient> _connectSupervisedControlChannel({
     required BridgeCliOptions options,
     required BridgeShutdownCoordinator shutdownCoordinator,
     required void Function(int code) requestAbnormalExit,
@@ -512,6 +531,7 @@ class BridgeRuntimeRunner {
     shutdownCoordinator.add(disposable: lossListener.dispose);
 
     await controlChannelClient.connect();
+    return controlChannelClient;
   }
 
   /// Graceful termination for the control-channel parent-loss policy (ADR A9):

--- a/bridge/app/lib/src/control/control_channel_token_service.dart
+++ b/bridge/app/lib/src/control/control_channel_token_service.dart
@@ -37,6 +37,7 @@ class ControlChannelTokenService {
   late final StreamSubscription<String> _subscription;
   int _nextRequestId = 0;
   bool _disposed = false;
+  Future<void>? _disposeFuture;
 
   ControlChannelTokenService({required ControlChannelClient client}) : _client = client {
     _subscription = _client.inbound.listen(_handleFrame);
@@ -79,8 +80,14 @@ class ControlChannelTokenService {
     }
   }
 
-  Future<void> dispose() async {
-    if (_disposed) return;
+  /// Memoized so concurrent callers await the same teardown — a second caller
+  /// must not observe completion before the first dispose's cancel/sweep has
+  /// finished.
+  Future<void> dispose() => _disposeFuture ??= _dispose();
+
+  Future<void> _dispose() async {
+    // Set synchronously (before the first await) so a requestToken racing
+    // dispose sees the disposed guard immediately.
     _disposed = true;
     // Isolate the cancel so a failure still lets teardown finish.
     try {

--- a/bridge/app/lib/src/control/control_channel_token_service.dart
+++ b/bridge/app/lib/src/control/control_channel_token_service.dart
@@ -50,6 +50,14 @@ class ControlChannelTokenService {
     bool forceRefresh = false,
     Duration timeout = _defaultRequestTimeout,
   }) async {
+    // After dispose the inbound subscription is cancelled, so a response can
+    // never arrive — fail fast instead of registering a completer that would
+    // only resolve via the timeout.
+    if (_disposed) {
+      throw const ControlTokenUnavailableException(
+        "Control channel token service has been disposed.",
+      );
+    }
     final id = "token-${_nextRequestId++}";
     final completer = Completer<String?>();
     _pending[id] = completer;
@@ -72,6 +80,7 @@ class ControlChannelTokenService {
   }
 
   Future<void> dispose() async {
+    if (_disposed) return;
     _disposed = true;
     // Isolate the cancel so a failure still lets teardown finish.
     try {

--- a/bridge/app/lib/src/control/control_channel_token_service.dart
+++ b/bridge/app/lib/src/control/control_channel_token_service.dart
@@ -1,0 +1,114 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+import "package:sesori_shared/sesori_shared.dart" show ControlMessage, ControlTokenResponse, jsonDecodeMap;
+
+import "../foundation/control_channel_client.dart";
+
+/// Thrown when the GUI cannot supply an access token over the control channel —
+/// either it replied with a null token (signed out / mid-login) or it did not
+/// reply within the request timeout. The supervised-startup caller surfaces and
+/// logs this once, so this path deliberately does not log it (avoids
+/// double-logging).
+class ControlTokenUnavailableException implements Exception {
+  final String reason;
+  const ControlTokenUnavailableException(this.reason);
+  @override
+  String toString() => "ControlTokenUnavailableException: $reason";
+}
+
+/// Supervised-mode token bootstrap over the loopback control channel: the GUI,
+/// not an interactive terminal, is the bridge's token authority. This service
+/// asks the GUI for an access token by sending a [ControlMessage.tokenRequest]
+/// and awaiting the id-correlated [ControlMessage.tokenResponse], replacing the
+/// standalone interactive login during startup.
+///
+/// It owns its subscription to [ControlChannelClient.inbound], decoding each
+/// frame into a [ControlMessage] and completing the matching pending request.
+/// Non-token-response frames are ignored here (other control messages are
+/// handled elsewhere); undecodable frames are logged and skipped so a malformed
+/// or forward-compat message can't stall the bootstrap.
+class ControlChannelTokenService {
+  static const Duration _defaultRequestTimeout = Duration(seconds: 30);
+
+  final ControlChannelClient _client;
+  final Map<String, Completer<String?>> _pending = <String, Completer<String?>>{};
+  late final StreamSubscription<String> _subscription;
+  int _nextRequestId = 0;
+  bool _disposed = false;
+
+  ControlChannelTokenService({required ControlChannelClient client}) : _client = client {
+    _subscription = _client.inbound.listen(_handleFrame);
+  }
+
+  /// Requests an access token from the GUI over the control channel and waits
+  /// for the correlated reply. Throws [ControlTokenUnavailableException] when
+  /// the GUI replies with no token (signed out / mid-login) or does not reply
+  /// within [timeout]. Does not log on failure — the caller surfaces it once.
+  Future<String> requestToken({
+    bool forceRefresh = false,
+    Duration timeout = _defaultRequestTimeout,
+  }) async {
+    final id = "token-${_nextRequestId++}";
+    final completer = Completer<String?>();
+    _pending[id] = completer;
+    try {
+      _client.send(jsonEncode(ControlMessage.tokenRequest(id: id, forceRefresh: forceRefresh).toJson()));
+      final accessToken = await completer.future.timeout(timeout);
+      if (accessToken == null) {
+        throw const ControlTokenUnavailableException(
+          "The desktop app could not supply an access token (signed out or mid-login).",
+        );
+      }
+      return accessToken;
+    } on TimeoutException {
+      throw const ControlTokenUnavailableException(
+        "Timed out waiting for the desktop app to supply an access token.",
+      );
+    } finally {
+      _pending.remove(id);
+    }
+  }
+
+  Future<void> dispose() async {
+    _disposed = true;
+    // Isolate the cancel so a failure still lets teardown finish.
+    try {
+      await _subscription.cancel();
+    } on Object catch (error, stackTrace) {
+      Log.w("[control][token] failed to cancel inbound subscription", error, stackTrace);
+    }
+    // Fail any in-flight request so a shutdown mid-request doesn't hang on the
+    // full request timeout.
+    final pending = List<Completer<String?>>.of(_pending.values);
+    _pending.clear();
+    for (final completer in pending) {
+      if (!completer.isCompleted) {
+        completer.completeError(
+          const ControlTokenUnavailableException("Control channel token service disposed before a token arrived."),
+        );
+      }
+    }
+  }
+
+  void _handleFrame(String frame) {
+    if (_disposed) return;
+    final ControlMessage message;
+    try {
+      message = ControlMessage.fromJson(jsonDecodeMap(frame));
+    } on Object catch (error, stackTrace) {
+      // A frame we can't decode (malformed, or a forward-compat message type a
+      // newer GUI added) is not fatal — skip it and keep serving requests.
+      Log.w("[control][token] ignoring undecodable control frame", error, stackTrace);
+      return;
+    }
+    if (message is ControlTokenResponse) {
+      final completer = _pending.remove(message.id);
+      if (completer != null && !completer.isCompleted) {
+        completer.complete(message.accessToken);
+      }
+    }
+    // Other control-message variants are not this service's concern.
+  }
+}

--- a/bridge/app/test/control/control_channel_token_service_test.dart
+++ b/bridge/app/test/control/control_channel_token_service_test.dart
@@ -114,6 +114,28 @@ void main() {
       await service.dispose();
       await expectation;
     });
+
+    test("requestToken after dispose fails fast without waiting for the timeout", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlChannelTokenService(client: client);
+      await service.dispose();
+
+      // A long timeout proves the failure is the disposed guard, not the timer.
+      await expectLater(
+        service.requestToken(timeout: const Duration(seconds: 30)),
+        throwsA(isA<ControlTokenUnavailableException>()),
+      );
+      // No request frame is sent once disposed.
+      expect(client.sentFrames, isEmpty);
+    });
+
+    test("dispose is idempotent", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlChannelTokenService(client: client);
+
+      await service.dispose();
+      await service.dispose();
+    });
   });
 }
 

--- a/bridge/app/test/control/control_channel_token_service_test.dart
+++ b/bridge/app/test/control/control_channel_token_service_test.dart
@@ -136,6 +136,19 @@ void main() {
       await service.dispose();
       await service.dispose();
     });
+
+    test("concurrent dispose callers await the same teardown", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlChannelTokenService(client: client);
+
+      final first = service.dispose();
+      final second = service.dispose();
+
+      // Memoized: both callers observe the same in-progress teardown, so a
+      // second caller can't complete before the first finishes.
+      expect(identical(first, second), isTrue);
+      await Future.wait<void>([first, second]);
+    });
   });
 }
 

--- a/bridge/app/test/control/control_channel_token_service_test.dart
+++ b/bridge/app/test/control/control_channel_token_service_test.dart
@@ -1,0 +1,146 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:sesori_bridge/src/control/control_channel_token_service.dart";
+import "package:sesori_bridge/src/foundation/control_channel_client.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ControlChannelTokenService", () {
+    test("sends a token_request and resolves with the matching token_response", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlChannelTokenService(client: client);
+      addTearDown(service.dispose);
+
+      final future = service.requestToken();
+      await pumpEventQueue();
+
+      expect(client.sentFrames, hasLength(1));
+      final request = _decode(client.sentFrames.single) as ControlTokenRequest;
+      expect(request.forceRefresh, isFalse);
+
+      client.emit(_encode(ControlMessage.tokenResponse(id: request.id, accessToken: "tok-123")));
+
+      expect(await future, equals("tok-123"));
+    });
+
+    test("forwards forceRefresh in the request", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlChannelTokenService(client: client);
+      addTearDown(service.dispose);
+
+      final future = service.requestToken(forceRefresh: true);
+      await pumpEventQueue();
+
+      final request = _decode(client.sentFrames.single) as ControlTokenRequest;
+      expect(request.forceRefresh, isTrue);
+
+      client.emit(_encode(ControlMessage.tokenResponse(id: request.id, accessToken: "tok")));
+      await future;
+    });
+
+    test("a null access token surfaces a typed failure", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlChannelTokenService(client: client);
+      addTearDown(service.dispose);
+
+      final future = service.requestToken();
+      await pumpEventQueue();
+      final request = _decode(client.sentFrames.single) as ControlTokenRequest;
+
+      client.emit(_encode(ControlMessage.tokenResponse(id: request.id, accessToken: null)));
+
+      await expectLater(future, throwsA(isA<ControlTokenUnavailableException>()));
+    });
+
+    test("times out with a typed failure when no response arrives", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlChannelTokenService(client: client);
+      addTearDown(service.dispose);
+
+      await expectLater(
+        service.requestToken(timeout: const Duration(milliseconds: 20)),
+        throwsA(isA<ControlTokenUnavailableException>()),
+      );
+    });
+
+    test("correlates by id — a mismatched response is ignored", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlChannelTokenService(client: client);
+      addTearDown(service.dispose);
+
+      final future = service.requestToken(timeout: const Duration(seconds: 5));
+      await pumpEventQueue();
+      final request = _decode(client.sentFrames.single) as ControlTokenRequest;
+
+      client.emit(_encode(const ControlMessage.tokenResponse(id: "someone-else", accessToken: "wrong")));
+      client.emit(_encode(ControlMessage.tokenResponse(id: request.id, accessToken: "right")));
+
+      expect(await future, equals("right"));
+    });
+
+    test("ignores unrelated and undecodable frames", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlChannelTokenService(client: client);
+      addTearDown(service.dispose);
+
+      final future = service.requestToken(timeout: const Duration(seconds: 5));
+      await pumpEventQueue();
+      final request = _decode(client.sentFrames.single) as ControlTokenRequest;
+
+      client.emit("not valid json");
+      client.emit(
+        _encode(
+          const ControlMessage.status(
+            relay: ControlRelayConnectionState.connected,
+            plugin: ControlPluginHealthState.healthy,
+          ),
+        ),
+      );
+      client.emit(_encode(ControlMessage.tokenResponse(id: request.id, accessToken: "ok")));
+
+      expect(await future, equals("ok"));
+    });
+
+    test("dispose fails any in-flight request", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlChannelTokenService(client: client);
+
+      final future = service.requestToken(timeout: const Duration(seconds: 30));
+      await pumpEventQueue();
+      final expectation = expectLater(future, throwsA(isA<ControlTokenUnavailableException>()));
+
+      await service.dispose();
+      await expectation;
+    });
+  });
+}
+
+ControlMessage _decode(String frame) => ControlMessage.fromJson(jsonDecodeMap(frame));
+
+String _encode(ControlMessage message) => jsonEncode(message.toJson());
+
+class _FakeControlChannelClient implements ControlChannelClient {
+  final StreamController<String> _inbound = StreamController<String>.broadcast();
+  final List<String> sentFrames = <String>[];
+
+  void emit(String frame) => _inbound.add(frame);
+
+  @override
+  Stream<String> get inbound => _inbound.stream;
+
+  @override
+  void send(String frame) => sentFrames.add(frame);
+
+  @override
+  Stream<ControlChannelConnectionState> get connectionState => const Stream<ControlChannelConnectionState>.empty();
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> dispose() async {
+    await _inbound.close();
+  }
+}

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -133,7 +133,39 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   reads** (this is distinct from PR 1.1's optional one-shot secret-bootstrap
   stdin handshake, which is not an auth prompt); standalone interactive flow
   untouched.
-- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+- **Aristotle:** plan ☑ · impl ☑.
+- **Findings:** Shipped `ControlChannelTokenService` in `control/` (beside
+  `ControlChannelLossListener`), NOT `auth/`: the service depends on the Layer-0
+  `ControlChannelClient`, and `auth/` is a self-contained subsystem that must not
+  depend on core `foundation/`. It owns the token request/response round-trip —
+  sends an id-correlated `ControlMessage.tokenRequest` (monotonic id), subscribes
+  to `ControlChannelClient.inbound`, decodes each frame to `ControlMessage`, and
+  completes the matching pending request on `tokenResponse`. A null `accessToken`
+  (GUI signed-out/mid-login) or a request timeout yields a typed
+  `ControlTokenUnavailableException` — not logged at the throw (the `run()` catch
+  surfaces it once, no double-log); undecodable/forward-compat frames are warned
+  and skipped, other variants ignored. `dispose()` cancels the inbound
+  subscription and fails any in-flight request so shutdown can't hang on the
+  timeout. Composition: `_startSupervisedControlChannel` is renamed
+  `_connectSupervisedControlChannel` and now returns the connected client; the
+  runner builds the token service from that same client (shared with the loss
+  listener) and registers its dispose. The auth bootstrap branches — supervised ⇒
+  `requestToken()`, standalone ⇒ unchanged `ensureAuthenticated()` — and
+  `logAuthenticatedUser` runs identically on both paths. `BridgeRuntimeAuthService`
+  is unchanged, so standalone is byte-identical (its existing tests stay green);
+  `dart analyze --fatal-infos` clean; 1517 app tests pass (7 new for the service).
+- **Deltas:** §6 / the PR-1.4 line place this class in `auth/` (Layer 3); plan
+  review re-homed it to `control/` for this PR because `auth/` cannot depend on
+  the Layer-0 `ControlChannelClient`. When PR 1.4 makes the class implement the
+  `auth/` interfaces (`AccessTokenProvider`/`TokenRefresher`), it must resolve the
+  resulting `control/`→`auth/` direction (an auth-side adapter, or an auth-local
+  transport abstraction). PR 1.3 handles only the token request/response
+  correlation; `token_update` push, the provider/refresher interfaces,
+  force-refresh policy, and richer GUI-down/mid-login wait semantics remain PR
+  1.4 (the initial pull is a one-shot request with a 30s timeout). Downstream
+  `TokenManager` still seeds from the resolved access token on both paths;
+  supervised registration/refresh rework is deferred to PRs 1.4/1.5/1.6 and isn't
+  reached pre-GUI (Phase 2).
 
 ## PR 1.4 — Token provider **pull** over channel
 - **Goal:** `ControlChannelTokenService` (Layer 3 `auth/`) implements


### PR DESCRIPTION
## Goal

PR 1.3 of **Phase 1 — Bridge Supervised Mode**. In supervised mode (bridge launched with `--control-url`), short-circuit the interactive auth bootstrap so **no interactive auth/prompt stdin reads** happen; instead obtain the initial access token from the GUI over the already-connected loopback control channel. Standalone behaviour is byte-identical.

## What changed

- **New `ControlChannelTokenService` (`control/`)** — owns the supervised-mode token request/response round-trip over the control channel:
  - sends an id-correlated `ControlMessage.tokenRequest` (monotonic id), subscribes once to `ControlChannelClient.inbound`, decodes each frame to `ControlMessage`, completes the matching pending request on `tokenResponse`.
  - a null `accessToken` (GUI signed-out / mid-login) or a request timeout yields a typed `ControlTokenUnavailableException` — **not logged at the throw** (the `run()` catch surfaces it once, no double-log).
  - undecodable / forward-compat frames are warned and skipped; other variants ignored.
  - `dispose()` cancels the inbound subscription and fails any in-flight request so shutdown can't hang on the timeout.
  - Lives in `control/` (beside `ControlChannelLossListener`), **not** `auth/`: it depends on the Layer-0 `ControlChannelClient`, and `auth/` is a self-contained subsystem that must not depend on core `foundation/` (per plan review).

- **Runner (`bridge_runtime_runner.dart`)** — `_startSupervisedControlChannel` renamed to `_connectSupervisedControlChannel` and now returns the connected client. The runner builds the token service from that **same** client (shared with the loss listener) and registers its dispose. The auth bootstrap branches: supervised ⇒ `requestToken()`, standalone ⇒ unchanged `ensureAuthenticated()`. `logAuthenticatedUser` runs identically on both paths.

- **`BridgeRuntimeAuthService` is unchanged** ⇒ standalone is byte-identical (its existing tests stay green).

## Scope boundary (deferred to later PRs)

`token_update` push, the `AccessTokenProvider`/`TokenRefresher` interfaces, force-refresh policy, and richer GUI-down/mid-login wait semantics are **PR 1.4**. The initial pull is a one-shot request with a 30s timeout. Supervised registration/refresh rework is PRs 1.4/1.5/1.6 and isn't reached pre-GUI (Phase 2).

## Tests

- New `test/control/control_channel_token_service_test.dart` (7 tests): request/response resolve, `forceRefresh` forwarded, null token → typed failure, timeout → typed failure, id correlation, unrelated/undecodable frames ignored, dispose fails in-flight.
- Existing `bridge_runtime_auth_test.dart` (standalone) stays green.

## Verification

- `dart analyze --fatal-infos` clean (app); `make analyze` clean (all bridge modules).
- `dart test` — 1517 app tests pass.
- Aristotle: plan ☑ · impl ☑.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add supervised auth bootstrap over the control channel. With `--control-url`, the bridge now pulls the initial access token from the desktop app via the loopback control channel and skips interactive prompts; standalone flow is unchanged.

- **New Features**
  - Added ControlChannelTokenService to request an access token over the control channel (id-correlated request/response), throwing ControlTokenUnavailableException on null/timeout and ignoring undecodable/unrelated frames; dispose cancels and fails in-flight requests.
  - Updated BridgeRuntimeRunner: `_startSupervisedControlChannel` renamed to `_connectSupervisedControlChannel` (returns the connected client); builds the token service from that client and uses `requestToken()` in supervised mode, otherwise `ensureAuthenticated()`; `logAuthenticatedUser` is unchanged.

- **Bug Fixes**
  - Guarded post-dispose use: `requestToken()` now fails fast when disposed; `dispose()` is idempotent.
  - Memoized `dispose()` so concurrent callers await the same teardown; the disposed guard remains synchronous.

<sup>Written for commit 0544ad0537838b4616cbd85234c2beaf10b49ab3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

