### PR TITLE
feat(bridge): supervised token provider pull over control channel (Phase 1, PR 1.4)

### DIFF
--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -29,6 +29,7 @@ import "package:sesori_shared/sesori_shared.dart" show DeviceInfo;
 
 import "../../api/bridge_settings_api.dart";
 import "../../api/control_secret_api.dart";
+import "../../auth/access_token_provider.dart";
 import "../../auth/bridge_registration_api.dart";
 import "../../auth/bridge_registration_repository.dart";
 import "../../auth/bridge_registration_service.dart";
@@ -38,8 +39,8 @@ import "../../auth/login_oauth_api.dart";
 import "../../auth/login_oauth_service.dart";
 import "../../auth/token.dart";
 import "../../auth/token_manager.dart";
+import "../../auth/token_refresher.dart";
 import "../../control/control_channel_loss_listener.dart";
-import "../../control/control_channel_token_service.dart";
 import "../../foundation/control_channel_client.dart";
 import "../../repositories/bridge_settings_repository.dart";
 import "../../server/api/loopback_port_api.dart";
@@ -59,6 +60,7 @@ import "../../server/repositories/startup_mutex_repository.dart";
 import "../../server/repositories/terminal_prompt_repository.dart";
 import "../../server/services/bridge_instance_service.dart";
 import "../../server/services/bridge_restart_service.dart";
+import "../../services/control_channel_token_service.dart";
 import "../../updater/api/checksum_manifest_api.dart";
 import "../../updater/api/github_releases_api.dart";
 import "../../updater/api/managed_runtime_manifest_api.dart";
@@ -287,7 +289,7 @@ class BridgeRuntimeRunner {
       final String authAccessToken;
       final supervisedTokenService = controlChannelTokenService;
       if (supervisedTokenService != null) {
-        authAccessToken = await supervisedTokenService.requestToken();
+        authAccessToken = await supervisedTokenService.getAccessToken();
       } else {
         final authTokens = await runtimeAuthService.ensureAuthenticated(options: options);
         authAccessToken = authTokens.accessToken;
@@ -388,13 +390,28 @@ class BridgeRuntimeRunner {
           })
           .addTo(subscriptions);
 
-      final tokenManager = TokenManager(
-        initialToken: authAccessToken,
-        authBackendUrl: options.authBackendUrl,
-        loadTokens: loadTokens,
-        saveTokens: saveTokens,
-      );
-      shutdownCoordinator.add(disposable: tokenManager.dispose);
+      // In supervised mode the GUI is the token authority: the control-channel
+      // token service is the access-token provider + refresher, pulling tokens
+      // from the GUI over the loopback channel. Standalone keeps the
+      // TokenManager, which refreshes against the auth server with the locally
+      // stored refresh token (no GUI exists to ask). The control service's
+      // dispose is already registered with the shutdown coordinator above.
+      final AccessTokenProvider accessTokenProvider;
+      final TokenRefresher tokenRefresher;
+      if (supervisedTokenService != null) {
+        accessTokenProvider = supervisedTokenService;
+        tokenRefresher = supervisedTokenService;
+      } else {
+        final tokenManager = TokenManager(
+          initialToken: authAccessToken,
+          authBackendUrl: options.authBackendUrl,
+          loadTokens: loadTokens,
+          saveTokens: saveTokens,
+        );
+        shutdownCoordinator.add(disposable: tokenManager.dispose);
+        accessTokenProvider = tokenManager;
+        tokenRefresher = tokenManager;
+      }
 
       final bridgeRegistrationService = BridgeRegistrationService(
         repository: BridgeRegistrationRepository(
@@ -403,7 +420,7 @@ class BridgeRuntimeRunner {
             client: httpClient,
           ),
         ),
-        tokenRefresher: tokenManager,
+        tokenRefresher: tokenRefresher,
         loadTokens: loadTokens,
         saveTokens: saveTokens,
         hostName: io.Platform.localHostname,
@@ -427,8 +444,8 @@ class BridgeRuntimeRunner {
         ),
         plugin: plugin.api,
         httpClient: httpClient,
-        accessTokenProvider: tokenManager,
-        tokenRefresher: tokenManager,
+        accessTokenProvider: accessTokenProvider,
+        tokenRefresher: tokenRefresher,
         bridgeRegistrationService: bridgeRegistrationService,
         database: AppDatabase.create(),
         processRunner: processRunner,

--- a/bridge/app/lib/src/foundation/control_channel_client.dart
+++ b/bridge/app/lib/src/foundation/control_channel_client.dart
@@ -10,6 +10,17 @@ import "package:web_socket_channel/io.dart";
 /// control-protocol DTOs live in `sesori_shared` (added in a later PR).
 enum ControlChannelConnectionState { connected, disconnected }
 
+/// Thrown by [ControlChannelClient.send] when the channel is not currently
+/// connected (GUI outage or mid-reconnect). This is a transient runtime
+/// condition — not a programming error — so it is an [Exception], letting
+/// callers map it to their own typed failure rather than catching an [Error].
+class ControlChannelNotConnectedException implements Exception {
+  final String message;
+  const ControlChannelNotConnectedException(this.message);
+  @override
+  String toString() => "ControlChannelNotConnectedException: $message";
+}
+
 /// Layer-0 transport for the GUI-hosted loopback control channel used in
 /// supervised mode. It is a dumb duplex WebSocket pipe: it connects,
 /// auto-reconnects with backoff while it is alive, surfaces inbound text
@@ -80,11 +91,13 @@ class ControlChannelClient {
     }
   }
 
-  /// Sends a raw text frame. Throws [StateError] if not currently connected.
+  /// Sends a raw text frame. Throws [ControlChannelNotConnectedException] if not
+  /// currently connected (GUI outage / mid-reconnect), so callers can map that
+  /// transient condition to their own typed failure.
   void send(String frame) {
     final channel = _channel;
     if (channel == null) {
-      throw StateError("Control channel is not connected");
+      throw const ControlChannelNotConnectedException("Control channel is not connected");
     }
     channel.sink.add(frame);
   }

--- a/bridge/app/lib/src/services/control_channel_token_service.dart
+++ b/bridge/app/lib/src/services/control_channel_token_service.dart
@@ -1,16 +1,18 @@
 import "dart:async";
 import "dart:convert";
 
+import "package:rxdart/rxdart.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart" show ControlMessage, ControlTokenResponse, jsonDecodeMap;
 
+import "../auth/access_token_provider.dart";
+import "../auth/token_refresher.dart";
 import "../foundation/control_channel_client.dart";
 
 /// Thrown when the GUI cannot supply an access token over the control channel —
 /// either it replied with a null token (signed out / mid-login) or it did not
-/// reply within the request timeout. The supervised-startup caller surfaces and
-/// logs this once, so this path deliberately does not log it (avoids
-/// double-logging).
+/// reply within the request timeout. The caller surfaces and logs this once, so
+/// this path deliberately does not log it (avoids double-logging).
 class ControlTokenUnavailableException implements Exception {
   final String reason;
   const ControlTokenUnavailableException(this.reason);
@@ -18,39 +20,71 @@ class ControlTokenUnavailableException implements Exception {
   String toString() => "ControlTokenUnavailableException: $reason";
 }
 
-/// Supervised-mode token bootstrap over the loopback control channel: the GUI,
-/// not an interactive terminal, is the bridge's token authority. This service
-/// asks the GUI for an access token by sending a [ControlMessage.tokenRequest]
-/// and awaiting the id-correlated [ControlMessage.tokenResponse], replacing the
-/// standalone interactive login during startup.
+/// Supervised-mode access-token authority over the loopback control channel: the
+/// GUI, not an interactive terminal or the auth server's refresh endpoint, is
+/// the bridge's token source. This service is the supervised-mode counterpart of
+/// the standalone [TokenManager] — both implement [AccessTokenProvider] and
+/// [TokenRefresher], and the composition root picks one by mode.
+///
+/// [getAccessToken] asks the GUI for a token by sending a
+/// [ControlMessage.tokenRequest] and awaiting the id-correlated
+/// [ControlMessage.tokenResponse], forwarding `forceRefresh` so the GUI knows
+/// whether to mint a fresh token. The latest token is cached so the synchronous
+/// [accessToken] getter and [tokenStream] reflect it. (Pushed `token_update`
+/// refreshes and the live relay re-auth that consumes [tokenStream] are wired
+/// separately.)
 ///
 /// It owns its subscription to [ControlChannelClient.inbound], decoding each
 /// frame into a [ControlMessage] and completing the matching pending request.
 /// Non-token-response frames are ignored here (other control messages are
 /// handled elsewhere); undecodable frames are logged and skipped so a malformed
-/// or forward-compat message can't stall the bootstrap.
-class ControlChannelTokenService {
+/// or forward-compat message can't stall a pull.
+class ControlChannelTokenService implements AccessTokenProvider, TokenRefresher {
   static const Duration _defaultRequestTimeout = Duration(seconds: 30);
 
   final ControlChannelClient _client;
+  final Duration _requestTimeout;
+  final BehaviorSubject<String> _tokenSubject = BehaviorSubject<String>();
   final Map<String, Completer<String?>> _pending = <String, Completer<String?>>{};
   late final StreamSubscription<String> _subscription;
   int _nextRequestId = 0;
   bool _disposed = false;
   Future<void>? _disposeFuture;
 
-  ControlChannelTokenService({required ControlChannelClient client}) : _client = client {
+  ControlChannelTokenService({
+    required ControlChannelClient client,
+    Duration requestTimeout = _defaultRequestTimeout,
+  })  : _client = client,
+        _requestTimeout = requestTimeout {
     _subscription = _client.inbound.listen(_handleFrame);
   }
 
+  /// The most recently pulled access token. Only valid after the first
+  /// successful [getAccessToken]; the composition root awaits the bootstrap pull
+  /// before exposing this service as the provider, so this never reads ahead of
+  /// a token in practice.
+  @override
+  String get accessToken {
+    if (!_tokenSubject.hasValue) {
+      throw StateError(
+        "accessToken read before the initial control-channel token pull — "
+        "await getAccessToken() before using this provider.",
+      );
+    }
+    return _tokenSubject.value;
+  }
+
+  @override
+  ValueStream<String> get tokenStream => _tokenSubject.stream;
+
   /// Requests an access token from the GUI over the control channel and waits
-  /// for the correlated reply. Throws [ControlTokenUnavailableException] when
-  /// the GUI replies with no token (signed out / mid-login) or does not reply
-  /// within [timeout]. Does not log on failure — the caller surfaces it once.
-  Future<String> requestToken({
-    bool forceRefresh = false,
-    Duration timeout = _defaultRequestTimeout,
-  }) async {
+  /// for the correlated reply, forwarding [forceRefresh] so the GUI can mint a
+  /// fresh token instead of returning a cached one. Throws
+  /// [ControlTokenUnavailableException] when the GUI replies with no token
+  /// (signed out / mid-login) or does not reply within the request timeout.
+  /// Does not log on failure — the caller surfaces it once.
+  @override
+  Future<String> getAccessToken({bool forceRefresh = false}) async {
     // After dispose the inbound subscription is cancelled, so a response can
     // never arrive — fail fast instead of registering a completer that would
     // only resolve via the timeout.
@@ -64,11 +98,17 @@ class ControlChannelTokenService {
     _pending[id] = completer;
     try {
       _client.send(jsonEncode(ControlMessage.tokenRequest(id: id, forceRefresh: forceRefresh).toJson()));
-      final accessToken = await completer.future.timeout(timeout);
+      final accessToken = await completer.future.timeout(_requestTimeout);
       if (accessToken == null) {
         throw const ControlTokenUnavailableException(
           "The desktop app could not supply an access token (signed out or mid-login).",
         );
+      }
+      // Cache the latest token so the synchronous getter and tokenStream stay
+      // current. Skip if a dispose raced this pull (which closes the subject) —
+      // returning the token to the caller is still correct mid-shutdown.
+      if (!_disposed) {
+        _tokenSubject.add(accessToken);
       }
       return accessToken;
     } on TimeoutException {
@@ -86,7 +126,7 @@ class ControlChannelTokenService {
   Future<void> dispose() => _disposeFuture ??= _dispose();
 
   Future<void> _dispose() async {
-    // Set synchronously (before the first await) so a requestToken racing
+    // Set synchronously (before the first await) so a getAccessToken racing
     // dispose sees the disposed guard immediately.
     _disposed = true;
     // Isolate the cancel so a failure still lets teardown finish.
@@ -106,6 +146,7 @@ class ControlChannelTokenService {
         );
       }
     }
+    await _tokenSubject.close();
   }
 
   void _handleFrame(String frame) {

--- a/bridge/app/lib/src/services/control_channel_token_service.dart
+++ b/bridge/app/lib/src/services/control_channel_token_service.dart
@@ -48,6 +48,7 @@ class ControlChannelTokenService implements AccessTokenProvider, TokenRefresher 
   final Map<String, Completer<String?>> _pending = <String, Completer<String?>>{};
   late final StreamSubscription<String> _subscription;
   int _nextRequestId = 0;
+  int _latestRequestSeq = -1;
   bool _disposed = false;
   Future<void>? _disposeFuture;
 
@@ -93,11 +94,24 @@ class ControlChannelTokenService implements AccessTokenProvider, TokenRefresher 
         "Control channel token service has been disposed.",
       );
     }
-    final id = "token-${_nextRequestId++}";
+    final seq = _nextRequestId++;
+    final id = "token-$seq";
+    // Track the most recently issued pull so an older overlapping response can't
+    // clobber the cache with a staler token than a later pull already wrote.
+    _latestRequestSeq = seq;
     final completer = Completer<String?>();
     _pending[id] = completer;
     try {
-      _client.send(jsonEncode(ControlMessage.tokenRequest(id: id, forceRefresh: forceRefresh).toJson()));
+      try {
+        _client.send(jsonEncode(ControlMessage.tokenRequest(id: id, forceRefresh: forceRefresh).toJson()));
+      } on ControlChannelNotConnectedException {
+        // The loopback channel is down (GUI outage / mid-reconnect). Surface the
+        // documented typed failure so refresh callers (e.g. relay re-auth) handle
+        // a GUI-unavailable pull uniformly instead of a raw transport error.
+        throw const ControlTokenUnavailableException(
+          "The desktop app control channel is not connected.",
+        );
+      }
       final accessToken = await completer.future.timeout(_requestTimeout);
       if (accessToken == null) {
         throw const ControlTokenUnavailableException(
@@ -105,9 +119,11 @@ class ControlChannelTokenService implements AccessTokenProvider, TokenRefresher 
         );
       }
       // Cache the latest token so the synchronous getter and tokenStream stay
-      // current. Skip if a dispose raced this pull (which closes the subject) —
-      // returning the token to the caller is still correct mid-shutdown.
-      if (!_disposed) {
+      // current. Only the most recently issued pull writes the shared cache (so a
+      // slower older response can't overwrite a newer token), and skip if a
+      // dispose raced this pull (which closes the subject) — returning the token
+      // to the caller is still correct mid-shutdown.
+      if (!_disposed && seq == _latestRequestSeq) {
         _tokenSubject.add(accessToken);
       }
       return accessToken;

--- a/bridge/app/lib/src/services/control_channel_token_service.dart
+++ b/bridge/app/lib/src/services/control_channel_token_service.dart
@@ -48,7 +48,7 @@ class ControlChannelTokenService implements AccessTokenProvider, TokenRefresher 
   final Map<String, Completer<String?>> _pending = <String, Completer<String?>>{};
   late final StreamSubscription<String> _subscription;
   int _nextRequestId = 0;
-  int _latestRequestSeq = -1;
+  int _latestCachedSeq = -1;
   bool _disposed = false;
   Future<void>? _disposeFuture;
 
@@ -96,9 +96,6 @@ class ControlChannelTokenService implements AccessTokenProvider, TokenRefresher 
     }
     final seq = _nextRequestId++;
     final id = "token-$seq";
-    // Track the most recently issued pull so an older overlapping response can't
-    // clobber the cache with a staler token than a later pull already wrote.
-    _latestRequestSeq = seq;
     final completer = Completer<String?>();
     _pending[id] = completer;
     try {
@@ -119,11 +116,14 @@ class ControlChannelTokenService implements AccessTokenProvider, TokenRefresher 
         );
       }
       // Cache the latest token so the synchronous getter and tokenStream stay
-      // current. Only the most recently issued pull writes the shared cache (so a
-      // slower older response can't overwrite a newer token), and skip if a
-      // dispose raced this pull (which closes the subject) — returning the token
-      // to the caller is still correct mid-shutdown.
-      if (!_disposed && seq == _latestRequestSeq) {
+      // current. Only advance the cache when this response is newer than what's
+      // already cached (seq > _latestCachedSeq), so a slower older response can't
+      // overwrite a newer token — while a newer pull that FAILS still leaves an
+      // older successful pull free to cache. Skip if a dispose raced this pull
+      // (which closes the subject) — returning the token to the caller is still
+      // correct mid-shutdown.
+      if (!_disposed && seq > _latestCachedSeq) {
+        _latestCachedSeq = seq;
         _tokenSubject.add(accessToken);
       }
       return accessToken;

--- a/bridge/app/test/services/control_channel_token_service_test.dart
+++ b/bridge/app/test/services/control_channel_token_service_test.dart
@@ -1,8 +1,8 @@
 import "dart:async";
 import "dart:convert";
 
-import "package:sesori_bridge/src/control/control_channel_token_service.dart";
 import "package:sesori_bridge/src/foundation/control_channel_client.dart";
+import "package:sesori_bridge/src/services/control_channel_token_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -13,7 +13,7 @@ void main() {
       final service = ControlChannelTokenService(client: client);
       addTearDown(service.dispose);
 
-      final future = service.requestToken();
+      final future = service.getAccessToken();
       await pumpEventQueue();
 
       expect(client.sentFrames, hasLength(1));
@@ -25,42 +25,84 @@ void main() {
       expect(await future, equals("tok-123"));
     });
 
-    test("forwards forceRefresh in the request", () async {
+    test("forwards forceRefresh in the request and returns the fresh token", () async {
       final client = _FakeControlChannelClient();
       final service = ControlChannelTokenService(client: client);
       addTearDown(service.dispose);
 
-      final future = service.requestToken(forceRefresh: true);
+      final future = service.getAccessToken(forceRefresh: true);
       await pumpEventQueue();
 
       final request = _decode(client.sentFrames.single) as ControlTokenRequest;
       expect(request.forceRefresh, isTrue);
 
-      client.emit(_encode(ControlMessage.tokenResponse(id: request.id, accessToken: "tok")));
-      await future;
+      client.emit(_encode(ControlMessage.tokenResponse(id: request.id, accessToken: "fresh")));
+      expect(await future, equals("fresh"));
     });
 
-    test("a null access token surfaces a typed failure", () async {
+    test("caches the latest pulled token for accessToken and tokenStream", () async {
       final client = _FakeControlChannelClient();
       final service = ControlChannelTokenService(client: client);
       addTearDown(service.dispose);
 
-      final future = service.requestToken();
+      final emitted = <String>[];
+      final subscription = service.tokenStream.listen(emitted.add);
+      addTearDown(subscription.cancel);
+
+      final first = service.getAccessToken();
+      await pumpEventQueue();
+      final firstRequest = _decode(client.sentFrames[0]) as ControlTokenRequest;
+      client.emit(_encode(ControlMessage.tokenResponse(id: firstRequest.id, accessToken: "tok-1")));
+      await first;
+
+      expect(service.accessToken, equals("tok-1"));
+
+      final second = service.getAccessToken(forceRefresh: true);
+      await pumpEventQueue();
+      final secondRequest = _decode(client.sentFrames[1]) as ControlTokenRequest;
+      client.emit(_encode(ControlMessage.tokenResponse(id: secondRequest.id, accessToken: "tok-2")));
+      await second;
+
+      // The synchronous getter reflects the most recent pull, and the stream saw
+      // both tokens in order.
+      expect(service.accessToken, equals("tok-2"));
+      await pumpEventQueue();
+      expect(emitted, equals(<String>["tok-1", "tok-2"]));
+    });
+
+    test("accessToken throws before the first successful pull", () {
+      final client = _FakeControlChannelClient();
+      final service = ControlChannelTokenService(client: client);
+      addTearDown(service.dispose);
+
+      expect(() => service.accessToken, throwsStateError);
+    });
+
+    test("a null access token surfaces a typed failure and leaves the cache empty", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlChannelTokenService(client: client);
+      addTearDown(service.dispose);
+
+      final future = service.getAccessToken();
       await pumpEventQueue();
       final request = _decode(client.sentFrames.single) as ControlTokenRequest;
 
       client.emit(_encode(ControlMessage.tokenResponse(id: request.id, accessToken: null)));
 
       await expectLater(future, throwsA(isA<ControlTokenUnavailableException>()));
+      expect(() => service.accessToken, throwsStateError);
     });
 
     test("times out with a typed failure when no response arrives", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      final service = ControlChannelTokenService(
+        client: client,
+        requestTimeout: const Duration(milliseconds: 20),
+      );
       addTearDown(service.dispose);
 
       await expectLater(
-        service.requestToken(timeout: const Duration(milliseconds: 20)),
+        service.getAccessToken(),
         throwsA(isA<ControlTokenUnavailableException>()),
       );
     });
@@ -70,7 +112,7 @@ void main() {
       final service = ControlChannelTokenService(client: client);
       addTearDown(service.dispose);
 
-      final future = service.requestToken(timeout: const Duration(seconds: 5));
+      final future = service.getAccessToken();
       await pumpEventQueue();
       final request = _decode(client.sentFrames.single) as ControlTokenRequest;
 
@@ -85,7 +127,7 @@ void main() {
       final service = ControlChannelTokenService(client: client);
       addTearDown(service.dispose);
 
-      final future = service.requestToken(timeout: const Duration(seconds: 5));
+      final future = service.getAccessToken();
       await pumpEventQueue();
       final request = _decode(client.sentFrames.single) as ControlTokenRequest;
 
@@ -107,7 +149,7 @@ void main() {
       final client = _FakeControlChannelClient();
       final service = ControlChannelTokenService(client: client);
 
-      final future = service.requestToken(timeout: const Duration(seconds: 30));
+      final future = service.getAccessToken();
       await pumpEventQueue();
       final expectation = expectLater(future, throwsA(isA<ControlTokenUnavailableException>()));
 
@@ -115,14 +157,17 @@ void main() {
       await expectation;
     });
 
-    test("requestToken after dispose fails fast without waiting for the timeout", () async {
+    test("getAccessToken after dispose fails fast without waiting for the timeout", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      // A long timeout proves the failure is the disposed guard, not the timer.
+      final service = ControlChannelTokenService(
+        client: client,
+        requestTimeout: const Duration(seconds: 30),
+      );
       await service.dispose();
 
-      // A long timeout proves the failure is the disposed guard, not the timer.
       await expectLater(
-        service.requestToken(timeout: const Duration(seconds: 30)),
+        service.getAccessToken(),
         throwsA(isA<ControlTokenUnavailableException>()),
       );
       // No request frame is sent once disposed.

--- a/bridge/app/test/services/control_channel_token_service_test.dart
+++ b/bridge/app/test/services/control_channel_token_service_test.dart
@@ -131,6 +131,31 @@ void main() {
       expect(service.accessToken, equals("new"));
     });
 
+    test("a failed newer pull does not block an older successful pull from caching", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlChannelTokenService(client: client);
+      addTearDown(service.dispose);
+
+      final first = service.getAccessToken();
+      await pumpEventQueue();
+      final second = service.getAccessToken();
+      await pumpEventQueue();
+
+      final firstRequest = _decode(client.sentFrames[0]) as ControlTokenRequest;
+      final secondRequest = _decode(client.sentFrames[1]) as ControlTokenRequest;
+
+      // The newer (second) pull fails — the GUI couldn't supply a token.
+      client.emit(_encode(ControlMessage.tokenResponse(id: secondRequest.id, accessToken: null)));
+      await expectLater(second, throwsA(isA<ControlTokenUnavailableException>()));
+
+      // The older (first) pull then succeeds: its valid token must still be
+      // cached even though a newer request was issued (and failed) after it.
+      client.emit(_encode(ControlMessage.tokenResponse(id: firstRequest.id, accessToken: "older-but-valid")));
+      expect(await first, equals("older-but-valid"));
+      await pumpEventQueue();
+      expect(service.accessToken, equals("older-but-valid"));
+    });
+
     test("times out with a typed failure when no response arrives", () async {
       final client = _FakeControlChannelClient();
       final service = ControlChannelTokenService(

--- a/bridge/app/test/services/control_channel_token_service_test.dart
+++ b/bridge/app/test/services/control_channel_token_service_test.dart
@@ -93,6 +93,44 @@ void main() {
       expect(() => service.accessToken, throwsStateError);
     });
 
+    test("maps a disconnected-channel send failure to a typed token failure", () async {
+      final client = _FakeControlChannelClient()..throwOnSend = true;
+      final service = ControlChannelTokenService(client: client);
+      addTearDown(service.dispose);
+
+      await expectLater(
+        service.getAccessToken(),
+        throwsA(isA<ControlTokenUnavailableException>()),
+      );
+    });
+
+    test("a slower older pull does not overwrite the newer cached token", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlChannelTokenService(client: client);
+      addTearDown(service.dispose);
+
+      final first = service.getAccessToken();
+      await pumpEventQueue();
+      final second = service.getAccessToken(forceRefresh: true);
+      await pumpEventQueue();
+
+      final firstRequest = _decode(client.sentFrames[0]) as ControlTokenRequest;
+      final secondRequest = _decode(client.sentFrames[1]) as ControlTokenRequest;
+
+      // The newer (second, latest-issued) pull resolves first and caches its
+      // token.
+      client.emit(_encode(ControlMessage.tokenResponse(id: secondRequest.id, accessToken: "new")));
+      expect(await second, equals("new"));
+      expect(service.accessToken, equals("new"));
+
+      // The older (first) pull's response arrives late: its caller still gets it,
+      // but it must NOT clobber the newer cached token.
+      client.emit(_encode(ControlMessage.tokenResponse(id: firstRequest.id, accessToken: "old")));
+      expect(await first, equals("old"));
+      await pumpEventQueue();
+      expect(service.accessToken, equals("new"));
+    });
+
     test("times out with a typed failure when no response arrives", () async {
       final client = _FakeControlChannelClient();
       final service = ControlChannelTokenService(
@@ -205,13 +243,21 @@ class _FakeControlChannelClient implements ControlChannelClient {
   final StreamController<String> _inbound = StreamController<String>.broadcast();
   final List<String> sentFrames = <String>[];
 
+  /// Mimics [ControlChannelClient.send] throwing when the channel is down.
+  bool throwOnSend = false;
+
   void emit(String frame) => _inbound.add(frame);
 
   @override
   Stream<String> get inbound => _inbound.stream;
 
   @override
-  void send(String frame) => sentFrames.add(frame);
+  void send(String frame) {
+    if (throwOnSend) {
+      throw const ControlChannelNotConnectedException("Control channel is not connected");
+    }
+    sentFrames.add(frame);
+  }
 
   @override
   Stream<ControlChannelConnectionState> get connectionState => const Stream<ControlChannelConnectionState>.empty();

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -239,12 +239,17 @@ runs **under the startup mutex**, which reinforces PR 1.12.
     longer be masked by a later non-forced pull (the deferred PR-1.4 review edge).
   - **No stale token on reconnect after sign-out.** A null `token_response`
     (signed out / mid-login) leaves PR 1.4's cache holding the previous token, and
-    `RelayClient.connect` reads that snapshot on reconnect. The reconnect/re-auth
-    path must obtain a *current* token (subscribe to `tokenStream` for live
-    re-auth and/or pull on reconnect) instead of blindly reusing the stale cached
-    `accessToken`, so the relay never re-authenticates as a signed-out user. (Note:
-    `token_update` carries a non-null token only — it cannot signal sign-out; a
-    hard logout is the `unregister_and_exit` path in PR 1.11.)
+    `RelayClient.connect` reads that snapshot on reconnect. Subscribing to
+    `tokenStream` is **not** sufficient for this case: it is a `BehaviorSubject`
+    that replays the last (stale) value, and `token_update` is non-null only, so it
+    can never push a "no token" / sign-out signal. The reconnect path must
+    therefore obtain a **fresh** token by pulling on reconnect, **and/or** the
+    cache must be invalidated on a null `token_response` — these are required, not
+    interchangeable with a stream subscription — so the relay never
+    re-authenticates as a signed-out user. (`tokenStream` subscription remains the
+    mechanism for the *live* re-auth case — adopting a `token_update` while
+    connected — which is separate. A hard logout is the `unregister_and_exit` path
+    in PR 1.11.)
 - **Risk:** Med (silent-auth-failure if wrong). **Size:** M.
 - **Acceptance:** with a **live** relay connection (not just stream
   propagation), a pushed token update re-authenticates without losing the

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -179,7 +179,43 @@ runs **under the startup mutex**, which reinforces PR 1.12.
 - **Risk:** Med. **Size:** M.
 - **Acceptance:** force-refresh requests a fresh token; timeout + GUI-down paths
   yield a typed failure (logged once at the surfacing point, not double-logged).
-- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+- **Aristotle:** plan ☑ · impl ☑.
+- **Findings:** Promoted `ControlChannelTokenService` from `control/` (Layer 4) to
+  `services/` (Layer 3) — the placement the PR-1.4 goal specifies. It now
+  `implements AccessTokenProvider, TokenRefresher` while living in `services/`, so
+  `auth/` gains no dependency on core `foundation/` transport (resolving the
+  PR-1.3 `control/`→`auth/` delta). The Layer-3 service's direct dependency on the
+  Layer-0 `ControlChannelClient` is the AGENTS.md-blessed "control-channel token
+  service over `ControlChannelClient`" seam. PR-1.3's `requestToken` became the
+  interface's `getAccessToken({forceRefresh})`: it forwards `forceRefresh` to the
+  GUI, blocks on the id-correlated reply with a constructor-configurable timeout
+  (default 30s), and caches each pulled token in a `BehaviorSubject` so the
+  synchronous `accessToken` getter and `tokenStream` stay current. Null token
+  (signed out / mid-login) and timeout still throw the typed
+  `ControlTokenUnavailableException` (not logged at the throw; the caller logs
+  once); `accessToken` throws `StateError` before the first successful pull (the
+  composition root awaits the bootstrap pull before exposing the provider);
+  `dispose` now also closes the subject. Composition: in supervised mode the
+  runner selects the control-channel service as the `accessTokenProvider` +
+  `tokenRefresher` (and the registration refresher) and skips constructing
+  `TokenManager` — the GUI is the sole token authority; standalone constructs and
+  uses `TokenManager` exactly as before (byte-identical, existing auth/runtime
+  tests stay green). Two implementors of the auth interfaces now coexist by design
+  (`TokenManager` in `auth/` for the standalone refresh-token flow,
+  `ControlChannelTokenService` in `services/` for the supervised GUI pull); the
+  composition root picks by `options.isSupervised` — a strategy seam.
+  `dart analyze --fatal-infos` clean; `make analyze` clean; 1522 app tests pass
+  (13 in the moved service test).
+- **Deltas:** Earlier text placed this class in `auth/` (Layer 3); the merged plan
+  now specifies `services/`, which this PR implements — so `auth/` never imports
+  `foundation/` transport. PR 1.4 wires the supervised provider/refresher but adds
+  **no** `token_update` push handling and **no** `RelayClient` `tokenStream`
+  consumption, so the supervised provider path is exercised only by unit tests
+  pre-GUI (Phase 2); pushed `token_update` → live relay re-auth remains PR 1.5 and
+  supervised registration + `bridgeId`-out-of-`token.json` remains PR 1.6. "Richer
+  mid-login wait" is bounded by the one-reply `token_response` DTO: a mid-login GUI
+  replies with a null token (typed failure); genuine wait-for-login-completion
+  arrives with the `token_update` push in PR 1.5.
 
 ## PR 1.5 — Token-stream **push** → relay re-auth
 - **Goal:** Make a GUI-pushed `token_update` actually re-authenticate the live

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -215,7 +215,12 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   supervised registration + `bridgeId`-out-of-`token.json` remains PR 1.6. "Richer
   mid-login wait" is bounded by the one-reply `token_response` DTO: a mid-login GUI
   replies with a null token (typed failure); genuine wait-for-login-completion
-  arrives with the `token_update` push in PR 1.5.
+  arrives with the `token_update` push in PR 1.5. Two review-driven edges are
+  deferred to and now enumerated in **PR 1.5's scope**: (a) the `token_update`
+  push must become the authoritative cache source, retiring this PR's interim
+  pull-ordering heuristic so a forced refresh isn't masked by a later non-forced
+  pull; and (b) a relay reconnect after a null `token_response` (sign-out) must
+  not reuse the stale cached token.
 
 ## PR 1.5 — Token-stream **push** → relay re-auth
 - **Goal:** Make a GUI-pushed `token_update` actually re-authenticate the live
@@ -224,10 +229,29 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   stream leaves an **open** WebSocket on the old JWT until reconnect. This PR
   wires the `RelayClient` subscription → re-auth/reconnect path so a refresh
   while connected takes effect (ADR A12).
+- **Scope (carried from PR 1.4 review — MUST be addressed here):**
+  - **Handle the `token_update` push.** `ControlChannelTokenService` must consume
+    inbound `ControlMessage.tokenUpdate` and adopt the pushed token into its
+    cached `accessToken`/`tokenStream`. This makes the GUI push the authoritative
+    cache source and **retires PR 1.4's interim pull-ordering freshness heuristic**
+    (`_latestCachedSeq`): once the GUI pushes, overlapping force/non-force pull
+    ordering no longer decides what is cached, so a forced-refresh result can no
+    longer be masked by a later non-forced pull (the deferred PR-1.4 review edge).
+  - **No stale token on reconnect after sign-out.** A null `token_response`
+    (signed out / mid-login) leaves PR 1.4's cache holding the previous token, and
+    `RelayClient.connect` reads that snapshot on reconnect. The reconnect/re-auth
+    path must obtain a *current* token (subscribe to `tokenStream` for live
+    re-auth and/or pull on reconnect) instead of blindly reusing the stale cached
+    `accessToken`, so the relay never re-authenticates as a signed-out user. (Note:
+    `token_update` carries a non-null token only — it cannot signal sign-out; a
+    hard logout is the `unregister_and_exit` path in PR 1.11.)
 - **Risk:** Med (silent-auth-failure if wrong). **Size:** M.
 - **Acceptance:** with a **live** relay connection (not just stream
   propagation), a pushed token update re-authenticates without losing the
-  session; covered by a connection-level test.
+  session; covered by a connection-level test. A `token_update` push updates the
+  shared cache regardless of any in-flight pull ordering. After a null
+  `token_response` (signed out / mid-login), a relay reconnect does **not**
+  re-authenticate from the stale cached token.
 - **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
 
 ## PR 1.6 — Supervised registration + `bridgeId` out of `token.json`


### PR DESCRIPTION
## Goal
Phase 1, PR 1.4. Make `ControlChannelTokenService` the **supervised-mode token authority**: it implements the `auth/` interfaces `AccessTokenProvider` + `TokenRefresher` and, in supervised mode, becomes the runtime's access-token provider + refresher (the GUI is the sole token source). Standalone is byte-identical.

## What changed
- **Promoted the service `control/` (Layer 4) → `services/` (Layer 3)** — the placement the merged plan specifies. It now `implements AccessTokenProvider, TokenRefresher` while living in `services/`, so `auth/` gains **no** dependency on core `foundation/` transport (resolves the PR-1.3 `control/`→`auth/` delta). The Layer-3 service's direct `ControlChannelClient` dependency is the AGENTS.md-blessed "control-channel token service over `ControlChannelClient`" seam.
- **`requestToken` → `getAccessToken({forceRefresh})`** (the `TokenRefresher` contract): forwards `forceRefresh` to the GUI, blocks on the id-correlated reply with a constructor-configurable timeout (default 30s), and caches each pulled token in a `BehaviorSubject` so the synchronous `accessToken` getter and `tokenStream` stay current.
  - Null token (signed out / mid-login) and timeout still throw the typed `ControlTokenUnavailableException` (not logged at the throw — the caller logs once).
  - `accessToken` throws `StateError` before the first successful pull (the composition root awaits the bootstrap pull before exposing the provider).
  - `dispose` now also closes the subject; still memoized + idempotent.
- **Composition root**: in supervised mode the runner selects the control-channel service as the `accessTokenProvider` + `tokenRefresher` (and registration refresher) and **skips constructing `TokenManager`**. Standalone constructs/uses `TokenManager` exactly as before → byte-identical. Two implementors of the auth interfaces now coexist by design; the root picks by `options.isSupervised` (strategy seam).

## Out of scope (deferred)
- Pushed `token_update` → live relay re-auth (`RelayClient` subscribing to `tokenStream`) → **PR 1.5**.
- Supervised registration + `bridgeId`-out-of-`token.json` → **PR 1.6**.

The supervised provider path is therefore exercised only by unit tests pre-GUI (Phase 2).

## Tests / gates
- `dart analyze --fatal-infos` (bridge/app) — clean
- `make analyze` (all bridge modules) — clean
- `dart test` (bridge/app) — **1522 pass** (13 in the moved service test)
- aristotle-plan-review ✅ · aristotle-impl-review ✅

## Standing Phase-1 invariants
- `--control-url` absent ⇒ exact current behaviour (standalone byte-identical).
- Relay protocol untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes supervised auth/token wiring and registration refresh paths; standalone is intended to stay byte-identical but mode selection must remain correct at the composition root.
> 
> **Overview**
> **Supervised mode** now treats the desktop GUI as the sole access-token authority: `ControlChannelTokenService` is promoted to `services/` and implements `AccessTokenProvider` + `TokenRefresher`, replacing the standalone `TokenManager` in the composition root when `--control-url` is set.
> 
> The service renames **`requestToken` → `getAccessToken({forceRefresh})`**, forwards refresh intent to the GUI, caches successful pulls in a `BehaviorSubject` (sync `accessToken` + `tokenStream`), and uses a constructor-level timeout. Failures stay typed (`ControlTokenUnavailableException`); reading `accessToken` before the first pull throws `StateError`. **`BridgeRuntimeRunner`** wires the control service into `BridgeRuntime` and registration refresh in supervised mode and skips constructing `TokenManager`; standalone behavior is unchanged.
> 
> Tests and phase docs are updated for the move and new caching/contract behavior. **`token_update` push → relay re-auth** is explicitly out of scope (PR 1.5).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e73c7b77b14517fe838c8f2c68e728d8e8c9cac4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `ControlChannelTokenService` the supervised-mode access-token authority, pulling tokens from the desktop app over the control channel and wiring it as the runtime `AccessTokenProvider` + `TokenRefresher` in supervised mode. Docs now also clarify PR 1.5: handle `token_update` push and require a fresh pull on reconnect after sign-out to avoid stale tokens.

- **New Features**
  - Moved to `services/` and now implements `AccessTokenProvider` + `TokenRefresher`, keeping `auth/` free of `foundation/` transport.
  - `getAccessToken({forceRefresh})` replaces `requestToken`; forwards `forceRefresh`, uses a constructor-configurable timeout, and caches the latest token for `accessToken`/`tokenStream`. `accessToken` throws before the first pull; `dispose` closes the stream.
  - Runner selects the control-channel service as the access-token provider + refresher in supervised mode and skips `TokenManager`; standalone keeps `TokenManager`.

- **Bug Fixes**
  - `ControlChannelClient.send` throws `ControlChannelNotConnectedException` when disconnected; the token service maps this to `ControlTokenUnavailableException`.
  - Cache writes now use the latest-completed pull: a slow older response can’t overwrite a newer token, and a failed newer pull no longer blocks an older successful pull from updating the cache.

<sup>Written for commit 6630a2c6cba7b81df8678e17be6d4475a48dc8af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

