### PR TITLE
docs: product vision, roadmap, and directional-invariant review gate

### DIFF
--- a/.opencode/agents/aristotle-impl-review.md
+++ b/.opencode/agents/aristotle-impl-review.md
@@ -208,7 +208,7 @@ Concretely checkable in code:
 3. **One session-control surface** — new code that drives sessions through an automation-only path that bypasses the normal session/request API.
 4. **Two trust postures** — new code that routes local-mode application data through a path the relay or a Sesori backend can read in cleartext.
 
-For the remaining `docs/VISION.md` invariants (per-bridge addressing, headless-first, teams-later owner/identity), flag only when the change concretely breaks them in the diff; do not speculate.
+For the remaining `docs/VISION.md` invariants (per-bridge addressing, headless-first, teams-later owner/identity, autonomy at the bridge seam), flag only when the change concretely breaks them in the diff; do not speculate.
 
 **Mirror image (A5):** new abstraction or infrastructure built for a future `docs/VISION.md` / `docs/ROADMAP.md` item with no present consumer is an **A5** violation — reject under A5. Direction never licences premature construction.
 

--- a/.opencode/agents/aristotle-impl-review.md
+++ b/.opencode/agents/aristotle-impl-review.md
@@ -1,5 +1,5 @@
 ---
-description: Reviews implemented code (branches, PRs, changed files) against strict architectural rules for the Sesori monorepo. Validates layer boundaries, dependency direction, class cohesion, naming discipline, and simplicity in actual code. Rejects god classes, pass-through parameters, peer-as-child dependency patterns, asymmetric trigger handling, and misuse of class suffixes. Only flags new or changed code — preexisting legacy patterns are not flagged unless the change extends them. Always invoke before opening a PR.
+description: Reviews implemented code (branches, PRs, changed files) against strict architectural rules for the Sesori monorepo. Validates layer boundaries, dependency direction, class cohesion, naming discipline, and simplicity in actual code. Rejects god classes, pass-through parameters, peer-as-child dependency patterns, asymmetric trigger handling, and misuse of class suffixes. Also flags new code that forecloses the documented product-direction invariants in docs/VISION.md, such as backend specifics leaking past the plugin boundary. Only flags new or changed code — preexisting legacy patterns are not flagged unless the change extends them. Always invoke before opening a PR.
 mode: subagent
 model: kimi-for-coding/k2p7
 variant: max
@@ -196,6 +196,21 @@ Every extracted collaborator must own at least one of:
 If the changed class owns none of those, the logic must stay as cohesive private methods on the existing class.
 
 This review question is mandatory and blocking: **Would this class still deserve to exist if the original file were under the line limit?** If the answer is no, reject the change.
+
+**A12. Directional Invariants (do not foreclose the product direction)**
+
+`docs/VISION.md` defines the product's directional invariants — doors that must stay open for the roadmap. In code review, flag a NEW or CHANGED line that concretely violates one of these. Only flag a present, concrete violation visible in the diff — never reject for a speculative "might foreclose."
+
+Concretely checkable in code:
+
+1. **Plugin boundary is sacred (primary)** — a changed file under `shared/sesori_shared/`, the relay protocol, or `client/` that references a specific backend's concepts (OpenCode/Codex endpoints, event shapes, model identifiers, config) is a violation: backend specifics must stay behind `BridgePluginApi`. Likewise, a second backend special-cased with `if (plugin == ...)` branches in bridge core instead of via the interface's declared capabilities.
+2. **Shared brain** — `module_core` importing `package:flutter`, or surface-specific assumptions entering shared logic (also covered by the B-C hard constraints).
+3. **One session-control surface** — new code that drives sessions through an automation-only path that bypasses the normal session/request API.
+4. **Two trust postures** — new code that routes local-mode application data through a path the relay or a Sesori backend can read in cleartext.
+
+For the remaining `docs/VISION.md` invariants (per-bridge addressing, headless-first, teams-later owner/identity), flag only when the change concretely breaks them in the diff; do not speculate.
+
+**Mirror image (A5):** new abstraction or infrastructure built for a future `docs/VISION.md` / `docs/ROADMAP.md` item with no present consumer is an **A5** violation — reject under A5. Direction never licences premature construction.
 
 ---
 

--- a/.opencode/agents/aristotle-impl-review.md
+++ b/.opencode/agents/aristotle-impl-review.md
@@ -1028,7 +1028,7 @@ Applied: [B-Client / B-Bridge / B-Shared]
 Skipped: [the others, with reason]
 
 ### Section A — General Architecture
-[List each violated principle (A1-A10) with file:line references. Only list violations.]
+[List each violated principle (A1-A12) with file:line references. Only list violations.]
 
 ### Section B — Project-Specific Rules
 [For each applied subsection, list violated rules with file:line references. Only list violations.]

--- a/.opencode/agents/aristotle-plan-review.md
+++ b/.opencode/agents/aristotle-plan-review.md
@@ -988,7 +988,7 @@ Applied: [B-Client / B-Bridge / B-Shared]
 Skipped: [the others, with reason]
 
 ### Section A — General Architecture
-[List each violated principle (A1-A10) with a reference to the specific plan step or class. Only list violations — do not list rules that pass.]
+[List each violated principle (A1-A12) with a reference to the specific plan step or class. Only list violations — do not list rules that pass.]
 
 ### Section B — Project-Specific Rules
 [For each applied subsection, list violated rules with references to specific plan steps or classes. Only list violations.]

--- a/.opencode/agents/aristotle-plan-review.md
+++ b/.opencode/agents/aristotle-plan-review.md
@@ -1,5 +1,5 @@
 ---
-description: Reviews development plans against strict architectural rules for the Sesori monorepo. Validates proposed layer boundaries, dependency direction, class cohesion, naming discipline, and simplicity before any code is written. Rejects god classes, pass-through parameters, peer-as-child dependency patterns, asymmetric trigger handling, and misuse of class suffixes. Input is a plan containing a clear goal plus concrete implementation steps. Always invoke before implementation begins.
+description: Reviews development plans against strict architectural rules for the Sesori monorepo. Validates proposed layer boundaries, dependency direction, class cohesion, naming discipline, and simplicity before any code is written. Rejects god classes, pass-through parameters, peer-as-child dependency patterns, asymmetric trigger handling, and misuse of class suffixes. Also rejects designs that foreclose the documented product-direction invariants in docs/VISION.md, or that build speculatively ahead of need. Input is a plan containing a clear goal plus concrete implementation steps. Always invoke before implementation begins.
 mode: subagent
 model: kimi-for-coding/k2p7
 variant: max
@@ -202,6 +202,25 @@ Every extracted collaborator must own at least one of:
 If the proposed class owns none of those, the logic must stay as cohesive private methods on the existing class.
 
 This review question is mandatory and blocking: **Would this class still deserve to exist if the original file were under the line limit?** If the answer is no, reject the plan.
+
+**A12. Directional Invariants (do not foreclose the product direction)**
+
+`docs/VISION.md` defines the product's directional invariants — the small set of "doors" that must stay open because the roadmap (`docs/ROADMAP.md`) will need them. A plan is an architecture defect if it **welds one of these doors shut** when a compliant alternative of similar cost exists. This is a forward-compatibility check and is part of architectural integrity, not scope creep.
+
+The invariants (see `docs/VISION.md` for the full statements):
+
+1. **Plugin boundary is sacred** — no backend/assistant specifics (OpenCode, Codex, our own harness) leak past `BridgePluginApi` into `shared/sesori_shared`, the relay protocol, or `client/`. A new backend ability is an optional, declared capability on the interface — never a special-case branch in shared/relay/client code.
+2. **The bridge is one of many** — session/bridge addressing stays per-bridge; do not bake in a single-bridge assumption (e.g., a global "the bridge" singleton in relay/auth/client routing).
+3. **Shared brain, thin shells** — `module_core` stays Flutter-free and surface-agnostic; surface-specific (phone/desktop/web) assumptions do not enter shared logic.
+4. **Headless-first bridge** — bridge capabilities stay runnable headless; a feature must not depend on the desktop GUI being present.
+5. **One session-control surface** — anything that drives sessions (including future automation) goes through the same API a human uses; no automation-only backdoor.
+6. **Two trust postures, kept apart** — local mode stays zero-knowledge (E2E phone↔bridge); do not route local-mode application data through a Sesori-readable path, and do not let a managed-mode assumption weaken local mode.
+7. **Teams-later** — new durable entities carry an owner/identity field even while it is always the local user, so multi-user needs no later data migration.
+8. **Autonomy at the bridge seam** — opt-in automation (auto-handle CI/review, future auto-approve) is intercepted at the bridge, not scattered into clients or plugins.
+
+Reject a plan that violates any invariant above. State the invariant, the foreclosure, and the compliant alternative.
+
+**The mirror image is equally blocking.** This rule does NOT licence building for the future. A plan that adds abstraction, generalization, or infrastructure for a `docs/VISION.md` / `docs/ROADMAP.md` item that has no concrete present need is an **A5** violation (No Unnecessary Complexity) — reject it under A5. Direction breaks ties between otherwise-compliant designs; it never justifies premature construction. YAGNI wins.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,10 @@ Sesori today is "monitor + answer one assistant from your phone." The destinatio
 - **The bridge is one of many** — keep per-bridge addressing first-class across client/relay/auth (multi-client per bridge already works; multi-bridge is the new axis).
 - **Shared brain, thin shells** — `module_core` stays Flutter-free and surface-agnostic; the client is online-first with minimal local cache.
 - **Headless-first bridge** — desktop GUI supervision is additive and gated; the standalone/VM path stays first-class (this is what enables managed VMs).
-- **One session-control surface** — a human and a future master agent drive sessions through the same API; no automation backdoor; autonomy is opt-in and intercepted at the bridge seam.
+- **One session-control surface** — a human and a future master agent drive sessions through the same API; no automation backdoor.
 - **Two trust postures, kept apart** — local mode is zero-knowledge (E2E phone↔bridge); **managed VMs are a trusted-Sesori posture** where that guarantee does not hold. Never let managed mode silently weaken local mode.
 - **Teams-later, cheaply** — carry an owner/identity on durable entities even while it's always "me".
+- **Autonomy at the bridge seam** — opt-in automation (auto-handle CI/review, future auto-approve) is intercepted at the bridge, not scattered into clients or plugins.
 
 **Explicitly NOT building now** (don't design for these): cross-plugin live session migration (dropped); cost/usage metering; a permission-policy framework (trivial to add later at the bridge interception point); teams/multi-user implementation; offline/local-first client caching.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,24 @@ Sesori connects AI coding assistants (like OpenCode) to mobile devices over an e
 
 Phone ↔ bridge traffic is end-to-end encrypted (X25519 key exchange + XChaCha20-Poly1305). The phone can browse projects, read sessions, respond to AI questions, and receive real-time events.
 
+## Product Direction (read before planning a feature)
+
+Sesori today is "monitor + answer one assistant from your phone." The destination is an **ambient dev cockpit**: multiple surfaces (phone, `client/desktop`, later web), multiple bridges (laptop, desktop, managed VMs), multiple plugin backends (OpenCode, Codex, our own harness), opt-in autonomy over CI/review, and eventually a master agent across sessions. Full detail in **`docs/VISION.md`**; build order in **`docs/ROADMAP.md`**; the active desktop workstream in **`docs/desktop/PLAN.md`**.
+
+**This biases design; it does not licence building the future early.** When two designs both satisfy the layer rules, prefer the one that doesn't foreclose a direction below — but **never add abstraction/generalization for these before a concrete present need**. YAGNI and the cohesion/ownership rules still win.
+
+**Directional invariants (don't weld these doors shut):**
+
+- **Plugin boundary is sacred** — no backend specifics leak past `BridgePluginApi` into `shared/`, the relay protocol, or the client; our own harness is *just a plugin*; differing abilities are optional, declared capabilities.
+- **The bridge is one of many** — keep per-bridge addressing first-class across client/relay/auth (multi-client per bridge already works; multi-bridge is the new axis).
+- **Shared brain, thin shells** — `module_core` stays Flutter-free and surface-agnostic; the client is online-first with minimal local cache.
+- **Headless-first bridge** — desktop GUI supervision is additive and gated; the standalone/VM path stays first-class (this is what enables managed VMs).
+- **One session-control surface** — a human and a future master agent drive sessions through the same API; no automation backdoor; autonomy is opt-in and intercepted at the bridge seam.
+- **Two trust postures, kept apart** — local mode is zero-knowledge (E2E phone↔bridge); **managed VMs are a trusted-Sesori posture** where that guarantee does not hold. Never let managed mode silently weaken local mode.
+- **Teams-later, cheaply** — carry an owner/identity on durable entities even while it's always "me".
+
+**Explicitly NOT building now** (don't design for these): cross-plugin live session migration (dropped); cost/usage metering; a permission-policy framework (trivial to add later at the bridge interception point); teams/multi-user implementation; offline/local-first client caching.
+
 ## Data Flow (condensed)
 
 Understand these three hops when working on any module:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,7 +13,6 @@
 
 ## Already in flight / landed
 
-- `mobile/` → `client/` rename — multi-surface groundwork.
 - Second backend shipped: **Codex** plugin alongside OpenCode — proves
   multi-backend.
 - Bridge **control channel** + supervised mode — desktop-supervision groundwork.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,113 @@
+# Sesori — Implementation Roadmap
+
+> A **dependency-ordered** suggestion for the order to build toward `VISION.md` —
+> *not* a calendar and *not* a commitment (horizon is ≥ ~1 year, funding/team
+> dependent). The *what / why* lives in `VISION.md`; the *how* (layer rules) in
+> `AGENTS.md`; the active desktop workstream in `docs/desktop/PLAN.md`.
+>
+> **Use it like this:** pick the earliest stage whose dependencies are met;
+> stages can overlap. Every stage still goes through `aristotle-plan-review`
+> before code and `aristotle-impl-review` before a PR — this doc pre-approves no
+> design. Ordering is by what *unblocks* what, biased to keep the `VISION.md`
+> invariants (numbered below as I1–I8) intact.
+
+## Already in flight / landed
+
+- `mobile/` → `client/` rename — multi-surface groundwork.
+- Second backend shipped: **Codex** plugin alongside OpenCode — proves
+  multi-backend.
+- Bridge **control channel** + supervised mode — desktop-supervision groundwork.
+- Shared **runtime provisioning** — auto-installs backend runtimes on first run.
+- Multi-bridge **seam** on the client (`bridge_api` / `bridge_repository` /
+  `registered_bridges_store`).
+
+## Stage A — Desktop app (multi-surface) — *in progress*
+
+- **Outcome:** a downloadable desktop app that supervises the headless bridge
+  (tray + window), and a client split into shared UI + per-surface shells.
+- **Detail:** owned entirely by `docs/desktop/PLAN.md` (Phases 0–5); not
+  duplicated here.
+- **Unlocks:** always-on ergonomics; proof the core is surface-agnostic; the
+  `module_app_ui` shared-UI split.
+- **Invariants:** I3 (shared brain / thin shells), I4 (headless-first).
+
+## Stage B — Multi-plugin parallelism + per-session model control
+
+- **Outcome:** run multiple plugins concurrently; per-session model/agent
+  selection in the client; a **capability descriptor** on `BridgePluginApi` so
+  the client renders only what a given plugin supports.
+- **Priority:** the next major capability after Stage A — and may run **in
+  parallel with** it; this is ahead of multi-bridge.
+- **Depends on:** additive plugin-interface evolution; independent of Stage A.
+- **Unlocks:** own harness (D), master agent (G), a richer client.
+- **Explicitly excluded:** moving a *live* session between plugins (VISION
+  non-goal).
+- **Invariants:** I1 (plugin boundary; capabilities declared, not special-cased).
+
+## Stage C — Multi-bridge addressing
+
+- **Outcome:** a user can enumerate and choose among *their* bridges (laptop,
+  desktop, later a VM); the client aggregates sessions across bridges; relay +
+  auth route to a specific bridge.
+- **Depends on:** little new plumbing — multi-client per bridge already works and
+  the client seam exists; this is mostly addressing/selection + relay/auth
+  routing by bridge identity. Independent of Stage B.
+- **Unlocks:** the cockpit across machines; **prerequisite for managed VMs** (a
+  VM is "just another bridge").
+- **Invariants:** I2 (bridge is one of many), I3.
+
+## Stage D — Sesori's own harness (as a plugin)
+
+- **Outcome:** a first-party agent harness implemented **behind
+  `BridgePluginApi`**, using the optional-capability mechanism from Stage B; no
+  privileged path.
+- **Depends on:** B (capability model).
+- **Invariants:** I1.
+
+## Stage E — CI / review integration with opt-in auto-handle
+
+- **Outcome:** forge-neutral PRs / comments / checks surfaced in the client; an
+  **opt-in** mode where the bridge posts a message into the relevant session to
+  address a failed check or new review automatically.
+- **Depends on:** a stable session-control surface; notifications (already core);
+  bridge-side forge access (keeps local E2E — the bridge holds the creds).
+- **Invariants:** I5 (one session-control surface), I8 (autonomy at the bridge
+  seam).
+
+## Stage F — Managed service (paid)
+
+- **Outcome:** run sessions on Sesori-controlled VMs — pick a repo, work without
+  keeping your machine on. A cloud control-plane: VM provisioning/lifecycle, repo
+  selection, **secure secret/credential injection**, the headless bridge running
+  on the VM, and billing.
+- **Depends on:** C (a managed VM is just another bridge), I4 (headless-first
+  bridge), and an explicit trust-posture boundary (I6). Largest, cloud-heavy
+  effort. **Not currently in play.**
+- **Invariants:** I6 (two trust postures kept apart), I2.
+
+## Stage G — Master agent / orchestrator
+
+- **Outcome:** an agent that navigates across sessions, dispatches and manages
+  tasks, and holds the big picture — most likely a **session + Sesori-authored
+  plugin/MCP** that drives the *same* session-control surface a human uses (shape
+  not locked).
+- **Depends on:** B (multi-session control/visibility), E (acting on outcomes),
+  and I5. Most speculative; furthest out.
+- **Invariants:** I5.
+
+## Deferred / non-goals (mirror of `VISION.md`)
+
+- Cross-plugin live session migration — dropped.
+- Cost / usage metering — out for now.
+- Permission-policy framework up front — trivial late add at the bridge seam.
+- Teams / multi-user implementation — later (I7 keeps the door open).
+- Offline / local-first client caching — intentionally not pursued.
+
+## Notes on ordering
+
+- **B (multi-plugin) is the priority after A** and can run in parallel with A.
+- **C (multi-bridge)** can follow or overlap B; the two are independent.
+- **F** should not start before **C** is real (it depends on the bridge being
+  "one of many" and fully headless).
+- Nothing here is approved to build ahead of need — each stage earns its design
+  at `aristotle-plan-review` time, against the then-current code.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,0 +1,151 @@
+# Sesori — Product Vision & Direction
+
+> **What this is.** The north star: where Sesori is going, so day-to-day
+> architectural choices bias toward that destination instead of locally-cheap
+> solutions that weld a door shut.
+>
+> **What this is not.** A build order (see `ROADMAP.md`), a feature spec, or a
+> licence to build the future early.
+>
+> **How to use it.** When two designs both satisfy the layer rules in
+> `AGENTS.md`, prefer the one that does not *foreclose* something below. That is
+> this doc's only job: break ties and stop us welding doors shut. It never
+> overrides YAGNI or the cohesion/ownership rules — **do not add abstraction,
+> generalization, or infrastructure for anything here until there is a concrete,
+> present need.** Direction guides *reversibility*, not premature construction.
+>
+> Living document. Correct it the moment intent changes.
+
+## The destination in one paragraph
+
+Sesori is becoming an **ambient dev cockpit**: monitor and drive AI coding work
+from any device, across multiple assistant backends, with a powerful local
+**bridge** as the core — one that can *also* be run for you as a managed cloud
+service. Today you watch and answer one assistant from your phone. The
+destination is many surfaces (phone, desktop, later web), many bridges (your
+laptop, your desktop, managed VMs), many plugins (OpenCode, Codex, our own
+harness), opt-in autonomy over CI/review, and eventually a master agent that
+coordinates work across sessions.
+
+## Where this is going (the pillars)
+
+### 1. Multi-surface clients, online-first, multi-bridge
+
+The client is the same brain on every surface. `module_core` is the shared,
+Flutter-free logic; each surface (mobile `client/app`, `client/desktop`, future
+web) is a thin shell. The client is **online-first by design** — it caches almost
+nothing locally, precisely so it can switch between bridges cheaply. A single
+bridge already serves **multiple clients** concurrently; the new axis is
+**multi-bridge**: the client (with the relay + auth server) lets a user choose
+*which* bridge to talk to. The seam already exists
+(`bridge_api` / `bridge_repository` / `registered_bridges_store` in
+`module_core`).
+
+- *Door to keep open:* per-bridge addressing/identity is first-class; never
+  collapse it into "the user's one bridge", and don't bake phone-only
+  assumptions into shared logic.
+
+### 2. The bridge is the product's core
+
+The bridge is, and will remain, the heavy part. It runs as a **headless daemon**
+(terminal / VM, unchanged) *and*, on desktop, under a **Flutter supervisor app**
+(tray/menu-bar popup + a main window that is the client UI with desktop-specific
+changes) — the Tailscale model (`Tailscale.app` supervises `tailscaled`; the same
+daemon also runs headless on a server). It will run **multiple plugins in
+parallel** and is the **system of record for now (bridge-owned)**.
+
+- *Door to keep open:* the bridge must always be runnable headless; the desktop
+  GUI supervises the *same* daemon and is never the only way to run it (this is
+  what makes managed VMs possible). The active plan is `docs/desktop/PLAN.md`.
+
+### 3. The plugin interface is a platform contract
+
+Backends are truly pluggable. OpenCode and Codex already ship; **our own harness
+will be just another plugin** behind `BridgePluginApi`, with no privileged
+backdoor. The interface may grow **optional, discoverable capabilities** (e.g.
+model switching) that not every plugin implements — capability differences are
+*declared*, not special-cased into the bridge or client.
+
+- *Door to keep open:* nothing assistant-specific (OpenCode / Codex / own
+  harness) leaks past the plugin boundary into `shared/`, the relay protocol, or
+  the client.
+
+### 4. Autonomy & integrations
+
+Sesori moves up the workflow. **CI / PR review** becomes first-class — surface
+PRs, comments, and checks (forge-neutral) and, with **opt-in auto-handle**, the
+bridge posts a message into the relevant session to address a failed check or a
+new review *automatically*, rather than only notifying. **Notifications are
+already a core delivery channel.** Later, a **master agent** coordinates across
+sessions — most likely itself a session plus a Sesori-authored plugin/MCP that
+teaches it to list/inspect sessions and dispatch tasks through the *same*
+session-control surface a human uses (exact shape not locked).
+
+- *Door to keep open:* whatever a human uses to create/drive/inspect a session is
+  the same API automation uses; autonomy (auto-handle, future auto-approve) lives
+  at the **bridge interception layer**, opt-in and observable.
+
+### 5. Managed service tier (future, paid)
+
+Sesori will offer running sessions on **Sesori-controlled VMs**: pick a repo,
+start working, no need to keep your own machine on. The value is convenience and
+always-on; it is a **paid** tier and **not currently in play**.
+
+- **Trust posture (explicit).** On a managed VM the bridge runs on Sesori
+  infrastructure, so Sesori *can* see that session's data — the "zero-knowledge
+  relay / E2E phone↔bridge" guarantee of **local mode does not hold** for managed
+  sessions. This is an accepted, deliberate trade for convenience. Keep local
+  mode (zero-knowledge) and managed mode (trusted VM) clearly separated in code,
+  and surface the difference honestly in the UI; managed mode must never silently
+  weaken the local guarantee. Architecturally a managed VM is "just another
+  bridge" (see pillar 1).
+
+## Directional invariants (the doors we must not weld shut)
+
+1. **Plugin boundary is sacred** — no backend specifics past `BridgePluginApi`;
+   our own harness is *just a plugin*; differing abilities are optional, declared
+   capabilities.
+2. **The bridge is one of many** — per-bridge addressing across client / relay /
+   auth (multi-client per bridge already works; multi-bridge is the new axis).
+3. **Shared brain, thin shells** — `module_core` stays Flutter-free and
+   surface-agnostic; the client is online-first with minimal local cache.
+4. **Headless-first bridge** — GUI supervision is additive and gated; the
+   standalone / VM path stays first-class.
+5. **One session-control surface** — a human and a future master agent drive
+   sessions through the same API; no automation backdoor.
+6. **Two trust postures, kept apart** — local = zero-knowledge; managed = trusted
+   VM; never let managed weaken local.
+7. **Teams-later, cheaply** — carry an owner/identity on durable entities even
+   while it is always "me", so multi-user needs no data migration later.
+8. **Autonomy at the bridge seam** — auto-handle / future auto-approve are
+   opt-in, observable, and intercepted at the bridge, not scattered into clients
+   or plugins.
+
+## Explicitly NOT building (now, maybe ever)
+
+Listed so nobody designs for them prematurely:
+
+- **Cross-plugin live session migration** (moving a running session A→B).
+  Dropped — an edge-case nice-to-have not worth the system complexity.
+  *Corollary:* do **not** over-invest in a migration-grade canonical transcript;
+  the bridge-owned system-of-record stays only as rich as today's needs require.
+- **Cost / usage metering.** Out of scope for now.
+- **A permission-policy framework up front.** Auto-approving known permissions is
+  trivial to add later by intercepting at the bridge before the prompt reaches
+  the client — so it is *not* a design constraint now.
+- **Teams / multi-user implementation.** Later; only invariant 7 applies today.
+- **Offline / local-first client caching.** Intentionally not pursued; the client
+  stays online-first.
+
+## Horizon
+
+Realistically **≥ ~1 year** of work at a fast pace, gated by team size and
+funding — so this is sequenced by **dependency, not calendar** (see
+`ROADMAP.md`). The managed-service tier is *not currently in play*. Treat every
+line here as intent, not commitment.
+
+## Related docs
+
+- `ROADMAP.md` — dependency-ordered implementation suggestion.
+- `docs/desktop/PLAN.md` — the active desktop-app workstream (pillar 2).
+- `AGENTS.md` — the *how* (layer architecture). This doc is the *where*.


### PR DESCRIPTION
## Why

A known failure mode of AI-assisted development: agents solve the immediate
ticket with a locally-cheap design, but without a north star they pick solutions
that quietly foreclose where the product is heading. This PR adds that north star
and wires it into the architecture review gate so feature plans are checked
against it.

## What

**New docs**

- `docs/VISION.md` — the destination (an *ambient dev cockpit*), 5 pillars,
  **8 directional invariants** ("doors not to weld shut"), explicit non-goals,
  and the local-vs-managed **trust posture** split. Explicitly framed as a
  tie-breaker between otherwise-compliant designs — **not** a licence to build
  the future early (YAGNI still wins).
- `docs/ROADMAP.md` — a **dependency-ordered** (not calendar) suggestion, stages
  A–G. Multi-plugin parallelism (B) is prioritized **ahead of** multi-bridge (C).
  Desktop detail stays in `docs/desktop/PLAN.md`.

**Governance**

- `AGENTS.md` — a concise "Product Direction" section right after the System
  Overview, linking both docs.
- `aristotle-plan-review` / `aristotle-impl-review` — a new **A12 (Directional
  Invariants)** check. Plan-review runs the full "does this foreclose a door?"
  check **plus** a mirror clause that routes speculative future-proofing back to
  **A5** (No Unnecessary Complexity). Impl-review runs a lighter, concrete-code
  subset (primary: no backend specifics leaking past `BridgePluginApi` into
  `shared/`, the relay protocol, or `client/`).

Docs + agent-config only — **no source/code changes**.

## Assumptions baked in (please confirm)

- System-of-record stays **bridge-owned and lightweight** (cross-plugin live
  session migration was dropped, so no migration-grade transcript store).
- Managed VMs are an **openly different trust posture** (Sesori can see
  managed-session data; local mode stays zero-knowledge).
- Multi-bridge selection routes by the existing **`bridgeId`**.
- CI/review entities are **forge-neutral** (build GitHub, don't hardcode it into
  `shared/`/client).

## Known open item (not designed here)

- Managed-VM **secret/credential injection** — flagged in the roadmap as the
  riskiest undesigned piece; far off (Stage F), but called out so it isn't
  improvised later.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a clear product north star and wires it into plan and implementation reviews so designs don’t weld future doors shut. Aligns all review gates to the canonical 8-invariant set and fixes the templates to emit A1–A12 violations.

- **New Features**
  - Added `docs/VISION.md` (pillars, 8 directional invariants, non-goals, and the local vs managed trust split).
  - Added `docs/ROADMAP.md` (dependency-ordered stages; B: multi-plugin ahead of C: multi-bridge) and removed an outdated rename note.
  - Updated `AGENTS.md` with a concise Product Direction section linking both docs and listing all 8 invariants.
  - Introduced A12 “Directional Invariants” checks in `aristotle-plan-review` (foreclose-a-door + A5 mirror) and `aristotle-impl-review` (concrete violations like backend specifics leaking past `BridgePluginApi`). Docs and agent config only; no source code changes.

- **Bug Fixes**
  - Expanded both Aristotle review output templates from (A1–A10) to (A1–A12) so A11/A12 violations are not dropped.

<sup>Written for commit f8161180578c764445a625070efa393e1572f03e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

