### PR TITLE
fix: use scaffold background color for fade gradient

### DIFF
--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -138,11 +138,6 @@ class PregoGlassScaffold extends StatefulWidget {
 class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
   final ScrollController _scrollController = ScrollController();
 
-  /// How far past the bar the scroll-edge colour fade ramps out. A little longer
-  /// than the package default (20) for a softer, smoother release of content
-  /// below the bar.
-  static const double _scrollEdgeFadeExtent = 80;
-
   /// Page glass-layer settings replicated from the showcase's
   /// `RecommendedGlassSettings.standard` (an example-only constant, not a
   /// package export).
@@ -167,6 +162,7 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
 
   @override
   Widget build(BuildContext context) {
+    final backgroundColor = widget.backgroundColor ?? context.prego.colors.bgPrimary;
     final topPad = MediaQuery.paddingOf(context).top;
     final extendBehind = widget.extendBodyBehindBar;
     final inline = widget.inlineTitle;
@@ -230,9 +226,9 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
               decoration: BoxDecoration(
                 gradient: LinearGradient(
                   colors: [
-                    context.prego.colors.bgPrimary.withValues(alpha: 0.9),
-                    context.prego.colors.bgPrimary.withValues(alpha: 0.7),
-                    context.prego.colors.bgPrimary.withValues(alpha: 0),
+                    backgroundColor.withValues(alpha: 0.9),
+                    backgroundColor.withValues(alpha: 0.7),
+                    backgroundColor.withValues(alpha: 0),
                   ],
                   stops: const [0, 0.8, 1.0],
                   begin: Alignment.topCenter,
@@ -247,13 +243,12 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
     ];
 
     return GlassScaffold(
-      backgroundColor: widget.backgroundColor ?? context.prego.colors.bgPrimary,
+      backgroundColor: backgroundColor,
       settings: _pageSettings,
       statusBarStyle: GlassStatusBarStyle.auto,
       extendBody: extendBehind,
-      // Extend the package's colour fade past the bar by the same amount the
-      // blur ramps out over, so the two scroll-edge effects share one boundary.
-      topEdgeFadeExtent: _scrollEdgeFadeExtent,
+      topEdgeFade: false, // Disable the top edge fade -- we use our own custom gradient
+      bottomEdgeFade: false, // Disable the bottom edge fade -- we use our own custom gradient
       floatingActionButton: widget.floatingActionButton,
       bodyOverlays: bodyOverlays.isEmpty ? null : bodyOverlays,
       appBar: topNav,

--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -226,9 +226,9 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
               decoration: BoxDecoration(
                 gradient: LinearGradient(
                   colors: [
-                    backgroundColor.withValues(alpha: 0.9),
-                    backgroundColor.withValues(alpha: 0.7),
-                    backgroundColor.withValues(alpha: 0),
+                    backgroundColor.withMultipliedOpacity(0.9),
+                    backgroundColor.withMultipliedOpacity(0.7),
+                    backgroundColor.withMultipliedOpacity(0),
                   ],
                   stops: const [0, 0.8, 1.0],
                   begin: Alignment.topCenter,


### PR DESCRIPTION
## Summary
- Drive the `PregoGlassScaffold` top fade gradient from the resolved `backgroundColor` (honoring `widget.backgroundColor` override) instead of always using `bgPrimary`.
- Disable the `GlassScaffold` built-in top/bottom edge fades since we render our own custom gradient, removing the now-unused `_scrollEdgeFadeExtent` / `topEdgeFadeExtent` wiring.

## Test plan
- Visual check: scaffold fade matches the configured background color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align the `PregoGlassScaffold` top fade gradient with the resolved scaffold background color and scale the fade alpha by the background’s opacity. Disable `GlassScaffold` edge fades to avoid double fades.

- **Bug Fixes**
  - Gradient now uses the resolved `backgroundColor` and multiplies its opacity for fade stops.
  - Disabled `topEdgeFade`/`bottomEdgeFade` in `GlassScaffold`; removed unused scroll-edge fade constant/wiring.

<sup>Written for commit 19e11fc01a1c0ad724325f87b9eeab6cdacef8e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

