### PR TITLE
fix: session chat UI bugs + glass polish

### DIFF
--- a/client/app/lib/core/widgets/agent_model_buttons.dart
+++ b/client/app/lib/core/widgets/agent_model_buttons.dart
@@ -428,7 +428,7 @@ LiquidGlassSettings _menuGlass(BuildContext context) {
 /// the follow-offset to zero, and this re-applies the correction on top.
 void _alignMenuToTrigger(BuildContext context, {required GlassMenuController controller}) {
   final overlayBox = Overlay.maybeOf(context)?.context.findRenderObject();
-  if (overlayBox is! RenderBox || !overlayBox.hasSize) return;
+  if (overlayBox is! RenderBox || !overlayBox.attached || !overlayBox.hasSize) return;
   controller.setFollowOffset(-overlayBox.localToGlobal(Offset.zero));
 }
 

--- a/client/app/lib/core/widgets/agent_model_buttons.dart
+++ b/client/app/lib/core/widgets/agent_model_buttons.dart
@@ -56,6 +56,12 @@ class _AgentModelButtonsState extends State<AgentModelButtons> {
   /// dismiss the glass popup before the full-screen search sheet rises.
   final GlassMenuController _modelMenuController = GlassMenuController();
 
+  /// Drive the agent/variant popups imperatively so that, in a master-detail
+  /// layout, each one can re-anchor under its trigger on open via
+  /// [_alignMenuToTrigger]. (The model menu reuses [_modelMenuController].)
+  final GlassMenuController _agentMenuController = GlassMenuController();
+  final GlassMenuController _variantMenuController = GlassMenuController();
+
   @override
   void initState() {
     super.initState();
@@ -90,6 +96,7 @@ class _AgentModelButtonsState extends State<AgentModelButtons> {
         children: [
           Expanded(
             child: _AgentMenu(
+              controller: _agentMenuController,
               agents: widget.agents,
               selectedAgent: widget.selectedAgent,
               onAgentSelected: widget.onAgentSelected,
@@ -110,6 +117,7 @@ class _AgentModelButtonsState extends State<AgentModelButtons> {
             const SizedBox(width: 8),
             Expanded(
               child: _VariantMenu(
+                controller: _variantMenuController,
                 availableVariants: widget.availableVariants,
                 selectedVariant: selected?.variant,
                 onVariantSelected: widget.onVariantSelected,
@@ -147,11 +155,13 @@ class _AgentModelButtonsState extends State<AgentModelButtons> {
 /// Agent-selection pill + its popup. Extracted as a widget (rather than a build
 /// method) so it gets its own element subtree and only rebuilds with its inputs.
 class _AgentMenu extends StatelessWidget {
+  final GlassMenuController controller;
   final List<AgentInfo> agents;
   final String selectedAgent;
   final ValueChanged<String> onAgentSelected;
 
   const _AgentMenu({
+    required this.controller,
     required this.agents,
     required this.selectedAgent,
     required this.onAgentSelected,
@@ -161,6 +171,7 @@ class _AgentMenu extends StatelessWidget {
   Widget build(BuildContext context) {
     final loc = context.loc;
     return GlassMenu(
+      controller: controller,
       menuWidth: 240,
       menuHeight: agents.length > 6 ? 320 : null,
       menuBorderRadius: 24,
@@ -170,7 +181,10 @@ class _AgentMenu extends StatelessWidget {
       triggerBuilder: (context, toggle) => _Trigger(
         icon: Icons.smart_toy_outlined,
         label: selectedAgent,
-        onTap: toggle,
+        onTap: () {
+          toggle();
+          _alignMenuToTrigger(context, controller: controller);
+        },
       ),
       items: [
         _menuLabel(context, text: loc.sessionDetailPickerAgent),
@@ -243,7 +257,10 @@ class _ModelMenu extends StatelessWidget {
       triggerBuilder: (context, toggle) => _Trigger(
         icon: Icons.memory_outlined,
         label: _resolveModelName(context, providers: providers, selected: selected),
-        onTap: toggle,
+        onTap: () {
+          toggle();
+          _alignMenuToTrigger(context, controller: controller);
+        },
       ),
       items: items,
     );
@@ -252,11 +269,13 @@ class _ModelMenu extends StatelessWidget {
 
 /// Variant-selection pill + its popup.
 class _VariantMenu extends StatelessWidget {
+  final GlassMenuController controller;
   final List<SessionVariant> availableVariants;
   final String? selectedVariant;
   final ValueChanged<SessionVariant?> onVariantSelected;
 
   const _VariantMenu({
+    required this.controller,
     required this.availableVariants,
     required this.selectedVariant,
     required this.onVariantSelected,
@@ -266,6 +285,7 @@ class _VariantMenu extends StatelessWidget {
   Widget build(BuildContext context) {
     final loc = context.loc;
     return GlassMenu(
+      controller: controller,
       menuWidth: 220,
       menuHeight: availableVariants.length > 6 ? 320 : null,
       menuBorderRadius: 24,
@@ -275,7 +295,10 @@ class _VariantMenu extends StatelessWidget {
       triggerBuilder: (context, toggle) => _Trigger(
         icon: Icons.speed_outlined,
         label: selectedVariant ?? loc.sessionDetailVariantDefault,
-        onTap: toggle,
+        onTap: () {
+          toggle();
+          _alignMenuToTrigger(context, controller: controller);
+        },
       ),
       items: [
         _menuLabel(context, text: loc.sessionDetailPickerVariant),
@@ -387,6 +410,26 @@ LiquidGlassSettings _menuGlass(BuildContext context) {
   return LiquidGlassSettings(
     glassColor: colors.buttonGlassPrimaryBackground,
   );
+}
+
+/// Re-anchors a just-opened [GlassMenu] popup under its trigger when the
+/// composer is hosted inside a master-detail right pane.
+///
+/// In split/landscape layouts the session detail lives in the right pane's
+/// nested Navigator, whose Overlay is inset from the screen by the sidebar
+/// width. [GlassMenu] captures its trigger in global (screen) coordinates but
+/// paints the popup inside that nested Overlay, so the popup lands one
+/// sidebar-width too far along the main axis. Feeding the negated Overlay
+/// origin to the menu's follow-offset cancels that inset, pulling the popup
+/// back under its trigger. In a single-pane layout the Overlay already sits at
+/// the screen origin, so the correction is zero and this is a no-op.
+///
+/// Must be called right after the menu opens (after `toggle()`): opening resets
+/// the follow-offset to zero, and this re-applies the correction on top.
+void _alignMenuToTrigger(BuildContext context, {required GlassMenuController controller}) {
+  final overlayBox = Overlay.maybeOf(context)?.context.findRenderObject();
+  if (overlayBox is! RenderBox || !overlayBox.hasSize) return;
+  controller.setFollowOffset(-overlayBox.localToGlobal(Offset.zero));
 }
 
 String _resolveModelName(

--- a/client/app/lib/features/session_detail/widgets/background_task_row.dart
+++ b/client/app/lib/features/session_detail/widgets/background_task_row.dart
@@ -58,12 +58,19 @@ class BackgroundTaskRow extends StatelessWidget {
   }
 
   Widget _statusIcon({required SessionStatus? status, required PregoDesignSystem prego}) => switch (status) {
-    SessionStatusBusy() || SessionStatusRetry() => SizedBox(
-      width: 16,
-      height: 16,
-      child: CircularProgressIndicator(
-        strokeWidth: 2,
-        color: prego.colors.bgBrandSolid,
+    // GlassListTile forces the leading slot to a tight width of 32 but leaves
+    // its height free. A CircularProgressIndicator has no intrinsic size and
+    // paints to its box without preserving aspect ratio, so it renders as an
+    // oval. Center re-loosens the constraints around a fixed square so the
+    // spinner stays a 16px circle.
+    SessionStatusBusy() || SessionStatusRetry() => Center(
+      heightFactor: 1,
+      child: SizedBox.square(
+        dimension: 16,
+        child: CircularProgressIndicator(
+          strokeWidth: 2,
+          color: prego.colors.bgBrandSolid,
+        ),
       ),
     ),
     SessionStatusIdle() || null => Icon(

--- a/client/app/lib/features/session_detail/widgets/background_task_row.dart
+++ b/client/app/lib/features/session_detail/widgets/background_task_row.dart
@@ -1,4 +1,5 @@
 import "package:flutter/material.dart";
+import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
@@ -7,16 +8,21 @@ import "../../../core/routing/app_router.dart";
 import "../../../core/routing/current_project_name.dart";
 import "../../../l10n/app_localizations.dart";
 
+/// A single background task as a glass row inside the tasks card. Shows the
+/// session's status icon, title + status text, and a disclosure chevron that
+/// opens the (read-only) session detail.
 class BackgroundTaskRow extends StatelessWidget {
   final String? projectId;
   final Session session;
   final SessionStatus? status;
+  final bool isLast;
 
   const BackgroundTaskRow({
     super.key,
     required this.projectId,
     required this.session,
     this.status,
+    this.isLast = false,
   });
 
   @override
@@ -25,7 +31,8 @@ class BackgroundTaskRow extends StatelessWidget {
     final loc = context.loc;
     final title = session.title ?? loc.sessionDetailSubtaskUnnamed;
 
-    return InkWell(
+    return GlassListTile(
+      isLast: isLast,
       onTap: () => context.pushRoute(
         AppRoute.sessionDetail(
           projectId: projectId ?? session.projectID,
@@ -35,37 +42,17 @@ class BackgroundTaskRow extends StatelessWidget {
           sessionTitle: session.title,
         ),
       ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-        child: Row(
-          children: [
-            _statusIcon(status: status, prego: prego),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    title,
-                    style: prego.textTheme.textSm.regular,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  _statusTextWidget(
-                    loc: loc,
-                    status: status,
-                    prego: prego,
-                  ),
-                ],
-              ),
-            ),
-            Icon(
-              Icons.chevron_right,
-              size: 20,
-              color: prego.colors.textSecondary,
-            ),
-          ],
-        ),
+      leading: _statusIcon(status: status, prego: prego),
+      title: Text(title, maxLines: 1, overflow: TextOverflow.ellipsis),
+      titleStyle: prego.textTheme.textSm.regular,
+      subtitle: _statusTextWidget(loc: loc, status: status, prego: prego),
+      subtitleStyle: prego.textTheme.textXs.regular.copyWith(
+        color: prego.colors.textSecondary,
+      ),
+      trailing: Icon(
+        Icons.chevron_right,
+        size: 20,
+        color: prego.colors.textSecondary,
       ),
     );
   }
@@ -131,9 +118,9 @@ class BackgroundTaskRow extends StatelessWidget {
       DateTime.fromMillisecondsSinceEpoch(updatedMs, isUtc: true),
     );
 
-    if (diff.inMinutes < 1) return "${loc.backgroundTaskStatusIdle} \u00b7 ${loc.timestampJustNow}";
-    if (diff.inHours < 1) return "${loc.backgroundTaskStatusIdle} \u00b7 ${loc.timestampMinutesAgo(diff.inMinutes)}";
-    if (diff.inDays < 1) return "${loc.backgroundTaskStatusIdle} \u00b7 ${loc.timestampHoursAgo(diff.inHours)}";
-    return "${loc.backgroundTaskStatusIdle} \u00b7 ${loc.timestampDaysAgo(diff.inDays)}";
+    if (diff.inMinutes < 1) return "${loc.backgroundTaskStatusIdle} · ${loc.timestampJustNow}";
+    if (diff.inHours < 1) return "${loc.backgroundTaskStatusIdle} · ${loc.timestampMinutesAgo(diff.inMinutes)}";
+    if (diff.inDays < 1) return "${loc.backgroundTaskStatusIdle} · ${loc.timestampHoursAgo(diff.inHours)}";
+    return "${loc.backgroundTaskStatusIdle} · ${loc.timestampDaysAgo(diff.inDays)}";
   }
 }

--- a/client/app/lib/features/session_detail/widgets/background_tasks_bar.dart
+++ b/client/app/lib/features/session_detail/widgets/background_tasks_bar.dart
@@ -106,6 +106,9 @@ class _BackgroundTasksBarState extends State<BackgroundTasksBar> {
       children: [
         CompositedTransformFollower(
           link: _link,
+          // Hide until linked so the card never flashes at the screen origin
+          // before its header target is laid out (e.g. during route transitions).
+          showWhenUnlinked: false,
           // Pin the card's bottom edge to the header's bottom edge so it grows
           // upward over the chat, leaving the composer below untouched.
           targetAnchor: Alignment.bottomLeft,

--- a/client/app/lib/features/session_detail/widgets/background_tasks_bar.dart
+++ b/client/app/lib/features/session_detail/widgets/background_tasks_bar.dart
@@ -72,15 +72,6 @@ class _BackgroundTasksBarState extends State<BackgroundTasksBar> {
     }
   }
 
-  void _collapse() {
-    if (!_expanded) return;
-    setState(() {
-      _expanded = false;
-      _showCompleted = false;
-    });
-    _overlayController.hide();
-  }
-
   @override
   Widget build(BuildContext context) {
     if (widget.children.isEmpty) return const SizedBox.shrink();
@@ -113,13 +104,6 @@ class _BackgroundTasksBarState extends State<BackgroundTasksBar> {
   Widget _buildOverlay(BuildContext context) {
     return Stack(
       children: [
-        // Tap anywhere outside the card to collapse it.
-        Positioned.fill(
-          child: GestureDetector(
-            behavior: HitTestBehavior.translucent,
-            onTap: _collapse,
-          ),
-        ),
         CompositedTransformFollower(
           link: _link,
           // Pin the card's bottom edge to the header's bottom edge so it grows

--- a/client/app/lib/features/session_detail/widgets/background_tasks_bar.dart
+++ b/client/app/lib/features/session_detail/widgets/background_tasks_bar.dart
@@ -1,12 +1,18 @@
 import "package:flutter/material.dart";
+import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
 import "background_tasks_header.dart";
 import "background_tasks_list.dart";
 
-/// A floating bar shown above the prompt input when background tasks (child
-/// sessions) exist. Collapsed it shows "N Tasks Running"; tapping expands to
-/// reveal the individual task list with status + navigation.
+/// A floating glass card shown above the prompt input when background tasks
+/// (child sessions) exist. Collapsed it shows "N Tasks Running"; tapping
+/// expands the same glass surface to reveal the individual task list with
+/// status + navigation.
+///
+/// The whole bar is a single liquid-glass surface (its own layer) so it reads
+/// as one frosted card that grows, matching the glass pills in the composer
+/// directly below it.
 ///
 /// Running tasks are always shown first. Completed tasks are hidden behind a
 /// "Show N completed" toggle.
@@ -46,35 +52,44 @@ class _BackgroundTasksBarState extends State<BackgroundTasksBar> {
     if (widget.children.isEmpty) return const SizedBox.shrink();
 
     final prego = context.prego;
-    final running = _runningTasks;
-    final completed = _completedTasks;
 
-    return Material(
-      elevation: 2,
-      color: prego.colors.bgTertiary,
-      borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          BackgroundTasksHeader(
-            runningCount: _runningCount,
-            expanded: _expanded,
-            onTap: () => setState(() {
-              _expanded = !_expanded;
-              // Reset completed visibility when collapsing.
-              if (!_expanded) _showCompleted = false;
-            }),
-          ),
-          if (_expanded)
-            BackgroundTasksList(
-              projectId: widget.projectId,
-              runningTasks: running,
-              completedTasks: completed,
-              childStatuses: widget.childStatuses,
-              showCompleted: _showCompleted,
-              onToggleCompleted: () => setState(() => _showCompleted = !_showCompleted),
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+      child: GlassContainer(
+        useOwnLayer: true,
+        clipBehavior: Clip.antiAlias,
+        padding: EdgeInsets.zero,
+        shape: const LiquidRoundedSuperellipse(borderRadius: 20),
+        settings: LiquidGlassSettings(glassColor: prego.colors.buttonGlassPrimaryBackground),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            BackgroundTasksHeader(
+              runningCount: _runningCount,
+              expanded: _expanded,
+              onTap: () => setState(() {
+                _expanded = !_expanded;
+                // Reset completed visibility when collapsing.
+                if (!_expanded) _showCompleted = false;
+              }),
             ),
-        ],
+            AnimatedSize(
+              duration: const Duration(milliseconds: 240),
+              curve: Curves.easeInOut,
+              alignment: Alignment.topCenter,
+              child: _expanded
+                  ? BackgroundTasksList(
+                      projectId: widget.projectId,
+                      runningTasks: _runningTasks,
+                      completedTasks: _completedTasks,
+                      childStatuses: widget.childStatuses,
+                      showCompleted: _showCompleted,
+                      onToggleCompleted: () => setState(() => _showCompleted = !_showCompleted),
+                    )
+                  : const SizedBox(width: double.infinity),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/client/app/lib/features/session_detail/widgets/background_tasks_bar.dart
+++ b/client/app/lib/features/session_detail/widgets/background_tasks_bar.dart
@@ -86,12 +86,18 @@ class _BackgroundTasksBarState extends State<BackgroundTasksBar> {
             child: OverlayPortal(
               controller: _overlayController,
               overlayChildBuilder: _buildOverlay,
-              // In-flow footprint: only ever the collapsed header. Kept (with
-              // its size) but hidden + non-interactive while expanded, so the
-              // floating card above is the single visible surface and the
-              // cluster height — and thus the chat's bottom inset — is constant.
-              child: Visibility.maintain(
+              // In-flow footprint: only ever the collapsed header. While
+              // expanded we maintain only its size (so the cluster height — and
+              // thus the chat's bottom inset — stays constant) but NOT its
+              // interactivity or semantics: it must drop out of hit-testing and
+              // the focus/screen-reader order so the floating card above is the
+              // single live surface. (Visibility.maintain would keep it
+              // interactive and announced, hence plain Visibility here.)
+              child: Visibility(
                 visible: !_expanded,
+                maintainState: true,
+                maintainAnimation: true,
+                maintainSize: true,
                 child: _buildCard(context, expanded: false),
               ),
             ),

--- a/client/app/lib/features/session_detail/widgets/background_tasks_bar.dart
+++ b/client/app/lib/features/session_detail/widgets/background_tasks_bar.dart
@@ -10,9 +10,11 @@ import "background_tasks_list.dart";
 /// expands the same glass surface to reveal the individual task list with
 /// status + navigation.
 ///
-/// The whole bar is a single liquid-glass surface (its own layer) so it reads
-/// as one frosted card that grows, matching the glass pills in the composer
-/// directly below it.
+/// The collapsed header is the only thing that occupies layout space in the
+/// bottom-controls cluster — the expanded card is painted in an [OverlayPortal]
+/// anchored to that header, growing upward over the chat. Keeping the in-flow
+/// footprint constant means opening/closing the card never changes the chat's
+/// bottom inset, so the message list doesn't scroll when the card toggles.
 ///
 /// Running tasks are always shown first. Completed tasks are hidden behind a
 /// "Show N completed" toggle.
@@ -33,8 +35,18 @@ class BackgroundTasksBar extends StatefulWidget {
 }
 
 class _BackgroundTasksBarState extends State<BackgroundTasksBar> {
+  final OverlayPortalController _overlayController = OverlayPortalController();
+
+  /// Links the floating expanded card to the in-flow collapsed header so it
+  /// tracks the header's position (and grows upward from its bottom edge).
+  final LayerLink _link = LayerLink();
+
   bool _expanded = false;
   bool _showCompleted = false;
+
+  /// Width of the in-flow header, captured at layout so the floating card
+  /// matches it exactly (the overlay otherwise gets the full-screen width).
+  double _cardWidth = 0;
 
   bool _isRunning(Session child) {
     final status = widget.childStatuses[child.id];
@@ -47,49 +59,108 @@ class _BackgroundTasksBarState extends State<BackgroundTasksBar> {
 
   List<Session> get _completedTasks => widget.children.where((c) => !_isRunning(c)).toList();
 
+  void _toggleExpanded() {
+    setState(() {
+      _expanded = !_expanded;
+      // Reset completed visibility when collapsing.
+      if (!_expanded) _showCompleted = false;
+    });
+    if (_expanded) {
+      _overlayController.show();
+    } else {
+      _overlayController.hide();
+    }
+  }
+
+  void _collapse() {
+    if (!_expanded) return;
+    setState(() {
+      _expanded = false;
+      _showCompleted = false;
+    });
+    _overlayController.hide();
+  }
+
   @override
   Widget build(BuildContext context) {
     if (widget.children.isEmpty) return const SizedBox.shrink();
 
-    final prego = context.prego;
-
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
-      child: GlassContainer(
-        useOwnLayer: true,
-        clipBehavior: Clip.antiAlias,
-        padding: EdgeInsets.zero,
-        shape: const LiquidRoundedSuperellipse(borderRadius: 20),
-        settings: LiquidGlassSettings(glassColor: prego.colors.buttonGlassPrimaryBackground),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            BackgroundTasksHeader(
-              runningCount: _runningCount,
-              expanded: _expanded,
-              onTap: () => setState(() {
-                _expanded = !_expanded;
-                // Reset completed visibility when collapsing.
-                if (!_expanded) _showCompleted = false;
-              }),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          _cardWidth = constraints.maxWidth;
+          return CompositedTransformTarget(
+            link: _link,
+            child: OverlayPortal(
+              controller: _overlayController,
+              overlayChildBuilder: _buildOverlay,
+              // In-flow footprint: only ever the collapsed header. Kept (with
+              // its size) but hidden + non-interactive while expanded, so the
+              // floating card above is the single visible surface and the
+              // cluster height — and thus the chat's bottom inset — is constant.
+              child: Visibility.maintain(
+                visible: !_expanded,
+                child: _buildCard(context, expanded: false),
+              ),
             ),
-            AnimatedSize(
-              duration: const Duration(milliseconds: 240),
-              curve: Curves.easeInOut,
-              alignment: Alignment.topCenter,
-              child: _expanded
-                  ? BackgroundTasksList(
-                      projectId: widget.projectId,
-                      runningTasks: _runningTasks,
-                      completedTasks: _completedTasks,
-                      childStatuses: widget.childStatuses,
-                      showCompleted: _showCompleted,
-                      onToggleCompleted: () => setState(() => _showCompleted = !_showCompleted),
-                    )
-                  : const SizedBox(width: double.infinity),
-            ),
-          ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildOverlay(BuildContext context) {
+    return Stack(
+      children: [
+        // Tap anywhere outside the card to collapse it.
+        Positioned.fill(
+          child: GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTap: _collapse,
+          ),
         ),
+        CompositedTransformFollower(
+          link: _link,
+          // Pin the card's bottom edge to the header's bottom edge so it grows
+          // upward over the chat, leaving the composer below untouched.
+          targetAnchor: Alignment.bottomLeft,
+          followerAnchor: Alignment.bottomLeft,
+          child: SizedBox(
+            width: _cardWidth,
+            child: _buildCard(context, expanded: true),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCard(BuildContext context, {required bool expanded}) {
+    final prego = context.prego;
+    return GlassContainer(
+      useOwnLayer: true,
+      clipBehavior: Clip.antiAlias,
+      padding: EdgeInsets.zero,
+      shape: const LiquidRoundedSuperellipse(borderRadius: 20),
+      settings: LiquidGlassSettings(glassColor: prego.colors.buttonGlassPrimaryBackground),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          BackgroundTasksHeader(
+            runningCount: _runningCount,
+            expanded: expanded,
+            onTap: _toggleExpanded,
+          ),
+          if (expanded)
+            BackgroundTasksList(
+              projectId: widget.projectId,
+              runningTasks: _runningTasks,
+              completedTasks: _completedTasks,
+              childStatuses: widget.childStatuses,
+              showCompleted: _showCompleted,
+              onToggleCompleted: () => setState(() => _showCompleted = !_showCompleted),
+            ),
+        ],
       ),
     );
   }

--- a/client/app/lib/features/session_detail/widgets/background_tasks_bar.dart
+++ b/client/app/lib/features/session_detail/widgets/background_tasks_bar.dart
@@ -86,7 +86,7 @@ class _BackgroundTasksBarState extends State<BackgroundTasksBar> {
     if (widget.children.isEmpty) return const SizedBox.shrink();
 
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+      padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 8),
       child: LayoutBuilder(
         builder: (context, constraints) {
           _cardWidth = constraints.maxWidth;

--- a/client/app/lib/features/session_detail/widgets/background_tasks_header.dart
+++ b/client/app/lib/features/session_detail/widgets/background_tasks_header.dart
@@ -1,7 +1,12 @@
 import "package:flutter/material.dart";
+import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:theme_prego/module_prego.dart";
 import "../../../core/extensions/build_context_x.dart";
 
+/// Tappable header row of the background-tasks glass card. Shows a spinner +
+/// "N Tasks Running" (or a check + "Completed") and a chevron that rotates as
+/// the card expands. Rendered as a [GlassListTile] so it shares the card's
+/// glass surface and press feedback with the task rows below it.
 class BackgroundTasksHeader extends StatelessWidget {
   final int runningCount;
   final bool expanded;
@@ -20,43 +25,33 @@ class BackgroundTasksHeader extends StatelessWidget {
     final loc = context.loc;
     final hasRunning = runningCount > 0;
 
-    return InkWell(
-      borderRadius: expanded ? const BorderRadius.vertical(top: Radius.circular(12)) : BorderRadius.circular(12),
+    return GlassListTile(
       onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-        child: Row(
-          children: [
-            if (hasRunning)
-              SizedBox(
-                width: 16,
-                height: 16,
-                child: CircularProgressIndicator(
-                  strokeWidth: 2,
-                  color: prego.colors.bgBrandSolid,
-                ),
-              )
-            else
-              Icon(
-                Icons.check_circle,
-                size: 16,
+      showDivider: false,
+      leading: hasRunning
+          ? SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
                 color: prego.colors.bgBrandSolid,
               ),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Text(
-                hasRunning ? loc.backgroundTasksRunning(runningCount) : loc.backgroundTasksCompleted,
-                style: prego.textTheme.textMd.bold.copyWith(
-                  color: prego.colors.textPrimary,
-                ),
-              ),
+            )
+          : Icon(
+              Icons.check_circle,
+              size: 16,
+              color: prego.colors.bgBrandSolid,
             ),
-            Icon(
-              expanded ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down,
-              size: 20,
-              color: prego.colors.textSecondary,
-            ),
-          ],
+      title: Text(hasRunning ? loc.backgroundTasksRunning(runningCount) : loc.backgroundTasksCompleted),
+      titleStyle: prego.textTheme.textMd.bold.copyWith(color: prego.colors.textPrimary),
+      trailing: AnimatedRotation(
+        turns: expanded ? 0.5 : 0.0,
+        duration: const Duration(milliseconds: 240),
+        curve: Curves.easeInOut,
+        child: Icon(
+          Icons.keyboard_arrow_down,
+          size: 20,
+          color: prego.colors.textSecondary,
         ),
       ),
     );

--- a/client/app/lib/features/session_detail/widgets/background_tasks_header.dart
+++ b/client/app/lib/features/session_detail/widgets/background_tasks_header.dart
@@ -29,12 +29,19 @@ class BackgroundTasksHeader extends StatelessWidget {
       onTap: onTap,
       showDivider: false,
       leading: hasRunning
-          ? SizedBox(
-              width: 16,
-              height: 16,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                color: prego.colors.bgBrandSolid,
+          // GlassListTile forces the leading slot to a tight width of 32 but
+          // leaves its height free. A CircularProgressIndicator has no intrinsic
+          // size and paints to its box without preserving aspect ratio, so it
+          // renders as an oval. Center re-loosens the constraints around a fixed
+          // square so the spinner stays a 16px circle.
+          ? Center(
+              heightFactor: 1,
+              child: SizedBox.square(
+                dimension: 16,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: prego.colors.bgBrandSolid,
+                ),
               ),
             )
           : Icon(

--- a/client/app/lib/features/session_detail/widgets/background_tasks_list.dart
+++ b/client/app/lib/features/session_detail/widgets/background_tasks_list.dart
@@ -1,9 +1,12 @@
 import "package:flutter/material.dart";
+import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:sesori_shared/sesori_shared.dart";
-import "package:theme_prego/module_prego.dart";
 import "background_task_row.dart";
 import "background_tasks_toggle.dart";
 
+/// The expandable body of the background-tasks glass card: a glass divider
+/// under the header, then the scrollable list of task rows. Running tasks come
+/// first; completed tasks appear after a "Show N completed" toggle.
 class BackgroundTasksList extends StatelessWidget {
   final String? projectId;
   final List<Session> runningTasks;
@@ -24,7 +27,6 @@ class BackgroundTasksList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final prego = context.prego;
     final hasRunning = runningTasks.isNotEmpty;
     final hasCompleted = completedTasks.isNotEmpty;
 
@@ -33,44 +35,42 @@ class BackgroundTasksList extends StatelessWidget {
 
     // Show toggle only when there's a mix of running and completed.
     final showToggle = hasRunning && hasCompleted;
+    final itemCount = visibleTasks.length + (showToggle ? 1 : 0);
 
-    return Container(
-      constraints: const BoxConstraints(maxHeight: 200),
-      decoration: BoxDecoration(
-        border: Border(
-          top: BorderSide(
-            color: prego.colors.borderSecondary,
-            width: 0.5,
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const GlassDivider(),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: 240),
+          child: ListView.builder(
+            shrinkWrap: true,
+            padding: EdgeInsets.zero,
+            itemCount: itemCount,
+            itemBuilder: (context, index) {
+              // Toggle button goes after the visible tasks, as the last row.
+              if (showToggle && index == visibleTasks.length) {
+                return BackgroundTasksToggle(
+                  completedCount: completedTasks.length,
+                  showCompleted: showCompleted,
+                  onTap: onToggleCompleted,
+                );
+              }
+
+              final child = visibleTasks[index];
+              // Suppress the final row's divider only when nothing follows it.
+              final isLast = !showToggle && index == visibleTasks.length - 1;
+              return BackgroundTaskRow(
+                projectId: projectId,
+                session: child,
+                status: childStatuses[child.id],
+                isLast: isLast,
+              );
+            },
           ),
         ),
-      ),
-      child: ListView.separated(
-        shrinkWrap: true,
-        padding: const EdgeInsets.symmetric(vertical: 4),
-        itemCount: visibleTasks.length + (showToggle ? 1 : 0),
-        separatorBuilder: (_, __) => Divider(
-          height: 1,
-          indent: 42,
-          color: prego.colors.borderSecondary.withValues(alpha: 0.5),
-        ),
-        itemBuilder: (context, index) {
-          // Toggle button goes after visible tasks.
-          if (index == visibleTasks.length) {
-            return BackgroundTasksToggle(
-              completedCount: completedTasks.length,
-              showCompleted: showCompleted,
-              onTap: onToggleCompleted,
-            );
-          }
-
-          final child = visibleTasks[index];
-          return BackgroundTaskRow(
-            projectId: projectId,
-            session: child,
-            status: childStatuses[child.id],
-          );
-        },
-      ),
+      ],
     );
   }
 }

--- a/client/app/lib/features/session_detail/widgets/background_tasks_toggle.dart
+++ b/client/app/lib/features/session_detail/widgets/background_tasks_toggle.dart
@@ -1,7 +1,11 @@
 import "package:flutter/material.dart";
+import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:theme_prego/module_prego.dart";
 import "../../../core/extensions/build_context_x.dart";
 
+/// The "Show / Hide N completed" toggle row at the bottom of the tasks card.
+/// Rendered as a brand-tinted [GlassListTile] so it aligns with the task rows
+/// above it but reads as an action rather than a navigable task.
 class BackgroundTasksToggle extends StatelessWidget {
   final int completedCount;
   final bool showCompleted;
@@ -19,29 +23,17 @@ class BackgroundTasksToggle extends StatelessWidget {
     final prego = context.prego;
     final loc = context.loc;
 
-    return InkWell(
+    return GlassListTile(
       onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-        child: Row(
-          children: [
-            Icon(
-              showCompleted ? Icons.visibility_off_outlined : Icons.visibility_outlined,
-              size: 16,
-              color: prego.colors.bgBrandSolid,
-            ),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Text(
-                showCompleted ? loc.backgroundTasksHideCompleted : loc.backgroundTasksShowCompleted(completedCount),
-                style: prego.textTheme.textSm.bold.copyWith(
-                  color: prego.colors.bgBrandSolid,
-                ),
-              ),
-            ),
-          ],
-        ),
+      isLast: true,
+      showDivider: false,
+      leading: Icon(
+        showCompleted ? Icons.visibility_off_outlined : Icons.visibility_outlined,
+        size: 16,
+        color: prego.colors.bgBrandSolid,
       ),
+      title: Text(showCompleted ? loc.backgroundTasksHideCompleted : loc.backgroundTasksShowCompleted(completedCount)),
+      titleStyle: prego.textTheme.textSm.bold.copyWith(color: prego.colors.bgBrandSolid),
     );
   }
 }

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -326,6 +326,7 @@ class _PromptInputState extends State<PromptInput> {
                 PregoButtonsIconGlass(
                   onPressed: _voiceState == _VoiceState.idle ? _openCommandPicker : null,
                   icon: TablerRegular.slash,
+                  semanticLabel: loc.sessionDetailCommandPickerTitle,
                 ),
                 Expanded(
                   child: switch (_voiceState) {

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -323,9 +323,9 @@ class _PromptInputState extends State<PromptInput> {
               spacing: 8,
               crossAxisAlignment: .end,
               children: [
-                _SlashButton(
-                  enabled: _voiceState == _VoiceState.idle,
-                  onTap: _openCommandPicker,
+                PregoButtonsIconGlass(
+                  onPressed: _voiceState == _VoiceState.idle ? _openCommandPicker : null,
+                  icon: TablerRegular.slash,
                 ),
                 Expanded(
                   child: switch (_voiceState) {
@@ -383,47 +383,6 @@ class _PromptInputState extends State<PromptInput> {
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-// -----------------------------------------------------------------------------
-// Slash button
-// -----------------------------------------------------------------------------
-
-class _SlashButton extends StatelessWidget {
-  final bool enabled;
-  final Future<void> Function() onTap;
-
-  const _SlashButton({
-    required this.enabled,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final prego = context.prego;
-
-    return Material(
-      color: enabled ? prego.colors.bgQuaternary : prego.colors.bgQuaternary.withValues(alpha: 0.5),
-      shape: const CircleBorder(),
-      child: InkWell(
-        customBorder: const CircleBorder(),
-        onTap: enabled ? onTap : null,
-        child: SizedBox(
-          width: 44,
-          height: 44,
-          child: Center(
-            child: Text(
-              "/",
-              style: prego.textTheme.textMd.bold.copyWith(
-                color: enabled ? prego.colors.textSecondary : prego.colors.borderPrimary,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-          ),
-        ),
       ),
     );
   }

--- a/client/app/lib/features/session_detail/widgets/question_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/question_modal.dart
@@ -1,7 +1,6 @@
 import "package:flutter/material.dart";
 import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
 import "package:go_router/go_router.dart";
-import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
 
@@ -200,17 +199,13 @@ class _QuestionModalState extends State<QuestionModal> {
     final height = MediaQuery.sizeOf(context).height * 0.7;
     final info = _currentInfo;
 
-    return GlassContainer(
+    return Container(
       height: height,
-      useOwnLayer: true,
-      clipBehavior: Clip.antiAlias,
-      padding: EdgeInsets.zero,
-      // Round only the top so the sheet still sits flush to the bottom edge.
-      shape: const LiquidVerticalRoundedSuperellipse(topRadius: 20, bottomRadius: 0),
-      // Frosted but kept fairly opaque: this is a content-heavy modal, so the
-      // chat blurs behind its edges without hurting the question's legibility.
-      settings: LiquidGlassSettings(
-        glassColor: prego.colors.bgPrimary.withValues(alpha: 0.78),
+      decoration: BoxDecoration(
+        color: prego.colors.bgPrimary,
+        borderRadius: const BorderRadius.vertical(
+          top: Radius.circular(16),
+        ),
       ),
       child: Column(
         children: [
@@ -285,7 +280,7 @@ class _QuestionModalState extends State<QuestionModal> {
               ),
             ),
 
-          const GlassDivider(),
+          const Divider(height: 1),
 
           // Scrollable body
           Expanded(
@@ -304,22 +299,19 @@ class _QuestionModalState extends State<QuestionModal> {
                 ),
                 const SizedBox(height: 16),
 
-                // Option tiles — a grouped glass list that shares the sheet's
-                // frosted layer. Selection is shown by the filled check/radio
-                // and a brand-tinted label rather than a filled background.
-                for (var i = 0; i < info.options.length; i++)
-                  _OptionTile(
-                    option: info.options[i],
+                // Option tiles
+                ...info.options.map(
+                  (option) => _OptionTile(
+                    option: option,
                     isMultiple: info.multiple,
-                    isSelected: _selectedLabels.contains(info.options[i].label),
-                    // Suppress the trailing divider only when nothing (no
-                    // custom-answer tile) follows this option.
-                    isLast: !info.custom && i == info.options.length - 1,
-                    onTap: () => _onOptionTap(info.options[i].label),
+                    isSelected: _selectedLabels.contains(option.label),
+                    onTap: () => _onOptionTap(option.label),
                   ),
+                ),
 
-                // Custom answer tile continues the same grouped list.
-                if (info.custom)
+                // Custom answer tile
+                if (info.custom) ...[
+                  const SizedBox(height: 8),
                   _CustomAnswerTile(
                     controller: _customController,
                     focusNode: _customFocus,
@@ -327,30 +319,21 @@ class _QuestionModalState extends State<QuestionModal> {
                     isMultiple: info.multiple,
                     onTap: _onCustomTileTap,
                   ),
+                ],
               ],
             ),
           ),
 
-          // Submit / Next button. The sheet runs its glass flush to the bottom
-          // edge (handleBottomSafeArea: false), so the home-indicator inset
-          // isn't padded for us — add it here to lift the button clear of the
-          // indicator. It collapses to 0 while the keyboard is up, which already
-          // lifts the whole sheet.
+          // Submit / Next button
           Padding(
-            padding: EdgeInsetsDirectional.fromSTEB(16, 0, 16, 16 + MediaQuery.paddingOf(context).bottom),
-            child: GlassButton.custom(
-              // `_onProceed` no-ops on an empty answer, so gating via `enabled`
-              // is enough — no need to swap the callback when disabled.
-              onTap: _onProceed,
-              enabled: _canProceed,
+            padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 16),
+            child: SizedBox(
               width: double.infinity,
-              height: 52,
-              useOwnLayer: true,
-              shape: const LiquidRoundedSuperellipse(borderRadius: 16),
-              settings: LiquidGlassSettings(glassColor: prego.colors.bgBrandSolid),
-              child: Text(
-                _isLastQuestion ? loc.questionModalSubmit : loc.questionModalNext,
-                style: prego.textTheme.textMd.bold.copyWith(color: prego.colors.textWhite),
+              child: FilledButton(
+                onPressed: _canProceed ? _onProceed : null,
+                child: Text(
+                  _isLastQuestion ? loc.questionModalSubmit : loc.questionModalNext,
+                ),
               ),
             ),
           ),
@@ -368,14 +351,12 @@ class _OptionTile extends StatelessWidget {
   final QuestionOption option;
   final bool isMultiple;
   final bool isSelected;
-  final bool isLast;
   final VoidCallback onTap;
 
   const _OptionTile({
     required this.option,
     required this.isMultiple,
     required this.isSelected,
-    required this.isLast,
     required this.onTap,
   });
 
@@ -383,22 +364,51 @@ class _OptionTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final prego = context.prego;
 
-    return GlassListTile(
-      onTap: onTap,
-      isLast: isLast,
-      leading: Icon(
-        isMultiple
-            ? (isSelected ? Icons.check_box : Icons.check_box_outline_blank)
-            : (isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked),
-        color: isSelected ? prego.colors.bgBrandSolid : prego.colors.borderPrimary,
-      ),
-      title: Text(option.label),
-      titleStyle: prego.textTheme.textSm.bold.copyWith(
-        color: isSelected ? prego.colors.bgBrandSolid : prego.colors.textPrimary,
-      ),
-      subtitle: option.description.isNotEmpty ? Text(option.description) : null,
-      subtitleStyle: prego.textTheme.textXs.regular.copyWith(
-        color: prego.colors.textSecondary,
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(bottom: 8),
+      child: Material(
+        color: isSelected ? prego.colors.bgBrandPrimary : prego.colors.bgSecondary,
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+              children: [
+                Icon(
+                  isMultiple
+                      ? (isSelected ? Icons.check_box : Icons.check_box_outline_blank)
+                      : (isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked),
+                  color: isSelected ? prego.colors.bgBrandSolid : prego.colors.borderPrimary,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: .start,
+                    children: [
+                      Text(
+                        option.label,
+                        style: prego.textTheme.textSm.bold.copyWith(
+                          fontWeight: .bold,
+                        ),
+                      ),
+                      if (option.description.isNotEmpty) ...[
+                        const SizedBox(height: 2),
+                        Text(
+                          option.description,
+                          style: prego.textTheme.textXs.regular.copyWith(
+                            color: prego.colors.textSecondary,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }
@@ -428,50 +438,47 @@ class _CustomAnswerTile extends StatelessWidget {
     final prego = context.prego;
     final loc = context.loc;
 
-    // Rendered as a bare grouped row on the sheet's glass (no own surface) so
-    // it continues seamlessly from the option tiles above. The text field
-    // can't live inside a GlassListTile, so the row is composed by hand but
-    // mirrors the tile's leading-icon + content padding.
-    return GestureDetector(
-      onTap: onTap,
-      behavior: HitTestBehavior.opaque,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Padding(
-              key: const Key("custom-answer-toggle"),
-              padding: const EdgeInsetsDirectional.only(top: 10),
-              child: Icon(
-                isMultiple
-                    ? (isSelected ? Icons.check_box : Icons.check_box_outline_blank)
-                    : (isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked),
-                color: isSelected ? prego.colors.bgBrandSolid : prego.colors.borderPrimary,
-              ),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: TextField(
-                controller: controller,
-                focusNode: focusNode,
-                minLines: 1,
-                maxLines: 5,
-                style: prego.textTheme.textSm.regular.copyWith(
-                  color: prego.colors.textPrimary,
-                ),
-                decoration: InputDecoration(
-                  hintText: loc.questionModalCustomHint,
-                  hintStyle: prego.textTheme.textSm.regular.copyWith(
-                    color: prego.colors.textSecondary,
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(bottom: 8),
+      child: Material(
+        color: isSelected ? prego.colors.bgBrandPrimary : prego.colors.bgSecondary,
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(12),
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+              crossAxisAlignment: .start,
+              children: [
+                Padding(
+                  key: const Key("custom-answer-toggle"),
+                  padding: const EdgeInsetsDirectional.only(top: 10),
+                  child: Icon(
+                    isMultiple
+                        ? (isSelected ? Icons.check_box : Icons.check_box_outline_blank)
+                        : (isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked),
+                    color: isSelected ? prego.colors.bgBrandSolid : prego.colors.borderPrimary,
                   ),
-                  border: InputBorder.none,
-                  isDense: true,
-                  contentPadding: const EdgeInsets.symmetric(vertical: 8),
                 ),
-              ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: TextField(
+                    controller: controller,
+                    focusNode: focusNode,
+                    minLines: 1,
+                    maxLines: 5,
+                    decoration: InputDecoration(
+                      hintText: loc.questionModalCustomHint,
+                      border: InputBorder.none,
+                      isDense: true,
+                      contentPadding: const EdgeInsets.symmetric(vertical: 8),
+                    ),
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/client/app/lib/features/session_detail/widgets/question_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/question_modal.dart
@@ -34,6 +34,7 @@ class QuestionModal extends StatefulWidget {
     required void Function(String requestId) onReject,
   }) {
     return showAppModalBottomSheet<void>(
+      handleBottomSafeArea: false,
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
@@ -291,10 +292,10 @@ class _QuestionModalState extends State<QuestionModal> {
                   data: info.question,
                   selectable: true,
                   onTapLink: handleMarkdownLinkTap,
-                    styleSheet: buildSessionMarkdownStyleSheet(
-                      prego: prego,
-                      paragraphStyle: prego.textTheme.textSm.medium,
-                    ),
+                  styleSheet: buildSessionMarkdownStyleSheet(
+                    prego: prego,
+                    paragraphStyle: prego.textTheme.textSm.medium,
+                  ),
                 ),
                 const SizedBox(height: 16),
 
@@ -396,9 +397,9 @@ class _OptionTile extends StatelessWidget {
                         const SizedBox(height: 2),
                         Text(
                           option.description,
-                            style: prego.textTheme.textXs.regular.copyWith(
-                              color: prego.colors.textSecondary,
-                            ),
+                          style: prego.textTheme.textXs.regular.copyWith(
+                            color: prego.colors.textSecondary,
+                          ),
                         ),
                       ],
                     ],

--- a/client/app/lib/features/session_detail/widgets/question_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/question_modal.dart
@@ -326,7 +326,7 @@ class _QuestionModalState extends State<QuestionModal> {
 
           // Submit / Next button
           Padding(
-            padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 16),
+            padding: EdgeInsetsDirectional.fromSTEB(16, 0, 16, 16 + MediaQuery.paddingOf(context).bottom),
             child: SizedBox(
               width: double.infinity,
               child: FilledButton(

--- a/client/app/lib/features/session_detail/widgets/question_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/question_modal.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
 import "package:go_router/go_router.dart";
+import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
 
@@ -199,13 +200,17 @@ class _QuestionModalState extends State<QuestionModal> {
     final height = MediaQuery.sizeOf(context).height * 0.7;
     final info = _currentInfo;
 
-    return Container(
+    return GlassContainer(
       height: height,
-      decoration: BoxDecoration(
-        color: prego.colors.bgPrimary,
-        borderRadius: const BorderRadius.vertical(
-          top: Radius.circular(16),
-        ),
+      useOwnLayer: true,
+      clipBehavior: Clip.antiAlias,
+      padding: EdgeInsets.zero,
+      // Round only the top so the sheet still sits flush to the bottom edge.
+      shape: const LiquidVerticalRoundedSuperellipse(topRadius: 20, bottomRadius: 0),
+      // Frosted but kept fairly opaque: this is a content-heavy modal, so the
+      // chat blurs behind its edges without hurting the question's legibility.
+      settings: LiquidGlassSettings(
+        glassColor: prego.colors.bgPrimary.withValues(alpha: 0.78),
       ),
       child: Column(
         children: [
@@ -280,7 +285,7 @@ class _QuestionModalState extends State<QuestionModal> {
               ),
             ),
 
-          const Divider(height: 1),
+          const GlassDivider(),
 
           // Scrollable body
           Expanded(
@@ -299,19 +304,22 @@ class _QuestionModalState extends State<QuestionModal> {
                 ),
                 const SizedBox(height: 16),
 
-                // Option tiles
-                ...info.options.map(
-                  (option) => _OptionTile(
-                    option: option,
+                // Option tiles — a grouped glass list that shares the sheet's
+                // frosted layer. Selection is shown by the filled check/radio
+                // and a brand-tinted label rather than a filled background.
+                for (var i = 0; i < info.options.length; i++)
+                  _OptionTile(
+                    option: info.options[i],
                     isMultiple: info.multiple,
-                    isSelected: _selectedLabels.contains(option.label),
-                    onTap: () => _onOptionTap(option.label),
+                    isSelected: _selectedLabels.contains(info.options[i].label),
+                    // Suppress the trailing divider only when nothing (no
+                    // custom-answer tile) follows this option.
+                    isLast: !info.custom && i == info.options.length - 1,
+                    onTap: () => _onOptionTap(info.options[i].label),
                   ),
-                ),
 
-                // Custom answer tile
-                if (info.custom) ...[
-                  const SizedBox(height: 8),
+                // Custom answer tile continues the same grouped list.
+                if (info.custom)
                   _CustomAnswerTile(
                     controller: _customController,
                     focusNode: _customFocus,
@@ -319,21 +327,30 @@ class _QuestionModalState extends State<QuestionModal> {
                     isMultiple: info.multiple,
                     onTap: _onCustomTileTap,
                   ),
-                ],
               ],
             ),
           ),
 
-          // Submit / Next button
+          // Submit / Next button. The sheet runs its glass flush to the bottom
+          // edge (handleBottomSafeArea: false), so the home-indicator inset
+          // isn't padded for us — add it here to lift the button clear of the
+          // indicator. It collapses to 0 while the keyboard is up, which already
+          // lifts the whole sheet.
           Padding(
-            padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 16),
-            child: SizedBox(
+            padding: EdgeInsetsDirectional.fromSTEB(16, 0, 16, 16 + MediaQuery.paddingOf(context).bottom),
+            child: GlassButton.custom(
+              // `_onProceed` no-ops on an empty answer, so gating via `enabled`
+              // is enough — no need to swap the callback when disabled.
+              onTap: _onProceed,
+              enabled: _canProceed,
               width: double.infinity,
-              child: FilledButton(
-                onPressed: _canProceed ? _onProceed : null,
-                child: Text(
-                  _isLastQuestion ? loc.questionModalSubmit : loc.questionModalNext,
-                ),
+              height: 52,
+              useOwnLayer: true,
+              shape: const LiquidRoundedSuperellipse(borderRadius: 16),
+              settings: LiquidGlassSettings(glassColor: prego.colors.bgBrandSolid),
+              child: Text(
+                _isLastQuestion ? loc.questionModalSubmit : loc.questionModalNext,
+                style: prego.textTheme.textMd.bold.copyWith(color: prego.colors.textWhite),
               ),
             ),
           ),
@@ -351,12 +368,14 @@ class _OptionTile extends StatelessWidget {
   final QuestionOption option;
   final bool isMultiple;
   final bool isSelected;
+  final bool isLast;
   final VoidCallback onTap;
 
   const _OptionTile({
     required this.option,
     required this.isMultiple,
     required this.isSelected,
+    required this.isLast,
     required this.onTap,
   });
 
@@ -364,51 +383,22 @@ class _OptionTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final prego = context.prego;
 
-    return Padding(
-      padding: const EdgeInsetsDirectional.only(bottom: 8),
-      child: Material(
-        color: isSelected ? prego.colors.bgBrandPrimary : prego.colors.bgSecondary,
-        borderRadius: BorderRadius.circular(12),
-        child: InkWell(
-          borderRadius: BorderRadius.circular(12),
-          onTap: onTap,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-            child: Row(
-              children: [
-                Icon(
-                  isMultiple
-                      ? (isSelected ? Icons.check_box : Icons.check_box_outline_blank)
-                      : (isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked),
-                  color: isSelected ? prego.colors.bgBrandSolid : prego.colors.borderPrimary,
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: .start,
-                    children: [
-                      Text(
-                        option.label,
-                        style: prego.textTheme.textSm.bold.copyWith(
-                          fontWeight: .bold,
-                        ),
-                      ),
-                      if (option.description.isNotEmpty) ...[
-                        const SizedBox(height: 2),
-                        Text(
-                          option.description,
-                          style: prego.textTheme.textXs.regular.copyWith(
-                            color: prego.colors.textSecondary,
-                          ),
-                        ),
-                      ],
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
+    return GlassListTile(
+      onTap: onTap,
+      isLast: isLast,
+      leading: Icon(
+        isMultiple
+            ? (isSelected ? Icons.check_box : Icons.check_box_outline_blank)
+            : (isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked),
+        color: isSelected ? prego.colors.bgBrandSolid : prego.colors.borderPrimary,
+      ),
+      title: Text(option.label),
+      titleStyle: prego.textTheme.textSm.bold.copyWith(
+        color: isSelected ? prego.colors.bgBrandSolid : prego.colors.textPrimary,
+      ),
+      subtitle: option.description.isNotEmpty ? Text(option.description) : null,
+      subtitleStyle: prego.textTheme.textXs.regular.copyWith(
+        color: prego.colors.textSecondary,
       ),
     );
   }
@@ -438,47 +428,50 @@ class _CustomAnswerTile extends StatelessWidget {
     final prego = context.prego;
     final loc = context.loc;
 
-    return Padding(
-      padding: const EdgeInsetsDirectional.only(bottom: 8),
-      child: Material(
-        color: isSelected ? prego.colors.bgBrandPrimary : prego.colors.bgSecondary,
-        borderRadius: BorderRadius.circular(12),
-        child: InkWell(
-          borderRadius: BorderRadius.circular(12),
-          onTap: onTap,
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-            child: Row(
-              crossAxisAlignment: .start,
-              children: [
-                Padding(
-                  key: const Key("custom-answer-toggle"),
-                  padding: const EdgeInsetsDirectional.only(top: 10),
-                  child: Icon(
-                    isMultiple
-                        ? (isSelected ? Icons.check_box : Icons.check_box_outline_blank)
-                        : (isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked),
-                    color: isSelected ? prego.colors.bgBrandSolid : prego.colors.borderPrimary,
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: TextField(
-                    controller: controller,
-                    focusNode: focusNode,
-                    minLines: 1,
-                    maxLines: 5,
-                    decoration: InputDecoration(
-                      hintText: loc.questionModalCustomHint,
-                      border: InputBorder.none,
-                      isDense: true,
-                      contentPadding: const EdgeInsets.symmetric(vertical: 8),
-                    ),
-                  ),
-                ),
-              ],
+    // Rendered as a bare grouped row on the sheet's glass (no own surface) so
+    // it continues seamlessly from the option tiles above. The text field
+    // can't live inside a GlassListTile, so the row is composed by hand but
+    // mirrors the tile's leading-icon + content padding.
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              key: const Key("custom-answer-toggle"),
+              padding: const EdgeInsetsDirectional.only(top: 10),
+              child: Icon(
+                isMultiple
+                    ? (isSelected ? Icons.check_box : Icons.check_box_outline_blank)
+                    : (isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked),
+                color: isSelected ? prego.colors.bgBrandSolid : prego.colors.borderPrimary,
+              ),
             ),
-          ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: TextField(
+                controller: controller,
+                focusNode: focusNode,
+                minLines: 1,
+                maxLines: 5,
+                style: prego.textTheme.textSm.regular.copyWith(
+                  color: prego.colors.textPrimary,
+                ),
+                decoration: InputDecoration(
+                  hintText: loc.questionModalCustomHint,
+                  hintStyle: prego.textTheme.textSm.regular.copyWith(
+                    color: prego.colors.textSecondary,
+                  ),
+                  border: InputBorder.none,
+                  isDense: true,
+                  contentPadding: const EdgeInsets.symmetric(vertical: 8),
+                ),
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/client/app/lib/features/session_detail/widgets/session_detail_body.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_body.dart
@@ -129,6 +129,10 @@ class _SessionDetailBodyState extends State<SessionDetailBody> {
       // behind the transparent bar like every other screen. Skip the auto top
       // spacer that would otherwise confine the loaded view below the bar.
       reserveBarSpace: false,
+      // The loaded view fills the viewport and the chat list owns its own
+      // (reversed) scroll, so the outer page must not scroll — otherwise a drag
+      // that starts on the pinned composer overscrolls/bounces the whole page.
+      scrollable: false,
       automaticallyImplyLeading: showLeading,
       actions: actions.isEmpty ? null : actions,
       slivers: [

--- a/client/app/lib/features/session_detail/widgets/session_detail_scaffold_sections.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_scaffold_sections.dart
@@ -36,7 +36,7 @@ class SessionDetailPendingBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     final prego = context.prego;
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+      padding: const EdgeInsetsDirectional.fromSTEB(16, 8, 16, 0),
       child: GlassContainer(
         useOwnLayer: true,
         clipBehavior: Clip.antiAlias,

--- a/client/app/lib/features/session_detail/widgets/session_detail_scaffold_sections.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_scaffold_sections.dart
@@ -1,5 +1,6 @@
 import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
+import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:theme_prego/module_prego.dart";
 
@@ -7,8 +8,16 @@ import "../../../core/extensions/build_context_x.dart";
 import "../../../core/extensions/remote_failure_x.dart";
 import "queued_message_bubble.dart";
 
+/// A floating call-to-action pinned below the top bar when the session has a
+/// pending question or permission. Rendered as a semantic-tinted liquid-glass
+/// card (brand for questions, success for permissions) so it pops over the chat
+/// while sharing the glass language of the background-tasks card and the
+/// composer pills below.
 class SessionDetailPendingBanner extends StatelessWidget {
   final IconData icon;
+
+  /// Semantic surface colour for the glass tint — applied with reduced alpha so
+  /// the card stays frosted and the chat refracts through its edges.
   final Color backgroundColor;
   final Color foregroundColor;
   final String label;
@@ -25,26 +34,22 @@ class SessionDetailPendingBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      elevation: 2,
-      color: backgroundColor,
-      child: InkWell(
-        onTap: onTap,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-          child: Row(
-            children: [
-              Icon(icon, size: 20, color: foregroundColor),
-              const SizedBox(width: 10),
-              Expanded(
-                child: Text(
-                  label,
-                  style: context.prego.textTheme.textMd.bold.copyWith(color: foregroundColor),
-                ),
-              ),
-              Icon(Icons.chevron_right, size: 20, color: foregroundColor),
-            ],
-          ),
+    final prego = context.prego;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+      child: GlassContainer(
+        useOwnLayer: true,
+        clipBehavior: Clip.antiAlias,
+        padding: EdgeInsets.zero,
+        shape: const LiquidRoundedSuperellipse(borderRadius: 20),
+        settings: LiquidGlassSettings(glassColor: backgroundColor.withValues(alpha: 0.6)),
+        child: GlassListTile(
+          onTap: onTap,
+          showDivider: false,
+          leading: Icon(icon, size: 20, color: foregroundColor),
+          title: Text(label),
+          titleStyle: prego.textTheme.textMd.bold.copyWith(color: foregroundColor),
+          trailing: Icon(Icons.chevron_right, size: 20, color: foregroundColor),
         ),
       ),
     );

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.9
-  liquid_glass_widgets: ^0.19.1
+  liquid_glass_widgets: ^0.19.4
   http: ^1.6.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.12.0

--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -74,7 +74,7 @@ class PregoGlassScaffold extends StatefulWidget {
     this.extendBodyBehindBar = true,
     this.reserveBarSpace = true,
     this.scrollable = true,
-  });
+  }) : assert(scrollable || onRefresh == null, "onRefresh requires scrollable to be true (RefreshIndicator needs a draggable page)");
 
   /// Primary title — shown large below the bar and, once collapsed, inline.
   final String title;

--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -1,5 +1,3 @@
-import "dart:math" as math;
-
 import "package:flutter/material.dart";
 import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 
@@ -149,22 +147,6 @@ class PregoGlassScaffold extends StatefulWidget {
 class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
   final ScrollController _scrollController = ScrollController();
 
-  /// Page glass-layer settings replicated from the showcase's
-  /// `RecommendedGlassSettings.standard` (an example-only constant, not a
-  /// package export).
-  static const LiquidGlassSettings _pageSettings = LiquidGlassSettings(
-    blur: 4,
-    thickness: 10,
-    glassColor: Color.fromRGBO(255, 255, 255, 0.08),
-    lightAngle: 0.75 * math.pi,
-    lightIntensity: 0.7,
-    ambientStrength: 0,
-    saturation: 1.2,
-    refractiveIndex: 1.2,
-    chromaticAberration: 0.01,
-    specularSharpness: GlassSpecularSharpness.medium,
-  );
-
   @override
   void dispose() {
     _scrollController.dispose();
@@ -193,9 +175,7 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
 
     Widget scrollView = CustomScrollView(
       controller: _scrollController,
-      physics: widget.scrollable
-          ? const AlwaysScrollableScrollPhysics()
-          : const NeverScrollableScrollPhysics(),
+      physics: widget.scrollable ? const AlwaysScrollableScrollPhysics() : const NeverScrollableScrollPhysics(),
       slivers: [
         // When the body scrolls behind the bar, reserve space so the title
         // clears it. When it doesn't, GlassScaffold already insets the body
@@ -206,7 +186,11 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
         // Inline mode shows a fixed title in the bar, so there is no large
         // title sliver to scroll away.
         if (!inline)
-          _LargeTitleSliver(title: widget.title, subtitle: widget.subtitle, scrollController: _scrollController),
+          _LargeTitleSliver(
+            title: widget.title,
+            subtitle: widget.subtitle,
+            scrollController: _scrollController,
+          ),
         ...widget.slivers,
       ],
     );
@@ -257,7 +241,6 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
 
     return GlassScaffold(
       backgroundColor: backgroundColor,
-      settings: _pageSettings,
       statusBarStyle: GlassStatusBarStyle.auto,
       extendBody: extendBehind,
       topEdgeFade: false, // Disable the top edge fade -- we use our own custom gradient
@@ -290,7 +273,12 @@ class _LargeTitleSliver extends StatelessWidget {
 
     return SliverToBoxAdapter(
       child: Padding(
-        padding: const EdgeInsetsDirectional.fromSTEB(PregoSpacing.x3l, 0, PregoSpacing.x3l, PregoSpacing.xl),
+        padding: const EdgeInsetsDirectional.fromSTEB(
+          PregoSpacing.x3l,
+          0,
+          PregoSpacing.x3l,
+          PregoSpacing.xl,
+        ),
         child: ListenableBuilder(
           listenable: scrollController,
           builder: (context, _) {

--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -75,6 +75,7 @@ class PregoGlassScaffold extends StatefulWidget {
     this.backgroundColor,
     this.extendBodyBehindBar = true,
     this.reserveBarSpace = true,
+    this.scrollable = true,
   });
 
   /// Primary title — shown large below the bar and, once collapsed, inline.
@@ -131,6 +132,16 @@ class PregoGlassScaffold extends StatefulWidget {
   /// insets itself (see the class doc).
   final bool reserveBarSpace;
 
+  /// Whether the page itself scrolls. Defaults to `true`
+  /// ([AlwaysScrollableScrollPhysics]). Set `false`
+  /// ([NeverScrollableScrollPhysics]) for screens whose body fills the viewport
+  /// and owns its own scroll (e.g. a reversed chat list): the outer page then
+  /// can't overscroll/bounce, so a drag that starts outside the inner list —
+  /// e.g. on a pinned composer — no longer drags the whole page. Only the body's
+  /// own scrollable moves. Incompatible with [onRefresh], which needs the page
+  /// to be draggable.
+  final bool scrollable;
+
   @override
   State<PregoGlassScaffold> createState() => _PregoGlassScaffoldState();
 }
@@ -182,7 +193,9 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
 
     Widget scrollView = CustomScrollView(
       controller: _scrollController,
-      physics: const AlwaysScrollableScrollPhysics(),
+      physics: widget.scrollable
+          ? const AlwaysScrollableScrollPhysics()
+          : const NeverScrollableScrollPhysics(),
       slivers: [
         // When the body scrolls behind the bar, reserve space so the title
         // clears it. When it doesn't, GlassScaffold already insets the body

--- a/client/module_prego/pubspec.yaml
+++ b/client/module_prego/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   meta: ^1.18.0
   flutter_svg: ^2.3.0
   universal_platform: ^1.1.0
-  liquid_glass_widgets: ^0.19.1
+  liquid_glass_widgets: ^0.19.4
 
 flutter:
   assets:

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -921,10 +921,10 @@ packages:
     dependency: transitive
     description:
       name: liquid_glass_widgets
-      sha256: "417bb3a833f1625103e85a8db71364e9c866b68e6a9bbd9c38cafa8b4e162197"
+      sha256: b666083eb5d37fb2fedacbda9e9466da9ee86583cc761e41859afe2711907a60
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.1"
+    version: "0.19.4"
   logging:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

A batch of UI bug fixes and glass-styling polish, mostly on the session chat (session detail) screen.

## Bug fixes

- **Chat overscroll/bounce** — A drag that started on the pinned composer used to bounce the whole page. The session detail page now sets `scrollable: false` on the glass scaffold (new `PregoGlassScaffold.scrollable` flag → `NeverScrollableScrollPhysics`), so only the reversed chat list scrolls.
- **Chat jumping when expanding background tasks** — The background-tasks card now paints in an `OverlayPortal` anchored to its collapsed header and grows upward over the chat. The in-flow footprint stays constant, so toggling the card no longer changes the chat's bottom inset (and the message list no longer scrolls).
- **Mis-anchored picker popups in split/landscape** — In the master-detail layout the agent/model/variant glass popups landed one sidebar-width off. Each popup now re-anchors under its trigger on open via `_alignMenuToTrigger`, cancelling the nested-Overlay inset. No-op in single-pane.
- **Oval loading spinner** — `CircularProgressIndicator` rendered as an oval inside `GlassListTile`'s fixed-width leading slot. Wrapped in a `Center` + `SizedBox.square` so it stays a 16px circle (background-tasks header and rows).
- **Question modal bottom padding / safe area** — Stop double-applying the bottom safe area (`handleBottomSafeArea: false`) and pad the submit button by `MediaQuery.paddingOf(context).bottom` so it clears the home indicator.
- **Tap bug** + lint-warning cleanup.

## Glass styling polish

- Background-tasks bar, its header/rows/toggle, and the pending question/permission banner converted to liquid-glass cards (`GlassContainer` / `GlassListTile` / `GlassDivider`).
- Slash button in the composer replaced with `PregoButtonsIconGlass`.
- Removed the now-unused page-level glass settings from `PregoGlassScaffold`.

## Dependency

- `liquid_glass_widgets` `0.19.1` → `0.19.4`.

## Test plan

- [ ] Session chat: drag from the composer — page doesn't bounce; only the chat scrolls.
- [ ] Expand/collapse background tasks — chat doesn't jump; spinner is a circle.
- [ ] Landscape/split: open agent/model/variant pickers — popups anchor under their triggers.
- [ ] Question modal clears the home indicator.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session chat scrolling and popup alignment, and polishes glass styling across background tasks and banners. Improves accessibility by adding a semantic label to the slash command button and removing hidden header semantics when tasks expand.

- **Bug Fixes**
  - Stop page bounce: session detail sets `PregoGlassScaffold.scrollable: false` so only the reversed chat list scrolls.
  - No chat jump when toggling background tasks: the expanded card renders in an overlay anchored to the header and grows upward; while expanded, the hidden header drops from hit-testing and semantics so the floating card is the only interactive surface.
  - Agent/model/variant picker popups anchor under their triggers in split/landscape via `_alignMenuToTrigger`.
  - Spinner stays circular inside `GlassListTile`; fixed question modal bottom safe area.
  - Slash command button gets a `semanticLabel` for screen readers; minor tap fix and lint cleanup.

- **Refactors**
  - Converted background-tasks header/list/toggle and the pending question/permission banner to liquid-glass (`GlassContainer`/`GlassListTile`/`GlassDivider`).
  - Replaced the composer slash button with `PregoButtonsIconGlass`; removed unused scaffold glass settings.
  - Upgraded `liquid_glass_widgets` to `0.19.4`.

<sup>Written for commit 08e72920e54e66810485fbb46ce4ce3c0d36d0b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

