### PR TITLE
feat(bridge): persist bridgeId outside token.json

### DIFF
--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart' as http;
 import 'package:sesori_bridge/src/api/bridge_settings_api.dart';
 import 'package:sesori_bridge/src/api/default_editor_api.dart';
 import 'package:sesori_bridge/src/api/wake_lock_client.dart';
+import 'package:sesori_bridge/src/auth/bridge_id_migration_service.dart';
 import 'package:sesori_bridge/src/auth/bridge_id_storage.dart';
 import 'package:sesori_bridge/src/auth/bridge_registration_api.dart';
 import 'package:sesori_bridge/src/auth/bridge_registration_repository.dart';
@@ -273,16 +274,16 @@ class LogoutCommand extends cli.Command<void> {
 /// file is deleted. Callers treat any failure as non-fatal.
 Future<void> _unregisterBridgeRegistration({required String authBackendUrl}) async {
   final bridgeIdStorage = BridgeIdStorage(filePath: bridgeIdPath());
+  // Adopt a legacy id persisted inside token.json first, so a never-reconnected
+  // legacy install still unregisters cleanly; the service reads the bridge id
+  // back out of storage.
+  await BridgeIdMigrationService(
+    bridgeIdStorage: bridgeIdStorage,
+    readLegacyBridgeId: readLegacyBridgeId,
+  ).migrate();
   if (await bridgeIdStorage.read() == null) {
-    // Adopt a legacy id persisted by an older bridge inside token.json so a
-    // never-reconnected legacy install still unregisters cleanly; the service
-    // reads the bridge id back out of storage.
-    final legacy = await readLegacyBridgeId();
-    if (legacy == null) {
-      // Nothing registered to remove.
-      return;
-    }
-    await bridgeIdStorage.write(bridgeId: legacy);
+    // Nothing registered to remove.
+    return;
   }
 
   final TokenData tokens;
@@ -310,7 +311,6 @@ Future<void> _unregisterBridgeRegistration({required String authBackendUrl}) asy
       ),
       tokenRefresher: tokenManager,
       bridgeIdStorage: bridgeIdStorage,
-      readLegacyBridgeId: readLegacyBridgeId,
       hostName: Platform.localHostname,
       platform: BridgeRegistrationService.currentPlatformName(),
     );

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart' as http;
 import 'package:sesori_bridge/src/api/bridge_settings_api.dart';
 import 'package:sesori_bridge/src/api/default_editor_api.dart';
 import 'package:sesori_bridge/src/api/wake_lock_client.dart';
+import 'package:sesori_bridge/src/auth/bridge_id_storage.dart';
 import 'package:sesori_bridge/src/auth/bridge_registration_api.dart';
 import 'package:sesori_bridge/src/auth/bridge_registration_repository.dart';
 import 'package:sesori_bridge/src/auth/bridge_registration_service.dart';
@@ -271,16 +272,27 @@ class LogoutCommand extends cli.Command<void> {
 /// Removes this bridge's registration on the auth server before the token
 /// file is deleted. Callers treat any failure as non-fatal.
 Future<void> _unregisterBridgeRegistration({required String authBackendUrl}) async {
+  final bridgeIdStorage = BridgeIdStorage(filePath: bridgeIdPath());
+  if (await bridgeIdStorage.read() == null) {
+    // Adopt a legacy id persisted by an older bridge inside token.json so a
+    // never-reconnected legacy install still unregisters cleanly; the service
+    // reads the bridge id back out of storage.
+    final legacy = await readLegacyBridgeId();
+    if (legacy == null) {
+      // Nothing registered to remove.
+      return;
+    }
+    await bridgeIdStorage.write(bridgeId: legacy);
+  }
+
   final TokenData tokens;
   try {
     tokens = await loadTokens();
   } on Object catch (e) {
-    // No stored tokens — nothing registered to remove. A corrupt token file
-    // also lands here; logout still proceeds, but leave a trace.
+    // A registered bridge with no usable token file — there is no credential
+    // left to authenticate the unregister call. Logout still proceeds, but
+    // leave a trace.
     Log.w('Skipping bridge unregistration; could not load tokens: $e');
-    return;
-  }
-  if (tokens.bridgeId == null) {
     return;
   }
 
@@ -297,8 +309,8 @@ Future<void> _unregisterBridgeRegistration({required String authBackendUrl}) asy
         api: BridgeRegistrationApi(authBackendUrl: authBackendUrl, client: httpClient),
       ),
       tokenRefresher: tokenManager,
-      loadTokens: loadTokens,
-      saveTokens: saveTokens,
+      bridgeIdStorage: bridgeIdStorage,
+      readLegacyBridgeId: readLegacyBridgeId,
       hostName: Platform.localHostname,
       platform: BridgeRegistrationService.currentPlatformName(),
     );

--- a/bridge/app/lib/src/auth/bridge_id_migration_service.dart
+++ b/bridge/app/lib/src/auth/bridge_id_migration_service.dart
@@ -1,0 +1,38 @@
+import "bridge_id_storage.dart";
+
+/// Copies a bridge id persisted by an older bridge inside `token.json` into the
+/// dedicated [BridgeIdStorage], exactly once.
+///
+/// Earlier bridges stored the server-minted id alongside the tokens. It now
+/// lives in its own file, so an upgraded install must copy the legacy id across
+/// before any auth path rewrites `token.json` — the new `TokenData` no longer
+/// serializes `bridgeId`, so the first token save would otherwise erase the
+/// only copy and force a duplicate registration. [migrate] must therefore run
+/// before the first authentication, and its failures propagate so startup
+/// retries the copy instead of proceeding with an empty storage.
+class BridgeIdMigrationService {
+  final BridgeIdStorage _bridgeIdStorage;
+  final Future<String?> Function() _readLegacyBridgeId;
+
+  BridgeIdMigrationService({
+    required BridgeIdStorage bridgeIdStorage,
+    required Future<String?> Function() readLegacyBridgeId,
+  }) : _bridgeIdStorage = bridgeIdStorage,
+       _readLegacyBridgeId = readLegacyBridgeId;
+
+  /// Adopts the legacy bridge id when [BridgeIdStorage] is empty.
+  ///
+  /// A no-op once the storage already holds an id (a fresh install never had a
+  /// legacy id, and a completed migration is idempotent). Any read/write
+  /// failure propagates so the caller can abort startup and retry before a
+  /// token save erases the legacy source.
+  Future<void> migrate() async {
+    if (await _bridgeIdStorage.read() != null) {
+      return;
+    }
+    final legacy = await _readLegacyBridgeId();
+    if (legacy != null) {
+      await _bridgeIdStorage.write(bridgeId: legacy);
+    }
+  }
+}

--- a/bridge/app/lib/src/auth/bridge_id_storage.dart
+++ b/bridge/app/lib/src/auth/bridge_id_storage.dart
@@ -1,0 +1,48 @@
+import "dart:io";
+
+/// File-backed persistence for the bridge id assigned by the auth server's
+/// `/auth/bridges` endpoint.
+///
+/// The bridge id lives in its own plain-text file (one trimmed string, no
+/// JSON) rather than inside the token file, so it survives in supervised mode
+/// where the GUI supplies tokens over the control channel and no token file
+/// exists on disk.
+class BridgeIdStorage {
+  final String _path;
+
+  BridgeIdStorage({required String filePath}) : _path = filePath;
+
+  /// Returns the persisted bridge id, or null when no id has been stored yet
+  /// (missing file) or the file is empty.
+  Future<String?> read() async {
+    if (!File(_path).existsSync()) {
+      return null;
+    }
+    final contents = (await File(_path).readAsString()).trim();
+    return contents.isEmpty ? null : contents;
+  }
+
+  /// Persists [bridgeId], creating the data directory (0700) and the file
+  /// (0600) with restricted permissions on Unix, mirroring the token file.
+  Future<void> write({required String bridgeId}) async {
+    final dir = Directory(_path).parent;
+
+    await dir.create(recursive: true);
+    if (!Platform.isWindows) {
+      await Process.run('chmod', ['700', dir.path]);
+    }
+
+    await File(_path).writeAsString(bridgeId);
+    if (!Platform.isWindows) {
+      await Process.run('chmod', ['600', _path]);
+    }
+  }
+
+  /// Deletes the bridge id file. Does nothing when the file is absent.
+  Future<void> clear() async {
+    final file = File(_path);
+    if (file.existsSync()) {
+      await file.delete();
+    }
+  }
+}

--- a/bridge/app/lib/src/auth/bridge_registration_service.dart
+++ b/bridge/app/lib/src/auth/bridge_registration_service.dart
@@ -1,11 +1,9 @@
 import "dart:io";
 
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
-
 import "bridge_id_provider.dart";
+import "bridge_id_storage.dart";
 import "bridge_registration_api.dart";
 import "bridge_registration_repository.dart";
-import "token.dart";
 import "token_refresher.dart";
 
 /// Registers this bridge with the auth server and tracks the assigned
@@ -17,25 +15,26 @@ import "token_refresher.dart";
 class BridgeRegistrationService implements BridgeIdProvider {
   final BridgeRegistrationRepository _repository;
   final TokenRefresher _tokenRefresher;
-  final Future<TokenData> Function() _loadTokens;
-  final Future<void> Function(TokenData) _saveTokens;
+  final BridgeIdStorage _bridgeIdStorage;
+  final Future<String?> Function() _readLegacyBridgeId;
   final String _hostName;
   final String _platform;
 
   bool _registered = false;
+  bool _legacyAdoptionAttempted = false;
   String? _bridgeId;
 
   BridgeRegistrationService({
     required BridgeRegistrationRepository repository,
     required TokenRefresher tokenRefresher,
-    required Future<TokenData> Function() loadTokens,
-    required Future<void> Function(TokenData) saveTokens,
+    required BridgeIdStorage bridgeIdStorage,
+    required Future<String?> Function() readLegacyBridgeId,
     required String hostName,
     required String platform,
   }) : _repository = repository,
        _tokenRefresher = tokenRefresher,
-       _loadTokens = loadTokens,
-       _saveTokens = saveTokens,
+       _bridgeIdStorage = bridgeIdStorage,
+       _readLegacyBridgeId = readLegacyBridgeId,
        _hostName = sanitizeBridgeName(hostName),
        _platform = platform;
 
@@ -61,7 +60,7 @@ class BridgeRegistrationService implements BridgeIdProvider {
   /// Ensures this bridge is registered with the auth server.
   ///
   /// Posts the persisted bridge id (if any) so the server updates the
-  /// existing registration; the returned id is persisted to the token file.
+  /// existing registration; the returned id is persisted to its file.
   /// Throws on failure so the caller can fail the connect attempt and retry
   /// on its existing backoff.
   Future<void> ensureRegistered() async {
@@ -69,19 +68,19 @@ class BridgeRegistrationService implements BridgeIdProvider {
       return;
     }
 
-    final tokens = await _loadTokens();
+    final existingId = await _bridgeIdStorage.read() ?? await _adoptLegacyBridgeId();
     final summary = await _withAccessTokenRetry(
       (accessToken) => _repository.register(
         name: _hostName,
         platform: _platform,
-        bridgeId: tokens.bridgeId,
+        bridgeId: existingId,
         accessToken: accessToken,
       ),
     );
 
     _bridgeId = summary.id;
-    if (tokens.bridgeId != summary.id) {
-      await _persistBridgeId(summary.id);
+    if (existingId != summary.id) {
+      await _bridgeIdStorage.write(bridgeId: summary.id);
     }
     _registered = true;
   }
@@ -95,13 +94,7 @@ class BridgeRegistrationService implements BridgeIdProvider {
   Future<void> handleBridgeRevoked() async {
     _registered = false;
     _bridgeId = null;
-    try {
-      await _persistBridgeId(null);
-    } on Object catch (e) {
-      // A stale persisted id self-heals: re-registering with a revoked id
-      // makes the server mint a fresh one.
-      Log.w("[bridge-registration] failed to clear persisted bridge id: $e");
-    }
+    await _bridgeIdStorage.clear();
   }
 
   /// Removes this bridge's registration on the auth server.
@@ -109,8 +102,7 @@ class BridgeRegistrationService implements BridgeIdProvider {
   /// Does nothing when no bridge id is persisted. A 404 (already revoked)
   /// counts as success; any other failure is rethrown.
   Future<void> unregister() async {
-    final tokens = await _loadTokens();
-    final bridgeId = tokens.bridgeId;
+    final bridgeId = await _bridgeIdStorage.read();
     if (bridgeId == null) {
       return;
     }
@@ -126,6 +118,25 @@ class BridgeRegistrationService implements BridgeIdProvider {
     }
   }
 
+  /// Adopts the bridge id an older bridge persisted inside `token.json`, once.
+  ///
+  /// Runs only when [BridgeIdStorage] is empty (a fresh install or an upgrade
+  /// before the first registration) and at most once per process. Writing the
+  /// adopted id through to storage means subsequent calls read it from there
+  /// and never touch the legacy file again.
+  Future<String?> _adoptLegacyBridgeId() async {
+    if (_legacyAdoptionAttempted) {
+      return null;
+    }
+    _legacyAdoptionAttempted = true;
+
+    final legacy = await _readLegacyBridgeId();
+    if (legacy != null) {
+      await _bridgeIdStorage.write(bridgeId: legacy);
+    }
+    return legacy;
+  }
+
   Future<T> _withAccessTokenRetry<T>(Future<T> Function(String accessToken) action) async {
     final accessToken = await _tokenRefresher.getAccessToken();
     try {
@@ -137,21 +148,5 @@ class BridgeRegistrationService implements BridgeIdProvider {
       final refreshedToken = await _tokenRefresher.getAccessToken(forceRefresh: true);
       return action(refreshedToken);
     }
-  }
-
-  // Always re-reads the token file: the token refresher persists a rotated
-  // access/refresh pair mid-registration (e.g. on the 401-retry path), so a
-  // snapshot from before the register call would write stale credentials
-  // back to disk.
-  Future<void> _persistBridgeId(String? bridgeId) async {
-    final tokens = await _loadTokens();
-    await _saveTokens(
-      TokenData(
-        accessToken: tokens.accessToken,
-        refreshToken: tokens.refreshToken,
-        bridgeId: bridgeId,
-        lastProvider: tokens.lastProvider,
-      ),
-    );
   }
 }

--- a/bridge/app/lib/src/auth/bridge_registration_service.dart
+++ b/bridge/app/lib/src/auth/bridge_registration_service.dart
@@ -1,5 +1,7 @@
 import "dart:io";
 
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
 import "bridge_id_provider.dart";
 import "bridge_id_storage.dart";
 import "bridge_registration_api.dart";
@@ -12,29 +14,29 @@ import "token_refresher.dart";
 /// Registration is memoized per process: once [ensureRegistered] succeeds it
 /// returns immediately on subsequent calls until [handleBridgeRevoked]
 /// resets it (relay close code 4006 — bridge revoked).
+///
+/// The persisted bridge id is read from [BridgeIdStorage]; legacy ids from an
+/// older `token.json` are copied into that storage by `BridgeIdMigrationService`
+/// before authentication, so this service never reads `token.json`.
 class BridgeRegistrationService implements BridgeIdProvider {
   final BridgeRegistrationRepository _repository;
   final TokenRefresher _tokenRefresher;
   final BridgeIdStorage _bridgeIdStorage;
-  final Future<String?> Function() _readLegacyBridgeId;
   final String _hostName;
   final String _platform;
 
   bool _registered = false;
-  bool _legacyAdoptionAttempted = false;
   String? _bridgeId;
 
   BridgeRegistrationService({
     required BridgeRegistrationRepository repository,
     required TokenRefresher tokenRefresher,
     required BridgeIdStorage bridgeIdStorage,
-    required Future<String?> Function() readLegacyBridgeId,
     required String hostName,
     required String platform,
   }) : _repository = repository,
        _tokenRefresher = tokenRefresher,
        _bridgeIdStorage = bridgeIdStorage,
-       _readLegacyBridgeId = readLegacyBridgeId,
        _hostName = sanitizeBridgeName(hostName),
        _platform = platform;
 
@@ -68,7 +70,7 @@ class BridgeRegistrationService implements BridgeIdProvider {
       return;
     }
 
-    final existingId = await _bridgeIdStorage.read() ?? await _adoptLegacyBridgeId();
+    final existingId = await _bridgeIdStorage.read();
     final summary = await _withAccessTokenRetry(
       (accessToken) => _repository.register(
         name: _hostName,
@@ -94,13 +96,21 @@ class BridgeRegistrationService implements BridgeIdProvider {
   Future<void> handleBridgeRevoked() async {
     _registered = false;
     _bridgeId = null;
-    await _bridgeIdStorage.clear();
+    try {
+      await _bridgeIdStorage.clear();
+    } on Object catch (error, stackTrace) {
+      // Best-effort: a stale persisted id self-heals because re-registering
+      // with a revoked id makes the server mint a fresh one. Swallowing here
+      // keeps a transient filesystem error from aborting the reconnect path.
+      Log.w("Failed to clear persisted bridge id after revocation", error, stackTrace);
+    }
   }
 
   /// Removes this bridge's registration on the auth server.
   ///
   /// Does nothing when no bridge id is persisted. A 404 (already revoked)
-  /// counts as success; any other failure is rethrown.
+  /// counts as success; any other failure is rethrown. Clears the persisted
+  /// bridge id once the server no longer holds the registration.
   Future<void> unregister() async {
     final bridgeId = await _bridgeIdStorage.read();
     if (bridgeId == null) {
@@ -116,25 +126,7 @@ class BridgeRegistrationService implements BridgeIdProvider {
         rethrow;
       }
     }
-  }
-
-  /// Adopts the bridge id an older bridge persisted inside `token.json`, once.
-  ///
-  /// Runs only when [BridgeIdStorage] is empty (a fresh install or an upgrade
-  /// before the first registration) and at most once per process. Writing the
-  /// adopted id through to storage means subsequent calls read it from there
-  /// and never touch the legacy file again.
-  Future<String?> _adoptLegacyBridgeId() async {
-    if (_legacyAdoptionAttempted) {
-      return null;
-    }
-    _legacyAdoptionAttempted = true;
-
-    final legacy = await _readLegacyBridgeId();
-    if (legacy != null) {
-      await _bridgeIdStorage.write(bridgeId: legacy);
-    }
-    return legacy;
+    await _bridgeIdStorage.clear();
   }
 
   Future<T> _withAccessTokenRetry<T>(Future<T> Function(String accessToken) action) async {

--- a/bridge/app/lib/src/auth/login_email_repository.dart
+++ b/bridge/app/lib/src/auth/login_email_repository.dart
@@ -62,7 +62,6 @@ class LoginEmailRepository {
       TokenData(
         accessToken: authResponse.accessToken,
         refreshToken: authResponse.refreshToken,
-        bridgeId: null,
         lastProvider: AuthProvider.email,
       ),
       authResponse.user.providerUsername ?? "",

--- a/bridge/app/lib/src/auth/login_oauth_service.dart
+++ b/bridge/app/lib/src/auth/login_oauth_service.dart
@@ -236,7 +236,6 @@ class LoginOAuthService {
             return TokenData(
               accessToken: accessToken,
               refreshToken: refreshToken,
-              bridgeId: null,
               lastProvider: provider,
             );
           case AuthSessionStatusResponseDenied():

--- a/bridge/app/lib/src/auth/token.dart
+++ b/bridge/app/lib/src/auth/token.dart
@@ -2,22 +2,18 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:sesori_bridge_foundation/sesori_bridge_foundation.dart';
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Log;
 import 'package:sesori_shared/sesori_shared.dart';
 
 /// TokenData holds authentication tokens for the Sesori Bridge.
 class TokenData {
   final String accessToken;
   final String refreshToken;
-
-  /// The bridge id assigned by the auth server's `/auth/bridges` endpoint,
-  /// or null when this bridge has not registered yet.
-  final String? bridgeId;
   final AuthProvider lastProvider;
 
   TokenData({
     required this.accessToken,
     required this.refreshToken,
-    required this.bridgeId,
     required this.lastProvider,
   });
 
@@ -35,26 +31,49 @@ class TokenData {
     return TokenData(
       accessToken: json['accessToken'] as String,
       refreshToken: json['refreshToken'] as String,
-      bridgeId: json['bridgeId'] as String?,
       lastProvider: provider,
     );
   }
 
   /// Converts the TokenData instance to a JSON map.
   Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{
+    return <String, dynamic>{
       'accessToken': accessToken,
       'refreshToken': refreshToken,
+      'lastProvider': lastProvider.key,
     };
-    if (bridgeId != null) {
-      json['bridgeId'] = bridgeId;
-    }
-    json['lastProvider'] = lastProvider.key;
-    return json;
   }
 }
 
 String tokenPath() => '${sesoriDataDirectory()}/token.json';
+
+String bridgeIdPath() => '${sesoriDataDirectory()}/bridge_id';
+
+/// Reads the bridge id persisted by an older bridge inside `token.json`.
+///
+/// Earlier versions stored the server-minted bridge id alongside the tokens.
+/// It now lives in its own file, so this one-shot reader lets a freshly
+/// upgraded bridge adopt the legacy id once instead of re-registering and
+/// minting a duplicate entry. Returns null when the token file is absent,
+/// corrupt, or has no `bridgeId` key.
+Future<String?> readLegacyBridgeId() async {
+  final file = File(tokenPath());
+
+  try {
+    final json = jsonDecodeMap(await file.readAsString());
+    return json['bridgeId'] as String?;
+  } on PathNotFoundException {
+    // No legacy token file — nothing to adopt. This is the expected path on a
+    // fresh install and in supervised mode, so it is not worth logging.
+    return null;
+  } on FileSystemException catch (error) {
+    Log.w("Could not read legacy bridge id; skipping adoption", error);
+    return null;
+  } on FormatException catch (error) {
+    Log.w("Legacy token file is corrupt; skipping bridge-id adoption", error);
+    return null;
+  }
+}
 
 /// Saves the token data to the token file.
 /// Creates the directory structure if it doesn't exist.

--- a/bridge/app/lib/src/auth/token.dart
+++ b/bridge/app/lib/src/auth/token.dart
@@ -61,16 +61,17 @@ Future<String?> readLegacyBridgeId() async {
 
   try {
     final json = jsonDecodeMap(await file.readAsString());
-    return json['bridgeId'] as String?;
+    final bridgeId = json['bridgeId'];
+    return bridgeId is String ? bridgeId : null;
   } on PathNotFoundException {
     // No legacy token file — nothing to adopt. This is the expected path on a
     // fresh install and in supervised mode, so it is not worth logging.
     return null;
-  } on FileSystemException catch (error) {
-    Log.w("Could not read legacy bridge id; skipping adoption", error);
-    return null;
-  } on FormatException catch (error) {
-    Log.w("Legacy token file is corrupt; skipping bridge-id adoption", error);
+  } on Object catch (error, stackTrace) {
+    // A corrupt or unexpectedly-shaped legacy token file (FileSystemException,
+    // FormatException, or a TypeError from a non-map root) must not crash
+    // startup — skip adoption and let registration mint a fresh id.
+    Log.w("Could not read legacy bridge id; skipping adoption", error, stackTrace);
     return null;
   }
 }

--- a/bridge/app/lib/src/auth/token_manager.dart
+++ b/bridge/app/lib/src/auth/token_manager.dart
@@ -114,23 +114,10 @@ class TokenManager implements AccessTokenProvider, AccessTokenUpdater, TokenRefr
 
     _tokenSubject.add(authResponse.accessToken);
 
-    // Re-read the token file before persisting: bridge registration can write
-    // a freshly minted bridgeId while this refresh is in flight (the
-    // background refresh at startup races registration), and persisting the
-    // pre-refresh snapshot would wipe it. A corrupt file falls back to the
-    // snapshot (the save below repairs it); a missing file propagates so a
-    // logout that deleted the file mid-refresh is not resurrected.
-    TokenData latestTokens;
-    try {
-      latestTokens = await _loadTokens() ?? tokens;
-    } on FormatException {
-      latestTokens = tokens;
-    }
     final persistedTokens = TokenData(
       accessToken: authResponse.accessToken,
       refreshToken: authResponse.refreshToken,
-      bridgeId: latestTokens.bridgeId,
-      lastProvider: latestTokens.lastProvider,
+      lastProvider: tokens.lastProvider,
     );
     await _saveTokens(persistedTokens);
 

--- a/bridge/app/lib/src/auth/token_manager.dart
+++ b/bridge/app/lib/src/auth/token_manager.dart
@@ -112,16 +112,21 @@ class TokenManager implements AccessTokenProvider, AccessTokenUpdater, TokenRefr
 
     final authResponse = AuthResponse.fromJson(jsonDecodeMap(response.body));
 
-    _tokenSubject.add(authResponse.accessToken);
-
-    // Re-read the token file before persisting so a logout that deletes it
-    // mid-refresh is not resurrected: a missing file propagates (the refresh
-    // does not recreate cleared credentials), while a corrupt file falls back
-    // to the pre-refresh snapshot and the save below repairs it. Only
+    // Re-read the token file before persisting (and before publishing the new
+    // access token in-memory) so a logout that deletes it mid-refresh is not
+    // resurrected: a missing file — whether it throws or loads as null —
+    // propagates a TokenRefreshException so the refresh neither recreates the
+    // file nor leaves a usable token on the in-memory stream for a reconnect.
+    // A corrupt file (FormatException) is the one recoverable case: fall back
+    // to the pre-refresh snapshot and let the save below repair it. Only
     // `lastProvider` carries over; access/refresh come from the response.
     TokenData latestTokens;
     try {
-      latestTokens = await _loadTokens() ?? tokens;
+      final reloaded = await _loadTokens();
+      if (reloaded == null) {
+        throw const TokenRefreshException("Token file cleared during refresh");
+      }
+      latestTokens = reloaded;
     } on FormatException {
       latestTokens = tokens;
     }
@@ -131,6 +136,8 @@ class TokenManager implements AccessTokenProvider, AccessTokenUpdater, TokenRefr
       lastProvider: latestTokens.lastProvider,
     );
     await _saveTokens(persistedTokens);
+
+    _tokenSubject.add(authResponse.accessToken);
 
     return authResponse.accessToken;
   }

--- a/bridge/app/lib/src/auth/token_manager.dart
+++ b/bridge/app/lib/src/auth/token_manager.dart
@@ -114,10 +114,21 @@ class TokenManager implements AccessTokenProvider, AccessTokenUpdater, TokenRefr
 
     _tokenSubject.add(authResponse.accessToken);
 
+    // Re-read the token file before persisting so a logout that deletes it
+    // mid-refresh is not resurrected: a missing file propagates (the refresh
+    // does not recreate cleared credentials), while a corrupt file falls back
+    // to the pre-refresh snapshot and the save below repairs it. Only
+    // `lastProvider` carries over; access/refresh come from the response.
+    TokenData latestTokens;
+    try {
+      latestTokens = await _loadTokens() ?? tokens;
+    } on FormatException {
+      latestTokens = tokens;
+    }
     final persistedTokens = TokenData(
       accessToken: authResponse.accessToken,
       refreshToken: authResponse.refreshToken,
-      lastProvider: tokens.lastProvider,
+      lastProvider: latestTokens.lastProvider,
     );
     await _saveTokens(persistedTokens);
 

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart
@@ -84,7 +84,6 @@ class BridgeRuntimeAuthService {
           final tokensToSave = TokenData(
             accessToken: validation.accessToken,
             refreshToken: validation.refreshToken,
-            bridgeId: storedTokens.bridgeId,
             lastProvider: storedTokens.lastProvider,
           );
           await _saveTokens(tokensToSave);
@@ -153,30 +152,9 @@ class BridgeRuntimeAuthService {
         oAuthSessionToken = null;
     }
 
-    // A fresh login response never carries a bridge id, so carry over the one
-    // persisted by a previous registration. Otherwise an interactive re-login
-    // (e.g. expired refresh token) would wipe it and the next registration
-    // would mint a duplicate bridge entry. Carrying it across an account
-    // switch is safe: registration is idempotent on (userId, bridgeId), and a
-    // bridge id not owned by the new account just gets a fresh mint.
-    String? existingBridgeId;
-    try {
-      final existingTokens = await _loadTokens();
-      existingBridgeId = existingTokens.bridgeId;
-    } on PathNotFoundException {
-      // Token file missing — no previous bridge id to carry over.
-      existingBridgeId = null;
-    } on FileSystemException {
-      rethrow;
-    } on FormatException {
-      // Token file corrupt — no previous bridge id to carry over.
-      existingBridgeId = null;
-    }
-
     final tokensToSave = TokenData(
       accessToken: tokens.accessToken,
       refreshToken: tokens.refreshToken,
-      bridgeId: tokens.bridgeId ?? existingBridgeId,
       lastProvider: provider,
     );
     await _saveTokens(tokensToSave);

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -30,6 +30,7 @@ import "package:sesori_shared/sesori_shared.dart" show DeviceInfo;
 import "../../api/bridge_settings_api.dart";
 import "../../api/control_secret_api.dart";
 import "../../auth/access_token_provider.dart";
+import "../../auth/bridge_id_migration_service.dart";
 import "../../auth/bridge_id_storage.dart";
 import "../../auth/bridge_registration_api.dart";
 import "../../auth/bridge_registration_repository.dart";
@@ -283,6 +284,17 @@ class BridgeRuntimeRunner {
         }
       }
 
+      // Copy a legacy bridge id out of token.json into its own storage before
+      // authentication: the first token save no longer serializes bridgeId, so
+      // it would otherwise erase the only copy and force a duplicate
+      // registration. A failure here aborts startup so the next run retries the
+      // copy with the legacy source still intact.
+      final bridgeIdStorage = BridgeIdStorage(filePath: bridgeIdPath());
+      await BridgeIdMigrationService(
+        bridgeIdStorage: bridgeIdStorage,
+        readLegacyBridgeId: readLegacyBridgeId,
+      ).migrate();
+
       // Supervised mode short-circuits the interactive auth bootstrap: no
       // provider menu, no email/password prompt — the access token comes from
       // the GUI over the control channel. Standalone runs the unchanged
@@ -422,8 +434,7 @@ class BridgeRuntimeRunner {
           ),
         ),
         tokenRefresher: tokenRefresher,
-        bridgeIdStorage: BridgeIdStorage(filePath: bridgeIdPath()),
-        readLegacyBridgeId: readLegacyBridgeId,
+        bridgeIdStorage: bridgeIdStorage,
         hostName: io.Platform.localHostname,
         platform: BridgeRegistrationService.currentPlatformName(),
       );

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -30,6 +30,7 @@ import "package:sesori_shared/sesori_shared.dart" show DeviceInfo;
 import "../../api/bridge_settings_api.dart";
 import "../../api/control_secret_api.dart";
 import "../../auth/access_token_provider.dart";
+import "../../auth/bridge_id_storage.dart";
 import "../../auth/bridge_registration_api.dart";
 import "../../auth/bridge_registration_repository.dart";
 import "../../auth/bridge_registration_service.dart";
@@ -421,8 +422,8 @@ class BridgeRuntimeRunner {
           ),
         ),
         tokenRefresher: tokenRefresher,
-        loadTokens: loadTokens,
-        saveTokens: saveTokens,
+        bridgeIdStorage: BridgeIdStorage(filePath: bridgeIdPath()),
+        readLegacyBridgeId: readLegacyBridgeId,
         hostName: io.Platform.localHostname,
         platform: BridgeRegistrationService.currentPlatformName(),
       );

--- a/bridge/app/test/auth/bridge_id_migration_service_test.dart
+++ b/bridge/app/test/auth/bridge_id_migration_service_test.dart
@@ -1,0 +1,67 @@
+import "dart:io";
+
+import "package:sesori_bridge/src/auth/bridge_id_migration_service.dart";
+import "package:test/test.dart";
+
+import "../helpers/test_helpers.dart";
+
+void main() {
+  late FakeBridgeIdStorage storage;
+  late _RecordingLegacyReader legacyReader;
+
+  BridgeIdMigrationService buildService() => BridgeIdMigrationService(
+    bridgeIdStorage: storage,
+    readLegacyBridgeId: legacyReader.read,
+  );
+
+  setUp(() {
+    storage = FakeBridgeIdStorage();
+    legacyReader = _RecordingLegacyReader();
+  });
+
+  test("copies a legacy bridge id into empty storage", () async {
+    legacyReader.value = "br_legacy999";
+
+    await buildService().migrate();
+
+    expect(legacyReader.callCount, equals(1));
+    expect(storage.bridgeId, equals("br_legacy999"));
+  });
+
+  test("is a no-op and never reads legacy when storage already holds an id", () async {
+    storage.bridgeId = "br_existing1";
+    legacyReader.value = "br_legacy999";
+
+    await buildService().migrate();
+
+    expect(legacyReader.callCount, equals(0));
+    expect(storage.bridgeId, equals("br_existing1"));
+  });
+
+  test("leaves storage empty when there is no legacy id", () async {
+    legacyReader.value = null;
+
+    await buildService().migrate();
+
+    expect(storage.bridgeId, isNull);
+  });
+
+  test("propagates a write failure so startup can retry before token.json is rewritten", () async {
+    legacyReader.value = "br_legacy999";
+    storage.writeError = const FileSystemException("disk full");
+
+    await expectLater(buildService().migrate(), throwsA(isA<FileSystemException>()));
+    // The legacy source is untouched, so a retry can still adopt it.
+    expect(legacyReader.value, equals("br_legacy999"));
+  });
+}
+
+class _RecordingLegacyReader {
+  String? value;
+  int callCount = 0;
+
+  Future<String?> read() async {
+    callCount += 1;
+    return value;
+  }
+}

--- a/bridge/app/test/auth/bridge_id_storage_test.dart
+++ b/bridge/app/test/auth/bridge_id_storage_test.dart
@@ -1,0 +1,50 @@
+import "dart:io";
+
+import "package:sesori_bridge/src/auth/bridge_id_storage.dart";
+import "package:test/test.dart";
+
+void main() {
+  late Directory tempDir;
+  late BridgeIdStorage storage;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp("bridge_id_storage_test");
+    storage = BridgeIdStorage(filePath: "${tempDir.path}/nested/bridge_id");
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test("read returns null when the file is missing", () async {
+    expect(await storage.read(), isNull);
+  });
+
+  test("write then read round-trips the bridge id and creates the directory", () async {
+    await storage.write(bridgeId: "br_test1234");
+
+    expect(await storage.read(), equals("br_test1234"));
+  });
+
+  test("read returns null for an empty file", () async {
+    await storage.write(bridgeId: "   ");
+
+    expect(await storage.read(), isNull);
+  });
+
+  test("clear removes the persisted file", () async {
+    await storage.write(bridgeId: "br_test1234");
+
+    await storage.clear();
+
+    expect(await storage.read(), isNull);
+  });
+
+  test("clear is a no-op when the file is absent", () async {
+    await storage.clear();
+
+    expect(await storage.read(), isNull);
+  });
+}

--- a/bridge/app/test/auth/bridge_registration_service_test.dart
+++ b/bridge/app/test/auth/bridge_registration_service_test.dart
@@ -1,3 +1,5 @@
+import "dart:io";
+
 import "package:sesori_bridge/src/auth/bridge_registration_api.dart";
 import "package:sesori_bridge/src/auth/bridge_registration_repository.dart";
 import "package:sesori_bridge/src/auth/bridge_registration_service.dart";
@@ -11,24 +13,19 @@ void main() {
   late FakeBridgeRegistrationRepository repository;
   late FakeBridgeIdStorage bridgeIdStorage;
   late _RecordingTokenRefresher tokenRefresher;
-  late _RecordingLegacyReader legacyReader;
   late BridgeRegistrationService service;
-
-  BridgeRegistrationService buildService() => BridgeRegistrationService(
-    repository: repository,
-    tokenRefresher: tokenRefresher,
-    bridgeIdStorage: bridgeIdStorage,
-    readLegacyBridgeId: legacyReader.read,
-    hostName: "dev-laptop",
-    platform: "macos",
-  );
 
   setUp(() {
     repository = FakeBridgeRegistrationRepository();
     bridgeIdStorage = FakeBridgeIdStorage();
     tokenRefresher = _RecordingTokenRefresher();
-    legacyReader = _RecordingLegacyReader();
-    service = buildService();
+    service = BridgeRegistrationService(
+      repository: repository,
+      tokenRefresher: tokenRefresher,
+      bridgeIdStorage: bridgeIdStorage,
+      hostName: "dev-laptop",
+      platform: "macos",
+    );
   });
 
   group("BridgeRegistrationService.ensureRegistered", () {
@@ -49,32 +46,6 @@ void main() {
       expect(repository.registeredBridgeIds, equals(["br_persisted1"]));
       expect(service.bridgeId, equals("br_persisted1"));
       expect(bridgeIdStorage.bridgeId, equals("br_persisted1"));
-      expect(legacyReader.callCount, equals(0));
-    });
-
-    test("adopts a legacy bridge id from token.json when storage is empty", () async {
-      legacyReader.value = "br_legacy999";
-      repository.nextBridgeId = "br_legacy999";
-
-      await service.ensureRegistered();
-
-      expect(legacyReader.callCount, equals(1));
-      expect(repository.registeredBridgeIds, equals(["br_legacy999"]));
-      expect(service.bridgeId, equals("br_legacy999"));
-      // The adopted id is written through to storage during adoption.
-      expect(bridgeIdStorage.bridgeId, equals("br_legacy999"));
-    });
-
-    test("attempts legacy adoption at most once per process", () async {
-      legacyReader.value = null;
-      repository.registerError = BridgeRegistrationException(statusCode: 500, body: "boom");
-
-      await expectLater(service.ensureRegistered(), throwsA(isA<BridgeRegistrationException>()));
-
-      repository.registerError = null;
-      await service.ensureRegistered();
-
-      expect(legacyReader.callCount, equals(1));
     });
 
     test("is memoized per process — a second call does not re-register", () async {
@@ -142,6 +113,20 @@ void main() {
       expect(service.bridgeId, equals("br_fresh5678"));
       expect(bridgeIdStorage.bridgeId, equals("br_fresh5678"));
     });
+
+    test("still resets the memoization when clearing storage fails", () async {
+      await service.ensureRegistered();
+      bridgeIdStorage.clearError = const FileSystemException("clear failed");
+
+      await service.handleBridgeRevoked();
+
+      expect(service.bridgeId, isNull);
+
+      bridgeIdStorage.clearError = null;
+      await service.ensureRegistered();
+
+      expect(repository.registeredBridgeIds, hasLength(2));
+    });
   });
 
   group("BridgeRegistrationService.unregister", () {
@@ -151,37 +136,38 @@ void main() {
       expect(repository.unregisteredBridgeIds, isEmpty);
     });
 
-    test("deletes the persisted bridge id on the auth server", () async {
+    test("deletes the persisted bridge id on the auth server and clears storage", () async {
       bridgeIdStorage.bridgeId = "br_persisted1";
 
       await service.unregister();
 
       expect(repository.unregisteredBridgeIds, equals(["br_persisted1"]));
+      expect(bridgeIdStorage.bridgeId, isNull);
     });
 
-    test("treats a 404 (already revoked) as success", () async {
+    test("treats a 404 (already revoked) as success and clears storage", () async {
       bridgeIdStorage.bridgeId = "br_persisted1";
       final failingRepository = _UnregisterFailingRepository(statusCode: 404);
       final failingService = BridgeRegistrationService(
         repository: failingRepository,
         tokenRefresher: tokenRefresher,
         bridgeIdStorage: bridgeIdStorage,
-        readLegacyBridgeId: legacyReader.read,
         hostName: "dev-laptop",
         platform: "macos",
       );
 
       await failingService.unregister();
+
+      expect(bridgeIdStorage.bridgeId, isNull);
     });
 
-    test("rethrows non-404 failures", () async {
+    test("rethrows non-404 failures and keeps the persisted id", () async {
       bridgeIdStorage.bridgeId = "br_persisted1";
       final failingRepository = _UnregisterFailingRepository(statusCode: 500);
       final failingService = BridgeRegistrationService(
         repository: failingRepository,
         tokenRefresher: tokenRefresher,
         bridgeIdStorage: bridgeIdStorage,
-        readLegacyBridgeId: legacyReader.read,
         hostName: "dev-laptop",
         platform: "macos",
       );
@@ -190,6 +176,7 @@ void main() {
         failingService.unregister(),
         throwsA(isA<BridgeRegistrationException>().having((e) => e.statusCode, "statusCode", 500)),
       );
+      expect(bridgeIdStorage.bridgeId, equals("br_persisted1"));
     });
   });
 }
@@ -206,16 +193,6 @@ class _RecordingTokenRefresher implements TokenRefresher {
       return "refreshed-token";
     }
     return "access-token";
-  }
-}
-
-class _RecordingLegacyReader {
-  String? value;
-  int callCount = 0;
-
-  Future<String?> read() async {
-    callCount += 1;
-    return value;
   }
 }
 

--- a/bridge/app/test/auth/bridge_registration_service_test.dart
+++ b/bridge/app/test/auth/bridge_registration_service_test.dart
@@ -1,7 +1,6 @@
 import "package:sesori_bridge/src/auth/bridge_registration_api.dart";
 import "package:sesori_bridge/src/auth/bridge_registration_repository.dart";
 import "package:sesori_bridge/src/auth/bridge_registration_service.dart";
-import "package:sesori_bridge/src/auth/token.dart";
 import "package:sesori_bridge/src/auth/token_refresher.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -10,24 +9,26 @@ import "../helpers/test_helpers.dart";
 
 void main() {
   late FakeBridgeRegistrationRepository repository;
-  late InMemoryTokenStore tokenStore;
+  late FakeBridgeIdStorage bridgeIdStorage;
   late _RecordingTokenRefresher tokenRefresher;
+  late _RecordingLegacyReader legacyReader;
   late BridgeRegistrationService service;
+
+  BridgeRegistrationService buildService() => BridgeRegistrationService(
+    repository: repository,
+    tokenRefresher: tokenRefresher,
+    bridgeIdStorage: bridgeIdStorage,
+    readLegacyBridgeId: legacyReader.read,
+    hostName: "dev-laptop",
+    platform: "macos",
+  );
 
   setUp(() {
     repository = FakeBridgeRegistrationRepository();
-    tokenStore = InMemoryTokenStore(
-      TokenData(accessToken: "access", refreshToken: "refresh", bridgeId: null, lastProvider: AuthProvider.github),
-    );
+    bridgeIdStorage = FakeBridgeIdStorage();
     tokenRefresher = _RecordingTokenRefresher();
-    service = BridgeRegistrationService(
-      repository: repository,
-      tokenRefresher: tokenRefresher,
-      loadTokens: tokenStore.load,
-      saveTokens: tokenStore.save,
-      hostName: "dev-laptop",
-      platform: "macos",
-    );
+    legacyReader = _RecordingLegacyReader();
+    service = buildService();
   });
 
   group("BridgeRegistrationService.ensureRegistered", () {
@@ -36,48 +37,44 @@ void main() {
 
       expect(repository.registeredBridgeIds, equals([null]));
       expect(service.bridgeId, equals("br_test1234"));
-      expect(tokenStore.tokens!.bridgeId, equals("br_test1234"));
-      expect(tokenStore.tokens!.accessToken, equals("access"));
-      expect(tokenStore.tokens!.refreshToken, equals("refresh"));
-      expect(tokenStore.tokens!.lastProvider, equals(AuthProvider.github));
+      expect(bridgeIdStorage.bridgeId, equals("br_test1234"));
     });
 
     test("posts the persisted bridge id when one exists", () async {
-      tokenStore.tokens = TokenData(
-        accessToken: "access",
-        refreshToken: "refresh",
-        bridgeId: "br_persisted1",
-        lastProvider: AuthProvider.github,
-      );
+      bridgeIdStorage.bridgeId = "br_persisted1";
       repository.nextBridgeId = "br_persisted1";
 
       await service.ensureRegistered();
 
       expect(repository.registeredBridgeIds, equals(["br_persisted1"]));
       expect(service.bridgeId, equals("br_persisted1"));
-      expect(tokenStore.tokens!.bridgeId, equals("br_persisted1"));
+      expect(bridgeIdStorage.bridgeId, equals("br_persisted1"));
+      expect(legacyReader.callCount, equals(0));
     });
 
-    test("does not clobber tokens rotated and persisted mid-registration (401-retry path)", () async {
-      // TokenManager persists a rotated access/refresh pair to the token file
-      // when it force-refreshes; persisting the bridge id afterwards must keep
-      // those rotated credentials, not a snapshot from before the refresh.
-      repository.registerError = BridgeRegistrationException(statusCode: 401, body: "expired");
-      tokenRefresher.onForceRefresh = () {
-        repository.registerError = null;
-        tokenStore.tokens = TokenData(
-          accessToken: "rotated-access",
-          refreshToken: "rotated-refresh",
-          bridgeId: null,
-          lastProvider: AuthProvider.github,
-        );
-      };
+    test("adopts a legacy bridge id from token.json when storage is empty", () async {
+      legacyReader.value = "br_legacy999";
+      repository.nextBridgeId = "br_legacy999";
 
       await service.ensureRegistered();
 
-      expect(tokenStore.tokens!.bridgeId, equals("br_test1234"));
-      expect(tokenStore.tokens!.accessToken, equals("rotated-access"));
-      expect(tokenStore.tokens!.refreshToken, equals("rotated-refresh"));
+      expect(legacyReader.callCount, equals(1));
+      expect(repository.registeredBridgeIds, equals(["br_legacy999"]));
+      expect(service.bridgeId, equals("br_legacy999"));
+      // The adopted id is written through to storage during adoption.
+      expect(bridgeIdStorage.bridgeId, equals("br_legacy999"));
+    });
+
+    test("attempts legacy adoption at most once per process", () async {
+      legacyReader.value = null;
+      repository.registerError = BridgeRegistrationException(statusCode: 500, body: "boom");
+
+      await expectLater(service.ensureRegistered(), throwsA(isA<BridgeRegistrationException>()));
+
+      repository.registerError = null;
+      await service.ensureRegistered();
+
+      expect(legacyReader.callCount, equals(1));
     });
 
     test("is memoized per process — a second call does not re-register", () async {
@@ -137,22 +134,13 @@ void main() {
       await service.handleBridgeRevoked();
 
       expect(service.bridgeId, isNull);
-      expect(tokenStore.tokens!.bridgeId, isNull);
+      expect(bridgeIdStorage.bridgeId, isNull);
 
       await service.ensureRegistered();
 
       expect(repository.registeredBridgeIds, equals([null, null]));
       expect(service.bridgeId, equals("br_fresh5678"));
-      expect(tokenStore.tokens!.bridgeId, equals("br_fresh5678"));
-    });
-
-    test("still resets the memoization when the token file cannot be updated", () async {
-      await service.ensureRegistered();
-      tokenStore.tokens = null; // Loading now throws FileSystemException.
-
-      await service.handleBridgeRevoked();
-
-      expect(service.bridgeId, isNull);
+      expect(bridgeIdStorage.bridgeId, equals("br_fresh5678"));
     });
   });
 
@@ -164,12 +152,7 @@ void main() {
     });
 
     test("deletes the persisted bridge id on the auth server", () async {
-      tokenStore.tokens = TokenData(
-        accessToken: "access",
-        refreshToken: "refresh",
-        bridgeId: "br_persisted1",
-        lastProvider: AuthProvider.github,
-      );
+      bridgeIdStorage.bridgeId = "br_persisted1";
 
       await service.unregister();
 
@@ -177,18 +160,13 @@ void main() {
     });
 
     test("treats a 404 (already revoked) as success", () async {
-      tokenStore.tokens = TokenData(
-        accessToken: "access",
-        refreshToken: "refresh",
-        bridgeId: "br_persisted1",
-        lastProvider: AuthProvider.github,
-      );
+      bridgeIdStorage.bridgeId = "br_persisted1";
       final failingRepository = _UnregisterFailingRepository(statusCode: 404);
       final failingService = BridgeRegistrationService(
         repository: failingRepository,
         tokenRefresher: tokenRefresher,
-        loadTokens: tokenStore.load,
-        saveTokens: tokenStore.save,
+        bridgeIdStorage: bridgeIdStorage,
+        readLegacyBridgeId: legacyReader.read,
         hostName: "dev-laptop",
         platform: "macos",
       );
@@ -197,18 +175,13 @@ void main() {
     });
 
     test("rethrows non-404 failures", () async {
-      tokenStore.tokens = TokenData(
-        accessToken: "access",
-        refreshToken: "refresh",
-        bridgeId: "br_persisted1",
-        lastProvider: AuthProvider.github,
-      );
+      bridgeIdStorage.bridgeId = "br_persisted1";
       final failingRepository = _UnregisterFailingRepository(statusCode: 500);
       final failingService = BridgeRegistrationService(
         repository: failingRepository,
         tokenRefresher: tokenRefresher,
-        loadTokens: tokenStore.load,
-        saveTokens: tokenStore.save,
+        bridgeIdStorage: bridgeIdStorage,
+        readLegacyBridgeId: legacyReader.read,
         hostName: "dev-laptop",
         platform: "macos",
       );
@@ -233,6 +206,16 @@ class _RecordingTokenRefresher implements TokenRefresher {
       return "refreshed-token";
     }
     return "access-token";
+  }
+}
+
+class _RecordingLegacyReader {
+  String? value;
+  int callCount = 0;
+
+  Future<String?> read() async {
+    callCount += 1;
+    return value;
   }
 }
 

--- a/bridge/app/test/auth/token_manager_test.dart
+++ b/bridge/app/test/auth/token_manager_test.dart
@@ -207,8 +207,9 @@ void main() {
 
       var loadCalls = 0;
       TokenData? savedTokens;
+      final initialToken = _makeJwtFromNow(10);
       final manager = TokenManager(
-        initialToken: _makeJwtFromNow(10),
+        initialToken: initialToken,
         authBackendUrl: server.baseUrl,
         loadTokens: () async {
           loadCalls += 1;
@@ -228,6 +229,40 @@ void main() {
 
       await expectLater(manager.getAccessToken(), throwsA(isA<FileSystemException>()));
       expect(savedTokens, isNull);
+      // The refreshed token must not leak onto the in-memory stream when the
+      // file was cleared mid-refresh — a reconnect must not be able to use it.
+      expect(manager.accessToken, initialToken);
+    });
+
+    test("refresh that finds the token file cleared (null) does not publish the new token", () async {
+      final server = await _RefreshTestServer.start();
+      addTearDown(server.close);
+
+      var loadCalls = 0;
+      TokenData? savedTokens;
+      final initialToken = _makeJwtFromNow(10);
+      final manager = TokenManager(
+        initialToken: initialToken,
+        authBackendUrl: server.baseUrl,
+        loadTokens: () async {
+          loadCalls += 1;
+          if (loadCalls > 1) {
+            return null;
+          }
+          return TokenData(
+            accessToken: "old-access",
+            refreshToken: "refresh-token",
+            lastProvider: AuthProvider.github,
+          );
+        },
+        saveTokens: (tokens) async {
+          savedTokens = tokens;
+        },
+      );
+
+      await expectLater(manager.getAccessToken(), throwsA(isA<TokenRefreshException>()));
+      expect(savedTokens, isNull);
+      expect(manager.accessToken, initialToken);
     });
 
     test("successful refresh updates current access token", () async {

--- a/bridge/app/test/auth/token_manager_test.dart
+++ b/bridge/app/test/auth/token_manager_test.dart
@@ -20,7 +20,7 @@ void main() {
         initialToken: currentToken,
         authBackendUrl: server.baseUrl,
         loadTokens: () async =>
-            TokenData(accessToken: "a", refreshToken: "r", bridgeId: null, lastProvider: AuthProvider.github),
+            TokenData(accessToken: "a", refreshToken: "r", lastProvider: AuthProvider.github),
         saveTokens: (_) async {},
       );
 
@@ -52,7 +52,6 @@ void main() {
           return TokenData(
             accessToken: "old-access",
             refreshToken: "refresh-token",
-            bridgeId: null,
             lastProvider: AuthProvider.github,
           );
         },
@@ -85,7 +84,6 @@ void main() {
         loadTokens: () async => TokenData(
           accessToken: "old-access",
           refreshToken: "refresh-token",
-          bridgeId: null,
           lastProvider: AuthProvider.github,
         ),
         saveTokens: (_) async {},
@@ -107,7 +105,6 @@ void main() {
         loadTokens: () async => TokenData(
           accessToken: "old-access",
           refreshToken: "refresh-token",
-          bridgeId: null,
           lastProvider: AuthProvider.github,
         ),
         saveTokens: (_) async {},
@@ -129,7 +126,6 @@ void main() {
         loadTokens: () async => TokenData(
           accessToken: "old-access",
           refreshToken: "refresh-token",
-          bridgeId: null,
           lastProvider: AuthProvider.github,
         ),
         saveTokens: (_) async {},
@@ -145,7 +141,7 @@ void main() {
       expect(server.requestCount, 1);
     });
 
-    test("successful refresh persists new tokens while preserving bridgeId", () async {
+    test("successful refresh persists the rotated access/refresh pair", () async {
       final server = await _RefreshTestServer.start();
       addTearDown(server.close);
 
@@ -156,7 +152,6 @@ void main() {
         loadTokens: () async => TokenData(
           accessToken: "old-access",
           refreshToken: "refresh-token",
-          bridgeId: "br_abc12345",
           lastProvider: AuthProvider.github,
         ),
         saveTokens: (tokens) async {
@@ -169,117 +164,7 @@ void main() {
       expect(savedTokens, isNotNull);
       expect(savedTokens!.accessToken, "new-access-token");
       expect(savedTokens!.refreshToken, "new-refresh-token");
-      expect(savedTokens!.bridgeId, "br_abc12345");
-    });
-
-    test("refresh keeps a bridgeId persisted while the refresh was in flight", () async {
-      final requestReceived = Completer<void>();
-      final server = await _RefreshTestServer.start(
-        responseDelay: const Duration(milliseconds: 60),
-        onRequest: (_, __) {
-          if (!requestReceived.isCompleted) {
-            requestReceived.complete();
-          }
-        },
-      );
-      addTearDown(server.close);
-
-      var stored = TokenData(
-        accessToken: "old-access",
-        refreshToken: "refresh-token",
-        bridgeId: null,
-        lastProvider: AuthProvider.github,
-      );
-      final manager = TokenManager(
-        initialToken: _makeJwtFromNow(300),
-        authBackendUrl: server.baseUrl,
-        loadTokens: () async => stored,
-        saveTokens: (tokens) async {
-          stored = tokens;
-        },
-      );
-
-      final refreshFuture = manager.getAccessToken(forceRefresh: true);
-      // The refresh has loaded its pre-registration snapshot and is awaiting
-      // the HTTP response; registration now persists a freshly minted id.
-      await requestReceived.future.timeout(const Duration(seconds: 2));
-      stored = TokenData(
-        accessToken: stored.accessToken,
-        refreshToken: stored.refreshToken,
-        bridgeId: "br_minted123",
-        lastProvider: stored.lastProvider,
-      );
-
-      await refreshFuture;
-
-      expect(stored.bridgeId, "br_minted123");
-      expect(stored.accessToken, "new-access-token");
-      expect(stored.refreshToken, "new-refresh-token");
-    });
-
-    test("refresh repairs a corrupt token file by persisting the snapshot's merge fields", () async {
-      final server = await _RefreshTestServer.start();
-      addTearDown(server.close);
-
-      var loadCalls = 0;
-      TokenData? savedTokens;
-      final manager = TokenManager(
-        initialToken: _makeJwtFromNow(10),
-        authBackendUrl: server.baseUrl,
-        loadTokens: () async {
-          loadCalls += 1;
-          if (loadCalls > 1) {
-            throw const FormatException("corrupt token file");
-          }
-          return TokenData(
-            accessToken: "old-access",
-            refreshToken: "refresh-token",
-            bridgeId: "br_abc12345",
-            lastProvider: AuthProvider.github,
-          );
-        },
-        saveTokens: (tokens) async {
-          savedTokens = tokens;
-        },
-      );
-
-      final token = await manager.getAccessToken();
-
-      expect(token, "new-access-token");
-      expect(savedTokens, isNotNull);
-      expect(savedTokens!.accessToken, "new-access-token");
-      expect(savedTokens!.refreshToken, "new-refresh-token");
-      expect(savedTokens!.bridgeId, "br_abc12345");
-    });
-
-    test("refresh does not recreate a token file deleted mid-refresh", () async {
-      final server = await _RefreshTestServer.start();
-      addTearDown(server.close);
-
-      var loadCalls = 0;
-      TokenData? savedTokens;
-      final manager = TokenManager(
-        initialToken: _makeJwtFromNow(10),
-        authBackendUrl: server.baseUrl,
-        loadTokens: () async {
-          loadCalls += 1;
-          if (loadCalls > 1) {
-            throw const FileSystemException("token file deleted", "token.json", OSError("No such file", 2));
-          }
-          return TokenData(
-            accessToken: "old-access",
-            refreshToken: "refresh-token",
-            bridgeId: null,
-            lastProvider: AuthProvider.github,
-          );
-        },
-        saveTokens: (tokens) async {
-          savedTokens = tokens;
-        },
-      );
-
-      await expectLater(manager.getAccessToken(), throwsA(isA<FileSystemException>()));
-      expect(savedTokens, isNull);
+      expect(savedTokens!.lastProvider, AuthProvider.github);
     });
 
     test("successful refresh updates current access token", () async {
@@ -292,7 +177,6 @@ void main() {
         loadTokens: () async => TokenData(
           accessToken: "old-access",
           refreshToken: "refresh-token",
-          bridgeId: null,
           lastProvider: AuthProvider.github,
         ),
         saveTokens: (_) async {},
@@ -313,7 +197,6 @@ void main() {
         loadTokens: () async => TokenData(
           accessToken: "old-access",
           refreshToken: "refresh-token",
-          bridgeId: null,
           lastProvider: AuthProvider.github,
         ),
         saveTokens: (_) async {},
@@ -329,7 +212,6 @@ void main() {
         loadTokens: () async => TokenData(
           accessToken: "old-access",
           refreshToken: "refresh-token",
-          bridgeId: null,
           lastProvider: AuthProvider.github,
         ),
         saveTokens: (_) async {},
@@ -361,7 +243,7 @@ void main() {
         initialToken: _makeJwtFromNow(10),
         authBackendUrl: server.baseUrl,
         loadTokens: () async =>
-            TokenData(accessToken: "old-access", refreshToken: "", bridgeId: null, lastProvider: AuthProvider.github),
+            TokenData(accessToken: "old-access", refreshToken: "", lastProvider: AuthProvider.github),
         saveTokens: (_) async {},
       );
 
@@ -379,7 +261,6 @@ void main() {
         loadTokens: () async => TokenData(
           accessToken: "old-access",
           refreshToken: "refresh-token",
-          bridgeId: null,
           lastProvider: AuthProvider.github,
         ),
         saveTokens: (_) async {},

--- a/bridge/app/test/auth/token_manager_test.dart
+++ b/bridge/app/test/auth/token_manager_test.dart
@@ -167,6 +167,69 @@ void main() {
       expect(savedTokens!.lastProvider, AuthProvider.github);
     });
 
+    test("refresh repairs a corrupt token file by persisting the response tokens", () async {
+      final server = await _RefreshTestServer.start();
+      addTearDown(server.close);
+
+      var loadCalls = 0;
+      TokenData? savedTokens;
+      final manager = TokenManager(
+        initialToken: _makeJwtFromNow(10),
+        authBackendUrl: server.baseUrl,
+        loadTokens: () async {
+          loadCalls += 1;
+          if (loadCalls > 1) {
+            throw const FormatException("corrupt token file");
+          }
+          return TokenData(
+            accessToken: "old-access",
+            refreshToken: "refresh-token",
+            lastProvider: AuthProvider.github,
+          );
+        },
+        saveTokens: (tokens) async {
+          savedTokens = tokens;
+        },
+      );
+
+      final token = await manager.getAccessToken();
+
+      expect(token, "new-access-token");
+      expect(savedTokens, isNotNull);
+      expect(savedTokens!.accessToken, "new-access-token");
+      expect(savedTokens!.refreshToken, "new-refresh-token");
+      expect(savedTokens!.lastProvider, AuthProvider.github);
+    });
+
+    test("refresh does not recreate a token file deleted mid-refresh", () async {
+      final server = await _RefreshTestServer.start();
+      addTearDown(server.close);
+
+      var loadCalls = 0;
+      TokenData? savedTokens;
+      final manager = TokenManager(
+        initialToken: _makeJwtFromNow(10),
+        authBackendUrl: server.baseUrl,
+        loadTokens: () async {
+          loadCalls += 1;
+          if (loadCalls > 1) {
+            throw const FileSystemException("token file deleted", "token.json", OSError("No such file", 2));
+          }
+          return TokenData(
+            accessToken: "old-access",
+            refreshToken: "refresh-token",
+            lastProvider: AuthProvider.github,
+          );
+        },
+        saveTokens: (tokens) async {
+          savedTokens = tokens;
+        },
+      );
+
+      await expectLater(manager.getAccessToken(), throwsA(isA<FileSystemException>()));
+      expect(savedTokens, isNull);
+    });
+
     test("successful refresh updates current access token", () async {
       final server = await _RefreshTestServer.start();
       addTearDown(server.close);

--- a/bridge/app/test/auth/token_test.dart
+++ b/bridge/app/test/auth/token_test.dart
@@ -8,7 +8,6 @@ void main() {
       final original = TokenData(
         accessToken: "access-token",
         refreshToken: "refresh-token",
-        bridgeId: "br_abc12345",
         lastProvider: AuthProvider.github,
       );
 
@@ -16,50 +15,33 @@ void main() {
 
       expect(restored.accessToken, equals(original.accessToken));
       expect(restored.refreshToken, equals(original.refreshToken));
-      expect(restored.bridgeId, equals(original.bridgeId));
       expect(restored.lastProvider, equals(original.lastProvider));
     });
 
-    test("toJson omits bridgeId when it is null", () {
+    test("toJson serializes the provider key", () {
       final data = TokenData(
         accessToken: "access-token",
         refreshToken: "refresh-token",
-        bridgeId: null,
         lastProvider: AuthProvider.github,
       );
 
       final json = data.toJson();
 
-      expect(json.containsKey("bridgeId"), isFalse);
       expect(json["lastProvider"], equals("github"));
     });
 
-    test("fromJson sets bridgeId to null when missing", () {
+    test("fromJson ignores a legacy bridgeId key from old token files", () {
       final restored = TokenData.fromJson(<String, dynamic>{
         "accessToken": "access-token",
         "refreshToken": "refresh-token",
-        "lastProvider": "google",
-      });
-
-      expect(restored.accessToken, equals("access-token"));
-      expect(restored.refreshToken, equals("refresh-token"));
-      expect(restored.bridgeId, isNull);
-      expect(restored.lastProvider, equals(AuthProvider.google));
-    });
-
-    test("fromJson ignores the legacy bridgeToken key from old token files", () {
-      final restored = TokenData.fromJson(<String, dynamic>{
-        "accessToken": "access-token",
-        "refreshToken": "refresh-token",
-        "bridgeToken": "legacy-bridge-token",
+        "bridgeId": "br_abc12345",
         "lastProvider": "github",
       });
 
       expect(restored.accessToken, equals("access-token"));
       expect(restored.refreshToken, equals("refresh-token"));
-      expect(restored.bridgeId, isNull);
       expect(restored.lastProvider, equals(AuthProvider.github));
-      expect(restored.toJson().containsKey("bridgeToken"), isFalse);
+      expect(restored.toJson().containsKey("bridgeId"), isFalse);
     });
 
     test("fromJson throws when lastProvider is missing", () {

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -4,7 +4,6 @@ import "dart:io";
 import "package:http/http.dart" as http;
 import "package:sesori_bridge/src/auth/bridge_registration_api.dart";
 import "package:sesori_bridge/src/auth/bridge_registration_service.dart";
-import "package:sesori_bridge/src/auth/token.dart";
 import "package:sesori_bridge/src/bridge/api/filesystem_api.dart";
 import "package:sesori_bridge/src/bridge/api/git_cli_api.dart";
 import "package:sesori_bridge/src/bridge/foundation/filesystem_permission_validator.dart";
@@ -68,7 +67,7 @@ void main() {
       final authMessage = await _firstTextMessage(bridgeSocket);
 
       expect(repository.registeredBridgeIds, equals([null]));
-      expect(harness.tokenStore.tokens!.bridgeId, equals("br_first001"));
+      expect(harness.bridgeIdStorage.bridgeId, equals("br_first001"));
       expect(authMessage["type"], equals("auth"));
       expect(authMessage["role"], equals("bridge"));
       expect(authMessage["bridgeId"], equals("br_first001"));
@@ -109,7 +108,7 @@ void main() {
         equals([null, null]),
         reason: "the revoked bridge id must not be re-posted",
       );
-      expect(harness.tokenStore.tokens!.bridgeId, equals("br_second002"));
+      expect(harness.bridgeIdStorage.bridgeId, equals("br_second002"));
       expect(authMessage["bridgeId"], equals("br_second002"));
     });
 
@@ -161,7 +160,7 @@ Future<void> _waitFor(bool Function() condition, {required String reason}) async
 
 class _RegistrationHarness {
   final FakeBridgePlugin plugin;
-  final InMemoryTokenStore tokenStore;
+  final FakeBridgeIdStorage bridgeIdStorage;
   final OrchestratorSession session;
   final Future<void> runFuture;
   final _CountingRelayServer relayServer;
@@ -169,7 +168,7 @@ class _RegistrationHarness {
 
   _RegistrationHarness._({
     required this.plugin,
-    required this.tokenStore,
+    required this.bridgeIdStorage,
     required this.session,
     required this.runFuture,
     required this.relayServer,
@@ -182,14 +181,12 @@ class _RegistrationHarness {
     final relayServer = await _CountingRelayServer.start();
     final database = createTestDatabase();
     final plugin = FakeBridgePlugin();
-    final tokenStore = InMemoryTokenStore(
-      TokenData(accessToken: "access", refreshToken: "refresh", bridgeId: null, lastProvider: AuthProvider.github),
-    );
+    final bridgeIdStorage = FakeBridgeIdStorage();
     final registrationService = BridgeRegistrationService(
       repository: repository,
       tokenRefresher: FakeTokenRefresher(),
-      loadTokens: tokenStore.load,
-      saveTokens: tokenStore.save,
+      bridgeIdStorage: bridgeIdStorage,
+      readLegacyBridgeId: () async => null,
       hostName: "test-host",
       platform: "macos",
     );
@@ -296,7 +293,7 @@ class _RegistrationHarness {
 
     return _RegistrationHarness._(
       plugin: plugin,
-      tokenStore: tokenStore,
+      bridgeIdStorage: bridgeIdStorage,
       session: session,
       runFuture: runFuture,
       relayServer: relayServer,

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -186,7 +186,6 @@ class _RegistrationHarness {
       repository: repository,
       tokenRefresher: FakeTokenRefresher(),
       bridgeIdStorage: bridgeIdStorage,
-      readLegacyBridgeId: () async => null,
       hostName: "test-host",
       platform: "macos",
     );

--- a/bridge/app/test/bridge/runtime/bridge_runtime_auth_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_auth_test.dart
@@ -40,13 +40,11 @@ void main() {
       final storedTokens = TokenData(
         accessToken: 'expired-access-token',
         refreshToken: 'expired-refresh-token',
-        bridgeId: 'existing-bridge-id',
         lastProvider: AuthProvider.google,
       );
       final oauthTokens = TokenData(
         accessToken: 'oauth-access-token',
         refreshToken: 'oauth-refresh-token',
-        bridgeId: null,
         lastProvider: AuthProvider.google,
       );
       TokenData? savedTokens;
@@ -56,7 +54,6 @@ void main() {
           expect(sessionToken, equals('oauth-session-token'));
           expect(savedTokens, isNotNull);
           expect(savedTokens!.accessToken, equals('oauth-access-token'));
-          expect(savedTokens!.bridgeId, equals('existing-bridge-id'));
         },
       );
       final service = BridgeRuntimeAuthService(
@@ -73,7 +70,6 @@ void main() {
       final result = await service.ensureAuthenticated(options: _options(authBackendUrl: authBackend.baseUrl));
 
       expect(result.accessToken, equals('oauth-access-token'));
-      expect(result.bridgeId, equals('existing-bridge-id'));
       expect(oauthService.ackCalls, equals(['oauth-session-token']));
     });
 
@@ -83,7 +79,6 @@ void main() {
       final storedTokens = TokenData(
         accessToken: 'expired-access-token',
         refreshToken: 'expired-refresh-token',
-        bridgeId: null,
         lastProvider: AuthProvider.github,
       );
       final oauthService = _FakeLoginOAuthService(error: Exception('authorization denied'));
@@ -110,13 +105,11 @@ void main() {
       final storedTokens = TokenData(
         accessToken: 'expired-access-token',
         refreshToken: 'expired-refresh-token',
-        bridgeId: null,
         lastProvider: AuthProvider.google,
       );
       final oauthTokens = TokenData(
         accessToken: 'oauth-access-token',
         refreshToken: 'oauth-refresh-token',
-        bridgeId: null,
         lastProvider: AuthProvider.google,
       );
       TokenData? savedTokens;

--- a/bridge/app/test/helpers/test_helpers.dart
+++ b/bridge/app/test/helpers/test_helpers.dart
@@ -43,6 +43,12 @@ class FakeTokenRefresher implements TokenRefresher {
 class FakeBridgeIdStorage implements BridgeIdStorage {
   String? bridgeId;
 
+  /// When non-null, [clear] throws this error instead of clearing.
+  Object? clearError;
+
+  /// When non-null, [write] throws this error instead of persisting.
+  Object? writeError;
+
   FakeBridgeIdStorage({this.bridgeId});
 
   @override
@@ -50,11 +56,19 @@ class FakeBridgeIdStorage implements BridgeIdStorage {
 
   @override
   Future<void> write({required String bridgeId}) async {
+    final error = writeError;
+    if (error != null) {
+      throw error;
+    }
     this.bridgeId = bridgeId;
   }
 
   @override
   Future<void> clear() async {
+    final error = clearError;
+    if (error != null) {
+      throw error;
+    }
     bridgeId = null;
   }
 }
@@ -105,13 +119,11 @@ class FakeBridgeRegistrationRepository implements BridgeRegistrationRepository {
 BridgeRegistrationService createFakeBridgeRegistrationService({
   BridgeRegistrationRepository? repository,
   BridgeIdStorage? bridgeIdStorage,
-  Future<String?> Function()? readLegacyBridgeId,
 }) {
   return BridgeRegistrationService(
     repository: repository ?? FakeBridgeRegistrationRepository(),
     tokenRefresher: FakeTokenRefresher(),
     bridgeIdStorage: bridgeIdStorage ?? FakeBridgeIdStorage(),
-    readLegacyBridgeId: readLegacyBridgeId ?? () async => null,
     hostName: "test-host",
     platform: "macos",
   );

--- a/bridge/app/test/helpers/test_helpers.dart
+++ b/bridge/app/test/helpers/test_helpers.dart
@@ -6,9 +6,9 @@ import "dart:math";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_bridge/src/auth/access_token_provider.dart";
 import "package:sesori_bridge/src/auth/bridge_id_provider.dart";
+import "package:sesori_bridge/src/auth/bridge_id_storage.dart";
 import "package:sesori_bridge/src/auth/bridge_registration_repository.dart";
 import "package:sesori_bridge/src/auth/bridge_registration_service.dart";
-import "package:sesori_bridge/src/auth/token.dart";
 import "package:sesori_bridge/src/auth/token_refresher.dart";
 import "package:sesori_bridge/src/bridge/relay_client.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -39,22 +39,23 @@ class FakeTokenRefresher implements TokenRefresher {
   Future<String> getAccessToken({bool forceRefresh = false}) async => "test-token";
 }
 
-/// In-memory token file substitute for [BridgeRegistrationService] tests.
-class InMemoryTokenStore {
-  TokenData? tokens;
+/// In-memory [BridgeIdStorage] substitute for [BridgeRegistrationService] tests.
+class FakeBridgeIdStorage implements BridgeIdStorage {
+  String? bridgeId;
 
-  InMemoryTokenStore([this.tokens]);
+  FakeBridgeIdStorage({this.bridgeId});
 
-  Future<TokenData> load() async {
-    final stored = tokens;
-    if (stored == null) {
-      throw const FileSystemException("no tokens stored");
-    }
-    return stored;
+  @override
+  Future<String?> read() async => bridgeId;
+
+  @override
+  Future<void> write({required String bridgeId}) async {
+    this.bridgeId = bridgeId;
   }
 
-  Future<void> save(TokenData data) async {
-    tokens = data;
+  @override
+  Future<void> clear() async {
+    bridgeId = null;
   }
 }
 
@@ -103,18 +104,14 @@ class FakeBridgeRegistrationRepository implements BridgeRegistrationRepository {
 /// for orchestrator and runtime tests.
 BridgeRegistrationService createFakeBridgeRegistrationService({
   BridgeRegistrationRepository? repository,
-  InMemoryTokenStore? tokenStore,
+  BridgeIdStorage? bridgeIdStorage,
+  Future<String?> Function()? readLegacyBridgeId,
 }) {
-  final store =
-      tokenStore ??
-      InMemoryTokenStore(
-        TokenData(accessToken: "access", refreshToken: "refresh", bridgeId: null, lastProvider: AuthProvider.github),
-      );
   return BridgeRegistrationService(
     repository: repository ?? FakeBridgeRegistrationRepository(),
     tokenRefresher: FakeTokenRefresher(),
-    loadTokens: store.load,
-    saveTokens: store.save,
+    bridgeIdStorage: bridgeIdStorage ?? FakeBridgeIdStorage(),
+    readLegacyBridgeId: readLegacyBridgeId ?? () async => null,
     hostName: "test-host",
     platform: "macos",
   );

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -265,7 +265,7 @@ seams through `module_core` interfaces, not `AuthManager` internals.
 | A3 | Single token authority (GUI), helper token-provided | eliminates cross-process refresh-rotation race |
 | A4 | Control-protocol DTOs in `sesori_shared` | only shared point between bridge + client workspaces; pure data |
 | A5 | `ControlChannelServer` name kept (vs Aristotle's `Listener`) | `Listener` implies one-way subscription; this is a duplex socket host; `Server` is now an explicit transport-host suffix and `DebugServer` is the precedent |
-| A6 | `bridgeId` persistence = a small file-backed storage **inside `auth/`** (no Dao) | one string; no DB/migration; keeps it within the self-contained auth subsystem so auth code doesn't depend on top-level `repositories/` |
+| A6 | `bridgeId` persistence = a small file-backed storage **inside `auth/`** (no Dao) — **implemented as `BridgeIdStorage`** | one string; no DB/migration; keeps it within the self-contained auth subsystem so auth code doesn't depend on top-level `repositories/`. Removing `bridgeId` from `TokenData` also deleted the token↔bridgeId carry-over re-reads; legacy ids are adopted once from `token.json` via an injected `readLegacyBridgeId` seam |
 | A7 | First-run provisioning UI is **v1** | first launch downloads OpenCode; user must see progress |
 | A8 | Control-channel secret delivered **off-argv** (inherited FD/pipe or stdin handshake), not `--control-secret` | argv is readable by other local processes/users; this channel issues bearer tokens, so an argv-leaked secret = token theft |
 | A9 | Helper exits on **control-channel loss** after a short grace period | if the GUI crashes/force-quits, the OS does not reliably kill the child; the helper must not linger invisibly with a live token |
@@ -314,7 +314,7 @@ Legend: ☐ pending · ◐ in-progress · ☑ done. Sizes: **S** ≤150 LOC · *
 - ☐ 1.3 Supervised auth bootstrap (short-circuit `ensureAuthenticated`) — Med / M
 - ☐ 1.4 Token provider **pull** over channel (+ timeout/GUI-down) — Med / M
 - ☐ 1.5 Token-stream **push** → relay client — Med / S-M
-- ☐ 1.6 Supervised registration + `bridgeId` out of `token.json` — Med / M
+- ☑ 1.6 Supervised registration + `bridgeId` out of `token.json` — Med / M
 - ☐ 1.7 Exit-code restart (`86`) + bypass successor-spawn — Med / S-M
 - ☐ 1.8 Disable self-update + reconcile when supervised — Low / S
 - ☐ 1.9 Re-home prompts/Console → control events — Med / M

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -278,12 +278,25 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   file-backed storage that lives **inside the `auth/` subsystem** (NOT new
   top-level `api/`+`repositories/` classes — that would make `auth/` depend back
   on the core repository layer; see ADR A6). Supervised registration uses the
-  supplied token; preserve carry-over semantics. Use **synchronous** filesystem
-  checks (`existsSync`/`statSync`) for the `avoid_slow_async_io` lint.
+  supplied token. Use **synchronous** filesystem checks (`existsSync`) for the
+  `avoid_slow_async_io` lint.
 - **Risk:** Med (touches `TokenData` persistence). **Size:** M.
 - **Acceptance:** supervised registers + persists bridgeId; standalone token.json
-  path unchanged.
-- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+  path unchanged (only the `bridgeId` field is removed).
+- **Aristotle:** plan ☑ · impl ☑. **Findings:** impl-review (3 rounds): (1)
+  `readLegacyBridgeId()` initially swallowed `FileSystemException`/`FormatException`
+  silently — now logs via `Log.w(message, error)` and treats `PathNotFoundException`
+  as the expected no-legacy path; (2) `BridgeIdStorage.write` used a positional
+  arg — made named `required`; (3) `FakeBridgeIdStorage` test fake used a
+  positional constructor param — made named. **Deltas:** since `bridgeId` now
+  owns its own file, the cross-writer races between token refresh and
+  registration disappear, so the carry-over re-read gymnastics in
+  `TokenManager._doRefresh`, `BridgeRuntimeAuthService._loginAndPersist`, and
+  `BridgeRegistrationService._persistBridgeId` were **deleted** rather than
+  ported. Legacy standalone users keep their id via one-time adoption from
+  `token.json` (read once when the new file is absent), implemented as an
+  injected `readLegacyBridgeId` seam so `auth/` never learns about `token.json`
+  internals from the service side.
 
 ## PR 1.7 — Exit-code restart (`86`) + bypass successor-spawn
 - **Goal:** In supervised mode `handleRestartHandoff()` flushes the


### PR DESCRIPTION
## Goal

In supervised mode (desktop GUI) the bridge receives its access token from the GUI over the control channel and there is **no `token.json`** on disk. But `bridgeId` was persisted inside `token.json` (`TokenData.bridgeId`), so `BridgeRegistrationService.ensureRegistered()` → `loadTokens()` threw `PathNotFoundException` in supervised mode and the server-minted id could not be persisted.

This moves `bridgeId` into a dedicated file-backed `BridgeIdStorage` inside the self-contained `auth/` subsystem (ADR A6). It works in both modes and lets us delete the bridgeId carry-over gymnastics that existed only because tokens and bridgeId shared one file.

## Changes

- **New `BridgeIdStorage`** (`auth/bridge_id_storage.dart`) — Layer-1 `Storage`, plain-text one-string file at `<sesori-data>/bridge_id`, injected path (tests pass a temp path). Mirrors `token.dart`'s 0700/0600 hardening; sync `existsSync` checks for `avoid_slow_async_io`.
- **`BridgeRegistrationService`** now depends on `BridgeIdStorage` + an injected `readLegacyBridgeId` seam instead of `loadTokens`/`saveTokens`. `handleBridgeRevoked` clears storage; `unregister` reads storage. Legacy adoption is memoized to run at most once per process.
- **`TokenData`** loses its `bridgeId` field. `token.dart` gains `bridgeIdPath()` and a top-level `readLegacyBridgeId()` (logs corrupt/unreadable token files via `Log.w`, treats `PathNotFoundException` as the expected no-legacy path).
- **Deleted carry-over**: `TokenManager._doRefresh` re-read/merge, `BridgeRuntimeAuthService._loginAndPersist` carry-over block, and `BridgeRegistrationService._persistBridgeId`. The mid-refresh races genuinely disappear once bridgeId has its own file.
- **Composition roots** (`bridge_runtime_runner.dart`, `bin/bridge.dart` logout-time unregister) wire `BridgeIdStorage(filePath: bridgeIdPath())` + `readLegacyBridgeId`.

## Behavior preserved

- Standalone `token.json` login/refresh path is behaviorally unchanged (only the `bridgeId` field is removed).
- Existing standalone users keep their id via **one-time legacy adoption** from `token.json` (read once when the new file is absent), rather than re-registering.

## Tests

- New `test/auth/bridge_id_storage_test.dart` (read-missing→null, round-trip, empty→null, clear).
- Rewrote `bridge_registration_service_test.dart` with `FakeBridgeIdStorage` + `readLegacyBridgeId` stub: minted-id persist, posts persisted id, legacy adoption + write-through, adoption-at-most-once, 401 retry, revoked clears + re-registers fresh, unregister reads storage, 404 success, rethrow non-404.
- Updated `token_test.dart`, `token_manager_test.dart`, `bridge_runtime_auth_test.dart`, `orchestrator_registration_test.dart`, `test_helpers.dart`.

## Verification

- `dart analyze --fatal-infos` (bridge/app) and `make analyze` (bridge/) clean.
- `make test` (bridge/) — all 1549 tests pass.
- `aristotle-impl-review`: **APPROVED** (3 rounds; findings on silent-swallow, named-required arg, and a positional test-fake ctor all addressed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted bridgeId in its own file via `BridgeIdStorage` instead of `token.json`, fixing supervised-mode registration and eliminating token/bridgeId write races. Added `BridgeIdMigrationService` to adopt legacy ids before any token save (startup and logout), preventing duplicate registrations on upgrade.

- **Bug Fixes**
  - Supervised mode no longer fails without `token.json`; bridge id is stored at `<sesori-data>/bridge_id`.
  - Upgrades keep their id via a one-time migration run before auth and before logout; unregister clears the stored id and treats 404 as success.
  - Refresh no longer publishes a new access token or recreates `token.json` when the file is deleted/cleared mid-refresh; it throws `TokenRefreshException` instead.

- **Refactors**
  - `BridgeRegistrationService` reads/writes the id via `BridgeIdStorage` only and clears best‑effort on revoke.
  - Removed `bridgeId` from `TokenData` and deleted carry-over code; refresh now publishes after a successful re‑read and save.

<sup>Written for commit fe42ed4c36df691fb41d29ed2d81768beae5637d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

