### PR TITLE
fix: keep composer keyboard up only on send, dismiss on menu taps

### DIFF
--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -314,73 +314,83 @@ class _PromptInputState extends State<PromptInput> {
             ),
           },
 
-          Padding(
-            padding: EdgeInsetsDirectional.only(
-              top: widget.header != null ? 4 : 8,
-              bottom: MediaQuery.of(context).padding.bottom + 8,
-            ),
-            child: Row(
-              spacing: 8,
-              crossAxisAlignment: .end,
-              children: [
-                PregoButtonsIconGlass(
-                  onPressed: _voiceState == _VoiceState.idle ? _openCommandPicker : null,
-                  icon: TablerRegular.slash,
-                  semanticLabel: loc.sessionDetailCommandPickerTitle,
-                ),
-                Expanded(
-                  child: switch (_voiceState) {
-                    _VoiceState.recording => _RecordingIndicator(amplitudeStream: _voiceService.amplitudeStream),
-                    _VoiceState.transcribing => const _TranscribingIndicator(),
-                    _VoiceState.idle => CallbackShortcuts(
-                      // Cmd/Ctrl+Enter sends (handy with a hardware keyboard);
-                      // plain Enter stays a newline via textInputAction below.
-                      bindings: <ShortcutActivator, VoidCallback>{
-                        const SingleActivator(LogicalKeyboardKey.enter, meta: true): _handleSend,
-                        const SingleActivator(LogicalKeyboardKey.enter, control: true): _handleSend,
-                      },
-                      child: GlassTextField(
-                        controller: _controller,
-                        focusNode: _focusNode,
-                        minLines: 1,
-                        maxLines: 5,
-                        textInputAction: TextInputAction.newline,
-                        // Command-aware placeholder: the staged command's hint,
-                        // else the default prompt hint. The glass field supplies
-                        // its own surface/fill/border, so only the hint text
-                        // carries over from the old InputDecoration.
-                        placeholder: _commandHintText(context),
-                      ),
-                    ),
-                  },
-                ),
-                _MicButton(
-                  voiceState: _voiceState,
-                  onTap: _handleMicTap,
-                ),
-                if (_voiceState == _VoiceState.idle) ...[
-                  // GlassIconButton has no tooltip/semanticLabel, so wrap it in
-                  // a Tooltip to restore the long-press/hover label and the
-                  // screen-reader name the old IconButton carried.
-                  Tooltip(
-                    message: loc.sessionDetailSend,
-                    child: GlassIconButton(
-                      onPressed: _handleSend,
-                      icon: const Icon(Icons.send),
-                      glowColor: prego.colors.bgBrandSolid,
-                    ),
+          // Group only the input row with the text field via a
+          // TextFieldTapRegion. The field's default `onTapOutside` unfocuses
+          // (and dismisses the keyboard) on any pointer-down outside this
+          // region; keeping the send button inside stops the hide/re-show
+          // flicker that came from [_handleSend] re-requesting focus right
+          // after. The agent/model/variant pills in [composerHeader] are
+          // deliberately left outside the region, so tapping them dismisses the
+          // keyboard (their menus want the screen space the keyboard occupies).
+          TextFieldTapRegion(
+            child: Padding(
+              padding: EdgeInsetsDirectional.only(
+                top: widget.header != null ? 4 : 8,
+                bottom: MediaQuery.of(context).padding.bottom + 8,
+              ),
+              child: Row(
+                spacing: 8,
+                crossAxisAlignment: .end,
+                children: [
+                  PregoButtonsIconGlass(
+                    onPressed: _voiceState == _VoiceState.idle ? _openCommandPicker : null,
+                    icon: TablerRegular.slash,
+                    semanticLabel: loc.sessionDetailCommandPickerTitle,
                   ),
-                  if (widget.isBusy)
+                  Expanded(
+                    child: switch (_voiceState) {
+                      _VoiceState.recording => _RecordingIndicator(amplitudeStream: _voiceService.amplitudeStream),
+                      _VoiceState.transcribing => const _TranscribingIndicator(),
+                      _VoiceState.idle => CallbackShortcuts(
+                        // Cmd/Ctrl+Enter sends (handy with a hardware keyboard);
+                        // plain Enter stays a newline via textInputAction below.
+                        bindings: <ShortcutActivator, VoidCallback>{
+                          const SingleActivator(LogicalKeyboardKey.enter, meta: true): _handleSend,
+                          const SingleActivator(LogicalKeyboardKey.enter, control: true): _handleSend,
+                        },
+                        child: GlassTextField(
+                          controller: _controller,
+                          focusNode: _focusNode,
+                          minLines: 1,
+                          maxLines: 5,
+                          textInputAction: TextInputAction.newline,
+                          // Command-aware placeholder: the staged command's hint,
+                          // else the default prompt hint. The glass field supplies
+                          // its own surface/fill/border, so only the hint text
+                          // carries over from the old InputDecoration.
+                          placeholder: _commandHintText(context),
+                        ),
+                      ),
+                    },
+                  ),
+                  _MicButton(
+                    voiceState: _voiceState,
+                    onTap: _handleMicTap,
+                  ),
+                  if (_voiceState == _VoiceState.idle) ...[
+                    // GlassIconButton has no tooltip/semanticLabel, so wrap it in
+                    // a Tooltip to restore the long-press/hover label and the
+                    // screen-reader name the old IconButton carried.
                     Tooltip(
-                      message: loc.sessionDetailAbort,
+                      message: loc.sessionDetailSend,
                       child: GlassIconButton(
-                        onPressed: widget.onAbort,
-                        icon: const Icon(Icons.stop_circle),
-                        glowColor: prego.colors.fgErrorPrimary,
+                        onPressed: _handleSend,
+                        icon: const Icon(Icons.send),
+                        glowColor: prego.colors.bgBrandSolid,
                       ),
                     ),
+                    if (widget.isBusy)
+                      Tooltip(
+                        message: loc.sessionDetailAbort,
+                        child: GlassIconButton(
+                          onPressed: widget.onAbort,
+                          icon: const Icon(Icons.stop_circle),
+                          glowColor: prego.colors.fgErrorPrimary,
+                        ),
+                      ),
+                  ],
                 ],
-              ],
+              ),
             ),
           ),
         ],

--- a/client/app/lib/features/session_detail/widgets/prompt_input.dart
+++ b/client/app/lib/features/session_detail/widgets/prompt_input.dart
@@ -326,7 +326,7 @@ class _PromptInputState extends State<PromptInput> {
             child: Padding(
               padding: EdgeInsetsDirectional.only(
                 top: widget.header != null ? 4 : 8,
-                bottom: MediaQuery.of(context).padding.bottom + 8,
+                bottom: MediaQuery.paddingOf(context).bottom + 8,
               ),
               child: Row(
                 spacing: 8,

--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -1,6 +1,7 @@
 import "dart:async";
 
 import "package:bloc_test/bloc_test.dart";
+import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_test/flutter_test.dart";
@@ -202,5 +203,60 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text("Diffs"), findsOneWidget);
+  });
+
+  // Only the input row is grouped with the text field via a TextFieldTapRegion,
+  // so tapping the send button does not fire the field's default `onTapOutside`
+  // (which unfocuses and dismisses the keyboard) — without the region, send
+  // flickered the keyboard (hide then re-show). The agent/model/variant pills
+  // live in the composer header, outside the region, so tapping them is a tap
+  // "outside" the field and dismisses the keyboard by design.
+  FocusNode composerFocus(WidgetTester tester) => tester.widget<EditableText>(find.byType(EditableText)).focusNode;
+
+  testWidgets("pressing send keeps the composer field focused", (tester) async {
+    await tester.pumpWidget(_buildApp(cubit: cubit));
+    await tester.pumpAndSettle();
+
+    // Focus the field — the keyboard would rise.
+    await tester.tap(find.byType(EditableText));
+    await tester.pump();
+    expect(composerFocus(tester).hasFocus, isTrue);
+
+    // Send with an empty field: `_handleSend` is a no-op that does not
+    // re-request focus, so focus retention here proves the tap itself didn't
+    // unfocus the field (which is what produced the hide/re-show flicker).
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pump();
+    expect(composerFocus(tester).hasFocus, isTrue, reason: "send must not dismiss the keyboard");
+  });
+
+  testWidgets("opening a composer menu dismisses the keyboard (glass path)", (tester) async {
+    // Force the iOS glass path: there PregoAnchorMenu opens GlassMenu as an
+    // overlay (not a route), so the only thing that can dismiss the keyboard is
+    // the field's `onTapOutside` firing because the pill sits outside the
+    // TextFieldTapRegion. That makes this the precise guard that the menus are
+    // NOT grouped with the field. (On the Android flat path the menu is a modal
+    // route that moves focus anyway, so it can't tell the two designs apart.)
+    // Reset in a finally so a failed expect can't leak the override into later
+    // tests (the binding asserts foundation debug vars are clear before
+    // tearDowns run).
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    try {
+      await tester.pumpWidget(_buildApp(cubit: cubit));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(EditableText));
+      await tester.pump();
+      expect(composerFocus(tester).hasFocus, isTrue);
+
+      // Tapping the variant pill opens its glass popup and, because the pill is
+      // outside the field's tap region, dismisses the keyboard.
+      await tester.tap(find.widgetWithText(GlassButton, "xhigh"));
+      await tester.pumpAndSettle();
+      expect(find.widgetWithText(GlassMenuItem, "xhigh"), findsOneWidget);
+      expect(composerFocus(tester).hasFocus, isFalse, reason: "opening a composer menu must dismiss the keyboard");
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
   });
 }


### PR DESCRIPTION
## What

On the session-chat composer, pressing **send** flickered the keyboard (a quick hide→re-show). This keeps the keyboard up when send is pressed, while the **agent/model/variant** menu pills now dismiss it by design.

## Why

`GlassTextField` wires `CupertinoTextField.onTapOutside` to the default unfocus handler, so any pointer-down *outside* the field's tap region dismisses the keyboard. On send, `_handleSend` re-requests focus immediately after the unfocus → visible flicker.

## How

Wrap **only the input `Row`** (text field + send/mic/command-picker controls) in a `TextFieldTapRegion`, instead of the whole composer:

- **Send** is inside the region → no `onTapOutside` → keyboard stays (flicker fixed).
- The **agent/model/variant pills** render via `composerHeader` (the `AgentModelButtons`), which sits in the `Column` *above* the wrapped row, so they're outside the region → tapping one is a tap "outside" the field → keyboard dismisses by design. Their popup menus want the screen space the keyboard occupies.

## Tests

`session_detail_body_test.dart`:
- `pressing send keeps the composer field focused` — focus retained.
- `opening a composer menu dismisses the keyboard (glass path)` — focus dropped; forced onto the iOS glass-overlay path (`debugDefaultTargetPlatformOverride = TargetPlatform.iOS`), where the *only* reason focus can drop is the pill sitting outside the region (on the Android flat path the menu is a modal route that moves focus regardless).

Both verified as real guards: the menu test fails if the header is grouped back into the region; the send test fails if the region is removed. `flutter analyze` clean; session_detail + new_session widget tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes keyboard flicker in the session-chat composer: pressing Send keeps the keyboard up, while tapping agent/model/variant pills dismisses it. Also switches to `MediaQuery.paddingOf` for a small inset perf win.

- **Bug Fixes**
  - Wrapped only the input row (text field + send/mic/command picker) in a `TextFieldTapRegion` to avoid `onTapOutside` unfocus on Send.
  - Left header pills outside the region so their taps dismiss the keyboard for popup menus.
  - Added widget tests to assert Send keeps focus and menus drop focus (iOS glass path).
  - Used `MediaQuery.paddingOf(context)` for the bottom inset.

<sup>Written for commit cf56424e83b91c9c8f0ad82b37f6c152a6da03c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

