### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/bridge/app/lib/src/version.dart
+++ b/bridge/app/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '1.2.0';
+const String appVersion = '1.3.0';

--- a/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-arm64",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS ARM64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.2.0",
+    "releaseTag": "v1.3.0",
     "releaseArtifact": "sesori-bridge-macos-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-darwin-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-x64",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS x64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.2.0",
+    "releaseTag": "v1.3.0",
     "releaseArtifact": "sesori-bridge-macos-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-arm64",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux ARM64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.2.0",
+    "releaseTag": "v1.3.0",
     "releaseArtifact": "sesori-bridge-linux-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-x64",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux x64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.2.0",
+    "releaseTag": "v1.3.0",
     "releaseArtifact": "sesori-bridge-linux-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-arm64",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows ARM64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.2.0",
+    "releaseTag": "v1.3.0",
     "releaseArtifact": "sesori-bridge-windows-arm64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-x64",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows x64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.2.0",
+    "releaseTag": "v1.3.0",
     "releaseArtifact": "sesori-bridge-windows-x64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge/package.json
+++ b/bridge/app/npm/sesori-bridge/package.json
@@ -1,22 +1,22 @@
 {
   "name": "@sesori/bridge",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Bootstrap launcher for the managed Sesori Bridge runtime",
   "bin": {
     "sesori-bridge": "bin/bridge.js"
   },
   "optionalDependencies": {
-    "@sesori/bridge-darwin-arm64": "1.2.0",
-    "@sesori/bridge-darwin-x64": "1.2.0",
-    "@sesori/bridge-linux-x64": "1.2.0",
-    "@sesori/bridge-linux-arm64": "1.2.0",
-    "@sesori/bridge-win32-x64": "1.2.0",
-    "@sesori/bridge-win32-arm64": "1.2.0"
+    "@sesori/bridge-darwin-arm64": "1.3.0",
+    "@sesori/bridge-darwin-x64": "1.3.0",
+    "@sesori/bridge-linux-x64": "1.3.0",
+    "@sesori/bridge-linux-arm64": "1.3.0",
+    "@sesori/bridge-win32-x64": "1.3.0",
+    "@sesori/bridge-win32-arm64": "1.3.0"
   },
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.2.0",
+    "releaseTag": "v1.3.0",
     "runtimeBundleSource": "github-release-assets"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sesori_bridge
 description: Dart implementation of the Sesori Bridge CLI for WebSocket communication.
-version: 1.2.0
+version: 1.3.0
 publish_to: none
 resolution: workspace
 

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -17,7 +17,7 @@ resolution: workspace
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0+1
+version: 1.3.0+1
 environment:
   sdk: ^3.12.2
 


### PR DESCRIPTION
## Summary
- Bump shared App + Bridge version to v1.3.0 (minor)

## Changes
- No new product changes since v1.2.0; this prepares the next release version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare the v1.3.0 release for Bridge and Client. Bumps versions and release tags across Dart and npm packages; no product changes.

- **Dependencies**
  - `@sesori/bridge` set to 1.3.0; optional deps `@sesori/bridge-{darwin,linux,win32}-{x64,arm64}` set to 1.3.0; `releaseTag` updated to `v1.3.0`.
  - Dart: `appVersion` updated to 1.3.0; `sesori_bridge` package to 1.3.0.
  - Client: `pubspec.yaml` version to `1.3.0+1`.

<sup>Written for commit 107584afe56e805127a9988817b9efec7d6a9b08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

