### PR TITLE
chore: weekly dependency update (2026-06-30)

### DIFF
--- a/.ai/skills/update-dependencies/SKILL.md
+++ b/.ai/skills/update-dependencies/SKILL.md
@@ -26,6 +26,7 @@ The repo has two Dart workspaces and two standalone packages. Workspace members 
 - `bridge/sesori_bridge_foundation/pubspec.yaml` (depends on `sesori_plugin_interface`; bridge-wide shared primitives)
 - `bridge/sesori_plugin_runtime/pubspec.yaml` (depends on `sesori_plugin_interface`)
 - `bridge/sesori_plugin_opencode/pubspec.yaml`
+- `bridge/sesori_plugin_codex/pubspec.yaml`
 - `bridge/app/pubspec.yaml` (CLI relay server)
 
 **Standalone packages** (NOT in any workspace — resolve independently with their own lockfile):
@@ -134,6 +135,7 @@ For each pubspec.yaml below, read its `environment` section and update only the 
 | `bridge/sesori_bridge_foundation/pubspec.yaml` | ✅ | — | caret |
 | `bridge/sesori_plugin_runtime/pubspec.yaml` | ✅ | — | caret |
 | `bridge/sesori_plugin_opencode/pubspec.yaml` | ✅ | — | caret |
+| `bridge/sesori_plugin_codex/pubspec.yaml` | ✅ | — | caret |
 | `shared/sesori_shared/pubspec.yaml` | ✅ | — | caret |
 
 Example:
@@ -204,6 +206,7 @@ set -e
 (cd bridge/sesori_bridge_foundation && dart pub outdated)
 (cd bridge/sesori_plugin_runtime && dart pub outdated)
 (cd bridge/sesori_plugin_opencode && dart pub outdated)
+(cd bridge/sesori_plugin_codex && dart pub outdated)
 (cd bridge/app && dart pub outdated)
 ```
 
@@ -231,7 +234,7 @@ set -e
 <step name="3.1">For each pubspec.yaml, in this order:
 
 1. `shared/sesori_shared/pubspec.yaml` (consumed by both workspaces)
-2. Bridge workspace members (dependency order): `bridge/sesori_plugin_interface`, `bridge/sesori_bridge_foundation`, `bridge/sesori_plugin_runtime`, `bridge/sesori_plugin_opencode`, `bridge/app`
+2. Bridge workspace members (dependency order): `bridge/sesori_plugin_interface`, `bridge/sesori_bridge_foundation`, `bridge/sesori_plugin_runtime`, `bridge/sesori_plugin_opencode`, `bridge/sesori_plugin_codex`, `bridge/app`
 3. Client workspace members: `client/module_auth`, `client/module_core`, `client/module_prego`, `client/app`
 
 **SKIP** `shared/no_slop_linter/pubspec.yaml` — analyzer-plugin constraints are bumped manually (see the project structure note). Do not edit it here even if `pub outdated` reports newer versions.
@@ -294,7 +297,7 @@ For each, confirm one of two outcomes: either (a) its pubspec(s) appear in the d
 ```bash
 set -e
 (cd shared && make analyze)   # sesori_shared + no_slop_linter
-(cd bridge && make analyze)   # sesori_plugin_interface, sesori_bridge_foundation, sesori_plugin_runtime, sesori_plugin_opencode, app
+(cd bridge && make analyze)   # sesori_plugin_interface, sesori_bridge_foundation, sesori_plugin_runtime, sesori_plugin_opencode, sesori_plugin_codex, app
 (cd client && make analyze)   # module_auth, module_core, module_prego, app (with --fatal-infos)
 ```
 
@@ -454,7 +457,7 @@ Report this list at the end of the update process for visibility.
 <success_criteria>
 
 - Preflight discovery (Phase 0) ran; every discovered source pubspec and workspace member is accounted for, with none silently skipped
-- Environment constraints (sdk, flutter) updated in 12 pubspec.yaml files (every pubspec EXCEPT `shared/no_slop_linter/pubspec.yaml`, which is excluded entirely — the count INCLUDES `bridge/sesori_bridge_foundation` and `bridge/sesori_plugin_runtime`)
+- Environment constraints (sdk, flutter) updated in 13 pubspec.yaml files (every pubspec EXCEPT `shared/no_slop_linter/pubspec.yaml`, which is excluded entirely — the count INCLUDES `bridge/sesori_bridge_foundation`, `bridge/sesori_plugin_runtime`, and `bridge/sesori_plugin_codex`)
 - Version constraints bumped to latest resolvable versions in every pubspec EXCEPT `shared/no_slop_linter/pubspec.yaml`
 - All three workspaces (shared, bridge, client) are individually accounted for: each either has bumped constraints or provably had no upgradable deps (Phase 3.4)
 - All pubspec.lock files regenerated (workspace roots + 2 standalone packages = 4 lockfiles)

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-flutter 3.44.3-stable
+flutter 3.44.4-stable

--- a/bridge/sesori_bridge_foundation/pubspec.yaml
+++ b/bridge/sesori_bridge_foundation/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   crypto: ^3.0.7
   http: ^1.6.0
-  meta: ^1.16.0
+  meta: ^1.18.3
   path: ^1.9.1
   sesori_plugin_interface:
     path: ../sesori_plugin_interface

--- a/bridge/sesori_plugin_codex/pubspec.yaml
+++ b/bridge/sesori_plugin_codex/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     path: ../../shared/sesori_shared
   web_socket_channel: ^3.0.3
   http: ^1.6.0
-  path: ^1.9.0
+  path: ^1.9.1
   freezed_annotation: ^3.1.0
   json_annotation: ^4.12.0
 

--- a/bridge/sesori_plugin_opencode/pubspec.yaml
+++ b/bridge/sesori_plugin_opencode/pubspec.yaml
@@ -15,11 +15,11 @@ dependencies:
     path: ../sesori_bridge_foundation
   sesori_shared:
     path: ../../shared/sesori_shared
-  collection: ^1.19.0
+  collection: ^1.19.1
   http: ^1.6.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.12.0
-  meta: ^1.16.0
+  meta: ^1.18.3
   path: ^1.9.1
 
 dev_dependencies:

--- a/bridge/sesori_plugin_runtime/pubspec.yaml
+++ b/bridge/sesori_plugin_runtime/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   freezed_annotation: ^3.1.0
   json_annotation: ^4.12.0
-  path: ^1.9.0
+  path: ^1.9.1
   sesori_bridge_foundation:
     path: ../sesori_bridge_foundation
   sesori_plugin_interface:

--- a/client/app/android/Gemfile.lock
+++ b/client/app/android/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.112.0)
-    faraday (1.10.5)
+    faraday (1.10.6)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -125,7 +125,7 @@ GEM
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
     fastlane-sirp (1.1.0)
     gh_inspector (1.1.3)
-    google-apis-androidpublisher_v3 (0.103.0)
+    google-apis-androidpublisher_v3 (0.104.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-core (0.18.0)
       addressable (~> 2.5, >= 2.5.1)
@@ -266,7 +266,7 @@ CHECKSUMS
   dotenv (2.8.1) sha256=c5944793349ae03c432e1780a2ca929d60b88c7d14d52d630db0508c3a8a17d8
   emoji_regex (3.2.3) sha256=ecd8be856b7691406c6bf3bb3a5e55d6ed683ffab98b4aa531bb90e1ddcc564b
   excon (0.112.0) sha256=daf9ac3a4c2fc9aa48383a33da77ecb44fa395111e973084d5c52f6f214ae0f0
-  faraday (1.10.5) sha256=b144f1d2b045652fa820b5f532723e1643cc28b93dae911d784e5c5f88e8f6ed
+  faraday (1.10.6) sha256=7ff4802a6b312876a2241b3e641ce0d5045e168dd871b422c35b505e5261ad4d
   faraday-cookie_jar (0.0.8) sha256=0140605823f8cc63c7028fccee486aaed8e54835c360cffc1f7c8c07c4299dbb
   faraday-em_http (1.0.0) sha256=7a3d4c7079789121054f57e08cd4ef7e40ad1549b63101f38c7093a9d6c59689
   faraday-em_synchrony (1.0.1) sha256=bf3ce45dcf543088d319ab051f80985ea6d294930635b7a0b966563179f81750
@@ -283,7 +283,7 @@ CHECKSUMS
   fastlane (2.236.1) sha256=fb89e618e0f38636e487743622cf710ad722723f5d33a63f19e367f84d3770bc
   fastlane-sirp (1.1.0) sha256=10bc94f9682efd8e1badfb31452a76dd8981f1f3a33717c765fde6d75b54d847
   gh_inspector (1.1.3) sha256=04cca7171b87164e053aa43147971d3b7f500fcb58177698886b48a9fc4a1939
-  google-apis-androidpublisher_v3 (0.103.0) sha256=8075b9da398b201493ad1cd4074ff1a76ae67abf7eaad4242c0c75d22d61b559
+  google-apis-androidpublisher_v3 (0.104.0) sha256=3bf7f0dee23ae71e070e279848374834853204e304831cf6aa76fa435a4d6eff
   google-apis-core (0.18.0) sha256=96b057816feeeab448139ed5b5c78eab7fc2a9d8958f0fbc8217dedffad054ee
   google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
   google-apis-playcustomapp_v1 (0.18.0) sha256=44b277b9dee4a59ac5e9d98be1485edc5e382d2f9d73c79ae8908a455786a254

--- a/client/app/ios/Gemfile.lock
+++ b/client/app/ios/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       ffi (>= 1.15.0)
       logger
     excon (0.112.0)
-    faraday (1.10.5)
+    faraday (1.10.6)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -188,7 +188,7 @@ GEM
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    google-apis-androidpublisher_v3 (0.103.0)
+    google-apis-androidpublisher_v3 (0.104.0)
       google-apis-core (>= 0.15.0, < 2.a)
     google-apis-core (0.18.0)
       addressable (~> 2.5, >= 2.5.1)
@@ -359,7 +359,7 @@ CHECKSUMS
   escape (0.0.4) sha256=e49f44ae2b4f47c6a3abd544ae77fe4157802794e32f19b8e773cbc4dcec4169
   ethon (0.18.0) sha256=b598afc9f30448cb068b850714b7d6948e941476095d04f90a4ac65b8d6efcb2
   excon (0.112.0) sha256=daf9ac3a4c2fc9aa48383a33da77ecb44fa395111e973084d5c52f6f214ae0f0
-  faraday (1.10.5) sha256=b144f1d2b045652fa820b5f532723e1643cc28b93dae911d784e5c5f88e8f6ed
+  faraday (1.10.6) sha256=7ff4802a6b312876a2241b3e641ce0d5045e168dd871b422c35b505e5261ad4d
   faraday-cookie_jar (0.0.8) sha256=0140605823f8cc63c7028fccee486aaed8e54835c360cffc1f7c8c07c4299dbb
   faraday-em_http (1.0.0) sha256=7a3d4c7079789121054f57e08cd4ef7e40ad1549b63101f38c7093a9d6c59689
   faraday-em_synchrony (1.0.1) sha256=bf3ce45dcf543088d319ab051f80985ea6d294930635b7a0b966563179f81750
@@ -380,7 +380,7 @@ CHECKSUMS
   fourflusher (2.3.1) sha256=1b3de61c7c791b6a4e64f31e3719eb25203d151746bb519a0292bff1065ccaa9
   fuzzy_match (2.0.4) sha256=b5de4f95816589c5b5c3ad13770c0af539b75131c158135b3f3bbba75d0cfca5
   gh_inspector (1.1.3) sha256=04cca7171b87164e053aa43147971d3b7f500fcb58177698886b48a9fc4a1939
-  google-apis-androidpublisher_v3 (0.103.0) sha256=8075b9da398b201493ad1cd4074ff1a76ae67abf7eaad4242c0c75d22d61b559
+  google-apis-androidpublisher_v3 (0.104.0) sha256=3bf7f0dee23ae71e070e279848374834853204e304831cf6aa76fa435a4d6eff
   google-apis-core (0.18.0) sha256=96b057816feeeab448139ed5b5c78eab7fc2a9d8958f0fbc8217dedffad054ee
   google-apis-iamcredentials_v1 (0.28.0) sha256=0a92ffe6cc39c569554af2a77a25dfc61519ed8bbb64ab04cffdd352dc5ef106
   google-apis-playcustomapp_v1 (0.18.0) sha256=44b277b9dee4a59ac5e9d98be1485edc5e382d2f9d73c79ae8908a455786a254

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -1730,4 +1730,4 @@ packages:
     version: "2.2.4"
 sdks:
   dart: ">=3.12.2 <4.0.0"
-  flutter: ">=3.44.3 <3.45.0"
+  flutter: ">=3.44.4 <3.45.0"

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 environment:
   sdk: ^3.12.2
-  flutter: ">=3.44.3 <3.45.0"
+  flutter: ">=3.44.4 <3.45.0"
 
 workspace:
   - app


### PR DESCRIPTION
Weekly dependency update for the week of 2026-06-30 (automated run of the `update-dependencies` skill).

## Toolchain
- Flutter **3.44.3 → 3.44.4** (`.tool-versions`, `client/pubspec.yaml` flutter floor `>=3.44.4 <3.45.0`). Dart unchanged at 3.12.2.

## Dependency changes
This was a heavily-pinned week — no direct package could be bumped to a newer release. The only constraint edits are caret-floor hygiene (raising floors to the already-resolved versions):

- **bridge**: `meta ^1.16.0 → ^1.18.3` (sesori_bridge_foundation, sesori_plugin_opencode), `path ^1.9.0 → ^1.9.1` (sesori_plugin_runtime, sesori_plugin_codex), `collection ^1.19.0 → ^1.19.1` (sesori_plugin_opencode). Lockfile unchanged (already resolving there).
- **client**: lockfile reflects the new Flutter floor only; all upgradable packages (`intl`, `meta`, `injectable_generator`, `test`) are held back by Flutter SDK pins.
- **shared**: already at resolvable versions; nothing to bump.

### Deferred (blocked by `freezed 3.2.5` pinning `analyzer <11`)
| Dependency | Current | Latest | Reason |
|---|---|---|---|
| bridge `test` | 1.31.1 | 1.31.2 | 1.31.2 needs analyzer ≥13 |
| bridge `drift_dev` | 2.34.0 | 2.34.1+1 | needs analyzer ^13 |

The whole analyzer / `_fe_analyzer_shared` / `dart_style` chain stays pinned until `freezed` ships a stable release allowing analyzer 13/14 (only `freezed >3.2.5` is a `-dev` prerelease today).

## Native deps
- **SwiftPM** (`Package.resolved`, iOS + macOS): re-resolved via `flutter build --config-only` — genuinely no change this week.
- **Ruby gems**: fastlane already at latest 2.236.1; `bundle update` bumped transitive gems (faraday 1.10.5→1.10.6, json 2.20.0, google-apis-androidpublisher_v3 0.103.0→0.104.0) in both iOS and Android `Gemfile.lock`.

## Skill maintenance
Phase 0 preflight found `bridge/sesori_plugin_codex` as a workspace member missing from the skill inventory — registered it in `.ai/skills/update-dependencies/SKILL.md` (package list, env table, outdated/bump steps, env count 12→13).

## Verification
- `make analyze` / `make test` / `make codegen` — **shared** and **bridge** pass (analyze + codegen). All three workspaces re-resolve and codegen cleanly.
- Pre-existing failures (NOT caused by this update; base tree unchanged by these commits):
  - **client `make analyze`**: 6 info-level lints in `module_prego` (`prego_anchor_menu.dart` / `prego_surfaces_test.dart`, from #350) trip `--fatal-infos`.
  - **client `make test`**: the client `Makefile` runs `dart test` for `module_prego`, but it's a Flutter package whose widget tests (added in #350) require `flutter test` — they pass under `flutter test`, fail under `dart test` (framework `text_painter.dart` invalid-type errors).
  - **bridge `make test`**: `installers_test.dart` install.sh glyph test expects `✓` but the headless CI shell is a `C` (non-UTF-8) locale, so install.sh emits ASCII `[OK]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Weekly dependency sweep: bump Flutter floor to 3.44.4, align Dart package caret floors in bridge, and refresh Ruby gems. No functional changes; workspaces re-resolve and codegen cleanly.

- **Dependencies**
  - Flutter: `3.44.3 → 3.44.4` in `.tool-versions` and client `pubspec` floor; Dart stays `3.12.2`.
  - Bridge caret floors only: `meta ^1.18.3`, `path ^1.9.1`, `collection ^1.19.1` (no lockfile changes).
  - Client: lockfile reflects the new Flutter floor; other upgrades held by SDK pins.
  - Native/tooling: SwiftPM unchanged; Ruby `Gemfile.lock` bumps `faraday 1.10.6` and `google-apis-androidpublisher_v3 0.104.0`.
  - Skill maintenance: register `bridge/sesori_plugin_codex` in the update-dependencies inventory.
  - Deferred: analyzer chain remains pinned by `freezed 3.2.5` (`analyzer <11`), deferring `test 1.31.2` and `drift_dev 2.34.1+1`.

<sup>Written for commit 2abc1643989b7583ae1ddb68b116b6d5081a7d6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

