### PR TITLE
fix(codex): sync projects from session CWDs and persist added folders

### DIFF
--- a/bridge/sesori_plugin_codex/lib/codex_plugin.dart
+++ b/bridge/sesori_plugin_codex/lib/codex_plugin.dart
@@ -9,6 +9,7 @@ export "src/codex_app_server_client.dart";
 export "src/codex_config_reader.dart";
 export "src/codex_event_mapper.dart";
 export "src/codex_plugin_impl.dart";
+export "src/codex_project_storage.dart";
 export "src/codex_skill_reader.dart";
 // Runtime lifecycle: the descriptor is the public entry point the bridge
 // registers in bin/bridge.dart.

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -89,6 +89,14 @@ class CodexPlugin implements CodexManagedApi {
   /// this never goes stale against a live connection.
   final Set<String> _loadedThreads = {};
 
+  /// Working directory of each thread created in this bridge run, keyed by
+  /// thread id. codex flushes a session's rollout header to disk slightly after
+  /// `thread/start` returns, so for a just-created session this is the only
+  /// place that knows its directory — used by [_directoryForSession] and
+  /// [getProjectQuestions] so a fresh non-launch session resolves to its real
+  /// project (not the launch CWD) before its rollout exists.
+  final Map<String, String> _threadDirectory = {};
+
   factory CodexPlugin({
     required String serverUrl,
     String? capabilityToken,
@@ -297,6 +305,7 @@ class CodexPlugin implements CodexManagedApi {
         _sessionStatuses.remove(threadId);
         // The app-server unloaded this thread; a later turn must resume it.
         _loadedThreads.remove(threadId);
+        _threadDirectory.remove(threadId);
       case "thread/started":
         final thread = (params["thread"] as Map?)?.cast<String, dynamic>();
         final id = thread?["id"] as String?;
@@ -392,15 +401,14 @@ class CodexPlugin implements CodexManagedApi {
     return out;
   }
 
-  /// Dedupe key for a directory: strips a single trailing path separator so
-  /// `/a` and `/a/` collapse to one project. The project `id` emitted from
-  /// [_deriveProjects] stays verbatim — this key is only used to merge sources.
-  String _projectKey(String dir) {
-    if (dir.length > 1 && (dir.endsWith("/") || dir.endsWith(r"\"))) {
-      return dir.substring(0, dir.length - 1);
-    }
-    return dir;
-  }
+  /// Normalised dedupe/equivalence key for a directory: collapses trailing
+  /// separators and `.`/`..` segments so `/a`, `/a/`, and `/a/b/..` map to one
+  /// project (and, on Windows, preserves drive roots like `C:\`). The project
+  /// `id` emitted from [_deriveProjects] stays the verbatim cwd — this key is
+  /// only used to merge sources here and to match sessions in [getSessions]/
+  /// [getProjectQuestions], so a directory recorded under two spellings stays
+  /// reachable from its single project.
+  String _projectKey(String dir) => p.normalize(dir);
 
   String _projectName(String dir) {
     final base = p.basename(dir);
@@ -455,7 +463,14 @@ class CodexPlugin implements CodexManagedApi {
     int? limit,
   }) async {
     final records = _rolloutReader.listSessions();
-    final filtered = records.where((r) => r.cwd == projectId);
+    // Match by the normalised project key (not exact cwd) so sessions recorded
+    // under a different spelling of the same directory — e.g. a trailing
+    // separator that [_deriveProjects] merged into one project — stay reachable.
+    final target = _projectKey(projectId);
+    final filtered = records.where((r) {
+      final cwd = r.cwd;
+      return cwd != null && _projectKey(cwd) == target;
+    });
     final mapped = filtered.map(_toPluginSession).toList(growable: false);
     final from = start ?? 0;
     final until = limit == null
@@ -549,6 +564,9 @@ class CodexPlugin implements CodexManagedApi {
     // Record the directory so a session started in a brand-new project surfaces
     // as a project immediately, before codex has flushed its rollout to disk.
     _projectStorage.upsertProject(path: resolvedDirectory);
+    // Remember the thread's directory in memory so renameSession/project
+    // questions resolve it before the rollout header lands on disk.
+    _threadDirectory[threadId] = resolvedDirectory;
     return PluginSession(
       id: threadId,
       projectID: resolvedDirectory,
@@ -766,11 +784,18 @@ class CodexPlugin implements CodexManagedApi {
     );
   }
 
-  /// The CWD of the session with [sessionId] from its on-disk rollout, falling
-  /// back to the launch CWD when the session has no resolvable directory.
+  /// The CWD of the session with [sessionId]: the in-memory mapping for a
+  /// thread created this run (correct even before its rollout flushes), else the
+  /// session's own rollout header, falling back to the launch CWD. Resolves the
+  /// single rollout directly ([SessionRolloutReader.findRolloutPath] +
+  /// [SessionRolloutReader.readMeta]) rather than scanning every session.
   String _directoryForSession(String sessionId) {
-    for (final record in _rolloutReader.listSessions()) {
-      if (record.id == sessionId) return record.cwd ?? _projectCwd;
+    final live = _threadDirectory[sessionId];
+    if (live != null) return live;
+    final rolloutPath = _rolloutReader.findRolloutPath(sessionId);
+    if (rolloutPath != null) {
+      final cwd = _rolloutReader.readMeta(rolloutPath)?.cwd;
+      if (cwd != null) return cwd;
     }
     return _projectCwd;
   }
@@ -808,6 +833,7 @@ class CodexPlugin implements CodexManagedApi {
     _activeTurnByThread.remove(sessionId);
     _sessionStatuses.remove(sessionId);
     _loadedThreads.remove(sessionId);
+    _threadDirectory.remove(sessionId);
   }
 
   @override
@@ -925,16 +951,19 @@ class CodexPlugin implements CodexManagedApi {
   }) async {
     final registry = _approvalRegistry;
     if (registry == null) return const [];
-    // Scope to the sessions that belong to this project (cwd == projectId) so a
-    // pending approval in one codex project doesn't surface under every other.
-    // A just-created session whose rollout hasn't flushed yet won't be joined
-    // here; its question is still reachable in the session via getPendingQuestions.
-    final cwdById = <String, String?>{
+    // Scope to the sessions that belong to this project so a pending approval in
+    // one codex project doesn't surface under every other. Directory per session
+    // comes from the on-disk rollout (cwd, or the launch CWD when unrecorded —
+    // matching _toPluginSession) overlaid with the in-memory mapping, so a
+    // just-created session whose rollout hasn't flushed yet is still attributed.
+    final cwdById = <String, String>{
       for (final record in _rolloutReader.listSessions())
-        record.id: record.cwd,
+        record.id: record.cwd ?? _projectCwd,
+      ..._threadDirectory,
     };
+    final target = _projectKey(projectId);
     final sessionIds = _sessionStatuses.keys
-        .where((id) => cwdById[id] == projectId)
+        .where((id) => _projectKey(cwdById[id] ?? _projectCwd) == target)
         .toList(growable: false);
     return registry.pendingForProject(sessionIds);
   }

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -401,14 +401,16 @@ class CodexPlugin implements CodexManagedApi {
     return out;
   }
 
-  /// Normalised dedupe/equivalence key for a directory: collapses trailing
-  /// separators and `.`/`..` segments so `/a`, `/a/`, and `/a/b/..` map to one
-  /// project (and, on Windows, preserves drive roots like `C:\`). The project
-  /// `id` emitted from [_deriveProjects] stays the verbatim cwd — this key is
-  /// only used to merge sources here and to match sessions in [getSessions]/
-  /// [getProjectQuestions], so a directory recorded under two spellings stays
-  /// reachable from its single project.
-  String _projectKey(String dir) => p.normalize(dir);
+  /// Normalised dedupe/equivalence key for a directory: makes it absolute
+  /// (against the bridge CWD) then collapses trailing separators and `.`/`..`
+  /// segments, so `/a`, `/a/`, `/a/b/..`, and a relative spelling of the same
+  /// directory all map to one project (and, on Windows, preserves drive roots
+  /// like `C:\`). The project `id` emitted from [_deriveProjects] stays the
+  /// verbatim cwd — this key is only used to merge sources here and to match
+  /// sessions in [getSessions]/[getProjectQuestions], so a directory recorded
+  /// under two spellings stays reachable from its single project. (codex cwds
+  /// and opened-dir paths are already absolute, so this is defensive.)
+  String _projectKey(String dir) => p.normalize(p.absolute(dir));
 
   String _projectName(String dir) {
     final base = p.basename(dir);

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -8,6 +8,7 @@ import "approval_registry.dart";
 import "codex_app_server_client.dart";
 import "codex_config_reader.dart";
 import "codex_event_mapper.dart";
+import "codex_project_storage.dart";
 import "codex_skill_reader.dart";
 import "runtime/codex_managed_api.dart";
 import "session_rollout_reader.dart";
@@ -43,6 +44,7 @@ class CodexPlugin implements CodexManagedApi {
   final CodexConfigReader _configReader;
   final CodexSkillReader _skillReader;
   final CodexEventMapper _eventMapper;
+  final CodexProjectStorage _projectStorage;
   final String _projectCwd;
   final Duration _keepaliveInterval;
 
@@ -95,6 +97,7 @@ class CodexPlugin implements CodexManagedApi {
     CodexConfigReader? configReader,
     CodexSkillReader? skillReader,
     CodexEventMapper? eventMapper,
+    CodexProjectStorage? projectStorage,
     String? projectCwd,
     void Function()? onConnected,
     void Function()? onDisconnected,
@@ -118,6 +121,7 @@ class CodexPlugin implements CodexManagedApi {
             projectCwd: resolvedProjectCwd,
             config: resolvedConfigReader.readDefaults(),
           ),
+      projectStorage: projectStorage ?? CodexProjectStorage(),
       projectCwd: resolvedProjectCwd,
       onConnected: onConnected,
       onDisconnected: onDisconnected,
@@ -133,6 +137,7 @@ class CodexPlugin implements CodexManagedApi {
     required CodexConfigReader configReader,
     required CodexSkillReader skillReader,
     required CodexEventMapper eventMapper,
+    required CodexProjectStorage projectStorage,
     required String projectCwd,
     void Function()? onConnected,
     void Function()? onDisconnected,
@@ -145,6 +150,7 @@ class CodexPlugin implements CodexManagedApi {
        _configReader = configReader,
        _skillReader = skillReader,
        _eventMapper = eventMapper,
+       _projectStorage = projectStorage,
        _projectCwd = projectCwd,
        _onConnected = onConnected,
        _onDisconnected = onDisconnected,
@@ -321,23 +327,126 @@ class CodexPlugin implements CodexManagedApi {
     }
   }
 
-  PluginProject _synthesizedProject() {
-    final updated = DateTime.now().millisecondsSinceEpoch;
+  /// Builds the codex project set, keyed by a dedupe key (trailing-separator-
+  /// insensitive), from three sources:
+  ///   1. the bridge launch CWD (always present),
+  ///   2. every directory the user explicitly opened/created/renamed (persisted
+  ///      in [CodexProjectStorage]),
+  ///   3. every distinct session CWD on disk.
+  ///
+  /// Each project's `id` is the directory *verbatim* — never normalized — so
+  /// [getSessions]'s exact-equality `record.cwd == projectId` filter keeps
+  /// matching. When a directory appears as both a session CWD and another
+  /// source, the session CWD is the authoritative id and session timestamps win
+  /// over the opened-dir placeholder; a stored name override wins over the
+  /// basename. A directory with no sessions deterministically gets its
+  /// `addedAt` time (or `0`), so listing order is stable across calls.
+  Map<String, PluginProject> _deriveProjects() {
+    final accumulators = <String, _ProjectAccumulator>{};
+
+    _ProjectAccumulator accumulatorFor(String dir) => accumulators.putIfAbsent(
+      _projectKey(dir),
+      () => _ProjectAccumulator(id: dir),
+    );
+
+    // 1. Launch CWD — always present so there is at least one project and a
+    // home for the "current" project lookup.
+    accumulatorFor(_projectCwd);
+
+    // 2. Persisted opened/renamed directories.
+    for (final opened in _projectStorage.listOpenedProjects()) {
+      final accumulator = accumulatorFor(opened.path);
+      if (opened.name != null) accumulator.nameOverride = opened.name;
+      accumulator.addedAt = opened.addedAt;
+    }
+
+    // 3. Distinct session CWDs (real timestamps; cwd is the canonical id).
+    for (final record in _rolloutReader.listSessions()) {
+      final cwd = record.cwd;
+      if (cwd == null) continue;
+      final accumulator = accumulatorFor(cwd);
+      // The session's verbatim cwd is the authoritative id so getSessions' exact
+      // filter matches the id we hand back here.
+      accumulator.id = cwd;
+      final created = record.createdAt?.millisecondsSinceEpoch;
+      final updated = record.updatedAt?.millisecondsSinceEpoch ?? created;
+      if (created != null) {
+        final prior = accumulator.created;
+        accumulator.created = prior == null || created < prior ? created : prior;
+      }
+      if (updated != null) {
+        final prior = accumulator.updated;
+        accumulator.updated = prior == null || updated > prior ? updated : prior;
+      }
+    }
+
+    final out = <String, PluginProject>{};
+    for (final accumulator in accumulators.values) {
+      out[accumulator.id] = _projectForPath(
+        path: accumulator.id,
+        created: accumulator.created ?? accumulator.addedAt,
+        updated: accumulator.updated ?? accumulator.addedAt,
+        name: accumulator.nameOverride,
+      );
+    }
+    return out;
+  }
+
+  /// Dedupe key for a directory: strips a single trailing path separator so
+  /// `/a` and `/a/` collapse to one project. The project `id` emitted from
+  /// [_deriveProjects] stays verbatim — this key is only used to merge sources.
+  String _projectKey(String dir) {
+    if (dir.length > 1 && (dir.endsWith("/") || dir.endsWith(r"\"))) {
+      return dir.substring(0, dir.length - 1);
+    }
+    return dir;
+  }
+
+  String _projectName(String dir) {
+    final base = p.basename(dir);
+    return base.isEmpty ? dir : base;
+  }
+
+  PluginProject _projectForPath({
+    required String path,
+    int? created,
+    int? updated,
+    String? name,
+  }) {
     return PluginProject(
-      id: _projectCwd,
-      name: p.basename(_projectCwd).isEmpty
-          ? _projectCwd
-          : p.basename(_projectCwd),
-      time: PluginProjectTime(created: updated, updated: updated),
+      id: path,
+      name: name ?? _projectName(path),
+      time: PluginProjectTime(created: created ?? 0, updated: updated ?? 0),
     );
   }
 
   @override
-  Future<List<PluginProject>> getProjects() async => [_synthesizedProject()];
+  Future<List<PluginProject>> getProjects() async {
+    final projects = _deriveProjects().values.toList();
+    projects.sort(
+      (a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0),
+    );
+    return projects;
+  }
 
   @override
-  Future<PluginProject> getProject(String projectId) async =>
-      _synthesizedProject();
+  Future<PluginProject> getProject(String projectId) async {
+    // Honors the requested path (so opening/discovering a folder returns THAT
+    // folder, not the launch CWD) and persists it so a directory with no codex
+    // sessions yet still survives the refresh and later bridge restarts.
+    _projectStorage.upsertProject(path: projectId);
+    return _findDerivedProject(projectId) ?? _projectForPath(path: projectId);
+  }
+
+  /// The derived project whose directory matches [projectId] (trailing-separator
+  /// insensitive), or null when none is known yet.
+  PluginProject? _findDerivedProject(String projectId) {
+    final key = _projectKey(projectId);
+    for (final project in _deriveProjects().values) {
+      if (_projectKey(project.id) == key) return project;
+    }
+    return null;
+  }
 
   @override
   Future<List<PluginSession>> getSessions(
@@ -359,10 +468,13 @@ class CodexPlugin implements CodexManagedApi {
   PluginSession _toPluginSession(CodexSessionRecord record) {
     final created = record.createdAt?.millisecondsSinceEpoch;
     final updated = record.updatedAt?.millisecondsSinceEpoch ?? created;
+    // The session belongs to the project for its own CWD — never the launch CWD
+    // — so it groups under the right directory once projects are per-CWD.
+    final directory = record.cwd ?? _projectCwd;
     return PluginSession(
       id: record.id,
-      projectID: _projectCwd,
-      directory: record.cwd ?? _projectCwd,
+      projectID: directory,
+      directory: directory,
       parentID: null,
       title: record.threadName,
       time: created == null || updated == null
@@ -433,10 +545,14 @@ class CodexPlugin implements CodexManagedApi {
         variant: variant,
       );
     }
+    final resolvedDirectory = (thread?["cwd"] as String?) ?? directory;
+    // Record the directory so a session started in a brand-new project surfaces
+    // as a project immediately, before codex has flushed its rollout to disk.
+    _projectStorage.upsertProject(path: resolvedDirectory);
     return PluginSession(
       id: threadId,
-      projectID: _projectCwd,
-      directory: (thread?["cwd"] as String?) ?? directory,
+      projectID: resolvedDirectory,
+      directory: resolvedDirectory,
       parentID: parentSessionId,
       title: thread?["name"] as String?,
       time: _timeFromThread(thread),
@@ -638,10 +754,11 @@ class CodexPlugin implements CodexManagedApi {
       method: "thread/name/set",
       params: {"threadId": sessionId, "name": title},
     );
+    final directory = _directoryForSession(sessionId);
     return PluginSession(
       id: sessionId,
-      projectID: _projectCwd,
-      directory: _projectCwd,
+      projectID: directory,
+      directory: directory,
       parentID: null,
       title: title,
       time: null,
@@ -649,17 +766,26 @@ class CodexPlugin implements CodexManagedApi {
     );
   }
 
+  /// The CWD of the session with [sessionId] from its on-disk rollout, falling
+  /// back to the launch CWD when the session has no resolvable directory.
+  String _directoryForSession(String sessionId) {
+    for (final record in _rolloutReader.listSessions()) {
+      if (record.id == sessionId) return record.cwd ?? _projectCwd;
+    }
+    return _projectCwd;
+  }
+
   @override
   Future<PluginProject> renameProject({
     required String projectId,
     required String name,
   }) async {
-    // The codex backend uses a single synthesised project per launch CWD,
-    // so there is no per-project name to persist. Honour the contract by
-    // returning a project with the requested name applied so any local
-    // UI cache stays consistent.
-    final base = _synthesizedProject();
-    return PluginProject(id: base.id, name: name, time: base.time);
+    // codex has no native per-project name, so persist a display-name override
+    // in the project store; _deriveProjects applies it on the next listing so
+    // the rename survives a refresh and a bridge restart.
+    _projectStorage.upsertProject(path: projectId, name: name);
+    return _findDerivedProject(projectId) ??
+        _projectForPath(path: projectId, name: name);
   }
 
   /// Removes a codex session by deleting its rollout JSONL and dropping
@@ -799,9 +925,17 @@ class CodexPlugin implements CodexManagedApi {
   }) async {
     final registry = _approvalRegistry;
     if (registry == null) return const [];
-    // Single-project model: every codex session belongs to the launch
-    // project. Pull every known session id we've seen.
-    final sessionIds = _sessionStatuses.keys.toList(growable: false);
+    // Scope to the sessions that belong to this project (cwd == projectId) so a
+    // pending approval in one codex project doesn't surface under every other.
+    // A just-created session whose rollout hasn't flushed yet won't be joined
+    // here; its question is still reachable in the session via getPendingQuestions.
+    final cwdById = <String, String?>{
+      for (final record in _rolloutReader.listSessions())
+        record.id: record.cwd,
+    };
+    final sessionIds = _sessionStatuses.keys
+        .where((id) => cwdById[id] == projectId)
+        .toList(growable: false);
     return registry.pendingForProject(sessionIds);
   }
 
@@ -980,4 +1114,21 @@ class CodexPlugin implements CodexManagedApi {
     _client = null;
     await _eventBuffer.close();
   }
+}
+
+/// Mutable scratch holder used by [CodexPlugin._deriveProjects] to merge a
+/// directory's facts across its three sources (launch CWD, opened-dir store,
+/// session CWDs) before materializing one [PluginProject]. File-private and
+/// single-use — it owns no behaviour, just the partial state of one project
+/// while sources are folded together.
+class _ProjectAccumulator {
+  _ProjectAccumulator({required this.id});
+
+  /// The directory verbatim; a session CWD overwrites a placeholder so the
+  /// emitted id matches what getSessions filters on.
+  String id;
+  String? nameOverride;
+  int? addedAt;
+  int? created;
+  int? updated;
 }

--- a/bridge/sesori_plugin_codex/lib/src/codex_project_storage.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_project_storage.dart
@@ -1,0 +1,120 @@
+import "dart:convert";
+import "dart:io";
+
+import "package:freezed_annotation/freezed_annotation.dart";
+import "package:path/path.dart" as p;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+import "package:sesori_shared/sesori_shared.dart" show jsonDecodeListMap;
+
+part "codex_project_storage.freezed.dart";
+part "codex_project_storage.g.dart";
+
+/// One directory the user explicitly opened, created, or renamed from the app.
+///
+/// codex has no project concept of its own, so the plugin derives projects from
+/// session CWDs. This record covers the gaps that derivation alone can't: a
+/// directory with no codex sessions yet (so a freshly-added folder doesn't
+/// vanish on the next refresh) and a custom display name (so a rename survives).
+///
+/// `path` is stored verbatim (NOT normalized) so it matches the rollout `cwd`
+/// that the plugin uses as a project id elsewhere. `addedAt` (ms since epoch) is
+/// used as the project's time when it has no sessions to derive one from. A
+/// malformed entry that omits `path` decodes to an empty path and is skipped by
+/// [CodexProjectStorage.listOpenedProjects].
+@freezed
+sealed class CodexOpenedProject with _$CodexOpenedProject {
+  const factory CodexOpenedProject({
+    @Default("") String path,
+    String? name,
+    @Default(0) int addedAt,
+  }) = _CodexOpenedProject;
+
+  factory CodexOpenedProject.fromJson(Map<String, dynamic> json) =>
+      _$CodexOpenedProjectFromJson(json);
+}
+
+/// File-backed store of the project directories the user has explicitly opened,
+/// created, or renamed from the app, persisted as a JSON array at
+/// `<CODEX_HOME>/sesori_projects.json`.
+///
+/// CODEX_HOME resolution mirrors [SessionRolloutReader]/[CodexConfigReader]:
+///   1. `$CODEX_HOME` if set.
+///   2. `$HOME/.codex` (or `$USERPROFILE/.codex` on Windows).
+///
+/// All operations are best-effort: reads fail soft to an empty list; a write
+/// failure is logged and dropped (the added folder simply won't survive a
+/// restart) rather than thrown, since project listing must never break on a
+/// single unwritable file.
+class CodexProjectStorage {
+  CodexProjectStorage({Map<String, String>? environment})
+    : _environment = environment ?? Platform.environment;
+
+  final Map<String, String> _environment;
+
+  static const String _fileName = "sesori_projects.json";
+
+  String? get codexHome {
+    final explicit = _environment["CODEX_HOME"];
+    if (explicit != null && explicit.isNotEmpty) return explicit;
+    final home = _environment["HOME"] ?? _environment["USERPROFILE"];
+    if (home == null || home.isEmpty) return null;
+    return p.join(home, ".codex");
+  }
+
+  /// Absolute path to `sesori_projects.json`, or null when CODEX_HOME can't be
+  /// resolved.
+  String? get filePath {
+    final home = codexHome;
+    if (home == null) return null;
+    return p.join(home, _fileName);
+  }
+
+  /// Every persisted opened/renamed project. Fails soft to `const []` on a
+  /// missing file, an unresolvable home, or a parse/IO error; entries that
+  /// decode without a usable path are skipped.
+  List<CodexOpenedProject> listOpenedProjects() {
+    final path = filePath;
+    if (path == null) return const [];
+    final file = File(path);
+    if (!file.existsSync()) return const [];
+    try {
+      final entries = jsonDecodeListMap(file.readAsStringSync());
+      return [
+        for (final entry in entries)
+          if (CodexOpenedProject.fromJson(entry) case final project
+              when project.path.isNotEmpty)
+            project,
+      ];
+    } catch (error, stackTrace) {
+      Log.w("CodexProjectStorage: failed to read $path", error, stackTrace);
+      return const [];
+    }
+  }
+
+  /// Records [path] as an opened project. Idempotent: a new path is stamped with
+  /// the current time; an existing path keeps its original `addedAt`. When
+  /// [name] is non-null it sets/overrides the display name; a null [name] leaves
+  /// any existing name intact.
+  void upsertProject({required String path, String? name}) {
+    final target = filePath;
+    if (target == null) return;
+    final byPath = <String, CodexOpenedProject>{
+      for (final e in listOpenedProjects()) e.path: e,
+    };
+    final prior = byPath[path];
+    byPath[path] = CodexOpenedProject(
+      path: path,
+      name: name ?? prior?.name,
+      addedAt: prior?.addedAt ?? DateTime.now().millisecondsSinceEpoch,
+    );
+    try {
+      final file = File(target);
+      file.parent.createSync(recursive: true);
+      file.writeAsStringSync(
+        jsonEncode([for (final e in byPath.values) e.toJson()]),
+      );
+    } catch (error, stackTrace) {
+      Log.w("CodexProjectStorage: failed to write $target", error, stackTrace);
+    }
+  }
+}

--- a/bridge/sesori_plugin_codex/lib/src/codex_project_storage.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_project_storage.freezed.dart
@@ -1,0 +1,154 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'codex_project_storage.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$CodexOpenedProject {
+
+ String get path; String? get name; int get addedAt;
+/// Create a copy of CodexOpenedProject
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexOpenedProjectCopyWith<CodexOpenedProject> get copyWith => _$CodexOpenedProjectCopyWithImpl<CodexOpenedProject>(this as CodexOpenedProject, _$identity);
+
+  /// Serializes this CodexOpenedProject to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexOpenedProject&&(identical(other.path, path) || other.path == path)&&(identical(other.name, name) || other.name == name)&&(identical(other.addedAt, addedAt) || other.addedAt == addedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,path,name,addedAt);
+
+@override
+String toString() {
+  return 'CodexOpenedProject(path: $path, name: $name, addedAt: $addedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexOpenedProjectCopyWith<$Res>  {
+  factory $CodexOpenedProjectCopyWith(CodexOpenedProject value, $Res Function(CodexOpenedProject) _then) = _$CodexOpenedProjectCopyWithImpl;
+@useResult
+$Res call({
+ String path, String? name, int addedAt
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexOpenedProjectCopyWithImpl<$Res>
+    implements $CodexOpenedProjectCopyWith<$Res> {
+  _$CodexOpenedProjectCopyWithImpl(this._self, this._then);
+
+  final CodexOpenedProject _self;
+  final $Res Function(CodexOpenedProject) _then;
+
+/// Create a copy of CodexOpenedProject
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? path = null,Object? name = freezed,Object? addedAt = null,}) {
+  return _then(_self.copyWith(
+path: null == path ? _self.path : path // ignore: cast_nullable_to_non_nullable
+as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,addedAt: null == addedAt ? _self.addedAt : addedAt // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _CodexOpenedProject implements CodexOpenedProject {
+  const _CodexOpenedProject({this.path = "", this.name, this.addedAt = 0});
+  factory _CodexOpenedProject.fromJson(Map<String, dynamic> json) => _$CodexOpenedProjectFromJson(json);
+
+@override@JsonKey() final  String path;
+@override final  String? name;
+@override@JsonKey() final  int addedAt;
+
+/// Create a copy of CodexOpenedProject
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexOpenedProjectCopyWith<_CodexOpenedProject> get copyWith => __$CodexOpenedProjectCopyWithImpl<_CodexOpenedProject>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$CodexOpenedProjectToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexOpenedProject&&(identical(other.path, path) || other.path == path)&&(identical(other.name, name) || other.name == name)&&(identical(other.addedAt, addedAt) || other.addedAt == addedAt));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,path,name,addedAt);
+
+@override
+String toString() {
+  return 'CodexOpenedProject(path: $path, name: $name, addedAt: $addedAt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexOpenedProjectCopyWith<$Res> implements $CodexOpenedProjectCopyWith<$Res> {
+  factory _$CodexOpenedProjectCopyWith(_CodexOpenedProject value, $Res Function(_CodexOpenedProject) _then) = __$CodexOpenedProjectCopyWithImpl;
+@override @useResult
+$Res call({
+ String path, String? name, int addedAt
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexOpenedProjectCopyWithImpl<$Res>
+    implements _$CodexOpenedProjectCopyWith<$Res> {
+  __$CodexOpenedProjectCopyWithImpl(this._self, this._then);
+
+  final _CodexOpenedProject _self;
+  final $Res Function(_CodexOpenedProject) _then;
+
+/// Create a copy of CodexOpenedProject
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? path = null,Object? name = freezed,Object? addedAt = null,}) {
+  return _then(_CodexOpenedProject(
+path: null == path ? _self.path : path // ignore: cast_nullable_to_non_nullable
+as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String?,addedAt: null == addedAt ? _self.addedAt : addedAt // ignore: cast_nullable_to_non_nullable
+as int,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/sesori_plugin_codex/lib/src/codex_project_storage.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_project_storage.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'codex_project_storage.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_CodexOpenedProject _$CodexOpenedProjectFromJson(Map json) =>
+    _CodexOpenedProject(
+      path: json['path'] as String? ?? "",
+      name: json['name'] as String?,
+      addedAt: (json['addedAt'] as num?)?.toInt() ?? 0,
+    );
+
+Map<String, dynamic> _$CodexOpenedProjectToJson(_CodexOpenedProject instance) =>
+    <String, dynamic>{
+      'path': instance.path,
+      'name': instance.name,
+      'addedAt': instance.addedAt,
+    };

--- a/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
@@ -126,6 +126,45 @@ void main() {
       }
     });
 
+    test("sessions under merged trailing-slash spellings stay reachable from the one project", () async {
+      final tempHome = Directory.systemTemp.createTempSync("codex-home-reach-");
+      try {
+        // Same directory recorded two ways — with and without a trailing slash.
+        _writeMetaRollout(
+          tempHome,
+          sessionId: "019a0000-1111-2222-3333-e00000000001",
+          cwd: "/work/dup",
+          timestamp: "2026-05-07T10:00:00Z",
+        );
+        _writeMetaRollout(
+          tempHome,
+          sessionId: "019a0000-1111-2222-3333-e00000000002",
+          cwd: "/work/dup/",
+          timestamp: "2026-05-07T11:00:00Z",
+        );
+
+        final plugin = _hermeticPlugin(home: tempHome, projectCwd: "/launch/dir");
+        final dupProjects = (await plugin.getProjects())
+            .where((pr) => pr.id == "/work/dup" || pr.id == "/work/dup/")
+            .toList();
+        // The two spellings collapse to a single project…
+        expect(dupProjects, hasLength(1));
+        // …and getSessions on that project's id returns BOTH sessions, not just
+        // the one whose cwd spelling matched verbatim.
+        final sessions = await plugin.getSessions(dupProjects.single.id);
+        expect(
+          sessions.map((s) => s.id).toSet(),
+          equals({
+            "019a0000-1111-2222-3333-e00000000001",
+            "019a0000-1111-2222-3333-e00000000002",
+          }),
+        );
+        await plugin.dispose();
+      } finally {
+        _rmTree(tempHome);
+      }
+    });
+
     test("getProject registers and persists an opened directory with no sessions", () async {
       final tempHome = Directory.systemTemp.createTempSync("codex-home-open-");
       try {

--- a/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
@@ -20,27 +20,138 @@ void main() {
       expect(plugin.id, equals("codex"));
     });
 
-    test("getProjects synthesises a single project from launch CWD", () async {
-      // Phase 3: a single PluginProject is returned for the launch CWD.
-      // Pin both CODEX_HOME (away from the user's real history) and
-      // projectCwd so the test is hermetic.
-      final tempHome = Directory.systemTemp.createTempSync("codex-home-stub-");
+    test("getProjects derives a project per distinct session cwd plus launch cwd", () async {
+      final tempHome = Directory.systemTemp.createTempSync("codex-home-proj-");
       try {
-        final plugin = CodexPlugin(
-          serverUrl: "ws://127.0.0.1:0",
-          rolloutReader: SessionRolloutReader(
-            environment: {"CODEX_HOME": tempHome.path},
-          ),
-          projectCwd: "/repo/example",
+        _writeMetaRollout(
+          tempHome,
+          sessionId: "019a0000-1111-2222-3333-a00000000001",
+          cwd: "/work/alpha",
+          timestamp: "2026-05-01T10:00:00Z",
         );
+        _writeMetaRollout(
+          tempHome,
+          sessionId: "019a0000-1111-2222-3333-a00000000002",
+          cwd: "/work/alpha",
+          timestamp: "2026-05-03T12:00:00Z",
+        );
+        _writeMetaRollout(
+          tempHome,
+          sessionId: "019a0000-1111-2222-3333-b00000000001",
+          cwd: "/work/beta",
+          timestamp: "2026-05-02T10:00:00Z",
+        );
+
+        final plugin = _hermeticPlugin(home: tempHome, projectCwd: "/launch/dir");
         final projects = await plugin.getProjects();
-        expect(projects, hasLength(1));
-        expect(projects.single.id, equals("/repo/example"));
+        final byId = {for (final pr in projects) pr.id: pr};
+        expect(
+          byId.keys,
+          containsAll(<String>["/work/alpha", "/work/beta", "/launch/dir"]),
+        );
+        expect(byId["/work/alpha"]!.name, equals("alpha"));
+        expect(byId["/work/beta"]!.name, equals("beta"));
+        // Most-recent session activity sorts first; the session-less launch dir
+        // (time 0/0) sorts last.
+        expect(projects.first.id, equals("/work/alpha"));
+        expect(projects.last.id, equals("/launch/dir"));
+        expect(
+          byId["/work/alpha"]!.time?.updated,
+          equals(DateTime.parse("2026-05-03T12:00:00Z").millisecondsSinceEpoch),
+        );
         await plugin.dispose();
       } finally {
-        try {
-          tempHome.deleteSync(recursive: true);
-        } catch (_) {}
+        _rmTree(tempHome);
+      }
+    });
+
+    test("getSessions groups sessions by their own cwd with the correct projectID", () async {
+      final tempHome = Directory.systemTemp.createTempSync("codex-home-grp-");
+      try {
+        _writeMetaRollout(
+          tempHome,
+          sessionId: "019a0000-1111-2222-3333-a00000000001",
+          cwd: "/work/alpha",
+          timestamp: "2026-05-01T10:00:00Z",
+        );
+        _writeMetaRollout(
+          tempHome,
+          sessionId: "019a0000-1111-2222-3333-b00000000001",
+          cwd: "/work/beta",
+          timestamp: "2026-05-02T10:00:00Z",
+        );
+
+        final plugin = _hermeticPlugin(home: tempHome, projectCwd: "/launch/dir");
+        final alpha = await plugin.getSessions("/work/alpha");
+        expect(
+          alpha.map((s) => s.id).toList(),
+          equals(["019a0000-1111-2222-3333-a00000000001"]),
+        );
+        expect(alpha.single.projectID, equals("/work/alpha"));
+        expect(alpha.single.directory, equals("/work/alpha"));
+
+        final beta = await plugin.getSessions("/work/beta");
+        expect(
+          beta.map((s) => s.id).toList(),
+          equals(["019a0000-1111-2222-3333-b00000000001"]),
+        );
+        expect(beta.single.projectID, equals("/work/beta"));
+        await plugin.dispose();
+      } finally {
+        _rmTree(tempHome);
+      }
+    });
+
+    test("a session cwd and a trailing-slash launch cwd dedupe to one project", () async {
+      final tempHome = Directory.systemTemp.createTempSync("codex-home-dup-");
+      try {
+        _writeMetaRollout(
+          tempHome,
+          sessionId: "019a0000-1111-2222-3333-d00000000001",
+          cwd: "/work/dup",
+          timestamp: "2026-05-05T10:00:00Z",
+        );
+        // Launch CWD carries a trailing separator; the session CWD does not.
+        final plugin = _hermeticPlugin(home: tempHome, projectCwd: "/work/dup/");
+        final ids = (await plugin.getProjects()).map((pr) => pr.id).toList();
+        // They collapse to a single project whose id is the session cwd verbatim
+        // (so getSessions' exact filter keeps matching).
+        expect(
+          ids.where((id) => id == "/work/dup" || id == "/work/dup/").toList(),
+          equals(["/work/dup"]),
+        );
+        await plugin.dispose();
+      } finally {
+        _rmTree(tempHome);
+      }
+    });
+
+    test("getProject registers and persists an opened directory with no sessions", () async {
+      final tempHome = Directory.systemTemp.createTempSync("codex-home-open-");
+      try {
+        final plugin = _hermeticPlugin(home: tempHome, projectCwd: "/launch/dir");
+        final opened = await plugin.getProject("/work/new-folder");
+        expect(opened.id, equals("/work/new-folder"));
+        expect(opened.name, equals("new-folder"));
+        // Appears in the list right away…
+        expect(
+          (await plugin.getProjects()).map((pr) => pr.id),
+          contains("/work/new-folder"),
+        );
+        await plugin.dispose();
+
+        // …and survives a fresh plugin instance (persisted under CODEX_HOME).
+        final restarted = _hermeticPlugin(
+          home: tempHome,
+          projectCwd: "/launch/dir",
+        );
+        expect(
+          (await restarted.getProjects()).map((pr) => pr.id),
+          contains("/work/new-folder"),
+        );
+        await restarted.dispose();
+      } finally {
+        _rmTree(tempHome);
       }
     });
 
@@ -146,22 +257,12 @@ void main() {
     });
 
     test(
-      "renameProject returns the synthesised project with the new name",
+      "renameProject persists a display-name override that survives a refresh",
       () async {
-        // Phase 6 dropped the last UnimplementedError. renameProject is a
-        // no-op against codex (single-project model) but echoes the new
-        // name so any caller's local cache stays consistent.
         final tempHome = Directory.systemTemp.createTempSync("codex-home-rn-");
         try {
-          final plugin = CodexPlugin(
-            serverUrl: "ws://127.0.0.1:0",
-            rolloutReader: SessionRolloutReader(
-              environment: {"CODEX_HOME": tempHome.path},
-            ),
-            skillReader: CodexSkillReader(
-              environment: {"CODEX_HOME": tempHome.path},
-              projectCwd: tempHome.path,
-            ),
+          final plugin = _hermeticPlugin(
+            home: tempHome,
             projectCwd: "/repo/example",
           );
           final renamed =
@@ -169,10 +270,18 @@ void main() {
           expect(renamed.id, equals("/repo/example"));
           expect(renamed.name, equals("X"));
           await plugin.dispose();
+
+          // The override is persisted, so a fresh plugin still lists the name.
+          final restarted = _hermeticPlugin(
+            home: tempHome,
+            projectCwd: "/repo/example",
+          );
+          final project = (await restarted.getProjects())
+              .firstWhere((pr) => pr.id == "/repo/example");
+          expect(project.name, equals("X"));
+          await restarted.dispose();
         } finally {
-          try {
-            tempHome.deleteSync(recursive: true);
-          } catch (_) {}
+          _rmTree(tempHome);
         }
       },
     );
@@ -311,6 +420,60 @@ void main() {
       await client.dispose();
     });
   });
+}
+
+/// Builds a fully-hermetic CodexPlugin: every reader and the project store are
+/// pinned to a temp CODEX_HOME so a test never touches the user's real history.
+CodexPlugin _hermeticPlugin({
+  required Directory home,
+  required String projectCwd,
+}) {
+  final env = {"CODEX_HOME": home.path};
+  return CodexPlugin(
+    serverUrl: "ws://127.0.0.1:0",
+    rolloutReader: SessionRolloutReader(environment: env),
+    configReader: CodexConfigReader(environment: env),
+    skillReader: CodexSkillReader(environment: env, projectCwd: projectCwd),
+    projectStorage: CodexProjectStorage(environment: env),
+    projectCwd: projectCwd,
+  );
+}
+
+/// Writes a minimal rollout carrying only the `session_meta` header (id, cwd,
+/// timestamp) under a date-derived `sessions/YYYY/MM/DD/` path.
+void _writeMetaRollout(
+  Directory codexHome, {
+  required String sessionId,
+  required String cwd,
+  required String timestamp,
+}) {
+  final date = DateTime.parse(timestamp).toUtc();
+  String two(int v) => v.toString().padLeft(2, "0");
+  final dateDir = "${date.year}/${two(date.month)}/${two(date.day)}";
+  final fileName =
+      "rollout-${date.year}-${two(date.month)}-${two(date.day)}T00-00-00-$sessionId.jsonl";
+  final full = p.join(codexHome.path, "sessions", dateDir, fileName);
+  Directory(p.dirname(full)).createSync(recursive: true);
+  final line = jsonEncode({
+    "timestamp": timestamp,
+    "type": "session_meta",
+    "payload": {
+      "id": sessionId,
+      "timestamp": timestamp,
+      "cwd": cwd,
+      "cli_version": "0.142.0",
+      "model_provider": "openai",
+    },
+  });
+  File(full).writeAsStringSync("$line\n");
+}
+
+void _rmTree(Directory dir) {
+  try {
+    dir.deleteSync(recursive: true);
+  } catch (_) {
+    // Best-effort cleanup.
+  }
 }
 
 const Map<String, dynamic> _initOk = {

--- a/bridge/sesori_plugin_codex/test/codex_plugin_phase6_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_phase6_test.dart
@@ -39,6 +39,9 @@ void main() {
         environment: {"CODEX_HOME": codexHome.path},
         projectCwd: projectCwd.path,
       ),
+      projectStorage: CodexProjectStorage(
+        environment: {"CODEX_HOME": codexHome.path},
+      ),
       projectCwd: projectCwd.path,
     );
 

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -132,6 +132,32 @@ void main() {
       expect(fake.sentMethods, equals(["initialize", "thread/name/set"]));
     });
 
+    test("renameSession resolves a freshly-created session's directory from memory before its rollout flushes", () async {
+      // createSession reports cwd /work/live; no rollout is written to disk for
+      // it, so only the in-memory thread→directory mapping knows the project.
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(result: {"thread": {"id": "t-live", "cwd": "/work/live"}}),
+        const _Response(result: {}),
+      ]);
+      await plugin.createSession(
+        directory: "/work/live",
+        parentSessionId: null,
+        parts: const [],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+
+      final renamed = await plugin.renameSession(
+        sessionId: "t-live",
+        title: "Renamed",
+      );
+      // Resolves to /work/live (the created directory), not the launch CWD.
+      expect(renamed.projectID, equals("/work/live"));
+      expect(renamed.directory, equals("/work/live"));
+    });
+
     test("getProjectQuestions scopes pending questions to the project's own sessions", () async {
       // Two live sessions in distinct project directories.
       _writeMetaRollout(

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -30,6 +30,9 @@ void main() {
         rolloutReader: SessionRolloutReader(
           environment: {"CODEX_HOME": codexHome.path},
         ),
+        projectStorage: CodexProjectStorage(
+          environment: {"CODEX_HOME": codexHome.path},
+        ),
         projectCwd: "/work/sample",
       );
     });
@@ -78,6 +81,103 @@ void main() {
       final turnStartParams = fake.sentParamsFor("turn/start");
       expect(turnStartParams["threadId"], equals("t-new"));
       expect((turnStartParams["input"] as List).first["text"], equals("hello codex"));
+    });
+
+    test("createSession in a new directory stamps it as projectID and registers it", () async {
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(result: {"thread": {"id": "t-other", "cwd": "/work/other"}}),
+      ]);
+
+      final session = await plugin.createSession(
+        directory: "/work/other",
+        parentSessionId: null,
+        parts: const [],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+
+      // The session belongs to its own directory, not the launch CWD…
+      expect(session.projectID, equals("/work/other"));
+      expect(session.directory, equals("/work/other"));
+      // …and the brand-new directory surfaces as a project immediately, before
+      // codex flushes a rollout for it.
+      expect(
+        (await plugin.getProjects()).map((p) => p.id),
+        contains("/work/other"),
+      );
+    });
+
+    test("renameSession returns the session's real cwd as projectID/directory", () async {
+      _writeMetaRollout(
+        codexHome,
+        sessionId: "019a0000-1111-2222-3333-c00000000001",
+        cwd: "/work/gamma",
+        timestamp: "2026-05-04T10:00:00Z",
+      );
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(result: {}),
+      ]);
+
+      final renamed = await plugin.renameSession(
+        sessionId: "019a0000-1111-2222-3333-c00000000001",
+        title: "Renamed",
+      );
+
+      expect(renamed.title, equals("Renamed"));
+      expect(renamed.projectID, equals("/work/gamma"));
+      expect(renamed.directory, equals("/work/gamma"));
+      expect(fake.sentMethods, equals(["initialize", "thread/name/set"]));
+    });
+
+    test("getProjectQuestions scopes pending questions to the project's own sessions", () async {
+      // Two live sessions in distinct project directories.
+      _writeMetaRollout(
+        codexHome,
+        sessionId: "019a0000-1111-2222-3333-q0000000000a",
+        cwd: "/work/qa",
+        timestamp: "2026-05-06T10:00:00Z",
+      );
+      _writeMetaRollout(
+        codexHome,
+        sessionId: "019a0000-1111-2222-3333-q0000000000b",
+        cwd: "/work/qb",
+        timestamp: "2026-05-06T11:00:00Z",
+      );
+
+      fake.respondInOrder([const _Response(result: _initOk)]);
+      await plugin.healthCheck(); // connect + attach the approval registry
+
+      // Mark both threads live, then raise an elicitation only on the /work/qa one.
+      fake.pushNotification("turn/started", {
+        "threadId": "019a0000-1111-2222-3333-q0000000000a",
+        "turn": {"id": "u-a"},
+      });
+      fake.pushNotification("turn/started", {
+        "threadId": "019a0000-1111-2222-3333-q0000000000b",
+        "turn": {"id": "u-b"},
+      });
+      fake.pushServerRequest(900, "mcpServer/elicitation/request", {
+        "threadId": "019a0000-1111-2222-3333-q0000000000a",
+        "serverName": "fs-mcp",
+        "mode": "form",
+        "message": "Where should I write the result?",
+        "requestedSchema": {"type": "string"},
+      });
+      await pumpEventQueue();
+
+      // The /work/qa project sees its session's question…
+      expect(
+        await plugin.getProjectQuestions(projectId: "/work/qa"),
+        hasLength(1),
+      );
+      // …while /work/qb does not (no cross-project leakage).
+      expect(
+        await plugin.getProjectQuestions(projectId: "/work/qb"),
+        isEmpty,
+      );
     });
 
     test("sendPrompt resumes a thread from a prior run before the turn", () async {
@@ -265,6 +365,9 @@ void main() {
         rolloutReader: SessionRolloutReader(
           environment: {"CODEX_HOME": codexHome.path},
         ),
+        projectStorage: CodexProjectStorage(
+          environment: {"CODEX_HOME": codexHome.path},
+        ),
         projectCwd: "/work/sample",
         keepaliveInterval: const Duration(milliseconds: 20),
       );
@@ -409,6 +512,35 @@ const Map<String, dynamic> _initOk = {
   "platformFamily": "unix",
 };
 
+/// Writes a minimal rollout (session_meta header only) so the rollout reader can
+/// resolve a session's cwd in tests that exercise the read path.
+void _writeMetaRollout(
+  Directory codexHome, {
+  required String sessionId,
+  required String cwd,
+  required String timestamp,
+}) {
+  final date = DateTime.parse(timestamp).toUtc();
+  String two(int v) => v.toString().padLeft(2, "0");
+  final dateDir = "${date.year}/${two(date.month)}/${two(date.day)}";
+  final fileName =
+      "rollout-${date.year}-${two(date.month)}-${two(date.day)}T00-00-00-$sessionId.jsonl";
+  final full = "${codexHome.path}/sessions/$dateDir/$fileName";
+  Directory("${codexHome.path}/sessions/$dateDir").createSync(recursive: true);
+  final line = jsonEncode({
+    "timestamp": timestamp,
+    "type": "session_meta",
+    "payload": {
+      "id": sessionId,
+      "timestamp": timestamp,
+      "cwd": cwd,
+      "cli_version": "0.142.0",
+      "model_provider": "openai",
+    },
+  });
+  File(full).writeAsStringSync("$line\n");
+}
+
 class _Response {
   // ignore: unused_element_parameter
   const _Response({this.result, this.error});
@@ -457,12 +589,33 @@ class _FakeAppServer {
     );
   }
 
+  /// Pushes a server-originated JSON-RPC request (carries an `id`, unlike a
+  /// notification), which the client routes to its `serverRequests` stream —
+  /// the path approval/elicitation prompts arrive on.
+  void pushServerRequest(int id, String method, Map<String, dynamic> params) {
+    _serverToClient.add(
+      jsonEncode({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": method,
+        "params": params,
+      }),
+    );
+  }
+
   void _onClientFrame(Object? frame) {
     final raw = frame as String;
     final decoded = jsonDecode(raw) as Map<String, dynamic>;
+    final method = decoded["method"];
+    if (method is! String) {
+      // A client response to a server-originated request (id + result/error, no
+      // method) — e.g. the plugin denying a still-pending elicitation on
+      // dispose. No test inspects client responses, so ignore it.
+      return;
+    }
     _sent.add(
       _SentFrame(
-        method: decoded["method"] as String,
+        method: method,
         params: (decoded["params"] as Map?)?.cast<String, dynamic>(),
       ),
     );

--- a/bridge/sesori_plugin_codex/test/codex_project_storage_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_project_storage_test.dart
@@ -1,0 +1,101 @@
+import "dart:io";
+
+import "package:codex_plugin/codex_plugin.dart";
+import "package:path/path.dart" as p;
+import "package:test/test.dart";
+
+void main() {
+  group("CodexProjectStorage", () {
+    late Directory codexHome;
+
+    setUp(() {
+      codexHome = Directory.systemTemp.createTempSync("codex-store-");
+    });
+
+    tearDown(() {
+      try {
+        codexHome.deleteSync(recursive: true);
+      } catch (_) {
+        // Best-effort cleanup.
+      }
+    });
+
+    CodexProjectStorage storageFor(Map<String, String> env) =>
+        CodexProjectStorage(environment: env);
+
+    test(r"codexHome resolves $CODEX_HOME, then $HOME/.codex, else null", () {
+      expect(
+        storageFor({"CODEX_HOME": "/explicit/home"}).codexHome,
+        equals("/explicit/home"),
+      );
+      expect(
+        storageFor({"HOME": "/users/me"}).codexHome,
+        equals(p.join("/users/me", ".codex")),
+      );
+      expect(storageFor(const {}).codexHome, isNull);
+    });
+
+    test("reads are empty and writes are no-ops when CODEX_HOME is unresolvable", () {
+      final storage = storageFor(const {});
+      expect(storage.filePath, isNull);
+      expect(storage.listOpenedProjects(), isEmpty);
+      // Must not throw even though there is nowhere to persist.
+      expect(() => storage.upsertProject(path: "/x"), returnsNormally);
+    });
+
+    test("listOpenedProjects is empty when the file does not exist", () {
+      expect(storageFor({"CODEX_HOME": codexHome.path}).listOpenedProjects(), isEmpty);
+    });
+
+    test("upsertProject persists a path with a positive addedAt", () {
+      final storage = storageFor({"CODEX_HOME": codexHome.path});
+      storage.upsertProject(path: "/work/alpha");
+
+      final projects = storage.listOpenedProjects();
+      expect(projects, hasLength(1));
+      expect(projects.single.path, equals("/work/alpha"));
+      expect(projects.single.name, isNull);
+      expect(projects.single.addedAt, greaterThan(0));
+    });
+
+    test("re-upserting a path preserves its addedAt and applies a later name", () {
+      final storage = storageFor({"CODEX_HOME": codexHome.path});
+      storage.upsertProject(path: "/work/alpha");
+      final firstAddedAt = storage.listOpenedProjects().single.addedAt;
+
+      // Name-only update keeps the original timestamp.
+      storage.upsertProject(path: "/work/alpha", name: "Alpha");
+      final afterName = storage.listOpenedProjects().single;
+      expect(afterName.addedAt, equals(firstAddedAt));
+      expect(afterName.name, equals("Alpha"));
+
+      // A subsequent null-name upsert leaves the existing name intact.
+      storage.upsertProject(path: "/work/alpha");
+      expect(storage.listOpenedProjects().single.name, equals("Alpha"));
+    });
+
+    test("malformed JSON degrades to an empty list", () {
+      File(p.join(codexHome.path, "sesori_projects.json"))
+          .writeAsStringSync("{ this is not valid json");
+      expect(storageFor({"CODEX_HOME": codexHome.path}).listOpenedProjects(), isEmpty);
+    });
+
+    test("entries with no usable path are skipped", () {
+      File(p.join(codexHome.path, "sesori_projects.json")).writeAsStringSync(
+        '[{"name":"orphan"},{"path":"","addedAt":1},{"path":"/ok","addedAt":2}]',
+      );
+      final projects = storageFor({"CODEX_HOME": codexHome.path}).listOpenedProjects();
+      expect(projects.map((e) => e.path).toList(), equals(["/ok"]));
+    });
+
+    test("persists across separate storage instances (survives restart)", () {
+      storageFor({"CODEX_HOME": codexHome.path})
+          .upsertProject(path: "/work/beta", name: "Beta");
+
+      final reopened = storageFor({"CODEX_HOME": codexHome.path}).listOpenedProjects();
+      expect(reopened, hasLength(1));
+      expect(reopened.single.path, equals("/work/beta"));
+      expect(reopened.single.name, equals("Beta"));
+    });
+  });
+}

--- a/bridge/sesori_plugin_codex/test/session_rollout_reader_test.dart
+++ b/bridge/sesori_plugin_codex/test/session_rollout_reader_test.dart
@@ -276,6 +276,9 @@ void main() {
         rolloutReader: SessionRolloutReader(
           environment: {"CODEX_HOME": codexHome.path},
         ),
+        projectStorage: CodexProjectStorage(
+          environment: {"CODEX_HOME": codexHome.path},
+        ),
         projectCwd: "/work/sample-app",
       );
       final projects = await plugin.getProjects();
@@ -304,6 +307,9 @@ void main() {
       final plugin = CodexPlugin(
         serverUrl: "ws://127.0.0.1:0",
         rolloutReader: SessionRolloutReader(
+          environment: {"CODEX_HOME": codexHome.path},
+        ),
+        projectStorage: CodexProjectStorage(
           environment: {"CODEX_HOME": codexHome.path},
         ),
         projectCwd: "/work/sample-app",
@@ -351,6 +357,9 @@ void main() {
       final plugin = CodexPlugin(
         serverUrl: "ws://127.0.0.1:0",
         rolloutReader: SessionRolloutReader(
+          environment: {"CODEX_HOME": codexHome.path},
+        ),
+        projectStorage: CodexProjectStorage(
           environment: {"CODEX_HOME": codexHome.path},
         ),
         projectCwd: "/work/sample-app",


### PR DESCRIPTION
## Problem

A user on the codex backend reported:
> It works, but it doesn't sync my existing projects. Just this project and inside are all my random (no project) sessions. Also tried adding a new project (folder from PC) and it just said "project discovered" but did not add it to my list.

Both symptoms trace to one root cause: the codex plugin synthesised a **single** project from the bridge's launch CWD.

- **Projects don't sync:** `getProjects()` returned only `[launchCwdProject]`, and `_toPluginSession` hardcoded every session's `projectID` to the launch CWD — so a user's real codex project directories never appeared, and their sessions all looked like "random no-project" sessions under the one launch project.
- **Added folder vanishes:** `discoverProject` → `POST /project/open` → `getProject(path)` **ignored the path** and returned the launch-CWD project; nothing persisted the directory, so the "Project discovered" toast showed but the folder was gone on the next refresh.

## Fix (entirely within `bridge/sesori_plugin_codex`)

- `getProjects()` derives one project per **distinct session CWD** ∪ launch CWD ∪ user-opened dirs, deduped by a trailing-separator-insensitive key with **verbatim ids** (so `getSessions`' exact `cwd == projectId` filter keeps matching). Session timestamps drive recency; basenames (or a stored override) drive names; a session-less dir gets a stable `0/0` time.
- New **`CodexProjectStorage`** (Layer-1, Freezed model + `jsonDecodeListMap`) persists opened/created/renamed directories to `~/.codex/sesori_projects.json`, so an added folder with no sessions survives the refresh and bridge restarts.
- `getProject(path)` honours the path and registers it; `createSession`/`renameSession`/`_toPluginSession` stamp the session's own directory; `renameProject` persists a name override; `getProjectQuestions` is scoped to the project's own sessions (no cross-project badge leakage).

## Verification

- `make analyze` clean; **all 1548 bridge tests pass** (new tests cover multi-project derivation, per-CWD session grouping, opened-folder persistence across restart, rename override, trailing-slash dedupe, and question scoping; all codex test plugin constructions made hermetic).
- Real-data harness against an actual `~/.codex`: **24 projects** derived from 76 sessions (was 1), each grouping its own sessions.
- **Live on iPhone 17 Pro Max:** the app shows all 24 projects (was 1); sessions group under the correct project; adding an empty folder shows "Project discovered" **and** it appears at the top, persists, and opens cleanly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex project sync by deriving one project per session CWD and persisting user-added folders. Adds absolute-normalized path matching and in-memory session directory tracking so sessions and questions map to the right project across refresh, restart, and path spellings.

- **Bug Fixes**
  - `getProjects()` derives from distinct session CWDs ∪ launch CWD ∪ stored dirs, dedupes via an absolute-normalized key (`p.absolute` + `p.normalize`), keeps verbatim ids, and sorts by most recent activity.
  - Introduced `CodexProjectStorage` to persist opened/renamed directories and display-name overrides at `~/.codex/sesori_projects.json`.
  - `getProject(path)` honors and registers the path; `createSession` stamps/registers its cwd and tracks a thread→directory map; unload clears the mapping.
  - `getSessions` and `getProjectQuestions` match by the absolute-normalized path key (handles trailing slashes and `.`/`..`, and collapses relative vs absolute spellings) so all spellings collapse to one project; questions are scoped to that project's sessions.
  - `_directoryForSession` resolves cwd via `findRolloutPath` + `readMeta` (O(1)) with in-memory fallback for fresh sessions; `renameSession` uses the real cwd; `renameProject` persists a display-name override.

<sup>Written for commit 7ff60e1392d8056aea3a66c04485a1928680de5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

