### PR TITLE
feat(onboarding): pin flat "Need help?" support menu bottom-right

### DIFF
--- a/client/app/lib/core/external_link.dart
+++ b/client/app/lib/core/external_link.dart
@@ -1,0 +1,19 @@
+import "package:sesori_dart_core/sesori_dart_core.dart";
+
+import "di/injection.dart";
+
+/// Opens an external [url] (web page, mailto, etc.) via the DI-registered
+/// [UrlLauncher], logging (rather than crashing) when the platform reports the
+/// URL could not be handled.
+///
+/// This is the single shell-wide entry point for launching outbound links from
+/// presentation code — markdown link taps, support/contact menu items, and the
+/// login screen's terms/privacy links all funnel through here.
+Future<void> openExternalLink({required Uri url}) async {
+  try {
+    final launched = await getIt<UrlLauncher>().launch(url);
+    if (!launched) logw("Could not open external link: ${url.toString()}");
+  } on Object catch (error, stackTrace) {
+    logw("Failed to open external link", error, stackTrace);
+  }
+}

--- a/client/app/lib/core/support_links.dart
+++ b/client/app/lib/core/support_links.dart
@@ -1,0 +1,11 @@
+/// External support/contact destinations opened from the onboarding
+/// "Need help?" menu (Email / Discord / X).
+///
+/// Kept together so the destinations live in one place rather than being
+/// scattered across widgets. Launched through the DI-registered `UrlLauncher`.
+class SupportLinks {
+  const SupportLinks._();
+  static const String email = "mailto:hello@sesori.com";
+  static const String discord = "https://discord.gg/5KBC8dV9uR";
+  static const String x = "https://x.com/sesori_ai";
+}

--- a/client/app/lib/core/widgets/agent_model_buttons.dart
+++ b/client/app/lib/core/widgets/agent_model_buttons.dart
@@ -1,7 +1,6 @@
 import "dart:async";
 
 import "package:flutter/material.dart";
-import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart" show ModelPickerSection, ModelPickerSectionBuilder;
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
@@ -10,8 +9,9 @@ import "../extensions/build_context_x.dart";
 import "model_picker_sheet.dart";
 
 /// Composer header exposing the agent / model / variant selection as three
-/// liquid-glass pill buttons. Tapping a pill morphs it into a [GlassMenu]
-/// popup listing the pickable values (instead of a modal bottom sheet).
+/// glass pill buttons ([PregoButtonsGlass]). Tapping a pill opens its
+/// [PregoAnchorMenu] popup listing the pickable values (instead of a modal
+/// bottom sheet).
 ///
 /// The widget owns the menu contents, so it receives the selectable data and
 /// the selection callbacks directly rather than a "open picker" callback.
@@ -158,10 +158,10 @@ class _AgentMenu extends StatelessWidget {
     return PregoAnchorMenu(
       menuWidth: 240,
       menuHeight: agents.length > 6 ? 320 : null,
-      triggerBuilder: (context, toggle) => _Trigger(
-        icon: Icons.smart_toy_outlined,
+      triggerBuilder: (context, toggle) => PregoButtonsGlass(
+        leadingIcon: Icons.smart_toy_outlined,
         label: selectedAgent,
-        onTap: toggle,
+        onPressed: toggle,
       ),
       entries: [
         PregoMenuLabel(text: loc.sessionDetailPickerAgent),
@@ -232,10 +232,10 @@ class _ModelMenu extends StatelessWidget {
     return PregoAnchorMenu(
       menuWidth: 320,
       menuHeight: _modelMenuHeight(modelRows: modelRows, headerRows: headerRows),
-      triggerBuilder: (context, toggle) => _Trigger(
-        icon: Icons.memory_outlined,
+      triggerBuilder: (context, toggle) => PregoButtonsGlass(
+        leadingIcon: Icons.memory_outlined,
         label: _resolveModelName(context, providers: providers, selected: selected),
-        onTap: toggle,
+        onPressed: toggle,
       ),
       entries: entries,
     );
@@ -260,10 +260,10 @@ class _VariantMenu extends StatelessWidget {
     return PregoAnchorMenu(
       menuWidth: 220,
       menuHeight: availableVariants.length > 6 ? 320 : null,
-      triggerBuilder: (context, toggle) => _Trigger(
-        icon: Icons.speed_outlined,
+      triggerBuilder: (context, toggle) => PregoButtonsGlass(
+        leadingIcon: Icons.speed_outlined,
         label: selectedVariant ?? loc.sessionDetailVariantDefault,
-        onTap: toggle,
+        onPressed: toggle,
       ),
       entries: [
         PregoMenuLabel(text: loc.sessionDetailPickerVariant),
@@ -355,47 +355,4 @@ String _resolveModelName(
     }
   }
   return modelID.isNotEmpty ? modelID : fallback;
-}
-
-/// A single glass pill that triggers one of the menus. Fills its [Expanded]
-/// slot (so long labels ellipsize) and shows a caret to signal it opens a menu.
-class _Trigger extends StatelessWidget {
-  final IconData icon;
-  final String label;
-  final VoidCallback onTap;
-
-  const _Trigger({required this.icon, required this.label, required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    final prego = context.prego;
-    final foreground = prego.colors.textSecondary;
-    return GlassButton.custom(
-      onTap: onTap,
-      width: double.infinity,
-      height: 36,
-      shape: const LiquidRoundedRectangle(borderRadius: 18),
-      useOwnLayer: true,
-      settings: LiquidGlassSettings(glassColor: prego.colors.buttonGlassPrimaryBackground),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12),
-        child: Row(
-          children: [
-            Icon(icon, size: 14, color: foreground),
-            const SizedBox(width: 6),
-            Expanded(
-              child: Text(
-                label,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: prego.textTheme.textXs.medium.copyWith(color: foreground),
-              ),
-            ),
-            const SizedBox(width: 4),
-            Icon(Icons.unfold_more, size: 14, color: foreground),
-          ],
-        ),
-      ),
-    );
-  }
 }

--- a/client/app/lib/core/widgets/markdown_styles.dart
+++ b/client/app/lib/core/widgets/markdown_styles.dart
@@ -1,20 +1,21 @@
+import "dart:async";
+
 import "package:flutter/material.dart";
 import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
-import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:theme_prego/module_prego.dart";
 
-import "../di/injection.dart";
 import "../extensions/text_style_x.dart";
+import "../external_link.dart";
 import "code_block.dart";
 
 /// Shared [MarkdownBody.onTapLink] handler that opens URLs in the system
-/// browser via the DI-registered [UrlLauncher].
+/// browser via [openExternalLink].
 // ignore: no_slop_linter/prefer_required_named_parameters, callback signature is defined by MarkdownBody.onTapLink
 void handleMarkdownLinkTap(String text, String? href, String title) {
   if (href == null) return;
   final uri = Uri.tryParse(href);
   if (uri == null) return;
-  getIt<UrlLauncher>().launch(uri);
+  unawaited(openExternalLink(url: uri));
 }
 
 // ignore: no_slop_linter/prefer_required_named_parameters, paragraphStyle is an optional override

--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -34,9 +34,23 @@ class _BridgeOnboardingView extends StatelessWidget {
   }
 }
 
+/// Opens an external "Need help?" contact link via the DI-registered
+/// [UrlLauncher], logging (rather than crashing) when the platform reports it
+/// could not be handled.
+Future<void> _openSupportLink(String url) async {
+  try {
+    final launched = await getIt<UrlLauncher>().launch(Uri.parse(url));
+    if (!launched) logw("Could not open support link: $url");
+  } on Object catch (error, stackTrace) {
+    logw("Failed to open support link", error, stackTrace);
+  }
+}
+
 /// The shared onboarding body: the phone/PC connection status lines, the
-/// connection graphic, the "Why is this needed?" info button, and the
-/// per-platform install command boxes.
+/// connection graphic, and the per-platform install command boxes. The
+/// "Need help?" support menu ([_NeedHelpMenu]) is not part of this scroll flow —
+/// it rides the scaffold's floating-action slot, pinned to the bottom-right
+/// corner above the home indicator.
 ///
 /// [connected] switches the connection graphic between its "off" and "on"
 /// states; the rest of the body is shared by both empty Projects states.
@@ -101,27 +115,62 @@ class _OnboardingChecklist extends StatelessWidget {
           style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textPrimary),
           textAlign: TextAlign.center,
         ),
-        const SizedBox(height: PregoSpacing.lg),
-        // Wrapped so the parent Column's stretch alignment doesn't force the
-        // button full-width; fullWidth: false then sizes it to its content.
-        // TODO(daniil): add the button back
-        /* Center(
-          child: PregoButtonsSolid(
-            fullWidth: false,
-            leadingIcon: TablerRegular.info_circle,
-            label: loc.projectsOnboardingPcStatusWhy,
-            hierarchy: PregoButtonsSolidHierarchy.secondary,
-            size: PregoButtonsSolidSize.sm,
-            onPressed: () {
-              // TODO(daniil): show the new bottom sheet
-            },
-          ),
-        ),*/
         // 40px gap from the header group to the install boxes (Figma gap-5xl).
         const SizedBox(height: PregoSpacing.x5l),
         const Padding(
           padding: EdgeInsetsDirectional.fromSTEB(PregoSpacing.xl, 0, PregoSpacing.xl, PregoSpacing.x3l),
           child: _InstallCommandBoxes(),
+        ),
+        // Bottom breathing room so the last install box can be scrolled clear of
+        // the "Need help?" button pinned in the bottom-right corner.
+        const SizedBox(height: PregoSpacing.x6l),
+      ],
+    );
+  }
+}
+
+/// The onboarding support menu: a flat "Need help?" pill that opens a flat
+/// anchored menu of support channels (email, Discord, X), each launching an
+/// external link. Forced flat on every platform ([PregoAnchorMenu.flat]) so the
+/// popup matches its solid pill trigger instead of morphing in as glass.
+class _NeedHelpMenu extends StatelessWidget {
+  const _NeedHelpMenu();
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = context.loc;
+    return PregoAnchorMenu(
+      flat: true,
+      menuWidth: 200,
+      triggerBuilder: (context, toggle) => PregoButtonsSolid(
+        leadingIcon: TablerRegular.help,
+        label: loc.projectsOnboardingNeedHelp,
+        hierarchy: PregoButtonsSolidHierarchy.secondary,
+        size: PregoButtonsSolidSize.xl,
+        onPressed: toggle,
+      ),
+      entries: [
+        PregoMenuItem(
+          leadingIcon: TablerRegular.mail,
+          title: loc.projectsOnboardingNeedHelpEmail,
+          subtitle: null,
+          isSelected: false,
+          onTap: () => unawaited(_openSupportLink(SupportLinks.email)),
+        ),
+        PregoMenuItem(
+          leadingIcon: TablerRegular.brand_discord,
+          title: loc.projectsOnboardingNeedHelpDiscord,
+          subtitle: null,
+          isSelected: false,
+          onTap: () => unawaited(_openSupportLink(SupportLinks.discord)),
+        ),
+        PregoMenuItem(
+          // Tabler's pinned set ships the legacy bird glyph, not the X mark.
+          leadingIcon: TablerRegular.brand_twitter,
+          title: loc.projectsOnboardingNeedHelpX,
+          subtitle: null,
+          isSelected: false,
+          onTap: () => unawaited(_openSupportLink(SupportLinks.x)),
         ),
       ],
     );

--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -34,17 +34,9 @@ class _BridgeOnboardingView extends StatelessWidget {
   }
 }
 
-/// Opens an external "Need help?" contact link via the DI-registered
-/// [UrlLauncher], logging (rather than crashing) when the platform reports it
-/// could not be handled.
-Future<void> _openSupportLink({required String url}) async {
-  try {
-    final launched = await getIt<UrlLauncher>().launch(Uri.parse(url));
-    if (!launched) logw("Could not open support link: $url");
-  } on Object catch (error, stackTrace) {
-    logw("Failed to open support link", error, stackTrace);
-  }
-}
+/// Opens one of the "Need help?" contact links ([SupportLinks]) through the
+/// shared [openExternalLink] helper.
+Future<void> _openSupportLink({required String url}) => openExternalLink(url: Uri.parse(url));
 
 /// The shared onboarding body: the phone/PC connection status lines, the
 /// connection graphic, and the per-platform install command boxes. The

--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -37,7 +37,7 @@ class _BridgeOnboardingView extends StatelessWidget {
 /// Opens an external "Need help?" contact link via the DI-registered
 /// [UrlLauncher], logging (rather than crashing) when the platform reports it
 /// could not be handled.
-Future<void> _openSupportLink(String url) async {
+Future<void> _openSupportLink({required String url}) async {
   try {
     final launched = await getIt<UrlLauncher>().launch(Uri.parse(url));
     if (!launched) logw("Could not open support link: $url");
@@ -155,14 +155,14 @@ class _NeedHelpMenu extends StatelessWidget {
           title: loc.projectsOnboardingNeedHelpEmail,
           subtitle: null,
           isSelected: false,
-          onTap: () => unawaited(_openSupportLink(SupportLinks.email)),
+          onTap: () => unawaited(_openSupportLink(url: SupportLinks.email)),
         ),
         PregoMenuItem(
           leadingIcon: TablerRegular.brand_discord,
           title: loc.projectsOnboardingNeedHelpDiscord,
           subtitle: null,
           isSelected: false,
-          onTap: () => unawaited(_openSupportLink(SupportLinks.discord)),
+          onTap: () => unawaited(_openSupportLink(url: SupportLinks.discord)),
         ),
         PregoMenuItem(
           // Tabler's pinned set ships the legacy bird glyph, not the X mark.
@@ -170,7 +170,7 @@ class _NeedHelpMenu extends StatelessWidget {
           title: loc.projectsOnboardingNeedHelpX,
           subtitle: null,
           isSelected: false,
-          onTap: () => unawaited(_openSupportLink(SupportLinks.x)),
+          onTap: () => unawaited(_openSupportLink(url: SupportLinks.x)),
         ),
       ],
     );

--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -15,6 +15,7 @@ import "../../core/di/injection.dart";
 import "../../core/extensions/build_context_x.dart";
 import "../../core/extensions/remote_failure_x.dart";
 import "../../core/extensions/text_style_x.dart";
+import "../../core/external_link.dart";
 import "../../core/routing/app_router.dart";
 import "../../core/support_links.dart";
 import "../../core/widgets/connection_graphic.dart";

--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -16,6 +16,7 @@ import "../../core/extensions/build_context_x.dart";
 import "../../core/extensions/remote_failure_x.dart";
 import "../../core/extensions/text_style_x.dart";
 import "../../core/routing/app_router.dart";
+import "../../core/support_links.dart";
 import "../../core/widgets/connection_graphic.dart";
 import "add_project_dialog.dart";
 import "rename_project_dialog.dart";
@@ -114,6 +115,25 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
     );
   }
 
+  /// The scaffold's bottom-right floating action for the current [state]: the
+  /// add-project FAB once projects exist, the onboarding "Need help?" support
+  /// menu in the two empty states (never-registered setup and connected-but-
+  /// empty), and nothing otherwise.
+  Widget? _floatingAction({required BuildContext context, required ProjectListState state}) {
+    if (state is ProjectListLoaded && state.projects.isNotEmpty) {
+      return PregoButtonsIconGlass(
+        icon: TablerRegular.folder_plus,
+        size: PregoButtonsIconGlassSize.xl,
+        iconSize: 22,
+        onPressed: () => showAddProjectDialog(context, context.read<ProjectListCubit>()),
+      );
+    }
+    final isOnboarding =
+        (state is ProjectListBridgeDisconnected && !state.hasRegisteredBridges) ||
+        (state is ProjectListLoaded && state.projects.isEmpty);
+    return isOnboarding ? const _NeedHelpMenu() : null;
+  }
+
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
@@ -129,18 +149,10 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
           onPressed: () => context.pushRoute(const AppRoute.settings()),
         ),
       ],
-      // The FAB only makes sense once the bridge is connected with a non-empty
-      // project list. It is absent from the not-connected onboarding and from
-      // the connected-but-empty state, where the inline Step 3 folder button is
-      // the add-project affordance.
-      floatingActionButton: state is ProjectListLoaded && state.projects.isNotEmpty
-          ? PregoButtonsIconGlass(
-              icon: TablerRegular.folder_plus,
-              size: PregoButtonsIconGlassSize.xl,
-              iconSize: 22,
-              onPressed: () => showAddProjectDialog(context, context.read<ProjectListCubit>()),
-            )
-          : null,
+      // Bottom-right floating action, resolved per state: the add-project FAB
+      // once projects exist, the onboarding "Need help?" support menu in the two
+      // empty states, and nothing while loading/offline/errored.
+      floatingActionButton: _floatingAction(context: context, state: state),
       // Pull-to-refresh re-fetches the project list once connected; the
       // disconnected states keep their own inner reconnect-on-pull.
       onRefresh: state is ProjectListLoaded ? () => _refreshProjects(context) : null,

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -45,9 +45,21 @@
   "@projectsOnboardingPcStatusRun": {
     "description": "Secondary portion of the PC status line, rendered in the secondary text color."
   },
-  "projectsOnboardingPcStatusWhy": "Why is this needed?",
-  "@projectsOnboardingPcStatusWhy": {
-    "description": "Label for the secondary info button below the PC status line that explains why running Sesori on the PC is required."
+  "projectsOnboardingNeedHelp": "Need help?",
+  "@projectsOnboardingNeedHelp": {
+    "description": "Label for the glass pill button below the PC status line that opens a menu of support channels."
+  },
+  "projectsOnboardingNeedHelpEmail": "Email",
+  "@projectsOnboardingNeedHelpEmail": {
+    "description": "Need-help menu item that opens the user's mail app to contact support."
+  },
+  "projectsOnboardingNeedHelpDiscord": "Discord",
+  "@projectsOnboardingNeedHelpDiscord": {
+    "description": "Need-help menu item that opens the Sesori Discord. 'Discord' is a brand name; do not translate."
+  },
+  "projectsOnboardingNeedHelpX": "DM on X",
+  "@projectsOnboardingNeedHelpX": {
+    "description": "Need-help menu item that opens a direct message on X (formerly Twitter). 'X' is a brand name; do not translate."
   },
   "projectsOnboardingInstallUnixLabel": "macOS, Linux, WSL",
   "@projectsOnboardingInstallUnixLabel": {

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -59,7 +59,7 @@
   },
   "projectsOnboardingNeedHelpX": "DM on X",
   "@projectsOnboardingNeedHelpX": {
-    "description": "Need-help menu item that opens a direct message on X (formerly Twitter). 'X' is a brand name; do not translate."
+    "description": "Need-help menu item that opens the Sesori profile on X (formerly Twitter), where users can send a direct message. 'X' is a brand name; do not translate."
   },
   "projectsOnboardingInstallUnixLabel": "macOS, Linux, WSL",
   "@projectsOnboardingInstallUnixLabel": {

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -223,7 +223,7 @@ abstract class AppLocalizations {
   /// **'Discord'**
   String get projectsOnboardingNeedHelpDiscord;
 
-  /// Need-help menu item that opens a direct message on X (formerly Twitter). 'X' is a brand name; do not translate.
+  /// Need-help menu item that opens the Sesori profile on X (formerly Twitter), where users can send a direct message. 'X' is a brand name; do not translate.
   ///
   /// In en, this message translates to:
   /// **'DM on X'**

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -205,11 +205,29 @@ abstract class AppLocalizations {
   /// **'Run Sesori on your PC'**
   String get projectsOnboardingPcStatusRun;
 
-  /// Label for the secondary info button below the PC status line that explains why running Sesori on the PC is required.
+  /// Label for the glass pill button below the PC status line that opens a menu of support channels.
   ///
   /// In en, this message translates to:
-  /// **'Why is this needed?'**
-  String get projectsOnboardingPcStatusWhy;
+  /// **'Need help?'**
+  String get projectsOnboardingNeedHelp;
+
+  /// Need-help menu item that opens the user's mail app to contact support.
+  ///
+  /// In en, this message translates to:
+  /// **'Email'**
+  String get projectsOnboardingNeedHelpEmail;
+
+  /// Need-help menu item that opens the Sesori Discord. 'Discord' is a brand name; do not translate.
+  ///
+  /// In en, this message translates to:
+  /// **'Discord'**
+  String get projectsOnboardingNeedHelpDiscord;
+
+  /// Need-help menu item that opens a direct message on X (formerly Twitter). 'X' is a brand name; do not translate.
+  ///
+  /// In en, this message translates to:
+  /// **'DM on X'**
+  String get projectsOnboardingNeedHelpX;
 
   /// Group label above the macOS/Linux/WSL install command box in the onboarding.
   ///

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -76,7 +76,16 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectsOnboardingPcStatusRun => 'Run Sesori on your PC';
 
   @override
-  String get projectsOnboardingPcStatusWhy => 'Why is this needed?';
+  String get projectsOnboardingNeedHelp => 'Need help?';
+
+  @override
+  String get projectsOnboardingNeedHelpEmail => 'Email';
+
+  @override
+  String get projectsOnboardingNeedHelpDiscord => 'Discord';
+
+  @override
+  String get projectsOnboardingNeedHelpX => 'DM on X';
 
   @override
   String get projectsOnboardingInstallUnixLabel => 'macOS, Linux, WSL';

--- a/client/module_prego/lib/components/buttons/prego_buttons_glass.dart
+++ b/client/module_prego/lib/components/buttons/prego_buttons_glass.dart
@@ -1,0 +1,71 @@
+import "package:flutter/material.dart";
+import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
+
+import "../../theme/prego_theme.dart";
+
+/// A liquid-glass pill that opens a menu: leading glyph, one-line [label], and
+/// a trailing unfold caret signalling the popup. This is the shared trigger
+/// for [PregoAnchorMenu]-style pickers — the composer's agent/model/variant
+/// pills all render this pill.
+///
+/// The pill fills its parent's width (each composer pill sits in an
+/// [Expanded] slot) and ellipsizes long labels.
+///
+/// Usage:
+/// ```dart
+/// PregoButtonsGlass(
+///   leadingIcon: Icons.smart_toy_outlined,
+///   label: selectedAgent,
+///   onPressed: toggle,
+/// )
+/// ```
+class PregoButtonsGlass extends StatelessWidget {
+  const PregoButtonsGlass({
+    super.key,
+    required this.leadingIcon,
+    required this.label,
+    required this.onPressed,
+  });
+
+  /// The glyph rendered before the label.
+  final IconData leadingIcon;
+
+  /// One-line button text; ellipsizes when it doesn't fit.
+  final String label;
+
+  /// Called when the pill is tapped. Wire this to the menu's open callback.
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    final foreground = prego.colors.textSecondary;
+    return GlassButton.custom(
+      onTap: onPressed,
+      width: double.infinity,
+      height: 36,
+      shape: const LiquidRoundedRectangle(borderRadius: 18),
+      useOwnLayer: true,
+      settings: LiquidGlassSettings(glassColor: prego.colors.buttonGlassPrimaryBackground),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        child: Row(
+          children: [
+            Icon(leadingIcon, size: 14, color: foreground),
+            const SizedBox(width: 6),
+            Expanded(
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: prego.textTheme.textXs.medium.copyWith(color: foreground),
+              ),
+            ),
+            const SizedBox(width: 4),
+            Icon(Icons.unfold_more, size: 14, color: foreground),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/client/module_prego/lib/components/menus/prego_anchor_menu.dart
+++ b/client/module_prego/lib/components/menus/prego_anchor_menu.dart
@@ -24,20 +24,26 @@ class PregoMenuLabel extends PregoMenuEntry {
   final String text;
 }
 
-/// A tappable menu row with a [title], optional [subtitle], and an optional
-/// selected check mark. Tapping runs [onTap] and dismisses the menu.
+/// A tappable menu row with a [title], optional [subtitle], an optional
+/// [leadingIcon], and an optional selected check mark. Tapping runs [onTap] and
+/// dismisses the menu.
 class PregoMenuItem extends PregoMenuEntry {
   const PregoMenuItem({
     required this.title,
     required this.subtitle,
     required this.isSelected,
     required this.onTap,
+    this.leadingIcon,
   });
 
   final String title;
   final String? subtitle;
   final bool isSelected;
   final VoidCallback onTap;
+
+  /// Optional glyph shown before the title. Rendered identically on the glass
+  /// and flat paths (muted to the secondary text colour).
+  final IconData? leadingIcon;
 }
 
 /// A thin separator line between entries.
@@ -69,7 +75,9 @@ typedef PregoMenuTriggerBuilder = Widget Function(BuildContext context, VoidCall
 /// (a [CueModalTransition]) — same anchored-popup behaviour, zero shader cost.
 ///
 /// The same [entries] and [triggerBuilder] drive both paths; only the rendering
-/// differs. See [glassEffectsEnabled] for the platform switch.
+/// differs. See [glassEffectsEnabled] for the platform switch. Set [flat] to
+/// force the flat/`cue` path on every platform (including Apple) — for a menu
+/// paired with a flat trigger, where a glass popup would look out of place.
 class PregoAnchorMenu extends StatefulWidget {
   const PregoAnchorMenu({
     super.key,
@@ -79,6 +87,7 @@ class PregoAnchorMenu extends StatefulWidget {
     this.menuHeight,
     this.menuBorderRadius = 24,
     this.menuScreenPadding = const EdgeInsets.all(12),
+    this.flat = false,
   });
 
   /// Builds the tappable trigger. The provided callback opens the menu.
@@ -101,6 +110,11 @@ class PregoAnchorMenu extends StatefulWidget {
   /// Minimum gap kept between the menu and the screen edges.
   final EdgeInsets menuScreenPadding;
 
+  /// Forces the flat/`cue` path on every platform when `true`. When `false`
+  /// (the default) the path follows [glassEffectsEnabled] — glass on Apple,
+  /// flat on Android.
+  final bool flat;
+
   @override
   State<PregoAnchorMenu> createState() => _PregoAnchorMenuState();
 }
@@ -113,7 +127,8 @@ class _PregoAnchorMenuState extends State<PregoAnchorMenu> {
 
   @override
   Widget build(BuildContext context) {
-    return glassEffectsEnabled() ? _buildGlass(context) : _buildFlat(context);
+    final useGlass = !widget.flat && glassEffectsEnabled();
+    return useGlass ? _buildGlass(context) : _buildFlat(context);
   }
 
   // ── Glass path (Apple) ─────────────────────────────────────────────────────
@@ -160,11 +175,12 @@ class _PregoAnchorMenuState extends State<PregoAnchorMenu> {
       case PregoMenuLabel(:final text):
         // GlassMenuLabel uppercases the title itself; we only supply the style.
         return GlassMenuLabel(title: text, style: _labelStyle(prego));
-      case PregoMenuItem(:final title, :final subtitle, :final isSelected, :final onTap):
+      case PregoMenuItem(:final title, :final subtitle, :final isSelected, :final onTap, :final leadingIcon):
         return GlassMenuItem(
           title: title,
           subtitle: subtitle,
           isSelected: isSelected,
+          icon: leadingIcon == null ? null : Icon(leadingIcon, size: 20, color: prego.colors.textSecondary),
           titleStyle: _titleStyle(prego),
           subtitleStyle: _subtitleStyle(prego),
           trailing: isSelected ? _selectedCheck(prego) : null,
@@ -296,11 +312,12 @@ class _FlatAnchoredMenu extends StatelessWidget {
           // Uppercased to match GlassMenuLabel on the glass path.
           child: Text(text.toUpperCase(), style: _labelStyle(prego)),
         );
-      case PregoMenuItem(:final title, :final subtitle, :final isSelected, :final onTap):
+      case PregoMenuItem(:final title, :final subtitle, :final isSelected, :final onTap, :final leadingIcon):
         return _FlatMenuTile(
           title: title,
           subtitle: subtitle,
           isSelected: isSelected,
+          leadingIcon: leadingIcon,
           onTap: () {
             close();
             onTap();
@@ -328,17 +345,20 @@ class _FlatMenuTile extends StatelessWidget {
     required this.subtitle,
     required this.isSelected,
     required this.onTap,
+    this.leadingIcon,
   });
 
   final String title;
   final String? subtitle;
   final bool isSelected;
   final VoidCallback onTap;
+  final IconData? leadingIcon;
 
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
     final subtitle = this.subtitle;
+    final leadingIcon = this.leadingIcon;
     return InkWell(
       onTap: onTap,
       borderRadius: BorderRadius.circular(16),
@@ -349,6 +369,10 @@ class _FlatMenuTile extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
           child: Row(
             children: [
+              if (leadingIcon != null) ...[
+                Icon(leadingIcon, size: 20, color: prego.colors.textSecondary),
+                const SizedBox(width: 12),
+              ],
               Expanded(
                 child: Column(
                   mainAxisSize: MainAxisSize.min,

--- a/client/module_prego/lib/module_prego.dart
+++ b/client/module_prego/lib/module_prego.dart
@@ -3,6 +3,7 @@ library;
 
 export 'components/alerts/prego_inline_alerts_notifications.dart';
 export 'components/alerts/prego_popup_alerts_notifications.dart';
+export 'components/buttons/prego_buttons_glass.dart';
 export 'components/buttons/prego_buttons_icon_glass.dart';
 export 'components/menus/prego_anchor_menu.dart';
 export 'components/navigation/prego_glass_scaffold.dart';

--- a/client/module_prego/test/components/prego_anchor_menu_test.dart
+++ b/client/module_prego/test/components/prego_anchor_menu_test.dart
@@ -3,13 +3,14 @@ import "package:flutter_test/flutter_test.dart";
 import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:theme_prego/module_prego.dart";
 
-Widget _harness(List<PregoMenuEntry> entries) {
+Widget _harness(List<PregoMenuEntry> entries, {bool flat = false}) {
   return MaterialApp(
     theme: ThemeData(extensions: [PregoDesignSystem.light]),
     home: Scaffold(
       body: Center(
         child: PregoAnchorMenu(
           menuWidth: 240,
+          flat: flat,
           entries: entries,
           triggerBuilder: (context, toggle) => ElevatedButton(
             onPressed: toggle,
@@ -28,7 +29,13 @@ void main() {
       await tester.pumpWidget(
         _harness([
           const PregoMenuLabel(text: "Section"),
-          PregoMenuItem(title: "Alpha", subtitle: "first", isSelected: false, onTap: () => taps++),
+          PregoMenuItem(
+            title: "Alpha",
+            subtitle: "first",
+            isSelected: false,
+            leadingIcon: Icons.mail_outline,
+            onTap: () => taps++,
+          ),
           const PregoMenuDivider(),
           PregoMenuItem(title: "Beta", subtitle: null, isSelected: true, onTap: () {}),
         ]),
@@ -45,6 +52,8 @@ void main() {
       expect(find.text("SECTION"), findsOneWidget);
       expect(find.widgetWithText(InkWell, "Alpha"), findsOneWidget);
       expect(find.widgetWithText(InkWell, "Beta"), findsOneWidget);
+      // The optional leading icon renders on the flat row.
+      expect(find.widgetWithIcon(InkWell, Icons.mail_outline), findsOneWidget);
 
       await tester.tap(find.widgetWithText(InkWell, "Alpha"));
       await tester.pumpAndSettle();
@@ -118,7 +127,13 @@ void main() {
       await tester.pumpWidget(
         _harness([
           const PregoMenuLabel(text: "Section"),
-          PregoMenuItem(title: "Alpha", subtitle: "first", isSelected: false, onTap: () => taps++),
+          PregoMenuItem(
+            title: "Alpha",
+            subtitle: "first",
+            isSelected: false,
+            leadingIcon: Icons.mail_outline,
+            onTap: () => taps++,
+          ),
         ]),
       );
 
@@ -129,11 +144,47 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.widgetWithText(GlassMenuItem, "Alpha"), findsOneWidget);
+      // The optional leading icon renders on the glass item.
+      expect(find.widgetWithIcon(GlassMenuItem, Icons.mail_outline), findsOneWidget);
 
       await tester.tap(find.widgetWithText(GlassMenuItem, "Alpha"));
       await tester.pumpAndSettle();
 
       expect(taps, 1);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+
+    testWidgets("flat: true forces the flat path even on Apple", (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        _harness(
+          flat: true,
+          [
+            PregoMenuItem(
+              title: "Alpha",
+              subtitle: null,
+              isSelected: false,
+              leadingIcon: Icons.mail_outline,
+              onTap: () => taps++,
+            ),
+          ],
+        ),
+      );
+
+      // With the flat override the glass popup is never built, even on iOS.
+      expect(find.byType(GlassMenu), findsNothing);
+
+      await tester.tap(find.text("Open"));
+      await tester.pumpAndSettle();
+
+      // Flat (InkWell) row with its leading icon, and taps still route.
+      expect(find.widgetWithText(InkWell, "Alpha"), findsOneWidget);
+      expect(find.widgetWithIcon(InkWell, Icons.mail_outline), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(InkWell, "Alpha"));
+      await tester.pumpAndSettle();
+
+      expect(taps, 1);
+      expect(find.text("Alpha"), findsNothing);
     }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
   });
 }

--- a/client/module_prego/test/components/prego_buttons_glass_test.dart
+++ b/client/module_prego/test/components/prego_buttons_glass_test.dart
@@ -1,0 +1,59 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:theme_prego/module_prego.dart";
+
+Widget _harness(Widget child) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [PregoDesignSystem.light]),
+    home: Scaffold(body: Center(child: child)),
+  );
+}
+
+void main() {
+  testWidgets("renders leading icon, label, caret, and routes taps", (tester) async {
+    var taps = 0;
+    await tester.pumpWidget(
+      _harness(
+        PregoButtonsGlass(
+          leadingIcon: Icons.smart_toy_outlined,
+          label: "Agent",
+          onPressed: () => taps++,
+        ),
+      ),
+    );
+
+    expect(find.text("Agent"), findsOneWidget);
+    expect(find.byIcon(Icons.smart_toy_outlined), findsOneWidget);
+    // The trailing caret signals the pill opens a menu.
+    expect(find.byIcon(Icons.unfold_more), findsOneWidget);
+
+    await tester.tap(find.byType(PregoButtonsGlass));
+    await tester.pumpAndSettle();
+
+    expect(taps, 1);
+  });
+
+  testWidgets("ellipsizes a long label instead of overflowing", (tester) async {
+    await tester.pumpWidget(
+      _harness(
+        Row(
+          children: [
+            Expanded(
+              child: PregoButtonsGlass(
+                leadingIcon: Icons.memory_outlined,
+                label: "An extremely long model name that cannot possibly fit in one pill" * 3,
+                onPressed: () {},
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    // No overflow error: the label clamps to one ellipsized line inside the pill.
+    expect(tester.takeException(), isNull);
+    final text = tester.widget<Text>(find.byType(Text));
+    expect(text.maxLines, 1);
+    expect(text.overflow, TextOverflow.ellipsis);
+  });
+}


### PR DESCRIPTION
## Summary

- Pins a "Need help?" support menu to the bottom-right of the two empty Projects onboarding states (never-registered setup and connected-but-empty), riding the scaffold's floating-action slot so it stays clear of the scrolling checklist.
- The trigger is a solid `PregoButtonsSolid` pill (leading help icon, no caret); the popup is forced flat on every platform via the new `PregoAnchorMenu.flat` flag so it matches its solid trigger instead of morphing in as glass.
- Menu lists the support channels (Email / Discord / X on `SupportLinks`), each launching externally through the DI-registered `UrlLauncher`.
- Adds `PregoMenuItem.leadingIcon`, rendered symmetrically on both the glass and flat menu paths.
- Extracts the composer's private agent/model/variant trigger pill into `PregoButtonsGlass` in `module_prego`, now shared by all three composer pickers.

## Test plan

- `client/module_prego`: `flutter test` — anchor-menu suite covers the flat-forced-on-iOS path, leading icons on both paths, and the new `PregoButtonsGlass` widget tests.
- `client/app`: `flutter test test/features` + `flutter analyze` clean.
- Verified visually on the iOS simulator (both onboarding states).
- `aristotle-impl-review`: APPROVED.

https://claude.ai/code/session_01FSCwtbJKeDgk5c5TGbUAmK

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins a “Need help?” support menu to the bottom-right of the two empty Projects onboarding states, giving quick access to Email, Discord, and X without covering the scrolling checklist. The trigger is a solid pill and the anchored popup is forced flat for a consistent look across platforms.

- **New Features**
  - Bottom-right “Need help?” pill on onboarding (never-registered and connected-but-empty) with an anchored menu (flat on all platforms).
  - Support channels: Email, Discord, X; opened via `openExternalLink`. URLs centralized in `SupportLinks`.
  - `PregoMenuItem` supports an optional leading icon on both glass and flat paths. Added l10n labels for the new items.

- **Refactors**
  - Extracted shared `PregoButtonsGlass` and used it for the composer’s agent/model/variant pickers.
  - Added `openExternalLink`; onboarding and markdown link taps now route through it with error logging.
  - `PregoAnchorMenu` adds a `flat` flag; floating action now resolves per state (add-project FAB when projects exist; “Need help?” on onboarding; none otherwise).
  - Tests cover the flat override, leading icons, and `PregoButtonsGlass`.

<sup>Written for commit 3233b3bf722f24993e0700c5207a8da5242330f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

