### PR TITLE
feat(onboarding): Add "Why is this needed?" bridge explainer bottom sheet

### DIFF
--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -107,6 +107,23 @@ class _OnboardingChecklist extends StatelessWidget {
           style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textPrimary),
           textAlign: TextAlign.center,
         ),
+        const SizedBox(height: PregoSpacing.lg),
+        // Wrapped so the parent Column's stretch alignment doesn't force the
+        // button full-width; fullWidth: false then sizes it to its content.
+        Center(
+          child: PregoButtonsSolid(
+            fullWidth: false,
+            leadingIcon: TablerRegular.info_circle,
+            label: loc.projectsOnboardingPcStatusWhy,
+            hierarchy: PregoButtonsSolidHierarchy.secondary,
+            size: PregoButtonsSolidSize.sm,
+            onPressed: () => showPregoBottomSheet<void>(
+              context: context,
+              title: loc.projectsOnboardingPcStatusWhy,
+              builder: (_) => const _WhyBridgeInfoSheet(),
+            ),
+          ),
+        ),
         // 40px gap from the header group to the install boxes (Figma gap-5xl).
         const SizedBox(height: PregoSpacing.x5l),
         const Padding(

--- a/client/app/lib/features/project_list/onboarding/why_bridge_info_sheet.dart
+++ b/client/app/lib/features/project_list/onboarding/why_bridge_info_sheet.dart
@@ -228,6 +228,9 @@ class _WhyFaqItemState extends State<_WhyFaqItem> {
                       style: prego.textTheme.textXs.regular.copyWith(color: colors.textSecondary),
                     ),
                   )
+                // Collapsed placeholder keeps full width so AnimatedSize only
+                // animates height; a 0x0 child would sweep the width open too
+                // if the parent ever stopped stretching its children.
                 : const SizedBox(width: double.infinity),
           ),
         ],

--- a/client/app/lib/features/project_list/onboarding/why_bridge_info_sheet.dart
+++ b/client/app/lib/features/project_list/onboarding/why_bridge_info_sheet.dart
@@ -1,0 +1,237 @@
+part of "../project_list_screen.dart";
+
+// ===========================================================================
+// "Why is this needed?" info sheet
+//
+// The onboarding "Why is this needed?" button opens this as a PregoBottomSheet.
+// It explains why the Bridge sits between the phone and the developer's machine:
+// a lede paragraph, the connection graphic, three reassurance rows, and an FAQ.
+// ===========================================================================
+
+/// Content of the onboarding "Why is this needed?" bottom sheet. Pure
+/// presentation with only per-row FAQ expand/collapse state; opened via
+/// [showPregoBottomSheet] from [_OnboardingChecklist].
+class _WhyBridgeInfoSheet extends StatelessWidget {
+  const _WhyBridgeInfoSheet();
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    final colors = prego.colors;
+    final loc = context.loc;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: PregoSpacing.md),
+        // Lede: first line reads as the headline (primary), the rest as
+        // supporting context (secondary), centred under the title.
+        Text.rich(
+          TextSpan(
+            children: [
+              TextSpan(
+                text: loc.projectsOnboardingWhyLede,
+                style: prego.textTheme.textMd.regular.copyWith(color: colors.textPrimary),
+              ),
+              const TextSpan(text: "\n"),
+              TextSpan(
+                text: loc.projectsOnboardingWhyBody,
+                style: prego.textTheme.textSm.regular.copyWith(color: colors.textSecondary),
+              ),
+            ],
+          ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: PregoSpacing.x2l),
+        // Reused decorative onboarding artwork. The Figma sheet shows a
+        // phone+desktop "E2E Encrypted" illustration; swapping to that would
+        // need a dedicated asset export.
+        const Center(
+          child: ExcludeSemantics(
+            child: ConnectionGraphic.connectionOn(),
+          ),
+        ),
+        const SizedBox(height: PregoSpacing.x2l),
+        _WhyFeatureRow(
+          icon: TablerRegular.lock,
+          title: loc.projectsOnboardingWhySecureTitle,
+          subtitle: loc.projectsOnboardingWhySecureSubtitle,
+        ),
+        const PregoDivider(indent: PregoSpacing.x5l),
+        _WhyFeatureRow(
+          icon: TablerRegular.world,
+          title: loc.projectsOnboardingWhyAnywhereTitle,
+          subtitle: loc.projectsOnboardingWhyAnywhereSubtitle,
+        ),
+        const PregoDivider(indent: PregoSpacing.x5l),
+        _WhyFeatureRow(
+          icon: TablerRegular.bell,
+          title: loc.projectsOnboardingWhyNotifiedTitle,
+          subtitle: loc.projectsOnboardingWhyNotifiedSubtitle,
+        ),
+        const SizedBox(height: PregoSpacing.x3l),
+        Text(
+          loc.projectsOnboardingWhyFaqHeader,
+          style: prego.textTheme.textMd.medium.copyWith(color: colors.textSecondary),
+        ),
+        const SizedBox(height: PregoSpacing.xs),
+        _WhyFaqItem(
+          question: loc.projectsOnboardingWhyFaqDirectQuestion,
+          answer: loc.projectsOnboardingWhyFaqDirectAnswer,
+        ),
+        const PregoDivider(indent: PregoSpacing.xl),
+        _WhyFaqItem(
+          question: loc.projectsOnboardingWhyFaqPcOnQuestion,
+          answer: loc.projectsOnboardingWhyFaqPcOnAnswer,
+        ),
+        const PregoDivider(indent: PregoSpacing.xl),
+        _WhyFaqItem(
+          question: loc.projectsOnboardingWhyFaqReadQuestion,
+          answer: loc.projectsOnboardingWhyFaqReadAnswer,
+        ),
+        const SizedBox(height: PregoSpacing.md),
+      ],
+    );
+  }
+}
+
+/// One reassurance row: a leading icon and a title + subtitle. Merged into a
+/// single semantics node so the icon, title, and subtitle are read as one unit.
+class _WhyFeatureRow extends StatelessWidget {
+  const _WhyFeatureRow({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    final colors = prego.colors;
+
+    return MergeSemantics(
+      child: Padding(
+        padding: const EdgeInsetsDirectional.symmetric(
+          vertical: PregoSpacing.lg,
+          horizontal: PregoSpacing.xl,
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Icon(icon, size: 16, color: colors.textPrimary),
+            const SizedBox(width: PregoSpacing.lg),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    title,
+                    style: prego.textTheme.textMd.regular.copyWith(color: colors.textPrimary),
+                  ),
+                  const SizedBox(height: PregoSpacing.xxs),
+                  Text(
+                    subtitle,
+                    style: prego.textTheme.textXs.regular.copyWith(color: colors.textSecondary),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A single expandable FAQ row: a tappable question with a chevron that rotates
+/// as its answer expands. Announces its expanded/collapsed state to screen
+/// readers; wrapped in a [RepaintBoundary] so the expand animation (which sits
+/// behind the sheet's glass header) doesn't repaint the whole column.
+class _WhyFaqItem extends StatefulWidget {
+  const _WhyFaqItem({required this.question, required this.answer});
+
+  final String question;
+  final String answer;
+
+  @override
+  State<_WhyFaqItem> createState() => _WhyFaqItemState();
+}
+
+class _WhyFaqItemState extends State<_WhyFaqItem> {
+  bool _expanded = false;
+
+  void _toggle() => setState(() => _expanded = !_expanded);
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    final colors = prego.colors;
+
+    return RepaintBoundary(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Semantics(
+            button: true,
+            expanded: _expanded,
+            // Transparent Material so the InkWell ripple paints on top of the
+            // sheet surface instead of behind it on the modal's transparent
+            // Material — same pattern as the onboarding install boxes.
+            child: Material(
+              type: MaterialType.transparency,
+              child: InkWell(
+                onTap: _toggle,
+                child: Padding(
+                  padding: const EdgeInsetsDirectional.symmetric(
+                    vertical: PregoSpacing.lg,
+                    horizontal: PregoSpacing.xl,
+                  ),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          widget.question,
+                          style: prego.textTheme.textMd.regular.copyWith(color: colors.textPrimary),
+                        ),
+                      ),
+                      const SizedBox(width: PregoSpacing.md),
+                      AnimatedRotation(
+                        // Chevron points down when collapsed, up when expanded.
+                        turns: _expanded ? 0.5 : 0.0,
+                        duration: const Duration(milliseconds: 200),
+                        child: Icon(TablerRegular.chevron_down, size: 20, color: colors.textSecondary),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          AnimatedSize(
+            alignment: Alignment.topCenter,
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeInOut,
+            child: _expanded
+                ? Padding(
+                    padding: const EdgeInsetsDirectional.only(
+                      bottom: PregoSpacing.lg,
+                      start: PregoSpacing.xl,
+                      end: PregoSpacing.xl,
+                    ),
+                    child: Text(
+                      widget.answer,
+                      style: prego.textTheme.textXs.regular.copyWith(color: colors.textSecondary),
+                    ),
+                  )
+                : const SizedBox(width: double.infinity),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -23,6 +23,7 @@ import "add_project_dialog.dart";
 import "rename_project_dialog.dart";
 
 part "onboarding/onboarding_view.dart";
+part "onboarding/why_bridge_info_sheet.dart";
 part "widgets/bridge_offline_view.dart";
 part "widgets/error_view.dart";
 part "widgets/project_tile.dart";

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -45,6 +45,10 @@
   "@projectsOnboardingPcStatusRun": {
     "description": "Secondary portion of the PC status line, rendered in the secondary text color."
   },
+  "projectsOnboardingPcStatusWhy": "Why is this needed?",
+  "@projectsOnboardingPcStatusWhy": {
+    "description": "Label for the button below the PC status line that opens the bridge explainer bottom sheet; also used as that sheet's title."
+  },
   "projectsOnboardingNeedHelp": "Need help?",
   "@projectsOnboardingNeedHelp": {
     "description": "Label for the glass pill button below the PC status line that opens a menu of support channels."
@@ -473,5 +477,65 @@
   "sessionDetailShowMore": "Show more",
   "sessionDetailShowLess": "Show less",
   "emptySessionDetailTitle": "Select a session",
-  "emptySessionDetailSubtitle": "Choose a session from the list to view details"
+  "emptySessionDetailSubtitle": "Choose a session from the list to view details",
+  "projectsOnboardingWhyLede": "Your LLM of choice runs on your computer.",
+  "@projectsOnboardingWhyLede": {
+    "description": "Headline line of the onboarding 'Why is this needed?' sheet, explaining that the AI model runs on the developer's own machine."
+  },
+  "projectsOnboardingWhyBody": "The Bridge securely connects it to Sesori on your phone.",
+  "@projectsOnboardingWhyBody": {
+    "description": "Supporting line under the 'Why is this needed?' headline, explaining the Bridge's role."
+  },
+  "projectsOnboardingWhySecureTitle": "Secure access",
+  "@projectsOnboardingWhySecureTitle": {
+    "description": "Title of the 'secure access' reassurance row in the 'Why is this needed?' sheet."
+  },
+  "projectsOnboardingWhySecureSubtitle": "Your sessions are end-to-end encrypted.",
+  "@projectsOnboardingWhySecureSubtitle": {
+    "description": "Subtitle of the 'secure access' reassurance row."
+  },
+  "projectsOnboardingWhyAnywhereTitle": "Connect from anywhere",
+  "@projectsOnboardingWhyAnywhereTitle": {
+    "description": "Title of the 'connect from anywhere' reassurance row in the 'Why is this needed?' sheet."
+  },
+  "projectsOnboardingWhyAnywhereSubtitle": "No shared Wi-Fi required.",
+  "@projectsOnboardingWhyAnywhereSubtitle": {
+    "description": "Subtitle of the 'connect from anywhere' reassurance row."
+  },
+  "projectsOnboardingWhyNotifiedTitle": "Get notified",
+  "@projectsOnboardingWhyNotifiedTitle": {
+    "description": "Title of the 'get notified' reassurance row in the 'Why is this needed?' sheet."
+  },
+  "projectsOnboardingWhyNotifiedSubtitle": "Know when a task needs you.",
+  "@projectsOnboardingWhyNotifiedSubtitle": {
+    "description": "Subtitle of the 'get notified' reassurance row."
+  },
+  "projectsOnboardingWhyFaqHeader": "FAQs",
+  "@projectsOnboardingWhyFaqHeader": {
+    "description": "Section header above the FAQ list in the 'Why is this needed?' sheet."
+  },
+  "projectsOnboardingWhyFaqDirectQuestion": "Why can't the app connect directly?",
+  "@projectsOnboardingWhyFaqDirectQuestion": {
+    "description": "FAQ question about why the phone cannot reach the computer without the Bridge."
+  },
+  "projectsOnboardingWhyFaqDirectAnswer": "Your AI assistant runs on your computer, not our servers. The Bridge is the secure link that lets your phone reach it from anywhere.",
+  "@projectsOnboardingWhyFaqDirectAnswer": {
+    "description": "DRAFT copy pending final wording. Answer to the 'connect directly' FAQ question."
+  },
+  "projectsOnboardingWhyFaqPcOnQuestion": "Does my PC stay on?",
+  "@projectsOnboardingWhyFaqPcOnQuestion": {
+    "description": "FAQ question about whether the developer's computer must stay powered on."
+  },
+  "projectsOnboardingWhyFaqPcOnAnswer": "Your computer needs to be on and running Sesori for live sessions. You can start or stop it whenever you like.",
+  "@projectsOnboardingWhyFaqPcOnAnswer": {
+    "description": "DRAFT copy pending final wording. Answer to the 'does my PC stay on' FAQ question."
+  },
+  "projectsOnboardingWhyFaqReadQuestion": "Can Sesori read my sessions?",
+  "@projectsOnboardingWhyFaqReadQuestion": {
+    "description": "FAQ question about whether Sesori can read the developer's session data."
+  },
+  "projectsOnboardingWhyFaqReadAnswer": "No. Everything between your phone and computer is end-to-end encrypted — the relay only passes along sealed data it can't read.",
+  "@projectsOnboardingWhyFaqReadAnswer": {
+    "description": "DRAFT copy pending final wording. Answer to the 'can Sesori read my sessions' FAQ question."
+  }
 }

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -205,6 +205,12 @@ abstract class AppLocalizations {
   /// **'Run Sesori on your PC'**
   String get projectsOnboardingPcStatusRun;
 
+  /// Label for the button below the PC status line that opens the bridge explainer bottom sheet; also used as that sheet's title.
+  ///
+  /// In en, this message translates to:
+  /// **'Why is this needed?'**
+  String get projectsOnboardingPcStatusWhy;
+
   /// Label for the glass pill button below the PC status line that opens a menu of support channels.
   ///
   /// In en, this message translates to:
@@ -1698,6 +1704,96 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Choose a session from the list to view details'**
   String get emptySessionDetailSubtitle;
+
+  /// Headline line of the onboarding 'Why is this needed?' sheet, explaining that the AI model runs on the developer's own machine.
+  ///
+  /// In en, this message translates to:
+  /// **'Your LLM of choice runs on your computer.'**
+  String get projectsOnboardingWhyLede;
+
+  /// Supporting line under the 'Why is this needed?' headline, explaining the Bridge's role.
+  ///
+  /// In en, this message translates to:
+  /// **'The Bridge securely connects it to Sesori on your phone.'**
+  String get projectsOnboardingWhyBody;
+
+  /// Title of the 'secure access' reassurance row in the 'Why is this needed?' sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Secure access'**
+  String get projectsOnboardingWhySecureTitle;
+
+  /// Subtitle of the 'secure access' reassurance row.
+  ///
+  /// In en, this message translates to:
+  /// **'Your sessions are end-to-end encrypted.'**
+  String get projectsOnboardingWhySecureSubtitle;
+
+  /// Title of the 'connect from anywhere' reassurance row in the 'Why is this needed?' sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Connect from anywhere'**
+  String get projectsOnboardingWhyAnywhereTitle;
+
+  /// Subtitle of the 'connect from anywhere' reassurance row.
+  ///
+  /// In en, this message translates to:
+  /// **'No shared Wi-Fi required.'**
+  String get projectsOnboardingWhyAnywhereSubtitle;
+
+  /// Title of the 'get notified' reassurance row in the 'Why is this needed?' sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'Get notified'**
+  String get projectsOnboardingWhyNotifiedTitle;
+
+  /// Subtitle of the 'get notified' reassurance row.
+  ///
+  /// In en, this message translates to:
+  /// **'Know when a task needs you.'**
+  String get projectsOnboardingWhyNotifiedSubtitle;
+
+  /// Section header above the FAQ list in the 'Why is this needed?' sheet.
+  ///
+  /// In en, this message translates to:
+  /// **'FAQs'**
+  String get projectsOnboardingWhyFaqHeader;
+
+  /// FAQ question about why the phone cannot reach the computer without the Bridge.
+  ///
+  /// In en, this message translates to:
+  /// **'Why can\'t the app connect directly?'**
+  String get projectsOnboardingWhyFaqDirectQuestion;
+
+  /// DRAFT copy pending final wording. Answer to the 'connect directly' FAQ question.
+  ///
+  /// In en, this message translates to:
+  /// **'Your AI assistant runs on your computer, not our servers. The Bridge is the secure link that lets your phone reach it from anywhere.'**
+  String get projectsOnboardingWhyFaqDirectAnswer;
+
+  /// FAQ question about whether the developer's computer must stay powered on.
+  ///
+  /// In en, this message translates to:
+  /// **'Does my PC stay on?'**
+  String get projectsOnboardingWhyFaqPcOnQuestion;
+
+  /// DRAFT copy pending final wording. Answer to the 'does my PC stay on' FAQ question.
+  ///
+  /// In en, this message translates to:
+  /// **'Your computer needs to be on and running Sesori for live sessions. You can start or stop it whenever you like.'**
+  String get projectsOnboardingWhyFaqPcOnAnswer;
+
+  /// FAQ question about whether Sesori can read the developer's session data.
+  ///
+  /// In en, this message translates to:
+  /// **'Can Sesori read my sessions?'**
+  String get projectsOnboardingWhyFaqReadQuestion;
+
+  /// DRAFT copy pending final wording. Answer to the 'can Sesori read my sessions' FAQ question.
+  ///
+  /// In en, this message translates to:
+  /// **'No. Everything between your phone and computer is end-to-end encrypted — the relay only passes along sealed data it can\'t read.'**
+  String get projectsOnboardingWhyFaqReadAnswer;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -76,6 +76,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectsOnboardingPcStatusRun => 'Run Sesori on your PC';
 
   @override
+  String get projectsOnboardingPcStatusWhy => 'Why is this needed?';
+
+  @override
   String get projectsOnboardingNeedHelp => 'Need help?';
 
   @override
@@ -886,4 +889,52 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get emptySessionDetailSubtitle => 'Choose a session from the list to view details';
+
+  @override
+  String get projectsOnboardingWhyLede => 'Your LLM of choice runs on your computer.';
+
+  @override
+  String get projectsOnboardingWhyBody => 'The Bridge securely connects it to Sesori on your phone.';
+
+  @override
+  String get projectsOnboardingWhySecureTitle => 'Secure access';
+
+  @override
+  String get projectsOnboardingWhySecureSubtitle => 'Your sessions are end-to-end encrypted.';
+
+  @override
+  String get projectsOnboardingWhyAnywhereTitle => 'Connect from anywhere';
+
+  @override
+  String get projectsOnboardingWhyAnywhereSubtitle => 'No shared Wi-Fi required.';
+
+  @override
+  String get projectsOnboardingWhyNotifiedTitle => 'Get notified';
+
+  @override
+  String get projectsOnboardingWhyNotifiedSubtitle => 'Know when a task needs you.';
+
+  @override
+  String get projectsOnboardingWhyFaqHeader => 'FAQs';
+
+  @override
+  String get projectsOnboardingWhyFaqDirectQuestion => 'Why can\'t the app connect directly?';
+
+  @override
+  String get projectsOnboardingWhyFaqDirectAnswer =>
+      'Your AI assistant runs on your computer, not our servers. The Bridge is the secure link that lets your phone reach it from anywhere.';
+
+  @override
+  String get projectsOnboardingWhyFaqPcOnQuestion => 'Does my PC stay on?';
+
+  @override
+  String get projectsOnboardingWhyFaqPcOnAnswer =>
+      'Your computer needs to be on and running Sesori for live sessions. You can start or stop it whenever you like.';
+
+  @override
+  String get projectsOnboardingWhyFaqReadQuestion => 'Can Sesori read my sessions?';
+
+  @override
+  String get projectsOnboardingWhyFaqReadAnswer =>
+      'No. Everything between your phone and computer is end-to-end encrypted — the relay only passes along sealed data it can\'t read.';
 }

--- a/client/module_prego/lib/components/menus/prego_anchor_menu.dart
+++ b/client/module_prego/lib/components/menus/prego_anchor_menu.dart
@@ -146,7 +146,7 @@ class _PregoAnchorMenuState extends State<PregoAnchorMenu> {
         toggle();
         _alignGlassMenuToTrigger(context);
       }),
-      items: [for (final entry in widget.entries) _glassEntry(context, entry)],
+      items: [for (final entry in widget.entries) _glassEntry(context, entry: entry)],
     );
   }
 
@@ -169,7 +169,7 @@ class _PregoAnchorMenuState extends State<PregoAnchorMenu> {
     _glassController.setFollowOffset(-overlayBox.localToGlobal(Offset.zero));
   }
 
-  Widget _glassEntry(BuildContext context, PregoMenuEntry entry) {
+  Widget _glassEntry(BuildContext context, {required PregoMenuEntry entry}) {
     final prego = context.prego;
     switch (entry) {
       case PregoMenuLabel(:final text):
@@ -254,8 +254,12 @@ class _FlatAnchoredMenu extends StatelessWidget {
         screen.height - keyboard - safe.bottom - screenPadding.bottom - triggerRect.bottom - _gap;
     final expandUp = spaceAbove >= spaceBelow;
     final available = math.max(0.0, expandUp ? spaceAbove : spaceBelow);
-    final maxHeight = menuHeight != null ? math.min(menuHeight!, available) : available;
+    final menuHeight = this.menuHeight;
+    final maxHeight = menuHeight != null ? math.min(menuHeight, available) : available;
 
+    // module_prego is a GoRouter-agnostic design module (no go_router dep);
+    // this pops the modal route CueModalTransition pushed for the menu.
+    // ignore: no_slop_linter/avoid_navigator_of, design module has no go_router dep; pops the modal route CueModalTransition pushed
     void close() => Navigator.of(context).pop();
 
     final panel = DecoratedBox(
@@ -275,7 +279,7 @@ class _FlatAnchoredMenu extends StatelessWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [for (final entry in entries) _flatEntry(context, entry, close)],
+            children: [for (final entry in entries) _flatEntry(context, entry: entry, close: close)],
           ),
         ),
       ),
@@ -303,7 +307,7 @@ class _FlatAnchoredMenu extends StatelessWidget {
     );
   }
 
-  Widget _flatEntry(BuildContext context, PregoMenuEntry entry, VoidCallback close) {
+  Widget _flatEntry(BuildContext context, {required PregoMenuEntry entry, required VoidCallback close}) {
     final prego = context.prego;
     switch (entry) {
       case PregoMenuLabel(:final text):

--- a/client/module_prego/lib/components/navigation/prego_nav_title.dart
+++ b/client/module_prego/lib/components/navigation/prego_nav_title.dart
@@ -8,10 +8,10 @@ import "../../module_prego.dart";
 ///
 /// Renders [title] in `text-lg / medium / text-primary` with an optional
 /// [subtitle] in `text-md / medium / text-secondary` on a centred second line.
-/// Both lines are centred and clipped to a single ellipsised line. Optional
-/// [leading] (e.g. an avatar) and [trailing] (e.g. a verified tick) widgets sit
-/// either side of the title with a `spacing-sm` gap, mirroring the component's
-/// avatar and check-mark variants.
+/// Both lines are centred and clipped to a single ellipsised line.
+///
+/// This is the top bar's centred title; the sheet header uses its own bolder,
+/// leading-or-centred title block (see [PregoTopNavigationSheets]).
 ///
 /// Used by [PregoTopNavigation] to render its fixed inline title, so the bar
 /// title looks identical wherever the bar appears (including inside

--- a/client/module_prego/lib/components/navigation/prego_top_navigation_sheets.dart
+++ b/client/module_prego/lib/components/navigation/prego_top_navigation_sheets.dart
@@ -1,0 +1,244 @@
+import "package:flutter/material.dart";
+import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
+
+import "../../module_prego.dart";
+
+/// How the [PregoTopNavigationSheets] title (and subtitle) are aligned across the
+/// bar: [center] mirrors [PregoTopNavigation]'s centred title, [start] pins the
+/// block to the leading edge (the Figma "Title 2 Line Left" style).
+enum PregoSheetTitleAlignment { center, start }
+
+/// The header of [PregoBottomSheet] — the Figma `pregoTopNavigationSheets`
+/// component: a drag [showGrabber] pill above a fixed nav row with a leading
+/// close/back button, a centred-or-leading title (+ optional [subtitle]), and
+/// trailing [actions].
+///
+/// It is the sheet counterpart to [PregoTopNavigation]: same transparent bar
+/// with glass buttons ([PregoButtonsIconGlass]) and the same leading resolution,
+/// but with a drag grabber instead of a large collapsing title. It is a fixed,
+/// self-contained header — it never collapses on scroll — so a sheet body can
+/// scroll behind it (see [PregoBottomSheet]).
+///
+/// Leading resolution (first match wins):
+/// 1. an explicit [leading] widget;
+/// 2. a glass back button ([TablerRegular.chevron_left]) wired to [onBack], for
+///    in-sheet navigation (the X becomes a back arrow);
+/// 3. a glass close button ([TablerRegular.x]) wired to [onClose].
+///
+/// The back/close affordances announce the platform's standard
+/// back/close tooltips so screen readers describe them without a bespoke string.
+class PregoTopNavigationSheets extends StatelessWidget implements PreferredSizeWidget {
+  const PregoTopNavigationSheets({
+    super.key,
+    required this.title,
+    this.subtitle,
+    this.alignment = PregoSheetTitleAlignment.center,
+    this.showGrabber = true,
+    this.onClose,
+    this.onBack,
+    this.actions,
+    this.leading,
+  });
+
+  /// Primary title — `text-lg / bold / text-primary`.
+  final String title;
+
+  /// Optional second line in `text-md / regular / text-secondary`. A `null` or
+  /// empty value renders the title on its own.
+  final String? subtitle;
+
+  /// Whether the title block is centred across the bar or pinned to the leading
+  /// edge. Defaults to [PregoSheetTitleAlignment.center].
+  final PregoSheetTitleAlignment alignment;
+
+  /// Whether to render the drag grabber pill above the nav row. Defaults to
+  /// `true`. The grabber is decorative — dragging it dismisses the sheet, but
+  /// the affordance is owned by the enclosing modal, not this widget.
+  final bool showGrabber;
+
+  /// Renders a glass close button (`x`) that invokes this callback, unless
+  /// [leading] or [onBack] takes precedence.
+  final VoidCallback? onClose;
+
+  /// Renders a glass back button (`chevron-left`) that invokes this callback.
+  /// Takes precedence over [onClose] so an in-sheet navigation step swaps the
+  /// close affordance for a back one.
+  final VoidCallback? onBack;
+
+  /// Trailing bar actions. Build these with [PregoButtonsIconGlass] so they
+  /// match the leading button.
+  final List<Widget>? actions;
+
+  /// Overrides the leading slot entirely. Takes precedence over [onBack] and
+  /// [onClose].
+  final Widget? leading;
+
+  /// Height of the drag-grabber block above the nav row.
+  static const double grabberBlockHeight = 16;
+
+  /// Height of the nav (controls) row — matches the glass button diameter.
+  static const double controlsRowHeight = 44;
+
+  /// Total header height, exposed so [PregoBottomSheet] can reserve the space
+  /// its body must scroll behind.
+  static const double headerHeight = grabberBlockHeight + controlsRowHeight;
+
+  static const double _grabberWidth = 36;
+  static const double _grabberHeight = 5;
+
+  /// Line-height multiplier for the title/subtitle, overriding the body-text
+  /// leading so a two-line title+subtitle stack fits the fixed
+  /// [controlsRowHeight] on every platform (mirrors [PregoNavTitle]'s rationale
+  /// for the taller top bar).
+  static const double _titleLineHeight = 1.2;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(headerHeight);
+
+  @override
+  Widget build(BuildContext context) {
+    final leading = _resolveLeading(context);
+    final actions = this.actions;
+    final isCenter = alignment == PregoSheetTitleAlignment.center;
+
+    // Same layout PregoTopNavigation uses: hand NavigationToolbar a single
+    // full-width row so the centred title is centred across the whole bar (not
+    // just the gap between side widgets), and shifted only if it would overlap.
+    final controls = SizedBox(
+      height: controlsRowHeight,
+      child: NavigationToolbar(
+        centerMiddle: isCenter,
+        // NavigationToolbar stretches its leading slot full-height and
+        // top-aligns it, which would squash the circular glass button; wrap in
+        // an [Align] (widthFactor 1) to keep it its natural size, centred.
+        leading: leading == null ? null : Align(widthFactor: 1, child: leading),
+        middle: _SheetTitle(
+          title: title,
+          subtitle: subtitle,
+          alignment: alignment,
+          lineHeight: _titleLineHeight,
+        ),
+        trailing: actions == null
+            ? null
+            : Row(mainAxisSize: MainAxisSize.min, spacing: PregoSpacing.md, children: actions),
+      ),
+    );
+
+    // Force the glass buttons to render their own layer, exactly as
+    // [GlassAppBar] does. Unlike the top bar, a sheet header has no
+    // enclosing [GlassScaffold]/[GlassPage] (a modal route sits outside the
+    // page), so without this the buttons would have no glass layer to join.
+    return GlassIsolationScope(
+      isolated: true,
+      defaultQuality: GlassQuality.premium,
+      child: Padding(
+        // Leading/trailing buttons sit 16pt from the bar edges.
+        padding: const EdgeInsetsDirectional.symmetric(horizontal: PregoSpacing.xl),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (showGrabber) _buildGrabber(context),
+            controls,
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGrabber(BuildContext context) {
+    // Decorative: no semantics node. Drag-to-dismiss is unreachable by screen
+    // readers, so the close button and the modal barrier are the announced
+    // dismiss affordances.
+    return SizedBox(
+      height: grabberBlockHeight,
+      child: Center(
+        child: Container(
+          width: _grabberWidth,
+          height: _grabberHeight,
+          decoration: BoxDecoration(
+            color: context.prego.colors.textSecondary.withValues(alpha: 0.4),
+            borderRadius: BorderRadius.circular(PregoRadius.full),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Resolves the leading bar button. Always renders the app's glass button
+  /// ([PregoButtonsIconGlass]) so the affordance matches the design on every
+  /// screen, announcing the platform's standard back/close tooltip.
+  Widget? _resolveLeading(BuildContext context) {
+    final leading = this.leading;
+    if (leading != null) return leading;
+
+    final onBack = this.onBack;
+    if (onBack != null) {
+      return PregoButtonsIconGlass(
+        icon: TablerRegular.chevron_left,
+        onPressed: onBack,
+        semanticLabel: MaterialLocalizations.of(context).backButtonTooltip,
+      );
+    }
+
+    final onClose = this.onClose;
+    if (onClose != null) {
+      return PregoButtonsIconGlass(
+        icon: TablerRegular.x,
+        onPressed: onClose,
+        semanticLabel: MaterialLocalizations.of(context).closeButtonTooltip,
+      );
+    }
+
+    return null;
+  }
+}
+
+/// The sheet header's title block: [title] in `text-lg / bold / text-primary`
+/// with an optional [subtitle] in `text-md / regular / text-secondary`, aligned
+/// per [alignment]. Distinct from [PregoNavTitle] (which is `text-lg / medium`,
+/// centre-only, tuned for the taller top bar): the sheet uses a bold title,
+/// leading-or-centred alignment, and this bar's tighter [lineHeight].
+class _SheetTitle extends StatelessWidget {
+  const _SheetTitle({
+    required this.title,
+    required this.subtitle,
+    required this.alignment,
+    required this.lineHeight,
+  });
+
+  final String title;
+  final String? subtitle;
+  final PregoSheetTitleAlignment alignment;
+  final double lineHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    final subtitle = this.subtitle;
+    final isCenter = alignment == PregoSheetTitleAlignment.center;
+    final textAlign = isCenter ? TextAlign.center : TextAlign.start;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: isCenter ? CrossAxisAlignment.center : CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: prego.textTheme.textLg.bold.copyWith(color: prego.colors.textPrimary, height: lineHeight),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          textAlign: textAlign,
+        ),
+        if (subtitle != null && subtitle.isNotEmpty)
+          Text(
+            subtitle,
+            style: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textSecondary, height: lineHeight),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            textAlign: textAlign,
+          ),
+      ],
+    );
+  }
+}

--- a/client/module_prego/lib/components/navigation/prego_top_navigation_sheets.dart
+++ b/client/module_prego/lib/components/navigation/prego_top_navigation_sheets.dart
@@ -93,7 +93,7 @@ class PregoTopNavigationSheets extends StatelessWidget implements PreferredSizeW
   static const double _titleLineHeight = 1.2;
 
   @override
-  Size get preferredSize => const Size.fromHeight(headerHeight);
+  Size get preferredSize => Size.fromHeight(showGrabber ? headerHeight : controlsRowHeight);
 
   @override
   Widget build(BuildContext context) {

--- a/client/module_prego/lib/components/navigation/prego_top_navigation_sheets.dart
+++ b/client/module_prego/lib/components/navigation/prego_top_navigation_sheets.dart
@@ -130,7 +130,6 @@ class PregoTopNavigationSheets extends StatelessWidget implements PreferredSizeW
     // page), so without this the buttons would have no glass layer to join.
     return GlassIsolationScope(
       isolated: true,
-      defaultQuality: GlassQuality.premium,
       child: Padding(
         // Leading/trailing buttons sit 16pt from the bar edges.
         padding: const EdgeInsetsDirectional.symmetric(horizontal: PregoSpacing.xl),

--- a/client/module_prego/lib/components/surfaces/prego_bottom_sheet.dart
+++ b/client/module_prego/lib/components/surfaces/prego_bottom_sheet.dart
@@ -123,7 +123,9 @@ class PregoBottomSheet extends StatelessWidget {
       clipBehavior: Clip.antiAlias,
       decoration: BoxDecoration(
         color: surface,
-        borderRadius: const BorderRadius.vertical(top: Radius.circular(PregoRadius.x4l)),
+        borderRadius: const BorderRadius.vertical(
+          top: Radius.circular(38),
+        ), // TODO(daniil): replace radius once Figma is updated
       ),
       child: ConstrainedBox(
         constraints: BoxConstraints(maxHeight: maxHeight),

--- a/client/module_prego/lib/components/surfaces/prego_bottom_sheet.dart
+++ b/client/module_prego/lib/components/surfaces/prego_bottom_sheet.dart
@@ -124,8 +124,8 @@ class PregoBottomSheet extends StatelessWidget {
       decoration: BoxDecoration(
         color: surface,
         borderRadius: const BorderRadius.vertical(
-          top: Radius.circular(38),
-        ), // TODO(daniil): replace radius once Figma is updated
+          top: Radius.circular(PregoRadius.x6l),
+        ),
       ),
       child: ConstrainedBox(
         constraints: BoxConstraints(maxHeight: maxHeight),

--- a/client/module_prego/lib/components/surfaces/prego_bottom_sheet.dart
+++ b/client/module_prego/lib/components/surfaces/prego_bottom_sheet.dart
@@ -1,0 +1,264 @@
+import "package:flutter/material.dart";
+
+import "../../module_prego.dart";
+import "../../utils/color_extensions.dart";
+
+/// A modal bottom sheet with the app's glass navigation header
+/// ([PregoTopNavigationSheets]) over a solid rounded-top surface.
+///
+/// It sizes to its [child]: short content sits part-way up the screen; tall
+/// content grows until it meets the status bar and then scrolls. The body
+/// scrolls *behind* the transparent glass header, dissolving into a scroll-edge
+/// gradient just below the bar — the same treatment [PregoGlassScaffold] gives a
+/// full page. Drag the header/grabber down to dismiss.
+///
+/// Prefer [showPregoBottomSheet], which presents this widget as a modal route
+/// and wires the close button to pop it. Using [PregoBottomSheet] directly is
+/// supported, but then the caller owns dismissal: supply [onClose] (or [onBack])
+/// so the sheet has an in-sheet dismiss affordance for screen-reader users.
+///
+/// Usage:
+/// ```dart
+/// showPregoBottomSheet(
+///   context: context,
+///   title: loc.whyTitle,
+///   builder: (_) => const WhyContent(),
+/// );
+/// ```
+class PregoBottomSheet extends StatelessWidget {
+  const PregoBottomSheet({
+    super.key,
+    required this.title,
+    required this.child,
+    this.subtitle,
+    this.alignment = PregoSheetTitleAlignment.center,
+    this.onClose,
+    this.onBack,
+    this.actions,
+    this.leading,
+    this.surfaceColor,
+    this.contentPadding = const EdgeInsetsDirectional.symmetric(horizontal: PregoSpacing.xl),
+    this.handleBottomSafeArea = true,
+    this.controller,
+    this.topInset,
+  });
+
+  /// Header title. See [PregoTopNavigationSheets.title].
+  final String title;
+
+  /// Optional header subtitle. See [PregoTopNavigationSheets.subtitle].
+  final String? subtitle;
+
+  /// The sheet body. It is padded down to clear the header and scrolls behind
+  /// it; wrap tall content in a single widget (e.g. a [Column]).
+  final Widget child;
+
+  /// Header title alignment. Defaults to [PregoSheetTitleAlignment.center].
+  final PregoSheetTitleAlignment alignment;
+
+  /// Invoked by the header's close button. [showPregoBottomSheet] injects a
+  /// route-pop; pass your own when using this widget directly.
+  final VoidCallback? onClose;
+
+  /// When set, the header's leading slot is a back button invoking this instead
+  /// of the close button — for in-sheet navigation.
+  final VoidCallback? onBack;
+
+  /// Trailing header actions. See [PregoTopNavigationSheets.actions].
+  final List<Widget>? actions;
+
+  /// Overrides the header's leading slot entirely.
+  final Widget? leading;
+
+  /// The sheet surface colour (also the scroll-edge fade colour). Defaults to
+  /// `bg-secondary` — a raised surface that flips correctly in dark mode.
+  final Color? surfaceColor;
+
+  /// Padding applied around [child] (not the header). Defaults to 16pt
+  /// horizontal.
+  final EdgeInsetsGeometry contentPadding;
+
+  /// Whether to pad the body up by the bottom safe area (home indicator) when
+  /// the keyboard is hidden. Set `false` for content that scrolls to the very
+  /// bottom edge. The keyboard inset is always applied.
+  final bool handleBottomSafeArea;
+
+  /// Optional controller for the body scroll view.
+  final ScrollController? controller;
+
+  /// The top inset (status bar / notch) the sheet keeps clear when it grows to
+  /// full height.
+  ///
+  /// [showPregoBottomSheet] supplies the real inset captured from the presenting
+  /// context, because the modal route strips the top padding from the sheet's
+  /// own [MediaQuery] (`showModalBottomSheet` wraps `useSafeArea: false` content
+  /// in `MediaQuery.removePadding(removeTop: true)`). When null — e.g. a direct
+  /// caller not behind that wrapper — the sheet falls back to
+  /// [MediaQuery.paddingOf].
+  final double? topInset;
+
+  /// Extra height, below the header, over which the scroll-edge gradient fades
+  /// content out.
+  static const double _fadeExtent = PregoSpacing.x3l;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.prego.colors;
+    // The modal strips the top padding from the sheet's own MediaQuery, so use
+    // the inset [showPregoBottomSheet] captured from the presenting context;
+    // only fall back to MediaQuery for a direct caller (see [topInset]).
+    final topInset = this.topInset ?? MediaQuery.paddingOf(context).top;
+    final bottomSafe = MediaQuery.paddingOf(context).bottom;
+    final keyboard = MediaQuery.viewInsetsOf(context).bottom;
+    final surface = surfaceColor ?? colors.bgSecondary;
+
+    // Cap the sheet just below the status bar. Size is unaffected by the modal's
+    // padding removal, so subtracting the real [topInset] stops a full-height
+    // sheet from sliding its header under the status bar / notch.
+    final maxHeight = MediaQuery.sizeOf(context).height - topInset;
+
+    // Push the body above the keyboard when it is up, otherwise clear the home
+    // indicator — but never both at once. Mirrors the app's _ModalSafeArea.
+    final bottomInset = keyboard > 0 ? keyboard : (handleBottomSafeArea ? bottomSafe : 0.0);
+
+    return Container(
+      // A real clipper (not DecoratedBox) so the rounded top corners clip the
+      // scroll-edge gradient and any content scrolling behind the header.
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: surface,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(PregoRadius.x4l)),
+      ),
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxHeight: maxHeight),
+        child: Stack(
+          children: [
+            // (1) The body — the sole non-positioned child, so the Stack (and
+            // thus the sheet) sizes to it: it wraps its content when short and
+            // caps at [maxHeight], scrolling, when tall.
+            CustomScrollView(
+              controller: controller,
+              shrinkWrap: true,
+              slivers: [
+                const SliverToBoxAdapter(
+                  child: SizedBox(height: PregoTopNavigationSheets.headerHeight),
+                ),
+                SliverToBoxAdapter(
+                  child: Padding(padding: contentPadding, child: child),
+                ),
+                SliverToBoxAdapter(child: SizedBox(height: bottomInset)),
+              ],
+            ),
+
+            // (2) Scroll-edge fade: content dissolves into the surface just
+            // below the bar. Same-hue (surface -> alpha 0), not Colors
+            // .transparent, so it never fades through a muddy tint. Mirrors
+            // PregoGlassScaffold's custom gradient (its bar owns the fade, not
+            // the package edge effect).
+            Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              child: IgnorePointer(
+                child: Container(
+                  height: PregoTopNavigationSheets.headerHeight + _fadeExtent,
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      stops: const [0, 0.75, 1.0],
+                      colors: [
+                        surface.withMultipliedOpacity(1),
+                        surface.withMultipliedOpacity(0.9),
+                        surface.withMultipliedOpacity(0),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+
+            // (3) The glass header, pinned on top. The opaque hit-test barrier
+            // stops header/grabber drags from falling through to the scroll
+            // view behind it (which would overscroll instead of dismissing), so
+            // those drags reach the modal's own drag-to-dismiss recognizer. The
+            // glass buttons are descendants and still receive their taps.
+            Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                child: PregoTopNavigationSheets(
+                  title: title,
+                  subtitle: subtitle,
+                  alignment: alignment,
+                  onClose: onClose,
+                  onBack: onBack,
+                  actions: actions,
+                  leading: leading,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Presents a [PregoBottomSheet] as a modal route and returns the value it is
+/// popped with.
+///
+/// The sheet is scroll-controlled (so it can grow to the status bar) over a
+/// transparent route background — [PregoBottomSheet] paints its own rounded
+/// surface — with drag-to-dismiss enabled. The close button pops this route.
+// ignore: no_slop_linter/prefer_required_named_parameters, contentPadding/handleBottomSafeArea keep sheet-chrome defaults
+Future<T?> showPregoBottomSheet<T>({
+  required BuildContext context,
+  required String title,
+  required WidgetBuilder builder,
+  String? subtitle,
+  PregoSheetTitleAlignment alignment = PregoSheetTitleAlignment.center,
+  List<Widget>? actions,
+  VoidCallback? onBack,
+  Widget? leading,
+  Color? surfaceColor,
+  EdgeInsetsGeometry contentPadding = const EdgeInsetsDirectional.symmetric(
+    horizontal: PregoSpacing.xl,
+  ),
+  bool handleBottomSafeArea = true,
+  bool isDismissible = true,
+}) {
+  // Capture the real status-bar inset here, from the presenting context: the
+  // modal route strips the top padding from the sheet's own MediaQuery, so the
+  // sheet can't read it once inside.
+  final topInset = MediaQuery.paddingOf(context).top;
+  return showModalBottomSheet<T>(
+    context: context,
+    isScrollControlled: true,
+    // PregoBottomSheet paints the rounded surface; keep the route transparent.
+    backgroundColor: Colors.transparent,
+    // The sheet caps itself just below the status bar, so no route SafeArea.
+    useSafeArea: false,
+    isDismissible: isDismissible,
+    builder: (sheetContext) => PregoBottomSheet(
+      title: title,
+      subtitle: subtitle,
+      alignment: alignment,
+      actions: actions,
+      onBack: onBack,
+      leading: leading,
+      surfaceColor: surfaceColor,
+      contentPadding: contentPadding,
+      handleBottomSafeArea: handleBottomSafeArea,
+      topInset: topInset,
+      // Pops the modal route this helper pushed (always dismissible). This
+      // design module has no go_router dependency, so it pops the sheet's own
+      // Navigator route directly.
+      // ignore: no_slop_linter/avoid_navigator_of, design module has no go_router dep; pops the modal route this helper pushed
+      onClose: () => Navigator.of(sheetContext).pop(),
+      child: builder(sheetContext),
+    ),
+  );
+}

--- a/client/module_prego/lib/components/surfaces/prego_bottom_sheet.dart
+++ b/client/module_prego/lib/components/surfaces/prego_bottom_sheet.dart
@@ -39,7 +39,6 @@ class PregoBottomSheet extends StatelessWidget {
     this.surfaceColor,
     this.contentPadding = const EdgeInsetsDirectional.symmetric(horizontal: PregoSpacing.xl),
     this.handleBottomSafeArea = true,
-    this.controller,
     this.topInset,
   });
 
@@ -82,9 +81,6 @@ class PregoBottomSheet extends StatelessWidget {
   /// the keyboard is hidden. Set `false` for content that scrolls to the very
   /// bottom edge. The keyboard inset is always applied.
   final bool handleBottomSafeArea;
-
-  /// Optional controller for the body scroll view.
-  final ScrollController? controller;
 
   /// The top inset (status bar / notch) the sheet keeps clear when it grows to
   /// full height.
@@ -137,11 +133,13 @@ class PregoBottomSheet extends StatelessWidget {
             // thus the sheet) sizes to it: it wraps its content when short and
             // caps at [maxHeight], scrolling, when tall.
             CustomScrollView(
-              controller: controller,
               shrinkWrap: true,
               slivers: [
+                // Clear the header plus the fade below it, so resting content
+                // starts fully legible and only dissolves once it scrolls up
+                // under the bar.
                 const SliverToBoxAdapter(
-                  child: SizedBox(height: PregoTopNavigationSheets.headerHeight),
+                  child: SizedBox(height: PregoTopNavigationSheets.headerHeight + _fadeExtent),
                 ),
                 SliverToBoxAdapter(
                   child: Padding(padding: contentPadding, child: child),
@@ -212,7 +210,8 @@ class PregoBottomSheet extends StatelessWidget {
 ///
 /// The sheet is scroll-controlled (so it can grow to the status bar) over a
 /// transparent route background — [PregoBottomSheet] paints its own rounded
-/// surface — with drag-to-dismiss enabled. The close button pops this route.
+/// surface. Scrim-tap and drag-to-dismiss both follow [isDismissible]. The
+/// close button pops this route.
 // ignore: no_slop_linter/prefer_required_named_parameters, contentPadding/handleBottomSafeArea keep sheet-chrome defaults
 Future<T?> showPregoBottomSheet<T>({
   required BuildContext context,
@@ -242,6 +241,9 @@ Future<T?> showPregoBottomSheet<T>({
     // The sheet caps itself just below the status bar, so no route SafeArea.
     useSafeArea: false,
     isDismissible: isDismissible,
+    // Keep swipe-down consistent with the scrim: a non-dismissible sheet must
+    // not be drag-dismissable either (enableDrag defaults to true otherwise).
+    enableDrag: isDismissible,
     builder: (sheetContext) => PregoBottomSheet(
       title: title,
       subtitle: subtitle,

--- a/client/module_prego/lib/module_prego.dart
+++ b/client/module_prego/lib/module_prego.dart
@@ -9,6 +9,8 @@ export 'components/menus/prego_anchor_menu.dart';
 export 'components/navigation/prego_glass_scaffold.dart';
 export 'components/navigation/prego_nav_title.dart';
 export 'components/navigation/prego_top_navigation.dart';
+export 'components/navigation/prego_top_navigation_sheets.dart';
+export 'components/surfaces/prego_bottom_sheet.dart';
 export 'components/surfaces/prego_surfaces.dart';
 export 'icons/tabler_icons.g.dart';
 export 'icons/vespr_icons.g.dart';

--- a/client/module_prego/lib/theme/primitives/prego_radius.g.dart
+++ b/client/module_prego/lib/theme/primitives/prego_radius.g.dart
@@ -13,7 +13,6 @@
 /// )
 /// ```
 abstract final class PregoRadius {
-
   /// 0px - Figma: radius-none
   static const double none = 0;
 
@@ -46,6 +45,9 @@ abstract final class PregoRadius {
 
   /// 34px - Figma: radius-5xl
   static const double x5l = 34;
+
+  /// 38px - Figma: radius-6xl
+  static const double x6l = 38;
 
   /// 9999px - Figma: radius-full
   static const double full = 9999;

--- a/client/module_prego/test/components/prego_bottom_sheet_test.dart
+++ b/client/module_prego/test/components/prego_bottom_sheet_test.dart
@@ -1,0 +1,159 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:theme_prego/module_prego.dart";
+
+/// Bottom-anchors the sheet with loose constraints so it wraps to its content
+/// height — matching how a modal route lays it out (and making the height
+/// measurable).
+Widget _harness(Widget child) => MaterialApp(
+  theme: ThemeData(extensions: [PregoDesignSystem.light]),
+  home: Scaffold(
+    body: Align(alignment: Alignment.bottomCenter, child: child),
+  ),
+);
+
+Widget _sheet({
+  String title = "Sheet title",
+  String? subtitle,
+  PregoSheetTitleAlignment alignment = PregoSheetTitleAlignment.center,
+  VoidCallback? onClose,
+  VoidCallback? onBack,
+  List<Widget>? actions,
+  Widget? child,
+}) => PregoBottomSheet(
+  title: title,
+  subtitle: subtitle,
+  alignment: alignment,
+  onClose: onClose,
+  onBack: onBack,
+  actions: actions,
+  child: child ?? const SizedBox(height: 120),
+);
+
+void main() {
+  group("PregoBottomSheet", () {
+    testWidgets("renders the header title, subtitle, and grabber", (tester) async {
+      await tester.pumpWidget(_harness(_sheet(title: "Why", subtitle: "Because")));
+      await tester.pump();
+
+      expect(find.text("Why"), findsOneWidget);
+      expect(find.text("Because"), findsOneWidget);
+      expect(find.byType(PregoTopNavigationSheets), findsOneWidget);
+    });
+
+    testWidgets("close button is labelled and invokes onClose", (tester) async {
+      var closed = 0;
+      await tester.pumpWidget(_harness(_sheet(onClose: () => closed++)));
+      await tester.pump();
+
+      expect(find.byIcon(TablerRegular.x), findsOneWidget);
+      // Uses the platform's localized close tooltip — no bespoke string.
+      expect(find.bySemanticsLabel("Close"), findsOneWidget);
+
+      await tester.tap(find.byIcon(TablerRegular.x));
+      await tester.pump();
+      expect(closed, 1);
+    });
+
+    testWidgets("onBack swaps the close button for a back button", (tester) async {
+      var backs = 0;
+      await tester.pumpWidget(_harness(_sheet(onClose: () {}, onBack: () => backs++)));
+      await tester.pump();
+
+      expect(find.byIcon(TablerRegular.chevron_left), findsOneWidget);
+      expect(find.byIcon(TablerRegular.x), findsNothing);
+
+      await tester.tap(find.byIcon(TablerRegular.chevron_left));
+      await tester.pump();
+      expect(backs, 1);
+    });
+
+    testWidgets("renders trailing actions", (tester) async {
+      await tester.pumpWidget(
+        _harness(
+          _sheet(
+            actions: [PregoButtonsIconGlass(icon: TablerRegular.bell, onPressed: () {})],
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byIcon(TablerRegular.bell), findsOneWidget);
+    });
+
+    testWidgets("centre alignment centres the title; start alignment leads it", (tester) async {
+      // The default test surface is 800pt wide, so mid-screen is x=400.
+      await tester.pumpWidget(_harness(_sheet(title: "Centered")));
+      await tester.pump();
+      expect((tester.getCenter(find.text("Centered")).dx - 400).abs(), lessThan(40));
+
+      await tester.pumpWidget(_harness(_sheet(title: "Leading", alignment: PregoSheetTitleAlignment.start)));
+      await tester.pump();
+      expect(tester.getCenter(find.text("Leading")).dx, lessThan(300));
+    });
+
+    testWidgets("wraps to its content when short", (tester) async {
+      await tester.pumpWidget(_harness(_sheet(child: const SizedBox(height: 100))));
+      await tester.pump();
+
+      // header (60) + content (100) with no insets — well below the 600pt cap.
+      expect(tester.getSize(find.byType(PregoBottomSheet)).height, lessThan(300));
+    });
+
+    testWidgets("caps at the screen height and scrolls when tall", (tester) async {
+      await tester.pumpWidget(_harness(_sheet(child: const SizedBox(height: 2000))));
+      await tester.pump();
+
+      // Capped just below the (zero-height) status bar: the full 600pt surface.
+      expect(tester.getSize(find.byType(PregoBottomSheet)).height, closeTo(600, 0.5));
+
+      final position = tester.state<ScrollableState>(find.byType(Scrollable).first).position;
+      expect(position.maxScrollExtent, greaterThan(0));
+    });
+
+    testWidgets("reserves topInset so a full-height sheet clears the status bar", (tester) async {
+      // The modal strips the sheet's own top padding, so the inset is passed in.
+      await tester.pumpWidget(
+        _harness(const PregoBottomSheet(title: "T", topInset: 50, child: SizedBox(height: 2000))),
+      );
+      await tester.pump();
+
+      // 600pt surface - 50pt reserved inset = 550pt cap (header stays clear).
+      expect(tester.getSize(find.byType(PregoBottomSheet)).height, closeTo(550, 0.5));
+    });
+  });
+
+  group("showPregoBottomSheet", () {
+    testWidgets("opens the sheet and the close button pops it", (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(extensions: [PregoDesignSystem.light]),
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => Center(
+                child: TextButton(
+                  onPressed: () => showPregoBottomSheet<void>(
+                    context: context,
+                    title: "Info",
+                    builder: (_) => const Text("Body content"),
+                  ),
+                  child: const Text("Open"),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text("Open"));
+      await tester.pumpAndSettle();
+      expect(find.text("Info"), findsOneWidget);
+      expect(find.text("Body content"), findsOneWidget);
+
+      // The glass close button works with no GlassPage ancestor (modal route).
+      await tester.tap(find.byIcon(TablerRegular.x));
+      await tester.pumpAndSettle();
+      expect(find.text("Info"), findsNothing);
+    });
+  });
+}

--- a/client/module_prego/test/components/prego_surfaces_test.dart
+++ b/client/module_prego/test/components/prego_surfaces_test.dart
@@ -33,7 +33,7 @@ void main() {
                   subtitle: const Text("first"),
                   onTap: () => taps++,
                 ),
-                PregoListTile(title: const Text("Beta"), isLast: true),
+                const PregoListTile(title: Text("Beta"), isLast: true),
               ],
             ),
           ),


### PR DESCRIPTION
## Summary

Adds the onboarding "Why is this needed?" explainer, built on a new reusable modal bottom sheet component in `module_prego`, matching the Figma design.

### module_prego (design system)

- **`PregoBottomSheet`** — new modal sheet surface (Figma `pregoBottomSheet`): glass background via `GlassIsolationScope`, drag handle, scrollable content, and a `showPregoBottomSheet<T>` entry point mirroring the `showModalBottomSheet` idiom. `topInset` is passed from the caller since `useSafeArea: false` strips top padding inside the modal route.
- **`PregoTopNavigationSheets`** — new sheet header component (Figma `pregoTopNavigationSheets`) with title + close button, used by `PregoBottomSheet`.
- `PregoAnchorMenu` — small cleanups (named args, local shadow fix, justified lint ignore); `PregoNavTitle` doc-only.
- Widget tests for the new sheet component (`prego_bottom_sheet_test.dart`).

### client/app (onboarding integration)

- New "Why is this needed?" secondary button under the PC status line in the onboarding checklist, opening the explainer sheet.
- `_WhyBridgeInfoSheet` content: lede + supporting line, reassurance rows (secure access / connect from anywhere / get notified), and an expandable FAQ section.
- New l10n strings for all sheet copy.

### Notes for review

- **FAQ answer copy is DRAFT** (flagged in the arb descriptions) — final wording pending.
- The sheet reuses the existing `ConnectionGraphic.connectionOn()` artwork; the Figma sheet shows a dedicated phone+desktop "E2E Encrypted" illustration that would need a separate asset export.

### Verification

- `aristotle-impl-review` pass: **APPROVED**, no violations (layer boundaries, cohesion, naming all clean; `flutter analyze` clean on `module_prego` and `app`).
- Widget tests added for the sheet component; existing surface tests updated.

https://claude.ai/code/session_01XtSXhexDGb9x2Wf5WGTt3E

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the onboarding “Why is this needed?” explainer, powered by a reusable bottom sheet in `module_prego`. Users can tap a new secondary button to learn why the Bridge exists; design matches Figma with updated corner radius and glass defaults.

- **New Features**
  - New `PregoBottomSheet` and `PregoTopNavigationSheets` with a glass header, back/close support, and scroll-behind fade; available via `showPregoBottomSheet<T>`.
  - Onboarding: added a “Why is this needed?” button under the PC status; opens a sheet with a lede, connection graphic, three reassurance rows, and an expandable FAQ.
  - Design tokens: added `PregoRadius.x6l` (38px) for the sheet’s top radius.
  - Added l10n strings for all sheet copy; widget tests for the new sheet.

- **Bug Fixes**
  - Bottom sheet polish: reserve scroll-edge fade space; tie swipe-to-dismiss to `isDismissible`; compute `preferredSize` from `showGrabber`; update top radius to match Figma; remove premium glass mode.
  - API cleanup: removed an unused `ScrollController` param from `PregoBottomSheet`.

<sup>Written for commit 582f78a3bfff5c0f6e4c4351096f76ac76e8210b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

