### PR TITLE
fix(bridge): don't clear unseen state on re-emitted user messages

### DIFF
--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -655,6 +655,7 @@ class OrchestratorSession {
           sessionId: info.id,
           projectId: info.projectID,
           parentId: info.parentID,
+          occurredAt: info.time?.created,
         );
       case SesoriSessionDeleted(:final info):
         await _sessionUnseenService.recordSessionDeleted(sessionId: info.id, projectId: info.projectID);

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -662,6 +662,7 @@ class OrchestratorSession {
         await _sessionUnseenService.recordActivity(
           sessionId: info.sessionID,
           isUserMessage: info is MessageUser,
+          occurredAt: info.time?.created,
         );
       // For child/subagent requests, `displaySessionId` is the root session the
       // UI surfaces the request under; the child has no persisted row, so route

--- a/bridge/app/lib/src/bridge/persistence/daos/session_dao.dart
+++ b/bridge/app/lib/src/bridge/persistence/daos/session_dao.dart
@@ -139,6 +139,14 @@ class SessionDao extends DatabaseAccessor<AppDatabase> with _$SessionDaoMixin {
     );
   }
 
+  /// Sets ONLY [lastUserMessageAt] for [sessionId], leaving the activity and
+  /// seen timestamps untouched.
+  Future<void> setUserMessageAt({required String sessionId, required int userMessageAt}) async {
+    await (update(sessionTable)..where((t) => t.sessionId.equals(sessionId))).write(
+      SessionTableCompanion(lastUserMessageAt: Value(userMessageAt)),
+    );
+  }
+
   /// Forces [sessionId] into an unseen state for an explicit "Mark as Unread":
   /// stamps activity at [activityAt] and seen just before it, so
   /// `activity > max(userMessage, seen)` holds regardless of prior state.

--- a/bridge/app/lib/src/bridge/repositories/session_unseen_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_unseen_repository.dart
@@ -94,10 +94,18 @@ class SessionUnseenRepository {
   /// the seen timestamp is advanced too so it does not bold under the watcher.
   /// When [isUserMessage] is true, the user-message marker is stamped so the
   /// user's own first message doesn't bold the session.
+  ///
+  /// [createdAt] is the row-creation guard timestamp and MUST be bridge-local:
+  /// the vanished-session reconcile compares it against a locally-captured
+  /// fetch-start time to protect rows created during an in-flight fetch, so a
+  /// backend-domain value here (skewed behind the local clock) could get a
+  /// freshly-created session's row wrongly reconcile-deleted. [activityAt] may
+  /// live in the backend's clock domain.
   /// Wrapped in a transaction so the project FK cannot fire.
   Future<void> ensureRootSessionActivity({
     required String sessionId,
     required String projectId,
+    required int createdAt,
     required int activityAt,
     required bool advanceSeen,
     required bool isUserMessage,
@@ -105,7 +113,7 @@ class SessionUnseenRepository {
     await _db.transaction(() async {
       await _projectsDao.insertProjectsIfMissing(projectIds: [projectId]);
       await _sessionDao.insertSessionsIfMissing(
-        sessions: [(sessionId: sessionId, projectId: projectId, createdAt: activityAt, archivedAt: null)],
+        sessions: [(sessionId: sessionId, projectId: projectId, createdAt: createdAt, archivedAt: null)],
       );
       await _sessionDao.setActivityTimestamps(
         sessionId: sessionId,

--- a/bridge/app/lib/src/bridge/repositories/session_unseen_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_unseen_repository.dart
@@ -68,6 +68,14 @@ class SessionUnseenRepository {
     );
   }
 
+  /// Advances ONLY the user-message marker for [sessionId] (UPDATE-only).
+  /// Used for user messages carrying their own creation time: engagement is
+  /// recorded without touching the activity/seen timeline, so a re-emitted
+  /// (old) user message can never clear unseen activity.
+  Future<void> recordUserMessage({required String sessionId, required int at}) {
+    return _sessionDao.setUserMessageAt(sessionId: sessionId, userMessageAt: at);
+  }
+
   /// Marks [sessionId] seen as of [at] ("Mark as Read" / viewing).
   Future<void> markSessionSeen({required String sessionId, required int at}) {
     return _sessionDao.setSeenAt(sessionId: sessionId, seenAt: at);

--- a/bridge/app/lib/src/bridge/services/session_unseen_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_unseen_service.dart
@@ -103,9 +103,14 @@ class SessionUnseenService {
   /// fetch inserts its row and later activity stamps it. While the session is
   /// being viewed, the seen timestamp is advanced too so it never bolds under
   /// the watcher.
+  ///
+  /// [occurredAt] is the triggering message's own creation time (ms epoch),
+  /// when the caller has one. It makes user-message stamping idempotent: see
+  /// the re-emission guard below.
   Future<void> recordActivity({
     required String sessionId,
     required bool isUserMessage,
+    int? occurredAt,
   }) {
     // Capture the viewed state at submission time, not when the (possibly
     // delayed) serialized write executes — otherwise navigating away while
@@ -114,6 +119,18 @@ class SessionUnseenService {
     return _serialize(sessionId, () async {
       final row = await _unseenRepository.getUnseenRow(sessionId: sessionId);
       if (row == null) return;
+      // A user message may only count ONCE. Backends re-emit the user message
+      // record whenever server-side bookkeeping attached to it changes (e.g.
+      // OpenCode updates its diff summary mid- and post-response); treating a
+      // re-emission as a fresh interaction would stamp `last_user_message_at`
+      // past the assistant's activity and permanently clear the unseen state.
+      // A re-emission carries the message's ORIGINAL creation time, which is
+      // never newer than the stamp recorded when it was first processed, so it
+      // is skipped entirely (its content change is bookkeeping, not unseen-
+      // worthy transcript activity).
+      if (isUserMessage && occurredAt != null && (row.userMessageAt ?? 0) >= occurredAt) {
+        return;
+      }
       // Coalesce repeated assistant activity: once the session is already
       // unseen and no phone is viewing it, another non-user event changes
       // nothing observable — skip the redundant write + emit. (A later

--- a/bridge/app/lib/src/bridge/services/session_unseen_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_unseen_service.dart
@@ -124,10 +124,10 @@ class SessionUnseenService {
       // OpenCode updates its diff summary mid- and post-response); treating a
       // re-emission as a fresh interaction would stamp `last_user_message_at`
       // past the assistant's activity and permanently clear the unseen state.
-      // A re-emission carries the message's ORIGINAL creation time, which is
-      // never newer than the stamp recorded when it was first processed, so it
-      // is skipped entirely (its content change is bookkeeping, not unseen-
-      // worthy transcript activity).
+      // A re-emission carries the message's ORIGINAL creation time — never
+      // newer than the marker stored when it was first processed (stamped from
+      // that same creation time, see below) — so it is skipped entirely (its
+      // content change is bookkeeping, not unseen-worthy transcript activity).
       if (isUserMessage && occurredAt != null && (row.userMessageAt ?? 0) >= occurredAt) {
         return;
       }
@@ -139,9 +139,21 @@ class SessionUnseenService {
       if (!isUserMessage && !viewedAtSubmit && _unseenRepository.unseenForRow(row)) {
         return;
       }
+      // A user message with a known creation time is stamped AT that creation
+      // time, keeping the stored marker in the same clock domain as the
+      // re-emission guard above — a locally-clocked stamp would drift from it
+      // under clock skew (remote `--opencode-host`) or delayed processing
+      // (reconnect backlog), either resurrecting re-emission clears or
+      // swallowing genuine replies. Storing a foreign-domain value is safe: a
+      // user message always leaves the session seen (activity == userMessage),
+      // and every later write clamps strictly past stored markers whatever
+      // their domain ([_activityTimestamp], markRead's max(now, activity)).
+      final at = isUserMessage && occurredAt != null
+          ? occurredAt
+          : _activityTimestamp(userMessageAt: row.userMessageAt, seenAt: row.seenAt);
       await _unseenRepository.recordActivity(
         sessionId: sessionId,
-        at: _activityTimestamp(userMessageAt: row.userMessageAt, seenAt: row.seenAt),
+        at: at,
         isUserMessage: isUserMessage,
         advanceSeen: viewedAtSubmit,
       );

--- a/bridge/app/lib/src/bridge/services/session_unseen_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_unseen_service.dart
@@ -182,10 +182,18 @@ class SessionUnseenService {
   /// sessions ([parentId] != null) are ignored. The new root is stamped with
   /// activity so it is immediately unseen — unless a phone is already viewing
   /// it, in which case it stays seen.
+  ///
+  /// [occurredAt] is the session's own creation time, preferred for the stamp
+  /// so it lives in the same clock domain as the message-derived stamps: the
+  /// creator's first message (created at/after the session itself) then
+  /// reliably clears this creation bold, which a locally-clocked stamp could
+  /// prevent (SSE latency puts local processing time past the first message's
+  /// creation time even without skew).
   Future<void> recordSessionCreated({
     required String sessionId,
     required String projectId,
     required String? parentId,
+    int? occurredAt,
   }) {
     if (parentId != null) return Future<void>.value();
     final viewedAtSubmit = _viewTracker.isViewed(sessionId: sessionId);
@@ -207,7 +215,7 @@ class SessionUnseenService {
       await _unseenRepository.ensureRootSessionActivity(
         sessionId: sessionId,
         projectId: projectId,
-        activityAt: _nextTimestamp(),
+        activityAt: occurredAt ?? _nextTimestamp(),
         advanceSeen: viewedAtSubmit,
         isUserMessage: false,
       );

--- a/bridge/app/lib/src/bridge/services/session_unseen_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_unseen_service.dart
@@ -215,6 +215,9 @@ class SessionUnseenService {
       await _unseenRepository.ensureRootSessionActivity(
         sessionId: sessionId,
         projectId: projectId,
+        // Local-domain guard timestamp (see [ensureRootSessionActivity]); only
+        // the activity marker uses the session's own creation time.
+        createdAt: _wallClock(),
         activityAt: occurredAt ?? _nextTimestamp(),
         advanceSeen: viewedAtSubmit,
         isUserMessage: false,

--- a/bridge/app/lib/src/bridge/services/session_unseen_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_unseen_service.dart
@@ -82,16 +82,23 @@ class SessionUnseenService {
     return _lastIssued = wall > _lastIssued ? wall : _lastIssued + 1;
   }
 
-  /// Activity timestamp clamped above the row's persisted markers. The
-  /// monotonic clock is process-local, so after a restart or a system-clock
-  /// rollback it can start below stored timestamps; without this clamp a new
-  /// assistant activity could write `last_activity_at` <= `max(userMessage,
-  /// seen)` and the session would never bold. Clamping keeps the monotonic
-  /// invariant intact for subsequent writes.
-  int _activityTimestamp({required int? userMessageAt, required int? seenAt}) {
+  /// Activity timestamp clamped above the row's persisted markers.
+  ///
+  /// [occurredAt] — the triggering message's own creation time — is preferred
+  /// when available so activity stamps live in the same clock domain as the
+  /// user-message markers (also stamped from creation times), keeping the
+  /// unseen comparison meaningful under clock skew (remote `--opencode-host`)
+  /// and delayed processing (reconnect backlog). The local monotonic clock is
+  /// the fallback for events without a payload time.
+  ///
+  /// Either source is clamped above `max(userMessage, seen)`: stored markers
+  /// can be ahead of the candidate (clock rollback, restart, cross-domain
+  /// drift), and without the clamp a new activity could write a value <= the
+  /// markers and the session would never bold.
+  int _activityTimestamp({required int? userMessageAt, required int? seenAt, int? occurredAt}) {
     final floor = (userMessageAt ?? 0) > (seenAt ?? 0) ? (userMessageAt ?? 0) : (seenAt ?? 0);
-    final next = _nextTimestamp();
-    if (next > floor) return next;
+    final candidate = occurredAt ?? _nextTimestamp();
+    if (candidate > floor) return candidate;
     final at = floor + 1;
     if (at > _lastIssued) _lastIssued = at;
     return at;
@@ -105,8 +112,11 @@ class SessionUnseenService {
   /// the watcher.
   ///
   /// [occurredAt] is the triggering message's own creation time (ms epoch),
-  /// when the caller has one. It makes user-message stamping idempotent: see
-  /// the re-emission guard below.
+  /// when the caller has one. It keeps the message timeline in a single clock
+  /// domain: user messages advance only their marker at that time (idempotent
+  /// across re-emissions — see the guard below), and assistant activity is
+  /// stamped from it so genuine replies compare correctly against prior
+  /// activity even under clock skew or delayed processing.
   Future<void> recordActivity({
     required String sessionId,
     required bool isUserMessage,
@@ -139,21 +149,28 @@ class SessionUnseenService {
       if (!isUserMessage && !viewedAtSubmit && _unseenRepository.unseenForRow(row)) {
         return;
       }
-      // A user message with a known creation time is stamped AT that creation
-      // time, keeping the stored marker in the same clock domain as the
-      // re-emission guard above — a locally-clocked stamp would drift from it
-      // under clock skew (remote `--opencode-host`) or delayed processing
-      // (reconnect backlog), either resurrecting re-emission clears or
-      // swallowing genuine replies. Storing a foreign-domain value is safe: a
-      // user message always leaves the session seen (activity == userMessage),
-      // and every later write clamps strictly past stored markers whatever
-      // their domain ([_activityTimestamp], markRead's max(now, activity)).
-      final at = isUserMessage && occurredAt != null
-          ? occurredAt
-          : _activityTimestamp(userMessageAt: row.userMessageAt, seenAt: row.seenAt);
+      // A user message with a known creation time advances ONLY the
+      // user-message marker, stamped at that creation time. A user message
+      // proves engagement as of when it was written; it must not rewrite the
+      // activity/seen timeline — otherwise a re-emission that slips past the
+      // guard above (a row whose marker was never stamped, e.g. learned via a
+      // `/sessions` placeholder) would drag `last_activity_at` down onto the
+      // old message and clear genuinely-unseen assistant activity. Whether the
+      // session is seen falls out of the formula: a fresh reply's creation
+      // time exceeds the (same-domain) activity stamp; an old re-emission's
+      // does not.
+      if (isUserMessage && occurredAt != null) {
+        await _unseenRepository.recordUserMessage(sessionId: sessionId, at: occurredAt);
+        await _emit(sessionId: sessionId, projectId: row.projectId);
+        return;
+      }
       await _unseenRepository.recordActivity(
         sessionId: sessionId,
-        at: at,
+        at: _activityTimestamp(
+          userMessageAt: row.userMessageAt,
+          seenAt: row.seenAt,
+          occurredAt: isUserMessage ? null : occurredAt,
+        ),
         isUserMessage: isUserMessage,
         advanceSeen: viewedAtSubmit,
       );

--- a/bridge/app/test/bridge/services/session_unseen_service_test.dart
+++ b/bridge/app/test/bridge/services/session_unseen_service_test.dart
@@ -310,6 +310,34 @@ void main() {
       await sub.cancel();
     });
 
+    test("a re-emitted user message does not clear unseen state (OpenCode re-sends the user record)", () async {
+      await db.projectsDao.insertProjectsIfMissing(projectIds: ["p1"]);
+      await db.sessionDao.insertSessionsIfMissing(
+        sessions: [(sessionId: "s1", projectId: "p1", createdAt: 500, archivedAt: null)],
+      );
+      // The user sends a message (payload created at 2000, processed now).
+      clock = 2000;
+      await service.recordActivity(sessionId: "s1", isUserMessage: true, occurredAt: 2000);
+      expect(await unseen("s1"), isFalse);
+
+      // The assistant replies -> unseen.
+      clock = 3000;
+      await service.recordActivity(sessionId: "s1", isUserMessage: false);
+      expect(await unseen("s1"), isTrue);
+
+      // The backend re-emits the SAME user message (diff-summary bookkeeping,
+      // fired after the assistant completes) — original created time. This is
+      // not a user interaction and must not clear the unseen state.
+      clock = 4000;
+      await service.recordActivity(sessionId: "s1", isUserMessage: true, occurredAt: 2000);
+      expect(await unseen("s1"), isTrue);
+
+      // A genuinely NEW user message (newer created time) clears it.
+      clock = 5000;
+      await service.recordActivity(sessionId: "s1", isUserMessage: true, occurredAt: 5000);
+      expect(await unseen("s1"), isFalse);
+    });
+
     test("a user message after the session is unseen is NOT coalesced (updates user-message marker)", () async {
       await db.projectsDao.insertProjectsIfMissing(projectIds: ["p1"]);
       await db.sessionDao.insertSessionsIfMissing(

--- a/bridge/app/test/bridge/services/session_unseen_service_test.dart
+++ b/bridge/app/test/bridge/services/session_unseen_service_test.dart
@@ -384,6 +384,26 @@ void main() {
       expect(await unseen("s1"), isFalse);
     });
 
+    test("the creator's first message clears the creation bold (same-domain creation stamp)", () async {
+      // Live session.created processed late (local clock far past the
+      // session's actual creation) — the stamp comes from the session's own
+      // creation time, not the processing time.
+      clock = 9000;
+      await service.recordSessionCreated(sessionId: "s1", projectId: "p1", parentId: null, occurredAt: 2000);
+      expect(await unseen("s1"), isTrue);
+
+      // The creator's first message (created just after the session) must
+      // clear the creation bold even though the local clock is way ahead.
+      clock = 9001;
+      await service.recordActivity(sessionId: "s1", isUserMessage: true, occurredAt: 2005);
+      expect(await unseen("s1"), isFalse);
+
+      // And the assistant's reply re-bolds it.
+      clock = 9002;
+      await service.recordActivity(sessionId: "s1", isUserMessage: false, occurredAt: 2500);
+      expect(await unseen("s1"), isTrue);
+    });
+
     test("an old user re-emission cannot clear unseen state on a row with no user marker", () async {
       // A row learned via a /sessions placeholder (all markers null): the
       // original user message was processed before this bridge ever ran, so

--- a/bridge/app/test/bridge/services/session_unseen_service_test.dart
+++ b/bridge/app/test/bridge/services/session_unseen_service_test.dart
@@ -367,20 +367,46 @@ void main() {
       await db.sessionDao.insertSessionsIfMissing(
         sessions: [(sessionId: "s1", projectId: "p1", createdAt: 500, archivedAt: null)],
       );
-      // A reconnect backlog: a user message created at 2000 is only processed
-      // at local time 9000. The marker must record its creation time, not the
-      // (much later) processing time.
+      // A reconnect backlog processed late (local clock 9000+): user message
+      // created at 2000, assistant reply created at 2500, user reply created
+      // at 3000. All stamps come from the messages' own creation times, so the
+      // late processing time is irrelevant.
       clock = 9000;
       await service.recordActivity(sessionId: "s1", isUserMessage: true, occurredAt: 2000);
       clock = 9001;
-      await service.recordActivity(sessionId: "s1", isUserMessage: false);
+      await service.recordActivity(sessionId: "s1", isUserMessage: false, occurredAt: 2500);
       expect(await unseen("s1"), isTrue);
 
-      // The user's next reply was created at 3000 — after the first message,
-      // but before the delayed processing time. It is a genuine interaction
-      // and must clear the unseen state, not be mistaken for a re-emission.
+      // The user's reply (created 3000, after the assistant's 2500) is a
+      // genuine interaction: not mistaken for a re-emission, clears the state.
       clock = 9002;
       await service.recordActivity(sessionId: "s1", isUserMessage: true, occurredAt: 3000);
+      expect(await unseen("s1"), isFalse);
+    });
+
+    test("an old user re-emission cannot clear unseen state on a row with no user marker", () async {
+      // A row learned via a /sessions placeholder (all markers null): the
+      // original user message was processed before this bridge ever ran, so
+      // the re-emission guard has no marker to compare against.
+      await db.projectsDao.insertProjectsIfMissing(projectIds: ["p1"]);
+      await db.sessionDao.insertSessionsIfMissing(
+        sessions: [(sessionId: "s1", projectId: "p1", createdAt: 500, archivedAt: null)],
+      );
+      // Assistant activity bolds the session.
+      clock = 5000;
+      await service.recordActivity(sessionId: "s1", isUserMessage: false, occurredAt: 5000);
+      expect(await unseen("s1"), isTrue);
+
+      // The backend re-emits an OLD user message (diff bookkeeping) created
+      // long before the assistant activity. It bootstraps the marker but must
+      // not clear the unseen state — it only proves engagement as of 1000.
+      clock = 6000;
+      await service.recordActivity(sessionId: "s1", isUserMessage: true, occurredAt: 1000);
+      expect(await unseen("s1"), isTrue);
+
+      // A genuine reply (created after the assistant activity) clears it.
+      clock = 7000;
+      await service.recordActivity(sessionId: "s1", isUserMessage: true, occurredAt: 7000);
       expect(await unseen("s1"), isFalse);
     });
 

--- a/bridge/app/test/bridge/services/session_unseen_service_test.dart
+++ b/bridge/app/test/bridge/services/session_unseen_service_test.dart
@@ -338,6 +338,52 @@ void main() {
       expect(await unseen("s1"), isFalse);
     });
 
+    test("re-emission guard holds when the bridge clock is BEHIND the server clock", () async {
+      await db.projectsDao.insertProjectsIfMissing(projectIds: ["p1"]);
+      await db.sessionDao.insertSessionsIfMissing(
+        sessions: [(sessionId: "s1", projectId: "p1", createdAt: 500, archivedAt: null)],
+      );
+      // Server creation time (5000) is ahead of the bridge's local clock
+      // (1000). The marker is stamped from the creation time, so the domains
+      // stay comparable.
+      clock = 1000;
+      await service.recordActivity(sessionId: "s1", isUserMessage: true, occurredAt: 5000);
+      expect(await unseen("s1"), isFalse);
+
+      // Assistant activity clamps strictly past the (locally-future) marker
+      // and still bolds despite the skew.
+      clock = 1500;
+      await service.recordActivity(sessionId: "s1", isUserMessage: false);
+      expect(await unseen("s1"), isTrue);
+
+      // The re-emission (original creation time) must still be skipped.
+      clock = 2000;
+      await service.recordActivity(sessionId: "s1", isUserMessage: true, occurredAt: 5000);
+      expect(await unseen("s1"), isTrue);
+    });
+
+    test("a delayed first user message does not swallow a genuinely newer reply (backlog replay)", () async {
+      await db.projectsDao.insertProjectsIfMissing(projectIds: ["p1"]);
+      await db.sessionDao.insertSessionsIfMissing(
+        sessions: [(sessionId: "s1", projectId: "p1", createdAt: 500, archivedAt: null)],
+      );
+      // A reconnect backlog: a user message created at 2000 is only processed
+      // at local time 9000. The marker must record its creation time, not the
+      // (much later) processing time.
+      clock = 9000;
+      await service.recordActivity(sessionId: "s1", isUserMessage: true, occurredAt: 2000);
+      clock = 9001;
+      await service.recordActivity(sessionId: "s1", isUserMessage: false);
+      expect(await unseen("s1"), isTrue);
+
+      // The user's next reply was created at 3000 — after the first message,
+      // but before the delayed processing time. It is a genuine interaction
+      // and must clear the unseen state, not be mistaken for a re-emission.
+      clock = 9002;
+      await service.recordActivity(sessionId: "s1", isUserMessage: true, occurredAt: 3000);
+      expect(await unseen("s1"), isFalse);
+    });
+
     test("a user message after the session is unseen is NOT coalesced (updates user-message marker)", () async {
       await db.projectsDao.insertProjectsIfMissing(projectIds: ["p1"]);
       await db.sessionDao.insertSessionsIfMissing(

--- a/bridge/app/test/bridge/services/session_unseen_service_test.dart
+++ b/bridge/app/test/bridge/services/session_unseen_service_test.dart
@@ -245,6 +245,25 @@ void main() {
       await sub.cancel();
     });
 
+    test("reconcile keeps a session created live during the fetch, even with a skewed backend clock", () async {
+      await service.recordSessionCreated(sessionId: "s1", projectId: "p1", parentId: null);
+      // A live session.created lands DURING an in-flight /sessions fetch
+      // (fetch started at local 8000; we process the event at local 9000). The
+      // backend's clock is behind, so the session's own creation time (7000)
+      // predates the fetch start — the row-creation guard must use the local
+      // clock, not the backend time, or this fresh row would be deleted.
+      clock = 9000;
+      await service.recordSessionCreated(sessionId: "fresh", projectId: "p1", parentId: null, occurredAt: 7000);
+
+      await service.reconcileVanishedSessions(
+        projectId: "p1",
+        keepSessionIds: ["s1"],
+        fetchStartedAt: 8000,
+      );
+
+      expect(await unseen("fresh"), isTrue);
+    });
+
     test("reconcileVanishedSessions keeps rows created after the fetch started", () async {
       await service.recordSessionCreated(sessionId: "s1", projectId: "p1", parentId: null);
       // A session created AFTER the (stale) snapshot was taken: its row's


### PR DESCRIPTION
## Summary

Fixes the just-merged unseen tracking (#366) never bolding anything in practice.

## Root cause (verified against a live OpenCode server)

OpenCode re-emits the **user** message's `message.updated` event whenever server-side bookkeeping attached to that record changes (diff summaries) — mid-response and **after the assistant completes**. The bridge treated every user-role emission as a fresh user interaction and stamped `last_user_message_at` (+activity) past the assistant's activity:

1. user send → stamped (seen) ✓
2. assistant reply → activity advances → **unseen** ✓
3. user message **re-emitted** with diff summary after completion → stamped again → **seen** ✗

Every exchange ended seen; the unseen state existed for ~2s mid-response. Invisible to unit tests — it's a semantic property of the real event stream.

## Fix

A user message counts **once**: `recordActivity` gains an optional `occurredAt` (the message's own creation time, passed by the orchestrator from the event payload) and skips the user-message stamp when the stored marker is already at/past it — a re-emission always carries the message's original creation time. Backend-neutral idempotence rule; no OpenCode-specific branching. Assistant activity is deliberately not guarded this way (the clock-rollback clamp requires stale-looking activity to still bold; the coalesce guard bounds redundant writes).

## Testing

- Regression test reproducing the observed sequence (re-emission must not clear; a genuinely new user message must clear)
- Bridge: 1,596 tests pass; `dart analyze --fatal-infos` clean
- **Live end-to-end verification**: with a source-run bridge against the real OpenCode server, the probe session now goes UNSEEN on assistant activity and stays unseen through the trailing re-emissions (DB timestamps confirmed)
- `aristotle-impl-review` approved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop clearing unseen when the backend re-emits the same user message. Stamps now use event creation times, and session rows keep a local `created_at` so unseen stays correct under skew and backlog.

- **Bug Fixes**
  - Idempotent, clock-safe user stamping: `recordActivity(occurredAt)` skips re-emissions and advances only `last_user_message_at` (doesn’t rewrite activity/seen).
  - Timestamping: activity stamps prefer event creation times; session-created activity uses the session’s creation time, while the row’s `created_at` stays local for reconcile safety; all stamps clamp above `max(userMessage, seen)`.
  - Plumbing/tests: orchestrator forwards `info.time?.created`; repo adds a user-marker-only update; tests cover re-emission, bridge/server skew, backlog replay, rows without a prior user marker, creation bolding, and reconcile keeping sessions created during an in-flight fetch.

<sup>Written for commit 2b138fbef70af66b23cf0cfc01ebd96901f691d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

