### PR TITLE
feat(bridge): disable self-update + reconcile when supervised (Phase 1, PR 1.8)

### DIFF
--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -275,6 +275,7 @@ class BridgeRuntimeRunner {
         processRunner: processRunner,
         managedRuntimePaths: managedRuntimePaths,
         releaseTrack: releaseTrack,
+        isSupervised: options.isSupervised,
       );
       // Reconcile a prior in-place update first (fast, local): confirm a
       // pending activation, surface a prior failure, sweep residue. Best-effort:
@@ -282,11 +283,13 @@ class BridgeRuntimeRunner {
       //
       // Gate it on the same skip check the periodic update path uses: a
       // non-managed binary (npm payload, dev build, CI, or updates disabled)
-      // must not touch the managed install's attempt/residue state.
+      // must not touch the managed install's attempt/residue state, and a
+      // supervised (GUI-bundled) bridge must never rewrite itself.
       final bool updatesEnabledForThisInstall = !shouldSkipUpdates(
         environment: environment,
         executablePath: io.Platform.resolvedExecutable,
         managedExecutablePath: managedRuntimePaths.binaryPath,
+        isSupervised: options.isSupervised,
       );
       if (updatesEnabledForThisInstall) {
         try {
@@ -796,6 +799,7 @@ class BridgeRuntimeRunner {
     required ProcessRunner processRunner,
     required ManagedRuntimePaths managedRuntimePaths,
     required ReleaseTrack releaseTrack,
+    required bool isSupervised,
   }) {
     const clock = Clock();
     const messageFormatter = UpdateMessageFormatter();
@@ -871,6 +875,7 @@ class BridgeRuntimeRunner {
       executablePath: io.Platform.resolvedExecutable,
       managedExecutablePath: managedRuntimePaths.binaryPath,
       environment: io.Platform.environment,
+      isSupervised: isSupervised,
     );
 
     final reconciliationService = UpdateReconciliationService(

--- a/bridge/app/lib/src/updater/foundation/update_policy.dart
+++ b/bridge/app/lib/src/updater/foundation/update_policy.dart
@@ -48,16 +48,23 @@ bool isUpdateDisabled({required Map<String, String> environment}) {
   return environment.containsKey('SESORI_NO_UPDATE');
 }
 
-/// Whether the updater must not run for this install: explicitly disabled, a CI
-/// environment, an npm-owned payload, or simply not the managed binary. Gates
-/// BOTH the periodic update cycle and startup reconciliation so neither touches
-/// the managed install's state when this process is not the managed runtime.
+/// Whether the updater must not run for this install: supervised by the
+/// desktop GUI, explicitly disabled, a CI environment, an npm-owned payload,
+/// or simply not the managed binary. Gates BOTH the periodic update cycle and
+/// startup reconciliation so neither touches the managed install's state when
+/// this process is not the managed runtime.
+///
+/// A supervised (GUI-spawned, bundled) bridge must never rewrite itself — the
+/// GUI's own updater owns updating the bundle, and an in-place swap under a
+/// running supervisor would produce a mixed-version install.
 bool shouldSkipUpdates({
   required Map<String, String> environment,
   required String executablePath,
   required String managedExecutablePath,
+  required bool isSupervised,
 }) {
-  return isUpdateDisabled(environment: environment) ||
+  return isSupervised ||
+      isUpdateDisabled(environment: environment) ||
       isCiEnvironment(environment: environment) ||
       isNpmInstall(executablePath: executablePath) ||
       !isManagedInstall(

--- a/bridge/app/lib/src/updater/services/update_service.dart
+++ b/bridge/app/lib/src/updater/services/update_service.dart
@@ -36,6 +36,7 @@ class UpdateService {
     required String executablePath,
     required String managedExecutablePath,
     required Map<String, String> environment,
+    required bool isSupervised,
   }) : _releaseRepository = releaseRepository,
        _updateInstallService = updateInstallService,
        _updateApplyService = updateApplyService,
@@ -44,7 +45,8 @@ class UpdateService {
        _installRoot = installRoot,
        _executablePath = executablePath,
        _managedExecutablePath = managedExecutablePath,
-       _environment = environment;
+       _environment = environment,
+       _isSupervised = isSupervised;
 
   final ReleaseRepository _releaseRepository;
   final UpdateInstallService _updateInstallService;
@@ -55,6 +57,7 @@ class UpdateService {
   final String _executablePath;
   final String _managedExecutablePath;
   final Map<String, String> _environment;
+  final bool _isSupervised;
 
   StreamSubscription<void>? _subscription;
   bool _disposed = false;
@@ -75,8 +78,9 @@ class UpdateService {
   Duration pollInterval = const Duration(hours: 4);
 
   /// Begins the initial + periodic check/stage/apply pipeline in the
-  /// background. A no-op when updates are disabled or this is not the managed
-  /// install. Idempotent — calling it again while already running does nothing.
+  /// background. A no-op when updates are disabled, this is not the managed
+  /// install, or the bridge is supervised (the GUI updater owns the bundle).
+  /// Idempotent — calling it again while already running does nothing.
   void start() {
     if (_subscription != null || _shouldSkipUpdates()) {
       return;
@@ -105,6 +109,7 @@ class UpdateService {
       environment: _environment,
       executablePath: _executablePath,
       managedExecutablePath: _managedExecutablePath,
+      isSupervised: _isSupervised,
     );
   }
 

--- a/bridge/app/test/updater/update_policy_test.dart
+++ b/bridge/app/test/updater/update_policy_test.dart
@@ -45,6 +45,7 @@ void main() {
           environment: const <String, String>{},
           executablePath: managed,
           managedExecutablePath: managed,
+          isSupervised: false,
         ),
         isFalse,
       );
@@ -56,6 +57,7 @@ void main() {
           environment: const <String, String>{},
           executablePath: '/tmp/custom/sesori-bridge',
           managedExecutablePath: managed,
+          isSupervised: false,
         ),
         isTrue,
       );
@@ -67,6 +69,7 @@ void main() {
           environment: const <String, String>{},
           executablePath: '/tmp/project/node_modules/@sesori/bridge-linux-x64/lib/runtime/bin/sesori-bridge',
           managedExecutablePath: managed,
+          isSupervised: false,
         ),
         isTrue,
       );
@@ -78,6 +81,7 @@ void main() {
           environment: const <String, String>{'SESORI_NO_UPDATE': '1'},
           executablePath: managed,
           managedExecutablePath: managed,
+          isSupervised: false,
         ),
         isTrue,
       );
@@ -86,6 +90,19 @@ void main() {
           environment: const <String, String>{'CI': 'true'},
           executablePath: managed,
           managedExecutablePath: managed,
+          isSupervised: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('true when supervised, even for the managed binary', () {
+      expect(
+        shouldSkipUpdates(
+          environment: const <String, String>{},
+          executablePath: managed,
+          managedExecutablePath: managed,
+          isSupervised: true,
         ),
         isTrue,
       );

--- a/bridge/app/test/updater/update_service_test.dart
+++ b/bridge/app/test/updater/update_service_test.dart
@@ -86,6 +86,7 @@ void main() {
   UpdateService buildService({
     String executablePath = _managedPath,
     Map<String, String> environment = const {},
+    bool isSupervised = false,
   }) {
     final service = UpdateService(
       releaseRepository: release,
@@ -97,6 +98,7 @@ void main() {
       executablePath: executablePath,
       managedExecutablePath: _managedPath,
       environment: environment,
+      isSupervised: isSupervised,
     );
     service.emitMessage = infoMessages.add;
     service.emitError = errors.add;
@@ -245,6 +247,14 @@ void main() {
 
     test('an unmanaged executable path disables the pipeline', () {
       runStarted(buildService(executablePath: '/somewhere/else/sesori-bridge'), (async) {
+        expect(release.checkCount, 0);
+      });
+    });
+
+    test('supervised mode disables the pipeline even on the managed install', () {
+      runStarted(buildService(isSupervised: true), (async) {
+        async.elapse(const Duration(hours: 8));
+        async.flushMicrotasks();
         expect(release.checkCount, 0);
       });
     });

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -8,8 +8,8 @@
 
 ## Current pointer
 
-- **Last completed phase:** Phase 1 — PR 1.7 Exit-code restart (`86`) + bypass successor-spawn (PR raised on branch `implement-next-desktop-step`)
-- **Next up:** Phase 1 — PR 1.8 Disable self-update + reconcile when supervised
+- **Last completed phase:** Phase 1 — PR 1.8 Disable self-update + reconcile when supervised (PR raised on branch `next-desktop-implementation-stage`)
+- **Next up:** Phase 1 — PR 1.9 `BridgeControlMessageDispatcher` + prompts/Console → control events + auth-required exit `87`
 - **Branch:** one feature branch per PR, cut from `main`
 
 > **Tracking lives in four places that MUST move together in the same PR.**
@@ -389,7 +389,7 @@ them). Only the user checks an MT box.
 - ☑ 1.5 Token-stream **push** → relay client — Med / S-M
 - ☑ 1.6 Supervised registration + `bridgeId` out of `token.json` — Med / M
 - ☑ 1.7 Exit-code restart (`86`) + bypass successor-spawn — Med / S-M
-- ☐ 1.8 Disable self-update + reconcile when supervised — Low / S
+- ☑ 1.8 Disable self-update + reconcile when supervised — Low / S
 - ☐ 1.9 `BridgeControlMessageDispatcher` + prompts/Console → control events + auth-required exit `87` — Med / M
 - ☐ 1.10 Status push (relay/plugin/active sessions) — Low / S-M
 - ☐ 1.11 `unregister-and-exit` control command — Low / S-M

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -404,7 +404,33 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   `isCiEnvironment`, `!isManagedInstall`) unchanged.
 - **Acceptance:** no update/reconcile attempt in supervised mode; standalone
   self-update intact.
-- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+- **Aristotle:** plan ☑ · impl ☑. **Findings:** Implemented as a new
+  `required bool isSupervised` input to the single policy choke point
+  `shouldSkipUpdates` (`updater/foundation/update_policy.dart`) — supervised
+  joins the existing suppressor list (`SESORI_NO_UPDATE`, CI, npm,
+  non-managed) rather than adding a separate gate, so it automatically covers
+  BOTH surfaces the policy already gates: the runner's
+  `updatesEnabledForThisInstall` local (which guards the startup reconcile AND
+  the re-reconcile after restart-predecessor exit — one gate, both call
+  sites) and `UpdateService.start()`'s background 4h cadence (constructor
+  gains `required bool isSupervised`, stored and read by its
+  `_shouldSkipUpdates()`). The composition root passes
+  `options.isSupervised` at both wiring points
+  (`_buildUpdateLifecycleService` + the reconcile gate);
+  `updateLifecycle.start()` stays unconditional because the service
+  self-suppresses via the shared policy, exactly like the other suppressors
+  (symmetric handling). `ManualUpdateService` (explicit `sesori-bridge
+  update`) is untouched by design — it never runs with `--control-url` and
+  deliberately overrides background-only suppressors. No env-var plumbing was
+  needed: the bridge knows `isSupervised` from `--control-url` directly, which
+  is more robust than requiring the GUI to remember to set `SESORI_NO_UPDATE`
+  when spawning (the GUI may still set it as belt-and-suspenders). Tests:
+  policy matrix gains "supervised ⇒ skip even on a managed install";
+  `update_service_test` gating group gains "supervised disables the pipeline"
+  (checkCount stays 0 across an 8h fake-async window); all existing cases pass
+  `isSupervised: false` unchanged (standalone matrix asserted intact).
+  `make analyze` clean; `dart analyze --fatal-infos` clean; `make test`
+  1611 pass. **Deltas:** —
 
 ## PR 1.9 — `BridgeControlMessageDispatcher` + prompts/Console → control events + auth-required exit `87`
 - **Goal:** Three tightly-coupled pieces of the inbound/prompt seam:


### PR DESCRIPTION
## Summary

Phase 1, PR 1.8 of the desktop plan (`docs/desktop/phase-1-bridge-supervised.md`): a bridge spawned by the desktop GUI (`--control-url`, supervised mode) must never self-update or reconcile the managed install — a bundled bridge must never rewrite itself; the GUI's own updater (Sparkle/WinSparkle) owns updating the bundle.

## What changed

- **`update_policy.dart`** — `shouldSkipUpdates` gains `required bool isSupervised`; supervised joins the existing composed suppressor list (`SESORI_NO_UPDATE`, CI, npm payload, non-managed binary) at the single policy choke point, so it automatically gates BOTH surfaces the policy already covers.
- **`update_service.dart`** — constructor gains `required bool isSupervised` (stored, read by `_shouldSkipUpdates()`), suppressing the background 4h check/stage/apply cadence when supervised.
- **`bridge_runtime_runner.dart`** — the composition root passes `options.isSupervised` into `_buildUpdateLifecycleService` and into the `updatesEnabledForThisInstall` gate (which guards both the startup reconcile and the re-reconcile after restart-predecessor exit). `updateLifecycle.start()` stays unconditional — the service self-suppresses via the shared policy, exactly like every other suppressor (symmetric handling).
- **Untouched by design:** `ManualUpdateService` (explicit `sesori-bridge update`) never runs with `--control-url` and deliberately overrides background-only suppressors.
- **Plan tracking:** PLAN.md pointer + §9 row flipped; phase doc PR 1.8 entry filled (Aristotle verdicts, Findings).

## Regression guide (verified)

1. Standalone managed installs still reconcile at startup and re-reconcile after predecessor exit — gate unchanged for `isSupervised: false`; existing reconcile tests green.
2. Background cadence still runs standalone — `update_service_test` non-gating cases green with `isSupervised: false`.
3. Explicit `sesori-bridge update` still overrides background suppressors — `ManualUpdateService` untouched, its tests green.
4. npm/CI/non-managed/`SESORI_NO_UPDATE` suppression unchanged — full policy matrix asserted with `isSupervised: false`.

## Tests

- Policy: supervised ⇒ skip even on a managed install in a normal environment.
- Service gating: supervised ⇒ background pipeline never runs (`checkCount == 0` across an 8h fake-async window).
- `make analyze` clean · `dart analyze --fatal-infos` (bridge/app) clean · `make test` 1611 pass.

## Aristotle

- plan-review: APPROVED
- impl-review: APPROVED

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable self-update and startup reconcile when the bridge runs in supervised mode (`--control-url`). This ensures a GUI-bundled bridge never rewrites itself; the desktop updater owns the bundle.

- **New Features**
  - Policy: `shouldSkipUpdates` now accepts `isSupervised` and skips when true, alongside `SESORI_NO_UPDATE`, CI, npm, and non-managed cases.
  - Service: `UpdateService` takes `isSupervised` and self-suppresses; the 4h background cadence does not run in supervised mode.
  - Runner: passes `options.isSupervised` into updater wiring and the startup reconcile gate, blocking both reconcile paths when supervised.
  - Manual updates: `ManualUpdateService` unchanged and not used with `--control-url`.
  - Tests/docs: Added supervised gating tests; updated `docs/desktop/PLAN.md` and phase notes to mark Phase 1 — PR 1.8 complete.

<sup>Written for commit 8c8420d0217315be71e9830f6c3d7282d395efe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

