### PR TITLE
feat(bridge): suppress self-update + reconcile in supervised mode (Phase 1, PR 1.8)

### DIFF
--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -275,6 +275,7 @@ class BridgeRuntimeRunner {
         processRunner: processRunner,
         managedRuntimePaths: managedRuntimePaths,
         releaseTrack: releaseTrack,
+        isSupervised: options.isSupervised,
       );
       // Reconcile a prior in-place update first (fast, local): confirm a
       // pending activation, surface a prior failure, sweep residue. Best-effort:
@@ -282,11 +283,14 @@ class BridgeRuntimeRunner {
       //
       // Gate it on the same skip check the periodic update path uses: a
       // non-managed binary (npm payload, dev build, CI, or updates disabled)
-      // must not touch the managed install's attempt/residue state.
+      // must not touch the managed install's attempt/residue state — and a
+      // supervised (GUI-spawned) bridge must never rewrite its own install,
+      // since the desktop app owns update delivery for the bundle.
       final bool updatesEnabledForThisInstall = !shouldSkipUpdates(
         environment: environment,
         executablePath: io.Platform.resolvedExecutable,
         managedExecutablePath: managedRuntimePaths.binaryPath,
+        isSupervised: options.isSupervised,
       );
       if (updatesEnabledForThisInstall) {
         try {
@@ -796,6 +800,7 @@ class BridgeRuntimeRunner {
     required ProcessRunner processRunner,
     required ManagedRuntimePaths managedRuntimePaths,
     required ReleaseTrack releaseTrack,
+    required bool isSupervised,
   }) {
     const clock = Clock();
     const messageFormatter = UpdateMessageFormatter();
@@ -871,6 +876,7 @@ class BridgeRuntimeRunner {
       executablePath: io.Platform.resolvedExecutable,
       managedExecutablePath: managedRuntimePaths.binaryPath,
       environment: io.Platform.environment,
+      isSupervised: isSupervised,
     );
 
     final reconciliationService = UpdateReconciliationService(

--- a/bridge/app/lib/src/updater/foundation/update_policy.dart
+++ b/bridge/app/lib/src/updater/foundation/update_policy.dart
@@ -48,16 +48,24 @@ bool isUpdateDisabled({required Map<String, String> environment}) {
   return environment.containsKey('SESORI_NO_UPDATE');
 }
 
-/// Whether the updater must not run for this install: explicitly disabled, a CI
-/// environment, an npm-owned payload, or simply not the managed binary. Gates
-/// BOTH the periodic update cycle and startup reconciliation so neither touches
-/// the managed install's state when this process is not the managed runtime.
+/// Whether the updater must not run for this install: supervised by the
+/// desktop GUI, explicitly disabled, a CI environment, an npm-owned payload,
+/// or simply not the managed binary. Gates BOTH the periodic update cycle and
+/// startup reconciliation so neither touches the managed install's state when
+/// this process is not the managed runtime.
+///
+/// A supervised (GUI-spawned) bridge never rewrites its own install: the
+/// desktop app owns update delivery for the whole bundle, so in-place
+/// self-update or reconciliation from the helper would fight the bundle's
+/// updater and could corrupt a signed install.
 bool shouldSkipUpdates({
   required Map<String, String> environment,
   required String executablePath,
   required String managedExecutablePath,
+  required bool isSupervised,
 }) {
-  return isUpdateDisabled(environment: environment) ||
+  return isSupervised ||
+      isUpdateDisabled(environment: environment) ||
       isCiEnvironment(environment: environment) ||
       isNpmInstall(executablePath: executablePath) ||
       !isManagedInstall(

--- a/bridge/app/lib/src/updater/services/update_service.dart
+++ b/bridge/app/lib/src/updater/services/update_service.dart
@@ -36,6 +36,7 @@ class UpdateService {
     required String executablePath,
     required String managedExecutablePath,
     required Map<String, String> environment,
+    required bool isSupervised,
   }) : _releaseRepository = releaseRepository,
        _updateInstallService = updateInstallService,
        _updateApplyService = updateApplyService,
@@ -44,7 +45,8 @@ class UpdateService {
        _installRoot = installRoot,
        _executablePath = executablePath,
        _managedExecutablePath = managedExecutablePath,
-       _environment = environment;
+       _environment = environment,
+       _isSupervised = isSupervised;
 
   final ReleaseRepository _releaseRepository;
   final UpdateInstallService _updateInstallService;
@@ -55,6 +57,7 @@ class UpdateService {
   final String _executablePath;
   final String _managedExecutablePath;
   final Map<String, String> _environment;
+  final bool _isSupervised;
 
   StreamSubscription<void>? _subscription;
   bool _disposed = false;
@@ -105,6 +108,7 @@ class UpdateService {
       environment: _environment,
       executablePath: _executablePath,
       managedExecutablePath: _managedExecutablePath,
+      isSupervised: _isSupervised,
     );
   }
 

--- a/bridge/app/test/updater/update_policy_test.dart
+++ b/bridge/app/test/updater/update_policy_test.dart
@@ -45,6 +45,7 @@ void main() {
           environment: const <String, String>{},
           executablePath: managed,
           managedExecutablePath: managed,
+          isSupervised: false,
         ),
         isFalse,
       );
@@ -56,6 +57,7 @@ void main() {
           environment: const <String, String>{},
           executablePath: '/tmp/custom/sesori-bridge',
           managedExecutablePath: managed,
+          isSupervised: false,
         ),
         isTrue,
       );
@@ -67,6 +69,19 @@ void main() {
           environment: const <String, String>{},
           executablePath: '/tmp/project/node_modules/@sesori/bridge-linux-x64/lib/runtime/bin/sesori-bridge',
           managedExecutablePath: managed,
+          isSupervised: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('true when supervised, even for the managed binary in a clean environment', () {
+      expect(
+        shouldSkipUpdates(
+          environment: const <String, String>{},
+          executablePath: managed,
+          managedExecutablePath: managed,
+          isSupervised: true,
         ),
         isTrue,
       );
@@ -78,6 +93,7 @@ void main() {
           environment: const <String, String>{'SESORI_NO_UPDATE': '1'},
           executablePath: managed,
           managedExecutablePath: managed,
+          isSupervised: false,
         ),
         isTrue,
       );
@@ -86,6 +102,7 @@ void main() {
           environment: const <String, String>{'CI': 'true'},
           executablePath: managed,
           managedExecutablePath: managed,
+          isSupervised: false,
         ),
         isTrue,
       );

--- a/bridge/app/test/updater/update_service_test.dart
+++ b/bridge/app/test/updater/update_service_test.dart
@@ -86,6 +86,7 @@ void main() {
   UpdateService buildService({
     String executablePath = _managedPath,
     Map<String, String> environment = const {},
+    bool isSupervised = false,
   }) {
     final service = UpdateService(
       releaseRepository: release,
@@ -97,6 +98,7 @@ void main() {
       executablePath: executablePath,
       managedExecutablePath: _managedPath,
       environment: environment,
+      isSupervised: isSupervised,
     );
     service.emitMessage = infoMessages.add;
     service.emitError = errors.add;
@@ -239,6 +241,14 @@ void main() {
 
     test('SESORI_NO_UPDATE disables the pipeline', () {
       runStarted(buildService(environment: const {'SESORI_NO_UPDATE': '1'}), (async) {
+        expect(release.checkCount, 0);
+      });
+    });
+
+    test('supervised mode disables the pipeline', () {
+      runStarted(buildService(isSupervised: true), (async) {
+        async.elapse(const Duration(hours: 8));
+        async.flushMicrotasks();
         expect(release.checkCount, 0);
       });
     });

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -8,8 +8,8 @@
 
 ## Current pointer
 
-- **Last completed phase:** Phase 1 — PR 1.7 Exit-code restart (`86`) + bypass successor-spawn (PR raised on branch `implement-next-desktop-step`)
-- **Next up:** Phase 1 — PR 1.8 Disable self-update + reconcile when supervised
+- **Last completed phase:** Phase 1 — PR 1.8 Disable self-update + reconcile when supervised (PR raised on branch `next-desktop-implementation`)
+- **Next up:** Phase 1 — PR 1.9 `BridgeControlMessageDispatcher` + prompts/Console → control events + auth-required exit `87`
 - **Branch:** one feature branch per PR, cut from `main`
 
 > **Tracking lives in four places that MUST move together in the same PR.**
@@ -389,7 +389,7 @@ them). Only the user checks an MT box.
 - ☑ 1.5 Token-stream **push** → relay client — Med / S-M
 - ☑ 1.6 Supervised registration + `bridgeId` out of `token.json` — Med / M
 - ☑ 1.7 Exit-code restart (`86`) + bypass successor-spawn — Med / S-M
-- ☐ 1.8 Disable self-update + reconcile when supervised — Low / S
+- ☑ 1.8 Disable self-update + reconcile when supervised — Low / S
 - ☐ 1.9 `BridgeControlMessageDispatcher` + prompts/Console → control events + auth-required exit `87` — Med / M
 - ☐ 1.10 Status push (relay/plugin/active sessions) — Low / S-M
 - ☐ 1.11 `unregister-and-exit` control command — Low / S-M

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -404,7 +404,24 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   `isCiEnvironment`, `!isManagedInstall`) unchanged.
 - **Acceptance:** no update/reconcile attempt in supervised mode; standalone
   self-update intact.
-- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+- **Aristotle:** plan ☑ · impl ☑ (PR raised on branch `next-desktop-implementation`).
+- **Findings:** No new env var was needed: supervised suppression is enforced
+  in-process by the existing skip policy rather than relying on the GUI to set
+  `SESORI_NO_UPDATE` at spawn (the bridge must not rewrite itself even if a
+  future spawner forgets the env). `shouldSkipUpdates` gained a
+  `required bool isSupervised` parameter (first check in the OR-chain), wired
+  from `BridgeCliOptions.isSupervised` at the composition root into (a) the
+  runner's `updatesEnabledForThisInstall` gate — covering the startup reconcile
+  AND the post-predecessor-exit re-reconcile — and (b) a new stored
+  `UpdateService` constructor field used by its internal `start()` gate, so the
+  4h background cadence never begins. `ManualUpdateService` (explicit
+  `sesori-bridge update`) deliberately untouched: it keys on `isManagedInstall`
+  only and is a separate CLI command that never runs supervised. Standalone
+  byte-identical (`isSupervised: false` leaves every existing OR-condition
+  unchanged — asserted by the updated policy/service tests plus a new
+  supervised-skips case in each). `make analyze` + `dart analyze --fatal-infos`
+  clean; `make test` all pass (app 1611).
+- **Deltas:** —
 
 ## PR 1.9 — `BridgeControlMessageDispatcher` + prompts/Console → control events + auth-required exit `87`
 - **Goal:** Three tightly-coupled pieces of the inbound/prompt seam:


### PR DESCRIPTION
## Summary

Phase 1, PR 1.8 of the desktop plan (`docs/desktop/PLAN.md`): a bridge running **supervised** (`--control-url`, spawned by the desktop GUI) must never self-update or reconcile its managed install — the desktop app owns update delivery for the whole bundle (Sparkle/WinSparkle/zsync in Phase 3), and an in-place helper self-update would fight the bundle's updater and could corrupt a signed install.

- `shouldSkipUpdates` gains a `required bool isSupervised` parameter (first check in the OR-chain). No new env var: suppression is enforced in-process rather than relying on the GUI to set `SESORI_NO_UPDATE` at spawn.
- Wired from `BridgeCliOptions.isSupervised` at the composition root into:
  - the runner's `updatesEnabledForThisInstall` gate — covers the startup reconcile AND the post-predecessor-exit re-reconcile;
  - a new stored `UpdateService` constructor field used by its `start()` gate — the 4h background cadence never begins.
- `ManualUpdateService` (explicit `sesori-bridge update`) deliberately untouched: separate CLI command, never runs supervised, still overrides background suppressors.
- Plan tracking advanced (PLAN.md pointer + §9 row, phase doc Aristotle/Findings).

## Regression guide (re-verified)

1. Standalone managed installs still reconcile at startup and re-reconcile after predecessor exit — `isSupervised: false` leaves the skip result identical.
2. Background update cadence still runs standalone (`updateLifecycle.start()` gating unchanged for `isSupervised: false`).
3. Explicit `sesori-bridge update` untouched (keys on `isManagedInstall` only).
4. npm/CI/non-managed suppression unchanged (existing OR conditions preserved; asserted by updated policy tests).

## Tests

- `update_policy_test.dart`: new supervised⇒skip case (managed binary, clean env); existing cases pass `isSupervised: false` with unchanged expectations.
- `update_service_test.dart`: new gating test — supervised mode performs zero release checks over 8h of fake time; all existing tests green with `isSupervised: false` default.
- `make analyze` + `dart analyze --fatal-infos` (bridge/app) clean; `make test` all pass.

## Aristotle

- plan-review: APPROVED
- impl-review: APPROVED

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent the bridge from self-updating or reconciling when running in supervised mode, so the desktop app fully controls bundle updates. Standalone behavior and the `sesori-bridge update` command are unchanged.

- **New Features**
  - Added `isSupervised` to `shouldSkipUpdates`; supervised short-circuits all update logic.
  - Plumbed `isSupervised` from CLI options to gate startup/restart reconcile and the background cadence in `UpdateService`.
  - Kept manual `sesori-bridge update` intact; it still runs when invoked directly.
  - Added tests for supervised skip behavior; updated docs to reflect Phase 1.8 completion.

<sup>Written for commit b2ad0119b828627812a8880954a93a944a8cc9de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

