### PR TITLE
feat(bridge): control-message dispatcher + GUI prompts + auth-required exit 87 (Phase 1, PR 1.9)

### DIFF
--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -239,7 +239,8 @@ class LogoutCommand extends cli.Command<void> {
       bridgeInstanceRepository: bridgeInstanceRepository,
       bridgeInstanceService: BridgeInstanceService(
         bridgeInstanceRepository: bridgeInstanceRepository,
-        terminalPromptRepository: terminalPromptRepository,
+        // The logout CLI always runs from a terminal, never supervised.
+        replacePrompt: terminalPromptRepository,
         processRepository: ProcessRepository(
           api: systemProcessApi,
           currentUser: currentUser,

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -42,6 +42,7 @@ import "../../auth/login_oauth_service.dart";
 import "../../auth/token.dart";
 import "../../auth/token_manager.dart";
 import "../../auth/token_refresher.dart";
+import "../../control/bridge_control_message_dispatcher.dart";
 import "../../control/control_channel_loss_listener.dart";
 import "../../foundation/control_channel_client.dart";
 import "../../repositories/bridge_settings_repository.dart";
@@ -49,6 +50,7 @@ import "../../server/api/loopback_port_api.dart";
 import "../../server/api/runtime_file_api.dart";
 import "../../server/api/system_process_api.dart";
 import "../../server/api/terminal_prompt_api.dart";
+import "../../server/foundation/bridge_replace_prompt.dart";
 import "../../server/foundation/bridge_restart_command_builder.dart";
 import "../../server/foundation/bridge_restart_env.dart";
 import "../../server/host/bridge_host_info_impl.dart";
@@ -63,6 +65,7 @@ import "../../server/repositories/terminal_prompt_repository.dart";
 import "../../server/services/bridge_instance_service.dart";
 import "../../server/services/bridge_restart_service.dart";
 import "../../services/control_channel_token_service.dart";
+import "../../services/control_prompt_service.dart";
 import "../../updater/api/checksum_manifest_api.dart";
 import "../../updater/api/github_releases_api.dart";
 import "../../updater/api/managed_runtime_manifest_api.dart";
@@ -112,6 +115,14 @@ import "runtime_provision_formatter.dart";
 /// an intentional restart apart and respawn rather than treat it as a crash.
 const int supervisedRestartExitCode = 86;
 
+/// Exit code a supervised bridge returns when the desktop GUI cannot supply an
+/// access token at bootstrap (signed out / mid-login / unreachable). Distinct
+/// from a crash so the GUI supervisor surfaces a login prompt instead of
+/// backoff-respawning a helper that can never start. The exit code is the
+/// authoritative signal; the best-effort `loginNeeded` prompt sent just before
+/// exiting is advisory.
+const int supervisedAuthRequiredExitCode = 87;
+
 Future<int> runBridgeApp({
   required BridgeCliOptions options,
   required PluginConfig pluginConfig,
@@ -149,9 +160,18 @@ class BridgeRuntimeRunner {
     // bridge instead of treating the exit as a crash or clean stop. Read by the
     // backstop too, so a hung restart-shutdown still reports the sentinel.
     int? requestedSupervisedRestartExitCode;
+    // Set when the supervised bootstrap token pull fails because the GUI cannot
+    // supply a token: the runner returns the auth-required sentinel (87) so the
+    // GUI prompts for login instead of backoff-respawning. Read by the backstop
+    // and the shutdown-error path too, so the sentinel survives a hung or
+    // throwing shutdown.
+    int? requestedSupervisedAuthRequiredExitCode;
     final shutdownCoordinator = BridgeShutdownCoordinator(
       backstopExitCode: () =>
-          requestedSupervisedRestartExitCode ?? supervisedLossExitCode ?? (failureLatch.failure == null ? 0 : 1),
+          requestedSupervisedRestartExitCode ??
+          requestedSupervisedAuthRequiredExitCode ??
+          supervisedLossExitCode ??
+          (failureLatch.failure == null ? 0 : 1),
     );
     final subscriptions = CompositeSubscription();
     shutdownCoordinator.add(disposable: subscriptions.cancel);
@@ -193,15 +213,6 @@ class BridgeRuntimeRunner {
     final terminalPromptRepository = TerminalPromptRepository(
       api: terminalPromptApi,
     );
-    final bridgeInstanceService = BridgeInstanceService(
-      bridgeInstanceRepository: BridgeInstanceRepository(
-        api: systemProcessApi,
-        currentUser: currentUser,
-      ),
-      terminalPromptRepository: terminalPromptRepository,
-      processRepository: processRepository,
-      clock: serverClock,
-    );
     shutdownCoordinator.add(disposable: httpClient.close);
 
     final runtimeAuthService = BridgeRuntimeAuthService(
@@ -230,6 +241,7 @@ class BridgeRuntimeRunner {
       // before anything else so the GUI sees the helper connect promptly. Every
       // step here is gated by `--control-url`; standalone startup is unchanged.
       ControlChannelTokenService? controlChannelTokenService;
+      ControlPromptService? controlPromptService;
       if (options.isSupervised) {
         final controlChannelClient = await _connectSupervisedControlChannel(
           options: options,
@@ -241,7 +253,32 @@ class BridgeRuntimeRunner {
         // terminal login. Shares the same client the loss listener observes.
         controlChannelTokenService = ControlChannelTokenService(client: controlChannelClient);
         shutdownCoordinator.add(disposable: controlChannelTokenService.dispose);
+        // User prompts (replace-bridge, login-needed) go to the GUI instead of
+        // a terminal the helper doesn't have.
+        controlPromptService = ControlPromptService(client: controlChannelClient);
+        shutdownCoordinator.add(disposable: controlPromptService.dispose);
+        // The single inbound subscriber: decodes GUI→helper frames once and
+        // routes them to the owning service. Started before the bootstrap token
+        // pull below so its response is never missed.
+        final controlMessageDispatcher = BridgeControlMessageDispatcher(
+          client: controlChannelClient,
+          tokenService: controlChannelTokenService,
+          promptService: controlPromptService,
+        );
+        controlMessageDispatcher.start();
+        shutdownCoordinator.add(disposable: controlMessageDispatcher.dispose);
       }
+
+      final BridgeReplacePrompt replacePrompt = controlPromptService ?? terminalPromptRepository;
+      final bridgeInstanceService = BridgeInstanceService(
+        bridgeInstanceRepository: BridgeInstanceRepository(
+          api: systemProcessApi,
+          currentUser: currentUser,
+        ),
+        replacePrompt: replacePrompt,
+        processRepository: processRepository,
+        clock: serverClock,
+      );
 
       final runtimeOwnershipError = unsupportedPackageRuntimeMessage(
         executablePath: io.Platform.resolvedExecutable,
@@ -317,7 +354,18 @@ class BridgeRuntimeRunner {
       final String authAccessToken;
       final supervisedTokenService = controlChannelTokenService;
       if (supervisedTokenService != null) {
-        authAccessToken = await supervisedTokenService.getAccessToken();
+        try {
+          authAccessToken = await supervisedTokenService.getAccessToken();
+        } on ControlTokenUnavailableException catch (error) {
+          // The GUI cannot supply a token (signed out / mid-login / down). Exit
+          // with the auth-required sentinel so the GUI prompts for login instead
+          // of backoff-respawning a helper that can never start. The prompt is
+          // advisory (best-effort); the exit code is the authoritative signal.
+          Log.e("Cannot start supervised: $error");
+          controlPromptService?.announceLoginNeeded();
+          requestedSupervisedAuthRequiredExitCode = supervisedAuthRequiredExitCode;
+          return supervisedAuthRequiredExitCode;
+        }
       } else {
         final authTokens = await runtimeAuthService.ensureAuthenticated(options: options);
         authAccessToken = authTokens.accessToken;
@@ -562,14 +610,14 @@ class BridgeRuntimeRunner {
         // `shutdownCoordinator.shutdown()` rethrows a failed ordered/parallel
         // step (by design — a failed plugin stop must surface as a non-zero
         // exit). Thrown from this `finally`, that would override the return
-        // value. For a supervised restart that must NOT happen: the exit must
-        // stay the sentinel so the GUI respawns rather than treating an
-        // intentional restart as a crash. For every other exit, preserve the
-        // loud-failure behaviour by rethrowing.
-        if (requestedSupervisedRestartExitCode == null) {
+        // value. For a supervised restart or auth-required exit that must NOT
+        // happen: the exit must stay the sentinel so the GUI respawns (86) or
+        // prompts for login (87) rather than treating it as a crash. For every
+        // other exit, preserve the loud-failure behaviour by rethrowing.
+        if (requestedSupervisedRestartExitCode == null && requestedSupervisedAuthRequiredExitCode == null) {
           rethrow;
         }
-        Log.w("Shutdown error during a supervised restart; preserving the sentinel exit code", error, stackTrace);
+        Log.w("Shutdown error during a supervised sentinel exit; preserving the sentinel exit code", error, stackTrace);
       }
     }
   }

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -356,12 +356,12 @@ class BridgeRuntimeRunner {
       if (supervisedTokenService != null) {
         try {
           authAccessToken = await supervisedTokenService.getAccessToken();
-        } on ControlTokenUnavailableException catch (error) {
+        } on ControlTokenUnavailableException catch (error, stackTrace) {
           // The GUI cannot supply a token (signed out / mid-login / down). Exit
           // with the auth-required sentinel so the GUI prompts for login instead
           // of backoff-respawning a helper that can never start. The prompt is
           // advisory (best-effort); the exit code is the authoritative signal.
-          Log.e("Cannot start supervised: $error");
+          Log.e("Cannot start supervised — no access token from the desktop app", error, stackTrace);
           controlPromptService?.announceLoginNeeded();
           requestedSupervisedAuthRequiredExitCode = supervisedAuthRequiredExitCode;
           return supervisedAuthRequiredExitCode;

--- a/bridge/app/lib/src/control/bridge_control_message_dispatcher.dart
+++ b/bridge/app/lib/src/control/bridge_control_message_dispatcher.dart
@@ -1,0 +1,82 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../foundation/control_channel_client.dart";
+import "../services/control_channel_token_service.dart";
+import "../services/control_prompt_service.dart";
+
+/// The single inbound subscriber/decoder for GUI→helper control messages in
+/// supervised mode: it owns the one subscription to
+/// [ControlChannelClient.inbound], decodes each frame into a [ControlMessage]
+/// exactly once, and routes it to the owning service through typed delegate
+/// calls. The services keep their own correlation state and outbound send
+/// paths — this class sends nothing.
+///
+/// An undecodable frame (malformed, or a forward-compat message type a newer
+/// GUI added) is logged and skipped so it can never stall the channel. Variants
+/// this bridge does not consume inbound are ignored: `restart` is helper→GUI
+/// only and is never an inbound command (the GUI restarts the helper by
+/// kill+respawn, not by message), and helper→GUI variants echoed back have no
+/// inbound meaning.
+class BridgeControlMessageDispatcher {
+  final ControlChannelClient _client;
+  final ControlChannelTokenService _tokenService;
+  final ControlPromptService _promptService;
+
+  StreamSubscription<String>? _subscription;
+
+  BridgeControlMessageDispatcher({
+    required ControlChannelClient client,
+    required ControlChannelTokenService tokenService,
+    required ControlPromptService promptService,
+  })  : _client = client,
+        _tokenService = tokenService,
+        _promptService = promptService;
+
+  /// Subscribes to the client's inbound stream. Idempotent — a second call
+  /// while already started does nothing.
+  void start() {
+    _subscription ??= _client.inbound.listen(_handleFrame);
+  }
+
+  Future<void> dispose() async {
+    // Isolate the cancel so a failure still lets teardown finish.
+    try {
+      await _subscription?.cancel();
+    } on Object catch (error, stackTrace) {
+      Log.w("[control][dispatcher] failed to cancel inbound subscription", error, stackTrace);
+    }
+    _subscription = null;
+  }
+
+  void _handleFrame(String frame) {
+    final ControlMessage message;
+    try {
+      message = ControlMessage.fromJson(jsonDecodeMap(frame));
+    } on Object catch (error, stackTrace) {
+      Log.w("[control][dispatcher] ignoring undecodable control frame", error, stackTrace);
+      return;
+    }
+    switch (message) {
+      case ControlTokenResponse(:final id, :final accessToken):
+        _tokenService.handleTokenResponse(id: id, accessToken: accessToken);
+      case ControlTokenUpdate(:final accessToken):
+        _tokenService.handleTokenUpdate(accessToken: accessToken);
+      case ControlPromptResponse(:final id, :final accepted):
+        _promptService.handlePromptResponse(id: id, accepted: accepted);
+      case ControlTokenRequest():
+      case ControlStatus():
+      case ControlPromptRequest():
+      case ControlRestart():
+      case ControlUnregisterAndExit():
+      case ControlRegistered():
+      case ControlProvisionProgressMessage():
+        // Not consumed inbound (yet): helper→GUI variants have no inbound
+        // meaning, `restart` is never an inbound command, and
+        // `unregister_and_exit` gains its route when the unregister flow lands.
+        Log.d("[control][dispatcher] ignoring inbound ${message.runtimeType}");
+    }
+  }
+}

--- a/bridge/app/lib/src/server/foundation/bridge_replace_prompt.dart
+++ b/bridge/app/lib/src/server/foundation/bridge_replace_prompt.dart
@@ -1,0 +1,16 @@
+import 'terminal_prompt_decision.dart';
+
+/// Asks the user whether an already-running (or still-starting) Sesori bridge
+/// should be killed so this one can take its place.
+///
+/// Two production implementations exist: the standalone bridge asks on the
+/// interactive terminal (`TerminalPromptRepository`), while a supervised bridge
+/// has no terminal and asks the desktop GUI over the loopback control channel
+/// (`ControlPromptService`). [TerminalPromptDecision.nonInteractive] means the
+/// question could not be asked at all (no terminal / GUI unreachable), not that
+/// the user declined.
+abstract class BridgeReplacePrompt {
+  Future<TerminalPromptDecision> askReplaceExistingBridge({required int bridgeCount});
+
+  Future<TerminalPromptDecision> askReplaceStartingBridge({required int holderPid});
+}

--- a/bridge/app/lib/src/server/foundation/bridge_replace_prompt.dart
+++ b/bridge/app/lib/src/server/foundation/bridge_replace_prompt.dart
@@ -10,6 +10,14 @@ import 'terminal_prompt_decision.dart';
 /// question could not be asked at all (no terminal / GUI unreachable), not that
 /// the user declined.
 abstract class BridgeReplacePrompt {
+  /// Shared question copy for both implementations, so the terminal and GUI
+  /// paths never drift apart (the terminal appends its own `[y/N]` hint).
+  static const String replaceExistingBridgeMessage = 'Another Sesori bridge is already running. Kill it and start fresh?';
+
+  /// See [replaceExistingBridgeMessage].
+  static String replaceStartingBridgeMessage({required int holderPid}) =>
+      'Another Sesori bridge is still starting up (pid $holderPid). Kill it and start fresh?';
+
   Future<TerminalPromptDecision> askReplaceExistingBridge({required int bridgeCount});
 
   Future<TerminalPromptDecision> askReplaceStartingBridge({required int holderPid});

--- a/bridge/app/lib/src/server/repositories/terminal_prompt_repository.dart
+++ b/bridge/app/lib/src/server/repositories/terminal_prompt_repository.dart
@@ -1,17 +1,20 @@
 import '../api/terminal_prompt_api.dart';
+import '../foundation/bridge_replace_prompt.dart';
 import '../foundation/terminal_prompt_decision.dart';
 
-class TerminalPromptRepository {
+class TerminalPromptRepository implements BridgeReplacePrompt {
   TerminalPromptRepository({required TerminalPromptApi api}) : _api = api;
 
   final TerminalPromptApi _api;
 
+  @override
   Future<TerminalPromptDecision> askReplaceExistingBridge({required int bridgeCount}) async {
     return _askYesNo(
       message: 'Another Sesori bridge is already running. Kill it and start fresh? [y/N]',
     );
   }
 
+  @override
   Future<TerminalPromptDecision> askReplaceStartingBridge({required int holderPid}) async {
     return _askYesNo(
       message: 'Another Sesori bridge is still starting up (pid $holderPid). Kill it and start fresh? [y/N]',

--- a/bridge/app/lib/src/server/repositories/terminal_prompt_repository.dart
+++ b/bridge/app/lib/src/server/repositories/terminal_prompt_repository.dart
@@ -10,14 +10,14 @@ class TerminalPromptRepository implements BridgeReplacePrompt {
   @override
   Future<TerminalPromptDecision> askReplaceExistingBridge({required int bridgeCount}) async {
     return _askYesNo(
-      message: 'Another Sesori bridge is already running. Kill it and start fresh? [y/N]',
+      message: '${BridgeReplacePrompt.replaceExistingBridgeMessage} [y/N]',
     );
   }
 
   @override
   Future<TerminalPromptDecision> askReplaceStartingBridge({required int holderPid}) async {
     return _askYesNo(
-      message: 'Another Sesori bridge is still starting up (pid $holderPid). Kill it and start fresh? [y/N]',
+      message: '${BridgeReplacePrompt.replaceStartingBridgeMessage(holderPid: holderPid)} [y/N]',
     );
   }
 

--- a/bridge/app/lib/src/server/services/bridge_instance_service.dart
+++ b/bridge/app/lib/src/server/services/bridge_instance_service.dart
@@ -1,11 +1,11 @@
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
 
+import '../foundation/bridge_replace_prompt.dart';
 import '../foundation/process_match.dart';
 import '../foundation/terminal_prompt_decision.dart';
 import '../models/bridge_startup_lock.dart';
 import '../repositories/bridge_instance_repository.dart';
 import '../repositories/process_repository.dart';
-import '../repositories/terminal_prompt_repository.dart';
 
 const Duration _bridgeShutdownWait = Duration(seconds: 5);
 
@@ -26,16 +26,16 @@ class BridgeInstanceResolution {
 class BridgeInstanceService {
   BridgeInstanceService({
     required BridgeInstanceRepository bridgeInstanceRepository,
-    required TerminalPromptRepository terminalPromptRepository,
+    required BridgeReplacePrompt replacePrompt,
     required ProcessRepository processRepository,
     required ServerClock clock,
   }) : _bridgeInstanceRepository = bridgeInstanceRepository,
-       _terminalPromptRepository = terminalPromptRepository,
+       _replacePrompt = replacePrompt,
        _processRepository = processRepository,
        _clock = clock;
 
   final BridgeInstanceRepository _bridgeInstanceRepository;
-  final TerminalPromptRepository _terminalPromptRepository;
+  final BridgeReplacePrompt _replacePrompt;
   final ProcessRepository _processRepository;
   final ServerClock _clock;
 
@@ -92,7 +92,7 @@ class BridgeInstanceService {
       );
     }
 
-    final decision = await _terminalPromptRepository.askReplaceExistingBridge(bridgeCount: existingBridges.length);
+    final decision = await _replacePrompt.askReplaceExistingBridge(bridgeCount: existingBridges.length);
     switch (decision) {
       case TerminalPromptDecision.nonInteractive:
         return BridgeInstanceResolution(
@@ -128,7 +128,7 @@ class BridgeInstanceService {
       return BridgeInstanceResolutionStatus.allowed;
     }
 
-    final decision = await _terminalPromptRepository.askReplaceStartingBridge(holderPid: holder.identity.pid);
+    final decision = await _replacePrompt.askReplaceStartingBridge(holderPid: holder.identity.pid);
     switch (decision) {
       case TerminalPromptDecision.nonInteractive:
         return BridgeInstanceResolutionStatus.nonInteractive;

--- a/bridge/app/lib/src/services/control_channel_token_service.dart
+++ b/bridge/app/lib/src/services/control_channel_token_service.dart
@@ -2,9 +2,7 @@ import "dart:async";
 import "dart:convert";
 
 import "package:rxdart/rxdart.dart";
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
-import "package:sesori_shared/sesori_shared.dart"
-    show ControlMessage, ControlTokenResponse, ControlTokenUpdate, jsonDecodeMap;
+import "package:sesori_shared/sesori_shared.dart" show ControlMessage;
 
 import "../auth/access_token_provider.dart";
 import "../auth/token_refresher.dart";
@@ -38,11 +36,11 @@ import "../foundation/control_channel_client.dart";
 /// from a stale cached token. (`tokenUpdate.accessToken` is non-null, so a push can
 /// never signal sign-out — only a null `tokenResponse` can.)
 ///
-/// It owns its subscription to [ControlChannelClient.inbound], decoding each
-/// frame into a [ControlMessage] and completing the matching pending request.
-/// Non-token frames are ignored here (other control messages are handled
-/// elsewhere); undecodable frames are logged and skipped so a malformed or
-/// forward-compat message can't stall a pull.
+/// It does NOT subscribe to [ControlChannelClient.inbound] itself: the
+/// `BridgeControlMessageDispatcher` owns the single inbound subscription and
+/// decode, delivering token-class messages through the typed delegates
+/// [handleTokenResponse] and [handleTokenUpdate]. The request-correlation state
+/// and the `token_request` send path stay here.
 class ControlChannelTokenService implements AccessTokenProvider, TokenRefresher {
   static const Duration _defaultRequestTimeout = Duration(seconds: 30);
 
@@ -50,7 +48,6 @@ class ControlChannelTokenService implements AccessTokenProvider, TokenRefresher 
   final Duration _requestTimeout;
   final BehaviorSubject<String> _tokenSubject = BehaviorSubject<String>();
   final Map<String, Completer<String?>> _pending = <String, Completer<String?>>{};
-  late final StreamSubscription<String> _subscription;
   // Monotonic sequence stamped on every write candidate at the moment it is
   // ordered: a pull captures its seq when it is ISSUED; a push takes a fresh seq
   // when it is ADOPTED (so it always outranks every pull already in flight).
@@ -74,9 +71,7 @@ class ControlChannelTokenService implements AccessTokenProvider, TokenRefresher 
     required ControlChannelClient client,
     Duration requestTimeout = _defaultRequestTimeout,
   })  : _client = client,
-        _requestTimeout = requestTimeout {
-    _subscription = _client.inbound.listen(_handleFrame);
-  }
+        _requestTimeout = requestTimeout;
 
   /// The most recently cached access token. Only valid after the first token is
   /// cached (the bootstrap [getAccessToken] the composition root awaits before
@@ -112,9 +107,9 @@ class ControlChannelTokenService implements AccessTokenProvider, TokenRefresher 
   /// Does not log on failure — the caller surfaces it once.
   @override
   Future<String> getAccessToken({bool forceRefresh = false}) async {
-    // After dispose the inbound subscription is cancelled, so a response can
-    // never arrive — fail fast instead of registering a completer that would
-    // only resolve via the timeout.
+    // After dispose no delegate delivery is accepted, so a response can never
+    // arrive — fail fast instead of registering a completer that would only
+    // resolve via the timeout.
     if (_disposed) {
       throw const ControlTokenUnavailableException(
         "Control channel token service has been disposed.",
@@ -176,12 +171,6 @@ class ControlChannelTokenService implements AccessTokenProvider, TokenRefresher 
     // Set synchronously (before the first await) so a getAccessToken racing
     // dispose sees the disposed guard immediately.
     _disposed = true;
-    // Isolate the cancel so a failure still lets teardown finish.
-    try {
-      await _subscription.cancel();
-    } on Object catch (error, stackTrace) {
-      Log.w("[control][token] failed to cancel inbound subscription", error, stackTrace);
-    }
     // Fail any in-flight request so a shutdown mid-request doesn't hang on the
     // full request timeout.
     final pending = List<Completer<String?>>.of(_pending.values);
@@ -196,34 +185,26 @@ class ControlChannelTokenService implements AccessTokenProvider, TokenRefresher 
     await _tokenSubject.close();
   }
 
-  void _handleFrame(String frame) {
+  /// Delivers the GUI's reply to a pending [ControlMessage.tokenRequest].
+  /// Called by the control-message dispatcher (the single inbound subscriber);
+  /// replies for unknown or already-resolved ids are ignored (e.g. arriving
+  /// after the request timed out).
+  void handleTokenResponse({required String id, required String? accessToken}) {
     if (_disposed) return;
-    final ControlMessage message;
-    try {
-      message = ControlMessage.fromJson(jsonDecodeMap(frame));
-    } on Object catch (error, stackTrace) {
-      // A frame we can't decode (malformed, or a forward-compat message type a
-      // newer GUI added) is not fatal — skip it and keep serving requests.
-      Log.w("[control][token] ignoring undecodable control frame", error, stackTrace);
-      return;
+    final completer = _pending.remove(id);
+    if (completer != null && !completer.isCompleted) {
+      completer.complete(accessToken);
     }
-    switch (message) {
-      case ControlTokenResponse():
-        final completer = _pending.remove(message.id);
-        if (completer != null && !completer.isCompleted) {
-          completer.complete(message.accessToken);
-        }
-      case ControlTokenUpdate(:final accessToken):
-        // The GUI pushed a refreshed token to adopt without a request. It takes a
-        // fresh seq at adoption time, so it outranks every pull already in flight
-        // and becomes the newest write — a slow older pull resolving afterwards
-        // can't revert it. (Non-null by protocol, so a push never invalidates the
-        // cache — only a null pull response can.)
-        _applyWrite(_nextSeq++, () => _cacheToken(accessToken));
-      default:
-        // Other control-message variants are not this service's concern.
-        break;
-    }
+  }
+
+  /// Adopts a token the GUI pushed without a request. It takes a fresh seq at
+  /// adoption time, so it outranks every pull already in flight and becomes the
+  /// newest write — a slow older pull resolving afterwards can't revert it.
+  /// (Non-null by protocol, so a push never invalidates the cache — only a null
+  /// pull response can.) Called by the control-message dispatcher.
+  void handleTokenUpdate({required String accessToken}) {
+    if (_disposed) return;
+    _applyWrite(_nextSeq++, () => _cacheToken(accessToken));
   }
 
   /// Runs [write] only if [seq] is newer than the write currently reflected in

--- a/bridge/app/lib/src/services/control_prompt_service.dart
+++ b/bridge/app/lib/src/services/control_prompt_service.dart
@@ -1,0 +1,141 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+import "package:sesori_shared/sesori_shared.dart" show ControlMessage, ControlPromptKind;
+
+import "../foundation/control_channel_client.dart";
+import "../server/foundation/bridge_replace_prompt.dart";
+import "../server/foundation/terminal_prompt_decision.dart";
+
+/// Supervised-mode user prompts over the loopback control channel: the desktop
+/// GUI, not an interactive terminal, answers the bridge's questions. This is
+/// the supervised counterpart of `TerminalPromptRepository` for the
+/// replace-bridge questions — both implement [BridgeReplacePrompt] and the
+/// composition root picks one by mode.
+///
+/// It owns the prompt-class correlation state and ALL prompt-class outbound
+/// sends: an ask sends an id-correlated [ControlMessage.promptRequest] and
+/// awaits the matching [ControlMessage.promptResponse], which the
+/// `BridgeControlMessageDispatcher` (the single inbound subscriber) delivers via
+/// [handlePromptResponse]. An unanswerable ask — channel down, GUI not replying
+/// within the timeout, or teardown mid-flight — degrades to
+/// [TerminalPromptDecision.nonInteractive], mirroring the terminal path's
+/// "couldn't ask" semantics, and is logged since the transport failure is
+/// otherwise swallowed into a decision.
+class ControlPromptService implements BridgeReplacePrompt {
+  /// A human answers these through a GUI dialog, so the wait is generous —
+  /// unlike the token pull's machine-speed timeout.
+  static const Duration _defaultResponseTimeout = Duration(minutes: 2);
+
+  final ControlChannelClient _client;
+  final Duration _responseTimeout;
+  final Map<String, Completer<bool>> _pending = <String, Completer<bool>>{};
+  int _nextId = 0;
+  bool _disposed = false;
+
+  ControlPromptService({
+    required ControlChannelClient client,
+    Duration responseTimeout = _defaultResponseTimeout,
+  })  : _client = client,
+        _responseTimeout = responseTimeout;
+
+  @override
+  Future<TerminalPromptDecision> askReplaceExistingBridge({required int bridgeCount}) {
+    return _ask(
+      kind: ControlPromptKind.replaceBridge,
+      message: "Another Sesori bridge is already running. Kill it and start fresh?",
+    );
+  }
+
+  @override
+  Future<TerminalPromptDecision> askReplaceStartingBridge({required int holderPid}) {
+    return _ask(
+      kind: ControlPromptKind.replaceBridge,
+      message: "Another Sesori bridge is still starting up (pid $holderPid). Kill it and start fresh?",
+    );
+  }
+
+  /// Best-effort heads-up that the bridge needs the user to log in (the GUI
+  /// could not supply a token at bootstrap). Fire-and-forget: no response is
+  /// awaited — the authoritative signal is the auth-required exit sentinel; this
+  /// prompt is advisory, so a send failure is logged and swallowed.
+  void announceLoginNeeded() {
+    final id = "prompt-${_nextId++}";
+    try {
+      _client.send(
+        jsonEncode(
+          ControlMessage.promptRequest(
+            id: id,
+            kind: ControlPromptKind.loginNeeded,
+            message: "Sign in to the Sesori desktop app to start the bridge.",
+          ).toJson(),
+        ),
+      );
+    } on ControlChannelNotConnectedException catch (error) {
+      Log.w("[control][prompt] could not announce login-needed — control channel down", error);
+    }
+  }
+
+  /// Delivers the GUI's answer to a pending ask. Called by the control-message
+  /// dispatcher (the single inbound subscriber); answers for unknown or
+  /// already-resolved ids are ignored (e.g. a reply arriving after the timeout).
+  void handlePromptResponse({required String id, required bool accepted}) {
+    final completer = _pending.remove(id);
+    if (completer != null && !completer.isCompleted) {
+      completer.complete(accepted);
+    }
+  }
+
+  /// Resolves any in-flight asks as [TerminalPromptDecision.nonInteractive] so
+  /// shutdown never hangs on the response timeout.
+  Future<void> dispose() async {
+    _disposed = true;
+    final pending = List<Completer<bool>>.of(_pending.values);
+    _pending.clear();
+    for (final completer in pending) {
+      if (!completer.isCompleted) {
+        // Resolved via the completer's normal path; _ask maps the sentinel to
+        // nonInteractive. Using the decision (not an error) keeps teardown quiet.
+        completer.complete(false);
+      }
+    }
+  }
+
+  Future<TerminalPromptDecision> _ask({
+    required ControlPromptKind kind,
+    required String message,
+  }) async {
+    if (_disposed) {
+      return TerminalPromptDecision.nonInteractive;
+    }
+    final id = "prompt-${_nextId++}";
+    final completer = Completer<bool>();
+    _pending[id] = completer;
+    try {
+      try {
+        _client.send(
+          jsonEncode(ControlMessage.promptRequest(id: id, kind: kind, message: message).toJson()),
+        );
+      } on ControlChannelNotConnectedException catch (error) {
+        // The GUI is unreachable (outage / mid-reconnect): the question cannot
+        // be asked. Degrade like a non-interactive terminal; logged because the
+        // transport failure is otherwise swallowed into a decision.
+        Log.w("[control][prompt] could not send prompt — control channel down", error);
+        return TerminalPromptDecision.nonInteractive;
+      }
+      final accepted = await completer.future.timeout(_responseTimeout);
+      // A dispose-resolved completer answers false; distinguish it from a real
+      // decline so teardown reads as "couldn't ask", not "user said no".
+      if (_disposed) {
+        return TerminalPromptDecision.nonInteractive;
+      }
+      return accepted ? TerminalPromptDecision.replace : TerminalPromptDecision.decline;
+    } on TimeoutException {
+      Log.w("[control][prompt] no answer from the desktop app within ${_responseTimeout.inSeconds}s");
+      return TerminalPromptDecision.nonInteractive;
+    } finally {
+      _pending.remove(id);
+    }
+  }
+}

--- a/bridge/app/lib/src/services/control_prompt_service.dart
+++ b/bridge/app/lib/src/services/control_prompt_service.dart
@@ -44,7 +44,7 @@ class ControlPromptService implements BridgeReplacePrompt {
   Future<TerminalPromptDecision> askReplaceExistingBridge({required int bridgeCount}) {
     return _ask(
       kind: ControlPromptKind.replaceBridge,
-      message: "Another Sesori bridge is already running. Kill it and start fresh?",
+      message: BridgeReplacePrompt.replaceExistingBridgeMessage,
     );
   }
 
@@ -52,7 +52,7 @@ class ControlPromptService implements BridgeReplacePrompt {
   Future<TerminalPromptDecision> askReplaceStartingBridge({required int holderPid}) {
     return _ask(
       kind: ControlPromptKind.replaceBridge,
-      message: "Another Sesori bridge is still starting up (pid $holderPid). Kill it and start fresh?",
+      message: BridgeReplacePrompt.replaceStartingBridgeMessage(holderPid: holderPid),
     );
   }
 
@@ -74,6 +74,11 @@ class ControlPromptService implements BridgeReplacePrompt {
       );
     } on ControlChannelNotConnectedException catch (error) {
       Log.w("[control][prompt] could not announce login-needed — control channel down", error);
+    } on Object catch (error, stackTrace) {
+      // Best-effort by contract: an unexpected transport failure (e.g. a
+      // mid-close sink) must never mask the authoritative auth-required exit
+      // code the caller is about to return.
+      Log.w("[control][prompt] could not announce login-needed", error, stackTrace);
     }
   }
 
@@ -122,6 +127,11 @@ class ControlPromptService implements BridgeReplacePrompt {
         // be asked. Degrade like a non-interactive terminal; logged because the
         // transport failure is otherwise swallowed into a decision.
         Log.w("[control][prompt] could not send prompt — control channel down", error);
+        return TerminalPromptDecision.nonInteractive;
+      } on Object catch (error, stackTrace) {
+        // Any other transport failure (e.g. a mid-close sink) equally means the
+        // question cannot be asked — degrade instead of crashing startup.
+        Log.w("[control][prompt] could not send prompt", error, stackTrace);
         return TerminalPromptDecision.nonInteractive;
       }
       final accepted = await completer.future.timeout(_responseTimeout);

--- a/bridge/app/test/control/bridge_control_message_dispatcher_test.dart
+++ b/bridge/app/test/control/bridge_control_message_dispatcher_test.dart
@@ -1,0 +1,184 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:sesori_bridge/src/control/bridge_control_message_dispatcher.dart";
+import "package:sesori_bridge/src/foundation/control_channel_client.dart";
+import "package:sesori_bridge/src/services/control_channel_token_service.dart";
+import "package:sesori_bridge/src/services/control_prompt_service.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("BridgeControlMessageDispatcher", () {
+    late _FakeControlChannelClient client;
+    late _RecordingTokenService tokenService;
+    late _RecordingPromptService promptService;
+    late BridgeControlMessageDispatcher dispatcher;
+
+    setUp(() {
+      client = _FakeControlChannelClient();
+      tokenService = _RecordingTokenService();
+      promptService = _RecordingPromptService();
+      dispatcher = BridgeControlMessageDispatcher(
+        client: client,
+        tokenService: tokenService,
+        promptService: promptService,
+      );
+      addTearDown(dispatcher.dispose);
+    });
+
+    test("routes token_response to the token service delegate", () async {
+      dispatcher.start();
+      client.emit(_encode(const ControlMessage.tokenResponse(id: "t-1", accessToken: "tok")));
+      client.emit(_encode(const ControlMessage.tokenResponse(id: "t-2", accessToken: null)));
+      await pumpEventQueue();
+
+      expect(tokenService.responses, equals([("t-1", "tok"), ("t-2", null)]));
+      expect(tokenService.updates, isEmpty);
+      expect(promptService.responses, isEmpty);
+    });
+
+    test("routes token_update to the token service delegate", () async {
+      dispatcher.start();
+      client.emit(_encode(const ControlMessage.tokenUpdate(accessToken: "pushed")));
+      await pumpEventQueue();
+
+      expect(tokenService.updates, equals(["pushed"]));
+      expect(tokenService.responses, isEmpty);
+    });
+
+    test("routes prompt_response to the prompt service delegate", () async {
+      dispatcher.start();
+      client.emit(_encode(const ControlMessage.promptResponse(id: "p-1", accepted: true)));
+      client.emit(_encode(const ControlMessage.promptResponse(id: "p-2", accepted: false)));
+      await pumpEventQueue();
+
+      expect(promptService.responses, equals([("p-1", true), ("p-2", false)]));
+      expect(tokenService.responses, isEmpty);
+    });
+
+    test("an undecodable frame is skipped and later frames are still routed", () async {
+      dispatcher.start();
+      client.emit("not valid json");
+      client.emit(_encode(const ControlMessage.tokenUpdate(accessToken: "after-garbage")));
+      await pumpEventQueue();
+
+      expect(tokenService.updates, equals(["after-garbage"]));
+    });
+
+    test("variants with no inbound meaning are ignored — restart is never an inbound command", () async {
+      dispatcher.start();
+      client.emit(_encode(const ControlMessage.restart()));
+      client.emit(_encode(const ControlMessage.unregisterAndExit()));
+      client.emit(_encode(const ControlMessage.registered(bridgeId: "b-1")));
+      client.emit(_encode(const ControlMessage.tokenRequest(id: "t-1")));
+      client.emit(
+        _encode(
+          const ControlMessage.status(
+            relay: ControlRelayConnectionState.connected,
+            plugin: ControlPluginHealthState.healthy,
+          ),
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(tokenService.responses, isEmpty);
+      expect(tokenService.updates, isEmpty);
+      expect(promptService.responses, isEmpty);
+    });
+
+    test("the dispatcher is the only inbound subscriber — services never self-subscribe", () async {
+      // Constructing the real services must not subscribe to the client.
+      final realTokenService = ControlChannelTokenService(client: client);
+      addTearDown(realTokenService.dispose);
+      final realPromptService = ControlPromptService(client: client);
+      addTearDown(realPromptService.dispose);
+      expect(client.listenCount, equals(0));
+
+      final wired = BridgeControlMessageDispatcher(
+        client: client,
+        tokenService: realTokenService,
+        promptService: realPromptService,
+      );
+      addTearDown(wired.dispose);
+      wired.start();
+      expect(client.listenCount, equals(1));
+
+      // start() is idempotent: no second subscription.
+      wired.start();
+      expect(client.listenCount, equals(1));
+    });
+
+    test("frames after dispose are not routed", () async {
+      dispatcher.start();
+      await dispatcher.dispose();
+      client.emit(_encode(const ControlMessage.tokenUpdate(accessToken: "late")));
+      await pumpEventQueue();
+
+      expect(tokenService.updates, isEmpty);
+    });
+  });
+}
+
+String _encode(ControlMessage message) => jsonEncode(message.toJson());
+
+class _FakeControlChannelClient implements ControlChannelClient {
+  final StreamController<String> _inbound = StreamController<String>.broadcast();
+  int listenCount = 0;
+
+  void emit(String frame) => _inbound.add(frame);
+
+  @override
+  Stream<String> get inbound {
+    // Counts every listen while keeping subscription synchronous (an async*
+    // wrapper would subscribe in a microtask and miss synchronously emitted
+    // frames).
+    return Stream<String>.multi((controller) {
+      listenCount++;
+      final subscription = _inbound.stream.listen(
+        controller.add,
+        onError: controller.addError,
+        onDone: controller.close,
+      );
+      controller.onCancel = subscription.cancel;
+    });
+  }
+
+  @override
+  void send(String frame) {}
+
+  @override
+  Stream<ControlChannelConnectionState> get connectionState => const Stream<ControlChannelConnectionState>.empty();
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> dispose() async {
+    await _inbound.close();
+  }
+}
+
+class _RecordingTokenService implements ControlChannelTokenService {
+  final List<(String, String?)> responses = <(String, String?)>[];
+  final List<String> updates = <String>[];
+
+  @override
+  void handleTokenResponse({required String id, required String? accessToken}) => responses.add((id, accessToken));
+
+  @override
+  void handleTokenUpdate({required String accessToken}) => updates.add(accessToken);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _RecordingPromptService implements ControlPromptService {
+  final List<(String, bool)> responses = <(String, bool)>[];
+
+  @override
+  void handlePromptResponse({required String id, required bool accepted}) => responses.add((id, accepted));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/server/services/bridge_instance_service_test.dart
+++ b/bridge/app/test/server/services/bridge_instance_service_test.dart
@@ -25,7 +25,7 @@ void main() {
       clock = _FakeServerClock();
       service = BridgeInstanceService(
         bridgeInstanceRepository: bridgeInstanceRepository,
-        terminalPromptRepository: terminalPromptRepository,
+        replacePrompt: terminalPromptRepository,
         processRepository: processRepository,
         clock: clock,
       );

--- a/bridge/app/test/services/control_channel_token_service_test.dart
+++ b/bridge/app/test/services/control_channel_token_service_test.dart
@@ -2,16 +2,37 @@ import "dart:async";
 import "dart:convert";
 
 import "package:sesori_bridge/src/auth/token_refresher.dart";
+import "package:sesori_bridge/src/control/bridge_control_message_dispatcher.dart";
 import "package:sesori_bridge/src/foundation/control_channel_client.dart";
 import "package:sesori_bridge/src/services/control_channel_token_service.dart";
+import "package:sesori_bridge/src/services/control_prompt_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
 void main() {
+  // The service no longer subscribes to the client itself — the dispatcher is
+  // the single inbound subscriber — so these behaviour tests wire one over the
+  // same fake client to keep driving the service with raw emitted frames.
+  ControlChannelTokenService buildService(
+    _FakeControlChannelClient client, {
+    Duration? requestTimeout,
+  }) {
+    final service = requestTimeout == null
+        ? ControlChannelTokenService(client: client)
+        : ControlChannelTokenService(client: client, requestTimeout: requestTimeout);
+    final dispatcher = BridgeControlMessageDispatcher(
+      client: client,
+      tokenService: service,
+      promptService: ControlPromptService(client: client),
+    )..start();
+    addTearDown(dispatcher.dispose);
+    return service;
+  }
+
   group("ControlChannelTokenService", () {
     test("sends a token_request and resolves with the matching token_response", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      final service = buildService(client);
       addTearDown(service.dispose);
 
       final future = service.getAccessToken();
@@ -28,7 +49,7 @@ void main() {
 
     test("forwards forceRefresh in the request and returns the fresh token", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      final service = buildService(client);
       addTearDown(service.dispose);
 
       final future = service.getAccessToken(forceRefresh: true);
@@ -43,7 +64,7 @@ void main() {
 
     test("caches the latest pulled token for accessToken and tokenStream", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      final service = buildService(client);
       addTearDown(service.dispose);
 
       final emitted = <String>[];
@@ -73,7 +94,7 @@ void main() {
 
     test("accessToken throws before the first successful pull", () {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      final service = buildService(client);
       addTearDown(service.dispose);
 
       expect(() => service.accessToken, throwsStateError);
@@ -81,7 +102,7 @@ void main() {
 
     test("a null access token surfaces a typed failure and leaves the cache empty", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      final service = buildService(client);
       addTearDown(service.dispose);
 
       final future = service.getAccessToken();
@@ -96,7 +117,7 @@ void main() {
 
     test("maps a disconnected-channel send failure to a typed token failure", () async {
       final client = _FakeControlChannelClient()..throwOnSend = true;
-      final service = ControlChannelTokenService(client: client);
+      final service = buildService(client);
       addTearDown(service.dispose);
 
       await expectLater(
@@ -107,7 +128,7 @@ void main() {
 
     test("a pushed token_update is adopted into accessToken and tokenStream", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      final service = buildService(client);
       addTearDown(service.dispose);
 
       final emitted = <String>[];
@@ -129,7 +150,7 @@ void main() {
 
     test("a pushed token_update clears a prior sign-out invalidation", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      final service = buildService(client);
       addTearDown(service.dispose);
 
       // Seed, then sign out (null response) which invalidates the cache.
@@ -155,7 +176,7 @@ void main() {
 
     test("a null token_response invalidates a previously cached token", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      final service = buildService(client);
       addTearDown(service.dispose);
 
       final first = service.getAccessToken();
@@ -185,7 +206,7 @@ void main() {
 
     test("an older in-flight pull does not clear a newer sign-out invalidation", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      final service = buildService(client);
       addTearDown(service.dispose);
 
       final first = service.getAccessToken();
@@ -222,7 +243,7 @@ void main() {
 
     test("a pushed token_update wins over a slower older pull response", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      final service = buildService(client);
       addTearDown(service.dispose);
 
       // A pull is issued, then the GUI pushes a fresher token before the pull's
@@ -245,7 +266,7 @@ void main() {
 
     test("the newest-issued pull wins even when an older pull completes first", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      final service = buildService(client);
       addTearDown(service.dispose);
 
       // Two overlapping pulls: the older (first-issued) and the newer (e.g. a
@@ -274,10 +295,7 @@ void main() {
 
     test("times out with a typed failure when no response arrives", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(
-        client: client,
-        requestTimeout: const Duration(milliseconds: 20),
-      );
+      final service = buildService(client, requestTimeout: const Duration(milliseconds: 20));
       addTearDown(service.dispose);
 
       await expectLater(
@@ -288,7 +306,7 @@ void main() {
 
     test("correlates by id — a mismatched response is ignored", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      final service = buildService(client);
       addTearDown(service.dispose);
 
       final future = service.getAccessToken();
@@ -303,7 +321,7 @@ void main() {
 
     test("ignores unrelated and undecodable frames", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      final service = buildService(client);
       addTearDown(service.dispose);
 
       final future = service.getAccessToken();
@@ -326,7 +344,7 @@ void main() {
 
     test("dispose fails any in-flight request", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      final service = buildService(client);
 
       final future = service.getAccessToken();
       await pumpEventQueue();
@@ -339,10 +357,7 @@ void main() {
     test("getAccessToken after dispose fails fast without waiting for the timeout", () async {
       final client = _FakeControlChannelClient();
       // A long timeout proves the failure is the disposed guard, not the timer.
-      final service = ControlChannelTokenService(
-        client: client,
-        requestTimeout: const Duration(seconds: 30),
-      );
+      final service = buildService(client, requestTimeout: const Duration(seconds: 30));
       await service.dispose();
 
       await expectLater(
@@ -355,7 +370,7 @@ void main() {
 
     test("dispose is idempotent", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      final service = buildService(client);
 
       await service.dispose();
       await service.dispose();
@@ -363,7 +378,7 @@ void main() {
 
     test("concurrent dispose callers await the same teardown", () async {
       final client = _FakeControlChannelClient();
-      final service = ControlChannelTokenService(client: client);
+      final service = buildService(client);
 
       final first = service.dispose();
       final second = service.dispose();

--- a/bridge/app/test/services/control_prompt_service_test.dart
+++ b/bridge/app/test/services/control_prompt_service_test.dart
@@ -1,0 +1,155 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/foundation/control_channel_client.dart";
+import "package:sesori_bridge/src/server/foundation/terminal_prompt_decision.dart";
+import "package:sesori_bridge/src/services/control_prompt_service.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ControlPromptService", () {
+    test("askReplaceExistingBridge sends a replace_bridge prompt and maps accepted to replace", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlPromptService(client: client);
+      addTearDown(service.dispose);
+
+      final future = service.askReplaceExistingBridge(bridgeCount: 1);
+      await pumpEventQueue();
+
+      final request = _decode(client.sentFrames.single) as ControlPromptRequest;
+      expect(request.kind, equals(ControlPromptKind.replaceBridge));
+      expect(request.message, contains("already running"));
+
+      service.handlePromptResponse(id: request.id, accepted: true);
+      expect(await future, equals(TerminalPromptDecision.replace));
+    });
+
+    test("askReplaceStartingBridge maps a rejected answer to decline", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlPromptService(client: client);
+      addTearDown(service.dispose);
+
+      final future = service.askReplaceStartingBridge(holderPid: 4242);
+      await pumpEventQueue();
+
+      final request = _decode(client.sentFrames.single) as ControlPromptRequest;
+      expect(request.kind, equals(ControlPromptKind.replaceBridge));
+      expect(request.message, contains("4242"));
+
+      service.handlePromptResponse(id: request.id, accepted: false);
+      expect(await future, equals(TerminalPromptDecision.decline));
+    });
+
+    test("correlates by id — a mismatched answer is ignored", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlPromptService(client: client);
+      addTearDown(service.dispose);
+
+      final future = service.askReplaceExistingBridge(bridgeCount: 1);
+      await pumpEventQueue();
+      final request = _decode(client.sentFrames.single) as ControlPromptRequest;
+
+      service.handlePromptResponse(id: "someone-else", accepted: true);
+      service.handlePromptResponse(id: request.id, accepted: false);
+
+      expect(await future, equals(TerminalPromptDecision.decline));
+    });
+
+    test("no answer within the timeout degrades to nonInteractive", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlPromptService(
+        client: client,
+        responseTimeout: const Duration(milliseconds: 20),
+      );
+      addTearDown(service.dispose);
+
+      expect(
+        await service.askReplaceExistingBridge(bridgeCount: 1),
+        equals(TerminalPromptDecision.nonInteractive),
+      );
+    });
+
+    test("a disconnected channel degrades to nonInteractive", () async {
+      final client = _FakeControlChannelClient()..throwOnSend = true;
+      final service = ControlPromptService(client: client);
+      addTearDown(service.dispose);
+
+      expect(
+        await service.askReplaceExistingBridge(bridgeCount: 1),
+        equals(TerminalPromptDecision.nonInteractive),
+      );
+    });
+
+    test("dispose resolves an in-flight ask as nonInteractive", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlPromptService(client: client);
+
+      final future = service.askReplaceExistingBridge(bridgeCount: 1);
+      await pumpEventQueue();
+
+      await service.dispose();
+      expect(await future, equals(TerminalPromptDecision.nonInteractive));
+    });
+
+    test("an ask after dispose is nonInteractive without sending", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlPromptService(client: client);
+      await service.dispose();
+
+      expect(
+        await service.askReplaceExistingBridge(bridgeCount: 1),
+        equals(TerminalPromptDecision.nonInteractive),
+      );
+      expect(client.sentFrames, isEmpty);
+    });
+
+    test("announceLoginNeeded sends a login_needed prompt without awaiting an answer", () async {
+      final client = _FakeControlChannelClient();
+      final service = ControlPromptService(client: client);
+      addTearDown(service.dispose);
+
+      service.announceLoginNeeded();
+
+      final request = _decode(client.sentFrames.single) as ControlPromptRequest;
+      expect(request.kind, equals(ControlPromptKind.loginNeeded));
+    });
+
+    test("announceLoginNeeded is best-effort — a disconnected channel does not throw", () {
+      final client = _FakeControlChannelClient()..throwOnSend = true;
+      final service = ControlPromptService(client: client);
+      addTearDown(service.dispose);
+
+      expect(service.announceLoginNeeded, returnsNormally);
+      expect(client.sentFrames, isEmpty);
+    });
+  });
+}
+
+ControlMessage _decode(String frame) => ControlMessage.fromJson(jsonDecodeMap(frame));
+
+class _FakeControlChannelClient implements ControlChannelClient {
+  final List<String> sentFrames = <String>[];
+
+  /// Mimics [ControlChannelClient.send] throwing when the channel is down.
+  bool throwOnSend = false;
+
+  @override
+  Stream<String> get inbound => const Stream<String>.empty();
+
+  @override
+  void send(String frame) {
+    if (throwOnSend) {
+      throw const ControlChannelNotConnectedException("Control channel is not connected");
+    }
+    sentFrames.add(frame);
+  }
+
+  @override
+  Stream<ControlChannelConnectionState> get connectionState => const Stream<ControlChannelConnectionState>.empty();
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> dispose() async {}
+}

--- a/bridge/app/test/services/control_prompt_service_test.dart
+++ b/bridge/app/test/services/control_prompt_service_test.dart
@@ -80,6 +80,17 @@ void main() {
       );
     });
 
+    test("an unexpected transport failure degrades to nonInteractive instead of crashing", () async {
+      final client = _FakeControlChannelClient()..sendError = StateError("sink is closed");
+      final service = ControlPromptService(client: client);
+      addTearDown(service.dispose);
+
+      expect(
+        await service.askReplaceExistingBridge(bridgeCount: 1),
+        equals(TerminalPromptDecision.nonInteractive),
+      );
+    });
+
     test("dispose resolves an in-flight ask as nonInteractive", () async {
       final client = _FakeControlChannelClient();
       final service = ControlPromptService(client: client);
@@ -122,6 +133,15 @@ void main() {
       expect(service.announceLoginNeeded, returnsNormally);
       expect(client.sentFrames, isEmpty);
     });
+
+    test("announceLoginNeeded is best-effort — an unexpected transport failure does not throw", () {
+      final client = _FakeControlChannelClient()..sendError = StateError("sink is closed");
+      final service = ControlPromptService(client: client);
+      addTearDown(service.dispose);
+
+      expect(service.announceLoginNeeded, returnsNormally);
+      expect(client.sentFrames, isEmpty);
+    });
   });
 }
 
@@ -133,6 +153,9 @@ class _FakeControlChannelClient implements ControlChannelClient {
   /// Mimics [ControlChannelClient.send] throwing when the channel is down.
   bool throwOnSend = false;
 
+  /// Mimics an unexpected transport failure (e.g. a mid-close sink).
+  Object? sendError;
+
   @override
   Stream<String> get inbound => const Stream<String>.empty();
 
@@ -140,6 +163,10 @@ class _FakeControlChannelClient implements ControlChannelClient {
   void send(String frame) {
     if (throwOnSend) {
       throw const ControlChannelNotConnectedException("Control channel is not connected");
+    }
+    final error = sendError;
+    if (error != null) {
+      throw error;
     }
     sentFrames.add(frame);
   }

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -8,8 +8,8 @@
 
 ## Current pointer
 
-- **Last completed phase:** Phase 1 — PR 1.8 Disable self-update + reconcile when supervised (PR raised on branch `next-desktop-implementation-stage`)
-- **Next up:** Phase 1 — PR 1.9 `BridgeControlMessageDispatcher` + prompts/Console → control events + auth-required exit `87`
+- **Last completed phase:** Phase 1 — PR 1.9 `BridgeControlMessageDispatcher` + prompts → control events + auth-required exit `87` (PR raised on branch `next-desktop-implementation`)
+- **Next up:** Phase 1 — PR 1.10 Status push (relay/plugin/active sessions)
 - **Branch:** one feature branch per PR, cut from `main`
 
 > **Tracking lives in four places that MUST move together in the same PR.**
@@ -278,7 +278,9 @@ mobile release.**
 | `ControlChannelLossListener` | Layer 4 `control/` | ADR A9 grace-period process exit on sustained control-channel loss; injected `exitProcess` (PR 1.1). `control/` is part of the core layered bridge app, not a self-contained subsystem. |
 | Control-protocol Freezed DTOs | `shared/sesori_shared` | pure wire types (incl. provision-progress mirror) |
 | `ControlChannelTokenService` | Layer 3 `services/` | implements `auth/` `AccessTokenProvider`/`TokenRefresher`; pull + push token stream over injected `ControlChannelClient`. Kept out of the self-contained `auth/` subsystem so `auth/` does not import core `foundation/`. PR 1.9 re-homes its **inbound** subscription behind `BridgeControlMessageDispatcher` (typed delegate calls); request-correlation state and the `token_request` send path stay inside the service. |
-| `BridgeControlMessageDispatcher` | Layer 4 `control/` | owns the **single** inbound subscription + decode of GUI→helper control messages (created in PR 1.9). Routes: `token_response`/`token_update` → token-service delegate, `prompt_response` → prompt correlation, `unregister_and_exit` → unregister flow (PR 1.11). `restart` is **helper→GUI only** and is never an inbound command — the GUI restarts the helper by kill+respawn, not by message. |
+| `BridgeControlMessageDispatcher` | Layer 4 `control/` | owns the **single** inbound subscription + decode of GUI→helper control messages (created in PR 1.9). Routes: `token_response`/`token_update` → token-service delegate, `prompt_response` → prompt-service delegate, `unregister_and_exit` → unregister flow (PR 1.11). `restart` is **helper→GUI only** and is never an inbound command — the GUI restarts the helper by kill+respawn, not by message. |
+| `ControlPromptService` | Layer 3 `services/` | supervised-mode user prompts over the injected `ControlChannelClient` (same blessed seam as the token service): owns prompt-class correlation state + ALL prompt-class outbound sends (`prompt_request`); implements the `server/foundation/` `BridgeReplacePrompt` interface so `BridgeInstanceService` asks the GUI instead of a terminal; `announceLoginNeeded()` is the best-effort advisory before the exit-87 sentinel (ADR A23). Unanswerable asks (channel down / timeout / teardown) degrade to `nonInteractive`. |
+| `BridgeReplacePrompt` | interface in `server/foundation/` | the replace-bridge ask contract with two production implementations: `TerminalPromptRepository` (standalone) and `ControlPromptService` (supervised); keeps the `server/` subsystem free of core-layer imports (mirrors the auth-interface precedent from PR 1.4). |
 | `ControlStatusNotifier` | Layer 4 `control/` | owns **all outbound** status-class control sends (created in PR 1.10): observes Layer-0 state streams (relay connection state incl. close code/reason, plugin health, active-session summary, registration events) and maps them to `status`/`registered`/takeover pushes over the injected `ControlChannelClient`. Higher layers (Orchestrator) never call `ControlChannelClient.send` directly. |
 | `BridgeIdStorage` (file API + reader) | **inside the `auth/` subsystem** | persist `bridgeId` separately from `token.json`; kept within `auth/` (which is self-contained, outside the core layer hierarchy) so auth code doesn't depend back on top-level `repositories/`. Injected from the composition root. |
 | supervised auth bootstrap | composition root | short-circuit `BridgeRuntimeAuthService.ensureAuthenticated` (no stdin); keep an equivalent `logAuthenticatedUser` |
@@ -390,7 +392,7 @@ them). Only the user checks an MT box.
 - ☑ 1.6 Supervised registration + `bridgeId` out of `token.json` — Med / M
 - ☑ 1.7 Exit-code restart (`86`) + bypass successor-spawn — Med / S-M
 - ☑ 1.8 Disable self-update + reconcile when supervised — Low / S
-- ☐ 1.9 `BridgeControlMessageDispatcher` + prompts/Console → control events + auth-required exit `87` — Med / M
+- ☑ 1.9 `BridgeControlMessageDispatcher` + prompts/Console → control events + auth-required exit `87` — Med / M
 - ☐ 1.10 Status push (relay/plugin/active sessions) — Low / S-M
 - ☐ 1.11 `unregister-and-exit` control command — Low / S-M
 - ☐ 1.12 Single-live precedence under supervised `--hidden` — Med / M

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -470,7 +470,51 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   structured prompt/login events; the dispatcher is the only `inbound` subscriber
   (asserted by test); bootstrap token-unavailable exits `87` after a best-effort
   `loginNeeded` prompt; PR 2.7's mapping consumes `87`.
-- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+- **Aristotle:** plan ☑ · impl ☑ (PR raised on branch `next-desktop-implementation`).
+- **Findings:** Shipped as four units. (1) `BridgeControlMessageDispatcher`
+  (Layer 4 `control/`): the single `inbound` subscriber; decodes each frame once
+  (warn+skip on undecodable, preserved from the token service's old decode
+  point) and routes via an exhaustive switch — `token_response`/`token_update` →
+  token-service typed delegates, `prompt_response` → prompt-service delegate;
+  every other variant (incl. `restart` and, until its route lands,
+  `unregister_and_exit`) is `Log.d`-ignored, never a command. Single-subscriber
+  property asserted by a listen-counting fake client. (2)
+  `ControlChannelTokenService` no longer subscribes/decodes: it gained
+  `handleTokenResponse`/`handleTokenUpdate` delegates; correlation map, seq
+  ordering, `token_request` send path, timeout and dispose semantics unchanged —
+  all 19 existing behaviour tests kept their expectations, re-wired through a
+  dispatcher over the same fake client. (3) Prompts: new `ControlPromptService`
+  (Layer 3 `services/`, same blessed `ControlChannelClient` seam) owns
+  prompt-class correlation + sends and implements the new
+  `BridgeReplacePrompt` interface (`server/foundation/`, two production impls —
+  `TerminalPromptRepository` gained `implements`); `BridgeInstanceService` now
+  takes `BridgeReplacePrompt replacePrompt`, so supervised replace-bridge
+  questions go to the GUI (accepted→replace, rejected→decline; channel-down /
+  2-min timeout / teardown → `nonInteractive`, logged — mirroring the
+  terminal's "couldn't ask"). The logout CLI keeps the terminal impl (never
+  supervised). (4) ADR A23: `supervisedAuthRequiredExitCode = 87` beside 86;
+  the supervised bootstrap pull catches `ControlTokenUnavailableException`,
+  logs once, sends a best-effort `announceLoginNeeded()` (fire-and-forget,
+  swallow+log when the channel is down) and returns 87; the sentinel is wired
+  into the shutdown backstop chain and the outer-finally shutdown-error guard,
+  so a hung or throwing shutdown still reports 87 (same robustness 86 has).
+  Composition: prompt service + dispatcher are built with the token service in
+  the supervised block, dispatcher started **before** the bootstrap pull;
+  `BridgeInstanceService` construction moved after that block to receive
+  `controlPromptService ?? terminalPromptRepository`. Standalone byte-identical
+  (no Console call-site changes; nothing supervised is constructed). `make
+  analyze` + `dart analyze --fatal-infos` clean; `make test` all pass (app
+  1627; +16 new dispatcher/prompt tests).
+- **Deltas:** §6 gained two rows that PR planning had not pre-specified as
+  components: `ControlPromptService` (Layer 3 `services/`) as the owner of the
+  prompt correlation the PR text placed only vaguely "via the dispatcher", and
+  the `BridgeReplacePrompt` interface (`server/foundation/`) that lets
+  `BridgeInstanceService` stay inside the self-contained `server/` subsystem
+  (PR-1.4 auth-interface precedent). "Essential `Console` output" re-homing was
+  realized as the prompt-class events only: the PR-1.2 DTO surface deliberately
+  has no generic console/log variant (status is health/counts only), and the
+  GUI captures stdout/stderr as logs (PR 2.6) — so non-prompt Console output
+  intentionally stays on stdio in supervised mode.
 
 ## PR 1.10 — Status push (incl. registered `bridgeId`) via `ControlStatusNotifier`
 - **Goal:** Bridge pushes `status` (relay connection state, plugin health,


### PR DESCRIPTION
## Summary

Phase 1, PR 1.9 of the desktop plan (`docs/desktop/PLAN.md`): three tightly-coupled pieces of the supervised-mode inbound/prompt seam. All gated by `--control-url`; standalone behaviour is byte-identical.

### 1. `BridgeControlMessageDispatcher` (Layer 4 `control/`)
The **single** inbound subscriber/decoder for GUI→helper control messages. Decodes each frame exactly once (warn+skip on undecodable, preserved from the token service's old decode point) and routes via an exhaustive switch:
- `token_response` / `token_update` → `ControlChannelTokenService` typed delegates
- `prompt_response` → `ControlPromptService` delegate
- everything else ignored — `restart` is helper→GUI only and is **never** an inbound command; `unregister_and_exit` gains its route in PR 1.11.

`ControlChannelTokenService` no longer subscribes to `inbound`; it gained `handleTokenResponse`/`handleTokenUpdate` delegates while keeping its correlation map, issue-sequence ordering, `token_request` send path, timeout and dispose semantics unchanged. The single-subscriber property is asserted by test (listen-counting fake client).

### 2. Prompts become structured control events
New `ControlPromptService` (Layer 3 `services/`, the same blessed `ControlChannelClient` seam as the token service) owns prompt-class correlation and **all** prompt-class sends. It implements the new `BridgeReplacePrompt` interface (`server/foundation/`; `TerminalPromptRepository` implements it too — two production impls), and `BridgeInstanceService` now takes `BridgeReplacePrompt replacePrompt`. A supervised bridge therefore surfaces replace-bridge contention to the desktop GUI (accepted→replace, rejected→decline; channel down / 2-min timeout / teardown → `nonInteractive`, mirroring the terminal's "couldn't ask"). The logout CLI keeps the terminal implementation (never supervised).

### 3. Auth-required exit sentinel `87` (ADR A23)
When the GUI cannot supply a token at bootstrap (`ControlTokenUnavailableException` — signed out / mid-login / unreachable), the supervised bridge logs once, sends a best-effort `loginNeeded` prompt (fire-and-forget, swallow+log when the channel is down) and exits **87** — distinct from restart (86), control-loss (1), crash (other) — so the Phase-2 GUI state machine can prompt for login instead of backoff-respawn-thrashing. The sentinel is wired into the shutdown backstop chain and the outer-finally shutdown-error guard, so a hung or throwing shutdown still reports 87 (same robustness 86 has).

## Regression guide (re-verified)

1. Token pull round-trip, force-refresh, push adoption, null-response cache invalidation, dispose-fails-in-flight: all 19 existing token-service behaviour tests kept their expectations — only re-wired through a dispatcher over the same fake client.
2. `ControlChannelLossListener` untouched (separate `connectionState` subscription).
3. Undecodable-frame warn+skip preserved at the single decode point (dispatcher test).
4. Standalone Console output byte-identical — no Console call sites changed; nothing supervised is constructed without `--control-url`; `TerminalPromptRepository` behaviour untouched.
5. Supervised exit codes: token-unavailable at bootstrap = 87; control-loss = 1 (unchanged); restart = 86 (unchanged); normal shutdown = 0.

## Tests

- New `bridge_control_message_dispatcher_test.dart` (7) + `control_prompt_service_test.dart` (9).
- `make analyze` + `dart analyze --fatal-infos` (bridge/app) clean; `make test` all pass (app: 1627).

## Plan tracking

PLAN.md pointer + §9 row flipped; §6 gained `ControlPromptService` / `BridgeReplacePrompt` rows; phase doc Findings + Deltas recorded (incl. the deliberate scoping of "essential Console output" to prompt-class events only — the DTO surface has no generic console variant; stdout/stderr stays the log path for the PR-2.6 capture).

## Aristotle

- plan-review: APPROVED
- impl-review: APPROVED

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a single control-channel dispatcher, moves user prompts to the desktop app, and adds exit code 87 when auth is required during supervised startup. Gated by `--control-url`; standalone behavior is unchanged.

- **New Features**
  - Single inbound `BridgeControlMessageDispatcher` routes `token_response`, `token_update`, and `prompt_response`; warns and skips undecodable frames; ignores non-inbound commands like `restart`.
  - New `ControlPromptService` sends GUI prompts and tracks replies; degrades to `nonInteractive` if the channel is down, times out, or a transport error occurs; implements `BridgeReplacePrompt` so `BridgeInstanceService` asks the GUI in supervised mode; the logout CLI keeps the terminal prompt.
  - Supervised bootstrap exits with sentinel 87 when the GUI cannot supply a token; sends a best-effort `loginNeeded` prompt and preserves the sentinel through shutdown; restart 86 unchanged.

- **Refactors**
  - `ControlChannelTokenService` no longer subscribes to inbound; adds `handleTokenResponse`/`handleTokenUpdate` delegates; request correlation, ordering, timeouts, and dispose behavior unchanged.
  - Dispatcher is started before the bootstrap token pull; prompt copy centralized in `BridgeReplacePrompt` constants; supervised wiring lives behind `--control-url`.
  - Fixed bootstrap token-failure logging to include the caught error.
  - Added tests for the dispatcher and prompt service; updated token-service tests to run through the dispatcher.

<sup>Written for commit aca62491b95793d66999b86c64c0b070b7a83617. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

