### PR TITLE
feat: add unseen dot indicator to project and session tiles

### DIFF
--- a/client/app/lib/features/project_list/widgets/project_tile.dart
+++ b/client/app/lib/features/project_list/widgets/project_tile.dart
@@ -68,16 +68,17 @@ class _ProjectTile extends StatelessWidget {
         ],
       ),
       isThreeLine: updatedAt != null || isActive,
-      trailing: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (unseen) ...[
+      trailing: switch (unseen) {
+        true => Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
             Icon(Icons.circle, size: 10, color: prego.colors.bgBrandSolid),
             const SizedBox(width: 8),
+            const Icon(Icons.chevron_right),
           ],
-          const Icon(Icons.chevron_right),
-        ],
-      ),
+        ),
+        false => const Icon(Icons.chevron_right),
+      },
       onTap: () {
         context.read<ProjectListCubit>().setActiveProject(project);
         context.pushRoute(

--- a/client/app/lib/features/project_list/widgets/project_tile.dart
+++ b/client/app/lib/features/project_list/widgets/project_tile.dart
@@ -68,7 +68,16 @@ class _ProjectTile extends StatelessWidget {
         ],
       ),
       isThreeLine: updatedAt != null || isActive,
-      trailing: const Icon(Icons.chevron_right),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (unseen) ...[
+            Icon(Icons.circle, size: 10, color: prego.colors.bgBrandSolid),
+            const SizedBox(width: 8),
+          ],
+          const Icon(Icons.chevron_right),
+        ],
+      ),
       onTap: () {
         context.read<ProjectListCubit>().setActiveProject(project);
         context.pushRoute(

--- a/client/app/lib/features/session_list/session_tile.dart
+++ b/client/app/lib/features/session_list/session_tile.dart
@@ -104,7 +104,16 @@ class SessionTile extends StatelessWidget {
           session.pullRequest != null,
           isActive,
         ].where((v) => v).length >= 2,
-        trailing: const Icon(Icons.chevron_right),
+        trailing: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (unseen) ...[
+              Icon(Icons.circle, size: 10, color: context.prego.colors.bgBrandSolid),
+              const SizedBox(width: 8),
+            ],
+            const Icon(Icons.chevron_right),
+          ],
+        ),
         onTap: onTap,
         onLongPress: onLongPress,
       ),

--- a/client/app/lib/features/session_list/session_tile.dart
+++ b/client/app/lib/features/session_list/session_tile.dart
@@ -104,16 +104,17 @@ class SessionTile extends StatelessWidget {
           session.pullRequest != null,
           isActive,
         ].where((v) => v).length >= 2,
-        trailing: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (unseen) ...[
+        trailing: switch (unseen) {
+          true => Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
               Icon(Icons.circle, size: 10, color: context.prego.colors.bgBrandSolid),
               const SizedBox(width: 8),
+              const Icon(Icons.chevron_right),
             ],
-            const Icon(Icons.chevron_right),
-          ],
-        ),
+          ),
+          false => const Icon(Icons.chevron_right),
+        },
         onTap: onTap,
         onLongPress: onLongPress,
       ),


### PR DESCRIPTION
## What

Makes the "new content since last seen" indicator more visible. Previously, projects and sessions with unseen changes were only distinguished by **bold title text**, which is easy to miss.

This adds a brand-colored dot next to the chevron in each tile's trailing area, shown only when the item is `unseen`. The bold title styling is kept — the dot reinforces it.

## Changes

- `project_tile.dart` — trailing chevron wrapped in a `Row`; a `bgBrandSolid` dot precedes it when `unseen`.
- `session_tile.dart` — same treatment.

Color comes from the Prego design token `colors.bgBrandSolid` (consistent with the existing "active session" dot).

## Testing

- `dart analyze` clean on both feature dirs
- Existing `project_list` / `session_list` widget tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a brand-colored dot to project and session tiles to highlight unseen updates. The dot appears next to the chevron only when unseen; seen tiles show only the chevron, and the dot uses `prego.colors.bgBrandSolid` for consistency.

<sup>Written for commit 506bdb5fc665076cd6303d35338ab144327addbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

