### PR TITLE
fix(bridge): scope codex commands and model defaults to the selected derived project

### DIFF
--- a/bridge/sesori_plugin_codex/lib/codex_plugin.dart
+++ b/bridge/sesori_plugin_codex/lib/codex_plugin.dart
@@ -8,6 +8,7 @@ export "src/approval_registry.dart";
 export "src/codex_app_server_client.dart";
 export "src/codex_config_reader.dart";
 export "src/codex_event_mapper.dart";
+export "src/codex_metadata_repository.dart";
 export "src/codex_plugin_impl.dart";
 export "src/codex_skill_reader.dart";
 // Runtime lifecycle: the descriptor is the public entry point the bridge

--- a/bridge/sesori_plugin_codex/lib/src/codex_metadata_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_metadata_repository.dart
@@ -84,4 +84,22 @@ class CodexMetadataRepository {
       providerID: latest?.modelProvider ?? config.modelProvider ?? "openai",
     );
   }
+
+  /// Selects the picker's preselected model for a project given the live
+  /// catalog: the project's own most recent model (the [resolveModelDefaults]
+  /// result) wins when it is still in the catalog — keeping the provider
+  /// picker consistent with the project-scoped default the agent list
+  /// resolves — then codex's live default, then the first catalog model.
+  /// Returns null only for an empty catalog.
+  String? selectCatalogDefaultModel({
+    required String? scopedModelID,
+    required List<String> catalogModelIds,
+    required String? catalogDefaultId,
+  }) {
+    if (scopedModelID != null && catalogModelIds.contains(scopedModelID)) {
+      return scopedModelID;
+    }
+    if (catalogDefaultId != null) return catalogDefaultId;
+    return catalogModelIds.isEmpty ? null : catalogModelIds.first;
+  }
 }

--- a/bridge/sesori_plugin_codex/lib/src/codex_metadata_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_metadata_repository.dart
@@ -1,3 +1,4 @@
+import "package:path/path.dart" as p;
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show normalizeProjectDirectory;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginCommand, PluginCommandSource;
 
@@ -55,7 +56,14 @@ class CodexMetadataRepository {
   /// then the global `config.toml`, then `openai` as a last-resort provider.
   /// Sessions are matched to the project by their normalized cwd — a record
   /// with no cwd falls back to the launch directory, the same grouping rule
-  /// the session listing uses.
+  /// the session listing uses. A session running in a subdirectory of the
+  /// project also counts as the project's: the bridge runs dedicated-worktree
+  /// sessions inside the project tree (`<project>/.worktrees/<name>`) while
+  /// attributing them to the parent project, so a strict-equality match would
+  /// skip the project's newest sessions and hand back stale defaults. The
+  /// within-tree rule intentionally avoids coupling to the bridge's worktree
+  /// naming; a nested distinct project matching its outer project too is an
+  /// accepted trade-off for a "most recent model in this project" heuristic.
   ({String? modelID, String providerID}) resolveModelDefaults({
     required String projectId,
   }) {
@@ -66,7 +74,7 @@ class CodexMetadataRepository {
     // project's most recent session.
     for (final record in _rolloutReader.listSessions()) {
       final directory = normalizeProjectDirectory(directory: record.cwd ?? _launchDirectory);
-      if (directory == target) {
+      if (directory == target || p.isWithin(target, directory)) {
         latest = record;
         break;
       }

--- a/bridge/sesori_plugin_codex/lib/src/codex_metadata_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_metadata_repository.dart
@@ -1,0 +1,79 @@
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show normalizeProjectDirectory;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginCommand, PluginCommandSource;
+
+import "codex_config_reader.dart";
+import "codex_skill_reader.dart";
+import "session_rollout_reader.dart";
+
+/// Project-scoped codex metadata: slash commands (skills) and model/provider
+/// defaults.
+///
+/// codex is a bridge-derived-projects backend, so a project id handed to the
+/// plugin IS the normalized project directory. Everything here is resolved
+/// against that directory — a derived project outside the launch cwd gets its
+/// own `.codex/skills` and its own most-recent-session model defaults instead
+/// of inheriting the launch project's.
+class CodexMetadataRepository {
+  CodexMetadataRepository({
+    required CodexSkillReader skillReader,
+    required SessionRolloutReader rolloutReader,
+    required CodexConfigReader configReader,
+    required String launchDirectory,
+  }) : _skillReader = skillReader,
+       _rolloutReader = rolloutReader,
+       _configReader = configReader,
+       _launchDirectory = launchDirectory;
+
+  final CodexSkillReader _skillReader;
+  final SessionRolloutReader _rolloutReader;
+  final CodexConfigReader _configReader;
+  final String _launchDirectory;
+
+  /// The slash commands (codex skills) available to [projectId]'s project:
+  /// user-level skills plus that project directory's own `.codex/skills`.
+  ///
+  /// A null [projectId] comes from the deprecated project-less commands route
+  /// and falls back to the launch directory.
+  List<PluginCommand> getCommands({required String? projectId}) {
+    final target = normalizeProjectDirectory(directory: projectId ?? _launchDirectory);
+    final skills = _skillReader.list(projectCwd: target);
+    return [
+      for (final skill in skills)
+        PluginCommand(
+          name: skill.name,
+          description: skill.description.isEmpty ? null : skill.description,
+          source: PluginCommandSource.skill,
+          provider: null,
+        ),
+    ];
+  }
+
+  /// Resolves the model/provider defaults for [projectId]'s project.
+  ///
+  /// Codex exposes no agent/provider API, so this derives from local state:
+  /// the project's most recent session rollout (per-session accurate) wins,
+  /// then the global `config.toml`, then `openai` as a last-resort provider.
+  /// Sessions are matched to the project by their normalized cwd — a record
+  /// with no cwd falls back to the launch directory, the same grouping rule
+  /// the session listing uses.
+  ({String? modelID, String providerID}) resolveModelDefaults({
+    required String projectId,
+  }) {
+    final config = _configReader.readDefaults();
+    final target = normalizeProjectDirectory(directory: projectId);
+    CodexSessionRecord? latest;
+    // listSessions() is sorted newest-first, so the first match is the
+    // project's most recent session.
+    for (final record in _rolloutReader.listSessions()) {
+      final directory = normalizeProjectDirectory(directory: record.cwd ?? _launchDirectory);
+      if (directory == target) {
+        latest = record;
+        break;
+      }
+    }
+    return (
+      modelID: latest?.model ?? config.model,
+      providerID: latest?.modelProvider ?? config.modelProvider ?? "openai",
+    );
+  }
+}

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -895,6 +895,11 @@ class CodexPlugin implements CodexManagedApi {
         );
       }
       if (pluginModels.isNotEmpty) {
+        final defaultModelID = _metadataRepository.selectCatalogDefaultModel(
+          scopedModelID: modelID,
+          catalogModelIds: [for (final model in pluginModels) model.id],
+          catalogDefaultId: defaultId,
+        );
         return PluginProvidersResult(
           providers: [
             PluginProvider.custom(
@@ -902,7 +907,9 @@ class CodexPlugin implements CodexManagedApi {
               name: _providerDisplayName(providerID),
               authType: PluginProviderAuthType.unknown,
               models: pluginModels,
-              defaultModelID: defaultId ?? modelID ?? pluginModels.first.id,
+              // Non-null: the catalog is non-empty here, so the repository
+              // always resolves at least the first catalog model.
+              defaultModelID: defaultModelID ?? pluginModels.first.id,
             ),
           ],
         );

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -8,6 +8,7 @@ import "approval_registry.dart";
 import "codex_app_server_client.dart";
 import "codex_config_reader.dart";
 import "codex_event_mapper.dart";
+import "codex_metadata_repository.dart";
 import "codex_skill_reader.dart";
 import "runtime/codex_managed_api.dart";
 import "session_rollout_reader.dart";
@@ -41,7 +42,7 @@ class CodexPlugin implements CodexManagedApi {
   final CodexAppServerClient Function()? _clientFactory;
   final SessionRolloutReader _rolloutReader;
   final CodexConfigReader _configReader;
-  final CodexSkillReader _skillReader;
+  final CodexMetadataRepository _metadataRepository;
   final CodexEventMapper _eventMapper;
   final String _projectCwd;
   final Duration _keepaliveInterval;
@@ -101,7 +102,7 @@ class CodexPlugin implements CodexManagedApi {
     CodexAppServerClient Function()? clientFactory,
     SessionRolloutReader? rolloutReader,
     CodexConfigReader? configReader,
-    CodexSkillReader? skillReader,
+    CodexMetadataRepository? metadataRepository,
     CodexEventMapper? eventMapper,
     String? projectCwd,
     void Function()? onConnected,
@@ -110,16 +111,25 @@ class CodexPlugin implements CodexManagedApi {
   }) {
     final resolvedProjectCwd = projectCwd ?? Directory.current.path;
     final resolvedConfigReader = configReader ?? CodexConfigReader();
+    final resolvedRolloutReader = rolloutReader ?? SessionRolloutReader();
     return CodexPlugin._(
       serverUrl: serverUrl,
       capabilityToken: capabilityToken,
       // When null, [_ensureConnected] builds the default client so it can wire
       // the client's `onDisconnected` through [_handleClientDisconnected].
       clientFactory: clientFactory,
-      rolloutReader: rolloutReader ?? SessionRolloutReader(),
+      rolloutReader: resolvedRolloutReader,
       configReader: resolvedConfigReader,
-      skillReader:
-          skillReader ?? CodexSkillReader(projectCwd: resolvedProjectCwd),
+      // Shares the plugin's own rollout/config readers so both resolve project
+      // metadata from the same codex home.
+      metadataRepository:
+          metadataRepository ??
+          CodexMetadataRepository(
+            skillReader: CodexSkillReader(),
+            rolloutReader: resolvedRolloutReader,
+            configReader: resolvedConfigReader,
+            launchDirectory: resolvedProjectCwd,
+          ),
       eventMapper:
           eventMapper ??
           CodexEventMapper(
@@ -139,7 +149,7 @@ class CodexPlugin implements CodexManagedApi {
     required CodexAppServerClient Function()? clientFactory,
     required SessionRolloutReader rolloutReader,
     required CodexConfigReader configReader,
-    required CodexSkillReader skillReader,
+    required CodexMetadataRepository metadataRepository,
     required CodexEventMapper eventMapper,
     required String projectCwd,
     void Function()? onConnected,
@@ -151,7 +161,7 @@ class CodexPlugin implements CodexManagedApi {
        _clientFactory = clientFactory,
        _rolloutReader = rolloutReader,
        _configReader = configReader,
-       _skillReader = skillReader,
+       _metadataRepository = metadataRepository,
        _eventMapper = eventMapper,
        _projectCwd = projectCwd,
        _onConnected = onConnected,
@@ -394,18 +404,8 @@ class CodexPlugin implements CodexManagedApi {
   @override
   Future<List<PluginCommand>> getCommands({
     required String? projectId,
-  }) async {
-    final skills = _skillReader.list();
-    return [
-      for (final skill in skills)
-        PluginCommand(
-          name: skill.name,
-          description: skill.description.isEmpty ? null : skill.description,
-          source: PluginCommandSource.skill,
-          provider: null,
-        ),
-    ];
-  }
+  }) async =>
+      _metadataRepository.getCommands(projectId: projectId);
 
   @override
   Future<PluginSession> createSession({
@@ -773,7 +773,8 @@ class CodexPlugin implements CodexManagedApi {
 
   @override
   Future<List<PluginAgent>> getAgents({required String projectId}) async {
-    final (:modelID, :providerID) = _resolveModelDefaults();
+    final (:modelID, :providerID) =
+        _metadataRepository.resolveModelDefaults(projectId: projectId);
     return [
       PluginAgent(
         name: "codex",
@@ -789,21 +790,6 @@ class CodexPlugin implements CodexManagedApi {
         hidden: false,
       ),
     ];
-  }
-
-  /// Resolves the configured model/provider for codex.
-  ///
-  /// Codex exposes no agent/provider API, so we derive it from local state:
-  /// the most recent session's rollout (per-session accurate) wins, then the
-  /// global `config.toml`, then `openai` as a last-resort provider.
-  ({String? modelID, String providerID}) _resolveModelDefaults() {
-    final config = _configReader.readDefaults();
-    final sessions = _rolloutReader.listSessions();
-    final latest = sessions.isEmpty ? null : sessions.first;
-    return (
-      modelID: latest?.model ?? config.model,
-      providerID: latest?.modelProvider ?? config.modelProvider ?? "openai",
-    );
   }
 
   static String _providerDisplayName(String providerId) {
@@ -882,7 +868,8 @@ class CodexPlugin implements CodexManagedApi {
 
   @override
   Future<PluginProvidersResult> getProviders({required String projectId}) async {
-    final (:modelID, :providerID) = _resolveModelDefaults();
+    final (:modelID, :providerID) =
+        _metadataRepository.resolveModelDefaults(projectId: projectId);
 
     // Prefer codex's live catalog (`model/list`) so the mobile picker shows
     // every model the user can switch to, not just the configured default.

--- a/bridge/sesori_plugin_codex/lib/src/codex_skill_reader.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_skill_reader.dart
@@ -24,16 +24,16 @@ enum CodexSkillSource { user, project }
 /// Codex stores skills as `<dir>/<slug>/SKILL.md` with a YAML frontmatter
 /// block carrying `name:` and `description:`. Two locations are scanned:
 ///   - User-level: `$CODEX_HOME/skills` (defaults to `~/.codex/skills`).
-///   - Project-local: `<projectCwd>/.codex/skills`.
+///   - Project-local: `<projectCwd>/.codex/skills`, where the caller supplies
+///     the project directory per call — skills are project-scoped, so the
+///     reader must not bake in any single project.
 ///
 /// Project-local skills win when names collide.
 class CodexSkillReader {
-  CodexSkillReader({Map<String, String>? environment, String? projectCwd})
-    : _environment = environment ?? Platform.environment,
-      _projectCwd = projectCwd;
+  CodexSkillReader({Map<String, String>? environment})
+    : _environment = environment ?? Platform.environment;
 
   final Map<String, String> _environment;
-  final String? _projectCwd;
 
   String? get _codexHome {
     final explicit = _environment["CODEX_HOME"];
@@ -43,13 +43,12 @@ class CodexSkillReader {
     return p.join(home, ".codex");
   }
 
-  List<CodexSkill> list() {
+  List<CodexSkill> list({required String? projectCwd}) {
     final out = <String, CodexSkill>{};
     final userRoot = _codexHome;
     if (userRoot != null) {
       _scan(p.join(userRoot, "skills"), CodexSkillSource.user, out);
     }
-    final projectCwd = _projectCwd;
     if (projectCwd != null) {
       _scan(
         p.join(projectCwd, ".codex", "skills"),

--- a/bridge/sesori_plugin_codex/test/codex_metadata_repository_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_metadata_repository_test.dart
@@ -209,6 +209,44 @@ void main() {
         expect(defaults.providerID, equals("openai"));
       });
     });
+
+    group("selectCatalogDefaultModel", () {
+      test("the project-scoped model wins over the catalog default when in the catalog", () {
+        final selected = newRepository().selectCatalogDefaultModel(
+          scopedModelID: "gpt-5.4-mini",
+          catalogModelIds: ["gpt-5.5", "gpt-5.4-mini"],
+          catalogDefaultId: "gpt-5.5",
+        );
+        expect(selected, equals("gpt-5.4-mini"));
+      });
+
+      test("a scoped model missing from the catalog falls back to the catalog default", () {
+        final selected = newRepository().selectCatalogDefaultModel(
+          scopedModelID: "retired-model",
+          catalogModelIds: ["gpt-5.5", "gpt-5.4-mini"],
+          catalogDefaultId: "gpt-5.5",
+        );
+        expect(selected, equals("gpt-5.5"));
+      });
+
+      test("no scoped model and no catalog default falls back to the first catalog model", () {
+        final selected = newRepository().selectCatalogDefaultModel(
+          scopedModelID: null,
+          catalogModelIds: ["gpt-5.5", "gpt-5.4-mini"],
+          catalogDefaultId: null,
+        );
+        expect(selected, equals("gpt-5.5"));
+      });
+
+      test("an empty catalog resolves to null", () {
+        final selected = newRepository().selectCatalogDefaultModel(
+          scopedModelID: "gpt-5.5",
+          catalogModelIds: const [],
+          catalogDefaultId: null,
+        );
+        expect(selected, isNull);
+      });
+    });
   });
 }
 

--- a/bridge/sesori_plugin_codex/test/codex_metadata_repository_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_metadata_repository_test.dart
@@ -1,0 +1,224 @@
+import "dart:convert";
+import "dart:io";
+
+import "package:codex_plugin/codex_plugin.dart";
+import "package:path/path.dart" as p;
+import "package:test/test.dart";
+
+void main() {
+  group("CodexMetadataRepository", () {
+    late Directory codexHome;
+    late Directory launchProject;
+    late Directory otherProject;
+
+    setUp(() {
+      codexHome = Directory.systemTemp.createTempSync("codex-home-meta-");
+      launchProject = Directory.systemTemp.createTempSync("codex-launch-meta-");
+      otherProject = Directory.systemTemp.createTempSync("codex-other-meta-");
+    });
+
+    tearDown(() {
+      for (final dir in [codexHome, launchProject, otherProject]) {
+        try {
+          dir.deleteSync(recursive: true);
+        } catch (_) {}
+      }
+    });
+
+    CodexMetadataRepository newRepository() => CodexMetadataRepository(
+      skillReader: CodexSkillReader(
+        environment: {"CODEX_HOME": codexHome.path},
+      ),
+      rolloutReader: SessionRolloutReader(
+        environment: {"CODEX_HOME": codexHome.path},
+      ),
+      configReader: CodexConfigReader(
+        environment: {"CODEX_HOME": codexHome.path},
+      ),
+      launchDirectory: launchProject.path,
+    );
+
+    group("getCommands", () {
+      test("scopes project-local skills to the selected project directory", () {
+        _writeSkill(codexHome, "skills/shared/SKILL.md", name: "shared");
+        _writeSkill(
+          launchProject,
+          ".codex/skills/launch-only/SKILL.md",
+          name: "launch-only",
+        );
+        _writeSkill(
+          otherProject,
+          ".codex/skills/other-only/SKILL.md",
+          name: "other-only",
+        );
+
+        final repository = newRepository();
+        expect(
+          repository
+              .getCommands(projectId: launchProject.path)
+              .map((c) => c.name)
+              .toList(),
+          equals(["launch-only", "shared"]),
+        );
+        expect(
+          repository
+              .getCommands(projectId: otherProject.path)
+              .map((c) => c.name)
+              .toList(),
+          equals(["other-only", "shared"]),
+        );
+      });
+
+      test("null projectId falls back to the launch directory", () {
+        _writeSkill(
+          launchProject,
+          ".codex/skills/launch-only/SKILL.md",
+          name: "launch-only",
+        );
+
+        final commands = newRepository().getCommands(projectId: null);
+        expect(commands.map((c) => c.name).toList(), equals(["launch-only"]));
+      });
+
+      test("empty skill descriptions map to null", () {
+        _writeSkill(
+          launchProject,
+          ".codex/skills/terse/SKILL.md",
+          name: "terse",
+          description: "",
+        );
+
+        final command = newRepository()
+            .getCommands(projectId: launchProject.path)
+            .single;
+        expect(command.description, isNull);
+      });
+    });
+
+    group("resolveModelDefaults", () {
+      test("the selected project's own latest rollout wins over a newer rollout elsewhere", () {
+        _writeRollout(
+          codexHome,
+          id: "019a0000-1111-2222-3333-aaaaaaaaaaaa",
+          timestamp: "2026-06-01T10:00:00Z",
+          cwd: launchProject.path,
+          modelProvider: "openai",
+          model: "gpt-5.4-codex",
+        );
+        // Newer, but in a different derived project.
+        _writeRollout(
+          codexHome,
+          id: "019a0000-1111-2222-3333-bbbbbbbbbbbb",
+          timestamp: "2026-06-02T10:00:00Z",
+          cwd: otherProject.path,
+          modelProvider: "anthropic",
+          model: "claude-x",
+        );
+
+        final repository = newRepository();
+        final launchDefaults =
+            repository.resolveModelDefaults(projectId: launchProject.path);
+        expect(launchDefaults.modelID, equals("gpt-5.4-codex"));
+        expect(launchDefaults.providerID, equals("openai"));
+
+        final otherDefaults =
+            repository.resolveModelDefaults(projectId: otherProject.path);
+        expect(otherDefaults.modelID, equals("claude-x"));
+        expect(otherDefaults.providerID, equals("anthropic"));
+      });
+
+      test("a rollout without a cwd groups under the launch directory", () {
+        _writeRollout(
+          codexHome,
+          id: "019a0000-1111-2222-3333-aaaaaaaaaaaa",
+          timestamp: "2026-06-01T10:00:00Z",
+          cwd: null,
+          modelProvider: "openai",
+          model: "gpt-5.4-codex",
+        );
+
+        final defaults = newRepository()
+            .resolveModelDefaults(projectId: launchProject.path);
+        expect(defaults.modelID, equals("gpt-5.4-codex"));
+      });
+
+      test("a project with no sessions falls back to config.toml", () {
+        File(p.join(codexHome.path, "config.toml")).writeAsStringSync(
+          'model = "gpt-5.5"\nmodel_provider = "azure"\n',
+        );
+        _writeRollout(
+          codexHome,
+          id: "019a0000-1111-2222-3333-bbbbbbbbbbbb",
+          timestamp: "2026-06-02T10:00:00Z",
+          cwd: otherProject.path,
+          modelProvider: "anthropic",
+          model: "claude-x",
+        );
+
+        final defaults = newRepository()
+            .resolveModelDefaults(projectId: launchProject.path);
+        expect(defaults.modelID, equals("gpt-5.5"));
+        expect(defaults.providerID, equals("azure"));
+      });
+
+      test("no sessions and no config resolves to a null model and openai", () {
+        final defaults = newRepository()
+            .resolveModelDefaults(projectId: launchProject.path);
+        expect(defaults.modelID, isNull);
+        expect(defaults.providerID, equals("openai"));
+      });
+    });
+  });
+}
+
+void _writeSkill(
+  Directory root,
+  String relPath, {
+  required String name,
+  String description = "A skill",
+}) {
+  final full = p.join(root.path, relPath);
+  Directory(p.dirname(full)).createSync(recursive: true);
+  File(full).writeAsStringSync(
+    [
+      "---",
+      "name: $name",
+      if (description.isNotEmpty) "description: $description",
+      "---",
+      "",
+      "Body.",
+    ].join("\n"),
+  );
+}
+
+void _writeRollout(
+  Directory codexHome, {
+  required String id,
+  required String timestamp,
+  required String? cwd,
+  required String modelProvider,
+  required String model,
+}) {
+  final day = timestamp.substring(0, 10).replaceAll("-", "/");
+  final stamp = timestamp.replaceAll(":", "-").substring(0, 19);
+  final full = p.join(
+    codexHome.path,
+    "sessions/$day/rollout-$stamp-$id.jsonl",
+  );
+  Directory(p.dirname(full)).createSync(recursive: true);
+  File(full).writeAsStringSync(
+    "${jsonEncode({
+      "type": "session_meta",
+      "payload": {
+        "id": id,
+        "timestamp": timestamp,
+        "cwd": ?cwd,
+        "model_provider": modelProvider,
+      },
+    })}\n"
+    "${jsonEncode({
+      "type": "turn_context",
+      "payload": {"model": model},
+    })}\n",
+  );
+}

--- a/bridge/sesori_plugin_codex/test/codex_metadata_repository_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_metadata_repository_test.dart
@@ -127,6 +127,47 @@ void main() {
         expect(otherDefaults.providerID, equals("anthropic"));
       });
 
+      test("a newer dedicated-worktree session inside the project tree wins the parent project's defaults", () {
+        _writeRollout(
+          codexHome,
+          id: "019a0000-1111-2222-3333-aaaaaaaaaaaa",
+          timestamp: "2026-06-01T10:00:00Z",
+          cwd: launchProject.path,
+          modelProvider: "openai",
+          model: "gpt-5.4-codex",
+        );
+        // The bridge runs dedicated-worktree sessions in a subdirectory of the
+        // project while attributing them to the parent project.
+        _writeRollout(
+          codexHome,
+          id: "019a0000-1111-2222-3333-bbbbbbbbbbbb",
+          timestamp: "2026-06-02T10:00:00Z",
+          cwd: p.join(launchProject.path, ".worktrees", "feature-x"),
+          modelProvider: "openai",
+          model: "gpt-5.5",
+        );
+
+        final defaults = newRepository()
+            .resolveModelDefaults(projectId: launchProject.path);
+        expect(defaults.modelID, equals("gpt-5.5"));
+      });
+
+      test("a worktree session does not leak into an unrelated project's defaults", () {
+        _writeRollout(
+          codexHome,
+          id: "019a0000-1111-2222-3333-bbbbbbbbbbbb",
+          timestamp: "2026-06-02T10:00:00Z",
+          cwd: p.join(launchProject.path, ".worktrees", "feature-x"),
+          modelProvider: "openai",
+          model: "gpt-5.5",
+        );
+
+        final defaults = newRepository()
+            .resolveModelDefaults(projectId: otherProject.path);
+        expect(defaults.modelID, isNull);
+        expect(defaults.providerID, equals("openai"));
+      });
+
       test("a rollout without a cwd groups under the launch directory", () {
         _writeRollout(
           codexHome,

--- a/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
@@ -47,19 +47,25 @@ void main() {
     test("read methods return empty when no codex history exists", () async {
       final tempHome = Directory.systemTemp.createTempSync("codex-home-stub-");
       try {
+        // Hermetic readers so the user's real ~/.codex/ doesn't leak into
+        // this test.
+        final rolloutReader = SessionRolloutReader(
+          environment: {"CODEX_HOME": tempHome.path},
+        );
+        final configReader = CodexConfigReader(
+          environment: {"CODEX_HOME": tempHome.path},
+        );
         final plugin = CodexPlugin(
           serverUrl: "ws://127.0.0.1:0",
-          rolloutReader: SessionRolloutReader(
-            environment: {"CODEX_HOME": tempHome.path},
-          ),
-          // Hermetic config/skill readers so the user's real ~/.codex/
-          // doesn't leak into this test.
-          configReader: CodexConfigReader(
-            environment: {"CODEX_HOME": tempHome.path},
-          ),
-          skillReader: CodexSkillReader(
-            environment: {"CODEX_HOME": tempHome.path},
-            projectCwd: tempHome.path,
+          rolloutReader: rolloutReader,
+          configReader: configReader,
+          metadataRepository: CodexMetadataRepository(
+            skillReader: CodexSkillReader(
+              environment: {"CODEX_HOME": tempHome.path},
+            ),
+            rolloutReader: rolloutReader,
+            configReader: configReader,
+            launchDirectory: "/repo/example",
           ),
           projectCwd: "/repo/example",
         );
@@ -86,7 +92,7 @@ void main() {
       }
     });
 
-    test("getAgents/getProviders synthesise from config + latest rollout", () async {
+    test("getAgents/getProviders synthesise from config + the project's own latest rollout", () async {
       final tempHome = Directory.systemTemp.createTempSync("codex-home-syn-");
       try {
         File(p.join(tempHome.path, "config.toml"))
@@ -112,18 +118,45 @@ void main() {
             "payload": {"model": "gpt-5.4-codex"},
           })}\n",
         );
+        // A NEWER rollout in a different derived project — it must not leak
+        // into /repo/example's defaults.
+        final otherRollout = File(p.join(
+          tempHome.path,
+          "sessions/2026/05/28/rollout-2026-05-28T10-00-00-019a0000-1111-2222-3333-cccccccccccc.jsonl",
+        ))..createSync(recursive: true);
+        otherRollout.writeAsStringSync(
+          "${jsonEncode({
+            "type": "session_meta",
+            "payload": {
+              "id": "019a0000-1111-2222-3333-cccccccccccc",
+              "timestamp": "2026-05-28T10:00:00Z",
+              "cwd": "/repo/other",
+              "model_provider": "anthropic",
+            },
+          })}\n"
+          "${jsonEncode({
+            "type": "turn_context",
+            "payload": {"model": "claude-x"},
+          })}\n",
+        );
 
+        final rolloutReader = SessionRolloutReader(
+          environment: {"CODEX_HOME": tempHome.path},
+        );
+        final configReader = CodexConfigReader(
+          environment: {"CODEX_HOME": tempHome.path},
+        );
         final plugin = CodexPlugin(
           serverUrl: "ws://127.0.0.1:0",
-          rolloutReader: SessionRolloutReader(
-            environment: {"CODEX_HOME": tempHome.path},
-          ),
-          configReader: CodexConfigReader(
-            environment: {"CODEX_HOME": tempHome.path},
-          ),
-          skillReader: CodexSkillReader(
-            environment: {"CODEX_HOME": tempHome.path},
-            projectCwd: tempHome.path,
+          rolloutReader: rolloutReader,
+          configReader: configReader,
+          metadataRepository: CodexMetadataRepository(
+            skillReader: CodexSkillReader(
+              environment: {"CODEX_HOME": tempHome.path},
+            ),
+            rolloutReader: rolloutReader,
+            configReader: configReader,
+            launchDirectory: "/repo/example",
           ),
           projectCwd: "/repo/example",
         );
@@ -137,6 +170,16 @@ void main() {
             (await plugin.getProviders(projectId: "/repo/example")).providers;
         expect(providers.single.id, equals("openai"));
         expect(providers.single.defaultModelID, equals("gpt-5.4-codex"));
+
+        // The other derived project resolves its own rollout's defaults.
+        final otherAgent = (await plugin.getAgents(projectId: "/repo/other")).single;
+        expect(otherAgent.model?.modelID, equals("claude-x"));
+        expect(otherAgent.model?.providerID, equals("anthropic"));
+
+        // A project with no sessions falls back to the global config.toml.
+        final freshAgent = (await plugin.getAgents(projectId: "/repo/fresh")).single;
+        expect(freshAgent.model?.modelID, equals("gpt-5.5"));
+        expect(freshAgent.model?.providerID, equals("openai"));
         await plugin.dispose();
       } finally {
         try {

--- a/bridge/sesori_plugin_codex/test/codex_plugin_phase6_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_phase6_test.dart
@@ -30,17 +30,26 @@ void main() {
       } catch (_) {}
     });
 
-    CodexPlugin newPlugin() => CodexPlugin(
-      serverUrl: "ws://127.0.0.1:0",
-      rolloutReader: SessionRolloutReader(
+    CodexPlugin newPlugin() {
+      final rolloutReader = SessionRolloutReader(
         environment: {"CODEX_HOME": codexHome.path},
-      ),
-      skillReader: CodexSkillReader(
-        environment: {"CODEX_HOME": codexHome.path},
+      );
+      return CodexPlugin(
+        serverUrl: "ws://127.0.0.1:0",
+        rolloutReader: rolloutReader,
+        metadataRepository: CodexMetadataRepository(
+          skillReader: CodexSkillReader(
+            environment: {"CODEX_HOME": codexHome.path},
+          ),
+          rolloutReader: rolloutReader,
+          configReader: CodexConfigReader(
+            environment: {"CODEX_HOME": codexHome.path},
+          ),
+          launchDirectory: projectCwd.path,
+        ),
         projectCwd: projectCwd.path,
-      ),
-      projectCwd: projectCwd.path,
-    );
+      );
+    }
 
     test("getCommands enumerates codex skills as PluginCommand(source=skill)", () async {
       _writeSkill(
@@ -62,6 +71,34 @@ void main() {
       for (final cmd in commands) {
         expect(cmd.source, equals(PluginCommandSource.skill));
       }
+      await plugin.dispose();
+    });
+
+    test("getCommands scopes project-local skills to the selected derived project", () async {
+      _writeSkill(
+        projectCwd,
+        ".codex/skills/launch-only/SKILL.md",
+        name: "launch-only",
+        description: "Launch project skill",
+      );
+      final otherProject = Directory.systemTemp.createTempSync("codex-other-p6-");
+      addTearDown(() {
+        try {
+          otherProject.deleteSync(recursive: true);
+        } catch (_) {}
+      });
+      _writeSkill(
+        otherProject,
+        ".codex/skills/other-only/SKILL.md",
+        name: "other-only",
+        description: "Derived project skill",
+      );
+
+      final plugin = newPlugin();
+      // A derived project outside the launch directory sees its own project-
+      // local skills, not the launch project's.
+      final commands = await plugin.getCommands(projectId: otherProject.path);
+      expect(commands.map((c) => c.name).toList(), equals(["other-only"]));
       await plugin.dispose();
     });
 

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -8,6 +8,7 @@ import "dart:convert";
 import "dart:io";
 
 import "package:codex_plugin/codex_plugin.dart";
+import "package:path/path.dart" as p;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 import "package:web_socket_channel/web_socket_channel.dart";
@@ -418,6 +419,75 @@ void main() {
       // A model without supportedReasoningEfforts exposes no variants.
       expect(provider.models[1].variants, isEmpty);
       expect(fake.sentMethods, contains("model/list"));
+    });
+
+    test("getProviders preselects the project's own latest rollout model over codex's live default", () async {
+      // The selected project's newest rollout used gpt-5.4-mini, while codex's
+      // live catalog marks gpt-5.5 as the global default — the project-scoped
+      // model must win the picker preselection.
+      final rollout = File(
+        p.join(
+          codexHome.path,
+          "sessions/2026/06/01/rollout-2026-06-01T10-00-00-019a0000-1111-2222-3333-dddddddddddd.jsonl",
+        ),
+      )..createSync(recursive: true);
+      rollout.writeAsStringSync(
+        "${jsonEncode({
+          "type": "session_meta",
+          "payload": {
+            "id": "019a0000-1111-2222-3333-dddddddddddd",
+            "timestamp": "2026-06-01T10:00:00Z",
+            "cwd": "/work/sample",
+            "model_provider": "openai",
+          },
+        })}\n"
+        "${jsonEncode({
+          "type": "turn_context",
+          "payload": {"model": "gpt-5.4-mini"},
+        })}\n",
+      );
+      final scopedFake = _FakeAppServer();
+      final rolloutReader = SessionRolloutReader(
+        environment: {"CODEX_HOME": codexHome.path},
+      );
+      final configReader = CodexConfigReader(
+        environment: {"CODEX_HOME": codexHome.path},
+      );
+      final scopedPlugin = CodexPlugin(
+        serverUrl: "ws://127.0.0.1:0",
+        clientFactory: () => CodexAppServerClient(
+          serverUrl: "ws://127.0.0.1:0",
+          channelFactory: (_) => scopedFake.channel,
+        ),
+        rolloutReader: rolloutReader,
+        configReader: configReader,
+        metadataRepository: CodexMetadataRepository(
+          skillReader: CodexSkillReader(
+            environment: {"CODEX_HOME": codexHome.path},
+          ),
+          rolloutReader: rolloutReader,
+          configReader: configReader,
+          launchDirectory: "/work/sample",
+        ),
+        projectCwd: "/work/sample",
+      );
+      addTearDown(scopedPlugin.dispose);
+      scopedFake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "data": [
+              {"id": "gpt-5.5", "displayName": "GPT-5.5", "hidden": false, "isDefault": true},
+              {"id": "gpt-5.4-mini", "displayName": "GPT-5.4 mini", "hidden": false, "isDefault": false},
+            ],
+          },
+        ),
+      ]);
+
+      await scopedPlugin.healthCheck(); // connect so model/list can be called
+      final result = await scopedPlugin.getProviders(projectId: "/work/sample");
+
+      expect(result.providers.single.defaultModelID, equals("gpt-5.4-mini"));
     });
 
     test("sendPrompt forwards the selected variant as the turn/start effort", () async {

--- a/bridge/sesori_plugin_codex/test/codex_skill_reader_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_skill_reader_test.dart
@@ -39,10 +39,9 @@ void main() {
 
       final reader = CodexSkillReader(
         environment: {"CODEX_HOME": codexHome.path},
-        projectCwd: projectCwd.path,
       );
 
-      final skills = reader.list();
+      final skills = reader.list(projectCwd: projectCwd.path);
       expect(skills.map((s) => s.name).toList(), equals(["plan", "ralph"]));
       expect(skills.first.description, equals("Strategic planning workflow"));
       expect(skills.first.source, equals(CodexSkillSource.user));
@@ -64,10 +63,9 @@ void main() {
 
       final reader = CodexSkillReader(
         environment: {"CODEX_HOME": codexHome.path},
-        projectCwd: projectCwd.path,
       );
 
-      final skills = reader.list();
+      final skills = reader.list(projectCwd: projectCwd.path);
       expect(skills, hasLength(1));
       expect(skills.single.description, equals("project-local override"));
       expect(skills.single.source, equals(CodexSkillSource.project));
@@ -83,10 +81,9 @@ void main() {
 
       final reader = CodexSkillReader(
         environment: {"CODEX_HOME": codexHome.path},
-        projectCwd: projectCwd.path,
       );
 
-      final skills = reader.list();
+      final skills = reader.list(projectCwd: projectCwd.path);
       expect(skills.single.name, equals("no-name"));
       expect(skills.single.description, equals("just-a-description"));
     });
@@ -105,10 +102,9 @@ void main() {
 
         final reader = CodexSkillReader(
           environment: {"CODEX_HOME": codexHome.path},
-          projectCwd: projectCwd.path,
         );
 
-        expect(reader.list(), isEmpty);
+        expect(reader.list(projectCwd: projectCwd.path), isEmpty);
       },
     );
   });

--- a/client/module_core/lib/src/services/session_detail_load_service.dart
+++ b/client/module_core/lib/src/services/session_detail_load_service.dart
@@ -43,13 +43,13 @@ class SessionDetailLoadService {
       final projectContextFuture = _loadProjectSessionContext(sessionId: sessionId);
       final commandsFuture = routeProjectId == null ? null : _listCommands(projectId: routeProjectId);
       final agentsFuture = routeProjectId == null ? null : _listAgents(projectId: routeProjectId);
+      final providersFuture = routeProjectId == null ? null : _listProviders(projectId: routeProjectId);
       final (
         messagesResponse,
         questionsResponse,
         permissionsResponse,
         childrenResponse,
         statusesResponse,
-        providersResponse,
         sessionResponse,
       ) = await (
         _repository.getMessages(sessionId: sessionId),
@@ -57,15 +57,15 @@ class SessionDetailLoadService {
         _repository.getPendingPermissions(sessionId: sessionId),
         _repository.getChildren(sessionId: sessionId),
         _repository.getSessionStatuses(),
-        _repository.listProviders(projectId: projectId),
         _repository.getSession(sessionId: sessionId),
       ).wait;
       final projectContext = await projectContextFuture;
       final effectiveProjectId = routeProjectId ?? projectContext?.projectId;
       // When the route carries no project id, resolve it from the session
-      // context so agents and commands are still project-scoped.
+      // context so agents, commands, and providers are still project-scoped.
       final commandsResponse = await (commandsFuture ?? _listCommands(projectId: effectiveProjectId));
       final agentsResponse = await (agentsFuture ?? _listAgents(projectId: effectiveProjectId));
+      final providersResponse = await (providersFuture ?? _listProviders(projectId: effectiveProjectId));
       final session = switch (sessionResponse) {
         SuccessResponse(:final data) => data,
         ErrorResponse(:final error) => () {
@@ -162,6 +162,19 @@ class SessionDetailLoadService {
     }
 
     return _repository.listCommands(projectId: normalizedProjectId);
+  }
+
+  Future<ApiResponse<ProviderListResponse>> _listProviders({required String? projectId}) {
+    final normalizedProjectId = projectId?.normalize();
+    if (normalizedProjectId == null) {
+      // Without any project context there is no project to scope providers to;
+      // an empty list keeps the UI consistent instead of guessing a project.
+      return Future<ApiResponse<ProviderListResponse>>.value(
+        ApiResponse.success(const ProviderListResponse(items: <ProviderInfo>[], connectedOnly: false)),
+      );
+    }
+
+    return _repository.listProviders(projectId: normalizedProjectId);
   }
 
   Future<ProjectSessionContext?> _loadProjectSessionContext({required String sessionId}) async {

--- a/client/module_core/test/services/session_detail_load_service_test.dart
+++ b/client/module_core/test/services/session_detail_load_service_test.dart
@@ -133,6 +133,33 @@ void main() {
       expect(loaded.snapshot.canonicalSessionTitle, isNull);
     });
 
+    test("blank route projectId scopes providers to the session's resolved project", () async {
+      connectionStatus.add(connectedStatus);
+      _stubRepositorySnapshot(repository: repository, projectRepository: projectRepository);
+
+      final result = await service.load(sessionId: "session-1", projectId: "");
+
+      expect(result, isA<SessionDetailLoadResultLoaded>());
+      // Providers must be requested with the project resolved from the session
+      // context — never the raw blank route id, which backends would normalize
+      // to the bridge process CWD (the wrong project).
+      verify(() => repository.listProviders(projectId: "project-1")).called(1);
+      verifyNever(() => repository.listProviders(projectId: ""));
+    });
+
+    test("no route project and no session context loads empty providers without a request", () async {
+      connectionStatus.add(connectedStatus);
+      _stubRepositorySnapshot(repository: repository, projectRepository: projectRepository);
+      when(() => projectRepository.findSessionContext(sessionId: "session-1")).thenAnswer((_) async => null);
+
+      final result = await service.load(sessionId: "session-1", projectId: "");
+
+      expect(result, isA<SessionDetailLoadResultLoaded>());
+      final loaded = result as SessionDetailLoadResultLoaded;
+      expect(loaded.snapshot.providerData?.items, isEmpty);
+      verifyNever(() => repository.listProviders(projectId: any(named: "projectId")));
+    });
+
     test("project session context lookup failure is non-fatal when required reads succeed", () async {
       connectionStatus.add(connectedStatus);
       _stubRepositorySnapshot(repository: repository, projectRepository: projectRepository);


### PR DESCRIPTION
## Summary

Addresses the post-merge P2 review comment on #360 (https://github.com/sesori-ai/sesori_apps_monorepo/pull/360/changes/70bfadce92d32d0063c37500825e92c84bb694c5#r3520903527): now that the bridge derives one codex project per session cwd, the project-scoped metadata endpoints must honour the selected project instead of launch/global state.

Previously:
- `CodexPlugin.getCommands` ignored `projectId` and read skills from the launch cwd's `.codex/skills`, so a derived project showed another project's slash commands (missing or invalid for the session being started).
- `getAgents`/`getProviders` resolved model/provider defaults from the newest rollout across **all** projects, so mobile pickers could show a different project's recent model.

## Changes (all in `bridge/sesori_plugin_codex`)

- `CodexSkillReader` no longer bakes in a project cwd; `list({required String? projectCwd})` takes the project directory per call (Layer 1 stays a pure enumerator).
- New `CodexMetadataRepository` (Layer 2) owns project-scoped metadata:
  - `getCommands(projectId:)` — user-level skills + the selected project directory's `.codex/skills`, mapped to `PluginCommand` (null projectId falls back to the launch directory, matching the deprecated project-less route).
  - `resolveModelDefaults(projectId:)` — the selected project's own newest rollout wins (matched by the same normalized-cwd rule `getSessions` uses, including the null-cwd → launch-dir fallback), then `config.toml`, then `openai`.
- `CodexPlugin` delegates `getCommands`/`getAgents`/`getProviders` scoping to the repository; the live `model/list` catalog path in `getProviders` is unchanged.

## Testing

- New `codex_metadata_repository_test.dart`: cross-project skill scoping, null-projectId fallback, per-project model defaults (newer rollout in another project doesn't leak), config/openai fallbacks, null-cwd grouping.
- Extended plugin tests: `getCommands` on a non-launch derived project returns that project's skills; `getAgents`/`getProviders` resolve per-project defaults.
- `make analyze` + `make test` (1666 tests) pass from `bridge/`; `dart analyze --fatal-infos` clean in the package.

Plan and implementation both approved by the aristotle review agents.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Codex slash commands and model/provider defaults to the selected derived project so each project sees its own `.codex/skills` and rollout-based defaults, and aligns the provider picker with the project’s latest model. Also scopes provider loading in the client to the resolved project to prevent CWD leakage on blank routes.

- **Bug Fixes**
  - `getCommands` reads user skills + the selected project's `.codex/skills`; null `projectId` falls back to the launch directory.
  - `getAgents`/`getProviders` resolve defaults from the selected project's latest rollout; fall back to `config.toml`, then `openai`.
  - Model defaults include sessions within the project tree (e.g., `<project>/.worktrees/<name>`).
  - Provider picker default: prefer the project's scoped model if still in the live catalog, else codex’s catalog default, else the first catalog model.
  - Client `SessionDetailLoadService` scopes providers like commands/agents: use the route `projectId` or the session context; avoids sending a blank id normalized to the bridge process CWD.

- **Refactors**
  - Added `CodexMetadataRepository` with `getCommands(projectId:)`, `resolveModelDefaults(projectId:)`, and catalog default selection.
  - `CodexSkillReader` now takes `list(projectCwd:)` instead of storing a cwd.
  - `CodexPlugin` delegates scoping to the repository; the live `model/list` catalog path remains unchanged.

<sup>Written for commit 583394cf02ae8f2922697f80a4416fe39321f79e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

