### PR TITLE
feat(bridge): supervised status push via ControlStatusNotifier (Phase 1, PR 1.10)

### DIFF
--- a/bridge/app/lib/src/auth/bridge_registration_service.dart
+++ b/bridge/app/lib/src/auth/bridge_registration_service.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:io";
 
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
@@ -27,6 +28,7 @@ class BridgeRegistrationService implements BridgeIdProvider {
 
   bool _registered = false;
   String? _bridgeId;
+  final StreamController<String> _registrations = StreamController<String>.broadcast();
 
   BridgeRegistrationService({
     required BridgeRegistrationRepository repository,
@@ -59,6 +61,14 @@ class BridgeRegistrationService implements BridgeIdProvider {
   @override
   String? get bridgeId => _bridgeId;
 
+  /// Emits the assigned bridge id each time a registration round-trip
+  /// actually succeeds: the first [ensureRegistered] of the process and any
+  /// post-revocation re-registration. Memoized [ensureRegistered] calls
+  /// (every reconnect) do NOT emit, so listeners see one event per real
+  /// registration. Lets a supervised-mode observer push the id to the GUI
+  /// right after registration, before any crash/stop.
+  Stream<String> get registrations => _registrations.stream;
+
   /// Ensures this bridge is registered with the auth server.
   ///
   /// Posts the persisted bridge id (if any) so the server updates the
@@ -85,6 +95,9 @@ class BridgeRegistrationService implements BridgeIdProvider {
       await _bridgeIdStorage.write(bridgeId: summary.id);
     }
     _registered = true;
+    if (!_registrations.isClosed) {
+      _registrations.add(summary.id);
+    }
   }
 
   /// Clears the in-memory and persisted bridge id and resets the
@@ -127,6 +140,13 @@ class BridgeRegistrationService implements BridgeIdProvider {
       }
     }
     await _bridgeIdStorage.clear();
+  }
+
+  /// Closes the [registrations] stream. Idempotent.
+  Future<void> dispose() async {
+    if (!_registrations.isClosed) {
+      await _registrations.close();
+    }
   }
 
   Future<T> _withAccessTokenRetry<T>(Future<T> Function(String accessToken) action) async {

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -11,6 +11,7 @@ import "package:sesori_shared/sesori_shared.dart";
 import "../auth/access_token_provider.dart";
 import "../auth/bridge_registration_service.dart";
 import "../auth/token_refresher.dart";
+import "../control/control_status_notifier.dart";
 import "../push/completion_push_listener.dart";
 import "../push/maintenance_push_listener.dart";
 import "../push/push_dispatcher.dart";
@@ -77,6 +78,7 @@ class Orchestrator {
   final WorktreeService _worktreeService;
   final SessionEventEnrichmentService _sessionEventEnrichmentService;
   final BridgeRestartService _restartService;
+  final ControlStatusNotifier? _statusNotifier;
 
   Orchestrator({
     required this.config,
@@ -106,6 +108,9 @@ class Orchestrator {
     required WorktreeService worktreeService,
     required SessionEventEnrichmentService sessionEventEnrichmentService,
     required BridgeRestartService restartService,
+    // Supervised mode only: owns the status-class pushes to the desktop GUI.
+    // Standalone has no control channel, so this is null there.
+    required ControlStatusNotifier? statusNotifier,
   }) : _client = client,
        _plugin = plugin,
        _metadataService = metadataService,
@@ -131,7 +136,8 @@ class Orchestrator {
        _sessionPersistenceService = sessionPersistenceService,
        _worktreeService = worktreeService,
        _sessionEventEnrichmentService = sessionEventEnrichmentService,
-       _restartService = restartService;
+       _restartService = restartService,
+       _statusNotifier = statusNotifier;
 
   /// Creates a new session with a fresh room key and SSE manager.
   OrchestratorSession create() {
@@ -188,6 +194,7 @@ class Orchestrator {
       sessionAbortService: sessionAbortService,
       sessionEventEnrichmentService: _sessionEventEnrichmentService,
       restartService: _restartService,
+      statusNotifier: _statusNotifier,
     );
   }
 
@@ -225,6 +232,7 @@ class OrchestratorSession {
   final SessionEventEnrichmentService _sessionEventEnrichmentService;
   final SessionAbortService _sessionAbortService;
   final BridgeRestartService _restartService;
+  final ControlStatusNotifier? _statusNotifier;
   final CompositeSubscription _subscriptions = CompositeSubscription();
 
   bool _cancelled = false;
@@ -280,6 +288,7 @@ class OrchestratorSession {
     required SessionAbortService sessionAbortService,
     required SessionEventEnrichmentService sessionEventEnrichmentService,
     required BridgeRestartService restartService,
+    required ControlStatusNotifier? statusNotifier,
   }) : _client = client,
        _plugin = plugin,
        _pushDispatcher = pushDispatcher,
@@ -297,6 +306,7 @@ class OrchestratorSession {
        _sessionViewTracker = sessionViewTracker,
        _sessionAbortService = sessionAbortService,
        _restartService = restartService,
+       _statusNotifier = statusNotifier,
        _router = RequestRouter(
          plugin: plugin,
          getCommandsHandler: GetCommandsHandler(
@@ -367,6 +377,9 @@ class OrchestratorSession {
       final startupSummary = _mapper.buildProjectsSummaryEvent();
       if (startupSummary != null) {
         _completionListener.handleSseEvent(startupSummary);
+        if (startupSummary is SesoriProjectsSummary) {
+          _statusNotifier?.handleProjectsSummary(summary: startupSummary);
+        }
       }
 
       Log.d("subscribing to plugin event stream...");
@@ -618,6 +631,9 @@ class OrchestratorSession {
           "[sse] mapped to: ${sesoriEvent.runtimeType} — enqueuing (subscribers: ${_sseManager.subscriberCount})",
         );
         _completionListener.handleSseEvent(sesoriEvent);
+        if (sesoriEvent is SesoriProjectsSummary) {
+          _statusNotifier?.handleProjectsSummary(summary: sesoriEvent);
+        }
         _sseManager.enqueueEvent(sesoriEvent);
         unawaited(
           _routeUnseenActivity(sesoriEvent).catchError((Object e, StackTrace st) {

--- a/bridge/app/lib/src/bridge/relay_client.dart
+++ b/bridge/app/lib/src/bridge/relay_client.dart
@@ -144,7 +144,7 @@ class RelayClient {
       channel.sink.done.then<void>(
         (_) => _handleChannelDone(channel),
         onError: (Object error) {
-          Log.d("relay socket closed with error: $error");
+          Log.w("relay socket closed with error", error);
           _handleChannelDone(channel);
         },
       ),

--- a/bridge/app/lib/src/bridge/relay_client.dart
+++ b/bridge/app/lib/src/bridge/relay_client.dart
@@ -18,12 +18,45 @@ class RelayClientMessage {
   const RelayClientMessage({required this.isText, required this.data});
 }
 
+/// Live connection state of the relay WebSocket, emitted on
+/// [RelayClient.connectionState].
+///
+/// This is internal lifecycle state, NOT a wire-protocol type. A remote drop
+/// carries the WebSocket [RelayDisconnected.closeCode] so observers can key on
+/// close semantics (e.g. revoked/replaced) without racing the reconnect loop's
+/// own [RelayClient.closeCode] read.
+sealed class RelayConnectionState {
+  const RelayConnectionState();
+}
+
+/// A connect attempt is in flight (initial connect or a reconnect).
+final class RelayConnecting extends RelayConnectionState {
+  const RelayConnecting();
+}
+
+/// The relay socket is open and the auth message (if any) has been sent.
+final class RelayConnected extends RelayConnectionState {
+  const RelayConnected();
+}
+
+/// The relay socket dropped or a connect attempt failed.
+///
+/// [closeCode] is the WebSocket close code of the dropped connection, or
+/// `null` when none is available (e.g. a failed connect attempt).
+final class RelayDisconnected extends RelayConnectionState {
+  final int? closeCode;
+
+  const RelayDisconnected({required this.closeCode});
+}
+
 class RelayClient {
   final String _relayURL;
   final AccessTokenProvider _accessTokenProvider;
   final BridgeIdProvider _bridgeIdProvider;
   final Duration _pingInterval;
   final Duration _connectTimeout;
+  final StreamController<RelayConnectionState> _connectionState =
+      StreamController<RelayConnectionState>.broadcast();
   IOWebSocketChannel? _channel;
   String? _lastAuthedToken;
 
@@ -49,7 +82,22 @@ class RelayClient {
   /// actually authenticated with, so it re-auths only on a real change.
   String? get lastAuthedToken => _lastAuthedToken;
 
+  /// Live connection-state transitions of the relay socket.
+  ///
+  /// A connect attempt emits [RelayConnecting] then [RelayConnected] on
+  /// success or [RelayDisconnected] on failure; a remote drop emits
+  /// [RelayDisconnected] with the socket's close code. A deliberate [close]
+  /// emits nothing — a clean shutdown is not an outage (same contract as the
+  /// control channel's connection-state stream).
+  ///
+  /// Remote-drop detection rides on the socket's close handshake, which
+  /// `dart:io` only processes while the inbound message stream is being
+  /// consumed — true whenever the orchestrator's relay loop is running
+  /// (it always drains [read] on a live connection).
+  Stream<RelayConnectionState> get connectionState => _connectionState.stream;
+
   Future<void> connect() async {
+    _connectionState.add(const RelayConnecting());
     final wsURL = _buildWebSocketURL(_relayURL);
     final channel = IOWebSocketChannel.connect(
       wsURL,
@@ -59,6 +107,7 @@ class RelayClient {
     try {
       await channel.ready.timeout(_connectTimeout);
     } catch (e) {
+      _connectionState.add(const RelayDisconnected(closeCode: null));
       // Clean up the channel if connection fails or times out to prevent
       // zombie WebSocket connections from lingering.
       try {
@@ -70,6 +119,8 @@ class RelayClient {
     }
 
     _channel = channel;
+    _watchChannelDone(channel);
+    _connectionState.add(const RelayConnected());
 
     if (_accessTokenProvider.accessToken case final String token when token.isNotEmpty) {
       final authMessage = RelayMessage.auth(
@@ -82,6 +133,27 @@ class RelayClient {
     } else {
       _lastAuthedToken = null;
     }
+  }
+
+  /// Emits [RelayDisconnected] when [channel]'s socket closes while it is
+  /// still the current channel. A deliberate [close] (or [reconnect]) nulls
+  /// [_channel] before the sink-done future settles, so this watcher stays
+  /// silent for intentional teardown and only surfaces genuine drops.
+  void _watchChannelDone(IOWebSocketChannel channel) {
+    unawaited(
+      channel.sink.done.then<void>(
+        (_) => _handleChannelDone(channel),
+        onError: (Object error) {
+          Log.d("relay socket closed with error: $error");
+          _handleChannelDone(channel);
+        },
+      ),
+    );
+  }
+
+  void _handleChannelDone(IOWebSocketChannel channel) {
+    if (!identical(_channel, channel)) return;
+    _connectionState.add(RelayDisconnected(closeCode: channel.closeCode));
   }
 
   Future<void> reconnect() async {

--- a/bridge/app/lib/src/bridge/relay_client.dart
+++ b/bridge/app/lib/src/bridge/relay_client.dart
@@ -97,8 +97,11 @@ class RelayClient {
   Stream<RelayConnectionState> get connectionState => _connectionState.stream;
 
   Future<void> connect() async {
-    _connectionState.add(const RelayConnecting());
+    // Build (and thereby validate) the URL before announcing the attempt: a
+    // throwing parse must not leave observers stuck on a connecting state
+    // that never resolves to a terminal one.
     final wsURL = _buildWebSocketURL(_relayURL);
+    _connectionState.add(const RelayConnecting());
     final channel = IOWebSocketChannel.connect(
       wsURL,
       pingInterval: _pingInterval,

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
@@ -9,6 +9,7 @@ import "package:sesori_shared/sesori_shared.dart";
 import "../../auth/access_token_provider.dart";
 import "../../auth/bridge_registration_service.dart";
 import "../../auth/token_refresher.dart";
+import "../../control/control_status_notifier.dart";
 import "../../push/completion_notifier.dart";
 import "../../push/completion_push_listener.dart";
 import "../../push/maintenance_push_listener.dart";
@@ -86,6 +87,9 @@ class BridgeRuntime {
   static BridgeRuntime create({
     required BridgeConfig config,
     required BridgePluginApi plugin,
+    // Constructed at the composition root (not here) so supervised mode can
+    // wire its connectionState stream into the ControlStatusNotifier.
+    required RelayClient relayClient,
     required http.Client httpClient,
     required AccessTokenProvider accessTokenProvider,
     required TokenRefresher tokenRefresher,
@@ -95,6 +99,8 @@ class BridgeRuntime {
     required FailureReporter failureReporter,
     required BridgeRestartService restartService,
     required bool filesystemAccessOk,
+    // Supervised mode only; null in standalone (no control channel).
+    required ControlStatusNotifier? statusNotifier,
   }) {
     final pullRequestRepository = PullRequestRepository(
       pullRequestDao: database.pullRequestDao,
@@ -185,11 +191,7 @@ class BridgeRuntime {
       sessionViewTracker: sessionViewTracker,
       session: Orchestrator(
         config: config,
-        client: RelayClient(
-          relayURL: config.relayURL,
-          accessTokenProvider: accessTokenProvider,
-          bridgeIdProvider: bridgeRegistrationService,
-        ),
+        client: relayClient,
         plugin: plugin,
         metadataService: MetadataService(
           client: httpClient,
@@ -248,6 +250,7 @@ class BridgeRuntime {
         ),
         sessionEventEnrichmentService: sessionEventEnrichmentService,
         restartService: restartService,
+        statusNotifier: statusNotifier,
       ).create(),
     );
   }

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -44,6 +44,7 @@ import "../../auth/token_manager.dart";
 import "../../auth/token_refresher.dart";
 import "../../control/bridge_control_message_dispatcher.dart";
 import "../../control/control_channel_loss_listener.dart";
+import "../../control/control_status_notifier.dart";
 import "../../foundation/control_channel_client.dart";
 import "../../repositories/bridge_settings_repository.dart";
 import "../../server/api/loopback_port_api.dart";
@@ -98,6 +99,7 @@ import "../log_failure_reporter.dart";
 import "../models/bridge_config.dart";
 import "../persistence/bridge_diagnostics.dart";
 import "../persistence/database.dart";
+import "../relay_client.dart";
 import "../sse/sse_manager.dart";
 import "bridge_cli_options.dart";
 import "bridge_runtime.dart";
@@ -242,8 +244,11 @@ class BridgeRuntimeRunner {
       // step here is gated by `--control-url`; standalone startup is unchanged.
       ControlChannelTokenService? controlChannelTokenService;
       ControlPromptService? controlPromptService;
+      // Kept in scope past this block: the ControlStatusNotifier (built later,
+      // once the plugin and registration service exist) shares this client.
+      ControlChannelClient? controlChannelClient;
       if (options.isSupervised) {
-        final controlChannelClient = await _connectSupervisedControlChannel(
+        controlChannelClient = await _connectSupervisedControlChannel(
           options: options,
           shutdownCoordinator: shutdownCoordinator,
           requestAbnormalExit: (code) => supervisedLossExitCode = code,
@@ -501,6 +506,32 @@ class BridgeRuntimeRunner {
         hostName: io.Platform.localHostname,
         platform: BridgeRegistrationService.currentPlatformName(),
       );
+      shutdownCoordinator.add(disposable: bridgeRegistrationService.dispose);
+
+      // Constructed here (not inside BridgeRuntime.create) so supervised mode
+      // can observe its connectionState stream below.
+      final relayClient = RelayClient(
+        relayURL: options.relayUrl,
+        accessTokenProvider: accessTokenProvider,
+        bridgeIdProvider: bridgeRegistrationService,
+      );
+
+      // Supervised status pushes: the notifier owns every outbound
+      // status-class send (status + registered) over the control channel,
+      // observing the plugin's lifecycle stream, the relay's connection-state
+      // stream, and registration successes. Started before the session runs so
+      // the initial registration and relay connect are never missed.
+      ControlStatusNotifier? controlStatusNotifier;
+      if (controlChannelClient != null) {
+        controlStatusNotifier = ControlStatusNotifier(
+          client: controlChannelClient,
+          pluginStatus: plugin.status,
+          relayConnectionState: relayClient.connectionState,
+          registrations: bridgeRegistrationService.registrations,
+        );
+        controlStatusNotifier.start();
+        shutdownCoordinator.add(disposable: controlStatusNotifier.dispose);
+      }
 
       final restartService = BridgeRestartService(
         processRepository: processRepository,
@@ -536,6 +567,7 @@ class BridgeRuntimeRunner {
           sseReplayWindow: SSEManager.defaultReplayWindow,
         ),
         plugin: plugin.api,
+        relayClient: relayClient,
         httpClient: httpClient,
         accessTokenProvider: accessTokenProvider,
         tokenRefresher: tokenRefresher,
@@ -545,6 +577,7 @@ class BridgeRuntimeRunner {
         failureReporter: LogFailureReporter(),
         restartService: restartService,
         filesystemAccessOk: filesystemAccessOk,
+        statusNotifier: controlStatusNotifier,
       );
       shutdownCoordinator.add(disposable: runtime.close);
       // Defined stop semantics: stopping the active plugin cancels the

--- a/bridge/app/lib/src/control/control_status_notifier.dart
+++ b/bridge/app/lib/src/control/control_status_notifier.dart
@@ -1,0 +1,171 @@
+import "dart:convert";
+
+import "package:rxdart/rxdart.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../bridge/relay_client.dart";
+import "../foundation/control_channel_client.dart";
+
+/// Owns ALL outbound status-class control sends in supervised mode: it
+/// observes the bridge's live state streams and pushes `status` /
+/// `registered` control messages to the GUI over the injected
+/// [ControlChannelClient]. Higher layers (the Orchestrator) never call
+/// `ControlChannelClient.send` directly.
+///
+/// Observed triggers — all push-based, no timers:
+/// - plugin health: the replay-latest `BridgePlugin.status` lifecycle stream;
+/// - relay connection state: [RelayClient.connectionState];
+/// - registration success: the auth-subsystem `registrations` stream, mapped
+///   to a `registered{bridgeId}` push so the GUI can persist a readable copy
+///   of the id before any crash/stop (offline-unregister fallback);
+/// - active-session summary: fed by the Orchestrator's SSE pipeline through
+///   [handleProjectsSummary] (the same already-built summary event phones
+///   receive), so no second derivation path into the plugin exists;
+/// - the control channel's own connection state: after a reconnect the GUI
+///   may have missed edge-triggered pushes, so the current snapshot (and the
+///   `registered` event) is re-sent to converge.
+///
+/// Sends are best-effort and never throw to callers: status is informational,
+/// and a frame lost to a channel blip is repaired by the reconnect re-sync.
+/// Consecutive identical status frames are deduped so live state changes are
+/// pushed exactly once (no periodic spam).
+class ControlStatusNotifier {
+  final ControlChannelClient _client;
+  final Stream<PluginStatus> _pluginStatus;
+  final Stream<RelayConnectionState> _relayConnectionState;
+  final Stream<String> _registrations;
+  final CompositeSubscription _subscriptions = CompositeSubscription();
+
+  // The relay is genuinely not connected before the orchestrator's first
+  // connect attempt; the plugin's health is unknown until its replay-latest
+  // status stream delivers the current value (immediately on subscribe).
+  ControlRelayConnectionState _relay = ControlRelayConnectionState.disconnected;
+  ControlPluginHealthState _plugin = ControlPluginHealthState.unknown;
+  int _activeSessionCount = 0;
+  ControlStatus? _lastSentStatus;
+  String? _bridgeId;
+  bool _started = false;
+
+  ControlStatusNotifier({
+    required ControlChannelClient client,
+    required Stream<PluginStatus> pluginStatus,
+    required Stream<RelayConnectionState> relayConnectionState,
+    required Stream<String> registrations,
+  }) : _client = client,
+       _pluginStatus = pluginStatus,
+       _relayConnectionState = relayConnectionState,
+       _registrations = registrations;
+
+  /// Subscribes to the observed streams. Idempotent — a second call while
+  /// already started does nothing.
+  void start() {
+    if (_started) return;
+    _started = true;
+    _pluginStatus.listen(_handlePluginStatus).addTo(_subscriptions);
+    _relayConnectionState.listen(_handleRelayConnectionState).addTo(_subscriptions);
+    _registrations.listen(_handleRegistered).addTo(_subscriptions);
+    _client.connectionState.listen(_handleControlChannelState).addTo(_subscriptions);
+  }
+
+  Future<void> dispose() async {
+    // Isolate the cancel so a failure still lets teardown finish.
+    try {
+      await _subscriptions.cancel();
+    } on Object catch (error, stackTrace) {
+      Log.w("[control][status] failed to cancel subscriptions", error, stackTrace);
+    }
+  }
+
+  /// Typed delegate fed by the Orchestrator's SSE pipeline with the
+  /// already-built projects-summary event (the same one phones receive), on
+  /// startup and whenever the plugin reports project activity changes.
+  void handleProjectsSummary({required SesoriProjectsSummary summary}) {
+    final count = summary.projects.fold<int>(
+      0,
+      (total, project) => total + project.activeSessions.length,
+    );
+    if (count == _activeSessionCount) return;
+    _activeSessionCount = count;
+    _pushStatus();
+  }
+
+  void _handlePluginStatus(PluginStatus status) {
+    final mapped = _mapPluginStatus(status);
+    if (mapped == _plugin) return;
+    _plugin = mapped;
+    _pushStatus();
+  }
+
+  void _handleRelayConnectionState(RelayConnectionState state) {
+    final mapped = _mapRelayState(state);
+    if (mapped == _relay) return;
+    _relay = mapped;
+    _pushStatus();
+  }
+
+  void _handleRegistered(String bridgeId) {
+    _bridgeId = bridgeId;
+    _send(ControlMessage.registered(bridgeId: bridgeId));
+  }
+
+  /// After a control-channel blip the GUI may have missed edge-triggered
+  /// pushes (sends throw while the channel is down), so a reconnect re-sends
+  /// the `registered` event and the current status snapshot, bypassing the
+  /// dedupe. A clean client dispose closes the state stream without emitting,
+  /// so shutdown never triggers a re-sync.
+  void _handleControlChannelState(ControlChannelConnectionState state) {
+    if (state != ControlChannelConnectionState.connected) return;
+    final bridgeId = _bridgeId;
+    if (bridgeId != null) {
+      _send(ControlMessage.registered(bridgeId: bridgeId));
+    }
+    _pushStatus(force: true);
+  }
+
+  void _pushStatus({bool force = false}) {
+    final status = ControlStatus(
+      relay: _relay,
+      plugin: _plugin,
+      activeSessionCount: _activeSessionCount,
+    );
+    if (!force && status == _lastSentStatus) return;
+    _lastSentStatus = status;
+    _send(status);
+  }
+
+  /// Best-effort send: status pushes are informational and must never throw
+  /// into an observed stream's callback or block the caller.
+  void _send(ControlMessage message) {
+    try {
+      _client.send(jsonEncode(message.toJson()));
+    } on ControlChannelNotConnectedException {
+      // Expected while the GUI is briefly away; the reconnect re-sync in
+      // _handleControlChannelState converges the missed state.
+      Log.d("[control][status] channel down — dropping ${message.runtimeType}");
+    } on Object catch (error, stackTrace) {
+      Log.w("[control][status] failed to send ${message.runtimeType}", error, stackTrace);
+    }
+  }
+
+  ControlPluginHealthState _mapPluginStatus(PluginStatus status) {
+    return switch (status) {
+      // Health is not yet determined while start() is still in flight.
+      PluginStarting() => ControlPluginHealthState.unknown,
+      PluginReady() => ControlPluginHealthState.healthy,
+      PluginDegraded() => ControlPluginHealthState.degraded,
+      PluginRestarting() => ControlPluginHealthState.degraded,
+      PluginFailed() => ControlPluginHealthState.unavailable,
+      PluginStopping() => ControlPluginHealthState.unavailable,
+      PluginStopped() => ControlPluginHealthState.unavailable,
+    };
+  }
+
+  ControlRelayConnectionState _mapRelayState(RelayConnectionState state) {
+    return switch (state) {
+      RelayConnecting() => ControlRelayConnectionState.connecting,
+      RelayConnected() => ControlRelayConnectionState.connected,
+      RelayDisconnected() => ControlRelayConnectionState.disconnected,
+    };
+  }
+}

--- a/bridge/app/test/auth/bridge_registration_service_test.dart
+++ b/bridge/app/test/auth/bridge_registration_service_test.dart
@@ -82,6 +82,63 @@ void main() {
     });
   });
 
+  group("BridgeRegistrationService.registrations", () {
+    test("emits the assigned bridge id when registration succeeds", () async {
+      final emitted = <String>[];
+      service.registrations.listen(emitted.add);
+
+      await service.ensureRegistered();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, equals(["br_test1234"]));
+    });
+
+    test("memoized calls do not re-emit", () async {
+      final emitted = <String>[];
+      service.registrations.listen(emitted.add);
+
+      await service.ensureRegistered();
+      await service.ensureRegistered();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, hasLength(1));
+    });
+
+    test("re-emits the fresh id after a revocation re-registers", () async {
+      final emitted = <String>[];
+      service.registrations.listen(emitted.add);
+
+      await service.ensureRegistered();
+      repository.nextBridgeId = "br_fresh5678";
+      await service.handleBridgeRevoked();
+      await service.ensureRegistered();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, equals(["br_test1234", "br_fresh5678"]));
+    });
+
+    test("a failed registration emits nothing", () async {
+      final emitted = <String>[];
+      service.registrations.listen(emitted.add);
+      repository.registerError = BridgeRegistrationException(statusCode: 500, body: "boom");
+
+      await expectLater(service.ensureRegistered(), throwsA(isA<BridgeRegistrationException>()));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted, isEmpty);
+    });
+
+    test("dispose closes the stream and a later registration does not throw", () async {
+      final done = expectLater(service.registrations, emitsDone);
+
+      await service.dispose();
+      await done;
+
+      await service.ensureRegistered();
+      expect(service.bridgeId, equals("br_test1234"));
+    });
+  });
+
   group("BridgeRegistrationService.sanitizeBridgeName", () {
     test("passes a normal hostname through unchanged", () {
       expect(BridgeRegistrationService.sanitizeBridgeName("Alexs-MacBook"), equals("Alexs-MacBook"));

--- a/bridge/app/test/bridge/client_test.dart
+++ b/bridge/app/test/bridge/client_test.dart
@@ -132,6 +132,130 @@ void main() {
     });
   });
 
+  group("RelayClient connectionState", () {
+    test("connect emits connecting then connected", () async {
+      final server = await TestRelayServer.start();
+      addTearDown(server.close);
+
+      final client = RelayClient(
+        relayURL: "ws://127.0.0.1:${server.port}",
+        accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
+      );
+      final states = <RelayConnectionState>[];
+      client.connectionState.listen(states.add);
+
+      await client.connect();
+      addTearDown(client.close);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(states, hasLength(2));
+      expect(states[0], isA<RelayConnecting>());
+      expect(states[1], isA<RelayConnected>());
+    });
+
+    test("remote close emits disconnected carrying the close code", () async {
+      final server = await TestRelayServer.start();
+      addTearDown(server.close);
+
+      final client = RelayClient(
+        relayURL: "ws://127.0.0.1:${server.port}",
+        accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
+      );
+      final states = <RelayConnectionState>[];
+      client.connectionState.listen(states.add);
+      await client.connect();
+      addTearDown(client.close);
+
+      final serverWs = await server.nextClient();
+      // Drop detection requires the inbound stream to be consumed, exactly
+      // like the orchestrator's relay loop does on a live connection.
+      client.read().listen((_) {});
+      final disconnected = client.connectionState.firstWhere((state) => state is RelayDisconnected);
+      await serverWs.close(RelayCloseCodes.bridgeRevoked);
+
+      final state = await disconnected.timeout(const Duration(seconds: 5)) as RelayDisconnected;
+      expect(state.closeCode, equals(RelayCloseCodes.bridgeRevoked));
+    });
+
+    test("deliberate close emits no disconnected state", () async {
+      final server = await TestRelayServer.start();
+      addTearDown(server.close);
+
+      final client = RelayClient(
+        relayURL: "ws://127.0.0.1:${server.port}",
+        accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
+      );
+      final states = <RelayConnectionState>[];
+      client.connectionState.listen(states.add);
+      await client.connect();
+      await server.nextClient();
+
+      await client.close();
+      // Give the sink-done watcher time to fire if it (incorrectly) would.
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(states.whereType<RelayDisconnected>(), isEmpty);
+    });
+
+    test("failed connect emits disconnected with no close code", () async {
+      // A TCP server that accepts but never completes the WebSocket upgrade.
+      final rawServer = await ServerSocket.bind("127.0.0.1", 0);
+      addTearDown(rawServer.close);
+
+      final client = RelayClient(
+        relayURL: "ws://127.0.0.1:${rawServer.port}",
+        accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
+        connectTimeout: const Duration(milliseconds: 500),
+      );
+      final states = <RelayConnectionState>[];
+      client.connectionState.listen(states.add);
+
+      await expectLater(client.connect(), throwsA(isA<TimeoutException>()));
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(states[0], isA<RelayConnecting>());
+      expect(states[1], isA<RelayDisconnected>());
+      expect((states[1] as RelayDisconnected).closeCode, isNull);
+    });
+
+    test("reconnect after a remote drop emits connecting then connected again", () async {
+      final server = await TestRelayServer.start();
+      addTearDown(server.close);
+
+      final client = RelayClient(
+        relayURL: "ws://127.0.0.1:${server.port}",
+        accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
+      );
+      final states = <RelayConnectionState>[];
+      client.connectionState.listen(states.add);
+      await client.connect();
+      addTearDown(client.close);
+
+      final serverWs1 = await server.nextClient();
+      // Drop detection requires the inbound stream to be consumed, exactly
+      // like the orchestrator's relay loop does on a live connection.
+      client.read().listen((_) {});
+      final disconnected = client.connectionState.firstWhere((state) => state is RelayDisconnected);
+      await serverWs1.close();
+      await disconnected.timeout(const Duration(seconds: 5));
+
+      final serverWs2Future = server.nextClient();
+      await client.reconnect();
+      await serverWs2Future;
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(
+        states.map((state) => state.runtimeType).toList(),
+        equals([RelayConnecting, RelayConnected, RelayDisconnected, RelayConnecting, RelayConnected]),
+      );
+    });
+  });
+
   group("RelayClient reconnection", () {
     test("read stream ends when server closes connection", () async {
       final server = await TestRelayServer.start();

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -10,6 +10,7 @@ import "package:sesori_bridge/src/bridge/debug_server.dart";
 import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
 import "package:sesori_bridge/src/bridge/models/bridge_config.dart";
 import "package:sesori_bridge/src/bridge/persistence/database.dart";
+import "package:sesori_bridge/src/bridge/relay_client.dart";
 import "package:sesori_bridge/src/bridge/runtime/bridge_runtime.dart";
 import "package:sesori_bridge/src/server/api/system_process_api.dart";
 import "package:sesori_bridge/src/server/foundation/bridge_restart_command_builder.dart";
@@ -39,6 +40,11 @@ _DebugServerHarness _createDebugServerHarness({
       sseReplayWindow: Duration(minutes: 5),
     ),
     plugin: plugin,
+    relayClient: RelayClient(
+      relayURL: "ws://127.0.0.1:9999",
+      accessTokenProvider: FakeAccessTokenProvider(),
+      bridgeIdProvider: FakeBridgeIdProvider(),
+    ),
     httpClient: httpClient,
     accessTokenProvider: FakeAccessTokenProvider(),
     tokenRefresher: _FakeTokenRefresher(),
@@ -48,6 +54,7 @@ _DebugServerHarness _createDebugServerHarness({
     failureReporter: FakeFailureReporter(),
     restartService: restartService ?? buildTestRestartService(),
     filesystemAccessOk: true,
+    statusNotifier: null,
   );
   final debugServer = runtime.createDebugServer(port: port);
   return _DebugServerHarness(

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -38,6 +38,8 @@ import "package:sesori_bridge/src/bridge/services/session_persistence_service.da
 import "package:sesori_bridge/src/bridge/services/session_unseen_service.dart";
 import "package:sesori_bridge/src/bridge/services/session_view_tracker.dart";
 import "package:sesori_bridge/src/bridge/services/worktree_service.dart";
+import "package:sesori_bridge/src/control/control_status_notifier.dart";
+import "package:sesori_bridge/src/foundation/control_channel_client.dart";
 import "package:sesori_bridge/src/push/completion_notifier.dart";
 import "package:sesori_bridge/src/push/completion_push_listener.dart";
 import "package:sesori_bridge/src/push/maintenance_push_listener.dart";
@@ -176,6 +178,7 @@ void main() {
       worktreeService: worktreeService,
       sessionEventEnrichmentService: sessionEventEnrichmentService,
       restartService: buildTestRestartService(),
+      statusNotifier: null,
     );
 
     final session = orchestrator.create();
@@ -355,6 +358,7 @@ void main() {
       worktreeService: worktreeService,
       sessionEventEnrichmentService: sessionEventEnrichmentService,
       restartService: buildTestRestartService(),
+      statusNotifier: null,
     );
 
     final session = orchestrator.create();
@@ -393,6 +397,178 @@ void main() {
 
     await session.cancel();
     await runFuture.timeout(const Duration(seconds: 5));
+    await plugin.close();
+    await database.close();
+    await relayServer.close();
+  });
+
+  test("feeds startup and live projects summaries to the control status notifier", () async {
+    final relayServer = await TestRelayServer.start();
+    final database = createTestDatabase();
+    final pushSubsystem = _createPushSubsystem();
+    final plugin = _MutableSummaryPlugin();
+    plugin.summaries = const <PluginProjectActivitySummary>[
+      PluginProjectActivitySummary(
+        id: "project-1",
+        activeSessions: <PluginActiveSession>[PluginActiveSession(id: "session-1")],
+      ),
+    ];
+    final fakePrSyncService = _FakePrSyncService();
+    final pullRequestRepository = PullRequestRepository(
+      pullRequestDao: database.pullRequestDao,
+      projectsDao: database.projectsDao,
+    );
+    final sessionRepository = SessionRepository(
+      plugin: plugin,
+      sessionDao: database.sessionDao,
+      pullRequestRepository: pullRequestRepository,
+      unseenCalculator: const SessionUnseenCalculator(),
+    );
+    final projectRepository = ProjectRepository(
+      plugin: plugin,
+      projectsDao: database.projectsDao,
+      sessionDao: database.sessionDao,
+      unseenCalculator: const SessionUnseenCalculator(),
+    );
+    final permissionRepository = PermissionRepository(plugin: plugin);
+    final sessionPersistenceService = SessionPersistenceService(
+      projectsDao: database.projectsDao,
+      sessionDao: database.sessionDao,
+      db: database,
+      pluginId: "opencode",
+    );
+    final worktreeService = WorktreeService(
+      worktreeRepository: WorktreeRepository(
+        projectsDao: database.projectsDao,
+        sessionDao: database.sessionDao,
+        gitApi: GitCliApi(
+          processRunner: FakeProcessRunner(),
+          gitPathExists: ({required String gitPath}) => true,
+        ),
+        plugin: plugin,
+      ),
+    );
+    final relayClient = RelayClient(
+      relayURL: "ws://127.0.0.1:${relayServer.port}",
+      accessTokenProvider: FakeAccessTokenProvider(),
+      bridgeIdProvider: FakeBridgeIdProvider(),
+    );
+    final sessionEventEnrichmentService = SessionEventEnrichmentService(
+      sessionRepository: sessionRepository,
+      failureReporter: FakeFailureReporter(),
+    );
+    // Wired exactly like the supervised composition root: the notifier
+    // observes the relay client's real connection-state stream and owns the
+    // control-channel sends; the orchestrator only feeds it summaries.
+    final controlClient = _RecordingControlChannelClient();
+    final statusNotifier = ControlStatusNotifier(
+      client: controlClient,
+      pluginStatus: const Stream<PluginStatus>.empty(),
+      relayConnectionState: relayClient.connectionState,
+      registrations: const Stream<String>.empty(),
+    );
+    statusNotifier.start();
+
+    final orchestrator = Orchestrator(
+      config: BridgeConfig(
+        relayURL: "ws://127.0.0.1:${relayServer.port}",
+        pluginEndpoint: "http://127.0.0.1:4096",
+        authBackendURL: "http://127.0.0.1:8080",
+        sseReplayWindow: const Duration(minutes: 1),
+      ),
+      client: relayClient,
+      plugin: plugin,
+      metadataService: _FakeMetadataService(),
+      pushDispatcher: pushSubsystem.dispatcher,
+      completionListener: pushSubsystem.completionListener,
+      maintenanceListener: pushSubsystem.maintenanceListener,
+      accessTokenProvider: FakeAccessTokenProvider(),
+      tokenRefresher: _FakeTokenRefresher(),
+      bridgeRegistrationService: createFakeBridgeRegistrationService(),
+      failureReporter: FakeFailureReporter(),
+      prSyncService: fakePrSyncService,
+      sessionRepository: sessionRepository,
+      projectRepository: projectRepository,
+      sessionUnseenService: SessionUnseenService(
+        unseenRepository: SessionUnseenRepository(
+          pluginId: "opencode",
+          sessionDao: database.sessionDao,
+          projectsDao: database.projectsDao,
+          db: database,
+          calculator: const SessionUnseenCalculator(),
+        ),
+        projectRepository: projectRepository,
+        viewTracker: SessionViewTracker(),
+      ),
+      sessionViewTracker: SessionViewTracker(),
+      filesystemRepository: FilesystemRepository(
+        filesystemApi: const FilesystemApi(),
+        permissionValidator: const FilesystemPermissionValidator(),
+      ),
+      projectInitializationService: ProjectInitializationService(
+        worktreeRepository: WorktreeRepository(
+          projectsDao: database.projectsDao,
+          sessionDao: database.sessionDao,
+          plugin: plugin,
+          gitApi: GitCliApi(
+            processRunner: ProcessRunner(),
+            gitPathExists: ({required String gitPath}) => false,
+          ),
+        ),
+        filesystemRepository: FilesystemRepository(
+          filesystemApi: const FilesystemApi(),
+          permissionValidator: const FilesystemPermissionValidator(),
+        ),
+      ),
+      healthRepository: HealthRepository(
+        plugin: plugin,
+        bridgeVersion: "0.0.0-test",
+        filesystemAccessOk: true,
+      ),
+      providerRepository: ProviderRepository(plugin: plugin),
+      agentRepository: AgentRepository(plugin: plugin),
+      permissionRepository: permissionRepository,
+      questionRepository: QuestionRepository(plugin: plugin, sessionDao: database.sessionDao),
+      sessionPersistenceService: sessionPersistenceService,
+      worktreeService: worktreeService,
+      sessionEventEnrichmentService: sessionEventEnrichmentService,
+      restartService: buildTestRestartService(),
+      statusNotifier: statusNotifier,
+    );
+
+    final session = orchestrator.create();
+    final runFuture = session.run();
+
+    await relayServer.nextClient();
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+
+    // The startup summary reaches the notifier: the last status combines the
+    // live relay state (connected) with the pre-seeded active-session count.
+    final startupStatuses = controlClient.sentMessages.whereType<ControlStatus>().toList();
+    expect(startupStatuses, isNotEmpty);
+    expect(startupStatuses.last.activeSessionCount, 1);
+    expect(startupStatuses.last.relay, ControlRelayConnectionState.connected);
+
+    // A live project-updated event re-derives the summary and pushes the
+    // changed count.
+    plugin.summaries = const <PluginProjectActivitySummary>[
+      PluginProjectActivitySummary(
+        id: "project-1",
+        activeSessions: <PluginActiveSession>[
+          PluginActiveSession(id: "session-1"),
+          PluginActiveSession(id: "session-2"),
+        ],
+      ),
+    ];
+    plugin.emitProjectUpdated();
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+
+    final statuses = controlClient.sentMessages.whereType<ControlStatus>().toList();
+    expect(statuses.last.activeSessionCount, 2);
+
+    await session.cancel();
+    await runFuture.timeout(const Duration(seconds: 5));
+    await statusNotifier.dispose();
     await plugin.close();
     await database.close();
     await relayServer.close();
@@ -560,6 +736,7 @@ void main() {
       worktreeService: worktreeService,
       sessionEventEnrichmentService: sessionEventEnrichmentService,
       restartService: buildTestRestartService(),
+      statusNotifier: null,
     );
 
     final session = orchestrator.create();
@@ -735,6 +912,7 @@ void main() {
       worktreeService: worktreeService,
       sessionEventEnrichmentService: sessionEventEnrichmentService,
       restartService: buildTestRestartService(),
+      statusNotifier: null,
     );
 
     final session = orchestrator.create();
@@ -881,6 +1059,7 @@ void main() {
       worktreeService: worktreeService,
       sessionEventEnrichmentService: sessionEventEnrichmentService,
       restartService: buildTestRestartService(),
+      statusNotifier: null,
     );
 
     final session = orchestrator.create();
@@ -1052,6 +1231,7 @@ void main() {
       worktreeService: worktreeService,
       sessionEventEnrichmentService: sessionEventEnrichmentService,
       restartService: buildTestRestartService(),
+      statusNotifier: null,
     );
 
     final session = orchestrator.create();
@@ -1479,6 +1659,44 @@ class _SummaryPlugin implements NativeProjectsPluginApi {
   Future<void> dispose() async {}
 
   Future<void> close() => _controller.close();
+}
+
+/// A [_SummaryPlugin] whose active-session summary can be swapped mid-test and
+/// that can emit a project-updated SSE event to trigger a live re-derivation.
+class _MutableSummaryPlugin extends _SummaryPlugin {
+  List<PluginProjectActivitySummary> summaries = const <PluginProjectActivitySummary>[];
+
+  _MutableSummaryPlugin() : super(onSubscribe: () {});
+
+  @override
+  List<PluginProjectActivitySummary> getActiveSessionsSummary() => summaries;
+
+  void emitProjectUpdated() => _controller.add(const BridgeSseProjectUpdated());
+}
+
+/// Records the control frames the status notifier sends, decoded back into
+/// [ControlMessage]s for assertions.
+class _RecordingControlChannelClient implements ControlChannelClient {
+  final List<String> sentFrames = <String>[];
+
+  List<ControlMessage> get sentMessages =>
+      sentFrames.map((frame) => ControlMessage.fromJson(jsonDecodeMap(frame))).toList();
+
+  @override
+  Stream<String> get inbound => const Stream<String>.empty();
+
+  @override
+  Stream<ControlChannelConnectionState> get connectionState =>
+      const Stream<ControlChannelConnectionState>.empty();
+
+  @override
+  void send(String frame) => sentFrames.add(frame);
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> dispose() async {}
 }
 
 class _NoopPlugin implements NativeProjectsPluginApi {

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -173,6 +173,7 @@ void main() {
           failureReporter: FakeFailureReporter(),
         ),
         restartService: buildTestRestartService(),
+        statusNotifier: null,
       );
 
       final session = orchestrator.create();
@@ -384,6 +385,7 @@ class _TestHarness {
       worktreeService: worktreeService,
       sessionEventEnrichmentService: sessionEventEnrichmentService,
       restartService: buildTestRestartService(),
+      statusNotifier: null,
     );
 
     final session = orchestrator.create();

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -310,6 +310,7 @@ class _RegistrationHarness {
         failureReporter: FakeFailureReporter(),
       ),
       restartService: buildTestRestartService(),
+      statusNotifier: null,
     );
 
     final session = orchestrator.create();

--- a/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
+++ b/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
@@ -447,6 +447,7 @@ class _ReauthHarness {
         failureReporter: FakeFailureReporter(),
       ),
       restartService: buildTestRestartService(),
+      statusNotifier: null,
     );
 
     final session = orchestrator.create();

--- a/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
@@ -3,6 +3,7 @@ import "package:http/http.dart" as http;
 import "package:sesori_bridge/src/auth/token_refresher.dart";
 import "package:sesori_bridge/src/bridge/foundation/process_runner.dart";
 import "package:sesori_bridge/src/bridge/models/bridge_config.dart";
+import "package:sesori_bridge/src/bridge/relay_client.dart";
 import "package:sesori_bridge/src/bridge/runtime/bridge_runtime.dart";
 import "package:sesori_bridge/src/push/completion_notifier.dart";
 import "package:sesori_bridge/src/push/completion_push_listener.dart";
@@ -49,6 +50,11 @@ void main() {
         sseReplayWindow: Duration(minutes: 5),
       ),
       plugin: plugin,
+      relayClient: RelayClient(
+        relayURL: "ws://127.0.0.1:9999",
+        accessTokenProvider: FakeAccessTokenProvider(),
+        bridgeIdProvider: FakeBridgeIdProvider(),
+      ),
       httpClient: httpClient,
       accessTokenProvider: FakeAccessTokenProvider(),
       tokenRefresher: _FakeTokenRefresher(),
@@ -58,6 +64,7 @@ void main() {
       failureReporter: FakeFailureReporter(),
       restartService: buildTestRestartService(),
       filesystemAccessOk: true,
+      statusNotifier: null,
     );
     final debugServer = runtime.createDebugServer(port: 0);
 

--- a/bridge/app/test/control/control_status_notifier_test.dart
+++ b/bridge/app/test/control/control_status_notifier_test.dart
@@ -1,0 +1,290 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/bridge/relay_client.dart";
+import "package:sesori_bridge/src/control/control_status_notifier.dart";
+import "package:sesori_bridge/src/foundation/control_channel_client.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  late _FakeControlChannelClient client;
+  late StreamController<PluginStatus> pluginStatus;
+  late StreamController<RelayConnectionState> relayState;
+  late StreamController<String> registrations;
+  late ControlStatusNotifier notifier;
+
+  setUp(() {
+    client = _FakeControlChannelClient();
+    pluginStatus = StreamController<PluginStatus>.broadcast();
+    relayState = StreamController<RelayConnectionState>.broadcast();
+    registrations = StreamController<String>.broadcast();
+    notifier = ControlStatusNotifier(
+      client: client,
+      pluginStatus: pluginStatus.stream,
+      relayConnectionState: relayState.stream,
+      registrations: registrations.stream,
+    );
+    notifier.start();
+  });
+
+  tearDown(() async {
+    await notifier.dispose();
+    await pluginStatus.close();
+    await relayState.close();
+    await registrations.close();
+    await client.dispose();
+  });
+
+  Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+  group("status pushes", () {
+    test("a plugin status change pushes a status with the mapped health", () async {
+      pluginStatus.add(const PluginReady());
+      await pump();
+
+      expect(client.sentMessages, hasLength(1));
+      final status = client.sentMessages.single as ControlStatus;
+      expect(status.plugin, ControlPluginHealthState.healthy);
+      expect(status.relay, ControlRelayConnectionState.disconnected);
+      expect(status.activeSessionCount, 0);
+    });
+
+    test("plugin lifecycle states map to the wire health enum", () async {
+      pluginStatus.add(const PluginReady());
+      pluginStatus.add(
+        PluginDegraded(
+          since: DateTime.utc(2026),
+          recoverable: true,
+          requiresUserAction: false,
+          userActionHint: null,
+        ),
+      );
+      pluginStatus.add(const PluginFailed(reason: "gone", cause: null));
+      await pump();
+
+      expect(
+        client.sentMessages.whereType<ControlStatus>().map((s) => s.plugin).toList(),
+        equals([
+          ControlPluginHealthState.healthy,
+          ControlPluginHealthState.degraded,
+          ControlPluginHealthState.unavailable,
+        ]),
+      );
+    });
+
+    test("relay connection transitions push mapped statuses", () async {
+      relayState.add(const RelayConnecting());
+      relayState.add(const RelayConnected());
+      relayState.add(const RelayDisconnected(closeCode: 4006));
+      await pump();
+
+      expect(
+        client.sentMessages.whereType<ControlStatus>().map((s) => s.relay).toList(),
+        equals([
+          ControlRelayConnectionState.connecting,
+          ControlRelayConnectionState.connected,
+          ControlRelayConnectionState.disconnected,
+        ]),
+      );
+    });
+
+    test("a status combines the latest of every dimension", () async {
+      pluginStatus.add(const PluginReady());
+      relayState.add(const RelayConnected());
+      notifier.handleProjectsSummary(summary: _summaryWithSessionCount(2));
+      await pump();
+
+      final last = client.sentMessages.last as ControlStatus;
+      expect(last.relay, ControlRelayConnectionState.connected);
+      expect(last.plugin, ControlPluginHealthState.healthy);
+      expect(last.activeSessionCount, 2);
+    });
+
+    test("identical consecutive states are deduped", () async {
+      pluginStatus.add(const PluginReady());
+      pluginStatus.add(const PluginReady());
+      // Restarting maps to degraded...
+      pluginStatus.add(const PluginRestarting(attempt: 1, reason: "crash"));
+      // ...and Degraded maps to degraded too: no second frame.
+      pluginStatus.add(
+        PluginDegraded(
+          since: DateTime.utc(2026),
+          recoverable: true,
+          requiresUserAction: false,
+          userActionHint: null,
+        ),
+      );
+      await pump();
+
+      expect(
+        client.sentMessages.whereType<ControlStatus>().map((s) => s.plugin).toList(),
+        equals([ControlPluginHealthState.healthy, ControlPluginHealthState.degraded]),
+      );
+    });
+
+    test("an unchanged active-session count pushes nothing", () async {
+      notifier.handleProjectsSummary(summary: _summaryWithSessionCount(3));
+      notifier.handleProjectsSummary(summary: _summaryWithSessionCount(3));
+      await pump();
+
+      expect(client.sentMessages, hasLength(1));
+      final status = client.sentMessages.single as ControlStatus;
+      expect(status.activeSessionCount, 3);
+    });
+
+    test("the count sums active sessions across projects", () async {
+      notifier.handleProjectsSummary(
+        summary: SesoriSseEvent.projectsSummary(
+          projects: [
+            ProjectActivitySummary(id: "p1", activeSessions: [_session("a"), _session("b")]),
+            ProjectActivitySummary(id: "p2", activeSessions: [_session("c")]),
+            const ProjectActivitySummary(id: "p3", activeSessions: []),
+          ],
+        ) as SesoriProjectsSummary,
+      );
+      await pump();
+
+      final status = client.sentMessages.single as ControlStatus;
+      expect(status.activeSessionCount, 3);
+    });
+  });
+
+  group("registered pushes", () {
+    test("a registration success pushes registered with the bridge id", () async {
+      registrations.add("br_test1234");
+      await pump();
+
+      expect(client.sentMessages, hasLength(1));
+      final registered = client.sentMessages.single as ControlRegistered;
+      expect(registered.bridgeId, "br_test1234");
+    });
+
+    test("a re-registration after revocation pushes the fresh id", () async {
+      registrations.add("br_old");
+      registrations.add("br_fresh5678");
+      await pump();
+
+      expect(
+        client.sentMessages.whereType<ControlRegistered>().map((r) => r.bridgeId).toList(),
+        equals(["br_old", "br_fresh5678"]),
+      );
+    });
+  });
+
+  group("control-channel resilience", () {
+    test("a send failure while the channel is down is swallowed and later sends recover", () async {
+      client.throwOnSend = true;
+      pluginStatus.add(const PluginReady());
+      await pump();
+      expect(client.sentMessages, isEmpty);
+
+      client.throwOnSend = false;
+      relayState.add(const RelayConnected());
+      await pump();
+
+      expect(client.sentMessages, hasLength(1));
+    });
+
+    test("a control-channel reconnect re-sends registered and the status snapshot", () async {
+      pluginStatus.add(const PluginReady());
+      registrations.add("br_test1234");
+      await pump();
+      client.sentFrames.clear();
+
+      client.emitConnectionState(ControlChannelConnectionState.connected);
+      await pump();
+
+      expect(client.sentMessages, hasLength(2));
+      final registered = client.sentMessages[0] as ControlRegistered;
+      expect(registered.bridgeId, "br_test1234");
+      final status = client.sentMessages[1] as ControlStatus;
+      expect(status.plugin, ControlPluginHealthState.healthy);
+    });
+
+    test("a reconnect before any registration re-sends only the status snapshot", () async {
+      client.emitConnectionState(ControlChannelConnectionState.connected);
+      await pump();
+
+      expect(client.sentMessages, hasLength(1));
+      expect(client.sentMessages.single, isA<ControlStatus>());
+    });
+
+    test("a control-channel disconnect event alone pushes nothing", () async {
+      client.emitConnectionState(ControlChannelConnectionState.disconnected);
+      await pump();
+
+      expect(client.sentMessages, isEmpty);
+    });
+  });
+
+  group("lifecycle", () {
+    test("start is idempotent — a second start does not double-subscribe", () async {
+      notifier.start();
+      pluginStatus.add(const PluginReady());
+      await pump();
+
+      expect(client.sentMessages, hasLength(1));
+    });
+
+    test("dispose cancels the subscriptions — later events push nothing", () async {
+      await notifier.dispose();
+
+      pluginStatus.add(const PluginReady());
+      relayState.add(const RelayConnected());
+      registrations.add("br_test1234");
+      await pump();
+
+      expect(client.sentMessages, isEmpty);
+    });
+  });
+}
+
+ActiveSession _session(String id) => ActiveSession(id: id);
+
+SesoriProjectsSummary _summaryWithSessionCount(int count) {
+  return SesoriSseEvent.projectsSummary(
+    projects: [
+      ProjectActivitySummary(
+        id: "project-1",
+        activeSessions: List<ActiveSession>.generate(count, (i) => _session("session-$i")),
+      ),
+    ],
+  ) as SesoriProjectsSummary;
+}
+
+class _FakeControlChannelClient implements ControlChannelClient {
+  final StreamController<ControlChannelConnectionState> _connectionState =
+      StreamController<ControlChannelConnectionState>.broadcast();
+  final List<String> sentFrames = <String>[];
+
+  /// Mimics [ControlChannelClient.send] throwing when the channel is down.
+  bool throwOnSend = false;
+
+  List<ControlMessage> get sentMessages =>
+      sentFrames.map((frame) => ControlMessage.fromJson(jsonDecodeMap(frame))).toList();
+
+  void emitConnectionState(ControlChannelConnectionState state) => _connectionState.add(state);
+
+  @override
+  Stream<String> get inbound => const Stream<String>.empty();
+
+  @override
+  Stream<ControlChannelConnectionState> get connectionState => _connectionState.stream;
+
+  @override
+  void send(String frame) {
+    if (throwOnSend) {
+      throw const ControlChannelNotConnectedException("Control channel is not connected");
+    }
+    sentFrames.add(frame);
+  }
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> dispose() async {
+    await _connectionState.close();
+  }
+}

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -8,8 +8,8 @@
 
 ## Current pointer
 
-- **Last completed phase:** Phase 1 — PR 1.9 `BridgeControlMessageDispatcher` + prompts → control events + auth-required exit `87` (PR raised on branch `next-desktop-implementation`)
-- **Next up:** Phase 1 — PR 1.10 Status push (relay/plugin/active sessions)
+- **Last completed phase:** Phase 1 — PR 1.10 Status push (relay/plugin/active sessions) via `ControlStatusNotifier` (PR raised on branch `desktop-implementation-stage`)
+- **Next up:** Phase 1 — PR 1.11 `unregister-and-exit` control command
 - **Branch:** one feature branch per PR, cut from `main`
 
 > **Tracking lives in four places that MUST move together in the same PR.**
@@ -281,7 +281,7 @@ mobile release.**
 | `BridgeControlMessageDispatcher` | Layer 4 `control/` | owns the **single** inbound subscription + decode of GUI→helper control messages (created in PR 1.9). Routes: `token_response`/`token_update` → token-service delegate, `prompt_response` → prompt-service delegate, `unregister_and_exit` → unregister flow (PR 1.11). `restart` is **helper→GUI only** and is never an inbound command — the GUI restarts the helper by kill+respawn, not by message. |
 | `ControlPromptService` | Layer 3 `services/` | supervised-mode user prompts over the injected `ControlChannelClient` (same blessed seam as the token service): owns prompt-class correlation state + ALL prompt-class outbound sends (`prompt_request`); implements the `server/foundation/` `BridgeReplacePrompt` interface so `BridgeInstanceService` asks the GUI instead of a terminal; `announceLoginNeeded()` is the best-effort advisory before the exit-87 sentinel (ADR A23). Unanswerable asks (channel down / timeout / teardown) degrade to `nonInteractive`. |
 | `BridgeReplacePrompt` | interface in `server/foundation/` | the replace-bridge ask contract with two production implementations: `TerminalPromptRepository` (standalone) and `ControlPromptService` (supervised); keeps the `server/` subsystem free of core-layer imports (mirrors the auth-interface precedent from PR 1.4). |
-| `ControlStatusNotifier` | Layer 4 `control/` | owns **all outbound** status-class control sends (created in PR 1.10): observes Layer-0 state streams (relay connection state incl. close code/reason, plugin health, active-session summary, registration events) and maps them to `status`/`registered`/takeover pushes over the injected `ControlChannelClient`. Higher layers (Orchestrator) never call `ControlChannelClient.send` directly. |
+| `ControlStatusNotifier` | Layer 4 `control/` | owns **all outbound** status-class control sends (created in PR 1.10): observes Layer-0 state streams (relay connection state incl. close code via `RelayClient.connectionState`, plugin health via `BridgePlugin.status`, registration events via the auth seam's `registrations` stream, plus the control channel's own state for a reconnect re-sync) and receives the **active-session summary as a typed delegate feed** from the Orchestrator's SSE pipeline (`handleProjectsSummary` — same shape as `CompletionPushListener.handleSseEvent`; avoids a second Layer-4→Layer-1 derivation path into the plugin). Maps them to `status`/`registered`/takeover pushes over the injected `ControlChannelClient`, deduped. Higher layers (Orchestrator) never call `ControlChannelClient.send` directly. |
 | `BridgeIdStorage` (file API + reader) | **inside the `auth/` subsystem** | persist `bridgeId` separately from `token.json`; kept within `auth/` (which is self-contained, outside the core layer hierarchy) so auth code doesn't depend back on top-level `repositories/`. Injected from the composition root. |
 | supervised auth bootstrap | composition root | short-circuit `BridgeRuntimeAuthService.ensureAuthenticated` (no stdin); keep an equivalent `logAuthenticatedUser` |
 | restart change | `orchestrator`/runner seam | `handleRestartHandoff()` → `exit(86)` instead of `spawnSuccessor()` |
@@ -393,7 +393,7 @@ them). Only the user checks an MT box.
 - ☑ 1.7 Exit-code restart (`86`) + bypass successor-spawn — Med / S-M
 - ☑ 1.8 Disable self-update + reconcile when supervised — Low / S
 - ☑ 1.9 `BridgeControlMessageDispatcher` + prompts/Console → control events + auth-required exit `87` — Med / M
-- ☐ 1.10 Status push (relay/plugin/active sessions) — Low / S-M
+- ☑ 1.10 Status push (relay/plugin/active sessions) — Low / S-M
 - ☐ 1.11 `unregister-and-exit` control command — Low / S-M
 - ☐ 1.12 Single-live precedence under supervised `--hidden` — Med / M
 - ☐ 1.13 Tee `RuntimeProvisionProgress` → control channel — Low / S-M

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -538,7 +538,52 @@ runs **under the startup mutex**, which reinforces PR 1.12.
 - **Acceptance:** status events received by a fake server; the `registered`
   event carries `bridgeId` and is emitted right after registration; reflects
   live changes (reactive, no polling).
-- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+- **Aristotle:** plan ☑ · impl ☑ (PR raised on branch `desktop-implementation-stage`).
+- **Findings:** Shipped as four units, no shared-package changes (the PR-1.2
+  DTOs already carried the status/registered shapes). (1) `RelayClient`
+  (Layer 0) gained a broadcast `Stream<RelayConnectionState>` — a new sealed
+  type (`RelayConnecting`/`RelayConnected`/`RelayDisconnected{closeCode}`) —
+  the stream PLAN §6 and PR 1.14 already assumed exists. Emissions:
+  `connect()` → connecting, then connected on success / disconnected(null) on
+  failure; a remote drop emits disconnected with the socket's close code via a
+  `sink.done` watcher armed per installed channel; a deliberate `close()`
+  emits nothing (clean shutdown ≠ outage — the `ControlChannelClient`
+  contract). Note: `dart:io` only processes the close handshake while the
+  inbound stream is consumed — always true on a live connection (the relay
+  loop drains `read()`); documented on the getter. (2)
+  `BridgeRegistrationService` gained a broadcast `Stream<String> registrations`
+  emitting the assigned id once per real registration round-trip (fresh + post-
+  4006 re-registration; memoized reconnect calls do NOT emit) plus a `dispose()`
+  registered with the shutdown coordinator. (3) `ControlStatusNotifier`
+  (Layer 4 `control/`): subscribes (one `CompositeSubscription`) to plugin
+  status, relay state, registrations, and the control channel's own
+  `connectionState` — on control reconnect it re-sends `registered` + the
+  current status snapshot (bypassing dedupe), since sends throw while the
+  channel is down and status is edge-triggered. Consecutive identical statuses
+  are deduped (no spam); sends are best-effort (`Log.d` on
+  not-connected, `Log.w` catch-all — never throws into a stream callback).
+  Health mapping: Starting→unknown, Ready→healthy, Degraded/Restarting→degraded,
+  Failed/Stopping/Stopped→unavailable. (4) Composition: `RelayClient`
+  construction lifted from `BridgeRuntime.create` into the runner (so the
+  notifier can observe its state stream before the runtime composes);
+  `BridgeRuntime.create` gains `required RelayClient relayClient` and
+  `required ControlStatusNotifier? statusNotifier` (null in standalone);
+  the notifier is constructed+started only inside the supervised gate, after
+  `startPlugin` and the registration service, before `session.run()` — so the
+  first registration/connect are never missed and standalone constructs zero
+  control senders. Tests: 15 new notifier tests, 5 relay connectionState
+  tests, 5 registrations-stream tests, 1 orchestrator end-to-end feed test
+  (startup + live summary through a real notifier). `make analyze` +
+  `dart analyze --fatal-infos` clean; `make test` all pass (app 1692).
+- **Deltas:** the active-session summary is NOT an observed stream: it reaches
+  the notifier as a typed delegate feed (`handleProjectsSummary`) from the
+  Orchestrator's existing SSE pipeline — the count lives only in the plugin
+  (Layer 1), and the summary event is already built there for phones, so the
+  delegate reuses it instead of adding a Layer-4→Layer-1 access or a duplicate
+  derivation (the `CompletionPushListener.handleSseEvent` precedent; §6
+  amended). `Orchestrator`/`OrchestratorSession` carry a
+  `required ControlStatusNotifier?` (nullable = standalone), mirroring how the
+  runner gates every other supervised component.
 
 ## PR 1.11 — `unregister-and-exit` control command
 - **Goal:** Handle a control command that unregisters the `bridgeId` (current


### PR DESCRIPTION
## Summary

Phase 1, PR 1.10 of the desktop plan (`docs/desktop/phase-1-bridge-supervised.md`): in supervised mode (`--control-url`) the bridge now pushes **`status`** (relay connection state + plugin health + active-session count) and **`registered{bridgeId}`** control messages to the desktop GUI over the loopback control channel — so the GUI can persist a readable copy of the bridge id before any crash/stop (ADR A13/A17) and render live health in the tray. Reactive only, no timers. Standalone behaviour is byte-identical: no control senders are constructed without `--control-url`.

No `sesori_shared` changes — the PR-1.2 DTOs already carry these shapes.

## What changed

- **`RelayClient` (Layer 0)** gains a broadcast `connectionState` stream with a new sealed `RelayConnectionState` (`RelayConnecting` / `RelayConnected` / `RelayDisconnected{closeCode}`). A remote drop carries the socket's close code (the stream PR 1.14's takeover detection builds on); a deliberate `close()` emits nothing — clean shutdown is not an outage, mirroring `ControlChannelClient`'s contract.
- **`BridgeRegistrationService` (auth/ seam)** gains a broadcast `registrations` stream emitting the assigned bridge id once per real registration round-trip (first registration + post-4006 re-registration; memoized reconnect calls do NOT emit), plus a `dispose()` registered with the shutdown coordinator.
- **New `ControlStatusNotifier` (Layer 4 `control/`)** owns ALL outbound status-class sends over the injected `ControlChannelClient`: observes plugin lifecycle status (replay-latest `BridgePlugin.status`), the relay state stream, registrations, and the control channel's own connection state — after a control-channel blip it re-sends `registered` + the current status snapshot, since sends throw while the channel is down and status is edge-triggered. Consecutive identical statuses are deduped (live changes, no periodic spam). Sends are best-effort and never throw into stream callbacks.
- **Orchestrator feed:** the already-built projects-summary SSE event (the one phones receive) is fed to the notifier via a typed delegate (`handleProjectsSummary`) at the two existing summary call sites — the `CompletionPushListener.handleSseEvent` precedent — so the Layer-4 notifier never touches the Layer-1 plugin and no duplicate derivation path exists. The Orchestrator never calls `ControlChannelClient.send`.
- **Composition root:** `RelayClient` construction lifted from `BridgeRuntime.create` into the runner so the supervised block can wire its state stream; the notifier is constructed/started only inside the supervised gate, after `startPlugin` + the registration service and before `session.run()`, so the first registration and relay connect are never missed.
- **Docs:** PLAN.md pointer + §9 row flipped, §6 `ControlStatusNotifier` row amended to the shipped shape; phase-1 doc Findings/Deltas recorded.

## Regression guide (from the phase doc — verified)

1. Registration stays memoized (no duplicate POSTs per process) — existing `orchestrator_registration_test` green unmodified; the new stream emits only on real round-trips (asserted).
2. 4006 → `handleBridgeRevoked` → fresh-id re-registration still works and now emits an updated `registered` event (asserted in service tests).
3. Status emission is driven by existing streams — no new timers (reactive-vs-polling rule).
4. Standalone: zero control sends — nothing supervised is constructed without `--control-url`; the new relay/registration streams simply have no subscribers.
5. Relay reconnect loop untouched (it still reads `closeCode` for 4006); deliberate `close()`/`reconnect()` semantics covered by 5 new `connectionState` tests.

## Testing

- 15 new `ControlStatusNotifier` tests (mapping, dedupe, summary counting, registered pushes, send-failure resilience, reconnect re-sync, lifecycle).
- 5 new `RelayClient.connectionState` tests (connect, remote drop w/ close code, silent deliberate close, failed connect, reconnect sequence).
- 5 new `BridgeRegistrationService.registrations` tests.
- 1 end-to-end orchestrator test: startup + live summaries flow through a real notifier wired to the real relay state stream.
- `make analyze` clean, `dart analyze --fatal-infos` clean, `make test` all pass (app: 1692).

## Aristotle

- `aristotle-plan-review`: APPROVED (pre-implementation).
- `aristotle-impl-review`: 1 finding (inlined error in a log call) — fixed in the follow-up commit; re-verified clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
In supervised mode (`--control-url`), the bridge now pushes live status (relay connection state, plugin health, active-session count) and `registered{bridgeId}` messages to the desktop GUI over the loopback control channel. Standalone behavior is unchanged.

- **New Features**
  - Added `ControlStatusNotifier` to own all status-class sends (`status`, `registered`). Listens to plugin status, relay connection state, registration successes, and control-channel reconnects; dedupes identical statuses; best-effort sends.
  - `RelayClient` exposes a broadcast `connectionState` stream with `RelayConnecting`/`RelayConnected`/`RelayDisconnected{closeCode}`. Remote drops include the WebSocket close code; deliberate `close()` stays silent.
  - `BridgeRegistrationService` exposes a broadcast `registrations` stream that emits on real registration round-trips (initial and post-4006). Added `dispose()` for shutdown.
  - Orchestrator feeds the already-built projects summary to the notifier via `handleProjectsSummary` to update active-session count. Orchestrator never calls `ControlChannelClient.send`.
  - Composition: `RelayClient` is constructed in the runner; `BridgeRuntime.create` now accepts `relayClient` and optional `statusNotifier`. The notifier starts only in supervised mode, after plugin start and registration, before `session.run()`.

- **Bug Fixes**
  - Validate the relay URL before emitting `RelayConnecting` to avoid a stuck “connecting” state on bad config.

<sup>Written for commit 37ffdf6e93841d74093e9d5f43e8f18fc85d7330. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

