### PR TITLE
feat(bridge): supervised unregister-and-exit control command (Phase 1, PR 1.11)

### DIFF
--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -169,10 +169,16 @@ class BridgeRuntimeRunner {
     // and the shutdown-error path too, so the sentinel survives a hung or
     // throwing shutdown.
     int? requestedSupervisedAuthRequiredExitCode;
+    // Set when the GUI's `unregister_and_exit` logout command triggers shutdown:
+    // logout is a deliberate clean stop, so the backstop must report 0 even if a
+    // plugin failure was already latched and the ordered shutdown then hangs —
+    // otherwise the supervisor would misread the logout as a crash and respawn.
+    int? requestedSupervisedLogoutExitCode;
     final shutdownCoordinator = BridgeShutdownCoordinator(
       backstopExitCode: () =>
           requestedSupervisedRestartExitCode ??
           requestedSupervisedAuthRequiredExitCode ??
+          requestedSupervisedLogoutExitCode ??
           supervisedLossExitCode ??
           (failureLatch.failure == null ? 0 : 1),
     );
@@ -246,6 +252,19 @@ class BridgeRuntimeRunner {
     final bridgeIdStorage = BridgeIdStorage(filePath: bridgeIdPath());
 
     try {
+      // Copy a legacy bridge id out of token.json into its own storage before
+      // anything ID-dependent runs — in particular before the supervised control
+      // channel + dispatcher come up, so a GUI `unregister_and_exit` that arrives
+      // during early startup unregisters the migrated id instead of reading an
+      // empty store and leaking the server-side registration. The first token
+      // save no longer serializes bridgeId, so skipping this would erase the only
+      // copy. A failure here aborts startup so the next run retries the copy with
+      // the legacy source still intact.
+      await BridgeIdMigrationService(
+        bridgeIdStorage: bridgeIdStorage,
+        readLegacyBridgeId: readLegacyBridgeId,
+      ).migrate();
+
       // Supervised mode (desktop GUI): bring up the loopback control channel
       // before anything else so the GUI sees the helper connect promptly. Every
       // step here is gated by `--control-url`; standalone startup is unchanged.
@@ -287,10 +306,14 @@ class BridgeRuntimeRunner {
         shutdownCoordinator.add(disposable: supervisedRegistrationService.dispose);
         // Handles the GUI's `unregister_and_exit` logout command: unregister the
         // bridgeId, then gracefully shut down and exit 0 (a clean stop, so the
-        // GUI does not respawn us).
+        // GUI does not respawn us). Record the logout sentinel first so a hung
+        // shutdown's backstop still reports 0 rather than a latched-failure 1.
         final controlUnregisterService = ControlUnregisterService(
           registrationService: supervisedRegistrationService,
-          terminate: () => _shutdownThenExit(shutdownCoordinator: shutdownCoordinator, code: 0),
+          terminate: () {
+            requestedSupervisedLogoutExitCode = 0;
+            return _shutdownThenExit(shutdownCoordinator: shutdownCoordinator, code: 0);
+          },
         );
         // The single inbound subscriber: decodes GUI→helper frames once and
         // routes them to the owning service. Started before the bootstrap token
@@ -371,16 +394,6 @@ class BridgeRuntimeRunner {
           Log.w("Update reconciliation failed (non-fatal): $error");
         }
       }
-
-      // Copy a legacy bridge id out of token.json into its own storage before
-      // authentication: the first token save no longer serializes bridgeId, so
-      // it would otherwise erase the only copy and force a duplicate
-      // registration. A failure here aborts startup so the next run retries the
-      // copy with the legacy source still intact.
-      await BridgeIdMigrationService(
-        bridgeIdStorage: bridgeIdStorage,
-        readLegacyBridgeId: readLegacyBridgeId,
-      ).migrate();
 
       // Supervised mode short-circuits the interactive auth bootstrap: no
       // provider menu, no email/password prompt — the access token comes from
@@ -488,11 +501,17 @@ class BridgeRuntimeRunner {
         }
       }
 
-      final plugin = await pluginManager.startPlugin(id: pluginId);
+      // Register the ordered plugin-stop BEFORE starting the plugin. A logout
+      // (or the ADR-A9 control-loss exit) can trigger `_shutdownThenExit` while
+      // `startPlugin()` is still in-flight; registering the stop first means the
+      // ordered shutdown covers a partially-started plugin (`stopPlugin` awaits
+      // the in-flight start, then shuts it down) instead of exiting without
+      // stopping it and orphaning the backend. It is a no-op if start never ran.
       shutdownCoordinator.addOrdered(
         action: () => pluginManager.stopPlugin(id: pluginId),
         budget: _pluginShutdownBudget,
       );
+      final plugin = await pluginManager.startPlugin(id: pluginId);
       plugin.status
           .listen((status) {
             if (status is PluginFailed) {
@@ -763,7 +782,11 @@ class BridgeRuntimeRunner {
       ),
       tokenRefresher: tokenRefresher,
       bridgeIdStorage: bridgeIdStorage,
-      hostName: io.Platform.localHostname,
+      // Safe helper (not io.Platform.localHostname directly): hostname
+      // resolution can throw a SocketException in restricted/containerized
+      // environments; degrade to "" (which BridgeRegistrationService clamps to
+      // "sesori-bridge") instead of crashing startup.
+      hostName: _localHostname(),
       platform: BridgeRegistrationService.currentPlatformName(),
     );
   }

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -67,6 +67,7 @@ import "../../server/services/bridge_instance_service.dart";
 import "../../server/services/bridge_restart_service.dart";
 import "../../services/control_channel_token_service.dart";
 import "../../services/control_prompt_service.dart";
+import "../../services/control_unregister_service.dart";
 import "../../updater/api/checksum_manifest_api.dart";
 import "../../updater/api/github_releases_api.dart";
 import "../../updater/api/managed_runtime_manifest_api.dart";
@@ -238,6 +239,12 @@ class BridgeRuntimeRunner {
       clearTokens: clearTokens,
     );
 
+    // Persisted bridge-id storage (its own file, not token.json). Constructed
+    // here so the supervised registration service below can share it; the
+    // legacy-id migration that populates it still runs at its normal point
+    // before authentication.
+    final bridgeIdStorage = BridgeIdStorage(filePath: bridgeIdPath());
+
     try {
       // Supervised mode (desktop GUI): bring up the loopback control channel
       // before anything else so the GUI sees the helper connect promptly. Every
@@ -245,8 +252,13 @@ class BridgeRuntimeRunner {
       ControlChannelTokenService? controlChannelTokenService;
       ControlPromptService? controlPromptService;
       // Kept in scope past this block: the ControlStatusNotifier (built later,
-      // once the plugin and registration service exist) shares this client.
+      // once the plugin exists) shares this client.
       ControlChannelClient? controlChannelClient;
+      // Built early in supervised mode so the dispatcher can route the logout
+      // `unregister_and_exit` command; reused as THE registration service later.
+      // Standalone builds it after the interactive auth flow yields its token
+      // refresher.
+      BridgeRegistrationService? supervisedRegistrationService;
       if (options.isSupervised) {
         controlChannelClient = await _connectSupervisedControlChannel(
           options: options,
@@ -262,6 +274,24 @@ class BridgeRuntimeRunner {
         // a terminal the helper doesn't have.
         controlPromptService = ControlPromptService(client: controlChannelClient);
         shutdownCoordinator.add(disposable: controlPromptService.dispose);
+        // The GUI's supplied token is this bridge's authority, so the control
+        // token service is the refresher. Reads the persisted id only at
+        // runtime (unregister/register), after the migration below, so building
+        // it before that migration is safe.
+        supervisedRegistrationService = _buildRegistrationService(
+          httpClient: httpClient,
+          authBackendUrl: options.authBackendUrl,
+          tokenRefresher: controlChannelTokenService,
+          bridgeIdStorage: bridgeIdStorage,
+        );
+        shutdownCoordinator.add(disposable: supervisedRegistrationService.dispose);
+        // Handles the GUI's `unregister_and_exit` logout command: unregister the
+        // bridgeId, then gracefully shut down and exit 0 (a clean stop, so the
+        // GUI does not respawn us).
+        final controlUnregisterService = ControlUnregisterService(
+          registrationService: supervisedRegistrationService,
+          terminate: () => _shutdownThenExit(shutdownCoordinator: shutdownCoordinator, code: 0),
+        );
         // The single inbound subscriber: decodes GUI→helper frames once and
         // routes them to the owning service. Started before the bootstrap token
         // pull below so its response is never missed.
@@ -269,6 +299,7 @@ class BridgeRuntimeRunner {
           client: controlChannelClient,
           tokenService: controlChannelTokenService,
           promptService: controlPromptService,
+          unregisterService: controlUnregisterService,
         );
         controlMessageDispatcher.start();
         shutdownCoordinator.add(disposable: controlMessageDispatcher.dispose);
@@ -346,7 +377,6 @@ class BridgeRuntimeRunner {
       // it would otherwise erase the only copy and force a duplicate
       // registration. A failure here aborts startup so the next run retries the
       // copy with the legacy source still intact.
-      final bridgeIdStorage = BridgeIdStorage(filePath: bridgeIdPath());
       await BridgeIdMigrationService(
         bridgeIdStorage: bridgeIdStorage,
         readLegacyBridgeId: readLegacyBridgeId,
@@ -494,19 +524,21 @@ class BridgeRuntimeRunner {
         tokenRefresher = tokenManager;
       }
 
-      final bridgeRegistrationService = BridgeRegistrationService(
-        repository: BridgeRegistrationRepository(
-          api: BridgeRegistrationApi(
-            authBackendUrl: options.authBackendUrl,
-            client: httpClient,
-          ),
-        ),
-        tokenRefresher: tokenRefresher,
-        bridgeIdStorage: bridgeIdStorage,
-        hostName: io.Platform.localHostname,
-        platform: BridgeRegistrationService.currentPlatformName(),
-      );
-      shutdownCoordinator.add(disposable: bridgeRegistrationService.dispose);
+      // Supervised mode already built this early (so the dispatcher could route
+      // the logout command); reuse that instance. Standalone builds it here, now
+      // that the interactive auth flow has produced its token refresher.
+      final BridgeRegistrationService bridgeRegistrationService;
+      if (supervisedRegistrationService != null) {
+        bridgeRegistrationService = supervisedRegistrationService;
+      } else {
+        bridgeRegistrationService = _buildRegistrationService(
+          httpClient: httpClient,
+          authBackendUrl: options.authBackendUrl,
+          tokenRefresher: tokenRefresher,
+          bridgeIdStorage: bridgeIdStorage,
+        );
+        shutdownCoordinator.add(disposable: bridgeRegistrationService.dispose);
+      }
 
       // Constructed here (not inside BridgeRuntime.create) so supervised mode
       // can observe its connectionState stream below.
@@ -712,14 +744,38 @@ class BridgeRuntimeRunner {
     return controlChannelClient;
   }
 
-  /// Graceful termination for the control-channel parent-loss policy (ADR A9):
-  /// run the ordered shutdown (which stops the plugin and any owned runtime)
-  /// before exiting, so a hard exit from the loss timer cannot orphan the
-  /// backend process. If the stop hangs, the coordinator backstop fires — and
-  /// because the loss code was recorded via `requestAbnormalExit`, the backstop
-  /// reports that abnormal code, not the neutral 0, so a loss is never seen as a
-  /// clean exit regardless of the backstop's (step-count-dependent) timing. The
-  /// precise exit code the GUI observes is finalized in Phase 2 (PR 2.7).
+  /// Builds the bridge registration service. Extracted so supervised mode can
+  /// construct it early (sharing the control token service as its refresher) to
+  /// route the logout command, while standalone builds it after interactive auth
+  /// yields its refresher — both from one definition.
+  static BridgeRegistrationService _buildRegistrationService({
+    required http.Client httpClient,
+    required String authBackendUrl,
+    required TokenRefresher tokenRefresher,
+    required BridgeIdStorage bridgeIdStorage,
+  }) {
+    return BridgeRegistrationService(
+      repository: BridgeRegistrationRepository(
+        api: BridgeRegistrationApi(
+          authBackendUrl: authBackendUrl,
+          client: httpClient,
+        ),
+      ),
+      tokenRefresher: tokenRefresher,
+      bridgeIdStorage: bridgeIdStorage,
+      hostName: io.Platform.localHostname,
+      platform: BridgeRegistrationService.currentPlatformName(),
+    );
+  }
+
+  /// Runs the ordered shutdown (stopping the plugin and any owned runtime),
+  /// then exits with [code]. Two supervised paths use it: the control-channel
+  /// parent-loss policy (ADR A9) and the GUI logout `unregister_and_exit`
+  /// command. Running the ordered shutdown first means a hard exit can never
+  /// orphan the backend process. If the stop hangs, the coordinator backstop
+  /// fires; for the loss path the abnormal code recorded via
+  /// `requestAbnormalExit` is reported so a loss is never seen as a clean exit.
+  /// The precise exit code the GUI observes is finalized in Phase 2 (PR 2.7).
   static Future<void> _shutdownThenExit({
     required BridgeShutdownCoordinator shutdownCoordinator,
     required int code,

--- a/bridge/app/lib/src/control/bridge_control_message_dispatcher.dart
+++ b/bridge/app/lib/src/control/bridge_control_message_dispatcher.dart
@@ -6,6 +6,7 @@ import "package:sesori_shared/sesori_shared.dart";
 import "../foundation/control_channel_client.dart";
 import "../services/control_channel_token_service.dart";
 import "../services/control_prompt_service.dart";
+import "../services/control_unregister_service.dart";
 
 /// The single inbound subscriber/decoder for GUI→helper control messages in
 /// supervised mode: it owns the one subscription to
@@ -24,6 +25,7 @@ class BridgeControlMessageDispatcher {
   final ControlChannelClient _client;
   final ControlChannelTokenService _tokenService;
   final ControlPromptService _promptService;
+  final ControlUnregisterService _unregisterService;
 
   StreamSubscription<String>? _subscription;
 
@@ -31,9 +33,11 @@ class BridgeControlMessageDispatcher {
     required ControlChannelClient client,
     required ControlChannelTokenService tokenService,
     required ControlPromptService promptService,
+    required ControlUnregisterService unregisterService,
   })  : _client = client,
         _tokenService = tokenService,
-        _promptService = promptService;
+        _promptService = promptService,
+        _unregisterService = unregisterService;
 
   /// Subscribes to the client's inbound stream. Idempotent — a second call
   /// while already started does nothing.
@@ -66,16 +70,19 @@ class BridgeControlMessageDispatcher {
         _tokenService.handleTokenUpdate(accessToken: accessToken);
       case ControlPromptResponse(:final id, :final accepted):
         _promptService.handlePromptResponse(id: id, accepted: accepted);
+      case ControlUnregisterAndExit():
+        // Unregisters then terminates the process; fire-and-forget because the
+        // flow ends in a graceful shutdown + exit and owns its own errors.
+        unawaited(_unregisterService.handleUnregisterAndExit());
       case ControlTokenRequest():
       case ControlStatus():
       case ControlPromptRequest():
       case ControlRestart():
-      case ControlUnregisterAndExit():
       case ControlRegistered():
       case ControlProvisionProgressMessage():
-        // Not consumed inbound (yet): helper→GUI variants have no inbound
-        // meaning, `restart` is never an inbound command, and
-        // `unregister_and_exit` gains its route when the unregister flow lands.
+        // Not consumed inbound: helper→GUI variants have no inbound meaning and
+        // `restart` is never an inbound command (the GUI restarts the helper by
+        // kill+respawn, not by message).
         Log.d("[control][dispatcher] ignoring inbound ${message.runtimeType}");
     }
   }

--- a/bridge/app/lib/src/services/control_unregister_service.dart
+++ b/bridge/app/lib/src/services/control_unregister_service.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 import "../auth/bridge_registration_service.dart";
@@ -18,21 +20,32 @@ import "../auth/bridge_registration_service.dart";
 /// process-termination effect is injected ([_terminate]) so the composition root
 /// keeps ownership of the graceful-shutdown-then-exit path.
 class ControlUnregisterService {
+  /// The unregister DELETE is a single machine-to-server call with a
+  /// GUI-supplied (already cached) token, so it should be quick. Bounding it
+  /// keeps a stalled network (silent packet loss / blackhole) from hanging the
+  /// GUI's logout forever — on timeout the process still terminates and the
+  /// GUI's offline-unregister fallback (ADR A13) cleans up the leaked
+  /// registration.
+  static const Duration _defaultUnregisterTimeout = Duration(seconds: 10);
+
   final BridgeRegistrationService _registrationService;
   final Future<void> Function() _terminate;
+  final Duration _unregisterTimeout;
 
   ControlUnregisterService({
     required BridgeRegistrationService registrationService,
     required Future<void> Function() terminate,
+    Duration unregisterTimeout = _defaultUnregisterTimeout,
   })  : _registrationService = registrationService,
-        _terminate = terminate;
+        _terminate = terminate,
+        _unregisterTimeout = unregisterTimeout;
 
   /// Unregisters the bridge, then terminates the process. Terminates even when
-  /// the unregister throws so the GUI's logout is never blocked by a bridge that
-  /// can't reach the auth server.
+  /// the unregister throws or times out, so the GUI's logout is never blocked by
+  /// a bridge that can't reach the auth server.
   Future<void> handleUnregisterAndExit() async {
     try {
-      await _registrationService.unregister();
+      await _registrationService.unregister().timeout(_unregisterTimeout);
     } on Object catch (error, stackTrace) {
       Log.w("[control] unregister on logout failed; terminating anyway", error, stackTrace);
     }

--- a/bridge/app/lib/src/services/control_unregister_service.dart
+++ b/bridge/app/lib/src/services/control_unregister_service.dart
@@ -1,0 +1,41 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
+import "../auth/bridge_registration_service.dart";
+
+/// Handles the supervised-mode `unregister_and_exit` control command the desktop
+/// GUI sends while logging out: unregister this bridge's `bridgeId` on the auth
+/// server, then terminate the process so the GUI can order logout cleanly.
+///
+/// It owns the logout ordering boundary: the unregister runs BEFORE the process
+/// terminates, and the process still terminates even if the unregister fails, so
+/// a stuck bridge can never hang the GUI's logout. A failed unregister only
+/// leaks the server-side registration until the GUI's offline-unregister
+/// fallback cleans it up (it keeps a readable `bridgeId` copy for exactly this,
+/// ADR A13).
+///
+/// The dispatcher (the single inbound subscriber) invokes this on the command;
+/// this class owns no subscription or correlation state of its own. The
+/// process-termination effect is injected ([_terminate]) so the composition root
+/// keeps ownership of the graceful-shutdown-then-exit path.
+class ControlUnregisterService {
+  final BridgeRegistrationService _registrationService;
+  final Future<void> Function() _terminate;
+
+  ControlUnregisterService({
+    required BridgeRegistrationService registrationService,
+    required Future<void> Function() terminate,
+  })  : _registrationService = registrationService,
+        _terminate = terminate;
+
+  /// Unregisters the bridge, then terminates the process. Terminates even when
+  /// the unregister throws so the GUI's logout is never blocked by a bridge that
+  /// can't reach the auth server.
+  Future<void> handleUnregisterAndExit() async {
+    try {
+      await _registrationService.unregister();
+    } on Object catch (error, stackTrace) {
+      Log.w("[control] unregister on logout failed; terminating anyway", error, stackTrace);
+    }
+    await _terminate();
+  }
+}

--- a/bridge/app/test/control/bridge_control_message_dispatcher_test.dart
+++ b/bridge/app/test/control/bridge_control_message_dispatcher_test.dart
@@ -5,6 +5,7 @@ import "package:sesori_bridge/src/control/bridge_control_message_dispatcher.dart
 import "package:sesori_bridge/src/foundation/control_channel_client.dart";
 import "package:sesori_bridge/src/services/control_channel_token_service.dart";
 import "package:sesori_bridge/src/services/control_prompt_service.dart";
+import "package:sesori_bridge/src/services/control_unregister_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -13,16 +14,19 @@ void main() {
     late _FakeControlChannelClient client;
     late _RecordingTokenService tokenService;
     late _RecordingPromptService promptService;
+    late _RecordingUnregisterService unregisterService;
     late BridgeControlMessageDispatcher dispatcher;
 
     setUp(() {
       client = _FakeControlChannelClient();
       tokenService = _RecordingTokenService();
       promptService = _RecordingPromptService();
+      unregisterService = _RecordingUnregisterService();
       dispatcher = BridgeControlMessageDispatcher(
         client: client,
         tokenService: tokenService,
         promptService: promptService,
+        unregisterService: unregisterService,
       );
       addTearDown(dispatcher.dispose);
     });
@@ -57,6 +61,16 @@ void main() {
       expect(tokenService.responses, isEmpty);
     });
 
+    test("routes unregister_and_exit to the unregister service delegate", () async {
+      dispatcher.start();
+      client.emit(_encode(const ControlMessage.unregisterAndExit()));
+      await pumpEventQueue();
+
+      expect(unregisterService.calls, equals(1));
+      expect(tokenService.responses, isEmpty);
+      expect(promptService.responses, isEmpty);
+    });
+
     test("an undecodable frame is skipped and later frames are still routed", () async {
       dispatcher.start();
       client.emit("not valid json");
@@ -69,7 +83,6 @@ void main() {
     test("variants with no inbound meaning are ignored — restart is never an inbound command", () async {
       dispatcher.start();
       client.emit(_encode(const ControlMessage.restart()));
-      client.emit(_encode(const ControlMessage.unregisterAndExit()));
       client.emit(_encode(const ControlMessage.registered(bridgeId: "b-1")));
       client.emit(_encode(const ControlMessage.tokenRequest(id: "t-1")));
       client.emit(
@@ -85,6 +98,7 @@ void main() {
       expect(tokenService.responses, isEmpty);
       expect(tokenService.updates, isEmpty);
       expect(promptService.responses, isEmpty);
+      expect(unregisterService.calls, isZero);
     });
 
     test("the dispatcher is the only inbound subscriber — services never self-subscribe", () async {
@@ -99,6 +113,7 @@ void main() {
         client: client,
         tokenService: realTokenService,
         promptService: realPromptService,
+        unregisterService: _RecordingUnregisterService(),
       );
       addTearDown(wired.dispose);
       wired.start();
@@ -178,6 +193,16 @@ class _RecordingPromptService implements ControlPromptService {
 
   @override
   void handlePromptResponse({required String id, required bool accepted}) => responses.add((id, accepted));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _RecordingUnregisterService implements ControlUnregisterService {
+  int calls = 0;
+
+  @override
+  Future<void> handleUnregisterAndExit() async => calls++;
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/bridge/app/test/services/control_channel_token_service_test.dart
+++ b/bridge/app/test/services/control_channel_token_service_test.dart
@@ -6,6 +6,7 @@ import "package:sesori_bridge/src/control/bridge_control_message_dispatcher.dart
 import "package:sesori_bridge/src/foundation/control_channel_client.dart";
 import "package:sesori_bridge/src/services/control_channel_token_service.dart";
 import "package:sesori_bridge/src/services/control_prompt_service.dart";
+import "package:sesori_bridge/src/services/control_unregister_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -24,6 +25,7 @@ void main() {
       client: client,
       tokenService: service,
       promptService: ControlPromptService(client: client),
+      unregisterService: _NoopUnregisterService(),
     )..start();
     addTearDown(dispatcher.dispose);
     return service;
@@ -425,4 +427,14 @@ class _FakeControlChannelClient implements ControlChannelClient {
   Future<void> dispose() async {
     await _inbound.close();
   }
+}
+
+/// The token-service tests wire a real dispatcher but never exercise the logout
+/// command, so its unregister delegate is a no-op stand-in.
+class _NoopUnregisterService implements ControlUnregisterService {
+  @override
+  Future<void> handleUnregisterAndExit() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/bridge/app/test/services/control_unregister_service_test.dart
+++ b/bridge/app/test/services/control_unregister_service_test.dart
@@ -1,0 +1,49 @@
+import "package:sesori_bridge/src/auth/bridge_registration_service.dart";
+import "package:sesori_bridge/src/services/control_unregister_service.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ControlUnregisterService", () {
+    test("unregisters then terminates, in that order", () async {
+      final events = <String>[];
+      final registrationService = _FakeRegistrationService(
+        onUnregister: () async => events.add("unregister"),
+      );
+      final service = ControlUnregisterService(
+        registrationService: registrationService,
+        terminate: () async => events.add("terminate"),
+      );
+
+      await service.handleUnregisterAndExit();
+
+      expect(events, equals(["unregister", "terminate"]));
+    });
+
+    test("terminates even when unregister fails, so logout is never blocked", () async {
+      var terminated = false;
+      final registrationService = _FakeRegistrationService(
+        onUnregister: () async => throw StateError("auth server unreachable"),
+      );
+      final service = ControlUnregisterService(
+        registrationService: registrationService,
+        terminate: () async => terminated = true,
+      );
+
+      await service.handleUnregisterAndExit();
+
+      expect(terminated, isTrue);
+    });
+  });
+}
+
+class _FakeRegistrationService implements BridgeRegistrationService {
+  final Future<void> Function() _onUnregister;
+
+  _FakeRegistrationService({required Future<void> Function() onUnregister}) : _onUnregister = onUnregister;
+
+  @override
+  Future<void> unregister() => _onUnregister();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/services/control_unregister_service_test.dart
+++ b/bridge/app/test/services/control_unregister_service_test.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:sesori_bridge/src/auth/bridge_registration_service.dart";
 import "package:sesori_bridge/src/services/control_unregister_service.dart";
 import "package:test/test.dart";
@@ -27,6 +29,24 @@ void main() {
       final service = ControlUnregisterService(
         registrationService: registrationService,
         terminate: () async => terminated = true,
+      );
+
+      await service.handleUnregisterAndExit();
+
+      expect(terminated, isTrue);
+    });
+
+    test("terminates when a stalled unregister exceeds the timeout", () async {
+      var terminated = false;
+      final registrationService = _FakeRegistrationService(
+        // Never completes — a blackholed network would hang logout forever
+        // without the bounding timeout.
+        onUnregister: () => Completer<void>().future,
+      );
+      final service = ControlUnregisterService(
+        registrationService: registrationService,
+        terminate: () async => terminated = true,
+        unregisterTimeout: const Duration(milliseconds: 20),
       );
 
       await service.handleUnregisterAndExit();

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -8,8 +8,8 @@
 
 ## Current pointer
 
-- **Last completed phase:** Phase 1 — PR 1.10 Status push (relay/plugin/active sessions) via `ControlStatusNotifier` (PR raised on branch `desktop-implementation-stage`)
-- **Next up:** Phase 1 — PR 1.11 `unregister-and-exit` control command
+- **Last completed phase:** Phase 1 — PR 1.11 `unregister-and-exit` control command via `ControlUnregisterService` (PR raised on branch `next-desktop-plan-step`)
+- **Next up:** Phase 1 — PR 1.12 Single-live precedence under supervised `--hidden`
 - **Branch:** one feature branch per PR, cut from `main`
 
 > **Tracking lives in four places that MUST move together in the same PR.**
@@ -280,6 +280,7 @@ mobile release.**
 | `ControlChannelTokenService` | Layer 3 `services/` | implements `auth/` `AccessTokenProvider`/`TokenRefresher`; pull + push token stream over injected `ControlChannelClient`. Kept out of the self-contained `auth/` subsystem so `auth/` does not import core `foundation/`. PR 1.9 re-homes its **inbound** subscription behind `BridgeControlMessageDispatcher` (typed delegate calls); request-correlation state and the `token_request` send path stay inside the service. |
 | `BridgeControlMessageDispatcher` | Layer 4 `control/` | owns the **single** inbound subscription + decode of GUI→helper control messages (created in PR 1.9). Routes: `token_response`/`token_update` → token-service delegate, `prompt_response` → prompt-service delegate, `unregister_and_exit` → unregister flow (PR 1.11). `restart` is **helper→GUI only** and is never an inbound command — the GUI restarts the helper by kill+respawn, not by message. |
 | `ControlPromptService` | Layer 3 `services/` | supervised-mode user prompts over the injected `ControlChannelClient` (same blessed seam as the token service): owns prompt-class correlation state + ALL prompt-class outbound sends (`prompt_request`); implements the `server/foundation/` `BridgeReplacePrompt` interface so `BridgeInstanceService` asks the GUI instead of a terminal; `announceLoginNeeded()` is the best-effort advisory before the exit-87 sentinel (ADR A23). Unanswerable asks (channel down / timeout / teardown) degrade to `nonInteractive`. |
+| `ControlUnregisterService` | Layer 3 `services/` | supervised logout `unregister_and_exit` handler (created in PR 1.11): the dispatcher's third typed delegate. Owns the logout ordering boundary — unregisters the `bridgeId` via the injected `BridgeRegistrationService`, then runs the injected `terminate` (composition-root-wired to the graceful `_shutdownThenExit(code: 0)`). Still terminates if unregister throws (logged) so a stuck bridge can't hang the GUI's logout; the GUI's offline-unregister fallback (ADR A13) cleans up any leak. |
 | `BridgeReplacePrompt` | interface in `server/foundation/` | the replace-bridge ask contract with two production implementations: `TerminalPromptRepository` (standalone) and `ControlPromptService` (supervised); keeps the `server/` subsystem free of core-layer imports (mirrors the auth-interface precedent from PR 1.4). |
 | `ControlStatusNotifier` | Layer 4 `control/` | owns **all outbound** status-class control sends (created in PR 1.10): observes Layer-0 state streams (relay connection state incl. close code via `RelayClient.connectionState`, plugin health via `BridgePlugin.status`, registration events via the auth seam's `registrations` stream, plus the control channel's own state for a reconnect re-sync) and receives the **active-session summary as a typed delegate feed** from the Orchestrator's SSE pipeline (`handleProjectsSummary` — same shape as `CompletionPushListener.handleSseEvent`; avoids a second Layer-4→Layer-1 derivation path into the plugin). Maps them to `status`/`registered`/takeover pushes over the injected `ControlChannelClient`, deduped. Higher layers (Orchestrator) never call `ControlChannelClient.send` directly. |
 | `BridgeIdStorage` (file API + reader) | **inside the `auth/` subsystem** | persist `bridgeId` separately from `token.json`; kept within `auth/` (which is self-contained, outside the core layer hierarchy) so auth code doesn't depend back on top-level `repositories/`. Injected from the composition root. |
@@ -394,7 +395,7 @@ them). Only the user checks an MT box.
 - ☑ 1.8 Disable self-update + reconcile when supervised — Low / S
 - ☑ 1.9 `BridgeControlMessageDispatcher` + prompts/Console → control events + auth-required exit `87` — Med / M
 - ☑ 1.10 Status push (relay/plugin/active sessions) — Low / S-M
-- ☐ 1.11 `unregister-and-exit` control command — Low / S-M
+- ☑ 1.11 `unregister-and-exit` control command — Low / S-M
 - ☐ 1.12 Single-live precedence under supervised `--hidden` — Med / M
 - ☐ 1.13 Tee `RuntimeProvisionProgress` → control channel — Low / S-M
 - ☐ 1.14 Relay replaced-close (`4007`) → takeover state, no reconnect war (ADR A22) — Med / S-M

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -625,6 +625,23 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   Standalone byte-identical: every new object is built inside the
   `if (options.isSupervised)` gate. `make analyze` + `dart analyze --fatal-infos`
   clean; `make test` all pass (app 1695; +3 unregister-service/dispatcher tests).
+- **Review round** (codex/cubic/gemini, 3 P2s + 1 P1 + hardening): closed four
+  early-startup teardown gaps the new command exposes. (1) The dispatcher starts
+  before `startPlugin()` registers its ordered stop, so a logout mid-start could
+  exit without stopping the backend → the ordered `stopPlugin` is now registered
+  **before** `startPlugin()` (`stopPlugin` safely awaits an in-flight start),
+  which also hardens the pre-existing ADR-A9 loss path. (2) The dispatcher starts
+  before `BridgeIdMigrationService.migrate()`, so a logout on a legacy
+  `token.json`-only install could read an empty store and leak the registration →
+  `migrate()` now runs first, before the control channel/dispatcher. (3) A hung
+  logout-shutdown backstop reported the `failureLatch`-derived `1` when a plugin
+  had already failed → added a `requestedSupervisedLogoutExitCode = 0` sentinel to
+  the backstop chain. (4) A blackholed network could hang logout forever →
+  `ControlUnregisterService` bounds `unregister()` with a configurable timeout
+  (default 10s) and still terminates on timeout. Also switched the extracted
+  registration builder to the safe `_localHostname()` helper. Declined gemini's
+  auth-generation counter: the process exits immediately after unregister, so
+  there are no surviving in-flight operations to invalidate. `make test` app 1696.
 - **Deltas:** To route the command, the supervised `BridgeRegistrationService`
   had to exist when the dispatcher is built (before the bootstrap token pull, so
   `token_response` is never missed). Its construction was extracted into a static

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -599,7 +599,42 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   GUI's logout; (4) standalone logout (`bridge logout` CLI path) untouched.
 - **Acceptance:** command unregisters then exits 0; routed via
   `BridgeControlMessageDispatcher`.
-- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+- **Aristotle:** plan ☑ · impl ☑ (PR raised on branch `next-desktop-plan-step`).
+- **Findings:** Shipped as a new Layer-3 `ControlUnregisterService`
+  (`services/control_unregister_service.dart`), the supervised counterpart of the
+  token/prompt services the dispatcher already routes to. It takes the
+  `auth/`-subsystem `BridgeRegistrationService` and an injected
+  `Future<void> Function() terminate`, and owns the logout ordering boundary:
+  `handleUnregisterAndExit()` calls `registrationService.unregister()` then
+  `terminate()`, and **still terminates when unregister throws** (`Log.w`-logged,
+  swallowed) so a bridge that can't reach the auth server can never hang the GUI's
+  logout — the leaked registration is cleaned up by the GUI's offline-unregister
+  fallback (ADR A13). The dispatcher gained a third `required` delegate; the
+  existing `case ControlUnregisterAndExit()` flipped from `Log.d`-ignore to
+  `unawaited(_unregisterService.handleUnregisterAndExit())`, keeping all three
+  routes symmetric typed-delegate calls (`restart` stays the only inbound
+  helper→GUI variant that is ignored). `terminate` is wired at the composition
+  root to the existing `_shutdownThenExit(shutdownCoordinator, code: 0)` — the
+  same graceful-shutdown-then-`io.exit` path the ADR-A9 loss policy uses, so the
+  ordered plugin stop runs before exit (no orphaned runtime). Exit `0` on both
+  success and unregister failure: a GUI-ordered logout is a clean stop, and a
+  non-zero would risk PR-2.7's exit-code state machine backoff-respawning during
+  logout; the shutdown backstop already defaults to 0 when no sentinel is set, so
+  a hung logout-shutdown exits 0 too. `unregister()`'s 404-is-success and
+  clear-bridge-id-once semantics are unchanged (reused, not reimplemented).
+  Standalone byte-identical: every new object is built inside the
+  `if (options.isSupervised)` gate. `make analyze` + `dart analyze --fatal-infos`
+  clean; `make test` all pass (app 1695; +3 unregister-service/dispatcher tests).
+- **Deltas:** To route the command, the supervised `BridgeRegistrationService`
+  had to exist when the dispatcher is built (before the bootstrap token pull, so
+  `token_response` is never missed). Its construction was extracted into a static
+  `_buildRegistrationService(...)` helper and built **early** in the supervised
+  gate (its refresher is the already-present control token service); the original
+  site now reuses that instance or builds the standalone one (whose refresher is
+  the interactive-auth `TokenManager`, only available late). `bridgeIdStorage`
+  construction moved a few lines earlier (pure, no I/O) so both build sites share
+  it; the legacy-id migration still runs at its original point before auth. §6
+  gains one row: `ControlUnregisterService` (Layer 3 `services/`).
 
 ## PR 1.12 — Single-live precedence under supervised `--hidden`
 - **Goal:** Define/implement contention behaviour when no stdin: a supervised


### PR DESCRIPTION
## What

Implements desktop PLAN.md **Phase 1, PR 1.11** — the supervised-mode `unregister_and_exit` control command the desktop GUI sends during logout. The bridge unregisters its `bridgeId` on the auth server (using the current access token), then gracefully shuts down and exits `0`, so the GUI can order logout cleanly.

## How

- **New `ControlUnregisterService`** (Layer 3 `services/`) — the supervised counterpart of the token/prompt services the dispatcher already routes to. Takes the `auth/`-subsystem `BridgeRegistrationService` and an injected `terminate` action. `handleUnregisterAndExit()` unregisters, then terminates — and **still terminates when unregister throws** (logged, swallowed) so a bridge that can't reach the auth server can never hang the GUI's logout (the GUI's offline-unregister fallback per ADR A13 cleans up any leak).
- **`BridgeControlMessageDispatcher`** gains a third `required` delegate; the existing `case ControlUnregisterAndExit()` flips from `Log.d`-ignore to routing the command. All three routes stay symmetric typed-delegate calls.
- **Composition root** — `terminate` is wired to the existing `_shutdownThenExit(shutdownCoordinator, code: 0)` (same graceful-shutdown-then-`io.exit` path the ADR-A9 loss policy uses, so the ordered plugin stop runs before exit). To route the command, the supervised `BridgeRegistrationService` is built early (extracted into a `_buildRegistrationService(...)` helper); the original site reuses that instance or builds the standalone one.

Exit `0` on both success and unregister failure: a GUI-ordered logout is a clean stop; a non-zero would risk PR-2.7's future exit-code state machine backoff-respawning during logout.

## Release safety

Standalone byte-identical — every new object is built inside the `if (options.isSupervised)` gate; standalone still builds the registration service at the original site via the same helper. Relay protocol untouched.

## Tests

`make analyze` + `dart analyze --fatal-infos` clean; `make test` all pass (app 1695; +3 unregister-service/dispatcher routing tests).

## Reviews

Both Aristotle gates passed: `aristotle-plan-review` (APPROVED) before implementation, `aristotle-impl-review` (APPROVED) before this PR.

## Plan tracking

All four surfaces advanced in this PR: Current pointer → PR 1.12, §9 row 1.11 ☑, phase-1 doc Aristotle line `impl ☑` + Findings/Deltas, and §6 gains the `ControlUnregisterService` row.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the supervised `unregister_and_exit` command so the desktop GUI can log out cleanly. The bridge unregisters on the auth server, then does a graceful shutdown and exits 0 — even on unregister failures or a hung shutdown.

- New Features
  - Added ControlUnregisterService to handle logout: calls BridgeRegistrationService.unregister() with a 10s timeout, then runs the injected graceful `_shutdownThenExit(..., code: 0)`. Logs and still exits when unregister fails or times out.
  - BridgeControlMessageDispatcher now routes ControlUnregisterAndExit to the unregister service (fire-and-forget). Supervised-only; standalone behavior is unchanged.

- Refactors
  - Built BridgeRegistrationService early in supervised mode for routing and extracted `_buildRegistrationService(...)` (reused later); hostname resolved via a safe helper.
  - Moved BridgeIdStorage construction and BridgeIdMigrationService.migrate() earlier so a logout during early startup unregisters the migrated id instead of leaking a registration.
  - Registered the ordered plugin stop before starting the plugin to avoid orphaning the backend if logout triggers mid-start.
  - Added a logout sentinel for the shutdown backstop so it reports exit 0 on GUI-ordered logout, even if a plugin failure was latched or shutdown hangs.

<sup>Written for commit cf92c11680e3537b5167d29e6a774e1780faed63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

