### PR TITLE
ci: use GitHub-hosted ubuntu-latest runners instead of Blacksmith

### DIFF
--- a/.github/workflows/bridge-ci.yml
+++ b/.github/workflows/bridge-ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   test:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     env:
       PUB_CACHE: ${{ github.workspace }}/.pub-cache
     steps:
@@ -79,7 +79,7 @@ jobs:
         working-directory: bridge/sesori_plugin_codex
 
   build-smoke:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     env:
       PUB_CACHE: ${{ github.workspace }}/.pub-cache
     steps:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   cla:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: CLA Assistant
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'

--- a/.github/workflows/lint-suppressions.yml
+++ b/.github/workflows/lint-suppressions.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   check-suppressions:
     name: Check for New Lint Suppressions
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   test:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

Switches all GitHub Actions jobs that were pinned to Blacksmith runners (`blacksmith-2vcpu-ubuntu-2404`) over to GitHub's default `ubuntu-latest` runners, matching the rest of the workflows in the repo.

## Changes

- `bridge-ci.yml` — `test` and `build-smoke` jobs
- `cla.yml` — `cla` job
- `lint-suppressions.yml` — `check-suppressions` job
- `mobile-ci.yml` — `test` job

No Blacksmith-specific actions (e.g. caching) or `runner:` inputs referenced Blacksmith, so only the `runs-on` values changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched CI jobs from Blacksmith runners to GitHub-hosted `ubuntu-latest` to align workflows and reduce external runner dependency. Only `runs-on` values changed.

- **Refactors**
  - Updated `bridge-ci.yml` (test, build-smoke), `cla.yml` (cla), `lint-suppressions.yml` (check-suppressions), and `mobile-ci.yml` (test) to use `ubuntu-latest`.

<sup>Written for commit c14fd6ecacf08859705fed2ad3afd71e436533d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

