### PR TITLE
fix(bridge): pin LC_ALL in installer UTF-8 glyph test

### DIFF
--- a/bridge/app/test/tool/installers_test.dart
+++ b/bridge/app/test/tool/installers_test.dart
@@ -578,9 +578,11 @@ cat "\$HOME/.zprofile"
         environment: {
           'PATH': Platform.environment['PATH'] ?? '',
           'FORCE_COLOR': '1',
-          // LC_ALL has the highest locale precedence, so setting it here keeps the
-          // UTF-8 assertion deterministic even when the runner exports its own
-          // non-UTF-8 LC_ALL/LC_CTYPE (which Process.run inherits by default).
+          // should_use_unicode gates on both a non-dumb TERM and a UTF-8 locale.
+          // Process.run inherits the parent env, and CI runners export TERM=dumb
+          // plus their own non-UTF-8 LC_ALL/LC_CTYPE, either of which forces the
+          // ASCII fallback. Pin both here so the Unicode assertion is deterministic.
+          'TERM': 'xterm-256color',
           'LC_ALL': 'en_US.UTF-8',
           'LANG': 'en_US.UTF-8',
         },

--- a/bridge/app/test/tool/installers_test.dart
+++ b/bridge/app/test/tool/installers_test.dart
@@ -578,6 +578,10 @@ cat "\$HOME/.zprofile"
         environment: {
           'PATH': Platform.environment['PATH'] ?? '',
           'FORCE_COLOR': '1',
+          // LC_ALL has the highest locale precedence, so setting it here keeps the
+          // UTF-8 assertion deterministic even when the runner exports its own
+          // non-UTF-8 LC_ALL/LC_CTYPE (which Process.run inherits by default).
+          'LC_ALL': 'en_US.UTF-8',
           'LANG': 'en_US.UTF-8',
         },
       );


### PR DESCRIPTION
## Problem

Bridge CI failed on latest `main` (the `chore(release): v1.4.0` commit). The failing test is:

```
test/tool/installers_test.dart: install.sh emits ANSI color and the SESORI banner when FORCE_COLOR is set
Expected: contains '✓'
  Actual: '[OK]'
```

## Root cause

The test only set `LANG=en_US.UTF-8` in the subprocess environment. `Process.run` **inherits** the parent environment by default, so the ambient `LC_ALL`/`LC_CTYPE` leak in. In `install.sh`, `should_use_unicode` resolves the locale as `${LC_ALL:-${LC_CTYPE:-${LANG}}}` — `LC_ALL` outranks `LANG`. 

The switch to GitHub-hosted `ubuntu-latest` runners (#378) changed the ambient locale env: the new runners export a non-UTF-8 `LC_ALL`/`LC_CTYPE` that the old Blacksmith runners didn't. That overrode the test's `LANG`, forced the ASCII `[OK]` fallback, and broke the `✓` assertion. Verified locally: the test fails under `LC_ALL=C` and passes with the fix.

## Fix

Set `LC_ALL=en_US.UTF-8` (highest locale precedence) in the test so the UTF-8 glyph path is deterministic regardless of the runner's ambient locale. This mirrors the existing ASCII-fallback test, which already pins both `LANG` and `LC_ALL`.

## Verification

- `dart test test/tool/installers_test.dart` — all pass, including under a simulated `LC_ALL=C LC_CTYPE=C` ambient env
- `dart analyze --fatal-infos` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin TERM=xterm-256color and LC_ALL=en_US.UTF-8 in the installer test to make the UTF-8 glyph check deterministic across CI runners. This prevents the ASCII "[OK]" fallback on runners with TERM=dumb or non-UTF-8 locales and restores the "✓" assertion.

<sup>Written for commit 4195f418481508294bef9b251dd5ae3c0cc62115. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

