### PR TITLE
chore: bump opencode-pr-monitor plugin to v0.1.4

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["github:sesori-ai/opencode-pr-monitor#v0.1.3"],
+  "plugin": ["github:sesori-ai/opencode-pr-monitor#v0.1.4"],
   "mcp": {
     "mobile-mcp": {
       "type": "local",


### PR DESCRIPTION
Bumps the `opencode-pr-monitor` plugin pin in `opencode.json` from v0.1.3 to v0.1.4.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `opencode-pr-monitor` plugin pin in `opencode.json` from `github:sesori-ai/opencode-pr-monitor#v0.1.3` to `github:sesori-ai/opencode-pr-monitor#v0.1.4` to pick up the latest fixes and improvements.

<sup>Written for commit 4fdaf6dded86b8ec5827048274149c4810d10186. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

