### PR TITLE
chore: bump opencode-pr-monitor plugin to v0.1.5

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["github:sesori-ai/opencode-pr-monitor#v0.1.3"],
+  "plugin": ["github:sesori-ai/opencode-pr-monitor#v0.1.4"],
   "mcp": {
     "mobile-mcp": {
       "type": "local",

--- a/opencode.json
+++ b/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["github:sesori-ai/opencode-pr-monitor#v0.1.4"],
+  "plugin": ["github:sesori-ai/opencode-pr-monitor#v0.1.5"],
   "mcp": {
     "mobile-mcp": {
       "type": "local",


### PR DESCRIPTION
Bumps the `opencode-pr-monitor` plugin pin in `opencode.json` from v0.1.4 to v0.1.5.

## Why

v0.1.5 fixes a regression in v0.1.4's mergeability-churn suppression. v0.1.4 ignored **any** mergeable transition where either side was `UNKNOWN`, while the watcher still advanced its stored snapshot every poll. A real `MERGEABLE → UNKNOWN → CONFLICTING` settle spans two polls, so once the previous snapshot became the transient `UNKNOWN`, the genuine conflict on the next poll was swallowed and never reported.

v0.1.5 tracks the last *definite* (`MERGEABLE`/`CONFLICTING`) mergeability value in `PrWatch` and compares against it — keeping base-branch `UNKNOWN` churn quiet while still catching a conflict once it resolves.

Flagged by the codex reviewer on #381.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `opencode-pr-monitor` to v0.1.5 to fix a mergeability-churn regression. Restores accurate conflict detection while keeping transient UNKNOWN noise quiet.

- **Bug Fixes**
  - Tracks the last definite (`MERGEABLE`/`CONFLICTING`) state in `PrWatch` for comparisons.
  - Correctly reports `MERGEABLE → UNKNOWN → CONFLICTING` transitions; ignores base-branch `UNKNOWN` churn.

<sup>Written for commit b38fbdd4ad80f98f7389435c26038185d7731ec0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

