### PR TITLE
feat(bridge): tee runtime-provisioning progress to control channel (Phase 1, PR 1.13)

### DIFF
--- a/bridge/app/lib/src/bridge/repositories/mappers/runtime_provision_progress_mapper.dart
+++ b/bridge/app/lib/src/bridge/repositories/mappers/runtime_provision_progress_mapper.dart
@@ -1,0 +1,23 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+extension RuntimeProvisionProgressMapping on RuntimeProvisionProgress {
+  /// Maps a plugin's runtime-provisioning progress to the shared
+  /// [ControlProvisionProgress] wire DTO the GUI renders in supervised mode.
+  ///
+  /// The source type's derived `fraction` getter is intentionally dropped — the
+  /// wire DTO is pure data, and the GUI recomputes it from
+  /// [ControlProvisionDownloading.totalBytes].
+  ControlProvisionProgress toControlProvisionProgress() {
+    return switch (this) {
+      ProvisionResolving() => const ControlProvisionProgress.resolving(),
+      ProvisionDownloading(:final receivedBytes, :final totalBytes) =>
+        ControlProvisionProgress.downloading(receivedBytes: receivedBytes, totalBytes: totalBytes),
+      ProvisionExtracting() => const ControlProvisionProgress.extracting(),
+      ProvisionVerifying() => const ControlProvisionProgress.verifying(),
+      ProvisionNotice(:final message) => ControlProvisionProgress.notice(message: message),
+      ProvisionReady(:final binaryPath) => ControlProvisionProgress.ready(binaryPath: binaryPath),
+      ProvisionFailed(:final message) => ControlProvisionProgress.failed(message: message),
+    };
+  }
+}

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -44,6 +44,7 @@ import "../../auth/token_manager.dart";
 import "../../auth/token_refresher.dart";
 import "../../control/bridge_control_message_dispatcher.dart";
 import "../../control/control_channel_loss_listener.dart";
+import "../../control/control_provision_notifier.dart";
 import "../../control/control_status_notifier.dart";
 import "../../foundation/control_channel_client.dart";
 import "../../repositories/bridge_settings_repository.dart";
@@ -286,6 +287,9 @@ class BridgeRuntimeRunner {
       // Kept in scope past this block: the ControlStatusNotifier (built later,
       // once the plugin exists) shares this client.
       ControlChannelClient? controlChannelClient;
+      // Kept in scope for the plugin starter: tees runtime-provisioning progress
+      // onto the control channel so the GUI can render first-run progress.
+      ControlProvisionNotifier? controlProvisionNotifier;
       // Built early in supervised mode so the dispatcher can route the logout
       // `unregister_and_exit` command; reused as THE registration service later.
       // Standalone builds it after the interactive auth flow yields its token
@@ -344,6 +348,10 @@ class BridgeRuntimeRunner {
         );
         controlMessageDispatcher.start();
         shutdownCoordinator.add(disposable: controlMessageDispatcher.dispose);
+        // Provision-progress tee: the runner's provisioning loop feeds each
+        // event here, and the notifier maps + best-effort pushes it to the GUI.
+        // It observes no stream and owns no subscription, so nothing to dispose.
+        controlProvisionNotifier = ControlProvisionNotifier(client: controlChannelClient);
       }
 
       final BridgeReplacePrompt replacePrompt = controlPromptService ?? terminalPromptRepository;
@@ -493,6 +501,7 @@ class BridgeRuntimeRunner {
           environment: environment,
           currentUser: currentUser,
           startAborted: startAbortController.signal,
+          provisionNotifier: controlProvisionNotifier,
         ),
       );
       // If this bridge was spawned by a restart, wait for the predecessor to
@@ -864,9 +873,14 @@ class BridgeRuntimeRunner {
   /// stays unset, and `start()` proceeds in a degraded state. A cooperative
   /// abort during provisioning surfaces as [PluginStartAbortedException], which
   /// the caller already treats as "aborted as requested".
+  ///
+  /// In supervised mode [provisionNotifier] tees each event onto the control
+  /// channel so the GUI can render first-run progress; standalone passes null
+  /// and only the stderr render runs (byte-identical).
   static Future<void> _ensurePluginRuntime({
     required BridgePluginDescriptor descriptor,
     required BridgePluginHostImpl host,
+    required ControlProvisionNotifier? provisionNotifier,
   }) async {
     final formatter = RuntimeProvisionFormatter(
       interactive: io.stderr.hasTerminal,
@@ -877,6 +891,7 @@ class BridgeRuntimeRunner {
       if (rendered != null) {
         io.stderr.write(rendered);
       }
+      provisionNotifier?.handleProvisionProgress(event: event);
       if (event is ProvisionReady) {
         host.provisionedRuntimePath = event.binaryPath;
       }
@@ -906,6 +921,7 @@ class BridgeRuntimeRunner {
     required Map<String, String> environment,
     required ProcessUser? currentUser,
     required StartAbortSignal startAborted,
+    required ControlProvisionNotifier? provisionNotifier,
   }) {
     Future<BridgePlugin> attemptStart({required int attempt}) {
       return startupMutexRepository.withLock<BridgePlugin>(
@@ -950,7 +966,11 @@ class BridgeRuntimeRunner {
               // needed), recording the resolved launch path on the host, before
               // start(). Runs under the mutex so concurrent bridge instances
               // can't install the same managed runtime at once.
-              await _ensurePluginRuntime(descriptor: descriptor, host: host);
+              await _ensurePluginRuntime(
+                descriptor: descriptor,
+                host: host,
+                provisionNotifier: provisionNotifier,
+              );
               return descriptor.start(host);
             case BridgeInstanceResolutionStatus.declined:
               throw const BridgeRuntimeServerException(

--- a/bridge/app/lib/src/control/control_provision_notifier.dart
+++ b/bridge/app/lib/src/control/control_provision_notifier.dart
@@ -1,0 +1,45 @@
+import "dart:convert";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../bridge/repositories/mappers/runtime_provision_progress_mapper.dart";
+import "../foundation/control_channel_client.dart";
+
+/// Owns ALL outbound provision-class control sends in supervised mode: it maps
+/// the bridge's runtime-provisioning progress to the shared wire DTOs and
+/// pushes them to the GUI over the injected [ControlChannelClient] so it can
+/// render first-run download/install progress. Higher layers (the runner's
+/// provisioning loop) never call `ControlChannelClient.send` directly.
+///
+/// This is the provisioning-progress analogue of `ControlStatusNotifier`
+/// (status-class sends). Unlike the status notifier it observes no stream and
+/// owns no subscription: provisioning is consumed synchronously by the runner
+/// (which records `ProvisionReady.binaryPath`), so events arrive as a typed
+/// fed sink via [handleProvisionProgress]. It therefore has nothing to dispose.
+///
+/// Sends are best-effort and never throw to the caller: progress is
+/// informational, and a frame lost to a channel blip only skips a UI update —
+/// the terminal `ready`/`failed` state still governs the plugin's health.
+class ControlProvisionNotifier {
+  final ControlChannelClient _client;
+
+  ControlProvisionNotifier({required ControlChannelClient client}) : _client = client;
+
+  /// Typed feed from the runner's provisioning loop: maps [event] to its wire
+  /// DTO and best-effort sends it to the GUI.
+  void handleProvisionProgress({required RuntimeProvisionProgress event}) {
+    final message = ControlMessage.provisionProgress(
+      progress: event.toControlProvisionProgress(),
+    );
+    try {
+      _client.send(jsonEncode(message.toJson()));
+    } on ControlChannelNotConnectedException {
+      // Expected while the GUI is briefly away; a dropped progress frame only
+      // skips a UI update, so there is no re-sync to attempt.
+      Log.d("[control][provision] channel down — dropping progress frame");
+    } on Object catch (error, stackTrace) {
+      Log.w("[control][provision] failed to send progress frame", error, stackTrace);
+    }
+  }
+}

--- a/bridge/app/test/bridge/repositories/mappers/runtime_provision_progress_mapper_test.dart
+++ b/bridge/app/test/bridge/repositories/mappers/runtime_provision_progress_mapper_test.dart
@@ -1,0 +1,64 @@
+import "package:sesori_bridge/src/bridge/repositories/mappers/runtime_provision_progress_mapper.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("RuntimeProvisionProgressMapping.toControlProvisionProgress", () {
+    test("resolving maps to the resolving wire variant", () {
+      expect(
+        const ProvisionResolving().toControlProvisionProgress(),
+        equals(const ControlProvisionProgress.resolving()),
+      );
+    });
+
+    test("downloading carries received/total bytes (fraction dropped)", () {
+      expect(
+        const ProvisionDownloading(receivedBytes: 512, totalBytes: 2048).toControlProvisionProgress(),
+        equals(const ControlProvisionProgress.downloading(receivedBytes: 512, totalBytes: 2048)),
+      );
+    });
+
+    test("downloading preserves a null total (indeterminate progress)", () {
+      expect(
+        const ProvisionDownloading(receivedBytes: 100, totalBytes: null).toControlProvisionProgress(),
+        equals(const ControlProvisionProgress.downloading(receivedBytes: 100, totalBytes: null)),
+      );
+    });
+
+    test("extracting maps to the extracting wire variant", () {
+      expect(
+        const ProvisionExtracting().toControlProvisionProgress(),
+        equals(const ControlProvisionProgress.extracting()),
+      );
+    });
+
+    test("verifying maps to the verifying wire variant", () {
+      expect(
+        const ProvisionVerifying().toControlProvisionProgress(),
+        equals(const ControlProvisionProgress.verifying()),
+      );
+    });
+
+    test("notice carries its message", () {
+      expect(
+        const ProvisionNotice(message: "using managed runtime").toControlProvisionProgress(),
+        equals(const ControlProvisionProgress.notice(message: "using managed runtime")),
+      );
+    });
+
+    test("ready carries the binary path", () {
+      expect(
+        const ProvisionReady(binaryPath: "/opt/opencode/bin/opencode").toControlProvisionProgress(),
+        equals(const ControlProvisionProgress.ready(binaryPath: "/opt/opencode/bin/opencode")),
+      );
+    });
+
+    test("failed carries its message", () {
+      expect(
+        const ProvisionFailed(message: "checksum mismatch").toControlProvisionProgress(),
+        equals(const ControlProvisionProgress.failed(message: "checksum mismatch")),
+      );
+    });
+  });
+}

--- a/bridge/app/test/bridge/runtime/bridge_runtime_server_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_server_test.dart
@@ -2,6 +2,7 @@ import "dart:io";
 
 import "package:sesori_bridge/src/bridge/runtime/bridge_runtime_runner.dart";
 import "package:sesori_bridge/src/bridge/runtime/bridge_runtime_server_exception.dart";
+import "package:sesori_bridge/src/control/control_provision_notifier.dart";
 import "package:sesori_bridge/src/server/api/runtime_file_api.dart";
 import "package:sesori_bridge/src/server/foundation/process_match.dart";
 import "package:sesori_bridge/src/server/models/bridge_startup_lock.dart";
@@ -37,7 +38,7 @@ void main() {
       }
     });
 
-    Future<BridgePlugin> startPlugin({String? stateDirectory}) {
+    Future<BridgePlugin> startPlugin({String? stateDirectory, ControlProvisionNotifier? provisionNotifier}) {
       final directory = stateDirectory ?? runtimeDirectory.path;
       return BridgeRuntimeRunner.startPluginUnderStartupMutex(
         descriptor: descriptor,
@@ -53,6 +54,7 @@ void main() {
         environment: const <String, String>{"HOME": "/home/alex"},
         currentUser: ProcessUser.fromRawUser("alex"),
         startAborted: StartAbortSignal.never,
+        provisionNotifier: provisionNotifier,
       );
     }
 
@@ -255,6 +257,41 @@ void main() {
 
       await expectLater(startPlugin(), throwsA(isA<PluginStartAbortedException>()));
     });
+
+    group("runtime-provisioning tee", () {
+      test("supervised mode tees each provision event to the notifier, in order", () async {
+        descriptor.provisionEvents.addAll(const <RuntimeProvisionProgress>[
+          ProvisionResolving(),
+          ProvisionDownloading(receivedBytes: 256, totalBytes: 1024),
+          ProvisionReady(binaryPath: "/bin/opencode"),
+        ]);
+        final provisionNotifier = _RecordingProvisionNotifier();
+
+        await startPlugin(provisionNotifier: provisionNotifier);
+
+        expect(provisionNotifier.events, equals(descriptor.provisionEvents));
+      });
+
+      test("teeing does not disturb the runner recording ProvisionReady.binaryPath on the host", () async {
+        descriptor.provisionEvents.addAll(const <RuntimeProvisionProgress>[
+          ProvisionResolving(),
+          ProvisionReady(binaryPath: "/opt/opencode/bin/opencode"),
+        ]);
+
+        await startPlugin(provisionNotifier: _RecordingProvisionNotifier());
+
+        expect(descriptor.startedHosts.single.provisionedRuntimePath, equals("/opt/opencode/bin/opencode"));
+      });
+
+      test("standalone mode (no notifier) still records the resolved path with no tee", () async {
+        descriptor.provisionEvents.add(const ProvisionReady(binaryPath: "/opt/opencode/bin/opencode"));
+
+        // No provisionNotifier passed — the standalone/byte-identical path.
+        await startPlugin();
+
+        expect(descriptor.startedHosts.single.provisionedRuntimePath, equals("/opt/opencode/bin/opencode"));
+      });
+    });
   });
 }
 
@@ -296,6 +333,9 @@ class _RecordingDescriptor extends BridgePluginDescriptor {
   /// When non-empty, `start()` throws the first entry instead of returning.
   final List<Object> startErrors = <Object>[];
 
+  /// Emitted, in order, from `ensureRuntime()` before `start()`.
+  final List<RuntimeProvisionProgress> provisionEvents = <RuntimeProvisionProgress>[];
+
   @override
   String get id => "fake";
 
@@ -304,6 +344,13 @@ class _RecordingDescriptor extends BridgePluginDescriptor {
 
   @override
   List<PluginOption> get options => const [];
+
+  @override
+  Stream<RuntimeProvisionProgress> ensureRuntime({required PluginHost host}) async* {
+    for (final event in provisionEvents) {
+      yield event;
+    }
+  }
 
   @override
   Future<BridgePlugin> start(PluginHost host) async {
@@ -427,5 +474,16 @@ class _FakeBridgeInstanceService implements BridgeInstanceService {
   }) async {
     startupLockContentionCalls.add((lock: lock, holder: holder, currentPid: currentPid));
     return startupLockStatus;
+  }
+}
+
+/// Records every provision event the runner tees to it, so a supervised-mode
+/// test can assert the tee fires for each event in order.
+class _RecordingProvisionNotifier implements ControlProvisionNotifier {
+  final List<RuntimeProvisionProgress> events = <RuntimeProvisionProgress>[];
+
+  @override
+  void handleProvisionProgress({required RuntimeProvisionProgress event}) {
+    events.add(event);
   }
 }

--- a/bridge/app/test/control/control_provision_notifier_test.dart
+++ b/bridge/app/test/control/control_provision_notifier_test.dart
@@ -1,0 +1,122 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/control/control_provision_notifier.dart";
+import "package:sesori_bridge/src/foundation/control_channel_client.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ControlProvisionNotifier", () {
+    late _FakeControlChannelClient client;
+    late ControlProvisionNotifier notifier;
+
+    setUp(() {
+      client = _FakeControlChannelClient();
+      notifier = ControlProvisionNotifier(client: client);
+    });
+
+    tearDown(() async {
+      await client.dispose();
+    });
+
+    test("maps a progress event to a provision_progress control message", () {
+      notifier.handleProvisionProgress(
+        event: const ProvisionDownloading(receivedBytes: 128, totalBytes: 512),
+      );
+
+      expect(client.sentMessages, hasLength(1));
+      final message = client.sentMessages.single as ControlProvisionProgressMessage;
+      expect(
+        message.progress,
+        equals(const ControlProvisionProgress.downloading(receivedBytes: 128, totalBytes: 512)),
+      );
+    });
+
+    test("conveys the ProvisionReady terminal event with its binary path", () {
+      notifier.handleProvisionProgress(event: const ProvisionReady(binaryPath: "/bin/opencode"));
+
+      final message = client.sentMessages.single as ControlProvisionProgressMessage;
+      expect(message.progress, equals(const ControlProvisionProgress.ready(binaryPath: "/bin/opencode")));
+    });
+
+    test("conveys the ProvisionFailed terminal event with its message", () {
+      notifier.handleProvisionProgress(event: const ProvisionFailed(message: "checksum mismatch"));
+
+      final message = client.sentMessages.single as ControlProvisionProgressMessage;
+      expect(message.progress, equals(const ControlProvisionProgress.failed(message: "checksum mismatch")));
+    });
+
+    test("sends one frame per event, in order", () {
+      notifier.handleProvisionProgress(event: const ProvisionResolving());
+      notifier.handleProvisionProgress(event: const ProvisionExtracting());
+      notifier.handleProvisionProgress(event: const ProvisionVerifying());
+
+      expect(
+        client.sentMessages.map((message) => (message as ControlProvisionProgressMessage).progress),
+        equals(const <ControlProvisionProgress>[
+          ControlProvisionProgress.resolving(),
+          ControlProvisionProgress.extracting(),
+          ControlProvisionProgress.verifying(),
+        ]),
+      );
+    });
+
+    test("a channel-down send is swallowed (best-effort — no throw)", () {
+      client.throwOnSend = true;
+
+      expect(
+        () => notifier.handleProvisionProgress(event: const ProvisionExtracting()),
+        returnsNormally,
+      );
+      expect(client.sentFrames, isEmpty);
+    });
+
+    test("an unexpected send error is swallowed (best-effort — no throw)", () {
+      client.sendError = StateError("sink is closed");
+
+      expect(
+        () => notifier.handleProvisionProgress(event: const ProvisionExtracting()),
+        returnsNormally,
+      );
+      expect(client.sentFrames, isEmpty);
+    });
+  });
+}
+
+class _FakeControlChannelClient implements ControlChannelClient {
+  final List<String> sentFrames = <String>[];
+
+  /// Mimics [ControlChannelClient.send] throwing when the channel is down.
+  bool throwOnSend = false;
+
+  /// An arbitrary send failure (exercises the catch-all path).
+  Object? sendError;
+
+  List<ControlMessage> get sentMessages =>
+      sentFrames.map((frame) => ControlMessage.fromJson(jsonDecodeMap(frame))).toList();
+
+  @override
+  Stream<String> get inbound => const Stream<String>.empty();
+
+  @override
+  Stream<ControlChannelConnectionState> get connectionState => const Stream<ControlChannelConnectionState>.empty();
+
+  @override
+  void send(String frame) {
+    if (throwOnSend) {
+      throw const ControlChannelNotConnectedException("Control channel is not connected");
+    }
+    final error = sendError;
+    if (error != null) {
+      throw error;
+    }
+    sentFrames.add(frame);
+  }
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> dispose() async {}
+}

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -8,8 +8,8 @@
 
 ## Current pointer
 
-- **Last completed phase:** Phase 1 — PR 1.12 Single-live precedence under supervised `--hidden` (exit-88 contention sentinel, ADR A25; PR raised on branch `next-step-desktop-plan`)
-- **Next up:** Phase 1 — PR 1.13 Tee `RuntimeProvisionProgress` → control channel
+- **Last completed phase:** Phase 1 — PR 1.13 Tee `RuntimeProvisionProgress` → control channel (`ControlProvisionNotifier` + mapper; PR raised on branch `next-step-desktop-plan`)
+- **Next up:** Phase 1 — PR 1.14 Relay replaced-close (`4007`) → takeover state, no reconnect war (ADR A22)
 - **Branch:** one feature branch per PR, cut from `main`
 
 > **Tracking lives in four places that MUST move together in the same PR.**
@@ -398,7 +398,7 @@ them). Only the user checks an MT box.
 - ☑ 1.10 Status push (relay/plugin/active sessions) — Low / S-M
 - ☑ 1.11 `unregister-and-exit` control command — Low / S-M
 - ☑ 1.12 Single-live precedence under supervised `--hidden` — Med / M
-- ☐ 1.13 Tee `RuntimeProvisionProgress` → control channel — Low / S-M
+- ☑ 1.13 Tee `RuntimeProvisionProgress` → control channel — Low / S-M
 - ☐ 1.14 Relay replaced-close (`4007`) → takeover state, no reconnect war (ADR A22) — Med / S-M
 - ☐ 1.15 Dev control-host harness for manual supervised testing (`tool/`) — Low / S
 - ☐ MT-1 Manual checkpoint: bridge supervised mode end-to-end (see phase doc) — user-run

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -732,7 +732,42 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   provisioning (send is fire-and-forget/buffered).
 - **Acceptance:** provision events reach a fake server; `ProvisionReady`/`Failed`
   terminal events conveyed; standalone formatter output unchanged.
-- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+- **Aristotle:** plan ☑ · impl ☑ (PR raised on branch `next-step-desktop-plan`).
+- **Findings:** Shipped as two new units + the runner tee, no shared-package
+  change (the PR-1.2 `ControlProvisionProgress`/`ControlMessage.provisionProgress`
+  DTOs already carried the wire shape). (1) `RuntimeProvisionProgressMapping`
+  (Layer 2 extension in `repositories/mappers/`): an exhaustive `switch` mapping
+  each of the 7 `RuntimeProvisionProgress` variants 1:1 to the shared
+  `ControlProvisionProgress` union; the source's derived `fraction` getter is
+  intentionally dropped (pure-data DTO — the GUI recomputes it from
+  `totalBytes`). (2) `ControlProvisionNotifier` (Layer 4 `control/`): owns ALL
+  provision-class outbound sends over the injected `ControlChannelClient` — the
+  provisioning analogue of `ControlStatusNotifier` (it can't fold into the
+  status notifier because provisioning runs BEFORE `plugin.status`/`relayClient`
+  exist). It observes no stream and owns no subscription: `_ensurePluginRuntime`
+  already consumes the single-subscription provisioning stream synchronously to
+  record `ProvisionReady.binaryPath`, so events arrive as a typed fed sink via
+  `handleProvisionProgress({required RuntimeProvisionProgress event})` — nothing
+  to dispose. Sends are best-effort (mirrors `ControlStatusNotifier._send`):
+  `ControlChannelNotConnectedException` → `Log.d` (GUI briefly away — a dropped
+  progress frame only skips a UI update, so there is no re-sync to attempt),
+  catch-all → `Log.w` with the error/stack as logger args, never throwing into
+  the runner loop. (3) Tee wiring: a nullable `ControlProvisionNotifier?` is
+  threaded through the static `startPluginUnderStartupMutex` → `_ensurePluginRuntime`;
+  after the existing stderr render the loop calls
+  `provisionNotifier?.handleProvisionProgress(event: event)`. The notifier is
+  built inside the existing `if (options.isSupervised)` control gate (sharing the
+  same `controlChannelClient`) and captured in the plugin `starter` closure;
+  standalone passes null so the `?.` is a no-op and the stderr path is
+  byte-identical. Tests: mapper (7 variants + null-total), notifier (map→send,
+  ready/failed terminal, one-frame-per-event ordering, channel-down + unexpected
+  send-error both swallowed no-throw), and 3 runner integration tests (supervised
+  tees each event in order; tee does not disturb `ProvisionReady.binaryPath`
+  landing on the host; standalone with no notifier still records the path). `make
+  analyze` + `dart analyze --fatal-infos` clean; `make test` all pass (app; +17
+  new). **Deltas:** §6's PR-1.2 DTO row is unchanged; the mapper is realized as an
+  extension in `repositories/mappers/` (matching every other bridge mapper) rather
+  than a standalone class.
 
 ## PR 1.14 — Relay replaced-close (`4007`) → takeover state, no reconnect war (ADR A22)
 - **Goal:** The relay keeps a single bridge slot per account and closes a


### PR DESCRIPTION
## Phase 1, PR 1.13 — Tee `RuntimeProvisionProgress` → control channel

In supervised mode (`--control-url`), tee the plugin's `RuntimeProvisionProgress`
stream (from `ensureRuntime`) onto the GUI-hosted loopback control channel — mapped
to the PR-1.2 shared wire DTOs — so the desktop app can render first-run
download/install progress. Standalone keeps rendering to stderr, byte-identical.

### What changed
- **`RuntimeProvisionProgressMapping`** (Layer 2 mapper, `repositories/mappers/`):
  exhaustive `switch` mapping each of the 7 `RuntimeProvisionProgress` variants 1:1
  to the shared `ControlProvisionProgress` union. Drops the source's derived
  `fraction` (pure-data DTO — the GUI recomputes it from `totalBytes`).
- **`ControlProvisionNotifier`** (Layer 4 `control/`): owns all provision-class
  outbound sends over the injected `ControlChannelClient` — the provisioning
  analogue of `ControlStatusNotifier` (it can't fold in: provisioning runs before
  `plugin.status`/`relayClient` exist). It's a typed **fed sink** (`handleProvisionProgress`),
  not a stream observer — the runner already consumes the single-subscription
  provisioning stream synchronously — so nothing to dispose. Best-effort sends
  mirror the status notifier: channel-down → `Log.d`, catch-all → `Log.w`, never
  throws into the runner loop.
- **Runner tee**: a nullable `ControlProvisionNotifier?` threaded through the static
  `startPluginUnderStartupMutex` → `_ensurePluginRuntime`; after the existing stderr
  render, `provisionNotifier?.handleProvisionProgress(event: event)`. Built inside
  the existing `if (options.isSupervised)` gate; standalone passes `null` → no-op.

No `sesori_shared` change (the DTOs already existed from PR 1.2).

### Regression guide (per plan)
1. Teeing does not break the runner's own consumption — `ProvisionReady.binaryPath`
   still lands on `host.provisionedRuntimePath`; `ProvisionFailed` still degrades
   (unchanged). ✅ covered by a runner integration test.
2. Cooperative abort (`PluginStartAbortedException`) surfaces unchanged (the tee is
   a no-throw sink; the abort path is untouched). ✅ existing test green.
3. Standalone `RuntimeProvisionFormatter` stderr output byte-identical — the tee is
   gated by `--control-url` (null notifier in standalone). ✅ covered.
4. A slow/blocked control channel does not stall provisioning — the notifier's send
   is best-effort/non-blocking and swallows `ControlChannelNotConnectedException`. ✅.

### Verification
- `dart analyze --fatal-infos` clean (bridge/app); `make analyze` clean (all bridge modules).
- `make test` all pass (bridge app; +17 new: mapper, notifier, runner tee).

### Aristotle
- plan review: ✅ approved
- impl review: ✅ approved

Plan state advanced (all four surfaces): Current pointer → PR 1.14, §9 row 1.13 ☑,
phase-1 doc Aristotle line + Findings log.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tee runtime-provisioning progress to the GUI control channel in supervised mode so the desktop app can show first-run download/install progress. Standalone remains stderr-only and byte-identical.

- **New Features**
  - Added `RuntimeProvisionProgressMapping` to map all 7 progress variants to the shared `ControlProvisionProgress` (drops derived fraction; GUI recomputes from `totalBytes`).
  - Added `ControlProvisionNotifier` to push mapped progress over the `ControlChannelClient`; best-effort sends that swallow channel-down and unexpected errors; no streams/subscriptions to manage.
  - Runner builds the notifier only with `--control-url` and feeds each event after stderr render; does not block provisioning and still records `ProvisionReady.binaryPath`. Tests cover mapper, notifier, supervised tee ordering, and unchanged standalone behavior.

<sup>Written for commit 4b8d70612b26ff35a4625ec314e46606b71df139. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

