### PR TITLE
feat(bridge): tee runtime-provisioning progress to control channel (Phase 1, PR 1.13)

### DIFF
--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -44,6 +44,7 @@ import "../../auth/token_manager.dart";
 import "../../auth/token_refresher.dart";
 import "../../control/bridge_control_message_dispatcher.dart";
 import "../../control/control_channel_loss_listener.dart";
+import "../../control/control_provision_notifier.dart";
 import "../../control/control_status_notifier.dart";
 import "../../foundation/control_channel_client.dart";
 import "../../repositories/bridge_settings_repository.dart";
@@ -286,6 +287,11 @@ class BridgeRuntimeRunner {
       // Kept in scope past this block: the ControlStatusNotifier (built later,
       // once the plugin exists) shares this client.
       ControlChannelClient? controlChannelClient;
+      // Tees first-run runtime-provisioning progress onto the control channel so
+      // the GUI can render download/install progress. Built here (once the
+      // client exists) and captured by the plugin `starter` closure below, which
+      // runs the provisioning phase. Null in standalone (stderr only).
+      ControlProvisionNotifier? controlProvisionNotifier;
       // Built early in supervised mode so the dispatcher can route the logout
       // `unregister_and_exit` command; reused as THE registration service later.
       // Standalone builds it after the interactive auth flow yields its token
@@ -308,6 +314,9 @@ class BridgeRuntimeRunner {
         // a terminal the helper doesn't have.
         controlPromptService = ControlPromptService(client: controlChannelClient);
         shutdownCoordinator.add(disposable: controlPromptService.dispose);
+        // Tees runtime-provisioning progress to the GUI. Stateless (fed per
+        // event from the provisioning loop), so nothing to dispose.
+        controlProvisionNotifier = ControlProvisionNotifier(client: controlChannelClient);
         // The GUI's supplied token is this bridge's authority, so the control
         // token service is the refresher. Reads the persisted id only at
         // runtime (unregister/register), after the migration below, so building
@@ -493,6 +502,7 @@ class BridgeRuntimeRunner {
           environment: environment,
           currentUser: currentUser,
           startAborted: startAbortController.signal,
+          provisionNotifier: controlProvisionNotifier,
         ),
       );
       // If this bridge was spawned by a restart, wait for the predecessor to
@@ -864,9 +874,16 @@ class BridgeRuntimeRunner {
   /// stays unset, and `start()` proceeds in a degraded state. A cooperative
   /// abort during provisioning surfaces as [PluginStartAbortedException], which
   /// the caller already treats as "aborted as requested".
+  ///
+  /// In supervised mode [provisionNotifier] tees each event onto the GUI
+  /// control channel (mapped to the shared DTOs) so the GUI can render first-run
+  /// progress. The tee is a best-effort side effect: it never blocks or breaks
+  /// the runner's own consumption of the stream. Standalone passes null and only
+  /// renders to stderr.
   static Future<void> _ensurePluginRuntime({
     required BridgePluginDescriptor descriptor,
     required BridgePluginHostImpl host,
+    required ControlProvisionNotifier? provisionNotifier,
   }) async {
     final formatter = RuntimeProvisionFormatter(
       interactive: io.stderr.hasTerminal,
@@ -877,6 +894,7 @@ class BridgeRuntimeRunner {
       if (rendered != null) {
         io.stderr.write(rendered);
       }
+      provisionNotifier?.notify(event);
       if (event is ProvisionReady) {
         host.provisionedRuntimePath = event.binaryPath;
       }
@@ -906,6 +924,7 @@ class BridgeRuntimeRunner {
     required Map<String, String> environment,
     required ProcessUser? currentUser,
     required StartAbortSignal startAborted,
+    required ControlProvisionNotifier? provisionNotifier,
   }) {
     Future<BridgePlugin> attemptStart({required int attempt}) {
       return startupMutexRepository.withLock<BridgePlugin>(
@@ -950,7 +969,11 @@ class BridgeRuntimeRunner {
               // needed), recording the resolved launch path on the host, before
               // start(). Runs under the mutex so concurrent bridge instances
               // can't install the same managed runtime at once.
-              await _ensurePluginRuntime(descriptor: descriptor, host: host);
+              await _ensurePluginRuntime(
+                descriptor: descriptor,
+                host: host,
+                provisionNotifier: provisionNotifier,
+              );
               return descriptor.start(host);
             case BridgeInstanceResolutionStatus.declined:
               throw const BridgeRuntimeServerException(

--- a/bridge/app/lib/src/control/control_provision_notifier.dart
+++ b/bridge/app/lib/src/control/control_provision_notifier.dart
@@ -1,0 +1,57 @@
+import "dart:convert";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../foundation/control_channel_client.dart";
+
+/// Owns ALL outbound `provision_progress`-class control sends in supervised
+/// mode: it maps a plugin's [RuntimeProvisionProgress] events onto the GUI
+/// control channel as [ControlMessage.provisionProgress] frames so the GUI can
+/// render first-run download/install progress. Higher layers (the runtime
+/// runner's provisioning loop) hand each event to [notify] instead of touching
+/// [ControlChannelClient.send] directly.
+///
+/// Fed synchronously one event at a time from the runner's existing
+/// single-subscription provisioning loop, so it owns no subscription and no
+/// lifecycle — there is nothing to dispose.
+///
+/// Sends are best-effort and never throw back into the provisioning loop: a
+/// frame lost to a channel blip (or a slow/absent GUI) must never stall the
+/// bridge's runtime provisioning, which is the load-bearing path. The wire
+/// mirror [ControlProvisionProgress] deliberately omits the source type's
+/// derived `fraction` getter (pure data); the GUI recomputes it.
+class ControlProvisionNotifier {
+  final ControlChannelClient _client;
+
+  ControlProvisionNotifier({required ControlChannelClient client}) : _client = client;
+
+  /// Tees a single provisioning event onto the control channel. Best-effort:
+  /// swallows a not-connected channel (the GUI is briefly away) and any other
+  /// send failure so provisioning is never blocked or crashed by a lost frame.
+  void notify(RuntimeProvisionProgress event) {
+    final message = ControlMessage.provisionProgress(progress: _mapProgress(event));
+    try {
+      _client.send(jsonEncode(message.toJson()));
+    } on ControlChannelNotConnectedException {
+      // Expected while the GUI is briefly away; first-run progress is
+      // informational, so a dropped frame just means the GUI misses one tick.
+      Log.d("[control][provision] channel down — dropping ${event.runtimeType}");
+    } on Object catch (error, stackTrace) {
+      Log.w("[control][provision] failed to send ${event.runtimeType}", error, stackTrace);
+    }
+  }
+
+  ControlProvisionProgress _mapProgress(RuntimeProvisionProgress event) {
+    return switch (event) {
+      ProvisionResolving() => const ControlProvisionProgress.resolving(),
+      ProvisionDownloading(:final receivedBytes, :final totalBytes) =>
+        ControlProvisionProgress.downloading(receivedBytes: receivedBytes, totalBytes: totalBytes),
+      ProvisionExtracting() => const ControlProvisionProgress.extracting(),
+      ProvisionVerifying() => const ControlProvisionProgress.verifying(),
+      ProvisionNotice(:final message) => ControlProvisionProgress.notice(message: message),
+      ProvisionReady(:final binaryPath) => ControlProvisionProgress.ready(binaryPath: binaryPath),
+      ProvisionFailed(:final message) => ControlProvisionProgress.failed(message: message),
+    };
+  }
+}

--- a/bridge/app/test/bridge/runtime/bridge_runtime_server_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_server_test.dart
@@ -2,6 +2,8 @@ import "dart:io";
 
 import "package:sesori_bridge/src/bridge/runtime/bridge_runtime_runner.dart";
 import "package:sesori_bridge/src/bridge/runtime/bridge_runtime_server_exception.dart";
+import "package:sesori_bridge/src/control/control_provision_notifier.dart";
+import "package:sesori_bridge/src/foundation/control_channel_client.dart";
 import "package:sesori_bridge/src/server/api/runtime_file_api.dart";
 import "package:sesori_bridge/src/server/foundation/process_match.dart";
 import "package:sesori_bridge/src/server/models/bridge_startup_lock.dart";
@@ -9,6 +11,7 @@ import "package:sesori_bridge/src/server/repositories/process_repository.dart";
 import "package:sesori_bridge/src/server/repositories/startup_mutex_repository.dart";
 import "package:sesori_bridge/src/server/services/bridge_instance_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
 // The plugin-specific start flows (managed start, attach mode, ownership
@@ -37,7 +40,10 @@ void main() {
       }
     });
 
-    Future<BridgePlugin> startPlugin({String? stateDirectory}) {
+    Future<BridgePlugin> startPlugin({
+      String? stateDirectory,
+      ControlProvisionNotifier? provisionNotifier,
+    }) {
       final directory = stateDirectory ?? runtimeDirectory.path;
       return BridgeRuntimeRunner.startPluginUnderStartupMutex(
         descriptor: descriptor,
@@ -53,6 +59,7 @@ void main() {
         environment: const <String, String>{"HOME": "/home/alex"},
         currentUser: ProcessUser.fromRawUser("alex"),
         startAborted: StartAbortSignal.never,
+        provisionNotifier: provisionNotifier,
       );
     }
 
@@ -255,7 +262,61 @@ void main() {
 
       await expectLater(startPlugin(), throwsA(isA<PluginStartAbortedException>()));
     });
+
+    test("supervised: tees every provisioning event onto the control channel, in order", () async {
+      bridgeInstanceService.resolution = _allowedResolution();
+      descriptor.provisionEvents.addAll(const <RuntimeProvisionProgress>[
+        ProvisionResolving(),
+        ProvisionDownloading(receivedBytes: 50, totalBytes: 100),
+        ProvisionExtracting(),
+        ProvisionReady(binaryPath: "/opt/opencode"),
+      ]);
+      final client = _FakeControlChannelClient();
+      addTearDown(client.dispose);
+
+      await startPlugin(provisionNotifier: ControlProvisionNotifier(client: client));
+
+      expect(
+        client.sentMessages,
+        equals(const <ControlMessage>[
+          ControlMessage.provisionProgress(progress: ControlProvisionProgress.resolving()),
+          ControlMessage.provisionProgress(
+            progress: ControlProvisionProgress.downloading(receivedBytes: 50, totalBytes: 100),
+          ),
+          ControlMessage.provisionProgress(progress: ControlProvisionProgress.extracting()),
+          ControlMessage.provisionProgress(progress: ControlProvisionProgress.ready(binaryPath: "/opt/opencode")),
+        ]),
+      );
+    });
+
+    test("supervised: ProvisionReady is still recorded on the host despite teeing", () async {
+      bridgeInstanceService.resolution = _allowedResolution();
+      descriptor.provisionEvents.add(const ProvisionReady(binaryPath: "/opt/opencode"));
+      final client = _FakeControlChannelClient();
+      addTearDown(client.dispose);
+
+      await startPlugin(provisionNotifier: ControlProvisionNotifier(client: client));
+
+      expect(descriptor.startedHosts.single.provisionedRuntimePath, equals("/opt/opencode"));
+    });
+
+    test("standalone: no notifier means zero control sends, ProvisionReady still recorded", () async {
+      bridgeInstanceService.resolution = _allowedResolution();
+      descriptor.provisionEvents.add(const ProvisionReady(binaryPath: "/opt/opencode"));
+
+      await startPlugin();
+
+      expect(descriptor.startedHosts.single.provisionedRuntimePath, equals("/opt/opencode"));
+    });
   });
+}
+
+BridgeInstanceResolution _allowedResolution() {
+  return const BridgeInstanceResolution(
+    status: BridgeInstanceResolutionStatus.allowed,
+    existingBridges: <ProcessIdentity>[],
+    terminatedBridges: <ProcessIdentity>[],
+  );
 }
 
 ProcessIdentity _identity({required int pid, required String? startMarker}) {
@@ -296,6 +357,10 @@ class _RecordingDescriptor extends BridgePluginDescriptor {
   /// When non-empty, `start()` throws the first entry instead of returning.
   final List<Object> startErrors = <Object>[];
 
+  /// Emitted in order by `ensureRuntime()` before `start()` runs, letting tests
+  /// drive the provisioning tee.
+  final List<RuntimeProvisionProgress> provisionEvents = <RuntimeProvisionProgress>[];
+
   @override
   String get id => "fake";
 
@@ -304,6 +369,13 @@ class _RecordingDescriptor extends BridgePluginDescriptor {
 
   @override
   List<PluginOption> get options => const [];
+
+  @override
+  Stream<RuntimeProvisionProgress> ensureRuntime({required PluginHost host}) async* {
+    for (final event in provisionEvents) {
+      yield event;
+    }
+  }
 
   @override
   Future<BridgePlugin> start(PluginHost host) async {
@@ -428,4 +500,29 @@ class _FakeBridgeInstanceService implements BridgeInstanceService {
     startupLockContentionCalls.add((lock: lock, holder: holder, currentPid: currentPid));
     return startupLockStatus;
   }
+}
+
+/// Records outbound control frames so the provisioning-tee tests can assert
+/// exactly what the notifier pushed to the GUI.
+class _FakeControlChannelClient implements ControlChannelClient {
+  final List<String> sentFrames = <String>[];
+
+  List<ControlMessage> get sentMessages =>
+      sentFrames.map((frame) => ControlMessage.fromJson(jsonDecodeMap(frame))).toList();
+
+  @override
+  Stream<String> get inbound => const Stream<String>.empty();
+
+  @override
+  Stream<ControlChannelConnectionState> get connectionState =>
+      const Stream<ControlChannelConnectionState>.empty();
+
+  @override
+  void send(String frame) => sentFrames.add(frame);
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> dispose() async {}
 }

--- a/bridge/app/test/control/control_provision_notifier_test.dart
+++ b/bridge/app/test/control/control_provision_notifier_test.dart
@@ -1,0 +1,110 @@
+import "dart:async";
+
+import "package:sesori_bridge/src/control/control_provision_notifier.dart";
+import "package:sesori_bridge/src/foundation/control_channel_client.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ControlProvisionNotifier", () {
+    late _FakeControlChannelClient client;
+    late ControlProvisionNotifier notifier;
+
+    setUp(() {
+      client = _FakeControlChannelClient();
+      notifier = ControlProvisionNotifier(client: client);
+    });
+
+    tearDown(() async {
+      await client.dispose();
+    });
+
+    ControlProvisionProgress progressOf(ControlMessage message) {
+      final provision = message as ControlProvisionProgressMessage;
+      return provision.progress;
+    }
+
+    test("maps each RuntimeProvisionProgress variant onto the wire mirror", () {
+      notifier.notify(const ProvisionResolving());
+      notifier.notify(const ProvisionDownloading(receivedBytes: 10, totalBytes: 100));
+      notifier.notify(const ProvisionDownloading(receivedBytes: 5, totalBytes: null));
+      notifier.notify(const ProvisionExtracting());
+      notifier.notify(const ProvisionVerifying());
+      notifier.notify(const ProvisionNotice(message: "using managed runtime"));
+      notifier.notify(const ProvisionReady(binaryPath: "/opt/opencode"));
+      notifier.notify(const ProvisionFailed(message: "network down"));
+
+      final sent = client.sentMessages.map(progressOf).toList();
+      expect(sent, <ControlProvisionProgress>[
+        const ControlProvisionProgress.resolving(),
+        const ControlProvisionProgress.downloading(receivedBytes: 10, totalBytes: 100),
+        const ControlProvisionProgress.downloading(receivedBytes: 5, totalBytes: null),
+        const ControlProvisionProgress.extracting(),
+        const ControlProvisionProgress.verifying(),
+        const ControlProvisionProgress.notice(message: "using managed runtime"),
+        const ControlProvisionProgress.ready(binaryPath: "/opt/opencode"),
+        const ControlProvisionProgress.failed(message: "network down"),
+      ]);
+    });
+
+    test("round-trips through JSON as a provision_progress control message", () {
+      notifier.notify(const ProvisionDownloading(receivedBytes: 42, totalBytes: 84));
+
+      final message = client.sentMessages.single;
+      expect(
+        message,
+        const ControlMessage.provisionProgress(
+          progress: ControlProvisionProgress.downloading(receivedBytes: 42, totalBytes: 84),
+        ),
+      );
+    });
+
+    test("swallows a not-connected channel so provisioning is never blocked", () {
+      client.throwOnSend = const ControlChannelNotConnectedException("down");
+
+      expect(() => notifier.notify(const ProvisionExtracting()), returnsNormally);
+      expect(client.sentFrames, isEmpty);
+    });
+
+    test("swallows any other send failure so provisioning is never blocked", () {
+      client.throwOnSend = StateError("boom");
+
+      expect(() => notifier.notify(const ProvisionReady(binaryPath: "/x")), returnsNormally);
+      expect(client.sentFrames, isEmpty);
+    });
+  });
+}
+
+class _FakeControlChannelClient implements ControlChannelClient {
+  final List<String> sentFrames = <String>[];
+
+  /// When set, [send] throws this instead of recording the frame, mimicking a
+  /// down channel or an unexpected transport error.
+  Object? throwOnSend;
+
+  List<ControlMessage> get sentMessages =>
+      sentFrames.map((frame) => ControlMessage.fromJson(jsonDecodeMap(frame))).toList();
+
+  @override
+  Stream<String> get inbound => const Stream<String>.empty();
+
+  @override
+  Stream<ControlChannelConnectionState> get connectionState =>
+      const Stream<ControlChannelConnectionState>.empty();
+
+  @override
+  void send(String frame) {
+    final error = throwOnSend;
+    if (error != null) {
+      throw error;
+    }
+    sentFrames.add(frame);
+  }
+
+  @override
+  Future<void> connect() async {}
+
+  @override
+  Future<void> dispose() async {}
+}

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -8,8 +8,8 @@
 
 ## Current pointer
 
-- **Last completed phase:** Phase 1 — PR 1.12 Single-live precedence under supervised `--hidden` (exit-88 contention sentinel, ADR A25; PR raised on branch `next-step-desktop-plan`)
-- **Next up:** Phase 1 — PR 1.13 Tee `RuntimeProvisionProgress` → control channel
+- **Last completed phase:** Phase 1 — PR 1.13 Tee `RuntimeProvisionProgress` → control channel (`ControlProvisionNotifier`; PR raised on branch `next-step-desktop-plan-6d9fe2`)
+- **Next up:** Phase 1 — PR 1.14 Relay replaced-close (`4007`) → takeover state, no reconnect war (ADR A22)
 - **Branch:** one feature branch per PR, cut from `main`
 
 > **Tracking lives in four places that MUST move together in the same PR.**
@@ -283,6 +283,7 @@ mobile release.**
 | `ControlUnregisterService` | Layer 3 `services/` | supervised logout `unregister_and_exit` handler (created in PR 1.11): the dispatcher's third typed delegate. Owns the logout ordering boundary — unregisters the `bridgeId` via the injected `BridgeRegistrationService`, then runs the injected `terminate` (composition-root-wired to the graceful `_shutdownThenExit(code: 0)`). Still terminates if unregister throws (logged) so a stuck bridge can't hang the GUI's logout; the GUI's offline-unregister fallback (ADR A13) cleans up any leak. |
 | `BridgeReplacePrompt` | interface in `server/foundation/` | the replace-bridge ask contract with two production implementations: `TerminalPromptRepository` (standalone) and `ControlPromptService` (supervised); keeps the `server/` subsystem free of core-layer imports (mirrors the auth-interface precedent from PR 1.4). |
 | `ControlStatusNotifier` | Layer 4 `control/` | owns **all outbound** status-class control sends (created in PR 1.10): observes Layer-0 state streams (relay connection state incl. close code via `RelayClient.connectionState`, plugin health via `BridgePlugin.status`, registration events via the auth seam's `registrations` stream, plus the control channel's own state for a reconnect re-sync) and receives the **active-session summary as a typed delegate feed** from the Orchestrator's SSE pipeline (`handleProjectsSummary` — same shape as `CompletionPushListener.handleSseEvent`; avoids a second Layer-4→Layer-1 derivation path into the plugin). Maps them to `status`/`registered`/takeover pushes over the injected `ControlChannelClient`, deduped. Higher layers (Orchestrator) never call `ControlChannelClient.send` directly. |
+| `ControlProvisionNotifier` | Layer 4 `control/` | owns **all outbound** `provision_progress`-class sends (created in PR 1.13): the runner's `_ensurePluginRuntime` provisioning loop hands each `RuntimeProvisionProgress` event to `notify(...)`, which maps it to the PR-1.2 wire mirror `ControlProvisionProgress` (private exhaustive switch, same pattern as `ControlStatusNotifier`'s inline status/relay mappers) and sends a `ControlMessage.provisionProgress` over the injected `ControlChannelClient`, best-effort. Stateless (fed synchronously per event), so no subscription/`dispose`. The runner never calls `ControlChannelClient.send` for provisioning directly. |
 | `BridgeIdStorage` (file API + reader) | **inside the `auth/` subsystem** | persist `bridgeId` separately from `token.json`; kept within `auth/` (which is self-contained, outside the core layer hierarchy) so auth code doesn't depend back on top-level `repositories/`. Injected from the composition root. |
 | supervised auth bootstrap | composition root | short-circuit `BridgeRuntimeAuthService.ensureAuthenticated` (no stdin); keep an equivalent `logAuthenticatedUser` |
 | restart change | `orchestrator`/runner seam | `handleRestartHandoff()` → `exit(86)` instead of `spawnSuccessor()` |
@@ -398,7 +399,7 @@ them). Only the user checks an MT box.
 - ☑ 1.10 Status push (relay/plugin/active sessions) — Low / S-M
 - ☑ 1.11 `unregister-and-exit` control command — Low / S-M
 - ☑ 1.12 Single-live precedence under supervised `--hidden` — Med / M
-- ☐ 1.13 Tee `RuntimeProvisionProgress` → control channel — Low / S-M
+- ☑ 1.13 Tee `RuntimeProvisionProgress` → control channel — Low / S-M
 - ☐ 1.14 Relay replaced-close (`4007`) → takeover state, no reconnect war (ADR A22) — Med / S-M
 - ☐ 1.15 Dev control-host harness for manual supervised testing (`tool/`) — Low / S
 - ☐ MT-1 Manual checkpoint: bridge supervised mode end-to-end (see phase doc) — user-run

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -732,7 +732,47 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   provisioning (send is fire-and-forget/buffered).
 - **Acceptance:** provision events reach a fake server; `ProvisionReady`/`Failed`
   terminal events conveyed; standalone formatter output unchanged.
-- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+- **Aristotle:** plan ☑ · impl ☑ (PR raised on branch `next-step-desktop-plan-6d9fe2`).
+- **Findings:** Shipped one new Layer-4 `control/` class,
+  `ControlProvisionNotifier`, that owns ALL outbound `provision_progress`-class
+  sends over the injected `ControlChannelClient` — the same blessed seam and
+  best-effort send pattern as PR-1.10's `ControlStatusNotifier`
+  (`ControlChannelNotConnectedException` → `Log.d`, any other → `Log.w`, never
+  throws back into the caller). Its single public `notify(RuntimeProvisionProgress)`
+  maps each event to the PR-1.2 wire mirror `ControlProvisionProgress` via a
+  private exhaustive switch (mirroring `ControlStatusNotifier`'s inline
+  `_mapPluginStatus`/`_mapRelayState` — a standalone `Mapper` would own no
+  lifecycle/state and failed the ownership-boundary test at plan review) and
+  sends a `ControlMessage.provisionProgress`. It is stateless — fed synchronously
+  one event at a time from the runner's existing single-subscription provisioning
+  loop — so it owns no subscription and has no `dispose`. Wiring: the runner's
+  `_ensurePluginRuntime` gained an optional `ControlProvisionNotifier?
+  provisionNotifier` teed inside the existing `await for` loop (after the stderr
+  render, before recording `ProvisionReady.binaryPath`); `startPluginUnderStartupMutex`
+  threads the notifier down; the plugin `starter` closure passes the instance
+  built in the `if (options.isSupervised)` gate (null in standalone). The tee is a
+  best-effort side effect on the existing single subscription, so stream
+  single-subscription/error/terminal semantics are unchanged: `ProvisionReady.binaryPath`
+  still lands on the host, `ProvisionFailed` still degrades (non-fatal), a
+  cooperative abort still surfaces as `PluginStartAbortedException`, and a
+  slow/absent channel cannot stall provisioning (`send` is synchronous and
+  non-blocking, throwing only the swallowed not-connected case). No shared-package
+  change (the DTOs already existed since PR 1.2); no relay-protocol change.
+  Standalone is byte-identical: the notifier is null and the `RuntimeProvisionFormatter`
+  stderr path is untouched. Tests: 4 new `ControlProvisionNotifier` unit tests
+  (7-variant mapping, JSON round-trip, not-connected + generic-error swallow) and
+  3 new `bridge_runtime_server_test` integration tests (supervised tees every
+  event in order via a real notifier + fake client; `ProvisionReady` still
+  recorded on the host despite teeing; standalone with a null notifier still
+  records `ProvisionReady` and sends nothing). `make analyze` +
+  `dart analyze --fatal-infos` clean; `make test` all pass (app 1708; +7).
+- **Deltas:** §6 gains one row: `ControlProvisionNotifier` (Layer 4 `control/`),
+  the owner of all outbound `provision_progress`-class sends — the PR text named
+  no component, placing the tee only "onto the control channel". Kept the
+  RuntimeProvisionProgress→ControlProvisionProgress mapping as a private method
+  inside the notifier (consistency with `ControlStatusNotifier`), not a separate
+  `Mapper` or a `repositories/mappers/` file (this is a Layer-4 wire mapping in
+  the control subsystem, not a repository DTO mapping).
 
 ## PR 1.14 — Relay replaced-close (`4007`) → takeover state, no reconnect war (ADR A22)
 - **Goal:** The relay keeps a single bridge slot per account and closes a


### PR DESCRIPTION
## Summary

Phase 1, PR 1.13 of the desktop plan (`docs/desktop/phase-1-bridge-supervised.md`).

In supervised mode, tee the plugin's `RuntimeProvisionProgress` stream from the
runner's `ensureRuntime` phase onto the GUI control channel (mapped to the PR-1.2
shared DTOs) so the desktop app can render first-run download/install progress.
Standalone stays byte-identical — the `RuntimeProvisionFormatter` stderr path is
untouched and everything is gated by `--control-url`.

## What changed

- **New `ControlProvisionNotifier`** (Layer 4 `control/`) — owns all outbound
  `provision_progress`-class sends over the injected `ControlChannelClient`,
  mirroring `ControlStatusNotifier` (PR 1.10). `notify(RuntimeProvisionProgress)`
  maps each event to the wire mirror `ControlProvisionProgress` via a private
  exhaustive switch and sends a `ControlMessage.provisionProgress`, best-effort
  (channel-down → `Log.d`, other → `Log.w`), never throwing back into the
  provisioning loop. Stateless (fed synchronously per event) → no subscription /
  no `dispose`.
- **`_ensurePluginRuntime`** tees each event inside its existing
  single-subscription `await for` loop (after the stderr render, before recording
  `ProvisionReady.binaryPath`). `startPluginUnderStartupMutex` threads the
  notifier down; the supervised gate builds it and the plugin `starter` closure
  passes it (null standalone).

## Invariants preserved

- Stream single-subscription/error/terminal semantics unchanged:
  `ProvisionReady.binaryPath` still lands on the host, `ProvisionFailed` still
  degrades (non-fatal), a cooperative abort still surfaces as
  `PluginStartAbortedException`.
- The send is synchronous/non-blocking, so a slow/absent channel cannot stall
  provisioning.
- No shared-package change (DTOs pre-exist from PR 1.2); no relay-protocol change.
- Standalone byte-identical (notifier is null; zero control sends).

## Regression guide

1. Teeing does not break runner consumption — `ProvisionReady.binaryPath` still
   recorded, `ProvisionFailed` still degrades (never exits).
2. Cooperative abort still surfaces as `PluginStartAbortedException`.
3. Standalone `RuntimeProvisionFormatter` stderr output byte-identical.
4. A slow/blocked control channel must not stall provisioning (send is
   fire-and-forget, synchronous, throws only NotConnected which is swallowed).

## Tests

- 4 new `ControlProvisionNotifier` unit tests (7-variant mapping, JSON round-trip,
  not-connected + generic-error swallow).
- 3 new `bridge_runtime_server_test` integration tests (supervised tees every
  event in order via a real notifier + fake client; `ProvisionReady` still
  recorded on the host despite teeing; standalone with a null notifier records
  `ProvisionReady` and sends nothing).

`make analyze` + `dart analyze --fatal-infos` clean; `make test` all pass (app 1708, +7).

## Aristotle

- plan review: APPROVED
- impl review: APPROVED

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tee runtime provisioning progress to the control channel in supervised mode so the desktop app can show first-run download/install status. Standalone behavior is unchanged and remains byte-identical.

- **New Features**
  - Added `ControlProvisionNotifier` to own all outbound `provision_progress` sends over `ControlChannelClient`, mapping `RuntimeProvisionProgress` → `ControlProvisionProgress` and sending `ControlMessage.provisionProgress`.
  - Wired `_ensurePluginRuntime` to call `provisionNotifier.notify(event)` inside the existing loop; plumbed via `startPluginUnderStartupMutex`.
  - Sends are best-effort and non-blocking: swallow `ControlChannelNotConnectedException`, log other errors, never impact provisioning.
  - Gated by `--control-url`; in standalone the notifier is null and stderr rendering stays the same.

<sup>Written for commit d24408b49544d7faf27f24b0a936bdcaa325f5e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

