### PR TITLE
feat(bridge): relay replaced-close (4007) takeover state, no reconnect war (Phase 1, PR 1.14)

### DIFF
--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -234,6 +234,7 @@ class OrchestratorSession {
   final BridgeRestartService _restartService;
   final ControlStatusNotifier? _statusNotifier;
   final CompositeSubscription _subscriptions = CompositeSubscription();
+  final Random _backoffJitter = Random();
 
   bool _cancelled = false;
 
@@ -478,7 +479,24 @@ class OrchestratorSession {
           await _bridgeRegistrationService.handleBridgeRevoked();
         }
 
-        var backoff = const Duration(seconds: 1);
+        // Another bridge on this account took the single relay slot. Reconnect
+        // only on a long backoff so two always-on bridges don't tight-loop
+        // kicking each other (ADR A22); headless/VM failover is preserved
+        // because we still retry, just slowly. The GUI is told separately via
+        // ControlStatusNotifier (it observes the same replaced-close on the
+        // connection-state stream); this loop owns only the backoff policy.
+        final takenOver = RelayCloseCodes.isBridgeReplaced(
+          closeCode: _client.closeCode,
+          closeReason: _client.closeReason,
+        );
+        if (takenOver) {
+          Console.warning(
+            "Another bridge for this account has taken over the relay connection. "
+            "Retrying on a long backoff — stop the other bridge to reclaim this slot.",
+          );
+        }
+
+        var backoff = _initialBackoff(takenOver: takenOver);
         while (!_cancelled) {
           await Future<void>.delayed(backoff);
           if (_cancelled) {
@@ -491,7 +509,7 @@ class OrchestratorSession {
           // retry — a later refresh (or a token_update push) recovers.
           if (!await _refreshAccessToken()) {
             Log.w("No access token available — deferring reconnect (retrying in $backoff)");
-            backoff = _nextBackoff(backoff);
+            backoff = _nextBackoff(backoff, takenOver: takenOver);
             continue;
           }
 
@@ -500,11 +518,11 @@ class OrchestratorSession {
             await _client.reconnect();
           } catch (e) {
             Log.w("Reconnect failed: $e (retrying in $backoff)");
-            backoff = _nextBackoff(backoff);
+            backoff = _nextBackoff(backoff, takenOver: takenOver);
             continue;
           }
 
-          backoff = const Duration(seconds: 1);
+          backoff = _initialBackoff(takenOver: takenOver);
           Log.i("Reconnected to relay");
           break;
         }
@@ -1105,13 +1123,34 @@ class OrchestratorSession {
     }
   }
 
-  Duration _nextBackoff(Duration backoff) {
+  // Ordinary drop (network blip, relay restart) reconnects promptly; a
+  // takeover drop reconnects on a minutes-order backoff so two always-on
+  // bridges don't tight-loop kicking each other (ADR A22).
+  static const _ordinaryInitialBackoff = Duration(seconds: 1);
+  static const _ordinaryMaxBackoff = Duration(seconds: 30);
+  static const _takeoverInitialBackoff = Duration(minutes: 2);
+  static const _takeoverMaxBackoff = Duration(minutes: 5);
+
+  Duration _initialBackoff({required bool takenOver}) {
+    if (!takenOver) return _ordinaryInitialBackoff;
+    // Jitter the takeover backoff so two mutually-displacing bridges don't
+    // resynchronize onto the same retry cadence.
+    return _jitter(_takeoverInitialBackoff);
+  }
+
+  Duration _nextBackoff(Duration backoff, {required bool takenOver}) {
+    final max = takenOver ? _takeoverMaxBackoff : _ordinaryMaxBackoff;
     final next = Duration(microseconds: backoff.inMicroseconds * 2);
-    const maxBackoff = Duration(seconds: 30);
-    if (next > maxBackoff) {
-      return maxBackoff;
+    if (next > max) {
+      return takenOver ? _jitter(max) : max;
     }
     return next;
+  }
+
+  Duration _jitter(Duration base) {
+    // Add up to +25% random jitter to spread out retries.
+    final extra = (base.inMilliseconds * 0.25 * _backoffJitter.nextDouble()).round();
+    return base + Duration(milliseconds: extra);
   }
 
   Future<void> _encryptAndSend({

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -1141,10 +1141,14 @@ class OrchestratorSession {
   Duration _nextBackoff(Duration backoff, {required bool takenOver}) {
     final max = takenOver ? _takeoverMaxBackoff : _ordinaryMaxBackoff;
     final next = Duration(microseconds: backoff.inMicroseconds * 2);
+    // Re-jitter every takeover step (not just the cap) so two mutually
+    // displacing bridges don't resynchronize onto the same retry cadence as
+    // they climb the backoff curve. Ordinary reconnects keep the deterministic
+    // fast backoff.
     if (next > max) {
       return takenOver ? _jitter(max) : max;
     }
-    return next;
+    return takenOver ? _jitter(next) : next;
   }
 
   Duration _jitter(Duration base) {

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -498,7 +498,7 @@ class OrchestratorSession {
 
         var backoff = _initialBackoff(takenOver: takenOver);
         while (!_cancelled) {
-          await Future<void>.delayed(backoff);
+          await _backoffDelay(backoff);
           if (_cancelled) {
             return;
           }
@@ -1130,6 +1130,18 @@ class OrchestratorSession {
   static const _ordinaryMaxBackoff = Duration(seconds: 30);
   static const _takeoverInitialBackoff = Duration(minutes: 2);
   static const _takeoverMaxBackoff = Duration(minutes: 5);
+
+  /// Waits out a reconnect backoff, but wakes immediately on shutdown so a
+  /// pending long wait (a minutes-order takeover backoff, ADR A22) never blocks
+  /// teardown/exit on SIGTERM — [cancel] completes [_shutdownCompleter], which
+  /// races the timer. A single completed-completer wait is safe to reuse across
+  /// iterations because it only ever resolves once (on shutdown).
+  Future<void> _backoffDelay(Duration backoff) {
+    return Future.any<void>([
+      Future<void>.delayed(backoff),
+      _shutdownCompleter.future,
+    ]);
+  }
 
   Duration _initialBackoff({required bool takenOver}) {
     if (!takenOver) return _ordinaryInitialBackoff;

--- a/bridge/app/lib/src/bridge/relay_client.dart
+++ b/bridge/app/lib/src/bridge/relay_client.dart
@@ -43,10 +43,15 @@ final class RelayConnected extends RelayConnectionState {
 ///
 /// [closeCode] is the WebSocket close code of the dropped connection, or
 /// `null` when none is available (e.g. a failed connect attempt).
+/// [closeReason] is the paired close reason string, needed to detect a
+/// bridge-replaced close during the relay-deploy rollout window (the relay
+/// sends `1000 + "replaced"` until it emits the dedicated code); it is fragile
+/// and only consulted for that fallback — the close code is authoritative.
 final class RelayDisconnected extends RelayConnectionState {
   final int? closeCode;
+  final String? closeReason;
 
-  const RelayDisconnected({required this.closeCode});
+  const RelayDisconnected({required this.closeCode, required this.closeReason});
 }
 
 class RelayClient {
@@ -75,6 +80,12 @@ class RelayClient {
   /// The WebSocket close code of the current connection, available once the
   /// connection has closed and until [close] or [reconnect] discards it.
   int? get closeCode => _channel?.closeCode;
+
+  /// The WebSocket close reason of the current connection, paired with
+  /// [closeCode]. Only meaningful for the bridge-replaced rollout fallback
+  /// (`1000 + "replaced"`); close reason strings are fragile, so close-code
+  /// semantics are authoritative everywhere else.
+  String? get closeReason => _channel?.closeReason;
 
   /// The access token most recently sent in an auth message by [connect], or
   /// `null` if the last connect sent no auth (empty token). Lets a live re-auth
@@ -110,7 +121,7 @@ class RelayClient {
     try {
       await channel.ready.timeout(_connectTimeout);
     } catch (e) {
-      _connectionState.add(const RelayDisconnected(closeCode: null));
+      _connectionState.add(const RelayDisconnected(closeCode: null, closeReason: null));
       // Clean up the channel if connection fails or times out to prevent
       // zombie WebSocket connections from lingering.
       try {
@@ -156,7 +167,9 @@ class RelayClient {
 
   void _handleChannelDone(IOWebSocketChannel channel) {
     if (!identical(_channel, channel)) return;
-    _connectionState.add(RelayDisconnected(closeCode: channel.closeCode));
+    _connectionState.add(
+      RelayDisconnected(closeCode: channel.closeCode, closeReason: channel.closeReason),
+    );
   }
 
   Future<void> reconnect() async {

--- a/bridge/app/lib/src/control/control_status_notifier.dart
+++ b/bridge/app/lib/src/control/control_status_notifier.dart
@@ -165,6 +165,13 @@ class ControlStatusNotifier {
     return switch (state) {
       RelayConnecting() => ControlRelayConnectionState.connecting,
       RelayConnected() => ControlRelayConnectionState.connected,
+      // A displaced-by-another-bridge drop surfaces as a distinct takenOver
+      // status so the GUI can offer "take over" instead of a plain outage
+      // (ADR A22); the same shared predicate the reconnect loop uses keys it,
+      // so the two never disagree.
+      RelayDisconnected(:final closeCode, :final closeReason)
+          when RelayCloseCodes.isBridgeReplaced(closeCode: closeCode, closeReason: closeReason) =>
+        ControlRelayConnectionState.takenOver,
       RelayDisconnected() => ControlRelayConnectionState.disconnected,
     };
   }

--- a/bridge/app/test/bridge/client_test.dart
+++ b/bridge/app/test/bridge/client_test.dart
@@ -130,6 +130,28 @@ void main() {
 
       expect(client.closeCode, equals(RelayCloseCodes.bridgeRevoked));
     });
+
+    test("exposes the server's close reason (bridge-replaced rollout fallback)", () async {
+      final server = await TestRelayServer.start();
+      addTearDown(server.close);
+
+      final client = RelayClient(
+        relayURL: "ws://127.0.0.1:${server.port}",
+        accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
+      );
+      await client.connect();
+      addTearDown(client.close);
+
+      final serverWs = await server.nextClient();
+      final streamDone = Completer<void>();
+      client.read().listen((_) {}, onDone: streamDone.complete);
+      await serverWs.close(1000, "replaced");
+      await streamDone.future.timeout(const Duration(seconds: 5));
+
+      expect(client.closeCode, equals(1000));
+      expect(client.closeReason, equals("replaced"));
+    });
   });
 
   group("RelayClient connectionState", () {
@@ -177,6 +199,30 @@ void main() {
 
       final state = await disconnected.timeout(const Duration(seconds: 5)) as RelayDisconnected;
       expect(state.closeCode, equals(RelayCloseCodes.bridgeRevoked));
+    });
+
+    test("remote close carries the close reason on the disconnected state", () async {
+      final server = await TestRelayServer.start();
+      addTearDown(server.close);
+
+      final client = RelayClient(
+        relayURL: "ws://127.0.0.1:${server.port}",
+        accessTokenProvider: FakeAccessTokenProvider(""),
+        bridgeIdProvider: FakeBridgeIdProvider(),
+      );
+      final states = <RelayConnectionState>[];
+      client.connectionState.listen(states.add);
+      await client.connect();
+      addTearDown(client.close);
+
+      final serverWs = await server.nextClient();
+      client.read().listen((_) {});
+      final disconnected = client.connectionState.firstWhere((state) => state is RelayDisconnected);
+      await serverWs.close(1000, "replaced");
+
+      final state = await disconnected.timeout(const Duration(seconds: 5)) as RelayDisconnected;
+      expect(state.closeCode, equals(1000));
+      expect(state.closeReason, equals("replaced"));
     });
 
     test("deliberate close emits no disconnected state", () async {

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -145,6 +145,64 @@ void main() {
       expect(authMessage["bridgeId"], equals("br_second002"));
     });
   });
+
+  group("OrchestratorSession relay takeover (ADR A22)", () {
+    test("a 4007 replaced-close does not reconnect within the war window", () async {
+      final repository = FakeBridgeRegistrationRepository()..nextBridgeId = "br_first001";
+      final harness = await _RegistrationHarness.start(repository: repository);
+      addTearDown(harness.close);
+
+      final firstSocket = await harness.relayServer.nextClient();
+      await _firstTextMessage(firstSocket);
+
+      // The relay displaces this bridge: another bridge for the account took
+      // the slot. The displaced bridge must NOT tight-loop back — it uses a
+      // long backoff, so no reconnect happens within the war window.
+      await firstSocket.close(RelayCloseCodes.bridgeReplaced, "replaced");
+
+      await expectLater(
+        harness.relayServer.nextClient(timeout: const Duration(seconds: 3)),
+        throwsA(isA<TimeoutException>()),
+        reason: "displaced bridge must not reconnect on a tight loop",
+      );
+      expect(harness.relayServer.connectedClientCount, equals(1));
+    });
+
+    test("the 1000/replaced rollout fallback also holds off reconnect", () async {
+      final repository = FakeBridgeRegistrationRepository()..nextBridgeId = "br_first001";
+      final harness = await _RegistrationHarness.start(repository: repository);
+      addTearDown(harness.close);
+
+      final firstSocket = await harness.relayServer.nextClient();
+      await _firstTextMessage(firstSocket);
+
+      await firstSocket.close(1000, "replaced");
+
+      await expectLater(
+        harness.relayServer.nextClient(timeout: const Duration(seconds: 3)),
+        throwsA(isA<TimeoutException>()),
+        reason: "the rollout fallback (1000/replaced) must be treated as a takeover",
+      );
+      expect(harness.relayServer.connectedClientCount, equals(1));
+    });
+
+    test("a plain normal drop (1000, no replaced reason) reconnects promptly", () async {
+      final repository = FakeBridgeRegistrationRepository()..nextBridgeId = "br_first001";
+      final harness = await _RegistrationHarness.start(repository: repository);
+      addTearDown(harness.close);
+
+      final firstSocket = await harness.relayServer.nextClient();
+      await _firstTextMessage(firstSocket);
+
+      // A vanilla close (network blip / relay restart) is not a takeover and
+      // must reconnect on the ordinary 1s-reset backoff, unchanged by this PR.
+      await firstSocket.close();
+
+      final secondSocket = await harness.relayServer.nextClient(timeout: const Duration(seconds: 5));
+      final authMessage = await _firstTextMessage(secondSocket);
+      expect(authMessage["bridgeId"], equals("br_first001"));
+    });
+  });
 }
 
 Future<Map<String, dynamic>> _firstTextMessage(WebSocket socket) async {

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -186,6 +186,33 @@ void main() {
       expect(harness.relayServer.connectedClientCount, equals(1));
     });
 
+    test("cancel wakes a long takeover backoff promptly (no shutdown stall)", () async {
+      final repository = FakeBridgeRegistrationRepository()..nextBridgeId = "br_first001";
+      final harness = await _RegistrationHarness.start(repository: repository);
+      addTearDown(harness.close);
+
+      final firstSocket = await harness.relayServer.nextClient();
+      await _firstTextMessage(firstSocket);
+
+      // Displace the bridge: it enters the minutes-order takeover backoff.
+      await firstSocket.close(RelayCloseCodes.bridgeReplaced, "replaced");
+      // Give the loop a moment to settle into the long Future.delayed wait.
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      // A SIGTERM-style cancel must wake the loop immediately, not wait out the
+      // 2+ minute backoff. run() should return well within a few seconds.
+      final sw = Stopwatch()..start();
+      await harness.session.cancel();
+      await harness.runFuture.timeout(const Duration(seconds: 10));
+      sw.stop();
+
+      expect(
+        sw.elapsed,
+        lessThan(const Duration(seconds: 10)),
+        reason: "cancel must not block on the long takeover backoff",
+      );
+    });
+
     test("a plain normal drop (1000, no replaced reason) reconnects promptly", () async {
       final repository = FakeBridgeRegistrationRepository()..nextBridgeId = "br_first001";
       final harness = await _RegistrationHarness.start(repository: repository);

--- a/bridge/app/test/control/control_status_notifier_test.dart
+++ b/bridge/app/test/control/control_status_notifier_test.dart
@@ -76,7 +76,7 @@ void main() {
     test("relay connection transitions push mapped statuses", () async {
       relayState.add(const RelayConnecting());
       relayState.add(const RelayConnected());
-      relayState.add(const RelayDisconnected(closeCode: 4006));
+      relayState.add(const RelayDisconnected(closeCode: 4006, closeReason: null));
       await pump();
 
       expect(
@@ -86,6 +86,44 @@ void main() {
           ControlRelayConnectionState.connected,
           ControlRelayConnectionState.disconnected,
         ]),
+      );
+    });
+
+    test("a bridge-replaced close (4007) maps to takenOver", () async {
+      relayState.add(const RelayConnected());
+      relayState.add(
+        const RelayDisconnected(closeCode: RelayCloseCodes.bridgeReplaced, closeReason: null),
+      );
+      await pump();
+
+      expect(
+        client.sentMessages.whereType<ControlStatus>().map((s) => s.relay).toList(),
+        equals([
+          ControlRelayConnectionState.connected,
+          ControlRelayConnectionState.takenOver,
+        ]),
+      );
+    });
+
+    test("the 1000/replaced rollout fallback also maps to takenOver", () async {
+      relayState.add(const RelayConnected());
+      relayState.add(const RelayDisconnected(closeCode: 1000, closeReason: "replaced"));
+      await pump();
+
+      expect(
+        client.sentMessages.whereType<ControlStatus>().last.relay,
+        ControlRelayConnectionState.takenOver,
+      );
+    });
+
+    test("a plain 1000 close (no replaced reason) stays disconnected", () async {
+      relayState.add(const RelayConnected());
+      relayState.add(const RelayDisconnected(closeCode: 1000, closeReason: null));
+      await pump();
+
+      expect(
+        client.sentMessages.whereType<ControlStatus>().last.relay,
+        ControlRelayConnectionState.disconnected,
       );
     });
 

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -8,8 +8,8 @@
 
 ## Current pointer
 
-- **Last completed phase:** Phase 1 — PR 1.13 Tee `RuntimeProvisionProgress` → control channel (`ControlProvisionNotifier` + mapper; PR raised on branch `next-step-desktop-plan`)
-- **Next up:** Phase 1 — PR 1.14 Relay replaced-close (`4007`) → takeover state, no reconnect war (ADR A22)
+- **Last completed phase:** Phase 1 — PR 1.14 Relay replaced-close (`4007`) → takeover state, no reconnect war (ADR A22) — bridge PR raised on branch `start-next-step-desktop-plan`; relay prerequisite raised as `sesori-ai/sesori_relay_server#7` (must deploy to prod before this merges)
+- **Next up:** Phase 1 — PR 1.15 Dev control-host harness for manual supervised testing (`tool/`)
 - **Branch:** one feature branch per PR, cut from `main`
 
 > **Tracking lives in four places that MUST move together in the same PR.**
@@ -356,7 +356,7 @@ seams through `module_core` interfaces, not `AuthManager` internals.
 | Item | Status | Owner | Notes |
 |---|---|---|---|
 | Windows code-signing cert | **OPEN — lead time, START PROCUREMENT NOW** | TBD | blocks PR 3.4 (signed Windows); EV clears SmartScreen faster. Non-code and parallelizable — do not serialize behind Phase 2; if it slips, ship macOS-first (phase-3 preamble allows per-OS v1). |
-| Relay single-slot replace war (cross-machine) | **OPEN → PR 1.14** | TBD | Relay keeps ONE bridge slot per account and closes the displaced bridge with 1000/`"replaced"`; the bridge treats that as a generic drop and reconnects on a backoff that resets to 1s — two always-on bridges mutually kick forever, phones see flapping. PR 1.12's mutex only covers same-machine. PR 1.14 (ADR A22) adds a dedicated relay close code `4007` + the takeover policy; verified in MT-1/MT-3. Stage C multi-bridge dissolves the problem properly. |
+| Relay single-slot replace war (cross-machine) | **RESOLVED in bridge PR 1.14 (relay deploy gate open → `sesori_relay_server#7`)** | TBD | Relay keeps ONE bridge slot per account and closed the displaced bridge with 1000/`"replaced"`; the bridge treated that as a generic drop and reconnected on a backoff that resets to 1s — two always-on bridges mutually kick forever, phones see flapping. PR 1.12's mutex only covers same-machine. PR 1.14 (ADR A22) adds `RelayCloseCodes.bridgeReplaced = 4007` + `isBridgeReplaced` detection (code-authoritative, `1000/"replaced"` rollout fallback), a minutes-order takeover backoff in the orchestrator reconnect loop (standalone `Console.warning`), and a `ControlRelayConnectionState.takenOver` status push (supervised). **Relay prerequisite `sesori-ai/sesori_relay_server#7` must be merged AND deployed to prod before the bridge PR merges** — the bridge's `1000/"replaced"` fallback keeps an older relay safe during rollout. Verified in MT-1/MT-3. Stage C multi-bridge dissolves the problem properly. |
 | Linux tray availability (GNOME) | OPEN | TBD | `tray_manager` needs AppIndicator; stock GNOME hides tray icons without an extension → tray-only `--hidden` boot = running but unreachable app. PR 2.9 adds windowed fallback, PR 2.11 refuses hidden boot without a tray (ADR A24); verified on GNOME in MT-3/MT-4. |
 | GUI crash → helper self-exits (A9) → bridge silently down | OPEN — accepted for v1 | TBD | Login items don't relaunch crashed apps (macOS `SMAppService`, Windows run keys), so a 2am GUI crash kills the bridge until the user notices a missing tray icon. Deliberate v1 trade against orphaned helpers; revisit post-v1 (watchdog / `KeepAlive`-style relaunch) if telemetry (PR 2.14) shows it matters. |
 | Control-channel secret bootstrap (off-argv) | OPEN | TBD | ADR A8; designed in PR 1.1 / PR 2.6 |
@@ -399,7 +399,7 @@ them). Only the user checks an MT box.
 - ☑ 1.11 `unregister-and-exit` control command — Low / S-M
 - ☑ 1.12 Single-live precedence under supervised `--hidden` — Med / M
 - ☑ 1.13 Tee `RuntimeProvisionProgress` → control channel — Low / S-M
-- ☐ 1.14 Relay replaced-close (`4007`) → takeover state, no reconnect war (ADR A22) — Med / S-M
+- ☑ 1.14 Relay replaced-close (`4007`) → takeover state, no reconnect war (ADR A22) — Med / S-M
 - ☐ 1.15 Dev control-host harness for manual supervised testing (`tool/`) — Low / S
 - ☐ MT-1 Manual checkpoint: bridge supervised mode end-to-end (see phase doc) — user-run
 

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -829,7 +829,55 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   supervised); detection works on close code `4007` alone (no reason string)
   AND on the `1000/"replaced"` rollout fallback; normal drop reconnection
   unchanged; covered by connection-level tests.
-- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+- **Aristotle:** plan ☑ · impl ☑ (bridge PR raised on branch `start-next-step-desktop-plan`;
+  relay prerequisite raised as `sesori-ai/sesori_relay_server#7`).
+- **Findings:** Shipped as an additive shared constant + predicate, a Layer-0
+  transport accessor, an orchestrator backoff-policy change, and a notifier map
+  extension — no new classes. (1) **Shared** (`close_codes.dart`):
+  `RelayCloseCodes.bridgeReplaced = 4007` (deliberately NOT in
+  `noReconnectCodes` — the policy is long-backoff, not never-reconnect) plus a
+  single `isBridgeReplaced({closeCode, closeReason})` predicate — the
+  authoritative detection rule shared by the reconnect loop and the status push
+  so the two never diverge. The dedicated `4007` code is reason-independent; a
+  `1000` close whose reason is `bridgeReplacedFallbackReason = "replaced"` is
+  matched only as a rollout fallback for the relay-deploy window. `taken_over`
+  was added to `ControlRelayConnectionState` (before the `unknown` fallback), an
+  additive enum value on the existing `status` DTO (no new message variant). (2)
+  **RelayClient** (Layer 0): a dumb `closeReason` accessor mirroring `closeCode`,
+  and `RelayDisconnected` now carries `closeReason` so the notifier detects the
+  replaced-close off the connection-state stream without racing the loop's own
+  `_client.closeReason` read. (3) **Orchestrator reconnect loop:** after the
+  existing `bridgeRevoked` branch it computes `isBridgeReplaced(...)`; a takeover
+  drop logs a loud `Console.warning` and uses a minutes-order backoff
+  (`_takeoverInitialBackoff = 2min`, cap `5min`, +25% jitter so two mutually
+  displacing bridges don't resynchronise) instead of the ordinary 1s-reset
+  seconds-order backoff — `_initialBackoff`/`_nextBackoff` are now
+  takeover-scoped. The loop still reconnects (headless/VM failover preserved),
+  just slowly, so two bridges don't tight-loop; every other close code keeps
+  today's behaviour byte-for-byte. The orchestrator owns ONLY this policy change
+  and never calls `ControlChannelClient.send`. (4) **ControlStatusNotifier:**
+  `_mapRelayState` maps a `RelayDisconnected` matching `isBridgeReplaced` to
+  `ControlRelayConnectionState.takenOver`, else `disconnected`; it still owns all
+  outbound status sends (deduped), so supervised takeover reaches the GUI as a
+  normal `status` push. (5) **Relay prerequisite** (`sesori_relay_server#7`):
+  `CloseBridgeReplaced = 4007`; the displaced bridge is closed with `4007`
+  (writing the frame before cancelling the old connection's context, off the new
+  bridge's hot path) keeping `"replaced"` as the rollout-fallback reason. Tests:
+  shared `isBridgeReplaced` matrix + `taken_over` round-trip; RelayClient
+  `closeReason` accessor + `RelayDisconnected.closeReason` connection-level
+  tests; notifier `4007`/`1000-replaced`/plain-`1000` mapping tests; orchestrator
+  takeover tests (a `4007` and a `1000/"replaced"` drop hold off reconnect within
+  the war window; a plain `1000` drop reconnects promptly). `make analyze` +
+  `dart analyze --fatal-infos` clean; bridge `make test` all pass (app 1726);
+  shared 282 pass; `client/app` (mobile) `flutter analyze` clean (additive shared
+  change). **Standing-acceptance exception honored:** only the replaced-close
+  standalone behaviour changed; `4006` and normal drops are asserted unchanged.
+- **Deltas:** §6 gains no rows — the change is a shared predicate + additive enum
+  value + an orchestrator-owned policy tweak + a notifier map arm, none of which
+  warrant a new component (confirmed by `aristotle-plan-review`). The relay
+  prerequisite is a **deploy gate**, tracked in §8 and this entry: `#7` must be
+  merged AND deployed to production before this bridge PR merges; the bridge's
+  `1000/"replaced"` fallback keeps an older relay safe during rollout.
 
 ## PR 1.15 — Dev control-host harness for manual supervised testing
 - **Goal:** A small dev-only tool (`bridge/app/tool/dev_control_host.dart`,

--- a/shared/sesori_shared/lib/src/protocol/close_codes.dart
+++ b/shared/sesori_shared/lib/src/protocol/close_codes.dart
@@ -20,6 +20,20 @@ abstract final class RelayCloseCodes {
   /// reconnect with the same bridge id.
   static const bridgeRevoked = 4006;
 
+  /// Bridge replaced — another bridge for the same account connected and took
+  /// this bridge's single relay slot. The displaced bridge SHOULD still
+  /// reconnect (headless/VM failover), but only on a long backoff so two
+  /// always-on bridges don't tight-loop kicking each other. Deliberately NOT
+  /// in [noReconnectCodes]: the policy is long-backoff, not never-reconnect.
+  static const bridgeReplaced = 4007;
+
+  /// The close reason the relay pairs with a `1000` normal close when it
+  /// displaces a bridge, used only as a rollout fallback before the relay
+  /// emits [bridgeReplaced]. Close reason strings are fragile (intermediaries
+  /// may strip/rewrite them), so [bridgeReplaced] is the authoritative signal;
+  /// this matches only during the relay-deploy window.
+  static const bridgeReplacedFallbackReason = "replaced";
+
   static const noReconnectCodes = {
     authFailure,
     authRequired,
@@ -35,5 +49,19 @@ abstract final class RelayCloseCodes {
   static bool shouldReconnect(int? closeCode) {
     if (closeCode == null) return true;
     return !noReconnectCodes.contains(closeCode);
+  }
+
+  /// Whether a close indicates this bridge was displaced by another bridge on
+  /// the same account (see [bridgeReplaced]). The dedicated [bridgeReplaced]
+  /// code is authoritative and reason-independent; a `1000` normal close whose
+  /// reason is [bridgeReplacedFallbackReason] is only matched as a rollout
+  /// fallback for the relay-deploy window.
+  ///
+  /// This is the single detection rule shared by the reconnect-loop policy and
+  /// the supervised status push, so the two never diverge on what a takeover
+  /// looks like.
+  static bool isBridgeReplaced({required int? closeCode, required String? closeReason}) {
+    if (closeCode == bridgeReplaced) return true;
+    return closeCode == 1000 && closeReason == bridgeReplacedFallbackReason;
   }
 }

--- a/shared/sesori_shared/lib/src/protocol/control_message.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_message.dart
@@ -101,6 +101,12 @@ enum ControlRelayConnectionState {
   connecting,
   @JsonValue("disconnected")
   disconnected,
+
+  /// Another bridge for this account took the single relay slot; this bridge
+  /// is displaced and reconnecting only on a long backoff. The GUI surfaces a
+  /// "take over" affordance (a plain helper respawn).
+  @JsonValue("taken_over")
+  takenOver,
   @JsonValue("unknown")
   unknown,
 }

--- a/shared/sesori_shared/lib/src/protocol/control_message.g.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_message.g.dart
@@ -74,6 +74,7 @@ const _$ControlRelayConnectionStateEnumMap = {
   ControlRelayConnectionState.connected: 'connected',
   ControlRelayConnectionState.connecting: 'connecting',
   ControlRelayConnectionState.disconnected: 'disconnected',
+  ControlRelayConnectionState.takenOver: 'taken_over',
   ControlRelayConnectionState.unknown: 'unknown',
 };
 

--- a/shared/sesori_shared/test/protocol/close_codes_test.dart
+++ b/shared/sesori_shared/test/protocol/close_codes_test.dart
@@ -17,5 +17,38 @@ void main() {
       expect(RelayCloseCodes.shouldReconnect(1000), isTrue);
       expect(RelayCloseCodes.shouldReconnect(1006), isTrue);
     });
+
+    test("bridgeReplaced is 4007 and still reconnects (long-backoff, not never)", () {
+      expect(RelayCloseCodes.bridgeReplaced, equals(4007));
+      expect(RelayCloseCodes.noReconnectCodes, isNot(contains(RelayCloseCodes.bridgeReplaced)));
+      expect(RelayCloseCodes.shouldReconnect(RelayCloseCodes.bridgeReplaced), isTrue);
+    });
+
+    group("isBridgeReplaced", () {
+      test("matches the dedicated 4007 code regardless of reason", () {
+        expect(
+          RelayCloseCodes.isBridgeReplaced(closeCode: 4007, closeReason: null),
+          isTrue,
+        );
+        expect(
+          RelayCloseCodes.isBridgeReplaced(closeCode: 4007, closeReason: "anything"),
+          isTrue,
+        );
+      });
+
+      test("matches the 1000/replaced rollout fallback", () {
+        expect(
+          RelayCloseCodes.isBridgeReplaced(closeCode: 1000, closeReason: "replaced"),
+          isTrue,
+        );
+      });
+
+      test("does not match a plain 1000 close or other codes", () {
+        expect(RelayCloseCodes.isBridgeReplaced(closeCode: 1000, closeReason: null), isFalse);
+        expect(RelayCloseCodes.isBridgeReplaced(closeCode: 1000, closeReason: "bye"), isFalse);
+        expect(RelayCloseCodes.isBridgeReplaced(closeCode: 4006, closeReason: "replaced"), isFalse);
+        expect(RelayCloseCodes.isBridgeReplaced(closeCode: null, closeReason: "replaced"), isFalse);
+      });
+    });
   });
 }

--- a/shared/sesori_shared/test/protocol/control_message_test.dart
+++ b/shared/sesori_shared/test/protocol/control_message_test.dart
@@ -101,5 +101,17 @@ void main() {
         expect((parsed as ControlPromptRequest).kind, equals(ControlPromptKind.unknown));
       });
     });
+
+    test("status round-trips the takenOver relay state", () {
+      const original = ControlMessage.status(
+        relay: ControlRelayConnectionState.takenOver,
+        plugin: ControlPluginHealthState.healthy,
+      );
+
+      final json = original.toJson();
+
+      expect(json["relay"], equals("taken_over"));
+      expect(ControlMessage.fromJson(json), equals(original));
+    });
   });
 }


### PR DESCRIPTION
## What (desktop plan Phase 1, PR 1.14 — ADR A22)

Make a bridge **displaced** by the relay's single-slot replacement stop tight-looping (the "takeover war").

The relay holds one bridge slot per account and closes the displaced bridge on contact. Today it closes with `1000 + reason "replaced"`, which the bridge treats as a generic drop and reconnects on a backoff that resets to 1s on success — so two always-on bridges (two desktops, or a desktop + a forgotten `systemd` bridge) mutually kick each other forever while phones see `bridge_connected` flapping. Desktop autostart makes this mainstream.

## How

- **shared** (`close_codes.dart`): `RelayCloseCodes.bridgeReplaced = 4007` (deliberately **NOT** in `noReconnectCodes` — policy is long-backoff, not never-reconnect) + a single `isBridgeReplaced({closeCode, closeReason})` predicate, the authoritative detection rule shared by both consumers so they never diverge. The `4007` code is reason-independent; `1000 + "replaced"` is matched only as a rollout fallback. Added `ControlRelayConnectionState.takenOver` (additive enum value on the existing `status` DTO — no new message variant).
- **RelayClient** (Layer 0): a dumb `closeReason` accessor mirroring `closeCode`, and `closeReason` on `RelayDisconnected`, so the notifier detects the replaced-close off the connection-state stream without racing the loop's own read.
- **orchestrator reconnect loop:** a takeover drop logs a loud `Console.warning` and reconnects on a minutes-order jittered backoff (2 min initial, 5 min cap, +25% jitter) instead of the ordinary 1s-reset/30s-cap one. Still reconnects (headless/VM failover preserved), just slowly. Every other close code is unchanged. The orchestrator owns only this policy — it never calls `ControlChannelClient.send`.
- **ControlStatusNotifier** (Layer 4): maps the replaced-close to `takenOver` so the supervised GUI can offer a plain-respawn "take over" instead of a plain outage.

## Relay prerequisite — deploy gate ⚠️

Detection is authoritative on close code `4007`, emitted by **`sesori-ai/sesori_relay_server#7`**. That relay change **must be merged AND deployed to the production relay before this bridge PR merges.** The bridge keeps the `1000/"replaced"` fallback so an older relay never breaks it during the rollout window. This is the single tracked exception to release-safety invariant #1 (see `docs/desktop/PLAN.md` §4 / §8).

## Standing-acceptance exception (explicit)

This PR intentionally changes standalone behaviour **for the replaced-close case only** (ADR A22). All other close codes — incl. `4006` revoked → re-register — keep today's behaviour, asserted by test.

## Tests / verification

- shared: `isBridgeReplaced` matrix + `taken_over` round-trip. `dart analyze` clean, `dart test` 282 pass.
- bridge: RelayClient `closeReason` accessor + `RelayDisconnected.closeReason` connection-level tests; notifier `4007`/`1000-replaced`/plain-`1000` mapping tests; orchestrator takeover tests (a `4007` and a `1000/"replaced"` drop hold off reconnect within the war window; a plain `1000` drop reconnects promptly). `make analyze` + `dart analyze --fatal-infos` clean; `make test` all pass (app 1726).
- `client/app` (mobile) `flutter analyze` clean (additive shared change, no consumer break).
- `aristotle-plan-review` and `aristotle-impl-review`: both APPROVED.

## Plan bookkeeping (all four surfaces advanced in this PR)

Current pointer → 1.14 done / 1.15 next; §9 row `1.14 ☑`; §8 risk register row updated; phase-1 doc Findings/Deltas + Aristotle line filled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents “takeover wars” when two bridges compete for the relay slot by detecting a “bridge replaced” close and using a slow, jittered reconnect. Adds a taken-over state to the GUI and makes long backoff waits cancellable so shutdown doesn’t stall.

- **New Features**
  - Added `RelayCloseCodes.bridgeReplaced = 4007` and `isBridgeReplaced({closeCode, closeReason})` (also matches `1000`/`"replaced"` during rollout).
  - Exposed `closeReason` on `RelayClient` and included it on `RelayDisconnected`.
  - Orchestrator uses a long, jittered backoff on takeover (2 min start, 5 min cap, +25% jitter), re-jitters each step, and cancels backoff waits on shutdown; other codes unchanged.
  - Mapped takeover to `ControlRelayConnectionState.takenOver` so the GUI can offer a “take over” action.

- **Migration**
  - Deploy relay change `sesori-ai/sesori_relay_server#7` to emit `4007` before merging this PR. The `1000`/`"replaced"` fallback keeps older relays safe during rollout.

<sup>Written for commit d78e66c0ec6ae082420087e0bd3b1b88be9217e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

