### PR TITLE
Update liquid_glass_widgets to 0.21.1

### DIFF
--- a/client/app/lib/features/session_detail/widgets/session_detail_scaffold_sections.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_scaffold_sections.dart
@@ -45,7 +45,6 @@ class SessionDetailPendingBanner extends StatelessWidget {
         settings: LiquidGlassSettings(glassColor: backgroundColor.withValues(alpha: 0.6)),
         child: GlassListTile(
           onTap: onTap,
-          showDivider: false,
           leading: Icon(icon, size: 20, color: foregroundColor),
           title: Text(label),
           titleStyle: prego.textTheme.textMd.bold.copyWith(color: foregroundColor),

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.9
-  liquid_glass_widgets: ^0.19.5
+  liquid_glass_widgets: ^0.21.1
   http: ^1.6.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.12.0

--- a/client/module_prego/lib/components/surfaces/prego_surfaces.dart
+++ b/client/module_prego/lib/components/surfaces/prego_surfaces.dart
@@ -177,6 +177,7 @@ class PregoListTile extends StatelessWidget {
       final indent = dividerIndent ?? (leading != null ? 56.0 : 16.0);
       return Column(
         mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [tile, PregoDivider(indent: indent)],
       );
     }

--- a/client/module_prego/lib/components/surfaces/prego_surfaces.dart
+++ b/client/module_prego/lib/components/surfaces/prego_surfaces.dart
@@ -122,10 +122,11 @@ class PregoDivider extends StatelessWidget {
 /// A grouped-list row: leading slot, title (+ optional subtitle), trailing slot,
 /// with press feedback and an optional bottom divider.
 ///
-/// Apple: delegates to [GlassListTile] (identical to the existing glass rows).
-/// Android: a flat [InkWell] row with the same metrics — 32px leading box, 12px
-/// gap, title/subtitle column, trailing — and a [PregoDivider] below unless it
-/// is the last row.
+/// Apple: the row itself is a [GlassListTile] (identical metrics to the existing
+/// glass rows). Android: a flat [InkWell] row with the same metrics — 32px
+/// leading box, 12px gap, title/subtitle column, trailing. On both paths the row
+/// composes a [PregoDivider] below itself unless it is the last row —
+/// [GlassListTile] is position-agnostic and no longer owns divider rendering.
 class PregoListTile extends StatelessWidget {
   const PregoListTile({
     super.key,
@@ -166,24 +167,35 @@ class PregoListTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (glassEffectsEnabled()) {
-      return GlassListTile(
-        leading: leading,
-        title: title,
-        subtitle: subtitle,
-        trailing: trailing,
-        onTap: onTap,
-        isLast: isLast,
-        showDivider: showDivider,
-        contentPadding: contentPadding,
-        leadingIconColor: leadingIconColor,
-        titleStyle: titleStyle,
-        subtitleStyle: subtitleStyle,
-        dividerIndent: dividerIndent,
+    // GlassListTile is position-agnostic in liquid_glass_widgets — it no longer
+    // draws its own divider. PregoListTile owns that layout concern on both
+    // paths, composing a PregoDivider below the row (frosted hairline on Apple,
+    // flat Divider on Android) so the same call site renders either way.
+    final tile = glassEffectsEnabled() ? _buildGlass() : _buildFlat(context);
+
+    if (showDivider && !isLast) {
+      final indent = dividerIndent ?? (leading != null ? 56.0 : 16.0);
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [tile, PregoDivider(indent: indent)],
       );
     }
 
-    return _buildFlat(context);
+    return tile;
+  }
+
+  Widget _buildGlass() {
+    return GlassListTile(
+      leading: leading,
+      title: title,
+      subtitle: subtitle,
+      trailing: trailing,
+      onTap: onTap,
+      contentPadding: contentPadding,
+      leadingIconColor: leadingIconColor,
+      titleStyle: titleStyle,
+      subtitleStyle: subtitleStyle,
+    );
   }
 
   Widget _buildFlat(BuildContext context) {
@@ -233,14 +245,6 @@ class PregoListTile extends StatelessWidget {
     Widget tile = Padding(padding: contentPadding, child: row);
     if (onTap != null) {
       tile = InkWell(onTap: onTap, child: tile);
-    }
-
-    if (showDivider && !isLast) {
-      final indent = dividerIndent ?? (leading != null ? 56.0 : 16.0);
-      return Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [tile, PregoDivider(indent: indent)],
-      );
     }
 
     return tile;

--- a/client/module_prego/pubspec.yaml
+++ b/client/module_prego/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   meta: ^1.18.0
   flutter_svg: ^2.3.0
   universal_platform: ^1.1.0
-  liquid_glass_widgets: ^0.19.4
+  liquid_glass_widgets: ^0.21.1
   cue: ^0.3.1
 
 flutter:

--- a/client/module_prego/test/components/prego_surfaces_test.dart
+++ b/client/module_prego/test/components/prego_surfaces_test.dart
@@ -55,6 +55,25 @@ void main() {
       expect(find.byType(GlassDivider), findsNothing);
       expect(find.byType(Divider), findsOneWidget);
     }, variant: TargetPlatformVariant.only(TargetPlatform.android));
+
+    testWidgets("PregoListTile draws a flat Divider below itself unless it is the last row", (tester) async {
+      await tester.pumpWidget(
+        _harness(
+          const PregoCard(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                PregoListTile(title: Text("Alpha")),
+                PregoListTile(title: Text("Beta"), isLast: true),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Only the first (non-last) row composes a divider; the last row suppresses it.
+      expect(find.byType(Divider), findsOneWidget);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.android));
   });
 
   group("Apple (glass) path", () {
@@ -81,6 +100,27 @@ void main() {
       await tester.tap(find.text("Alpha"));
       await tester.pumpAndSettle();
       expect(taps, 1);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+
+    testWidgets("PregoListTile draws its own GlassDivider unless it is the last row", (tester) async {
+      await tester.pumpWidget(
+        _harness(
+          const PregoCard(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                PregoListTile(title: Text("Alpha")),
+                PregoListTile(title: Text("Beta"), isLast: true),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // GlassListTile no longer owns divider rendering; PregoListTile composes a
+      // GlassDivider below the first (non-last) row and none below the last.
+      expect(find.byType(GlassListTile), findsNWidgets(2));
+      expect(find.byType(GlassDivider), findsOneWidget);
     }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
   });
 }

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -921,10 +921,10 @@ packages:
     dependency: transitive
     description:
       name: liquid_glass_widgets
-      sha256: "1bb64164d5b47623c82ef0b9d412764329e054f25be8d21fb770750098f364ca"
+      sha256: f9af2ef9587d4644739b16a9dbc7c57391e652990c9cc6c367be45e74154e03a
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.5"
+    version: "0.21.1"
   logging:
     dependency: transitive
     description:


### PR DESCRIPTION
## What

Bumps `liquid_glass_widgets` from 0.19.x → **0.21.1** across the client and adapts to its one breaking change.

## Why it's two commits

**1. `chore(client): bump liquid_glass_widgets to 0.21.1`**
Bumps the dep in `client/app` (0.19.5 → 0.21.1) and `client/module_prego` (0.19.4 → 0.21.1), plus the resolved `client/pubspec.lock`.

**2. `fix(prego): adapt to GlassListTile divider refactor`**
`liquid_glass_widgets` 0.20.0 made `GlassListTile` **position-agnostic** and removed its `isLast` / `showDivider` / `dividerIndent` params — divider rendering is now the parent's responsibility. This surfaced as 8 compile errors.

- `PregoListTile` keeps `isLast` / `showDivider` / `dividerIndent` as **its own public contract** (callers and tests depend on them) and now composes the bottom divider itself via `PregoDivider` — frosted hairline on Apple, flat `Divider` on Android. The glass and flat paths, previously divergent (glass delegated divider rendering to the package; flat composed it manually), are now unified through one shared wrapper.
- The standalone pending-banner tile drops its now-obsolete `showDivider: false`.
- Added tests locking in the divider composition on **both** platform paths (non-last row draws a divider; last row suppresses it).

## Scope check

Reviewed the full 0.19.5 → 0.21.1 CHANGELOG: the `GlassListTile` divider refactor is the **only** hard break. The 0.20.1 `GlassButton.custom` default-height change doesn't affect us (our call site sets `height: 36` explicitly).

## Verification

- `dart analyze` — clean across the entire `client` workspace (app, desktop, all modules).
- Tests green: 22 in `module_prego`, 136 in app `session_detail` + `new_session`.
- Repo-wide sweep confirmed no other `GlassListTile` call site referenced the removed params.

https://claude.ai/code/session_01HNxL1U5jUyrxDgWNPhq3u9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `liquid_glass_widgets` to 0.21.1 and adapt to the `GlassListTile` divider refactor so list tiles render dividers consistently on iOS and Android. This keeps `PregoListTile` APIs stable and adds tests for both paths.

- **Dependencies**
  - Bump `liquid_glass_widgets` 0.19.x → 0.21.1 in `client/app` and `client/module_prego`; update `pubspec.lock`.

- **Refactors**
  - `PregoListTile` keeps `isLast` / `showDivider` / `dividerIndent` and now composes its own divider via `PregoDivider` (glass: `GlassDivider`, Android: `Divider`) since `GlassListTile` no longer handles dividers; the tile+divider Column now stretches to full width.
  - Remove obsolete `showDivider: false` from the pending-banner tile.
  - Add tests asserting divider behavior on iOS and Android.

<sup>Written for commit 5022dcdd5d3ded738cff28caa3415eb444641be5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

