### PR TITLE
feat(app): shimmer skeleton loading states for projects and sessions lists

### DIFF
--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -179,8 +179,10 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
     required bool isRefreshing,
   }) {
     return switch (state) {
-      ProjectListLoading() => const [
-        SliverFillRemaining(hasScrollBody: false, child: Center(child: CircularProgressIndicator())),
+      ProjectListLoading() => [
+        SliverToBoxAdapter(
+          child: PregoSkeletonList(semanticLabel: context.loc.projectListLoadingSemantics),
+        ),
       ],
       // No bridge has ever been registered → setup onboarding; a bridge exists
       // but isn't running → ask to turn it on. Both are full-screen views that

--- a/client/app/lib/features/session_list/session_list_content.dart
+++ b/client/app/lib/features/session_list/session_list_content.dart
@@ -51,9 +51,8 @@ class SessionListContent extends StatelessWidget {
     final state = context.watch<SessionListCubit>().state;
 
     return switch (state) {
-      SessionListLoading() => const SliverFillRemaining(
-        hasScrollBody: false,
-        child: Center(child: CircularProgressIndicator()),
+      SessionListLoading() => SliverToBoxAdapter(
+        child: PregoSkeletonList(semanticLabel: loc.sessionListLoadingSemantics),
       ),
       SessionListLoaded(:final sessions, :final showArchived, :final activeSessionIds, :final unseenBySessionId) =>
         sessions.isEmpty

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -7,6 +7,7 @@
   "apiErrorServerRejected": "The server returned an error. Please try again.",
   "apiErrorNetworkDown": "Connection failed — check your network and try again.",
   "projectListTitle": "Projects",
+  "projectListLoadingSemantics": "Loading projects",
   "projectListEmpty": "No projects found",
   "projectListUpdated": "Updated {timestamp}",
   "@projectListUpdated": {

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -135,6 +135,7 @@
       }
     }
   },
+  "sessionListLoadingSemantics": "Loading sessions",
   "sessionListEmpty": "No sessions found",
   "sessionListUntitled": "Untitled session",
   "sessionListUpdated": "Updated {timestamp}",

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -427,6 +427,12 @@ abstract class AppLocalizations {
   /// **'{name} — Sessions'**
   String sessionListTitleWithName(String name);
 
+  /// No description provided for @sessionListLoadingSemantics.
+  ///
+  /// In en, this message translates to:
+  /// **'Loading sessions'**
+  String get sessionListLoadingSemantics;
+
   /// No description provided for @sessionListEmpty.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -133,6 +133,12 @@ abstract class AppLocalizations {
   /// **'Projects'**
   String get projectListTitle;
 
+  /// No description provided for @projectListLoadingSemantics.
+  ///
+  /// In en, this message translates to:
+  /// **'Loading projects'**
+  String get projectListLoadingSemantics;
+
   /// No description provided for @projectListEmpty.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -30,6 +30,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectListTitle => 'Projects';
 
   @override
+  String get projectListLoadingSemantics => 'Loading projects';
+
+  @override
   String get projectListEmpty => 'No projects found';
 
   @override

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -192,6 +192,9 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get sessionListLoadingSemantics => 'Loading sessions';
+
+  @override
   String get sessionListEmpty => 'No sessions found';
 
   @override

--- a/client/module_prego/lib/components/loaders/prego_skeleton.dart
+++ b/client/module_prego/lib/components/loaders/prego_skeleton.dart
@@ -1,0 +1,338 @@
+/// Skeleton loading primitives for the Prego design system.
+///
+/// The designed loading state for content-bearing surfaces: pill-shaped
+/// placeholder bars that fade toward their trailing edge, swept by a moving
+/// sheen while real data loads. Compose a bespoke layout from
+/// [PregoSkeletonBar] and [PregoSkeletonListTile] and wrap it in
+/// [PregoShimmer], or drop in [PregoSkeletonList] — the ready-made shimmering
+/// list for list screens loading their first page.
+library;
+
+import "dart:async";
+
+import "package:flutter/material.dart";
+
+import "../../theme/prego_theme.dart";
+
+/// Animates a shimmer sheen across [child].
+///
+/// A translucent highlight band sweeps from the leading to the trailing edge,
+/// restricted to [child]'s opaque pixels ([BlendMode.srcATop]) so the gaps
+/// between skeleton shapes stay untouched. The mask is a single saveLayer for
+/// the whole region — wrap one [PregoShimmer] around a screen's entire
+/// skeleton, never one per row. The child renders unmasked when [enabled] is
+/// false or the platform requests reduced motion — the static fade of the
+/// bars still reads as a loading state.
+///
+/// To avoid a one-frame skeleton flash on fast loads, the region stays laid
+/// out but invisible for [appearDelay], then fades in.
+///
+/// Skeletons are decorative: descendants are excluded from semantics, and
+/// [semanticLabel] (when given) is announced in their place.
+class PregoShimmer extends StatefulWidget {
+  const PregoShimmer({
+    super.key,
+    required this.child,
+    this.enabled = true,
+    this.period = const Duration(milliseconds: 1500),
+    this.appearDelay = const Duration(milliseconds: 300),
+    this.highlightColor,
+    this.semanticLabel,
+  });
+
+  final Widget child;
+
+  /// Whether the sheen sweeps. The skeleton shapes render either way.
+  final bool enabled;
+
+  /// Time for one full sweep across the child.
+  final Duration period;
+
+  /// How long the skeleton stays invisible before fading in, so loads that
+  /// finish quickly never flash it. [Duration.zero] shows it immediately.
+  final Duration appearDelay;
+
+  /// Peak colour of the sheen band. Defaults to a translucent white, which
+  /// lightens the grey bars in both themes.
+  final Color? highlightColor;
+
+  /// Announced to screen readers in place of the decorative skeleton.
+  final String? semanticLabel;
+
+  @override
+  State<PregoShimmer> createState() => _PregoShimmerState();
+}
+
+class _PregoShimmerState extends State<PregoShimmer>
+    with SingleTickerProviderStateMixin, WidgetsBindingObserver {
+  /// Sweep position in multiples of the child's width. The band (20% wide,
+  /// centred at 0.5 + value) is fully off-screen outside [-0.6, 0.6]; the
+  /// extra margin below/above gives it a clean entry and a short rest between
+  /// sweeps.
+  static const double _slideMin = -0.7;
+  static const double _slideMax = 1.1;
+
+  late final AnimationController _slide = AnimationController.unbounded(vsync: this)
+    ..value = _slideMin;
+
+  late bool _visible = widget.appearDelay == Duration.zero;
+  Timer? _appearTimer;
+
+  bool get _shouldAnimate {
+    if (!widget.enabled || !_visible) return false;
+    // MediaQuery only carries Android's "Remove animations"; iOS "Reduce
+    // Motion" surfaces solely through accessibilityFeatures.reduceMotion.
+    if (MediaQuery.disableAnimationsOf(context)) return false;
+    return !View.of(context).platformDispatcher.accessibilityFeatures.reduceMotion;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    if (!_visible) _scheduleAppear();
+  }
+
+  void _scheduleAppear() {
+    _appearTimer?.cancel();
+    _appearTimer = Timer(widget.appearDelay, () {
+      if (!mounted) return;
+      setState(() => _visible = true);
+      _syncAnimation();
+    });
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _syncAnimation();
+  }
+
+  @override
+  void didUpdateWidget(PregoShimmer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.period != widget.period) _slide.stop();
+    if (oldWidget.appearDelay != widget.appearDelay && !_visible) {
+      if (widget.appearDelay == Duration.zero) {
+        _appearTimer?.cancel();
+        _visible = true;
+      } else {
+        _scheduleAppear();
+      }
+    }
+    _syncAnimation();
+  }
+
+  @override
+  void didChangeAccessibilityFeatures() {
+    // Reduce Motion toggles don't reach MediaQuery on iOS; re-evaluate the
+    // sweep when the platform's accessibility features change.
+    if (!mounted) return;
+    setState(() {});
+    _syncAnimation();
+  }
+
+  void _syncAnimation() {
+    if (_shouldAnimate && !_slide.isAnimating) {
+      _slide.repeat(min: _slideMin, max: _slideMax, period: widget.period);
+    } else if (!_shouldAnimate && _slide.isAnimating) {
+      _slide.stop();
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _appearTimer?.cancel();
+    _slide.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget result = ExcludeSemantics(child: widget.child);
+
+    if (_shouldAnimate) {
+      final highlight = widget.highlightColor ?? Colors.white.withValues(alpha: 0.30);
+      // In RTL the band sweeps right-to-left so it still travels leading →
+      // trailing.
+      final direction = switch (Directionality.of(context)) {
+        TextDirection.ltr => 1.0,
+        TextDirection.rtl => -1.0,
+      };
+      // A horizontal band, matching the bars' own horizontal fades. Kept
+      // untilted on purpose: an x-only translation traverses a tilted band's
+      // gradient line at a height-dependent rate, which makes the entry/exit
+      // margins wrong on tall regions.
+      result = RepaintBoundary(
+        child: AnimatedBuilder(
+          animation: _slide,
+          child: result,
+          builder: (context, child) => ShaderMask(
+            blendMode: BlendMode.srcATop,
+            shaderCallback: (bounds) => LinearGradient(
+              begin: Alignment.centerLeft,
+              end: Alignment.centerRight,
+              colors: [highlight.withValues(alpha: 0), highlight, highlight.withValues(alpha: 0)],
+              stops: const [0.4, 0.5, 0.6],
+              transform: _SlidingGradientTransform(slidePercent: _slide.value * direction),
+            ).createShader(bounds),
+            child: child,
+          ),
+        ),
+      );
+    }
+
+    // Held invisible (but laid out, so nothing jumps) until the appear delay
+    // elapses, then faded in.
+    result = AnimatedOpacity(
+      opacity: _visible ? 1.0 : 0.0,
+      duration: const Duration(milliseconds: 200),
+      child: result,
+    );
+
+    final semanticLabel = widget.semanticLabel;
+    if (semanticLabel == null) return result;
+    return Semantics(container: true, label: semanticLabel, child: result);
+  }
+}
+
+/// Translates the sweep gradient horizontally by [slidePercent] of the
+/// masked area's width.
+class _SlidingGradientTransform extends GradientTransform {
+  const _SlidingGradientTransform({required this.slidePercent});
+
+  final double slidePercent;
+
+  @override
+  Matrix4? transform(Rect bounds, {TextDirection? textDirection}) =>
+      Matrix4.translationValues(bounds.width * slidePercent, 0.0, 0.0);
+}
+
+/// A single pill-shaped skeleton bar that fades toward its trailing edge.
+class PregoSkeletonBar extends StatelessWidget {
+  const PregoSkeletonBar({
+    super.key,
+    required this.height,
+    this.width,
+    this.color,
+  });
+
+  final double height;
+
+  /// Fixed width; null fills the available width.
+  final double? width;
+
+  /// Solid (leading) colour of the fade. Defaults to the quaternary
+  /// foreground, which the fade dissolves into the screen background.
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = this.color ?? context.prego.colors.fgQuaternary;
+    return Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(PregoRadius.full),
+        gradient: LinearGradient(
+          begin: AlignmentDirectional.centerStart,
+          end: AlignmentDirectional.centerEnd,
+          colors: [color, color.withValues(alpha: 0)],
+        ),
+      ),
+    );
+  }
+}
+
+/// A two-line list-row skeleton: a title bar over a shorter indented detail
+/// bar, closed by the hairline bottom border list rows carry.
+class PregoSkeletonListTile extends StatelessWidget {
+  const PregoSkeletonListTile({
+    super.key,
+    this.titleWidthFraction = 1.0,
+  });
+
+  /// Fraction of the row's content width the title bar spans. Varying this
+  /// across rows keeps the placeholder list looking organic.
+  final double titleWidthFraction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(PregoSpacing.lg),
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: context.prego.colors.borderTertiary)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        spacing: PregoSpacing.xxs,
+        children: [
+          // Title slot: a 20px bar centred in its 24px line box.
+          SizedBox(
+            height: 24,
+            child: FractionallySizedBox(
+              alignment: AlignmentDirectional.centerStart,
+              widthFactor: titleWidthFraction,
+              child: const Align(
+                alignment: AlignmentDirectional.centerStart,
+                child: PregoSkeletonBar(height: 20),
+              ),
+            ),
+          ),
+          // Detail slot: a fixed-width 14px bar in its 20px line box, indented
+          // like the metadata row under a list title.
+          const SizedBox(
+            height: 20,
+            child: Padding(
+              padding: EdgeInsetsDirectional.only(start: PregoSpacing.xl),
+              child: Align(
+                alignment: AlignmentDirectional.centerStart,
+                child: PregoSkeletonBar(height: 14, width: 99),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The ready-made shimmering list skeleton: [itemCount] two-line rows with a
+/// varied title-width rhythm, wrapped in a [PregoShimmer].
+class PregoSkeletonList extends StatelessWidget {
+  const PregoSkeletonList({
+    super.key,
+    this.itemCount = 6,
+    this.padding = const EdgeInsetsDirectional.symmetric(horizontal: PregoSpacing.xl, vertical: 10),
+    this.semanticLabel,
+  });
+
+  final int itemCount;
+
+  final EdgeInsetsGeometry padding;
+
+  /// Announced to screen readers in place of the decorative rows.
+  final String? semanticLabel;
+
+  /// Title-bar width fractions cycled across rows; the variation keeps the
+  /// placeholder from reading as a striped pattern.
+  static const List<double> _titleWidths = [0.74, 0.51, 0.51, 0.83, 1.0, 0.51];
+
+  @override
+  Widget build(BuildContext context) {
+    return PregoShimmer(
+      semanticLabel: semanticLabel,
+      child: Padding(
+        padding: padding,
+        child: Column(
+          spacing: 10,
+          children: [
+            for (var i = 0; i < itemCount; i++)
+              PregoSkeletonListTile(titleWidthFraction: _titleWidths[i % _titleWidths.length]),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/client/module_prego/lib/module_prego.dart
+++ b/client/module_prego/lib/module_prego.dart
@@ -5,6 +5,7 @@ export 'components/alerts/prego_inline_alerts_notifications.dart';
 export 'components/alerts/prego_popup_alerts_notifications.dart';
 export 'components/buttons/prego_buttons_glass.dart';
 export 'components/buttons/prego_buttons_icon_glass.dart';
+export 'components/loaders/prego_skeleton.dart';
 export 'components/menus/prego_anchor_menu.dart';
 export 'components/navigation/prego_glass_scaffold.dart';
 export 'components/navigation/prego_nav_title.dart';

--- a/client/module_prego/test/components/prego_skeleton_test.dart
+++ b/client/module_prego/test/components/prego_skeleton_test.dart
@@ -1,0 +1,193 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:theme_prego/module_prego.dart";
+
+/// Behavioural guards for the skeleton loading primitives.
+///
+/// The shimmer sweep is an infinite repeating animation, so these tests pump
+/// fixed durations and never `pumpAndSettle`.
+void main() {
+  Widget harness(Widget child, {bool disableAnimations = false}) {
+    return MaterialApp(
+      theme: ThemeData(extensions: [PregoDesignSystem.light]),
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(disableAnimations: disableAnimations),
+        child: child!,
+      ),
+      home: Scaffold(
+        body: Align(
+          alignment: Alignment.topCenter,
+          child: SizedBox(width: 402, child: child),
+        ),
+      ),
+    );
+  }
+
+  /// Pumps past the anti-flash appear delay (300ms) and the fade-in (200ms).
+  /// The extra frame lets the fade ticker anchor its start time before the
+  /// completing pump.
+  Future<void> pumpVisible(WidgetTester tester, Widget child, {bool disableAnimations = false}) async {
+    await tester.pumpWidget(harness(child, disableAnimations: disableAnimations));
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump(const Duration(milliseconds: 16));
+    await tester.pump(const Duration(milliseconds: 250));
+  }
+
+  Finder titleBars() => find.byWidgetPredicate((w) => w is PregoSkeletonBar && w.height == 20);
+  Finder detailBars() => find.byWidgetPredicate((w) => w is PregoSkeletonBar && w.height == 14);
+
+  group("PregoSkeletonList", () {
+    testWidgets("renders six two-line rows with the designed width rhythm", (tester) async {
+      await pumpVisible(tester, const PregoSkeletonList());
+
+      expect(find.byType(PregoSkeletonListTile), findsNWidgets(6));
+      expect(titleBars(), findsNWidgets(6));
+      expect(detailBars(), findsNWidgets(6));
+
+      // Content width: 402 - 2*16 (list padding) - 2*12 (row padding) = 346.
+      const contentWidth = 402.0 - 32.0 - 24.0;
+      const fractions = [0.74, 0.51, 0.51, 0.83, 1.0, 0.51];
+      final widths = titleBars()
+          .evaluate()
+          .map((e) => (e.renderObject! as RenderBox).size.width)
+          .toList();
+      for (var i = 0; i < fractions.length; i++) {
+        expect(widths[i], moreOrLessEquals(fractions[i] * contentWidth, epsilon: 1.0));
+      }
+
+      // Detail bars are fixed-size 99x14 pills.
+      for (final element in detailBars().evaluate()) {
+        expect((element.renderObject! as RenderBox).size, const Size(99, 14));
+      }
+    });
+
+    testWidgets("the width pattern cycles past six rows", (tester) async {
+      // Scrollable: eight rows are taller than the test viewport.
+      await pumpVisible(tester, const SingleChildScrollView(child: PregoSkeletonList(itemCount: 8)));
+
+      expect(find.byType(PregoSkeletonListTile), findsNWidgets(8));
+      final widths = titleBars()
+          .evaluate()
+          .map((e) => (e.renderObject! as RenderBox).size.width)
+          .toList();
+      expect(widths[6], moreOrLessEquals(widths[0], epsilon: 0.1));
+      expect(widths[7], moreOrLessEquals(widths[1], epsilon: 0.1));
+    });
+
+    testWidgets("announces the semantic label and hides the decorative rows", (tester) async {
+      final semantics = tester.ensureSemantics();
+      await pumpVisible(tester, const PregoSkeletonList(semanticLabel: "Loading projects"));
+
+      expect(find.bySemanticsLabel("Loading projects"), findsOneWidget);
+      expect(find.byType(ExcludeSemantics), findsWidgets);
+      semantics.dispose();
+    });
+  });
+
+  group("PregoShimmer", () {
+    testWidgets("stays invisible during the appear delay, then fades in and sweeps", (tester) async {
+      await tester.pumpWidget(harness(const PregoSkeletonList()));
+
+      // Before the appear delay: laid out but fully transparent, no sweep.
+      final opacityFinder = find.byWidgetPredicate((w) => w is AnimatedOpacity && w.opacity == 0.0);
+      expect(opacityFinder, findsOneWidget);
+      expect(find.byType(ShaderMask), findsNothing);
+      expect(find.byType(PregoSkeletonListTile), findsNWidgets(6));
+
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(
+        find.byWidgetPredicate((w) => w is AnimatedOpacity && w.opacity == 1.0),
+        findsOneWidget,
+      );
+      // One mask for the whole region, and the sweep is running.
+      expect(find.byType(ShaderMask), findsOneWidget);
+      expect(tester.hasRunningAnimations, isTrue);
+    });
+
+    testWidgets("shows immediately when the appear delay is zero", (tester) async {
+      await tester.pumpWidget(
+        harness(
+          const PregoShimmer(
+            appearDelay: Duration.zero,
+            child: PregoSkeletonBar(height: 20, width: 100),
+          ),
+        ),
+      );
+
+      expect(find.byType(ShaderMask), findsOneWidget);
+      expect(tester.hasRunningAnimations, isTrue);
+    });
+
+    testWidgets("reduced motion keeps the static bars but never sweeps", (tester) async {
+      await pumpVisible(tester, const PregoSkeletonList(), disableAnimations: true);
+
+      expect(find.byType(PregoSkeletonListTile), findsNWidgets(6));
+      expect(find.byType(ShaderMask), findsNothing);
+      expect(tester.hasRunningAnimations, isFalse);
+    });
+
+    testWidgets("enabled: false renders the bars without a sweep", (tester) async {
+      await pumpVisible(
+        tester,
+        const PregoShimmer(
+          enabled: false,
+          appearDelay: Duration.zero,
+          child: PregoSkeletonBar(height: 20, width: 100),
+        ),
+      );
+
+      expect(find.byType(PregoSkeletonBar), findsOneWidget);
+      expect(find.byType(ShaderMask), findsNothing);
+      expect(tester.hasRunningAnimations, isFalse);
+    });
+
+    testWidgets("sweeps under RTL without errors", (tester) async {
+      await tester.pumpWidget(
+        harness(
+          const Directionality(
+            textDirection: TextDirection.rtl,
+            child: PregoSkeletonList(),
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 200));
+      // A few sweep frames must paint cleanly with the mirrored gradient.
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(ShaderMask), findsOneWidget);
+      expect(tester.hasRunningAnimations, isTrue);
+    });
+  });
+
+  group("PregoSkeletonBar", () {
+    testWidgets("paints a fully rounded pill fading from the quaternary foreground", (tester) async {
+      await pumpVisible(
+        tester,
+        const PregoShimmer(
+          appearDelay: Duration.zero,
+          // Align loosens the harness's tight width, as list rows do.
+          child: Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: PregoSkeletonBar(height: 20, width: 120),
+          ),
+        ),
+      );
+
+      final container = tester.widget<Container>(
+        find.descendant(of: find.byType(PregoSkeletonBar), matching: find.byType(Container)),
+      );
+      final box = container.decoration! as BoxDecoration;
+      final gradient = box.gradient! as LinearGradient;
+      expect(gradient.colors.first, PregoDesignSystem.light.colors.fgQuaternary);
+      expect(gradient.colors.last.a, 0.0);
+      expect(gradient.begin, AlignmentDirectional.centerStart);
+      expect(box.borderRadius, BorderRadius.circular(PregoRadius.full));
+      expect(tester.getSize(find.byType(PregoSkeletonBar)), const Size(120, 20));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the designed shimmer skeleton loading state (Figma node 2396-25597) as reusable design-system primitives in `module_prego`, and renders it while the projects list and the sessions list load, replacing the centered spinners.

## What's new

**`module_prego` — `components/loaders/prego_skeleton.dart`:**
- `PregoShimmer` — region wrapper that sweeps a translucent sheen band across its child: a single srcATop `ShaderMask` per region (one saveLayer, never per row), driven by one `AnimationController`. Includes a 300ms anti-flash appear delay with fade-in (fast loads never blink a skeleton), reduced-motion support via both `MediaQuery.disableAnimations` and `accessibilityFeatures.reduceMotion` (reactive through `WidgetsBindingObserver` — iOS Reduce Motion doesn't reach MediaQuery), RTL-aware sweep direction, and semantics: decorative rows are excluded, an optional label is announced instead.
- `PregoSkeletonBar` — pill placeholder fading `fgQuaternary` → transparent toward the trailing edge.
- `PregoSkeletonListTile` / `PregoSkeletonList` — the two-line row and the ready-made 6-row list with the Figma title-width rhythm.

**Custom over a package, deliberately:** skeletonizer's effects paint one whole-canvas shader shared by all bones and can't express the per-bar gradient fill this design specifies; `shimmer` (hnvn) is unmaintained since 2023 and uses a saveLayer per item.

**Consumers:**
- `project_list_screen.dart` — `ProjectListLoading` renders `PregoSkeletonList` (+ `projectListLoadingSemantics`).
- `session_list_content.dart` — `SessionListLoading` renders the same, covering both the phone scaffold and the split-pane panel (+ `sessionListLoadingSemantics`).

## Verification

- 9 new widget tests for the primitives (width rhythm, pattern cycling, appear-delay/fade sequence, reduced motion, `enabled: false`, RTL smoke, semantics label, bar decoration); module_prego 29/29, app 537/537, analyzers clean.
- Verified live on the iPhone 17 Pro Max simulator against a running bridge + relay: cold launch → skeleton shimmer → loaded project list. Launching with no bridge confirmed the anti-flash path (sub-300ms resolutions never show the skeleton).

## Notes

- The skeleton geometry previews the new Figma row design rather than the current `ListTile` rows, so content arrival shifts layout slightly until the row redesign lands (this branch's workstream).
- The shimmer loops while loading; error states still transition to the retry views.

https://claude.ai/code/session_01YLKQhHX7MxMtkZ2fcVkRQJ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the centered spinners with a shimmer skeleton for the projects and sessions lists, using new reusable loaders in `module_prego`. Improves perceived load time and accessibility with reduced-motion support and screen-reader labels.

- **New Features**
  - Added `PregoShimmer` (single-region srcATop sweep, 300ms anti-flash delay, fade-in, reduced-motion aware, RTL sweep, optional semantics label).
  - Added `PregoSkeletonBar`, `PregoSkeletonListTile`, and `PregoSkeletonList` (6-row rhythm matching the design).
  - Swapped loading states in ProjectList and SessionList to `PregoSkeletonList`, announcing `projectListLoadingSemantics` and `sessionListLoadingSemantics`.
  - Exported loaders from `module_prego`; added 9 widget tests.

<sup>Written for commit 19d79ed8316ce662e8feabcbe34baf1371409c82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

