### PR TITLE
chore(bridge): dev control-host harness for manual supervised testing (Phase 1, PR 1.15)

### DIFF
--- a/bridge/app/tool/dev_control_host.dart
+++ b/bridge/app/tool/dev_control_host.dart
@@ -195,9 +195,19 @@ class _DevControlHost {
 
   Future<void> _spawnBridge({required String controlUrl}) async {
     stdout.writeln("spawning: $_bridgePath --control-url $controlUrl ${_bridgeArgs.join(" ")}");
+    // Inherit the parent environment (the bridge needs PATH/HOME/etc.) but strip
+    // the dev token: only the harness needs it, and Process.start would otherwise
+    // leak it into the bridge env and — via the plugin host copying its
+    // environment — the backend (OpenCode) process too.
+    final childEnvironment = Map<String, String>.from(Platform.environment)..remove("SESORI_DEV_CONTROL_TOKEN");
     final Process child;
     try {
-      child = await Process.start(_bridgePath, ["--control-url", controlUrl, ..._bridgeArgs]);
+      child = await Process.start(
+        _bridgePath,
+        ["--control-url", controlUrl, ..._bridgeArgs],
+        environment: childEnvironment,
+        includeParentEnvironment: false,
+      );
     } on Object catch (error) {
       stderr.writeln("Failed to spawn the bridge at '$_bridgePath': $error");
       await _flushAndExit(70);

--- a/bridge/app/tool/dev_control_host.dart
+++ b/bridge/app/tool/dev_control_host.dart
@@ -195,18 +195,19 @@ class _DevControlHost {
 
   Future<void> _spawnBridge({required String controlUrl}) async {
     stdout.writeln("spawning: $_bridgePath --control-url $controlUrl ${_bridgeArgs.join(" ")}");
-    // Inherit the parent environment (the bridge needs PATH/HOME/etc.) but strip
-    // the dev token: only the harness needs it, and Process.start would otherwise
-    // leak it into the bridge env and — via the plugin host copying its
-    // environment — the backend (OpenCode) process too.
-    final childEnvironment = Map<String, String>.from(Platform.environment)..remove("SESORI_DEV_CONTROL_TOKEN");
     final Process child;
     try {
       child = await Process.start(
         _bridgePath,
         ["--control-url", controlUrl, ..._bridgeArgs],
-        environment: childEnvironment,
-        includeParentEnvironment: false,
+        // Inherit the parent environment natively (the bridge needs PATH/HOME/…),
+        // but blank out the dev token so it isn't leaked to the bridge — or, via
+        // the plugin host copying its environment, the OpenCode backend. Overriding
+        // it to empty (vs copying all of Platform.environment into an explicit map)
+        // avoids re-encoding every inherited value, which can fail on non-ASCII
+        // environments, and still removes the secret since the bridge never reads
+        // this var.
+        environment: const <String, String>{"SESORI_DEV_CONTROL_TOKEN": ""},
       );
     } on Object catch (error) {
       stderr.writeln("Failed to spawn the bridge at '$_bridgePath': $error");

--- a/bridge/app/tool/dev_control_host.dart
+++ b/bridge/app/tool/dev_control_host.dart
@@ -101,7 +101,9 @@ String? _readStoredToken() {
 
   final file = File(path);
   if (!file.existsSync()) {
-    stderr.writeln("No token at $path — log in with the standalone bridge once, or pass --token. Continuing token-less.");
+    stderr.writeln(
+      "No token at $path — log in with the standalone bridge once, or set SESORI_DEV_CONTROL_TOKEN. Continuing token-less.",
+    );
     return null;
   }
 

--- a/bridge/app/tool/dev_control_host.dart
+++ b/bridge/app/tool/dev_control_host.dart
@@ -1,0 +1,416 @@
+import "dart:async";
+import "dart:convert";
+import "dart:io";
+import "dart:math";
+
+import "package:args/args.dart";
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+/// Dev-only harness that drives the bridge's **supervised mode** without the
+/// desktop GUI (which doesn't exist yet — Phase 2). It stands in for the GUI's
+/// control-channel host so a human can exercise the whole Phase-1 supervised
+/// surface end-to-end (the MT-1 manual checkpoint).
+///
+/// It hosts a loopback WebSocket control server, spawns a locally-built bridge
+/// with `--control-url`, hands the per-spawn secret to the child off-argv (first
+/// stdin line, ADR A8), answers `token_request` from the developer's own
+/// `token.json` (or a `--token` flag), prints every inbound [ControlMessage],
+/// and offers keyboard commands to push a token, log out, answer prompts, and
+/// simulate the GUI vanishing so the helper's grace-period exit (ADR A9) can be
+/// observed.
+///
+/// This file lives in `tool/` and is never compiled into the shipped binary
+/// (`dart build cli` compiles `bin/bridge.dart` only). It adds no production
+/// wiring and no new dependencies.
+///
+/// Usage (from `bridge/app/`, after `dart build cli -o build/cli`):
+/// ```sh
+/// dart run tool/dev_control_host.dart --bridge build/cli/bundle/bin/bridge \
+///   -- --log-level debug
+/// ```
+Future<void> main(List<String> args) async {
+  final parser = ArgParser()
+    ..addOption(
+      "bridge",
+      help: "Path to a locally-built bridge binary (e.g. build/cli/bundle/bin/bridge).",
+    )
+    ..addOption(
+      "token",
+      help: "Access token to answer token_request with. Defaults to token.json's accessToken.",
+    )
+    ..addFlag(
+      "deny-token",
+      negatable: false,
+      help: "Start denying tokens (token_request -> null) to exercise the exit-87 / sign-out paths.",
+    )
+    ..addFlag("help", abbr: "h", negatable: false, help: "Show usage.");
+
+  final ArgResults results;
+  try {
+    results = parser.parse(args);
+  } on FormatException catch (error) {
+    stderr.writeln("dev_control_host: ${error.message}\n");
+    stderr.writeln(_usage(parser));
+    await _flushAndExit(64);
+  }
+
+  if (results.flag("help")) {
+    stdout.writeln(_usage(parser));
+    return;
+  }
+
+  final bridgePath = results.option("bridge");
+  if (bridgePath == null || bridgePath.isEmpty) {
+    stderr.writeln("Missing required --bridge <path>.\n");
+    stderr.writeln(_usage(parser));
+    await _flushAndExit(64);
+  }
+
+  final explicitToken = results.option("token");
+  final token = (explicitToken != null && explicitToken.isNotEmpty) ? explicitToken : _readStoredToken();
+
+  final host = _DevControlHost(
+    bridgePath: bridgePath,
+    bridgeArgs: results.rest,
+    token: token,
+    denyToken: results.flag("deny-token"),
+  );
+  await host.run();
+}
+
+String _usage(ArgParser parser) {
+  return "Usage: dart run tool/dev_control_host.dart --bridge <path> [--token <jwt>] [--deny-token] [-- <bridge args>]\n\n"
+      "${parser.usage}\n\n"
+      "Everything after `--` is forwarded verbatim to the bridge (e.g. --log-level debug, --auth-backend ...).";
+}
+
+/// Reads the developer's own access token from the standalone bridge's
+/// `token.json`. Returns null (and explains why) when it is missing or
+/// unreadable so the harness can still run token-less (answering `token_request`
+/// with null, which exercises the signed-out / exit-87 paths).
+String? _readStoredToken() {
+  final String path;
+  try {
+    path = "${sesoriDataDirectory()}/token.json";
+  } on Object catch (error) {
+    stderr.writeln("Could not resolve the Sesori data directory ($error). Continuing token-less.");
+    return null;
+  }
+
+  final file = File(path);
+  if (!file.existsSync()) {
+    stderr.writeln("No token at $path — log in with the standalone bridge once, or pass --token. Continuing token-less.");
+    return null;
+  }
+
+  try {
+    final json = jsonDecodeMap(file.readAsStringSync());
+    final token = json["accessToken"];
+    if (token is String && token.isNotEmpty) {
+      return token;
+    }
+    stderr.writeln("token.json has no usable accessToken. Continuing token-less.");
+    return null;
+  } on Object catch (error, stackTrace) {
+    stderr.writeln("Could not read token.json ($error). Continuing token-less.\n$stackTrace");
+    return null;
+  }
+}
+
+String _generateSecret() {
+  final random = Random.secure();
+  final bytes = List<int>.generate(32, (_) => random.nextInt(256));
+  return base64Url.encode(bytes);
+}
+
+/// Flushes stdout/stderr before terminating: `dart:io`'s [exit] stops the VM
+/// immediately and can drop buffered output (e.g. when the harness is piped to
+/// a file), so the final status line would otherwise be lost. The `finally`
+/// guarantees the exit even if a flush fails on a broken pipe.
+Future<Never> _flushAndExit(int code) async {
+  try {
+    await stdout.flush();
+    await stderr.flush();
+  } finally {
+    exit(code);
+  }
+}
+
+/// Owns one harness session: the per-spawn secret, the loopback control server,
+/// the single connected helper socket, and the pending-prompt bookkeeping. It
+/// speaks the real [ControlMessage] wire protocol so it stays on the exact
+/// GUI<->helper contract the desktop app will implement in Phase 2.
+class _DevControlHost {
+  _DevControlHost({
+    required String bridgePath,
+    required List<String> bridgeArgs,
+    required String? token,
+    required bool denyToken,
+  })  : _bridgePath = bridgePath,
+        _bridgeArgs = bridgeArgs,
+        _token = token,
+        _denyToken = denyToken,
+        _secret = _generateSecret();
+
+  final String _bridgePath;
+  final List<String> _bridgeArgs;
+  final String? _token;
+  final String _secret;
+
+  bool _denyToken;
+  final List<String> _pendingPrompts = <String>[];
+
+  HttpServer? _server;
+  WebSocket? _socket;
+
+  Future<void> run() async {
+    final HttpServer server;
+    try {
+      server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    } on Object catch (error) {
+      stderr.writeln("Could not bind the loopback control server: $error");
+      await _flushAndExit(70);
+    }
+    _server = server;
+    final controlUrl = "ws://127.0.0.1:${server.port}";
+    server.listen(
+      (request) => unawaited(_handleHttpRequest(request)),
+      onError: (Object error, StackTrace stackTrace) => stderr.writeln("control server error: $error"),
+    );
+
+    _printBanner(controlUrl);
+    stdin.transform(utf8.decoder).transform(const LineSplitter()).listen(
+          _onCommand,
+          onError: (Object error, StackTrace stackTrace) => stderr.writeln("stdin error: $error"),
+        );
+
+    await _spawnBridge(controlUrl: controlUrl);
+    // The event loop keeps the harness alive (listening server + stdin + the
+    // child's exitCode future) until the child exits or the dev quits.
+  }
+
+  Future<void> _spawnBridge({required String controlUrl}) async {
+    stdout.writeln("spawning: $_bridgePath --control-url $controlUrl ${_bridgeArgs.join(" ")}");
+    final Process child;
+    try {
+      child = await Process.start(_bridgePath, ["--control-url", controlUrl, ..._bridgeArgs]);
+    } on Object catch (error) {
+      stderr.writeln("Failed to spawn the bridge at '$_bridgePath': $error");
+      await _flushAndExit(70);
+    }
+
+    // Deliver the per-spawn secret off-argv as the first stdin line (ADR A8).
+    child.stdin.writeln(_secret);
+    await child.stdin.flush();
+
+    // Drain the child's stdio so it never blocks, echoing bridge logs inline.
+    child.stdout.transform(utf8.decoder).listen(
+          (chunk) => stdout.write(chunk),
+          onError: (Object error, StackTrace stackTrace) => stderr.writeln("bridge stdout pipe error: $error"),
+        );
+    child.stderr.transform(utf8.decoder).listen(
+          (chunk) => stderr.write(chunk),
+          onError: (Object error, StackTrace stackTrace) => stderr.writeln("bridge stderr pipe error: $error"),
+        );
+
+    unawaited(child.exitCode.then(_onChildExit));
+  }
+
+  Future<void> _handleHttpRequest(HttpRequest request) async {
+    // The helper presents the per-spawn secret as the WS upgrade bearer; reject
+    // anything that doesn't match so a leaked/absent secret can't attach.
+    final authorization = request.headers.value(HttpHeaders.authorizationHeader);
+    if (authorization != "Bearer $_secret") {
+      stderr.writeln("Rejecting control upgrade: bad or missing Authorization header.");
+      request.response.statusCode = HttpStatus.unauthorized;
+      await request.response.close();
+      return;
+    }
+    if (!WebSocketTransformer.isUpgradeRequest(request)) {
+      request.response.statusCode = HttpStatus.badRequest;
+      await request.response.close();
+      return;
+    }
+    if (_socket != null) {
+      // One authenticated helper per spawn, mirroring the real control server.
+      stderr.writeln("A helper is already connected; rejecting the extra connection.");
+      request.response.statusCode = HttpStatus.conflict;
+      await request.response.close();
+      return;
+    }
+
+    final socket = await WebSocketTransformer.upgrade(request);
+    _socket = socket;
+    stdout.writeln("[ok] helper connected — secret verified");
+    socket.listen(
+      _onFrameData,
+      onError: (Object error, StackTrace stackTrace) => stderr.writeln("helper socket error: $error"),
+      onDone: () => stdout.writeln("[--] helper closed the control socket"),
+      cancelOnError: false,
+    );
+  }
+
+  void _onFrameData(dynamic data) {
+    final frame = data is String ? data : (data is List<int> ? utf8.decode(data) : null);
+    if (frame == null) {
+      stderr.writeln("ignoring non-text control frame: ${data.runtimeType}");
+      return;
+    }
+
+    final ControlMessage message;
+    try {
+      message = ControlMessage.fromJson(jsonDecodeMap(frame));
+    } on Object catch (error) {
+      stderr.writeln("[helper->harness] undecodable frame ($error): $frame");
+      return;
+    }
+
+    stdout.writeln("[helper->harness] $message");
+    _react(message);
+  }
+
+  void _react(ControlMessage message) {
+    switch (message) {
+      case ControlTokenRequest(:final id, :final forceRefresh):
+        _respondToken(id: id, forceRefresh: forceRefresh);
+      case ControlPromptRequest(:final id, :final kind, message: final promptMessage):
+        _pendingPrompts.add(id);
+        stdout.writeln("  >> prompt [$id] $kind: ${promptMessage ?? "(no message)"} — reply 'y $id' or 'n $id'");
+      // The remaining variants are informational (already printed above) or are
+      // GUI->helper messages the harness would not normally receive back.
+      case ControlTokenResponse():
+      case ControlTokenUpdate():
+      case ControlStatus():
+      case ControlPromptResponse():
+      case ControlRestart():
+      case ControlUnregisterAndExit():
+      case ControlRegistered():
+      case ControlProvisionProgressMessage():
+        break;
+    }
+  }
+
+  void _respondToken({required String id, required bool forceRefresh}) {
+    final token = _denyToken ? null : _token;
+    if (token == null) {
+      stdout.writeln("  << token_request[$id]: replying NULL (denyToken=$_denyToken, hasToken=${_token != null})");
+    } else {
+      stdout.writeln("  << token_request[$id] (forceRefresh=$forceRefresh): replying with token");
+    }
+    _send(ControlMessage.tokenResponse(id: id, accessToken: token));
+  }
+
+  void _onCommand(String line) {
+    final parts = line.trim().split(RegExp(r"\s+"));
+    final command = parts.first.toLowerCase();
+    final argument = parts.length > 1 ? parts[1] : null;
+    switch (command) {
+      case "":
+        break;
+      case "t":
+      case "token":
+        _pushTokenUpdate();
+      case "u":
+      case "unregister":
+        _send(const ControlMessage.unregisterAndExit());
+      case "y":
+      case "a":
+        _answerPrompt(accepted: true, id: argument);
+      case "n":
+        _answerPrompt(accepted: false, id: argument);
+      case "x":
+      case "deny":
+        _denyToken = !_denyToken;
+        stdout.writeln("token denial is now ${_denyToken ? "ON" : "OFF"}");
+      case "q":
+      case "quit":
+        unawaited(_simulateGuiGone());
+      case "?":
+      case "h":
+      case "help":
+        _printCommands();
+      default:
+        stderr.writeln("unknown command '$command' — type '?' for help");
+    }
+  }
+
+  void _pushTokenUpdate() {
+    final token = _denyToken ? null : _token;
+    if (token == null) {
+      stderr.writeln("no token to push (denyToken=$_denyToken, hasToken=${_token != null})");
+      return;
+    }
+    _send(ControlMessage.tokenUpdate(accessToken: token));
+  }
+
+  void _answerPrompt({required bool accepted, required String? id}) {
+    final promptId = id ?? (_pendingPrompts.isNotEmpty ? _pendingPrompts.first : null);
+    if (promptId == null) {
+      stderr.writeln("no pending prompt to answer");
+      return;
+    }
+    _pendingPrompts.remove(promptId);
+    _send(ControlMessage.promptResponse(id: promptId, accepted: accepted));
+  }
+
+  /// Closes the control channel (socket + server) so the helper's reconnects
+  /// fail, letting the dev watch its ADR-A9 grace-period exit. The harness stays
+  /// alive so it can still print the child's exit code when it terminates.
+  Future<void> _simulateGuiGone() async {
+    stdout.writeln("simulating GUI-gone: closing the control channel — the helper should exit after its ~5s grace (ADR A9)…");
+    final socket = _socket;
+    _socket = null;
+    await socket?.close();
+    final server = _server;
+    _server = null;
+    await server?.close(force: true);
+  }
+
+  void _send(ControlMessage message) {
+    final socket = _socket;
+    if (socket == null) {
+      stderr.writeln("[harness->helper] no helper connected — dropping ${message.runtimeType}");
+      return;
+    }
+    socket.add(jsonEncode(message.toJson()));
+    stdout.writeln("[harness->helper] $message");
+  }
+
+  Future<void> _onChildExit(int code) async {
+    stdout.writeln("== bridge exited with code $code (${_interpretExitCode(code)}) ==");
+    await _flushAndExit(0);
+  }
+
+  String _interpretExitCode(int code) {
+    switch (code) {
+      case 0:
+        return "clean stop / logout";
+      case 1:
+        return "control-channel lost (ADR A9 grace exit) or generic error";
+      case 86:
+        return "intentional restart — GUI would respawn";
+      case 87:
+        return "auth required — GUI would prompt for login";
+      case 88:
+        return "single-live contention — GUI would offer 'take over'";
+      default:
+        return "crash / unrecognized";
+    }
+  }
+
+  void _printBanner(String controlUrl) {
+    stdout.writeln("Sesori dev control-host harness");
+    stdout.writeln("control URL : $controlUrl (loopback WS; per-spawn secret via child stdin)");
+    final tokenState = _token == null ? "NONE (token_request -> null)" : "loaded from token.json/--token";
+    stdout.writeln("token       : $tokenState${_denyToken ? "  [deny ON]" : ""}");
+    _printCommands();
+  }
+
+  void _printCommands() {
+    stdout.writeln(
+      "commands: t=push token_update  u=unregister_and_exit  y/n [id]=answer prompt  "
+      "x=toggle token-deny  q=simulate GUI-gone (grace exit)  ?=help",
+    );
+  }
+}

--- a/bridge/app/tool/dev_control_host.dart
+++ b/bridge/app/tool/dev_control_host.dart
@@ -15,7 +15,8 @@ import "package:sesori_shared/sesori_shared.dart";
 /// It hosts a loopback WebSocket control server, spawns a locally-built bridge
 /// with `--control-url`, hands the per-spawn secret to the child off-argv (first
 /// stdin line, ADR A8), answers `token_request` from the developer's own
-/// `token.json` (or a `--token` flag), prints every inbound [ControlMessage],
+/// `token.json` (or the `SESORI_DEV_CONTROL_TOKEN` env var — kept off argv, which
+/// other local processes can read), prints every inbound [ControlMessage],
 /// and offers keyboard commands to push a token, log out, answer prompts, and
 /// simulate the GUI vanishing so the helper's grace-period exit (ADR A9) can be
 /// observed.
@@ -34,10 +35,6 @@ Future<void> main(List<String> args) async {
     ..addOption(
       "bridge",
       help: "Path to a locally-built bridge binary (e.g. build/cli/bundle/bin/bridge).",
-    )
-    ..addOption(
-      "token",
-      help: "Access token to answer token_request with. Defaults to token.json's accessToken.",
     )
     ..addFlag(
       "deny-token",
@@ -67,8 +64,11 @@ Future<void> main(List<String> args) async {
     await _flushAndExit(64);
   }
 
-  final explicitToken = results.option("token");
-  final token = (explicitToken != null && explicitToken.isNotEmpty) ? explicitToken : _readStoredToken();
+  // The token override is read from the environment (not a CLI flag): argv is
+  // visible to other local processes via `ps`/`/proc`, and this token
+  // authenticates the supervised bridge.
+  final envToken = Platform.environment["SESORI_DEV_CONTROL_TOKEN"];
+  final token = (envToken != null && envToken.isNotEmpty) ? envToken : _readStoredToken();
 
   final host = _DevControlHost(
     bridgePath: bridgePath,
@@ -80,9 +80,10 @@ Future<void> main(List<String> args) async {
 }
 
 String _usage(ArgParser parser) {
-  return "Usage: dart run tool/dev_control_host.dart --bridge <path> [--token <jwt>] [--deny-token] [-- <bridge args>]\n\n"
+  return "Usage: dart run tool/dev_control_host.dart --bridge <path> [--deny-token] [-- <bridge args>]\n\n"
       "${parser.usage}\n\n"
-      "Everything after `--` is forwarded verbatim to the bridge (e.g. --log-level debug, --auth-backend ...).";
+      "The access token defaults to token.json's accessToken; set SESORI_DEV_CONTROL_TOKEN to override\n"
+      "it off-argv. Everything after `--` is forwarded verbatim to the bridge (e.g. --log-level debug).";
 }
 
 /// Reads the developer's own access token from the standalone bridge's
@@ -200,11 +201,9 @@ class _DevControlHost {
       await _flushAndExit(70);
     }
 
-    // Deliver the per-spawn secret off-argv as the first stdin line (ADR A8).
-    child.stdin.writeln(_secret);
-    await child.stdin.flush();
-
-    // Drain the child's stdio so it never blocks, echoing bridge logs inline.
+    // Wire observation BEFORE handing off the secret, so a child that crashes
+    // immediately (bad path, missing dependency) is still reported via its exit
+    // code instead of being masked by a broken-pipe throw on the stdin write.
     child.stdout.transform(utf8.decoder).listen(
           (chunk) => stdout.write(chunk),
           onError: (Object error, StackTrace stackTrace) => stderr.writeln("bridge stdout pipe error: $error"),
@@ -213,46 +212,84 @@ class _DevControlHost {
           (chunk) => stderr.write(chunk),
           onError: (Object error, StackTrace stackTrace) => stderr.writeln("bridge stderr pipe error: $error"),
         );
-
     unawaited(child.exitCode.then(_onChildExit));
+
+    // Deliver the per-spawn secret off-argv as the first stdin line (ADR A8).
+    // Best-effort: if the child already exited, the write throws a broken-pipe
+    // error — log it and let the exit-code handler above report the exit.
+    try {
+      child.stdin.writeln(_secret);
+      await child.stdin.flush();
+    } on Object catch (error) {
+      stderr.writeln("Failed to deliver the secret to the bridge (it may have exited): $error");
+    }
   }
 
   Future<void> _handleHttpRequest(HttpRequest request) async {
-    // The helper presents the per-spawn secret as the WS upgrade bearer; reject
-    // anything that doesn't match so a leaked/absent secret can't attach.
-    final authorization = request.headers.value(HttpHeaders.authorizationHeader);
-    if (authorization != "Bearer $_secret") {
-      stderr.writeln("Rejecting control upgrade: bad or missing Authorization header.");
-      request.response.statusCode = HttpStatus.unauthorized;
-      await request.response.close();
-      return;
-    }
-    if (!WebSocketTransformer.isUpgradeRequest(request)) {
-      request.response.statusCode = HttpStatus.badRequest;
-      await request.response.close();
-      return;
-    }
-    if (_socket != null) {
-      // One authenticated helper per spawn, mirroring the real control server.
-      stderr.writeln("A helper is already connected; rejecting the extra connection.");
-      request.response.statusCode = HttpStatus.conflict;
-      await request.response.close();
-      return;
-    }
+    // A premature client disconnect can make the upgrade or a response close
+    // throw; catch it so one bad connection never crashes the harness server.
+    try {
+      // The helper presents the per-spawn secret as the WS upgrade bearer;
+      // reject anything that doesn't match so a leaked/absent secret can't attach.
+      final authorization = request.headers.value(HttpHeaders.authorizationHeader);
+      if (authorization != "Bearer $_secret") {
+        stderr.writeln("Rejecting control upgrade: bad or missing Authorization header.");
+        request.response.statusCode = HttpStatus.unauthorized;
+        await request.response.close();
+        return;
+      }
+      if (!WebSocketTransformer.isUpgradeRequest(request)) {
+        request.response.statusCode = HttpStatus.badRequest;
+        await request.response.close();
+        return;
+      }
+      if (_socket != null) {
+        // One authenticated helper per spawn, mirroring the real control server.
+        stderr.writeln("A helper is already connected; rejecting the extra connection.");
+        request.response.statusCode = HttpStatus.conflict;
+        await request.response.close();
+        return;
+      }
 
-    final socket = await WebSocketTransformer.upgrade(request);
-    _socket = socket;
-    stdout.writeln("[ok] helper connected — secret verified");
-    socket.listen(
-      _onFrameData,
-      onError: (Object error, StackTrace stackTrace) => stderr.writeln("helper socket error: $error"),
-      onDone: () => stdout.writeln("[--] helper closed the control socket"),
-      cancelOnError: false,
-    );
+      final socket = await WebSocketTransformer.upgrade(request);
+      _socket = socket;
+      stdout.writeln("[ok] helper connected — secret verified");
+      socket.listen(
+        _onFrameData,
+        onError: (Object error, StackTrace stackTrace) {
+          stderr.writeln("helper socket error: $error");
+          _clearSocket(socket);
+        },
+        onDone: () {
+          stdout.writeln("[--] helper closed the control socket");
+          _clearSocket(socket);
+        },
+        cancelOnError: false,
+      );
+    } on Object catch (error) {
+      stderr.writeln("Error handling a control-upgrade request: $error");
+    }
+  }
+
+  /// Drops the current helper socket when it disconnects (only if it is still
+  /// the one we hold), so the helper's normal reconnect is accepted instead of
+  /// being rejected as "already connected" — the harness must exercise the real
+  /// reconnect / control-loss behaviour.
+  void _clearSocket(WebSocket socket) {
+    if (identical(_socket, socket)) {
+      _socket = null;
+    }
   }
 
   void _onFrameData(dynamic data) {
-    final frame = data is String ? data : (data is List<int> ? utf8.decode(data) : null);
+    String? frame;
+    if (data is String) {
+      frame = data;
+    } else if (data is List<int>) {
+      // Control frames are UTF-8 JSON; tolerate a malformed binary frame instead
+      // of letting the decode throw and tear down the socket listener.
+      frame = utf8.decode(data, allowMalformed: true);
+    }
     if (frame == null) {
       stderr.writeln("ignoring non-text control frame: ${data.runtimeType}");
       return;
@@ -266,8 +303,22 @@ class _DevControlHost {
       return;
     }
 
-    stdout.writeln("[helper->harness] $message");
+    stdout.writeln("[helper->harness] ${_describe(message)}");
     _react(message);
+  }
+
+  /// Human-readable one-liner for a control message with access tokens redacted,
+  /// so a saved harness/MT-1 terminal log never captures the developer's bearer
+  /// token (Freezed's `toString()` would otherwise print `accessToken` in full).
+  String _describe(ControlMessage message) {
+    if (message is ControlTokenResponse) {
+      final token = message.accessToken == null ? "null" : "<redacted>";
+      return "ControlMessage.tokenResponse(id: ${message.id}, accessToken: $token)";
+    }
+    if (message is ControlTokenUpdate) {
+      return "ControlMessage.tokenUpdate(accessToken: <redacted>)";
+    }
+    return message.toString();
   }
 
   void _react(ControlMessage message) {
@@ -373,8 +424,18 @@ class _DevControlHost {
       stderr.writeln("[harness->helper] no helper connected — dropping ${message.runtimeType}");
       return;
     }
-    socket.add(jsonEncode(message.toJson()));
-    stdout.writeln("[harness->helper] $message");
+    // Keep serialization outside the try so only the transport send is guarded:
+    // add() throws StateError once the socket has closed, and _send runs
+    // synchronously from the stdin command handler, so an uncaught throw here
+    // would take down the harness.
+    final payload = jsonEncode(message.toJson());
+    try {
+      socket.add(payload);
+    } on Object catch (error) {
+      stderr.writeln("[harness->helper] send failed (socket closed?): $error — dropping ${message.runtimeType}");
+      return;
+    }
+    stdout.writeln("[harness->helper] ${_describe(message)}");
   }
 
   Future<void> _onChildExit(int code) async {
@@ -402,7 +463,7 @@ class _DevControlHost {
   void _printBanner(String controlUrl) {
     stdout.writeln("Sesori dev control-host harness");
     stdout.writeln("control URL : $controlUrl (loopback WS; per-spawn secret via child stdin)");
-    final tokenState = _token == null ? "NONE (token_request -> null)" : "loaded from token.json/--token";
+    final tokenState = _token == null ? "NONE (token_request -> null)" : "loaded from token.json / SESORI_DEV_CONTROL_TOKEN";
     stdout.writeln("token       : $tokenState${_denyToken ? "  [deny ON]" : ""}");
     _printCommands();
   }

--- a/docs/desktop/PLAN.md
+++ b/docs/desktop/PLAN.md
@@ -8,8 +8,8 @@
 
 ## Current pointer
 
-- **Last completed phase:** Phase 1 — PR 1.14 Relay replaced-close (`4007`) → takeover state, no reconnect war (ADR A22) — bridge PR raised on branch `start-next-step-desktop-plan`; relay prerequisite raised as `sesori-ai/sesori_relay_server#7` (must deploy to prod before this merges)
-- **Next up:** Phase 1 — PR 1.15 Dev control-host harness for manual supervised testing (`tool/`)
+- **Last completed phase:** Phase 1 — PR 1.15 Dev control-host harness for manual supervised testing (`tool/`) — PR raised on branch `next-step-desktop-plan` (PR 1.14 merged as #385)
+- **Next up:** Phase 1 — MT-1 manual checkpoint: bridge supervised mode end-to-end (user-run; see phase doc). This is the last ☐ before Phase 2 and is **user-run** — per resume rule 5, present its checklist and let the user run it; do not implement anything.
 - **Branch:** one feature branch per PR, cut from `main`
 
 > **Tracking lives in four places that MUST move together in the same PR.**
@@ -400,7 +400,7 @@ them). Only the user checks an MT box.
 - ☑ 1.12 Single-live precedence under supervised `--hidden` — Med / M
 - ☑ 1.13 Tee `RuntimeProvisionProgress` → control channel — Low / S-M
 - ☑ 1.14 Relay replaced-close (`4007`) → takeover state, no reconnect war (ADR A22) — Med / S-M
-- ☐ 1.15 Dev control-host harness for manual supervised testing (`tool/`) — Low / S
+- ☑ 1.15 Dev control-host harness for manual supervised testing (`tool/`) — Low / S
 - ☐ MT-1 Manual checkpoint: bridge supervised mode end-to-end (see phase doc) — user-run
 
 ### Phase 2 — Desktop shell + supervisor → `phase-2-desktop-shell.md`

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -899,26 +899,34 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   harness kill.
 - **Aristotle:** plan ☑ · impl ☑ (PR raised on branch `next-step-desktop-plan`).
 - **Findings:** Shipped as a single dev-only file
-  (`bridge/app/tool/dev_control_host.dart`, ~400 lines with doc comments), no
+  (`bridge/app/tool/dev_control_host.dart`, ~490 lines with doc comments), no
   `lib/` change and no new dependency — it reuses the app package's existing
   `args`, `dart:io` (`HttpServer`/`WebSocketTransformer`), `sesori_shared`
   (`ControlMessage`, `jsonDecodeMap`) and `sesori_bridge_foundation`
   (`sesoriDataDirectory()`). `main()` parses `--bridge <path>` (required),
-  `--token <jwt>`, `--deny-token`, `--help`, and forwards everything after `--`
-  verbatim to the bridge; the access token defaults to the developer's own
-  `token.json` `accessToken` and degrades to token-less (answering
-  `token_request` with null) when it is missing. A private `_DevControlHost`
-  owns one harness session — the per-spawn secret (`Random.secure()` →
-  base64url), the loopback WS control server (`HttpServer.bind(loopbackIPv4, 0)`,
-  ephemeral port), the single helper socket, and the pending-prompt list. It
+  `--deny-token`, `--help`, and forwards everything after `--` verbatim to the
+  bridge; the access token defaults to the developer's own `token.json`
+  `accessToken`, is overridable via the `SESORI_DEV_CONTROL_TOKEN` env var
+  (kept off argv, which other local processes can read; the spawned bridge's
+  environment blanks that var so the override never reaches the child — or,
+  via the plugin host copying its environment, the backend), and degrades to
+  token-less (answering `token_request` with null) when both are absent. A
+  private `_DevControlHost` owns one harness session — the per-spawn secret
+  (`Random.secure()` → base64url), the loopback WS control server
+  (`HttpServer.bind(loopbackIPv4, 0)`, ephemeral port), the single helper
+  socket, and the pending-prompt list. It
   spawns the bridge with `--control-url ws://127.0.0.1:<port>`, delivers the
   secret **off-argv** as the child's first stdin line (ADR A8), and echoes the
   child's stdout/stderr inline. The WS upgrade is accepted only when the
   `Authorization: Bearer <secret>` header matches (else 401); one helper per
-  spawn (a second is 409'd). Inbound frames are decoded with the real
+  spawn (a concurrent second is 409'd, but a dropped socket is cleared so the
+  helper's reconnect is accepted, and a post-drop send logs-and-drops instead
+  of crashing the harness). Inbound frames are decoded with the real
   `ControlMessage.fromJson` (undecodable → stderr + skip, never swallowed),
-  printed, and reacted to via an exhaustive sealed switch: `token_request` →
-  auto-`token_response` (null when denied / token-less), `prompt_request` →
+  printed with `accessToken` redacted (a saved MT-1 terminal log never captures
+  the developer's bearer token), and reacted to via an exhaustive sealed
+  switch: `token_request` → auto-`token_response` (null when denied /
+  token-less), `prompt_request` →
   tracked + printed; all other variants are informational. Keyboard commands on
   the harness's own stdin: `t` push `token_update`, `u` `unregister_and_exit`,
   `y`/`n [id]` answer a prompt, `x` toggle token-denial, `q` simulate GUI-gone
@@ -931,7 +939,13 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   excluded from the bundle (same as `tool/bump_version.dart`); `avoid_print` is
   honoured (all output via `stdout`/`stderr`). `dart analyze --fatal-infos`
   clean; `make analyze` clean; `make test` all pass (1727, unchanged — the tool
-  is not in any import/test graph). Enables MT-1. **Deltas:** —
+  is not in any import/test graph). Enables MT-1.
+- **Deltas:** PR-review hardening dropped the goal's planned `--token` flag for
+  the `SESORI_DEV_CONTROL_TOKEN` env var (a bearer token must not sit in argv),
+  and added helper-reconnect acceptance, token redaction in printed frames,
+  guarded child-stdin/secret and socket writes (a child that crashes instantly
+  is still reported via its exit code), and upgrade-handler isolation (a
+  mid-handshake disconnect can't crash the control server).
 
 ---
 

--- a/docs/desktop/phase-1-bridge-supervised.md
+++ b/docs/desktop/phase-1-bridge-supervised.md
@@ -829,8 +829,8 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   supervised); detection works on close code `4007` alone (no reason string)
   AND on the `1000/"replaced"` rollout fallback; normal drop reconnection
   unchanged; covered by connection-level tests.
-- **Aristotle:** plan ☑ · impl ☑ (bridge PR raised on branch `start-next-step-desktop-plan`;
-  relay prerequisite raised as `sesori-ai/sesori_relay_server#7`).
+- **Aristotle:** plan ☑ · impl ☑ (merged #385; relay prerequisite
+  `sesori-ai/sesori_relay_server#7`).
 - **Findings:** Shipped as an additive shared constant + predicate, a Layer-0
   transport accessor, an orchestrator backoff-policy change, and a notifier map
   extension — no new classes. (1) **Shared** (`close_codes.dart`):
@@ -897,7 +897,41 @@ runs **under the startup mutex**, which reinforces PR 1.12.
   observe: secret handshake, token pull/push, status/registered/provision
   events, prompt round-trip, unregister-and-exit, and grace-period exit on
   harness kill.
-- **Aristotle:** plan ☐ · impl ☐. **Findings:** — **Deltas:** —
+- **Aristotle:** plan ☑ · impl ☑ (PR raised on branch `next-step-desktop-plan`).
+- **Findings:** Shipped as a single dev-only file
+  (`bridge/app/tool/dev_control_host.dart`, ~400 lines with doc comments), no
+  `lib/` change and no new dependency — it reuses the app package's existing
+  `args`, `dart:io` (`HttpServer`/`WebSocketTransformer`), `sesori_shared`
+  (`ControlMessage`, `jsonDecodeMap`) and `sesori_bridge_foundation`
+  (`sesoriDataDirectory()`). `main()` parses `--bridge <path>` (required),
+  `--token <jwt>`, `--deny-token`, `--help`, and forwards everything after `--`
+  verbatim to the bridge; the access token defaults to the developer's own
+  `token.json` `accessToken` and degrades to token-less (answering
+  `token_request` with null) when it is missing. A private `_DevControlHost`
+  owns one harness session — the per-spawn secret (`Random.secure()` →
+  base64url), the loopback WS control server (`HttpServer.bind(loopbackIPv4, 0)`,
+  ephemeral port), the single helper socket, and the pending-prompt list. It
+  spawns the bridge with `--control-url ws://127.0.0.1:<port>`, delivers the
+  secret **off-argv** as the child's first stdin line (ADR A8), and echoes the
+  child's stdout/stderr inline. The WS upgrade is accepted only when the
+  `Authorization: Bearer <secret>` header matches (else 401); one helper per
+  spawn (a second is 409'd). Inbound frames are decoded with the real
+  `ControlMessage.fromJson` (undecodable → stderr + skip, never swallowed),
+  printed, and reacted to via an exhaustive sealed switch: `token_request` →
+  auto-`token_response` (null when denied / token-less), `prompt_request` →
+  tracked + printed; all other variants are informational. Keyboard commands on
+  the harness's own stdin: `t` push `token_update`, `u` `unregister_and_exit`,
+  `y`/`n [id]` answer a prompt, `x` toggle token-denial, `q` simulate GUI-gone
+  (close socket+server so the helper's reconnects fail → observe the ADR-A9
+  grace exit while the harness stays attached to print the exit code), `?` help.
+  On child exit the harness prints and interprets the code against the
+  documented supervised sentinels (86 restart / 87 login-needed / 88 contention
+  / 1 control-loss / 0 clean). Never shipped: `dart build cli` compiles the
+  `bin/bridge.dart` entrypoint only and nothing imports the tool, so it is
+  excluded from the bundle (same as `tool/bump_version.dart`); `avoid_print` is
+  honoured (all output via `stdout`/`stderr`). `dart analyze --fatal-infos`
+  clean; `make analyze` clean; `make test` all pass (1727, unchanged — the tool
+  is not in any import/test graph). Enables MT-1. **Deltas:** —
 
 ---
 


### PR DESCRIPTION
## Phase 1, PR 1.15 — Dev control-host harness

Adds a **dev-only** harness (`bridge/app/tool/dev_control_host.dart`) that drives the bridge's **supervised mode** without the desktop GUI (which doesn't exist until Phase 2), so a human can exercise the whole Phase-1 supervised surface end-to-end. This **enables the MT-1 manual checkpoint** — the last ☐ before Phase 2.

### What it does
- Hosts a **loopback WS control server** and **spawns a locally-built bridge** with `--control-url ws://127.0.0.1:<port>`.
- Delivers the per-spawn secret **off-argv** as the child's first stdin line (ADR A8); accepts the WS upgrade only when the `Authorization: Bearer <secret>` header matches (else 401; one helper per spawn).
- Answers `token_request` from the developer's own `token.json` `accessToken` (or the `SESORI_DEV_CONTROL_TOKEN` env var — kept off-argv, and blanked in the child's environment); degrades **token-less** (null response) when absent, and `--deny-token` forces null to exercise the sign-out / exit-87 paths.
- Prints every inbound `ControlMessage` (decoded with the real `sesori_shared` DTOs) and offers keyboard commands: `t` push `token_update`, `u` `unregister_and_exit`, `y`/`n [id]` answer a prompt, `x` toggle token-denial, `q` simulate GUI-gone (to observe the ADR-A9 grace-period exit), `?` help.
- On child exit, interprets the supervised sentinels (86 restart / 87 login-needed / 88 contention / 1 control-loss / 0 clean).

### Why it's safe (release-safety invariant #1)
- **Tool-only**: no `lib/` changes, **no new dependencies** (reuses `args`, `dart:io`, `sesori_shared`, `sesori_bridge_foundation`).
- **Never shipped**: `dart build cli` compiles the `bin/bridge.dart` entrypoint only and nothing imports the tool, so it's excluded from the bundle (same as the existing `tool/bump_version.dart`).
- Reuses the real `ControlMessage` wire protocol, so the harness stays on the exact GUI↔helper contract Phase 2 implements — no hand-rolled JSON to drift.

### Regression guide
None to production code (`tool/` only). Verified the tool is excluded from the shipped binary and the gates stay green.

### Verification
- `dart analyze --fatal-infos` clean; `make analyze` clean; `make test` all pass (**1727**, unchanged — the tool is in no import/test graph).
- **End-to-end smoke** against a throwaway fake helper (real `WebSocket` client, no relay/OpenCode): secret handshake verified, `token_request`→`token_response` round-trip (and the `--deny-token` null path), inbound `registered`/`status`/`prompt_request` decode+print, `y p1`→`prompt_response{accepted:true}`, and clean child-exit interpretation.

### Aristotle
- plan ☑ (APPROVED, no changes) · impl ☑ (APPROVED, no changes)

### Plan bookkeeping (all four surfaces moved in this PR)
- `PLAN.md` Current pointer → last completed **1.15**, next up **MT-1** (user-run); §9 index **1.15 ☑**.
- `phase-1-bridge-supervised.md` PR 1.15 Aristotle line + Findings written.
- Reconciled PR **1.14** as merged **#385** (pointer + Aristotle line) per the git-ground-truth rule.

> Next up is **MT-1** — a user-run manual checkpoint, not a PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dev-only control-host harness to run the bridge’s supervised mode without the desktop GUI, enabling the MT‑1 manual checkpoint. Also hardens reconnects, token handling, and updates docs to match the review-hardened behavior.

- **New Features**
  - Adds `bridge/app/tool/dev_control_host.dart` to host a loopback WS control server and spawn the bridge with `--control-url`.
  - Sends a per‑spawn secret via the child’s first stdin line; WS upgrade requires `Authorization: Bearer <secret>`.
  - Answers `token_request` from `token.json` or `SESORI_DEV_CONTROL_TOKEN`; `--deny-token` forces null. Commands: `t`, `u`, `y/n [id]`, `x`, `q`, `?`.
  - Prints real `ControlMessage` types with `accessToken` redacted; interprets exit codes (0, 1, 86, 87, 88).
  - Tool‑only; no `lib/` changes or new deps (`args`, `dart:io`, `sesori_shared`, `sesori_bridge_foundation`); not shipped. Docs now mark 1.15 complete, prep MT‑1, and reconcile Findings/Deltas to reflect the env‑var override and other hardening.

- **Bug Fixes**
  - Accepts helper reconnects by clearing the socket on disconnect; guards sends so post‑drop commands don’t crash.
  - Reads token override from `SESORI_DEV_CONTROL_TOKEN` (kept off argv).
  - Wraps upgrade handling to survive mid‑handshake disconnects; tolerates malformed binary frames.
  - Wires child stdout/stderr/exit before writing the secret and guards broken pipes.
  - Blanks the dev token in the spawned bridge via env override (no full env copy) to prevent leaks and avoid env re‑encoding issues.

<sup>Written for commit 721390280630e5b363517b2c2dccbda678ac93c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

