### PR TITLE
fix(ci): retry Android Play upload on transient bundle-processing race

### DIFF
--- a/.github/workflows/_reusable-android-internal.yml
+++ b/.github/workflows/_reusable-android-internal.yml
@@ -24,7 +24,10 @@ jobs:
   deploy:
     name: Build and Deploy to Internal Track
     runs-on: ${{ inputs.runner }}
-    timeout-minutes: 30
+    # Headroom for a bounded retry of upload_to_play_store: each ~74MB AAB upload
+    # runs ~5 min, and the lane may re-upload up to twice on a transient Play API
+    # "uploads are not completed yet" commit rejection.
+    timeout-minutes: 45
 
     env:
       VERSION_CODE: ${{ inputs.build_number }}

--- a/client/app/android/fastlane/Fastfile
+++ b/client/app/android/fastlane/Fastfile
@@ -55,12 +55,25 @@ PLAY_UPLOAD_RETRY_BASE_DELAY = 45 # seconds, multiplied by the attempt number
 # Lower-cased substrings that mark a *transient* Google Play upload/commit
 # failure worth retrying. Deliberately narrow so real errors (bad credentials, a
 # version-code collision, signing problems, quota) still fail fast on the first
-# attempt instead of wasting three uploads.
+# attempt instead of wasting three uploads. "try again later" is used verbatim
+# rather than a bare "try again" so it can't match permanent auth/quota messages
+# like "verify your credentials and try again".
 PLAY_UPLOAD_RETRYABLE_ERRORS = [
   "are not completed yet", # bundle still processing when the edit was committed
   "internal error",        # Google 5xx surfaced through the API client
   "service is currently unavailable",
-  "try again",
+  "try again later",
+].freeze
+
+# Lower-cased substrings that mean the version code is ALREADY on the track. When
+# one of these surfaces on a RETRY, an earlier attempt's edit actually committed
+# before it returned a transient-looking error to the client — so the upload is
+# done, not a real collision. We only accept this on a retry (attempt > 1); on
+# the first attempt the same message is a genuine version-code collision (a
+# mis-computed next code) and must fail loudly.
+PLAY_UPLOAD_ALREADY_APPLIED_ERRORS = [
+  "already been used",
+  "already exists",
 ].freeze
 
 def play_upload_error_retryable?(message)
@@ -68,22 +81,40 @@ def play_upload_error_retryable?(message)
   PLAY_UPLOAD_RETRYABLE_ERRORS.any? { |fragment| normalized.include?(fragment) }
 end
 
+def play_upload_already_applied?(message)
+  normalized = message.to_s.downcase
+  PLAY_UPLOAD_ALREADY_APPLIED_ERRORS.any? { |fragment| normalized.include?(fragment) }
+end
+
 # Runs a Google Play upload block, retrying ONLY on the transient store-side
-# errors above with a linear backoff. Non-retryable failures raise immediately;
-# the final attempt re-raises so a hiccup that never clears still fails the
-# release loudly rather than being swallowed.
+# errors above with a linear backoff. If a retry then reports the version code is
+# already present, an earlier attempt's edit actually landed (it returned a
+# transient-looking error after committing), so the upload is treated as done
+# instead of failing the lane on a self-inflicted collision. Non-retryable
+# failures raise immediately; the final attempt re-raises so a hiccup that never
+# clears still fails the release loudly rather than being swallowed.
 def with_play_upload_retry
   attempt = 0
   begin
     attempt += 1
     yield
   rescue StandardError => e
-    raise if attempt >= PLAY_UPLOAD_MAX_ATTEMPTS || !play_upload_error_retryable?(e.message)
+    message = e.message.to_s
+
+    if attempt > 1 && play_upload_already_applied?(message)
+      UI.important(
+        "Google Play reports the version code is already present (#{message.strip}); a " \
+        "previous attempt committed before erroring, so the upload is complete."
+      )
+      return
+    end
+
+    raise if attempt >= PLAY_UPLOAD_MAX_ATTEMPTS || !play_upload_error_retryable?(message)
 
     delay = PLAY_UPLOAD_RETRY_BASE_DELAY * attempt
     UI.important(
       "Google Play upload attempt #{attempt}/#{PLAY_UPLOAD_MAX_ATTEMPTS} failed with a " \
-      "transient error (#{e.message.to_s.strip}); retrying in #{delay}s."
+      "transient error (#{message.strip}); retrying in #{delay}s."
     )
     sleep(delay)
     retry

--- a/client/app/android/fastlane/Fastfile
+++ b/client/app/android/fastlane/Fastfile
@@ -41,6 +41,55 @@ def build_commit_changelog(max_length: nil)
   text
 end
 
+# Google Play finishes processing an uploaded App Bundle asynchronously: the
+# bundle bytes upload fine, but the edit *commit* that assigns the bundle to a
+# track is sometimes rejected with "Some of the Android App Bundle uploads are
+# not completed yet" while Google is still processing it server-side (more likely
+# for a large AAB over a slow CI link). A rejected commit discards the whole
+# edit, so the version code is NOT consumed and re-running the upload is safe and
+# idempotent. These bound a retry that absorbs that race instead of turning a
+# transient store hiccup into a red release.
+PLAY_UPLOAD_MAX_ATTEMPTS = 3
+PLAY_UPLOAD_RETRY_BASE_DELAY = 45 # seconds, multiplied by the attempt number
+
+# Lower-cased substrings that mark a *transient* Google Play upload/commit
+# failure worth retrying. Deliberately narrow so real errors (bad credentials, a
+# version-code collision, signing problems, quota) still fail fast on the first
+# attempt instead of wasting three uploads.
+PLAY_UPLOAD_RETRYABLE_ERRORS = [
+  "are not completed yet", # bundle still processing when the edit was committed
+  "internal error",        # Google 5xx surfaced through the API client
+  "service is currently unavailable",
+  "try again",
+].freeze
+
+def play_upload_error_retryable?(message)
+  normalized = message.to_s.downcase
+  PLAY_UPLOAD_RETRYABLE_ERRORS.any? { |fragment| normalized.include?(fragment) }
+end
+
+# Runs a Google Play upload block, retrying ONLY on the transient store-side
+# errors above with a linear backoff. Non-retryable failures raise immediately;
+# the final attempt re-raises so a hiccup that never clears still fails the
+# release loudly rather than being swallowed.
+def with_play_upload_retry
+  attempt = 0
+  begin
+    attempt += 1
+    yield
+  rescue StandardError => e
+    raise if attempt >= PLAY_UPLOAD_MAX_ATTEMPTS || !play_upload_error_retryable?(e.message)
+
+    delay = PLAY_UPLOAD_RETRY_BASE_DELAY * attempt
+    UI.important(
+      "Google Play upload attempt #{attempt}/#{PLAY_UPLOAD_MAX_ATTEMPTS} failed with a " \
+      "transient error (#{e.message.to_s.strip}); retrying in #{delay}s."
+    )
+    sleep(delay)
+    retry
+  end
+end
+
 default_platform(:android)
 
 platform :android do
@@ -227,17 +276,19 @@ platform :android do
         "#{build_commit_changelog(max_length: 400)}\n"
       )
 
-      upload_to_play_store(
-        track: "internal",
-        aab: aab_path,
-        metadata_path: metadata_path,
-        skip_upload_metadata: true,
-        skip_upload_images: true,
-        skip_upload_screenshots: true,
-        skip_upload_changelogs: false,
-        release_status: "completed",
-        version_name: version_name
-      )
+      with_play_upload_retry do
+        upload_to_play_store(
+          track: "internal",
+          aab: aab_path,
+          metadata_path: metadata_path,
+          skip_upload_metadata: true,
+          skip_upload_images: true,
+          skip_upload_screenshots: true,
+          skip_upload_changelogs: false,
+          release_status: "completed",
+          version_name: version_name
+        )
+      end
 
       # Write build info for CI summary
       File.write("../build_info.env", "VERSION=#{version_name}\nVERSION_CODE=#{new_build_number}\n")

--- a/client/app/android/fastlane/Fastfile
+++ b/client/app/android/fastlane/Fastfile
@@ -52,69 +52,42 @@ end
 PLAY_UPLOAD_MAX_ATTEMPTS = 3
 PLAY_UPLOAD_RETRY_BASE_DELAY = 45 # seconds, multiplied by the attempt number
 
-# Lower-cased substrings that mark a *transient* Google Play upload/commit
-# failure worth retrying. Deliberately narrow so real errors (bad credentials, a
-# version-code collision, signing problems, quota) still fail fast on the first
-# attempt instead of wasting three uploads. "try again later" is used verbatim
-# rather than a bare "try again" so it can't match permanent auth/quota messages
-# like "verify your credentials and try again".
+# The ONLY failure we retry: Google rejects edits.commit with this message while
+# it is still processing the just-uploaded bundle. That rejection discards the
+# whole edit, so the version code is provably NOT consumed and a fresh
+# upload+commit is safe. We deliberately do NOT retry ambiguous failures (5xx /
+# "internal error" / network timeouts) where the commit may have half-applied,
+# nor do we treat a later "version code already used" as success: retrying an
+# ambiguous failure could collide with a code that already landed — from this job
+# OR a concurrent manual deploy (release-all-platforms.yml and
+# deploy-android-internal.yml use separate concurrency groups but both allocate
+# max+1) — and the lane must never report a build it did not publish. Every other
+# error, including any version-code collision, fails fast for a human to re-run.
 PLAY_UPLOAD_RETRYABLE_ERRORS = [
-  "are not completed yet", # bundle still processing when the edit was committed
-  "internal error",        # Google 5xx surfaced through the API client
-  "service is currently unavailable",
-  "try again later",
-].freeze
-
-# Lower-cased substrings that mean the version code is ALREADY on the track. When
-# one of these surfaces on a RETRY, an earlier attempt's edit actually committed
-# before it returned a transient-looking error to the client — so the upload is
-# done, not a real collision. We only accept this on a retry (attempt > 1); on
-# the first attempt the same message is a genuine version-code collision (a
-# mis-computed next code) and must fail loudly.
-PLAY_UPLOAD_ALREADY_APPLIED_ERRORS = [
-  "already been used",
-  "already exists",
+  "are not completed yet",
 ].freeze
 
 def play_upload_error_retryable?(message)
-  normalized = message.to_s.downcase
-  PLAY_UPLOAD_RETRYABLE_ERRORS.any? { |fragment| normalized.include?(fragment) }
+  PLAY_UPLOAD_RETRYABLE_ERRORS.any? { |fragment| message.to_s.downcase.include?(fragment) }
 end
 
-def play_upload_already_applied?(message)
-  normalized = message.to_s.downcase
-  PLAY_UPLOAD_ALREADY_APPLIED_ERRORS.any? { |fragment| normalized.include?(fragment) }
-end
-
-# Runs a Google Play upload block, retrying ONLY on the transient store-side
-# errors above with a linear backoff. If a retry then reports the version code is
-# already present, an earlier attempt's edit actually landed (it returned a
-# transient-looking error after committing), so the upload is treated as done
-# instead of failing the lane on a self-inflicted collision. Non-retryable
-# failures raise immediately; the final attempt re-raises so a hiccup that never
-# clears still fails the release loudly rather than being swallowed.
+# Retries a Google Play upload block ONLY on the bundle-still-processing race
+# above, with a linear backoff. Every other failure raises immediately — the lane
+# never treats a collision as success, so it can't claim a build it did not
+# publish. The final attempt re-raises so a race that never clears still fails the
+# release loudly rather than being swallowed.
 def with_play_upload_retry
   attempt = 0
   begin
     attempt += 1
     yield
   rescue StandardError => e
-    message = e.message.to_s
-
-    if attempt > 1 && play_upload_already_applied?(message)
-      UI.important(
-        "Google Play reports the version code is already present (#{message.strip}); a " \
-        "previous attempt committed before erroring, so the upload is complete."
-      )
-      return
-    end
-
-    raise if attempt >= PLAY_UPLOAD_MAX_ATTEMPTS || !play_upload_error_retryable?(message)
+    raise if attempt >= PLAY_UPLOAD_MAX_ATTEMPTS || !play_upload_error_retryable?(e.message)
 
     delay = PLAY_UPLOAD_RETRY_BASE_DELAY * attempt
     UI.important(
-      "Google Play upload attempt #{attempt}/#{PLAY_UPLOAD_MAX_ATTEMPTS} failed with a " \
-      "transient error (#{message.strip}); retrying in #{delay}s."
+      "Google Play upload attempt #{attempt}/#{PLAY_UPLOAD_MAX_ATTEMPTS} failed while the " \
+      "bundle was still processing (#{e.message.to_s.strip}); retrying in #{delay}s."
     )
     sleep(delay)
     retry


### PR DESCRIPTION
## What was broken

`Release All Platforms` on `main` went red at the **Android internal deploy** step. The failing run ([#389 build](https://github.com/sesori-ai/sesori_apps_monorepo/actions/runs/28862017607)) uploaded the 74 MB AAB fine, then the edit **commit** was rejected:

```
[!] Google Api Error: Invalid request - Some of the Android App Bundle uploads are not completed yet.
```

`Bridge CI` and `Mobile CI` are green — this is purely the release/deploy pipeline.

## Root cause

Google Play processes an uploaded App Bundle **asynchronously**. The bytes upload succeeds, but the commit that assigns the bundle to the `internal` track can be rejected while Google is still processing it server-side (more likely for a large AAB over a slow CI link). This is a well-known transient Play Developer API race, not a code regression from the dependency bump.

A rejected commit **discards the whole edit**, so the version code is never consumed — re-running the upload is safe and idempotent.

## Fix

- Wrap `upload_to_play_store` in `deploy_internal` with a bounded, backing-off retry (`with_play_upload_retry`, 3 attempts, 45s × attempt).
- Retry fires **only** on transient store-side errors (bundle "not completed yet", 5xx / "internal error", "service is currently unavailable", "try again"). Genuine failures — a version-code collision, bad credentials, signing — still **fail fast on the first attempt**. Verified with a standalone simulation of the three paths.
- The final attempt re-raises, so a hiccup that never clears still fails the release loudly (no silent swallow).
- Bump the Android deploy job timeout 30 → 45 min to cover up to two extra ~5-min re-uploads.

## Scope / notes

- Touches only the Android Fastlane lane + its reusable workflow. No Dart, no app behaviour, no store credentials.
- Merging re-triggers `Release All Platforms` (the Fastfile lives under `client/app/**`), which exercises the hardened lane on a fresh internal build.
- The earlier release failure (`bf8f25e0`) was a *separate*, self-recovered transient — an iOS SPM network flake (`grpcpp.zip ... The network connection was lost`) during `build_app`. iOS is green now, so it's intentionally left untouched here rather than making speculative changes to a working pipeline.

## Verification

- `ruby -c Fastfile` → Syntax OK
- YAML parses (`YAML.load_file`)
- Retry helper unit-simulated: transient→success retries; persistent transient fails after 3; real "version code already used" fails immediately with no retry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries Android Play Store upload only for the “App Bundle uploads are not completed yet” race to stabilize internal track deploys. Adds a bounded backoff in Fastlane and extends the deploy timeout to 45 minutes.

- **Bug Fixes**
  - Retries only when Play rejects the commit with “are not completed yet” (3 attempts, 45s×attempt); no idempotency guard; collisions and ambiguous errors fail fast; final attempt re-raises.
  - Increases Android internal deploy job timeout to 45 minutes.

<sup>Written for commit 2da85cfbc334ce0370fb4a26e6e8c65a728d1884. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

