### PR TITLE
feat(app): pill segmented OS switcher + "Run the bridge" on onboarding/offline screens

### DIFF
--- a/client/app/lib/core/bridge_install.dart
+++ b/client/app/lib/core/bridge_install.dart
@@ -25,4 +25,9 @@ class BridgeInstall {
 
   /// bun runner equivalent of [npmCommand].
   static const String bunCommand = "bunx @sesori/bridge";
+
+  /// Command that starts an already-installed bridge. Shown on the
+  /// bridge-offline Projects screen, where the common recovery is to (re)start
+  /// the bridge rather than reinstall it.
+  static const String runCommand = "sesori-bridge";
 }

--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -513,7 +513,7 @@ class _CommandActionRowState extends State<_CommandActionRow> {
     // derive it from this row so the popover points at the command instead of
     // floating (an unanchored sheet throws on iPad).
     final renderObject = context.findRenderObject();
-    final origin = renderObject is RenderBox && renderObject.hasSize
+    final origin = renderObject is RenderBox && renderObject.attached && renderObject.hasSize
         ? renderObject.localToGlobal(Offset.zero) & renderObject.size
         : null;
     try {

--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -335,9 +335,9 @@ class _OsSegmentedControl extends StatelessWidget {
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
                               textAlign: TextAlign.center,
-                              // Selected segment reads slightly heavier (medium),
-                              // matching iOS.
-                              style: (i == selectedIndex ? prego.textTheme.textSm.medium : prego.textTheme.textSm.regular)
+                              // Selected segment is bolded to highlight it,
+                              // matching the design.
+                              style: (i == selectedIndex ? prego.textTheme.textSm.bold : prego.textTheme.textSm.regular)
                                   .copyWith(color: prego.colors.textPrimary),
                             ),
                           ),

--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -186,56 +186,106 @@ class _NeedHelpMenu extends StatelessWidget {
   }
 }
 
-/// The per-platform install command boxes — Unix (curl/npm/bun) and Windows
-/// (irm/npm/bun). Shared by the [_OnboardingChecklist] and the bridge-offline
-/// reconnect disclosure ([_BridgeOfflineView]) so both stay in sync; callers
-/// supply their own surrounding padding.
-class _InstallCommandBoxes extends StatelessWidget {
+/// The per-platform install commands: a flat iOS-style segmented control that
+/// switches between the Unix (macOS/Linux/WSL) and Windows install groups, and
+/// a single [_InstallCommandBox] showing the selected group's methods. Shared
+/// by the [_OnboardingChecklist] and the bridge-offline reconnect disclosure
+/// ([_BridgeOfflineView]) so both stay in sync; callers supply their own
+/// surrounding padding.
+class _InstallCommandBoxes extends StatefulWidget {
   const _InstallCommandBoxes();
+
+  @override
+  State<_InstallCommandBoxes> createState() => _InstallCommandBoxesState();
+}
+
+class _InstallCommandBoxesState extends State<_InstallCommandBoxes> {
+  /// Index of the selected platform group; 0 (Unix) initially.
+  int _selectedOs = 0;
 
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
 
+    // The two platform groups the segmented control switches between. Built
+    // per-frame so the labels/commands follow the active locale.
+    final osGroups = <({String label, List<_InstallMethod> methods})>[
+      (
+        label: loc.projectsOnboardingInstallUnixLabel,
+        methods: [
+          _InstallMethod(label: loc.projectsOnboardingInstallUnixMethod, command: BridgeInstall.macLinuxCommand),
+          _InstallMethod(label: loc.projectsOnboardingInstallMethodNpm, command: BridgeInstall.npmCommand),
+          _InstallMethod(label: loc.projectsOnboardingInstallMethodBun, command: BridgeInstall.bunCommand),
+        ],
+      ),
+      (
+        label: loc.projectsOnboardingInstallWindowsLabel,
+        methods: [
+          _InstallMethod(label: loc.projectsOnboardingInstallWindowsMethod, command: BridgeInstall.windowsCommand),
+          _InstallMethod(label: loc.projectsOnboardingInstallMethodNpm, command: BridgeInstall.npmCommand),
+          _InstallMethod(label: loc.projectsOnboardingInstallMethodBun, command: BridgeInstall.bunCommand),
+        ],
+      ),
+    ];
+
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _InstallCommandBox(
-          osLabel: loc.projectsOnboardingInstallUnixLabel,
-          methods: [
-            _InstallMethod(
-              label: loc.projectsOnboardingInstallUnixMethod,
-              command: BridgeInstall.macLinuxCommand,
-            ),
-            _InstallMethod(
-              label: loc.projectsOnboardingInstallMethodNpm,
-              command: BridgeInstall.npmCommand,
-            ),
-            _InstallMethod(
-              label: loc.projectsOnboardingInstallMethodBun,
-              command: BridgeInstall.bunCommand,
-            ),
-          ],
+        _OsSegmentedControl(
+          labels: [for (final group in osGroups) group.label],
+          selectedIndex: _selectedOs,
+          onChanged: (index) => setState(() => _selectedOs = index),
         ),
-        const SizedBox(height: PregoSpacing.xl),
+        const SizedBox(height: PregoSpacing.lg),
+        // Keyed by platform so switching groups remounts the box and resets its
+        // method tab to the group's first entry (curl / native).
         _InstallCommandBox(
-          osLabel: loc.projectsOnboardingInstallWindowsLabel,
-          methods: [
-            _InstallMethod(
-              label: loc.projectsOnboardingInstallWindowsMethod,
-              command: BridgeInstall.windowsCommand,
-            ),
-            _InstallMethod(
-              label: loc.projectsOnboardingInstallMethodNpm,
-              command: BridgeInstall.npmCommand,
-            ),
-            _InstallMethod(
-              label: loc.projectsOnboardingInstallMethodBun,
-              command: BridgeInstall.bunCommand,
-            ),
-          ],
+          key: ValueKey(_selectedOs),
+          methods: osGroups[_selectedOs].methods,
         ),
       ],
+    );
+  }
+}
+
+/// Flat, non-glass segmented control that switches the install command group.
+/// Wraps the out-of-the-box [CupertinoSlidingSegmentedControl] — whose track
+/// and thumb match the Figma's native iOS control — rather than the glass
+/// variant the design deliberately renders flat. Track and thumb use the
+/// platform's adaptive fills so it themes in light and dark; the labels use the
+/// prego text theme. A tight, full-width constraint (from the parent's stretch
+/// Column) makes the two segments split the width equally.
+class _OsSegmentedControl extends StatelessWidget {
+  const _OsSegmentedControl({
+    required this.labels,
+    required this.selectedIndex,
+    required this.onChanged,
+  });
+
+  final List<String> labels;
+  final int selectedIndex;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    return CupertinoSlidingSegmentedControl<int>(
+      groupValue: selectedIndex,
+      onValueChanged: (value) {
+        if (value != null) onChanged(value);
+      },
+      children: {
+        for (var i = 0; i < labels.length; i++)
+          i: Text(
+            labels[i],
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            textAlign: TextAlign.center,
+            // Selected segment reads slightly heavier (medium), matching iOS.
+            style: (i == selectedIndex ? prego.textTheme.textSm.medium : prego.textTheme.textSm.regular)
+                .copyWith(color: prego.colors.textPrimary),
+          ),
+      },
     );
   }
 }
@@ -252,18 +302,13 @@ class _InstallMethod {
   final String command;
 }
 
-/// One platform's install instruction: a group label (e.g. "macOS, Linux,
-/// WSL"), a row of method tabs (e.g. curl/npm/bun), and the monospace one-line
-/// command for the selected method with a copy-to-clipboard button. Mirrors the
-/// Figma onboarding install boxes.
+/// One platform's install instruction box: a row of method tabs (e.g.
+/// curl/npm/bun) and, below them, the monospace one-line command for the
+/// selected method with copy and share actions. The platform group is chosen by
+/// the [_OsSegmentedControl] above it; this box just renders the given
+/// [methods]. Mirrors the Figma onboarding install box.
 class _InstallCommandBox extends StatefulWidget {
-  const _InstallCommandBox({
-    required this.osLabel,
-    required this.methods,
-  });
-
-  /// Platform group label shown above the box.
-  final String osLabel;
+  const _InstallCommandBox({super.key, required this.methods});
 
   /// Selectable install methods; the first is selected initially.
   final List<_InstallMethod> methods;
@@ -277,164 +322,29 @@ class _InstallCommandBoxState extends State<_InstallCommandBox> {
 
   _InstallMethod get _selected => widget.methods[_selectedIndex];
 
-  Future<void> _copyCommand() async {
-    final messenger = ScaffoldMessenger.of(context);
-    final loc = context.loc;
-    // Clipboard can throw on restricted platforms/states; fail soft and skip
-    // the success snackbar. Log so a broken copy button leaves a diagnostic
-    // trail instead of failing silently.
-    try {
-      await Clipboard.setData(ClipboardData(text: _selected.command));
-    } on Object catch (error, stackTrace) {
-      logw("Failed to copy install command", error, stackTrace);
-      return;
-    }
-    messenger.showSnackBar(
-      SnackBar(
-        content: Text(loc.projectsOnboardingCommandCopied),
-        duration: kSnackBarDuration,
-      ),
-    );
-  }
-
-  Future<void> _shareCommand() async {
-    final command = _selected.command;
-    // iPad presents the share sheet as a popover anchored to a source rect;
-    // derive it from this box so the popover points at the command instead of
-    // floating (an unanchored sheet throws on iPad).
-    final renderObject = context.findRenderObject();
-    final origin = renderObject is RenderBox && renderObject.hasSize
-        ? renderObject.localToGlobal(Offset.zero) & renderObject.size
-        : null;
-    try {
-      await SharePlus.instance.share(ShareParams(text: command, sharePositionOrigin: origin));
-    } on Object catch (error, stackTrace) {
-      // Dismissing the sheet is reported via ShareResultStatus, not a throw, so
-      // reaching here is a real platform failure with nothing to recover — log
-      // it and move on.
-      logw("Failed to share install command", error, stackTrace);
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
-    final prego = context.prego;
-    final colors = prego.colors;
-    final loc = context.loc;
-    final mono = prego.textTheme.textXs.regular.copyWith(color: colors.textSecondary).monospace;
+    final colors = context.prego.colors;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          widget.osLabel,
-          style: prego.textTheme.textSm.regular.copyWith(color: colors.textPrimary),
-        ),
-        const SizedBox(height: PregoSpacing.md),
-        Container(
-          clipBehavior: Clip.antiAlias,
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(PregoRadius.xl),
+    return _CommandBoxFrame(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Method tabs (curl/npm/bun); the selected one is highlighted and
+          // drives the command shown below.
+          Container(
+            width: double.infinity,
+            color: colors.bgSurface3,
+            child: Row(
+              spacing: PregoSpacing.sm,
+              children: [
+                for (var i = 0; i < widget.methods.length; i++) _buildTab(index: i),
+              ],
+            ),
           ),
-          foregroundDecoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(PregoRadius.xl),
-            border: Border.all(color: colors.borderPrimary),
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Method tabs (curl/npm/bun); the selected one is highlighted and
-              // drives the command shown below.
-              Container(
-                width: double.infinity,
-                color: colors.bgSurface2,
-                padding: const EdgeInsetsDirectional.only(
-                  start: PregoSpacing.sm,
-                  end: PregoSpacing.sm,
-                  top: PregoSpacing.xs,
-                  bottom: PregoSpacing.xs,
-                ),
-                child: Row(
-                  spacing: PregoSpacing.lg,
-                  children: [
-                    for (var i = 0; i < widget.methods.length; i++) _buildTab(index: i),
-                  ],
-                ),
-              ),
-              Container(
-                width: double.infinity,
-                decoration: BoxDecoration(
-                  color: colors.bgSurface1,
-                  border: Border(top: BorderSide(color: colors.borderSecondary)),
-                ),
-                padding: const EdgeInsetsDirectional.only(
-                  start: PregoSpacing.lg,
-                  top: PregoSpacing.sm,
-                  bottom: PregoSpacing.sm,
-                ),
-                child: Row(
-                  children: [
-                    Expanded(
-                      // semanticsLabel carries the full command so screen readers
-                      // read it even though the visible text clamps to one line.
-                      child: Text(
-                        _selected.command,
-                        semanticsLabel: _selected.command,
-                        style: mono,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                    const SizedBox(width: PregoSpacing.md),
-                    // Transparent Material so the InkResponse splash paints on
-                    // top of the bgSurface1 fill — without it the ripple renders
-                    // on the Scaffold's Material, hidden behind this Container.
-                    Semantics(
-                      button: true,
-                      label: loc.projectsOnboardingCopyCommand,
-                      child: Material(
-                        type: MaterialType.transparency,
-                        child: InkResponse(
-                          onTap: _copyCommand,
-                          radius: 22,
-                          child: SizedBox(
-                            width: 40,
-                            height: 40,
-                            child: Center(
-                              child: Icon(TablerRegular.copy, size: 18, color: colors.textSecondary),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-
-                    // Hands the selected command to the native share sheet so it
-                    // can be sent to the machine that will run it (AirDrop, etc.).
-                    Semantics(
-                      button: true,
-                      label: loc.projectsOnboardingShareCommand,
-                      child: Material(
-                        type: MaterialType.transparency,
-                        child: InkResponse(
-                          onTap: _shareCommand,
-                          radius: 22,
-                          child: SizedBox(
-                            width: 40,
-                            height: 40,
-                            child: Center(
-                              child: Icon(TablerRegular.share_3, size: 18, color: colors.textSecondary),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
-      ],
+          _CommandActionRow(command: _selected.command, topDivider: true),
+        ],
+      ),
     );
   }
 
@@ -448,21 +358,200 @@ class _InstallCommandBoxState extends State<_InstallCommandBox> {
       selected: selected,
       label: method.label,
       // Transparent Material so the InkWell splash paints on top of the
-      // bgSurface2 tab strip instead of behind it on the Scaffold's Material.
+      // bgSurface3 tab strip instead of behind it on the Scaffold's Material.
       child: Material(
         type: MaterialType.transparency,
         child: InkWell(
           onTap: selected ? null : () => setState(() => _selectedIndex = index),
           borderRadius: BorderRadius.circular(PregoRadius.sm),
           child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: PregoSpacing.sm, vertical: PregoSpacing.xs),
-            // The selected tab reads as the active method (brand color + bold);
-            // the rest stay quiet in the secondary text color.
+            padding: const EdgeInsets.symmetric(horizontal: PregoSpacing.lg, vertical: PregoSpacing.md),
+            // The selected tab reads as the active method (brand color); the
+            // rest stay quiet in the tertiary text color. Both are bold to match
+            // the Figma tab strip.
             child: Text(
               method.label,
-              style: selected
-                  ? prego.textTheme.textSm.bold.copyWith(color: colors.textPrimaryOnBrand)
-                  : prego.textTheme.textSm.regular.copyWith(color: colors.textSecondary),
+              style: prego.textTheme.textSm.bold.copyWith(
+                color: selected ? colors.textPrimaryOnBrand : colors.textTertiary,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The rounded, bordered chrome shared by the install-command box and the
+/// bridge-offline "Run the bridge" box, so both command boxes read as the same
+/// component. Clips [child] to the radius and paints the border on top.
+class _CommandBoxFrame extends StatelessWidget {
+  const _CommandBoxFrame({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.prego.colors;
+    return Container(
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(PregoRadius.xl),
+      ),
+      foregroundDecoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(PregoRadius.xl),
+        border: Border.all(color: colors.borderPrimary),
+      ),
+      child: child,
+    );
+  }
+}
+
+/// The command display plus copy/share actions, shared by the install-command
+/// box and the bridge-offline "Run the bridge" box. Shows [command] on a single
+/// monospace line that fades out at the trailing edge — so an over-long command
+/// reads as continuing off-screen rather than hard-clipping — with copy and
+/// native-share buttons. [topDivider] draws the hairline separating this row
+/// from the method tabs above it in the install box.
+class _CommandActionRow extends StatefulWidget {
+  const _CommandActionRow({required this.command, this.topDivider = false});
+
+  final String command;
+  final bool topDivider;
+
+  @override
+  State<_CommandActionRow> createState() => _CommandActionRowState();
+}
+
+class _CommandActionRowState extends State<_CommandActionRow> {
+  Future<void> _copyCommand() async {
+    final messenger = ScaffoldMessenger.of(context);
+    final loc = context.loc;
+    // Clipboard can throw on restricted platforms/states; fail soft and skip
+    // the success snackbar. Log so a broken copy button leaves a diagnostic
+    // trail instead of failing silently.
+    try {
+      await Clipboard.setData(ClipboardData(text: widget.command));
+    } on Object catch (error, stackTrace) {
+      logw("Failed to copy command", error, stackTrace);
+      return;
+    }
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(loc.projectsOnboardingCommandCopied),
+        duration: kSnackBarDuration,
+      ),
+    );
+  }
+
+  Future<void> _shareCommand() async {
+    // iPad presents the share sheet as a popover anchored to a source rect;
+    // derive it from this row so the popover points at the command instead of
+    // floating (an unanchored sheet throws on iPad).
+    final renderObject = context.findRenderObject();
+    final origin = renderObject is RenderBox && renderObject.hasSize
+        ? renderObject.localToGlobal(Offset.zero) & renderObject.size
+        : null;
+    try {
+      await SharePlus.instance.share(ShareParams(text: widget.command, sharePositionOrigin: origin));
+    } on Object catch (error, stackTrace) {
+      // Dismissing the sheet is reported via ShareResultStatus, not a throw, so
+      // reaching here is a real platform failure with nothing to recover — log
+      // it and move on.
+      logw("Failed to share command", error, stackTrace);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    final colors = prego.colors;
+    final loc = context.loc;
+    final mono = prego.textTheme.textXs.regular.copyWith(color: colors.textSecondary).monospace;
+
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: colors.bgSurface2,
+        border: widget.topDivider ? Border(top: BorderSide(color: colors.borderSecondary)) : null,
+      ),
+      padding: const EdgeInsetsDirectional.only(
+        start: PregoSpacing.lg,
+        top: PregoSpacing.sm,
+        bottom: PregoSpacing.sm,
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: ShaderMask(
+              // Fade the trailing edge to transparent so a long command reads as
+              // continuing off-screen instead of hard-clipping with an ellipsis.
+              // The gradient only bites the rightmost sliver, so short commands
+              // are unaffected.
+              shaderCallback: (bounds) => const LinearGradient(
+                begin: Alignment.centerLeft,
+                end: Alignment.centerRight,
+                colors: [Colors.black, Colors.black, Color(0x00000000)],
+                stops: [0.0, 0.88, 1.0],
+              ).createShader(bounds),
+              blendMode: BlendMode.dstIn,
+              // semanticsLabel carries the full command so screen readers read
+              // it even though the visible text clamps to one line.
+              child: Text(
+                widget.command,
+                semanticsLabel: widget.command,
+                style: mono,
+                maxLines: 1,
+                softWrap: false,
+                overflow: TextOverflow.clip,
+              ),
+            ),
+          ),
+          const SizedBox(width: PregoSpacing.md),
+          _CommandIconButton(
+            icon: TablerRegular.copy,
+            label: loc.projectsOnboardingCopyCommand,
+            onTap: _copyCommand,
+          ),
+          // Hands the command to the native share sheet so it can be sent to the
+          // machine that will run it (AirDrop, etc.).
+          _CommandIconButton(
+            icon: TablerRegular.share_3,
+            label: loc.projectsOnboardingShareCommand,
+            onTap: _shareCommand,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A 40×40 tap target rendering [icon] over the command surface, used for the
+/// copy and share actions. Transparent [Material] so the ripple paints on top
+/// of the surface fill rather than behind it on the Scaffold's Material.
+class _CommandIconButton extends StatelessWidget {
+  const _CommandIconButton({required this.icon, required this.label, required this.onTap});
+
+  final IconData icon;
+  final String label;
+  final Future<void> Function() onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.prego.colors;
+    return Semantics(
+      button: true,
+      label: label,
+      child: Material(
+        type: MaterialType.transparency,
+        child: InkResponse(
+          onTap: onTap,
+          radius: 22,
+          child: SizedBox(
+            width: 40,
+            height: 40,
+            child: Center(
+              child: Icon(icon, size: 18, color: colors.textSecondary),
             ),
           ),
         ),

--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -286,7 +286,7 @@ class _OsSegmentedControl extends StatelessWidget {
     final count = labels.length;
 
     return Container(
-      height: 32,
+      height: 36,
       padding: const EdgeInsets.all(2),
       decoration: ShapeDecoration(
         color: CupertinoColors.tertiarySystemFill.resolveFrom(context),

--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -249,12 +249,14 @@ class _InstallCommandBoxesState extends State<_InstallCommandBoxes> {
 }
 
 /// Flat, non-glass segmented control that switches the install command group.
-/// Wraps the out-of-the-box [CupertinoSlidingSegmentedControl] — whose track
-/// and thumb match the Figma's native iOS control — rather than the glass
-/// variant the design deliberately renders flat. Track and thumb use the
-/// platform's adaptive fills so it themes in light and dark; the labels use the
-/// prego text theme. A tight, full-width constraint (from the parent's stretch
-/// Column) makes the two segments split the width equally.
+/// Matches the Figma's pill-shaped iOS segmented control — a fully-rounded track
+/// with a rounded thumb that slides under the selected segment. Flutter's
+/// [CupertinoSlidingSegmentedControl] can't be used because its track (9px) and
+/// thumb (7px) corner radii are hardcoded constants with no override, and the
+/// design wants a full pill; this is a compact reimplementation that reuses the
+/// same adaptive iOS fills (so it themes in light and dark) with the prego text
+/// theme for the labels. Selection is tap-driven — the two-segment switch has no
+/// need for Cupertino's drag-to-slide gesture — and the thumb still animates.
 class _OsSegmentedControl extends StatelessWidget {
   const _OsSegmentedControl({
     required this.labels,
@@ -266,26 +268,88 @@ class _OsSegmentedControl extends StatelessWidget {
   final int selectedIndex;
   final ValueChanged<int> onChanged;
 
+  /// iOS segmented-control thumb fill (white in light, grey in dark) and its
+  /// subtle lift shadow, taken from Cupertino's own values so the thumb reads as
+  /// native despite the rounder pill shape.
+  static const CupertinoDynamicColor _thumbColor = CupertinoDynamicColor.withBrightness(
+    color: Color(0xFFFFFFFF),
+    darkColor: Color(0xFF636366),
+  );
+  static const List<BoxShadow> _thumbShadow = [
+    BoxShadow(color: Color(0x1F000000), offset: Offset(0, 3), blurRadius: 8),
+    BoxShadow(color: Color(0x0A000000), offset: Offset(0, 3), blurRadius: 1),
+  ];
+
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
-    return CupertinoSlidingSegmentedControl<int>(
-      groupValue: selectedIndex,
-      onValueChanged: (value) {
-        if (value != null) onChanged(value);
-      },
-      children: {
-        for (var i = 0; i < labels.length; i++)
-          i: Text(
-            labels[i],
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            textAlign: TextAlign.center,
-            // Selected segment reads slightly heavier (medium), matching iOS.
-            style: (i == selectedIndex ? prego.textTheme.textSm.medium : prego.textTheme.textSm.regular)
-                .copyWith(color: prego.colors.textPrimary),
-          ),
-      },
+    final count = labels.length;
+
+    return Container(
+      height: 32,
+      padding: const EdgeInsets.all(2),
+      decoration: ShapeDecoration(
+        color: CupertinoColors.tertiarySystemFill.resolveFrom(context),
+        shape: const StadiumBorder(),
+      ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final segmentWidth = constraints.maxWidth / count;
+          return Stack(
+            fit: StackFit.expand,
+            children: [
+              // The sliding thumb: one segment wide, positioned under the
+              // selected label and glided into place on selection change.
+              AnimatedPositioned(
+                duration: context.isReducedMotion ? Duration.zero : const Duration(milliseconds: 250),
+                curve: Curves.easeInOut,
+                left: selectedIndex * segmentWidth,
+                top: 0,
+                bottom: 0,
+                width: segmentWidth,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 1),
+                  child: DecoratedBox(
+                    decoration: ShapeDecoration(
+                      color: _thumbColor.resolveFrom(context),
+                      shape: const StadiumBorder(),
+                      shadows: _thumbShadow,
+                    ),
+                  ),
+                ),
+              ),
+              Row(
+                children: [
+                  for (var i = 0; i < count; i++)
+                    Expanded(
+                      child: Semantics(
+                        button: true,
+                        selected: i == selectedIndex,
+                        label: labels[i],
+                        child: GestureDetector(
+                          behavior: HitTestBehavior.opaque,
+                          onTap: i == selectedIndex ? null : () => onChanged(i),
+                          child: Center(
+                            child: Text(
+                              labels[i],
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              textAlign: TextAlign.center,
+                              // Selected segment reads slightly heavier (medium),
+                              // matching iOS.
+                              style: (i == selectedIndex ? prego.textTheme.textSm.medium : prego.textTheme.textSm.regular)
+                                  .copyWith(color: prego.colors.textPrimary),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ],
+          );
+        },
+      ),
     );
   }
 }

--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -1,5 +1,6 @@
 import "dart:async";
 
+import "package:flutter/cupertino.dart" show CupertinoSlidingSegmentedControl;
 import "package:flutter/material.dart";
 import "package:flutter/services.dart";
 import "package:flutter_bloc/flutter_bloc.dart";

--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -1,6 +1,6 @@
 import "dart:async";
 
-import "package:flutter/cupertino.dart" show CupertinoSlidingSegmentedControl;
+import "package:flutter/cupertino.dart" show CupertinoColors, CupertinoDynamicColor;
 import "package:flutter/material.dart";
 import "package:flutter/services.dart";
 import "package:flutter_bloc/flutter_bloc.dart";

--- a/client/app/lib/features/project_list/widgets/bridge_offline_view.dart
+++ b/client/app/lib/features/project_list/widgets/bridge_offline_view.dart
@@ -104,12 +104,44 @@ class _BridgeOfflineViewState extends State<_BridgeOfflineView> {
                       ),
                     ),
                   ),
+                  // Always visible: the bridge is already installed here, so the
+                  // common recovery is to (re)start it rather than reinstall.
+                  const SizedBox(height: PregoSpacing.xl),
+                  const _RunBridgeCommand(),
                 ],
               ),
             ),
           ),
         ],
       ),
+    );
+  }
+}
+
+/// The bridge-offline "Run the bridge" command: a label and a single-command
+/// box showing [BridgeInstall.runCommand]. Always visible (unlike the collapsed
+/// install commands) because the bridge is already installed, so the common
+/// recovery is to start it. Reuses the onboarding command-box chrome
+/// ([_CommandBoxFrame] / [_CommandActionRow]) so it matches the install
+/// commands.
+class _RunBridgeCommand extends StatelessWidget {
+  const _RunBridgeCommand();
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          context.loc.projectsBridgeOfflineRunBridge,
+          style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textPrimary),
+        ),
+        const SizedBox(height: PregoSpacing.md),
+        const _CommandBoxFrame(
+          child: _CommandActionRow(command: BridgeInstall.runCommand),
+        ),
+      ],
     );
   }
 }

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -102,6 +102,10 @@
   "@projectsBridgeOfflineInstallCommands": {
     "description": "Label for the disclosure on the bridge-offline Projects screen that expands to reveal the bridge install commands."
   },
+  "projectsBridgeOfflineRunBridge": "Run the bridge",
+  "@projectsBridgeOfflineRunBridge": {
+    "description": "Label above the command box on the bridge-offline Projects screen that shows the command to start an already-installed bridge."
+  },
   "connectionLostTitle": "Connection Lost",
   "connectionLostReconnect": "Reconnect",
   "connectionLostDisconnect": "Disconnect",

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -68,7 +68,7 @@
   },
   "projectsOnboardingInstallUnixLabel": "macOS, Linux, WSL",
   "@projectsOnboardingInstallUnixLabel": {
-    "description": "Group label above the macOS/Linux/WSL install command box in the onboarding."
+    "description": "Segmented-control label that selects the macOS/Linux/WSL install commands in the onboarding."
   },
   "projectsOnboardingInstallUnixMethod": "curl",
   "@projectsOnboardingInstallUnixMethod": {
@@ -76,7 +76,7 @@
   },
   "projectsOnboardingInstallWindowsLabel": "Windows PowerShell",
   "@projectsOnboardingInstallWindowsLabel": {
-    "description": "Group label above the Windows PowerShell install command box in the onboarding."
+    "description": "Segmented-control label that selects the Windows PowerShell install commands in the onboarding."
   },
   "projectsOnboardingInstallWindowsMethod": "native",
   "@projectsOnboardingInstallWindowsMethod": {

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -68,7 +68,7 @@
   },
   "projectsOnboardingInstallUnixLabel": "macOS, Linux, WSL",
   "@projectsOnboardingInstallUnixLabel": {
-    "description": "Segmented-control label that selects the macOS/Linux/WSL install commands in the onboarding."
+    "description": "Segmented-control label that selects the macOS/Linux/WSL install commands, shown both in the onboarding and in the bridge-offline install-commands disclosure."
   },
   "projectsOnboardingInstallUnixMethod": "curl",
   "@projectsOnboardingInstallUnixMethod": {
@@ -76,7 +76,7 @@
   },
   "projectsOnboardingInstallWindowsLabel": "Windows PowerShell",
   "@projectsOnboardingInstallWindowsLabel": {
-    "description": "Segmented-control label that selects the Windows PowerShell install commands in the onboarding."
+    "description": "Segmented-control label that selects the Windows PowerShell install commands, shown both in the onboarding and in the bridge-offline install-commands disclosure."
   },
   "projectsOnboardingInstallWindowsMethod": "native",
   "@projectsOnboardingInstallWindowsMethod": {

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -241,7 +241,7 @@ abstract class AppLocalizations {
   /// **'DM on X'**
   String get projectsOnboardingNeedHelpX;
 
-  /// Group label above the macOS/Linux/WSL install command box in the onboarding.
+  /// Segmented-control label that selects the macOS/Linux/WSL install commands in the onboarding.
   ///
   /// In en, this message translates to:
   /// **'macOS, Linux, WSL'**
@@ -253,7 +253,7 @@ abstract class AppLocalizations {
   /// **'curl'**
   String get projectsOnboardingInstallUnixMethod;
 
-  /// Group label above the Windows PowerShell install command box in the onboarding.
+  /// Segmented-control label that selects the Windows PowerShell install commands in the onboarding.
   ///
   /// In en, this message translates to:
   /// **'Windows PowerShell'**
@@ -312,6 +312,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Install commands'**
   String get projectsBridgeOfflineInstallCommands;
+
+  /// Label above the command box on the bridge-offline Projects screen that shows the command to start an already-installed bridge.
+  ///
+  /// In en, this message translates to:
+  /// **'Run the bridge'**
+  String get projectsBridgeOfflineRunBridge;
 
   /// No description provided for @connectionLostTitle.
   ///

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -130,6 +130,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectsBridgeOfflineInstallCommands => 'Install commands';
 
   @override
+  String get projectsBridgeOfflineRunBridge => 'Run the bridge';
+
+  @override
   String get connectionLostTitle => 'Connection Lost';
 
   @override


### PR DESCRIPTION
## What & why

Updates the project-list **onboarding** and **bridge-offline** screens to match the refreshed Figma designs.

### Onboarding — install commands
- Replaced the two stacked per-OS install boxes with a **flat, pill-shaped segmented control** that switches between the macOS/Linux/WSL and Windows install groups, plus a single command box for the selected group.
- The control is a compact custom widget rather than `CupertinoSlidingSegmentedControl`: the Cupertino control's track (9px) and thumb (7px) corner radii are hardcoded constants with no override, and the design calls for a full pill. It reuses the same adaptive iOS fills (so it themes in light/dark) with the prego text theme; the **selected segment is bold** to match the design.
- The command line now **fades at the trailing edge** instead of hard-clipping.

### Bridge-offline — run the bridge
- Added an always-visible **"Run the bridge"** command box (`sesori-bridge`) — the bridge is already installed in this state, so the common recovery is to (re)start it rather than reinstall.
- The "Install commands" disclosure now reveals the **same segmented install box** as onboarding.
- Extracted the shared command-box chrome/action-row (`_CommandBoxFrame`, `_CommandActionRow`, `_CommandIconButton`) so both screens stay in sync.

## Notes / decisions
- **Kept the existing "Bridge disconnected" title** rather than the Figma's "Disconnected / `<device-name>`" restructure — the device name isn't available in the `ProjectListBridgeDisconnected` state (only `hasRegisteredBridges`), so surfacing it would need out-of-scope data plumbing. Happy to follow up if wanted.
- The segmented control is **tap-driven** (no Cupertino drag-to-slide gesture); the thumb still animates. Fine for a two-segment switch.

## Verification
- Verified live on the iPhone 17 Pro Max simulator: light + dark (thumb resolves white→grey), tapping a segment slides the thumb and swaps the command group, bold selected label, trailing fade.
- `flutter analyze` clean; `project_list` tests pass.
- Passed the mandatory pre-PR architectural impl review (no violations).

https://claude.ai/code/session_01UyFyxLyWconAY9t93Bi5fj

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 36pt pill-shaped OS switcher for install commands on onboarding and an always-visible “Run the bridge” command on the bridge-offline screen. Also fixes a share-sheet crash by guarding the popover origin when the render box isn’t attached.

- New Features
  - Onboarding: Pill segmented control (macOS/Linux/WSL vs Windows) with bold selected label and animated thumb; single command box with a trailing fade for long commands.
  - Bridge-offline: Always-visible “Run the bridge” (`sesori-bridge`) and the same OS switcher for install commands; shared command-box components across both screens.
  - L10n: Clarified that the install-label strings are shared with bridge-offline.

- Bug Fixes
  - Prevent share-sheet failures by only using a `RenderBox` origin when it’s attached and has size.

<sup>Written for commit c5cbab7fea0814d20104374fd8a104cede485417. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

