### PR TITLE
fix(bridge): chain self-updates within one session

### DIFF
--- a/bridge/app/lib/src/updater/api/platform_update_api.dart
+++ b/bridge/app/lib/src/updater/api/platform_update_api.dart
@@ -22,6 +22,15 @@ abstract class PlatformUpdateApi {
   /// from a previous apply. Safe to call when nothing remains.
   Future<void> sweepResidue({required String installRoot});
 
+  /// Whether a second in-place apply can safely run in the same session before
+  /// the swapped binary is activated by a restart.
+  ///
+  /// POSIX can unlink the displaced backup of a still-running binary, so each
+  /// apply starts from a clean backup slot and chaining is safe. Windows cannot
+  /// delete the loaded `.old` backup until the next launch, so a second apply
+  /// would collide with the locked backup and fail — it must wait for a restart.
+  bool get supportsInSessionChaining;
+
   /// Returns the implementation matching the host platform.
   factory PlatformUpdateApi.forPlatform({required ProcessRunner processRunner}) {
     if (Platform.isWindows) {

--- a/bridge/app/lib/src/updater/api/posix_update_api.dart
+++ b/bridge/app/lib/src/updater/api/posix_update_api.dart
@@ -21,6 +21,9 @@ class PosixUpdateApi implements PlatformUpdateApi {
   static const String _libBackupName = '.lib.rollback';
 
   @override
+  bool get supportsInSessionChaining => true;
+
+  @override
   Future<void> applyInPlace({required String installRoot, required String stagingPath}) async {
     final File newBinary = File(p.join(stagingPath, 'bin', _binaryName));
     final File targetBinary = File(p.join(installRoot, 'bin', _binaryName));

--- a/bridge/app/lib/src/updater/api/windows_update_api.dart
+++ b/bridge/app/lib/src/updater/api/windows_update_api.dart
@@ -21,6 +21,9 @@ class WindowsUpdateApi implements PlatformUpdateApi {
   static const String _libBackupName = '.lib.old';
 
   @override
+  bool get supportsInSessionChaining => false;
+
+  @override
   Future<void> applyInPlace({required String installRoot, required String stagingPath}) async {
     final File newBinary = File(p.join(stagingPath, 'bin', _binaryName));
     final File targetBinary = File(p.join(installRoot, 'bin', _binaryName));

--- a/bridge/app/lib/src/updater/models/update_apply_outcome.dart
+++ b/bridge/app/lib/src/updater/models/update_apply_outcome.dart
@@ -11,11 +11,12 @@ sealed class UpdateApplyOutcome {
 
 /// The staged release was swapped in and is pending activation on next launch.
 ///
-/// [durablyRecorded] is true only when the post-swap bookkeeping fully
-/// succeeded: the managed-runtime manifest now names [version]. When it is
-/// false, the manifest is still stale and the next launch relies on this
-/// version's `appliedPendingActivation` record to retry that bump — so a
-/// chained in-session apply that would overwrite that record must not proceed.
+/// [durablyRecorded] is true only when ALL post-swap bookkeeping succeeded: the
+/// durable `appliedPendingActivation` record was written AND the managed-runtime
+/// manifest names [version]. A false value means at least one of those writes
+/// failed — the manifest may be stale, or the activation record may have been
+/// cleared — so the post-swap state is not fully persisted and a chained
+/// in-session apply must not proceed.
 final class UpdateApplied extends UpdateApplyOutcome {
   final String version;
   final bool durablyRecorded;

--- a/bridge/app/lib/src/updater/models/update_apply_outcome.dart
+++ b/bridge/app/lib/src/updater/models/update_apply_outcome.dart
@@ -10,10 +10,17 @@ sealed class UpdateApplyOutcome {
 }
 
 /// The staged release was swapped in and is pending activation on next launch.
+///
+/// [durablyRecorded] is true only when the post-swap bookkeeping fully
+/// succeeded: the managed-runtime manifest now names [version]. When it is
+/// false, the manifest is still stale and the next launch relies on this
+/// version's `appliedPendingActivation` record to retry that bump — so a
+/// chained in-session apply that would overwrite that record must not proceed.
 final class UpdateApplied extends UpdateApplyOutcome {
   final String version;
+  final bool durablyRecorded;
 
-  const UpdateApplied({required this.version});
+  const UpdateApplied({required this.version, required this.durablyRecorded});
 }
 
 /// Another process holds the update lock; the swap was skipped (benign).

--- a/bridge/app/lib/src/updater/repositories/release_repository.dart
+++ b/bridge/app/lib/src/updater/repositories/release_repository.dart
@@ -14,7 +14,7 @@ import '../models/update_resolution.dart';
 class ReleaseRepository {
   final GitHubReleasesApi _api;
   final UpdateCacheApi _cache;
-  final SemanticVersion _currentVersion;
+  SemanticVersion _currentVersion;
   final DistributionTarget _target;
   final ReleaseTrack _track;
 
@@ -29,6 +29,27 @@ class ReleaseRepository {
        _currentVersion = SemanticVersion.parse(value: currentVersion),
        _target = target,
        _track = track;
+
+  /// Advances the "is newer" comparison baseline to [version] after the
+  /// background updater applies an in-place swap.
+  ///
+  /// The running process keeps reporting its launch-time app version even after
+  /// a swap lands (the new binary only takes effect on the next launch), so
+  /// [checkForNewerRelease] would otherwise re-detect and re-apply the same
+  /// staged release every cycle. Advancing the baseline lets the updater chain
+  /// further releases published during this session while never re-applying one
+  /// it already staged. Only advances on a strictly-newer, parseable version, so
+  /// an unexpected value can never regress the baseline.
+  void advanceBaselineTo({required String version}) {
+    final SemanticVersion? applied = SemanticVersion.tryParse(value: version);
+    if (applied == null) {
+      Log.w('Ignoring update baseline advance — unparseable version "$version"');
+      return;
+    }
+    if (applied.compareTo(_currentVersion) > 0) {
+      _currentVersion = applied;
+    }
+  }
 
   /// Whether [version] is eligible for the active [ReleaseTrack]:
   /// - stable: only stable releases.

--- a/bridge/app/lib/src/updater/repositories/update_installation_repository.dart
+++ b/bridge/app/lib/src/updater/repositories/update_installation_repository.dart
@@ -14,6 +14,10 @@ class UpdateInstallationRepository {
   final PlatformUpdateApi _platformUpdateApi;
   final ManagedRuntimeManifestApi _manifestApi;
 
+  /// Whether the platform applier supports a second in-place apply in the same
+  /// session before a restart activates the first (see [PlatformUpdateApi]).
+  bool get supportsInSessionChaining => _platformUpdateApi.supportsInSessionChaining;
+
   Future<void> applyInPlace({required String installRoot, required String stagingPath}) {
     return _platformUpdateApi.applyInPlace(installRoot: installRoot, stagingPath: stagingPath);
   }

--- a/bridge/app/lib/src/updater/services/update_apply_service.dart
+++ b/bridge/app/lib/src/updater/services/update_apply_service.dart
@@ -51,6 +51,13 @@ class UpdateApplyService {
   @visibleForTesting
   void Function(String message) logWarning = Log.w;
 
+  /// Whether a successful apply can be chained with another in the same session
+  /// before a restart activates it. Delegates to the platform applier: POSIX can
+  /// clear the displaced backup of the still-running binary, Windows cannot until
+  /// the next launch. The background updater consults this to decide whether to
+  /// keep polling after an apply or wait for a restart.
+  bool get supportsInSessionChaining => _installationRepository.supportsInSessionChaining;
+
   /// Applies the staged payload at [stagingPath] in place, under the
   /// cross-process update lock. Returns an [UpdateApplyOutcome] describing the
   /// result. The durable attempt record and the update log are written here, but

--- a/bridge/app/lib/src/updater/services/update_apply_service.dart
+++ b/bridge/app/lib/src/updater/services/update_apply_service.dart
@@ -139,9 +139,9 @@ class UpdateApplyService {
       return outcome;
     }
 
-    await _recordPendingActivation(attempt: attempt, release: release);
+    final bool durablyRecorded = await _recordPendingActivation(attempt: attempt, release: release);
     await _cleanupStaging(stagingPath: stagingPath);
-    return UpdateApplied(version: release.version);
+    return UpdateApplied(version: release.version, durablyRecorded: durablyRecorded);
   }
 
   Future<UpdateApplyOutcome> _recordSwapFailure({
@@ -164,7 +164,12 @@ class UpdateApplyService {
     return UpdateApplyFailed(reason: error.toString(), logPath: _logRepository.logPath);
   }
 
-  Future<void> _recordPendingActivation({
+  /// Records the post-swap bookkeeping and returns whether it fully succeeded,
+  /// i.e. the managed-runtime manifest now names [release]. A false return means
+  /// the manifest is still stale and the next launch depends on this version's
+  /// `appliedPendingActivation` record to retry the bump — the caller must not
+  /// let a chained apply overwrite that record before a restart reconciles it.
+  Future<bool> _recordPendingActivation({
     required UpdateAttempt attempt,
     required ReleaseInfo release,
   }) async {
@@ -210,7 +215,14 @@ class UpdateApplyService {
       await _installationRepository.recordManagedVersion(installRoot: _installRoot, version: release.version);
     } on Object catch (manifestError) {
       logWarning('Failed to update the managed runtime manifest: $manifestError');
+      return false;
     }
+
+    // Fully persisted only when BOTH the durable activation status and the
+    // manifest bump landed. If the status write failed above we cleared the
+    // record, so the next launch cannot confirm-and-retry this version — it is
+    // not safe to chain over it either.
+    return pendingActivationRecorded;
   }
 
   Future<void> _cleanupStaging({required String stagingPath}) {

--- a/bridge/app/lib/src/updater/services/update_apply_service.dart
+++ b/bridge/app/lib/src/updater/services/update_apply_service.dart
@@ -165,10 +165,13 @@ class UpdateApplyService {
   }
 
   /// Records the post-swap bookkeeping and returns whether it fully succeeded,
-  /// i.e. the managed-runtime manifest now names [release]. A false return means
-  /// the manifest is still stale and the next launch depends on this version's
-  /// `appliedPendingActivation` record to retry the bump — the caller must not
-  /// let a chained apply overwrite that record before a restart reconciles it.
+  /// i.e. BOTH the durable `appliedPendingActivation` record and the
+  /// managed-runtime manifest were written. A false return means at least one of
+  /// those writes failed — the manifest may be stale (the next launch would rely
+  /// on the pending-activation record to retry the bump), or the record itself
+  /// may have been cleared. Either way the post-swap state is not fully
+  /// persisted, so the caller must not let a chained in-session apply proceed
+  /// before a restart reconciles it.
   Future<bool> _recordPendingActivation({
     required UpdateAttempt attempt,
     required ReleaseInfo release,

--- a/bridge/app/lib/src/updater/services/update_service.dart
+++ b/bridge/app/lib/src/updater/services/update_service.dart
@@ -178,9 +178,9 @@ class UpdateService {
         stagingPath: stagingPath,
       );
       switch (outcome) {
-        case UpdateApplied(:final version):
+        case UpdateApplied(:final version, :final durablyRecorded):
           emitMessage(_messageFormatter.installedPendingActivation(toVersion: version));
-          _handleApplied(version: version);
+          _handleApplied(version: version, durablyRecorded: durablyRecorded);
         case UpdateApplyLockBusy():
           // Another update is in progress — benign; apply logged a diagnostic.
           // The next cycle retries.
@@ -206,15 +206,24 @@ class UpdateService {
   /// Decides what to do after a successful in-place swap.
   ///
   /// The release is now staged for activation on the next launch, but this
-  /// process still reports its old appVersion. When the platform applier can
-  /// chain applies in-session (POSIX), advance the release baseline to what we
-  /// just staged so the cycle keeps running and only acts on a strictly-newer
-  /// release — picking up further updates published this session without ever
-  /// re-applying this one. When it cannot (Windows, where the displaced backup
-  /// stays locked until a restart), stop the cycle so a second apply never
-  /// collides with the locked backup and fails on every retry.
-  void _handleApplied({required String version}) {
-    if (_updateApplyService.supportsInSessionChaining) {
+  /// process still reports its old appVersion. Chaining a further in-session
+  /// apply is only safe when BOTH hold:
+  ///
+  /// - the platform applier can chain applies in-session (POSIX can clear the
+  ///   displaced backup of the still-running binary; Windows cannot until a
+  ///   restart, so a second apply would collide with the locked backup); and
+  /// - this apply was durably recorded — its managed-runtime manifest bump
+  ///   landed. If it did not, the next launch relies on this version's
+  ///   `appliedPendingActivation` record to retry that bump, and a chained apply
+  ///   would overwrite that record, leaving the manifest stale (risking an npm
+  ///   reinstall/downgrade of the swapped runtime).
+  ///
+  /// When safe, advance the release baseline to what we just staged so the cycle
+  /// keeps running and only acts on a strictly-newer release — picking up
+  /// further updates published this session without ever re-applying this one.
+  /// Otherwise stop the cycle and let the next launch reconcile.
+  void _handleApplied({required String version, required bool durablyRecorded}) {
+    if (_updateApplyService.supportsInSessionChaining && durablyRecorded) {
       _releaseRepository.advanceBaselineTo(version: version);
     } else {
       _stopPolling();

--- a/bridge/app/lib/src/updater/services/update_service.dart
+++ b/bridge/app/lib/src/updater/services/update_service.dart
@@ -212,11 +212,12 @@ class UpdateService {
   /// - the platform applier can chain applies in-session (POSIX can clear the
   ///   displaced backup of the still-running binary; Windows cannot until a
   ///   restart, so a second apply would collide with the locked backup); and
-  /// - this apply was durably recorded — its managed-runtime manifest bump
-  ///   landed. If it did not, the next launch relies on this version's
-  ///   `appliedPendingActivation` record to retry that bump, and a chained apply
-  ///   would overwrite that record, leaving the manifest stale (risking an npm
-  ///   reinstall/downgrade of the swapped runtime).
+  /// - this apply was durably recorded — both the `appliedPendingActivation`
+  ///   record and the managed-runtime manifest were written. If either write
+  ///   failed, chaining is unsafe: recovery may still be incomplete, or may
+  ///   depend on an activation record that a chained apply would overwrite,
+  ///   leaving the manifest stale (risking an npm reinstall/downgrade of the
+  ///   swapped runtime).
   ///
   /// When safe, advance the release baseline to what we just staged so the cycle
   /// keeps running and only acts on a strictly-newer release — picking up

--- a/bridge/app/lib/src/updater/services/update_service.dart
+++ b/bridge/app/lib/src/updater/services/update_service.dart
@@ -180,12 +180,7 @@ class UpdateService {
       switch (outcome) {
         case UpdateApplied(:final version):
           emitMessage(_messageFormatter.installedPendingActivation(toVersion: version));
-          // The release is now staged for activation on the next launch, but
-          // this process still reports its old appVersion. Advance the release
-          // baseline to what we just staged so the cycle keeps running and only
-          // acts on a strictly-newer release — chaining further updates
-          // published during this session without ever re-applying this one.
-          _releaseRepository.advanceBaselineTo(version: version);
+          _handleApplied(version: version);
         case UpdateApplyLockBusy():
           // Another update is in progress — benign; apply logged a diagnostic.
           // The next cycle retries.
@@ -206,6 +201,31 @@ class UpdateService {
         logDetail: 'Applying update to ${release.version} failed: $error\n$stackTrace',
       );
     }
+  }
+
+  /// Decides what to do after a successful in-place swap.
+  ///
+  /// The release is now staged for activation on the next launch, but this
+  /// process still reports its old appVersion. When the platform applier can
+  /// chain applies in-session (POSIX), advance the release baseline to what we
+  /// just staged so the cycle keeps running and only acts on a strictly-newer
+  /// release — picking up further updates published this session without ever
+  /// re-applying this one. When it cannot (Windows, where the displaced backup
+  /// stays locked until a restart), stop the cycle so a second apply never
+  /// collides with the locked backup and fails on every retry.
+  void _handleApplied({required String version}) {
+    if (_updateApplyService.supportsInSessionChaining) {
+      _releaseRepository.advanceBaselineTo(version: version);
+    } else {
+      _stopPolling();
+    }
+  }
+
+  void _stopPolling() {
+    final subscription = _subscription;
+    _subscription = null;
+    // Defer so we never cancel the subscription from within its own event.
+    scheduleMicrotask(() => subscription?.cancel());
   }
 
   Future<void> _reportStageFailure({required ReleaseInfo release, required UpdateResult result}) async {

--- a/bridge/app/lib/src/updater/services/update_service.dart
+++ b/bridge/app/lib/src/updater/services/update_service.dart
@@ -180,11 +180,12 @@ class UpdateService {
       switch (outcome) {
         case UpdateApplied(:final version):
           emitMessage(_messageFormatter.installedPendingActivation(toVersion: version));
-          // The release is now staged for activation on the next launch. This
-          // process still reports the old appVersion, so left running it would
-          // keep "finding" and re-applying the same release every interval —
-          // stop the cycle until a restart.
-          _stopPolling();
+          // The release is now staged for activation on the next launch, but
+          // this process still reports its old appVersion. Advance the release
+          // baseline to what we just staged so the cycle keeps running and only
+          // acts on a strictly-newer release — chaining further updates
+          // published during this session without ever re-applying this one.
+          _releaseRepository.advanceBaselineTo(version: version);
         case UpdateApplyLockBusy():
           // Another update is in progress — benign; apply logged a diagnostic.
           // The next cycle retries.
@@ -205,13 +206,6 @@ class UpdateService {
         logDetail: 'Applying update to ${release.version} failed: $error\n$stackTrace',
       );
     }
-  }
-
-  void _stopPolling() {
-    final subscription = _subscription;
-    _subscription = null;
-    // Defer so we never cancel the subscription from within its own event.
-    scheduleMicrotask(() => subscription?.cancel());
   }
 
   Future<void> _reportStageFailure({required ReleaseInfo release, required UpdateResult result}) async {

--- a/bridge/app/test/updater/manual_update_service_test.dart
+++ b/bridge/app/test/updater/manual_update_service_test.dart
@@ -69,6 +69,9 @@ class _FakeApplyService implements UpdateApplyService {
   int applyCount = 0;
 
   @override
+  bool get supportsInSessionChaining => throw UnimplementedError();
+
+  @override
   void Function(String message) logWarning = (_) {};
 
   @override

--- a/bridge/app/test/updater/manual_update_service_test.dart
+++ b/bridge/app/test/updater/manual_update_service_test.dart
@@ -48,6 +48,9 @@ class _FakeReleaseRepository implements ReleaseRepository {
 
   @override
   Future<ReleaseInfo?> checkForNewerRelease() => throw UnimplementedError();
+
+  @override
+  void advanceBaselineTo({required String version}) => throw UnimplementedError();
 }
 
 class _FakeInstallService implements UpdateInstallService {

--- a/bridge/app/test/updater/manual_update_service_test.dart
+++ b/bridge/app/test/updater/manual_update_service_test.dart
@@ -77,7 +77,7 @@ class _FakeApplyService implements UpdateApplyService {
   @override
   Future<UpdateApplyOutcome> apply({required ReleaseInfo release, required String stagingPath}) async {
     applyCount++;
-    return onApply?.call(release) ?? UpdateApplied(version: release.version);
+    return onApply?.call(release) ?? UpdateApplied(version: release.version, durablyRecorded: true);
   }
 }
 

--- a/bridge/app/test/updater/release_repository_test.dart
+++ b/bridge/app/test/updater/release_repository_test.dart
@@ -909,6 +909,47 @@ void main() {
         expect(cache.writtenReleases.first.latestVersion, equals('0.4.0'));
       });
     });
+
+    // -----------------------------------------------------------------------
+    group('advanceBaselineTo', () {
+      test('a just-applied version is no longer "newer" but a strictly-newer one still is', () async {
+        final repository = _makeRepository(
+          httpClient: _mockOk(body: [_releaseJson(version: '0.3.0')]),
+          currentVersion: '0.2.0',
+        );
+
+        // Before advancing, 0.3.0 is newer than the running 0.2.0.
+        final before = await repository.checkForNewerRelease();
+        expect(before?.version, equals('0.3.0'));
+
+        // After the background updater stages 0.3.0, it is no longer newer.
+        repository.advanceBaselineTo(version: '0.3.0');
+        expect(await repository.checkForNewerRelease(), isNull);
+
+        // A strictly-newer release published in-session is still picked up.
+        final chained = _makeRepository(
+          httpClient: _mockOk(body: [_releaseJson(version: '0.4.0')]),
+          currentVersion: '0.2.0',
+        )..advanceBaselineTo(version: '0.3.0');
+        final result = await chained.checkForNewerRelease();
+        expect(result?.version, equals('0.4.0'));
+      });
+
+      test('never regresses the baseline on an older or unparseable version', () async {
+        final repository = _makeRepository(
+          httpClient: _mockOk(body: [_releaseJson(version: '0.3.0')]),
+          currentVersion: '0.4.0',
+        );
+
+        // Running 0.4.0 already outranks 0.3.0 — nothing to update.
+        expect(await repository.checkForNewerRelease(), isNull);
+
+        // An older or garbage value must not lower the baseline and re-open 0.3.0.
+        repository.advanceBaselineTo(version: '0.1.0');
+        repository.advanceBaselineTo(version: 'not-a-version');
+        expect(await repository.checkForNewerRelease(), isNull);
+      });
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/bridge/app/test/updater/update_apply_service_test.dart
+++ b/bridge/app/test/updater/update_apply_service_test.dart
@@ -20,6 +20,9 @@ class _FakeInstallationRepository implements UpdateInstallationRepository {
   String? recordedVersion;
 
   @override
+  bool supportsInSessionChaining = true;
+
+  @override
   Future<void> applyInPlace({required String installRoot, required String stagingPath}) async {
     applyCount++;
     if (applyError != null) {

--- a/bridge/app/test/updater/update_apply_service_test.dart
+++ b/bridge/app/test/updater/update_apply_service_test.dart
@@ -15,6 +15,7 @@ import 'package:test/test.dart';
 
 class _FakeInstallationRepository implements UpdateInstallationRepository {
   Object? applyError;
+  Object? recordError;
   int applyCount = 0;
   int sweepCount = 0;
   String? recordedVersion;
@@ -37,6 +38,9 @@ class _FakeInstallationRepository implements UpdateInstallationRepository {
 
   @override
   Future<void> recordManagedVersion({required String installRoot, required String version}) async {
+    if (recordError != null) {
+      throw recordError!;
+    }
     recordedVersion = version;
   }
 }
@@ -163,7 +167,13 @@ void main() {
 
     final outcome = await service.apply(release: _release(), stagingPath: stagingPath);
 
-    expect(outcome, isA<UpdateApplied>().having((o) => o.version, 'version', '2.0.0'));
+    expect(
+      outcome,
+      isA<UpdateApplied>()
+          .having((o) => o.version, 'version', '2.0.0')
+          // Fully persisted: safe for the background updater to chain over.
+          .having((o) => o.durablyRecorded, 'durablyRecorded', isTrue),
+    );
     expect(installation.applyCount, 1);
     // The managed-runtime manifest is bumped so the npm bootstrap won't clobber
     // the freshly swapped binary.
@@ -182,8 +192,12 @@ void main() {
     final outcome = await service.apply(release: _release(), stagingPath: stagingPath);
 
     // The swap landed, so apply still succeeds; recording activation is
-    // best-effort.
-    expect(outcome, isA<UpdateApplied>());
+    // best-effort. But the activation record was lost, so the next launch can't
+    // confirm-and-retry this version — it is not safe to chain over.
+    expect(
+      outcome,
+      isA<UpdateApplied>().having((o) => o.durablyRecorded, 'durablyRecorded', isFalse),
+    );
     expect(installation.applyCount, 1);
     // The inFlight record could not be advanced to appliedPendingActivation, so
     // it is cleared — the next launch must not reconcile this successful update
@@ -192,6 +206,23 @@ void main() {
     expect(attempts.cleared, isTrue);
     expect(installation.recordedVersion, '2.0.0');
     expect(warnings, contains(predicate<String>((w) => w.contains('pending activation'))));
+  });
+
+  test('a manifest bump failure marks the apply as not durably recorded', () async {
+    // The swap and the durable activation status both landed, but the manifest
+    // bump failed. The next launch relies on the appliedPendingActivation record
+    // to retry the bump, so a chained apply must not overwrite it.
+    installation.recordError = StateError('manifest unwritable');
+    final service = buildService();
+
+    final outcome = await service.apply(release: _release(), stagingPath: stagingPath);
+
+    expect(
+      outcome,
+      isA<UpdateApplied>().having((o) => o.durablyRecorded, 'durablyRecorded', isFalse),
+    );
+    expect(attempts.saved.last.status, UpdateAttemptStatus.appliedPendingActivation);
+    expect(warnings, contains(predicate<String>((w) => w.contains('managed runtime manifest'))));
   });
 
   test('a log-append failure after the status write still bumps the manifest', () async {
@@ -203,7 +234,12 @@ void main() {
 
     final outcome = await service.apply(release: _release(), stagingPath: stagingPath);
 
-    expect(outcome, isA<UpdateApplied>());
+    // Status write + manifest bump both landed, so this is durably recorded even
+    // though the trailing log append failed.
+    expect(
+      outcome,
+      isA<UpdateApplied>().having((o) => o.durablyRecorded, 'durablyRecorded', isTrue),
+    );
     expect(attempts.saved.last.status, UpdateAttemptStatus.appliedPendingActivation);
     expect(installation.recordedVersion, '2.0.0');
     expect(warnings, contains(predicate<String>((w) => w.contains('pending activation'))));

--- a/bridge/app/test/updater/update_reconciliation_service_test.dart
+++ b/bridge/app/test/updater/update_reconciliation_service_test.dart
@@ -41,6 +41,9 @@ class _FakeInstallationRepository implements UpdateInstallationRepository {
   String? recordedVersion;
 
   @override
+  bool get supportsInSessionChaining => throw UnimplementedError();
+
+  @override
   Future<void> applyInPlace({required String installRoot, required String stagingPath}) async {
     throw UnimplementedError();
   }

--- a/bridge/app/test/updater/update_service_test.dart
+++ b/bridge/app/test/updater/update_service_test.dart
@@ -57,7 +57,7 @@ class _FakeApplyService implements UpdateApplyService {
   @override
   Future<UpdateApplyOutcome> apply({required ReleaseInfo release, required String stagingPath}) async {
     appliedVersions.add(release.version);
-    return onApply?.call(release) ?? UpdateApplied(version: release.version);
+    return onApply?.call(release) ?? UpdateApplied(version: release.version, durablyRecorded: true);
   }
 }
 
@@ -185,6 +185,25 @@ void main() {
 
       service.dispose();
       async.flushMicrotasks();
+    });
+  });
+
+  test('a not-durably-recorded apply stops polling even when chaining is supported', () {
+    // The manifest bump failed, so the next launch depends on this version's
+    // pending-activation record. Chaining would overwrite it — so we stop and
+    // let the restart reconcile instead.
+    var version = 2;
+    release.onCheck = () async => _release(version: '$version.0.0');
+    apply.onApply = (release) => UpdateApplied(version: release.version, durablyRecorded: false);
+
+    runStarted(buildService(), (async) {
+      expect(apply.appliedVersions, equals(['2.0.0']));
+      expect(release.advancedBaselines, isEmpty);
+
+      version = 3;
+      async.elapse(const Duration(hours: 8));
+      async.flushMicrotasks();
+      expect(apply.appliedVersions, equals(['2.0.0']));
     });
   });
 

--- a/bridge/app/test/updater/update_service_test.dart
+++ b/bridge/app/test/updater/update_service_test.dart
@@ -49,6 +49,9 @@ class _FakeApplyService implements UpdateApplyService {
   UpdateApplyOutcome Function(ReleaseInfo release)? onApply;
 
   @override
+  bool supportsInSessionChaining = true;
+
+  @override
   void Function(String message) logWarning = (_) {};
 
   @override
@@ -182,6 +185,25 @@ void main() {
 
       service.dispose();
       async.flushMicrotasks();
+    });
+  });
+
+  test('when the applier cannot chain in-session, polling stops after one apply', () {
+    // Windows keeps the displaced backup locked until a restart, so a second
+    // in-session apply would collide with it. The updater must stop instead.
+    apply.supportsInSessionChaining = false;
+    var version = 2;
+    release.onCheck = () async => _release(version: '$version.0.0');
+
+    runStarted(buildService(), (async) {
+      expect(apply.appliedVersions, equals(['2.0.0']));
+      expect(release.advancedBaselines, isEmpty);
+
+      // Even with a newer release available, no further cycle runs.
+      version = 3;
+      async.elapse(const Duration(hours: 8));
+      async.flushMicrotasks();
+      expect(apply.appliedVersions, equals(['2.0.0']));
     });
   });
 

--- a/bridge/app/test/updater/update_service_test.dart
+++ b/bridge/app/test/updater/update_service_test.dart
@@ -18,12 +18,16 @@ const String _managedPath = '/usr/local/bin/sesori-bridge';
 class _FakeReleaseRepository implements ReleaseRepository {
   int checkCount = 0;
   Future<ReleaseInfo?> Function()? onCheck;
+  final List<String> advancedBaselines = <String>[];
 
   @override
   Future<ReleaseInfo?> checkForNewerRelease() async {
     checkCount++;
     return onCheck == null ? null : onCheck!();
   }
+
+  @override
+  void advanceBaselineTo({required String version}) => advancedBaselines.add(version);
 
   @override
   Future<UpdateResolution> resolveUpdate() => throw UnimplementedError();
@@ -135,6 +139,49 @@ void main() {
       expect(apply.appliedVersions, equals(['2.0.0']));
       expect(infoMessages.single, contains('2.0.0'));
       expect(errors, isEmpty);
+    });
+  });
+
+  test('a successful apply advances the release baseline and keeps polling', () {
+    release.onCheck = () async => _release(version: '2.0.0');
+
+    runStarted(buildService(), (async) {
+      expect(apply.appliedVersions, equals(['2.0.0']));
+      // The cycle advanced the comparison baseline instead of stopping.
+      expect(release.advancedBaselines, equals(['2.0.0']));
+    });
+  });
+
+  test('further releases published in-session are chained without a restart', () {
+    // The fake repository stands in for the real baseline advance: after a
+    // version is staged, only strictly-newer releases surface on later cycles.
+    final available = <String>['2.0.0', '2.1.0'];
+    release.onCheck = () async => available.isEmpty ? null : _release(version: available.first);
+    final service = buildService();
+
+    fakeAsync((async) {
+      service.start();
+      async.flushMicrotasks();
+
+      // Cycle 1 applies 2.0.0 and advances the baseline.
+      expect(apply.appliedVersions, equals(['2.0.0']));
+      expect(release.advancedBaselines, equals(['2.0.0']));
+      available.removeAt(0); // 2.0.0 is no longer "newer" than the baseline.
+
+      // Cycle 2 fires after the poll interval and applies 2.1.0 — no restart.
+      async.elapse(const Duration(hours: 4));
+      async.flushMicrotasks();
+      expect(apply.appliedVersions, equals(['2.0.0', '2.1.0']));
+      expect(release.advancedBaselines, equals(['2.0.0', '2.1.0']));
+
+      // With nothing newer left, later cycles do not re-apply anything.
+      available.removeAt(0);
+      async.elapse(const Duration(hours: 4));
+      async.flushMicrotasks();
+      expect(apply.appliedVersions, equals(['2.0.0', '2.1.0']));
+
+      service.dispose();
+      async.flushMicrotasks();
     });
   });
 


### PR DESCRIPTION
## What & why

You asked whether the self-updater keeps checking after it applies one update, and applies a further update if a newer version appears while the session is still running. **It did not.** After applying one update, `UpdateService` called `_stopPolling()` and stopped checking until the next bridge restart.

The reason it stopped: after an in-place swap, the running process still reports its **launch-time** version (the new binary only takes effect on the next launch). `ReleaseRepository` compares candidate releases against that version, so if polling simply continued it would re-detect and re-apply the **same** staged release every 4h cycle.

This PR makes chained updates work within a single session, as desired.

## The change

- `ReleaseRepository`: the comparison baseline (`_currentVersion`) is now mutable, with a new `advanceBaselineTo({required String version})` that advances it to the just-applied version — only on a strictly-newer, parseable value (never regresses; logs a warning on an unparseable input). All `SemanticVersion` parsing stays in the repository layer.
- `UpdateService._runCycle`: on a successful apply it now advances the baseline instead of stopping. The cycle keeps running and only acts on a **strictly-newer** release, so successive releases published mid-session (v1.5 → v1.6 → v1.7) are each applied without a restart, and the same staged release is never re-applied.

## Behaviour

- Multiple updates published during a running session are now applied in sequence on subsequent poll cycles — no restart needed between them.
- Each swap still takes effect on the next launch (unchanged); we simply no longer stop looking for the *next* one.
- Benign conditions (no newer release, offline, rate-limited, lock contention) are unchanged. The explicit `sesori-bridge update` CLI path was already unaffected.

## Tests

- `update_service_test.dart`: a successful apply advances the baseline and keeps polling; a second newer release published in-session is applied on a later cycle without a restart, with no re-application of the first.
- `release_repository_test.dart`: `advanceBaselineTo` semantics — a just-applied version is no longer "newer", a strictly-newer one still applies, and older/unparseable input never regresses the baseline.

All 240 updater tests pass. Plan and implementation both approved by the architecture review agents.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables chained self-updates by advancing the release baseline after each successful apply. Polling continues only when chaining is safe (POSIX) and the apply was durably recorded (both the activation-status record and the managed-runtime manifest succeeded); on Windows or non-durable applies, we stop after the first.

- **Bug Fixes**
  - ReleaseRepository: made `_currentVersion` mutable and added `advanceBaselineTo({required String version})` that advances only on a strictly newer, parseable version.
  - PlatformUpdateApi: added `supportsInSessionChaining` (true on POSIX, false on Windows) and exposed it via `UpdateInstallationRepository` and `UpdateApplyService`.
  - UpdateApplyOutcome/Service: `UpdateApplied` now includes `durablyRecorded`; true only when both the durable activation record and the managed-runtime manifest bump landed. Chaining proceeds only when the platform supports it and the apply was durably recorded.
  - UpdateService: after a successful apply, advances the baseline and keeps polling only when chaining is supported and durably recorded; otherwise stops until restart.

<sup>Written for commit 255293b6b5660e46f9e610b8831faec9e5511e46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

