### PR TITLE
fix: surface projects whose folder was moved or deleted

### DIFF
--- a/bridge/app/lib/src/bridge/repositories/mappers/plugin_project_mapper.dart
+++ b/bridge/app/lib/src/bridge/repositories/mappers/plugin_project_mapper.dart
@@ -3,7 +3,7 @@ import "package:sesori_shared/sesori_shared.dart";
 
 /// Maps a [PluginProject] to the shared [Project] type used in relay responses.
 extension PluginProjectMapper on PluginProject {
-  Project toSharedProject({required bool hasUnseenChanges}) {
+  Project toSharedProject({required bool hasUnseenChanges, required bool directoryMissing}) {
     return Project(
       id: id,
       name: name,
@@ -16,6 +16,7 @@ extension PluginProjectMapper on PluginProject {
         null => null,
       },
       hasUnseenChanges: hasUnseenChanges,
+      directoryMissing: directoryMissing,
     );
   }
 }

--- a/bridge/app/lib/src/bridge/repositories/project_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/project_repository.dart
@@ -1,9 +1,12 @@
+import "dart:io" show FileSystemException;
+
 import "package:path/path.dart" as p;
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show normalizeProjectDirectory;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
-    show BridgeDerivedProjectsPluginApi, BridgePluginApi, NativeProjectsPluginApi;
+    show BridgeDerivedProjectsPluginApi, BridgePluginApi, Log, NativeProjectsPluginApi;
 import "package:sesori_shared/sesori_shared.dart" show Project;
 
+import "../api/filesystem_api.dart";
 import "../persistence/daos/projects_dao.dart";
 import "../persistence/daos/session_dao.dart";
 import "derived_project_builder.dart";
@@ -31,16 +34,19 @@ class ProjectRepository {
   final ProjectsDao _projectsDao;
   final SessionDao _sessionDao;
   final SessionUnseenCalculator _unseenCalculator;
+  final FilesystemApi _filesystemApi;
 
   ProjectRepository({
     required BridgePluginApi plugin,
     required ProjectsDao projectsDao,
     required SessionDao sessionDao,
     required SessionUnseenCalculator unseenCalculator,
+    required FilesystemApi filesystemApi,
   }) : _plugin = plugin,
        _projectsDao = projectsDao,
        _sessionDao = sessionDao,
-       _unseenCalculator = unseenCalculator;
+       _unseenCalculator = unseenCalculator,
+       _filesystemApi = filesystemApi;
 
   Future<List<Project>> getProjects() async {
     switch (_plugin) {
@@ -64,7 +70,10 @@ class ProjectRepository {
         );
         final projects = [
           for (final project in visible)
-            project.copyWith(hasUnseenChanges: unseenById[project.id] ?? false),
+            project.copyWith(
+              hasUnseenChanges: unseenById[project.id] ?? false,
+              directoryMissing: _directoryMissing(project.id),
+            ),
         ];
         projects.sort((a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0));
         return projects;
@@ -80,7 +89,12 @@ class ProjectRepository {
           projectIds: [for (final p in visible) p.id],
         );
         final projects = visible
-            .map((p) => p.toSharedProject(hasUnseenChanges: unseenById[p.id] ?? false))
+            .map(
+              (p) => p.toSharedProject(
+                hasUnseenChanges: unseenById[p.id] ?? false,
+                directoryMissing: _directoryMissing(p.id),
+              ),
+            )
             .toList();
         projects.sort(
           (a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0),
@@ -130,6 +144,7 @@ class ProjectRepository {
         final pluginProject = await plugin.getProject(projectId);
         return pluginProject.toSharedProject(
           hasUnseenChanges: await projectHasUnseenChanges(projectId: pluginProject.id),
+          directoryMissing: _directoryMissing(pluginProject.id),
         );
     }
   }
@@ -154,6 +169,7 @@ class ProjectRepository {
         await _projectsDao.unhideProject(projectId: pluginProject.id);
         return pluginProject.toSharedProject(
           hasUnseenChanges: await projectHasUnseenChanges(projectId: pluginProject.id),
+          directoryMissing: _directoryMissing(pluginProject.id),
         );
     }
   }
@@ -171,6 +187,7 @@ class ProjectRepository {
         final updated = await plugin.renameProject(projectId: projectId, name: name);
         return updated.toSharedProject(
           hasUnseenChanges: await projectHasUnseenChanges(projectId: updated.id),
+          directoryMissing: _directoryMissing(updated.id),
         );
     }
   }
@@ -213,9 +230,12 @@ class ProjectRepository {
   /// display-name override so a rename isn't lost to the directory basename.
   Future<Project> _findDerivedProject(BridgeDerivedProjectsPluginApi plugin, String canonicalId) async {
     final hasUnseenChanges = await projectHasUnseenChanges(projectId: canonicalId);
+    final directoryMissing = _directoryMissing(canonicalId);
     final derived = await _deriveProjects(plugin);
     for (final project in derived) {
-      if (project.id == canonicalId) return project.copyWith(hasUnseenChanges: hasUnseenChanges);
+      if (project.id == canonicalId) {
+        return project.copyWith(hasUnseenChanges: hasUnseenChanges, directoryMissing: directoryMissing);
+      }
     }
     final stored = await _projectsDao.getAllProjects();
     String? displayName;
@@ -231,6 +251,23 @@ class ProjectRepository {
       name: displayName != null && displayName.isNotEmpty ? displayName : (base.isEmpty ? canonicalId : base),
       time: null,
       hasUnseenChanges: hasUnseenChanges,
+      directoryMissing: directoryMissing,
     );
+  }
+
+  /// Whether the project directory at [path] no longer exists on disk (the
+  /// folder was moved or deleted). Only a definitive not-found counts as
+  /// missing: `directoryExists` returns false for a genuinely absent directory
+  /// but throws on a permission or other IO error, where existence can't be
+  /// determined — there we log and treat the project as present so a folder
+  /// isn't flagged missing merely because, e.g., the terminal running the
+  /// bridge lacks Full Disk Access.
+  bool _directoryMissing(String path) {
+    try {
+      return !_filesystemApi.directoryExists(path);
+    } on FileSystemException catch (error, stackTrace) {
+      Log.w("ProjectRepository: could not determine whether $path exists; treating as present", error, stackTrace);
+      return false;
+    }
   }
 }

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
@@ -118,6 +118,7 @@ class BridgeRuntime {
       projectsDao: database.projectsDao,
       sessionDao: database.sessionDao,
       unseenCalculator: unseenCalculator,
+      filesystemApi: const FilesystemApi(),
     );
     final sessionUnseenRepository = SessionUnseenRepository(
       sessionDao: database.sessionDao,

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -53,6 +53,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" hide PermissionReply;
 import "package:test/test.dart";
 
+import "../helpers/fake_filesystem_api.dart";
 import "../helpers/restart_test_support.dart";
 import "../helpers/test_database.dart";
 import "../helpers/test_helpers.dart";
@@ -80,6 +81,7 @@ void main() {
       projectsDao: database.projectsDao,
       sessionDao: database.sessionDao,
       unseenCalculator: const SessionUnseenCalculator(),
+      filesystemApi: FakeFilesystemApi(),
     );
     final permissionRepository = PermissionRepository(plugin: plugin);
     final sessionPersistenceService = SessionPersistenceService(
@@ -142,6 +144,7 @@ void main() {
           projectsDao: database.projectsDao,
           sessionDao: database.sessionDao,
           unseenCalculator: const SessionUnseenCalculator(),
+          filesystemApi: FakeFilesystemApi(),
         ),
         viewTracker: SessionViewTracker(),
       ),
@@ -269,6 +272,7 @@ void main() {
       projectsDao: database.projectsDao,
       sessionDao: database.sessionDao,
       unseenCalculator: const SessionUnseenCalculator(),
+      filesystemApi: FakeFilesystemApi(),
     );
     final permissionRepository = PermissionRepository(plugin: plugin);
     final sessionPersistenceService = SessionPersistenceService(
@@ -322,6 +326,7 @@ void main() {
           projectsDao: database.projectsDao,
           sessionDao: database.sessionDao,
           unseenCalculator: const SessionUnseenCalculator(),
+          filesystemApi: FakeFilesystemApi(),
         ),
         viewTracker: SessionViewTracker(),
       ),
@@ -429,6 +434,7 @@ void main() {
       projectsDao: database.projectsDao,
       sessionDao: database.sessionDao,
       unseenCalculator: const SessionUnseenCalculator(),
+      filesystemApi: FakeFilesystemApi(),
     );
     final permissionRepository = PermissionRepository(plugin: plugin);
     final sessionPersistenceService = SessionPersistenceService(
@@ -606,6 +612,7 @@ void main() {
       projectsDao: database.projectsDao,
       sessionDao: database.sessionDao,
       unseenCalculator: const SessionUnseenCalculator(),
+      filesystemApi: FakeFilesystemApi(),
     );
     final permissionRepository = PermissionRepository(plugin: plugin);
     final sessionPersistenceService = SessionPersistenceService(
@@ -700,6 +707,7 @@ void main() {
           projectsDao: database.projectsDao,
           sessionDao: database.sessionDao,
           unseenCalculator: const SessionUnseenCalculator(),
+          filesystemApi: FakeFilesystemApi(),
         ),
         viewTracker: SessionViewTracker(),
       ),
@@ -814,6 +822,7 @@ void main() {
       projectsDao: database.projectsDao,
       sessionDao: database.sessionDao,
       unseenCalculator: const SessionUnseenCalculator(),
+      filesystemApi: FakeFilesystemApi(),
     );
     final permissionRepository = PermissionRepository(plugin: plugin);
     final sessionPersistenceService = SessionPersistenceService(
@@ -876,6 +885,7 @@ void main() {
           projectsDao: database.projectsDao,
           sessionDao: database.sessionDao,
           unseenCalculator: const SessionUnseenCalculator(),
+          filesystemApi: FakeFilesystemApi(),
         ),
         viewTracker: SessionViewTracker(),
       ),
@@ -961,6 +971,7 @@ void main() {
       projectsDao: database.projectsDao,
       sessionDao: database.sessionDao,
       unseenCalculator: const SessionUnseenCalculator(),
+      filesystemApi: FakeFilesystemApi(),
     );
     final permissionRepository = PermissionRepository(plugin: plugin);
     final sessionPersistenceService = SessionPersistenceService(
@@ -1023,6 +1034,7 @@ void main() {
           projectsDao: database.projectsDao,
           sessionDao: database.sessionDao,
           unseenCalculator: const SessionUnseenCalculator(),
+          filesystemApi: FakeFilesystemApi(),
         ),
         viewTracker: SessionViewTracker(),
       ),
@@ -1133,6 +1145,7 @@ void main() {
       projectsDao: database.projectsDao,
       sessionDao: database.sessionDao,
       unseenCalculator: const SessionUnseenCalculator(),
+      filesystemApi: FakeFilesystemApi(),
     );
     final permissionRepository = PermissionRepository(plugin: plugin);
     final sessionPersistenceService = SessionPersistenceService(
@@ -1195,6 +1208,7 @@ void main() {
           projectsDao: database.projectsDao,
           sessionDao: database.sessionDao,
           unseenCalculator: const SessionUnseenCalculator(),
+          filesystemApi: FakeFilesystemApi(),
         ),
         viewTracker: SessionViewTracker(),
       ),

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -45,6 +45,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" hide PermissionReply;
 import "package:test/test.dart";
 
+import "../helpers/fake_filesystem_api.dart";
 import "../helpers/restart_test_support.dart";
 import "../helpers/test_database.dart";
 import "../helpers/test_helpers.dart";
@@ -97,6 +98,7 @@ void main() {
           projectsDao: database.projectsDao,
           sessionDao: database.sessionDao,
           unseenCalculator: const SessionUnseenCalculator(),
+          filesystemApi: FakeFilesystemApi(),
         ),
         sessionUnseenService: SessionUnseenService(
           unseenRepository: SessionUnseenRepository(
@@ -111,6 +113,7 @@ void main() {
             projectsDao: database.projectsDao,
             sessionDao: database.sessionDao,
             unseenCalculator: const SessionUnseenCalculator(),
+            filesystemApi: FakeFilesystemApi(),
           ),
           viewTracker: SessionViewTracker(),
         ),
@@ -284,6 +287,7 @@ class _TestHarness {
       projectsDao: database.projectsDao,
       sessionDao: database.sessionDao,
       unseenCalculator: const SessionUnseenCalculator(),
+      filesystemApi: FakeFilesystemApi(),
     );
     final permissionRepository = PermissionRepository(plugin: plugin);
     final sessionPersistenceService = SessionPersistenceService(
@@ -349,6 +353,7 @@ class _TestHarness {
           projectsDao: database.projectsDao,
           sessionDao: database.sessionDao,
           unseenCalculator: const SessionUnseenCalculator(),
+          filesystemApi: FakeFilesystemApi(),
         ),
         viewTracker: SessionViewTracker(),
       ),

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -42,6 +42,7 @@ import "package:sesori_bridge/src/push/push_session_state_tracker.dart";
 import "package:sesori_shared/sesori_shared.dart" hide PermissionReply;
 import "package:test/test.dart";
 
+import "../helpers/fake_filesystem_api.dart";
 import "../helpers/restart_test_support.dart";
 import "../helpers/test_database.dart";
 import "../helpers/test_helpers.dart";
@@ -319,6 +320,7 @@ class _RegistrationHarness {
         projectsDao: database.projectsDao,
         sessionDao: database.sessionDao,
         unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(),
       ),
       sessionUnseenService: SessionUnseenService(
         unseenRepository: SessionUnseenRepository(
@@ -333,6 +335,7 @@ class _RegistrationHarness {
           projectsDao: database.projectsDao,
           sessionDao: database.sessionDao,
           unseenCalculator: const SessionUnseenCalculator(),
+          filesystemApi: FakeFilesystemApi(),
         ),
         viewTracker: SessionViewTracker(),
       ),

--- a/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
+++ b/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
@@ -44,6 +44,7 @@ import "package:sesori_bridge/src/push/push_session_state_tracker.dart";
 import "package:sesori_shared/sesori_shared.dart" hide PermissionReply;
 import "package:test/test.dart";
 
+import "../helpers/fake_filesystem_api.dart";
 import "../helpers/restart_test_support.dart";
 import "../helpers/test_database.dart";
 import "../helpers/test_helpers.dart";
@@ -357,6 +358,7 @@ class _ReauthHarness {
         projectsDao: database.projectsDao,
         sessionDao: database.sessionDao,
         unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(),
       ),
       viewTracker: sessionViewTracker,
     );
@@ -394,6 +396,7 @@ class _ReauthHarness {
         projectsDao: database.projectsDao,
         sessionDao: database.sessionDao,
         unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(),
       ),
       sessionUnseenService: sessionUnseenService,
       sessionViewTracker: sessionViewTracker,

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -4,6 +4,7 @@ import "package:sesori_bridge/src/bridge/repositories/session_unseen_calculator.
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fake_filesystem_api.dart";
 import "../../helpers/test_database.dart";
 
 void main() {
@@ -20,6 +21,7 @@ void main() {
         projectsDao: db.projectsDao,
         sessionDao: db.sessionDao,
         unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(),
       );
     });
 
@@ -124,6 +126,55 @@ void main() {
       final stored = await db.projectsDao.getBaseBranch(projectId: "p-set");
       expect(stored, equals("main"));
     });
+
+    test("getProjects flags a project whose directory no longer exists on disk", () async {
+      plugin.projectsResult = const [
+        PluginProject(id: "/present", name: "Present", time: PluginProjectTime(created: 0, updated: 2)),
+        PluginProject(id: "/moved", name: "Moved", time: PluginProjectTime(created: 0, updated: 1)),
+      ];
+      final repoWithMissing = ProjectRepository(
+        plugin: plugin,
+        projectsDao: db.projectsDao,
+        sessionDao: db.sessionDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(missingPaths: {"/moved"}),
+      );
+
+      final result = await repoWithMissing.getProjects();
+
+      expect(result.firstWhere((p) => p.id == "/present").directoryMissing, isFalse);
+      expect(result.firstWhere((p) => p.id == "/moved").directoryMissing, isTrue);
+    });
+
+    test("getProject flags a since-deleted directory as missing", () async {
+      plugin.projectResult = const PluginProject(id: "/gone", name: "Gone");
+      final repoWithMissing = ProjectRepository(
+        plugin: plugin,
+        projectsDao: db.projectsDao,
+        sessionDao: db.sessionDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(missingPaths: {"/gone"}),
+      );
+
+      final result = await repoWithMissing.getProject(projectId: "/gone");
+
+      expect(result.directoryMissing, isTrue);
+    });
+
+    test("a directory whose existence probe throws is treated as present, not missing", () async {
+      plugin.projectsResult = const [PluginProject(id: "/denied", name: "Denied")];
+      final repoWithThrow = ProjectRepository(
+        plugin: plugin,
+        projectsDao: db.projectsDao,
+        sessionDao: db.sessionDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(throwingPaths: {"/denied"}),
+      );
+
+      final result = await repoWithThrow.getProjects();
+
+      expect(result.single.directoryMissing, isFalse);
+    });
   });
 
   group("ProjectRepository (bridge-derived)", () {
@@ -139,6 +190,7 @@ void main() {
         projectsDao: db.projectsDao,
         sessionDao: db.sessionDao,
         unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(),
       );
     });
 
@@ -243,6 +295,25 @@ void main() {
       expect(result.map((p) => p.id).toSet(), {parent});
       // The worktree session's later timestamp folded into the parent.
       expect(result.single.time?.updated, 200);
+    });
+
+    test("getProjects flags a derived project whose directory no longer exists on disk", () async {
+      plugin.sessions = [
+        _session("/tmp/proj/alpha", id: "a1", created: 1, updated: 2),
+        _session("/tmp/proj/beta", id: "b1", created: 1, updated: 1),
+      ];
+      final repoWithMissing = ProjectRepository(
+        plugin: plugin,
+        projectsDao: db.projectsDao,
+        sessionDao: db.sessionDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(missingPaths: {"/tmp/proj/beta"}),
+      );
+
+      final result = await repoWithMissing.getProjects();
+
+      expect(result.firstWhere((p) => p.id == "/tmp/proj/alpha").directoryMissing, isFalse);
+      expect(result.firstWhere((p) => p.id == "/tmp/proj/beta").directoryMissing, isTrue);
     });
   });
 }

--- a/bridge/app/test/bridge/routing/create_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_project_handler_test.dart
@@ -15,6 +15,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fake_filesystem_api.dart";
 import "../../helpers/test_database.dart";
 import "routing_test_helpers.dart";
 
@@ -51,6 +52,7 @@ void main() {
           projectsDao: db.projectsDao,
           sessionDao: db.sessionDao,
           unseenCalculator: const SessionUnseenCalculator(),
+          filesystemApi: FakeFilesystemApi(),
         ),
       );
       tempDir = await Directory.systemTemp.createTemp("create-project-handler-test-");

--- a/bridge/app/test/bridge/routing/get_base_branch_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_base_branch_handler_test.dart
@@ -5,6 +5,7 @@ import "package:sesori_bridge/src/bridge/routing/get_base_branch_handler.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fake_filesystem_api.dart";
 import "../../helpers/test_database.dart";
 import "routing_test_helpers.dart";
 
@@ -23,6 +24,7 @@ void main() {
         projectsDao: db.projectsDao,
         sessionDao: db.sessionDao,
         unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(),
       );
       handler = GetBaseBranchHandler(projectRepository: projectRepository);
     });

--- a/bridge/app/test/bridge/routing/get_current_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_current_project_handler_test.dart
@@ -6,6 +6,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fake_filesystem_api.dart";
 import "../../helpers/test_database.dart";
 import "routing_test_helpers.dart";
 
@@ -24,6 +25,7 @@ void main() {
           projectsDao: db.projectsDao,
           sessionDao: db.sessionDao,
           unseenCalculator: const SessionUnseenCalculator(),
+          filesystemApi: FakeFilesystemApi(),
         ),
       );
     });

--- a/bridge/app/test/bridge/routing/get_projects_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_projects_handler_test.dart
@@ -7,6 +7,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fake_filesystem_api.dart";
 import "../../helpers/test_database.dart";
 import "routing_test_helpers.dart";
 
@@ -27,6 +28,7 @@ void main() {
           projectsDao: projectsDao,
           sessionDao: db.sessionDao,
           unseenCalculator: const SessionUnseenCalculator(),
+          filesystemApi: FakeFilesystemApi(),
         ),
       );
     });

--- a/bridge/app/test/bridge/routing/hide_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/hide_project_handler_test.dart
@@ -5,6 +5,7 @@ import "package:sesori_bridge/src/bridge/routing/hide_project_handler.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fake_filesystem_api.dart";
 import "../../helpers/test_database.dart";
 import "routing_test_helpers.dart";
 
@@ -23,6 +24,7 @@ void main() {
         projectsDao: db.projectsDao,
         sessionDao: db.sessionDao,
         unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(),
       );
       handler = HideProjectHandler(projectRepository: projectRepository);
     });

--- a/bridge/app/test/bridge/routing/open_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/open_project_handler_test.dart
@@ -11,6 +11,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fake_filesystem_api.dart";
 import "../../helpers/test_database.dart";
 import "routing_test_helpers.dart";
 
@@ -33,6 +34,7 @@ void main() {
         projectsDao: db.projectsDao,
         sessionDao: db.sessionDao,
         unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(),
       );
       handler = OpenProjectHandler(
         filesystemRepository: FilesystemRepository(

--- a/bridge/app/test/bridge/routing/rename_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/rename_project_handler_test.dart
@@ -6,6 +6,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fake_filesystem_api.dart";
 import "../../helpers/test_database.dart";
 import "routing_test_helpers.dart";
 
@@ -24,6 +25,7 @@ void main() {
           projectsDao: db.projectsDao,
           sessionDao: db.sessionDao,
           unseenCalculator: const SessionUnseenCalculator(),
+          filesystemApi: FakeFilesystemApi(),
         ),
       );
     });

--- a/bridge/app/test/bridge/routing/request_router_test.dart
+++ b/bridge/app/test/bridge/routing/request_router_test.dart
@@ -32,6 +32,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fake_filesystem_api.dart";
 import "../../helpers/restart_test_support.dart";
 import "../../helpers/test_database.dart";
 import "get_session_diffs_handler_test_helpers.dart";
@@ -59,6 +60,7 @@ void main() {
         projectsDao: db.projectsDao,
         sessionDao: db.sessionDao,
         unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(),
       );
       final filesystemRepository = FilesystemRepository(
         filesystemApi: const FilesystemApi(),
@@ -423,6 +425,7 @@ void main() {
         projectsDao: db.projectsDao,
         sessionDao: db.sessionDao,
         unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(),
       );
       final filesystemRepository = FilesystemRepository(
         filesystemApi: const FilesystemApi(),

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -26,6 +26,7 @@ import "package:sesori_bridge/src/bridge/services/session_view_tracker.dart";
 import "package:sesori_bridge/src/bridge/sse/sse_manager.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" hide PermissionReply;
+import "../../helpers/fake_filesystem_api.dart";
 
 /// Builds a real [SessionUnseenService] backed by [db] for handler/router tests.
 SessionUnseenService buildTestSessionUnseenService(AppDatabase db, BridgePluginApi plugin) {
@@ -43,6 +44,7 @@ SessionUnseenService buildTestSessionUnseenService(AppDatabase db, BridgePluginA
       projectsDao: db.projectsDao,
       sessionDao: db.sessionDao,
       unseenCalculator: calculator,
+      filesystemApi: FakeFilesystemApi(),
     ),
     viewTracker: SessionViewTracker(),
   );

--- a/bridge/app/test/bridge/routing/set_base_branch_handler_test.dart
+++ b/bridge/app/test/bridge/routing/set_base_branch_handler_test.dart
@@ -5,6 +5,7 @@ import "package:sesori_bridge/src/bridge/routing/set_base_branch_handler.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fake_filesystem_api.dart";
 import "../../helpers/test_database.dart";
 import "routing_test_helpers.dart";
 
@@ -23,6 +24,7 @@ void main() {
         projectsDao: db.projectsDao,
         sessionDao: db.sessionDao,
         unseenCalculator: const SessionUnseenCalculator(),
+        filesystemApi: FakeFilesystemApi(),
       );
       handler = SetBaseBranchHandler(projectRepository: projectRepository);
     });

--- a/bridge/app/test/bridge/services/session_unseen_service_test.dart
+++ b/bridge/app/test/bridge/services/session_unseen_service_test.dart
@@ -7,6 +7,7 @@ import "package:sesori_bridge/src/bridge/services/session_view_tracker.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fake_filesystem_api.dart";
 import "../../helpers/test_database.dart";
 
 void main() {
@@ -29,6 +30,7 @@ void main() {
       projectsDao: db.projectsDao,
       sessionDao: db.sessionDao,
       unseenCalculator: const SessionUnseenCalculator(),
+      filesystemApi: FakeFilesystemApi(),
     );
 
     Future<bool> unseen(String sessionId) {

--- a/bridge/app/test/helpers/fake_filesystem_api.dart
+++ b/bridge/app/test/helpers/fake_filesystem_api.dart
@@ -1,0 +1,33 @@
+import "dart:io" show FileSystemException;
+
+import "package:sesori_bridge/src/bridge/api/filesystem_api.dart";
+
+/// Test fake for [FilesystemApi]. By default every path reports as an existing
+/// directory, so a repository built with it keeps `Project.directoryMissing`
+/// false — matching behaviour from before the existence check existed.
+///
+/// Pass [missingPaths] for directories that should report as absent (to
+/// exercise the "folder moved/deleted" flag) and [throwingPaths] for
+/// directories whose existence probe raises a [FileSystemException] (a
+/// permission or other IO error), which the repository treats as present.
+class FakeFilesystemApi implements FilesystemApi {
+  FakeFilesystemApi({
+    Set<String> missingPaths = const {},
+    Set<String> throwingPaths = const {},
+  }) : _missingPaths = missingPaths,
+       _throwingPaths = throwingPaths;
+
+  final Set<String> _missingPaths;
+  final Set<String> _throwingPaths;
+
+  @override
+  bool directoryExists(String path) {
+    if (_throwingPaths.contains(path)) {
+      throw const FileSystemException("permission denied");
+    }
+    return !_missingPaths.contains(path);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/integration/pr_sync_fk_regression_test.dart
+++ b/bridge/app/test/integration/pr_sync_fk_regression_test.dart
@@ -33,6 +33,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
+import "../helpers/fake_filesystem_api.dart";
 import "../helpers/test_database.dart";
 
 void main() {
@@ -62,6 +63,7 @@ void main() {
           projectsDao: db.projectsDao,
           sessionDao: db.sessionDao,
           unseenCalculator: const SessionUnseenCalculator(),
+          filesystemApi: FakeFilesystemApi(),
         );
         final prRepo = PullRequestRepository(
           pullRequestDao: db.pullRequestDao,

--- a/client/app/lib/features/project_list/widgets/project_tile.dart
+++ b/client/app/lib/features/project_list/widgets/project_tile.dart
@@ -22,18 +22,24 @@ class _ProjectTile extends StatelessWidget {
     final displayName = project.name ?? (lastSegment.isNotEmpty ? lastSegment : loc.projectListDefaultName);
     final updatedAt = project.time?.updated;
     final isActive = activeSessions > 0;
+    // The project's folder was moved or deleted on disk. Surface it as broken
+    // and block navigation so we don't drive into a dead path; Hide/Rename stay
+    // available via long-press.
+    final missing = project.directoryMissing;
 
     return ListTile(
       leading: CircleAvatar(
-        backgroundColor: prego.colors.bgBrandSolid,
+        backgroundColor: missing ? prego.colors.bgErrorPrimary : prego.colors.bgBrandSolid,
         child: Icon(
-          Icons.folder_outlined,
-          color: prego.colors.fgWhite,
+          missing ? Icons.folder_off_outlined : Icons.folder_outlined,
+          color: missing ? prego.colors.fgErrorPrimary : prego.colors.fgWhite,
         ),
       ),
       title: Text(
         displayName,
-        style: unseen ? prego.textTheme.textMd.bold : null,
+        style: (unseen ? prego.textTheme.textMd.bold : prego.textTheme.textMd.regular).copyWith(
+          color: missing ? prego.colors.textSecondary : null,
+        ),
       ),
       subtitle: Column(
         crossAxisAlignment: .start,
@@ -44,42 +50,62 @@ class _ProjectTile extends StatelessWidget {
             maxLines: 1,
             overflow: .ellipsis,
           ),
-          if (updatedAt != null)
+          if (missing)
             Text(
-              loc.projectListUpdated(context.formatTimestamp(updatedAt)),
+              loc.projectFolderMissing,
               style: prego.textTheme.textXs.regular.copyWith(
-                color: prego.colors.textSecondary,
+                color: prego.colors.fgErrorPrimary,
               ),
-            ),
-          if (isActive)
-            Row(
-              children: [
-                Icon(Icons.circle, size: 8, color: prego.colors.bgBrandSolid),
-                const SizedBox(width: 4),
-                Text(
-                  loc.projectListActiveSessions(activeSessions),
-                  style: prego.textTheme.textXs.regular.copyWith(
-                    color: prego.colors.bgBrandSolid,
-                    fontWeight: FontWeight.w500,
-                  ),
+            )
+          else ...[
+            if (updatedAt != null)
+              Text(
+                loc.projectListUpdated(context.formatTimestamp(updatedAt)),
+                style: prego.textTheme.textXs.regular.copyWith(
+                  color: prego.colors.textSecondary,
                 ),
-              ],
-            ),
+              ),
+            if (isActive)
+              Row(
+                children: [
+                  Icon(Icons.circle, size: 8, color: prego.colors.bgBrandSolid),
+                  const SizedBox(width: 4),
+                  Text(
+                    loc.projectListActiveSessions(activeSessions),
+                    style: prego.textTheme.textXs.regular.copyWith(
+                      color: prego.colors.bgBrandSolid,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ],
+              ),
+          ],
         ],
       ),
-      isThreeLine: updatedAt != null || isActive,
-      trailing: switch (unseen) {
-        true => Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(Icons.circle, size: 10, color: prego.colors.bgBrandSolid),
-            const SizedBox(width: 8),
-            const Icon(Icons.chevron_right),
-          ],
-        ),
-        false => const Icon(Icons.chevron_right),
-      },
+      isThreeLine: missing || updatedAt != null || isActive,
+      trailing: missing
+          ? Icon(Icons.error_outline, color: prego.colors.fgErrorPrimary)
+          : switch (unseen) {
+              true => Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.circle, size: 10, color: prego.colors.bgBrandSolid),
+                  const SizedBox(width: 8),
+                  const Icon(Icons.chevron_right),
+                ],
+              ),
+              false => const Icon(Icons.chevron_right),
+            },
       onTap: () {
+        if (missing) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(loc.projectFolderMissingMessage),
+              duration: kSnackBarDuration,
+            ),
+          );
+          return;
+        }
         context.read<ProjectListCubit>().setActiveProject(project);
         context.pushRoute(
           AppRoute.sessions(projectId: project.id, projectName: displayName),

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -331,6 +331,8 @@
   "gitRepoBadge": "git",
   "projectHidden": "Project hidden",
   "hideProject": "Hide Project",
+  "projectFolderMissing": "Folder not found",
+  "projectFolderMissingMessage": "This project's folder no longer exists — it may have been moved or deleted. Hide the project, or restore the folder to its original location.",
   "noProjects": "No projects",
   "addProjectPrompt": "Add a project to get started",
   "creatingProject": "Creating project...",

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -241,7 +241,7 @@ abstract class AppLocalizations {
   /// **'DM on X'**
   String get projectsOnboardingNeedHelpX;
 
-  /// Segmented-control label that selects the macOS/Linux/WSL install commands in the onboarding.
+  /// Segmented-control label that selects the macOS/Linux/WSL install commands, shown both in the onboarding and in the bridge-offline install-commands disclosure.
   ///
   /// In en, this message translates to:
   /// **'macOS, Linux, WSL'**
@@ -253,7 +253,7 @@ abstract class AppLocalizations {
   /// **'curl'**
   String get projectsOnboardingInstallUnixMethod;
 
-  /// Segmented-control label that selects the Windows PowerShell install commands in the onboarding.
+  /// Segmented-control label that selects the Windows PowerShell install commands, shown both in the onboarding and in the bridge-offline install-commands disclosure.
   ///
   /// In en, this message translates to:
   /// **'Windows PowerShell'**
@@ -1194,6 +1194,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Hide Project'**
   String get hideProject;
+
+  /// No description provided for @projectFolderMissing.
+  ///
+  /// In en, this message translates to:
+  /// **'Folder not found'**
+  String get projectFolderMissing;
+
+  /// No description provided for @projectFolderMissingMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'This project\'s folder no longer exists — it may have been moved or deleted. Hide the project, or restore the folder to its original location.'**
+  String get projectFolderMissingMessage;
 
   /// No description provided for @noProjects.
   ///

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -611,6 +611,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get hideProject => 'Hide Project';
 
   @override
+  String get projectFolderMissing => 'Folder not found';
+
+  @override
+  String get projectFolderMissingMessage =>
+      'This project\'s folder no longer exists — it may have been moved or deleted. Hide the project, or restore the folder to its original location.';
+
+  @override
   String get noProjects => 'No projects';
 
   @override

--- a/shared/sesori_shared/lib/src/models/sesori/project.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project.dart
@@ -23,6 +23,12 @@ sealed class Project with _$Project {
     // activity. Backend-derived from its sessions. Defaults to false so older
     // payloads (and the baseline) deserialize as "seen".
     @Default(false) bool hasUnseenChanges,
+    // Whether the project's directory no longer exists on disk at its recorded
+    // location (the folder was moved or deleted). The bridge stamps this from a
+    // filesystem check; the client renders such projects as "folder not found"
+    // instead of driving into a dead path. Defaults to false so older payloads
+    // deserialize as "present".
+    @Default(false) bool directoryMissing,
   }) = _Project;
 
   factory Project.fromJson(Map<String, dynamic> json) => _$ProjectFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/project.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project.freezed.dart
@@ -158,7 +158,12 @@ mixin _$Project {
  String get id; String? get name; ProjectTime? get time;// Whether this project has at least one non-archived session with unseen
 // activity. Backend-derived from its sessions. Defaults to false so older
 // payloads (and the baseline) deserialize as "seen".
- bool get hasUnseenChanges;
+ bool get hasUnseenChanges;// Whether the project's directory no longer exists on disk at its recorded
+// location (the folder was moved or deleted). The bridge stamps this from a
+// filesystem check; the client renders such projects as "folder not found"
+// instead of driving into a dead path. Defaults to false so older payloads
+// deserialize as "present".
+ bool get directoryMissing;
 /// Create a copy of Project
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -171,16 +176,16 @@ $ProjectCopyWith<Project> get copyWith => _$ProjectCopyWithImpl<Project>(this as
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Project&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.time, time) || other.time == time)&&(identical(other.hasUnseenChanges, hasUnseenChanges) || other.hasUnseenChanges == hasUnseenChanges));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Project&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.time, time) || other.time == time)&&(identical(other.hasUnseenChanges, hasUnseenChanges) || other.hasUnseenChanges == hasUnseenChanges)&&(identical(other.directoryMissing, directoryMissing) || other.directoryMissing == directoryMissing));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,time,hasUnseenChanges);
+int get hashCode => Object.hash(runtimeType,id,name,time,hasUnseenChanges,directoryMissing);
 
 @override
 String toString() {
-  return 'Project(id: $id, name: $name, time: $time, hasUnseenChanges: $hasUnseenChanges)';
+  return 'Project(id: $id, name: $name, time: $time, hasUnseenChanges: $hasUnseenChanges, directoryMissing: $directoryMissing)';
 }
 
 
@@ -191,7 +196,7 @@ abstract mixin class $ProjectCopyWith<$Res>  {
   factory $ProjectCopyWith(Project value, $Res Function(Project) _then) = _$ProjectCopyWithImpl;
 @useResult
 $Res call({
- String id, String? name, ProjectTime? time, bool hasUnseenChanges
+ String id, String? name, ProjectTime? time, bool hasUnseenChanges, bool directoryMissing
 });
 
 
@@ -208,12 +213,13 @@ class _$ProjectCopyWithImpl<$Res>
 
 /// Create a copy of Project
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = freezed,Object? time = freezed,Object? hasUnseenChanges = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = freezed,Object? time = freezed,Object? hasUnseenChanges = null,Object? directoryMissing = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String?,time: freezed == time ? _self.time : time // ignore: cast_nullable_to_non_nullable
 as ProjectTime?,hasUnseenChanges: null == hasUnseenChanges ? _self.hasUnseenChanges : hasUnseenChanges // ignore: cast_nullable_to_non_nullable
+as bool,directoryMissing: null == directoryMissing ? _self.directoryMissing : directoryMissing // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }
@@ -238,7 +244,7 @@ $ProjectTimeCopyWith<$Res>? get time {
 @JsonSerializable()
 
 class _Project implements Project {
-  const _Project({required this.id, required this.name, required this.time, this.hasUnseenChanges = false});
+  const _Project({required this.id, required this.name, required this.time, this.hasUnseenChanges = false, this.directoryMissing = false});
   factory _Project.fromJson(Map<String, dynamic> json) => _$ProjectFromJson(json);
 
 @override final  String id;
@@ -248,6 +254,12 @@ class _Project implements Project {
 // activity. Backend-derived from its sessions. Defaults to false so older
 // payloads (and the baseline) deserialize as "seen".
 @override@JsonKey() final  bool hasUnseenChanges;
+// Whether the project's directory no longer exists on disk at its recorded
+// location (the folder was moved or deleted). The bridge stamps this from a
+// filesystem check; the client renders such projects as "folder not found"
+// instead of driving into a dead path. Defaults to false so older payloads
+// deserialize as "present".
+@override@JsonKey() final  bool directoryMissing;
 
 /// Create a copy of Project
 /// with the given fields replaced by the non-null parameter values.
@@ -262,16 +274,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Project&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.time, time) || other.time == time)&&(identical(other.hasUnseenChanges, hasUnseenChanges) || other.hasUnseenChanges == hasUnseenChanges));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Project&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.time, time) || other.time == time)&&(identical(other.hasUnseenChanges, hasUnseenChanges) || other.hasUnseenChanges == hasUnseenChanges)&&(identical(other.directoryMissing, directoryMissing) || other.directoryMissing == directoryMissing));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,time,hasUnseenChanges);
+int get hashCode => Object.hash(runtimeType,id,name,time,hasUnseenChanges,directoryMissing);
 
 @override
 String toString() {
-  return 'Project(id: $id, name: $name, time: $time, hasUnseenChanges: $hasUnseenChanges)';
+  return 'Project(id: $id, name: $name, time: $time, hasUnseenChanges: $hasUnseenChanges, directoryMissing: $directoryMissing)';
 }
 
 
@@ -282,7 +294,7 @@ abstract mixin class _$ProjectCopyWith<$Res> implements $ProjectCopyWith<$Res> {
   factory _$ProjectCopyWith(_Project value, $Res Function(_Project) _then) = __$ProjectCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String? name, ProjectTime? time, bool hasUnseenChanges
+ String id, String? name, ProjectTime? time, bool hasUnseenChanges, bool directoryMissing
 });
 
 
@@ -299,12 +311,13 @@ class __$ProjectCopyWithImpl<$Res>
 
 /// Create a copy of Project
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = freezed,Object? time = freezed,Object? hasUnseenChanges = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = freezed,Object? time = freezed,Object? hasUnseenChanges = null,Object? directoryMissing = null,}) {
   return _then(_Project(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String?,time: freezed == time ? _self.time : time // ignore: cast_nullable_to_non_nullable
 as ProjectTime?,hasUnseenChanges: null == hasUnseenChanges ? _self.hasUnseenChanges : hasUnseenChanges // ignore: cast_nullable_to_non_nullable
+as bool,directoryMissing: null == directoryMissing ? _self.directoryMissing : directoryMissing // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }

--- a/shared/sesori_shared/lib/src/models/sesori/project.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project.g.dart
@@ -23,6 +23,7 @@ _Project _$ProjectFromJson(Map json) => _Project(
       ? null
       : ProjectTime.fromJson(Map<String, dynamic>.from(json['time'] as Map)),
   hasUnseenChanges: json['hasUnseenChanges'] as bool? ?? false,
+  directoryMissing: json['directoryMissing'] as bool? ?? false,
 );
 
 Map<String, dynamic> _$ProjectToJson(_Project instance) => <String, dynamic>{
@@ -30,6 +31,7 @@ Map<String, dynamic> _$ProjectToJson(_Project instance) => <String, dynamic>{
   'name': ?instance.name,
   'time': ?instance.time?.toJson(),
   'hasUnseenChanges': instance.hasUnseenChanges,
+  'directoryMissing': instance.directoryMissing,
 };
 
 _ProjectTime _$ProjectTimeFromJson(Map json) => _ProjectTime(


### PR DESCRIPTION
## The bug

Reported repro:
1. Open a project from a folder on the machine.
2. Move (or delete) that folder to another directory on disk.
3. Hide the project in the app.
4. Open a new project from the folder's new location.
5. Sesori still tries to use the **original** location.

## Assessment

A project's identity **is** its directory path for every shipped plugin (`Project.id == worktree`/normalized dir). When the folder moves or is deleted, the bridge keeps listing the stale path and every downstream call (`getProject`, sessions, the OpenCode `x-opencode-directory` header) drives into a location that no longer exists — with no signal to the user.

Auto-detecting that a folder *moved to a new path* and relinking its history is **out of scope**: it needs inode/git-remote/content matching, and OpenCode itself is path-keyed so its sessions can't be relocated by us. That would be speculative future-building. This PR does the faithful, minimal fix the report actually asks for — **show** projects whose folder no longer exists so the user can act.

## The fix

- **shared** — add `Project.directoryMissing` (`@Default(false)`, backward compatible).
- **bridge** — `ProjectRepository` gains a Layer-1 `FilesystemApi` dependency and stamps `directoryMissing` on every returned project. Only a definitive *not-found* counts as missing; a permission/IO error is logged and treated as **present**, so folders aren't wrongly flagged when the terminal running the bridge lacks Full Disk Access.
- **app** — a missing project renders with a folder-off icon + "Folder not found" and, on tap, shows an explanatory snackbar instead of navigating into a dead path. Hide/Rename stay available via long-press so the user can clean it up.

Handles **moved** and **deleted** identically (the folder is simply gone from the recorded path).

## Tests / verification

- New `ProjectRepository` tests (native + bridge-derived): missing dir ⇒ `directoryMissing` true, existing ⇒ false, existence-probe throw ⇒ treated as present.
- New shared `FakeFilesystemApi` test helper (default: everything exists) threaded through existing `ProjectRepository` test constructions so their behavior is unchanged.
- `make analyze` clean across all bridge modules (`dart analyze --fatal-infos` clean in `bridge/app`); bridge/app 1738 tests, shared, client/app (537) and module_core tests all pass; client analyze clean.

Reviewed by `aristotle-plan-review` (plan) and `aristotle-impl-review` (code) — no architectural violations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show projects whose folders were moved or deleted, and block navigation into dead paths. The bridge now flags missing directories and the app shows a clear “Folder not found” state.

- **Bug Fixes**
  - `ProjectRepository` checks each project path via `FilesystemApi` and sets `Project.directoryMissing`. Only a definite not-found counts as missing; permission/IO errors are logged and treated as present.
  - UI: missing projects render with a folder-off icon and “Folder not found”, tap shows a helpful snackbar, and navigation is blocked. Hide/Rename remain via long-press.
  - Treats moved and deleted folders the same.

- **Refactors**
  - Added `directoryMissing` to shared `Project` (default false) and wired it through `PluginProjectMapper`.
  - Injected `FilesystemApi` in `BridgeRuntime`; added `FakeFilesystemApi` for tests.
  - New tests cover present/missing/throwing cases; updated existing handler and integration tests.

<sup>Written for commit 7eb024cfd00f211268ba001029ed919efdef9568. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

