### PR TITLE
chore: update Flutter to 3.44.5 and bump dependencies

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-flutter 3.44.4-stable
+flutter 3.44.5-stable

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -29,7 +29,12 @@ dependencies:
   codex_plugin:
     path: ../sesori_plugin_codex
   meta: ^1.18.3
-  drift: ^2.34.0
+  # Pinned lock-step with drift_dev: 2.34.1+ requires analyzer ^13, but the
+  # workspace is held on analyzer 10 by injectable_generator. drift_dev is
+  # therefore capped at 2.34.0, and the runtime must match its codegen sibling —
+  # a 2.34.0/2.34.1 skew breaks the drift schema verifier. Bump both together
+  # once analyzer 13 is unblocked.
+  drift: 2.34.0
   collection: ^1.19.1
   win32: ^6.3.0
 

--- a/bridge/pubspec.lock
+++ b/bridge/pubspec.lock
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: drift
-      sha256: c21b9af62e78f86837638dda6c33506bd9444ca8a32cad2b99c07369cf9e2462
+      sha256: "6cc0b623c0e83f7080524d8396e9301b1d78b9c66a4fdceeb0f798211303254c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.34.1"
+    version: "2.34.0"
   drift_dev:
     dependency: transitive
     description:

--- a/bridge/pubspec.lock
+++ b/bridge/pubspec.lock
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: drift
-      sha256: "6cc0b623c0e83f7080524d8396e9301b1d78b9c66a4fdceeb0f798211303254c"
+      sha256: c21b9af62e78f86837638dda6c33506bd9444ca8a32cad2b99c07369cf9e2462
       url: "https://pub.dev"
     source: hosted
-    version: "2.34.0"
+    version: "2.34.1"
   drift_dev:
     dependency: transitive
     description:
@@ -381,10 +381,10 @@ packages:
     dependency: transitive
     description:
       name: native_toolchain_c
-      sha256: f59351d28f49520cd3a74eb1f41c5f19ae15e53c65a3231d14af672e46510a96
+      sha256: f9c168717100ae6d9fee9ffb0be379bf1f8b26b0f6bcbd4fdddcd931993a6a72
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.1"
+    version: "0.19.2"
   node_preamble:
     dependency: transitive
     description:

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.9
-  liquid_glass_widgets: ^0.21.1
+  liquid_glass_widgets: ^0.21.3
   http: ^1.6.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.12.0
@@ -47,7 +47,7 @@ dependencies:
   go_router: ^17.3.0
   get_it: ^9.2.1
   injectable: ^3.0.0
-  flutter_markdown_plus: ^1.0.9
+  flutter_markdown_plus: ^1.0.11
   markdown: ^7.3.1
   sesori_shared:
     path: ../../shared/sesori_shared

--- a/client/module_prego/pubspec.yaml
+++ b/client/module_prego/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   meta: ^1.18.0
   flutter_svg: ^2.3.0
   universal_platform: ^1.1.0
-  liquid_glass_widgets: ^0.21.1
+  liquid_glass_widgets: ^0.21.3
   cue: ^0.3.1
 
 flutter:

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -599,10 +599,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_markdown_plus
-      sha256: "3893b00caa52ce75cf9212f2c159ea517b9d64a641fc2226811bf5f218b5b77e"
+      sha256: "2e4b667a75c08e5710866ae010da392acf5af475f9ad0be9bf406525e9751b0c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.9"
+    version: "1.0.11"
   flutter_native_splash:
     dependency: transitive
     description:
@@ -921,10 +921,10 @@ packages:
     dependency: transitive
     description:
       name: liquid_glass_widgets
-      sha256: f9af2ef9587d4644739b16a9dbc7c57391e652990c9cc6c367be45e74154e03a
+      sha256: "0641f378af6e69455fe5c57717c8640792ae5ce1201a6e1fbb9733cb40901c22"
       url: "https://pub.dev"
     source: hosted
-    version: "0.21.1"
+    version: "0.21.3"
   logging:
     dependency: transitive
     description:
@@ -1208,10 +1208,10 @@ packages:
     dependency: transitive
     description:
       name: record_linux
-      sha256: "305526af0560866a0cc4219aa3726ef8541f819e14bd5f65b73ffdb7dc5911be"
+      sha256: b7484fdaf1f6d291543b9cf615e78096662b02df68d7a4728b13f352bde58d27
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   record_macos:
     dependency: transitive
     description:
@@ -1730,4 +1730,4 @@ packages:
     version: "2.2.4"
 sdks:
   dart: ">=3.12.2 <4.0.0"
-  flutter: ">=3.44.4 <3.45.0"
+  flutter: ">=3.44.5 <3.45.0"

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 environment:
   sdk: ^3.12.2
-  flutter: ">=3.44.4 <3.45.0"
+  flutter: ">=3.44.5 <3.45.0"
 
 workspace:
   - app


### PR DESCRIPTION
## Summary

Routine maintenance: bump the pinned Flutter toolchain and update dependencies across the client and bridge workspaces.

### Flutter toolchain
- `.tool-versions`: `3.44.4-stable` → `3.44.5-stable`
- `client/pubspec.yaml` constraint: `>=3.44.4 <3.45.0` → `>=3.44.5 <3.45.0`

### Client dependency bumps
- `liquid_glass_widgets` `0.21.1` → `0.21.3` (`client/app`, `module_prego`)
- `flutter_markdown_plus` `1.0.9` → `1.0.11` (`client/app`)
- Transitive: `record_linux` `2.1.0` → `2.1.1`

### Bridge dependency bumps (transitive)
- `drift` `2.34.0` → `2.34.1`
- `native_toolchain_c` `0.19.1` → `0.19.2`

Lockfiles (`client/pubspec.lock`, `bridge/pubspec.lock`) regenerated accordingly.

https://claude.ai/code/session_01MiXefhRPqV9kHhCjwDmxx4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades Flutter to 3.44.5 and refreshes client deps. Pins `drift` to 2.34.0 in the bridge to match `drift_dev` and fix schema verifier failures.

- **Dependencies**
  - Flutter: `.tool-versions` → `3.44.5-stable`; `client` env → `>=3.44.5 <3.45.0`
  - Client: `liquid_glass_widgets` → `0.21.3`, `flutter_markdown_plus` → `1.0.11`; transitive `record_linux` → `2.1.1`
  - Bridge: pin `drift` `2.34.0` (lock-step with `drift_dev` due to `analyzer` 10); transitive `native_toolchain_c` → `0.19.2`
  - Regenerated `pubspec.lock` files

<sup>Written for commit 663b8eaf06b3a5676a55650352141241e6a34fd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

