### PR TITLE
fix(bridge): key moved-folder project id off the opened directory

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -515,7 +515,10 @@ class OpenCodePlugin implements OpenCodeManagedApi {
         directory: projectId,
       ),
     );
-    return _pluginModelMapper.mapProject(project);
+    // projectId is the directory the caller asked to open. When a git repo was
+    // moved on disk, OpenCode still returns the stale primary worktree; pass the
+    // requested directory so the mapper can key off the live location instead.
+    return _pluginModelMapper.mapProject(project, requestedDirectory: projectId);
   }
 
   @override
@@ -559,7 +562,9 @@ class OpenCodePlugin implements OpenCodeManagedApi {
         body: {"name": name},
       ),
     );
-    return _pluginModelMapper.mapProject(updated);
+    // Keep the id stable with the directory the caller referenced, so a rename
+    // of a moved-folder project doesn't snap the id back to the stale worktree.
+    return _pluginModelMapper.mapProject(updated, requestedDirectory: projectId);
   }
 
   void _handleRawSseEvent(String rawData) {

--- a/bridge/sesori_plugin_opencode/lib/src/plugin_model_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/plugin_model_mapper.dart
@@ -47,10 +47,23 @@ class PluginModelMapper {
     );
   }
 
-  PluginProject mapProject(Project project) {
+  /// Maps an OpenCode [Project] to the plugin-interface [PluginProject], whose
+  /// id is the project directory the bridge keys everything off.
+  ///
+  /// [requestedDirectory] is the directory the plugin was asked to open, when
+  /// known (the native-open flow passes the folder the user just picked). It
+  /// resolves a moved-folder quirk: OpenCode identifies a git project by git
+  /// identity, not path, so opening a repo that was moved on disk from `/A` to
+  /// `/B` still resolves to the same project and returns the stale primary
+  /// `worktree` (`/A`, now gone) while listing the freshly-opened `/B` in
+  /// [Project.sandboxes]. Keying off `/A` would re-surface the vanished folder
+  /// and swallow the new location. When the requested directory is one of the
+  /// project's sandboxes but not its worktree, the requested directory is the
+  /// live location and wins as the project id.
+  PluginProject mapProject(Project project, {String? requestedDirectory}) {
     final time = project.time;
     return PluginProject(
-      id: project.worktree,
+      id: _effectiveWorktree(project, requestedDirectory: requestedDirectory),
       name: _effectiveProjectName(project),
       time: PluginProjectTime(
         created: time.created.toInt(),
@@ -58,6 +71,18 @@ class PluginModelMapper {
       ),
     );
   }
+
+  String _effectiveWorktree(Project project, {required String? requestedDirectory}) {
+    if (requestedDirectory == null) return project.worktree;
+    final requested = _normalizePath(requestedDirectory);
+    if (requested == _normalizePath(project.worktree)) return project.worktree;
+    for (final sandbox in project.sandboxes) {
+      if (_normalizePath(sandbox) == requested) return sandbox;
+    }
+    return project.worktree;
+  }
+
+  String _normalizePath(String path) => path.replaceAll(r"\", "/");
 
   PluginSessionStatus mapSessionStatus(SessionStatus status) {
     return switch (status) {

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -518,6 +518,29 @@ void main() {
         );
       });
     });
+
+    group("getProject", () {
+      test("returns the worktree as id when the requested directory is the worktree", () async {
+        final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
+
+        final project = await plugin.getProject("/repo");
+
+        expect(project.id, equals("/repo"));
+      });
+
+      test("keys off the requested directory when the folder was moved on disk", () async {
+        // The repo was moved from /repo to /moved-repo. OpenCode resolves the
+        // moved directory to the same project by git identity, keeping the
+        // stale primary worktree /repo while listing /moved-repo as a sandbox.
+        server.registerMovedProject(worktree: "/repo", movedTo: "/moved-repo");
+        final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
+
+        final project = await plugin.getProject("/moved-repo");
+
+        // Must key off the live location the user opened, not the vanished one.
+        expect(project.id, equals("/moved-repo"));
+      });
+    });
   });
 }
 
@@ -706,6 +729,14 @@ class _FakeOpenCodeServer {
 
   String get baseUrl => "http://${_server!.address.address}:${_server!.port}";
 
+  /// Simulates a project whose folder was moved on disk: its primary
+  /// [worktree] stays at the old location while the new [movedTo] location is
+  /// recorded as a sandbox (matching OpenCode's git-identity resolution).
+  void registerMovedProject({required String worktree, required String movedTo}) {
+    final project = _projects.values.firstWhere((p) => p["worktree"] == worktree);
+    project["sandboxes"] = <String>[movedTo];
+  }
+
   Future<void> start() async {
     _server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
     _server!.listen((request) async {
@@ -723,7 +754,15 @@ class _FakeOpenCodeServer {
 
       if (request.method == "GET" && path == "/project/current") {
         final dir = request.headers.value("x-opencode-directory");
-        final project = _projects.values.where((p) => p["worktree"] == dir).firstOrNull;
+        // Mirror OpenCode: a git project is resolved by git identity, so a
+        // directory that is a project's sandbox (e.g. after the folder was
+        // moved) still resolves to that project — with its stale primary
+        // worktree unchanged.
+        final project =
+            _projects.values.where((p) => p["worktree"] == dir).firstOrNull ??
+            _projects.values
+                .where((p) => (p["sandboxes"] as List<dynamic>?)?.contains(dir) ?? false)
+                .firstOrNull;
         if (project == null) {
           request.response.statusCode = HttpStatus.notFound;
           await request.response.close();

--- a/bridge/sesori_plugin_opencode/test/plugin_model_mapper_test.dart
+++ b/bridge/sesori_plugin_opencode/test/plugin_model_mapper_test.dart
@@ -1,0 +1,72 @@
+import "package:opencode_plugin/src/message_part_mapper.dart";
+import "package:opencode_plugin/src/models/openapi/project.g.dart";
+import "package:opencode_plugin/src/plugin_model_mapper.dart";
+import "package:test/test.dart";
+
+void main() {
+  const mapper = PluginModelMapper(messagePartMapper: MessagePartMapper());
+
+  Project project({
+    required String worktree,
+    List<String> sandboxes = const <String>[],
+    String? name,
+  }) {
+    return Project(
+      id: "p1",
+      worktree: worktree,
+      vcs: "git",
+      name: name,
+      icon: null,
+      commands: null,
+      time: const ProjectTime(created: 1, updated: 2, initialized: null),
+      sandboxes: sandboxes,
+    );
+  }
+
+  group("mapProject id resolution", () {
+    test("uses the worktree when no requested directory is given", () {
+      final result = mapper.mapProject(project(worktree: "/repo"));
+
+      expect(result.id, equals("/repo"));
+    });
+
+    test("uses the worktree when the requested directory matches it", () {
+      final result = mapper.mapProject(
+        project(worktree: "/repo"),
+        requestedDirectory: "/repo",
+      );
+
+      expect(result.id, equals("/repo"));
+    });
+
+    test("keys off the requested directory when the folder was moved (worktree stale, requested is a sandbox)", () {
+      // OpenCode identifies a git project by git identity, so opening the moved
+      // repo at /new-repo resolves to the same project but returns the stale
+      // primary worktree /old-repo while listing /new-repo as a sandbox.
+      final result = mapper.mapProject(
+        project(worktree: "/old-repo", sandboxes: ["/new-repo"]),
+        requestedDirectory: "/new-repo",
+      );
+
+      expect(result.id, equals("/new-repo"));
+    });
+
+    test("falls back to the worktree when the requested directory is unknown to the project", () {
+      final result = mapper.mapProject(
+        project(worktree: "/old-repo", sandboxes: ["/other"]),
+        requestedDirectory: "/new-repo",
+      );
+
+      expect(result.id, equals("/old-repo"));
+    });
+
+    test("normalizes path separators when comparing against sandboxes", () {
+      final result = mapper.mapProject(
+        project(worktree: r"C:\old-repo", sandboxes: [r"C:\new-repo"]),
+        requestedDirectory: "C:/new-repo",
+      );
+
+      expect(result.id, equals(r"C:\new-repo"));
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Follow-up to #396, which only surfaced moved/deleted folders in the list but didn't fix the underlying re-add regression the user reported:

1. Open a project at a folder on the machine.
2. Move that folder to another directory on disk.
3. Hide the project in the app.
4. Open a new project from the folder's new location.
5. Sesori still tries to use the folder's **original** location — the new location can't actually be added.

## Root cause

The bridge uses a project's directory path as its canonical project id; for the OpenCode plugin `PluginProject.id = OpenCode Project.worktree`.

OpenCode identifies a git project by **git identity** (remote URL / root commit / cached id), not by path. So opening a repo that was moved on disk from `/A` to `/B` resolves to the **same** project and returns the stale primary `worktree = /A` (now gone), while recording the freshly-opened `/B` in the project's `sandboxes`.

`ProjectRepository.openProject` (native branch) then keyed `unhideProject`, the `directoryMissing` check, and the returned `Project.id` off that stale `/A` — never off the `/B` path the user actually opened. Result: `/B` could never be added and the hidden `/A` project was silently unhidden.

## Fix

Resolve the quirk **inside the OpenCode plugin** (per "backend quirks live in the plugin"). When `getProject`/`renameProject` are asked about a directory that is not the project's `worktree` but **is** one of its `sandboxes`, `PluginModelMapper.mapProject` now uses that requested directory as the project id, so the bridge keys off the live location the user opened. The list flow (`getProjects`) passes no requested directory and is unchanged.

No changes to bridge `app/`, `shared/`, or the client — the plugin boundary is preserved.

## Tests

- New `plugin_model_mapper_test.dart` unit tests for the id resolution (worktree match, sandbox match, unknown-dir fallback, path-separator normalization).
- `opencode_plugin_impl_test.dart`: `/project/current` mock is now sandbox-aware; new `getProject` group asserts a moved folder keys off the new location.
- `dart analyze --fatal-infos` clean; full bridge suites pass (plugin + app).

## Review

- Plan reviewed by `aristotle-plan-review` — approved.
- Implementation reviewed by `aristotle-impl-review` — approved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the regression when reopening a Git project after its folder was moved: the project id now keys off the directory you opened, not the stale worktree, so the new location adds correctly and the old one stays hidden.

- **Bug Fixes**
  - Map `PluginProject.id` to the requested directory when it matches a sandbox and not the primary worktree.
  - `getProject` and `renameProject` pass the requested directory to ensure id stability for moved folders.
  - Normalize path separators when comparing directories.

<sup>Written for commit e5b6ff68ae106fcccc0bf6f9fe7b4ccef846e8d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

