### PR TITLE
fix(app): render live assistant→error message swaps in session detail

### DIFF
--- a/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
+++ b/client/app/lib/features/session_detail/widgets/session_detail_message_list.dart
@@ -128,6 +128,17 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
   static const _kUserAuthorId = "user";
   static const _kAgentAuthorId = "agent";
 
+  /// Metadata key carrying each entry's domain role. Assistant and error
+  /// messages share [_kAgentAuthorId], so without this discriminator a
+  /// message flipping from assistant to error mid-stream (same id, same
+  /// authorId) would be value-equal to its previous entry — the
+  /// controller diff would emit no update and the on-screen row would
+  /// stay the stale assistant card until the screen is remounted.
+  static const _kRoleMetadataKey = "role";
+  static const _kUserRole = "user";
+  static const _kAssistantRole = "assistant";
+  static const _kErrorRole = "error";
+
   late final ScrollFollowTracker _follow;
   late final chat_core.InMemoryChatController _chatController;
 
@@ -257,6 +268,10 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
     if (current.length != target.length) return false;
     for (var i = 0; i < target.length; i++) {
       if (current[i].id != target[i].id) return false;
+      // A same-id entry can still change role in place (assistant→error);
+      // that must not be filtered out as a streaming-only emit, or the
+      // controller never learns the row needs to swap to the error card.
+      if (current[i].metadata?[_kRoleMetadataKey] != target[i].metadata?[_kRoleMetadataKey]) return false;
     }
     return true;
   }
@@ -273,6 +288,17 @@ class _SessionDetailMessageListState extends State<SessionDetailMessageList> wit
             MessageUser() => _kUserAuthorId,
             MessageAssistant() => _kAgentAuthorId,
             MessageError() => _kAgentAuthorId,
+          },
+          // Role discriminates assistant from error under the shared
+          // agent authorId, so a live assistant→error transition on the
+          // same message id is no longer value-equal and forces the row
+          // to re-render as the error card.
+          metadata: <String, String>{
+            _kRoleMetadataKey: switch (message.info) {
+              MessageUser() => _kUserRole,
+              MessageAssistant() => _kAssistantRole,
+              MessageError() => _kErrorRole,
+            },
           },
         ),
       if (hasRetryError) const chat_core.Message.custom(id: _kRetryErrorRowId, authorId: _kAgentAuthorId),


### PR DESCRIPTION
## Problem

Permanent error messages did not appear in the session detail screen while watching a session **live**. Transitory/retry errors displayed fine, but when the assistant turn failed the error only showed up after navigating back to the session list and re-opening the session.

## Root cause

The error does arrive live — the bridge emits a `Message.error` via the `message.updated` SSE event, and `SessionDetailCubit._onMessageUpdated` correctly flips the message in place (same id, `info` goes `MessageAssistant` → `MessageError`) and emits new state. The bug is purely on the render side.

`SessionDetailMessageList` mirrors the transcript into the `flutter_chat_ui` controller as `chat_core.Message.custom(id, authorId)` entries. Both `MessageAssistant` and `MessageError` used the same `authorId` (`"agent"`) and carried no other distinguishing field, so:

- `_entriesMatch` gated the controller sync on **id only** → `setMessages` was skipped, and
- the controller diff (`MessageListDiff.areContentsTheSame` = freezed `==`) saw the new error entry as **value-equal** to the previous assistant entry → no `change` operation was emitted.

The animated list never rebuilt that row, and `flutter_chat_ui`'s `ChatMessageInternal` kept its cached message, leaving the stale assistant card on screen until the screen was remounted. The retry/transitory banner works because it's a synthetic row with a dedicated id that has no collision.

## Fix

Add a `role` discriminator (`user`/`assistant`/`error`) to each chat entry's `metadata` in `_chatEntriesFor`, and compare it in `_entriesMatch`. A same-id assistant→error transition now:

1. makes `_entriesMatch` return false → `setMessages` runs, and
2. makes `areContentsTheSame` false → the diff emits a `change` → the row rebuilds via `_buildRow` → the `ErrorMessageCard` renders live.

## Notes on testing

I explored a widget regression test but did not include one: `flutter_test`'s parent-rebuild pumps re-run the row builder more eagerly than production, so the test passed even against the unfixed code and could not actually catch the regression (the real failure depends on `flutter_chat_ui` internal caching + scroll/relayout timing the widget tester doesn't reproduce). `dart analyze` is clean and all 124 existing `session_detail` tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing live error rendering in session detail. When an assistant turn fails mid-stream, the message now updates in place and shows the error card immediately.

- **Bug Fixes**
  - Add `role` metadata (`user`/`assistant`/`error`) to chat entries in `_chatEntriesFor`.
  - Update `_entriesMatch` to compare `role`, ensuring same-id assistant→error swaps trigger `setMessages` and the diff emits a change so the row re-renders.

<sup>Written for commit 7919a1a229336de53ba511bcdb7445b123ac5ad2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

