### PR TITLE
fix(opencode): deliver live assistant errors as MessageError

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/assistant_message_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/assistant_message_mapper.dart
@@ -22,8 +22,7 @@ class AssistantMessageMapper {
       completed: message.time.completed,
     );
     final error = message.error;
-    final errorMap = error is Map<String, dynamic> ? error : null;
-    if (errorMap == null) {
+    if (error == null) {
       return PluginMessage.assistant(
         id: message.id,
         sessionID: message.sessionID,
@@ -33,7 +32,13 @@ class AssistantMessageMapper {
         time: time,
       );
     }
-    final data = errorMap["data"];
+    // OpenCode's structured errors are `{ "name": ..., "data": { "message": ... } }`,
+    // but `error` is typed `Object?`, so a non-map payload (e.g. a bare string)
+    // is possible. Never let a present error fall through as a plain assistant
+    // message — that is exactly the silent error loss this mapper exists to
+    // prevent — so fall back to `toString()` for a non-map error.
+    final errorMap = error is Map<String, dynamic> ? error : null;
+    final data = errorMap?["data"];
     final dataMap = data is Map<String, dynamic> ? data : const <String, dynamic>{};
     return PluginMessage.error(
       id: message.id,
@@ -41,8 +46,8 @@ class AssistantMessageMapper {
       agent: message.agent,
       modelID: message.modelID,
       providerID: message.providerID,
-      errorName: errorMap["name"]?.toString() ?? "UnknownError",
-      errorMessage: dataMap["message"]?.toString() ?? "Unknown error",
+      errorName: errorMap?["name"]?.toString() ?? "UnknownError",
+      errorMessage: dataMap["message"]?.toString() ?? (errorMap == null ? error.toString() : "Unknown error"),
       time: time,
     );
   }

--- a/bridge/sesori_plugin_opencode/lib/src/assistant_message_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/assistant_message_mapper.dart
@@ -1,0 +1,49 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "models/openapi/assistant_message.g.dart";
+
+/// Maps an OpenCode [AssistantMessage] to a plugin [PluginMessage],
+/// normalizing OpenCode's backend-specific error shape.
+///
+/// OpenCode reports a failed assistant turn as an assistant message that
+/// still has `role: "assistant"` but carries a non-null `error`
+/// (`{ "name": ..., "data": { "message": ... } }`). Both the REST load path
+/// and the live SSE path must collapse that into a flat
+/// [PluginMessage.error] so the phone renders it as an error — otherwise the
+/// live path silently drops the error and shows a blank assistant turn until
+/// the session is re-opened. This mapper is the single owner of that
+/// normalization, shared by both paths so they can never diverge again.
+class AssistantMessageMapper {
+  const AssistantMessageMapper();
+
+  PluginMessage map(AssistantMessage message) {
+    final time = PluginMessageTime(
+      created: message.time.created,
+      completed: message.time.completed,
+    );
+    final error = message.error;
+    final errorMap = error is Map<String, dynamic> ? error : null;
+    if (errorMap == null) {
+      return PluginMessage.assistant(
+        id: message.id,
+        sessionID: message.sessionID,
+        agent: message.agent,
+        modelID: message.modelID,
+        providerID: message.providerID,
+        time: time,
+      );
+    }
+    final data = errorMap["data"];
+    final dataMap = data is Map<String, dynamic> ? data : const <String, dynamic>{};
+    return PluginMessage.error(
+      id: message.id,
+      sessionID: message.sessionID,
+      agent: message.agent,
+      modelID: message.modelID,
+      providerID: message.providerID,
+      errorName: errorMap["name"]?.toString() ?? "UnknownError",
+      errorMessage: dataMap["message"]?.toString() ?? "Unknown error",
+      time: time,
+    );
+  }
+}

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -5,6 +5,7 @@ import "package:http/io_client.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "../opencode_plugin.dart";
+import "assistant_message_mapper.dart";
 import "sse/sse_connection.dart";
 import "sse_event_mapper.dart";
 
@@ -31,8 +32,15 @@ class OpenCodePlugin implements OpenCodeManagedApi {
   final SseEventParser _parser;
   final BufferedUntilFirstListener<BridgeSseEvent> _eventBuffer;
   final io.HttpClient _httpClient;
-  final SseEventMapper _mapper = SseEventMapper();
-  final PluginModelMapper _pluginModelMapper = const PluginModelMapper(messagePartMapper: MessagePartMapper());
+  // One shared error-normalization mapper drives both the live SSE path
+  // ([_mapper]) and the REST load path ([_pluginModelMapper]) so an errored
+  // assistant message is collapsed to a `MessageError` identically on both.
+  static const AssistantMessageMapper _assistantMessageMapper = AssistantMessageMapper();
+  final SseEventMapper _mapper = SseEventMapper(assistantMessageMapper: _assistantMessageMapper);
+  final PluginModelMapper _pluginModelMapper = const PluginModelMapper(
+    messagePartMapper: MessagePartMapper(),
+    assistantMessageMapper: _assistantMessageMapper,
+  );
   late final SseConnection _sseConnection;
   late final StreamSubscription<void> _summarySubscription;
   Future<void>? _initializeFuture;

--- a/bridge/sesori_plugin_opencode/lib/src/plugin_model_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/plugin_model_mapper.dart
@@ -1,5 +1,6 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
+import "assistant_message_mapper.dart";
 import "message_part_mapper.dart";
 import "models/openapi/agent.g.dart";
 import "models/openapi/assistant_message.g.dart";
@@ -17,11 +18,14 @@ class PluginModelMapper {
   const PluginModelMapper({
     required MessagePartMapper messagePartMapper,
     QuestionInfoMapper questionInfoMapper = const QuestionInfoMapper(),
+    AssistantMessageMapper assistantMessageMapper = const AssistantMessageMapper(),
   }) : _messagePartMapper = messagePartMapper,
-       _questionInfoMapper = questionInfoMapper;
+       _questionInfoMapper = questionInfoMapper,
+       _assistantMessageMapper = assistantMessageMapper;
 
   final MessagePartMapper _messagePartMapper;
   final QuestionInfoMapper _questionInfoMapper;
+  final AssistantMessageMapper _assistantMessageMapper;
 
   PluginSession mapSession(Session session, {required String projectID}) {
     final summary = session.summary;
@@ -127,16 +131,7 @@ class PluginModelMapper {
         agent: agent,
         time: _mapUserMessageTime(time),
       ),
-      AssistantMessage(:final id, :final sessionID, :final agent, :final modelID, :final providerID, :final error, :final time) =>
-        _mapAssistantMessage(
-          id: id,
-          sessionID: sessionID,
-          agent: agent,
-          modelID: modelID,
-          providerID: providerID,
-          error: error,
-          time: time,
-        ),
+      AssistantMessage() => _assistantMessageMapper.map(info),
       MessageUnknown(:final raw) => throw FormatException("Unknown message role: $raw"),
       _ => throw FormatException("Unknown message role: $info"),
     };
@@ -146,47 +141,8 @@ class PluginModelMapper {
     );
   }
 
-  PluginMessage _mapAssistantMessage({
-    required String id,
-    required String sessionID,
-    required String agent,
-    required String modelID,
-    required String providerID,
-    required Object? error,
-    required AssistantMessageTime time,
-  }) {
-    final pluginTime = _mapAssistantMessageTime(time);
-    final errorMap = error is Map<String, dynamic> ? error : null;
-    if (errorMap == null) {
-      return PluginMessage.assistant(
-        id: id,
-        sessionID: sessionID,
-        agent: agent,
-        modelID: modelID,
-        providerID: providerID,
-        time: pluginTime,
-      );
-    }
-    final data = errorMap["data"];
-    final dataMap = data is Map<String, dynamic> ? data : const <String, dynamic>{};
-    return PluginMessage.error(
-      id: id,
-      sessionID: sessionID,
-      agent: agent,
-      modelID: modelID,
-      providerID: providerID,
-      errorName: errorMap["name"]?.toString() ?? "UnknownError",
-      errorMessage: dataMap["message"]?.toString() ?? "Unknown error",
-      time: pluginTime,
-    );
-  }
-
   PluginMessageTime _mapUserMessageTime(UserMessageTime time) {
     return PluginMessageTime(created: time.created.toInt(), completed: null);
-  }
-
-  PluginMessageTime _mapAssistantMessageTime(AssistantMessageTime time) {
-    return PluginMessageTime(created: time.created, completed: time.completed);
   }
 
   String? _effectiveProjectName(Project project) {

--- a/bridge/sesori_plugin_opencode/lib/src/sse_event_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse_event_mapper.dart
@@ -1,6 +1,10 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
+import "assistant_message_mapper.dart";
 import "message_part_mapper.dart";
+import "models/openapi/assistant_message.g.dart";
+import "models/openapi/message.g.dart";
+import "models/openapi/user_message.g.dart";
 import "models/sse_event_data.g.dart";
 import "question_info_mapper.dart";
 
@@ -9,8 +13,12 @@ import "question_info_mapper.dart";
 /// Extracted from [OpenCodePlugin] to isolate the mapping concern.
 /// This class is stateless — all methods are pure transformations.
 class SseEventMapper {
+  SseEventMapper({AssistantMessageMapper assistantMessageMapper = const AssistantMessageMapper()})
+    : _assistantMessageMapper = assistantMessageMapper;
+
   final MessagePartMapper _messagePartMapper = const MessagePartMapper();
   final QuestionInfoMapper _questionInfoMapper = const QuestionInfoMapper();
+  final AssistantMessageMapper _assistantMessageMapper;
 
   /// Narrows a union's `Object? toJson()` result to the JSON map the bridge
   /// model carries — without a null-assertion (`!`). Known variants always
@@ -18,6 +26,30 @@ class SseEventMapper {
   /// payload is not a map.
   static Map<String, dynamic> _asMap(Object? json) =>
       json is Map<String, dynamic> ? json : const <String, dynamic>{};
+
+  /// Normalizes a `message.updated` payload into the shared-`Message` JSON
+  /// shape the phone parses, mirroring the REST load path
+  /// ([PluginModelMapper.mapMessageWithParts]). Crucially this collapses an
+  /// errored assistant message (`role: "assistant"` + `error`) into the
+  /// `role: "error"` shape via [AssistantMessageMapper]; forwarding the raw
+  /// OpenCode payload would keep `role: "assistant"` and the phone would drop
+  /// the error, leaving a blank turn until the session is re-opened.
+  Map<String, dynamic> _mapMessageInfo(Message info) {
+    final pluginMessage = switch (info) {
+      UserMessage(:final id, :final sessionID, :final agent, :final time) => PluginMessage.user(
+        id: id,
+        sessionID: sessionID,
+        agent: agent,
+        time: PluginMessageTime(created: time.created.toInt(), completed: null),
+      ),
+      AssistantMessage() => _assistantMessageMapper.map(info),
+      // Unknown roles from a newer OpenCode server: fall through to the raw
+      // payload below so the phone can still attempt to decode it.
+      _ => null,
+    };
+    if (pluginMessage == null) return _asMap(info.toJson());
+    return _asMap(pluginMessage.toJson());
+  }
 
   /// Maps an [SseEventData] to a [BridgeSseEvent], or null if the event
   /// type has no plugin representation.
@@ -52,7 +84,7 @@ class SseEventMapper {
         arguments: arguments,
         messageID: messageID,
       ),
-      SseMessageUpdated(:final info) => BridgeSseMessageUpdated(info: _asMap(info.toJson())),
+      SseMessageUpdated(:final info) => BridgeSseMessageUpdated(info: _mapMessageInfo(info)),
       SseMessageRemoved(:final sessionID, :final messageID) => BridgeSseMessageRemoved(
         sessionID: sessionID,
         messageID: messageID,

--- a/bridge/sesori_plugin_opencode/test/assistant_message_mapper_test.dart
+++ b/bridge/sesori_plugin_opencode/test/assistant_message_mapper_test.dart
@@ -78,6 +78,17 @@ void main() {
       expect(error.errorMessage, equals("Unknown error"));
     });
 
+    test("maps a non-map (string) error payload to PluginMessage.error via toString", () {
+      // OpenCode types `error` as `Object?`, so a bare string is possible. A
+      // present error must never fall through as a plain assistant message.
+      final result = mapper.map(_assistantMessage(error: "Internal Server Error"));
+
+      expect(result, isA<PluginMessageError>());
+      final error = result as PluginMessageError;
+      expect(error.errorName, equals("UnknownError"));
+      expect(error.errorMessage, equals("Internal Server Error"));
+    });
+
     test("serializes an errored message to the shared MessageError JSON shape", () {
       final result = mapper.map(
         _assistantMessage(

--- a/bridge/sesori_plugin_opencode/test/assistant_message_mapper_test.dart
+++ b/bridge/sesori_plugin_opencode/test/assistant_message_mapper_test.dart
@@ -1,0 +1,99 @@
+import "package:opencode_plugin/src/assistant_message_mapper.dart";
+import "package:opencode_plugin/src/models/openapi/assistant_message.g.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+AssistantMessage _assistantMessage({required Object? error}) {
+  return AssistantMessage(
+    id: "msg-1",
+    sessionID: "session-1",
+    time: const AssistantMessageTime(created: 100, completed: 200),
+    error: error,
+    parentID: "parent-1",
+    modelID: "gpt-4",
+    providerID: "openai",
+    mode: "build",
+    agent: "general",
+    path: const AssistantMessagePath(cwd: "/repo", root: "/repo"),
+    summary: null,
+    cost: 0,
+    tokens: const AssistantMessageTokens(
+      total: 0,
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: AssistantMessageTokensCache(read: 0, write: 0),
+    ),
+    structured: null,
+    variant: null,
+    finish: null,
+  );
+}
+
+void main() {
+  group("AssistantMessageMapper", () {
+    const mapper = AssistantMessageMapper();
+
+    test("maps a non-errored assistant message to PluginMessage.assistant", () {
+      final result = mapper.map(_assistantMessage(error: null));
+
+      expect(result, isA<PluginMessageAssistant>());
+      final assistant = result as PluginMessageAssistant;
+      expect(assistant.id, equals("msg-1"));
+      expect(assistant.sessionID, equals("session-1"));
+      expect(assistant.agent, equals("general"));
+      expect(assistant.modelID, equals("gpt-4"));
+      expect(assistant.providerID, equals("openai"));
+      expect(assistant.time?.created, equals(100));
+      expect(assistant.time?.completed, equals(200));
+    });
+
+    test("collapses an errored assistant message to PluginMessage.error with flat fields", () {
+      final result = mapper.map(
+        _assistantMessage(
+          error: <String, dynamic>{
+            "name": "ProviderAuthError",
+            "data": <String, dynamic>{"message": "invalid api key"},
+          },
+        ),
+      );
+
+      expect(result, isA<PluginMessageError>());
+      final error = result as PluginMessageError;
+      expect(error.id, equals("msg-1"));
+      expect(error.sessionID, equals("session-1"));
+      expect(error.errorName, equals("ProviderAuthError"));
+      expect(error.errorMessage, equals("invalid api key"));
+      expect(error.modelID, equals("gpt-4"));
+      expect(error.providerID, equals("openai"));
+      expect(error.time?.created, equals(100));
+    });
+
+    test("falls back to placeholders when the error shape is missing fields", () {
+      final result = mapper.map(_assistantMessage(error: <String, dynamic>{}));
+
+      expect(result, isA<PluginMessageError>());
+      final error = result as PluginMessageError;
+      expect(error.errorName, equals("UnknownError"));
+      expect(error.errorMessage, equals("Unknown error"));
+    });
+
+    test("serializes an errored message to the shared MessageError JSON shape", () {
+      final result = mapper.map(
+        _assistantMessage(
+          error: <String, dynamic>{
+            "name": "Boom",
+            "data": <String, dynamic>{"message": "kaboom"},
+          },
+        ),
+      );
+
+      // The phone re-parses this map via the shared `Message.fromJson`, which
+      // dispatches on `role`. It must read as an error, not an assistant.
+      final json = result.toJson();
+      expect(json["role"], equals("error"));
+      expect(json["errorName"], equals("Boom"));
+      expect(json["errorMessage"], equals("kaboom"));
+    });
+  });
+}

--- a/bridge/sesori_plugin_opencode/test/sse_event_mapper_test.dart
+++ b/bridge/sesori_plugin_opencode/test/sse_event_mapper_test.dart
@@ -1,12 +1,71 @@
+import "package:opencode_plugin/src/models/openapi/assistant_message.g.dart";
 import "package:opencode_plugin/src/models/openapi/session.g.dart";
 import "package:opencode_plugin/src/models/sse_event_data.g.dart";
 import "package:opencode_plugin/src/sse_event_mapper.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
+AssistantMessage _assistantMessage({required Object? error}) {
+  return AssistantMessage(
+    id: "msg-1",
+    sessionID: "session-1",
+    time: const AssistantMessageTime(created: 100, completed: 200),
+    error: error,
+    parentID: "parent-1",
+    modelID: "gpt-4",
+    providerID: "openai",
+    mode: "build",
+    agent: "general",
+    path: const AssistantMessagePath(cwd: "/repo", root: "/repo"),
+    summary: null,
+    cost: 0,
+    tokens: const AssistantMessageTokens(
+      total: 0,
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: AssistantMessageTokensCache(read: 0, write: 0),
+    ),
+    structured: null,
+    variant: null,
+    finish: null,
+  );
+}
+
 void main() {
   group("SseEventMapper", () {
     final mapper = SseEventMapper();
+
+    test("maps a live errored assistant message.updated to the error role", () {
+      final result = mapper.map(
+        SseEventData.messageUpdated(
+          info: _assistantMessage(
+            error: <String, dynamic>{
+              "name": "ProviderAuthError",
+              "data": <String, dynamic>{"message": "invalid api key"},
+            },
+          ),
+        ),
+      );
+
+      expect(result, isA<BridgeSseMessageUpdated>());
+      final event = result! as BridgeSseMessageUpdated;
+      // The phone parses this via the shared `Message.fromJson` `role`
+      // discriminator, so a live error must arrive as `role: "error"` with
+      // flat error fields — not as `role: "assistant"` with the error dropped.
+      expect(event.info["role"], equals("error"));
+      expect(event.info["errorName"], equals("ProviderAuthError"));
+      expect(event.info["errorMessage"], equals("invalid api key"));
+    });
+
+    test("maps a live non-errored assistant message.updated to the assistant role", () {
+      final result = mapper.map(SseEventData.messageUpdated(info: _assistantMessage(error: null)));
+
+      expect(result, isA<BridgeSseMessageUpdated>());
+      final event = result! as BridgeSseMessageUpdated;
+      expect(event.info["role"], equals("assistant"));
+      expect(event.info.containsKey("errorName"), isFalse);
+    });
 
     test("maps session.created using provided canonical projectID", () {
       const session = Session(


### PR DESCRIPTION
## Problem

Permanent assistant error messages still did not render live in the session detail screen after #399 — they only appeared after re-opening the session. #399 fixed the **client render** half of the problem, but the real root cause is in the OpenCode bridge plugin, so the client never actually received a live error to render.

## Root cause (the other half of #399)

When an assistant turn ends in error, OpenCode emits an SSE `message.updated` whose `info` still has `role: "assistant"` and a nested `error` field (`{ "name": ..., "data": { "message": ... } }`).

- **Live SSE path** (`SseEventMapper`) forwarded that raw OpenCode payload unchanged. Downstream, the phone's shared `Message.fromJson` dispatches on `role` and builds a `MessageAssistant`, **silently dropping the error**. The phone never got a `MessageError` live.
- **REST load path** (`PluginModelMapper._mapAssistantMessage`) already inspected `error` and produced a `PluginMessage.error` → `MessageError`. That's why re-opening the session showed it.

So #399's client-side fix (make a same-id assistant→error swap re-render) was correct but dormant: nothing upstream ever delivered the live `MessageError`. This PR delivers it, making the two halves work together.

## Fix

All in `bridge/sesori_plugin_opencode`:

1. **New `AssistantMessageMapper`** — a pure mapper (OpenCode `AssistantMessage` → `PluginMessage`) that collapses a non-null `error` into `PluginMessage.error` (with `UnknownError`/`Unknown error` fallbacks). Single owner of the backend-specific error-shape normalization, per the shared `Message` doc-comment and the bridge's "backend quirks live in the plugin" rule.
2. **`PluginModelMapper`** delegates its assistant mapping to it (removing the old inline `_mapAssistantMessage`).
3. **`SseEventMapper`** routes `message.updated` through the mapper so the map handed to `BridgeSseMessageUpdated.info` is already in the shared-`Message` shape (`role: "error"`, flat `errorName`/`errorMessage`) — identical to the load path.
4. **`OpenCodePlugin`** constructs one shared `AssistantMessageMapper` and injects the same instance into both mappers; `SseEventMapper` does not depend on `PluginModelMapper`.

## Tests

- New `assistant_message_mapper_test.dart` (assistant/error/fallback/JSON-shape).
- New `sse_event_mapper_test.dart` cases: a live errored `message.updated` maps to `role: "error"` with flat fields; a non-errored one stays `role: "assistant"`.
- `make analyze` and `make test` (1738 tests) pass.

Plan and implementation both reviewed by the architecture review agents.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the bug where assistant errors only appeared after reopening a session. Live SSE now collapses errored assistant turns to `MessageError` (including non-map error payloads), so the session detail updates immediately.

- **Bug Fixes**
  - Added `AssistantMessageMapper` to convert errored OpenCode `AssistantMessage` into `PluginMessage.error` with flat `errorName`/`errorMessage`.
  - Routed both paths through it: REST (`PluginModelMapper`) and SSE `message.updated` (`SseEventMapper`); one shared instance wired in `OpenCodePlugin`.
  - Treat non-map `error` payloads (e.g., strings) as errors via `toString()`, with `UnknownError`/message fallbacks, so they aren’t dropped.
  - Added tests for the mapper and SSE mapping to verify `role: "error"` is emitted for live errors.

<sup>Written for commit 3582697e9946db09146b342a3db1e630bb3d845f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

