### PR TITLE
[CI] Using Xcode 26.6 for iOS app builds

### DIFF
--- a/.github/workflows/_reusable-ios-testflight.yml
+++ b/.github/workflows/_reusable-ios-testflight.yml
@@ -33,7 +33,7 @@ on:
 
 # Xcode and CocoaPods versions — update these when upgrading
 env:
-  XCODE_VERSION: '26.3.0'
+  XCODE_VERSION: '26.6'
   COCOAPODS_VERSION: '1.16.2'
 
 jobs:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade iOS CI to Xcode 26.6 for TestFlight builds. Sets `XCODE_VERSION` from `26.3.0` to `26.6` in `.github/workflows/_reusable-ios-testflight.yml` to use the latest toolchain.

<sup>Written for commit 9b74a4dd221525acd2a69f0c7ad838f42895df68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

