### PR TITLE
fix(app): collapse the Projects title on the disconnected states

### DIFF
--- a/client/app/lib/core/widgets/connection_graphic.dart
+++ b/client/app/lib/core/widgets/connection_graphic.dart
@@ -26,6 +26,18 @@ class ConnectionGraphic extends StatelessWidget {
 
   final _ConnectionGraphicState _state;
 
+  /// The Figma frame the artwork is drawn at, pinned explicitly rather than
+  /// taken from the decoded asset.
+  ///
+  /// An unsized [Image] reports a *max intrinsic* height of
+  /// `crossAxisExtent / aspectRatio` — the height it would need if stretched to
+  /// the full available width — not the height it paints at. The onboarding
+  /// bodies hang under `SliverFillRemaining(hasScrollBody: false)`, which sizes
+  /// itself from that intrinsic, so an unsized graphic would inflate the page's
+  /// scroll extent by ~180pt of empty space below the content.
+  static const double _width = 141;
+  static const double _height = 101;
+
   static const String _dir = "assets/images/projects_onboarding/connection_graphic";
   static const String _offLight = "$_dir/connection_off-light.png";
   static const String _offDark = "$_dir/connection_off-dark.png";
@@ -41,6 +53,8 @@ class ConnectionGraphic extends StatelessWidget {
     };
     return Image.asset(
       asset,
+      width: _width,
+      height: _height,
       fit: BoxFit.contain,
       filterQuality: FilterQuality.medium,
     );

--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -275,7 +275,7 @@ class _NeedHelpMenu extends StatelessWidget {
       triggerBuilder: (context, toggle) => PregoButtonsSolid(
         leadingIcon: TablerRegular.help,
         label: loc.projectsOnboardingNeedHelp,
-        hierarchy: PregoButtonsSolidHierarchy.secondary,
+        hierarchy: PregoButtonsSolidHierarchy.tertiary,
         size: PregoButtonsSolidSize.xl,
         onPressed: toggle,
       ),

--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -5,36 +5,14 @@ part of "../project_list_screen.dart";
 //
 // The two empty Projects states have their own bodies now that they diverge:
 // * disconnected — the connect-your-computer onboarding (connection graphic in
-//   its "off" state): install + start the bridge. See [_ConnectBridgeChecklist]
-//   and [_BridgeOnboardingView].
+//   its "off" state): install + start the bridge. See [_ConnectBridgeChecklist].
 // * connected, no projects — the phone/PC status body with the graphic in its
 //   "on" state. See [_OnboardingChecklist].
+//
+// Both are bodies, not pages: [ProjectListScreen] hosts them in its own page
+// scroll — with the pull-to-refresh and the collapsing large title that come
+// with it — rather than each nesting a scroll view of its own.
 // ===========================================================================
-
-/// Not-yet-connected onboarding ("Connect your computer"). Wraps the
-/// [_ConnectBridgeChecklist] in a pull-to-refresh that re-attempts the bridge
-/// connection.
-class _BridgeOnboardingView extends StatelessWidget {
-  const _BridgeOnboardingView();
-
-  @override
-  Widget build(BuildContext context) {
-    return SafeArea(
-      top: false,
-      child: RefreshIndicator(
-        // Recovery affordance: pull down to re-attempt the bridge connection.
-        // Escaping this state is otherwise passive (it waits for a connection
-        // event), which can strand a never-connected bridge.
-        onRefresh: () => context.read<ProjectListCubit>().reconnectBridge(),
-        child: const SingleChildScrollView(
-          clipBehavior: Clip.none,
-          physics: AlwaysScrollableScrollPhysics(),
-          child: _ConnectBridgeChecklist(),
-        ),
-      ),
-    );
-  }
-}
 
 /// Opens one of the "Need help?" contact links ([SupportLinks]) through the
 /// shared [openExternalLink] helper.
@@ -123,9 +101,9 @@ class _OnboardingChecklist extends StatelessWidget {
 /// connection graphic in its "off" state with a "Waiting for bridge" caption,
 /// then two numbered command steps — install the bridge, then start it — each
 /// introduced by a label carrying an "ⓘ" info popover, and a "Why is this
-/// needed?" explainer button. Wrapped in the pull-to-refresh of
-/// [_BridgeOnboardingView]; the "Need help?" support menu ([_NeedHelpMenu])
-/// rides the scaffold's floating-action slot.
+/// needed?" explainer button. The "Need help?" support menu ([_NeedHelpMenu])
+/// is not part of this scroll flow — it rides the scaffold's floating-action
+/// slot.
 class _ConnectBridgeChecklist extends StatelessWidget {
   const _ConnectBridgeChecklist();
 
@@ -297,7 +275,7 @@ class _NeedHelpMenu extends StatelessWidget {
       triggerBuilder: (context, toggle) => PregoButtonsSolid(
         leadingIcon: TablerRegular.help,
         label: loc.projectsOnboardingNeedHelp,
-        hierarchy: PregoButtonsSolidHierarchy.tertiary,
+        hierarchy: PregoButtonsSolidHierarchy.secondary,
         size: PregoButtonsSolidSize.xl,
         onPressed: toggle,
       ),

--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -158,17 +158,9 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
     // connected) titles the screen "Connect"; every other state keeps
     // "Projects".
     final isConnectOnboarding = state is ProjectListBridgeDisconnected && !state.hasRegisteredBridges;
-    // The disconnected states (connect onboarding + bridge-offline) own their
-    // own inner scroll view with pull-to-reconnect. Turn the scaffold's outer
-    // page scroll OFF for them so the two don't fight: with both scrollable, the
-    // large-title collapse and the inner scroll deadlock — the page strands
-    // scrolled-up and won't come back. With it off the large title stays fixed
-    // and only the body scrolls.
-    final bodyOwnsScroll = state is ProjectListBridgeDisconnected;
 
     return PregoGlassScaffold(
       title: isConnectOnboarding ? loc.projectListConnectTitle : loc.projectListTitle,
-      scrollable: !bodyOwnsScroll,
       // A loaded list hosts the top-nav connection banner; the loading and
       // bridge-disconnected states own their messaging full-screen (setup
       // onboarding or the "turn on your bridge" design), so they suppress it.
@@ -184,11 +176,23 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
       // once projects exist, the onboarding "Need help?" support menu in the two
       // empty states, and nothing while loading/offline/errored.
       floatingActionButton: _floatingAction(context: context, state: state),
-      // Pull-to-refresh re-fetches the project list once connected; the
-      // disconnected states keep their own inner reconnect-on-pull.
-      onRefresh: state is ProjectListLoaded ? () => _refreshProjects(context) : null,
+      onRefresh: _refreshFor(context: context, state: state),
       slivers: _buildContentSlivers(context: context, state: state, isRefreshing: isRefreshing),
     );
+  }
+
+  /// The scaffold's pull-to-refresh action for [state], or `null` when there is
+  /// nothing to pull for.
+  ///
+  /// A loaded list re-fetches its projects. The disconnected states re-attempt
+  /// the bridge connection: escaping them is otherwise passive (they wait for a
+  /// connection event), which can strand a bridge that never came up.
+  Future<void> Function()? _refreshFor({required BuildContext context, required ProjectListState state}) {
+    return switch (state) {
+      ProjectListLoaded() => () => _refreshProjects(context),
+      ProjectListBridgeDisconnected() => () => context.read<ProjectListCubit>().reconnectBridge(),
+      ProjectListLoading() || ProjectListFailed() => null,
+    };
   }
 
   /// The top-nav connection banner for [state], or `null` when it should be
@@ -222,22 +226,26 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
         ),
       ],
       // No bridge has ever been registered → setup onboarding; a bridge exists
-      // but isn't running → ask to turn it on. Both are full-screen views that
-      // own their scroll and reconnect-on-pull, so they fill the body below the
-      // bar rather than joining the outer scroll.
+      // but isn't running → ask to turn it on. Both join the page scroll rather
+      // than nesting one of their own, so the large title scrolls away and
+      // collapses into the bar with them. hasScrollBody: false lets a body
+      // shorter than the viewport sit still while a taller one — the offline
+      // view with its install commands expanded — scrolls the page.
+      // SafeArea(top: false) keeps the last box clear of the home indicator.
       ProjectListBridgeDisconnected(:final hasRegisteredBridges) => [
         SliverFillRemaining(
-          hasScrollBody: true,
-          child: hasRegisteredBridges ? const _BridgeOfflineView() : const _BridgeOnboardingView(),
+          hasScrollBody: false,
+          child: SafeArea(
+            top: false,
+            child: hasRegisteredBridges ? const _BridgeOfflineView() : const _ConnectBridgeChecklist(),
+          ),
         ),
       ],
       ProjectListLoaded(:final projects, :final activityById, :final unseenByProjectId) => [
         if (isRefreshing) const SliverToBoxAdapter(child: LinearProgressIndicator()),
         if (projects.isEmpty)
-          // Render the shared onboarding body directly (not its own scroll
-          // view) so the scaffold's pull-to-refresh drives it. SafeArea(top:
-          // false) keeps the bottom install box clear of the home indicator,
-          // matching the disconnected onboarding view.
+          // Same shape as the disconnected bodies above: the onboarding joins
+          // the page scroll rather than nesting one of its own.
           const SliverFillRemaining(
             hasScrollBody: false,
             child: SafeArea(

--- a/client/app/lib/features/project_list/widgets/bridge_offline_view.dart
+++ b/client/app/lib/features/project_list/widgets/bridge_offline_view.dart
@@ -5,6 +5,11 @@ part of "../project_list_screen.dart";
 /// asked to reconnect. Mirrors the Figma "bridge disconnected" state: the
 /// connection graphic, a "Reconnect" CTA, and an expandable "Install commands"
 /// disclosure for when the bridge needs to be (re)installed or restarted.
+///
+/// A body, not a page: it is hosted in the project list's own page scroll (see
+/// [ProjectListScreen]) so the large title collapses into the bar as the
+/// expanded install commands scroll. Centred while it fits the viewport; the
+/// enclosing sliver grows past it once it doesn't.
 class _BridgeOfflineView extends StatefulWidget {
   const _BridgeOfflineView();
 
@@ -36,82 +41,69 @@ class _BridgeOfflineViewState extends State<_BridgeOfflineView> {
     final loc = context.loc;
     final prego = context.prego;
 
-    // Centred in the viewport, but scrollable so the content still fits small
-    // screens and the expanded install commands never overflow.
-    return SafeArea(
-      top: false,
-      child: CustomScrollView(
-        physics: const AlwaysScrollableScrollPhysics(),
-        slivers: [
-          SliverFillRemaining(
-            hasScrollBody: false,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: PregoSpacing.xl),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: PregoSpacing.xl),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const ExcludeSemantics(child: Center(child: ConnectionGraphic.connectionOff())),
+          const SizedBox(height: 18),
+          Text(
+            loc.projectsBridgeOfflineTitle,
+            textAlign: TextAlign.center,
+            style: prego.textTheme.textLg.medium.copyWith(color: prego.colors.textPrimary),
+          ),
+          const SizedBox(height: 28),
+          PregoButtonsSolid(
+            label: loc.projectsBridgeOfflineReconnect,
+            hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
+            size: PregoButtonsSolidSize.xl,
+            leadingIcon: TablerRegular.refresh,
+            fullWidth: true,
+            isLoading: _reconnecting,
+            onPressed: _reconnect,
+          ),
+          const SizedBox(height: 18),
+          // expanded semantics so screen readers announce the open/closed state
+          // of the install-commands disclosure; MergeSemantics folds it onto the
+          // button's own node.
+          MergeSemantics(
+            child: Semantics(
+              expanded: _showInstallCommands,
+              child: PregoButtonsSolid(
+                label: loc.projectsBridgeOfflineInstallCommands,
+                hierarchy: PregoButtonsSolidHierarchy.tertiary,
+                size: PregoButtonsSolidSize.xl,
+                trailingIcon: _showInstallCommands ? TablerRegular.chevron_up : TablerRegular.chevron_down,
+                fullWidth: true,
+                onPressed: () => setState(() => _showInstallCommands = !_showInstallCommands),
+              ),
+            ),
+          ),
+          AnimatedSize(
+            duration: context.isReducedMotion ? Duration.zero : const Duration(milliseconds: 220),
+            curve: Curves.easeInOut,
+            alignment: Alignment.topCenter,
+            // maintainState keeps the install boxes mounted while collapsed so
+            // the selected install method survives closing and reopening the
+            // disclosure.
+            child: Visibility(
+              visible: _showInstallCommands,
+              maintainState: true,
+              child: const Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  const ExcludeSemantics(child: Center(child: ConnectionGraphic.connectionOff())),
-                  const SizedBox(height: 18),
-                  Text(
-                    loc.projectsBridgeOfflineTitle,
-                    textAlign: TextAlign.center,
-                    style: prego.textTheme.textLg.medium.copyWith(color: prego.colors.textPrimary),
-                  ),
-                  const SizedBox(height: 28),
-                  PregoButtonsSolid(
-                    label: loc.projectsBridgeOfflineReconnect,
-                    hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
-                    size: PregoButtonsSolidSize.xl,
-                    leadingIcon: TablerRegular.refresh,
-                    fullWidth: true,
-                    isLoading: _reconnecting,
-                    onPressed: _reconnect,
-                  ),
-                  const SizedBox(height: 18),
-                  // expanded semantics so screen readers announce the
-                  // open/closed state of the install-commands disclosure;
-                  // MergeSemantics folds it onto the button's own node.
-                  MergeSemantics(
-                    child: Semantics(
-                      expanded: _showInstallCommands,
-                      child: PregoButtonsSolid(
-                        label: loc.projectsBridgeOfflineInstallCommands,
-                        hierarchy: PregoButtonsSolidHierarchy.tertiary,
-                        size: PregoButtonsSolidSize.xl,
-                        trailingIcon: _showInstallCommands ? TablerRegular.chevron_up : TablerRegular.chevron_down,
-                        fullWidth: true,
-                        onPressed: () => setState(() => _showInstallCommands = !_showInstallCommands),
-                      ),
-                    ),
-                  ),
-                  AnimatedSize(
-                    duration: context.isReducedMotion ? Duration.zero : const Duration(milliseconds: 220),
-                    curve: Curves.easeInOut,
-                    alignment: Alignment.topCenter,
-                    // maintainState keeps the install boxes mounted while
-                    // collapsed so the selected install method survives closing
-                    // and reopening the disclosure.
-                    child: Visibility(
-                      visible: _showInstallCommands,
-                      maintainState: true,
-                      child: const Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          SizedBox(height: PregoSpacing.lg),
-                          _InstallCommandBoxes(),
-                        ],
-                      ),
-                    ),
-                  ),
-                  // Always visible: the bridge is already installed here, so the
-                  // common recovery is to (re)start it rather than reinstall.
-                  const SizedBox(height: PregoSpacing.xl),
-                  const _RunBridgeCommand(),
+                  SizedBox(height: PregoSpacing.lg),
+                  _InstallCommandBoxes(),
                 ],
               ),
             ),
           ),
+          // Always visible: the bridge is already installed here, so the common
+          // recovery is to (re)start it rather than reinstall.
+          const SizedBox(height: PregoSpacing.xl),
+          const _RunBridgeCommand(),
         ],
       ),
     );

--- a/client/app/test/features/project_list/project_list_collapsing_title_test.dart
+++ b/client/app/test/features/project_list/project_list_collapsing_title_test.dart
@@ -1,0 +1,154 @@
+import "package:flutter/material.dart";
+import "package:flutter_bloc/flutter_bloc.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:mocktail/mocktail.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_mobile/core/di/injection.dart";
+import "package:sesori_mobile/features/project_list/project_list_screen.dart";
+import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/module_prego.dart";
+
+import "../../helpers/test_helpers.dart";
+
+/// The two disconnected Projects states — the connect-your-computer onboarding
+/// and the bridge-offline view — used to own an inner scroll view, which forced
+/// the page scroll off and left the large title pinned while the body moved
+/// underneath it. They are bodies now, hosted in the scaffold's page scroll, so
+/// the title scrolls away with the content and collapses into the top nav bar
+/// exactly as it does on the loaded project list.
+void main() {
+  const config = ServerConnectionConfig(relayHost: "relay.example.com", authToken: "test-token");
+  const health = HealthResponse(healthy: true, version: "0.1.200", filesystemAccessDegraded: null);
+  const bridgeOffline = ConnectionStatus.bridgeOffline(config: config, health: health);
+
+  late BehaviorSubject<ConnectionStatus> statusController;
+  late MockConnectionService mockConnectionService;
+  late MockProjectService mockProjectService;
+  late MockRegisteredBridgesService mockRegisteredBridgesService;
+  late StubConnectionOverlayCubit overlayCubit;
+
+  setUpAll(registerAllFallbackValues);
+
+  setUp(() {
+    statusController = BehaviorSubject<ConnectionStatus>.seeded(bridgeOffline);
+    mockConnectionService = MockConnectionService();
+    mockProjectService = MockProjectService();
+    mockRegisteredBridgesService = MockRegisteredBridgesService();
+    overlayCubit = StubConnectionOverlayCubit();
+
+    when(() => mockConnectionService.status).thenAnswer((_) => statusController.stream);
+    when(() => mockConnectionService.currentStatus).thenAnswer((_) => statusController.value);
+    when(() => mockConnectionService.connectWithFreshAuthToken()).thenAnswer((_) async => true);
+    when(() => mockProjectService.listProjects()).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
+
+    getIt.registerLazySingleton<ProjectService>(() => mockProjectService);
+    getIt.registerLazySingleton<ConnectionService>(() => mockConnectionService);
+    getIt.registerLazySingleton<SseEventRepository>(MockSseEventRepository.new);
+    getIt.registerLazySingleton<RouteSource>(MockRouteSource.new);
+    getIt.registerLazySingleton<SessionUnseenTracker>(FakeSessionUnseenTracker.new);
+    getIt.registerLazySingleton<RegisteredBridgesService>(() => mockRegisteredBridgesService);
+    getIt.registerLazySingleton<FailureReporter>(MockFailureReporter.new);
+  });
+
+  tearDown(() async {
+    await overlayCubit.close();
+    await statusController.close();
+    await getIt.reset();
+  });
+
+  Future<void> pumpScreen(WidgetTester tester, {required bool hasRegisteredBridges}) async {
+    when(() => mockRegisteredBridgesService.hasRegisteredBridges()).thenAnswer((_) async => hasRegisteredBridges);
+    // A phone-width viewport, deliberately short so both bodies overflow it.
+    // Overflow is the precondition for the behaviour under test: a body that
+    // fits leaves the page with no scroll extent, and a large title with
+    // nothing to scroll against correctly stays put.
+    tester.view.physicalSize = const Size(393, 500);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      BlocProvider<ConnectionOverlayCubit>.value(
+        value: overlayCubit,
+        child: MaterialApp(
+          theme: ThemeData(extensions: [PregoDesignSystem.light]),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const ProjectListScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// The large title rendered in the page's scroll view, as opposed to the
+  /// same-text title that lives in the top navigation bar. `skipOffstage: false`
+  /// keeps it findable once it has scrolled up out of the viewport — which is
+  /// precisely the state these tests assert.
+  Finder largeTitle(String title) => find.descendant(
+    of: find.byType(CustomScrollView),
+    matching: find.text(title, skipOffstage: false),
+    skipOffstage: false,
+  );
+
+  /// The alpha the large title is painted with: 1 while fully shown, 0 once it
+  /// has collapsed into the bar.
+  double largeTitleAlpha(WidgetTester tester, String title) =>
+      tester.widget<Text>(largeTitle(title)).style!.color!.a;
+
+  /// Drags the page up past [PregoTopNavigation.collapseDistance].
+  Future<void> scrollPageUp(WidgetTester tester) async {
+    await tester.drag(find.byType(CustomScrollView), const Offset(0, -180), warnIfMissed: false);
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets("the bridge-offline body scrolls the page, collapsing the large title", (tester) async {
+    await pumpScreen(tester, hasRegisteredBridges: true);
+    expect(find.text("Bridge disconnected"), findsOneWidget);
+    // A single scroll view for the whole page — the body no longer nests one.
+    expect(find.byType(CustomScrollView), findsOneWidget);
+    expect(find.byType(SingleChildScrollView), findsNothing);
+
+    // Collapsed, the view fits the viewport and there is nothing to scroll.
+    // Expanding the install commands overflows it, which is when the title must
+    // travel with the content.
+    await tester.tap(find.text("Install commands"));
+    await tester.pumpAndSettle();
+
+    final titleBefore = tester.getTopLeft(largeTitle("Projects")).dy;
+    expect(largeTitleAlpha(tester, "Projects"), closeTo(1, 0.001));
+
+    await scrollPageUp(tester);
+
+    expect(tester.getTopLeft(largeTitle("Projects")).dy, lessThan(titleBefore));
+    expect(largeTitleAlpha(tester, "Projects"), closeTo(0, 0.001));
+  });
+
+  testWidgets("the connect onboarding scrolls the page, collapsing the large title", (tester) async {
+    await pumpScreen(tester, hasRegisteredBridges: false);
+    expect(find.text("Waiting for the bridge..."), findsOneWidget);
+    expect(find.byType(CustomScrollView), findsOneWidget);
+    expect(find.byType(SingleChildScrollView), findsNothing);
+
+    final titleBefore = tester.getTopLeft(largeTitle("Connect")).dy;
+    expect(largeTitleAlpha(tester, "Connect"), closeTo(1, 0.001));
+
+    await scrollPageUp(tester);
+
+    expect(tester.getTopLeft(largeTitle("Connect")).dy, lessThan(titleBefore));
+    expect(largeTitleAlpha(tester, "Connect"), closeTo(0, 0.001));
+  });
+
+  testWidgets("pulling the disconnected page down re-attempts the bridge connection", (tester) async {
+    await pumpScreen(tester, hasRegisteredBridges: false);
+    verifyNever(() => mockConnectionService.reconnect());
+
+    // The scaffold's RefreshIndicator now drives the reconnect that the body's
+    // own pull-to-refresh used to.
+    await tester.fling(find.byType(CustomScrollView), const Offset(0, 300), 1000);
+    await tester.pumpAndSettle();
+
+    verify(() => mockConnectionService.reconnect()).called(1);
+  });
+}

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -331,20 +331,32 @@ class ProjectListCubit extends Cubit<ProjectListState> {
   /// reload to reconnectBridge during this window — see the guard there.
   bool _reconnectBridgeInFlight = false;
 
-  /// Re-attempts to reach the bridge from the onboarding state (driven by the
-  /// onboarding's pull-to-refresh). Recovery from [ProjectListBridgeDisconnected]
-  /// is otherwise passive — it waits for a [ConnectionConnected] transition that,
-  /// for a never-connected bridge ([ConnectionDisconnected]), may never arrive
-  /// on its own. This actively re-establishes the connection, then reloads.
+  /// In-flight bridge reconnect, used for coalescing.
+  Future<void>? _activeReconnect;
+
+  /// Re-attempts to reach the bridge from the disconnected state. Recovery from
+  /// [ProjectListBridgeDisconnected] is otherwise passive — it waits for a
+  /// [ConnectionConnected] transition that, for a never-connected bridge
+  /// ([ConnectionDisconnected]), may never arrive on its own. This actively
+  /// re-establishes the connection, then reloads.
   ///
   /// Does not emit a loading state: the caller (a [RefreshIndicator]) shows its
-  /// own progress, so the onboarding stays visible until a result is known.
+  /// own progress, so the disconnected body stays visible until a result is
+  /// known.
   ///
+  /// Concurrent calls are coalesced: the page's pull-to-refresh and the offline
+  /// body's Reconnect button both land here and neither blocks the other, so a
+  /// second attempt would fetch behind the first and release
+  /// [_reconnectBridgeInFlight] while the first is still connecting.
+  Future<void> reconnectBridge() {
+    return _activeReconnect ??= _reconnectBridge().whenComplete(() => _activeReconnect = null);
+  }
+
   /// [_reconnectBridgeInFlight] is held for the whole method so the
   /// ConnectionConnected transition emitted while connecting doesn't also drive
   /// [_onConnectionStatusChanged] into a duplicate (loading-flashing) reload —
   /// reconnectBridge owns the single, silent fetch below.
-  Future<void> reconnectBridge() async {
+  Future<void> _reconnectBridge() async {
     _reconnectBridgeInFlight = true;
     try {
       if (_connectionService.currentStatus is ConnectionDisconnected) {

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -426,6 +426,49 @@ void main() {
         },
       );
 
+      // Regression: the bridge-offline view's Reconnect button and the page's
+      // pull-to-refresh both drive reconnectBridge, and neither blocks the
+      // other. Overlapping triggers must share one attempt: a second pass would
+      // fetch again behind the first and clear _reconnectBridgeInFlight while
+      // the first is still connecting, re-opening the duplicate-reload window
+      // that flag exists to close.
+      blocTest<ProjectListCubit, ProjectListState>(
+        "reconnectBridge: overlapping triggers coalesce into a single attempt",
+        build: () {
+          statusController.add(const ConnectionStatus.disconnected());
+          when(() => mockConnectionService.connectWithFreshAuthToken()).thenAnswer((_) async => false);
+          return buildCubit();
+        },
+        act: (cubit) async {
+          await Future<void>.delayed(Duration.zero); // initial -> bridgeDisconnected
+          when(
+            () => mockProjectService.listProjects(),
+          ).thenAnswer((_) async => ApiResponse.success(Projects(data: [testProject()])));
+          // Hold the connect open so the second trigger lands mid-attempt.
+          final connect = Completer<bool>();
+          when(() => mockConnectionService.connectWithFreshAuthToken()).thenAnswer((_) {
+            when(() => mockConnectionService.currentStatus).thenReturn(_connectedStatus);
+            return connect.future;
+          });
+
+          final fromButton = cubit.reconnectBridge();
+          final fromPullToRefresh = cubit.reconnectBridge();
+          connect.complete(true);
+          await Future.wait([fromButton, fromPullToRefresh]);
+        },
+        skip: 1, // initial ProjectListBridgeDisconnected
+        expect: () => [
+          // One terminal Loaded: the second trigger awaited the first's future
+          // rather than running a fetch of its own.
+          isA<ProjectListLoaded>().having((s) => s.projects.length, "projects after reconnect", 1),
+        ],
+        verify: (_) {
+          // The constructor's attempt plus one coalesced reconnect — not two.
+          verify(() => mockConnectionService.connectWithFreshAuthToken()).called(2);
+          verify(() => mockProjectService.listProjects()).called(1);
+        },
+      );
+
       blocTest<ProjectListCubit, ProjectListState>(
         "reconnectBridge: stays on onboarding (no fetch) when the bridge is still unreachable",
         build: () {


### PR DESCRIPTION
## Problem

`PregoGlassScaffold` owns the page's `CustomScrollView` and couples the large title's collapse to *its* scroll controller. Both bridge-disconnected bodies nested a scroll view of their own — `SingleChildScrollView` for the connect onboarding, a whole `CustomScrollView` for the bridge-offline view — so the screen had to pass `scrollable: false` to stop the two from fighting. The result: the large title stayed frozen while the body slid underneath it, unlike every other screen.

## Change

Both become *bodies*, not pages, and join the scaffold's page scroll:

- They hang under `SliverFillRemaining(hasScrollBody: false)`, the same shape the connected-but-empty onboarding (`_OnboardingChecklist`) and the error state already used. A body that fits the viewport sits still — correct iOS behaviour, nothing to scroll. A taller one (the offline view with install commands expanded) scrolls the page and takes the title with it.
- `_BridgeOnboardingView` is deleted; it was only a `SafeArea` + `RefreshIndicator` + `SingleChildScrollView` wrapper. `_BridgeOfflineView` sheds its `CustomScrollView`.
- Pull-to-reconnect moves onto the scaffold via a new `_refreshFor()`. The offline view gains it — it previously had `AlwaysScrollableScrollPhysics` but no `RefreshIndicator`, so pulling did nothing.

## The bug this would have introduced

`SliverFillRemaining(hasScrollBody: false)` sizes itself from the child's **max intrinsic height**. `RenderImage.computeMaxIntrinsicHeight` returns the height the image would need if stretched to the full available width — for the 142×102 connection graphic at 393pt wide that's **282pt**, not the 102pt it actually paints ([`image.dart:388`](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/rendering/image.dart) → `BoxConstraints.constrainSizeAndAttemptToPreserveAspectRatio`, the `width < minWidth` branch).

That would have added ~180pt of blank scroll space below the Connect page's content. `ConnectionGraphic` is now pinned to its Figma frame (141×101) so its intrinsic matches what it paints — which also removes the same phantom space from the two states that were already using this sliver.

## Verification

New `project_list_collapsing_title_test.dart` asserts, for both disconnected states:

- exactly one `CustomScrollView`, no nested `SingleChildScrollView`
- the large title's `dy` decreases when the page is dragged
- its text alpha reaches `0` — fully collapsed into the bar
- a downward fling calls `ConnectionService.reconnect()`

`flutter analyze` clean; all 550 `client/app` tests pass.

## Blast radius

- `ConnectionGraphic` has three call sites, all in this onboarding. Its existing test only asserts light/dark asset mapping. No call site let it scale with available width, so pinning shifts nothing.
- The other two unsized `Image.asset` widgets in the app are intrinsic-safe: `SesoriBackgroundWidget` is always `Positioned.fill` (tight constraints), and the `why_bridge_info_sheet` illustration has no intrinsic-measuring ancestor.
- No other screen has a frozen title. `session_detail_body.dart` is now the only `scrollable: false` caller, and it pairs with `inlineTitle: true` for the reversed chat list — the documented use of the flag, not this bug.

https://claude.ai/code/session_01Pyankc1sqQqyiNXtppAr4m

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the frozen large title on the Projects screen when disconnected by moving the connect-onboarding and bridge-offline views into the page scroll. The title now collapses as you scroll, pull-to-refresh triggers a reconnect, and overlapping reconnects are coalesced to prevent duplicate reloads.

- **Bug Fixes**
  - Joined both disconnected bodies to the `PregoGlassScaffold` scroll via `SliverFillRemaining(hasScrollBody: false)`; removed nested scroll views and deleted `_BridgeOnboardingView`.
  - Moved pull-to-refresh to the scaffold: reload projects when loaded; reconnect the bridge when disconnected.
  - Coalesced overlapping reconnects from pull-to-refresh and the offline Reconnect button in `ProjectListCubit` into a single in-flight attempt.
  - Pinned `ConnectionGraphic` size to 141×101 to fix intrinsic height and remove extra blank scroll space.
  - Added tests to assert a single `CustomScrollView`, collapsing title alpha to 0, pull-to-reconnect behavior, and reconnect coalescing in the cubit.

<sup>Written for commit 3ea9d857a511240b6790425053af24fa042a693c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

