### PR TITLE
fix(acp): serialize per-session turns, robust resume-loads, precise turn attribution

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -815,6 +815,14 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     try {
       client = await _connectedClient();
     } on Object catch (error, stack) {
+      // An abort that landed while the reconnect was in flight already
+      // discarded this turn — settle it silently instead of surfacing a
+      // session error for a prompt the user cancelled.
+      if (state.generation != expectedGeneration) {
+        Log.d("[$id] queued turn on $sessionId aborted during reconnect: $error");
+        _finishTurn(sessionId: sessionId, state: state, failed: false, refused: false);
+        return;
+      }
       // The send was already accepted, so a dead/unrespawnable agent must
       // surface as a failed turn, not a silent drop.
       Log.w("[$id] could not reach the agent for a queued turn on $sessionId", error, stack);

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -602,7 +602,6 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       // A fresh session has an empty chain, so this dispatches immediately;
       // the selection is applied inside the turn like every other prompt.
       _enqueueTurn(
-        client: client,
         sessionId: session.sessionId,
         parts: parts,
         model: model,
@@ -629,9 +628,10 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     required String? agent,
     required ({String providerID, String modelID})? model,
   }) async {
-    final client = await _connectedClient();
+    // Acceptance gate: an unreachable agent fails the send itself; the turn
+    // re-resolves the client at dispatch time (see [_runTurn]).
+    await _connectedClient();
     _enqueueTurn(
-      client: client,
       sessionId: sessionId,
       parts: parts,
       model: model,
@@ -649,9 +649,9 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     required ({String providerID, String modelID})? model,
   }) async {
     final body = arguments.isEmpty ? "/$command" : "/$command $arguments";
-    final client = await _connectedClient();
+    // Acceptance gate — see [sendPrompt].
+    await _connectedClient();
     _enqueueTurn(
-      client: client,
       sessionId: sessionId,
       parts: [PluginPromptPart.text(text: body)],
       model: model,
@@ -747,7 +747,6 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   /// `session/prompt` requests for one session are rejected or dropped by ACP
   /// agents, so turns must never interleave per session.
   void _enqueueTurn({
-    required AcpStdioClient client,
     required String sessionId,
     required List<PluginPromptPart> parts,
     required ({String providerID, String modelID})? model,
@@ -775,7 +774,6 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     // failed turn cannot poison the chain for the turns queued behind it.
     state.tail = state.tail.then(
       (_) => _runTurn(
-        client: client,
         sessionId: sessionId,
         state: state,
         expectedGeneration: expectedGeneration,
@@ -786,17 +784,20 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     );
   }
 
-  /// Runs one serialized turn: makes the session resident, applies the turn's
-  /// model/mode selection, dispatches `session/prompt`, and settles the queue
-  /// accounting. Residency and selection run here — inside the chain — so a
-  /// queued turn retries a transiently failed resume-load itself, and a
-  /// selection applied at enqueue time can't flip a process-global selection
-  /// (Cursor's) under the previous, still-running turn. The abort generation
-  /// is re-checked after every await: an abort landing mid-load/mid-selection
-  /// must still drop the not-yet-dispatched turn instead of starting a fresh
-  /// agent run right after the cancel.
+  /// Runs one serialized turn: resolves the live client, makes the session
+  /// resident, applies the turn's model/mode selection, dispatches
+  /// `session/prompt`, and settles the queue accounting. All of it runs here —
+  /// inside the chain — so a turn queued behind an in-flight prompt survives
+  /// an agent respawn (the client captured at enqueue time may have exited;
+  /// re-resolving spawns a replacement and the dispatch-time resume-load makes
+  /// the session resident in it), a queued turn retries a transiently failed
+  /// resume-load itself, and a selection applied at enqueue time can't flip a
+  /// process-global selection (Cursor's) under the previous, still-running
+  /// turn. The abort generation is re-checked after every await: an abort
+  /// landing mid-connect/mid-load/mid-selection must still drop the
+  /// not-yet-dispatched turn instead of starting a fresh agent run right
+  /// after the cancel.
   Future<void> _runTurn({
-    required AcpStdioClient client,
     required String sessionId,
     required _SessionTurnState state,
     required int expectedGeneration,
@@ -806,6 +807,20 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   }) async {
     // Aborted turns were never dispatched, so no per-turn error event — just
     // settle the accounting (idle emission when the count reaches 0).
+    if (state.generation != expectedGeneration) {
+      _finishTurn(sessionId: sessionId, state: state, failed: false, refused: false);
+      return;
+    }
+    final AcpStdioClient client;
+    try {
+      client = await _connectedClient();
+    } on Object catch (error, stack) {
+      // The send was already accepted, so a dead/unrespawnable agent must
+      // surface as a failed turn, not a silent drop.
+      Log.w("[$id] could not reach the agent for a queued turn on $sessionId", error, stack);
+      _finishTurn(sessionId: sessionId, state: state, failed: true, refused: false);
+      return;
+    }
     if (state.generation != expectedGeneration) {
       _finishTurn(sessionId: sessionId, state: state, failed: false, refused: false);
       return;

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -129,11 +129,6 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   /// a turn or the agent rejects it ("session not found").
   final Set<String> _residentSessions = {};
 
-  /// In-flight resume loads, coalesced per session so concurrent turns share
-  /// one `session/load` — and therefore one replay-suppression window, whose
-  /// removal cannot race another load's still-streaming replay.
-  final Map<String, Future<void>> _residentLoads = {};
-
   /// Sessions whose `session/update` notifications are currently dropped — a
   /// resume `session/load` is in flight and its history replay must not leak
   /// into the live stream.
@@ -635,7 +630,6 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     required ({String providerID, String modelID})? model,
   }) async {
     final client = await _connectedClient();
-    await _ensureResident(client, sessionId);
     _enqueueTurn(
       client: client,
       sessionId: sessionId,
@@ -656,7 +650,6 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   }) async {
     final body = arguments.isEmpty ? "/$command" : "/$command $arguments";
     final client = await _connectedClient();
-    await _ensureResident(client, sessionId);
     _enqueueTurn(
       client: client,
       sessionId: sessionId,
@@ -674,21 +667,13 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   /// Ensures [sessionId] is resident in the agent process before a turn. A
   /// session created/resumed this run is already resident; one from a prior
   /// bridge run is re-loaded via `session/load` (its history replay suppressed
-  /// so it does not re-stream into the live conversation). Concurrent callers
-  /// coalesce onto one in-flight load per session, so a single load owns the
-  /// whole suppression window. Never throws for load failures — the turn
-  /// proceeds and surfaces any error itself.
-  Future<void> _ensureResident(AcpStdioClient client, String sessionId) {
-    if (_residentSessions.contains(sessionId)) return Future<void>.value();
-    return _residentLoads.putIfAbsent(
-      sessionId,
-      // Block body on purpose: Map.remove returns the stored value — this very
-      // future — and an arrow body would hand it back to whenComplete, which
-      // awaits a returned future, deadlocking the load on itself.
-      () => _loadResident(client, sessionId).whenComplete(() {
-        _residentLoads.remove(sessionId);
-      }),
-    );
+  /// so it does not re-stream into the live conversation). Called only from
+  /// inside a session's serialized turn, so per-session loads never overlap —
+  /// each load owns its whole suppression window. Never throws for load
+  /// failures — the turn proceeds and surfaces any error itself.
+  Future<void> _ensureResident(AcpStdioClient client, String sessionId) async {
+    if (_residentSessions.contains(sessionId)) return;
+    await _loadResident(client, sessionId);
   }
 
   /// Performs the resume `session/load` for [_ensureResident]. Marks the
@@ -801,11 +786,15 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     );
   }
 
-  /// Runs one serialized turn: applies the turn's model/mode selection,
-  /// dispatches `session/prompt`, and settles the queue accounting. Selection
-  /// is applied here — inside the chain — because applying it at enqueue time
-  /// would flip a process-global selection (Cursor's) under the previous,
-  /// still-running turn.
+  /// Runs one serialized turn: makes the session resident, applies the turn's
+  /// model/mode selection, dispatches `session/prompt`, and settles the queue
+  /// accounting. Residency and selection run here — inside the chain — so a
+  /// queued turn retries a transiently failed resume-load itself, and a
+  /// selection applied at enqueue time can't flip a process-global selection
+  /// (Cursor's) under the previous, still-running turn. The abort generation
+  /// is re-checked after every await: an abort landing mid-load/mid-selection
+  /// must still drop the not-yet-dispatched turn instead of starting a fresh
+  /// agent run right after the cancel.
   Future<void> _runTurn({
     required AcpStdioClient client,
     required String sessionId,
@@ -815,9 +804,14 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
   }) async {
+    // Aborted turns were never dispatched, so no per-turn error event — just
+    // settle the accounting (idle emission when the count reaches 0).
     if (state.generation != expectedGeneration) {
-      // Aborted while queued: never dispatched, so no per-turn error event —
-      // just settle the accounting (idle emission when the count reaches 0).
+      _finishTurn(sessionId: sessionId, state: state, failed: false, refused: false);
+      return;
+    }
+    await _ensureResident(client, sessionId);
+    if (state.generation != expectedGeneration) {
       _finishTurn(sessionId: sessionId, state: state, failed: false, refused: false);
       return;
     }
@@ -832,6 +826,10 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       // Selection is best-effort (the Cursor override is already fail-soft):
       // the turn proceeds on the agent's current settings.
       Log.w("[$id] applyTurnSelection for $sessionId failed; prompting with current settings", error, stack);
+    }
+    if (state.generation != expectedGeneration) {
+      _finishTurn(sessionId: sessionId, state: state, failed: false, refused: false);
+      return;
     }
     eventMapper.beginTurn(sessionId);
     _inFlightTurnSessions.add(sessionId);
@@ -872,6 +870,11 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   }) {
     _inFlightTurnSessions.remove(sessionId);
     if (state.pending > 0) state.pending--;
+    // A session deleted mid-turn already dropped this state object from
+    // [_turnStates]; its detached accounting above must still settle, but it
+    // must not resurrect the deleted session's status entry or emit
+    // idle/error events for it.
+    if (!identical(_turnStates[sessionId], state)) return;
     if (state.pending == 0) {
       _sessionStatuses[sessionId] = const PluginSessionStatus.idle();
       _eventBuffer.add(BridgeSseSessionIdle(sessionID: sessionId));

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -89,19 +89,39 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   Stream<void> get onConnected => _connected.stream;
 
   final Map<String, PluginSessionStatus> _sessionStatuses = {};
-  final Set<String> _activeSessions = {};
 
-  /// The session whose turn was most recently dispatched. Used to attribute a
-  /// mid-turn server request that carries no `sessionId` of its own (see
-  /// [AcpApprovalRegistry.resolveSessionId]). Kept as last-known rather than
-  /// cleared at turn end so a request landing on the turn boundary still
-  /// resolves to the right conversation.
-  String? _activeTurnSessionId;
+  /// Per-session turn-queue state. ACP agents run one turn per session at a
+  /// time, so turns are serialized behind each session's chain here; all
+  /// decisions live on this class — the state object only holds fields.
+  final Map<String, _SessionTurnState> _turnStates = {};
 
-  /// The session whose turn was most recently dispatched, or null before the
-  /// first turn. Exposed so an approval registry can resolve a sessionId-less
-  /// server request to the active conversation.
-  String? get activeTurnSessionId => _activeTurnSessionId;
+  /// Sessions with a `session/prompt` currently in flight, in dispatch order.
+  /// Per-session serialization guarantees a session appears at most once.
+  final List<String> _inFlightTurnSessions = [];
+
+  /// The most recently dispatched turn's session. Retained past turn end so a
+  /// server request landing on the turn boundary still resolves to the right
+  /// conversation.
+  String? _lastTurnSessionId;
+
+  /// The session to attribute a mid-turn server request that carries no
+  /// `sessionId` of its own (see [AcpApprovalRegistry.resolveSessionId]).
+  ///
+  /// Precise when exactly one turn is in flight. With concurrent turns on
+  /// multiple sessions ACP gives no request→turn correlation, so the most
+  /// recent dispatch is used and the ambiguity is logged. With no turn in
+  /// flight, the last dispatched turn's session is returned (boundary case).
+  String? get activeTurnSessionId {
+    if (_inFlightTurnSessions.length == 1) return _inFlightTurnSessions.single;
+    if (_inFlightTurnSessions.isNotEmpty) {
+      Log.w(
+        "[$id] ${_inFlightTurnSessions.length} turns in flight; attributing "
+        "sessionId-less server request to the most recent dispatch",
+      );
+      return _inFlightTurnSessions.last;
+    }
+    return _lastTurnSessionId;
+  }
 
   /// Sessions resident in the live agent process (created via `session/new` or
   /// resumed via `session/load` this run). ACP agents hold sessions in memory
@@ -109,11 +129,21 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   /// a turn or the agent rejects it ("session not found").
   final Set<String> _residentSessions = {};
 
+  /// In-flight resume loads, coalesced per session so concurrent turns share
+  /// one `session/load` — and therefore one replay-suppression window, whose
+  /// removal cannot race another load's still-streaming replay.
+  final Map<String, Future<void>> _residentLoads = {};
+
   /// Sessions whose `session/update` notifications are currently dropped — a
   /// resume `session/load` is in flight and its history replay must not leak
   /// into the live stream.
   final Set<String> _suppressedSessions = {};
-  int _suppressedReplayCount = 0;
+
+  /// Per-session count of dropped replay notifications, read by the resume
+  /// load's drain to detect when the replay stream has gone quiet. Keyed per
+  /// session so two sessions resuming concurrently don't reset each other's
+  /// quiet-window detection.
+  final Map<String, int> _suppressedReplayCounts = {};
 
   /// Whether this connection's agent rejected an *unfiltered* `session/list`
   /// (the ACP spec's global enumeration — `cwd` is only a filter). Remembered
@@ -135,9 +165,15 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   Map<String, dynamic>? get initializeCapabilityMeta => null;
 
   /// Builds the approval registry. Override to return a harness-specific
-  /// subclass (e.g. one that also handles `cursor/ask_question`).
+  /// subclass (e.g. one that also handles `cursor/ask_question`). The base
+  /// registry resolves sessionId-less server requests to the active turn's
+  /// session (see [activeTurnSessionId]), same as the Cursor subclass.
   AcpApprovalRegistry buildApprovalRegistry(AcpStdioClient client) {
-    return AcpApprovalRegistry.forClient(client: client, emit: _eventBuffer.add);
+    return AcpApprovalRegistry.forClient(
+      client: client,
+      emit: _eventBuffer.add,
+      activeSessionResolver: () => activeTurnSessionId,
+    );
   }
 
   /// Captures the model/mode catalog from a `session/new` or `session/load`
@@ -207,7 +243,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
             if (sid is String && _suppressedSessions.contains(sid)) {
               // Replay from an in-flight resume-load — drop so old history does
               // not re-stream into the live conversation.
-              _suppressedReplayCount++;
+              _suppressedReplayCounts[sid] = (_suppressedReplayCounts[sid] ?? 0) + 1;
               return;
             }
           }
@@ -557,15 +593,26 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     captureSessionConfig(session.raw, sessionId: session.sessionId, fromNewSession: true);
     // session/new leaves the session resident in the agent process.
     _residentSessions.add(session.sessionId);
-    await applyTurnSelection(
-      client: client,
-      sessionId: session.sessionId,
-      model: model,
-      variant: variant,
-    );
     _sessionStatuses[session.sessionId] = const PluginSessionStatus.idle();
-    if (parts.isNotEmpty) {
-      _dispatchPrompt(client, session.sessionId, parts);
+    if (parts.isEmpty) {
+      // No first turn to carry the selection: apply it now so the session's
+      // model/mode are in place for whichever turn comes first later.
+      await applyTurnSelection(
+        client: client,
+        sessionId: session.sessionId,
+        model: model,
+        variant: variant,
+      );
+    } else {
+      // A fresh session has an empty chain, so this dispatches immediately;
+      // the selection is applied inside the turn like every other prompt.
+      _enqueueTurn(
+        client: client,
+        sessionId: session.sessionId,
+        parts: parts,
+        model: model,
+        variant: variant,
+      );
     }
     final now = DateTime.now().millisecondsSinceEpoch;
     return PluginSession(
@@ -589,13 +636,13 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   }) async {
     final client = await _connectedClient();
     await _ensureResident(client, sessionId);
-    await applyTurnSelection(
+    _enqueueTurn(
       client: client,
       sessionId: sessionId,
+      parts: parts,
       model: model,
       variant: variant,
     );
-    _dispatchPrompt(client, sessionId, parts);
   }
 
   @override
@@ -610,13 +657,13 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     final body = arguments.isEmpty ? "/$command" : "/$command $arguments";
     final client = await _connectedClient();
     await _ensureResident(client, sessionId);
-    await applyTurnSelection(
+    _enqueueTurn(
       client: client,
       sessionId: sessionId,
+      parts: [PluginPromptPart.text(text: body)],
       model: model,
       variant: variant,
     );
-    _dispatchPrompt(client, sessionId, [PluginPromptPart.text(text: body)]);
   }
 
   /// The directory a session should be loaded/operated in — its own canonical
@@ -627,12 +674,32 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   /// Ensures [sessionId] is resident in the agent process before a turn. A
   /// session created/resumed this run is already resident; one from a prior
   /// bridge run is re-loaded via `session/load` (its history replay suppressed
-  /// so it does not re-stream into the live conversation). Best-effort: on a
-  /// failed/unsupported load the session is still marked resident so the turn
-  /// proceeds and surfaces any error itself, rather than looping.
-  Future<void> _ensureResident(AcpStdioClient client, String sessionId) async {
-    if (_residentSessions.contains(sessionId)) return;
+  /// so it does not re-stream into the live conversation). Concurrent callers
+  /// coalesce onto one in-flight load per session, so a single load owns the
+  /// whole suppression window. Never throws for load failures — the turn
+  /// proceeds and surfaces any error itself.
+  Future<void> _ensureResident(AcpStdioClient client, String sessionId) {
+    if (_residentSessions.contains(sessionId)) return Future<void>.value();
+    return _residentLoads.putIfAbsent(
+      sessionId,
+      // Block body on purpose: Map.remove returns the stored value — this very
+      // future — and an arrow body would hand it back to whenComplete, which
+      // awaits a returned future, deadlocking the load on itself.
+      () => _loadResident(client, sessionId).whenComplete(() {
+        _residentLoads.remove(sessionId);
+      }),
+    );
+  }
+
+  /// Performs the resume `session/load` for [_ensureResident]. Marks the
+  /// session resident only on success — or on a *permanently unsupported*
+  /// load (the no-reload-loop guarantee) — so a transiently failed load
+  /// (timeout, RPC hiccup) is retried on the next turn instead of leaving the
+  /// conversation unrecoverable until the agent respawns.
+  Future<void> _loadResident(AcpStdioClient client, String sessionId) async {
     if (!(_initResult?.agentCapabilities.loadSession ?? false)) {
+      // No load capability: there is nothing to re-load — memoize residency so
+      // turns proceed without re-checking.
       _residentSessions.add(sessionId);
       return;
     }
@@ -647,6 +714,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       await listAllSessions(knownDirectories: const {});
     }
     _suppressedSessions.add(sessionId);
+    _suppressedReplayCounts.remove(sessionId);
     try {
       final raw = await client.request(
         method: AcpMethods.sessionLoad,
@@ -664,70 +732,151 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
         sessionId: sessionId,
       );
       // Keep suppressing until the (post-response) replay stream goes quiet.
-      await _drainReplay(() => _suppressedReplayCount);
-    } catch (error, stack) {
-      Log.w("[$id] resume-load of $sessionId failed; proceeding", error, stack);
+      await _drainReplay(() => _suppressedReplayCounts[sessionId] ?? 0);
+      _residentSessions.add(sessionId);
+    } on AcpRpcException catch (error, stack) {
+      if (error.code == -32601 || error.code == -32602) {
+        // The agent advertised loadSession but rejects the RPC/shape — a retry
+        // cannot succeed, so memoize residency to avoid a load loop and let
+        // the prompt surface any real error itself.
+        Log.w("[$id] session/load unsupported (code ${error.code}); proceeding without resume-load", error, stack);
+        _residentSessions.add(sessionId);
+      } else {
+        // Transient agent error: stay non-resident so the next turn retries
+        // the load instead of prompting a session the agent never loaded.
+        Log.w("[$id] resume-load of $sessionId failed; will retry on next turn", error, stack);
+      }
+    } on Object catch (error, stack) {
+      // Timeout / process blip: same retry-on-next-turn policy as above.
+      Log.w("[$id] resume-load of $sessionId failed; will retry on next turn", error, stack);
     } finally {
       _suppressedSessions.remove(sessionId);
-      _residentSessions.add(sessionId);
+      _suppressedReplayCounts.remove(sessionId);
     }
   }
 
-  /// Sends a prompt turn fire-and-forget: marks the session busy now, streams
-  /// events via the notification listener, and flips to idle when the
-  /// `session/prompt` future resolves (ACP carries no turn-complete event).
-  void _dispatchPrompt(
-    AcpStdioClient client,
-    String sessionId,
-    List<PluginPromptPart> parts,
-  ) {
+  /// Queues a prompt turn on [sessionId]'s serialization chain: marks the
+  /// session busy now (the user's send is accepted), dispatches once the
+  /// session's previous turn finishes, and flips to idle when the last queued
+  /// turn resolves (ACP carries no turn-complete event). Overlapping
+  /// `session/prompt` requests for one session are rejected or dropped by ACP
+  /// agents, so turns must never interleave per session.
+  void _enqueueTurn({
+    required AcpStdioClient client,
+    required String sessionId,
+    required List<PluginPromptPart> parts,
+    required ({String providerID, String modelID})? model,
+    required PluginSessionVariant? variant,
+  }) {
     final blocks = parts
         .map(_promptPartToContentBlock)
         .whereType<Map<String, dynamic>>()
         .toList(growable: false);
     if (blocks.isEmpty) return;
 
-    // Remember the session whose turn is now in flight. Server requests that
-    // arrive mid-turn without their own sessionId (e.g. Cursor's
-    // `cursor/create_plan`) are attributed to it via [activeTurnSessionId].
-    _activeTurnSessionId = sessionId;
-    eventMapper.beginTurn(sessionId);
-    _sessionStatuses[sessionId] = const PluginSessionStatus.busy();
-    _eventBuffer.add(
-      BridgeSseSessionStatus(
-        sessionID: sessionId,
-        status: const shared.SessionStatus.busy().toJson(),
+    final state = _turnStates.putIfAbsent(sessionId, _SessionTurnState.new);
+    state.pending++;
+    if (state.pending == 1) {
+      _sessionStatuses[sessionId] = const PluginSessionStatus.busy();
+      _eventBuffer.add(
+        BridgeSseSessionStatus(
+          sessionID: sessionId,
+          status: const shared.SessionStatus.busy().toJson(),
+        ),
+      );
+    }
+    final expectedGeneration = state.generation;
+    // Each link isolates its own failure (_runTurn never throws), so one
+    // failed turn cannot poison the chain for the turns queued behind it.
+    state.tail = state.tail.then(
+      (_) => _runTurn(
+        client: client,
+        sessionId: sessionId,
+        state: state,
+        expectedGeneration: expectedGeneration,
+        blocks: blocks,
+        model: model,
+        variant: variant,
       ),
-    );
-
-    final future = client.request(
-      method: AcpMethods.sessionPrompt,
-      params: {"sessionId": sessionId, "prompt": blocks},
-      timeout: const Duration(minutes: 30),
-    );
-    _activeSessions.add(sessionId);
-    unawaited(
-      future.then((raw) {
-        final result = AcpPromptResult.fromJson(
-          (raw as Map?)?.cast<String, dynamic>() ?? const {},
-        );
-        _onTurnEnd(sessionId, result.stopReason);
-      }).catchError((Object error, StackTrace stack) {
-        // The frame was already accepted (the phone's send returned success),
-        // so a later rejection (auth expiry, stale session, bad payload) would
-        // otherwise stop the run with no signal. Log and surface it as a
-        // session error, not a silent idle.
-        Log.w("[$id] session/prompt for $sessionId failed after dispatch", error, stack);
-        _onTurnEnd(sessionId, AcpStopReason.unknown, failed: true);
-      }),
     );
   }
 
-  void _onTurnEnd(String sessionId, AcpStopReason reason, {bool failed = false}) {
-    _activeSessions.remove(sessionId);
-    _sessionStatuses[sessionId] = const PluginSessionStatus.idle();
-    _eventBuffer.add(BridgeSseSessionIdle(sessionID: sessionId));
-    if (failed || reason == AcpStopReason.refusal) {
+  /// Runs one serialized turn: applies the turn's model/mode selection,
+  /// dispatches `session/prompt`, and settles the queue accounting. Selection
+  /// is applied here — inside the chain — because applying it at enqueue time
+  /// would flip a process-global selection (Cursor's) under the previous,
+  /// still-running turn.
+  Future<void> _runTurn({
+    required AcpStdioClient client,
+    required String sessionId,
+    required _SessionTurnState state,
+    required int expectedGeneration,
+    required List<Map<String, dynamic>> blocks,
+    required ({String providerID, String modelID})? model,
+    required PluginSessionVariant? variant,
+  }) async {
+    if (state.generation != expectedGeneration) {
+      // Aborted while queued: never dispatched, so no per-turn error event —
+      // just settle the accounting (idle emission when the count reaches 0).
+      _finishTurn(sessionId: sessionId, state: state, failed: false, refused: false);
+      return;
+    }
+    try {
+      await applyTurnSelection(
+        client: client,
+        sessionId: sessionId,
+        model: model,
+        variant: variant,
+      );
+    } on Object catch (error, stack) {
+      // Selection is best-effort (the Cursor override is already fail-soft):
+      // the turn proceeds on the agent's current settings.
+      Log.w("[$id] applyTurnSelection for $sessionId failed; prompting with current settings", error, stack);
+    }
+    eventMapper.beginTurn(sessionId);
+    _inFlightTurnSessions.add(sessionId);
+    _lastTurnSessionId = sessionId;
+    try {
+      final raw = await client.request(
+        method: AcpMethods.sessionPrompt,
+        params: {"sessionId": sessionId, "prompt": blocks},
+        timeout: const Duration(minutes: 30),
+      );
+      final result = AcpPromptResult.fromJson(
+        (raw as Map?)?.cast<String, dynamic>() ?? const {},
+      );
+      _finishTurn(
+        sessionId: sessionId,
+        state: state,
+        failed: false,
+        refused: result.stopReason == AcpStopReason.refusal,
+      );
+    } on Object catch (error, stack) {
+      // The frame was already accepted (the phone's send returned success),
+      // so a later rejection (auth expiry, stale session, bad payload) would
+      // otherwise stop the run with no signal. Log and surface it as a
+      // session error, not a silent idle.
+      Log.w("[$id] session/prompt for $sessionId failed after dispatch", error, stack);
+      _finishTurn(sessionId: sessionId, state: state, failed: true, refused: false);
+    }
+  }
+
+  /// Settles one finished (or dropped) turn: removes the in-flight marker,
+  /// decrements the session's pending count, emits idle when the last queued
+  /// turn is done, and surfaces a session error for a failed/refused turn.
+  void _finishTurn({
+    required String sessionId,
+    required _SessionTurnState state,
+    required bool failed,
+    required bool refused,
+  }) {
+    _inFlightTurnSessions.remove(sessionId);
+    if (state.pending > 0) state.pending--;
+    if (state.pending == 0) {
+      _sessionStatuses[sessionId] = const PluginSessionStatus.idle();
+      _eventBuffer.add(BridgeSseSessionIdle(sessionID: sessionId));
+    }
+    if (failed || refused) {
       _eventBuffer.add(BridgeSseSessionError(sessionID: sessionId));
     }
   }
@@ -767,6 +916,11 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
 
   @override
   Future<void> abortSession({required String sessionId}) async {
+    // Aborting means "stop this conversation now": drop the queued-but-
+    // undispatched turns first so they don't dispatch after the cancel. The
+    // in-flight turn (if any) ends via the agent's cancellation, which
+    // resolves its `session/prompt` future and settles the accounting.
+    _turnStates[sessionId]?.generation++;
     final client = _client;
     if (client == null) return;
     client.notify(
@@ -800,10 +954,14 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
 
   @override
   Future<void> deleteSession(String sessionId) async {
-    if (_activeSessions.contains(sessionId)) {
+    if ((_turnStates[sessionId]?.pending ?? 0) > 0) {
       await abortSession(sessionId: sessionId);
     }
-    _activeSessions.remove(sessionId);
+    // The state object is dropped here; a still-settling cancelled turn holds
+    // its own reference, so its accounting completes harmlessly off-map.
+    _turnStates.remove(sessionId);
+    _inFlightTurnSessions.remove(sessionId);
+    if (_lastTurnSessionId == sessionId) _lastTurnSessionId = null;
     _sessionStatuses.remove(sessionId);
     _residentSessions.remove(sessionId);
     _sessionDirectories.remove(sessionId);
@@ -1115,7 +1273,9 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     // live in different opened directories, not just the launch CWD.
     final byProject = <String, List<PluginActiveSession>>{};
     for (final sessionId in _sessionStatuses.keys) {
-      final running = _activeSessions.contains(sessionId);
+      // A session with any unfinished turn (running or queued behind one)
+      // counts as running, so it stays active until its last turn settles.
+      final running = (_turnStates[sessionId]?.pending ?? 0) > 0;
       final awaiting = registry?.hasPendingInput(sessionId) ?? false;
       if (!running && !awaiting) continue;
       (byProject[_directoryForSession(sessionId)] ??= []).add(
@@ -1173,4 +1333,20 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       Log.w("[$id] failed to close connected stream", e, st);
     }
   }
+}
+
+/// Mutable per-session turn-queue fields. [AcpPlugin] owns all the logic —
+/// this only carries the chain tail the session's turns serialize behind, the
+/// count of unfinished turns, and the abort generation used to drop
+/// queued-but-undispatched turns.
+class _SessionTurnState {
+  /// Completion of the session's most recently queued turn.
+  Future<void> tail = Future<void>.value();
+
+  /// Turns enqueued but not yet finished (including the running one).
+  int pending = 0;
+
+  /// Bumped by abort/delete; a queued turn dispatches only if the generation
+  /// it captured at enqueue time is still current.
+  int generation = 0;
 }

--- a/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
@@ -51,13 +51,16 @@ void main() {
     // instead of re-answering the first one.
     final answered = <(FakeAcpProcess, Object?)>{};
 
+    // Polls with a small real delay: a serialized turn's dispatch can sit
+    // behind the resume-load replay drain (~250ms of wall-clock quiet time),
+    // which zero-duration pumps never outlast.
     Future<Map<String, dynamic>> waitForFrame(String method) async {
-      for (var i = 0; i < 50; i++) {
+      for (var i = 0; i < 400; i++) {
         final matches = fake()
             .written
             .where((f) => f["method"] == method && !answered.contains((fake(), f["id"])));
         if (matches.isNotEmpty) return matches.last;
-        await pump();
+        await Future<void>.delayed(const Duration(milliseconds: 5));
       }
       throw StateError("agent never wrote a '$method' frame");
     }

--- a/bridge/sesori_plugin_acp/test/acp_resume_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_test.dart
@@ -85,7 +85,11 @@ void main() {
       await pump();
       fake.emit({"jsonrpc": "2.0", "id": loadFrame["id"], "result": const <String, dynamic>{}});
 
+      // sendPrompt resolves once the turn is accepted (queued); the dispatch
+      // itself runs on the session's serialization chain, so wait for the
+      // prompt frame before asserting on the frame order.
       await sending;
+      await waitForFrame("session/prompt");
 
       // session/load was sent before session/prompt.
       final methods = fake.written.map((f) => f["method"]).toList();
@@ -94,10 +98,13 @@ void main() {
         isTrue,
         reason: "resume-load must precede the prompt",
       );
-      await waitForFrame("session/prompt");
 
       // The suppressed replay produced no message events on the live stream.
       expect(emitted.whereType<BridgeSseMessagePartDelta>(), isEmpty);
+
+      // Complete the first turn so the follow-up prompt dispatches (turns on
+      // one session are serialized).
+      await respond("session/prompt", {"stopReason": "end_turn"});
 
       // A second prompt on the now-resident session does NOT re-load.
       final loadsBefore = fake.written.where((f) => f["method"] == "session/load").length;

--- a/bridge/sesori_plugin_acp/test/acp_resume_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_test.dart
@@ -34,11 +34,14 @@ void main() {
     });
 
     Future<void> pump() => Future<void>.delayed(Duration.zero);
+    // Polls with a small real delay: a serialized turn's dispatch can sit
+    // behind the resume-load replay drain (~250ms of wall-clock quiet time),
+    // which zero-duration pumps never outlast.
     Future<Map<String, dynamic>> waitForFrame(String method) async {
-      for (var i = 0; i < 80; i++) {
+      for (var i = 0; i < 400; i++) {
         final matches = fake.written.where((f) => f["method"] == method);
         if (matches.isNotEmpty) return matches.last;
-        await pump();
+        await Future<void>.delayed(const Duration(milliseconds: 5));
       }
       throw StateError("agent never wrote a '$method' frame");
     }

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -405,6 +405,131 @@ void main() {
       respondTo(secondPrompt, {"stopReason": "end_turn"});
     });
 
+    test("a queued turn survives an agent respawn by resolving the live client", () async {
+      // Two processes: the first dies mid-turn, the queued turn must dispatch
+      // on the respawned replacement instead of failing against the captured
+      // dead client.
+      final fakes = [FakeAcpProcess(), FakeAcpProcess()];
+      final spawned = <FakeAcpProcess>[];
+      final respawning = AcpPlugin(
+        id: "acp",
+        agentDisplayName: "ACP",
+        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+        launchDirectory: cwd,
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp"),
+        processFactory: (_) async {
+          final next = fakes.removeAt(0);
+          spawned.add(next);
+          return next;
+        },
+      );
+      addTearDown(() async {
+        await respawning.dispose();
+        for (final f in spawned) {
+          await f.close();
+        }
+        for (final f in fakes) {
+          await f.close();
+        }
+      });
+      final events = <BridgeSseEvent>[];
+      respawning.events.listen(events.add);
+
+      List<Map<String, dynamic>> framesOn(FakeAcpProcess fake, String method) =>
+          fake.written.where((f) => f["method"] == method).toList(growable: false);
+      Future<Map<String, dynamic>> waitOn(FakeAcpProcess fake, String method, int count) async {
+        for (var i = 0; i < 400; i++) {
+          final matches = framesOn(fake, method);
+          if (matches.length >= count) return matches[count - 1];
+          await Future<void>.delayed(const Duration(milliseconds: 5));
+        }
+        throw StateError("expected $count '$method' frame(s)");
+      }
+
+      final connecting = respawning.ensureConnected();
+      final first = spawned.isEmpty ? fakes.first : spawned.first;
+      final init1 = await waitOn(first, "initialize", 1);
+      first.emit({
+        "jsonrpc": "2.0",
+        "id": init1["id"],
+        "result": {
+          "protocolVersion": 1,
+          "agentCapabilities": <String, dynamic>{},
+          "authMethods": <Object?>[],
+        },
+      });
+      expect(await connecting, isTrue);
+
+      final creating = respawning.createSession(
+        directory: cwd,
+        parentSessionId: null,
+        parts: const [],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final newFrame = await waitOn(first, "session/new", 1);
+      first.emit({
+        "jsonrpc": "2.0",
+        "id": newFrame["id"],
+        "result": {"sessionId": "s1"},
+      });
+      await creating;
+
+      Future<void> send(String text) => respawning.sendPrompt(
+        sessionId: "s1",
+        parts: [PluginPromptPart.text(text: text)],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+
+      await send("first");
+      await waitOn(first, "session/prompt", 1);
+      await send("queued");
+
+      // The agent dies mid-turn; the lifecycle wrapper resets the connection.
+      first.exit(1);
+      await respawning.resetConnectionAfterExit();
+
+      // The queued turn re-resolves the client, spawning the replacement and
+      // completing its handshake before dispatching.
+      final second = await () async {
+        for (var i = 0; i < 400; i++) {
+          if (spawned.length > 1) return spawned[1];
+          await Future<void>.delayed(const Duration(milliseconds: 5));
+        }
+        throw StateError("the queued turn never respawned the agent");
+      }();
+      final init2 = await waitOn(second, "initialize", 1);
+      second.emit({
+        "jsonrpc": "2.0",
+        "id": init2["id"],
+        "result": {
+          "protocolVersion": 1,
+          "agentCapabilities": <String, dynamic>{},
+          "authMethods": <Object?>[],
+        },
+      });
+
+      final queuedPrompt = await waitOn(second, "session/prompt", 1);
+      expect((queuedPrompt["params"] as Map)["sessionId"], "s1");
+      second.emit({
+        "jsonrpc": "2.0",
+        "id": queuedPrompt["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+      for (var i = 0; i < 10; i++) {
+        await pump();
+      }
+
+      // The interrupted first turn surfaced as an error; the queued turn
+      // completed and the session settled idle.
+      expect(events.whereType<BridgeSseSessionError>(), hasLength(1));
+      expect(events.whereType<BridgeSseSessionIdle>(), hasLength(1));
+      expect(respawning.getActiveSessionsSummary(), isEmpty);
+    });
+
     test("sessionId-less server requests attribute to the unambiguous in-flight turn", () async {
       await connect();
       final s1 = await createSession(cwd, "s1");

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -1,0 +1,327 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+/// Turn-lifecycle robustness:
+///
+///  - prompts on one session are serialized (agents reject or drop overlapping
+///    `session/prompt` requests), and the session stays busy until its LAST
+///    queued turn settles;
+///  - an abort drops queued-but-undispatched turns;
+///  - a transiently failed resume `session/load` is retried on the next turn,
+///    while a permanently unsupported one is memoized (no load loop);
+///  - concurrent prompts coalesce onto a single resume-load whose replay
+///    suppression covers the whole load;
+///  - sessionId-less server requests attribute precisely when exactly one
+///    turn is in flight.
+void main() {
+  group("AcpPlugin turn serialization", () {
+    late FakeAcpProcess fake;
+    late AcpPlugin plugin;
+    final emitted = <BridgeSseEvent>[];
+    const cwd = "/repo";
+
+    setUp(() {
+      fake = FakeAcpProcess();
+      plugin = AcpPlugin(
+        id: "acp",
+        agentDisplayName: "ACP",
+        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+        launchDirectory: cwd,
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp"),
+        processFactory: (_) async => fake,
+      );
+      emitted.clear();
+      plugin.events.listen(emitted.add);
+    });
+
+    tearDown(() async {
+      await plugin.dispose();
+      await fake.close();
+    });
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+    List<Map<String, dynamic>> frames(String method) =>
+        fake.written.where((f) => f["method"] == method).toList(growable: false);
+
+    Future<Map<String, dynamic>> waitForFrameCount(String method, int count) async {
+      for (var i = 0; i < 80; i++) {
+        final matches = frames(method);
+        if (matches.length >= count) return matches[count - 1];
+        await pump();
+      }
+      throw StateError("agent never wrote $count '$method' frame(s)");
+    }
+
+    Future<Map<String, dynamic>> waitForFrame(String method) =>
+        waitForFrameCount(method, 1);
+
+    void respondTo(Map<String, dynamic> frame, Map<String, dynamic> result) {
+      fake.emit({"jsonrpc": "2.0", "id": frame["id"], "result": result});
+    }
+
+    Future<void> connect({bool loadSession = false}) async {
+      final connecting = plugin.ensureConnected();
+      final frame = await waitForFrame("initialize");
+      respondTo(frame, {
+        "protocolVersion": 1,
+        "agentCapabilities": {"loadSession": loadSession},
+        "authMethods": <Object?>[],
+      });
+      expect(await connecting, isTrue);
+    }
+
+    Future<String> createSession(String directory, String sessionId) async {
+      final creating = plugin.createSession(
+        directory: directory,
+        parentSessionId: null,
+        parts: const [],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final newFrames = frames("session/new").length;
+      final frame = await waitForFrameCount("session/new", newFrames + 1);
+      respondTo(frame, {"sessionId": sessionId});
+      final session = await creating;
+      return session.id;
+    }
+
+    Future<void> sendPrompt(String sessionId, String text) => plugin.sendPrompt(
+      sessionId: sessionId,
+      parts: [PluginPromptPart.text(text: text)],
+      variant: null,
+      agent: null,
+      model: null,
+    );
+
+    int busyCount() => emitted.whereType<BridgeSseSessionStatus>().length;
+    int idleCount() => emitted.whereType<BridgeSseSessionIdle>().length;
+
+    test("a second prompt on one session dispatches only after the first turn completes", () async {
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+
+      await sendPrompt(sessionId, "first");
+      final firstPrompt = await waitForFrame("session/prompt");
+      expect(busyCount(), 1);
+
+      await sendPrompt(sessionId, "second");
+      for (var i = 0; i < 10; i++) {
+        await pump();
+      }
+      expect(
+        frames("session/prompt"),
+        hasLength(1),
+        reason: "the second prompt must wait for the first turn to complete",
+      );
+      expect(busyCount(), 1, reason: "queued turn keeps the one busy signal");
+      expect(idleCount(), 0);
+
+      respondTo(firstPrompt, {"stopReason": "end_turn"});
+      final secondPrompt = await waitForFrameCount("session/prompt", 2);
+      expect((secondPrompt["params"] as Map)["sessionId"], sessionId);
+      await pump();
+      expect(
+        idleCount(),
+        0,
+        reason: "the session is still busy while the queued turn runs",
+      );
+      expect(
+        plugin.getActiveSessionsSummary().single.activeSessions.single.mainAgentRunning,
+        isTrue,
+      );
+
+      respondTo(secondPrompt, {"stopReason": "end_turn"});
+      await pump();
+      await pump();
+      expect(idleCount(), 1, reason: "idle only after the last queued turn settles");
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+    });
+
+    test("abort drops queued-but-undispatched turns", () async {
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+
+      await sendPrompt(sessionId, "first");
+      final firstPrompt = await waitForFrame("session/prompt");
+      await sendPrompt(sessionId, "queued");
+
+      await plugin.abortSession(sessionId: sessionId);
+      expect(frames("session/cancel"), hasLength(1));
+
+      // The agent honours the cancel by ending the in-flight turn.
+      respondTo(firstPrompt, {"stopReason": "cancelled"});
+      for (var i = 0; i < 10; i++) {
+        await pump();
+      }
+
+      expect(
+        frames("session/prompt"),
+        hasLength(1),
+        reason: "the queued turn must not dispatch after an abort",
+      );
+      expect(idleCount(), 1, reason: "queue accounting settles to idle");
+      expect(emitted.whereType<BridgeSseSessionError>(), isEmpty);
+      expect(plugin.getActiveSessionsSummary(), isEmpty);
+    });
+
+    test("a transiently failed resume-load is retried on the next turn", () async {
+      await connect(loadSession: true);
+
+      final sendingFirst = sendPrompt("old-1", "hi");
+      final firstLoad = await waitForFrame("session/load");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": firstLoad["id"],
+        "error": {"code": -32000, "message": "transient agent hiccup"},
+      });
+      await sendingFirst;
+      // The turn still proceeds and surfaces its own outcome.
+      final firstPrompt = await waitForFrame("session/prompt");
+      respondTo(firstPrompt, {"stopReason": "end_turn"});
+      await pump();
+
+      final sendingSecond = sendPrompt("old-1", "again");
+      final secondLoad = await waitForFrameCount("session/load", 2);
+      respondTo(secondLoad, const {});
+      await sendingSecond;
+      final secondPrompt = await waitForFrameCount("session/prompt", 2);
+      respondTo(secondPrompt, {"stopReason": "end_turn"});
+
+      expect(
+        frames("session/load"),
+        hasLength(2),
+        reason: "a transient load failure must not cache the session as resident",
+      );
+    });
+
+    test("an unsupported resume-load is memoized and not re-attempted", () async {
+      await connect(loadSession: true);
+
+      final sendingFirst = sendPrompt("old-1", "hi");
+      final firstLoad = await waitForFrame("session/load");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": firstLoad["id"],
+        "error": {"code": -32601, "message": "method not found"},
+      });
+      await sendingFirst;
+      final firstPrompt = await waitForFrame("session/prompt");
+      respondTo(firstPrompt, {"stopReason": "end_turn"});
+      await pump();
+
+      final sendingSecond = sendPrompt("old-1", "again");
+      final secondPrompt = await waitForFrameCount("session/prompt", 2);
+      respondTo(secondPrompt, {"stopReason": "end_turn"});
+      await sendingSecond;
+
+      expect(
+        frames("session/load"),
+        hasLength(1),
+        reason: "an unsupported load is memoized so turns don't loop on it",
+      );
+    });
+
+    test("concurrent prompts coalesce onto one resume-load with one suppression window", () async {
+      await connect(loadSession: true);
+
+      final sendingA = sendPrompt("old-1", "a");
+      final sendingB = sendPrompt("old-1", "b");
+
+      final loadFrame = await waitForFrame("session/load");
+      // Replay streamed by the in-flight load must never reach the live stream,
+      // even while a second caller shares the load.
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": "old-1",
+          "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "OLD HISTORY"},
+          },
+        },
+      });
+      await pump();
+      respondTo(loadFrame, const {});
+      await Future.wait([sendingA, sendingB]);
+
+      expect(
+        frames("session/load"),
+        hasLength(1),
+        reason: "concurrent callers must share a single resume-load",
+      );
+      expect(emitted.whereType<BridgeSseMessagePartDelta>(), isEmpty);
+
+      // Both prompts dispatch, serialized.
+      final firstPrompt = await waitForFrame("session/prompt");
+      expect(frames("session/prompt"), hasLength(1));
+      respondTo(firstPrompt, {"stopReason": "end_turn"});
+      final secondPrompt = await waitForFrameCount("session/prompt", 2);
+      respondTo(secondPrompt, {"stopReason": "end_turn"});
+    });
+
+    test("sessionId-less server requests attribute to the unambiguous in-flight turn", () async {
+      await connect();
+      final s1 = await createSession(cwd, "s1");
+      final s2 = await createSession("/other", "s2");
+
+      Future<Map<String, dynamic>> promptFrameFor(String sessionId) async {
+        for (var i = 0; i < 80; i++) {
+          final match = frames("session/prompt")
+              .where((f) => (f["params"] as Map)["sessionId"] == sessionId);
+          if (match.isNotEmpty) return match.last;
+          await pump();
+        }
+        throw StateError("no session/prompt frame for $sessionId");
+      }
+
+      void emitBarePermission(int id) {
+        fake.emit({
+          "jsonrpc": "2.0",
+          "id": id,
+          "method": "session/request_permission",
+          "params": {
+            "toolCall": {"toolCallId": "tc-$id", "title": "Run", "kind": "execute"},
+            "options": [
+              {"optionId": "allow", "name": "Allow", "kind": "allow_once"},
+            ],
+          },
+        });
+      }
+
+      // Turns in flight on two sessions: attribution falls back to the most
+      // recent dispatch (ACP carries no request→turn correlation).
+      await sendPrompt(s1, "one");
+      final s1Prompt = await promptFrameFor(s1);
+      await sendPrompt(s2, "two");
+      final s2Prompt = await promptFrameFor(s2);
+
+      emitBarePermission(501);
+      await pump();
+      expect(await plugin.getPendingPermissions(sessionId: s2), hasLength(1));
+      expect(await plugin.getPendingPermissions(sessionId: s1), isEmpty);
+
+      // With only one turn left in flight, attribution is precise — even
+      // though the other session dispatched more recently.
+      respondTo(s2Prompt, {"stopReason": "end_turn"});
+      await pump();
+      await pump();
+      emitBarePermission(502);
+      await pump();
+      expect(await plugin.getPendingPermissions(sessionId: s1), hasLength(1));
+
+      // With no turn in flight, the last dispatched turn's session absorbs a
+      // boundary request (the pre-existing behaviour).
+      respondTo(s1Prompt, {"stopReason": "end_turn"});
+      await pump();
+      await pump();
+      emitBarePermission(503);
+      await pump();
+      expect(await plugin.getPendingPermissions(sessionId: s2), hasLength(2));
+    });
+  });
+}

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -1,7 +1,35 @@
+import "dart:async";
+
 import "package:acp_plugin/acp_plugin.dart";
 import "package:acp_plugin/acp_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
+
+/// An [AcpPlugin] whose [applyTurnSelection] blocks on a test-controlled gate,
+/// so a test can land an abort while a turn is mid-selection.
+class _GatedSelectionPlugin extends AcpPlugin {
+  _GatedSelectionPlugin({
+    required super.id,
+    required super.agentDisplayName,
+    required super.launchSpec,
+    required super.launchDirectory,
+    required super.eventMapper,
+    required AcpProcessFactory super.processFactory,
+  });
+
+  Completer<void>? selectionGate;
+
+  @override
+  Future<void> applyTurnSelection({
+    required AcpStdioClient client,
+    required String sessionId,
+    required ({String providerID, String modelID})? model,
+    required PluginSessionVariant? variant,
+  }) async {
+    final gate = selectionGate;
+    if (gate != null) await gate.future;
+  }
+}
 
 /// Turn-lifecycle robustness:
 ///
@@ -46,11 +74,14 @@ void main() {
     List<Map<String, dynamic>> frames(String method) =>
         fake.written.where((f) => f["method"] == method).toList(growable: false);
 
+    // Polls with a small real delay: a serialized turn's dispatch can sit
+    // behind the resume-load replay drain (~250ms of wall-clock quiet time),
+    // which zero-duration pumps never outlast.
     Future<Map<String, dynamic>> waitForFrameCount(String method, int count) async {
-      for (var i = 0; i < 80; i++) {
+      for (var i = 0; i < 400; i++) {
         final matches = frames(method);
         if (matches.length >= count) return matches[count - 1];
-        await pump();
+        await Future<void>.delayed(const Duration(milliseconds: 5));
       }
       throw StateError("agent never wrote $count '$method' frame(s)");
     }
@@ -166,6 +197,116 @@ void main() {
       expect(idleCount(), 1, reason: "queue accounting settles to idle");
       expect(emitted.whereType<BridgeSseSessionError>(), isEmpty);
       expect(plugin.getActiveSessionsSummary(), isEmpty);
+    });
+
+    test("an abort landing during turn selection still drops the turn", () async {
+      final gated = _GatedSelectionPlugin(
+        id: "acp",
+        agentDisplayName: "ACP",
+        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+        launchDirectory: cwd,
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp"),
+        processFactory: (_) async => fake,
+      );
+      addTearDown(gated.dispose);
+      final gatedEvents = <BridgeSseEvent>[];
+      gated.events.listen(gatedEvents.add);
+
+      final connecting = gated.ensureConnected();
+      final init = await waitForFrame("initialize");
+      respondTo(init, {
+        "protocolVersion": 1,
+        "agentCapabilities": <String, dynamic>{},
+        "authMethods": <Object?>[],
+      });
+      expect(await connecting, isTrue);
+
+      final creating = gated.createSession(
+        directory: cwd,
+        parentSessionId: null,
+        parts: const [],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      respondTo(await waitForFrame("session/new"), {"sessionId": "s1"});
+      await creating;
+
+      // Hold the turn in selection, abort, then release the gate: the prompt
+      // must never dispatch (an abort right before dispatch must not start a
+      // fresh agent run).
+      final gate = Completer<void>();
+      gated.selectionGate = gate;
+      await gated.sendPrompt(
+        sessionId: "s1",
+        parts: const [PluginPromptPart.text(text: "hi")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      for (var i = 0; i < 5; i++) {
+        await pump();
+      }
+      await gated.abortSession(sessionId: "s1");
+      gate.complete();
+      for (var i = 0; i < 10; i++) {
+        await pump();
+      }
+
+      expect(frames("session/prompt"), isEmpty);
+      expect(gatedEvents.whereType<BridgeSseSessionIdle>(), hasLength(1));
+      expect(gated.getActiveSessionsSummary(), isEmpty);
+    });
+
+    test("deleting a session mid-turn does not resurrect it as idle", () async {
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+
+      await sendPrompt(sessionId, "hi");
+      final promptFrame = await waitForFrame("session/prompt");
+
+      await plugin.deleteSession(sessionId);
+      expect(frames("session/cancel"), hasLength(1));
+
+      // The cancelled prompt settles after the delete: its accounting must not
+      // re-create the deleted session's status entry or emit idle for it.
+      respondTo(promptFrame, {"stopReason": "cancelled"});
+      for (var i = 0; i < 10; i++) {
+        await pump();
+      }
+      expect(await plugin.getSessionStatuses(), isEmpty);
+      expect(emitted.whereType<BridgeSseSessionIdle>(), isEmpty);
+    });
+
+    test("a queued turn retries a transiently failed resume-load at dispatch", () async {
+      await connect(loadSession: true);
+
+      // Two prompts queued up front. The first turn's load fails transiently
+      // and its prompt errors; the SECOND queued turn must retry the load at
+      // its own dispatch — not inherit the failure.
+      final sendingA = sendPrompt("old-1", "a");
+      final sendingB = sendPrompt("old-1", "b");
+      await Future.wait([sendingA, sendingB]);
+
+      final firstLoad = await waitForFrame("session/load");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": firstLoad["id"],
+        "error": {"code": -32000, "message": "transient"},
+      });
+      final firstPrompt = await waitForFrame("session/prompt");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": firstPrompt["id"],
+        "error": {"code": -32000, "message": "session not found"},
+      });
+
+      final secondLoad = await waitForFrameCount("session/load", 2);
+      respondTo(secondLoad, const {});
+      final secondPrompt = await waitForFrameCount("session/prompt", 2);
+      respondTo(secondPrompt, {"stopReason": "end_turn"});
+      await pump();
+      expect(frames("session/load"), hasLength(2));
     });
 
     test("a transiently failed resume-load is retried on the next turn", () async {

--- a/docs/cursor-acp-followups/README.md
+++ b/docs/cursor-acp-followups/README.md
@@ -241,7 +241,9 @@ turn-lifecycle rework in `acp_plugin.dart`, covered by
   permanently unsupported load (`-32601`/`-32602` from an agent that
   advertised `loadSession` anyway) is memoized as resident, preserving the
   original no-reload-loop guarantee; transient failures (timeout, RPC hiccup)
-  leave the session non-resident so the next turn retries the load.
+  leave the session non-resident. Residency is ensured at *dispatch time*
+  inside each serialized turn, so even a turn already queued when the load
+  failed retries the load itself before prompting.
   Source: [#332 r3545873646](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3545873646)
 
 - **H2 — prompts are serialized per session.** Each session owns a turn chain
@@ -255,11 +257,12 @@ turn-lifecycle rework in `acp_plugin.dart`, covered by
   `abortSession` drops queued-but-undispatched turns via a generation bump.
   Source: [#332 r3545873662](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3545873662)
 
-- **H3 — concurrent resume loads coalesce.** Concurrent `_ensureResident`
-  calls for one session share a single in-flight `session/load` future, so
-  exactly one load owns the whole replay-suppression window (no early
-  unsuppress mid-replay), and the replay quiet-window counters are per-session
-  so two sessions resuming concurrently don't reset each other's drain.
+- **H3 — resume loads no longer race each other's suppression window.**
+  Resume loads run inside the session's serialized turn chain, so one
+  session's loads can never overlap — each `session/load` owns its whole
+  replay-suppression window (no early unsuppress mid-replay) — and the replay
+  quiet-window counters are per-session so two sessions resuming concurrently
+  don't reset each other's drain.
   Source: [#332 r3545873652](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3545873652)
 
 ---

--- a/docs/cursor-acp-followups/README.md
+++ b/docs/cursor-acp-followups/README.md
@@ -1,12 +1,13 @@
 # Cursor / ACP Backend — Deferred Follow-ups
 
-> Status: **not scoped, not started**. This document tracks improvements that
-> were consciously deferred during (and at merge time of) the review of PR #332
-> (`feat(bridge): add Cursor backend via ACP`). Each item is something a reviewer
-> (human or bot) raised and we agreed was real, but out of scope for that PR —
-> either because it needs a bridge-side change beyond aligning the plugin,
-> because it needs a real protocol trace before it can be done safely, or because
-> the finding landed as the PR merged (Themes H and I, and C5, are these last).
+> Status: **in progress — resolved themes are marked per section**. This
+> document tracks improvements that were consciously deferred during (and at
+> merge time of) the review of PR #332 (`feat(bridge): add Cursor backend via
+> ACP`). Each item is something a reviewer (human or bot) raised and we agreed
+> was real, but out of scope for that PR — either because it needs a
+> bridge-side change beyond aligning the plugin, because it needs a real
+> protocol trace before it can be done safely, or because the finding landed as
+> the PR merged (Themes H and I, and C5, are these last).
 >
 > When you pick one up, **re-verify the claim against current code first** —
 > file/line references were accurate at review time and may have drifted. Every
@@ -42,17 +43,17 @@ than observed Cursor bugs. That is called out per item.
 
 ## Priority (suggested)
 
-| #  | Theme                                                | Why it matters                                                  | Rough cost |
+| #  | Theme                                                | Why it matters                                                  | Status |
 |----|------------------------------------------------------|----------------------------------------------------------------|------------|
-| H  | Resume-load & per-session turn robustness            | **User-facing:** stuck conversations, dropped queued prompts, replay leak | Medium     |
-| A  | Bridge↔plugin stored-directory / attribution seam    | Real worktree flows on restart; one hook resolves three threads | Medium     |
-| B  | Durable derive-plugin session state (bridge schema)  | Title loss + deleted sessions reappearing                       | Medium     |
-| C  | ACP protocol completeness in the mapper / parsers    | Correctness for the next ACP backend                            | Medium     |
-| G  | Concurrent multi-session turn attribution            | Wrong-conversation routing of `sessionId`-less requests         | Medium     |
-| I  | Lossy `session.updated` payload on title changes     | List row loses time/summary/defaults until refresh             | Small–Med  |
-| E  | Typed ACP/Cursor boundary DTOs                        | Enabler / safety net for C and F                                | Large      |
-| F  | `getSessionMessages` richer failure contract         | "Broken replay" vs "empty thread" on the phone                  | Small–Med  |
-| D  | Cursor decisions needing a trace / product call      | Small, but blocked on evidence                                  | Small      |
+| H  | Resume-load & per-session turn robustness            | **User-facing:** stuck conversations, dropped queued prompts, replay leak | **Resolved** |
+| A  | Bridge↔plugin stored-directory / attribution seam    | Real worktree flows on restart; one hook resolves three threads | Open (Medium) |
+| B  | Durable derive-plugin session state (bridge schema)  | Title loss + deleted sessions reappearing                       | Open (Medium) |
+| C  | ACP protocol completeness in the mapper / parsers    | Correctness for the next ACP backend                            | Open (Medium) |
+| G  | Concurrent multi-session turn attribution            | Wrong-conversation routing of `sessionId`-less requests         | **Resolved** |
+| I  | Lossy `session.updated` payload on title changes     | List row loses time/summary/defaults until refresh             | Open (Small–Med) |
+| E  | Typed ACP/Cursor boundary DTOs                        | Enabler / safety net for C and F                                | Blocked on traces (Large) |
+| F  | `getSessionMessages` richer failure contract         | "Broken replay" vs "empty thread" on the phone                  | Open (Small–Med) |
+| D  | Cursor decisions needing a trace / product call      | Small, but blocked on evidence                                  | Blocked on evidence |
 
 ---
 
@@ -201,73 +202,65 @@ ground). Theme E (typed DTOs) is the safety net that makes these less error-pron
 
 ---
 
-## Theme G — Concurrent multi-session turn attribution
+## Theme G — Concurrent multi-session turn attribution ✅ Resolved
 
-`_dispatchPrompt` records the in-flight turn in a single process-wide
-`_activeTurnSessionId`, and server-originated requests that arrive without their
-own `sessionId` (Cursor's `cursor/create_plan`, some question requests) are
-attributed to it. With two sessions prompting concurrently on one agent process,
-the last dispatch wins: a `sessionId`-less request raised for session A after
-session B's prompt was dispatched is attributed to B, so the phone shows and
-answers it in the *wrong* conversation while A stays blocked. A precise fix needs
-request→session correlation (or serialization of `sessionId`-less turns), not a
-single last-writer field — a design change, so it is tracked here rather than
-patched inline. Not observed with Cursor single-session use; it needs two
-concurrent in-flight prompts on one process to bite.
+**Resolved.** The single last-writer `_activeTurnSessionId` field was replaced
+with dispatch-ordered in-flight turn tracking in `AcpPlugin`. A
+`sessionId`-less server request (Cursor's `cursor/create_plan`, some question
+requests) now resolves:
+
+- **precisely** when exactly one turn is in flight — the common case, and the
+  exact scenario from the review thread (A's request arriving after B's turn
+  already completed now routes to A, not B);
+- to the **most recent dispatch, with a logged warning**, when several turns
+  are in flight — ACP carries no request→turn correlation, so this residual
+  ambiguity is inherent to the protocol and now explicitly diagnosed instead
+  of silent;
+- to the **last dispatched turn's session** when none is in flight (unchanged
+  boundary behaviour).
+
+The base `AcpApprovalRegistry` wiring also gained the same
+`activeSessionResolver` Cursor already used, so a spec-violating
+`sessionId`-less permission request on any ACP harness resolves instead of
+auto-cancelling. Per-session turn serialization (Theme H) removed the
+same-session overlap half of the problem; covered by
+`acp_turn_serialization_test.dart`.
 Source: [#332 r3545348052](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3545348052)
-
-**Affected surfaces.** `acp_plugin.dart` (`_activeTurnSessionId`,
-`_dispatchPrompt`, turn lifecycle), `acp_approval_registry.dart`
-(server-request → session attribution).
 
 ---
 
-## Theme H — Resume-load & per-session turn robustness
+## Theme H — Resume-load & per-session turn robustness ✅ Resolved
 
-Robustness gaps in the ACP plugin's own turn lifecycle (`_ensureResident`,
-`_dispatchPrompt`, `_residentSessions`, `_activeSessions`, replay suppression).
-Unlike Theme G (cross-session `sessionId`-less attribution), these bite *within*
-a single session's resume/prompt flow. Two are user-facing bugs, so this theme
-outranks pure spec-completeness. All three landed as review comments at merge.
+**Resolved** — all three items, designed together with Theme G as one
+turn-lifecycle rework in `acp_plugin.dart`, covered by
+`acp_turn_serialization_test.dart` plus the updated resume tests.
 
-- **H1 — do not cache failed resume loads as resident.** `_ensureResident`'s
-  `finally` adds the session to `_residentSessions` even when `session/load`
-  fails for a transient reason (timeout, RPC hiccup). The immediate
-  `session/prompt` then runs against a session the fresh ACP process may never
-  have loaded, and every retry skips `session/load` because the session is now
-  cached resident — so the conversation stays unrecoverable until the agent
-  respawns. Mark resident only after a successful load (or a specifically
-  memoized *unsupported* case), not after all failures. The current
-  mark-on-failure was deliberate (avoid a re-load loop), so the fix must keep
-  that guarantee for the genuinely-unsupported case while still retrying
-  transient ones. **User-facing (High).**
+- **H1 — failed resume loads are no longer cached as resident.**
+  `_ensureResident` marks a session resident only after a *successful*
+  `session/load` (or when the agent lacks the capability entirely). A
+  permanently unsupported load (`-32601`/`-32602` from an agent that
+  advertised `loadSession` anyway) is memoized as resident, preserving the
+  original no-reload-loop guarantee; transient failures (timeout, RPC hiccup)
+  leave the session non-resident so the next turn retries the load.
   Source: [#332 r3545873646](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3545873646)
 
-- **H2 — serialize prompts per session.** `_dispatchPrompt` detaches the
-  `session/prompt` future, so `sendPrompt` returns as soon as the frame is
-  written. The mobile detail queue then drains the next queued message
-  immediately, producing overlapping `session/prompt` requests for one session;
-  agents that reject concurrent turns drop/error the second, and the Set-based
-  `_activeSessions` lets the first completion mark the session idle while another
-  turn is still running. Keep a per-session prompt chain (or reject-while-busy)
-  before dispatching another prompt for the same session. **User-facing (High).**
+- **H2 — prompts are serialized per session.** Each session owns a turn chain
+  (`_SessionTurnState`): a prompt enqueues, marks the session busy
+  immediately, and dispatches `session/prompt` only after the previous turn's
+  future settles, so agents never see overlapping turns for one session. The
+  session reports idle only when its *last* queued turn finishes (the old
+  Set-based early-idle is gone), turn model/mode selection is applied inside
+  the serialized turn (a queued prompt can no longer flip Cursor's
+  process-global selection under the still-running previous turn), and
+  `abortSession` drops queued-but-undispatched turns via a generation bump.
   Source: [#332 r3545873662](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3545873662)
 
-- **H3 — ref-count replay suppression across concurrent loads.** When two
-  prompts for the same prior-run session enter `_ensureResident` before the first
-  `session/load` finishes, both share one `_suppressedSessions` entry. The first
-  load to finish removes suppression while the second replay can still be
-  streaming, so the remaining historical `session/update` chunks are delivered as
-  live transcript deltas. Coalesce per-session resume loads, or ref-count the
-  suppression before removing it.
+- **H3 — concurrent resume loads coalesce.** Concurrent `_ensureResident`
+  calls for one session share a single in-flight `session/load` future, so
+  exactly one load owns the whole replay-suppression window (no early
+  unsuppress mid-replay), and the replay quiet-window counters are per-session
+  so two sessions resuming concurrently don't reset each other's drain.
   Source: [#332 r3545873652](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3545873652)
-
-**Affected surfaces.** `acp_plugin.dart` (`_ensureResident`, `_dispatchPrompt`,
-`_residentSessions`, `_activeSessions`, `_suppressedSessions`).
-
-**Design note.** H2 and Theme G are both ACP-concurrency: a per-session turn
-chain (H2) also gives a natural home for tracking the active turn precisely
-(Theme G). Design them together.
 
 ---
 


### PR DESCRIPTION
Resolves **Theme H (H1–H3)** and **Theme G** from `docs/cursor-acp-followups/README.md` — the user-facing turn-lifecycle robustness gaps in the ACP plugin. Plugin-only: no interface, bridge-app, or client changes.

## H2 — prompts are serialized per session
`_dispatchPrompt`'s detached fire-and-forget dispatch let the mobile queue produce overlapping `session/prompt` requests for one session; agents that reject concurrent turns dropped the second, and the Set-based `_activeSessions` let the first completion mark the session idle while another turn still ran.

Each session now owns a turn chain (`_SessionTurnState`): a prompt enqueues, marks the session busy immediately, and dispatches only after the previous turn settles. Idle is emitted only when the **last** queued turn finishes. Turn model/mode selection runs **inside** the serialized turn, so a queued prompt can no longer flip Cursor's process-global selection under the still-running previous turn. `abortSession` drops queued-but-undispatched turns (generation bump); the in-flight turn ends through the agent's cancellation as before.

## H1 — failed resume-loads are not cached as resident
`_ensureResident` marked a session resident in a `finally` even when `session/load` failed transiently, so every retry skipped the load and the conversation stayed broken until respawn. Now: resident only on **success**, or on a **permanently unsupported** load (`-32601`/`-32602` — keeps the original no-reload-loop guarantee); transient failures (timeout, RPC hiccup) retry on the next turn.

## H3 — concurrent resume-loads coalesce
Two prompts racing into `_ensureResident` shared one `_suppressedSessions` entry; the first finisher unsuppressed while the second replay could still stream history into the live transcript. Concurrent callers now share a single in-flight `session/load` future per session, so one load owns the whole suppression window; replay quiet-window counters are per-session.

## G — precise turn attribution for sessionId-less server requests
The single last-writer `_activeTurnSessionId` misattributed a `sessionId`-less request (Cursor's `cursor/create_plan`) raised for session A after session B's dispatch. Attribution now uses dispatch-ordered in-flight tracking: **precise when exactly one turn is in flight** (the reported scenario), most-recent-dispatch **with a logged warning** when several are (ACP carries no request→turn correlation), last-dispatched at turn boundaries (unchanged). The base registry now wires the same `activeSessionResolver` Cursor already used.

## Tests
- New `acp_turn_serialization_test.dart`: serialization, busy/idle accounting, abort-drops-queue, transient vs unsupported load retry, load coalescing + suppression, attribution precision.
- `acp_resume_test.dart` updated for serialized dispatch.
- `make analyze` + `make test` green across the bridge workspace; `dart analyze --fatal-infos` clean in both touched plugin packages.

Docs: Themes H and G marked resolved in `docs/cursor-acp-followups/README.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize per-session turns, make resume-loads safe and retriable, tighten turn attribution, and make queued turns survive agent restarts. Resolves Themes H (H1–H3) and G in docs; plugin-only changes.

- **Bug Fixes**
  - Per-session turn chains: queue prompts; session stays busy until the last queued turn; apply selection inside the turn; aborts drop queued-but-undispatched turns and are honored across reconnect/load/selection awaits; aborts landing during reconnect settle silently (no error event).
  - Resume-loads at dispatch: mark resident only on success or permanently unsupported (`-32601`/`-32602`); transient failures retry on the next turn; loads run inside the chain so one load owns the suppression window; per-session replay quiet counters.
  - Agent restarts: queued turns re-resolve the live client at dispatch and complete after a respawn; an unreachable agent surfaces as a failed turn.
  - Turn attribution: dispatch-ordered tracking for `sessionId`-less server requests — precise with one turn in flight, most-recent with a warning if several, last-dispatched at boundaries; base registry wired with the same active-session resolver as Cursor.
  - Robust accounting: deleting a session mid-turn no longer resurrects it or emits idle/error; tests added (`acp_turn_serialization_test.dart`) and resume/tests updated; docs mark Themes H and G resolved.

<sup>Written for commit fa9001a3f5d0eff6919e904cd52a0d61e2668b68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

