### PR TITLE
feat(acp): ACP protocol completeness, full-fidelity session updates, official Cursor binary

### DIFF
--- a/bridge/app/lib/src/bridge/services/session_event_enrichment_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_event_enrichment_service.dart
@@ -22,6 +22,11 @@ class SessionEventEnrichmentService {
         BridgeSseSessionUpdated(:final info) => BridgeSseSessionUpdated(
           info: (await _sessionRepository.enrichSessionJson(sessionJson: info)).toJson(),
         ),
+        BridgeSseSessionsUpdated(:final sessionID, :final projectID) => BridgeSseSessionsUpdated(
+          sessionID: sessionID,
+          projectID:
+              await _sessionRepository.findProjectIdForSession(sessionId: sessionID) ?? projectID,
+        ),
         _ => event,
       };
     } catch (e, st) {

--- a/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
@@ -30,6 +30,7 @@ class BridgeEventMapper {
         BridgeSseGlobalDisposed() => const SesoriSseEvent.globalDisposed(),
         BridgeSseSessionCreated(:final info) => _tryParseSseEvent({"type": "session.created", "info": info}),
         BridgeSseSessionUpdated(:final info) => _tryParseSseEvent({"type": "session.updated", "info": info}),
+        BridgeSseSessionsUpdated(:final projectID) => SesoriSseEvent.sessionsUpdated(projectID: projectID),
         BridgeSseSessionDeleted(:final info) => _tryParseSseEvent({"type": "session.deleted", "info": info}),
         BridgeSseSessionDiff(:final sessionID) => SesoriSseEvent.sessionDiff(sessionID: sessionID),
         BridgeSseSessionError(:final sessionID) => SesoriSseEvent.sessionError(sessionID: sessionID),

--- a/bridge/app/test/bridge/services/session_event_enrichment_service_test.dart
+++ b/bridge/app/test/bridge/services/session_event_enrichment_service_test.dart
@@ -103,5 +103,32 @@ void main() {
       final info = (result as BridgeSseSessionCreated).info;
       expect(info["pullRequest"], isNotNull);
     });
+
+    test("routes a session refresh through its stored owning project", () async {
+      await db.projectsDao.insertProjectsIfMissing(projectIds: ["p1"]);
+      await db.sessionDao.insertSession(
+        pluginId: "opencode",
+        sessionId: "s1",
+        projectId: "p1",
+        isDedicated: true,
+        createdAt: 10,
+        worktreePath: "/tmp/worktree",
+        branchName: "feature/one",
+        baseBranch: null,
+        baseCommit: null,
+        lastAgent: null,
+        lastAgentModel: null,
+      );
+
+      final result = await service.enrich(
+        const BridgeSseSessionsUpdated(
+          sessionID: "s1",
+          projectID: "/tmp/worktree",
+        ),
+      );
+
+      expect(result, isA<BridgeSseSessionsUpdated>());
+      expect((result as BridgeSseSessionsUpdated).projectID, "p1");
+    });
   });
 }

--- a/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
+++ b/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
@@ -94,6 +94,13 @@ void main() {
       expect((result! as SesoriSessionDiff).sessionID, equals("s1"));
     });
 
+    test("maps stale project sessions to sessions.updated", () {
+      final result = mapper.map(const BridgeSseSessionsUpdated(projectID: "p1"));
+
+      expect(result, isA<SesoriSessionsUpdated>());
+      expect((result! as SesoriSessionsUpdated).projectID, "p1");
+    });
+
     test("maps command.executed events", () {
       final result = mapper.map(
         const BridgeSseCommandExecuted(

--- a/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
+++ b/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
@@ -95,7 +95,9 @@ void main() {
     });
 
     test("maps stale project sessions to sessions.updated", () {
-      final result = mapper.map(const BridgeSseSessionsUpdated(projectID: "p1"));
+      final result = mapper.map(
+        const BridgeSseSessionsUpdated(sessionID: "s1", projectID: "p1"),
+      );
 
       expect(result, isA<SesoriSessionsUpdated>());
       expect((result! as SesoriSessionsUpdated).projectID, "p1");

--- a/bridge/app/tool/cursor_smoke.dart
+++ b/bridge/app/tool/cursor_smoke.dart
@@ -1,8 +1,8 @@
 // Local smoke test for the Cursor backend. Drives CursorPlugin directly
-// against a real `cursor-agent acp` — no relay, no Sesori account needed.
+// against a real `agent acp` — no relay, no Sesori account needed.
 //
-// Prereqs: `cursor-agent` on PATH, authenticated (`cursor-agent login`), and
-// recent enough to expose the `acp` subcommand (`cursor-agent update`).
+// Prereqs: the Cursor CLI (`agent`) on PATH, authenticated (`agent login`),
+// and recent enough to expose the `acp` subcommand (`agent update`).
 //
 // Usage:
 //   dart run tool/cursor_smoke.dart "Reply with exactly: hello world"

--- a/bridge/sesori_plugin_acp/lib/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/acp_plugin.dart
@@ -5,6 +5,7 @@
 // session/load history replay, and a concrete AcpPlugin. Concrete harnesses
 // (e.g. cursor_plugin) consume these and layer on their own quirks.
 export "src/acp_approval_registry.dart";
+export "src/acp_command_tracker.dart";
 export "src/acp_event_mapper.dart";
 export "src/acp_plugin.dart";
 export "src/acp_process_factory.dart";

--- a/bridge/sesori_plugin_acp/lib/src/acp_command_tracker.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_command_tracker.dart
@@ -16,6 +16,9 @@ class AcpCommandTracker {
   List<PluginCommand> get commands => List.unmodifiable(_commands);
   List<PluginCommand> _commands = const [];
 
+  /// Drops commands advertised by the prior ACP process.
+  void clear() => _commands = const [];
+
   /// Consumes one agent notification; a no-op unless it is a
   /// `session/update` carrying an `available_commands_update`.
   void consume(AcpNotification notification) {

--- a/bridge/sesori_plugin_acp/lib/src/acp_command_tracker.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_command_tracker.dart
@@ -1,0 +1,55 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "acp_protocol.dart";
+import "acp_stdio_client.dart";
+
+/// Tracks the slash commands the agent last advertised via the ACP
+/// `available_commands_update` notification, so the plugin's `getCommands`
+/// can serve them (ACP has no request endpoint for commands).
+///
+/// The snapshot is process-global and the last update wins: ACP scopes the
+/// notification per session, but the commands are agent-global for every
+/// shipping backend, and `getCommands` is project-scoped — a per-session
+/// cache would invent scoping the plugin API can't express.
+class AcpCommandTracker {
+  /// The most recently advertised commands (empty until the first update).
+  List<PluginCommand> get commands => List.unmodifiable(_commands);
+  List<PluginCommand> _commands = const [];
+
+  /// Consumes one agent notification; a no-op unless it is a
+  /// `session/update` carrying an `available_commands_update`.
+  void consume(AcpNotification notification) {
+    if (notification.method != AcpMethods.sessionUpdate) return;
+    final update = notification.params["update"];
+    if (update is! Map) return;
+    final map = update.cast<String, dynamic>();
+    if (map["sessionUpdate"] != "available_commands_update") return;
+    _commands = _parse(map["availableCommands"]);
+  }
+
+  /// Fail-soft parse: a malformed entry is skipped rather than dropping the
+  /// whole batch — command advertisement must never break the event flow.
+  static List<PluginCommand> _parse(Object? raw) {
+    if (raw is! List) return const [];
+    final commands = <PluginCommand>[];
+    for (final entry in raw) {
+      if (entry is! Map) continue;
+      final map = entry.cast<String, dynamic>();
+      final name = map["name"];
+      if (name is! String || name.isEmpty) continue;
+      final description = map["description"];
+      final input = map["input"];
+      final hint = input is Map ? input["hint"] : null;
+      commands.add(
+        PluginCommand(
+          name: name,
+          description: description is String && description.isNotEmpty ? description : null,
+          hints: [if (hint is String && hint.isNotEmpty) hint],
+          provider: null,
+          source: PluginCommandSource.command,
+        ),
+      );
+    }
+    return commands;
+  }
+}

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -93,7 +93,10 @@ class AcpEventMapper {
       final prior = snapshot.createdMs;
       snapshot.createdMs = prior == null || createdMs < prior ? createdMs : prior;
     }
-    if (updatedMs != null) snapshot.updatedMs = updatedMs;
+    if (updatedMs != null) {
+      final prior = snapshot.updatedMs;
+      snapshot.updatedMs = prior == null || updatedMs > prior ? updatedMs : prior;
+    }
   }
 
   /// Per-session project directory (an ACP project id *is* its `cwd`). The
@@ -210,9 +213,9 @@ class AcpEventMapper {
         return [BridgeSseTodoUpdated(sessionID: sessionId)];
       case "available_commands_update":
         // The advertised commands themselves are tracked by AcpCommandTracker
-        // (served via getCommands); the refresh event tells the phone to
-        // re-fetch.
-        return const [BridgeSseProjectUpdated()];
+        // (served via getCommands); this makes the matching client session
+        // re-fetch its snapshot so the new command list becomes visible.
+        return [BridgeSseSessionsUpdated(projectID: projectForSession(sessionId))];
       case "session_info_update":
         // The notification may carry `updatedAt` (ISO 8601 or epoch) — keep
         // the snapshot's recency fresh even when no title change is emitted.
@@ -225,21 +228,19 @@ class AcpEventMapper {
             updatedMs: eventUpdatedMs,
           );
         }
-        // The agent's auto-generated title for the thread. Surfaced as a
-        // session update so the mobile session list / app bar live-update.
-        // Only emit when the update actually carries a `title` field: absent =
-        // some other metadata changed (no title change), while an explicit null
-        // or empty clears the title (ACP v1 documents `title` as nullable, null
-        // clears) — forward that clear rather than dropping it, else the phone
-        // keeps the stale title until a full refresh.
-        if (!update.containsKey("title")) return const [];
-        final rawTitle = update["title"];
-        final title = rawTitle is String && rawTitle.isNotEmpty ? rawTitle : null;
-        // Keep the snapshot's title in sync (including a clear) so a later
-        // emission doesn't resurrect the old title.
-        _sessionSnapshots.putIfAbsent(sessionId, _SessionSnapshot.new).title = title;
+        // The agent's auto-generated title for the thread. An explicit null or
+        // empty title clears it; absent leaves the cached title unchanged.
+        if (update.containsKey("title")) {
+          final rawTitle = update["title"];
+          _sessionSnapshots.putIfAbsent(sessionId, _SessionSnapshot.new).title =
+              rawTitle is String && rawTitle.isNotEmpty ? rawTitle : null;
+        }
+        // Session lists must receive timestamp-only metadata updates to retain
+        // their activity ordering. With neither a title nor timestamp, this
+        // update carries nothing the client can render.
+        if (!update.containsKey("title") && eventUpdatedMs == null) return const [];
         return [
-          BridgeSseSessionUpdated(info: _sessionUpdate(sessionId, title).toJson()),
+          BridgeSseSessionUpdated(info: _sessionUpdate(sessionId).toJson()),
         ];
     }
 
@@ -320,16 +321,16 @@ class AcpEventMapper {
       title: update["title"] is String ? update["title"] as String? : null,
       status: acpToolStatus(update["status"]),
       output: acpToolOutputText(update),
+      isFileMutation: _isFileMutation(update),
+      diffEmitted: false,
     );
     (_liveTools[sessionId] ??= {})[toolCallId] = state;
-    return [
+    final events = <BridgeSseEvent>[
       _toolEnvelope(sessionId: sessionId, messageId: messageId),
       _toolPartEvent(sessionId: sessionId, messageId: messageId, state: state),
-      // An agent may report the whole mutation as one complete initial
-      // `tool_call` (no follow-up update), so the diff signal must fire here
-      // too, mirroring `_toolCallUpdate`.
-      if (_isFileMutation(update)) BridgeSseSessionDiff(sessionID: sessionId),
     ];
+    _appendCompletedMutationDiff(events: events, sessionId: sessionId, state: state);
+    return events;
   }
 
   List<BridgeSseEvent> _toolCallUpdate({
@@ -358,6 +359,8 @@ class AcpEventMapper {
           : prior?.title,
       status: update.containsKey("status") ? acpToolStatus(update["status"]) : (prior?.status ?? PluginToolStatus.pending),
       output: newOutput ?? prior?.output,
+      isFileMutation: (prior?.isFileMutation ?? false) || _isFileMutation(update),
+      diffEmitted: prior?.diffEmitted ?? false,
     );
     final events = <BridgeSseEvent>[
       // ACP events can be reordered (reconnect / resume / replay), so a
@@ -372,9 +375,7 @@ class AcpEventMapper {
     // onto the terminal state; bounded by the [beginTurn] / [forgetSession]
     // clears.
     (_liveTools[sessionId] ??= {})[toolCallId] = state;
-    if (_isFileMutation(update)) {
-      events.add(BridgeSseSessionDiff(sessionID: sessionId));
-    }
+    _appendCompletedMutationDiff(events: events, sessionId: sessionId, state: state);
     return events;
   }
 
@@ -440,7 +441,7 @@ class AcpEventMapper {
   /// stored bridge row exists to enrich from (creation race, never-persisted
   /// historical session). Times come from the plugin-fed snapshot (see
   /// [setSessionSnapshot]); with no snapshot at all, time stays null.
-  shared.Session _sessionUpdate(String id, String? title) {
+  shared.Session _sessionUpdate(String id) {
     final project = projectForSession(id);
     final snapshot = _sessionSnapshots[id];
     final created = snapshot?.createdMs;
@@ -450,7 +451,7 @@ class AcpEventMapper {
       projectID: project,
       directory: project,
       parentID: null,
-      title: title,
+      title: snapshot?.title,
       time: created == null && updated == null
           ? null
           : shared.SessionTime(
@@ -536,6 +537,25 @@ class AcpEventMapper {
     return false;
   }
 
+  void _appendCompletedMutationDiff({
+    required List<BridgeSseEvent> events,
+    required String sessionId,
+    required _LiveTool state,
+  }) {
+    if (!state.isFileMutation || state.diffEmitted || !_isTerminalToolStatus(state.status)) {
+      return;
+    }
+    state.diffEmitted = true;
+    events.add(BridgeSseSessionDiff(sessionID: sessionId));
+  }
+
+  bool _isTerminalToolStatus(PluginToolStatus status) {
+    return switch (status) {
+      PluginToolStatus.completed || PluginToolStatus.error => true,
+      PluginToolStatus.pending || PluginToolStatus.running || PluginToolStatus.unknown => false,
+    };
+  }
+
   Map<String, dynamic>? _asMap(Object? value) {
     if (value is Map) return value.cast<String, dynamic>();
     return null;
@@ -544,8 +564,8 @@ class AcpEventMapper {
 
 enum _ChunkRole { user, assistant }
 
-/// Last-known metadata for one session (title, times), merged into the
-/// `session.updated` payload a `session_info_update` emits.
+/// Last-known metadata for one session, merged into the `session.updated`
+/// payload a `session_info_update` emits.
 class _SessionSnapshot {
   String? title;
   int? createdMs;
@@ -560,10 +580,14 @@ class _LiveTool {
     required this.title,
     required this.status,
     required this.output,
+    required this.isFileMutation,
+    required this.diffEmitted,
   });
 
   final String tool;
   final String? title;
   final PluginToolStatus status;
   final String? output;
+  final bool isFileMutation;
+  bool diffEmitted;
 }

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -96,14 +96,6 @@ class AcpEventMapper {
     if (updatedMs != null) snapshot.updatedMs = updatedMs;
   }
 
-  /// Commands last advertised by the agent via `available_commands_update`,
-  /// served by the plugin's `getCommands`. Process-global (last update wins):
-  /// ACP scopes the notification per session, but the commands are agent-global
-  /// for every shipping backend, and `getCommands` is project-scoped — so a
-  /// per-session cache would invent scoping the API can't express.
-  List<PluginCommand> get availableCommands => List.unmodifiable(_availableCommands);
-  List<PluginCommand> _availableCommands = const [];
-
   /// Per-session project directory (an ACP project id *is* its `cwd`). The
   /// plugin records it so `session_info_update` (title) events are filed under
   /// the session's real project, not the launch [launchDirectory]. The mobile
@@ -217,9 +209,9 @@ class AcpEventMapper {
       case "plan":
         return [BridgeSseTodoUpdated(sessionID: sessionId)];
       case "available_commands_update":
-        // Cache the advertised commands so `getCommands` can serve them; the
-        // refresh event tells the phone to re-fetch.
-        _availableCommands = _parseAvailableCommands(update["availableCommands"]);
+        // The advertised commands themselves are tracked by AcpCommandTracker
+        // (served via getCommands); the refresh event tells the phone to
+        // re-fetch.
         return const [BridgeSseProjectUpdated()];
       case "session_info_update":
         // The notification may carry `updatedAt` (ISO 8601 or epoch) — keep
@@ -470,32 +462,6 @@ class AcpEventMapper {
       pullRequest: null,
       promptDefaults: null,
     );
-  }
-
-  /// Parses an `available_commands_update` payload's `availableCommands` list
-  /// fail-soft: a malformed entry is skipped rather than dropping the batch.
-  static List<PluginCommand> _parseAvailableCommands(Object? raw) {
-    if (raw is! List) return const [];
-    final commands = <PluginCommand>[];
-    for (final entry in raw) {
-      if (entry is! Map) continue;
-      final map = entry.cast<String, dynamic>();
-      final name = map["name"];
-      if (name is! String || name.isEmpty) continue;
-      final description = map["description"];
-      final input = map["input"];
-      final hint = input is Map ? input["hint"] : null;
-      commands.add(
-        PluginCommand(
-          name: name,
-          description: description is String && description.isNotEmpty ? description : null,
-          hints: [if (hint is String && hint.isNotEmpty) hint],
-          provider: null,
-          source: PluginCommandSource.command,
-        ),
-      );
-    }
-    return commands;
   }
 
   /// Lenient timestamp: the spec sends ISO 8601 strings, live agents have

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -215,7 +215,12 @@ class AcpEventMapper {
         // The advertised commands themselves are tracked by AcpCommandTracker
         // (served via getCommands); this makes the matching client session
         // re-fetch its snapshot so the new command list becomes visible.
-        return [BridgeSseSessionsUpdated(projectID: projectForSession(sessionId))];
+        return [
+          BridgeSseSessionsUpdated(
+            sessionID: sessionId,
+            projectID: projectForSession(sessionId),
+          ),
+        ];
       case "session_info_update":
         // The notification may carry `updatedAt` (ISO 8601 or epoch) — keep
         // the snapshot's recency fresh even when no title change is emitted.
@@ -329,7 +334,12 @@ class AcpEventMapper {
       _toolEnvelope(sessionId: sessionId, messageId: messageId),
       _toolPartEvent(sessionId: sessionId, messageId: messageId, state: state),
     ];
-    _appendCompletedMutationDiff(events: events, sessionId: sessionId, state: state);
+    _appendCompletedMutationDiff(
+      events: events,
+      sessionId: sessionId,
+      state: state,
+      mutationAvailable: _hasDiffContent(update),
+    );
     return events;
   }
 
@@ -375,7 +385,12 @@ class AcpEventMapper {
     // onto the terminal state; bounded by the [beginTurn] / [forgetSession]
     // clears.
     (_liveTools[sessionId] ??= {})[toolCallId] = state;
-    _appendCompletedMutationDiff(events: events, sessionId: sessionId, state: state);
+    _appendCompletedMutationDiff(
+      events: events,
+      sessionId: sessionId,
+      state: state,
+      mutationAvailable: _hasDiffContent(update),
+    );
     return events;
   }
 
@@ -528,6 +543,10 @@ class AcpEventMapper {
   bool _isFileMutation(Map<String, dynamic> update) {
     final kind = update["kind"];
     if (kind == "edit" || kind == "delete" || kind == "move") return true;
+    return _hasDiffContent(update);
+  }
+
+  bool _hasDiffContent(Map<String, dynamic> update) {
     final content = update["content"];
     if (content is List) {
       for (final entry in content) {
@@ -541,8 +560,12 @@ class AcpEventMapper {
     required List<BridgeSseEvent> events,
     required String sessionId,
     required _LiveTool state,
+    required bool mutationAvailable,
   }) {
-    if (!state.isFileMutation || state.diffEmitted || !_isTerminalToolStatus(state.status)) {
+    if (!state.isFileMutation || state.diffEmitted) {
+      return;
+    }
+    if (!mutationAvailable && !_isTerminalToolStatus(state.status)) {
       return;
     }
     state.diffEmitted = true;

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -69,6 +69,41 @@ class AcpEventMapper {
   String? providerForSession(String sessionId) =>
       _sessionProvider[sessionId] ?? currentProviderId;
 
+  /// Last-known per-session metadata (title/times), fed by the plugin from
+  /// enumeration and creation (like [setSessionProject]). `session_info_update`
+  /// merges against it so the emitted `session.updated` payload doesn't null
+  /// out the session's time — which would make the mobile list row lose its
+  /// sort position until a full refresh.
+  final Map<String, _SessionSnapshot> _sessionSnapshots = {};
+
+  /// Records the last-known [title]/[createdMs]/[updatedMs] for [sessionId].
+  /// A null field leaves the prior value in place (an enumeration hit may
+  /// know times but not a cleared title). Title and updated take the latest
+  /// value; created keeps the earliest known (enumeration only reports
+  /// last-activity time, which must not drag the creation time forward).
+  void setSessionSnapshot({
+    required String sessionId,
+    required String? title,
+    required int? createdMs,
+    required int? updatedMs,
+  }) {
+    final snapshot = _sessionSnapshots.putIfAbsent(sessionId, _SessionSnapshot.new);
+    if (title != null && title.isNotEmpty) snapshot.title = title;
+    if (createdMs != null) {
+      final prior = snapshot.createdMs;
+      snapshot.createdMs = prior == null || createdMs < prior ? createdMs : prior;
+    }
+    if (updatedMs != null) snapshot.updatedMs = updatedMs;
+  }
+
+  /// Commands last advertised by the agent via `available_commands_update`,
+  /// served by the plugin's `getCommands`. Process-global (last update wins):
+  /// ACP scopes the notification per session, but the commands are agent-global
+  /// for every shipping backend, and `getCommands` is project-scoped — so a
+  /// per-session cache would invent scoping the API can't express.
+  List<PluginCommand> get availableCommands => List.unmodifiable(_availableCommands);
+  List<PluginCommand> _availableCommands = const [];
+
   /// Per-session project directory (an ACP project id *is* its `cwd`). The
   /// plugin records it so `session_info_update` (title) events are filed under
   /// the session's real project, not the launch [launchDirectory]. The mobile
@@ -99,6 +134,7 @@ class AcpEventMapper {
     _sessionModel.remove(sessionId);
     _sessionProvider.remove(sessionId);
     _sessionProject.remove(sessionId);
+    _sessionSnapshots.remove(sessionId);
     _turnSeq.remove(sessionId);
     _startedParts.remove(sessionId);
     // Exact per-session removal — session ids are opaque agent strings that may
@@ -181,8 +217,22 @@ class AcpEventMapper {
       case "plan":
         return [BridgeSseTodoUpdated(sessionID: sessionId)];
       case "available_commands_update":
+        // Cache the advertised commands so `getCommands` can serve them; the
+        // refresh event tells the phone to re-fetch.
+        _availableCommands = _parseAvailableCommands(update["availableCommands"]);
         return const [BridgeSseProjectUpdated()];
       case "session_info_update":
+        // The notification may carry `updatedAt` (ISO 8601 or epoch) — keep
+        // the snapshot's recency fresh even when no title change is emitted.
+        final eventUpdatedMs = _timestampMs(update["updatedAt"]);
+        if (eventUpdatedMs != null) {
+          setSessionSnapshot(
+            sessionId: sessionId,
+            title: null,
+            createdMs: null,
+            updatedMs: eventUpdatedMs,
+          );
+        }
         // The agent's auto-generated title for the thread. Surfaced as a
         // session update so the mobile session list / app bar live-update.
         // Only emit when the update actually carries a `title` field: absent =
@@ -193,8 +243,11 @@ class AcpEventMapper {
         if (!update.containsKey("title")) return const [];
         final rawTitle = update["title"];
         final title = rawTitle is String && rawTitle.isNotEmpty ? rawTitle : null;
+        // Keep the snapshot's title in sync (including a clear) so a later
+        // emission doesn't resurrect the old title.
+        _sessionSnapshots.putIfAbsent(sessionId, _SessionSnapshot.new).title = title;
         return [
-          BridgeSseSessionUpdated(info: _minimalSession(sessionId, title).toJson()),
+          BridgeSseSessionUpdated(info: _sessionUpdate(sessionId, title).toJson()),
         ];
     }
 
@@ -218,7 +271,16 @@ class AcpEventMapper {
     final text = acpContentText(update["content"]);
     if (text == null || text.isEmpty) return const [];
 
-    final messageId = "$sessionId-t${_turn(sessionId)}-${role.name}";
+    // ACP v1: chunks of one message share a `messageId`; a change starts a new
+    // message. Group by it when present, so an agent emitting several same-role
+    // messages in one turn doesn't collapse them into one sesori message. The
+    // role stays in the id so a pathological cross-role id reuse can't merge a
+    // user chunk into an assistant envelope. Absent (Cursor today) → the
+    // synthesized per-turn id.
+    final acpMessageId = update["messageId"];
+    final messageId = acpMessageId is String && acpMessageId.isNotEmpty
+        ? "$sessionId-m$acpMessageId-${role.name}"
+        : "$sessionId-t${_turn(sessionId)}-${role.name}";
     final partId = "$messageId-$partSuffix";
 
     final events = <BridgeSseEvent>[];
@@ -271,6 +333,10 @@ class AcpEventMapper {
     return [
       _toolEnvelope(sessionId: sessionId, messageId: messageId),
       _toolPartEvent(sessionId: sessionId, messageId: messageId, state: state),
+      // An agent may report the whole mutation as one complete initial
+      // `tool_call` (no follow-up update), so the diff signal must fire here
+      // too, mirroring `_toolCallUpdate`.
+      if (_isFileMutation(update)) BridgeSseSessionDiff(sessionID: sessionId),
     ];
   }
 
@@ -375,22 +441,69 @@ class AcpEventMapper {
     };
   }
 
-  /// A minimal [shared.Session] for a `session_info_update`; the bridge
-  /// enrichment + mobile merge it against existing state, so only the id and
-  /// title matter here.
-  shared.Session _minimalSession(String id, String? title) {
+  /// The [shared.Session] emitted for a `session_info_update`. The mobile list
+  /// handler REPLACES the whole session on `session.updated`, so beyond the id
+  /// and new title this must carry the best-known `time` — a null time would
+  /// drop the row's sort position to epoch 0 until a full refresh whenever no
+  /// stored bridge row exists to enrich from (creation race, never-persisted
+  /// historical session). Times come from the plugin-fed snapshot (see
+  /// [setSessionSnapshot]); with no snapshot at all, time stays null.
+  shared.Session _sessionUpdate(String id, String? title) {
     final project = projectForSession(id);
+    final snapshot = _sessionSnapshots[id];
+    final created = snapshot?.createdMs;
+    final updated = snapshot?.updatedMs ?? created;
     return shared.Session(
       id: id,
       projectID: project,
       directory: project,
       parentID: null,
       title: title,
-      time: null,
+      time: created == null && updated == null
+          ? null
+          : shared.SessionTime(
+              created: created ?? updated!,
+              updated: updated ?? created!,
+              archived: null,
+            ),
       summary: null,
       pullRequest: null,
       promptDefaults: null,
     );
+  }
+
+  /// Parses an `available_commands_update` payload's `availableCommands` list
+  /// fail-soft: a malformed entry is skipped rather than dropping the batch.
+  static List<PluginCommand> _parseAvailableCommands(Object? raw) {
+    if (raw is! List) return const [];
+    final commands = <PluginCommand>[];
+    for (final entry in raw) {
+      if (entry is! Map) continue;
+      final map = entry.cast<String, dynamic>();
+      final name = map["name"];
+      if (name is! String || name.isEmpty) continue;
+      final description = map["description"];
+      final input = map["input"];
+      final hint = input is Map ? input["hint"] : null;
+      commands.add(
+        PluginCommand(
+          name: name,
+          description: description is String && description.isNotEmpty ? description : null,
+          hints: [if (hint is String && hint.isNotEmpty) hint],
+          provider: null,
+          source: PluginCommandSource.command,
+        ),
+      );
+    }
+    return commands;
+  }
+
+  /// Lenient timestamp: the spec sends ISO 8601 strings, live agents have
+  /// shipped epoch numbers — accept both, anything else is null.
+  static int? _timestampMs(Object? raw) {
+    if (raw is num) return raw.round();
+    if (raw is String) return DateTime.tryParse(raw)?.millisecondsSinceEpoch;
+    return null;
   }
 
   PluginMessagePart _part({
@@ -441,9 +554,20 @@ class AcpEventMapper {
     );
   }
 
+  /// Whether a `tool_call`/`tool_call_update` payload reports a file mutation:
+  /// a mutating `kind`, or a standard tool `content` entry of `type: "diff"`
+  /// (a spec-compliant agent may report an edit only through the diff content
+  /// shape, with a non-mutating or absent kind).
   bool _isFileMutation(Map<String, dynamic> update) {
-    final kind = update["kind"] as String?;
-    return kind == "edit" || kind == "delete" || kind == "move";
+    final kind = update["kind"];
+    if (kind == "edit" || kind == "delete" || kind == "move") return true;
+    final content = update["content"];
+    if (content is List) {
+      for (final entry in content) {
+        if (entry is Map && entry["type"] == "diff") return true;
+      }
+    }
+    return false;
   }
 
   Map<String, dynamic>? _asMap(Object? value) {
@@ -453,6 +577,14 @@ class AcpEventMapper {
 }
 
 enum _ChunkRole { user, assistant }
+
+/// Last-known metadata for one session (title, times), merged into the
+/// `session.updated` payload a `session_info_update` emits.
+class _SessionSnapshot {
+  String? title;
+  int? createdMs;
+  int? updatedMs;
+}
 
 /// The last-rendered state of one live tool call, so a partial
 /// `tool_call_update` merges onto it instead of replacing it.

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1127,10 +1127,18 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
         return const [];
       }
       var received = 0;
+      final deferredCommandRefreshes = <BridgeSseSessionsUpdated>[];
       sub = replayClient.notifications.listen((notification) {
         if (notification.method == AcpMethods.sessionUpdate) {
           received++;
           collector.consume(notification.params);
+          final update = notification.params["update"];
+          if (update is Map && update["sessionUpdate"] == "available_commands_update") {
+            _commandTracker.consume(notification);
+            deferredCommandRefreshes.addAll(
+              eventMapper.map(notification).whereType<BridgeSseSessionsUpdated>(),
+            );
+          }
         }
       });
       final raw = await replayClient.request(
@@ -1154,6 +1162,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       // AFTER it. Drain until the replay stream goes quiet so multi-turn history
       // is captured in full, bounded so a chatty agent can't hang the request.
       await _drainReplay(() => received);
+      deferredCommandRefreshes.forEach(_eventBuffer.add);
       collector.modelId = eventMapper.modelForSession(sessionId);
       collector.providerId = eventMapper.providerForSession(sessionId);
       return collector.build();

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -6,6 +6,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" as shared;
 
 import "acp_approval_registry.dart";
+import "acp_command_tracker.dart";
 import "acp_event_mapper.dart";
 import "acp_process_factory.dart";
 import "acp_protocol.dart";
@@ -59,6 +60,10 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
 
   final AcpProcessFactory? _processFactory;
   final BufferedUntilFirstListener<BridgeSseEvent> _eventBuffer;
+
+  /// Snapshot of the agent's advertised slash commands, fed by the
+  /// notification listener and served by [getCommands].
+  final AcpCommandTracker _commandTracker = AcpCommandTracker();
 
   /// sessionId -> the canonical directory the session lives in. Populated on
   /// create and on every `session/list` hit, so a turn/history load runs in
@@ -233,6 +238,9 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       try {
         await client.connect();
         _notificationSubscription = client.notifications.listen((notification) {
+          // The command snapshot consumes every notification — including a
+          // suppressed resume replay, whose advertised commands are current.
+          _commandTracker.consume(notification);
           if (notification.method == AcpMethods.sessionUpdate) {
             final sid = notification.params["sessionId"];
             if (sid is String && _suppressedSessions.contains(sid)) {
@@ -562,9 +570,9 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
 
   @override
   Future<List<PluginCommand>> getCommands({required String? projectId}) async =>
-      // Served from the mapper's `available_commands_update` cache — ACP
-      // advertises commands via that notification, not a request endpoint.
-      eventMapper.availableCommands;
+      // Served from the `available_commands_update` snapshot — ACP advertises
+      // commands via that notification, not a request endpoint.
+      _commandTracker.commands;
 
   @override
   Future<PluginSession> createSession({

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1127,7 +1127,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
         return const [];
       }
       var received = 0;
-      final deferredCommandRefreshes = <BridgeSseSessionsUpdated>[];
+      BridgeSseSessionsUpdated? deferredCommandRefresh;
       sub = replayClient.notifications.listen((notification) {
         if (notification.method == AcpMethods.sessionUpdate) {
           received++;
@@ -1135,9 +1135,8 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
           final update = notification.params["update"];
           if (update is Map && update["sessionUpdate"] == "available_commands_update") {
             _commandTracker.consume(notification);
-            deferredCommandRefreshes.addAll(
-              eventMapper.map(notification).whereType<BridgeSseSessionsUpdated>(),
-            );
+            final refreshes = eventMapper.map(notification).whereType<BridgeSseSessionsUpdated>();
+            if (refreshes.isNotEmpty) deferredCommandRefresh = refreshes.last;
           }
         }
       });
@@ -1162,7 +1161,8 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       // AFTER it. Drain until the replay stream goes quiet so multi-turn history
       // is captured in full, bounded so a chatty agent can't hang the request.
       await _drainReplay(() => received);
-      deferredCommandRefreshes.forEach(_eventBuffer.add);
+      final commandRefresh = deferredCommandRefresh;
+      if (commandRefresh != null) _eventBuffer.add(commandRefresh);
       collector.modelId = eventMapper.modelForSession(sessionId);
       collector.providerId = eventMapper.providerForSession(sessionId);
       return collector.build();

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -243,7 +243,10 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
           _commandTracker.consume(notification);
           if (notification.method == AcpMethods.sessionUpdate) {
             final sid = notification.params["sessionId"];
-            if (sid is String && _suppressedSessions.contains(sid)) {
+            final update = notification.params["update"];
+            final isCommandUpdate =
+                update is Map && update["sessionUpdate"] == "available_commands_update";
+            if (sid is String && _suppressedSessions.contains(sid) && !isCommandUpdate) {
               // Replay from an in-flight resume-load — drop so old history does
               // not re-stream into the live conversation.
               _suppressedReplayCounts[sid] = (_suppressedReplayCounts[sid] ?? 0) + 1;

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -535,10 +535,18 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     final directory = normalizeProjectDirectory(directory: hasCwd ? rawCwd : fallbackDirectory);
     final id = info.sessionId;
     // Remember the session's directory so a later turn/history load uses its
-    // own cwd and events/activity attribute to the right project.
+    // own cwd and events/activity attribute to the right project. The
+    // title/time snapshot keeps `session_info_update` emissions full-fidelity
+    // (the mobile list replaces the whole session on session.updated).
     if (id.isNotEmpty) {
       _sessionDirectories[id] = directory;
       eventMapper.setSessionProject(id, directory);
+      eventMapper.setSessionSnapshot(
+        sessionId: id,
+        title: info.title,
+        createdMs: info.updatedAtMs,
+        updatedMs: info.updatedAtMs,
+      );
     }
     final ts = info.updatedAtMs;
     return PluginSession(
@@ -554,7 +562,9 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
 
   @override
   Future<List<PluginCommand>> getCommands({required String? projectId}) async =>
-      const [];
+      // Served from the mapper's `available_commands_update` cache — ACP
+      // advertises commands via that notification, not a request endpoint.
+      eventMapper.availableCommands;
 
   @override
   Future<PluginSession> createSession({
@@ -581,8 +591,17 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     if (session.sessionId.isEmpty) {
       throw StateError("session/new response missing sessionId");
     }
+    final createdAt = DateTime.now().millisecondsSinceEpoch;
     _sessionDirectories[session.sessionId] = canonicalDirectory;
     eventMapper.setSessionProject(session.sessionId, canonicalDirectory);
+    // Seed the snapshot so a title event during the creation race (before the
+    // bridge has a stored row to enrich from) still carries a sane time.
+    eventMapper.setSessionSnapshot(
+      sessionId: session.sessionId,
+      title: null,
+      createdMs: createdAt,
+      updatedMs: createdAt,
+    );
     // A session/new response is the authoritative source of the backend's
     // new-session default model/mode.
     captureSessionConfig(session.raw, sessionId: session.sessionId, fromNewSession: true);
@@ -608,14 +627,13 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
         variant: variant,
       );
     }
-    final now = DateTime.now().millisecondsSinceEpoch;
     return PluginSession(
       id: session.sessionId,
       projectID: canonicalDirectory,
       directory: canonicalDirectory,
       parentID: parentSessionId,
       title: null,
-      time: PluginSessionTime(created: now, updated: now, archived: null),
+      time: PluginSessionTime(created: createdAt, updated: createdAt, archived: null),
       summary: null,
     );
   }
@@ -682,8 +700,10 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   /// (timeout, RPC hiccup) is retried on the next turn instead of leaving the
   /// conversation unrecoverable until the agent respawns.
   Future<void> _loadResident(AcpStdioClient client, String sessionId) async {
-    if (!(_initResult?.agentCapabilities.loadSession ?? false)) {
-      // No load capability: there is nothing to re-load — memoize residency so
+    final loadSupported = _initResult?.agentCapabilities.loadSession ?? false;
+    final resumeSupported = _initResult?.agentCapabilities.resumeSession ?? false;
+    if (!loadSupported && !resumeSupported) {
+      // No way to re-activate a prior-run session — memoize residency so
       // turns proceed without re-checking.
       _residentSessions.add(sessionId);
       return;
@@ -697,6 +717,12 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     // the prior fallback behaviour remains.
     if (!_sessionDirectories.containsKey(sessionId)) {
       await listAllSessions(knownDirectories: const {});
+    }
+    if (!loadSupported) {
+      // Resume-only agent: `session/resume` re-activates the session with NO
+      // history replay, so no suppression window is needed.
+      await _resumeResident(client, sessionId);
+      return;
     }
     _suppressedSessions.add(sessionId);
     _suppressedReplayCounts.remove(sessionId);
@@ -737,6 +763,44 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     } finally {
       _suppressedSessions.remove(sessionId);
       _suppressedReplayCounts.remove(sessionId);
+    }
+  }
+
+  /// Re-activates [sessionId] via `session/resume` for an agent that
+  /// advertises `sessionCapabilities.resume` but not `loadSession`. Without
+  /// this, the session would be marked resident with no RPC at all and the
+  /// next `session/prompt` after a bridge restart would hit a session the
+  /// fresh agent process never loaded. Same residency policy as the load
+  /// path: resident on success or on a permanently unsupported RPC; transient
+  /// failures retry on the next turn.
+  Future<void> _resumeResident(AcpStdioClient client, String sessionId) async {
+    try {
+      final raw = await client.request(
+        method: AcpMethods.sessionResume,
+        params: {
+          "sessionId": sessionId,
+          "cwd": _directoryForSession(sessionId),
+          "mcpServers": const <Object?>[],
+        },
+        timeout: const Duration(minutes: 2),
+      );
+      // The resume result carries the modes/configOptions catalog (and this
+      // session's current selection) — capture it, but never as the
+      // new-session default.
+      captureSessionConfig(
+        raw is Map ? raw.cast<String, dynamic>() : const {},
+        sessionId: sessionId,
+      );
+      _residentSessions.add(sessionId);
+    } on AcpRpcException catch (error, stack) {
+      if (error.code == -32601 || error.code == -32602) {
+        Log.w("[$id] session/resume unsupported (code ${error.code}); proceeding without resume", error, stack);
+        _residentSessions.add(sessionId);
+      } else {
+        Log.w("[$id] session/resume of $sessionId failed; will retry on next turn", error, stack);
+      }
+    } on Object catch (error, stack) {
+      Log.w("[$id] session/resume of $sessionId failed; will retry on next turn", error, stack);
     }
   }
 

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -338,6 +338,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     _initResult = null;
     _residentSessions.clear();
     _bareSessionListUnsupported = false;
+    _commandTracker.clear();
     // Let subclasses drop any process-global state cached against the dead agent
     // (e.g. Cursor's applied model/mode) so it is re-applied on the next turn.
     onConnectionReset();

--- a/bridge/sesori_plugin_acp/lib/src/acp_protocol.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_protocol.dart
@@ -19,6 +19,7 @@ abstract final class AcpMethods {
   static const String sessionNew = "session/new";
   static const String sessionList = "session/list";
   static const String sessionLoad = "session/load";
+  static const String sessionResume = "session/resume";
   static const String sessionPrompt = "session/prompt";
   static const String sessionCancel = "session/cancel";
   static const String sessionUpdate = "session/update";
@@ -46,6 +47,7 @@ class AcpAgentCapabilities {
   const AcpAgentCapabilities({
     required this.loadSession,
     required this.listSessions,
+    required this.resumeSession,
     required this.raw,
   });
 
@@ -54,6 +56,11 @@ class AcpAgentCapabilities {
 
   /// Whether the standard `session/list` is supported.
   final bool listSessions;
+
+  /// Whether `session/resume` (re-activate a prior session with no history
+  /// replay) is supported. Used only when [loadSession] is absent — load is
+  /// strictly richer.
+  final bool resumeSession;
 
   /// Full raw capabilities object for harness-specific probing.
   final Map<String, dynamic> raw;
@@ -65,9 +72,11 @@ class AcpAgentCapabilities {
     // object (Cursor sends `"list": {}` to mean "supported"); presence of a
     // non-false value signals support.
     final list = session?["list"];
+    final resume = session?["resume"];
     return AcpAgentCapabilities(
       loadSession: json["loadSession"] == true,
       listSessions: list != null && list != false,
+      resumeSession: resume != null && resume != false,
       raw: json,
     );
   }

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -44,7 +44,7 @@ class AcpReplayCollector {
       case "tool_call":
         final id = update["toolCallId"] as String?;
         if (id == null) return;
-        _assistant().tools[id] = _ToolDraft(
+        _assistantForTool().tools[id] = _ToolDraft(
           tool: acpToolName(update),
           title: _toolTitle(update),
           status: acpToolStatus(update["status"]),
@@ -59,7 +59,7 @@ class AcpReplayCollector {
           // carry only the update). Seed a tool draft from the update payload so
           // the card still renders, mirroring the live mapper which emits a tool
           // part unconditionally.
-          _assistant().tools[id] = _ToolDraft(
+          _assistantForTool().tools[id] = _ToolDraft(
             tool: acpToolName(update),
             title: _toolTitle(update),
             status: acpToolStatus(update["status"]),
@@ -162,21 +162,28 @@ class AcpReplayCollector {
     );
   }
 
-  // Tool calls carry no messageId (they are not ContentChunks) and attach to
-  // the current assistant message, so the tool paths call these without one.
   _Draft _assistant({String? messageId}) => _ensureRole("assistant", messageId: messageId);
   _Draft _user({String? messageId}) => _ensureRole("user", messageId: messageId);
 
+  // Tool calls carry no messageId (they are not ContentChunks) and attach to
+  // the current assistant message even when its content chunks are stamped.
+  _Draft _assistantForTool() {
+    if (_drafts.isNotEmpty && _drafts.last.role == "assistant") {
+      return _drafts.last;
+    }
+    return _ensureRole("assistant");
+  }
+
   /// The draft the next chunk belongs to. ACP v1: chunks of one message share
   /// a `messageId`, and a change starts a new message — so the last draft is
-  /// reused only when both the role AND the message id match. An id-less chunk
-  /// (tool attachment included) continues the current same-role message, but
-  /// an explicit id never merges into an id-less draft. Comparison is against
+  /// reused only when both the role AND the message id match. An id-less
+  /// content chunk continues only an id-less draft; tool attachments use
+  /// [_assistantForTool] because ACP does not stamp them. Comparison is against
   /// the last draft only, matching the spec's sequential semantics.
   _Draft _ensureRole(String role, {String? messageId}) {
     if (_drafts.isNotEmpty && _drafts.last.role == role) {
       final last = _drafts.last;
-      if (messageId == null || last.acpMessageId == messageId) {
+      if (last.acpMessageId == messageId) {
         return last;
       }
     }

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -169,17 +169,14 @@ class AcpReplayCollector {
 
   /// The draft the next chunk belongs to. ACP v1: chunks of one message share
   /// a `messageId`, and a change starts a new message — so the last draft is
-  /// reused only when both the role AND the message id match (a chunk without
-  /// an id, tool attachment included, always continues the current same-role
-  /// message). Comparison is against the last draft only, matching the spec's
-  /// sequential "a change indicates a new message" semantics.
+  /// reused only when both the role AND the message id match. An id-less chunk
+  /// (tool attachment included) continues the current same-role message, but
+  /// an explicit id never merges into an id-less draft. Comparison is against
+  /// the last draft only, matching the spec's sequential semantics.
   _Draft _ensureRole(String role, {String? messageId}) {
     if (_drafts.isNotEmpty && _drafts.last.role == role) {
       final last = _drafts.last;
-      if (messageId == null || last.acpMessageId == null || last.acpMessageId == messageId) {
-        // Adopt the id when the running draft was started by id-less chunks:
-        // agents may stamp ids only on some chunk kinds of one message.
-        last.acpMessageId ??= messageId;
+      if (messageId == null || last.acpMessageId == messageId) {
         return last;
       }
     }
@@ -227,7 +224,6 @@ class _Draft {
   final String id;
 
   /// The ACP `messageId` this draft groups, when the agent stamped one.
-  /// Adopted late when the first stamped chunk arrives mid-message.
   String? acpMessageId;
   final StringBuffer text = StringBuffer();
   final StringBuffer reasoning = StringBuffer();

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -34,13 +34,13 @@ class AcpReplayCollector {
     switch (update["sessionUpdate"] as String?) {
       case "agent_message_chunk":
         final t = acpContentText(update["content"]);
-        if (t != null) _assistant().text.write(t);
+        if (t != null) _assistant(messageId: _chunkMessageId(update)).text.write(t);
       case "agent_thought_chunk":
         final t = acpContentText(update["content"]);
-        if (t != null) _assistant().reasoning.write(t);
+        if (t != null) _assistant(messageId: _chunkMessageId(update)).reasoning.write(t);
       case "user_message_chunk":
         final t = acpContentText(update["content"]);
-        if (t != null) _user().text.write(t);
+        if (t != null) _user(messageId: _chunkMessageId(update)).text.write(t);
       case "tool_call":
         final id = update["toolCallId"] as String?;
         if (id == null) return;
@@ -162,14 +162,42 @@ class AcpReplayCollector {
     );
   }
 
-  _Draft _assistant() => _ensureRole("assistant");
-  _Draft _user() => _ensureRole("user");
+  // Tool calls carry no messageId (they are not ContentChunks) and attach to
+  // the current assistant message, so the tool paths call these without one.
+  _Draft _assistant({String? messageId}) => _ensureRole("assistant", messageId: messageId);
+  _Draft _user({String? messageId}) => _ensureRole("user", messageId: messageId);
 
-  _Draft _ensureRole(String role) {
-    if (_drafts.isNotEmpty && _drafts.last.role == role) return _drafts.last;
-    final draft = _Draft(role: role, id: "$sessionId-h${_seq++}-$role");
+  /// The draft the next chunk belongs to. ACP v1: chunks of one message share
+  /// a `messageId`, and a change starts a new message — so the last draft is
+  /// reused only when both the role AND the message id match (a chunk without
+  /// an id, tool attachment included, always continues the current same-role
+  /// message). Comparison is against the last draft only, matching the spec's
+  /// sequential "a change indicates a new message" semantics.
+  _Draft _ensureRole(String role, {String? messageId}) {
+    if (_drafts.isNotEmpty && _drafts.last.role == role) {
+      final last = _drafts.last;
+      if (messageId == null || last.acpMessageId == null || last.acpMessageId == messageId) {
+        // Adopt the id when the running draft was started by id-less chunks:
+        // agents may stamp ids only on some chunk kinds of one message.
+        last.acpMessageId ??= messageId;
+        return last;
+      }
+    }
+    final draft = _Draft(
+      role: role,
+      id: messageId != null && messageId.isNotEmpty
+          ? "$sessionId-m$messageId-$role"
+          : "$sessionId-h${_seq++}-$role",
+      acpMessageId: messageId,
+    );
     _drafts.add(draft);
     return draft;
+  }
+
+  /// The chunk's ACP `messageId`, when present and well-formed.
+  static String? _chunkMessageId(Map<String, dynamic> update) {
+    final id = update["messageId"];
+    return id is String && id.isNotEmpty ? id : null;
   }
 
   _ToolDraft? _findTool(String toolId) {
@@ -193,10 +221,14 @@ class AcpReplayCollector {
 }
 
 class _Draft {
-  _Draft({required this.role, required this.id});
+  _Draft({required this.role, required this.id, required this.acpMessageId});
 
   final String role;
   final String id;
+
+  /// The ACP `messageId` this draft groups, when the agent stamped one.
+  /// Adopted late when the first stamped chunk arrives mid-message.
+  String? acpMessageId;
   final StringBuffer text = StringBuffer();
   final StringBuffer reasoning = StringBuffer();
   final Map<String, _ToolDraft> tools = {};

--- a/bridge/sesori_plugin_acp/test/acp_commands_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_commands_test.dart
@@ -164,4 +164,94 @@ void main() {
       expect(await plugin.getCommands(projectId: cwd), isEmpty);
     });
   });
+
+  test("history replay advertises commands and emits a session refresh", () async {
+    final live = FakeAcpProcess();
+    final replay = FakeAcpProcess();
+    final processes = [live, replay];
+    final emitted = <BridgeSseEvent>[];
+    final plugin = AcpPlugin(
+      id: "acp",
+      agentDisplayName: "ACP",
+      launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+      launchDirectory: "/repo",
+      eventMapper: AcpEventMapper(launchDirectory: "/repo", agentId: "acp"),
+      processFactory: (_) async => processes.removeAt(0),
+    );
+    plugin.events.listen(emitted.add);
+
+    Future<Map<String, dynamic>> waitForFrame(FakeAcpProcess process, String method) async {
+      for (var i = 0; i < 100; i++) {
+        final matches = process.written.where((frame) => frame["method"] == method);
+        if (matches.isNotEmpty) return matches.last;
+        await Future<void>.delayed(Duration.zero);
+      }
+      throw StateError("agent never wrote a '$method' frame");
+    }
+
+    try {
+      final connecting = plugin.ensureConnected();
+      final liveInit = await waitForFrame(live, "initialize");
+      live.emit({
+        "jsonrpc": "2.0",
+        "id": liveInit["id"],
+        "result": {
+          "protocolVersion": 1,
+          "agentCapabilities": {"loadSession": true},
+          "authMethods": <Object?>[],
+        },
+      });
+      expect(await connecting, isTrue);
+
+      final creating = plugin.createSession(
+        directory: "/repo/worktree",
+        parentSessionId: null,
+        parts: const [],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final sessionNew = await waitForFrame(live, "session/new");
+      live.emit({"jsonrpc": "2.0", "id": sessionNew["id"], "result": {"sessionId": "s1"}});
+      await creating;
+
+      final messages = plugin.getSessionMessages("s1");
+      final replayInit = await waitForFrame(replay, "initialize");
+      replay.emit({
+        "jsonrpc": "2.0",
+        "id": replayInit["id"],
+        "result": {
+          "protocolVersion": 1,
+          "agentCapabilities": {"loadSession": true},
+          "authMethods": <Object?>[],
+        },
+      });
+      final load = await waitForFrame(replay, "session/load");
+      replay.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": "s1",
+          "update": {
+            "sessionUpdate": "available_commands_update",
+            "availableCommands": [
+              {"name": "from_replay"},
+            ],
+          },
+        },
+      });
+      replay.emit({"jsonrpc": "2.0", "id": load["id"], "result": const <String, dynamic>{}});
+      await messages;
+
+      expect((await plugin.getCommands(projectId: "/repo")).single.name, "from_replay");
+      expect(
+        emitted.whereType<BridgeSseSessionsUpdated>().single.sessionID,
+        "s1",
+      );
+    } finally {
+      await plugin.dispose();
+      await live.close();
+      await replay.close();
+    }
+  });
 }

--- a/bridge/sesori_plugin_acp/test/acp_commands_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_commands_test.dart
@@ -235,6 +235,19 @@ void main() {
           "update": {
             "sessionUpdate": "available_commands_update",
             "availableCommands": [
+              {"name": "stale_replay_command"},
+            ],
+          },
+        },
+      });
+      replay.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": "s1",
+          "update": {
+            "sessionUpdate": "available_commands_update",
+            "availableCommands": [
               {"name": "from_replay"},
             ],
           },

--- a/bridge/sesori_plugin_acp/test/acp_commands_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_commands_test.dart
@@ -128,5 +128,40 @@ void main() {
       expect(commands.single.description, "Plan before coding");
       expect(commands.single.hints, ["what to plan"]);
     });
+
+    test("clears commands when the ACP process connection resets", () async {
+      final connecting = plugin.ensureConnected();
+      final init = await waitForFrame("initialize");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": init["id"],
+        "result": {
+          "protocolVersion": 1,
+          "agentCapabilities": <String, dynamic>{},
+          "authMethods": <Object?>[],
+        },
+      });
+      expect(await connecting, isTrue);
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": "s1",
+          "update": {
+            "sessionUpdate": "available_commands_update",
+            "availableCommands": [
+              {"name": "old_process_command"},
+            ],
+          },
+        },
+      });
+      await pump();
+      expect(await plugin.getCommands(projectId: cwd), hasLength(1));
+
+      await plugin.resetConnectionAfterExit();
+
+      expect(await plugin.getCommands(projectId: cwd), isEmpty);
+    });
   });
 }

--- a/bridge/sesori_plugin_acp/test/acp_commands_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_commands_test.dart
@@ -1,0 +1,85 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:test/test.dart";
+
+/// `getCommands` serves the commands the agent advertised via the
+/// `available_commands_update` notification (ACP has no request endpoint for
+/// them). Before any update arrives, the list is empty.
+void main() {
+  group("AcpPlugin.getCommands", () {
+    late FakeAcpProcess fake;
+    late AcpPlugin plugin;
+    const cwd = "/repo";
+
+    setUp(() {
+      fake = FakeAcpProcess();
+      plugin = AcpPlugin(
+        id: "acp",
+        agentDisplayName: "ACP",
+        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+        launchDirectory: cwd,
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp"),
+        processFactory: (_) async => fake,
+      );
+      plugin.events.listen((_) {});
+    });
+
+    tearDown(() async {
+      await plugin.dispose();
+      await fake.close();
+    });
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+    Future<Map<String, dynamic>> waitForFrame(String method) async {
+      for (var i = 0; i < 80; i++) {
+        final matches = fake.written.where((f) => f["method"] == method);
+        if (matches.isNotEmpty) return matches.last;
+        await pump();
+      }
+      throw StateError("agent never wrote a '$method' frame");
+    }
+
+    test("serves the agent's advertised slash commands", () async {
+      final connecting = plugin.ensureConnected();
+      final init = await waitForFrame("initialize");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": init["id"],
+        "result": {
+          "protocolVersion": 1,
+          "agentCapabilities": <String, dynamic>{},
+          "authMethods": <Object?>[],
+        },
+      });
+      expect(await connecting, isTrue);
+
+      expect(await plugin.getCommands(projectId: cwd), isEmpty);
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": "s1",
+          "update": {
+            "sessionUpdate": "available_commands_update",
+            "availableCommands": [
+              {
+                "name": "create_plan",
+                "description": "Plan before coding",
+                "input": {"hint": "what to plan"},
+              },
+            ],
+          },
+        },
+      });
+      await pump();
+
+      final commands = await plugin.getCommands(projectId: cwd);
+      expect(commands, hasLength(1));
+      expect(commands.single.name, "create_plan");
+      expect(commands.single.description, "Plan before coding");
+      expect(commands.single.hints, ["what to plan"]);
+    });
+  });
+}

--- a/bridge/sesori_plugin_acp/test/acp_commands_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_commands_test.dart
@@ -1,11 +1,58 @@
 import "package:acp_plugin/acp_plugin.dart";
 import "package:acp_plugin/acp_testing.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
 /// `getCommands` serves the commands the agent advertised via the
 /// `available_commands_update` notification (ACP has no request endpoint for
 /// them). Before any update arrives, the list is empty.
 void main() {
+  group("AcpCommandTracker", () {
+    AcpNotification update(Map<String, dynamic> body) => AcpNotification(
+      method: "session/update",
+      params: {"sessionId": "s1", "update": body},
+    );
+
+    test("parses advertised commands fail-soft; last update wins", () {
+      final tracker = AcpCommandTracker()
+        ..consume(update({
+          "sessionUpdate": "available_commands_update",
+          "availableCommands": [
+            {
+              "name": "create_plan",
+              "description": "Plan before coding",
+              "input": {"hint": "what to plan"},
+            },
+            {"name": "compress", "description": "Compact the thread"},
+            {"description": "malformed: no name"},
+            "not-a-map",
+          ],
+        }));
+
+      final commands = tracker.commands;
+      expect(commands, hasLength(2));
+      expect(commands[0].name, "create_plan");
+      expect(commands[0].description, "Plan before coding");
+      expect(commands[0].hints, ["what to plan"]);
+      expect(commands[0].source, PluginCommandSource.command);
+      expect(commands[1].name, "compress");
+      expect(commands[1].hints, isEmpty);
+
+      tracker.consume(update({
+        "sessionUpdate": "available_commands_update",
+        "availableCommands": const <Object?>[],
+      }));
+      expect(tracker.commands, isEmpty);
+    });
+
+    test("ignores unrelated notifications", () {
+      final tracker = AcpCommandTracker()
+        ..consume(const AcpNotification(method: "cursor/update_todos", params: {}))
+        ..consume(update({"sessionUpdate": "plan", "entries": <Object?>[]}));
+      expect(tracker.commands, isEmpty);
+    });
+  });
+
   group("AcpPlugin.getCommands", () {
     late FakeAcpProcess fake;
     late AcpPlugin plugin;

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -346,38 +346,6 @@ void main() {
       expect(late.whereType<BridgeSseMessagePartDelta>().single.messageID, firstId);
     });
 
-    test("available_commands_update caches the advertised commands", () {
-      final events = mapper.map(update({
-        "sessionUpdate": "available_commands_update",
-        "availableCommands": [
-          {
-            "name": "create_plan",
-            "description": "Plan before coding",
-            "input": {"hint": "what to plan"},
-          },
-          {"name": "compress", "description": "Compact the thread"},
-          {"description": "malformed: no name"},
-          "not-a-map",
-        ],
-      }));
-      expect(events.single, isA<BridgeSseProjectUpdated>());
-      final commands = mapper.availableCommands;
-      expect(commands, hasLength(2));
-      expect(commands[0].name, "create_plan");
-      expect(commands[0].description, "Plan before coding");
-      expect(commands[0].hints, ["what to plan"]);
-      expect(commands[0].source, PluginCommandSource.command);
-      expect(commands[1].name, "compress");
-      expect(commands[1].hints, isEmpty);
-
-      // The next update replaces the cache (last update wins).
-      mapper.map(update({
-        "sessionUpdate": "available_commands_update",
-        "availableCommands": const <Object?>[],
-      }));
-      expect(mapper.availableCommands, isEmpty);
-    });
-
     test("plan maps to a todo update, commands to a project update", () {
       expect(
         mapper.map(update({"sessionUpdate": "plan", "entries": const <Object?>[]})).single,

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -330,6 +330,18 @@ void main() {
       expect(events.whereType<BridgeSseSessionDiff>(), hasLength(1));
     });
 
+    test("diff content emits a session diff when status is omitted", () {
+      final events = mapper.map(update({
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "tc-statusless-diff",
+        "content": [
+          {"type": "diff", "path": "/repo/a.dart", "oldText": "a", "newText": "b"},
+        ],
+      }));
+
+      expect(events.whereType<BridgeSseSessionDiff>(), hasLength(1));
+    });
+
     test("chunks group by ACP messageId when present", () {
       mapper.beginTurn("s1");
       final first = mapper.map(update({
@@ -378,7 +390,9 @@ void main() {
       mapper.setSessionProject("s1", "/repo/other");
       expect(
         mapper.map(update({"sessionUpdate": "available_commands_update"})).single,
-        isA<BridgeSseSessionsUpdated>().having((event) => event.projectID, "projectID", "/repo/other"),
+        isA<BridgeSseSessionsUpdated>()
+            .having((event) => event.sessionID, "sessionID", "s1")
+            .having((event) => event.projectID, "projectID", "/repo/other"),
       );
     });
 

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -271,6 +271,113 @@ void main() {
       expect(events.whereType<BridgeSseSessionDiff>(), hasLength(1));
     });
 
+    test("an initial file-mutating tool_call emits a session diff", () {
+      // An agent may report the whole mutation as one complete tool_call with
+      // no follow-up update — the diff signal must fire on the initial
+      // notification too.
+      final events = mapper.map(update({
+        "sessionUpdate": "tool_call",
+        "toolCallId": "tc-init-edit",
+        "kind": "edit",
+        "status": "completed",
+      }));
+      expect(events.whereType<BridgeSseSessionDiff>(), hasLength(1));
+
+      final nonMutating = mapper.map(update({
+        "sessionUpdate": "tool_call",
+        "toolCallId": "tc-init-read",
+        "kind": "read",
+        "status": "completed",
+      }));
+      expect(nonMutating.whereType<BridgeSseSessionDiff>(), isEmpty);
+    });
+
+    test("a diff content entry marks the tool call as a file mutation", () {
+      // Spec-compliant agents can report an edit purely through the standard
+      // tool content shape (type: "diff") with no mutating kind.
+      final events = mapper.map(update({
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "tc-diff",
+        "status": "completed",
+        "content": [
+          {"type": "diff", "path": "/repo/a.dart", "oldText": "a", "newText": "b"},
+        ],
+      }));
+      expect(events.whereType<BridgeSseSessionDiff>(), hasLength(1));
+    });
+
+    test("chunks group by ACP messageId when present", () {
+      mapper.beginTurn("s1");
+      final first = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "m1",
+        "content": {"type": "text", "text": "one"},
+      }));
+      final firstEnvelope = first.whereType<BridgeSseMessageUpdated>().single;
+      final firstId = shared.Message.fromJson(firstEnvelope.info).id;
+
+      // Same id, same role → same message, delta only.
+      final more = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "m1",
+        "content": {"type": "text", "text": " more"},
+      }));
+      expect(more.whereType<BridgeSseMessageUpdated>(), isEmpty);
+
+      // A change in messageId starts a NEW message even within one turn and
+      // one role — the spec's message-boundary signal.
+      final second = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "m2",
+        "content": {"type": "text", "text": "two"},
+      }));
+      final secondEnvelope = second.whereType<BridgeSseMessageUpdated>().single;
+      final secondId = shared.Message.fromJson(secondEnvelope.info).id;
+      expect(secondId, isNot(firstId));
+
+      // A later chunk for the FIRST message merges back into it (no envelope,
+      // delta targets the first message id).
+      final late = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "m1",
+        "content": {"type": "text", "text": " tail"},
+      }));
+      expect(late.whereType<BridgeSseMessageUpdated>(), isEmpty);
+      expect(late.whereType<BridgeSseMessagePartDelta>().single.messageID, firstId);
+    });
+
+    test("available_commands_update caches the advertised commands", () {
+      final events = mapper.map(update({
+        "sessionUpdate": "available_commands_update",
+        "availableCommands": [
+          {
+            "name": "create_plan",
+            "description": "Plan before coding",
+            "input": {"hint": "what to plan"},
+          },
+          {"name": "compress", "description": "Compact the thread"},
+          {"description": "malformed: no name"},
+          "not-a-map",
+        ],
+      }));
+      expect(events.single, isA<BridgeSseProjectUpdated>());
+      final commands = mapper.availableCommands;
+      expect(commands, hasLength(2));
+      expect(commands[0].name, "create_plan");
+      expect(commands[0].description, "Plan before coding");
+      expect(commands[0].hints, ["what to plan"]);
+      expect(commands[0].source, PluginCommandSource.command);
+      expect(commands[1].name, "compress");
+      expect(commands[1].hints, isEmpty);
+
+      // The next update replaces the cache (last update wins).
+      mapper.map(update({
+        "sessionUpdate": "available_commands_update",
+        "availableCommands": const <Object?>[],
+      }));
+      expect(mapper.availableCommands, isEmpty);
+    });
+
     test("plan maps to a todo update, commands to a project update", () {
       expect(
         mapper.map(update({"sessionUpdate": "plan", "entries": const <Object?>[]})).single,
@@ -396,6 +503,71 @@ void main() {
         "_meta": {"tags": <String>[]},
       }));
       expect(events, isEmpty);
+    });
+
+    test("session_info_update carries the snapshot time instead of nulling it", () {
+      // The mobile list REPLACES the whole session on session.updated, so a
+      // null time would drop the row's sort position to epoch 0 whenever no
+      // stored bridge row exists to enrich from.
+      mapper.setSessionSnapshot(
+        sessionId: "s1",
+        title: "Old title",
+        createdMs: 1000,
+        updatedMs: 2000,
+      );
+      final events = mapper.map(update({
+        "sessionUpdate": "session_info_update",
+        "title": "New title",
+      }));
+      final session =
+          shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
+      expect(session.title, "New title");
+      expect(session.time?.created, 1000);
+      expect(session.time?.updated, 2000);
+    });
+
+    test("session_info_update honours the notification's own updatedAt", () {
+      mapper.setSessionSnapshot(
+        sessionId: "s1",
+        title: null,
+        createdMs: 1000,
+        updatedMs: 2000,
+      );
+      final at = DateTime.fromMillisecondsSinceEpoch(5000, isUtc: true);
+      final events = mapper.map(update({
+        "sessionUpdate": "session_info_update",
+        "title": "Fresh",
+        "updatedAt": at.toIso8601String(),
+      }));
+      final session =
+          shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
+      expect(session.time?.updated, 5000);
+      expect(session.time?.created, 1000, reason: "creation time is kept, not dragged forward");
+    });
+
+    test("snapshot keeps the earliest created and the latest updated", () {
+      mapper.setSessionSnapshot(sessionId: "s1", title: null, createdMs: 3000, updatedMs: 3000);
+      // A later enumeration reports an older last-activity time as created —
+      // it must not drag creation forward; updated advances.
+      mapper.setSessionSnapshot(sessionId: "s1", title: null, createdMs: 1000, updatedMs: 4000);
+      final events = mapper.map(update({
+        "sessionUpdate": "session_info_update",
+        "title": "T",
+      }));
+      final session =
+          shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
+      expect(session.time?.created, 1000);
+      expect(session.time?.updated, 4000);
+    });
+
+    test("with no snapshot at all the emitted time stays null", () {
+      final events = mapper.map(update({
+        "sessionUpdate": "session_info_update",
+        "title": "Unknown session",
+      }));
+      final session =
+          shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
+      expect(session.time, isNull);
     });
 
     test("a per-session model overrides the global stamp", () {

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -292,6 +292,30 @@ void main() {
       expect(nonMutating.whereType<BridgeSseSessionDiff>(), isEmpty);
     });
 
+    test("a mutating tool emits its diff when a later status-only update completes it", () {
+      final initial = mapper.map(update({
+        "sessionUpdate": "tool_call",
+        "toolCallId": "tc-progress-edit",
+        "kind": "edit",
+        "status": "in_progress",
+      }));
+      expect(initial.whereType<BridgeSseSessionDiff>(), isEmpty);
+
+      final completed = mapper.map(update({
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "tc-progress-edit",
+        "status": "completed",
+      }));
+      expect(completed.whereType<BridgeSseSessionDiff>(), hasLength(1));
+
+      final late = mapper.map(update({
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "tc-progress-edit",
+        "rawOutput": {"stdout": "done"},
+      }));
+      expect(late.whereType<BridgeSseSessionDiff>(), isEmpty);
+    });
+
     test("a diff content entry marks the tool call as a file mutation", () {
       // Spec-compliant agents can report an edit purely through the standard
       // tool content shape (type: "diff") with no mutating kind.
@@ -346,14 +370,15 @@ void main() {
       expect(late.whereType<BridgeSseMessagePartDelta>().single.messageID, firstId);
     });
 
-    test("plan maps to a todo update, commands to a project update", () {
+    test("plan maps to a todo update, commands mark their project sessions stale", () {
       expect(
         mapper.map(update({"sessionUpdate": "plan", "entries": const <Object?>[]})).single,
         isA<BridgeSseTodoUpdated>(),
       );
+      mapper.setSessionProject("s1", "/repo/other");
       expect(
         mapper.map(update({"sessionUpdate": "available_commands_update"})).single,
-        isA<BridgeSseProjectUpdated>(),
+        isA<BridgeSseSessionsUpdated>().having((event) => event.projectID, "projectID", "/repo/other"),
       );
     });
 
@@ -465,7 +490,23 @@ void main() {
       expect(session.title, isNull);
     });
 
-    test("session_info_update without a title key emits nothing", () {
+    test("timestamp-only session_info_update preserves the cached title and emits a session update", () {
+      mapper.setSessionSnapshot(
+        sessionId: "s1",
+        title: "Existing title",
+        createdMs: 1000,
+        updatedMs: 2000,
+      );
+      final events = mapper.map(update({
+        "sessionUpdate": "session_info_update",
+        "updatedAt": DateTime.fromMillisecondsSinceEpoch(3000, isUtc: true).toIso8601String(),
+      }));
+      final session = shared.Session.fromJson(events.whereType<BridgeSseSessionUpdated>().single.info);
+      expect(session.title, "Existing title");
+      expect(session.time?.updated, 3000);
+    });
+
+    test("session_info_update without a title or timestamp emits nothing", () {
       final events = mapper.map(update({
         "sessionUpdate": "session_info_update",
         "_meta": {"tags": <String>[]},
@@ -515,9 +556,10 @@ void main() {
 
     test("snapshot keeps the earliest created and the latest updated", () {
       mapper.setSessionSnapshot(sessionId: "s1", title: null, createdMs: 3000, updatedMs: 3000);
-      // A later enumeration reports an older last-activity time as created —
-      // it must not drag creation forward; updated advances.
+      // An enumeration may report a stale last-activity time. It must not
+      // drag either timestamp backwards.
       mapper.setSessionSnapshot(sessionId: "s1", title: null, createdMs: 1000, updatedMs: 4000);
+      mapper.setSessionSnapshot(sessionId: "s1", title: null, createdMs: 5000, updatedMs: 3500);
       final events = mapper.map(update({
         "sessionUpdate": "session_info_update",
         "title": "T",

--- a/bridge/sesori_plugin_acp/test/acp_resume_only_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_only_test.dart
@@ -1,0 +1,183 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+/// An agent that advertises `sessionCapabilities.resume` but NOT `loadSession`
+/// must have prior-run sessions re-activated via `session/resume` before a
+/// turn — otherwise the fresh agent process rejects the `session/prompt` as an
+/// unknown session. `session/resume` replays no history, so no replay
+/// suppression applies.
+void main() {
+  group("AcpPlugin resume-only sessions", () {
+    late FakeAcpProcess fake;
+    late AcpPlugin plugin;
+    final emitted = <BridgeSseEvent>[];
+    const cwd = "/repo";
+
+    setUp(() {
+      fake = FakeAcpProcess();
+      plugin = AcpPlugin(
+        id: "acp",
+        agentDisplayName: "ACP",
+        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+        launchDirectory: cwd,
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp"),
+        processFactory: (_) async => fake,
+      );
+      emitted.clear();
+      plugin.events.listen(emitted.add);
+    });
+
+    tearDown(() async {
+      await plugin.dispose();
+      await fake.close();
+    });
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+
+    List<Map<String, dynamic>> frames(String method) =>
+        fake.written.where((f) => f["method"] == method).toList(growable: false);
+
+    // Polls with a small real delay so a dispatch queued behind another
+    // serialized-turn step is not out-raced by zero-duration pumps.
+    Future<Map<String, dynamic>> waitForFrameCount(String method, int count) async {
+      for (var i = 0; i < 400; i++) {
+        final matches = frames(method);
+        if (matches.length >= count) return matches[count - 1];
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+      throw StateError("agent never wrote $count '$method' frame(s)");
+    }
+
+    Future<void> connect() async {
+      final connecting = plugin.ensureConnected();
+      final frame = await waitForFrameCount("initialize", 1);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": frame["id"],
+        "result": {
+          "protocolVersion": 1,
+          "agentCapabilities": {
+            "loadSession": false,
+            "sessionCapabilities": {"resume": <String, dynamic>{}},
+          },
+          "authMethods": <Object?>[],
+        },
+      });
+      expect(await connecting, isTrue);
+    }
+
+    Future<void> sendPrompt(String text) => plugin.sendPrompt(
+      sessionId: "old-1",
+      parts: [PluginPromptPart.text(text: text)],
+      variant: null,
+      agent: null,
+      model: null,
+    );
+
+    test("a prior-run session is resumed (not loaded) before the prompt, unsuppressed", () async {
+      await connect();
+
+      final sending = sendPrompt("hi");
+      final resumeFrame = await waitForFrameCount("session/resume", 1);
+      final params = (resumeFrame["params"] as Map).cast<String, dynamic>();
+      expect(params["sessionId"], "old-1");
+      expect(params["cwd"], cwd);
+
+      // A live update arriving during the resume is NOT replay — session/resume
+      // returns no history — so it must reach the live stream.
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": "old-1",
+          "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "live"},
+          },
+        },
+      });
+      await pump();
+      fake.emit({"jsonrpc": "2.0", "id": resumeFrame["id"], "result": const <String, dynamic>{}});
+      await sending;
+
+      expect(frames("session/load"), isEmpty, reason: "loadSession is not advertised");
+      expect(
+        emitted.whereType<BridgeSseMessagePartDelta>(),
+        isNotEmpty,
+        reason: "resume replays nothing, so mid-resume updates are live",
+      );
+
+      final promptFrame = await waitForFrameCount("session/prompt", 1);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": promptFrame["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+      await pump();
+
+      // The now-resident session is not re-resumed on the next turn.
+      final again = sendPrompt("again");
+      final secondPrompt = await waitForFrameCount("session/prompt", 2);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": secondPrompt["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+      await again;
+      expect(frames("session/resume"), hasLength(1));
+    });
+
+    test("a transiently failed resume is retried on the next turn", () async {
+      await connect();
+
+      final sending = sendPrompt("hi");
+      final firstResume = await waitForFrameCount("session/resume", 1);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": firstResume["id"],
+        "error": {"code": -32000, "message": "transient"},
+      });
+      await sending;
+      final firstPrompt = await waitForFrameCount("session/prompt", 1);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": firstPrompt["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+      await pump();
+
+      final again = sendPrompt("again");
+      final secondResume = await waitForFrameCount("session/resume", 2);
+      fake.emit({"jsonrpc": "2.0", "id": secondResume["id"], "result": const <String, dynamic>{}});
+      await again;
+      expect(frames("session/resume"), hasLength(2));
+    });
+
+    test("an unsupported resume (-32601) is memoized", () async {
+      await connect();
+
+      final sending = sendPrompt("hi");
+      final firstResume = await waitForFrameCount("session/resume", 1);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": firstResume["id"],
+        "error": {"code": -32601, "message": "method not found"},
+      });
+      await sending;
+      final firstPrompt = await waitForFrameCount("session/prompt", 1);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": firstPrompt["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+      await pump();
+
+      final again = sendPrompt("again");
+      await waitForFrameCount("session/prompt", 2);
+      await again;
+      expect(frames("session/resume"), hasLength(1));
+    });
+  });
+}

--- a/bridge/sesori_plugin_acp/test/acp_resume_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_test.dart
@@ -85,6 +85,17 @@ void main() {
           },
         },
       });
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": "old-session",
+          "update": {
+            "sessionUpdate": "available_commands_update",
+            "availableCommands": const <Object?>[],
+          },
+        },
+      });
       await pump();
       fake.emit({"jsonrpc": "2.0", "id": loadFrame["id"], "result": const <String, dynamic>{}});
 
@@ -104,6 +115,9 @@ void main() {
 
       // The suppressed replay produced no message events on the live stream.
       expect(emitted.whereType<BridgeSseMessagePartDelta>(), isEmpty);
+      // Command metadata is current even during a history replay, so the
+      // client receives the stale-session signal and re-fetches it.
+      expect(emitted.whereType<BridgeSseSessionsUpdated>(), hasLength(1));
 
       // Complete the first turn so the follow-up prompt dispatches (turns on
       // one session are serialized).

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -129,5 +129,72 @@ void main() {
       expect(assistant.modelID, "claude-opus-4-8");
       expect(assistant.providerID, "cursor");
     });
+
+    test("a messageId change splits consecutive same-role chunks into two messages", () {
+      // ACP v1: chunks of one message share a messageId; a change starts a new
+      // message. Without honouring it, distinct same-role messages collapse.
+      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "m1",
+          "content": {"type": "text", "text": "first"},
+        }))
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "m1",
+          "content": {"type": "text", "text": " message"},
+        }))
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "m2",
+          "content": {"type": "text", "text": "second message"},
+        }));
+
+      final messages = collector.build();
+      expect(messages, hasLength(2));
+      expect(messages[0].parts.single.text, "first message");
+      expect(messages[1].parts.single.text, "second message");
+      expect(messages[0].info.id, isNot(messages[1].info.id));
+    });
+
+    test("chunks without a messageId keep the role-grouping behaviour", () {
+      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "one"},
+        }))
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": " flow"},
+        }));
+      expect(collector.build().single.parts.single.text, "one flow");
+    });
+
+    test("a same-message thought and text share the message; tools attach without an id", () {
+      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
+        ..consume(upd({
+          "sessionUpdate": "agent_thought_chunk",
+          "messageId": "m1",
+          "content": {"type": "text", "text": "thinking"},
+        }))
+        ..consume(upd({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "t1",
+          "kind": "read",
+          "status": "completed",
+        }))
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "m1",
+          "content": {"type": "text", "text": "answer"},
+        }));
+
+      final message = collector.build().single;
+      expect(message.parts.map((p) => p.type), containsAll(<PluginMessagePartType>[
+        PluginMessagePartType.reasoning,
+        PluginMessagePartType.text,
+        PluginMessagePartType.tool,
+      ]));
+    });
   });
 }

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -188,6 +188,24 @@ void main() {
       expect(messages[1].parts.single.text, "identified message");
     });
 
+    test("id-less text after an explicit messageId starts a new message", () {
+      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "m1",
+          "content": {"type": "text", "text": "identified message"},
+        }))
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "id-less message"},
+        }));
+
+      final messages = collector.build();
+      expect(messages, hasLength(2));
+      expect(messages[0].parts.single.text, "identified message");
+      expect(messages[1].parts.single.text, "id-less message");
+    });
+
     test("a same-message thought and text share the message; tools attach without an id", () {
       final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
         ..consume(upd({

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -170,6 +170,24 @@ void main() {
       expect(collector.build().single.parts.single.text, "one flow");
     });
 
+    test("an explicit messageId after id-less text starts a new message", () {
+      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "id-less draft"},
+        }))
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "messageId": "m2",
+          "content": {"type": "text", "text": "identified message"},
+        }));
+
+      final messages = collector.build();
+      expect(messages, hasLength(2));
+      expect(messages[0].parts.single.text, "id-less draft");
+      expect(messages[1].parts.single.text, "identified message");
+    });
+
     test("a same-message thought and text share the message; tools attach without an id", () {
       final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
         ..consume(upd({

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_binary.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_binary.dart
@@ -1,12 +1,15 @@
 import "package:acp_plugin/acp_plugin.dart";
 
-/// Builds the launch spec for `cursor-agent acp`.
+/// Builds the launch spec for `agent acp`.
 ///
 /// Auth is out of band: the default process factory inherits the bridge's
 /// environment, so `CURSOR_API_KEY` / `CURSOR_AUTH_TOKEN` (or a prior
-/// `cursor-agent login`) are passed through automatically.
+/// `agent login`) are passed through automatically.
 abstract final class CursorBinary {
-  static const String defaultBinary = "cursor-agent";
+  /// The Cursor CLI's official binary name (`agent`, per cursor.com/docs/cli;
+  /// `agent acp` is the documented ACP server mode). Older installs that only
+  /// ship the legacy `cursor-agent` name can point `--cursor-bin` at it.
+  static const String defaultBinary = "agent";
 
   static AcpLaunchSpec launchSpec({
     String binary = defaultBinary,

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_model_probe.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_model_probe.dart
@@ -27,13 +27,29 @@ abstract final class CursorModelProbe {
       findConfig(session, "model");
 
   /// The selectable `{value, name}` entries for a config option.
+  ///
+  /// ACP allows the option list to be *grouped* (`{group, name, options: […]}`
+  /// entries instead of flat `{value, name}` ones). Groups are flattened in
+  /// order — a group entry carries no `value` of its own, so returning it
+  /// as-is would drop every nested model/variant from the catalog and leave
+  /// `applyTurnSelection` unable to find any selectable value.
   static List<Map<String, dynamic>> options(Map<String, dynamic> config) {
     final raw = config["options"];
     if (raw is! List) return const [];
-    return raw
-        .whereType<Map<dynamic, dynamic>>()
-        .map((m) => m.cast<String, dynamic>())
-        .toList(growable: false);
+    final flattened = <Map<String, dynamic>>[];
+    for (final entry in raw) {
+      if (entry is! Map) continue;
+      final map = entry.cast<String, dynamic>();
+      final nested = map["options"];
+      if (nested is List) {
+        flattened.addAll(
+          nested.whereType<Map<dynamic, dynamic>>().map((m) => m.cast<String, dynamic>()),
+        );
+      } else {
+        flattened.add(map);
+      }
+    }
+    return flattened;
   }
 
   /// Alias of [options] for the model config (reads more clearly at the model

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
@@ -11,8 +11,8 @@ import "../cursor_plugin_impl.dart";
 
 /// Builds the [CursorPlugin] (the live [BridgePluginApi]) for a resolved
 /// binary. The production default constructs the real plugin wired to the
-/// host-backed process factory; tests inject a fake to avoid spawning
-/// `cursor-agent`.
+/// host-backed process factory; tests inject a fake to avoid spawning the
+/// Cursor CLI.
 typedef CursorPluginFactory =
     CursorPlugin Function({
       required String binaryPath,
@@ -37,10 +37,10 @@ CursorPlugin _defaultBuildPlugin({
 
 /// The const Cursor plugin descriptor.
 ///
-/// Cursor drives a `cursor-agent acp` stdio subprocess over the generic ACP
+/// Cursor drives an `agent acp` stdio subprocess over the generic ACP
 /// machinery, so it needs no managed-runtime supervisor (no listening port to
 /// reclaim, no ownership file). It declares its CLI surface, probes the
-/// `cursor-agent` binary for availability, and on [start] spawns the agent
+/// Cursor CLI binary for availability, and on [start] spawns the agent
 /// through the [PluginHost] process seam and returns an [AcpBridgePlugin].
 ///
 /// The optional constructor parameters are test seams; the registered instance
@@ -58,14 +58,14 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
   final Duration _connectBudget;
   final Duration _versionProbeTimeout;
 
-  /// Minimum `cursor-agent` build the bridge supports. Earlier builds (e.g.
+  /// Minimum Cursor CLI build the bridge supports. Earlier builds (e.g.
   /// `2026.05.28`) advertise the `acp` model picker and `session/load` but
   /// silently no-op model switching and history replay, so the experience is
   /// broken in ways the user can't see. `2026.06.15` is the verified-good
   /// build where both work end-to-end.
   static const String minVersion = "2026.06.15";
 
-  /// CLI option naming the `cursor-agent` binary (path or PATH name). Declared
+  /// CLI option naming the Cursor CLI binary (path or PATH name). Declared
   /// as the bare local name — the bridge's [PluginCliOptionsMapper] namespaces
   /// it to the public `--cursor-bin` flag.
   static const String binOption = "bin";
@@ -77,7 +77,7 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
   static const List<PluginOption> cliOptions = [
     PluginValueOption(
       name: binOption,
-      help: "Path to the cursor-agent binary",
+      help: "Path to the Cursor CLI binary (agent)",
       defaultsTo: CursorBinary.defaultBinary,
       allowedValues: null,
       valueHelp: "path",
@@ -85,7 +85,7 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
     ),
     PluginValueOption(
       name: apiEndpointOption,
-      help: "Override the Cursor API endpoint (passed to cursor-agent as -e <endpoint>)",
+      help: "Override the Cursor API endpoint (passed to the Cursor CLI as -e <endpoint>)",
       defaultsTo: null,
       allowedValues: null,
       valueHelp: "url",
@@ -102,7 +102,7 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
   @override
   List<PluginOption> get options => cliOptions;
 
-  /// Confirms the `cursor-agent` CLI is installed and runnable before the
+  /// Confirms the Cursor CLI is installed and runnable before the
   /// bridge commits to startup. Runs `<bin> --version`: exit 0 within
   /// [versionProbeTimeout] is available; a failed launch (not installed / not
   /// on PATH), a non-zero exit, or a timeout are unavailable. Never throws.
@@ -164,7 +164,7 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
     final parsed = _CalVer.tryParse(version);
     final minimum = _CalVer.tryParse(minVersion);
     if (parsed != null && minimum != null && parsed.compareTo(minimum) < 0) {
-      Log.w("[cursor] cursor-agent $version is below the supported minimum $minVersion");
+      Log.w("[cursor] Cursor CLI $version is below the supported minimum $minVersion");
       return PluginUnavailable(
         message: _outdatedMessage(executablePath: executablePath, version: version),
       );
@@ -175,29 +175,30 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
 
   String _notInstalledMessage({required String executablePath}) {
     return [
-      "Cursor was not found — the Sesori bridge needs the cursor-agent CLI to run.",
+      "Cursor was not found — the Sesori bridge needs the Cursor CLI ($executablePath) to run.",
       "",
       "Verify it is installed:  $executablePath --version",
       "Install the Cursor CLI:  curl https://cursor.com/install -fsS | bash",
+      "Legacy installs that only ship `cursor-agent` can use --cursor-bin cursor-agent.",
     ].join("\n");
   }
 
   String _notWorkingMessage({required String executablePath}) {
     return [
-      'cursor-agent is installed but did not respond to "$executablePath --version".',
+      'The Cursor CLI is installed but did not respond to "$executablePath --version".',
       "",
       "Re-check your install:   $executablePath --version",
-      "Update the Cursor CLI:   cursor-agent update",
+      "Update the Cursor CLI:   $executablePath update",
     ].join("\n");
   }
 
   String _outdatedMessage({required String executablePath, required String version}) {
-    final headline = "cursor-agent $version is too old for the Sesori bridge — "
+    final headline = "Cursor CLI $version is too old for the Sesori bridge — "
         "model switching and chat history need $minVersion or newer.";
     return [
       headline,
       "",
-      "Update the Cursor CLI:   cursor-agent update",
+      "Update the Cursor CLI:   $executablePath update",
       "Then re-check:           $executablePath --version",
     ].join("\n");
   }
@@ -275,7 +276,7 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
   }
 }
 
-/// A cursor-agent calendar version (`YYYY.MM.DD`, the leading component of a
+/// A Cursor CLI calendar version (`YYYY.MM.DD`, the leading component of a
 /// build string like `2026.06.15-18-00-12-6f5a2cf`). Parsed once into a typed
 /// [Comparable] rather than comparing version strings ad hoc.
 class _CalVer implements Comparable<_CalVer> {
@@ -285,7 +286,7 @@ class _CalVer implements Comparable<_CalVer> {
   final int month;
   final int day;
 
-  /// Parses the leading `YYYY.MM.DD` from a cursor-agent version/build string,
+  /// Parses the leading `YYYY.MM.DD` from a Cursor CLI version/build string,
   /// or null if it does not start with that shape (caller fails open).
   static _CalVer? tryParse(String raw) {
     final match = RegExp(r"^\s*(\d{4})\.(\d{1,2})\.(\d{1,2})").firstMatch(raw);

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
@@ -156,6 +156,16 @@ void main() {
       expect(plugin.id, "cursor");
     });
 
+    test("the default binary is the official Cursor CLI name", () {
+      // cursor.com/docs/cli: the CLI installs as `agent`, and `agent acp` is
+      // the documented ACP server mode. Legacy installs that only ship
+      // `cursor-agent` override via --cursor-bin.
+      expect(CursorBinary.defaultBinary, "agent");
+      final spec = CursorBinary.launchSpec(cwd: "/repo");
+      expect(spec.command, "agent");
+      expect(spec.args, ["acp"]);
+    });
+
     test("captureSessionConfig populates providers, mode variants, and agents", () async {
       plugin.captureSessionConfig(catalogResult(), fromNewSession: true);
 

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
@@ -55,6 +55,43 @@ void main() {
       expect(CursorModelProbe.findModelConfig(none), isNull);
       expect(CursorModelProbe.findConfig(none, "mode"), isNull);
     });
+
+    test("options flattens grouped select options", () {
+      // ACP allows the option list to be grouped ({group, name, options}); a
+      // group entry has no value of its own, so returning it unflattened would
+      // drop every nested model from the catalog.
+      final grouped = AcpNewSessionResult.fromJson({
+        "sessionId": "s",
+        "configOptions": [
+          {
+            "id": "model-picker",
+            "category": "model",
+            "currentValue": "gpt-5.4",
+            "options": [
+              {
+                "group": "openai",
+                "name": "OpenAI",
+                "options": [
+                  {"value": "gpt-5.4", "name": "GPT-5.4"},
+                ],
+              },
+              {
+                "group": "anthropic",
+                "name": "Anthropic",
+                "options": [
+                  {"value": "sonnet-4.6", "name": "Sonnet 4.6"},
+                  {"value": "opus-4.8", "name": "Opus 4.8"},
+                ],
+              },
+            ],
+          },
+        ],
+      });
+      final config = CursorModelProbe.findModelConfig(grouped)!;
+      final options = CursorModelProbe.options(config);
+      expect(options.map((o) => o["value"]), ["gpt-5.4", "sonnet-4.6", "opus-4.8"]);
+      expect(CursorModelProbe.hasOption(options, "opus-4.8"), isTrue);
+    });
   });
 
   group("CursorPlugin", () {
@@ -508,6 +545,40 @@ void main() {
         "authMethods": <Object?>[],
       });
       expect((await providers).providers, isEmpty);
+    });
+
+    test("a grouped model catalog surfaces every nested model", () async {
+      plugin.captureSessionConfig({
+        "sessionId": "s1",
+        "configOptions": [
+          {
+            "id": "model",
+            "category": "model",
+            "currentValue": "gpt-5.4",
+            "options": [
+              {
+                "group": "openai",
+                "name": "OpenAI",
+                "options": [
+                  {"value": "gpt-5.4", "name": "GPT-5.4"},
+                ],
+              },
+              {
+                "group": "anthropic",
+                "name": "Anthropic",
+                "options": [
+                  {"value": "sonnet-4.6", "name": "Sonnet 4.6"},
+                ],
+              },
+            ],
+          },
+        ],
+      }, fromNewSession: true);
+
+      final providers = await plugin.getProviders(projectId: "/repo");
+      final provider = providers.providers.single;
+      expect(provider.models.map((m) => m.id), ["gpt-5.4", "sonnet-4.6"]);
+      expect(provider.defaultModelID, "gpt-5.4");
     });
   });
 }

--- a/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
@@ -34,8 +34,12 @@ class BridgeSseSessionUpdated extends BridgeSseEvent {
 
 /// Signals that every session under [projectID] should be re-fetched.
 class BridgeSseSessionsUpdated extends BridgeSseEvent {
+  final String sessionID;
   final String projectID;
-  const BridgeSseSessionsUpdated({required this.projectID});
+  const BridgeSseSessionsUpdated({
+    required this.sessionID,
+    required this.projectID,
+  });
 }
 
 class BridgeSseSessionDeleted extends BridgeSseEvent {

--- a/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
@@ -32,6 +32,12 @@ class BridgeSseSessionUpdated extends BridgeSseEvent {
   const BridgeSseSessionUpdated({required this.info});
 }
 
+/// Signals that every session under [projectID] should be re-fetched.
+class BridgeSseSessionsUpdated extends BridgeSseEvent {
+  final String projectID;
+  const BridgeSseSessionsUpdated({required this.projectID});
+}
+
 class BridgeSseSessionDeleted extends BridgeSseEvent {
   final Map<String, dynamic> info;
   const BridgeSseSessionDeleted({required this.info});

--- a/docs/cursor-acp-followups/README.md
+++ b/docs/cursor-acp-followups/README.md
@@ -53,7 +53,7 @@ than observed Cursor bugs. That is called out per item.
 | I  | Lossy `session.updated` payload on title changes     | List row loses time/summary/defaults until refresh             | **Resolved** |
 | E  | Typed ACP/Cursor boundary DTOs                        | Enabler / safety net for C and F                                | Blocked on traces (Large) |
 | F  | `getSessionMessages` richer failure contract         | "Broken replay" vs "empty thread" on the phone                  | Open (Small–Med) |
-| D  | Cursor decisions needing a trace / product call      | Small, but blocked on evidence                                  | Blocked on evidence |
+| D  | Cursor decisions needing a trace / product call      | Small, but blocked on evidence                                  | D2 resolved; D1 blocked on a trace |
 
 ---
 
@@ -277,25 +277,27 @@ Source: [#332 r3545873668](https://github.com/sesori-ai/sesori_apps_monorepo/pul
 
 ## Theme D — Cursor decisions needing a trace or product call
 
-Small changes, blocked on evidence rather than effort.
-
-- **D1 — plan-mode rejection routing.** For `cursor/create_plan`, the modal's
-  standard Reject button calls `rejectQuestion`, which sends a JSON-RPC error;
-  Cursor may expect a normal `{accepted: false}` response instead, so plan-mode
-  turns could abort unexpectedly. Needs a real trace of Cursor's plan-response
-  contract before changing — altering it blind risks breaking the accept path.
+- **D1 — plan-mode rejection routing. STILL OPEN (blocked on evidence).** For
+  `cursor/create_plan`, the modal's standard Reject button calls
+  `rejectQuestion`, which sends a JSON-RPC error; Cursor may expect a normal
+  `{accepted: false}` response instead, so plan-mode turns could abort
+  unexpectedly. Needs a real trace of Cursor's plan-response contract before
+  changing — altering it blind risks breaking the accept path. This is the one
+  remaining item in this document that requires a live `agent acp` trace.
   Source: [#332 r3536293286](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3536293286)
 
-- **D2 — default binary name (`cursor-agent` vs `agent`).** The PR was
-  live-verified end-to-end against `cursor-agent`, and `--cursor-bin` overrides
-  the default. Whether the current Cursor CLI installs `agent` or `cursor-agent`
-  on PATH is a product/naming call for the maintainer before flipping the
-  default.
+- **D2 — default binary name. ✅ Resolved (product call made).** The official
+  Cursor CLI docs (cursor.com/docs/cli) install and document the binary as
+  `agent` — including `agent acp`, the exact ACP server mode this plugin
+  drives — so the default flipped from the legacy `cursor-agent` to `agent`.
+  Availability/update guidance is derived from the configured path, and legacy
+  installs that only ship `cursor-agent` keep working via
+  `--cursor-bin cursor-agent`.
   Source: [#332 r3536171386](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3536171386)
 
 ---
 
-## Theme E — Typed ACP/Cursor boundary DTOs
+## Theme E — Typed ACP/Cursor boundary DTOs — STILL OPEN (deliberately deferred)
 
 Core ACP parsing is raw `Map`/`List` today. Replacing it with typed/freezed
 boundary DTOs would restore compile-time safety in a central bridge flow —

--- a/docs/cursor-acp-followups/README.md
+++ b/docs/cursor-acp-followups/README.md
@@ -48,9 +48,9 @@ than observed Cursor bugs. That is called out per item.
 | H  | Resume-load & per-session turn robustness            | **User-facing:** stuck conversations, dropped queued prompts, replay leak | **Resolved** |
 | A  | Bridge↔plugin stored-directory / attribution seam    | Real worktree flows on restart; one hook resolves three threads | Open (Medium) |
 | B  | Durable derive-plugin session state (bridge schema)  | Title loss + deleted sessions reappearing                       | Open (Medium) |
-| C  | ACP protocol completeness in the mapper / parsers    | Correctness for the next ACP backend                            | Open (Medium) |
+| C  | ACP protocol completeness in the mapper / parsers    | Correctness for the next ACP backend                            | **Resolved** |
 | G  | Concurrent multi-session turn attribution            | Wrong-conversation routing of `sessionId`-less requests         | **Resolved** |
-| I  | Lossy `session.updated` payload on title changes     | List row loses time/summary/defaults until refresh             | Open (Small–Med) |
+| I  | Lossy `session.updated` payload on title changes     | List row loses time/summary/defaults until refresh             | **Resolved** |
 | E  | Typed ACP/Cursor boundary DTOs                        | Enabler / safety net for C and F                                | Blocked on traces (Large) |
 | F  | `getSessionMessages` richer failure contract         | "Broken replay" vs "empty thread" on the phone                  | Open (Small–Med) |
 | D  | Cursor decisions needing a trace / product call      | Small, but blocked on evidence                                  | Blocked on evidence |
@@ -141,64 +141,51 @@ reconcile paths, `SessionRepository`, derived-session enumeration filtering.
 
 ---
 
-## Theme C — ACP protocol completeness in the mapper
+## Theme C — ACP protocol completeness in the mapper ✅ Resolved
 
-Cursor does not exercise these; a spec-compliant ACP agent would. **Gate each on
-a real trace of a driving agent** — do not add speculative branches (the live
-per-chunk `messageId` variant was already declined once on exactly this YAGNI
-ground). Theme E (typed DTOs) is the safety net that makes these less error-prone.
+**Resolved** — all five items. Each was verified against the published ACP v1
+JSON schema (`zed-industries/agent-client-protocol`, `schema/v1/schema.json`)
+before implementation, satisfying the "gate on evidence" requirement without a
+live trace: the schema pins `ContentChunk.messageId`, the `{type: "diff"}`
+tool-content variant, `available_commands_update.availableCommands`,
+`sessionCapabilities.resume` + `session/resume` (documented as replaying no
+history), and grouped `SessionConfigSelectOptions`. Parsing stays fail-soft
+raw-map (Theme E's typed DTOs remain deferred).
 
-- **C1 — honor `ContentChunk.messageId` for message boundaries.** ACP v1 says a
-  change in `messageId` starts a new message; the mapper groups solely by role,
-  so an agent emitting multiple same-role messages in one turn collapses distinct
-  ids into one Sesori message (later chunks can merge/overwrite the wrong one).
-  Applies to both the **live** path (`acp_event_mapper.dart`) and the **replay**
-  path (`acp_session_loader.dart` `_ensureRole`). Use chunk `messageId` when
-  present; synthesize a fallback only when absent.
+- **C1 — `ContentChunk.messageId` honoured for message boundaries.** Both the
+  live mapper and the replay collector group chunks by the explicit
+  `messageId` when present (a change starts a new sesori message, same-id
+  chunks merge back), and fall back to the previous synthesis (per-turn id
+  live, role-grouping in replay) when absent — Cursor today stamps none.
   Sources: [#332 r3542170721](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3542170721),
   [r3536293262](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3536293262),
   [r3542170730](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3542170730)
 
-- **C2 — treat diff `content` and initial file-mutating `tool_call` as
-  mutations.** Today `BridgeSseSessionDiff` is emitted only when a
-  `tool_call_update` carries `kind` `edit`/`delete`/`move`. An agent that reports
-  an edit through the standard tool `content` diff shape (`type: "diff"`), or
-  sends the mutation as a complete initial `tool_call`, never triggers the SSE,
-  so mobile diff/unseen refresh leaves session diff state stale. Detect `content`
-  entries with `type: "diff"` and mirror the emission for initial file-mutating
-  `tool_call`s.
+- **C2 — diff `content` and initial file-mutating `tool_call` emit the diff
+  signal.** `_isFileMutation` also detects `content` entries of
+  `type: "diff"`, and the initial `tool_call` mirrors `tool_call_update`'s
+  `BridgeSseSessionDiff` emission.
   Source: [#332 r3542170739](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3542170739)
 
-- **C3 — cache and serve ACP slash commands.** When an ACP agent advertises
-  commands via `available_commands_update`, the mapper emits a refresh signal but
-  the `/commands` endpoint (`getCommands`) always returns empty, so ACP/Cursor
-  users never see backend-provided slash commands. Store the latest command
-  payload from `available_commands_update` and map it in `getCommands`.
+- **C3 — ACP slash commands are cached and served.** The mapper caches the
+  latest `available_commands_update` payload (process-global, last update
+  wins — the notification is per-session but commands are agent-global for
+  every shipping backend) and `getCommands` serves it.
   Source: [#332 r3542170736](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3542170736)
 
-- **C4 — resume-only sessions (`session/resume`).** `_ensureResident` only
-  handles agents advertising `loadSession`; for one that advertises
-  `sessionCapabilities.resume` but not `loadSession`, it marks the session
-  resident without any resume RPC. After a bridge restart `_residentSessions` is
-  empty, so the next prompt hits `session/prompt` against a session the new agent
-  process never loaded, and resume-only agents reject it as unknown. Parse the
-  resume capability and issue `session/resume` before prompting. Cursor uses the
-  `loadSession` path, so no shipping backend needs this yet.
+- **C4 — resume-only sessions.** `sessionCapabilities.resume` is parsed, and
+  an agent advertising it without `loadSession` gets `session/resume`
+  (session cwd, no replay suppression — resume replays nothing) before the
+  first prompt of a prior-run session, with the same residency policy as the
+  load path: resident on success or permanently-unsupported RPC, transient
+  failures retry on the next turn.
   Source: [#332 r3545348046](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3545348046)
 
-- **C5 — flatten grouped `SessionConfigSelectOptions`.** ACP config select
-  options can be *grouped*, but `cursor_model_probe` only returns the top-level
-  maps. If Cursor (or another ACP agent) groups its model/mode choices, the
-  returned entries are group objects with no `value`, so `getProviders` drops
-  every nested model/variant and `applyTurnSelection` can no longer find a
-  selectable value. Flatten nested group `options` before caching the catalog.
-  (Landed at merge; Cursor's current shape is flat, so this is robustness for a
-  grouped agent rather than an observed Cursor bug.)
+- **C5 — grouped `SessionConfigSelectOptions` are flattened.**
+  `CursorModelProbe.options` expands group entries (`{group, name, options}`)
+  in order, so a grouped model/mode catalog surfaces every nested value for
+  `getProviders` and `applyTurnSelection`.
   Source: [#332 r3545873657](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3545873657)
-
-**Affected surfaces.** `acp_event_mapper.dart`, `acp_session_loader.dart`,
-`acp_plugin.dart` (command cache + `getCommands` + `_ensureResident`),
-`sesori_plugin_cursor/lib/src/cursor_model_probe.dart` (C5), plugin models.
 
 ---
 
@@ -267,23 +254,24 @@ turn-lifecycle rework in `acp_plugin.dart`, covered by
 
 ---
 
-## Theme I — Lossy `session.updated` payload on title changes
+## Theme I — Lossy `session.updated` payload on title changes ✅ Resolved
 
-`session_info_update` emits a full minimal `Session` (id + title, other fields
-null). When no stored bridge row exists yet — during ACP session creation before
-`insertStoredSession`, or for a historical Cursor session — enrichment cannot
-restore the omitted fields. Because the mobile list handler *replaces* the whole
-session on `session.updated`, `time`, `summary`, prompt defaults, etc. go null
-and the row can sort at updated-time `0` until a full refresh. Emit a title
-patch, or merge against the previous session, instead of a full minimal `Session`
-with null fields. This is the field-fidelity flip side of the title-clear work:
-clearing the title is correct, but the minimal payload should not null unrelated
-fields.
+**Resolved at the emitter.** The plugin feeds the mapper a per-session
+title/time snapshot (from every enumeration hit and from `createSession`, so
+the creation race before `insertStoredSession` is covered), and the
+`session_info_update` emission merges against it: the payload keeps the new
+title semantics (explicit null still clears) but now carries the best-known
+`time` — including the notification's own `updatedAt` when the agent sends
+one — instead of nulling it, so the mobile list row keeps its sort position
+even when no stored bridge row exists to enrich from.
+
+The client's `SessionListCubit._onSessionUpdated` replace semantics were
+deliberately left unchanged: a client-side merge would have to guess whether a
+null field means "unknown" or "cleared", while the emitter knows exactly which
+fields it has — fidelity is fixed at the source. (`summary`/`promptDefaults`/
+`pullRequest`/`unseen` are bridge-enrichment fields filled from the stored row
+when one exists; when none exists there is genuinely nothing to restore.)
 Source: [#332 r3545873668](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3545873668)
-
-**Affected surfaces.** `acp_event_mapper.dart` (`_minimalSession` / the
-`session_info_update` emission), and the client `session.updated` merge semantics
-(`SessionListCubit._onSessionUpdated`).
 
 ---
 


### PR DESCRIPTION
Resolves **Theme C (C1–C5)**, **Theme I**, and **Theme D2** from `docs/cursor-acp-followups/README.md`. Second PR in the follow-up series (after #406). Plugin-only — no interface, bridge-app, or client changes.

Every protocol item was verified against the published ACP v1 JSON schema (`zed-industries/agent-client-protocol`, `schema/v1/schema.json`) rather than implemented speculatively; parsing stays fail-soft raw-map (typed DTOs remain deferred as Theme E).

## Theme C — protocol completeness
- **C1 — `ContentChunk.messageId` message boundaries.** Live mapper and replay collector group chunks by the explicit `messageId` when present (spec: "a change in messageId indicates a new message"); same-role messages with distinct ids no longer collapse into one Sesori message. Absent id (Cursor today) keeps the existing synthesis.
- **C2 — diff content + initial mutating `tool_call`.** `BridgeSseSessionDiff` now also fires for a complete initial file-mutating `tool_call` and for tool `content` entries of `type: "diff"` — so a spec-compliant agent's edits refresh mobile diff state.
- **C3 — slash commands served.** New `AcpCommandTracker` snapshots the latest `available_commands_update` payload (fed by the plugin's notification listener, including during suppressed resume replays); `getCommands` serves it instead of always returning empty.
- **C4 — resume-only sessions.** `sessionCapabilities.resume` is parsed; an agent advertising it without `loadSession` gets `session/resume` (session cwd, no replay suppression — resume replays nothing) before the first prompt of a prior-run session, with the load path's residency policy (resident on success/permanently-unsupported, transient failures retry next turn).
- **C5 — grouped `SessionConfigSelectOptions`.** `CursorModelProbe.options` flattens group entries, so a grouped model/mode catalog surfaces every nested value for `getProviders`/`applyTurnSelection`.

## Theme I — full-fidelity `session.updated`
`session_info_update` emissions now merge a plugin-fed per-session title/time snapshot (populated from every enumeration hit and from `createSession`, covering the creation race before `insertStoredSession`) and honour the notification's own `updatedAt` — the payload no longer nulls `time`, so the mobile list row keeps its sort position even with no stored bridge row to enrich from. Title-clear semantics preserved (explicit null still clears). Client replace semantics deliberately unchanged: fidelity is fixed at the emitter, which knows exactly which fields it has.

## Theme D2 — official Cursor CLI binary name (product call made)
cursor.com/docs/cli installs and documents the CLI as **`agent`** — including `agent acp`, the exact ACP server mode this plugin drives — so the default flips from the legacy `cursor-agent`. Availability/update guidance derives from the configured path; legacy installs keep working via `--cursor-bin cursor-agent`.

## Tests
New/updated coverage across `acp_event_mapper_test`, `acp_session_loader_test`, `acp_commands_test`, `acp_resume_only_test`, `cursor_plugin_test` (grouped catalogs, default binary). `make analyze` clean; 106 + 37 plugin tests green; full bridge suite green.

Docs: Themes C, I, D2 marked resolved in `docs/cursor-acp-followups/README.md`; D1 and Theme E explicitly marked as the deliberately-open items (blocked on live traces).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings ACP protocol coverage to spec and fixes message/command/diff handling. Emits full‑fidelity `session.updated`, routes command refreshes to the session’s owning project, coalesces replay refreshes, and switches the Cursor CLI default to `agent`.

- New Features
  - Group live and replay chunks by `messageId`; a change starts a new message.
  - Fire diff refresh on initial file‑mutating `tool_call` and on tool `content` with `type: "diff"`.
  - Cache `available_commands_update` in a process‑global `AcpCommandTracker`; serve via `getCommands` and emit `sessions.updated` so clients refresh command metadata. Refresh is routed via stored project ownership, coalesced during history replays (emitted once after), still passed through during suppressed resume replays, and the cache clears on agent reconnect.
  - Support resume‑only agents: parse `sessionCapabilities.resume` and call `session/resume` (no history replay/suppression) before prompting; retry transient failures, memoize permanently unsupported.
  - Flatten grouped `SessionConfigSelectOptions` so all nested models/modes appear in `getProviders` and `applyTurnSelection`.
  - `session_info_update` merges a title/time snapshot and honors `updatedAt`, so `session.updated` carries correct `time` and list sorting.

- Migration
  - Default Cursor CLI binary is now `agent`. Legacy installs using `cursor-agent` should pass `--cursor-bin cursor-agent`.

<sup>Written for commit 83549754e40374c5e4e8faaf91d387760ac141d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

