### PR TITLE
[UI] Using secondary button for Need help?

### DIFF
--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -307,7 +307,7 @@ class _NeedHelpMenu extends StatelessWidget {
       triggerBuilder: (context, toggle) => PregoButtonsSolid(
         leadingIcon: TablerRegular.help,
         label: loc.projectsOnboardingNeedHelp,
-        hierarchy: PregoButtonsSolidHierarchy.tertiary,
+        hierarchy: PregoButtonsSolidHierarchy.secondary,
         size: PregoButtonsSolidSize.xl,
         onPressed: () {
           // While the popup is up its barrier covers the trigger, so a pill


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched the "Need help?" onboarding button from tertiary to secondary style to improve visibility and align with the design hierarchy.

<sup>Written for commit 40a5f134f130346c527653662f803820275edc0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

