### PR TITLE
feat(bridge): prime stored session directories and preserve replay failures

### DIFF
--- a/bridge/app/lib/src/bridge/debug_server.dart
+++ b/bridge/app/lib/src/bridge/debug_server.dart
@@ -177,9 +177,7 @@ class DebugServer {
           // summary from repository data; everything else maps 1:1.
           .asyncMap<SesoriSseEvent?>(
             (event) async => event is BridgeSseProjectUpdated
-                ? _mapper.buildProjectsSummaryEvent(
-                    projects: await _sessionRepository.getProjectActivitySummaries(),
-                  )
+                ? _buildProjectsSummary()
                 : _mapper.map(event),
           )
           .asyncMap((mapped) => _fanOutMappedEvent(mapped: mapped))
@@ -237,6 +235,35 @@ class DebugServer {
           Log.d("fan-out cleanup: client close failed (ignored): $e");
         }
       }
+    }
+  }
+
+  Future<SesoriSseEvent?> _buildProjectsSummary() async {
+    try {
+      return _mapper.buildProjectsSummaryEvent(
+        projects: await _sessionRepository.getProjectActivitySummaries(),
+      );
+    } on Object catch (error, stackTrace) {
+      Log.w("debug SSE projects-summary rebuild failed", error, stackTrace);
+      unawaited(
+        _failureReporter
+            .recordFailure(
+              error: error,
+              stackTrace: stackTrace,
+              uniqueIdentifier: "bridge.debug_server.projects_summary",
+              fatal: false,
+              reason: "debug SSE projects-summary rebuild failed",
+              information: const [],
+            )
+            .catchError((Object reportError, StackTrace reportStackTrace) {
+              Log.w(
+                "debug SSE projects-summary failure report failed",
+                reportError,
+                reportStackTrace,
+              );
+            }),
+      );
+      return null;
     }
   }
 

--- a/bridge/app/lib/src/bridge/debug_server.dart
+++ b/bridge/app/lib/src/bridge/debug_server.dart
@@ -7,6 +7,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../server/services/bridge_restart_service.dart";
+import "repositories/session_repository.dart";
 import "routing/request_router.dart";
 import "services/session_event_enrichment_service.dart";
 import "sse/bridge_event_mapper.dart";
@@ -15,6 +16,7 @@ class DebugServer {
   final BridgePluginApi _plugin;
   final RequestRouter _router;
   final BridgeEventMapper _mapper;
+  final SessionRepository _sessionRepository;
   final SessionEventEnrichmentService _sessionEventEnrichmentService;
   final FailureReporter _failureReporter;
   final BridgeRestartService _restartService;
@@ -34,15 +36,16 @@ class DebugServer {
     required this.port,
     required FailureReporter failureReporter,
     required SessionEventEnrichmentService sessionEventEnrichmentService,
+    required SessionRepository sessionRepository,
     required BridgeRestartService restartService,
     required Future<void> Function() restartHandoff,
   }) : _plugin = plugin,
        _router = router,
        _failureReporter = failureReporter,
+       _sessionRepository = sessionRepository,
        _restartService = restartService,
        _restartHandoff = restartHandoff,
        _mapper = BridgeEventMapper(
-         plugin: plugin,
          failureReporter: failureReporter,
        ),
        _sessionEventEnrichmentService = sessionEventEnrichmentService;
@@ -170,7 +173,15 @@ class DebugServer {
 
       _pluginEventsSub ??= _plugin.events
           .asyncMap<BridgeSseEvent>(_sessionEventEnrichmentService.enrich)
-          .map<SesoriSseEvent?>(_mapper.map)
+          // Mirrors the orchestrator: a project update rebuilds the full
+          // summary from repository data; everything else maps 1:1.
+          .asyncMap<SesoriSseEvent?>(
+            (event) async => event is BridgeSseProjectUpdated
+                ? _mapper.buildProjectsSummaryEvent(
+                    projects: await _sessionRepository.getProjectActivitySummaries(),
+                  )
+                : _mapper.map(event),
+          )
           .asyncMap((mapped) => _fanOutMappedEvent(mapped: mapped))
           .listen(
             (_) {},

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -705,7 +705,13 @@ class OrchestratorSession {
               reason: "Failed to build projects summary event",
               information: const [],
             )
-            .catchError((_) {}),
+            .catchError((Object reportError, StackTrace reportStackTrace) {
+              Log.w(
+                "[sse] projects-summary failure report failed",
+                reportError,
+                reportStackTrace,
+              );
+            }),
       );
       return null;
     }

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -387,10 +387,9 @@ class OrchestratorSession {
       Log.d("subscribing to plugin event stream...");
       _plugin.events
           .asyncMap<BridgeSseEvent>(_sessionEventEnrichmentService.enrich)
+          .asyncMap<void>(_processPluginEvent)
           .listen(
-            (event) {
-              unawaited(_processPluginEvent(event));
-            },
+            (_) {},
             onError: (Object e, StackTrace st) {
               Log.w("plugin event stream error: $e");
               unawaited(

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -229,6 +229,7 @@ class OrchestratorSession {
   final PrSyncService _prSyncService;
   final SessionUnseenService _sessionUnseenService;
   final SessionViewTracker _sessionViewTracker;
+  final SessionRepository _sessionRepository;
   final SessionEventEnrichmentService _sessionEventEnrichmentService;
   final SessionAbortService _sessionAbortService;
   final BridgeRestartService _restartService;
@@ -305,6 +306,7 @@ class OrchestratorSession {
        _prSyncService = prSyncService,
        _sessionUnseenService = sessionUnseenService,
        _sessionViewTracker = sessionViewTracker,
+       _sessionRepository = sessionRepository,
        _sessionAbortService = sessionAbortService,
        _restartService = restartService,
        _statusNotifier = statusNotifier,
@@ -342,7 +344,6 @@ class OrchestratorSession {
          restartService: restartService,
        ),
        _mapper = BridgeEventMapper(
-         plugin: plugin,
          failureReporter: failureReporter,
        ),
        _sessionEventEnrichmentService = sessionEventEnrichmentService;
@@ -375,7 +376,7 @@ class OrchestratorSession {
       _completionListener.start();
       _maintenanceListener.start();
 
-      final startupSummary = _mapper.buildProjectsSummaryEvent();
+      final startupSummary = await _buildProjectsSummary();
       if (startupSummary != null) {
         _completionListener.handleSseEvent(startupSummary);
         if (startupSummary is SesoriProjectsSummary) {
@@ -643,7 +644,12 @@ class OrchestratorSession {
   Future<void> _processPluginEvent(BridgeSseEvent event) async {
     try {
       Log.v("[sse] plugin event arrived: ${event.runtimeType}");
-      final sesoriEvent = _mapper.map(event);
+      // A project update means "activity changed" — rebuild the full summary
+      // (repository data: the bridge's session→project attribution), which the
+      // pure mapper cannot fetch itself.
+      final sesoriEvent = event is BridgeSseProjectUpdated
+          ? await _buildProjectsSummary()
+          : _mapper.map(event);
       if (sesoriEvent != null) {
         Log.v(
           "[sse] mapped to: ${sesoriEvent.runtimeType} — enqueuing (subscribers: ${_sseManager.subscriberCount})",
@@ -675,6 +681,34 @@ class OrchestratorSession {
             )
             .catchError((_) {}),
       );
+    }
+  }
+
+  /// Builds the projects-summary SSE event: fetches the activity summary with
+  /// the bridge's session→project attribution applied (so a derived plugin's
+  /// worktree session badges land on the stored parent project) and wraps it
+  /// via the pure mapper. Failures are recorded and yield null so the SSE
+  /// pipeline keeps flowing — the summary refreshes on the next trigger.
+  Future<SesoriSseEvent?> _buildProjectsSummary() async {
+    try {
+      return _mapper.buildProjectsSummaryEvent(
+        projects: await _sessionRepository.getProjectActivitySummaries(),
+      );
+    } catch (e, st) {
+      Log.e("[sse] error building projects summary: $e\n$st");
+      unawaited(
+        _failureReporter
+            .recordFailure(
+              error: e,
+              stackTrace: st,
+              uniqueIdentifier: "sse_projects_summary",
+              fatal: false,
+              reason: "Failed to build projects summary event",
+              information: const [],
+            )
+            .catchError((_) {}),
+      );
+      return null;
     }
   }
 
@@ -1103,7 +1137,7 @@ class OrchestratorSession {
         Log.v("SseSubscribe: path=${subscribe.path}");
         try {
           _sseManager.subscribePath(connID, subscribe.path, _client);
-          final projSummary = _mapper.buildProjectsSummaryEvent();
+          final projSummary = await _buildProjectsSummary();
           if (projSummary != null) {
             _sseManager.enqueueEvent(projSummary);
             _completionListener.handleSseEvent(projSummary);

--- a/bridge/app/lib/src/bridge/repositories/mappers/plugin_activity_summary_mapper.dart
+++ b/bridge/app/lib/src/bridge/repositories/mappers/plugin_activity_summary_mapper.dart
@@ -1,0 +1,14 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginActiveSession;
+import "package:sesori_shared/sesori_shared.dart" show ActiveSession;
+
+extension PluginActiveSessionMapper on PluginActiveSession {
+  ActiveSession toSharedActiveSession() {
+    return ActiveSession(
+      id: id,
+      mainAgentRunning: mainAgentRunning,
+      awaitingInput: awaitingInput,
+      isRetrying: isRetrying,
+      childSessionIds: childSessionIds,
+    );
+  }
+}

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -1,14 +1,33 @@
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show normalizeProjectDirectory;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
-    show BridgeDerivedProjectsPluginApi, BridgePluginApi, Log, NativeProjectsPluginApi, PluginSession, PluginSessionVariant;
+    show
+        BridgeDerivedProjectsPluginApi,
+        BridgePluginApi,
+        Log,
+        NativeProjectsPluginApi,
+        PluginActiveSession,
+        PluginSession,
+        PluginSessionVariant;
 import "package:sesori_shared/sesori_shared.dart"
-    show AgentModel, CommandListResponse, PrState, PromptModel, PromptPart, PullRequestInfo, Session, SessionVariant;
+    show
+        AgentModel,
+        CommandListResponse,
+        MessageWithParts,
+        PrState,
+        ProjectActivitySummary,
+        PromptModel,
+        PromptPart,
+        PullRequestInfo,
+        Session,
+        SessionVariant;
 
 import "../api/database/tables/pull_requests_table.dart";
 import "../persistence/daos/session_dao.dart";
 import "../persistence/tables/session_table.dart";
 import "derived_session_builder.dart";
+import "mappers/plugin_activity_summary_mapper.dart";
 import "mappers/plugin_command_mapper.dart";
+import "mappers/plugin_message_mapper.dart";
 import "mappers/plugin_session_mapper.dart";
 import "mappers/prompt_part_mapper.dart";
 import "mappers/pull_request_mapper.dart";
@@ -177,7 +196,8 @@ class SessionRepository {
     required SessionVariant? variant,
     required String? agent,
     required PromptModel? model,
-  }) {
+  }) async {
+    await _primeDerivedSessionDirectory(sessionId: sessionId);
     return _plugin.sendCommand(
       sessionId: sessionId,
       command: command,
@@ -197,7 +217,8 @@ class SessionRepository {
     required SessionVariant? variant,
     required String? agent,
     required PromptModel? model,
-  }) {
+  }) async {
+    await _primeDerivedSessionDirectory(sessionId: sessionId);
     return _plugin.sendPrompt(
       sessionId: sessionId,
       parts: parts.map((part) => part.toPlugin()).toList(growable: false),
@@ -208,6 +229,78 @@ class SessionRepository {
         null => null,
       },
     );
+  }
+
+  /// All messages of [sessionId], mapped to the shared model. The stored
+  /// directory is primed first: after a bridge restart, the history replay can
+  /// be the FIRST plugin call for a stored worktree session, and a
+  /// directory-scoped backend would otherwise replay in its launch directory.
+  Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async {
+    await _primeDerivedSessionDirectory(sessionId: sessionId);
+    final pluginMessages = await _plugin.getSessionMessages(sessionId);
+    return pluginMessages.toSharedMessageWithParts();
+  }
+
+  /// Feeds a derived plugin the bridge's stored session→directory attribution
+  /// (the dedicated worktree path, else the owning project directory — which
+  /// for derived plugins IS the canonical path) before an operation that
+  /// carries only a session id. No-op for native plugins and rowless sessions.
+  Future<void> _primeDerivedSessionDirectory({required String sessionId}) async {
+    if (_plugin case final BridgeDerivedProjectsPluginApi plugin) {
+      final stored = await _sessionDao.getSession(sessionId: sessionId);
+      if (stored == null) return;
+      plugin.primeSessionDirectory(
+        sessionId: sessionId,
+        directory: stored.worktreePath ?? stored.projectId,
+      );
+    }
+  }
+
+  /// The plugin's live activity summary with the bridge's session→project
+  /// attribution applied. A derived plugin reports each active session under
+  /// its own cwd — a dedicated worktree path for worktree sessions — while the
+  /// project list folds that session under the stored *parent* project row, so
+  /// without this remap the activity badge lands on a project id the phone
+  /// doesn't show. A native plugin owns its own attribution and passes
+  /// through 1:1.
+  Future<List<ProjectActivitySummary>> getProjectActivitySummaries() async {
+    final summaries = _plugin.getActiveSessionsSummary();
+    switch (_plugin) {
+      case NativeProjectsPluginApi():
+        return [
+          for (final summary in summaries)
+            ProjectActivitySummary(
+              id: summary.id,
+              activeSessions: [
+                for (final active in summary.activeSessions) active.toSharedActiveSession(),
+              ],
+            ),
+        ];
+      case final BridgeDerivedProjectsPluginApi plugin:
+        final rows = await _sessionDao.getSessionProjectPaths(pluginId: plugin.id);
+        final projectPathBySessionId = {for (final row in rows) row.sessionId: row.projectPath};
+        // Regroup under the stored attribution — the same rule the REST path's
+        // DerivedSessionBuilder/DerivedProjectBuilder apply. A rowless session
+        // keeps the plugin's own grouping.
+        final byProject = <String, List<PluginActiveSession>>{};
+        for (final summary in summaries) {
+          for (final active in summary.activeSessions) {
+            final target = normalizeProjectDirectory(
+              directory: projectPathBySessionId[active.id] ?? summary.id,
+            );
+            (byProject[target] ??= []).add(active);
+          }
+        }
+        return [
+          for (final entry in byProject.entries)
+            ProjectActivitySummary(
+              id: entry.key,
+              activeSessions: [
+                for (final active in entry.value) active.toSharedActiveSession(),
+              ],
+            ),
+        ];
+    }
   }
 
   PluginSessionVariant? _toPluginVariant(SessionVariant? variant) {

--- a/bridge/app/lib/src/bridge/routing/get_session_messages_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_session_messages_handler.dart
@@ -1,15 +1,15 @@
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
-import "../repositories/mappers/plugin_message_mapper.dart";
+import "../repositories/session_repository.dart";
 import "request_handler.dart";
 
 /// Handles `POST /session/messages` — returns all messages for a session.
 class GetSessionMessagesHandler extends BodyRequestHandler<SessionIdRequest, MessageWithPartsResponse> {
-  final BridgePluginApi _plugin;
+  final SessionRepository _sessionRepository;
 
-  GetSessionMessagesHandler(this._plugin)
-    : super(
+  GetSessionMessagesHandler({required SessionRepository sessionRepository})
+    : _sessionRepository = sessionRepository,
+      super(
         HttpMethod.post,
         "/session/messages",
         fromJson: SessionIdRequest.fromJson,
@@ -28,10 +28,8 @@ class GetSessionMessagesHandler extends BodyRequestHandler<SessionIdRequest, Mes
       throw buildErrorResponse(request, 400, "empty session id");
     }
 
-    final pluginMessages = await _plugin.getSessionMessages(sessionId);
-
     return MessageWithPartsResponse(
-      messages: pluginMessages.toSharedMessageWithParts(),
+      messages: await _sessionRepository.getSessionMessages(sessionId: sessionId),
     );
   }
 }

--- a/bridge/app/lib/src/bridge/routing/request_router.dart
+++ b/bridge/app/lib/src/bridge/routing/request_router.dart
@@ -141,7 +141,7 @@ class RequestRouter {
       GetSessionStatusesHandler(plugin),
       GetChildSessionsHandler(sessionRepository: sessionRepository),
       GetSessionHandler(sessionRepository),
-      GetSessionMessagesHandler(plugin),
+      GetSessionMessagesHandler(sessionRepository: sessionRepository),
       GetSessionsHandler(
         sessionRepository: sessionRepository,
         prSyncService: prSyncService,

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
@@ -65,6 +65,9 @@ class BridgeRuntime {
   // outlive any single OrchestratorSession (e.g. across a restart/reconnect).
   final SessionUnseenService _sessionUnseenService;
   final SessionViewTracker _sessionViewTracker;
+  // Shared with the DebugServer so it mirrors the orchestrator's
+  // projects-summary pipeline on the same instance.
+  final SessionRepository _sessionRepository;
   final OrchestratorSession session;
 
   BridgeRuntime({
@@ -75,6 +78,7 @@ class BridgeRuntime {
     required BridgeRestartService restartService,
     required SessionUnseenService sessionUnseenService,
     required SessionViewTracker sessionViewTracker,
+    required SessionRepository sessionRepository,
     required this.session,
   }) : _database = database,
        _plugin = plugin,
@@ -82,7 +86,8 @@ class BridgeRuntime {
        _sessionEventEnrichmentService = sessionEventEnrichmentService,
        _restartService = restartService,
        _sessionUnseenService = sessionUnseenService,
-       _sessionViewTracker = sessionViewTracker;
+       _sessionViewTracker = sessionViewTracker,
+       _sessionRepository = sessionRepository;
 
   static BridgeRuntime create({
     required BridgeConfig config,
@@ -190,6 +195,7 @@ class BridgeRuntime {
       restartService: restartService,
       sessionUnseenService: sessionUnseenService,
       sessionViewTracker: sessionViewTracker,
+      sessionRepository: sessionRepository,
       session: Orchestrator(
         config: config,
         client: relayClient,
@@ -267,6 +273,7 @@ class BridgeRuntime {
       port: port,
       failureReporter: _failureReporter,
       sessionEventEnrichmentService: _sessionEventEnrichmentService,
+      sessionRepository: _sessionRepository,
       restartService: _restartService,
       restartHandoff: session.handleRestartHandoff,
     );

--- a/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/bridge/sse/bridge_event_mapper.dart
@@ -7,16 +7,14 @@ import "../plugin_to_shared_mapping.dart";
 
 /// Maps [BridgeSseEvent]s from the plugin to [SesoriSseEvent]s for relay delivery.
 ///
-/// Handles all event type conversions and builds the projects summary event.
+/// Handles all event type conversions and builds the projects summary event
+/// from already-fetched summary data (the orchestrator owns fetching it).
 class BridgeEventMapper {
-  final BridgePluginApi _plugin;
   final FailureReporter _failureReporter;
 
   BridgeEventMapper({
-    required BridgePluginApi plugin,
     required FailureReporter failureReporter,
-  }) : _plugin = plugin,
-       _failureReporter = failureReporter;
+  }) : _failureReporter = failureReporter;
 
   /// Maps a [BridgeSseEvent] to a [SesoriSseEvent], or null if unmappable.
   SesoriSseEvent? map(BridgeSseEvent event) {
@@ -131,10 +129,11 @@ class BridgeEventMapper {
             displaySessionId: displaySessionId,
           ),
         BridgeSseTodoUpdated(:final sessionID) => SesoriSseEvent.todoUpdated(sessionID: sessionID),
-        // BridgeSseProjectUpdated is emitted on both activity changes and project
-        // metadata changes. We always send the full projectsSummary so the mobile
-        // client receives updated activity data in real time.
-        BridgeSseProjectUpdated() => buildProjectsSummaryEvent(),
+        // BridgeSseProjectUpdated triggers a full projects-summary rebuild, but
+        // the summary needs repository data (the bridge's session→project
+        // attribution) — the orchestrator fetches it and builds the event via
+        // [buildProjectsSummaryEvent] before reaching this mapper.
+        BridgeSseProjectUpdated() => null,
         BridgeSseVcsBranchUpdated() => const SesoriSseEvent.vcsBranchUpdated(),
         BridgeSseFileEdited(:final file) => SesoriSseEvent.fileEdited(file: file),
         BridgeSseFileWatcherUpdated(:final file, :final event) => SesoriSseEvent.fileWatcherUpdated(
@@ -180,46 +179,10 @@ class BridgeEventMapper {
     }
   }
 
-  /// Builds a projects summary event from the current active sessions.
-  SesoriSseEvent? buildProjectsSummaryEvent() {
-    try {
-      final summary = _plugin.getActiveSessionsSummary();
-      return SesoriSseEvent.projectsSummary(
-        projects: summary
-            .map(
-              (e) => ProjectActivitySummary(
-                id: e.id,
-                activeSessions: e.activeSessions
-                    .map(
-                      (a) => ActiveSession(
-                        id: a.id,
-                        mainAgentRunning: a.mainAgentRunning,
-                        awaitingInput: a.awaitingInput,
-                        isRetrying: a.isRetrying,
-                        childSessionIds: a.childSessionIds,
-                      ),
-                    )
-                    .toList(),
-              ),
-            )
-            .toList(),
-      );
-    } catch (e, st) {
-      Log.e("[sse-mapper] error building projects summary: $e\n$st");
-      unawaited(
-        _failureReporter
-            .recordFailure(
-              error: e,
-              stackTrace: st,
-              uniqueIdentifier: "sse_projects_summary",
-              fatal: false,
-              reason: "Failed to build projects summary event",
-              information: const [],
-            )
-            .catchError((_) {}),
-      );
-      return null;
-    }
+  /// Builds a projects summary event from already-remapped summary data
+  /// (see `SessionRepository.getProjectActivitySummaries`).
+  SesoriSseEvent buildProjectsSummaryEvent({required List<ProjectActivitySummary> projects}) {
+    return SesoriSseEvent.projectsSummary(projects: projects);
   }
 
   /// Attempts to parse an SSE event from a JSON payload.

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -29,6 +29,7 @@ _DebugServerHarness _createDebugServerHarness({
   required BridgePluginApi plugin,
   required AppDatabase db,
   required int port,
+  required FailureReporter failureReporter,
   BridgeRestartService? restartService,
 }) {
   final httpClient = http.Client();
@@ -51,7 +52,7 @@ _DebugServerHarness _createDebugServerHarness({
     bridgeRegistrationService: createFakeBridgeRegistrationService(),
     database: db,
     processRunner: ProcessRunner(),
-    failureReporter: FakeFailureReporter(),
+    failureReporter: failureReporter,
     restartService: restartService ?? buildTestRestartService(),
     filesystemAccessOk: true,
     statusNotifier: null,
@@ -74,7 +75,12 @@ void main() {
     setUp(() async {
       plugin = _FakeBridgePlugin();
       db = createTestDatabase();
-      harness = _createDebugServerHarness(plugin: plugin, db: db, port: 0);
+      harness = _createDebugServerHarness(
+        plugin: plugin,
+        db: db,
+        port: 0,
+        failureReporter: FakeFailureReporter(),
+      );
       debugServer = harness.debugServer;
       await debugServer.start();
     });
@@ -184,6 +190,7 @@ void main() {
         plugin: trackingPlugin,
         db: trackingDb,
         port: 0,
+        failureReporter: FakeFailureReporter(),
       );
       final trackingServer = trackingHarness.debugServer;
       await trackingServer.start();
@@ -204,6 +211,36 @@ void main() {
       await trackingServer.stop();
       expect(trackingPlugin.unsubscribeCount, equals(1));
     });
+
+    test("a failed projects summary is reported and later events still flow", () async {
+      final failureReporter = CapturingFailureReporter();
+      final failingPlugin = _FakeBridgePlugin()..throwOnActiveSummary = true;
+      final failingDb = createTestDatabase();
+      final failingHarness = _createDebugServerHarness(
+        plugin: failingPlugin,
+        db: failingDb,
+        port: 0,
+        failureReporter: failureReporter,
+      );
+      final failingServer = failingHarness.debugServer;
+      await failingServer.start();
+      addTearDown(failingHarness.close);
+      addTearDown(failingPlugin.close);
+
+      final client = await _SseTestClient.connect(failingServer.boundPort!);
+      addTearDown(client.close);
+      failingPlugin.add(const BridgeSseProjectUpdated());
+      failingPlugin.add(const BridgeSseServerConnected());
+
+      expect(await client.nextEvent(), contains("server.connected"));
+      final timeoutAt = DateTime.now().add(const Duration(seconds: 2));
+      while (!failureReporter.recordedIdentifiers.contains("bridge.debug_server.projects_summary")) {
+        if (DateTime.now().isAfter(timeoutAt)) {
+          fail("Timed out waiting for projects-summary failure reporting");
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      }
+    });
   });
 
   group("DebugServer HTTP requests", () {
@@ -215,7 +252,12 @@ void main() {
     setUp(() async {
       plugin = _FakeBridgePlugin();
       db = createTestDatabase();
-      harness = _createDebugServerHarness(plugin: plugin, db: db, port: 0);
+      harness = _createDebugServerHarness(
+        plugin: plugin,
+        db: db,
+        port: 0,
+        failureReporter: FakeFailureReporter(),
+      );
       debugServer = harness.debugServer;
       await debugServer.start();
     });
@@ -363,6 +405,7 @@ void main() {
         plugin: plugin,
         db: db,
         port: 0,
+        failureReporter: FakeFailureReporter(),
         restartService: _spawnableRestartService(
           binaryPath: binaryPath,
           processRunner: processRunner,
@@ -413,6 +456,7 @@ void main() {
         plugin: plugin,
         db: db,
         port: 0,
+        failureReporter: FakeFailureReporter(),
         restartService: _spawnableRestartService(
           binaryPath: binaryPath,
           processRunner: processRunner,
@@ -447,6 +491,7 @@ void main() {
         plugin: plugin,
         db: db,
         port: 0,
+        failureReporter: FakeFailureReporter(),
         restartService: _spawnableRestartService(
           binaryPath: p.join(tempDir.path, "missing"),
           processRunner: processRunner,
@@ -558,6 +603,7 @@ class _FakeBridgePlugin implements NativeProjectsPluginApi {
   List<PluginSession> sessionsResult = [];
   List<PluginMessageWithParts> messagesResult = [];
   bool throwOnGetProjects = false;
+  bool throwOnActiveSummary = false;
 
   @override
   String get id => "fake";
@@ -682,7 +728,10 @@ class _FakeBridgePlugin implements NativeProjectsPluginApi {
   Future<bool> healthCheck() async => true;
 
   @override
-  List<PluginProjectActivitySummary> getActiveSessionsSummary() => [];
+  List<PluginProjectActivitySummary> getActiveSessionsSummary() {
+    if (throwOnActiveSummary) throw StateError("summary failed");
+    return [];
+  }
 
   @override
   Future<PluginProvidersResult> getProviders({required String projectId}) async =>

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -788,6 +788,30 @@ void main() {
       equals(11),
     );
 
+    final summaryGate = Completer<void>();
+    sessionRepository.projectSummariesDelay = summaryGate.future;
+    plugin.add(const BridgeSseProjectUpdated());
+    plugin.add(const BridgeSseSessionDiff(sessionID: "s1"));
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    expect(
+      pushDispatcher.events,
+      hasLength(3),
+      reason: "a later plugin event must wait for the preceding summary rebuild",
+    );
+    summaryGate.complete();
+
+    final summaryTimeoutAt = DateTime.now().add(const Duration(seconds: 2));
+    while (pushDispatcher.events.length < 5) {
+      if (DateTime.now().isAfter(summaryTimeoutAt)) {
+        fail("Timed out waiting for ordered project summary events");
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    expect(
+      pushDispatcher.events.skip(3).map((event) => event.toJson()["type"]),
+      equals(["projects.summary", "session.diff"]),
+    );
+
     await session.cancel();
     await runFuture.timeout(const Duration(seconds: 5));
     await plugin.close();
@@ -2137,11 +2161,15 @@ class _DelayingSessionRepository implements SessionRepository {
       _base.getSessionMessages(sessionId: sessionId);
 
   @override
-  Future<List<ProjectActivitySummary>> getProjectActivitySummaries() =>
-      _base.getProjectActivitySummaries();
+  Future<List<ProjectActivitySummary>> getProjectActivitySummaries() async {
+    final delay = projectSummariesDelay;
+    if (delay != null) await delay;
+    return _base.getProjectActivitySummaries();
+  }
 
   final SessionRepository _base;
   final Map<String, Future<void>> _delaySessionIds;
+  Future<void>? projectSummariesDelay;
 
   _DelayingSessionRepository({
     required SessionRepository base,

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -2004,6 +2004,12 @@ class _NoopSessionRepository implements SessionRepository {
   bool get sessionListIsAuthoritative => true;
 
   @override
+  Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async => const [];
+
+  @override
+  Future<List<ProjectActivitySummary>> getProjectActivitySummaries() async => const [];
+
+  @override
   Future<Session> createSession({
     required String directory,
     required String? parentSessionId,
@@ -2125,6 +2131,14 @@ class _NoopSessionRepository implements SessionRepository {
 class _DelayingSessionRepository implements SessionRepository {
   @override
   bool get sessionListIsAuthoritative => true;
+
+  @override
+  Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) =>
+      _base.getSessionMessages(sessionId: sessionId);
+
+  @override
+  Future<List<ProjectActivitySummary>> getProjectActivitySummaries() =>
+      _base.getProjectActivitySummaries();
 
   final SessionRepository _base;
   final Map<String, Future<void>> _delaySessionIds;

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -836,6 +836,123 @@ void main() {
       expect(plugin.receivedKnownDirectories, contains(opened));
     });
 
+    test("sendPrompt/sendCommand/getSessionMessages prime a derived plugin with the stored directory", () async {
+      final db = createTestDatabase();
+      addTearDown(db.close);
+
+      const parent = "/tmp/proj/alpha";
+      const worktree = "/tmp/proj/alpha/.worktrees/session-001";
+      final plugin = _FakeDerivedPlugin(launchDirectory: parent, allSessions: const []);
+      final repository = SessionRepository(
+        plugin: plugin,
+        sessionDao: db.sessionDao,
+        pullRequestRepository: PullRequestRepository(
+          pullRequestDao: db.pullRequestDao,
+          projectsDao: db.projectsDao,
+        ),
+        unseenCalculator: const SessionUnseenCalculator(),
+      );
+      // One dedicated-worktree session and one plain in-project session.
+      await recordWorktreeSession(db, parent: parent, worktree: worktree, sessionId: "w1");
+      await db.sessionDao.insertSession(
+        sessionId: "p1",
+        projectId: parent,
+        isDedicated: false,
+        createdAt: 1,
+        worktreePath: null,
+        branchName: null,
+        baseBranch: null,
+        baseCommit: null,
+        lastAgent: null,
+        lastAgentModel: null,
+        pluginId: "codex",
+      );
+
+      // The worktree session primes with its worktree path...
+      await repository.sendPrompt(sessionId: "w1", parts: const [], variant: null, agent: null, model: null);
+      expect(plugin.primedDirectories.last, (sessionId: "w1", directory: worktree));
+
+      // ...a plain session primes with the owning project directory...
+      await repository.getSessionMessages(sessionId: "p1");
+      expect(plugin.primedDirectories.last, (sessionId: "p1", directory: parent));
+
+      await repository.sendCommand(
+        sessionId: "w1",
+        command: "review",
+        arguments: "",
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      expect(plugin.primedDirectories.last, (sessionId: "w1", directory: worktree));
+
+      // ...and a rowless session primes nothing (there is no stored attribution).
+      final primesBefore = plugin.primedDirectories.length;
+      await repository.sendPrompt(sessionId: "ghost", parts: const [], variant: null, agent: null, model: null);
+      expect(plugin.primedDirectories.length, primesBefore);
+    });
+
+    test("getProjectActivitySummaries folds a worktree session under its stored parent project", () async {
+      final db = createTestDatabase();
+      addTearDown(db.close);
+
+      const parent = "/tmp/proj/alpha";
+      const worktree = "/tmp/proj/alpha/.worktrees/session-001";
+      final plugin = _FakeDerivedPlugin(launchDirectory: parent, allSessions: const []);
+      final repository = SessionRepository(
+        plugin: plugin,
+        sessionDao: db.sessionDao,
+        pullRequestRepository: PullRequestRepository(
+          pullRequestDao: db.pullRequestDao,
+          projectsDao: db.projectsDao,
+        ),
+        unseenCalculator: const SessionUnseenCalculator(),
+      );
+      await recordWorktreeSession(db, parent: parent, worktree: worktree, sessionId: "w1");
+      // The plugin groups the active worktree session under its own cwd (the
+      // worktree) — exactly what the ACP plugin reports — plus a rowless
+      // session under its own directory.
+      plugin.activitySummaries = const [
+        PluginProjectActivitySummary(
+          id: worktree,
+          activeSessions: [
+            PluginActiveSession(
+              id: "w1",
+              mainAgentRunning: true,
+              awaitingInput: false,
+              isRetrying: false,
+              childSessionIds: [],
+            ),
+          ],
+        ),
+        PluginProjectActivitySummary(
+          id: "/tmp/proj/beta",
+          activeSessions: [
+            PluginActiveSession(
+              id: "b1",
+              mainAgentRunning: false,
+              awaitingInput: true,
+              isRetrying: false,
+              childSessionIds: [],
+            ),
+          ],
+        ),
+      ];
+
+      final summaries = await repository.getProjectActivitySummaries();
+
+      // The worktree session's badge lands on the stored parent project — the
+      // id the phone's project list actually shows.
+      final byId = {for (final s in summaries) s.id: s};
+      expect(byId.keys, containsAll(<String>[parent, "/tmp/proj/beta"]));
+      expect(byId.keys, isNot(contains(worktree)));
+      expect(byId[parent]!.activeSessions.single.id, "w1");
+      expect(byId[parent]!.activeSessions.single.mainAgentRunning, isTrue);
+      // A rowless session keeps the plugin's own grouping.
+      expect(byId["/tmp/proj/beta"]!.activeSessions.single.id, "b1");
+      expect(byId["/tmp/proj/beta"]!.activeSessions.single.awaitingInput, isTrue);
+    });
+
     test("sessionListIsAuthoritative is false for a derived plugin and true for a native one", () async {
       final db = createTestDatabase();
       addTearDown(db.close);
@@ -993,6 +1110,13 @@ class _FakeDerivedPlugin implements BridgeDerivedProjectsPluginApi {
   /// The hint set received on the most recent [listAllSessions] call.
   Set<String>? receivedKnownDirectories;
 
+  /// Every stored-directory prime the bridge fed this plugin, in order.
+  final List<({String sessionId, String directory})> primedDirectories = [];
+
+  /// Configurable activity summaries (the plugin's own grouping — for a
+  /// worktree session that is the worktree cwd).
+  List<PluginProjectActivitySummary> activitySummaries = const [];
+
   @override
   String get id => "codex";
 
@@ -1001,6 +1125,36 @@ class _FakeDerivedPlugin implements BridgeDerivedProjectsPluginApi {
     receivedKnownDirectories = knownDirectories;
     return allSessions;
   }
+
+  @override
+  void primeSessionDirectory({required String sessionId, required String directory}) {
+    primedDirectories.add((sessionId: sessionId, directory: directory));
+  }
+
+  @override
+  List<PluginProjectActivitySummary> getActiveSessionsSummary() => activitySummaries;
+
+  @override
+  Future<void> sendPrompt({
+    required String sessionId,
+    required List<PluginPromptPart> parts,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async {}
+
+  @override
+  Future<void> sendCommand({
+    required String sessionId,
+    required String command,
+    required String arguments,
+    required PluginSessionVariant? variant,
+    required String? agent,
+    required ({String providerID, String modelID})? model,
+  }) async {}
+
+  @override
+  Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId) async => const [];
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/bridge/app/test/bridge/routing/get_session_messages_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_session_messages_handler_test.dart
@@ -14,7 +14,9 @@ void main() {
 
     setUp(() {
       plugin = FakeBridgePlugin();
-      handler = GetSessionMessagesHandler(plugin);
+      handler = GetSessionMessagesHandler(
+        sessionRepository: FakeSessionRepository(plugin: plugin),
+      );
     });
 
     tearDown(() => plugin.close());

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -9,6 +9,7 @@ import "package:sesori_bridge/src/bridge/persistence/daos/session_dao.dart";
 import "package:sesori_bridge/src/bridge/persistence/database.dart";
 import "package:sesori_bridge/src/bridge/persistence/tables/session_table.dart";
 import "package:sesori_bridge/src/bridge/repositories/mappers/plugin_command_mapper.dart";
+import "package:sesori_bridge/src/bridge/repositories/mappers/plugin_message_mapper.dart";
 import "package:sesori_bridge/src/bridge/repositories/mappers/plugin_session_mapper.dart";
 import "package:sesori_bridge/src/bridge/repositories/mappers/prompt_part_mapper.dart";
 import "package:sesori_bridge/src/bridge/repositories/mappers/pull_request_mapper.dart";
@@ -708,6 +709,14 @@ class _NoopSessionRepository implements SessionRepository {
   bool get sessionListIsAuthoritative => true;
 
   @override
+  Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async =>
+      const <MessageWithParts>[];
+
+  @override
+  Future<List<ProjectActivitySummary>> getProjectActivitySummaries() async =>
+      const <ProjectActivitySummary>[];
+
+  @override
   Future<Session> createSession({
     required String directory,
     required String? parentSessionId,
@@ -848,6 +857,30 @@ class FakeSessionRepository implements SessionRepository {
   }) : _plugin = plugin,
        _sessionDao = sessionDao ?? FakeSessionDao(),
        _pullRequestRepository = pullRequestRepository ?? FakePullRequestRepository();
+
+  @override
+  Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async {
+    final pluginMessages = await _plugin.getSessionMessages(sessionId);
+    return pluginMessages.toSharedMessageWithParts();
+  }
+
+  @override
+  Future<List<ProjectActivitySummary>> getProjectActivitySummaries() async => [
+    for (final summary in _plugin.getActiveSessionsSummary())
+      ProjectActivitySummary(
+        id: summary.id,
+        activeSessions: [
+          for (final active in summary.activeSessions)
+            ActiveSession(
+              id: active.id,
+              mainAgentRunning: active.mainAgentRunning,
+              awaitingInput: active.awaitingInput,
+              isRetrying: active.isRetrying,
+              childSessionIds: active.childSessionIds,
+            ),
+        ],
+      ),
+  ];
 
   @override
   Future<Session> createSession({

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -401,6 +401,12 @@ class _FakeSessionRepository implements SessionRepository {
   @override
   bool get sessionListIsAuthoritative => true;
 
+  @override
+  Future<List<MessageWithParts>> getSessionMessages({required String sessionId}) async => const [];
+
+  @override
+  Future<List<ProjectActivitySummary>> getProjectActivitySummaries() async => const [];
+
   final Map<String, List<StoredSession>> sessionsByProject;
 
   _FakeSessionRepository({required this.sessionsByProject});

--- a/bridge/app/test/bridge/services/session_prompt_service_test.dart
+++ b/bridge/app/test/bridge/services/session_prompt_service_test.dart
@@ -66,9 +66,13 @@ void main() {
       // surfaces whatever the plugin throws.
       final completer = Completer<void>();
       plugin.sendCommandCompleter = completer;
-      completer.completeError(StateError("unknown command"));
 
-      await expectLater(sendCommand(), throwsA(isA<StateError>()));
+      // Attach the expectation before failing the completer: sendCommand has
+      // async steps ahead of the plugin call, so a pre-completed error future
+      // would count as unhandled before anyone listens.
+      final pending = expectLater(sendCommand(), throwsA(isA<StateError>()));
+      completer.completeError(StateError("unknown command"));
+      await pending;
     });
 
     test("updates prompt defaults after the command is dispatched", () async {

--- a/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
+++ b/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
@@ -4,17 +4,13 @@ import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
 import "../../helpers/test_helpers.dart";
-import "../routing/routing_test_helpers.dart";
 
 void main() {
   group("BridgeEventMapper", () {
     late BridgeEventMapper mapper;
-    late FakeBridgePlugin plugin;
 
     setUp(() {
-      plugin = FakeBridgePlugin();
       mapper = BridgeEventMapper(
-        plugin: plugin,
         failureReporter: FakeFailureReporter(),
       );
     });
@@ -358,37 +354,33 @@ void main() {
       expect(event.part.state?.output, equals("short"));
     });
 
-    test("map() returns null and reports failure when buildProjectsSummaryEvent() throws", () async {
-      final capturingReporter = CapturingFailureReporter();
-      final throwingMapper = BridgeEventMapper(
-        plugin: _ThrowingActiveSessionsPlugin(),
-        failureReporter: capturingReporter,
-      );
-
-      final result = throwingMapper.map(const BridgeSseProjectUpdated());
+    test("map() drops BridgeSseProjectUpdated (the orchestrator builds the summary)", () {
+      final result = mapper.map(const BridgeSseProjectUpdated());
 
       expect(result, isNull);
-      expect(capturingReporter.recordedIdentifiers, contains("sse_projects_summary"));
     });
 
-    test("buildProjectsSummaryEvent() returns null and reports failure when plugin throws", () {
-      final capturingReporter = CapturingFailureReporter();
-      final throwingMapper = BridgeEventMapper(
-        plugin: _ThrowingActiveSessionsPlugin(),
-        failureReporter: capturingReporter,
+    test("buildProjectsSummaryEvent() wraps already-remapped summary data", () {
+      final result = mapper.buildProjectsSummaryEvent(
+        projects: const [
+          ProjectActivitySummary(
+            id: "/repo",
+            activeSessions: [
+              ActiveSession(
+                id: "s1",
+                mainAgentRunning: true,
+                awaitingInput: false,
+                isRetrying: false,
+                childSessionIds: [],
+              ),
+            ],
+          ),
+        ],
       );
 
-      final result = throwingMapper.buildProjectsSummaryEvent();
-
-      expect(result, isNull);
-      expect(capturingReporter.recordedIdentifiers, contains("sse_projects_summary"));
+      final event = result as SesoriProjectsSummary;
+      expect(event.projects.single.id, "/repo");
+      expect(event.projects.single.activeSessions.single.id, "s1");
     });
   });
-}
-
-class _ThrowingActiveSessionsPlugin extends FakeBridgePlugin {
-  @override
-  List<PluginProjectActivitySummary> getActiveSessionsSummary() {
-    throw StateError("summary mapping failed");
-  }
 }

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -694,6 +694,20 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   String _directoryForSession(String sessionId) =>
       _sessionDirectories[sessionId] ?? launchDirectory;
 
+  @override
+  void primeSessionDirectory({required String sessionId, required String directory}) {
+    if (sessionId.isEmpty || directory.trim().isEmpty) return;
+    final canonical = normalizeProjectDirectory(directory: directory);
+    // Remember the directory for internal warm-up scans regardless — the hint
+    // set widens future enumerations even when this session is already known.
+    _hintedDirectories.add(canonical);
+    // A hint, not an override: a directory learned from the agent itself
+    // (enumeration hit, session/new) stays authoritative.
+    if (_sessionDirectories.containsKey(sessionId)) return;
+    _sessionDirectories[sessionId] = canonical;
+    eventMapper.setSessionProject(sessionId, canonical);
+  }
+
   /// Ensures [sessionId] is resident in the agent process before a turn. A
   /// session created/resumed this run is already resident; one from a prior
   /// bridge run is re-loaded via `session/load` (its history replay suppressed
@@ -1123,8 +1137,15 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     try {
       await replayClient.connect();
       final replayInit = await _initialize(replayClient);
-      if (!replayClient.isConnected || !replayInit.agentCapabilities.loadSession) {
+      if (!replayInit.agentCapabilities.loadSession) {
+        // History is genuinely unavailable on this agent — an empty thread,
+        // not a failure: the session must stay usable for new prompts.
         return const [];
+      }
+      if (!replayClient.isConnected) {
+        // The replay agent died right after the handshake — a failure, not an
+        // empty thread (wrapped into the typed failure below).
+        throw StateError("replay agent exited during initialization");
       }
       var received = 0;
       BridgeSseSessionsUpdated? deferredCommandRefresh;
@@ -1166,12 +1187,16 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       collector.modelId = eventMapper.modelForSession(sessionId);
       collector.providerId = eventMapper.providerForSession(sessionId);
       return collector.build();
-    } on Object catch (error, stack) {
-      // A broken replay (connect/init/auth/load failure) returns no messages;
-      // the phone can't tell that from a truly empty thread, so at least log
-      // it rather than silently swallowing the failure.
-      Log.w("[$id] history replay for $sessionId failed; returning no messages", error, stack);
-      return const [];
+    } on Object catch (error) {
+      // A broken replay (connect/init/auth/load failure) must stay
+      // distinguishable from a genuinely empty thread: surface it as a typed
+      // failure (the bridge router maps it to a 502 and the phone renders a
+      // retry state) instead of swallowing it into an empty list.
+      throw PluginOperationException(
+        "session/load history replay",
+        message: "history replay for $sessionId failed",
+        cause: error,
+      );
     } finally {
       try {
         await sub?.cancel();

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1187,15 +1187,18 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       collector.modelId = eventMapper.modelForSession(sessionId);
       collector.providerId = eventMapper.providerForSession(sessionId);
       return collector.build();
-    } on Object catch (error) {
+    } on Object catch (error, stackTrace) {
       // A broken replay (connect/init/auth/load failure) must stay
       // distinguishable from a genuinely empty thread: surface it as a typed
       // failure (the bridge router maps it to a 502 and the phone renders a
       // retry state) instead of swallowing it into an empty list.
-      throw PluginOperationException(
-        "session/load history replay",
-        message: "history replay for $sessionId failed",
-        cause: error,
+      Error.throwWithStackTrace(
+        PluginOperationException(
+          "session/load history replay",
+          message: "history replay for $sessionId failed",
+          cause: error,
+        ),
+        stackTrace,
       );
     } finally {
       try {

--- a/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
@@ -594,6 +594,98 @@ void main() {
       await respond("session/prompt", {"stopReason": "end_turn"});
     });
 
+    test("a primed directory is used for the resume-load without any enumeration", () async {
+      await connect(sessionCapabilities: true);
+      const stored = "/Users/x/kustos";
+
+      // The bridge feeds its stored attribution (worktree/project path) before
+      // the prompt — no warm-up enumeration is needed for the load to run in
+      // the session's own cwd.
+      plugin.primeSessionDirectory(sessionId: "cold-s", directory: stored);
+
+      final sending = plugin.sendPrompt(
+        sessionId: "cold-s",
+        parts: const [PluginPromptPart.text(text: "resume me")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final loadFrame = await waitForFrame("session/load");
+      expect((loadFrame["params"] as Map)["cwd"], stored);
+      expect(
+        fake().written.where((f) => f["method"] == "session/list"),
+        isEmpty,
+        reason: "a primed directory removes the need for the warm-up enumeration",
+      );
+      fake().emit({"jsonrpc": "2.0", "id": loadFrame["id"], "result": const <String, dynamic>{}});
+      await sending;
+      await respond("session/prompt", {"stopReason": "end_turn"});
+    });
+
+    test("a prime does not override an agent-reported directory", () async {
+      await connect(sessionCapabilities: true);
+      const opened = "/Users/x/kustos";
+
+      // The agent itself reported the session's cwd via enumeration…
+      final listing = plugin.getSessions(opened);
+      await respond("session/list", {
+        "sessions": [
+          {"sessionId": "old-s", "cwd": opened, "title": "Prior"},
+        ],
+      });
+      await listing;
+
+      // …so a later (hypothetically stale) bridge prime must not replace it.
+      plugin.primeSessionDirectory(sessionId: "old-s", directory: "/somewhere/stale");
+
+      final sending = plugin.sendPrompt(
+        sessionId: "old-s",
+        parts: const [PluginPromptPart.text(text: "again")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final loadFrame = await waitForFrame("session/load");
+      expect(
+        (loadFrame["params"] as Map)["cwd"],
+        opened,
+        reason: "the agent-reported cwd stays authoritative over a bridge hint",
+      );
+      fake().emit({"jsonrpc": "2.0", "id": loadFrame["id"], "result": const <String, dynamic>{}});
+      await sending;
+      await respond("session/prompt", {"stopReason": "end_turn"});
+    });
+
+    test("a broken history replay surfaces as a typed failure, not an empty thread", () async {
+      // Prime the directory so the replay needs no warm-up enumeration (and
+      // therefore no main-client connection).
+      plugin.primeSessionDirectory(sessionId: "s-x", directory: cwd);
+
+      final loading = plugin.getSessionMessages("s-x");
+      final init = await waitForFrame("initialize");
+      answered.add((fake(), init["id"]));
+      fake().emit({
+        "jsonrpc": "2.0",
+        "id": init["id"],
+        "error": {"code": -32603, "message": "agent exploded"},
+      });
+
+      await expectLater(loading, throwsA(isA<PluginOperationException>()));
+    });
+
+    test("an agent without loadSession serves an empty thread, not a failure", () async {
+      plugin.primeSessionDirectory(sessionId: "s-x", directory: cwd);
+
+      final loading = plugin.getSessionMessages("s-x");
+      await respond("initialize", {
+        "protocolVersion": 1,
+        "agentCapabilities": <String, dynamic>{},
+        "authMethods": <Object?>[],
+      });
+
+      expect(await loading, isEmpty, reason: "no history capability = empty thread; the session stays usable");
+    });
+
     test("catalog probe scans the launch directory and every extra directory", () async {
       await connect(sessionCapabilities: true);
       const opened = "/Users/x/kustos";

--- a/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
@@ -657,20 +657,29 @@ void main() {
     });
 
     test("a broken history replay surfaces as a typed failure, not an empty thread", () async {
+      final failingPlugin = AcpPlugin(
+        id: "acp",
+        agentDisplayName: "ACP",
+        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+        launchDirectory: cwd,
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp"),
+        processFactory: _throwReplayProcess,
+      );
+      addTearDown(failingPlugin.dispose);
       // Prime the directory so the replay needs no warm-up enumeration (and
       // therefore no main-client connection).
-      plugin.primeSessionDirectory(sessionId: "s-x", directory: cwd);
+      failingPlugin.primeSessionDirectory(sessionId: "s-x", directory: cwd);
 
-      final loading = plugin.getSessionMessages("s-x");
-      final init = await waitForFrame("initialize");
-      answered.add((fake(), init["id"]));
-      fake().emit({
-        "jsonrpc": "2.0",
-        "id": init["id"],
-        "error": {"code": -32603, "message": "agent exploded"},
-      });
-
-      await expectLater(loading, throwsA(isA<PluginOperationException>()));
+      try {
+        await failingPlugin.getSessionMessages("s-x");
+        fail("Expected history replay to fail");
+      } on PluginOperationException catch (_, stackTrace) {
+        expect(
+          stackTrace.toString(),
+          contains("_throwReplayProcess"),
+          reason: "the typed wrapper must retain the original replay failure stack",
+        );
+      }
     });
 
     test("an agent without loadSession serves an empty thread, not a failure", () async {
@@ -754,6 +763,10 @@ void main() {
       expect(openedQuestions.map((q) => q.sessionID).toSet(), {"s-opened"});
     });
   });
+}
+
+Future<AcpProcessHandle> _throwReplayProcess(AcpLaunchSpec _) async {
+  throw StateError("replay process failed to start");
 }
 
 /// [AcpPlugin] that captures the approval registry built at connect so tests

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -354,6 +354,13 @@ class CodexPlugin implements CodexManagedApi {
   @override
   String get launchDirectory => _projectCwd;
 
+  /// No-op: codex's global rollout index self-resolves every session's cwd,
+  /// so the bridge's stored-directory hint adds nothing. (Spelled out because
+  /// this class `implements` the plugin interface rather than extending it,
+  /// so the interface's no-op default does not apply.)
+  @override
+  void primeSessionDirectory({required String sessionId, required String directory}) {}
+
   @override
   Future<List<PluginSession>> getSessions(
     String projectId, {

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -79,6 +79,13 @@ sealed class BridgePluginApi {
   Future<Map<String, PluginSessionStatus>> getSessionStatuses();
 
   /// Get all messages for a session.
+  ///
+  /// An empty list means a **genuinely empty thread** (including a backend
+  /// that cannot serve history at all). Implementations MUST throw — e.g. a
+  /// [PluginOperationException] — when history retrieval *fails* (transport,
+  /// auth, replay errors), never swallow the failure into an empty list: the
+  /// phone renders an error-with-retry state for a failed load, which must
+  /// stay distinguishable from "no messages yet".
   Future<List<PluginMessageWithParts>> getSessionMessages(String sessionId);
 
   Future<void> sendPrompt({
@@ -218,4 +225,15 @@ abstract class BridgeDerivedProjectsPluginApi extends BridgePluginApi {
   /// "there is always somewhere to start a session" behaviour derive-style
   /// backends had before the bridge owned their project list.
   String get launchDirectory;
+
+  /// Hints the bridge's stored directory attribution for [sessionId] before an
+  /// operation that carries only the session id (prompt dispatch, history
+  /// replay). After a bridge restart a directory-scoped backend (ACP) may not
+  /// have enumerated the session yet, so without this hint it would operate in
+  /// its launch directory instead of the session's own cwd — the bridge's
+  /// stored row (worktree path or owning project directory) is the durable
+  /// attribution it cannot self-resolve. A hint, not an override: a backend
+  /// keeps its own fresher attribution when it has one. The default is a
+  /// no-op for backends with a global session index.
+  void primeSessionDirectory({required String sessionId, required String directory}) {}
 }

--- a/docs/cursor-acp-followups/README.md
+++ b/docs/cursor-acp-followups/README.md
@@ -46,69 +46,55 @@ than observed Cursor bugs. That is called out per item.
 | #  | Theme                                                | Why it matters                                                  | Status |
 |----|------------------------------------------------------|----------------------------------------------------------------|------------|
 | H  | Resume-load & per-session turn robustness            | **User-facing:** stuck conversations, dropped queued prompts, replay leak | **Resolved** |
-| A  | Bridge↔plugin stored-directory / attribution seam    | Real worktree flows on restart; one hook resolves three threads | Open (Medium) |
+| A  | Bridge↔plugin stored-directory / attribution seam    | Real worktree flows on restart; one hook resolves three threads | **Resolved** |
 | B  | Durable derive-plugin session state (bridge schema)  | Title loss + deleted sessions reappearing                       | Open (Medium) |
 | C  | ACP protocol completeness in the mapper / parsers    | Correctness for the next ACP backend                            | **Resolved** |
 | G  | Concurrent multi-session turn attribution            | Wrong-conversation routing of `sessionId`-less requests         | **Resolved** |
 | I  | Lossy `session.updated` payload on title changes     | List row loses time/summary/defaults until refresh             | **Resolved** |
 | E  | Typed ACP/Cursor boundary DTOs                        | Enabler / safety net for C and F                                | Blocked on traces (Large) |
-| F  | `getSessionMessages` richer failure contract         | "Broken replay" vs "empty thread" on the phone                  | Open (Small–Med) |
+| F  | `getSessionMessages` richer failure contract         | "Broken replay" vs "empty thread" on the phone                  | **Resolved** |
 | D  | Cursor decisions needing a trace / product call      | Small, but blocked on evidence                                  | D2 resolved; D1 blocked on a trace |
 
 ---
 
-## Theme A — The bridge↔plugin stored-directory / attribution seam
+## Theme A — The bridge↔plugin stored-directory / attribution seam ✅ Resolved
 
-**One root cause, raised three times.** A directory-scoped derived plugin needs
-the bridge's stored attribution before an operation it cannot self-resolve. The
-plugin has no DB access and the call carries only a `sessionId`, so this cannot
-be fixed inside the plugin.
+**Resolved with the recommended root fix.** One root cause (a directory-scoped
+derived plugin needing the bridge's stored attribution it cannot self-resolve),
+one seam:
 
-- **A1 — resume `sendPrompt` cwd.** After a bridge restart, a prompt opened
-  directly from a push/deep link for a bridge-created dedicated-worktree session
-  can leave `_sessionDirectories` empty; `_directoryForSession()` falls back to
-  the launch directory and `session/load` resumes against the wrong cwd (or
-  fails). Partially mitigated in-plugin (`_hintedDirectories` accumulation +
-  unfiltered `session/list`, which Cursor supports); the residual gap is a cold
-  restart + push-first prompt on a non-compliant agent.
-  Source: [#332 r3536171402](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3536171402)
+- **A1/A2 — `primeSessionDirectory` seam.** `BridgeDerivedProjectsPluginApi`
+  gained `primeSessionDirectory({required String sessionId, required String
+  directory})` with a no-op default. `SessionRepository` resolves
+  `worktreePath ?? projectId` from the stored session row and primes the
+  plugin at the top of `sendPrompt`, `sendCommand`, and the new repository
+  `getSessionMessages` — so a cold restart + push-first prompt (or a
+  history replay as the first plugin call) runs `session/load` in the
+  session's own cwd on any agent, compliant or not, with no warm-up
+  enumeration. The ACP plugin treats the prime as a hint (an agent-reported
+  cwd stays authoritative) and adds it to its scan-hint set; codex spells out
+  an explicit no-op (it `implements` the interface, and its global rollout
+  index self-resolves). The messages handler now goes through
+  `SessionRepository.getSessionMessages` (which also moved the
+  plugin→shared message mapping out of the routing layer, closing a known
+  Layer-1 leak).
+  Sources: [#332 r3536171402](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3536171402),
+  [r3537566944](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3537566944)
 
-- **A2 — `getSessionMessages` history replay cwd.** Same warm-up gap on the
-  history-replay path: an empty hint set means only the launch directory is
-  scanned before `session/load` replays, so a directory-scoped agent can replay
-  the wrong thread or fail. Covered for Cursor via unfiltered `session/list`.
-  Source: [#332 r3537566944](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3537566944)
-
-- **A3 — worktree activity attribution.** `getActiveSessionsSummary` reports the
-  active/awaiting session under the *worktree* cwd, but the repositories fold
-  that session back under the stored *parent* project row. So project activity
-  badges can vanish for Cursor worktree sessions. This is the same seam viewed
-  from the summary side (remap, not prime).
+- **A3 — worktree activity attribution.** The SSE `projects.summary` path now
+  matches the REST grouping: `SessionRepository.getProjectActivitySummaries()`
+  regroups a derived plugin's active sessions under the stored parent project
+  (via the existing pluginId-scoped `SessionDao.getSessionProjectPaths` join)
+  before mapping to the shared model; `BridgeEventMapper` became a pure
+  builder over that data (its direct plugin dependency is gone) and the
+  orchestrator owns fetching + building the summary event, per "Orchestrator
+  Owns SSE Decisions". Project activity badges no longer vanish for worktree
+  sessions.
   Source: [#332 r3536293277](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3536293277)
 
-**Recommended root fix.**
-
-- For A1/A2: add a no-op-default
-  `primeSessionDirectory({required String sessionId, required String directory})`
-  on `BridgeDerivedProjectsPluginApi`. The bridge resolves `worktreePath ??
-  projectId` from the stored session row (in `SessionRepository`) and calls it
-  before delegating `sendPrompt` / `getSessionMessages`. Codex inherits the
-  no-op default and is unaffected.
-- For A3: remap **bridge-side** in `BridgeEventMapper.buildProjectsSummaryEvent`
-  / the repository layer, which today passes the plugin's id straight through.
-  The join already exists (`SessionDao.getSessionProjectPaths`,
-  sessions⋈projects filtered by `plugin_id`).
-
-**Affected surfaces.** `sesori_plugin_interface` (`BridgeDerivedProjectsPluginApi`),
-`sesori_plugin_codex` (no-op), `sesori_plugin_acp`, bridge `SessionRepository`
-(+ a `getSessionMessages` repository method), routing/handler wiring,
-`BridgeEventMapper`, bridge-app tests.
-
-**Design note.** This is a `sesori_plugin_interface` evolution, as is
-"events carry plugin identity" from `parallel-plugins/CONSIDERATIONS.md` §3.4.
-If both land near each other, design the interface change once. Respect the
-`plugin_id` routing datum (CONSIDERATIONS §2) — never resolve a session's
-directory/parent across plugin boundaries.
+The `plugin_id` routing datum is respected throughout (the DAO join is
+pluginId-filtered; no cross-plugin resolution) — the seam stays compatible
+with the parallel-plugins direction in `parallel-plugins/CONSIDERATIONS.md`.
 
 ---
 
@@ -313,18 +299,18 @@ Source: [#332 r3481369047](https://github.com/sesori-ai/sesori_apps_monorepo/pul
 
 ---
 
-## Theme F — `getSessionMessages` richer failure contract
+## Theme F — `getSessionMessages` richer failure contract ✅ Resolved
 
-History replay currently returns a plain `List`, so a **broken replay**
-(connect/init/auth/`session/load` failure) is indistinguishable from a
-**genuinely empty thread** to the phone. The replay catch was widened to
-`on Object catch` + `Log.w` so failures are diagnosable server-side, but the
-phone still can't tell the two apart. Distinguishing them needs a
-`getSessionMessages` contract change (a typed result instead of a bare list).
-This pairs naturally with the `getSessionMessages` repository method from
-Theme A and the typing effort in Theme E.
+**Resolved without a signature change.** The `BridgePluginApi.getSessionMessages`
+contract now states that implementations MUST throw (e.g.
+`PluginOperationException`) when history retrieval fails — an empty list means
+a genuinely empty thread. The ACP plugin's replay catch-all stops swallowing
+failures into `[]` and throws a typed `PluginOperationException` instead;
+the bridge router already forwards it as a 502, and the phone already renders
+a failed messages load as a full-screen retry state — so "broken replay" and
+"empty thread" are distinguishable end to end with zero client changes. An
+agent that doesn't advertise `loadSession` still serves `[]` (history is
+genuinely unavailable, and the session must stay usable for new prompts).
+This landed together with the `getSessionMessages` repository method from
+Theme A.
 Source: [#332 r3536171443](https://github.com/sesori-ai/sesori_apps_monorepo/pull/332#discussion_r3536171443)
-
-**Affected surfaces.** Plugin-interface `getSessionMessages` signature,
-`SessionRepository`, routing handler, client-side rendering of the failure
-state.


### PR DESCRIPTION
## Summary
- prime derived plugins with bridge-owned session directories before prompts, commands, and history loads
- regroup active worktree sessions under their stored parent projects for live activity summaries
- move session-message loading/mapping into SessionRepository and surface replay failures as typed plugin errors

## Validation
- `dart analyze --fatal-infos && dart test` in `bridge/app` (1767 tests)
- `dart analyze --fatal-infos && dart test` in `bridge/sesori_plugin_acp` (117 tests)
- `dart analyze --fatal-infos && dart test` in `bridge/sesori_plugin_codex` (132 tests)
- `dart analyze --fatal-infos && dart test` in `bridge/sesori_plugin_interface` (141 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Primes derived plugins with stored session directories before prompts, commands, and history loads, and rebuilds project activity summaries from repository data so worktree activity shows on the parent project. Also reports summary rebuild failures and preserves SSE order, and returns a typed error for broken history replay instead of an empty thread.

- New Features
  - Added `primeSessionDirectory` to `BridgeDerivedProjectsPluginApi`; `SessionRepository` calls it before `sendPrompt`, `sendCommand`, and `getSessionMessages`.
  - Introduced `SessionRepository.getSessionMessages` (handles priming and maps messages); `GetSessionMessagesHandler` now uses the repository.
  - `projects.summary` is built from `SessionRepository.getProjectActivitySummaries`; `BridgeEventMapper` is a pure builder, and both Orchestrator and DebugServer rebuild the summary from repository data.

- Bug Fixes
  - Worktree session activity is grouped under the stored parent project, fixing missing project badges.
  - After a cold restart, prompts/commands/history run in the correct session cwd; SSE event order is preserved while the projects summary rebuilds.
  - Summary rebuild failures are captured and reported by the orchestrator and debug server.
  - `getSessionMessages` failure contract: `sesori_plugin_acp` throws `PluginOperationException` on replay failure (returns 502); agents without `loadSession` return an empty list.

<sup>Written for commit d05eff18d79f1f9af9c98c0146fc6d8fc88a13b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

