### PR TITLE
[UI] Bridge offline redesign to match Figma

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -545,6 +545,7 @@ Do not skip either step. The reviewers exist because violations compound — one
 - Treat user feedback in **PR comments** and in the **live chat** as guidance for future code, not just the current patch.
 - When the user pushes back on a coding practice, architecture choice, testing shape, utility placement, or workflow decision, proactively update the closest relevant `AGENTS.md` file so the same mistake is less likely to recur.
 - Prefer updating both the **repo-root `AGENTS.md`** for general guidance and the **workspace/module `AGENTS.md`** for domain-specific guidance when the feedback is scoped.
+- For UI review comments from bots, do not assume a changed shared component is an unintended regression just because the PR title names one screen. First check whether the design changed across all consumers; if the design source or user intent says the shared visual changed globally, decline the bot comment instead of preserving old styling on non-focused screens.
 - Do this proactively after the lesson is clear; do not wait for the user to ask a second time.
 - Assume the user reviews **committed and pushed code**, not your uncommitted local workspace. If you are expecting PR feedback to reflect your latest work, proactively commit and push first.
 - Never rely on users reviewing uncommitted changes. Remote PR state is the review source of truth unless the user explicitly says otherwise.

--- a/client/app/AGENTS.md
+++ b/client/app/AGENTS.md
@@ -37,6 +37,7 @@ lib/
 
 - Localize all user-facing text in `lib/l10n/app_en.arb`, access via `context.loc.myResource`
 - English only for now
+- When review feedback claims a shared widget style change unintentionally affects other screens, verify the design intent before preserving older styling. If the design changed for every consumer, keep the shared widget change and explain that in the PR reply.
 
 ## Theming
 

--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -134,9 +134,8 @@ class _ConnectBridgeChecklist extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: PregoSpacing.xl),
           child: _InstallCommandBoxes(
             surface: OnboardingSurface.connectSetup,
-            stepHeader: _OnboardingStepLabel(
-              number: 1,
-              title: loc.projectsOnboardingInstallStepTitle,
+            stepHeader: _InfoLabel(
+              title: "1. ${loc.projectsOnboardingInstallStepTitle}",
               info: loc.projectsOnboardingInstallStepInfo,
             ),
           ),
@@ -148,9 +147,8 @@ class _ConnectBridgeChecklist extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              _OnboardingStepLabel(
-                number: 2,
-                title: loc.projectsOnboardingStartStepTitle,
+              _InfoLabel(
+                title: "2. ${loc.projectsOnboardingStartStepTitle}",
                 info: loc.projectsOnboardingStartStepInfo,
               ),
               const SizedBox(height: PregoSpacing.md),
@@ -178,9 +176,10 @@ class _ConnectBridgeChecklist extends StatelessWidget {
   }
 }
 
-/// The "Why is this needed?" explainer button: a compact secondary pill that
-/// opens the [_WhyBridgeInfoSheet] bottom sheet. Centred so the stretch parent
-/// doesn't force it full-width. Shared by both empty Projects states.
+/// The "Why is this needed?" explainer button: a compact tertiary (ghost)
+/// pill that opens the [_WhyBridgeInfoSheet] bottom sheet. Centred so the
+/// stretch parent doesn't force it full-width. Shared by both empty Projects
+/// states and the bridge-offline recovery view.
 class _WhyBridgeButton extends StatelessWidget {
   const _WhyBridgeButton({required this.surface});
 
@@ -195,7 +194,7 @@ class _WhyBridgeButton extends StatelessWidget {
         fullWidth: false,
         leadingIcon: TablerRegular.info_circle,
         label: loc.projectsOnboardingPcStatusWhy,
-        hierarchy: PregoButtonsSolidHierarchy.secondary,
+        hierarchy: PregoButtonsSolidHierarchy.tertiary,
         size: PregoButtonsSolidSize.sm,
         onPressed: () {
           unawaited(
@@ -214,14 +213,13 @@ class _WhyBridgeButton extends StatelessWidget {
   }
 }
 
-/// A numbered connect-onboarding step title with a trailing "ⓘ" info popover —
-/// e.g. "1. Install the bridge ⓘ". Tapping the icon opens a [PregoInfoPopover]
-/// (glass on iOS, flat/`cue` on Android) anchored to it, showing [info]. Used
-/// above the install- and start-command boxes.
-class _OnboardingStepLabel extends StatelessWidget {
-  const _OnboardingStepLabel({required this.number, required this.title, required this.info});
+/// A command-box label with a trailing "ⓘ" info popover — e.g. "1. Install the
+/// bridge ⓘ" on the connect onboarding or "Start your bridge ⓘ" on the
+/// bridge-offline view. Tapping the icon opens a [PregoInfoPopover] (glass on
+/// iOS, flat/`cue` on Android) anchored to it, showing [info].
+class _InfoLabel extends StatelessWidget {
+  const _InfoLabel({required this.title, required this.info});
 
-  final int number;
   final String title;
   final String info;
 
@@ -233,7 +231,7 @@ class _OnboardingStepLabel extends StatelessWidget {
       children: [
         Flexible(
           child: Text(
-            "$number. $title",
+            title,
             style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textPrimary),
           ),
         ),
@@ -701,8 +699,8 @@ class _InstallCommandBoxState extends State<_InstallCommandBox> {
 }
 
 /// The rounded, bordered chrome shared by the install-command box and the
-/// bridge-offline "Run the bridge" box, so both command boxes read as the same
-/// component. Clips [child] to the radius and paints the border on top.
+/// bridge-offline "Start your bridge" box, so both command boxes read as the
+/// same component. Clips [child] to the radius and paints the border on top.
 class _CommandBoxFrame extends StatelessWidget {
   const _CommandBoxFrame({required this.child});
 
@@ -726,7 +724,7 @@ class _CommandBoxFrame extends StatelessWidget {
 }
 
 /// The command display plus copy/share actions, shared by the install-command
-/// box and the bridge-offline "Run the bridge" box. Shows [command] on a single
+/// box and the bridge-offline "Start your bridge" box. Shows [command] on a single
 /// monospace line that fades out at the trailing edge — so an over-long command
 /// reads as continuing off-screen rather than hard-clipping — with copy and
 /// native-share buttons. [topDivider] draws the hairline separating this row

--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -194,10 +194,7 @@ class _WhyBridgeButton extends StatelessWidget {
         fullWidth: false,
         leadingIcon: TablerRegular.info_circle,
         label: loc.projectsOnboardingPcStatusWhy,
-        hierarchy: switch (surface) {
-          OnboardingSurface.bridgeOffline => PregoButtonsSolidHierarchy.tertiary,
-          OnboardingSurface.connectedEmpty || OnboardingSurface.connectSetup => PregoButtonsSolidHierarchy.secondary,
-        },
+        hierarchy: PregoButtonsSolidHierarchy.tertiary,
         size: PregoButtonsSolidSize.sm,
         onPressed: () {
           unawaited(

--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -194,7 +194,10 @@ class _WhyBridgeButton extends StatelessWidget {
         fullWidth: false,
         leadingIcon: TablerRegular.info_circle,
         label: loc.projectsOnboardingPcStatusWhy,
-        hierarchy: PregoButtonsSolidHierarchy.tertiary,
+        hierarchy: switch (surface) {
+          OnboardingSurface.bridgeOffline => PregoButtonsSolidHierarchy.tertiary,
+          OnboardingSurface.connectedEmpty || OnboardingSurface.connectSetup => PregoButtonsSolidHierarchy.secondary,
+        },
         size: PregoButtonsSolidSize.sm,
         onPressed: () {
           unawaited(

--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -133,9 +133,9 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
   }
 
   /// The scaffold's bottom-right floating action for the current [state]: the
-  /// add-project FAB once projects exist, the onboarding "Need help?" support
-  /// menu in the two empty states (never-registered setup and connected-but-
-  /// empty), and nothing otherwise.
+  /// add-project FAB once projects exist, the "Need help?" support menu on the
+  /// onboarding and recovery surfaces (never-registered setup, connected-but-
+  /// empty, and bridge-offline), and nothing otherwise.
   Widget? _floatingAction({required BuildContext context, required ProjectListState state}) {
     if (state is ProjectListLoaded && state.projects.isNotEmpty) {
       return PregoButtonsIconGlass(
@@ -145,10 +145,12 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
         onPressed: () => showAddProjectDialog(context, context.read<ProjectListCubit>()),
       );
     }
-    // The two onboarding surfaces get the same pill but report distinct
+    // The onboarding/recovery surfaces get the same pill but report distinct
     // analytics surfaces, so help-seeking is attributable to the funnel step.
-    if (state is ProjectListBridgeDisconnected && !state.hasRegisteredBridges) {
-      return const _NeedHelpMenu(surface: OnboardingSurface.connectSetup);
+    if (state is ProjectListBridgeDisconnected) {
+      return _NeedHelpMenu(
+        surface: state.hasRegisteredBridges ? OnboardingSurface.bridgeOffline : OnboardingSurface.connectSetup,
+      );
     }
     if (state is ProjectListLoaded && state.projects.isEmpty) {
       return const _NeedHelpMenu(surface: OnboardingSurface.connectedEmpty);
@@ -180,8 +182,8 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
         ),
       ],
       // Bottom-right floating action, resolved per state: the add-project FAB
-      // once projects exist, the onboarding "Need help?" support menu in the two
-      // empty states, and nothing while loading/offline/errored.
+      // once projects exist, the "Need help?" support menu on the onboarding
+      // and bridge-offline surfaces, and nothing while loading/errored.
       floatingActionButton: _floatingAction(context: context, state: state),
       onRefresh: _refreshFor(context: context, state: state),
       slivers: _buildContentSlivers(context: context, state: state, isRefreshing: isRefreshing),
@@ -239,12 +241,12 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
       // shorter than the viewport sit still while a taller one — the offline
       // view with its install commands expanded — scrolls the page.
       // SafeArea(top: false) keeps the last box clear of the home indicator.
-      ProjectListBridgeDisconnected(:final hasRegisteredBridges) => [
+      ProjectListBridgeDisconnected(:final hasRegisteredBridges, :final bridges) => [
         SliverFillRemaining(
           hasScrollBody: false,
           child: SafeArea(
             top: false,
-            child: hasRegisteredBridges ? const _BridgeOfflineView() : const _ConnectBridgeChecklist(),
+            child: hasRegisteredBridges ? _BridgeOfflineView(bridges: bridges) : const _ConnectBridgeChecklist(),
           ),
         ),
       ],

--- a/client/app/lib/features/project_list/widgets/bridge_offline_view.dart
+++ b/client/app/lib/features/project_list/widgets/bridge_offline_view.dart
@@ -3,15 +3,25 @@ part of "../project_list_screen.dart";
 /// Shown when the account has a bridge registered but none is connected — the
 /// user already completed setup, so instead of the install onboarding they are
 /// asked to reconnect. Mirrors the Figma "bridge disconnected" state: the
-/// connection graphic, a "Reconnect" CTA, and an expandable "Install commands"
-/// disclosure for when the bridge needs to be (re)installed or restarted.
+/// connection graphic with a "Disconnected" status caption and the machine
+/// name of the bridge being reached, a "Reconnect" CTA, the always-visible
+/// "Start your bridge" command, a "Why is this needed?" explainer, and an
+/// expandable "Install commands" disclosure at the end for when the bridge
+/// needs to be (re)installed. The "Need help?" support menu ([_NeedHelpMenu])
+/// is not part of this scroll flow — it rides the scaffold's floating-action
+/// slot.
 ///
 /// A body, not a page: it is hosted in the project list's own page scroll (see
 /// [ProjectListScreen]) so the large title collapses into the bar as the
 /// expanded install commands scroll. Centred while it fits the viewport; the
 /// enclosing sliver grows past it once it doesn't.
 class _BridgeOfflineView extends StatefulWidget {
-  const _BridgeOfflineView();
+  const _BridgeOfflineView({required this.bridges});
+
+  /// The account's registered bridges, most recently seen first. Names the
+  /// machine the app is trying to reach; empty when the lookup failed (e.g.
+  /// the phone itself is offline), which hides the machine row.
+  final List<BridgeSummary> bridges;
 
   @override
   State<_BridgeOfflineView> createState() => _BridgeOfflineViewState();
@@ -48,23 +58,69 @@ class _BridgeOfflineViewState extends State<_BridgeOfflineView> {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           const ExcludeSemantics(child: Center(child: ConnectionGraphic.connectionOff())),
-          const SizedBox(height: 18),
-          Text(
-            loc.projectsBridgeOfflineTitle,
-            textAlign: TextAlign.center,
-            style: prego.textTheme.textLg.medium.copyWith(color: prego.colors.textPrimary),
+          const SizedBox(height: PregoSpacing.lg),
+          // "Disconnected ⊗" status caption: the crossed circle reads as part
+          // of the caption, mirroring the check on the onboarding's connected
+          // status line. Merged so screen readers announce it as one unit.
+          MergeSemantics(
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Flexible(
+                  child: Text(
+                    loc.projectsBridgeOfflineDisconnected,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textPrimary),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsetsDirectional.only(start: PregoSpacing.xs),
+                  child: Icon(
+                    TablerRegular.circle_x,
+                    size: 14,
+                    color: prego.colors.textTertiary,
+                  ),
+                ),
+              ],
+            ),
           ),
-          const SizedBox(height: 28),
+          if (widget.bridges.isNotEmpty) ...[
+            const SizedBox(height: PregoSpacing.xxs),
+            Center(child: _MachineNameRow(bridges: widget.bridges)),
+          ],
+          const SizedBox(height: PregoSpacing.x5l),
           PregoButtonsSolid(
             label: loc.projectsBridgeOfflineReconnect,
             hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
             size: PregoButtonsSolidSize.xl,
-            leadingIcon: TablerRegular.refresh,
+            leadingIcon: TablerRegular.rotate_clockwise,
             fullWidth: true,
             isLoading: _reconnecting,
             onPressed: _reconnect,
           ),
-          const SizedBox(height: 18),
+          // Always visible: the bridge is already installed here, so the common
+          // recovery is to (re)start it rather than reinstall.
+          const SizedBox(height: PregoSpacing.xl),
+          _InfoLabel(
+            title: loc.projectsBridgeOfflineStartBridge,
+            info: loc.projectsBridgeOfflineStartBridgeInfo,
+          ),
+          const SizedBox(height: PregoSpacing.md),
+          const _CommandBoxFrame(
+            child: _CommandActionRow(
+              command: BridgeInstall.runCommand,
+              copiedEvent: AnalyticsEvent.runCommandCopied(
+                surface: OnboardingSurface.bridgeOffline,
+              ),
+              sharedEvent: AnalyticsEvent.runCommandShared(
+                surface: OnboardingSurface.bridgeOffline,
+              ),
+            ),
+          ),
+          const SizedBox(height: PregoSpacing.xl),
+          const _WhyBridgeButton(surface: OnboardingSurface.bridgeOffline),
+          const SizedBox(height: PregoSpacing.xl),
           // expanded semantics so screen readers announce the open/closed state
           // of the install-commands disclosure; MergeSemantics folds it onto the
           // button's own node.
@@ -96,51 +152,116 @@ class _BridgeOfflineViewState extends State<_BridgeOfflineView> {
                 children: [
                   SizedBox(height: PregoSpacing.lg),
                   _InstallCommandBoxes(surface: OnboardingSurface.bridgeOffline),
+                  // Bottom breathing room so the last install box can be
+                  // scrolled clear of the "Need help?" button pinned in the
+                  // bottom-right corner. Inside the disclosure so the collapsed
+                  // body keeps its exact vertical centring.
+                  SizedBox(height: PregoSpacing.x6l),
                 ],
               ),
             ),
           ),
-          // Always visible: the bridge is already installed here, so the common
-          // recovery is to (re)start it rather than reinstall.
-          const SizedBox(height: PregoSpacing.xl),
-          const _RunBridgeCommand(),
         ],
       ),
     );
   }
 }
 
-/// The bridge-offline "Run the bridge" command: a label and a single-command
-/// box showing [BridgeInstall.runCommand]. Always visible (unlike the collapsed
-/// install commands) because the bridge is already installed, so the common
-/// recovery is to start it. Reuses the onboarding command-box chrome
-/// ([_CommandBoxFrame] / [_CommandActionRow]) so it matches the install
-/// commands.
-class _RunBridgeCommand extends StatelessWidget {
-  const _RunBridgeCommand();
+/// The machine identity row under the "Disconnected" caption: a laptop glyph
+/// and the most recently seen registered bridge's machine name (the hostname
+/// the bridge registered with the auth server). With more than one registered
+/// bridge a trailing chevron opens a flat anchored menu listing every machine,
+/// so the user can tell which computers this account knows about; with a
+/// single bridge the row is a plain, non-tappable label.
+class _MachineNameRow extends StatelessWidget {
+  const _MachineNameRow({required this.bridges});
+
+  /// Most recently seen first (as sorted by `RegisteredBridgesService`); the
+  /// first entry is the one named in the row. Never empty — the host omits
+  /// the row entirely when no bridges are known.
+  final List<BridgeSummary> bridges;
+
+  /// Human-readable label for a bridge's reported platform id. Falls back to
+  /// the raw value for platforms this app version doesn't know yet.
+  static String _platformLabel({required String platform}) {
+    return switch (platform) {
+      "macos" => "macOS",
+      "windows" => "Windows",
+      "linux" => "Linux",
+      _ => platform,
+    };
+  }
+
+  Widget _buildRow(BuildContext context) {
+    final prego = context.prego;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: 20,
+          height: 20,
+          child: Center(
+            child: Icon(TablerRegular.device_laptop, size: 12, color: prego.colors.textSecondary),
+          ),
+        ),
+        Flexible(
+          child: Text(
+            bridges.first.name,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textSecondary),
+          ),
+        ),
+        if (bridges.length > 1)
+          SizedBox(
+            width: 20,
+            height: 20,
+            child: Center(
+              child: Icon(TablerRegular.chevron_down, size: 12, color: prego.colors.textSecondary),
+            ),
+          ),
+      ],
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
-    final prego = context.prego;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Text(
-          context.loc.projectsBridgeOfflineRunBridge,
-          style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textPrimary),
-        ),
-        const SizedBox(height: PregoSpacing.md),
-        const _CommandBoxFrame(
-          child: _CommandActionRow(
-            command: BridgeInstall.runCommand,
-            copiedEvent: AnalyticsEvent.runCommandCopied(
-              surface: OnboardingSurface.bridgeOffline,
-            ),
-            sharedEvent: AnalyticsEvent.runCommandShared(
-              surface: OnboardingSurface.bridgeOffline,
-            ),
+    if (bridges.length == 1) return _buildRow(context);
+
+    // Several machines registered: the row becomes the trigger of a flat
+    // anchored menu listing all of them, most recently seen first, with the
+    // named (most recent) one marked selected. Purely informational — tapping
+    // an entry only dismisses the menu. Flat on every platform so the popup
+    // matches its flat text trigger instead of morphing in as glass.
+    return PregoAnchorMenu(
+      flat: true,
+      menuWidth: 260,
+      // MergeSemantics folds the machine name, the button role, and the tap
+      // action into a single node, so screen readers announce which machine
+      // the row names and can activate the menu from that same node — the
+      // bare nested GestureDetector would otherwise surface as a second,
+      // unlabelled tappable node.
+      triggerBuilder: (context, toggle) => MergeSemantics(
+        child: Semantics(
+          button: true,
+          label: context.loc.projectsBridgeOfflineMachinesSemantics,
+          onTap: toggle,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: toggle,
+            child: _buildRow(context),
           ),
         ),
+      ),
+      entries: [
+        for (final (index, bridge) in bridges.indexed)
+          PregoMenuItem(
+            leadingIcon: TablerRegular.device_laptop,
+            title: bridge.name,
+            subtitle: _platformLabel(platform: bridge.platform),
+            isSelected: index == 0,
+            onTap: () {},
+          ),
       ],
     );
   }

--- a/client/app/lib/features/project_list/widgets/bridge_offline_view.dart
+++ b/client/app/lib/features/project_list/widgets/bridge_offline_view.dart
@@ -18,9 +18,10 @@ part of "../project_list_screen.dart";
 class _BridgeOfflineView extends StatefulWidget {
   const _BridgeOfflineView({required this.bridges});
 
-  /// The account's registered bridges, most recently seen first. Names the
-  /// machine the app is trying to reach; empty when the lookup failed (e.g.
-  /// the phone itself is offline), which hides the machine row.
+  /// The account's registered bridges, most recently seen first. The first
+  /// entry names the machine the app is trying to reach; empty when the
+  /// lookup failed (e.g. the phone itself is offline), which hides the
+  /// machine row.
   final List<BridgeSummary> bridges;
 
   @override
@@ -87,7 +88,7 @@ class _BridgeOfflineViewState extends State<_BridgeOfflineView> {
           ),
           if (widget.bridges.isNotEmpty) ...[
             const SizedBox(height: PregoSpacing.xxs),
-            Center(child: _MachineNameRow(bridges: widget.bridges)),
+            Center(child: _MachineNameRow(name: widget.bridges.first.name)),
           ],
           const SizedBox(height: PregoSpacing.x5l),
           PregoButtonsSolid(
@@ -168,31 +169,18 @@ class _BridgeOfflineViewState extends State<_BridgeOfflineView> {
 }
 
 /// The machine identity row under the "Disconnected" caption: a laptop glyph
-/// and the most recently seen registered bridge's machine name (the hostname
-/// the bridge registered with the auth server). With more than one registered
-/// bridge a trailing chevron opens a flat anchored menu listing every machine,
-/// so the user can tell which computers this account knows about; with a
-/// single bridge the row is a plain, non-tappable label.
+/// and the machine name of the bridge being reached (the hostname the bridge
+/// registered with the auth server). A static, non-interactive label — the
+/// account runs a single bridge at a time, so there is nothing to act on
+/// here.
 class _MachineNameRow extends StatelessWidget {
-  const _MachineNameRow({required this.bridges});
+  const _MachineNameRow({required this.name});
 
-  /// Most recently seen first (as sorted by `RegisteredBridgesService`); the
-  /// first entry is the one named in the row. Never empty — the host omits
-  /// the row entirely when no bridges are known.
-  final List<BridgeSummary> bridges;
+  /// The registered bridge's machine name.
+  final String name;
 
-  /// Human-readable label for a bridge's reported platform id. Falls back to
-  /// the raw value for platforms this app version doesn't know yet.
-  static String _platformLabel({required String platform}) {
-    return switch (platform) {
-      "macos" => "macOS",
-      "windows" => "Windows",
-      "linux" => "Linux",
-      _ => platform,
-    };
-  }
-
-  Widget _buildRow(BuildContext context) {
+  @override
+  Widget build(BuildContext context) {
     final prego = context.prego;
     return Row(
       mainAxisSize: MainAxisSize.min,
@@ -206,62 +194,12 @@ class _MachineNameRow extends StatelessWidget {
         ),
         Flexible(
           child: Text(
-            bridges.first.name,
+            name,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
             style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textSecondary),
           ),
         ),
-        if (bridges.length > 1)
-          SizedBox(
-            width: 20,
-            height: 20,
-            child: Center(
-              child: Icon(TablerRegular.chevron_down, size: 12, color: prego.colors.textSecondary),
-            ),
-          ),
-      ],
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (bridges.length == 1) return _buildRow(context);
-
-    // Several machines registered: the row becomes the trigger of a flat
-    // anchored menu listing all of them, most recently seen first, with the
-    // named (most recent) one marked selected. Purely informational — tapping
-    // an entry only dismisses the menu. Flat on every platform so the popup
-    // matches its flat text trigger instead of morphing in as glass.
-    return PregoAnchorMenu(
-      flat: true,
-      menuWidth: 260,
-      // MergeSemantics folds the machine name, the button role, and the tap
-      // action into a single node, so screen readers announce which machine
-      // the row names and can activate the menu from that same node — the
-      // bare nested GestureDetector would otherwise surface as a second,
-      // unlabelled tappable node.
-      triggerBuilder: (context, toggle) => MergeSemantics(
-        child: Semantics(
-          button: true,
-          label: context.loc.projectsBridgeOfflineMachinesSemantics,
-          onTap: toggle,
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: toggle,
-            child: _buildRow(context),
-          ),
-        ),
-      ),
-      entries: [
-        for (final (index, bridge) in bridges.indexed)
-          PregoMenuItem(
-            leadingIcon: TablerRegular.device_laptop,
-            title: bridge.name,
-            subtitle: _platformLabel(platform: bridge.platform),
-            isSelected: index == 0,
-            onTap: () {},
-          ),
       ],
     );
   }

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -141,13 +141,9 @@
   "@projectsBridgeOfflineStartBridge": {
     "description": "Label above the command box on the bridge-offline Projects screen that shows the command to start an already-installed bridge; carries a trailing info icon."
   },
-  "projectsBridgeOfflineStartBridgeInfo": "Start the bridge\n\nLeave it running while you use Sesori from your phone.",
+  "projectsBridgeOfflineStartBridgeInfo": "Leave it running while you use Sesori from your phone.",
   "@projectsBridgeOfflineStartBridgeInfo": {
-    "description": "Popover text explaining the 'Start your bridge' command on the bridge-offline Projects screen, opened from the info icon next to that label."
-  },
-  "projectsBridgeOfflineMachinesSemantics": "Show registered machines",
-  "@projectsBridgeOfflineMachinesSemantics": {
-    "description": "Accessibility label for the machine-name row on the bridge-offline Projects screen when it opens a menu listing every machine with a registered bridge."
+    "description": "Popover text explaining the 'Start your bridge' command on the bridge-offline Projects screen, opened from the info icon next to that label. Kept in the same untitled single-sentence style as the onboarding step popovers."
   },
   "connectionLostTitle": "Connection Lost",
   "connectionLostReconnect": "Reconnect",

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -128,15 +128,26 @@
   "@projectsOnboardingStepInfoSemantics": {
     "description": "Accessibility label for the info icon button next to an onboarding step title, which opens a popover explaining that step."
   },
-  "projectsBridgeOfflineTitle": "Bridge disconnected",
+  "projectsBridgeOfflineDisconnected": "Disconnected",
+  "@projectsBridgeOfflineDisconnected": {
+    "description": "Status caption under the connection graphic on the bridge-offline Projects screen, rendered with a trailing crossed-circle icon."
+  },
   "projectsBridgeOfflineReconnect": "Reconnect",
   "projectsBridgeOfflineInstallCommands": "Install commands",
   "@projectsBridgeOfflineInstallCommands": {
     "description": "Label for the disclosure on the bridge-offline Projects screen that expands to reveal the bridge install commands."
   },
-  "projectsBridgeOfflineRunBridge": "Run the bridge",
-  "@projectsBridgeOfflineRunBridge": {
-    "description": "Label above the command box on the bridge-offline Projects screen that shows the command to start an already-installed bridge."
+  "projectsBridgeOfflineStartBridge": "Start your bridge",
+  "@projectsBridgeOfflineStartBridge": {
+    "description": "Label above the command box on the bridge-offline Projects screen that shows the command to start an already-installed bridge; carries a trailing info icon."
+  },
+  "projectsBridgeOfflineStartBridgeInfo": "Start the bridge\n\nLeave it running while you use Sesori from your phone.",
+  "@projectsBridgeOfflineStartBridgeInfo": {
+    "description": "Popover text explaining the 'Start your bridge' command on the bridge-offline Projects screen, opened from the info icon next to that label."
+  },
+  "projectsBridgeOfflineMachinesSemantics": "Show registered machines",
+  "@projectsBridgeOfflineMachinesSemantics": {
+    "description": "Accessibility label for the machine-name row on the bridge-offline Projects screen when it opens a menu listing every machine with a registered bridge."
   },
   "connectionLostTitle": "Connection Lost",
   "connectionLostReconnect": "Reconnect",

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -367,17 +367,11 @@ abstract class AppLocalizations {
   /// **'Start your bridge'**
   String get projectsBridgeOfflineStartBridge;
 
-  /// Popover text explaining the 'Start your bridge' command on the bridge-offline Projects screen, opened from the info icon next to that label.
+  /// Popover text explaining the 'Start your bridge' command on the bridge-offline Projects screen, opened from the info icon next to that label. Kept in the same untitled single-sentence style as the onboarding step popovers.
   ///
   /// In en, this message translates to:
-  /// **'Start the bridge\n\nLeave it running while you use Sesori from your phone.'**
+  /// **'Leave it running while you use Sesori from your phone.'**
   String get projectsBridgeOfflineStartBridgeInfo;
-
-  /// Accessibility label for the machine-name row on the bridge-offline Projects screen when it opens a menu listing every machine with a registered bridge.
-  ///
-  /// In en, this message translates to:
-  /// **'Show registered machines'**
-  String get projectsBridgeOfflineMachinesSemantics;
 
   /// No description provided for @connectionLostTitle.
   ///

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -343,11 +343,11 @@ abstract class AppLocalizations {
   /// **'More information'**
   String get projectsOnboardingStepInfoSemantics;
 
-  /// No description provided for @projectsBridgeOfflineTitle.
+  /// Status caption under the connection graphic on the bridge-offline Projects screen, rendered with a trailing crossed-circle icon.
   ///
   /// In en, this message translates to:
-  /// **'Bridge disconnected'**
-  String get projectsBridgeOfflineTitle;
+  /// **'Disconnected'**
+  String get projectsBridgeOfflineDisconnected;
 
   /// No description provided for @projectsBridgeOfflineReconnect.
   ///
@@ -361,11 +361,23 @@ abstract class AppLocalizations {
   /// **'Install commands'**
   String get projectsBridgeOfflineInstallCommands;
 
-  /// Label above the command box on the bridge-offline Projects screen that shows the command to start an already-installed bridge.
+  /// Label above the command box on the bridge-offline Projects screen that shows the command to start an already-installed bridge; carries a trailing info icon.
   ///
   /// In en, this message translates to:
-  /// **'Run the bridge'**
-  String get projectsBridgeOfflineRunBridge;
+  /// **'Start your bridge'**
+  String get projectsBridgeOfflineStartBridge;
+
+  /// Popover text explaining the 'Start your bridge' command on the bridge-offline Projects screen, opened from the info icon next to that label.
+  ///
+  /// In en, this message translates to:
+  /// **'Start the bridge\n\nLeave it running while you use Sesori from your phone.'**
+  String get projectsBridgeOfflineStartBridgeInfo;
+
+  /// Accessibility label for the machine-name row on the bridge-offline Projects screen when it opens a menu listing every machine with a registered bridge.
+  ///
+  /// In en, this message translates to:
+  /// **'Show registered machines'**
+  String get projectsBridgeOfflineMachinesSemantics;
 
   /// No description provided for @connectionLostTitle.
   ///

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -145,7 +145,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectsOnboardingStepInfoSemantics => 'More information';
 
   @override
-  String get projectsBridgeOfflineTitle => 'Bridge disconnected';
+  String get projectsBridgeOfflineDisconnected => 'Disconnected';
 
   @override
   String get projectsBridgeOfflineReconnect => 'Reconnect';
@@ -154,7 +154,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectsBridgeOfflineInstallCommands => 'Install commands';
 
   @override
-  String get projectsBridgeOfflineRunBridge => 'Run the bridge';
+  String get projectsBridgeOfflineStartBridge => 'Start your bridge';
+
+  @override
+  String get projectsBridgeOfflineStartBridgeInfo =>
+      'Start the bridge\n\nLeave it running while you use Sesori from your phone.';
+
+  @override
+  String get projectsBridgeOfflineMachinesSemantics => 'Show registered machines';
 
   @override
   String get connectionLostTitle => 'Connection Lost';

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -157,11 +157,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectsBridgeOfflineStartBridge => 'Start your bridge';
 
   @override
-  String get projectsBridgeOfflineStartBridgeInfo =>
-      'Start the bridge\n\nLeave it running while you use Sesori from your phone.';
-
-  @override
-  String get projectsBridgeOfflineMachinesSemantics => 'Show registered machines';
+  String get projectsBridgeOfflineStartBridgeInfo => 'Leave it running while you use Sesori from your phone.';
 
   @override
   String get connectionLostTitle => 'Connection Lost';

--- a/client/app/test/core/routing/adaptive_session_router_test_harness.dart
+++ b/client/app/test/core/routing/adaptive_session_router_test_harness.dart
@@ -84,6 +84,7 @@ class AdaptiveSessionRouterTestHarness {
     ).thenAnswer((_) async => ApiResponse.success(const <BridgeSummary>[]));
 
     when(() => registeredBridgesService.hasRegisteredBridges()).thenAnswer((_) async => false);
+    when(() => registeredBridgesService.getRegisteredBridges()).thenAnswer((_) async => const []);
 
     when(
       () => projectService.listSessions(

--- a/client/app/test/features/project_list/bridge_offline_view_test.dart
+++ b/client/app/test/features/project_list/bridge_offline_view_test.dart
@@ -123,8 +123,6 @@ void main() {
       await pumpScreen(tester);
 
       expect(find.text("Macbook-Pro.local"), findsOneWidget);
-      // A single machine is a plain label — no menu affordance.
-      expect(find.bySemanticsLabel(RegExp("Show registered machines")), findsNothing);
     });
 
     testWidgets("is hidden when the registered bridges could not be fetched", (tester) async {
@@ -136,42 +134,25 @@ void main() {
       expect(find.text("Start your bridge"), findsOneWidget);
     });
 
-    testWidgets("with several machines, tapping the row lists them all", (tester) async {
+    testWidgets("is a static label: only the most recent machine, tapping does nothing", (tester) async {
       when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer(
         (_) async => [
           _bridge(id: "a", name: "Macbook-Pro.local", lastSeenAt: DateTime.utc(2026, 7, 1)),
           _bridge(id: "b", name: "work-desktop", platform: "linux"),
-          _bridge(id: "c", name: "lab-box", platform: "freebsd"),
         ],
       );
 
       await pumpScreen(tester);
 
-      // The row names the most recent machine and carries the menu affordance.
+      // One bridge at a time: stale extra registrations are never listed.
       expect(find.text("Macbook-Pro.local"), findsOneWidget);
       expect(find.text("work-desktop"), findsNothing);
 
-      await tester.tap(find.bySemanticsLabel(RegExp("Show registered machines")));
+      // Not tappable — no menu or sheet opens off the row.
+      await tester.tap(find.text("Macbook-Pro.local"));
       await tester.pumpAndSettle();
-
-      // Menu open: every registered machine is listed with its platform —
-      // known ids prettified, unknown ones (freebsd) shown raw.
-      expect(find.text("Macbook-Pro.local"), findsNWidgets(2));
-      expect(find.text("work-desktop"), findsOneWidget);
-      expect(find.text("lab-box"), findsOneWidget);
-      expect(find.text("macOS"), findsOneWidget);
-      expect(find.text("Linux"), findsOneWidget);
-      expect(find.text("freebsd"), findsOneWidget);
-
-      // The selected marker sits on the machine the row names (the most
-      // recently seen one), not on any other entry.
-      final checkIcon = find.byIcon(Icons.check);
-      expect(checkIcon, findsOneWidget);
-      final markedTile = find.ancestor(of: checkIcon, matching: find.byType(InkWell)).first;
-      expect(
-        find.descendant(of: markedTile, matching: find.text("Macbook-Pro.local")),
-        findsOneWidget,
-      );
+      expect(find.text("Macbook-Pro.local"), findsOneWidget);
+      expect(find.text("work-desktop"), findsNothing);
     });
   });
 
@@ -183,7 +164,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      find.text("Start the bridge\n\nLeave it running while you use Sesori from your phone."),
+      find.text("Leave it running while you use Sesori from your phone."),
       findsOneWidget,
     );
   });

--- a/client/app/test/features/project_list/bridge_offline_view_test.dart
+++ b/client/app/test/features/project_list/bridge_offline_view_test.dart
@@ -1,0 +1,215 @@
+import "package:flutter/material.dart";
+import "package:flutter_bloc/flutter_bloc.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:mocktail/mocktail.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_mobile/core/analytics/analytics_reporter.dart";
+import "package:sesori_mobile/core/di/injection.dart";
+import "package:sesori_mobile/features/project_list/project_list_screen.dart";
+import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/module_prego.dart";
+
+import "../../helpers/test_helpers.dart";
+
+// ---------------------------------------------------------------------------
+// Behaviour guards for the redesigned bridge-offline recovery view: the
+// machine-name row fed from the account's registered bridges, the
+// "Start your bridge" info popover, and the install-commands disclosure that
+// now closes the body.
+//
+// Pumps the real [ProjectListScreen] (its cubit is built from getIt, so every
+// dependency is registered as a mock below) driven into the bridge-offline
+// state through the connection status stream.
+// ---------------------------------------------------------------------------
+
+const _connectionConfig = ServerConnectionConfig(
+  relayHost: "relay.example.com",
+  authToken: "test-token",
+);
+const _health = HealthResponse(healthy: true, version: "0.1.200", filesystemAccessDegraded: null);
+const _bridgeOfflineStatus = ConnectionStatus.bridgeOffline(
+  config: _connectionConfig,
+  health: _health,
+);
+
+BridgeSummary _bridge({
+  required String id,
+  required String name,
+  String platform = "macos",
+  DateTime? lastSeenAt,
+}) {
+  return BridgeSummary(
+    id: id,
+    name: name,
+    platform: platform,
+    addedAt: DateTime.utc(2026, 1, 1),
+    lastSeenAt: lastSeenAt,
+  );
+}
+
+void main() {
+  late MockProjectService mockProjectService;
+  late MockConnectionService mockConnectionService;
+  late MockRegisteredBridgesService mockRegisteredBridgesService;
+  late StubConnectionOverlayCubit overlayCubit;
+  late BehaviorSubject<ConnectionStatus> statusController;
+
+  setUpAll(registerAllFallbackValues);
+
+  setUp(() {
+    mockProjectService = MockProjectService();
+    mockConnectionService = MockConnectionService();
+    mockRegisteredBridgesService = MockRegisteredBridgesService();
+    overlayCubit = StubConnectionOverlayCubit();
+    statusController = BehaviorSubject<ConnectionStatus>.seeded(_bridgeOfflineStatus);
+
+    when(() => mockConnectionService.status).thenAnswer((_) => statusController.stream);
+    when(() => mockConnectionService.currentStatus).thenAnswer((_) => statusController.value);
+    when(() => mockConnectionService.connectWithFreshAuthToken()).thenAnswer((_) async => true);
+    when(() => mockProjectService.listProjects()).thenAnswer(
+      (_) async => ApiResponse.error(ApiError.generic()),
+    );
+    when(() => mockRegisteredBridgesService.hasRegisteredBridges()).thenAnswer((_) async => true);
+    when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer((_) async => const []);
+
+    getIt.registerLazySingleton<ProjectService>(() => mockProjectService);
+    getIt.registerLazySingleton<ConnectionService>(() => mockConnectionService);
+    getIt.registerLazySingleton<SseEventRepository>(MockSseEventRepository.new);
+    getIt.registerLazySingleton<RouteSource>(MockRouteSource.new);
+    getIt.registerLazySingleton<SessionUnseenTracker>(FakeSessionUnseenTracker.new);
+    getIt.registerLazySingleton<RegisteredBridgesService>(() => mockRegisteredBridgesService);
+    getIt.registerLazySingleton<FailureReporter>(MockFailureReporter.new);
+    getIt.registerLazySingleton<AnalyticsReporter>(MockAnalyticsReporter.new);
+  });
+
+  tearDown(() async {
+    await overlayCubit.close();
+    await statusController.close();
+    await getIt.reset();
+  });
+
+  /// Pumps the screen and settles. The tall viewport keeps the whole offline
+  /// body on-stage so taps land without scrolling; unmounting at the end of
+  /// the test disposes the screen's minute ticker, which would otherwise
+  /// linger as a pending timer.
+  Future<void> pumpScreen(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(393, 1500);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      BlocProvider<ConnectionOverlayCubit>.value(
+        value: overlayCubit,
+        child: MaterialApp(
+          theme: ThemeData(extensions: [PregoDesignSystem.light]),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const ProjectListScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text("Disconnected"), findsOneWidget);
+    addTearDown(() => tester.pumpWidget(const SizedBox.shrink()));
+  }
+
+  group("machine-name row", () {
+    testWidgets("names the most recently seen registered bridge", (tester) async {
+      when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer(
+        (_) async => [_bridge(id: "a", name: "Macbook-Pro.local", lastSeenAt: DateTime.utc(2026, 7, 1))],
+      );
+
+      await pumpScreen(tester);
+
+      expect(find.text("Macbook-Pro.local"), findsOneWidget);
+      // A single machine is a plain label — no menu affordance.
+      expect(find.bySemanticsLabel(RegExp("Show registered machines")), findsNothing);
+    });
+
+    testWidgets("is hidden when the registered bridges could not be fetched", (tester) async {
+      await pumpScreen(tester);
+
+      expect(find.byIcon(TablerRegular.device_laptop), findsNothing);
+      // The recovery view itself still renders in full.
+      expect(find.text("Reconnect"), findsOneWidget);
+      expect(find.text("Start your bridge"), findsOneWidget);
+    });
+
+    testWidgets("with several machines, tapping the row lists them all", (tester) async {
+      when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer(
+        (_) async => [
+          _bridge(id: "a", name: "Macbook-Pro.local", lastSeenAt: DateTime.utc(2026, 7, 1)),
+          _bridge(id: "b", name: "work-desktop", platform: "linux"),
+          _bridge(id: "c", name: "lab-box", platform: "freebsd"),
+        ],
+      );
+
+      await pumpScreen(tester);
+
+      // The row names the most recent machine and carries the menu affordance.
+      expect(find.text("Macbook-Pro.local"), findsOneWidget);
+      expect(find.text("work-desktop"), findsNothing);
+
+      await tester.tap(find.bySemanticsLabel(RegExp("Show registered machines")));
+      await tester.pumpAndSettle();
+
+      // Menu open: every registered machine is listed with its platform —
+      // known ids prettified, unknown ones (freebsd) shown raw.
+      expect(find.text("Macbook-Pro.local"), findsNWidgets(2));
+      expect(find.text("work-desktop"), findsOneWidget);
+      expect(find.text("lab-box"), findsOneWidget);
+      expect(find.text("macOS"), findsOneWidget);
+      expect(find.text("Linux"), findsOneWidget);
+      expect(find.text("freebsd"), findsOneWidget);
+
+      // The selected marker sits on the machine the row names (the most
+      // recently seen one), not on any other entry.
+      final checkIcon = find.byIcon(Icons.check);
+      expect(checkIcon, findsOneWidget);
+      final markedTile = find.ancestor(of: checkIcon, matching: find.byType(InkWell)).first;
+      expect(
+        find.descendant(of: markedTile, matching: find.text("Macbook-Pro.local")),
+        findsOneWidget,
+      );
+    });
+  });
+
+  testWidgets("the Start-your-bridge info icon opens its explainer popover", (tester) async {
+    await pumpScreen(tester);
+
+    // The "Start your bridge" label owns the only info trigger on this view.
+    await tester.tap(find.bySemanticsLabel("More information"));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text("Start the bridge\n\nLeave it running while you use Sesori from your phone."),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets("the install-commands disclosure closes the body and expands in place", (tester) async {
+    await pumpScreen(tester);
+
+    // End-of-body ordering: Reconnect → run box → explainer → disclosure.
+    final reconnectY = tester.getTopLeft(find.text("Reconnect")).dy;
+    final runBoxY = tester.getTopLeft(find.text("Start your bridge")).dy;
+    final whyY = tester.getTopLeft(find.text("Why is this needed?")).dy;
+    final disclosureY = tester.getTopLeft(find.text("Install commands")).dy;
+    expect(reconnectY, lessThan(runBoxY));
+    expect(runBoxY, lessThan(whyY));
+    expect(whyY, lessThan(disclosureY));
+
+    // Collapsed: no install command boxes on stage.
+    expect(find.text("macOS, Linux, WSL"), findsNothing);
+
+    await tester.tap(find.text("Install commands"));
+    await tester.pumpAndSettle();
+
+    // Expanded: the install boxes unfold below the disclosure button. The
+    // centred body shifts up as it grows, so re-measure the button.
+    final expandedDisclosureY = tester.getTopLeft(find.text("Install commands")).dy;
+    final installBoxY = tester.getTopLeft(find.text("macOS, Linux, WSL")).dy;
+    expect(installBoxY, greaterThan(expandedDisclosureY));
+  });
+}

--- a/client/app/test/features/project_list/onboarding_analytics_test.dart
+++ b/client/app/test/features/project_list/onboarding_analytics_test.dart
@@ -60,6 +60,7 @@ void main() {
     when(() => mockConnectionService.status).thenAnswer((_) => statusController.stream);
     when(() => mockConnectionService.currentStatus).thenAnswer((_) => statusController.value);
     when(() => mockConnectionService.connectWithFreshAuthToken()).thenAnswer((_) async => true);
+    when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer((_) async => const []);
     when(() => mockUrlLauncher.launch(any())).thenAnswer((_) async => true);
     when(
       () => mockAnalyticsReporter.logEvent(event: any(named: "event")),
@@ -136,7 +137,7 @@ void main() {
     );
     when(() => mockRegisteredBridgesService.hasRegisteredBridges()).thenAnswer((_) async => true);
     await pumpScreen(tester);
-    expect(find.text("Bridge disconnected"), findsOneWidget);
+    expect(find.text("Disconnected"), findsOneWidget);
   }
 
   void verifyLogged(AnalyticsEvent event) {
@@ -344,8 +345,9 @@ void main() {
       await tester.tap(find.text("Install commands"));
       await tester.pumpAndSettle();
 
-      // Expanded, the install box sits above the run box.
-      await tester.tap(find.bySemanticsLabel("Copy command").at(0));
+      // Expanded, the install box unfolds below the disclosure at the end of
+      // the body, so it sits after the always-visible run box.
+      await tester.tap(find.bySemanticsLabel("Copy command").at(1));
       await tester.pumpAndSettle();
 
       verifyLogged(
@@ -355,6 +357,32 @@ void main() {
           surface: OnboardingSurface.bridgeOffline,
         ),
       );
+    });
+
+    testWidgets("tapping the Need help pill logs the bridge-offline surface", (tester) async {
+      await pumpBridgeOffline(tester);
+
+      await tester.tap(find.text("Need help?"));
+      await tester.pumpAndSettle();
+
+      verifyLogged(
+        const AnalyticsEvent.needHelpMenuOpened(surface: OnboardingSurface.bridgeOffline),
+      );
+      // The popup actually opened alongside the event.
+      expect(find.text("Email"), findsOneWidget);
+    });
+
+    testWidgets("opening the why-bridge explainer logs the bridge-offline surface", (tester) async {
+      await pumpBridgeOffline(tester);
+
+      await tester.tap(find.text("Why is this needed?"));
+      await tester.pumpAndSettle();
+
+      verifyLogged(
+        const AnalyticsEvent.whyBridgeOpened(surface: OnboardingSurface.bridgeOffline),
+      );
+      // The sheet actually opened alongside the event (button + sheet title).
+      expect(find.text("Why is this needed?"), findsNWidgets(2));
     });
   });
 }

--- a/client/app/test/features/project_list/project_list_banner_suppression_test.dart
+++ b/client/app/test/features/project_list/project_list_banner_suppression_test.dart
@@ -44,6 +44,7 @@ void main() {
     when(() => mockConnectionService.currentStatus).thenAnswer((_) => statusController.value);
     when(() => mockConnectionService.connectWithFreshAuthToken()).thenAnswer((_) async => true);
     when(() => mockRegisteredBridgesService.hasRegisteredBridges()).thenAnswer((_) async => true);
+    when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer((_) async => const []);
 
     getIt.registerLazySingleton<ProjectService>(() => mockProjectService);
     getIt.registerLazySingleton<ConnectionService>(() => mockConnectionService);
@@ -83,7 +84,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // The dedicated "turn on your bridge" view owns the messaging …
-    expect(find.text("Bridge disconnected"), findsOneWidget);
+    expect(find.text("Disconnected"), findsOneWidget);
     // … and the nav banner stays out of it.
     expect(find.byType(ConnectionBanner), findsNothing);
   });

--- a/client/app/test/features/project_list/project_list_collapsing_title_test.dart
+++ b/client/app/test/features/project_list/project_list_collapsing_title_test.dart
@@ -60,6 +60,7 @@ void main() {
 
   Future<void> pumpScreen(WidgetTester tester, {required bool hasRegisteredBridges}) async {
     when(() => mockRegisteredBridgesService.hasRegisteredBridges()).thenAnswer((_) async => hasRegisteredBridges);
+    when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer((_) async => const []);
     // A phone-width viewport, deliberately short so both bodies overflow it.
     // Overflow is the precondition for the behaviour under test: a body that
     // fits leaves the page with no scroll extent, and a large title with
@@ -105,15 +106,19 @@ void main() {
 
   testWidgets("the bridge-offline body scrolls the page, collapsing the large title", (tester) async {
     await pumpScreen(tester, hasRegisteredBridges: true);
-    expect(find.text("Bridge disconnected"), findsOneWidget);
+    expect(find.text("Disconnected"), findsOneWidget);
     // A single scroll view for the whole page — the body no longer nests one.
     expect(find.byType(CustomScrollView), findsOneWidget);
     expect(find.byType(SingleChildScrollView), findsNothing);
 
-    // Collapsed, the view fits the viewport and there is nothing to scroll.
-    // Expanding the install commands overflows it, which is when the title must
-    // travel with the content.
+    // Expanding the install commands (the disclosure at the end of the body)
+    // grows the body past the viewport, which is when the title must travel
+    // with the content. The button may itself sit below the short viewport, so
+    // scroll it into view first, then return to the top for a clean baseline.
+    await tester.scrollUntilVisible(find.text("Install commands", skipOffstage: false), 100);
     await tester.tap(find.text("Install commands"));
+    await tester.pumpAndSettle();
+    await tester.drag(find.byType(CustomScrollView), const Offset(0, 600), warnIfMissed: false);
     await tester.pumpAndSettle();
 
     final titleBefore = tester.getTopLeft(largeTitle("Projects")).dy;

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -217,6 +217,26 @@ class ProjectListCubit extends Cubit<ProjectListState> {
     if (isClosed) return;
     if (!_isBridgeUnavailable) return;
     emit(ProjectListState.bridgeDisconnected(hasRegisteredBridges: hasRegisteredBridges));
+    // The machine identity arrives as an enrichment of the already-shown state:
+    // the latch above resolves without the network in the common (latched)
+    // case, so the recovery view is never held back by this fetch — and a
+    // failed fetch (e.g. the phone itself is offline) simply leaves the
+    // machine-name row hidden. The setup onboarding has no machine row, so a
+    // bridge-less account skips the fetch entirely.
+    if (!hasRegisteredBridges) return;
+    final bridges = await _registeredBridgesService.getRegisteredBridges();
+    if (isClosed || bridges.isEmpty) return;
+    // The bridge may have come back while the fetch was in flight — the
+    // connected transition owns the next state then.
+    if (!_isBridgeUnavailable) return;
+    if (state case ProjectListBridgeDisconnected(:final hasRegisteredBridges)) {
+      emit(
+        ProjectListState.bridgeDisconnected(
+          hasRegisteredBridges: hasRegisteredBridges,
+          bridges: bridges,
+        ),
+      );
+    }
   }
 
   void _onStaleReconnect() {

--- a/client/module_core/lib/src/cubits/project_list/project_list_state.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_state.dart
@@ -37,5 +37,12 @@ sealed class ProjectListState with _$ProjectListState {
   ///   bridge" view.
   const factory ProjectListState.bridgeDisconnected({
     required bool hasRegisteredBridges,
+
+    /// The account's registered bridges (most recently seen first), so the UI
+    /// can name the machine it is trying to reach. Emitted empty first and
+    /// enriched by a follow-up emit once the fetch resolves; stays empty when
+    /// the fetch fails (e.g. the phone itself is offline) — the UI hides the
+    /// machine identity in that case.
+    @Default(<BridgeSummary>[]) List<BridgeSummary> bridges,
   }) = ProjectListBridgeDisconnected;
 }

--- a/client/module_core/lib/src/cubits/project_list/project_list_state.freezed.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_state.freezed.dart
@@ -240,10 +240,25 @@ as RemoteFailureReason,
 
 
 class ProjectListBridgeDisconnected implements ProjectListState {
-  const ProjectListBridgeDisconnected({required this.hasRegisteredBridges});
+  const ProjectListBridgeDisconnected({required this.hasRegisteredBridges, final  List<BridgeSummary> bridges = const <BridgeSummary>[]}): _bridges = bridges;
   
 
  final  bool hasRegisteredBridges;
+/// The account's registered bridges (most recently seen first) as resolved
+/// when this state was emitted, so the UI can name the machine it is
+/// trying to reach. Empty when the lookup failed (e.g. the phone itself is
+/// offline) — the UI hides the machine identity in that case.
+ final  List<BridgeSummary> _bridges;
+/// The account's registered bridges (most recently seen first) as resolved
+/// when this state was emitted, so the UI can name the machine it is
+/// trying to reach. Empty when the lookup failed (e.g. the phone itself is
+/// offline) — the UI hides the machine identity in that case.
+@JsonKey() List<BridgeSummary> get bridges {
+  if (_bridges is EqualUnmodifiableListView) return _bridges;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_bridges);
+}
+
 
 /// Create a copy of ProjectListState
 /// with the given fields replaced by the non-null parameter values.
@@ -255,16 +270,16 @@ $ProjectListBridgeDisconnectedCopyWith<ProjectListBridgeDisconnected> get copyWi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectListBridgeDisconnected&&(identical(other.hasRegisteredBridges, hasRegisteredBridges) || other.hasRegisteredBridges == hasRegisteredBridges));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectListBridgeDisconnected&&(identical(other.hasRegisteredBridges, hasRegisteredBridges) || other.hasRegisteredBridges == hasRegisteredBridges)&&const DeepCollectionEquality().equals(other._bridges, _bridges));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,hasRegisteredBridges);
+int get hashCode => Object.hash(runtimeType,hasRegisteredBridges,const DeepCollectionEquality().hash(_bridges));
 
 @override
 String toString() {
-  return 'ProjectListState.bridgeDisconnected(hasRegisteredBridges: $hasRegisteredBridges)';
+  return 'ProjectListState.bridgeDisconnected(hasRegisteredBridges: $hasRegisteredBridges, bridges: $bridges)';
 }
 
 
@@ -275,7 +290,7 @@ abstract mixin class $ProjectListBridgeDisconnectedCopyWith<$Res> implements $Pr
   factory $ProjectListBridgeDisconnectedCopyWith(ProjectListBridgeDisconnected value, $Res Function(ProjectListBridgeDisconnected) _then) = _$ProjectListBridgeDisconnectedCopyWithImpl;
 @useResult
 $Res call({
- bool hasRegisteredBridges
+ bool hasRegisteredBridges, List<BridgeSummary> bridges
 });
 
 
@@ -292,10 +307,11 @@ class _$ProjectListBridgeDisconnectedCopyWithImpl<$Res>
 
 /// Create a copy of ProjectListState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? hasRegisteredBridges = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? hasRegisteredBridges = null,Object? bridges = null,}) {
   return _then(ProjectListBridgeDisconnected(
 hasRegisteredBridges: null == hasRegisteredBridges ? _self.hasRegisteredBridges : hasRegisteredBridges // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,bridges: null == bridges ? _self._bridges : bridges // ignore: cast_nullable_to_non_nullable
+as List<BridgeSummary>,
   ));
 }
 

--- a/client/module_core/lib/src/services/registered_bridges_service.dart
+++ b/client/module_core/lib/src/services/registered_bridges_service.dart
@@ -158,7 +158,7 @@ class RegisteredBridgesService {
           // write, so reporting the bridges here would still leak the old
           // account's answer to the caller. Retire the result to match.
           if (generation != _authGeneration) return const [];
-          final sorted = _sortedByRecency(bridges: data);
+          final sorted = List<BridgeSummary>.unmodifiable(_sortedByRecency(bridges: data));
           _cachedBridges = sorted;
           return sorted;
         case ErrorResponse(:final error):
@@ -193,6 +193,7 @@ class RegisteredBridgesService {
     switch (status) {
       // A live E2E connection proves a bridge exists — latch without a lookup.
       case ConnectionConnected():
+        _cachedBridges = null;
         unawaited(_latch());
       // Parked offline: (re)resolve so a consumer of [isRegistered] alone — the
       // overlay — gets the right answer. Coalesced, and a no-op once latched.

--- a/client/module_core/lib/src/services/registered_bridges_service.dart
+++ b/client/module_core/lib/src/services/registered_bridges_service.dart
@@ -57,6 +57,9 @@ class RegisteredBridgesService {
   /// [getRegisteredBridges] callers onto a single network request.
   Future<List<BridgeSummary>>? _activeFetch;
 
+  /// Last successful bridge-list result, sorted in display order.
+  List<BridgeSummary>? _cachedBridges;
+
   /// Auth generation, bumped on every logout. A lookup or connection-driven
   /// latch captures this when it starts; if a logout bumps it while the
   /// operation is in flight, the operation must not write the old account's
@@ -133,6 +136,8 @@ class RegisteredBridgesService {
   /// throw (network timeout, deserialization) — rather than an ErrorResponse —
   /// would otherwise surface as an uncaught async error.
   Future<List<BridgeSummary>> getRegisteredBridges() {
+    final cached = _cachedBridges;
+    if (cached != null) return Future.value(cached);
     return _activeFetch ??= _fetchRegisteredBridges().whenComplete(() => _activeFetch = null);
   }
 
@@ -153,7 +158,9 @@ class RegisteredBridgesService {
           // write, so reporting the bridges here would still leak the old
           // account's answer to the caller. Retire the result to match.
           if (generation != _authGeneration) return const [];
-          return _sortedByRecency(bridges: data);
+          final sorted = _sortedByRecency(bridges: data);
+          _cachedBridges = sorted;
+          return sorted;
         case ErrorResponse(:final error):
           logw("Failed to fetch registered bridges: ${error.toString()}");
           return const [];
@@ -171,7 +178,11 @@ class RegisteredBridgesService {
     return [...bridges]..sort((a, b) {
       final aSeen = a.lastSeenAt;
       final bSeen = b.lastSeenAt;
-      if (aSeen != null && bSeen != null) return bSeen.compareTo(aSeen);
+      if (aSeen != null && bSeen != null) {
+        final seenCompare = bSeen.compareTo(aSeen);
+        if (seenCompare != 0) return seenCompare;
+        return b.addedAt.compareTo(a.addedAt);
+      }
       if (aSeen != null) return -1;
       if (bSeen != null) return 1;
       return b.addedAt.compareTo(a.addedAt);
@@ -226,6 +237,7 @@ class RegisteredBridgesService {
   }
 
   void _reset() {
+    _cachedBridges = null;
     if (!_isRegistered.isClosed && _isRegistered.value) _isRegistered.add(false);
   }
 

--- a/client/module_core/lib/src/services/registered_bridges_service.dart
+++ b/client/module_core/lib/src/services/registered_bridges_service.dart
@@ -3,6 +3,7 @@ import "dart:async";
 import "package:injectable/injectable.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
+import "package:sesori_shared/sesori_shared.dart";
 
 import "../capabilities/server_connection/connection_service.dart";
 import "../capabilities/server_connection/models/connection_status.dart";
@@ -51,6 +52,10 @@ class RegisteredBridgesService {
   /// In-flight resolution, used to coalesce concurrent [hasRegisteredBridges]
   /// callers onto a single lookup.
   Future<bool>? _activeLookup;
+
+  /// In-flight bridge-list fetch, used to coalesce concurrent
+  /// [getRegisteredBridges] callers onto a single network request.
+  Future<List<BridgeSummary>>? _activeFetch;
 
   /// Auth generation, bumped on every logout. A lookup or connection-driven
   /// latch captures this when it starts; if a logout bumps it while the
@@ -115,36 +120,62 @@ class RegisteredBridgesService {
     return _lookup();
   }
 
-  Future<bool> _lookup() async {
-    // Invoked fire-and-forget from the connection listener, so an unexpected
-    // throw (network timeout, deserialization) — rather than an ErrorResponse —
-    // would otherwise surface as an uncaught async error. Fail soft to `false`,
-    // the safe default for an account we can't classify yet.
+  Future<bool> _lookup() async => (await getRegisteredBridges()).isNotEmpty;
+
+  /// Fetches the account's registered bridges from the auth server, most
+  /// recently seen first, latching the positive has-registered answer as a
+  /// side effect. Concurrent calls are coalesced into a single request.
+  ///
+  /// Fail-soft: an error response, an unexpected throw, or a logout racing the
+  /// request all yield an empty list, so callers degrade (e.g. hide the
+  /// machine-name row) instead of surfacing a failure. Reached fire-and-forget
+  /// from the connection listener via [hasRegisteredBridges], so an unexpected
+  /// throw (network timeout, deserialization) — rather than an ErrorResponse —
+  /// would otherwise surface as an uncaught async error.
+  Future<List<BridgeSummary>> getRegisteredBridges() {
+    return _activeFetch ??= _fetchRegisteredBridges().whenComplete(() => _activeFetch = null);
+  }
+
+  Future<List<BridgeSummary>> _fetchRegisteredBridges() async {
     final generation = _authGeneration;
     try {
       final response = await _bridgeRepository.getRegisteredBridges();
       // A logout during the in-flight request retires this result: the account
-      // that asked is gone, so latching its answer would leak onto the device
-      // and the next account would inherit it.
-      if (generation != _authGeneration) return false;
+      // that asked is gone, so latching or reporting its answer would leak onto
+      // the device and the next account would inherit it.
+      if (generation != _authGeneration) return const [];
       switch (response) {
         case SuccessResponse(:final data):
-          if (data.isEmpty) return false;
+          if (data.isEmpty) return const [];
           // Latch the positive answer so future transitions skip the network.
           await _latch(generation);
           // A logout may have raced the latch: it abandons (and undoes) the
-          // write, so reporting success here would still leak the old account's
-          // answer to the caller. Retire the result to match the latch.
-          if (generation != _authGeneration) return false;
-          return true;
+          // write, so reporting the bridges here would still leak the old
+          // account's answer to the caller. Retire the result to match.
+          if (generation != _authGeneration) return const [];
+          return _sortedByRecency(bridges: data);
         case ErrorResponse(:final error):
           logw("Failed to fetch registered bridges: ${error.toString()}");
-          return false;
+          return const [];
       }
     } on Object catch (error, stackTrace) {
       logw("Failed to fetch registered bridges (unexpected error)", error, stackTrace);
-      return false;
+      return const [];
     }
+  }
+
+  /// Most recently seen bridge first; never-seen bridges sort after seen ones,
+  /// newest registration first among themselves. The first entry is what a
+  /// consumer should name when it has room for only one machine.
+  static List<BridgeSummary> _sortedByRecency({required List<BridgeSummary> bridges}) {
+    return [...bridges]..sort((a, b) {
+      final aSeen = a.lastSeenAt;
+      final bSeen = b.lastSeenAt;
+      if (aSeen != null && bSeen != null) return bSeen.compareTo(aSeen);
+      if (aSeen != null) return -1;
+      if (bSeen != null) return 1;
+      return b.addedAt.compareTo(a.addedAt);
+    });
   }
 
   void _onConnectionStatusChanged(ConnectionStatus status) {

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -72,6 +72,7 @@ void main() {
       when(() => mockConnectionService.connectWithFreshAuthToken()).thenAnswer((_) async => true);
       // Default: a fresh account with no registered bridge (setup onboarding).
       when(() => mockRegisteredBridgesService.hasRegisteredBridges()).thenAnswer((_) async => false);
+      when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer((_) async => const []);
       when(
         () => mockFailureReporter.recordFailure(
           error: any(named: "error"),
@@ -516,6 +517,9 @@ void main() {
             isFalse,
           ),
         ],
+        // The setup onboarding has no machine row, so the bridge list is never
+        // fetched for a bridge-less account.
+        verify: (_) => verifyNever(() => mockRegisteredBridgesService.getRegisteredBridges()),
       );
 
       blocTest<ProjectListCubit, ProjectListState>(
@@ -526,12 +530,66 @@ void main() {
           when(() => mockRegisteredBridgesService.hasRegisteredBridges()).thenAnswer((_) async => true);
           return buildCubit();
         },
+        // The bridge fetch failed (empty list) while the boolean latch still
+        // answers positively — the turn-on view must be picked regardless, just
+        // without a machine name (no enrichment emit for an empty list).
         expect: () => [
-          isA<ProjectListBridgeDisconnected>().having(
-            (s) => s.hasRegisteredBridges,
-            "hasRegisteredBridges",
-            isTrue,
-          ),
+          isA<ProjectListBridgeDisconnected>()
+              .having((s) => s.hasRegisteredBridges, "hasRegisteredBridges", isTrue)
+              .having((s) => s.bridges, "bridges", isEmpty),
+        ],
+      );
+
+      blocTest<ProjectListCubit, ProjectListState>(
+        "the fetched machine identity enriches the disconnected state in a follow-up emit",
+        build: () {
+          statusController.add(const ConnectionStatus.disconnected());
+          when(() => mockConnectionService.connectWithFreshAuthToken()).thenAnswer((_) async => false);
+          when(() => mockRegisteredBridgesService.hasRegisteredBridges()).thenAnswer((_) async => true);
+          when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer(
+            (_) async => [testBridgeSummary(name: "Macbook-Pro.local")],
+          );
+          return buildCubit();
+        },
+        // The recovery view shows immediately off the latch; the machine names
+        // land as a second emit once the fetch resolves.
+        expect: () => [
+          isA<ProjectListBridgeDisconnected>()
+              .having((s) => s.hasRegisteredBridges, "hasRegisteredBridges", isTrue)
+              .having((s) => s.bridges, "bridges", isEmpty),
+          isA<ProjectListBridgeDisconnected>()
+              .having((s) => s.hasRegisteredBridges, "hasRegisteredBridges", isTrue)
+              .having((s) => s.bridges.map((b) => b.name), "bridge names", ["Macbook-Pro.local"]),
+        ],
+      );
+
+      blocTest<ProjectListCubit, ProjectListState>(
+        "connection recovery during the bridge fetch suppresses the stale enrichment emit",
+        build: () {
+          statusController.add(const ConnectionStatus.disconnected());
+          when(() => mockConnectionService.connectWithFreshAuthToken()).thenAnswer((_) async => false);
+          when(() => mockRegisteredBridgesService.hasRegisteredBridges()).thenAnswer((_) async => true);
+          pendingLookupGate = Completer<bool>();
+          when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer(
+            (_) => pendingLookupGate.future.then((_) => [testBridgeSummary(name: "Macbook-Pro.local")]),
+          );
+          addTearDown(() {
+            if (!pendingLookupGate.isCompleted) pendingLookupGate.complete(true);
+          });
+          return buildCubit();
+        },
+        act: (cubit) async {
+          await Future<void>.delayed(Duration.zero); // bridge fetch now in flight
+          // The bridge connects while the fetch is pending. Mutate currentStatus
+          // directly (no stream event) so only the post-fetch guard is exercised.
+          when(() => mockConnectionService.currentStatus).thenReturn(_connectedStatus);
+          pendingLookupGate.complete(true);
+          await Future<void>.delayed(Duration.zero);
+        },
+        // Only the immediate name-less state; no enrichment over the recovered
+        // connection — the connected transition owns the next state.
+        expect: () => [
+          isA<ProjectListBridgeDisconnected>().having((s) => s.bridges, "bridges", isEmpty),
         ],
       );
 

--- a/client/module_core/test/helpers/test_helpers.dart
+++ b/client/module_core/test/helpers/test_helpers.dart
@@ -310,13 +310,13 @@ HealthResponse testHealthResponse() {
   return const HealthResponse(healthy: true, version: "0.1.200", filesystemAccessDegraded: null);
 }
 
-BridgeSummary testBridgeSummary({String? id, String? name}) {
+BridgeSummary testBridgeSummary({String? id, String? name, DateTime? addedAt, DateTime? lastSeenAt}) {
   return BridgeSummary(
     id: id ?? "br_test1234",
     name: name ?? "test-macbook",
     platform: "macos",
-    addedAt: DateTime.utc(2026, 1, 1),
-    lastSeenAt: null,
+    addedAt: addedAt ?? DateTime.utc(2026, 1, 1),
+    lastSeenAt: lastSeenAt,
   );
 }
 

--- a/client/module_core/test/services/registered_bridges_service_test.dart
+++ b/client/module_core/test/services/registered_bridges_service_test.dart
@@ -134,18 +134,56 @@ void main() {
     test("returns the fetched bridges most recently seen first and latches the store", () async {
       final seenEarlier = testBridgeSummary(id: "a", name: "old-laptop", lastSeenAt: DateTime.utc(2026, 6, 1));
       final seenLatest = testBridgeSummary(id: "b", name: "new-laptop", lastSeenAt: DateTime.utc(2026, 7, 1));
+      final seenSameTimeNewer = testBridgeSummary(
+        id: "e",
+        name: "newest-tied-laptop",
+        addedAt: DateTime.utc(2026, 5, 3),
+        lastSeenAt: DateTime.utc(2026, 6, 1),
+      );
       final neverSeenNewer = testBridgeSummary(id: "c", name: "fresh-desktop", addedAt: DateTime.utc(2026, 5, 2));
       final neverSeenOlder = testBridgeSummary(id: "d", name: "stale-desktop", addedAt: DateTime.utc(2026, 5, 1));
       when(() => bridgeRepository.getRegisteredBridges()).thenAnswer(
-        (_) async => ApiResponse.success([neverSeenOlder, seenEarlier, neverSeenNewer, seenLatest]),
+        (_) async => ApiResponse.success([neverSeenOlder, seenEarlier, seenSameTimeNewer, neverSeenNewer, seenLatest]),
       );
       final service = build();
 
       final bridges = await service.getRegisteredBridges();
 
-      expect(bridges.map((b) => b.id), ["b", "a", "c", "d"]);
+      expect(bridges.map((b) => b.id), ["b", "e", "a", "c", "d"]);
       expect(service.isRegistered.value, isTrue);
       verify(() => store.markRegistered()).called(1);
+    });
+
+    test("reuses a bridge list fetched while resolving the registered latch", () async {
+      when(() => bridgeRepository.getRegisteredBridges()).thenAnswer(
+        (_) async => ApiResponse.success([testBridgeSummary()]),
+      );
+      final service = build();
+
+      expect(await service.hasRegisteredBridges(), isTrue);
+      final bridges = await service.getRegisteredBridges();
+
+      expect(bridges, hasLength(1));
+      verify(() => bridgeRepository.getRegisteredBridges()).called(1);
+    });
+
+    test("logout clears the cached bridge list", () async {
+      final oldBridge = testBridgeSummary(id: "old", name: "old-macbook");
+      final newBridge = testBridgeSummary(id: "new", name: "new-macbook");
+      when(() => bridgeRepository.getRegisteredBridges()).thenAnswer(
+        (_) async => ApiResponse.success([oldBridge]),
+      );
+      final service = build();
+
+      expect((await service.getRegisteredBridges()).map((b) => b.id), ["old"]);
+      authSubject.add(const AuthState.unauthenticated());
+      await _settle();
+      when(() => bridgeRepository.getRegisteredBridges()).thenAnswer(
+        (_) async => ApiResponse.success([newBridge]),
+      );
+
+      expect((await service.getRegisteredBridges()).map((b) => b.id), ["new"]);
+      verify(() => bridgeRepository.getRegisteredBridges()).called(2);
     });
 
     test("an empty result returns an empty list without latching", () async {

--- a/client/module_core/test/services/registered_bridges_service_test.dart
+++ b/client/module_core/test/services/registered_bridges_service_test.dart
@@ -167,6 +167,37 @@ void main() {
       verify(() => bridgeRepository.getRegisteredBridges()).called(1);
     });
 
+    test("returns an immutable cached bridge list", () async {
+      when(() => bridgeRepository.getRegisteredBridges()).thenAnswer(
+        (_) async => ApiResponse.success([testBridgeSummary()]),
+      );
+      final service = build();
+
+      await service.getRegisteredBridges();
+      final cached = await service.getRegisteredBridges();
+
+      expect(cached.clear, throwsUnsupportedError);
+    });
+
+    test("a live bridge connection invalidates the cached bridge list", () async {
+      final oldBridge = testBridgeSummary(id: "old", name: "old-macbook");
+      final newBridge = testBridgeSummary(id: "new", name: "new-macbook");
+      when(() => bridgeRepository.getRegisteredBridges()).thenAnswer(
+        (_) async => ApiResponse.success([oldBridge]),
+      );
+      final service = build();
+
+      expect((await service.getRegisteredBridges()).map((b) => b.id), ["old"]);
+      statusSubject.add(_connected);
+      await _settle();
+      when(() => bridgeRepository.getRegisteredBridges()).thenAnswer(
+        (_) async => ApiResponse.success([newBridge]),
+      );
+
+      expect((await service.getRegisteredBridges()).map((b) => b.id), ["new"]);
+      verify(() => bridgeRepository.getRegisteredBridges()).called(2);
+    });
+
     test("logout clears the cached bridge list", () async {
       final oldBridge = testBridgeSummary(id: "old", name: "old-macbook");
       final newBridge = testBridgeSummary(id: "new", name: "new-macbook");

--- a/client/module_core/test/services/registered_bridges_service_test.dart
+++ b/client/module_core/test/services/registered_bridges_service_test.dart
@@ -130,6 +130,84 @@ void main() {
     });
   });
 
+  group("getRegisteredBridges", () {
+    test("returns the fetched bridges most recently seen first and latches the store", () async {
+      final seenEarlier = testBridgeSummary(id: "a", name: "old-laptop", lastSeenAt: DateTime.utc(2026, 6, 1));
+      final seenLatest = testBridgeSummary(id: "b", name: "new-laptop", lastSeenAt: DateTime.utc(2026, 7, 1));
+      final neverSeenNewer = testBridgeSummary(id: "c", name: "fresh-desktop", addedAt: DateTime.utc(2026, 5, 2));
+      final neverSeenOlder = testBridgeSummary(id: "d", name: "stale-desktop", addedAt: DateTime.utc(2026, 5, 1));
+      when(() => bridgeRepository.getRegisteredBridges()).thenAnswer(
+        (_) async => ApiResponse.success([neverSeenOlder, seenEarlier, neverSeenNewer, seenLatest]),
+      );
+      final service = build();
+
+      final bridges = await service.getRegisteredBridges();
+
+      expect(bridges.map((b) => b.id), ["b", "a", "c", "d"]);
+      expect(service.isRegistered.value, isTrue);
+      verify(() => store.markRegistered()).called(1);
+    });
+
+    test("an empty result returns an empty list without latching", () async {
+      final service = build();
+
+      expect(await service.getRegisteredBridges(), isEmpty);
+      expect(service.isRegistered.value, isFalse);
+      verifyNever(() => store.markRegistered());
+    });
+
+    test("an error response fails soft to an empty list", () async {
+      when(() => bridgeRepository.getRegisteredBridges()).thenAnswer(
+        (_) async => ApiResponse.error(ApiError.generic()),
+      );
+      final service = build();
+
+      expect(await service.getRegisteredBridges(), isEmpty);
+      verifyNever(() => store.markRegistered());
+    });
+
+    test("an unexpected throw fails soft to an empty list", () async {
+      when(() => bridgeRepository.getRegisteredBridges()).thenAnswer(
+        (_) async => throw Exception("network blew up"),
+      );
+      final service = build();
+
+      expect(await service.getRegisteredBridges(), isEmpty);
+    });
+
+    test("concurrent callers are coalesced into a single network fetch", () async {
+      final gate = Completer<ApiResponse<List<BridgeSummary>>>();
+      when(() => bridgeRepository.getRegisteredBridges()).thenAnswer((_) => gate.future);
+      final service = build();
+
+      final a = service.getRegisteredBridges();
+      final b = service.getRegisteredBridges();
+      gate.complete(ApiResponse.success([testBridgeSummary()]));
+
+      final results = await Future.wait([a, b]);
+      expect(results[0], hasLength(1));
+      expect(results[1], hasLength(1));
+      verify(() => bridgeRepository.getRegisteredBridges()).called(1);
+    });
+
+    test("a logout during the fetch retires the result instead of leaking it", () async {
+      final gate = Completer<ApiResponse<List<BridgeSummary>>>();
+      when(() => bridgeRepository.getRegisteredBridges()).thenAnswer((_) => gate.future);
+      final service = build();
+      await _settle();
+
+      final pending = service.getRegisteredBridges();
+      await _settle();
+      authSubject.add(const AuthState.unauthenticated());
+      await _settle();
+      gate.complete(ApiResponse.success([testBridgeSummary()]));
+
+      expect(await pending, isEmpty);
+      expect(service.isRegistered.value, isFalse);
+      verifyNever(() => store.markRegistered());
+    });
+  });
+
   group("reactive latch", () {
     test("seeds the stream from a persisted store latch at construction (no network)", () async {
       when(() => store.hasRegisteredBridges()).thenAnswer((_) async => true);


### PR DESCRIPTION

https://github.com/user-attachments/assets/4246fb7d-881e-494b-beb9-ddbe959ac338


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the bridge-offline view to match Figma: clearer “Disconnected” status with the last-seen machine, a guided “Start your bridge” step, and install commands moved to the end. Improves recovery clarity and adds analytics coverage for the offline surface.

- **New Features**
  - Show the most recently seen machine name under “Disconnected” as a static label.
  - Add “Start your bridge” with an info popover and the start command box.
  - Make the “Why is this needed?” button tertiary on onboarding and recovery.
  - Move “Install commands” to an end-of-body disclosure with spacing for the “Need help?” button.
  - Show the “Need help?” floating menu on bridge-offline (logs bridgeOffline surface).

- **Refactors**
  - `ProjectListBridgeDisconnected` carries `bridges`; the view renders immediately and enriches with the machine name when the fetch completes.
  - New `RegisteredBridgesService.getRegisteredBridges()` API: sorts by recency, coalesces concurrent fetches, caches an immutable result (invalidated on live connection and logout), fail-softs to empty, and latches the positive “has registered” state.
  - Extracted `_InfoLabel` and applied to onboarding and recovery labels; updated “Reconnect” icon and the popover copy.
  - Updated l10n: “Bridge disconnected” → “Disconnected”; added “Start your bridge” strings and popover copy.
  - Added widget, cubit, and service tests; updated test harnesses to mock `getRegisteredBridges()`.

<sup>Written for commit f9eaf3f0c58c2550c4643d49ad609c799c3830b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

