### PR TITLE
feat(app): redesign the connected-empty Projects state

### DIFF
--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -15,11 +15,17 @@ part of "../project_list_screen.dart";
 // ===========================================================================
 
 /// The "connected, no projects" empty state: the connection graphic in its
-/// "on" state with a success-colored "Connected" caption sitting high in the
-/// body, and — anchored to the bottom — the no-projects message with the
-/// add-project call to action, which opens the existing Add Project sheet.
+/// "on" state with a success-colored "Connected" caption and the machine name
+/// of the connected bridge sitting high in the body, and — anchored to the
+/// bottom — the no-projects message with the add-project call to action,
+/// which opens the existing Add Project sheet.
 class _ConnectedEmptyView extends StatelessWidget {
-  const _ConnectedEmptyView();
+  const _ConnectedEmptyView({required this.bridges});
+
+  /// The account's registered bridges, most recently seen first. The first
+  /// entry names the machine the app is connected to; empty while the lookup
+  /// is in flight or when it failed, which hides the machine row.
+  final List<BridgeSummary> bridges;
 
   @override
   Widget build(BuildContext context) {
@@ -58,6 +64,10 @@ class _ConnectedEmptyView extends StatelessWidget {
           style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textSuccessPrimary),
           textAlign: TextAlign.center,
         ),
+        if (bridges.isNotEmpty) ...[
+          const SizedBox(height: PregoSpacing.xxs),
+          Center(child: _MachineNameRow(name: bridges.first.name)),
+        ],
         const Spacer(),
         Center(
           child: ConstrainedBox(

--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -6,22 +6,20 @@ part of "../project_list_screen.dart";
 // The two empty Projects states have their own bodies now that they diverge:
 // * disconnected — the connect-your-computer onboarding (connection graphic in
 //   its "off" state): install + start the bridge. See [_ConnectBridgeChecklist].
-// * connected, no projects — the phone/PC status body with the graphic in its
-//   "on" state. See [_OnboardingChecklist].
+// * connected, no projects — the graphic in its "on" state with a "Connected"
+//   caption and an add-project call to action. See [_ConnectedEmptyView].
 //
 // Both are bodies, not pages: [ProjectListScreen] hosts them in its own page
 // scroll — with the pull-to-refresh and the collapsing large title that come
 // with it — rather than each nesting a scroll view of its own.
 // ===========================================================================
 
-/// The "connected, no projects" empty state: the phone/PC status lines, the
-/// connection graphic in its "on" state, and the per-platform install command
-/// boxes. Shown once a bridge is connected but no projects exist yet. The
-/// "Need help?" support menu ([_NeedHelpMenu]) is not part of this scroll flow —
-/// it rides the scaffold's floating-action slot, pinned to the bottom-right
-/// corner above the home indicator.
-class _OnboardingChecklist extends StatelessWidget {
-  const _OnboardingChecklist();
+/// The "connected, no projects" empty state: the connection graphic in its
+/// "on" state with a success-colored "Connected" caption sitting high in the
+/// body, and — anchored to the bottom — the no-projects message with the
+/// add-project call to action, which opens the existing Add Project sheet.
+class _ConnectedEmptyView extends StatelessWidget {
+  const _ConnectedEmptyView();
 
   @override
   Widget build(BuildContext context) {
@@ -31,17 +29,19 @@ class _OnboardingChecklist extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        // 64px gap from the title area keeps the graphic in the upper portion
+        // of the screen (Figma gap-7xl), clear of the bottom CTA group.
+        const SizedBox(height: PregoSpacing.x7l),
+        const Center(
+          child: ExcludeSemantics(child: ConnectionGraphic.connectionOn()),
+        ),
+        const SizedBox(height: PregoSpacing.lg),
         Text.rich(
           TextSpan(
             children: [
-              TextSpan(text: loc.projectsOnboardingPhoneStatusStep),
-              const TextSpan(text: " "),
-              // "Phone connected" + check icon read as a single success-colored
-              // unit confirming the connection.
-              TextSpan(
-                text: loc.projectsOnboardingPhoneStatusConnected,
-                style: TextStyle(color: prego.colors.textSuccessPrimary),
-              ),
+              // "Connected" + check icon read as a single success-colored unit
+              // confirming the connection.
+              TextSpan(text: loc.projectsEmptyConnected),
               WidgetSpan(
                 alignment: PlaceholderAlignment.middle,
                 child: Padding(
@@ -55,39 +55,35 @@ class _OnboardingChecklist extends StatelessWidget {
               ),
             ],
           ),
-          style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textPrimary),
+          style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textSuccessPrimary),
           textAlign: TextAlign.center,
         ),
-        const SizedBox(height: PregoSpacing.x4l),
-        const Center(
-          child: ExcludeSemantics(child: ConnectionGraphic.connectionOn()),
-        ),
-        const SizedBox(height: PregoSpacing.lg),
-        Text.rich(
-          TextSpan(
-            children: [
-              TextSpan(text: loc.projectsOnboardingPcStatusStep),
-              const TextSpan(text: " "),
-              TextSpan(
-                text: loc.projectsOnboardingPcStatusRun,
-                style: TextStyle(color: prego.colors.textSecondary),
-              ),
-            ],
+        const Spacer(),
+        Center(
+          child: ConstrainedBox(
+            // Figma caps the message at 224px so it wraps into a compact
+            // two-line block instead of a full-width single line.
+            constraints: const BoxConstraints(maxWidth: 224),
+            child: Text(
+              loc.projectsEmptyMessage,
+              textAlign: TextAlign.center,
+              style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textPrimary),
+            ),
           ),
-          style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textPrimary),
-          textAlign: TextAlign.center,
         ),
-        const SizedBox(height: PregoSpacing.lg),
-        const _WhyBridgeButton(surface: OnboardingSurface.connectedEmpty),
-        // 40px gap from the header group to the install boxes (Figma gap-5xl).
-        const SizedBox(height: PregoSpacing.x5l),
-        const Padding(
-          padding: EdgeInsetsDirectional.fromSTEB(PregoSpacing.xl, 0, PregoSpacing.xl, PregoSpacing.x3l),
-          child: _InstallCommandBoxes(surface: OnboardingSurface.connectedEmpty),
+        const SizedBox(height: PregoSpacing.xl),
+        Center(
+          child: PregoButtonsSolid(
+            fullWidth: false,
+            leadingIcon: TablerRegular.folder_plus,
+            label: loc.projectsEmptyAddProject,
+            hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
+            size: PregoButtonsSolidSize.xl,
+            onPressed: () => showAddProjectDialog(context, context.read<ProjectListCubit>()),
+          ),
         ),
-        // Bottom breathing room so the last install box can be scrolled clear of
-        // the "Need help?" button pinned in the bottom-right corner.
-        const SizedBox(height: PregoSpacing.x6l),
+        // 24px above the home-indicator inset the hosting SafeArea applies.
+        const SizedBox(height: PregoSpacing.x3l),
       ],
     );
   }

--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -351,9 +351,9 @@ class _NeedHelpMenu extends StatelessWidget {
 /// The per-platform install commands: a flat iOS-style segmented control that
 /// switches between the Unix (macOS/Linux/WSL) and Windows install groups, and
 /// a single [_InstallCommandBox] showing the selected group's methods. Shared
-/// by the [_OnboardingChecklist] and the bridge-offline reconnect disclosure
-/// ([_BridgeOfflineView]) so both stay in sync; callers supply their own
-/// surrounding padding.
+/// by the connect-setup onboarding ([_ConnectBridgeChecklist]) and the
+/// bridge-offline reconnect disclosure ([_BridgeOfflineView]) so both stay in
+/// sync; callers supply their own surrounding padding.
 class _InstallCommandBoxes extends StatefulWidget {
   const _InstallCommandBoxes({required this.surface, this.stepHeader});
 

--- a/client/app/lib/features/project_list/onboarding/why_bridge_info_sheet.dart
+++ b/client/app/lib/features/project_list/onboarding/why_bridge_info_sheet.dart
@@ -10,7 +10,7 @@ part of "../project_list_screen.dart";
 
 /// Content of the onboarding "Why is this needed?" bottom sheet. Pure
 /// presentation with only per-row FAQ expand/collapse state; opened via
-/// [showPregoBottomSheet] from [_OnboardingChecklist].
+/// [showPregoBottomSheet] from [_WhyBridgeButton].
 class _WhyBridgeInfoSheet extends StatelessWidget {
   const _WhyBridgeInfoSheet();
 

--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -146,9 +146,10 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
   }
 
   /// The scaffold's bottom-right floating action for the current [state]: the
-  /// add-project FAB once projects exist, the "Need help?" support menu on the
-  /// onboarding and recovery surfaces (never-registered setup, connected-but-
-  /// empty, and bridge-offline), and nothing otherwise.
+  /// add-project FAB once projects exist, the onboarding "Need help?" support
+  /// menu on the never-registered setup surface, and nothing otherwise — the
+  /// connected-but-empty state anchors its own add-project call to action at
+  /// the bottom ([_ConnectedEmptyView]), so a floating pill would collide.
   Widget? _floatingAction({required BuildContext context, required ProjectListState state}) {
     if (state is ProjectListLoaded && state.projects.isNotEmpty) {
       return PregoButtonsIconGlass(
@@ -164,9 +165,6 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
       return _NeedHelpMenu(
         surface: state.hasRegisteredBridges ? OnboardingSurface.bridgeOffline : OnboardingSurface.connectSetup,
       );
-    }
-    if (state is ProjectListLoaded && state.projects.isEmpty) {
-      return const _NeedHelpMenu(surface: OnboardingSurface.connectedEmpty);
     }
     return null;
   }
@@ -220,8 +218,8 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
   /// The top-nav connection banner for [state], or `null` when it should be
   /// suppressed.
   ///
-  /// A non-empty loaded list always hosts it. The empty onboarding list
-  /// normally owns the screen full-screen (its checklist would contradict an
+  /// A non-empty loaded list always hosts it. The empty list normally owns
+  /// the screen full-screen (its "Connected" caption would contradict an
   /// offline banner, and a bridge-offline empty list transitions to the
   /// dedicated offline flow instead) — but a terminal `ConnectionLost` keeps
   /// the list loaded-empty with no other recovery surface, so surface the
@@ -266,13 +264,13 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
       ProjectListLoaded(:final projects, :final activityById, :final unseenByProjectId) => [
         if (isRefreshing) const SliverToBoxAdapter(child: LinearProgressIndicator()),
         if (projects.isEmpty)
-          // Same shape as the disconnected bodies above: the onboarding joins
+          // Same shape as the disconnected bodies above: the empty state joins
           // the page scroll rather than nesting one of its own.
           const SliverFillRemaining(
             hasScrollBody: false,
             child: SafeArea(
               top: false,
-              child: _OnboardingChecklist(),
+              child: _ConnectedEmptyView(),
             ),
           )
         else ...[

--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -261,16 +261,16 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
           ),
         ),
       ],
-      ProjectListLoaded(:final projects, :final activityById, :final unseenByProjectId) => [
+      ProjectListLoaded(:final projects, :final activityById, :final unseenByProjectId, :final bridges) => [
         if (isRefreshing) const SliverToBoxAdapter(child: LinearProgressIndicator()),
         if (projects.isEmpty)
           // Same shape as the disconnected bodies above: the empty state joins
           // the page scroll rather than nesting one of its own.
-          const SliverFillRemaining(
+          SliverFillRemaining(
             hasScrollBody: false,
             child: SafeArea(
               top: false,
-              child: _ConnectedEmptyView(),
+              child: _ConnectedEmptyView(bridges: bridges),
             ),
           )
         else ...[

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -12,7 +12,6 @@
     "description": "App-bar title shown in place of 'Projects' while the connect-your-computer onboarding is visible (no bridge has ever been registered and none is connected)."
   },
   "projectListLoadingSemantics": "Loading projects",
-  "projectListEmpty": "No projects found",
   "projectListUpdated": "Updated {timestamp}",
   "@projectListUpdated": {
     "placeholders": {
@@ -34,21 +33,17 @@
       }
     }
   },
-  "projectsOnboardingPhoneStatusStep": "Step 1:",
-  "@projectsOnboardingPhoneStatusStep": {
-    "description": "Leading label for the phone-connection status line above the onboarding hero, e.g. 'Step 1: Phone connected'."
+  "projectsEmptyConnected": "Connected",
+  "@projectsEmptyConnected": {
+    "description": "Status caption under the connection graphic on the connected-but-empty Projects screen, rendered in the success color with a check icon."
   },
-  "projectsOnboardingPhoneStatusConnected": "Phone connected",
-  "@projectsOnboardingPhoneStatusConnected": {
-    "description": "Success portion of the phone-connection status line, rendered in the success color with a check icon."
+  "projectsEmptyMessage": "You don't have any projects created or opened yet.",
+  "@projectsEmptyMessage": {
+    "description": "Message above the add-project button on the connected-but-empty Projects screen."
   },
-  "projectsOnboardingPcStatusStep": "Step 2:",
-  "@projectsOnboardingPcStatusStep": {
-    "description": "Leading label for the PC status line below the onboarding hero, e.g. 'Step 2: Run Sesori on your PC'."
-  },
-  "projectsOnboardingPcStatusRun": "Run Sesori on your PC",
-  "@projectsOnboardingPcStatusRun": {
-    "description": "Secondary portion of the PC status line, rendered in the secondary text color."
+  "projectsEmptyAddProject": "Add a new project to get started",
+  "@projectsEmptyAddProject": {
+    "description": "Label of the button on the connected-but-empty Projects screen that opens the Add Project sheet."
   },
   "projectsOnboardingPcStatusWhy": "Why is this needed?",
   "@projectsOnboardingPcStatusWhy": {

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -145,12 +145,6 @@ abstract class AppLocalizations {
   /// **'Loading projects'**
   String get projectListLoadingSemantics;
 
-  /// No description provided for @projectListEmpty.
-  ///
-  /// In en, this message translates to:
-  /// **'No projects found'**
-  String get projectListEmpty;
-
   /// No description provided for @projectListUpdated.
   ///
   /// In en, this message translates to:
@@ -193,29 +187,23 @@ abstract class AppLocalizations {
   /// **'{count, plural, =1{1 active session} other{{count} active sessions}}'**
   String projectListActiveSessions(int count);
 
-  /// Leading label for the phone-connection status line above the onboarding hero, e.g. 'Step 1: Phone connected'.
+  /// Status caption under the connection graphic on the connected-but-empty Projects screen, rendered in the success color with a check icon.
   ///
   /// In en, this message translates to:
-  /// **'Step 1:'**
-  String get projectsOnboardingPhoneStatusStep;
+  /// **'Connected'**
+  String get projectsEmptyConnected;
 
-  /// Success portion of the phone-connection status line, rendered in the success color with a check icon.
+  /// Message above the add-project button on the connected-but-empty Projects screen.
   ///
   /// In en, this message translates to:
-  /// **'Phone connected'**
-  String get projectsOnboardingPhoneStatusConnected;
+  /// **'You don\'t have any projects created or opened yet.'**
+  String get projectsEmptyMessage;
 
-  /// Leading label for the PC status line below the onboarding hero, e.g. 'Step 2: Run Sesori on your PC'.
+  /// Label of the button on the connected-but-empty Projects screen that opens the Add Project sheet.
   ///
   /// In en, this message translates to:
-  /// **'Step 2:'**
-  String get projectsOnboardingPcStatusStep;
-
-  /// Secondary portion of the PC status line, rendered in the secondary text color.
-  ///
-  /// In en, this message translates to:
-  /// **'Run Sesori on your PC'**
-  String get projectsOnboardingPcStatusRun;
+  /// **'Add a new project to get started'**
+  String get projectsEmptyAddProject;
 
   /// Label for the button below the PC status line that opens the bridge explainer bottom sheet; also used as that sheet's title.
   ///

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -36,9 +36,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get projectListLoadingSemantics => 'Loading projects';
 
   @override
-  String get projectListEmpty => 'No projects found';
-
-  @override
   String projectListUpdated(String timestamp) {
     return 'Updated $timestamp';
   }
@@ -70,16 +67,13 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String get projectsOnboardingPhoneStatusStep => 'Step 1:';
+  String get projectsEmptyConnected => 'Connected';
 
   @override
-  String get projectsOnboardingPhoneStatusConnected => 'Phone connected';
+  String get projectsEmptyMessage => 'You don\'t have any projects created or opened yet.';
 
   @override
-  String get projectsOnboardingPcStatusStep => 'Step 2:';
-
-  @override
-  String get projectsOnboardingPcStatusRun => 'Run Sesori on your PC';
+  String get projectsEmptyAddProject => 'Add a new project to get started';
 
   @override
   String get projectsOnboardingPcStatusWhy => 'Why is this needed?';

--- a/client/app/test/features/project_list/connected_empty_view_test.dart
+++ b/client/app/test/features/project_list/connected_empty_view_test.dart
@@ -1,0 +1,127 @@
+import "package:flutter/material.dart";
+import "package:flutter_bloc/flutter_bloc.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:mocktail/mocktail.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_mobile/core/analytics/analytics_reporter.dart";
+import "package:sesori_mobile/core/di/injection.dart";
+import "package:sesori_mobile/core/widgets/connection_graphic.dart";
+import "package:sesori_mobile/features/project_list/add_project_dialog.dart";
+import "package:sesori_mobile/features/project_list/project_list_screen.dart";
+import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/module_prego.dart";
+
+import "../../helpers/test_helpers.dart";
+
+// ---------------------------------------------------------------------------
+// Guards the connected-but-empty Projects body: the "on" connection graphic
+// with its "Connected" caption up top, and the bottom-anchored no-projects
+// message with the add-project call to action that opens the Add Project
+// sheet. Pumps the real [ProjectListScreen] driven into the loaded-empty
+// state through getIt-registered mocks.
+// ---------------------------------------------------------------------------
+
+const _connectionConfig = ServerConnectionConfig(
+  relayHost: "relay.example.com",
+  authToken: "test-token",
+);
+const _health = HealthResponse(healthy: true, version: "0.1.200", filesystemAccessDegraded: null);
+const _connectedStatus = ConnectionStatus.connected(config: _connectionConfig, health: _health);
+
+void main() {
+  late MockProjectService mockProjectService;
+  late MockConnectionService mockConnectionService;
+  late MockAnalyticsReporter mockAnalyticsReporter;
+  late StubConnectionOverlayCubit overlayCubit;
+  late BehaviorSubject<ConnectionStatus> statusController;
+
+  setUpAll(registerAllFallbackValues);
+
+  setUp(() {
+    mockProjectService = MockProjectService();
+    mockConnectionService = MockConnectionService();
+    mockAnalyticsReporter = MockAnalyticsReporter();
+    overlayCubit = StubConnectionOverlayCubit();
+    statusController = BehaviorSubject<ConnectionStatus>.seeded(_connectedStatus);
+
+    when(() => mockConnectionService.status).thenAnswer((_) => statusController.stream);
+    when(() => mockConnectionService.currentStatus).thenAnswer((_) => statusController.value);
+    when(() => mockProjectService.listProjects()).thenAnswer(
+      (_) async => ApiResponse.success(const Projects(data: [])),
+    );
+    when(
+      () => mockAnalyticsReporter.logEvent(event: any(named: "event")),
+    ).thenAnswer((_) async {});
+
+    getIt.registerLazySingleton<ProjectService>(() => mockProjectService);
+    getIt.registerLazySingleton<ConnectionService>(() => mockConnectionService);
+    getIt.registerLazySingleton<SseEventRepository>(MockSseEventRepository.new);
+    getIt.registerLazySingleton<RouteSource>(MockRouteSource.new);
+    getIt.registerLazySingleton<SessionUnseenTracker>(FakeSessionUnseenTracker.new);
+    getIt.registerLazySingleton<RegisteredBridgesService>(MockRegisteredBridgesService.new);
+    getIt.registerLazySingleton<FailureReporter>(MockFailureReporter.new);
+    getIt.registerLazySingleton<AnalyticsReporter>(() => mockAnalyticsReporter);
+  });
+
+  tearDown(() async {
+    await overlayCubit.close();
+    await statusController.close();
+    await getIt.reset();
+  });
+
+  /// Pumps the screen connected with zero projects and settles. Unmounting at
+  /// the end of the test disposes the screen's minute ticker, which would
+  /// otherwise linger as a pending timer.
+  Future<void> pumpConnectedEmpty(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(393, 852);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      BlocProvider<ConnectionOverlayCubit>.value(
+        value: overlayCubit,
+        child: MaterialApp(
+          theme: ThemeData(extensions: [PregoDesignSystem.light]),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const ProjectListScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    addTearDown(() => tester.pumpWidget(const SizedBox.shrink()));
+  }
+
+  testWidgets("shows the on-graphic, Connected caption, message and add-project CTA", (tester) async {
+    await pumpConnectedEmpty(tester);
+
+    expect(find.byType(ConnectionGraphic), findsOneWidget);
+    // Text.rich caption ("Connected" + inline check icon), so match by
+    // substring rather than the exact plain text.
+    expect(find.textContaining("Connected"), findsOneWidget);
+    expect(find.text("You don't have any projects created or opened yet."), findsOneWidget);
+    expect(find.text("Add a new project to get started"), findsOneWidget);
+  });
+
+  testWidgets("hosts no Need-help pill or install commands on this surface", (tester) async {
+    await pumpConnectedEmpty(tester);
+
+    expect(find.text("Need help?"), findsNothing);
+    expect(find.bySemanticsLabel("Copy command"), findsNothing);
+    expect(find.text("Why is this needed?"), findsNothing);
+  });
+
+  testWidgets("tapping the CTA opens the Add Project sheet", (tester) async {
+    when(() => mockProjectService.getFilesystemSuggestions(prefix: any(named: "prefix"))).thenAnswer(
+      (_) async => ApiResponse.success(const FilesystemSuggestions(data: [])),
+    );
+    await pumpConnectedEmpty(tester);
+
+    await tester.tap(find.text("Add a new project to get started"));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AddProjectDialog), findsOneWidget);
+    expect(find.text("Add Project"), findsOneWidget);
+  });
+}

--- a/client/app/test/features/project_list/connected_empty_view_test.dart
+++ b/client/app/test/features/project_list/connected_empty_view_test.dart
@@ -30,9 +30,20 @@ const _connectionConfig = ServerConnectionConfig(
 const _health = HealthResponse(healthy: true, version: "0.1.200", filesystemAccessDegraded: null);
 const _connectedStatus = ConnectionStatus.connected(config: _connectionConfig, health: _health);
 
+BridgeSummary _bridge({required String name, DateTime? lastSeenAt}) {
+  return BridgeSummary(
+    id: "bridge-1",
+    name: name,
+    platform: "macos",
+    addedAt: DateTime.utc(2026, 1, 1),
+    lastSeenAt: lastSeenAt,
+  );
+}
+
 void main() {
   late MockProjectService mockProjectService;
   late MockConnectionService mockConnectionService;
+  late MockRegisteredBridgesService mockRegisteredBridgesService;
   late MockAnalyticsReporter mockAnalyticsReporter;
   late StubConnectionOverlayCubit overlayCubit;
   late BehaviorSubject<ConnectionStatus> statusController;
@@ -42,6 +53,7 @@ void main() {
   setUp(() {
     mockProjectService = MockProjectService();
     mockConnectionService = MockConnectionService();
+    mockRegisteredBridgesService = MockRegisteredBridgesService();
     mockAnalyticsReporter = MockAnalyticsReporter();
     overlayCubit = StubConnectionOverlayCubit();
     statusController = BehaviorSubject<ConnectionStatus>.seeded(_connectedStatus);
@@ -51,6 +63,9 @@ void main() {
     when(() => mockProjectService.listProjects()).thenAnswer(
       (_) async => ApiResponse.success(const Projects(data: [])),
     );
+    // Default: the machine-identity fetch resolves empty (the fail-soft error
+    // shape), hiding the machine row; tests that show it override this.
+    when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer((_) async => const []);
     when(
       () => mockAnalyticsReporter.logEvent(event: any(named: "event")),
     ).thenAnswer((_) async {});
@@ -60,7 +75,7 @@ void main() {
     getIt.registerLazySingleton<SseEventRepository>(MockSseEventRepository.new);
     getIt.registerLazySingleton<RouteSource>(MockRouteSource.new);
     getIt.registerLazySingleton<SessionUnseenTracker>(FakeSessionUnseenTracker.new);
-    getIt.registerLazySingleton<RegisteredBridgesService>(MockRegisteredBridgesService.new);
+    getIt.registerLazySingleton<RegisteredBridgesService>(() => mockRegisteredBridgesService);
     getIt.registerLazySingleton<FailureReporter>(MockFailureReporter.new);
     getIt.registerLazySingleton<AnalyticsReporter>(() => mockAnalyticsReporter);
   });
@@ -110,6 +125,28 @@ void main() {
     expect(find.text("Need help?"), findsNothing);
     expect(find.bySemanticsLabel("Copy command"), findsNothing);
     expect(find.text("Why is this needed?"), findsNothing);
+  });
+
+  group("machine-name row", () {
+    testWidgets("names the most recently seen registered bridge under the caption", (tester) async {
+      when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer(
+        (_) async => [_bridge(name: "Macbook-Pro.local", lastSeenAt: DateTime.utc(2026, 7, 1))],
+      );
+
+      await pumpConnectedEmpty(tester);
+
+      expect(find.text("Macbook-Pro.local"), findsOneWidget);
+      expect(find.byIcon(TablerRegular.device_laptop), findsOneWidget);
+    });
+
+    testWidgets("is hidden when the registered bridges could not be fetched", (tester) async {
+      await pumpConnectedEmpty(tester);
+
+      expect(find.byIcon(TablerRegular.device_laptop), findsNothing);
+      // The empty state itself still renders in full.
+      expect(find.textContaining("Connected"), findsOneWidget);
+      expect(find.text("Add a new project to get started"), findsOneWidget);
+    });
   });
 
   testWidgets("tapping the CTA opens the Add Project sheet", (tester) async {

--- a/client/app/test/features/project_list/onboarding_analytics_test.dart
+++ b/client/app/test/features/project_list/onboarding_analytics_test.dart
@@ -19,7 +19,8 @@ import "../../helpers/test_helpers.dart";
 // End-to-end analytics guard for the Projects onboarding/recovery surfaces:
 // every AnalyticsEvent union case is fired through a real widget tap, and the
 // surface parameter tracks which body hosted it — the connect-your-computer
-// setup, the connected-but-empty checklist, or the bridge-offline view.
+// setup or the bridge-offline view. (The connected-but-empty state carries no
+// onboarding widgets anymore, so it fires no onboarding events.)
 //
 // Pumps the real [ProjectListScreen] (its cubit is built from getIt, so every
 // dependency is registered as a mock below) driven into each state through
@@ -106,16 +107,6 @@ void main() {
     addTearDown(() => tester.pumpWidget(const SizedBox.shrink()));
   }
 
-  /// Connected relay with zero projects → the connected-but-empty onboarding.
-  Future<void> pumpConnectedEmpty(WidgetTester tester) async {
-    when(() => mockProjectService.listProjects()).thenAnswer(
-      (_) async => ApiResponse.success(const Projects(data: [])),
-    );
-    when(() => mockRegisteredBridgesService.hasRegisteredBridges()).thenAnswer((_) async => true);
-    await pumpScreen(tester);
-    expect(find.text("Need help?"), findsOneWidget);
-  }
-
   /// Bridge offline with no bridge ever registered → the connect-your-computer
   /// setup onboarding.
   Future<void> pumpConnectSetup(WidgetTester tester) async {
@@ -144,22 +135,22 @@ void main() {
     verify(() => mockAnalyticsReporter.logEvent(event: event)).called(1);
   }
 
-  group("connected-but-empty onboarding", () {
+  group("connect-your-computer setup onboarding", () {
     testWidgets("tapping the Need help pill logs the menu-open event", (tester) async {
-      await pumpConnectedEmpty(tester);
+      await pumpConnectSetup(tester);
 
       await tester.tap(find.text("Need help?"));
       await tester.pumpAndSettle();
 
       verifyLogged(
-        const AnalyticsEvent.needHelpMenuOpened(surface: OnboardingSurface.connectedEmpty),
+        const AnalyticsEvent.needHelpMenuOpened(surface: OnboardingSurface.connectSetup),
       );
       // The popup actually opened alongside the event.
       expect(find.text("Email"), findsOneWidget);
     });
 
     testWidgets("tapping a support channel logs the channel event and launches the link", (tester) async {
-      await pumpConnectedEmpty(tester);
+      await pumpConnectSetup(tester);
 
       await tester.tap(find.text("Need help?"));
       await tester.pumpAndSettle();
@@ -170,7 +161,7 @@ void main() {
       verifyLogged(
         const AnalyticsEvent.supportLinkOpened(
           channel: SupportChannel.email,
-          surface: OnboardingSurface.connectedEmpty,
+          surface: OnboardingSurface.connectSetup,
         ),
       );
       final launched = verify(() => mockUrlLauncher.launch(captureAny())).captured.single as Uri;
@@ -178,7 +169,7 @@ void main() {
     });
 
     testWidgets("each support channel reports its own analytics channel value", (tester) async {
-      await pumpConnectedEmpty(tester);
+      await pumpConnectSetup(tester);
 
       const channelByLabel = {
         "Discord": SupportChannel.discord,
@@ -193,103 +184,13 @@ void main() {
         verifyLogged(
           AnalyticsEvent.supportLinkOpened(
             channel: entry.value,
-            surface: OnboardingSurface.connectedEmpty,
+            surface: OnboardingSurface.connectSetup,
           ),
         );
       }
     });
 
     testWidgets("opening the why-bridge explainer logs its event", (tester) async {
-      await pumpConnectedEmpty(tester);
-
-      await tester.tap(find.text("Why is this needed?"));
-      await tester.pumpAndSettle();
-
-      verifyLogged(
-        const AnalyticsEvent.whyBridgeOpened(surface: OnboardingSurface.connectedEmpty),
-      );
-      // The sheet actually opened alongside the event (button + sheet title).
-      expect(find.text("Why is this needed?"), findsNWidgets(2));
-    });
-
-    testWidgets("copying the default install command logs curl on unix", (tester) async {
-      await pumpConnectedEmpty(tester);
-
-      await tester.tap(find.bySemanticsLabel("Copy command"));
-      await tester.pumpAndSettle();
-
-      verifyLogged(
-        const AnalyticsEvent.installCommandCopied(
-          method: BridgeInstallMethod.curl,
-          os: BridgeInstallOs.unix,
-          surface: OnboardingSurface.connectedEmpty,
-        ),
-      );
-    });
-
-    testWidgets("copying after switching to the Windows group logs powershell", (tester) async {
-      await pumpConnectedEmpty(tester);
-
-      await tester.tap(find.text("Windows PowerShell"));
-      await tester.pumpAndSettle();
-      await tester.tap(find.bySemanticsLabel("Copy command"));
-      await tester.pumpAndSettle();
-
-      verifyLogged(
-        const AnalyticsEvent.installCommandCopied(
-          method: BridgeInstallMethod.powershell,
-          os: BridgeInstallOs.windows,
-          surface: OnboardingSurface.connectedEmpty,
-        ),
-      );
-    });
-
-    testWidgets("copying a method tab logs that method under the selected group", (tester) async {
-      await pumpConnectedEmpty(tester);
-
-      await tester.tap(find.text("npm"));
-      await tester.pumpAndSettle();
-      await tester.tap(find.bySemanticsLabel("Copy command"));
-      await tester.pumpAndSettle();
-
-      verifyLogged(
-        const AnalyticsEvent.installCommandCopied(
-          method: BridgeInstallMethod.npm,
-          os: BridgeInstallOs.unix,
-          surface: OnboardingSurface.connectedEmpty,
-        ),
-      );
-    });
-
-    testWidgets("sharing the install command logs the shared event", (tester) async {
-      await pumpConnectedEmpty(tester);
-
-      await tester.tap(find.bySemanticsLabel("Share command"));
-      await tester.pumpAndSettle();
-
-      verifyLogged(
-        const AnalyticsEvent.installCommandShared(
-          method: BridgeInstallMethod.curl,
-          os: BridgeInstallOs.unix,
-          surface: OnboardingSurface.connectedEmpty,
-        ),
-      );
-    });
-  });
-
-  group("connect-your-computer setup onboarding", () {
-    testWidgets("tapping the Need help pill logs the connect-setup surface", (tester) async {
-      await pumpConnectSetup(tester);
-
-      await tester.tap(find.text("Need help?"));
-      await tester.pumpAndSettle();
-
-      verifyLogged(
-        const AnalyticsEvent.needHelpMenuOpened(surface: OnboardingSurface.connectSetup),
-      );
-    });
-
-    testWidgets("opening the why-bridge explainer logs the connect-setup surface", (tester) async {
       await pumpConnectSetup(tester);
 
       await tester.tap(find.text("Why is this needed?"));
@@ -298,13 +199,79 @@ void main() {
       verifyLogged(
         const AnalyticsEvent.whyBridgeOpened(surface: OnboardingSurface.connectSetup),
       );
+      // The sheet actually opened alongside the event (button + sheet title).
+      expect(find.text("Why is this needed?"), findsNWidgets(2));
+    });
+
+    // Two command rows on this surface: the install box (step 1) first, the
+    // run box (step 2) below it — hence copy/share at index 0 vs 1.
+    testWidgets("copying the default install command logs curl on unix", (tester) async {
+      await pumpConnectSetup(tester);
+
+      await tester.tap(find.bySemanticsLabel("Copy command").at(0));
+      await tester.pumpAndSettle();
+
+      verifyLogged(
+        const AnalyticsEvent.installCommandCopied(
+          method: BridgeInstallMethod.curl,
+          os: BridgeInstallOs.unix,
+          surface: OnboardingSurface.connectSetup,
+        ),
+      );
+    });
+
+    testWidgets("copying after switching to the Windows group logs powershell", (tester) async {
+      await pumpConnectSetup(tester);
+
+      await tester.tap(find.text("Windows PowerShell"));
+      await tester.pumpAndSettle();
+      await tester.tap(find.bySemanticsLabel("Copy command").at(0));
+      await tester.pumpAndSettle();
+
+      verifyLogged(
+        const AnalyticsEvent.installCommandCopied(
+          method: BridgeInstallMethod.powershell,
+          os: BridgeInstallOs.windows,
+          surface: OnboardingSurface.connectSetup,
+        ),
+      );
+    });
+
+    testWidgets("copying a method tab logs that method under the selected group", (tester) async {
+      await pumpConnectSetup(tester);
+
+      await tester.tap(find.text("npm"));
+      await tester.pumpAndSettle();
+      await tester.tap(find.bySemanticsLabel("Copy command").at(0));
+      await tester.pumpAndSettle();
+
+      verifyLogged(
+        const AnalyticsEvent.installCommandCopied(
+          method: BridgeInstallMethod.npm,
+          os: BridgeInstallOs.unix,
+          surface: OnboardingSurface.connectSetup,
+        ),
+      );
+    });
+
+    testWidgets("sharing the install command logs the shared event", (tester) async {
+      await pumpConnectSetup(tester);
+
+      await tester.tap(find.bySemanticsLabel("Share command").at(0));
+      await tester.pumpAndSettle();
+
+      verifyLogged(
+        const AnalyticsEvent.installCommandShared(
+          method: BridgeInstallMethod.curl,
+          os: BridgeInstallOs.unix,
+          surface: OnboardingSurface.connectSetup,
+        ),
+      );
     });
 
     testWidgets("copying the step-2 run command logs the run event", (tester) async {
       await pumpConnectSetup(tester);
 
-      // Two command rows on this surface: the install box (step 1) first, the
-      // run box (step 2) below it.
       await tester.tap(find.bySemanticsLabel("Copy command").at(1));
       await tester.pumpAndSettle();
 

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -421,6 +421,9 @@ class ProjectListCubit extends Cubit<ProjectListState> {
           unseenByProjectId: _unseenByProjectId(remaining),
         ),
       );
+      // Hiding the last project lands on the connected-empty body, which
+      // names the machine — same follow-up enrichment as an empty fetch.
+      if (remaining.isEmpty) unawaited(_enrichLoadedEmptyWithBridges());
     }
   }
 

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -498,6 +498,30 @@ class ProjectListCubit extends Cubit<ProjectListState> {
     return error is NonSuccessCodeError && error.errorCode == 403;
   }
 
+  /// The current loaded state's registered bridges, or empty outside a loaded
+  /// state.
+  List<BridgeSummary> get _loadedBridges => switch (state) {
+    ProjectListLoaded(:final bridges) => bridges,
+    ProjectListLoading() || ProjectListFailed() || ProjectListBridgeDisconnected() => const [],
+  };
+
+  /// Enriches an empty loaded list with the account's registered bridges so
+  /// the connected-but-empty body can name the machine it is connected to.
+  /// Mirrors the bridge-disconnected enrichment: the empty state shows
+  /// immediately and the machine row lands in a follow-up emit once the fetch
+  /// resolves; a failed fetch (empty list) leaves the row hidden. No
+  /// registered-bridges gate is needed here — a loaded state means a bridge is
+  /// connected, so the account has one by definition.
+  Future<void> _enrichLoadedEmptyWithBridges() async {
+    final bridges = await _registeredBridgesService.getRegisteredBridges();
+    if (isClosed || bridges.isEmpty) return;
+    // Projects may have arrived while the fetch was in flight — that state
+    // owns the screen and has no machine row to enrich.
+    if (state case final ProjectListLoaded loaded when loaded.projects.isEmpty) {
+      emit(loaded.copyWith(bridges: bridges));
+    }
+  }
+
   Future<bool> _fetchProjects({bool silent = false}) async {
     // Captured BEFORE the fetch so the seed can't overwrite a live update that
     // arrives while the request is in flight.
@@ -519,8 +543,12 @@ class ProjectListCubit extends Cubit<ProjectListState> {
             projects: projects,
             activityById: _sseEventRepository.currentProjectActivity,
             unseenByProjectId: _unseenByProjectId(projects),
+            // Carrying the previous machine identity over keeps the row from
+            // flickering out and back across a refresh of a still-empty list.
+            bridges: projects.isEmpty ? _loadedBridges : const [],
           ),
         );
+        if (projects.isEmpty) unawaited(_enrichLoadedEmptyWithBridges());
         return true;
 
       case ErrorResponse(:final error):

--- a/client/module_core/lib/src/cubits/project_list/project_list_state.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_state.dart
@@ -18,6 +18,14 @@ sealed class ProjectListState with _$ProjectListState {
     /// `SesoriSessionUnseenChanged` updates, the latter taking precedence.
     @Default({}) Map<String, bool> unseenByProjectId,
     @Default(false) bool isRefreshing,
+
+    /// The account's registered bridges (most recently seen first), so the
+    /// connected-but-empty body can name the machine it is connected to.
+    /// Populated only while [projects] is empty — the only surface that shows
+    /// the machine identity. Emitted empty first and enriched by a follow-up
+    /// emit once the fetch resolves; stays empty when the fetch fails, which
+    /// hides the machine-name row.
+    @Default(<BridgeSummary>[]) List<BridgeSummary> bridges,
   }) = ProjectListLoaded;
 
   const factory ProjectListState.failed({required RemoteFailureReason reason}) = ProjectListFailed;

--- a/client/module_core/lib/src/cubits/project_list/project_list_state.freezed.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_state.freezed.dart
@@ -78,7 +78,7 @@ String toString() {
 
 
 class ProjectListLoaded implements ProjectListState {
-  const ProjectListLoaded({required final  List<Project> projects, required final  Map<String, int> activityById, final  Map<String, bool> unseenByProjectId = const {}, this.isRefreshing = false}): _projects = projects,_activityById = activityById,_unseenByProjectId = unseenByProjectId;
+  const ProjectListLoaded({required final  List<Project> projects, required final  Map<String, int> activityById, final  Map<String, bool> unseenByProjectId = const {}, this.isRefreshing = false, final  List<BridgeSummary> bridges = const <BridgeSummary>[]}): _projects = projects,_activityById = activityById,_unseenByProjectId = unseenByProjectId,_bridges = bridges;
   
 
  final  List<Project> _projects;
@@ -109,6 +109,25 @@ class ProjectListLoaded implements ProjectListState {
 }
 
 @JsonKey() final  bool isRefreshing;
+/// The account's registered bridges (most recently seen first), so the
+/// connected-but-empty body can name the machine it is connected to.
+/// Populated only while [projects] is empty — the only surface that shows
+/// the machine identity. Emitted empty first and enriched by a follow-up
+/// emit once the fetch resolves; stays empty when the fetch fails, which
+/// hides the machine-name row.
+ final  List<BridgeSummary> _bridges;
+/// The account's registered bridges (most recently seen first), so the
+/// connected-but-empty body can name the machine it is connected to.
+/// Populated only while [projects] is empty — the only surface that shows
+/// the machine identity. Emitted empty first and enriched by a follow-up
+/// emit once the fetch resolves; stays empty when the fetch fails, which
+/// hides the machine-name row.
+@JsonKey() List<BridgeSummary> get bridges {
+  if (_bridges is EqualUnmodifiableListView) return _bridges;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_bridges);
+}
+
 
 /// Create a copy of ProjectListState
 /// with the given fields replaced by the non-null parameter values.
@@ -120,16 +139,16 @@ $ProjectListLoadedCopyWith<ProjectListLoaded> get copyWith => _$ProjectListLoade
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectListLoaded&&const DeepCollectionEquality().equals(other._projects, _projects)&&const DeepCollectionEquality().equals(other._activityById, _activityById)&&const DeepCollectionEquality().equals(other._unseenByProjectId, _unseenByProjectId)&&(identical(other.isRefreshing, isRefreshing) || other.isRefreshing == isRefreshing));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectListLoaded&&const DeepCollectionEquality().equals(other._projects, _projects)&&const DeepCollectionEquality().equals(other._activityById, _activityById)&&const DeepCollectionEquality().equals(other._unseenByProjectId, _unseenByProjectId)&&(identical(other.isRefreshing, isRefreshing) || other.isRefreshing == isRefreshing)&&const DeepCollectionEquality().equals(other._bridges, _bridges));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_projects),const DeepCollectionEquality().hash(_activityById),const DeepCollectionEquality().hash(_unseenByProjectId),isRefreshing);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_projects),const DeepCollectionEquality().hash(_activityById),const DeepCollectionEquality().hash(_unseenByProjectId),isRefreshing,const DeepCollectionEquality().hash(_bridges));
 
 @override
 String toString() {
-  return 'ProjectListState.loaded(projects: $projects, activityById: $activityById, unseenByProjectId: $unseenByProjectId, isRefreshing: $isRefreshing)';
+  return 'ProjectListState.loaded(projects: $projects, activityById: $activityById, unseenByProjectId: $unseenByProjectId, isRefreshing: $isRefreshing, bridges: $bridges)';
 }
 
 
@@ -140,7 +159,7 @@ abstract mixin class $ProjectListLoadedCopyWith<$Res> implements $ProjectListSta
   factory $ProjectListLoadedCopyWith(ProjectListLoaded value, $Res Function(ProjectListLoaded) _then) = _$ProjectListLoadedCopyWithImpl;
 @useResult
 $Res call({
- List<Project> projects, Map<String, int> activityById, Map<String, bool> unseenByProjectId, bool isRefreshing
+ List<Project> projects, Map<String, int> activityById, Map<String, bool> unseenByProjectId, bool isRefreshing, List<BridgeSummary> bridges
 });
 
 
@@ -157,13 +176,14 @@ class _$ProjectListLoadedCopyWithImpl<$Res>
 
 /// Create a copy of ProjectListState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? projects = null,Object? activityById = null,Object? unseenByProjectId = null,Object? isRefreshing = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? projects = null,Object? activityById = null,Object? unseenByProjectId = null,Object? isRefreshing = null,Object? bridges = null,}) {
   return _then(ProjectListLoaded(
 projects: null == projects ? _self._projects : projects // ignore: cast_nullable_to_non_nullable
 as List<Project>,activityById: null == activityById ? _self._activityById : activityById // ignore: cast_nullable_to_non_nullable
 as Map<String, int>,unseenByProjectId: null == unseenByProjectId ? _self._unseenByProjectId : unseenByProjectId // ignore: cast_nullable_to_non_nullable
 as Map<String, bool>,isRefreshing: null == isRefreshing ? _self.isRefreshing : isRefreshing // ignore: cast_nullable_to_non_nullable
-as bool,
+as bool,bridges: null == bridges ? _self._bridges : bridges // ignore: cast_nullable_to_non_nullable
+as List<BridgeSummary>,
   ));
 }
 
@@ -244,15 +264,17 @@ class ProjectListBridgeDisconnected implements ProjectListState {
   
 
  final  bool hasRegisteredBridges;
-/// The account's registered bridges (most recently seen first) as resolved
-/// when this state was emitted, so the UI can name the machine it is
-/// trying to reach. Empty when the lookup failed (e.g. the phone itself is
-/// offline) — the UI hides the machine identity in that case.
+/// The account's registered bridges (most recently seen first), so the UI
+/// can name the machine it is trying to reach. Emitted empty first and
+/// enriched by a follow-up emit once the fetch resolves; stays empty when
+/// the fetch fails (e.g. the phone itself is offline) — the UI hides the
+/// machine identity in that case.
  final  List<BridgeSummary> _bridges;
-/// The account's registered bridges (most recently seen first) as resolved
-/// when this state was emitted, so the UI can name the machine it is
-/// trying to reach. Empty when the lookup failed (e.g. the phone itself is
-/// offline) — the UI hides the machine identity in that case.
+/// The account's registered bridges (most recently seen first), so the UI
+/// can name the machine it is trying to reach. Emitted empty first and
+/// enriched by a follow-up emit once the fetch resolves; stays empty when
+/// the fetch fails (e.g. the phone itself is offline) — the UI hides the
+/// machine identity in that case.
 @JsonKey() List<BridgeSummary> get bridges {
   if (_bridges is EqualUnmodifiableListView) return _bridges;
   // ignore: implicit_dynamic_type

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -620,6 +620,130 @@ void main() {
     });
 
     // -------------------------------------------------------------------------
+    // Connected-but-empty machine identity enrichment
+    // -------------------------------------------------------------------------
+
+    group("connected-empty machine identity", () {
+      late Completer<bool> pendingFetchGate;
+
+      blocTest<ProjectListCubit, ProjectListState>(
+        "an empty loaded list is enriched with the machine identity in a follow-up emit",
+        build: () {
+          when(() => mockProjectService.listProjects()).thenAnswer(
+            (_) async => ApiResponse.success(const Projects(data: [])),
+          );
+          when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer(
+            (_) async => [testBridgeSummary(name: "Macbook-Pro.local")],
+          );
+          return buildCubit();
+        },
+        // The empty body shows immediately; the machine name lands as a second
+        // emit once the fetch resolves.
+        expect: () => [
+          isA<ProjectListLoaded>()
+              .having((s) => s.projects, "projects", isEmpty)
+              .having((s) => s.bridges, "bridges", isEmpty),
+          isA<ProjectListLoaded>()
+              .having((s) => s.projects, "projects", isEmpty)
+              .having((s) => s.bridges.map((b) => b.name), "bridge names", ["Macbook-Pro.local"]),
+        ],
+      );
+
+      blocTest<ProjectListCubit, ProjectListState>(
+        "a failed bridge fetch leaves the empty loaded state without a follow-up emit",
+        build: () {
+          when(() => mockProjectService.listProjects()).thenAnswer(
+            (_) async => ApiResponse.success(const Projects(data: [])),
+          );
+          // The setUp default getRegisteredBridges stub resolves empty — the
+          // service's fail-soft error shape.
+          return buildCubit();
+        },
+        expect: () => [
+          isA<ProjectListLoaded>().having((s) => s.bridges, "bridges", isEmpty),
+        ],
+      );
+
+      blocTest<ProjectListCubit, ProjectListState>(
+        "a non-empty loaded list never fetches the machine identity",
+        build: () {
+          when(() => mockProjectService.listProjects()).thenAnswer(
+            (_) async => ApiResponse.success(Projects(data: [testProject()])),
+          );
+          return buildCubit();
+        },
+        expect: () => [
+          isA<ProjectListLoaded>()
+              .having((s) => s.projects, "projects", isNotEmpty)
+              .having((s) => s.bridges, "bridges", isEmpty),
+        ],
+        verify: (_) => verifyNever(() => mockRegisteredBridgesService.getRegisteredBridges()),
+      );
+
+      blocTest<ProjectListCubit, ProjectListState>(
+        "projects arriving during the bridge fetch suppress the stale enrichment emit",
+        build: () {
+          when(() => mockProjectService.listProjects()).thenAnswer(
+            (_) async => ApiResponse.success(const Projects(data: [])),
+          );
+          pendingFetchGate = Completer<bool>();
+          when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer(
+            (_) => pendingFetchGate.future.then((_) => [testBridgeSummary(name: "Macbook-Pro.local")]),
+          );
+          addTearDown(() {
+            if (!pendingFetchGate.isCompleted) pendingFetchGate.complete(true);
+          });
+          return buildCubit();
+        },
+        act: (cubit) async {
+          await Future<void>.delayed(Duration.zero); // bridge fetch now in flight
+          // Projects arrive while the fetch is pending; that state owns the
+          // screen and has no machine row to enrich.
+          when(() => mockProjectService.listProjects()).thenAnswer(
+            (_) async => ApiResponse.success(Projects(data: [testProject()])),
+          );
+          await cubit.refreshProjects();
+          pendingFetchGate.complete(true);
+          await Future<void>.delayed(Duration.zero);
+        },
+        expect: () => [
+          isA<ProjectListLoaded>().having((s) => s.projects, "projects", isEmpty),
+          isA<ProjectListLoaded>()
+              .having((s) => s.projects, "projects", isNotEmpty)
+              .having((s) => s.bridges, "bridges", isEmpty),
+        ],
+      );
+
+      blocTest<ProjectListCubit, ProjectListState>(
+        "a refresh of a still-empty list carries the machine identity over without a flicker",
+        build: () {
+          when(() => mockProjectService.listProjects()).thenAnswer(
+            (_) async => ApiResponse.success(const Projects(data: [])),
+          );
+          when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer(
+            (_) async => [testBridgeSummary(name: "Macbook-Pro.local")],
+          );
+          return buildCubit();
+        },
+        act: (cubit) async {
+          // Let the initial empty load and its enrichment land first.
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+          await cubit.refreshProjects();
+          await Future<void>.delayed(Duration.zero);
+        },
+        // Exactly the two initial emits: the refresh re-emits an identical
+        // enriched state (bridges carried over), which bloc dedupes — the row
+        // never blinks out.
+        expect: () => [
+          isA<ProjectListLoaded>().having((s) => s.bridges, "bridges", isEmpty),
+          isA<ProjectListLoaded>()
+              .having((s) => s.bridges.map((b) => b.name), "bridge names", ["Macbook-Pro.local"]),
+        ],
+      );
+    });
+
+    // -------------------------------------------------------------------------
     // Test 4a: hideProject
     // -------------------------------------------------------------------------
 

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -741,6 +741,38 @@ void main() {
               .having((s) => s.bridges.map((b) => b.name), "bridge names", ["Macbook-Pro.local"]),
         ],
       );
+
+      blocTest<ProjectListCubit, ProjectListState>(
+        "hiding the last project enriches the now-empty list with the machine identity",
+        build: () {
+          when(() => mockProjectService.listProjects()).thenAnswer(
+            (_) async => ApiResponse.success(Projects(data: [testProject(id: "only")])),
+          );
+          when(
+            () => mockProjectService.hideProject(projectId: any(named: "projectId")),
+          ).thenAnswer((_) async => ApiResponse.success(null));
+          when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer(
+            (_) async => [testBridgeSummary(name: "Macbook-Pro.local")],
+          );
+          return buildCubit();
+        },
+        act: (cubit) async {
+          await Future<void>.delayed(Duration.zero); // non-empty initial load
+          await cubit.hideProject("only");
+          await Future<void>.delayed(Duration.zero); // enrichment lands
+        },
+        skip: 1, // the non-empty initial load
+        // The local hide reaches the connected-empty body just like an empty
+        // fetch does, so it gets the same follow-up machine-identity emit.
+        expect: () => [
+          isA<ProjectListLoaded>()
+              .having((s) => s.projects, "projects", isEmpty)
+              .having((s) => s.bridges, "bridges", isEmpty),
+          isA<ProjectListLoaded>()
+              .having((s) => s.projects, "projects", isEmpty)
+              .having((s) => s.bridges.map((b) => b.name), "bridge names", ["Macbook-Pro.local"]),
+        ],
+      );
     });
 
     // -------------------------------------------------------------------------

--- a/client/module_prego/lib/components/buttons/prego_buttons_solid.dart
+++ b/client/module_prego/lib/components/buttons/prego_buttons_solid.dart
@@ -310,9 +310,20 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
 
     final List<Widget> children = [];
 
-    final labelWidget = Padding(
-      padding: const EdgeInsetsDirectional.symmetric(horizontal: PregoSpacing.xxs),
-      child: Text(widget.label ?? '', style: textStyle),
+    // Flexible + ellipsis so a label wider than the button's constraints
+    // truncates on one line instead of overflowing the Row. Loose fit in a
+    // min-size Row stays legal in unbounded-width parents, where the label
+    // keeps its intrinsic width as before.
+    final labelWidget = Flexible(
+      child: Padding(
+        padding: const EdgeInsetsDirectional.symmetric(horizontal: PregoSpacing.xxs),
+        child: Text(
+          widget.label ?? '',
+          style: textStyle,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ),
     );
 
     if (widget.isLoading) {


### PR DESCRIPTION
## Summary

Implements the new Figma design for the connected-but-empty Projects state (node 2325-48310, "Connected - No projects") and names the connected machine on it, reusing the same `_MachineNameRow` as the bridge-offline page.

### Empty-state redesign
- Replaces the old onboarding checklist on the connected-empty surface with the new layout: the "on" connection graphic with a "Connected ✓" caption up top, and a bottom-anchored message plus a dark `primaryAlt`/`xl` "Add a new project to get started" CTA that opens the Add Project sheet.
- The "Need help?" floating pill no longer renders on this surface — the CTA owns the bottom of the screen. The connect-setup and bridge-offline surfaces keep it.
- Removed now-orphaned l10n strings and fixed dartdoc references to the deleted checklist.

### Machine name
- `ProjectListLoaded` now carries the account's registered bridges, enriched fail-soft via `RegisteredBridgesService.getRegisteredBridges()` in a follow-up emit after an empty load (same source and widget as the bridge-offline view). The row hides if the fetch fails and carries over across refreshes of a still-empty list so it never flickers. Non-empty lists never fetch.
- The Figma chevron-down next to the name is intentionally omitted — the shared `_MachineNameRow` is a static label, matching the offline page.

### Prego fix
- `PregoButtonsSolid` labels now truncate with an ellipsis instead of overflowing the Row when the label outgrows the available width.

## Test plan
- New widget tests for the connected-empty view (graphic/caption/message/CTA, no Need-help pill, CTA opens the Add Project sheet, machine row shown/hidden).
- New cubit blocTests for the machine-identity enrichment (follow-up emit, fail-soft, non-empty skip, mid-fetch race suppression, refresh carry-over).
- Full suites green: module_core 466 tests, client/app 585 tests; analyzers clean.
- Manual verification on device pending (@shumkov-d).

https://claude.ai/code/session_01MK3DGDLRBMNWJNZDpmGJdM

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the connected-but-empty Projects screen to match the new Figma layout and added the connected machine name. Also ensures the machine name appears after hiding the last project.

- **New Features**
  - Added `_ConnectedEmptyView`: shows the “on” connection graphic, a success “Connected” caption, optional machine name, a short message, and a dark `primaryAlt`/`xl` “Add a new project to get started” button that opens the Add Project sheet.
  - Machine identity on empty state: `ProjectListLoaded` now carries `bridges` fetched via `RegisteredBridgesService.getRegisteredBridges()`. Loads after an empty result, fails soft (hides row), skips when projects exist, and carries across refreshes to avoid flicker.
  - Removed the “Need help?” pill and install commands from this surface; they remain on connect-setup and bridge-offline.
  - L10n updates: added `projectsEmptyConnected`, `projectsEmptyMessage`, `projectsEmptyAddProject`; removed old step-based strings.

- **Bug Fixes**
  - Trigger machine-identity enrichment when hiding the last project so the connected-empty state shows the machine name without waiting for a refresh.
  - `PregoButtonsSolid` labels now truncate with an ellipsis instead of overflowing.

<sup>Written for commit e0b5550ca7fa038ec8cd14745c9127f4328aa9fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

