### PR TITLE
fix(acp): show sent prompts in chronological order

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -132,6 +132,9 @@ class AcpEventMapper {
     _sessionSnapshots.remove(sessionId);
     _turnSeq.remove(sessionId);
     _startedParts.remove(sessionId);
+    _sentUserSeq.remove(sessionId);
+    _idlessAssistantSeq.remove(sessionId);
+    _openIdlessAssistant.remove(sessionId);
     // Exact per-session removal — session ids are opaque agent strings that may
     // themselves contain ':', so a prefix match on a composite key could wipe a
     // different session's tools.
@@ -153,6 +156,16 @@ class AcpEventMapper {
   /// grow without bound across a long-running session.
   final Map<String, Set<String>> _startedParts = {};
 
+  /// Sequence for user messages accepted by this plugin. These are emitted
+  /// locally because ACP agents do not reliably echo `user_message_chunk`.
+  final Map<String, int> _sentUserSeq = {};
+
+  /// Fallback assistant-envelope sequence when ACP omits `messageId`.
+  final Map<String, int> _idlessAssistantSeq = {};
+
+  /// Sessions whose current id-less assistant envelope has received content.
+  final Set<String> _openIdlessAssistant = {};
+
   /// Advance the turn counter for [sessionId]. Call before `session/prompt`
   /// so the next batch of streamed chunks groups under a fresh message id.
   void beginTurn(String sessionId) {
@@ -160,6 +173,8 @@ class AcpEventMapper {
     // The new turn uses fresh (turn-numbered) part ids, so the prior turn's are
     // dead weight — drop them to bound memory in long sessions.
     _startedParts.remove(sessionId);
+    _idlessAssistantSeq.remove(sessionId);
+    _openIdlessAssistant.remove(sessionId);
     // Tool state is retained across a turn (so a reordered late `tool_call_update`
     // still merges onto its terminal state instead of blanking the card), and
     // cleared here at the turn boundary to keep it bounded.
@@ -167,6 +182,37 @@ class AcpEventMapper {
   }
 
   int _turn(String sessionId) => _turnSeq[sessionId] ?? 1;
+
+  /// Maps an accepted outbound prompt to its canonical live user message.
+  List<BridgeSseEvent> mapSentPrompt({
+    required String sessionId,
+    required List<PluginPromptPart> parts,
+  }) {
+    final textParts = parts
+        .whereType<PluginPromptPartText>()
+        .where((part) => part.text.isNotEmpty)
+        .toList();
+    if (textParts.isEmpty) return const [];
+
+    final sequence = (_sentUserSeq[sessionId] ?? 0) + 1;
+    _sentUserSeq[sessionId] = sequence;
+    final messageId = "$sessionId-sent-$sequence-user";
+    return [
+      BridgeSseMessageUpdated(
+        info: _messageFor(_ChunkRole.user, messageId, sessionId).toJson(),
+      ),
+      for (var index = 0; index < textParts.length; index++)
+        BridgeSseMessagePartUpdated(
+          part: _part(
+            partId: "$messageId-text-$index",
+            messageId: messageId,
+            sessionId: sessionId,
+            type: PluginMessagePartType.text,
+            text: textParts[index].text,
+          ),
+        ),
+    ];
+  }
 
   /// Maps a single notification to zero or more bridge events.
   List<BridgeSseEvent> map(AcpNotification notification) {
@@ -198,13 +244,10 @@ class AcpEventMapper {
           partType: PluginMessagePartType.reasoning,
         );
       case "user_message_chunk":
-        return _textChunk(
-          sessionId: sessionId,
-          update: update,
-          role: _ChunkRole.user,
-          partSuffix: "text",
-          partType: PluginMessagePartType.text,
-        );
+        // This plugin emits the accepted prompt itself. A live user chunk is
+        // the agent echoing that same prompt and would render it twice. Replay
+        // is reconstructed separately by AcpReplayCollector.
+        return const [];
       case "tool_call":
         return _toolCall(sessionId: sessionId, update: update);
       case "tool_call_update":
@@ -279,9 +322,13 @@ class AcpEventMapper {
     // user chunk into an assistant envelope. Absent (Cursor today) → the
     // synthesized per-turn id.
     final acpMessageId = update["messageId"];
-    final messageId = acpMessageId is String && acpMessageId.isNotEmpty
+    final hasAcpMessageId = acpMessageId is String && acpMessageId.isNotEmpty;
+    final fallbackSuffix = role == _ChunkRole.assistant
+        ? "-a${_idlessAssistantSeq[sessionId] ?? 0}"
+        : "";
+    final messageId = hasAcpMessageId
         ? "$sessionId-m$acpMessageId-${role.name}"
-        : "$sessionId-t${_turn(sessionId)}-${role.name}";
+        : "$sessionId-t${_turn(sessionId)}-${role.name}$fallbackSuffix";
     final partId = "$messageId-$partSuffix";
 
     final events = <BridgeSseEvent>[];
@@ -311,6 +358,9 @@ class AcpEventMapper {
         delta: text,
       ),
     );
+    if (role == _ChunkRole.assistant && !hasAcpMessageId) {
+      _openIdlessAssistant.add(sessionId);
+    }
     return events;
   }
 
@@ -320,6 +370,9 @@ class AcpEventMapper {
   }) {
     final toolCallId = update["toolCallId"] as String?;
     if (toolCallId == null || toolCallId.isEmpty) return const [];
+    if (_liveTools[sessionId]?[toolCallId] == null) {
+      _closeIdlessAssistantEnvelope(sessionId);
+    }
     final messageId = "$sessionId-tool-$toolCallId";
     final state = _LiveTool(
       // Fail-soft like the tool name and `_toolCallUpdate`'s title: a non-string
@@ -359,6 +412,9 @@ class AcpEventMapper {
     // which would blank an existing tool card. Mirrors the replay collector,
     // which already merges — keeping live and history renderings consistent.
     final prior = _liveTools[sessionId]?[toolCallId];
+    if (prior == null) {
+      _closeIdlessAssistantEnvelope(sessionId);
+    }
     // Only re-resolve the tool identifier when `kind` is explicitly present; a
     // title-only update must NOT overwrite the canonical id (e.g. "edit") with
     // the title text (`title` lives separately in PluginToolState.title). This
@@ -395,6 +451,12 @@ class AcpEventMapper {
       mutationAvailable: _hasDiffContent(update),
     );
     return events;
+  }
+
+  void _closeIdlessAssistantEnvelope(String sessionId) {
+    if (!_openIdlessAssistant.remove(sessionId)) return;
+    _idlessAssistantSeq[sessionId] =
+        (_idlessAssistantSeq[sessionId] ?? 0) + 1;
   }
 
   BridgeSseMessageUpdated _toolEnvelope({required String sessionId, required String messageId}) {

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -637,6 +637,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
         parts: parts,
         model: model,
         variant: variant,
+        emitSentPrompt: false,
       );
     }
     return PluginSession(
@@ -666,6 +667,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       parts: parts,
       model: model,
       variant: variant,
+      emitSentPrompt: true,
     );
   }
 
@@ -686,6 +688,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       parts: [PluginPromptPart.text(text: body)],
       model: model,
       variant: variant,
+      emitSentPrompt: true,
     );
   }
 
@@ -841,6 +844,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     required List<PluginPromptPart> parts,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
+    required bool emitSentPrompt,
   }) {
     final blocks = parts
         .map(_promptPartToContentBlock)
@@ -848,9 +852,11 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
         .toList(growable: false);
     if (blocks.isEmpty) return;
 
-    eventMapper
-        .mapSentPrompt(sessionId: sessionId, parts: parts)
-        .forEach(_eventBuffer.add);
+    if (emitSentPrompt) {
+      eventMapper
+          .mapSentPrompt(sessionId: sessionId, parts: parts)
+          .forEach(_eventBuffer.add);
+    }
 
     final state = _turnStates.putIfAbsent(sessionId, _SessionTurnState.new);
     state.pending++;

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -848,6 +848,10 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
         .toList(growable: false);
     if (blocks.isEmpty) return;
 
+    eventMapper
+        .mapSentPrompt(sessionId: sessionId, parts: parts)
+        .forEach(_eventBuffer.add);
+
     final state = _turnStates.putIfAbsent(sessionId, _SessionTurnState.new);
     state.pending++;
     if (state.pending == 1) {

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -637,7 +637,6 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
         parts: parts,
         model: model,
         variant: variant,
-        emitSentPrompt: false,
       );
     }
     return PluginSession(
@@ -662,12 +661,14 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     // Acceptance gate: an unreachable agent fails the send itself; the turn
     // re-resolves the client at dispatch time (see [_runTurn]).
     await _connectedClient();
+    eventMapper
+        .mapSentPrompt(sessionId: sessionId, parts: parts)
+        .forEach(_eventBuffer.add);
     _enqueueTurn(
       sessionId: sessionId,
       parts: parts,
       model: model,
       variant: variant,
-      emitSentPrompt: true,
     );
   }
 
@@ -688,7 +689,6 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       parts: [PluginPromptPart.text(text: body)],
       model: model,
       variant: variant,
-      emitSentPrompt: true,
     );
   }
 
@@ -844,19 +844,12 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     required List<PluginPromptPart> parts,
     required ({String providerID, String modelID})? model,
     required PluginSessionVariant? variant,
-    required bool emitSentPrompt,
   }) {
     final blocks = parts
         .map(_promptPartToContentBlock)
         .whereType<Map<String, dynamic>>()
         .toList(growable: false);
     if (blocks.isEmpty) return;
-
-    if (emitSentPrompt) {
-      eventMapper
-          .mapSentPrompt(sessionId: sessionId, parts: parts)
-          .forEach(_eventBuffer.add);
-    }
 
     final state = _turnStates.putIfAbsent(sessionId, _SessionTurnState.new);
     state.pending++;

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -169,9 +169,13 @@ class AcpReplayCollector {
   // the current assistant message even when its content chunks are stamped.
   _Draft _assistantForTool() {
     if (_drafts.isNotEmpty && _drafts.last.role == "assistant") {
-      return _drafts.last;
+      final last = _drafts.last;
+      if (last.acpMessageId != null ||
+          (last.text.isEmpty && last.reasoning.isEmpty)) {
+        return last;
+      }
     }
-    return _ensureRole("assistant");
+    return _newDraft("assistant", messageId: null);
   }
 
   /// The draft the next chunk belongs to. ACP v1: chunks of one message share
@@ -183,10 +187,15 @@ class AcpReplayCollector {
   _Draft _ensureRole(String role, {String? messageId}) {
     if (_drafts.isNotEmpty && _drafts.last.role == role) {
       final last = _drafts.last;
-      if (last.acpMessageId == messageId) {
+      if (last.acpMessageId == messageId &&
+          !(messageId == null && last.tools.isNotEmpty)) {
         return last;
       }
     }
+    return _newDraft(role, messageId: messageId);
+  }
+
+  _Draft _newDraft(String role, {required String? messageId}) {
     final draft = _Draft(
       role: role,
       id: messageId != null && messageId.isNotEmpty

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -63,6 +63,71 @@ void main() {
       expect(part.type, PluginMessagePartType.reasoning);
     });
 
+    test("an accepted prompt maps to one canonical live user message", () {
+      final events = mapper.mapSentPrompt(
+        sessionId: "s1",
+        parts: [
+          const PluginPromptPart.text(text: "Hello"),
+          const PluginPromptPart.text(text: "Cursor"),
+        ],
+      );
+
+      final message = shared.Message.fromJson(
+        events.whereType<BridgeSseMessageUpdated>().single.info,
+      );
+      expect(message, isA<shared.MessageUser>());
+      expect(
+        events
+            .whereType<BridgeSseMessagePartUpdated>()
+            .map((event) => event.part.text),
+        ["Hello", "Cursor"],
+      );
+    });
+
+    test("a live agent user echo is dropped", () {
+      mapper.mapSentPrompt(
+        sessionId: "s1",
+        parts: [const PluginPromptPart.text(text: "Hello")],
+      );
+
+      final events = mapper.map(update({
+        "sessionUpdate": "user_message_chunk",
+        "content": {"type": "text", "text": "Hello"},
+      }));
+
+      expect(events, isEmpty);
+    });
+
+    test("id-less assistant text after a tool opens a later envelope", () {
+      mapper.beginTurn("s1");
+      final beforeTool = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "Before"},
+      }));
+      mapper.map(update({
+        "sessionUpdate": "tool_call",
+        "toolCallId": "tc-order",
+        "kind": "read",
+        "status": "completed",
+      }));
+      final afterTool = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "After"},
+      }));
+
+      final beforeId = shared.Message.fromJson(
+        beforeTool.whereType<BridgeSseMessageUpdated>().single.info,
+      ).id;
+      final afterId = shared.Message.fromJson(
+        afterTool.whereType<BridgeSseMessageUpdated>().single.info,
+      ).id;
+      expect(afterId, isNot(beforeId));
+      expect(
+        afterTool.whereType<BridgeSseMessagePartDelta>().single.delta,
+        "After",
+      );
+    });
+
     test("tool_call maps to an assistant message with a tool part", () {
       final events = mapper.map(update({
         "sessionUpdate": "tool_call",

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -38,19 +38,42 @@ void main() {
         }));
 
       final messages = collector.build();
-      expect(messages, hasLength(2));
+      expect(messages, hasLength(3));
 
       final user = messages.first;
       expect(user.info, isA<PluginMessageUser>());
       expect(user.parts.single.text, "list md files");
 
-      final assistant = messages.last;
-      expect(assistant.info, isA<PluginMessageAssistant>());
-      final toolPart = assistant.parts.firstWhere((p) => p.type == PluginMessagePartType.tool);
+      final toolMessage = messages[1];
+      expect(toolMessage.info, isA<PluginMessageAssistant>());
+      final toolPart = toolMessage.parts.single;
       expect(toolPart.state?.status, PluginToolStatus.completed);
       expect(toolPart.state?.output, "README.md");
-      final textPart = assistant.parts.firstWhere((p) => p.type == PluginMessagePartType.text);
-      expect(textPart.text, "There is 1 file.");
+      expect(messages.last.parts.single.text, "There is 1 file.");
+    });
+
+    test("id-less text after a tool stays chronologically after the tool", () {
+      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "Before"},
+        }))
+        ..consume(upd({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "t1",
+          "kind": "read",
+          "status": "completed",
+        }))
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "After"},
+        }));
+
+      final messages = collector.build();
+      expect(messages, hasLength(3));
+      expect(messages[0].parts.single.text, "Before");
+      expect(messages[1].parts.single.type, PluginMessagePartType.tool);
+      expect(messages[2].parts.single.text, "After");
     });
 
     test("a partial (output-only) update does not reset a completed tool to pending", () {

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -131,6 +131,25 @@ void main() {
     int busyCount() => emitted.whereType<BridgeSseSessionStatus>().length;
     int idleCount() => emitted.whereType<BridgeSseSessionIdle>().length;
 
+    test("an accepted prompt is emitted immediately as a user message", () async {
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+      emitted.clear();
+
+      await sendPrompt(sessionId, "visible immediately");
+      await pump();
+
+      final message = emitted.whereType<BridgeSseMessageUpdated>().single;
+      expect(message.info["role"], "user");
+      expect(
+        emitted.whereType<BridgeSseMessagePartUpdated>().single.part.text,
+        "visible immediately",
+      );
+
+      final prompt = await waitForFrame("session/prompt");
+      respondTo(prompt, {"stopReason": "end_turn"});
+    });
+
     test("a second prompt on one session dispatches only after the first turn completes", () async {
       await connect();
       final sessionId = await createSession(cwd, "s1");

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -176,6 +176,27 @@ void main() {
       respondTo(prompt, {"stopReason": "end_turn"});
     });
 
+    test("command arguments are not emitted as a user message", () async {
+      await connect();
+      final sessionId = await createSession(cwd, "s1");
+      emitted.clear();
+
+      await plugin.sendCommand(
+        sessionId: sessionId,
+        command: "review",
+        arguments: "[SYSTEM CONTEXT — IMPORTANT] internal\n\nuser arguments",
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await pump();
+
+      expect(emitted.whereType<BridgeSseMessageUpdated>(), isEmpty);
+
+      final prompt = await waitForFrame("session/prompt");
+      respondTo(prompt, {"stopReason": "end_turn"});
+    });
+
     test("a second prompt on one session dispatches only after the first turn completes", () async {
       await connect();
       final sessionId = await createSession(cwd, "s1");

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -150,6 +150,32 @@ void main() {
       respondTo(prompt, {"stopReason": "end_turn"});
     });
 
+    test("an initial create prompt is left to history replay", () async {
+      await connect();
+      emitted.clear();
+
+      final creating = plugin.createSession(
+        directory: cwd,
+        parentSessionId: null,
+        parts: [
+          const PluginPromptPart.text(text: "[SYSTEM CONTEXT — IMPORTANT] internal"),
+          const PluginPromptPart.text(text: "visible prompt"),
+        ],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final frame = await waitForFrame("session/new");
+      respondTo(frame, {"sessionId": "s1"});
+      await creating;
+      await pump();
+
+      expect(emitted.whereType<BridgeSseMessageUpdated>(), isEmpty);
+
+      final prompt = await waitForFrame("session/prompt");
+      respondTo(prompt, {"stopReason": "end_turn"});
+    });
+
     test("a second prompt on one session dispatches only after the first turn completes", () async {
       await connect();
       final sessionId = await createSession(cwd, "s1");

--- a/docs/cursor-acp-followups/README.md
+++ b/docs/cursor-acp-followups/README.md
@@ -46,6 +46,7 @@ than observed Cursor bugs. That is called out per item.
 | #  | Theme                                                | Why it matters                                                  | Status |
 |----|------------------------------------------------------|----------------------------------------------------------------|------------|
 | H  | Resume-load & per-session turn robustness            | **User-facing:** stuck conversations, dropped queued prompts, replay leak | **Resolved** |
+| J  | Live user messages and id-less envelope ordering     | **User-facing:** missing prompts and chronologically misplaced replies | **Resolved** |
 | A  | Bridge↔plugin stored-directory / attribution seam    | Real worktree flows on restart; one hook resolves three threads | **Resolved** |
 | B  | Durable derive-plugin session state (bridge schema)  | Title loss + deleted sessions reappearing                       | **Resolved** |
 | C  | ACP protocol completeness in the mapper / parsers    | Correctness for the next ACP backend                            | **Resolved** |
@@ -54,6 +55,21 @@ than observed Cursor bugs. That is called out per item.
 | E  | Typed ACP/Cursor boundary DTOs                        | Enabler / safety net for C and F                                | Blocked on traces (Large) |
 | F  | `getSessionMessages` richer failure contract         | "Broken replay" vs "empty thread" on the phone                  | **Resolved** |
 | D  | Cursor decisions needing a trace / product call      | Small, but blocked on evidence                                  | D2 resolved; D1 blocked on a trace |
+
+---
+
+## Theme J — Live user messages and id-less envelope ordering ✅ Resolved
+
+**Resolved.** `AcpPlugin` now emits each accepted prompt as the canonical live
+user message instead of waiting for an unreliable agent echo. The live mapper
+ignores duplicate `user_message_chunk` echoes; `session/load` replay continues
+to reconstruct persisted user messages independently.
+
+When an agent omits ACP `messageId` (Cursor's current behavior), a first-seen
+tool now closes preceding assistant text so later text opens a new envelope
+below the tool. `AcpReplayCollector` applies the same id-less boundary rule,
+preserving text → tool → text chronology after reload. Explicit ACP
+`messageId` grouping remains unchanged.
 
 ---
 


### PR DESCRIPTION
## Summary
- emit accepted ACP prompts immediately as canonical live user messages
- keep id-less assistant text after tool calls in a later message envelope
- apply the same text/tool boundary when reconstructing ACP replay history

## Validation
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_acp`
- `dart test` in `bridge/sesori_plugin_acp` (122 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show each sent prompt immediately as a live user message in order. Keep assistant text → tool → text when ACP omits `messageId`.

- **Bug Fixes**
  - `AcpPlugin`: emit only `sendPrompt` messages as canonical user messages; skip create-session context and command arguments.
  - `AcpEventMapper`: drop `user_message_chunk` echoes; close an id‑less assistant envelope before the first tool and open a new one after.
  - `AcpReplayCollector`: mirror the same id‑less boundary during `session/load` so history matches live order.

<sup>Written for commit 150f06faa631de17b8ffd556cfdb088d283c919f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

