### PR TITLE
fix(acp): let stored primes repair fallback directories

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -546,12 +546,11 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     final hasCwd = rawCwd != null && rawCwd.trim().isNotEmpty;
     final directory = normalizeProjectDirectory(directory: hasCwd ? rawCwd : fallbackDirectory);
     final id = info.sessionId;
-    // Remember the session's directory so a later turn/history load uses its
-    // own cwd and events/activity attribute to the right project. The
-    // title/time snapshot keeps `session_info_update` emissions full-fidelity
-    // (the mobile list replaces the whole session on session.updated).
+    // Only an agent-reported cwd is authoritative for later turn/history
+    // loads. A scan fallback remains eligible for a stored bridge prime to
+    // repair. Events can use the fallback until that prime arrives.
     if (id.isNotEmpty) {
-      _sessionDirectories[id] = directory;
+      if (hasCwd) _sessionDirectories[id] = directory;
       eventMapper.setSessionProject(id, directory);
       eventMapper.setSessionSnapshot(
         sessionId: id,

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -422,7 +422,11 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       try {
         for (final info in await _listSessionPages(client, cwd: null)) {
           if (info.sessionId.isEmpty) continue;
-          sessionsById[info.sessionId] = _toPluginSession(info, fallbackDirectory: launchDirectory);
+          sessionsById[info.sessionId] = _toPluginSession(
+            info,
+            fallbackDirectory: launchDirectory,
+            fallbackIsAuthoritative: false,
+          );
           final hasCwd = info.cwd != null && info.cwd!.trim().isNotEmpty;
           if (!hasCwd) fallbackAttributed.add(info.sessionId);
         }
@@ -448,7 +452,11 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
           // it fills a session not seen yet AND repairs one the unfiltered
           // pass could only attribute to the launch fallback.
           if (!sessionsById.containsKey(info.sessionId) || fallbackAttributed.remove(info.sessionId)) {
-            sessionsById[info.sessionId] = _toPluginSession(info, fallbackDirectory: directory);
+            sessionsById[info.sessionId] = _toPluginSession(
+              info,
+              fallbackDirectory: directory,
+              fallbackIsAuthoritative: true,
+            );
           }
         }
       } on Object catch (error, stack) {
@@ -476,7 +484,11 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     try {
       final mapped = [
         for (final info in await _listSessionPages(client, cwd: target))
-          _toPluginSession(info, fallbackDirectory: target),
+          _toPluginSession(
+            info,
+            fallbackDirectory: target,
+            fallbackIsAuthoritative: true,
+          ),
       ];
       final from = start ?? 0;
       if (from >= mapped.length) return const [];
@@ -536,7 +548,11 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     return infos;
   }
 
-  PluginSession _toPluginSession(AcpSessionInfo info, {required String fallbackDirectory}) {
+  PluginSession _toPluginSession(
+    AcpSessionInfo info, {
+    required String fallbackDirectory,
+    required bool fallbackIsAuthoritative,
+  }) {
     // The session belongs to its own cwd, canonicalized so it matches the
     // project id the bridge derives from the same value. A missing OR blank cwd
     // falls back to the directory that was scanned — the same `trim().isNotEmpty`
@@ -545,13 +561,14 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     final rawCwd = info.cwd;
     final hasCwd = rawCwd != null && rawCwd.trim().isNotEmpty;
     final directory = normalizeProjectDirectory(directory: hasCwd ? rawCwd : fallbackDirectory);
+    final directoryIsAuthoritative = hasCwd || fallbackIsAuthoritative;
     final id = info.sessionId;
-    // Only an agent-reported cwd is authoritative for later turn/history
-    // loads. A scan fallback remains eligible for a stored bridge prime to
-    // repair. Events can use the fallback until that prime arrives.
+    // A cwd-scoped response is authoritative even when its item omits cwd. Only
+    // the unfiltered launch fallback remains eligible for a stored bridge prime
+    // to repair.
     if (id.isNotEmpty) {
-      if (hasCwd) _sessionDirectories[id] = directory;
-      eventMapper.setSessionProject(id, directory);
+      if (directoryIsAuthoritative) _sessionDirectories[id] = directory;
+      eventMapper.setSessionProject(id, _sessionDirectories[id] ?? directory);
       eventMapper.setSessionSnapshot(
         sessionId: id,
         title: info.title,

--- a/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
@@ -622,6 +622,40 @@ void main() {
       await respond("session/prompt", {"stopReason": "end_turn"});
     });
 
+    test("a prime repairs a launch-directory fallback from enumeration", () async {
+      await connect(sessionCapabilities: true);
+      const stored = "/Users/x/kustos";
+
+      final stop = autoListResponder(
+        bare: () => {
+          "sessions": [
+            {"sessionId": "cold-s", "title": "Cold"},
+          ],
+        },
+      );
+      final sessions = await plugin.listAllSessions(knownDirectories: const {});
+      stop();
+      expect(sessions.single.directory, cwd);
+
+      plugin.primeSessionDirectory(sessionId: "cold-s", directory: stored);
+      final sending = plugin.sendPrompt(
+        sessionId: "cold-s",
+        parts: const [PluginPromptPart.text(text: "resume me")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final loadFrame = await waitForFrame("session/load");
+      expect(
+        (loadFrame["params"] as Map)["cwd"],
+        stored,
+        reason: "the stored bridge prime must repair a scan-only fallback",
+      );
+      fake().emit({"jsonrpc": "2.0", "id": loadFrame["id"], "result": const <String, dynamic>{}});
+      await sending;
+      await respond("session/prompt", {"stopReason": "end_turn"});
+    });
+
     test("a prime does not override an agent-reported directory", () async {
       await connect(sessionCapabilities: true);
       const opened = "/Users/x/kustos";

--- a/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
@@ -379,16 +379,33 @@ void main() {
         },
         byCwd: {
           home: [
-            {"sessionId": "s1", "cwd": home, "title": "One"},
+            {"sessionId": "s1", "title": "One"},
           ],
         },
       );
       final sessions = await plugin.listAllSessions(knownDirectories: const {home});
-      stop();
 
       final s1 = sessions.singleWhere((s) => s.id == "s1");
       expect(s1.directory, home, reason: "the cwd-scoped hit must replace the launch fallback");
       expect(s1.projectID, home);
+
+      final sending = plugin.sendPrompt(
+        sessionId: "s1",
+        parts: const [PluginPromptPart.text(text: "resume me")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final loadFrame = await waitForFrame("session/load");
+      stop();
+      expect(
+        (loadFrame["params"] as Map)["cwd"],
+        home,
+        reason: "a cwd-scoped hit stays authoritative when the item omits cwd",
+      );
+      fake().emit({"jsonrpc": "2.0", "id": loadFrame["id"], "result": const <String, dynamic>{}});
+      await sending;
+      await respond("session/prompt", {"stopReason": "end_turn"});
     });
 
     test("a blank cwd falls back to the launch directory, not the process cwd", () async {
@@ -638,6 +655,21 @@ void main() {
       expect(sessions.single.directory, cwd);
 
       plugin.primeSessionDirectory(sessionId: "cold-s", directory: stored);
+      final stopAgain = autoListResponder(
+        bare: () => {
+          "sessions": [
+            {"sessionId": "cold-s", "title": "Cold"},
+          ],
+        },
+      );
+      await plugin.listAllSessions(knownDirectories: const {});
+      stopAgain();
+      expect(
+        plugin.eventMapper.projectForSession("cold-s"),
+        stored,
+        reason: "an unfiltered fallback must not replace established event attribution",
+      );
+
       final sending = plugin.sendPrompt(
         sessionId: "cold-s",
         parts: const [PluginPromptPart.text(text: "resume me")],


### PR DESCRIPTION
## Summary
- keep only agent-reported ACP cwd values in the authoritative session-directory cache
- allow persisted bridge primes to replace scan-only launch-directory fallbacks
- preserve fallback display/event attribution and agent-reported cwd precedence

## Validation
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_acp`
- `dart test` in `bridge/sesori_plugin_acp` (125 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ACP session directory handling by treating agent-reported cwd and cwd-scoped listings as authoritative. Stored primes can repair scan-only launch fallbacks without overriding a real agent cwd or a scoped hit.

- **Bug Fixes**
  - Cache session directory only when the agent provides a cwd or the results are cwd-scoped; unfiltered launch fallbacks are not cached.
  - Allow persisted primes to replace unfiltered launch fallbacks on load and prompt send; keep fallback attribution until repaired and never override agent-reported or scoped directories.

<sup>Written for commit eac1feb3c8106cd20dccdccea16e2166c4133b97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

