### PR TITLE
fix(codex): surface transcript read failures

### DIFF
--- a/bridge/sesori_plugin_codex/lib/src/session_rollout_reader.dart
+++ b/bridge/sesori_plugin_codex/lib/src/session_rollout_reader.dart
@@ -9,6 +9,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
         PluginMessagePartType,
         PluginMessageTime,
         PluginMessageWithParts,
+        PluginOperationException,
         PluginToolState,
         PluginToolStatus;
 
@@ -339,10 +340,15 @@ class SessionRolloutReader {
     final List<String> lines;
     try {
       lines = file.readAsLinesSync();
-    } catch (_) {
-      // Permission/IO error reading the transcript: fail soft so the message
-      // fetch returns empty rather than throwing through getSessionMessages.
-      return const [];
+    } on Object catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        PluginOperationException(
+          "read Codex session transcript",
+          message: "history read for $sessionId failed",
+          cause: error,
+        ),
+        stackTrace,
+      );
     }
 
     // Pre-scan: a tool call (`function_call`) and its result

--- a/bridge/sesori_plugin_codex/test/session_rollout_reader_test.dart
+++ b/bridge/sesori_plugin_codex/test/session_rollout_reader_test.dart
@@ -184,6 +184,30 @@ void main() {
       expect(messages[0].info.sessionID, equals("019a0000-1111-2222-3333-aaaaaaaaaaaa"));
     });
 
+    test("readMessages surfaces transcript read failures", () {
+      const sessionId = "019a0000-1111-2222-3333-aaaaaaaaaaaa";
+      final path = p.join(codexHome.path, "broken-rollout.jsonl");
+      File(path).writeAsBytesSync([0xFF]);
+
+      expect(
+        () => reader.readMessages(path, sessionId),
+        throwsA(
+          isA<PluginOperationException>()
+              .having(
+                (error) => error.operation,
+                "operation",
+                "read Codex session transcript",
+              )
+              .having(
+                (error) => error.message,
+                "message",
+                "history read for $sessionId failed",
+              )
+              .having((error) => error.cause, "cause", isA<FileSystemException>()),
+        ),
+      );
+    });
+
     test("readMessages surfaces tool calls (function_call + output) as tool parts", () {
       final path = _writeRollout(
         codexHome,


### PR DESCRIPTION
## Summary
- surface Codex rollout read failures as `PluginOperationException` instead of an empty history
- preserve empty history semantics when no rollout file exists
- cover an existing but unreadable transcript with a regression test

## Testing
- `dart test` in `bridge/sesori_plugin_codex` (133 tests)
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_codex`

Follow-up to #418 review thread: https://github.com/sesori-ai/sesori_apps_monorepo/pull/418#discussion_r3558915467

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface transcript read failures in `sesori_plugin_codex` as a `PluginOperationException` instead of returning an empty history. Still return empty history when the rollout file is missing, and add a regression test for unreadable transcripts.

<sup>Written for commit bb903c8e8acb31510946b6f36e14642d14ee7974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

