### PR TITLE
feat: add plugin identity compatibility contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,11 +22,13 @@ have written. Before repairing a historical shape, identify the shipped writer,
 the exact inputs that produced it, and a reachable persisted example; a schema
 default or hypothetical future plugin is not evidence of compatibility debt.
 
-Compatibility sentinels are wire-boundary values, not nullable internal
-identity. Normalize missing legacy plugin identity to the shared
-`legacyMissingPluginId` constant, keep internal `pluginId` parameters non-null,
-and resolve the sentinel at the bridge routing boundary when an active plugin is
-available. Project-only request DTOs must not carry `pluginId`; use a dedicated
+Legacy payloads that omit plugin identity default to OpenCode because it was the
+only backend those released peers could target. Keep internal `pluginId`
+parameters non-null and forward this concrete compatibility identity unchanged;
+do not substitute whichever plugin happens to be active. This historical wire
+default is the sole backend-specific compatibility exception in shared models,
+not permission to expose backend capabilities or behavior past the plugin
+boundary. Project-only request DTOs must not carry `pluginId`; use a dedicated
 plugin-scoped DTO for operations whose routing depends on plugin identity.
 
 **Directional invariants (don't weld these doors shut):**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,11 @@ preserve a hypothetical backend distinction. Require a concrete wire trace,
 shipped behavior, or explicit product requirement before making that state
 durable; otherwise use the simpler observable semantics.
 
+Do not add compatibility repair code for rows that no released producer could
+have written. Before repairing a historical shape, identify the shipped writer,
+the exact inputs that produced it, and a reachable persisted example; a schema
+default or hypothetical future plugin is not evidence of compatibility debt.
+
 Compatibility sentinels are wire-boundary values, not nullable internal
 identity. Normalize missing legacy plugin identity to the shared
 `legacyMissingPluginId` constant, keep internal `pluginId` parameters non-null,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,13 @@ preserve a hypothetical backend distinction. Require a concrete wire trace,
 shipped behavior, or explicit product requirement before making that state
 durable; otherwise use the simpler observable semantics.
 
+Compatibility sentinels are wire-boundary values, not nullable internal
+identity. Normalize missing legacy plugin identity to the shared
+`legacyMissingPluginId` constant, keep internal `pluginId` parameters non-null,
+and resolve the sentinel at the bridge routing boundary when an active plugin is
+available. Project-only request DTOs must not carry `pluginId`; use a dedicated
+plugin-scoped DTO for operations whose routing depends on plugin identity.
+
 **Directional invariants (don't weld these doors shut):**
 
 - **Plugin boundary is sacred** — no backend specifics leak past `BridgePluginApi` into `shared/`, the relay protocol, or the client; our own harness is *just a plugin*; differing abilities are optional, declared capabilities.

--- a/bridge/AGENTS.md
+++ b/bridge/AGENTS.md
@@ -159,6 +159,11 @@ released bridge/plugin path that wrote the bad value and the concrete condition
 that triggered it first; if every shipped plugin wrote the same identity and
 directory, keep existing rows authoritative and seed only genuinely new rows.
 
+Plugin-local collaborators must reuse the plugin identity supplied by their
+composer instead of repeating its string literal. Prefer an injected identity
+when importing the plugin implementation would create a composer/collaborator
+dependency cycle.
+
 ### Orchestrator Owns SSE Decisions
 
 No component below the Orchestrator may emit SSE events directly. The Orchestrator subscribes to streams (`plugin.events`, `prSyncService.prChanges`) and decides what to emit to phones. No `emitBridgeEvent()` or similar public methods on the Orchestrator.

--- a/bridge/AGENTS.md
+++ b/bridge/AGENTS.md
@@ -154,6 +154,11 @@ Do not persist a backend edge case merely because its schema permits it. A
 sentinel, presence bit, or tri-state column needs evidence that the backend
 actually emits the distinction and that users observe different behavior.
 
+Do not mutate existing rows to repair a hypothetical legacy shape. Name the
+released bridge/plugin path that wrote the bad value and the concrete condition
+that triggered it first; if every shipped plugin wrote the same identity and
+directory, keep existing rows authoritative and seed only genuinely new rows.
+
 ### Orchestrator Owns SSE Decisions
 
 No component below the Orchestrator may emit SSE events directly. The Orchestrator subscribes to streams (`plugin.events`, `prSyncService.prChanges`) and decides what to emit to phones. No `emitBridgeEvent()` or similar public methods on the Orchestrator.

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -783,6 +783,7 @@ class OrchestratorSession {
         await _sessionUnseenService.recordSessionCreated(
           sessionId: info.id,
           projectId: info.projectID,
+          sessionDirectory: info.directory,
           parentId: info.parentID,
           occurredAt: info.time?.created,
         );

--- a/bridge/app/lib/src/bridge/persistence/daos/projects_dao.dart
+++ b/bridge/app/lib/src/bridge/persistence/daos/projects_dao.dart
@@ -196,6 +196,28 @@ class ProjectsDao extends DatabaseAccessor<AppDatabase> with _$ProjectsDaoMixin 
     });
   }
 
+  Future<void> insertProjectsWithPathsIfMissing({
+    required Map<String, ({String path, int? createdAt, int? updatedAt})> projects,
+  }) async {
+    if (projects.isEmpty) return;
+    await batch((b) {
+      b.insertAll(
+        projectsTable,
+        projects.entries
+            .map(
+              (entry) => ProjectsTableCompanion.insert(
+                projectId: entry.key,
+                path: entry.value.path,
+                createdAt: Value.absentIfNull(entry.value.createdAt),
+                updatedAt: Value.absentIfNull(entry.value.updatedAt),
+              ),
+            )
+            .toList(),
+        mode: InsertMode.insertOrIgnore,
+      );
+    });
+  }
+
   /// Inserts project rows with the exact [activities] for ids that are missing.
   /// Existing rows are untouched.
   Future<void> insertMissingProjectsWithActivity({

--- a/bridge/app/lib/src/bridge/persistence/daos/projects_dao.dart
+++ b/bridge/app/lib/src/bridge/persistence/daos/projects_dao.dart
@@ -9,13 +9,14 @@ part "projects_dao.g.dart";
 class ProjectsDao extends DatabaseAccessor<AppDatabase> with _$ProjectsDaoMixin {
   ProjectsDao(super.attachedDatabase);
 
-  // `path` is the project's live directory; `projectId` is its stable
-  // identifier (for every shipped plugin: the directory the project was FIRST
-  // opened at). They diverge when a folder is moved on disk and re-opened —
-  // [recordOpenedProject] is the only writer that stores a meaningful path.
-  // Every other insert below stamps the project id as the row's `path` purely
-  // as the new-row default (correct until a move is recorded); none of their
-  // conflict clauses touch `path`, so an existing recorded path is preserved.
+  // `path` is the project's live directory; `projectId` is its stable,
+  // plugin-defined identifier and may be opaque. They can also diverge when a
+  // folder is moved on disk and re-opened — [recordOpenedProject] is the writer
+  // that updates an existing row's path.
+  // Inserts without an explicit path stamp the project id as the row's `path`
+  // purely as the new-row default (correct until a move is recorded); none of
+  // their conflict clauses touch `path`, so an existing recorded path is
+  // preserved.
 
   /// Returns every stored project row.
   Future<List<ProjectDto>> getAllProjects() async {
@@ -194,6 +195,15 @@ class ProjectsDao extends DatabaseAccessor<AppDatabase> with _$ProjectsDaoMixin 
         mode: InsertMode.insertOrIgnore,
       );
     });
+  }
+
+  /// Inserts one project with its explicit [path] when it does not exist.
+  /// Existing rows are untouched.
+  Future<void> insertProjectIfMissing({required String projectId, required String path}) async {
+    await into(projectsTable).insert(
+      ProjectsTableCompanion.insert(projectId: projectId, path: path),
+      mode: InsertMode.insertOrIgnore,
+    );
   }
 
   Future<void> insertProjectsWithPathsIfMissing({

--- a/bridge/app/lib/src/bridge/persistence/daos/projects_dao.dart
+++ b/bridge/app/lib/src/bridge/persistence/daos/projects_dao.dart
@@ -218,6 +218,17 @@ class ProjectsDao extends DatabaseAccessor<AppDatabase> with _$ProjectsDaoMixin 
     });
   }
 
+  Future<void> replacePathIfMatches({
+    required String projectId,
+    required String expectedPath,
+    required String replacementPath,
+  }) async {
+    await (update(projectsTable)..where(
+          (project) => project.projectId.equals(projectId) & project.path.equals(expectedPath),
+        ))
+        .write(ProjectsTableCompanion(path: Value(replacementPath)));
+  }
+
   Future<void> setActivity({required String projectId, required int createdAt, required int updatedAt}) async {
     await into(projectsTable).insert(
       ProjectsTableCompanion.insert(

--- a/bridge/app/lib/src/bridge/persistence/daos/projects_dao.dart
+++ b/bridge/app/lib/src/bridge/persistence/daos/projects_dao.dart
@@ -199,7 +199,7 @@ class ProjectsDao extends DatabaseAccessor<AppDatabase> with _$ProjectsDaoMixin 
   /// Inserts project rows with the exact [activities] for ids that are missing.
   /// Existing rows are untouched.
   Future<void> insertMissingProjectsWithActivity({
-    required Map<String, ({int createdAt, int updatedAt})> activities,
+    required Map<String, ({String path, int createdAt, int updatedAt})> activities,
   }) async {
     if (activities.isEmpty) return;
     await batch((b) {
@@ -208,7 +208,7 @@ class ProjectsDao extends DatabaseAccessor<AppDatabase> with _$ProjectsDaoMixin 
         activities.entries.map((e) {
           return ProjectsTableCompanion.insert(
             projectId: e.key,
-            path: e.key,
+            path: e.value.path,
             createdAt: Value(e.value.createdAt),
             updatedAt: Value(e.value.updatedAt),
           );

--- a/bridge/app/lib/src/bridge/persistence/daos/projects_dao.dart
+++ b/bridge/app/lib/src/bridge/persistence/daos/projects_dao.dart
@@ -250,17 +250,6 @@ class ProjectsDao extends DatabaseAccessor<AppDatabase> with _$ProjectsDaoMixin 
     });
   }
 
-  Future<void> replacePathIfMatches({
-    required String projectId,
-    required String expectedPath,
-    required String replacementPath,
-  }) async {
-    await (update(projectsTable)..where(
-          (project) => project.projectId.equals(projectId) & project.path.equals(expectedPath),
-        ))
-        .write(ProjectsTableCompanion(path: Value(replacementPath)));
-  }
-
   Future<void> setActivity({required String projectId, required int createdAt, required int updatedAt}) async {
     await into(projectsTable).insert(
       ProjectsTableCompanion.insert(

--- a/bridge/app/lib/src/bridge/repositories/agent_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/agent_repository.dart
@@ -1,6 +1,6 @@
 import "dart:io" as io;
 
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginApi, PluginOperationException;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginApi;
 import "package:sesori_shared/sesori_shared.dart" show Agents, StringExtensions;
 
 import "../persistence/daos/projects_dao.dart";
@@ -15,8 +15,9 @@ class AgentRepository {
     : _plugin = plugin,
       _projectsDao = projectsDao;
 
-  Future<Agents> getAgents({required String? projectId, required String? pluginId}) async {
-    _validatePluginSelection(pluginId: pluginId);
+  String get pluginId => _plugin.id;
+
+  Future<Agents> getAgents({required String? projectId, required String pluginId}) async {
     // A null/blank projectId comes from the deprecated GET /agent route,
     // which carries no project context. Fall back to the bridge CWD, which
     // plugins treat as the active project. A real id resolves to the
@@ -35,14 +36,5 @@ class AgentRepository {
     final pluginAgents = await _plugin.getAgents(projectId: directory);
     final agents = pluginAgents.map((a) => a.toAgentInfo()).toList();
     return Agents(agents: agents);
-  }
-
-  void _validatePluginSelection({required String? pluginId}) {
-    if (pluginId == null || pluginId == _plugin.id) return;
-    throw const PluginOperationException(
-      "getAgents",
-      statusCode: 400,
-      message: "requested plugin is not active",
-    );
   }
 }

--- a/bridge/app/lib/src/bridge/repositories/agent_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/agent_repository.dart
@@ -1,6 +1,6 @@
 import "dart:io" as io;
 
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginApi;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginApi, PluginOperationException;
 import "package:sesori_shared/sesori_shared.dart" show Agents, StringExtensions;
 
 import "../persistence/daos/projects_dao.dart";
@@ -15,7 +15,8 @@ class AgentRepository {
     : _plugin = plugin,
       _projectsDao = projectsDao;
 
-  Future<Agents> getAgents({required String? projectId}) async {
+  Future<Agents> getAgents({required String? projectId, required String? pluginId}) async {
+    _validatePluginSelection(pluginId: pluginId);
     // A null/blank projectId comes from the deprecated GET /agent route,
     // which carries no project context. Fall back to the bridge CWD, which
     // plugins treat as the active project. A real id resolves to the
@@ -34,5 +35,14 @@ class AgentRepository {
     final pluginAgents = await _plugin.getAgents(projectId: directory);
     final agents = pluginAgents.map((a) => a.toAgentInfo()).toList();
     return Agents(agents: agents);
+  }
+
+  void _validatePluginSelection({required String? pluginId}) {
+    if (pluginId == null || pluginId == _plugin.id) return;
+    throw const PluginOperationException(
+      "getAgents",
+      statusCode: 400,
+      message: "requested plugin is not active",
+    );
   }
 }

--- a/bridge/app/lib/src/bridge/repositories/mappers/plugin_session_mapper.dart
+++ b/bridge/app/lib/src/bridge/repositories/mappers/plugin_session_mapper.dart
@@ -6,9 +6,10 @@ import "../session_unseen_calculator.dart";
 
 /// Maps a [PluginSession] to the shared [Session] type used in relay responses.
 extension PluginSessionMapper on PluginSession {
-  Session toSharedSession() {
+  Session toSharedSession({required String pluginId}) {
     return Session(
       id: id,
+      pluginId: pluginId,
       projectID: projectID,
       directory: directory,
       parentID: parentID,
@@ -36,19 +37,20 @@ extension PluginSessionMapper on PluginSession {
 }
 
 extension PluginSessionsMapper on Iterable<PluginSession> {
-  List<Session> toSharedSessions() {
-    return map((session) => session.toSharedSession()).toList(growable: false);
+  List<Session> toSharedSessions({required String pluginId}) {
+    return map((session) => session.toSharedSession(pluginId: pluginId)).toList(growable: false);
   }
 }
 
 Session enrichSharedSession({
   required Session session,
+  required String pluginId,
   required SessionDto? storedSession,
   required PullRequestInfo? pullRequest,
   required SessionUnseenCalculator unseenCalculator,
   required bool adoptStoredProjectId,
 }) {
-  var result = session;
+  var result = session.copyWith(pluginId: pluginId);
 
   if (storedSession != null) {
     final currentTime = session.time;
@@ -107,6 +109,7 @@ SessionPromptDefaults? _promptDefaultsFromStoredSession(SessionDto storedSession
 
 List<Session> enrichSharedSessions({
   required List<Session> sessions,
+  required String pluginId,
   required Map<String, SessionDto> storedSessionsById,
   required Map<String, PullRequestInfo> pullRequestsBySessionId,
   required SessionUnseenCalculator unseenCalculator,
@@ -116,6 +119,7 @@ List<Session> enrichSharedSessions({
       .map(
         (session) => enrichSharedSession(
           session: session,
+          pluginId: pluginId,
           storedSession: storedSessionsById[session.id],
           pullRequest: pullRequestsBySessionId[session.id],
           unseenCalculator: unseenCalculator,

--- a/bridge/app/lib/src/bridge/repositories/mappers/plugin_session_mapper.dart
+++ b/bridge/app/lib/src/bridge/repositories/mappers/plugin_session_mapper.dart
@@ -44,13 +44,12 @@ extension PluginSessionsMapper on Iterable<PluginSession> {
 
 Session enrichSharedSession({
   required Session session,
-  required String pluginId,
   required SessionDto? storedSession,
   required PullRequestInfo? pullRequest,
   required SessionUnseenCalculator unseenCalculator,
   required bool adoptStoredProjectId,
 }) {
-  var result = session.copyWith(pluginId: pluginId);
+  var result = session;
 
   if (storedSession != null) {
     final currentTime = session.time;
@@ -109,7 +108,6 @@ SessionPromptDefaults? _promptDefaultsFromStoredSession(SessionDto storedSession
 
 List<Session> enrichSharedSessions({
   required List<Session> sessions,
-  required String pluginId,
   required Map<String, SessionDto> storedSessionsById,
   required Map<String, PullRequestInfo> pullRequestsBySessionId,
   required SessionUnseenCalculator unseenCalculator,
@@ -119,7 +117,6 @@ List<Session> enrichSharedSessions({
       .map(
         (session) => enrichSharedSession(
           session: session,
-          pluginId: pluginId,
           storedSession: storedSessionsById[session.id],
           pullRequest: pullRequestsBySessionId[session.id],
           unseenCalculator: unseenCalculator,

--- a/bridge/app/lib/src/bridge/repositories/project_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/project_repository.dart
@@ -108,17 +108,8 @@ class ProjectRepository {
                 time: null,
               ),
               directActivity: p.activity,
-          ),
+            ),
         ], defaultTimestamp: defaultTimestamp);
-        for (final project in pluginProjects) {
-          if (project.id != project.directory) {
-            await _projectsDao.replacePathIfMatches(
-              projectId: project.id,
-              expectedPath: project.id,
-              replacementPath: project.directory,
-            );
-          }
-        }
         final storedProjects = await _projectsDao.getAllProjects();
         final pathById = {
           for (final stored in storedProjects)
@@ -334,15 +325,6 @@ class ProjectRepository {
               ),
           },
         );
-        for (final project in pluginProjects) {
-          if (project.id != project.directory) {
-            await _projectsDao.replacePathIfMatches(
-              projectId: project.id,
-              expectedPath: project.id,
-              replacementPath: project.directory,
-            );
-          }
-        }
         final storedProjects = await _projectsDao.getAllProjects();
         return ProjectActivityReconciliationData(
           evidence: [

--- a/bridge/app/lib/src/bridge/repositories/project_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/project_repository.dart
@@ -108,8 +108,17 @@ class ProjectRepository {
                 time: null,
               ),
               directActivity: p.activity,
-            ),
+          ),
         ], defaultTimestamp: defaultTimestamp);
+        for (final project in pluginProjects) {
+          if (project.id != project.directory) {
+            await _projectsDao.replacePathIfMatches(
+              projectId: project.id,
+              expectedPath: project.id,
+              replacementPath: project.directory,
+            );
+          }
+        }
         final storedProjects = await _projectsDao.getAllProjects();
         final pathById = {
           for (final stored in storedProjects)

--- a/bridge/app/lib/src/bridge/repositories/project_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/project_repository.dart
@@ -69,6 +69,7 @@ class ProjectRepository {
         await _projectsDao.insertMissingProjectsWithActivity(
           activities: {
             normalizeProjectDirectory(directory: plugin.launchDirectory): (
+              path: normalizeProjectDirectory(directory: plugin.launchDirectory),
               createdAt: defaultTimestamp,
               updatedAt: defaultTimestamp,
             ),
@@ -101,7 +102,7 @@ class ProjectRepository {
           for (final p in pluginProjects)
             (
               project: p.toSharedProject(
-                path: p.id,
+                path: p.directory,
                 hasUnseenChanges: false,
                 directoryMissing: false,
                 time: null,
@@ -121,7 +122,7 @@ class ProjectRepository {
         );
         final activityById = _mapActivities(storedProjects);
         final projects = visible.map((p) {
-          final path = pathById[p.id] ?? p.id;
+          final path = pathById[p.id] ?? p.directory;
           return p.toSharedProject(
             path: path,
             hasUnseenChanges: unseenById[p.id] ?? false,
@@ -428,6 +429,7 @@ class ProjectRepository {
       activities: {
         for (final item in projects)
           item.project.id: (
+            path: item.project.path,
             createdAt: item.directActivity?.createdAt ?? defaultTimestamp,
             updatedAt: item.directActivity?.updatedAt ?? defaultTimestamp,
           ),

--- a/bridge/app/lib/src/bridge/repositories/project_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/project_repository.dart
@@ -324,6 +324,25 @@ class ProjectRepository {
     switch (_plugin) {
       case final NativeProjectsPluginApi plugin:
         final pluginProjects = await plugin.getProjects();
+        await _projectsDao.insertProjectsWithPathsIfMissing(
+          projects: {
+            for (final project in pluginProjects)
+              project.id: (
+                path: project.directory,
+                createdAt: project.activity?.createdAt,
+                updatedAt: project.activity?.updatedAt,
+              ),
+          },
+        );
+        for (final project in pluginProjects) {
+          if (project.id != project.directory) {
+            await _projectsDao.replacePathIfMatches(
+              projectId: project.id,
+              expectedPath: project.id,
+              replacementPath: project.directory,
+            );
+          }
+        }
         final storedProjects = await _projectsDao.getAllProjects();
         return ProjectActivityReconciliationData(
           evidence: [

--- a/bridge/app/lib/src/bridge/repositories/provider_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/provider_repository.dart
@@ -1,4 +1,4 @@
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginApi, PluginOperationException;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginApi;
 import "package:sesori_shared/sesori_shared.dart" show ProviderListResponse;
 
 import "../persistence/daos/projects_dao.dart";
@@ -15,7 +15,6 @@ class ProviderRepository {
       _projectsDao = projectsDao;
 
   Future<ProviderListResponse> getProviders({required String projectId, required String? pluginId}) async {
-    _validatePluginSelection(pluginId: pluginId);
     // The plugin reads provider config from the project's directory, so
     // resolve the id to the live path first.
     final directory = await _projectsDao.getResolvedPath(projectId: projectId);
@@ -25,14 +24,5 @@ class ProviderRepository {
     final result = await _plugin.getProviders(projectId: directory);
     final providers = result.providers.map((p) => p.toSharedProviderInfo()).toList();
     return ProviderListResponse(items: providers, connectedOnly: true);
-  }
-
-  void _validatePluginSelection({required String? pluginId}) {
-    if (pluginId == null || pluginId == _plugin.id) return;
-    throw const PluginOperationException(
-      "getProviders",
-      statusCode: 400,
-      message: "requested plugin is not active",
-    );
   }
 }

--- a/bridge/app/lib/src/bridge/repositories/provider_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/provider_repository.dart
@@ -14,7 +14,9 @@ class ProviderRepository {
     : _plugin = plugin,
       _projectsDao = projectsDao;
 
-  Future<ProviderListResponse> getProviders({required String projectId, required String? pluginId}) async {
+  String get pluginId => _plugin.id;
+
+  Future<ProviderListResponse> getProviders({required String projectId, required String pluginId}) async {
     // The plugin reads provider config from the project's directory, so
     // resolve the id to the live path first.
     final directory = await _projectsDao.getResolvedPath(projectId: projectId);

--- a/bridge/app/lib/src/bridge/repositories/provider_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/provider_repository.dart
@@ -1,4 +1,4 @@
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginApi;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show BridgePluginApi, PluginOperationException;
 import "package:sesori_shared/sesori_shared.dart" show ProviderListResponse;
 
 import "../persistence/daos/projects_dao.dart";
@@ -14,7 +14,8 @@ class ProviderRepository {
     : _plugin = plugin,
       _projectsDao = projectsDao;
 
-  Future<ProviderListResponse> getProviders({required String projectId}) async {
+  Future<ProviderListResponse> getProviders({required String projectId, required String? pluginId}) async {
+    _validatePluginSelection(pluginId: pluginId);
     // The plugin reads provider config from the project's directory, so
     // resolve the id to the live path first.
     final directory = await _projectsDao.getResolvedPath(projectId: projectId);
@@ -24,5 +25,14 @@ class ProviderRepository {
     final result = await _plugin.getProviders(projectId: directory);
     final providers = result.providers.map((p) => p.toSharedProviderInfo()).toList();
     return ProviderListResponse(items: providers, connectedOnly: true);
+  }
+
+  void _validatePluginSelection({required String? pluginId}) {
+    if (pluginId == null || pluginId == _plugin.id) return;
+    throw const PluginOperationException(
+      "getProviders",
+      statusCode: 400,
+      message: "requested plugin is not active",
+    );
   }
 }

--- a/bridge/app/lib/src/bridge/repositories/provider_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/provider_repository.dart
@@ -14,8 +14,6 @@ class ProviderRepository {
     : _plugin = plugin,
       _projectsDao = projectsDao;
 
-  String get pluginId => _plugin.id;
-
   Future<ProviderListResponse> getProviders({required String projectId, required String pluginId}) async {
     // The plugin reads provider config from the project's directory, so
     // resolve the id to the live path first.

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -174,7 +174,7 @@ class SessionRepository {
   }
 
   Future<Session> createSession({
-    required String? pluginId,
+    required String pluginId,
     required String directory,
     required String? parentSessionId,
     required List<PromptPart> parts,
@@ -204,7 +204,7 @@ class SessionRepository {
     return updated.toSharedSession(pluginId: _plugin.id);
   }
 
-  Future<CommandListResponse> getCommands({required String? projectId, required String? pluginId}) async {
+  Future<CommandListResponse> getCommands({required String? projectId, required String pluginId}) async {
     final normalizedProjectId = projectId?.trim();
     final commands = await _plugin.getCommands(
       // The plugin reads commands from the project's directory, so resolve
@@ -457,6 +457,15 @@ class SessionRepository {
           projectIds: [for (final project in projects) project.id],
         );
         for (final project in projects) {
+          if (project.id != project.directory) {
+            await _projectsDao.replacePathIfMatches(
+              projectId: project.id,
+              expectedPath: project.id,
+              replacementPath: project.directory,
+            );
+          }
+        }
+        for (final project in projects) {
           final projectId = project.id;
           if (await _getPluginSession(projectId: projectId, sessionId: sessionId) != null) {
             return projectId;
@@ -693,4 +702,8 @@ class SessionRepository {
     }
     return null;
   }
+}
+
+extension SessionRepositoryIdentity on SessionRepository {
+  String get pluginId => _plugin.id;
 }

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -70,7 +70,7 @@ class SessionRepository {
       limit: limit,
     );
 
-    return enrichSessions(sessions: pluginSessions.toSharedSessions());
+    return enrichSessions(sessions: pluginSessions.toSharedSessions(pluginId: _plugin.id));
   }
 
   /// The plugin sessions that belong to [projectId].
@@ -164,7 +164,7 @@ class SessionRepository {
   }
 
   Future<Session> enrichPluginSession({required PluginSession pluginSession}) {
-    return enrichSession(session: pluginSession.toSharedSession());
+    return enrichSession(session: pluginSession.toSharedSession(pluginId: _plugin.id));
   }
 
   Future<Session> enrichSessionJson({required Map<String, dynamic> sessionJson}) {
@@ -172,6 +172,7 @@ class SessionRepository {
   }
 
   Future<Session> createSession({
+    required String? pluginId,
     required String directory,
     required String? parentSessionId,
     required List<PromptPart> parts,
@@ -179,6 +180,7 @@ class SessionRepository {
     required String? agent,
     required PromptModel? model,
   }) async {
+    _validatePluginSelection(pluginId: pluginId, operation: "createSession");
     final created = await _plugin.createSession(
       directory: directory,
       parentSessionId: parentSessionId,
@@ -190,7 +192,7 @@ class SessionRepository {
         null => null,
       },
     );
-    return created.toSharedSession();
+    return created.toSharedSession(pluginId: _plugin.id);
   }
 
   Future<Session> renameSession({required String sessionId, required String title}) async {
@@ -198,10 +200,11 @@ class SessionRepository {
       await _throwIfTombstoned(sessionId: sessionId, operation: "renameSession");
     }
     final updated = await _plugin.renameSession(sessionId: sessionId, title: title);
-    return updated.toSharedSession();
+    return updated.toSharedSession(pluginId: _plugin.id);
   }
 
-  Future<CommandListResponse> getCommands({required String? projectId}) async {
+  Future<CommandListResponse> getCommands({required String? projectId, required String? pluginId}) async {
+    _validatePluginSelection(pluginId: pluginId, operation: "getCommands");
     final normalizedProjectId = projectId?.trim();
     final commands = await _plugin.getCommands(
       // The plugin reads commands from the project's directory, so resolve
@@ -306,6 +309,7 @@ class SessionRepository {
     projectId ??= "";
     final deletionSnapshot = Session(
       id: sessionId,
+      pluginId: _plugin.id,
       projectID: projectId,
       directory: stored?.worktreePath ?? projectId,
       parentID: null,
@@ -494,6 +498,7 @@ class SessionRepository {
 
     return enrichSharedSessions(
       sessions: sessions,
+      pluginId: _plugin.id,
       storedSessionsById: dbSessions,
       pullRequestsBySessionId: pullRequestsBySessionId,
       unseenCalculator: _unseenCalculator,
@@ -541,10 +546,19 @@ class SessionRepository {
         );
       }
       final pluginSessions = await plugin.getChildSessions(sessionId);
-      return pluginSessions.where((session) => !tombstoned.contains(session.id)).toSharedSessions();
+      return pluginSessions.where((session) => !tombstoned.contains(session.id)).toSharedSessions(pluginId: _plugin.id);
     }
     final pluginSessions = await _plugin.getChildSessions(sessionId);
-    return pluginSessions.toSharedSessions();
+    return pluginSessions.toSharedSessions(pluginId: _plugin.id);
+  }
+
+  void _validatePluginSelection({required String? pluginId, required String operation}) {
+    if (pluginId == null || pluginId == _plugin.id) return;
+    throw PluginOperationException(
+      operation,
+      statusCode: 400,
+      message: "requested plugin is not active",
+    );
   }
 
   Future<void> _throwIfTombstoned({required String sessionId, required String operation}) async {

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -167,7 +167,7 @@ class SessionRepository {
     return enrichSession(session: pluginSession.toSharedSession(pluginId: _plugin.id));
   }
 
-  Future<Session> enrichSessionJson({required Map<String, dynamic> sessionJson}) {
+  Future<Session> enrichPluginEventSessionJson({required Map<String, dynamic> sessionJson}) {
     return enrichSession(
       session: Session.fromJson(sessionJson).copyWith(pluginId: _plugin.id),
     );

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -168,7 +168,9 @@ class SessionRepository {
   }
 
   Future<Session> enrichSessionJson({required Map<String, dynamic> sessionJson}) {
-    return enrichSession(session: Session.fromJson(sessionJson));
+    return enrichSession(
+      session: Session.fromJson(sessionJson).copyWith(pluginId: _plugin.id),
+    );
   }
 
   Future<Session> createSession({
@@ -180,7 +182,6 @@ class SessionRepository {
     required String? agent,
     required PromptModel? model,
   }) async {
-    _validatePluginSelection(pluginId: pluginId, operation: "createSession");
     final created = await _plugin.createSession(
       directory: directory,
       parentSessionId: parentSessionId,
@@ -204,7 +205,6 @@ class SessionRepository {
   }
 
   Future<CommandListResponse> getCommands({required String? projectId, required String? pluginId}) async {
-    _validatePluginSelection(pluginId: pluginId, operation: "getCommands");
     final normalizedProjectId = projectId?.trim();
     final commands = await _plugin.getCommands(
       // The plugin reads commands from the project's directory, so resolve
@@ -498,7 +498,6 @@ class SessionRepository {
 
     return enrichSharedSessions(
       sessions: sessions,
-      pluginId: _plugin.id,
       storedSessionsById: dbSessions,
       pullRequestsBySessionId: pullRequestsBySessionId,
       unseenCalculator: _unseenCalculator,
@@ -550,15 +549,6 @@ class SessionRepository {
     }
     final pluginSessions = await _plugin.getChildSessions(sessionId);
     return pluginSessions.toSharedSessions(pluginId: _plugin.id);
-  }
-
-  void _validatePluginSelection({required String? pluginId, required String operation}) {
-    if (pluginId == null || pluginId == _plugin.id) return;
-    throw PluginOperationException(
-      operation,
-      statusCode: 400,
-      message: "requested plugin is not active",
-    );
   }
 
   Future<void> _throwIfTombstoned({required String sessionId, required String operation}) async {

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -453,18 +453,16 @@ class SessionRepository {
         final projects = await plugin.getProjects();
         // The plugin's authoritative list makes these known projects. Persist
         // them before probing sessions so id→path resolution never guesses.
-        await _projectsDao.insertProjectsIfMissing(
-          projectIds: [for (final project in projects) project.id],
+        await _projectsDao.insertProjectsWithPathsIfMissing(
+          projects: {
+            for (final project in projects)
+              project.id: (
+                path: project.directory,
+                createdAt: project.activity?.createdAt,
+                updatedAt: project.activity?.updatedAt,
+              ),
+          },
         );
-        for (final project in projects) {
-          if (project.id != project.directory) {
-            await _projectsDao.replacePathIfMatches(
-              projectId: project.id,
-              expectedPath: project.id,
-              replacementPath: project.directory,
-            );
-          }
-        }
         for (final project in projects) {
           final projectId = project.id;
           if (await _getPluginSession(projectId: projectId, sessionId: sessionId) != null) {

--- a/bridge/app/lib/src/bridge/repositories/session_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_repository.dart
@@ -701,7 +701,3 @@ class SessionRepository {
     return null;
   }
 }
-
-extension SessionRepositoryIdentity on SessionRepository {
-  String get pluginId => _plugin.id;
-}

--- a/bridge/app/lib/src/bridge/repositories/session_unseen_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_unseen_repository.dart
@@ -1,3 +1,6 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
+    show BridgeDerivedProjectsPluginApi, BridgePluginApi, NativeProjectsPluginApi;
+
 import "../persistence/daos/projects_dao.dart";
 import "../persistence/daos/session_dao.dart";
 import "../persistence/database.dart";
@@ -26,21 +29,21 @@ class SessionUnseenRepository {
   final AppDatabase _db;
   final SessionUnseenCalculator _calculator;
 
-  /// The active plugin's id, stamped onto any session row this repository
-  /// creates ([ensureRootSessionActivity]).
-  final String _pluginId;
+  /// The active plugin determines both ownership and project-path semantics for
+  /// session rows this repository creates ([ensureRootSessionActivity]).
+  final BridgePluginApi _plugin;
 
   SessionUnseenRepository({
     required SessionDao sessionDao,
     required ProjectsDao projectsDao,
     required AppDatabase db,
     required SessionUnseenCalculator calculator,
-    required String pluginId,
+    required BridgePluginApi plugin,
   }) : _sessionDao = sessionDao,
        _projectsDao = projectsDao,
        _db = db,
        _calculator = calculator,
-       _pluginId = pluginId;
+       _plugin = plugin;
 
   /// Returns the unseen timestamps + project id for [sessionId], or null when
   /// the session has no persisted row (e.g. a child session, or one not yet
@@ -106,20 +109,27 @@ class SessionUnseenRepository {
   /// fetch-start time to protect rows created during an in-flight fetch, so a
   /// backend-domain value here (skewed behind the local clock) could get a
   /// freshly-created session's row wrongly reconcile-deleted. [activityAt] may
-  /// live in the backend's clock domain.
+  /// live in the backend's clock domain. [sessionDirectory] is persisted as the
+  /// project path only when the active plugin owns native projects; for a
+  /// bridge-derived project, [projectId] is already the owning project path.
   /// Wrapped in a transaction so the project FK cannot fire.
   Future<void> ensureRootSessionActivity({
     required String sessionId,
     required String projectId,
+    required String sessionDirectory,
     required int createdAt,
     required int activityAt,
     required bool advanceSeen,
     required bool isUserMessage,
   }) async {
+    final projectPath = switch (_plugin) {
+      NativeProjectsPluginApi() => sessionDirectory,
+      BridgeDerivedProjectsPluginApi() => projectId,
+    };
     await _db.transaction(() async {
-      await _projectsDao.insertProjectsIfMissing(projectIds: [projectId]);
+      await _projectsDao.insertProjectIfMissing(projectId: projectId, path: projectPath);
       await _sessionDao.insertSessionsIfMissing(
-        pluginId: _pluginId,
+        pluginId: _plugin.id,
         sessions: [(sessionId: sessionId, projectId: projectId, createdAt: createdAt, archivedAt: null)],
       );
       await _sessionDao.setActivityTimestamps(
@@ -155,7 +165,7 @@ class SessionUnseenRepository {
       projectId: projectId,
       keepSessionIds: keepSessionIds,
       createdBefore: createdBefore,
-      pluginId: _pluginId,
+      pluginId: _plugin.id,
     );
   }
 

--- a/bridge/app/lib/src/bridge/repositories/session_unseen_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_unseen_repository.dart
@@ -1,5 +1,5 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
-    show BridgeDerivedProjectsPluginApi, BridgePluginApi, NativeProjectsPluginApi;
+    show BridgeDerivedProjectsPluginApi, BridgePluginApi, Log, NativeProjectsPluginApi;
 
 import "../persistence/daos/projects_dao.dart";
 import "../persistence/daos/session_dao.dart";
@@ -122,13 +122,17 @@ class SessionUnseenRepository {
     required bool advanceSeen,
     required bool isUserMessage,
   }) async {
-    final String projectPath;
+    var projectPath = sessionDirectory;
     switch (_plugin) {
       case final NativeProjectsPluginApi plugin:
-        final projects = await plugin.getProjects();
-        projectPath =
-            projects.where((project) => project.id == projectId).map((project) => project.directory).firstOrNull ??
-            sessionDirectory;
+        try {
+          final projects = await plugin.getProjects();
+          projectPath =
+              projects.where((project) => project.id == projectId).map((project) => project.directory).firstOrNull ??
+              sessionDirectory;
+        } catch (error, stackTrace) {
+          Log.w("failed to resolve native project root for $projectId; using session directory", error, stackTrace);
+        }
       case BridgeDerivedProjectsPluginApi():
         projectPath = projectId;
     }

--- a/bridge/app/lib/src/bridge/repositories/session_unseen_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_unseen_repository.dart
@@ -128,6 +128,13 @@ class SessionUnseenRepository {
     };
     await _db.transaction(() async {
       await _projectsDao.insertProjectIfMissing(projectId: projectId, path: projectPath);
+      if (_plugin is NativeProjectsPluginApi && projectPath != projectId) {
+        await _projectsDao.replacePathIfMatches(
+          projectId: projectId,
+          expectedPath: projectId,
+          replacementPath: projectPath,
+        );
+      }
       await _sessionDao.insertSessionsIfMissing(
         pluginId: _plugin.id,
         sessions: [(sessionId: sessionId, projectId: projectId, createdAt: createdAt, archivedAt: null)],

--- a/bridge/app/lib/src/bridge/repositories/session_unseen_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_unseen_repository.dart
@@ -138,13 +138,6 @@ class SessionUnseenRepository {
     }
     await _db.transaction(() async {
       await _projectsDao.insertProjectIfMissing(projectId: projectId, path: projectPath);
-      if (_plugin is NativeProjectsPluginApi && projectPath != projectId) {
-        await _projectsDao.replacePathIfMatches(
-          projectId: projectId,
-          expectedPath: projectId,
-          replacementPath: projectPath,
-        );
-      }
       await _sessionDao.insertSessionsIfMissing(
         pluginId: _plugin.id,
         sessions: [(sessionId: sessionId, projectId: projectId, createdAt: createdAt, archivedAt: null)],

--- a/bridge/app/lib/src/bridge/repositories/session_unseen_repository.dart
+++ b/bridge/app/lib/src/bridge/repositories/session_unseen_repository.dart
@@ -122,10 +122,16 @@ class SessionUnseenRepository {
     required bool advanceSeen,
     required bool isUserMessage,
   }) async {
-    final projectPath = switch (_plugin) {
-      NativeProjectsPluginApi() => sessionDirectory,
-      BridgeDerivedProjectsPluginApi() => projectId,
-    };
+    final String projectPath;
+    switch (_plugin) {
+      case final NativeProjectsPluginApi plugin:
+        final projects = await plugin.getProjects();
+        projectPath =
+            projects.where((project) => project.id == projectId).map((project) => project.directory).firstOrNull ??
+            sessionDirectory;
+      case BridgeDerivedProjectsPluginApi():
+        projectPath = projectId;
+    }
     await _db.transaction(() async {
       await _projectsDao.insertProjectIfMissing(projectId: projectId, path: projectPath);
       if (_plugin is NativeProjectsPluginApi && projectPath != projectId) {

--- a/bridge/app/lib/src/bridge/routing/get_agents_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_agents_handler.dart
@@ -21,6 +21,6 @@ class GetAgentsHandler extends GetRequestHandler<Agents> {
     required Map<String, String> queryParams,
     required String? fragment,
   }) async {
-    return _repository.getAgents(projectId: null, pluginId: null);
+    return _repository.getAgents(projectId: null, pluginId: _repository.pluginId);
   }
 }

--- a/bridge/app/lib/src/bridge/routing/get_agents_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_agents_handler.dart
@@ -7,11 +7,11 @@ import "request_handler.dart";
 ///
 /// Carries no project context, so the repository falls back to the bridge
 /// CWD as the active project.
-@Deprecated("Use POST /agent with a ProjectIdRequest body (PostAgentsHandler)")
+@Deprecated("Use POST /agent with a PluginProjectIdRequest body (PostAgentsHandler)")
 class GetAgentsHandler extends GetRequestHandler<Agents> {
   final AgentRepository _repository;
 
-  @Deprecated("Use POST /agent with a ProjectIdRequest body (PostAgentsHandler)")
+  @Deprecated("Use POST /agent with a PluginProjectIdRequest body (PostAgentsHandler)")
   GetAgentsHandler(this._repository) : super("/agent");
 
   @override

--- a/bridge/app/lib/src/bridge/routing/get_agents_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_agents_handler.dart
@@ -21,6 +21,6 @@ class GetAgentsHandler extends GetRequestHandler<Agents> {
     required Map<String, String> queryParams,
     required String? fragment,
   }) async {
-    return _repository.getAgents(projectId: null);
+    return _repository.getAgents(projectId: null, pluginId: null);
   }
 }

--- a/bridge/app/lib/src/bridge/routing/get_commands_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_commands_handler.dart
@@ -23,6 +23,6 @@ class GetCommandsHandler extends BodyRequestHandler<ProjectIdRequest, CommandLis
     required Map<String, String> queryParams,
     required String? fragment,
   }) async {
-    return _sessionRepository.getCommands(projectId: body.projectId);
+    return _sessionRepository.getCommands(projectId: body.projectId, pluginId: body.pluginId);
   }
 }

--- a/bridge/app/lib/src/bridge/routing/get_commands_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_commands_handler.dart
@@ -25,7 +25,7 @@ class GetCommandsHandler extends BodyRequestHandler<PluginProjectIdRequest, Comm
   }) async {
     return _sessionRepository.getCommands(
       projectId: body.projectId,
-      pluginId: body.pluginId == legacyMissingPluginId ? _sessionRepository.pluginId : body.pluginId,
+      pluginId: body.pluginId,
     );
   }
 }

--- a/bridge/app/lib/src/bridge/routing/get_commands_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_commands_handler.dart
@@ -23,6 +23,9 @@ class GetCommandsHandler extends BodyRequestHandler<ProjectIdRequest, CommandLis
     required Map<String, String> queryParams,
     required String? fragment,
   }) async {
-    return _sessionRepository.getCommands(projectId: body.projectId, pluginId: body.pluginId);
+    return _sessionRepository.getCommands(
+      projectId: body.projectId,
+      pluginId: body.pluginId ?? _sessionRepository.pluginId,
+    );
   }
 }

--- a/bridge/app/lib/src/bridge/routing/get_commands_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_commands_handler.dart
@@ -4,7 +4,7 @@ import "../repositories/session_repository.dart";
 import "request_handler.dart";
 
 /// Handles `POST /command` — returns slash commands available to the project.
-class GetCommandsHandler extends BodyRequestHandler<ProjectIdRequest, CommandListResponse> {
+class GetCommandsHandler extends BodyRequestHandler<PluginProjectIdRequest, CommandListResponse> {
   final SessionRepository _sessionRepository;
 
   GetCommandsHandler({required SessionRepository sessionRepository})
@@ -12,20 +12,20 @@ class GetCommandsHandler extends BodyRequestHandler<ProjectIdRequest, CommandLis
       super(
         HttpMethod.post,
         "/command",
-        fromJson: ProjectIdRequest.fromJson,
+        fromJson: PluginProjectIdRequest.fromJson,
       );
 
   @override
   Future<CommandListResponse> handle(
     RelayRequest request, {
-    required ProjectIdRequest body,
+    required PluginProjectIdRequest body,
     required Map<String, String> pathParams,
     required Map<String, String> queryParams,
     required String? fragment,
   }) async {
     return _sessionRepository.getCommands(
       projectId: body.projectId,
-      pluginId: body.pluginId ?? _sessionRepository.pluginId,
+      pluginId: body.pluginId == legacyMissingPluginId ? _sessionRepository.pluginId : body.pluginId,
     );
   }
 }

--- a/bridge/app/lib/src/bridge/routing/get_providers_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_providers_handler.dart
@@ -22,6 +22,9 @@ class GetProvidersHandler extends BodyRequestHandler<ProjectIdRequest, ProviderL
     required Map<String, String> queryParams,
     required String? fragment,
   }) {
-    return _repository.getProviders(projectId: body.projectId, pluginId: body.pluginId);
+    return _repository.getProviders(
+      projectId: body.projectId,
+      pluginId: body.pluginId ?? _repository.pluginId,
+    );
   }
 }

--- a/bridge/app/lib/src/bridge/routing/get_providers_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_providers_handler.dart
@@ -24,7 +24,7 @@ class GetProvidersHandler extends BodyRequestHandler<PluginProjectIdRequest, Pro
   }) {
     return _repository.getProviders(
       projectId: body.projectId,
-      pluginId: body.pluginId == legacyMissingPluginId ? _repository.pluginId : body.pluginId,
+      pluginId: body.pluginId,
     );
   }
 }

--- a/bridge/app/lib/src/bridge/routing/get_providers_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_providers_handler.dart
@@ -22,6 +22,6 @@ class GetProvidersHandler extends BodyRequestHandler<ProjectIdRequest, ProviderL
     required Map<String, String> queryParams,
     required String? fragment,
   }) {
-    return _repository.getProviders(projectId: body.projectId);
+    return _repository.getProviders(projectId: body.projectId, pluginId: body.pluginId);
   }
 }

--- a/bridge/app/lib/src/bridge/routing/get_providers_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/get_providers_handler.dart
@@ -4,27 +4,27 @@ import "../repositories/provider_repository.dart";
 import "request_handler.dart";
 
 /// Handles `POST /provider` — returns providers and their models.
-class GetProvidersHandler extends BodyRequestHandler<ProjectIdRequest, ProviderListResponse> {
+class GetProvidersHandler extends BodyRequestHandler<PluginProjectIdRequest, ProviderListResponse> {
   final ProviderRepository _repository;
 
   GetProvidersHandler(this._repository)
     : super(
         HttpMethod.post,
         "/provider",
-        fromJson: ProjectIdRequest.fromJson,
+        fromJson: PluginProjectIdRequest.fromJson,
       );
 
   @override
   Future<ProviderListResponse> handle(
     RelayRequest request, {
-    required ProjectIdRequest body,
+    required PluginProjectIdRequest body,
     required Map<String, String> pathParams,
     required Map<String, String> queryParams,
     required String? fragment,
   }) {
     return _repository.getProviders(
       projectId: body.projectId,
-      pluginId: body.pluginId ?? _repository.pluginId,
+      pluginId: body.pluginId == legacyMissingPluginId ? _repository.pluginId : body.pluginId,
     );
   }
 }

--- a/bridge/app/lib/src/bridge/routing/post_agents_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/post_agents_handler.dart
@@ -24,7 +24,7 @@ class PostAgentsHandler extends BodyRequestHandler<PluginProjectIdRequest, Agent
   }) {
     return _repository.getAgents(
       projectId: body.projectId,
-      pluginId: body.pluginId == legacyMissingPluginId ? _repository.pluginId : body.pluginId,
+      pluginId: body.pluginId,
     );
   }
 }

--- a/bridge/app/lib/src/bridge/routing/post_agents_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/post_agents_handler.dart
@@ -4,27 +4,27 @@ import "../repositories/agent_repository.dart";
 import "request_handler.dart";
 
 /// Handles `POST /agent` — returns the agents available for the project.
-class PostAgentsHandler extends BodyRequestHandler<ProjectIdRequest, Agents> {
+class PostAgentsHandler extends BodyRequestHandler<PluginProjectIdRequest, Agents> {
   final AgentRepository _repository;
 
   PostAgentsHandler(this._repository)
     : super(
         HttpMethod.post,
         "/agent",
-        fromJson: ProjectIdRequest.fromJson,
+        fromJson: PluginProjectIdRequest.fromJson,
       );
 
   @override
   Future<Agents> handle(
     RelayRequest request, {
-    required ProjectIdRequest body,
+    required PluginProjectIdRequest body,
     required Map<String, String> pathParams,
     required Map<String, String> queryParams,
     required String? fragment,
   }) {
     return _repository.getAgents(
       projectId: body.projectId,
-      pluginId: body.pluginId ?? _repository.pluginId,
+      pluginId: body.pluginId == legacyMissingPluginId ? _repository.pluginId : body.pluginId,
     );
   }
 }

--- a/bridge/app/lib/src/bridge/routing/post_agents_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/post_agents_handler.dart
@@ -22,6 +22,6 @@ class PostAgentsHandler extends BodyRequestHandler<ProjectIdRequest, Agents> {
     required Map<String, String> queryParams,
     required String? fragment,
   }) {
-    return _repository.getAgents(projectId: body.projectId);
+    return _repository.getAgents(projectId: body.projectId, pluginId: body.pluginId);
   }
 }

--- a/bridge/app/lib/src/bridge/routing/post_agents_handler.dart
+++ b/bridge/app/lib/src/bridge/routing/post_agents_handler.dart
@@ -22,6 +22,9 @@ class PostAgentsHandler extends BodyRequestHandler<ProjectIdRequest, Agents> {
     required Map<String, String> queryParams,
     required String? fragment,
   }) {
-    return _repository.getAgents(projectId: body.projectId, pluginId: body.pluginId);
+    return _repository.getAgents(
+      projectId: body.projectId,
+      pluginId: body.pluginId ?? _repository.pluginId,
+    );
   }
 }

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
@@ -134,7 +134,7 @@ class BridgeRuntime {
       projectsDao: database.projectsDao,
       db: database,
       calculator: unseenCalculator,
-      pluginId: plugin.id,
+      plugin: plugin,
     );
     final sessionViewTracker = SessionViewTracker();
     final sessionUnseenService = SessionUnseenService(

--- a/bridge/app/lib/src/bridge/services/session_creation_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_creation_service.dart
@@ -34,6 +34,7 @@ class SessionCreationService {
     final metadata = await _generateMetadata(firstText: firstText);
     final worktreeResult = await _prepareWorktree(request: request, metadata: metadata);
     final created = await _sessionRepository.createSession(
+      pluginId: request.pluginId,
       directory: _resolveDirectory(projectDirectory: projectDirectory, worktreeResult: worktreeResult),
       parentSessionId: null,
       parts: _buildPromptParts(

--- a/bridge/app/lib/src/bridge/services/session_creation_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_creation_service.dart
@@ -34,7 +34,7 @@ class SessionCreationService {
     final metadata = await _generateMetadata(firstText: firstText);
     final worktreeResult = await _prepareWorktree(request: request, metadata: metadata);
     final created = await _sessionRepository.createSession(
-      pluginId: request.pluginId,
+      pluginId: request.pluginId ?? _sessionRepository.pluginId,
       directory: _resolveDirectory(projectDirectory: projectDirectory, worktreeResult: worktreeResult),
       parentSessionId: null,
       parts: _buildPromptParts(

--- a/bridge/app/lib/src/bridge/services/session_creation_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_creation_service.dart
@@ -34,7 +34,7 @@ class SessionCreationService {
     final metadata = await _generateMetadata(firstText: firstText);
     final worktreeResult = await _prepareWorktree(request: request, metadata: metadata);
     final created = await _sessionRepository.createSession(
-      pluginId: request.pluginId == legacyMissingPluginId ? _sessionRepository.pluginId : request.pluginId,
+      pluginId: request.pluginId,
       directory: _resolveDirectory(projectDirectory: projectDirectory, worktreeResult: worktreeResult),
       parentSessionId: null,
       parts: _buildPromptParts(

--- a/bridge/app/lib/src/bridge/services/session_creation_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_creation_service.dart
@@ -34,7 +34,7 @@ class SessionCreationService {
     final metadata = await _generateMetadata(firstText: firstText);
     final worktreeResult = await _prepareWorktree(request: request, metadata: metadata);
     final created = await _sessionRepository.createSession(
-      pluginId: request.pluginId ?? _sessionRepository.pluginId,
+      pluginId: request.pluginId == legacyMissingPluginId ? _sessionRepository.pluginId : request.pluginId,
       directory: _resolveDirectory(projectDirectory: projectDirectory, worktreeResult: worktreeResult),
       parentSessionId: null,
       parts: _buildPromptParts(

--- a/bridge/app/lib/src/bridge/services/session_event_enrichment_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_event_enrichment_service.dart
@@ -34,6 +34,9 @@ class SessionEventEnrichmentService {
           info: (await _captureTitleAndEnrich(info: info, titleChanged: titleChanged)).toJson(),
           titleChanged: titleChanged,
         ),
+        BridgeSseSessionDeleted(:final info) => BridgeSseSessionDeleted(
+          info: (await _sessionRepository.enrichSessionJson(sessionJson: info)).toJson(),
+        ),
         BridgeSseSessionsUpdated(:final sessionID, :final projectID) => BridgeSseSessionsUpdated(
           sessionID: sessionID,
           projectID: await _sessionRepository.findProjectIdForSession(sessionId: sessionID) ?? projectID,

--- a/bridge/app/lib/src/bridge/services/session_event_enrichment_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_event_enrichment_service.dart
@@ -28,14 +28,14 @@ class SessionEventEnrichmentService {
       }
       return switch (event) {
         BridgeSseSessionCreated(:final info) => BridgeSseSessionCreated(
-          info: (await _sessionRepository.enrichSessionJson(sessionJson: info)).toJson(),
+          info: (await _sessionRepository.enrichPluginEventSessionJson(sessionJson: info)).toJson(),
         ),
         BridgeSseSessionUpdated(:final info, :final titleChanged) => BridgeSseSessionUpdated(
           info: (await _captureTitleAndEnrich(info: info, titleChanged: titleChanged)).toJson(),
           titleChanged: titleChanged,
         ),
         BridgeSseSessionDeleted(:final info) => BridgeSseSessionDeleted(
-          info: (await _sessionRepository.enrichSessionJson(sessionJson: info)).toJson(),
+          info: (await _sessionRepository.enrichPluginEventSessionJson(sessionJson: info)).toJson(),
         ),
         BridgeSseSessionsUpdated(:final sessionID, :final projectID) => BridgeSseSessionsUpdated(
           sessionID: sessionID,
@@ -75,7 +75,7 @@ class SessionEventEnrichmentService {
     if (titleChanged) {
       await _sessionMutationDispatcher.captureTitle(sessionId: session.id, title: session.title);
     }
-    return _sessionRepository.enrichSessionJson(sessionJson: session.toJson());
+    return _sessionRepository.enrichPluginEventSessionJson(sessionJson: session.toJson());
   }
 
   List<String> _sessionIds(BridgeSseEvent event) {

--- a/bridge/app/lib/src/bridge/services/session_event_enrichment_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_event_enrichment_service.dart
@@ -72,7 +72,7 @@ class SessionEventEnrichmentService {
     if (titleChanged) {
       await _sessionMutationDispatcher.captureTitle(sessionId: session.id, title: session.title);
     }
-    return _sessionRepository.enrichSession(session: session);
+    return _sessionRepository.enrichSessionJson(sessionJson: session.toJson());
   }
 
   List<String> _sessionIds(BridgeSseEvent event) {

--- a/bridge/app/lib/src/bridge/services/session_unseen_service.dart
+++ b/bridge/app/lib/src/bridge/services/session_unseen_service.dart
@@ -181,7 +181,8 @@ class SessionUnseenService {
   /// Records that a brand-new ROOT session was created (observed live). Child
   /// sessions ([parentId] != null) are ignored. The new root is stamped with
   /// activity so it is immediately unseen — unless a phone is already viewing
-  /// it, in which case it stays seen.
+  /// it, in which case it stays seen. [sessionDirectory] supplies the live path
+  /// when a native-project plugin reports an opaque [projectId].
   ///
   /// [occurredAt] is the session's own creation time, preferred for the stamp
   /// so it lives in the same clock domain as the message-derived stamps: the
@@ -192,6 +193,7 @@ class SessionUnseenService {
   Future<void> recordSessionCreated({
     required String sessionId,
     required String projectId,
+    required String sessionDirectory,
     required String? parentId,
     int? occurredAt,
   }) {
@@ -215,6 +217,7 @@ class SessionUnseenService {
       await _unseenRepository.ensureRootSessionActivity(
         sessionId: sessionId,
         projectId: projectId,
+        sessionDirectory: sessionDirectory,
         // Local-domain guard timestamp (see [ensureRootSessionActivity]); only
         // the activity marker uses the session's own creation time.
         createdAt: _wallClock(),

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -270,7 +270,7 @@ void main() {
 
     test("GET /projects returns project list as JSON", () async {
       plugin.projectsResult = [
-        const PluginProject(id: "p1", name: "My Project"),
+        const PluginProject(id: "p1", directory: "p1", name: "My Project"),
       ];
 
       final client = HttpClient();
@@ -656,7 +656,7 @@ class _FakeBridgePlugin implements NativeProjectsPluginApi {
 
   @override
   Future<PluginProject> renameProject({required String projectId, required String name}) async =>
-      const PluginProject(id: "");
+      const PluginProject(id: "", directory: "");
 
   @override
   Future<void> deleteSession(String sessionId) async {}
@@ -723,7 +723,7 @@ class _FakeBridgePlugin implements NativeProjectsPluginApi {
   }) async {}
 
   @override
-  Future<PluginProject> getProject(String projectId) async => const PluginProject(id: "");
+  Future<PluginProject> getProject(String projectId) async => const PluginProject(id: "", directory: "");
 
   @override
   Future<bool> healthCheck() async => true;
@@ -824,7 +824,7 @@ class _TrackingBridgePlugin implements NativeProjectsPluginApi {
 
   @override
   Future<PluginProject> renameProject({required String projectId, required String name}) async =>
-      const PluginProject(id: "");
+      const PluginProject(id: "", directory: "");
 
   @override
   Future<void> deleteSession(String sessionId) async {}
@@ -891,7 +891,7 @@ class _TrackingBridgePlugin implements NativeProjectsPluginApi {
   }) async {}
 
   @override
-  Future<PluginProject> getProject(String projectId) async => const PluginProject(id: "");
+  Future<PluginProject> getProject(String projectId) async => const PluginProject(id: "", directory: "");
 
   @override
   Future<bool> healthCheck() async => true;

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -148,7 +148,7 @@ void main() {
       projectRepository: projectRepository,
       sessionUnseenService: SessionUnseenService(
         unseenRepository: SessionUnseenRepository(
-          pluginId: "opencode",
+          plugin: plugin,
           sessionDao: database.sessionDao,
           projectsDao: database.projectsDao,
           db: database,
@@ -360,7 +360,7 @@ void main() {
       projectRepository: projectRepository,
       sessionUnseenService: SessionUnseenService(
         unseenRepository: SessionUnseenRepository(
-          pluginId: "opencode",
+          plugin: plugin,
           sessionDao: database.sessionDao,
           projectsDao: database.projectsDao,
           db: database,
@@ -559,7 +559,7 @@ void main() {
       projectRepository: projectRepository,
       sessionUnseenService: SessionUnseenService(
         unseenRepository: SessionUnseenRepository(
-          pluginId: "opencode",
+          plugin: plugin,
           sessionDao: database.sessionDao,
           projectsDao: database.projectsDao,
           db: database,
@@ -775,7 +775,7 @@ void main() {
       projectRepository: projectRepository,
       sessionUnseenService: SessionUnseenService(
         unseenRepository: SessionUnseenRepository(
-          pluginId: "opencode",
+          plugin: plugin,
           sessionDao: database.sessionDao,
           projectsDao: database.projectsDao,
           db: database,
@@ -900,6 +900,29 @@ void main() {
       equals(["projects.summary", "session.diff"]),
     );
 
+    plugin.add(
+      const BridgeSseSessionCreated(
+        info: {
+          "id": "opaque-session",
+          "projectID": "0190f4c6-opaque-project-id",
+          "directory": "/projects/native-repository",
+          "parentID": null,
+          "title": "opaque project session",
+          "time": {"created": 3, "updated": 3, "archived": null},
+          "summary": null,
+        },
+      ),
+    );
+    final persistenceTimeoutAt = DateTime.now().add(const Duration(seconds: 2));
+    while (await database.projectsDao.getProject(projectId: "0190f4c6-opaque-project-id") == null) {
+      if (DateTime.now().isAfter(persistenceTimeoutAt)) {
+        fail("Timed out waiting for the native project placeholder");
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    final nativeProject = await database.projectsDao.getProject(projectId: "0190f4c6-opaque-project-id");
+    expect(nativeProject?.path, "/projects/native-repository");
+
     await session.cancel();
     await runFuture.timeout(const Duration(seconds: 5));
     await plugin.close();
@@ -994,7 +1017,7 @@ void main() {
       projectRepository: projectRepository,
       sessionUnseenService: SessionUnseenService(
         unseenRepository: SessionUnseenRepository(
-          pluginId: "opencode",
+          plugin: plugin,
           sessionDao: database.sessionDao,
           projectsDao: database.projectsDao,
           db: database,
@@ -1160,7 +1183,7 @@ void main() {
       projectRepository: projectRepository,
       sessionUnseenService: SessionUnseenService(
         unseenRepository: SessionUnseenRepository(
-          pluginId: "opencode",
+          plugin: plugin,
           sessionDao: database.sessionDao,
           projectsDao: database.projectsDao,
           db: database,
@@ -1351,7 +1374,7 @@ void main() {
       projectRepository: projectRepository,
       sessionUnseenService: SessionUnseenService(
         unseenRepository: SessionUnseenRepository(
-          pluginId: "opencode",
+          plugin: plugin,
           sessionDao: database.sessionDao,
           projectsDao: database.projectsDao,
           db: database,

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -2226,7 +2226,8 @@ class _NoopSessionRepository implements SessionRepository {
   Future<Session> enrichPluginSession({required PluginSession pluginSession}) async =>
       Session.fromJson(pluginSession.toJson());
   @override
-  Future<Session> enrichSessionJson({required Map<String, dynamic> sessionJson}) async => Session.fromJson(sessionJson);
+  Future<Session> enrichPluginEventSessionJson({required Map<String, dynamic> sessionJson}) async =>
+      Session.fromJson(sessionJson);
   @override
   Future<List<Session>> enrichSessions({required List<Session> sessions}) async => sessions;
   @override
@@ -2289,7 +2290,7 @@ class _NoopSessionRepository implements SessionRepository {
   }) async {}
 
   @override
-  Future<CommandListResponse> getCommands({required String? projectId, required String? pluginId}) async =>
+  Future<CommandListResponse> getCommands({required String? projectId, required String pluginId}) async =>
       const CommandListResponse(items: []);
 
   @override
@@ -2425,7 +2426,7 @@ class _DelayingSessionRepository implements SessionRepository {
   }
 
   @override
-  Future<Session> enrichSessionJson({required Map<String, dynamic> sessionJson}) async {
+  Future<Session> enrichPluginEventSessionJson({required Map<String, dynamic> sessionJson}) async {
     return enrichSession(session: Session.fromJson(sessionJson));
   }
 

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -1801,7 +1801,7 @@ class _SummaryPlugin implements NativeProjectsPluginApi {
   }) async {}
 
   @override
-  Future<PluginProject> getProject(String projectId) async => const PluginProject(id: "");
+  Future<PluginProject> getProject(String projectId) async => const PluginProject(id: "", directory: "");
 
   @override
   Future<bool> healthCheck() async => true;
@@ -1989,7 +1989,7 @@ class _NoopPlugin implements NativeProjectsPluginApi {
   }) async {}
 
   @override
-  Future<PluginProject> getProject(String projectId) async => PluginProject(id: projectId);
+  Future<PluginProject> getProject(String projectId) async => PluginProject(id: projectId, directory: projectId);
 
   @override
   Future<bool> healthCheck() async => true;
@@ -2163,6 +2163,7 @@ class _NoopPullRequestRepository implements PullRequestRepository {
 
 Session _deletedSession(String sessionId) => Session(
   id: sessionId,
+  pluginId: "fake",
   projectID: "",
   directory: "",
   parentID: null,
@@ -2194,6 +2195,7 @@ class _NoopSessionRepository implements SessionRepository {
 
   @override
   Future<Session> createSession({
+    required String? pluginId,
     required String directory,
     required String? parentSessionId,
     required List<PromptPart> parts,
@@ -2202,6 +2204,7 @@ class _NoopSessionRepository implements SessionRepository {
     required PromptModel? model,
   }) async => const Session(
     id: "",
+    pluginId: "fake",
     projectID: "",
     directory: "",
     parentID: null,
@@ -2286,7 +2289,8 @@ class _NoopSessionRepository implements SessionRepository {
   }) async {}
 
   @override
-  Future<CommandListResponse> getCommands({required String? projectId}) async => const CommandListResponse(items: []);
+  Future<CommandListResponse> getCommands({required String? projectId, required String? pluginId}) async =>
+      const CommandListResponse(items: []);
 
   @override
   Future<void> sendPrompt({
@@ -2300,6 +2304,7 @@ class _NoopSessionRepository implements SessionRepository {
   @override
   Future<Session> renameSession({required String sessionId, required String title}) async => const Session(
     id: "",
+    pluginId: "fake",
     projectID: "",
     directory: "",
     parentID: null,
@@ -2360,6 +2365,7 @@ class _DelayingSessionRepository implements SessionRepository {
 
   @override
   Future<Session> createSession({
+    required String? pluginId,
     required String directory,
     required String? parentSessionId,
     required List<PromptPart> parts,
@@ -2368,6 +2374,7 @@ class _DelayingSessionRepository implements SessionRepository {
     required PromptModel? model,
   }) {
     return _base.createSession(
+      pluginId: pluginId,
       directory: directory,
       parentSessionId: parentSessionId,
       parts: parts,
@@ -2397,8 +2404,8 @@ class _DelayingSessionRepository implements SessionRepository {
   }
 
   @override
-  Future<CommandListResponse> getCommands({required String? projectId}) {
-    return _base.getCommands(projectId: projectId);
+  Future<CommandListResponse> getCommands({required String? projectId, required String? pluginId}) {
+    return _base.getCommands(projectId: projectId, pluginId: pluginId);
   }
 
   @override

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -2195,7 +2195,7 @@ class _NoopSessionRepository implements SessionRepository {
 
   @override
   Future<Session> createSession({
-    required String? pluginId,
+    required String pluginId,
     required String directory,
     required String? parentSessionId,
     required List<PromptPart> parts,
@@ -2365,7 +2365,7 @@ class _DelayingSessionRepository implements SessionRepository {
 
   @override
   Future<Session> createSession({
-    required String? pluginId,
+    required String pluginId,
     required String directory,
     required String? parentSessionId,
     required List<PromptPart> parts,
@@ -2404,7 +2404,7 @@ class _DelayingSessionRepository implements SessionRepository {
   }
 
   @override
-  Future<CommandListResponse> getCommands({required String? projectId, required String? pluginId}) {
+  Future<CommandListResponse> getCommands({required String? projectId, required String pluginId}) {
     return _base.getCommands(projectId: projectId, pluginId: pluginId);
   }
 

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -131,7 +131,7 @@ void main() {
         projectRepository: projectRepository,
         sessionUnseenService: SessionUnseenService(
           unseenRepository: SessionUnseenRepository(
-            pluginId: "opencode",
+            plugin: plugin,
             sessionDao: database.sessionDao,
             projectsDao: database.projectsDao,
             db: database,
@@ -407,7 +407,7 @@ class _TestHarness {
       projectRepository: projectRepository,
       sessionUnseenService: SessionUnseenService(
         unseenRepository: SessionUnseenRepository(
-          pluginId: "opencode",
+          plugin: plugin,
           sessionDao: database.sessionDao,
           projectsDao: database.projectsDao,
           db: database,

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -626,7 +626,7 @@ class _ThrowingSummaryPlugin implements NativeProjectsPluginApi {
   Future<PluginProject> renameProject({
     required String projectId,
     required String name,
-  }) async => const PluginProject(id: "");
+  }) async => const PluginProject(id: "", directory: "");
 
   @override
   Future<void> deleteSession(String sessionId) async {}
@@ -699,7 +699,7 @@ class _ThrowingSummaryPlugin implements NativeProjectsPluginApi {
   }) async {}
 
   @override
-  Future<PluginProject> getProject(String projectId) async => const PluginProject(id: "");
+  Future<PluginProject> getProject(String projectId) async => const PluginProject(id: "", directory: "");
 
   @override
   Future<bool> healthCheck() async => true;

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -353,7 +353,7 @@ class _RegistrationHarness {
       projectRepository: projectRepository,
       sessionUnseenService: SessionUnseenService(
         unseenRepository: SessionUnseenRepository(
-          pluginId: "opencode",
+          plugin: plugin,
           sessionDao: database.sessionDao,
           projectsDao: database.projectsDao,
           db: database,

--- a/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
+++ b/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
@@ -351,7 +351,7 @@ class _ReauthHarness {
     final sessionViewTracker = SessionViewTracker();
     final sessionUnseenService = SessionUnseenService(
       unseenRepository: SessionUnseenRepository(
-        pluginId: "opencode",
+        plugin: plugin,
         sessionDao: database.sessionDao,
         projectsDao: database.projectsDao,
         db: database,

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -89,6 +89,26 @@ void main() {
       );
     });
 
+    test("getProjects repairs a legacy native id-as-path row", () async {
+      plugin.projectsResult = const [
+        PluginProject(id: "backend-project-1", directory: "/projects/one", name: "One"),
+      ];
+      await db.projectsDao.recordOpenedProject(
+        projectId: "backend-project-1",
+        path: "backend-project-1",
+        createdAt: 1,
+        updatedAt: 1,
+      );
+
+      final result = await repo.getProjects(defaultTimestamp: 9999);
+
+      expect(result.single.path, "/projects/one");
+      expect(
+        (await db.projectsDao.getProject(projectId: "backend-project-1"))!.path,
+        "/projects/one",
+      );
+    });
+
     test("getProjects rethrows PluginApiException when plugin throws", () async {
       plugin.getProjectsError = PluginApiException("/project", 500);
 

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -74,6 +74,21 @@ void main() {
       expect(result.map((p) => p.id).toList(), equals(["p3", "p1"]));
     });
 
+    test("getProjects persists a native project's declared directory instead of its id", () async {
+      plugin.projectsResult = const [
+        PluginProject(id: "backend-project-1", directory: "/projects/one", name: "One"),
+      ];
+
+      final result = await repo.getProjects(defaultTimestamp: 9999);
+
+      expect(result.single.id, "backend-project-1");
+      expect(result.single.path, "/projects/one");
+      expect(
+        (await db.projectsDao.getProject(projectId: "backend-project-1"))!.path,
+        "/projects/one",
+      );
+    });
+
     test("getProjects rethrows PluginApiException when plugin throws", () async {
       plugin.getProjectsError = PluginApiException("/project", 500);
 

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -37,9 +37,9 @@ void main() {
 
     test("getProjects fetches plugin projects, persists each, filters hidden, sorts by updated desc", () async {
       plugin.projectsResult = const [
-        PluginProject(id: "p1", name: "P1"),
-        PluginProject(id: "p2", name: "P2"),
-        PluginProject(id: "p3", name: "P3"),
+        PluginProject(id: "p1", directory: "p1", name: "P1"),
+        PluginProject(id: "p2", directory: "p2", name: "P2"),
+        PluginProject(id: "p3", directory: "p3", name: "P3"),
       ];
 
       // Pre-hide p2 and stamp each visible project's persisted updatedAt so
@@ -92,10 +92,10 @@ void main() {
       // Verify that all N plugin projects are persisted in a single batch call.
       // The batch API is internally atomic — all rows land or none do.
       plugin.projectsResult = const [
-        PluginProject(id: "p1"),
-        PluginProject(id: "p2"),
-        PluginProject(id: "p3"),
-        PluginProject(id: "p4"),
+        PluginProject(id: "p1", directory: "p1"),
+        PluginProject(id: "p2", directory: "p2"),
+        PluginProject(id: "p3", directory: "p3"),
+        PluginProject(id: "p4", directory: "p4"),
       ];
 
       await repo.getProjects(defaultTimestamp: 9999);
@@ -110,8 +110,12 @@ void main() {
 
     test("getProjects seeds direct activity and one now default for missing evidence", () async {
       plugin.projectsResult = const [
-        PluginProject(id: "direct", activity: PluginProjectActivity(createdAt: 10, updatedAt: 20)),
-        PluginProject(id: "default"),
+        PluginProject(
+          id: "direct",
+          directory: "direct",
+          activity: PluginProjectActivity(createdAt: 10, updatedAt: 20),
+        ),
+        PluginProject(id: "default", directory: "default"),
       ];
 
       final result = await repo.getProjects(defaultTimestamp: 1234);
@@ -126,7 +130,11 @@ void main() {
 
     test("getProjects reuses one post-seed project snapshot for paths and activity", () async {
       plugin.projectsResult = const [
-        PluginProject(id: "new", activity: PluginProjectActivity(createdAt: 10, updatedAt: 20)),
+        PluginProject(
+          id: "new",
+          directory: "new",
+          activity: PluginProjectActivity(createdAt: 10, updatedAt: 20),
+        ),
       ];
       final projectsDao = _CountingProjectsDao(database: db);
       final countingRepo = ProjectRepository(
@@ -145,9 +153,9 @@ void main() {
 
     test("getProjects sorts equal timestamps by name and then id", () async {
       plugin.projectsResult = const [
-        PluginProject(id: "z", name: "Beta"),
-        PluginProject(id: "b", name: "Alpha"),
-        PluginProject(id: "a", name: "Alpha"),
+        PluginProject(id: "z", directory: "z", name: "Beta"),
+        PluginProject(id: "b", directory: "b", name: "Alpha"),
+        PluginProject(id: "a", directory: "a", name: "Alpha"),
       ];
       for (final id in ["z", "b", "a"]) {
         await db.projectsDao.setActivity(projectId: id, createdAt: 1, updatedAt: 10);
@@ -159,7 +167,11 @@ void main() {
     });
 
     test("openProject discovers via plugin, unhides stored row, and maps result", () async {
-      plugin.projectResult = const PluginProject(id: "p-open", name: "Opened");
+      plugin.projectResult = const PluginProject(
+        id: "p-open",
+        directory: "/tmp/p-open",
+        name: "Opened",
+      );
       await db.projectsDao.hideProject(projectId: "p-open");
 
       final target = await repo.resolveProjectOpenTarget(path: "/tmp/p-open");
@@ -182,7 +194,7 @@ void main() {
         // OpenCode-style backend: the folder moved from /projects/a to
         // /moved/a, and the backend keeps reporting the pinned original
         // worktree as the project id.
-        plugin.projectResult = const PluginProject(id: "/projects/a", name: "A");
+        plugin.projectResult = const PluginProject(id: "/projects/a", directory: "/moved/a", name: "A");
         await db.projectsDao.hideProject(projectId: "/projects/a");
         await db.projectsDao.setBaseBranch(projectId: "/projects/a", baseBranch: "develop");
 
@@ -210,9 +222,9 @@ void main() {
         // Regression: remapping the id to the opened directory (instead of
         // storing a path) made the next list refresh drop the project — the
         // plugin list still reported the old id, which stayed hidden.
-        plugin.projectResult = const PluginProject(id: "/projects/a", name: "A");
+        plugin.projectResult = const PluginProject(id: "/projects/a", directory: "/moved/a", name: "A");
         plugin.projectsResult = const [
-          PluginProject(id: "/projects/a", name: "A"),
+          PluginProject(id: "/projects/a", directory: "/projects/a", name: "A"),
         ];
         await db.projectsDao.hideProject(projectId: "/projects/a");
         await db.projectsDao.setActivity(
@@ -235,8 +247,10 @@ void main() {
       });
 
       test("getProjects computes directoryMissing against the live path, not the id", () async {
-        plugin.projectResult = const PluginProject(id: "/projects/a", name: "A");
-        plugin.projectsResult = const [PluginProject(id: "/projects/a", name: "A")];
+        plugin.projectResult = const PluginProject(id: "/projects/a", directory: "/moved/a", name: "A");
+        plugin.projectsResult = const [
+          PluginProject(id: "/projects/a", directory: "/projects/a", name: "A"),
+        ];
         final repoWithMissing = ProjectRepository(
           plugin: plugin,
           projectsDao: db.projectsDao,
@@ -258,7 +272,7 @@ void main() {
       });
 
       test("getProject and renameProject hand the plugin the live path", () async {
-        plugin.projectResult = const PluginProject(id: "/projects/a", name: "A");
+        plugin.projectResult = const PluginProject(id: "/projects/a", directory: "/moved/a", name: "A");
         await db.projectsDao.recordOpenedProject(
           projectId: "/projects/a",
           path: "/moved/a",
@@ -300,8 +314,8 @@ void main() {
 
     test("getProjects flags a project whose directory no longer exists on disk", () async {
       plugin.projectsResult = const [
-        PluginProject(id: "/present", name: "Present"),
-        PluginProject(id: "/moved", name: "Moved"),
+        PluginProject(id: "/present", directory: "/present", name: "Present"),
+        PluginProject(id: "/moved", directory: "/moved", name: "Moved"),
       ];
       final repoWithMissing = ProjectRepository(
         plugin: plugin,
@@ -328,7 +342,7 @@ void main() {
     });
 
     test("getProject flags a since-deleted directory as missing", () async {
-      plugin.projectResult = const PluginProject(id: "/gone", name: "Gone");
+      plugin.projectResult = const PluginProject(id: "/gone", directory: "/gone", name: "Gone");
       await db.projectsDao.insertProjectsIfMissing(projectIds: ["/gone"]);
       final repoWithMissing = ProjectRepository(
         plugin: plugin,
@@ -344,7 +358,9 @@ void main() {
     });
 
     test("a directory whose existence probe throws is treated as present, not missing", () async {
-      plugin.projectsResult = const [PluginProject(id: "/denied", name: "Denied")];
+      plugin.projectsResult = const [
+        PluginProject(id: "/denied", directory: "/denied", name: "Denied"),
+      ];
       final repoWithThrow = ProjectRepository(
         plugin: plugin,
         projectsDao: db.projectsDao,
@@ -634,7 +650,7 @@ PluginSession _session(
 class _FakeBridgePlugin implements NativeProjectsPluginApi {
   List<PluginProject> projectsResult = const [];
   Object? getProjectsError;
-  PluginProject projectResult = const PluginProject(id: "project-id");
+  PluginProject projectResult = const PluginProject(id: "project-id", directory: "project-id");
   String? lastGetProjectId;
   String? lastRenameProjectId;
 

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -109,6 +109,49 @@ void main() {
       );
     });
 
+    test("activity reconciliation seeds native directories, repairs legacy paths, and preserves moved paths", () async {
+      plugin.projectsResult = const [
+        PluginProject(
+          id: "new-project",
+          directory: "/projects/new",
+          activity: PluginProjectActivity(createdAt: 10, updatedAt: 20),
+        ),
+        PluginProject(
+          id: "legacy-project",
+          directory: "/projects/legacy",
+          activity: PluginProjectActivity(createdAt: 30, updatedAt: 40),
+        ),
+        PluginProject(
+          id: "moved-project",
+          directory: "/projects/backend-path",
+          activity: PluginProjectActivity(createdAt: 50, updatedAt: 60),
+        ),
+      ];
+      await db.projectsDao.recordOpenedProject(
+        projectId: "legacy-project",
+        path: "legacy-project",
+        createdAt: 1,
+        updatedAt: 1,
+      );
+      await db.projectsDao.recordOpenedProject(
+        projectId: "moved-project",
+        path: "/projects/moved",
+        createdAt: 1,
+        updatedAt: 1,
+      );
+      final service = ProjectActivityService(projectRepository: repo, now: () => 9999);
+      addTearDown(service.dispose);
+
+      await service.reconcile();
+
+      final newProject = await db.projectsDao.getProject(projectId: "new-project");
+      expect(newProject?.path, "/projects/new");
+      expect(newProject?.createdAt, 10);
+      expect(newProject?.updatedAt, 20);
+      expect((await db.projectsDao.getProject(projectId: "legacy-project"))?.path, "/projects/legacy");
+      expect((await db.projectsDao.getProject(projectId: "moved-project"))?.path, "/projects/moved");
+    });
+
     test("getProjects rethrows PluginApiException when plugin throws", () async {
       plugin.getProjectsError = PluginApiException("/project", 500);
 

--- a/bridge/app/test/bridge/repositories/project_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/project_repository_test.dart
@@ -89,27 +89,7 @@ void main() {
       );
     });
 
-    test("getProjects repairs a legacy native id-as-path row", () async {
-      plugin.projectsResult = const [
-        PluginProject(id: "backend-project-1", directory: "/projects/one", name: "One"),
-      ];
-      await db.projectsDao.recordOpenedProject(
-        projectId: "backend-project-1",
-        path: "backend-project-1",
-        createdAt: 1,
-        updatedAt: 1,
-      );
-
-      final result = await repo.getProjects(defaultTimestamp: 9999);
-
-      expect(result.single.path, "/projects/one");
-      expect(
-        (await db.projectsDao.getProject(projectId: "backend-project-1"))!.path,
-        "/projects/one",
-      );
-    });
-
-    test("activity reconciliation seeds native directories, repairs legacy paths, and preserves moved paths", () async {
+    test("activity reconciliation seeds native directories and preserves existing paths", () async {
       plugin.projectsResult = const [
         PluginProject(
           id: "new-project",
@@ -117,22 +97,11 @@ void main() {
           activity: PluginProjectActivity(createdAt: 10, updatedAt: 20),
         ),
         PluginProject(
-          id: "legacy-project",
-          directory: "/projects/legacy",
-          activity: PluginProjectActivity(createdAt: 30, updatedAt: 40),
-        ),
-        PluginProject(
           id: "moved-project",
           directory: "/projects/backend-path",
           activity: PluginProjectActivity(createdAt: 50, updatedAt: 60),
         ),
       ];
-      await db.projectsDao.recordOpenedProject(
-        projectId: "legacy-project",
-        path: "legacy-project",
-        createdAt: 1,
-        updatedAt: 1,
-      );
       await db.projectsDao.recordOpenedProject(
         projectId: "moved-project",
         path: "/projects/moved",
@@ -148,7 +117,6 @@ void main() {
       expect(newProject?.path, "/projects/new");
       expect(newProject?.createdAt, 10);
       expect(newProject?.updatedAt, 20);
-      expect((await db.projectsDao.getProject(projectId: "legacy-project"))?.path, "/projects/legacy");
       expect((await db.projectsDao.getProject(projectId: "moved-project"))?.path, "/projects/moved");
     });
 

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -152,7 +152,7 @@ void main() {
       final result = await repository.enrichSession(
         session: const Session(
           id: "s1",
-          pluginId: null,
+          pluginId: "fake",
           projectID: "p1",
           directory: "/tmp/project",
           parentID: null,
@@ -211,7 +211,7 @@ void main() {
       final result = await repository.enrichSession(
         session: const Session(
           id: "s1",
-          pluginId: null,
+          pluginId: "fake",
           projectID: "p1",
           directory: "/tmp/project",
           parentID: null,
@@ -279,7 +279,7 @@ void main() {
         sessions: const [
           Session(
             id: "s1",
-            pluginId: null,
+            pluginId: "fake",
             projectID: "p1",
             directory: "/tmp/project",
             parentID: null,
@@ -291,7 +291,7 @@ void main() {
           ),
           Session(
             id: "s2",
-            pluginId: null,
+            pluginId: "fake",
             projectID: "p1",
             directory: "/tmp/project",
             parentID: null,
@@ -749,60 +749,6 @@ void main() {
 
       expect(missing.pluginId, equals(plugin.id));
       expect(explicitNull.pluginId, equals(plugin.id));
-    });
-
-    test("createSession rejects another plugin before plugin I/O", () async {
-      final db = createTestDatabase();
-      addTearDown(db.close);
-      final repository = SessionRepository(
-        plugin: plugin,
-        sessionDao: db.sessionDao,
-        projectsDao: db.projectsDao,
-        pullRequestRepository: PullRequestRepository(
-          pullRequestDao: db.pullRequestDao,
-          projectsDao: db.projectsDao,
-        ),
-        unseenCalculator: const SessionUnseenCalculator(),
-      );
-
-      await expectLater(
-        repository.createSession(
-          pluginId: "other",
-          directory: "/repo",
-          parentSessionId: null,
-          parts: const [],
-          variant: null,
-          agent: null,
-          model: null,
-        ),
-        throwsA(
-          isA<PluginOperationException>()
-              .having((error) => error.statusCode, "statusCode", 400)
-              .having((error) => error.message, "message", "requested plugin is not active"),
-        ),
-      );
-      expect(plugin.createSessionCalls, isZero);
-    });
-
-    test("getCommands rejects another plugin before project or plugin I/O", () async {
-      final db = createTestDatabase();
-      addTearDown(db.close);
-      final repository = SessionRepository(
-        plugin: plugin,
-        sessionDao: db.sessionDao,
-        projectsDao: db.projectsDao,
-        pullRequestRepository: PullRequestRepository(
-          pullRequestDao: db.pullRequestDao,
-          projectsDao: db.projectsDao,
-        ),
-        unseenCalculator: const SessionUnseenCalculator(),
-      );
-
-      await expectLater(
-        repository.getCommands(projectId: "unknown", pluginId: "other"),
-        throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 400)),
-      );
-      expect(plugin.lastGetCommandsProjectId, isNull);
     });
 
     group("moved project (stable id, new live path)", () {

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -716,7 +716,7 @@ void main() {
       }
     });
 
-    test("enrichSessionJson stamps the active plugin on missing and null attribution", () async {
+    test("enrichPluginEventSessionJson stamps the active plugin on missing and null attribution", () async {
       final db = createTestDatabase();
       addTearDown(db.close);
       final repository = SessionRepository(
@@ -731,7 +731,7 @@ void main() {
       );
       final sessionJson = const Session(
         id: "event-session",
-        pluginId: null,
+        pluginId: legacyMissingPluginId,
         projectID: "/repo",
         directory: "/repo",
         parentID: null,
@@ -742,8 +742,8 @@ void main() {
         promptDefaults: null,
       ).toJson();
 
-      final missing = await repository.enrichSessionJson(sessionJson: sessionJson);
-      final explicitNull = await repository.enrichSessionJson(
+      final missing = await repository.enrichPluginEventSessionJson(sessionJson: sessionJson);
+      final explicitNull = await repository.enrichPluginEventSessionJson(
         sessionJson: {...sessionJson, "pluginId": null},
       );
 

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -48,8 +48,9 @@ void main() {
         lastAgentModel: null,
       );
 
-      await repository.deleteSession(sessionId: "sess-tomb");
+      final deleted = await repository.deleteSession(sessionId: "sess-tomb");
 
+      expect(deleted.pluginId, equals(plugin.id));
       expect(await db.sessionDao.getSession(sessionId: "sess-tomb"), isNull);
       expect(
         await db.sessionDao.getTombstonedSessionIds(pluginId: plugin.id),
@@ -151,6 +152,7 @@ void main() {
       final result = await repository.enrichSession(
         session: const Session(
           id: "s1",
+          pluginId: null,
           projectID: "p1",
           directory: "/tmp/project",
           parentID: null,
@@ -163,6 +165,7 @@ void main() {
       );
 
       expect(result.time?.created, equals(1));
+      expect(result.pluginId, equals(plugin.id));
       expect(result.time?.updated, equals(2));
       expect(result.time?.archived, isNull);
       expect(result.hasWorktree, isTrue);
@@ -208,6 +211,7 @@ void main() {
       final result = await repository.enrichSession(
         session: const Session(
           id: "s1",
+          pluginId: null,
           projectID: "p1",
           directory: "/tmp/project",
           parentID: null,
@@ -275,6 +279,7 @@ void main() {
         sessions: const [
           Session(
             id: "s1",
+            pluginId: null,
             projectID: "p1",
             directory: "/tmp/project",
             parentID: null,
@@ -286,6 +291,7 @@ void main() {
           ),
           Session(
             id: "s2",
+            pluginId: null,
             projectID: "p1",
             directory: "/tmp/project",
             parentID: null,
@@ -299,6 +305,7 @@ void main() {
       );
 
       expect(result, hasLength(2));
+      expect(result.map((session) => session.pluginId), everyElement(plugin.id));
       expect(result[0].time?.created, equals(10));
       expect(result[0].time?.updated, equals(10));
       expect(result[0].time?.archived, equals(1234));
@@ -594,6 +601,7 @@ void main() {
 
       expect(plugin.lastRenameSessionId, equals("s1"));
       expect(plugin.lastRenameSessionTitle, equals("Renamed"));
+      expect(result.pluginId, equals(plugin.id));
       expect(result.title, equals("Renamed"));
       expect(result.hasWorktree, isFalse);
       expect(result.pullRequest, isNull);
@@ -651,8 +659,8 @@ void main() {
       );
 
       plugin.projectsResult = const [
-        PluginProject(id: "/repo-a"),
-        PluginProject(id: "/repo-b"),
+        PluginProject(id: "/repo-a", directory: "/repo-a"),
+        PluginProject(id: "/repo-b", directory: "/repo-b"),
       ];
       plugin.sessionsByWorktree = {
         "/repo-a": const [],
@@ -695,6 +703,7 @@ void main() {
 
       for (final variant in cases) {
         await repository.createSession(
+          pluginId: variant == null ? null : plugin.id,
           directory: "/repo",
           parentSessionId: null,
           parts: const [PromptPart.text(text: "Ship it")],
@@ -705,6 +714,95 @@ void main() {
 
         expect(plugin.lastCreateSessionVariant, equals(variant?.id));
       }
+    });
+
+    test("enrichSessionJson stamps the active plugin on missing and null attribution", () async {
+      final db = createTestDatabase();
+      addTearDown(db.close);
+      final repository = SessionRepository(
+        plugin: plugin,
+        sessionDao: db.sessionDao,
+        projectsDao: db.projectsDao,
+        pullRequestRepository: PullRequestRepository(
+          pullRequestDao: db.pullRequestDao,
+          projectsDao: db.projectsDao,
+        ),
+        unseenCalculator: const SessionUnseenCalculator(),
+      );
+      final sessionJson = const Session(
+        id: "event-session",
+        pluginId: null,
+        projectID: "/repo",
+        directory: "/repo",
+        parentID: null,
+        title: "Event session",
+        time: null,
+        summary: null,
+        pullRequest: null,
+        promptDefaults: null,
+      ).toJson();
+
+      final missing = await repository.enrichSessionJson(sessionJson: sessionJson);
+      final explicitNull = await repository.enrichSessionJson(
+        sessionJson: {...sessionJson, "pluginId": null},
+      );
+
+      expect(missing.pluginId, equals(plugin.id));
+      expect(explicitNull.pluginId, equals(plugin.id));
+    });
+
+    test("createSession rejects another plugin before plugin I/O", () async {
+      final db = createTestDatabase();
+      addTearDown(db.close);
+      final repository = SessionRepository(
+        plugin: plugin,
+        sessionDao: db.sessionDao,
+        projectsDao: db.projectsDao,
+        pullRequestRepository: PullRequestRepository(
+          pullRequestDao: db.pullRequestDao,
+          projectsDao: db.projectsDao,
+        ),
+        unseenCalculator: const SessionUnseenCalculator(),
+      );
+
+      await expectLater(
+        repository.createSession(
+          pluginId: "other",
+          directory: "/repo",
+          parentSessionId: null,
+          parts: const [],
+          variant: null,
+          agent: null,
+          model: null,
+        ),
+        throwsA(
+          isA<PluginOperationException>()
+              .having((error) => error.statusCode, "statusCode", 400)
+              .having((error) => error.message, "message", "requested plugin is not active"),
+        ),
+      );
+      expect(plugin.createSessionCalls, isZero);
+    });
+
+    test("getCommands rejects another plugin before project or plugin I/O", () async {
+      final db = createTestDatabase();
+      addTearDown(db.close);
+      final repository = SessionRepository(
+        plugin: plugin,
+        sessionDao: db.sessionDao,
+        projectsDao: db.projectsDao,
+        pullRequestRepository: PullRequestRepository(
+          pullRequestDao: db.pullRequestDao,
+          projectsDao: db.projectsDao,
+        ),
+        unseenCalculator: const SessionUnseenCalculator(),
+      );
+
+      await expectLater(
+        repository.getCommands(projectId: "unknown", pluginId: "other"),
+        throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 400)),
+      );
+      expect(plugin.lastGetCommandsProjectId, isNull);
     });
 
     group("moved project (stable id, new live path)", () {
@@ -752,6 +850,7 @@ void main() {
 
         expect(plugin.lastGetSessionsWorktree, equals("/moved/a"));
         expect(sessions.single.id, equals("s-live"));
+        expect(sessions.single.pluginId, equals(plugin.id));
         expect(sessions.single.projectID, equals("/projects/a"));
       });
 
@@ -776,11 +875,11 @@ void main() {
           unseenCalculator: const SessionUnseenCalculator(),
         );
 
-        await repository.getCommands(projectId: "/projects/a");
+        await repository.getCommands(projectId: "/projects/a", pluginId: plugin.id);
         expect(plugin.lastGetCommandsProjectId, equals("/moved/a"));
 
         // Null/blank keeps the plugin's own fallback untouched.
-        await repository.getCommands(projectId: "  ");
+        await repository.getCommands(projectId: "  ", pluginId: null);
         expect(plugin.lastGetCommandsProjectId, isNull);
       });
 
@@ -1299,6 +1398,7 @@ void main() {
       final children = await repository.getChildSessions(sessionId: "live-parent");
 
       expect(children.map((session) => session.id), ["live-child"]);
+      expect(children.single.pluginId, equals(plugin.id));
     });
 
     test("deleteSession survives rowless project discovery failure", () async {
@@ -1441,6 +1541,7 @@ class _FakeBridgePlugin implements NativeProjectsPluginApi {
   String? lastRenameSessionId;
   String? lastRenameSessionTitle;
   String? lastCreateSessionVariant;
+  int createSessionCalls = 0;
   String? lastSendPromptVariant;
   String? lastSendCommandVariant;
   String? lastGetSessionsWorktree;
@@ -1474,7 +1575,7 @@ class _FakeBridgePlugin implements NativeProjectsPluginApi {
   @override
   Future<PluginProject> getProject(String projectId) async {
     lastGetProjectDirectory = projectId;
-    return PluginProject(id: projectId);
+    return PluginProject(id: projectId, directory: projectId);
   }
 
   @override
@@ -1493,6 +1594,7 @@ class _FakeBridgePlugin implements NativeProjectsPluginApi {
     required String? agent,
     required ({String providerID, String modelID})? model,
   }) async {
+    createSessionCalls++;
     lastCreateSessionVariant = variant?.id;
     return createSessionResult;
   }

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -659,8 +659,8 @@ void main() {
       );
 
       plugin.projectsResult = const [
-        PluginProject(id: "/repo-a", directory: "/repo-a"),
-        PluginProject(id: "/repo-b", directory: "/repo-b"),
+        PluginProject(id: "project-a", directory: "/repo-a"),
+        PluginProject(id: "project-b", directory: "/repo-b"),
       ];
       plugin.sessionsByWorktree = {
         "/repo-a": const [],
@@ -679,9 +679,9 @@ void main() {
 
       final result = await repository.findProjectIdForSession(sessionId: "s-target");
 
-      expect(result, equals("/repo-b"));
-      expect(await db.projectsDao.getProject(projectId: "/repo-a"), isNotNull);
-      expect(await db.projectsDao.getProject(projectId: "/repo-b"), isNotNull);
+      expect(result, equals("project-b"));
+      expect((await db.projectsDao.getProject(projectId: "project-a"))?.path, "/repo-a");
+      expect((await db.projectsDao.getProject(projectId: "project-b"))?.path, "/repo-b");
     });
 
     test("createSession passes variant directly to plugin", () async {
@@ -703,7 +703,7 @@ void main() {
 
       for (final variant in cases) {
         await repository.createSession(
-          pluginId: variant == null ? null : plugin.id,
+          pluginId: plugin.id,
           directory: "/repo",
           parentSessionId: null,
           parts: const [PromptPart.text(text: "Ship it")],
@@ -825,7 +825,7 @@ void main() {
         expect(plugin.lastGetCommandsProjectId, equals("/moved/a"));
 
         // Null/blank keeps the plugin's own fallback untouched.
-        await repository.getCommands(projectId: "  ", pluginId: null);
+        await repository.getCommands(projectId: "  ", pluginId: plugin.id);
         expect(plugin.lastGetCommandsProjectId, isNull);
       });
 

--- a/bridge/app/test/bridge/routing/create_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_project_handler_test.dart
@@ -79,10 +79,11 @@ void main() {
 
     test("valid new path creates directory, runs git init, calls plugin, returns 200", () async {
       final path = "${tempDir.path}/new-project";
-      plugin.currentProjectResult = const PluginProject(
+      plugin.currentProjectResult = PluginProject(
         id: "p-1",
+        directory: path,
         name: "New Project",
-        activity: PluginProjectActivity(createdAt: 10, updatedAt: 20),
+        activity: const PluginProjectActivity(createdAt: 10, updatedAt: 20),
       );
 
       final result = await handler.handle(
@@ -103,10 +104,11 @@ void main() {
 
     test(".gitignore is created with .worktrees/ entry after git init", () async {
       final path = "${tempDir.path}/new-project-with-gitignore";
-      plugin.currentProjectResult = const PluginProject(
+      plugin.currentProjectResult = PluginProject(
         id: "p-2",
+        directory: path,
         name: "Project With Gitignore",
-        activity: PluginProjectActivity(createdAt: 30, updatedAt: 40),
+        activity: const PluginProjectActivity(createdAt: 30, updatedAt: 40),
       );
 
       final result = await handler.handle(

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -1,3 +1,4 @@
+import "dart:convert";
 import "dart:io";
 
 import "package:sesori_bridge/src/bridge/api/database/tables/pull_requests_table.dart";
@@ -87,6 +88,30 @@ void main() {
       expect(handler.canHandle(makeRequest("GET", "/session/create")), isFalse);
     });
 
+    test("accepts a request body without pluginId", () async {
+      final response = await handler.handleInternal(
+        makeRequest(
+          "POST",
+          "/session/create",
+          body: jsonEncode({
+            "projectId": "/repo",
+            "parts": <Object>[],
+            "agent": null,
+            "model": null,
+            "command": null,
+            "variant": null,
+            "dedicatedWorktree": false,
+          }),
+        ),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(response.status, equals(200));
+      expect(plugin.lastCreateSessionDirectory, equals("/repo"));
+    });
+
     test("dedicated=true and WorktreeSuccess injects system prompt and stores worktree metadata", () async {
       plugin.createSessionResult = const PluginSession(
         id: "s1",
@@ -108,6 +133,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: true,
           parts: [PromptPart.text(text: "Start")],
           variant: SessionVariant(id: "xhigh"),
@@ -166,6 +192,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Start")],
           variant: SessionVariant(id: "xhigh"),
@@ -207,6 +234,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Start")],
           variant: null,
@@ -259,6 +287,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Start")],
           variant: null,
@@ -305,6 +334,7 @@ void main() {
           makeRequest("POST", "/session/create"),
           body: const CreateSessionRequest(
             projectId: "/repo",
+            pluginId: null,
             dedicatedWorktree: true,
             parts: [PromptPart.text(text: "Start")],
             variant: null,
@@ -355,6 +385,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: true,
           parts: <PromptPart>[],
           variant: null,
@@ -425,6 +456,7 @@ void main() {
           makeRequest("POST", "/session/create"),
           body: const CreateSessionRequest(
             projectId: "/repo",
+            pluginId: null,
             dedicatedWorktree: true,
             parts: [PromptPart.text(text: "Start")],
             variant: null,
@@ -459,6 +491,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: "fake",
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Start")],
           variant: null,
@@ -472,6 +505,7 @@ void main() {
       );
 
       expect(result.id, equals("s1"));
+      expect(result.pluginId, equals("fake"));
       // The created session belongs to the requested project by construction,
       // so the response is re-keyed to the request's stable projectId — the
       // plugin can only echo the directory it created the session in.
@@ -524,6 +558,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: true,
           parts: [PromptPart.text(text: "Start")],
           variant: null,
@@ -556,6 +591,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Start")],
           variant: null,
@@ -590,6 +626,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: true,
           parts: [PromptPart.text(text: "Start")],
           variant: null,
@@ -610,6 +647,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/tmp",
+          pluginId: null,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Hello")],
           variant: null,
@@ -663,6 +701,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: true,
           parts: [PromptPart.text(text: "Fix the login bug")],
           variant: null,
@@ -703,6 +742,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: true,
           parts: [PromptPart.text(text: "Start")],
           variant: null,
@@ -736,6 +776,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: false,
           parts: [PromptPart.fileData(mime: "image/png", base64: "abc", filename: "img.png")],
           variant: null,
@@ -768,6 +809,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "   ")],
           variant: null,
@@ -799,6 +841,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Review this code")],
           variant: SessionVariant(id: "low"),
@@ -843,6 +886,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: true,
           parts: [PromptPart.text(text: "Review this code")],
           variant: null,
@@ -896,6 +940,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Review this code")],
           variant: null,
@@ -934,6 +979,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Review this")],
           variant: SessionVariant(id: "xhigh"),
@@ -964,6 +1010,7 @@ void main() {
           makeRequest("POST", "/session/create"),
           body: const CreateSessionRequest(
             projectId: "brand-new-proj",
+            pluginId: null,
             dedicatedWorktree: false,
             parts: [PromptPart.text(text: "Hello")],
             variant: null,
@@ -983,6 +1030,29 @@ void main() {
       expect(await db.sessionDao.getSession(sessionId: "new-sess-1"), isNull);
     });
 
+    test("rejects another plugin before plugin I/O", () async {
+      await expectLater(
+        handler.handle(
+          makeRequest("POST", "/session/create"),
+          body: const CreateSessionRequest(
+            projectId: "/repo",
+            pluginId: "other",
+            dedicatedWorktree: false,
+            parts: [],
+            variant: null,
+            agent: null,
+            model: null,
+            command: null,
+          ),
+          pathParams: {},
+          queryParams: {},
+          fragment: null,
+        ),
+        throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 400)),
+      );
+      expect(plugin.lastCreateSessionDirectory, isNull);
+    });
+
     test("no command — sendCommand not called", () async {
       plugin.createSessionResult = const PluginSession(
         id: "no-cmd-1",
@@ -998,6 +1068,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Hello")],
           variant: null,
@@ -1029,6 +1100,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Hello")],
           variant: null,
@@ -1085,6 +1157,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
+          pluginId: null,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Fix the login bug")],
           variant: null,

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -1030,29 +1030,6 @@ void main() {
       expect(await db.sessionDao.getSession(sessionId: "new-sess-1"), isNull);
     });
 
-    test("rejects another plugin before plugin I/O", () async {
-      await expectLater(
-        handler.handle(
-          makeRequest("POST", "/session/create"),
-          body: const CreateSessionRequest(
-            projectId: "/repo",
-            pluginId: "other",
-            dedicatedWorktree: false,
-            parts: [],
-            variant: null,
-            agent: null,
-            model: null,
-            command: null,
-          ),
-          pathParams: {},
-          queryParams: {},
-          fragment: null,
-        ),
-        throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 400)),
-      );
-      expect(plugin.lastCreateSessionDirectory, isNull);
-    });
-
     test("no command — sendCommand not called", () async {
       plugin.createSessionResult = const PluginSession(
         id: "no-cmd-1",

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -133,7 +133,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: true,
           parts: [PromptPart.text(text: "Start")],
           variant: SessionVariant(id: "xhigh"),
@@ -192,7 +192,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Start")],
           variant: SessionVariant(id: "xhigh"),
@@ -234,7 +234,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Start")],
           variant: null,
@@ -287,7 +287,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Start")],
           variant: null,
@@ -334,7 +334,7 @@ void main() {
           makeRequest("POST", "/session/create"),
           body: const CreateSessionRequest(
             projectId: "/repo",
-            pluginId: null,
+            pluginId: legacyMissingPluginId,
             dedicatedWorktree: true,
             parts: [PromptPart.text(text: "Start")],
             variant: null,
@@ -385,7 +385,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: true,
           parts: <PromptPart>[],
           variant: null,
@@ -456,7 +456,7 @@ void main() {
           makeRequest("POST", "/session/create"),
           body: const CreateSessionRequest(
             projectId: "/repo",
-            pluginId: null,
+            pluginId: legacyMissingPluginId,
             dedicatedWorktree: true,
             parts: [PromptPart.text(text: "Start")],
             variant: null,
@@ -558,7 +558,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: true,
           parts: [PromptPart.text(text: "Start")],
           variant: null,
@@ -591,7 +591,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Start")],
           variant: null,
@@ -626,7 +626,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: true,
           parts: [PromptPart.text(text: "Start")],
           variant: null,
@@ -647,7 +647,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/tmp",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Hello")],
           variant: null,
@@ -701,7 +701,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: true,
           parts: [PromptPart.text(text: "Fix the login bug")],
           variant: null,
@@ -742,7 +742,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: true,
           parts: [PromptPart.text(text: "Start")],
           variant: null,
@@ -776,7 +776,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: false,
           parts: [PromptPart.fileData(mime: "image/png", base64: "abc", filename: "img.png")],
           variant: null,
@@ -809,7 +809,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "   ")],
           variant: null,
@@ -841,7 +841,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Review this code")],
           variant: SessionVariant(id: "low"),
@@ -886,7 +886,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: true,
           parts: [PromptPart.text(text: "Review this code")],
           variant: null,
@@ -940,7 +940,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Review this code")],
           variant: null,
@@ -979,7 +979,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Review this")],
           variant: SessionVariant(id: "xhigh"),
@@ -1010,7 +1010,7 @@ void main() {
           makeRequest("POST", "/session/create"),
           body: const CreateSessionRequest(
             projectId: "brand-new-proj",
-            pluginId: null,
+            pluginId: legacyMissingPluginId,
             dedicatedWorktree: false,
             parts: [PromptPart.text(text: "Hello")],
             variant: null,
@@ -1045,7 +1045,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Hello")],
           variant: null,
@@ -1077,7 +1077,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Hello")],
           variant: null,
@@ -1134,7 +1134,7 @@ void main() {
         makeRequest("POST", "/session/create"),
         body: const CreateSessionRequest(
           projectId: "/repo",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           dedicatedWorktree: false,
           parts: [PromptPart.text(text: "Fix the login bug")],
           variant: null,

--- a/bridge/app/test/bridge/routing/get_base_branch_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_base_branch_handler_test.dart
@@ -49,7 +49,7 @@ void main() {
     test("returns baseBranch null for unknown project", () async {
       final response = await handler.handle(
         makeRequest("POST", "/project/base-branch"),
-        body: const ProjectIdRequest(projectId: "unknown-project"),
+        body: const ProjectIdRequest(projectId: "unknown-project", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -63,7 +63,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/project/base-branch"),
-        body: const ProjectIdRequest(projectId: "/Users/dev/my-app"),
+        body: const ProjectIdRequest(projectId: "/Users/dev/my-app", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -77,7 +77,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/project/base-branch"),
-        body: const ProjectIdRequest(projectId: "proj-1"),
+        body: const ProjectIdRequest(projectId: "proj-1", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,

--- a/bridge/app/test/bridge/routing/get_base_branch_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_base_branch_handler_test.dart
@@ -49,7 +49,7 @@ void main() {
     test("returns baseBranch null for unknown project", () async {
       final response = await handler.handle(
         makeRequest("POST", "/project/base-branch"),
-        body: const ProjectIdRequest(projectId: "unknown-project", pluginId: null),
+        body: const ProjectIdRequest(projectId: "unknown-project"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -63,7 +63,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/project/base-branch"),
-        body: const ProjectIdRequest(projectId: "/Users/dev/my-app", pluginId: null),
+        body: const ProjectIdRequest(projectId: "/Users/dev/my-app"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -77,7 +77,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/project/base-branch"),
-        body: const ProjectIdRequest(projectId: "proj-1", pluginId: null),
+        body: const ProjectIdRequest(projectId: "proj-1"),
         pathParams: {},
         queryParams: {},
         fragment: null,

--- a/bridge/app/test/bridge/routing/get_commands_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_commands_handler_test.dart
@@ -119,18 +119,5 @@ void main() {
       expect(plugin.lastGetCommandsProjectId, equals("/repo"));
     });
 
-    test("rejects another plugin before plugin I/O", () async {
-      await expectLater(
-        handler.handle(
-          makeRequest("POST", "/command"),
-          body: const ProjectIdRequest(projectId: "/repo", pluginId: "other"),
-          pathParams: {},
-          queryParams: {},
-          fragment: null,
-        ),
-        throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 400)),
-      );
-      expect(plugin.lastGetCommandsProjectId, isNull);
-    });
   });
 }

--- a/bridge/app/test/bridge/routing/get_commands_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_commands_handler_test.dart
@@ -78,7 +78,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/command"),
-        body: const ProjectIdRequest(projectId: "/repo", pluginId: null),
+        body: const PluginProjectIdRequest(projectId: "/repo"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -110,7 +110,7 @@ void main() {
     test("accepts the active plugin selection", () async {
       await handler.handle(
         makeRequest("POST", "/command"),
-        body: const ProjectIdRequest(projectId: "/repo", pluginId: "fake"),
+        body: const PluginProjectIdRequest(projectId: "/repo", pluginId: "fake"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -118,6 +118,5 @@ void main() {
 
       expect(plugin.lastGetCommandsProjectId, equals("/repo"));
     });
-
   });
 }

--- a/bridge/app/test/bridge/routing/get_commands_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_commands_handler_test.dart
@@ -1,3 +1,5 @@
+import "dart:convert";
+
 import "package:sesori_bridge/src/bridge/persistence/database.dart";
 import "package:sesori_bridge/src/bridge/repositories/pull_request_repository.dart";
 import "package:sesori_bridge/src/bridge/repositories/session_repository.dart";
@@ -43,6 +45,22 @@ void main() {
       expect(handler.canHandle(makeRequest("POST", "/command")), isTrue);
     });
 
+    test("accepts a request body without pluginId", () async {
+      final response = await handler.handleInternal(
+        makeRequest(
+          "POST",
+          "/command",
+          body: jsonEncode({"projectId": "/repo"}),
+        ),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(response.status, equals(200));
+      expect(plugin.lastGetCommandsProjectId, equals("/repo"));
+    });
+
     test("maps commands through repository mapper", () async {
       plugin.commandsResult = [
         const PluginCommand(
@@ -60,7 +78,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/command"),
-        body: const ProjectIdRequest(projectId: "/repo"),
+        body: const ProjectIdRequest(projectId: "/repo", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -87,6 +105,32 @@ void main() {
           ),
         ),
       );
+    });
+
+    test("accepts the active plugin selection", () async {
+      await handler.handle(
+        makeRequest("POST", "/command"),
+        body: const ProjectIdRequest(projectId: "/repo", pluginId: "fake"),
+        pathParams: {},
+        queryParams: {},
+        fragment: null,
+      );
+
+      expect(plugin.lastGetCommandsProjectId, equals("/repo"));
+    });
+
+    test("rejects another plugin before plugin I/O", () async {
+      await expectLater(
+        handler.handle(
+          makeRequest("POST", "/command"),
+          body: const ProjectIdRequest(projectId: "/repo", pluginId: "other"),
+          pathParams: {},
+          queryParams: {},
+          fragment: null,
+        ),
+        throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 400)),
+      );
+      expect(plugin.lastGetCommandsProjectId, isNull);
     });
   });
 }

--- a/bridge/app/test/bridge/routing/get_current_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_current_project_handler_test.dart
@@ -55,7 +55,7 @@ void main() {
       expect(
         () => handler.handle(
           makeRequest("POST", "/project/current"),
-          body: const ProjectIdRequest(projectId: "", pluginId: null),
+          body: const ProjectIdRequest(projectId: ""),
           pathParams: {},
           queryParams: {},
           fragment: null,
@@ -67,7 +67,7 @@ void main() {
     test("returns typed project", () async {
       final response = await handler.handle(
         makeRequest("POST", "/project/current"),
-        body: const ProjectIdRequest(projectId: "/tmp/project", pluginId: null),
+        body: const ProjectIdRequest(projectId: "/tmp/project"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -86,7 +86,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/project/current"),
-        body: const ProjectIdRequest(projectId: "/tmp/project", pluginId: null),
+        body: const ProjectIdRequest(projectId: "/tmp/project"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -105,7 +105,7 @@ void main() {
         makeRequest(
           "POST",
           "/project/current",
-          body: jsonEncode(const ProjectIdRequest(projectId: "/unknown", pluginId: null).toJson()),
+          body: jsonEncode(const ProjectIdRequest(projectId: "/unknown").toJson()),
         ),
         pathParams: {},
         queryParams: {},

--- a/bridge/app/test/bridge/routing/get_current_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_current_project_handler_test.dart
@@ -55,7 +55,7 @@ void main() {
       expect(
         () => handler.handle(
           makeRequest("POST", "/project/current"),
-          body: const ProjectIdRequest(projectId: ""),
+          body: const ProjectIdRequest(projectId: "", pluginId: null),
           pathParams: {},
           queryParams: {},
           fragment: null,
@@ -67,7 +67,7 @@ void main() {
     test("returns typed project", () async {
       final response = await handler.handle(
         makeRequest("POST", "/project/current"),
-        body: const ProjectIdRequest(projectId: "/tmp/project"),
+        body: const ProjectIdRequest(projectId: "/tmp/project", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -79,13 +79,14 @@ void main() {
     test("maps fields", () async {
       plugin.currentProjectResult = const PluginProject(
         id: "p1",
+        directory: "/tmp/project",
         name: "My Project",
         activity: PluginProjectActivity(createdAt: 11, updatedAt: 22),
       );
 
       final response = await handler.handle(
         makeRequest("POST", "/project/current"),
-        body: const ProjectIdRequest(projectId: "/tmp/project"),
+        body: const ProjectIdRequest(projectId: "/tmp/project", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -104,7 +105,7 @@ void main() {
         makeRequest(
           "POST",
           "/project/current",
-          body: jsonEncode(const ProjectIdRequest(projectId: "/unknown").toJson()),
+          body: jsonEncode(const ProjectIdRequest(projectId: "/unknown", pluginId: null).toJson()),
         ),
         pathParams: {},
         queryParams: {},

--- a/bridge/app/test/bridge/routing/get_project_questions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_project_questions_handler_test.dart
@@ -41,7 +41,7 @@ void main() {
     test("returns typed response on success", () async {
       final response = await handler.handle(
         makeRequest("POST", "/project/questions"),
-        body: const ProjectIdRequest(projectId: "/tmp/project", pluginId: null),
+        body: const ProjectIdRequest(projectId: "/tmp/project"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -73,7 +73,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/project/questions"),
-        body: const ProjectIdRequest(projectId: "/tmp/project", pluginId: null),
+        body: const ProjectIdRequest(projectId: "/tmp/project"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -101,7 +101,7 @@ void main() {
       expect(
         () => handler.handle(
           makeRequest("POST", "/project/questions"),
-          body: const ProjectIdRequest(projectId: "", pluginId: null),
+          body: const ProjectIdRequest(projectId: ""),
           pathParams: {},
           queryParams: {},
           fragment: null,

--- a/bridge/app/test/bridge/routing/get_project_questions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_project_questions_handler_test.dart
@@ -41,7 +41,7 @@ void main() {
     test("returns typed response on success", () async {
       final response = await handler.handle(
         makeRequest("POST", "/project/questions"),
-        body: const ProjectIdRequest(projectId: "/tmp/project"),
+        body: const ProjectIdRequest(projectId: "/tmp/project", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -73,7 +73,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/project/questions"),
-        body: const ProjectIdRequest(projectId: "/tmp/project"),
+        body: const ProjectIdRequest(projectId: "/tmp/project", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -101,7 +101,7 @@ void main() {
       expect(
         () => handler.handle(
           makeRequest("POST", "/project/questions"),
-          body: const ProjectIdRequest(projectId: ""),
+          body: const ProjectIdRequest(projectId: "", pluginId: null),
           pathParams: {},
           queryParams: {},
           fragment: null,

--- a/bridge/app/test/bridge/routing/get_projects_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_projects_handler_test.dart
@@ -81,6 +81,7 @@ void main() {
       plugin.projectsResult = [
         const PluginProject(
           id: "p1",
+          directory: "p1",
           name: "My Project",
         ),
       ];
@@ -101,6 +102,7 @@ void main() {
       plugin.projectsResult = [
         const PluginProject(
           id: "p1",
+          directory: "p1",
           activity: PluginProjectActivity(createdAt: 1000, updatedAt: 2000),
         ),
       ];
@@ -119,7 +121,7 @@ void main() {
 
     test("time uses the persisted insertion timestamp when plugin activity is absent", () async {
       plugin.projectsResult = [
-        const PluginProject(id: "p1"),
+        const PluginProject(id: "p1", directory: "p1"),
       ];
 
       final response = await handler.handle(
@@ -135,9 +137,9 @@ void main() {
 
     test("returns all projects when plugin returns multiple", () async {
       plugin.projectsResult = [
-        const PluginProject(id: "p1"),
-        const PluginProject(id: "p2"),
-        const PluginProject(id: "p3"),
+        const PluginProject(id: "p1", directory: "p1"),
+        const PluginProject(id: "p2", directory: "p2"),
+        const PluginProject(id: "p3", directory: "p3"),
       ];
 
       final response = await handler.handle(
@@ -152,9 +154,9 @@ void main() {
 
     test("filters out hidden project ids", () async {
       plugin.projectsResult = [
-        const PluginProject(id: "visible-1"),
-        const PluginProject(id: "hidden-1"),
-        const PluginProject(id: "visible-2"),
+        const PluginProject(id: "visible-1", directory: "visible-1"),
+        const PluginProject(id: "hidden-1", directory: "hidden-1"),
+        const PluginProject(id: "visible-2", directory: "visible-2"),
       ];
       await projectsDao.hideProject(projectId: "hidden-1");
 

--- a/bridge/app/test/bridge/routing/get_providers_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_providers_handler_test.dart
@@ -55,20 +55,6 @@ void main() {
       expect(plugin.lastGetProvidersProjectId, equals("project-1"));
     });
 
-    test("rejects another plugin before plugin I/O", () async {
-      await expectLater(
-        handler.handle(
-          makeRequest("POST", "/provider"),
-          body: const ProjectIdRequest(projectId: "project-1", pluginId: "other"),
-          pathParams: {},
-          queryParams: {},
-          fragment: null,
-        ),
-        throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 400)),
-      );
-      expect(plugin.lastGetProvidersProjectId, isNull);
-    });
-
     // ── Response format ─────────────────────────────────────────────────────
 
     test("returns typed provider list response", () async {

--- a/bridge/app/test/bridge/routing/get_providers_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_providers_handler_test.dart
@@ -47,7 +47,7 @@ void main() {
     test("passes projectId from body to plugin", () async {
       await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1"),
+        body: const ProjectIdRequest(projectId: "project-1", pluginId: "fake"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -55,12 +55,26 @@ void main() {
       expect(plugin.lastGetProvidersProjectId, equals("project-1"));
     });
 
+    test("rejects another plugin before plugin I/O", () async {
+      await expectLater(
+        handler.handle(
+          makeRequest("POST", "/provider"),
+          body: const ProjectIdRequest(projectId: "project-1", pluginId: "other"),
+          pathParams: {},
+          queryParams: {},
+          fragment: null,
+        ),
+        throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 400)),
+      );
+      expect(plugin.lastGetProvidersProjectId, isNull);
+    });
+
     // ── Response format ─────────────────────────────────────────────────────
 
     test("returns typed provider list response", () async {
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1"),
+        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -71,7 +85,7 @@ void main() {
     test("returns empty items list when plugin has no providers", () async {
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1"),
+        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -96,7 +110,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1"),
+        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -123,7 +137,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1"),
+        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -148,7 +162,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1"),
+        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -176,7 +190,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1"),
+        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -231,7 +245,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1"),
+        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -269,7 +283,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1"),
+        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -299,7 +313,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1"),
+        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -327,7 +341,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1"),
+        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -351,7 +365,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1"),
+        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -389,7 +403,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1"),
+        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,

--- a/bridge/app/test/bridge/routing/get_providers_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_providers_handler_test.dart
@@ -47,7 +47,7 @@ void main() {
     test("passes projectId from body to plugin", () async {
       await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1", pluginId: "fake"),
+        body: const PluginProjectIdRequest(projectId: "project-1", pluginId: "fake"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -60,7 +60,7 @@ void main() {
     test("returns typed provider list response", () async {
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
+        body: const PluginProjectIdRequest(projectId: "project-1"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -71,7 +71,7 @@ void main() {
     test("returns empty items list when plugin has no providers", () async {
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
+        body: const PluginProjectIdRequest(projectId: "project-1"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -96,7 +96,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
+        body: const PluginProjectIdRequest(projectId: "project-1"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -123,7 +123,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
+        body: const PluginProjectIdRequest(projectId: "project-1"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -148,7 +148,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
+        body: const PluginProjectIdRequest(projectId: "project-1"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -176,7 +176,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
+        body: const PluginProjectIdRequest(projectId: "project-1"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -231,7 +231,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
+        body: const PluginProjectIdRequest(projectId: "project-1"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -269,7 +269,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
+        body: const PluginProjectIdRequest(projectId: "project-1"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -299,7 +299,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
+        body: const PluginProjectIdRequest(projectId: "project-1"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -327,7 +327,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
+        body: const PluginProjectIdRequest(projectId: "project-1"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -351,7 +351,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
+        body: const PluginProjectIdRequest(projectId: "project-1"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -389,7 +389,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/provider"),
-        body: const ProjectIdRequest(projectId: "project-1", pluginId: null),
+        body: const PluginProjectIdRequest(projectId: "project-1"),
         pathParams: {},
         queryParams: {},
         fragment: null,

--- a/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
@@ -1013,7 +1013,7 @@ void main() {
     });
 
     test("triggers PR refresh in background when waitForPrData is false", () async {
-      plugin.currentProjectResult = const PluginProject(id: "/tmp/project");
+      plugin.currentProjectResult = const PluginProject(id: "/tmp/project", directory: "/tmp/project");
       await handler.handle(
         makeRequest("POST", "/sessions"),
         body: const SessionListRequest(projectId: "project-1", start: null, limit: null),
@@ -1029,7 +1029,7 @@ void main() {
     });
 
     test("triggers PR refresh with project path resolved from plugin.getProject", () async {
-      plugin.currentProjectResult = const PluginProject(id: "/tmp/project");
+      plugin.currentProjectResult = const PluginProject(id: "/tmp/project", directory: "/tmp/project");
       await handler.handle(
         makeRequest("POST", "/sessions"),
         body: const SessionListRequest(projectId: "project-1", start: null, limit: null, waitForPrData: true),

--- a/bridge/app/test/bridge/routing/hide_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/hide_project_handler_test.dart
@@ -45,7 +45,7 @@ void main() {
     test("returns 200 and stores hidden project id", () async {
       final response = await handler.handle(
         makeRequest("POST", "/project/hide"),
-        body: const ProjectIdRequest(projectId: "p1"),
+        body: const ProjectIdRequest(projectId: "p1", pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -60,7 +60,7 @@ void main() {
       expect(
         () => handler.handle(
           makeRequest("POST", "/project/hide"),
-          body: const ProjectIdRequest(projectId: ""),
+          body: const ProjectIdRequest(projectId: "", pluginId: null),
           pathParams: {},
           queryParams: {},
           fragment: null,
@@ -73,7 +73,7 @@ void main() {
       const projectId = "/Users/alex/projects/my-app";
       final response = await handler.handle(
         makeRequest("POST", "/project/hide"),
-        body: const ProjectIdRequest(projectId: projectId),
+        body: const ProjectIdRequest(projectId: projectId, pluginId: null),
         pathParams: {},
         queryParams: {},
         fragment: null,

--- a/bridge/app/test/bridge/routing/hide_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/hide_project_handler_test.dart
@@ -45,7 +45,7 @@ void main() {
     test("returns 200 and stores hidden project id", () async {
       final response = await handler.handle(
         makeRequest("POST", "/project/hide"),
-        body: const ProjectIdRequest(projectId: "p1", pluginId: null),
+        body: const ProjectIdRequest(projectId: "p1"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -60,7 +60,7 @@ void main() {
       expect(
         () => handler.handle(
           makeRequest("POST", "/project/hide"),
-          body: const ProjectIdRequest(projectId: "", pluginId: null),
+          body: const ProjectIdRequest(projectId: ""),
           pathParams: {},
           queryParams: {},
           fragment: null,
@@ -73,7 +73,7 @@ void main() {
       const projectId = "/Users/alex/projects/my-app";
       final response = await handler.handle(
         makeRequest("POST", "/project/hide"),
-        body: const ProjectIdRequest(projectId: projectId, pluginId: null),
+        body: const ProjectIdRequest(projectId: projectId),
         pathParams: {},
         queryParams: {},
         fragment: null,

--- a/bridge/app/test/bridge/routing/open_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/open_project_handler_test.dart
@@ -146,7 +146,7 @@ void main() {
     // ── Successful discovery ─────────────────────────────────────────────────
 
     test("calls plugin.getProject with the given path", () async {
-      plugin.currentProjectResult = PluginProject(id: tempDir.path);
+      plugin.currentProjectResult = PluginProject(id: tempDir.path, directory: tempDir.path);
 
       await handler.handle(
         makeRequest("POST", "/project/open"),
@@ -160,7 +160,7 @@ void main() {
     });
 
     test("returns 200 with application/json content-type", () async {
-      plugin.currentProjectResult = PluginProject(id: tempDir.path);
+      plugin.currentProjectResult = PluginProject(id: tempDir.path, directory: tempDir.path);
 
       final result = await handler.handle(
         makeRequest("POST", "/project/open"),
@@ -176,6 +176,7 @@ void main() {
     test("maps project id and name fields", () async {
       plugin.currentProjectResult = PluginProject(
         id: tempDir.path,
+        directory: tempDir.path,
         name: "My Project",
       );
 
@@ -194,6 +195,7 @@ void main() {
     test("maps ProjectTime from the persisted open timestamp", () async {
       plugin.currentProjectResult = PluginProject(
         id: tempDir.path,
+        directory: tempDir.path,
         activity: const PluginProjectActivity(createdAt: 1000, updatedAt: 2000),
       );
 
@@ -209,7 +211,7 @@ void main() {
     });
 
     test("time is non-null when plugin returns no activity", () async {
-      plugin.currentProjectResult = PluginProject(id: tempDir.path);
+      plugin.currentProjectResult = PluginProject(id: tempDir.path, directory: tempDir.path);
 
       final result = await handler.handle(
         makeRequest("POST", "/project/open"),
@@ -244,6 +246,7 @@ void main() {
     test("idempotent: calling twice with same path returns same result", () async {
       plugin.currentProjectResult = PluginProject(
         id: tempDir.path,
+        directory: tempDir.path,
         name: "Stable Project",
       );
 
@@ -267,7 +270,7 @@ void main() {
     });
 
     test("unhides discovered project id", () async {
-      plugin.currentProjectResult = PluginProject(id: tempDir.path);
+      plugin.currentProjectResult = PluginProject(id: tempDir.path, directory: tempDir.path);
       await db.projectsDao.hideProject(projectId: tempDir.path);
 
       await handler.handle(

--- a/bridge/app/test/bridge/routing/post_agents_handler_test.dart
+++ b/bridge/app/test/bridge/routing/post_agents_handler_test.dart
@@ -44,7 +44,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/agent"),
-        body: const ProjectIdRequest(projectId: "/repo", pluginId: "fake"),
+        body: const PluginProjectIdRequest(projectId: "/repo", pluginId: "fake"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -53,6 +53,5 @@ void main() {
       expect(plugin.lastAgentsProjectId, equals("/repo"));
       expect(response.agents.single.name, equals("planner"));
     });
-
   });
 }

--- a/bridge/app/test/bridge/routing/post_agents_handler_test.dart
+++ b/bridge/app/test/bridge/routing/post_agents_handler_test.dart
@@ -54,18 +54,5 @@ void main() {
       expect(response.agents.single.name, equals("planner"));
     });
 
-    test("rejects another plugin before plugin I/O", () async {
-      await expectLater(
-        handler.handle(
-          makeRequest("POST", "/agent"),
-          body: const ProjectIdRequest(projectId: "/repo", pluginId: "other"),
-          pathParams: {},
-          queryParams: {},
-          fragment: null,
-        ),
-        throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 400)),
-      );
-      expect(plugin.lastAgentsProjectId, isNull);
-    });
   });
 }

--- a/bridge/app/test/bridge/routing/post_agents_handler_test.dart
+++ b/bridge/app/test/bridge/routing/post_agents_handler_test.dart
@@ -44,7 +44,7 @@ void main() {
 
       final response = await handler.handle(
         makeRequest("POST", "/agent"),
-        body: const ProjectIdRequest(projectId: "/repo"),
+        body: const ProjectIdRequest(projectId: "/repo", pluginId: "fake"),
         pathParams: {},
         queryParams: {},
         fragment: null,
@@ -52,6 +52,20 @@ void main() {
 
       expect(plugin.lastAgentsProjectId, equals("/repo"));
       expect(response.agents.single.name, equals("planner"));
+    });
+
+    test("rejects another plugin before plugin I/O", () async {
+      await expectLater(
+        handler.handle(
+          makeRequest("POST", "/agent"),
+          body: const ProjectIdRequest(projectId: "/repo", pluginId: "other"),
+          pathParams: {},
+          queryParams: {},
+          fragment: null,
+        ),
+        throwsA(isA<PluginOperationException>().having((error) => error.statusCode, "statusCode", 400)),
+      );
+      expect(plugin.lastAgentsProjectId, isNull);
     });
   });
 }

--- a/bridge/app/test/bridge/routing/rename_project_handler_test.dart
+++ b/bridge/app/test/bridge/routing/rename_project_handler_test.dart
@@ -56,6 +56,7 @@ void main() {
     test("extracts projectId and name from typed body", () async {
       plugin.renameProjectResult = const PluginProject(
         id: "p1",
+        directory: "p1",
         name: "New Name",
         activity: null,
       );
@@ -75,6 +76,7 @@ void main() {
     test("returns mapped Project", () async {
       plugin.renameProjectResult = const PluginProject(
         id: "p1",
+        directory: "p1",
         name: "Renamed Project",
         activity: PluginProjectActivity(createdAt: 10, updatedAt: 20),
       );

--- a/bridge/app/test/bridge/routing/request_router_test.dart
+++ b/bridge/app/test/bridge/routing/request_router_test.dart
@@ -182,7 +182,7 @@ void main() {
 
     test("routes GET /projects to GetProjectsHandler", () async {
       plugin.projectsResult = [
-        const PluginProject(id: "p1", name: "P"),
+        const PluginProject(id: "p1", directory: "p1", name: "P"),
       ];
       final response = await router.route(makeRequest("GET", "/projects"));
       expect(response.status, equals(200));
@@ -400,7 +400,7 @@ void main() {
     });
 
     test("integrates PR merge and background refresh trigger for session list", () async {
-      plugin.currentProjectResult = const PluginProject(id: "/tmp/project");
+      plugin.currentProjectResult = const PluginProject(id: "/tmp/project", directory: "/tmp/project");
       plugin.sessionsResult = const [
         PluginSession(
           id: "s1",

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -249,7 +249,7 @@ class FakeBridgePlugin implements NativeProjectsPluginApi {
   }) async {
     lastRenameProjectId = projectId;
     lastRenameProjectName = name;
-    return renameProjectResult ?? const PluginProject(id: "");
+    return renameProjectResult ?? const PluginProject(id: "", directory: "");
   }
 
   @override
@@ -390,7 +390,7 @@ class FakeBridgePlugin implements NativeProjectsPluginApi {
       throw error;
     }
     lastGetCurrentProjectProjectId = projectId;
-    return currentProjectResult ?? const PluginProject(id: "");
+    return currentProjectResult ?? const PluginProject(id: "", directory: "");
   }
 
   @override
@@ -703,6 +703,7 @@ class _NoopPullRequestRepository implements PullRequestRepository {
 
 Session _deletedSession(String sessionId) => Session(
   id: sessionId,
+  pluginId: "fake",
   projectID: "",
   directory: "",
   parentID: null,
@@ -734,6 +735,7 @@ class _NoopSessionRepository implements SessionRepository {
 
   @override
   Future<Session> createSession({
+    required String? pluginId,
     required String directory,
     required String? parentSessionId,
     required List<PromptPart> parts,
@@ -742,6 +744,7 @@ class _NoopSessionRepository implements SessionRepository {
     required PromptModel? model,
   }) async => const Session(
     id: "",
+    pluginId: "fake",
     projectID: "",
     directory: "",
     parentID: null,
@@ -760,7 +763,8 @@ class _NoopSessionRepository implements SessionRepository {
   @override
   Future<Session> enrichSession({required Session session}) async => session;
   @override
-  Future<Session> enrichPluginSession({required PluginSession pluginSession}) async => pluginSession.toSharedSession();
+  Future<Session> enrichPluginSession({required PluginSession pluginSession}) async =>
+      pluginSession.toSharedSession(pluginId: "fake");
   @override
   Future<Session> enrichSessionJson({required Map<String, dynamic> sessionJson}) async => Session.fromJson(sessionJson);
   @override
@@ -826,7 +830,8 @@ class _NoopSessionRepository implements SessionRepository {
   }) async {}
 
   @override
-  Future<CommandListResponse> getCommands({required String? projectId}) async => const CommandListResponse(items: []);
+  Future<CommandListResponse> getCommands({required String? projectId, required String? pluginId}) async =>
+      const CommandListResponse(items: []);
 
   @override
   Future<void> sendPrompt({
@@ -840,6 +845,7 @@ class _NoopSessionRepository implements SessionRepository {
   @override
   Future<Session> renameSession({required String sessionId, required String title}) async => const Session(
     id: "",
+    pluginId: "fake",
     projectID: "",
     directory: "",
     parentID: null,
@@ -919,6 +925,7 @@ class FakeSessionRepository implements SessionRepository {
 
   @override
   Future<Session> createSession({
+    required String? pluginId,
     required String directory,
     required String? parentSessionId,
     required List<PromptPart> parts,
@@ -927,6 +934,7 @@ class FakeSessionRepository implements SessionRepository {
     required PromptModel? model,
   }) async => const Session(
     id: "",
+    pluginId: "fake",
     projectID: "",
     directory: "",
     parentID: null,
@@ -950,7 +958,7 @@ class FakeSessionRepository implements SessionRepository {
       start: start,
       limit: limit,
     );
-    final sessions = pluginSessions.map((s) => s.toSharedSession()).toList();
+    final sessions = pluginSessions.map((s) => s.toSharedSession(pluginId: _plugin.id)).toList();
     final sessionIds = sessions.map((s) => s.id).toList();
     final dbSessions = await _sessionDao.getSessionsByIds(sessionIds: sessionIds);
     final mergedSessions = sessions.map((session) {
@@ -984,7 +992,7 @@ class FakeSessionRepository implements SessionRepository {
 
   @override
   Future<Session> enrichPluginSession({required PluginSession pluginSession}) async {
-    return enrichSession(session: pluginSession.toSharedSession());
+    return enrichSession(session: pluginSession.toSharedSession(pluginId: _plugin.id));
   }
 
   @override
@@ -1003,6 +1011,7 @@ class FakeSessionRepository implements SessionRepository {
     };
     final enriched = enrichSharedSessions(
       sessions: sessions,
+      pluginId: _plugin.id,
       storedSessionsById: dbSessions,
       pullRequestsBySessionId: pullRequestsBySessionId,
       unseenCalculator: const SessionUnseenCalculator(),
@@ -1040,7 +1049,7 @@ class FakeSessionRepository implements SessionRepository {
   @override
   Future<List<Session>> getChildSessions({required String sessionId}) async {
     final pluginSessions = await _plugin.getChildSessions(sessionId);
-    return pluginSessions.map((s) => s.toSharedSession()).toList();
+    return pluginSessions.map((s) => s.toSharedSession(pluginId: _plugin.id)).toList();
   }
 
   @override
@@ -1153,7 +1162,7 @@ class FakeSessionRepository implements SessionRepository {
   }
 
   @override
-  Future<CommandListResponse> getCommands({required String? projectId}) async {
+  Future<CommandListResponse> getCommands({required String? projectId, required String? pluginId}) async {
     final normalizedProjectId = projectId?.trim();
     final commands = await _plugin.getCommands(
       projectId: normalizedProjectId == null || normalizedProjectId.isEmpty ? null : normalizedProjectId,
@@ -1193,6 +1202,7 @@ class FakeSessionRepository implements SessionRepository {
   @override
   Future<Session> renameSession({required String sessionId, required String title}) async => const Session(
     id: "",
+    pluginId: "fake",
     projectID: "",
     directory: "",
     parentID: null,

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -34,7 +34,7 @@ SessionUnseenService buildTestSessionUnseenService(AppDatabase db, BridgePluginA
   const calculator = SessionUnseenCalculator();
   return SessionUnseenService(
     unseenRepository: SessionUnseenRepository(
-      pluginId: plugin.id,
+      plugin: plugin,
       sessionDao: db.sessionDao,
       projectsDao: db.projectsDao,
       db: db,

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -1011,7 +1011,6 @@ class FakeSessionRepository implements SessionRepository {
     };
     final enriched = enrichSharedSessions(
       sessions: sessions,
-      pluginId: _plugin.id,
       storedSessionsById: dbSessions,
       pullRequestsBySessionId: pullRequestsBySessionId,
       unseenCalculator: const SessionUnseenCalculator(),

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -735,7 +735,7 @@ class _NoopSessionRepository implements SessionRepository {
 
   @override
   Future<Session> createSession({
-    required String? pluginId,
+    required String pluginId,
     required String directory,
     required String? parentSessionId,
     required List<PromptPart> parts,
@@ -766,7 +766,8 @@ class _NoopSessionRepository implements SessionRepository {
   Future<Session> enrichPluginSession({required PluginSession pluginSession}) async =>
       pluginSession.toSharedSession(pluginId: "fake");
   @override
-  Future<Session> enrichSessionJson({required Map<String, dynamic> sessionJson}) async => Session.fromJson(sessionJson);
+  Future<Session> enrichPluginEventSessionJson({required Map<String, dynamic> sessionJson}) async =>
+      Session.fromJson(sessionJson);
   @override
   Future<List<Session>> enrichSessions({required List<Session> sessions}) async => sessions;
   @override
@@ -830,7 +831,7 @@ class _NoopSessionRepository implements SessionRepository {
   }) async {}
 
   @override
-  Future<CommandListResponse> getCommands({required String? projectId, required String? pluginId}) async =>
+  Future<CommandListResponse> getCommands({required String? projectId, required String pluginId}) async =>
       const CommandListResponse(items: []);
 
   @override
@@ -925,7 +926,7 @@ class FakeSessionRepository implements SessionRepository {
 
   @override
   Future<Session> createSession({
-    required String? pluginId,
+    required String pluginId,
     required String directory,
     required String? parentSessionId,
     required List<PromptPart> parts,
@@ -996,7 +997,7 @@ class FakeSessionRepository implements SessionRepository {
   }
 
   @override
-  Future<Session> enrichSessionJson({required Map<String, dynamic> sessionJson}) async {
+  Future<Session> enrichPluginEventSessionJson({required Map<String, dynamic> sessionJson}) async {
     return enrichSession(session: Session.fromJson(sessionJson));
   }
 
@@ -1161,7 +1162,7 @@ class FakeSessionRepository implements SessionRepository {
   }
 
   @override
-  Future<CommandListResponse> getCommands({required String? projectId, required String? pluginId}) async {
+  Future<CommandListResponse> getCommands({required String? projectId, required String pluginId}) async {
     final normalizedProjectId = projectId?.trim();
     final commands = await _plugin.getCommands(
       projectId: normalizedProjectId == null || normalizedProjectId.isEmpty ? null : normalizedProjectId,

--- a/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
+++ b/bridge/app/test/bridge/routing/update_session_archive_status_handler_test.dart
@@ -456,7 +456,7 @@ void main() {
     });
 
     test("archive pre-migration session auto-inserts DB row", () async {
-      plugin.projectsResult = const [PluginProject(id: "/repo")];
+      plugin.projectsResult = const [PluginProject(id: "/repo", directory: "/repo")];
       plugin.sessionsResult = const [
         PluginSession(
           id: "s-pre-migration",
@@ -500,7 +500,7 @@ void main() {
 
     test("archives first-time project (no prior projects_table row) without FK violation", () async {
       // Empty projects_table — no pre-seeding at all.
-      plugin.projectsResult = const [PluginProject(id: "brand-new")];
+      plugin.projectsResult = const [PluginProject(id: "brand-new", directory: "brand-new")];
       plugin.sessionsResult = const [
         PluginSession(
           id: "s-brand-new",

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -433,7 +433,7 @@ class _FakeSessionRepository implements SessionRepository {
 
   @override
   Future<Session> createSession({
-    required String? pluginId,
+    required String pluginId,
     required String directory,
     required String? parentSessionId,
     required List<PromptPart> parts,
@@ -468,7 +468,8 @@ class _FakeSessionRepository implements SessionRepository {
       Session.fromJson(pluginSession.toJson());
 
   @override
-  Future<Session> enrichSessionJson({required Map<String, dynamic> sessionJson}) async => Session.fromJson(sessionJson);
+  Future<Session> enrichPluginEventSessionJson({required Map<String, dynamic> sessionJson}) async =>
+      Session.fromJson(sessionJson);
 
   @override
   Future<List<Session>> enrichSessions({required List<Session> sessions}) async => sessions;
@@ -539,7 +540,7 @@ class _FakeSessionRepository implements SessionRepository {
   }) async {}
 
   @override
-  Future<CommandListResponse> getCommands({required String? projectId, required String? pluginId}) async =>
+  Future<CommandListResponse> getCommands({required String? projectId, required String pluginId}) async =>
       const CommandListResponse(items: []);
 
   @override

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -407,6 +407,7 @@ class _FakeSessionRepository implements SessionRepository {
   @override
   Future<Session> deleteSession({required String sessionId}) async => Session(
     id: sessionId,
+    pluginId: "fake",
     projectID: "",
     directory: "",
     parentID: null,
@@ -432,6 +433,7 @@ class _FakeSessionRepository implements SessionRepository {
 
   @override
   Future<Session> createSession({
+    required String? pluginId,
     required String directory,
     required String? parentSessionId,
     required List<PromptPart> parts,
@@ -440,6 +442,7 @@ class _FakeSessionRepository implements SessionRepository {
     required PromptModel? model,
   }) async => const Session(
     id: "",
+    pluginId: "fake",
     projectID: "",
     directory: "",
     parentID: null,
@@ -536,7 +539,8 @@ class _FakeSessionRepository implements SessionRepository {
   }) async {}
 
   @override
-  Future<CommandListResponse> getCommands({required String? projectId}) async => const CommandListResponse(items: []);
+  Future<CommandListResponse> getCommands({required String? projectId, required String? pluginId}) async =>
+      const CommandListResponse(items: []);
 
   @override
   Future<void> sendPrompt({
@@ -550,6 +554,7 @@ class _FakeSessionRepository implements SessionRepository {
   @override
   Future<Session> renameSession({required String sessionId, required String title}) async => const Session(
     id: "",
+    pluginId: "fake",
     projectID: "",
     directory: "",
     parentID: null,

--- a/bridge/app/test/bridge/services/project_activity_service_test.dart
+++ b/bridge/app/test/bridge/services/project_activity_service_test.dart
@@ -166,7 +166,11 @@ void main() {
 
   test("ordinary project listing seeds with now without reconciling", () async {
     plugin.projectsResult = const [
-      PluginProject(id: "project", activity: PluginProjectActivity(createdAt: 10, updatedAt: 20)),
+      PluginProject(
+        id: "project",
+        directory: "project",
+        activity: PluginProjectActivity(createdAt: 10, updatedAt: 20),
+      ),
     ];
 
     final projects = await service.getProjects();
@@ -251,6 +255,7 @@ void main() {
       const SesoriSseEvent.sessionCreated(
         info: Session(
           id: "new-session",
+          pluginId: "fake",
           projectID: "project",
           directory: "/project",
           parentID: null,
@@ -312,8 +317,16 @@ void main() {
     await database.projectsDao.setActivity(projectId: "created-only", createdAt: 100, updatedAt: 500);
     await database.projectsDao.setActivity(projectId: "advanced", createdAt: 100, updatedAt: 500);
     plugin.projectsResult = const [
-      PluginProject(id: "created-only", activity: PluginProjectActivity(createdAt: 50, updatedAt: 400)),
-      PluginProject(id: "advanced", activity: PluginProjectActivity(createdAt: 80, updatedAt: 600)),
+      PluginProject(
+        id: "created-only",
+        directory: "created-only",
+        activity: PluginProjectActivity(createdAt: 50, updatedAt: 400),
+      ),
+      PluginProject(
+        id: "advanced",
+        directory: "advanced",
+        activity: PluginProjectActivity(createdAt: 80, updatedAt: 600),
+      ),
     ];
     final changes = <ProjectActivityChange>[];
     final subscription = service.changes.listen(changes.add);
@@ -335,7 +348,11 @@ void main() {
   });
 
   test("opening preserves canonical identity and emits only timestamp changes", () async {
-    plugin.currentProjectResult = const PluginProject(id: "canonical", name: "Project");
+    plugin.currentProjectResult = const PluginProject(
+      id: "canonical",
+      directory: "/new/path",
+      name: "Project",
+    );
     await database.projectsDao.recordOpenedProject(
       projectId: "canonical",
       path: "/old/path",

--- a/bridge/app/test/bridge/services/session_event_enrichment_service_test.dart
+++ b/bridge/app/test/bridge/services/session_event_enrichment_service_test.dart
@@ -179,7 +179,8 @@ void main() {
         isNull,
       );
       const deleted = BridgeSseSessionDeleted(info: info);
-      expect(await service.enrich(deleted), same(deleted));
+      final attributedDeleted = (await service.enrich(deleted))! as BridgeSseSessionDeleted;
+      expect(attributedDeleted.info["pluginId"], "fake");
       expect(
         await service.enrich(
           const BridgeSseMessagePartDelta(

--- a/bridge/app/test/bridge/services/session_persistence_service_test.dart
+++ b/bridge/app/test/bridge/services/session_persistence_service_test.dart
@@ -222,6 +222,7 @@ Session _session({
 }) {
   return Session(
     id: id,
+    pluginId: "fake",
     projectID: projectId,
     directory: "/tmp/$projectId",
     parentID: null,

--- a/bridge/app/test/bridge/services/session_unseen_service_test.dart
+++ b/bridge/app/test/bridge/services/session_unseen_service_test.dart
@@ -18,7 +18,7 @@ void main() {
     var clock = 1000;
 
     SessionUnseenRepository unseenRepository() => SessionUnseenRepository(
-      plugin: _FakePlugin(),
+      plugin: const _FakePlugin(),
       sessionDao: db.sessionDao,
       projectsDao: db.projectsDao,
       db: db,
@@ -26,7 +26,7 @@ void main() {
     );
 
     ProjectRepository projectRepository() => ProjectRepository(
-      plugin: _FakePlugin(),
+      plugin: const _FakePlugin(),
       projectsDao: db.projectsDao,
       sessionDao: db.sessionDao,
       unseenCalculator: const SessionUnseenCalculator(),
@@ -104,6 +104,43 @@ void main() {
       );
 
       expect((await db.projectsDao.getProject(projectId: projectId))?.path, directory);
+    });
+
+    test("native session creation prefers the declared project root over a session subdirectory", () async {
+      const projectId = "opaque-project-id";
+      const plugin = _FakePlugin(
+        projects: [
+          PluginProject(id: projectId, directory: "/projects/repository"),
+        ],
+      );
+      final rootAwareService = SessionUnseenService(
+        unseenRepository: SessionUnseenRepository(
+          plugin: plugin,
+          sessionDao: db.sessionDao,
+          projectsDao: db.projectsDao,
+          db: db,
+          calculator: const SessionUnseenCalculator(),
+        ),
+        projectRepository: ProjectRepository(
+          plugin: plugin,
+          projectsDao: db.projectsDao,
+          sessionDao: db.sessionDao,
+          unseenCalculator: const SessionUnseenCalculator(),
+          filesystemApi: FakeFilesystemApi(),
+        ),
+        viewTracker: viewTracker,
+        now: () => clock,
+      );
+      addTearDown(rootAwareService.dispose);
+
+      await rootAwareService.recordSessionCreated(
+        sessionId: "native-session",
+        projectId: projectId,
+        sessionDirectory: "/projects/repository/packages/foo",
+        parentId: null,
+      );
+
+      expect((await db.projectsDao.getProject(projectId: projectId))?.path, "/projects/repository");
     });
 
     test("derived project placeholder keeps owner attribution for a worktree session", () async {
@@ -730,8 +767,15 @@ void main() {
 }
 
 class _FakePlugin implements NativeProjectsPluginApi {
+  final List<PluginProject> projects;
+
+  const _FakePlugin({this.projects = const []});
+
   @override
   String get id => "opencode";
+
+  @override
+  Future<List<PluginProject>> getProjects() async => projects;
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/bridge/app/test/bridge/services/session_unseen_service_test.dart
+++ b/bridge/app/test/bridge/services/session_unseen_service_test.dart
@@ -18,7 +18,7 @@ void main() {
     var clock = 1000;
 
     SessionUnseenRepository unseenRepository() => SessionUnseenRepository(
-      pluginId: "opencode",
+      plugin: _FakePlugin(),
       sessionDao: db.sessionDao,
       projectsDao: db.projectsDao,
       db: db,
@@ -56,11 +56,78 @@ void main() {
     });
 
     test("new root session is unseen; child session is ignored", () async {
-      await service.recordSessionCreated(sessionId: "root", projectId: "p1", parentId: null);
-      await service.recordSessionCreated(sessionId: "child", projectId: "p1", parentId: "root");
+      await service.recordSessionCreated(
+        sessionId: "root",
+        projectId: "p1",
+        sessionDirectory: "/projects/p1",
+        parentId: null,
+      );
+      await service.recordSessionCreated(
+        sessionId: "child",
+        projectId: "p1",
+        sessionDirectory: "/projects/p1",
+        parentId: "root",
+      );
 
       expect(await unseen("root"), isTrue);
       expect(await unseen("child"), isFalse); // never persisted
+    });
+
+    test("native project placeholder stores the session directory for an opaque id", () async {
+      const projectId = "0190f4c6-opaque-project-id";
+      const directory = "/projects/native-repository";
+
+      await service.recordSessionCreated(
+        sessionId: "native-session",
+        projectId: projectId,
+        sessionDirectory: directory,
+        parentId: null,
+      );
+
+      final project = await db.projectsDao.getProject(projectId: projectId);
+      final session = await db.sessionDao.getSession(sessionId: "native-session");
+      expect(project?.path, directory);
+      expect(session?.projectId, projectId);
+      expect(session?.pluginId, "opencode");
+    });
+
+    test("derived project placeholder keeps owner attribution for a worktree session", () async {
+      final plugin = _FakeDerivedPlugin();
+      final derivedViewTracker = SessionViewTracker();
+      final derivedService = SessionUnseenService(
+        unseenRepository: SessionUnseenRepository(
+          plugin: plugin,
+          sessionDao: db.sessionDao,
+          projectsDao: db.projectsDao,
+          db: db,
+          calculator: const SessionUnseenCalculator(),
+        ),
+        projectRepository: ProjectRepository(
+          plugin: plugin,
+          projectsDao: db.projectsDao,
+          sessionDao: db.sessionDao,
+          unseenCalculator: const SessionUnseenCalculator(),
+          filesystemApi: FakeFilesystemApi(),
+        ),
+        viewTracker: derivedViewTracker,
+        now: () => clock,
+      );
+      addTearDown(derivedService.dispose);
+      addTearDown(derivedViewTracker.dispose);
+
+      const projectId = "/projects/owner";
+      await derivedService.recordSessionCreated(
+        sessionId: "derived-worktree-session",
+        projectId: projectId,
+        sessionDirectory: "/tmp/owner-worktree",
+        parentId: null,
+      );
+
+      final project = await db.projectsDao.getProject(projectId: projectId);
+      final session = await db.sessionDao.getSession(sessionId: "derived-worktree-session");
+      expect(project?.path, projectId);
+      expect(session?.projectId, projectId);
+      expect(session?.pluginId, "codex");
     });
 
     test("activity on an unviewed pre-existing session bolds it", () async {
@@ -90,7 +157,12 @@ void main() {
     });
 
     test("activity while viewing does not bold (seen advances)", () async {
-      await service.recordSessionCreated(sessionId: "s1", projectId: "p1", parentId: null);
+      await service.recordSessionCreated(
+        sessionId: "s1",
+        projectId: "p1",
+        sessionDirectory: "/projects/p1",
+        parentId: null,
+      );
       viewTracker.setViewing(connID: 1, sessionId: "s1");
       // view-start marks it seen.
       await Future<void>.delayed(Duration.zero);
@@ -140,7 +212,12 @@ void main() {
     });
 
     test("monotonic clock keeps same-ms user+assistant activity ordered (stays unseen)", () async {
-      await service.recordSessionCreated(sessionId: "s1", projectId: "p1", parentId: null);
+      await service.recordSessionCreated(
+        sessionId: "s1",
+        projectId: "p1",
+        sessionDirectory: "/projects/p1",
+        parentId: null,
+      );
       // Both events fall in the same wall-clock millisecond. A user message then
       // an assistant message must still leave activity strictly above the
       // user-message timestamp, so the session stays unseen.
@@ -151,7 +228,12 @@ void main() {
     });
 
     test("serializes ordered activity for one session (no out-of-order clear)", () async {
-      await service.recordSessionCreated(sessionId: "s1", projectId: "p1", parentId: null);
+      await service.recordSessionCreated(
+        sessionId: "s1",
+        projectId: "p1",
+        sessionDirectory: "/projects/p1",
+        parentId: null,
+      );
       clock = 2000;
       // Fire a user message then an AI message without awaiting between them;
       // the AI activity (later) must win so the session stays unseen.
@@ -184,7 +266,12 @@ void main() {
     });
 
     test("recordSessionDeleted removes the row so it stops contributing to the project", () async {
-      await service.recordSessionCreated(sessionId: "s1", projectId: "p1", parentId: null);
+      await service.recordSessionCreated(
+        sessionId: "s1",
+        projectId: "p1",
+        sessionDirectory: "/projects/p1",
+        parentId: null,
+      );
       expect(await unseen("s1"), isTrue);
 
       await service.recordSessionDeleted(sessionId: "s1", projectId: "p1");
@@ -194,7 +281,12 @@ void main() {
 
     test("recordSessionDeleted emits against the STORED project id, not the event's", () async {
       // Row persisted under the canonical project p1.
-      await service.recordSessionCreated(sessionId: "s1", projectId: "p1", parentId: null);
+      await service.recordSessionCreated(
+        sessionId: "s1",
+        projectId: "p1",
+        sessionDirectory: "/projects/p1",
+        parentId: null,
+      );
 
       final events = <UnseenChange>[];
       final sub = service.unseenChanges.listen(events.add);
@@ -228,8 +320,18 @@ void main() {
 
     test("reconcileVanishedSessions deletes stale rows and emits their clears", () async {
       // Two persisted sessions; the backend now only knows about s1.
-      await service.recordSessionCreated(sessionId: "s1", projectId: "p1", parentId: null);
-      await service.recordSessionCreated(sessionId: "gone", projectId: "p1", parentId: null);
+      await service.recordSessionCreated(
+        sessionId: "s1",
+        projectId: "p1",
+        sessionDirectory: "/projects/p1",
+        parentId: null,
+      );
+      await service.recordSessionCreated(
+        sessionId: "gone",
+        projectId: "p1",
+        sessionDirectory: "/projects/p1",
+        parentId: null,
+      );
       expect(await unseen("gone"), isTrue);
 
       final events = <UnseenChange>[];
@@ -253,14 +355,25 @@ void main() {
     });
 
     test("reconcile keeps a session created live during the fetch, even with a skewed backend clock", () async {
-      await service.recordSessionCreated(sessionId: "s1", projectId: "p1", parentId: null);
+      await service.recordSessionCreated(
+        sessionId: "s1",
+        projectId: "p1",
+        sessionDirectory: "/projects/p1",
+        parentId: null,
+      );
       // A live session.created lands DURING an in-flight /sessions fetch
       // (fetch started at local 8000; we process the event at local 9000). The
       // backend's clock is behind, so the session's own creation time (7000)
       // predates the fetch start — the row-creation guard must use the local
       // clock, not the backend time, or this fresh row would be deleted.
       clock = 9000;
-      await service.recordSessionCreated(sessionId: "fresh", projectId: "p1", parentId: null, occurredAt: 7000);
+      await service.recordSessionCreated(
+        sessionId: "fresh",
+        projectId: "p1",
+        sessionDirectory: "/projects/p1",
+        parentId: null,
+        occurredAt: 7000,
+      );
 
       await service.reconcileVanishedSessions(
         projectId: "p1",
@@ -272,12 +385,22 @@ void main() {
     });
 
     test("reconcileVanishedSessions keeps rows created after the fetch started", () async {
-      await service.recordSessionCreated(sessionId: "s1", projectId: "p1", parentId: null);
+      await service.recordSessionCreated(
+        sessionId: "s1",
+        projectId: "p1",
+        sessionDirectory: "/projects/p1",
+        parentId: null,
+      );
       // A session created AFTER the (stale) snapshot was taken: its row's
       // created_at is past fetchStartedAt, so it must survive the reconcile
       // even though it is absent from keepSessionIds.
       clock = 9000;
-      await service.recordSessionCreated(sessionId: "concurrent", projectId: "p1", parentId: null);
+      await service.recordSessionCreated(
+        sessionId: "concurrent",
+        projectId: "p1",
+        sessionDirectory: "/projects/p1",
+        parentId: null,
+      );
 
       await service.reconcileVanishedSessions(
         projectId: "p1",
@@ -298,7 +421,12 @@ void main() {
       );
       expect(await unseen("s1"), isFalse);
 
-      await service.recordSessionCreated(sessionId: "s1", projectId: "p1", parentId: null);
+      await service.recordSessionCreated(
+        sessionId: "s1",
+        projectId: "p1",
+        sessionDirectory: "/projects/p1",
+        parentId: null,
+      );
       expect(await unseen("s1"), isTrue);
     });
 
@@ -420,7 +548,13 @@ void main() {
       // session's actual creation) — the stamp comes from the session's own
       // creation time, not the processing time.
       clock = 9000;
-      await service.recordSessionCreated(sessionId: "s1", projectId: "p1", parentId: null, occurredAt: 2000);
+      await service.recordSessionCreated(
+        sessionId: "s1",
+        projectId: "p1",
+        sessionDirectory: "/projects/p1",
+        parentId: null,
+        occurredAt: 2000,
+      );
       expect(await unseen("s1"), isTrue);
 
       // The creator's first message (created just after the session) must
@@ -560,7 +694,12 @@ void main() {
       final events = <UnseenChange>[];
       final sub = service.unseenChanges.listen(events.add);
 
-      await service.recordSessionCreated(sessionId: "root", projectId: "p1", parentId: null);
+      await service.recordSessionCreated(
+        sessionId: "root",
+        projectId: "p1",
+        sessionDirectory: "/projects/p1",
+        parentId: null,
+      );
       await Future<void>.delayed(Duration.zero);
 
       expect(events, isNotEmpty);
@@ -576,6 +715,17 @@ void main() {
 }
 
 class _FakePlugin implements NativeProjectsPluginApi {
+  @override
+  String get id => "opencode";
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeDerivedPlugin implements BridgeDerivedProjectsPluginApi {
+  @override
+  String get id => "codex";
+
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/bridge/app/test/bridge/services/session_unseen_service_test.dart
+++ b/bridge/app/test/bridge/services/session_unseen_service_test.dart
@@ -91,21 +91,6 @@ void main() {
       expect(session?.pluginId, "opencode");
     });
 
-    test("native session creation repairs an existing id-as-path placeholder", () async {
-      const projectId = "0190f4c6-opaque-project-id";
-      const directory = "/projects/native-repository";
-      await db.projectsDao.insertProjectsIfMissing(projectIds: [projectId]);
-
-      await service.recordSessionCreated(
-        sessionId: "native-session",
-        projectId: projectId,
-        sessionDirectory: directory,
-        parentId: null,
-      );
-
-      expect((await db.projectsDao.getProject(projectId: projectId))?.path, directory);
-    });
-
     test("native session creation prefers the declared project root over a session subdirectory", () async {
       const projectId = "opaque-project-id";
       const plugin = _FakePlugin(

--- a/bridge/app/test/bridge/services/session_unseen_service_test.dart
+++ b/bridge/app/test/bridge/services/session_unseen_service_test.dart
@@ -91,6 +91,21 @@ void main() {
       expect(session?.pluginId, "opencode");
     });
 
+    test("native session creation repairs an existing id-as-path placeholder", () async {
+      const projectId = "0190f4c6-opaque-project-id";
+      const directory = "/projects/native-repository";
+      await db.projectsDao.insertProjectsIfMissing(projectIds: [projectId]);
+
+      await service.recordSessionCreated(
+        sessionId: "native-session",
+        projectId: projectId,
+        sessionDirectory: directory,
+        parentId: null,
+      );
+
+      expect((await db.projectsDao.getProject(projectId: projectId))?.path, directory);
+    });
+
     test("derived project placeholder keeps owner attribution for a worktree session", () async {
       final plugin = _FakeDerivedPlugin();
       final derivedViewTracker = SessionViewTracker();

--- a/bridge/app/test/bridge/services/session_unseen_service_test.dart
+++ b/bridge/app/test/bridge/services/session_unseen_service_test.dart
@@ -143,6 +143,34 @@ void main() {
       expect((await db.projectsDao.getProject(projectId: projectId))?.path, "/projects/repository");
     });
 
+    test("native session creation persists with the session directory when project discovery fails", () async {
+      const projectId = "opaque-project-id";
+      const plugin = _FakePlugin(throwOnGetProjects: true);
+      final fallbackService = SessionUnseenService(
+        unseenRepository: SessionUnseenRepository(
+          sessionDao: db.sessionDao,
+          projectsDao: db.projectsDao,
+          db: db,
+          calculator: const SessionUnseenCalculator(),
+          plugin: plugin,
+        ),
+        projectRepository: projectRepository(),
+        viewTracker: viewTracker,
+        now: () => clock,
+      );
+      addTearDown(fallbackService.dispose);
+
+      await fallbackService.recordSessionCreated(
+        sessionId: "native-root",
+        projectId: projectId,
+        sessionDirectory: "/projects/repository/packages/foo",
+        parentId: null,
+      );
+
+      expect((await db.projectsDao.getProject(projectId: projectId))?.path, "/projects/repository/packages/foo");
+      expect((await db.sessionDao.getSession(sessionId: "native-root"))?.projectId, projectId);
+    });
+
     test("derived project placeholder keeps owner attribution for a worktree session", () async {
       final plugin = _FakeDerivedPlugin();
       final derivedViewTracker = SessionViewTracker();
@@ -768,14 +796,18 @@ void main() {
 
 class _FakePlugin implements NativeProjectsPluginApi {
   final List<PluginProject> projects;
+  final bool throwOnGetProjects;
 
-  const _FakePlugin({this.projects = const []});
+  const _FakePlugin({this.projects = const [], this.throwOnGetProjects = false});
 
   @override
   String get id => "opencode";
 
   @override
-  Future<List<PluginProject>> getProjects() async => projects;
+  Future<List<PluginProject>> getProjects() async {
+    if (throwOnGetProjects) throw StateError("project discovery failed");
+    return projects;
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/bridge/app/test/integration/pr_sync_fk_regression_test.dart
+++ b/bridge/app/test/integration/pr_sync_fk_regression_test.dart
@@ -52,6 +52,7 @@ void main() {
           projects: const [
             PluginProject(
               id: "proj-X",
+              directory: "proj-X",
               name: "Project X",
               activity: PluginProjectActivity(createdAt: 0, updatedAt: 100),
             ),
@@ -231,6 +232,7 @@ Session _session({
   required int createdAt,
 }) => Session(
   id: id,
+  pluginId: "fake",
   projectID: projectId,
   directory: "/tmp/$projectId",
   parentID: null,

--- a/bridge/app/test/push/completion_notifier_test.dart
+++ b/bridge/app/test/push/completion_notifier_test.dart
@@ -1109,6 +1109,7 @@ Session _session({
 }) {
   return Session(
     id: id,
+    pluginId: "fake",
     projectID: projectID,
     directory: directory,
     parentID: parentID,

--- a/bridge/app/test/push/completion_push_listener_test.dart
+++ b/bridge/app/test/push/completion_push_listener_test.dart
@@ -273,6 +273,7 @@ Session _session({
 }) {
   return Session(
     id: id,
+    pluginId: "fake",
     projectID: projectID,
     directory: directory,
     parentID: parentID,

--- a/bridge/app/test/push/push_dispatcher_test.dart
+++ b/bridge/app/test/push/push_dispatcher_test.dart
@@ -678,6 +678,7 @@ Session _session({
 }) {
   return Session(
     id: id,
+    pluginId: "fake",
     projectID: projectID,
     directory: directory,
     parentID: parentID,

--- a/bridge/app/test/push/push_session_state_tracker_test.dart
+++ b/bridge/app/test/push/push_session_state_tracker_test.dart
@@ -1667,6 +1667,7 @@ Session _session({
 }) {
   return Session(
     id: id,
+    pluginId: "fake",
     projectID: projectID,
     directory: directory,
     parentID: parentID,

--- a/bridge/app/tool/benchmarks/live_list_baseline.dart
+++ b/bridge/app/tool/benchmarks/live_list_baseline.dart
@@ -123,6 +123,7 @@ class _LiveListBenchmark {
       500,
       (index) => PluginProject(
         id: "/benchmark/project-${index.toString().padLeft(4, "0")}",
+        directory: "/benchmark/project-${index.toString().padLeft(4, "0")}",
         name: "project-${index.toString().padLeft(4, "0")}",
         activity: PluginProjectActivity(
           createdAt: _defaultTimestamp + index,

--- a/bridge/app/tool/benchmarks/live_list_baseline.dart
+++ b/bridge/app/tool/benchmarks/live_list_baseline.dart
@@ -195,7 +195,11 @@ class _LiveListBenchmark {
 
     await database.projectsDao.insertMissingProjectsWithActivity(
       activities: const {
-        _projectDirectory: (createdAt: _defaultTimestamp, updatedAt: _defaultTimestamp),
+        _projectDirectory: (
+          path: _projectDirectory,
+          createdAt: _defaultTimestamp,
+          updatedAt: _defaultTimestamp,
+        ),
       },
     );
     final nativeLargeRepository = _sessionRepository(database: database, plugin: nativeLarge);

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -528,6 +528,7 @@ class AcpEventMapper {
     final updated = snapshot?.updatedMs ?? created;
     return shared.Session(
       id: id,
+      pluginId: null,
       projectID: project,
       directory: project,
       parentID: null,

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -25,7 +25,7 @@ import "acp_stdio_client.dart";
 /// Harness-specific notifications (e.g. Cursor's `cursor/*`) are routed to
 /// [mapExtension], which subclasses override.
 class AcpEventMapper {
-  AcpEventMapper({required String launchDirectory, required this.agentId})
+  AcpEventMapper({required String launchDirectory, required this.agentId, required this.pluginId})
     : launchDirectory = normalizeProjectDirectory(directory: launchDirectory);
 
   /// The bridge launch directory (canonicalized) — the fallback project
@@ -35,6 +35,8 @@ class AcpEventMapper {
 
   /// Agent name stamped on assistant messages (e.g. "cursor").
   final String agentId;
+
+  final String pluginId;
 
   /// Global fallback model/provider stamped on assistant messages when a
   /// session has no specific model recorded. The plugin sets these once the
@@ -528,7 +530,7 @@ class AcpEventMapper {
     final updated = snapshot?.updatedMs ?? created;
     return shared.Session(
       id: id,
-      pluginId: null,
+      pluginId: pluginId,
       projectID: project,
       directory: project,
       parentID: null,

--- a/bridge/sesori_plugin_acp/test/acp_commands_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_commands_test.dart
@@ -65,7 +65,7 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp"),
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp", pluginId: "acp"),
         processFactory: (_) async => fake,
       );
       plugin.events.listen((_) {});
@@ -175,7 +175,7 @@ void main() {
       agentDisplayName: "ACP",
       launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
       launchDirectory: "/repo",
-      eventMapper: AcpEventMapper(launchDirectory: "/repo", agentId: "acp"),
+      eventMapper: AcpEventMapper(launchDirectory: "/repo", agentId: "acp", pluginId: "acp"),
       processFactory: (_) async => processes.removeAt(0),
     );
     plugin.events.listen(emitted.add);

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -10,7 +10,7 @@ void main() {
     late AcpEventMapper mapper;
 
     setUp(() {
-      mapper = AcpEventMapper(launchDirectory: "/repo", agentId: "cursor")
+      mapper = AcpEventMapper(launchDirectory: "/repo", agentId: "cursor", pluginId: "cursor")
         ..currentModelId = "gpt-5.4"
         ..currentProviderId = "cursor";
     });
@@ -526,7 +526,7 @@ void main() {
       expect(updated.titleChanged, isTrue);
       final session = shared.Session.fromJson(updated.info);
       expect(session.id, "s1");
-      expect(session.pluginId, isNull);
+      expect(session.pluginId, "cursor");
       expect(session.title, "Fix the parser");
       // No per-session project recorded -> falls back to the launch cwd.
       expect(session.projectID, "/repo");

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -526,6 +526,7 @@ void main() {
       expect(updated.titleChanged, isTrue);
       final session = shared.Session.fromJson(updated.info);
       expect(session.id, "s1");
+      expect(session.pluginId, isNull);
       expect(session.title, "Fix the parser");
       // No per-session project recorded -> falls back to the launch cwd.
       expect(session.projectID, "/repo");

--- a/bridge/sesori_plugin_acp/test/acp_initialize_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_initialize_test.dart
@@ -19,7 +19,7 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp"),
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp", pluginId: "acp"),
         processFactory: (_) async {
           final fake = FakeAcpProcess();
           fakes.add(fake);

--- a/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
@@ -19,7 +19,7 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp"),
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp", pluginId: "acp"),
         processFactory: (_) async => fake,
       );
     });

--- a/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
@@ -25,7 +25,7 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp"),
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp", pluginId: "acp"),
         processFactory: (_) async {
           final fake = FakeAcpProcess();
           fakes.add(fake);
@@ -728,7 +728,7 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp"),
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp", pluginId: "acp"),
         processFactory: _throwReplayProcess,
       );
       addTearDown(failingPlugin.dispose);

--- a/bridge/sesori_plugin_acp/test/acp_reconnect_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_reconnect_test.dart
@@ -18,7 +18,7 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp"),
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp", pluginId: "acp"),
         processFactory: (_) async {
           final fake = FakeAcpProcess();
           fakes.add(fake);

--- a/bridge/sesori_plugin_acp/test/acp_resume_only_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_only_test.dart
@@ -22,7 +22,7 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp"),
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp", pluginId: "acp"),
         processFactory: (_) async => fake,
       );
       emitted.clear();

--- a/bridge/sesori_plugin_acp/test/acp_resume_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_resume_test.dart
@@ -21,7 +21,7 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp"),
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp", pluginId: "acp"),
         processFactory: (_) async => fake,
       );
       emitted.clear();

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -57,7 +57,7 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp"),
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp", pluginId: "acp"),
         processFactory: (_) async => fake,
       );
       emitted.clear();
@@ -271,7 +271,7 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp"),
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp", pluginId: "acp"),
         processFactory: (_) async => fake,
       );
       addTearDown(gated.dispose);
@@ -482,7 +482,7 @@ void main() {
         agentDisplayName: "ACP",
         launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
         launchDirectory: cwd,
-        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp"),
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp", pluginId: "acp"),
         processFactory: (_) async {
           final next = fakes.removeAt(0);
           spawned.add(next);

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -482,6 +482,7 @@ class CodexEventMapper {
     final projectId = _projectIdForThread(id, cwd: thread["cwd"] as String?);
     return shared.Session(
       id: id,
+      pluginId: null,
       projectID: projectId,
       directory: projectId,
       parentID: null,
@@ -501,6 +502,7 @@ class CodexEventMapper {
     final projectId = _projectIdForThread(id);
     return shared.Session(
       id: id,
+      pluginId: null,
       projectID: projectId,
       directory: projectId,
       parentID: null,

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -23,9 +23,12 @@ import "codex_config_reader.dart";
 /// representation today.
 class CodexEventMapper {
   CodexEventMapper({
+    required this.pluginId,
     required this.projectCwd,
     this.config = const CodexConfigDefaults.empty(),
   });
+
+  final String pluginId;
 
   /// The bridge launch CWD — codex's single synthesised project id. Used as
   /// the `projectID` for sessions, and as the `directory` fallback when a
@@ -482,7 +485,7 @@ class CodexEventMapper {
     final projectId = _projectIdForThread(id, cwd: thread["cwd"] as String?);
     return shared.Session(
       id: id,
-      pluginId: null,
+      pluginId: pluginId,
       projectID: projectId,
       directory: projectId,
       parentID: null,
@@ -502,7 +505,7 @@ class CodexEventMapper {
     final projectId = _projectIdForThread(id);
     return shared.Session(
       id: id,
-      pluginId: null,
+      pluginId: pluginId,
       projectID: projectId,
       directory: projectId,
       parentID: null,

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -31,6 +31,8 @@ import "session_rollout_reader.dart";
 ///
 /// Approval/permission flows still throw — those land in Phase 5.
 class CodexPlugin implements CodexManagedApi {
+  static const String pluginId = "codex";
+
   final String _serverUrl;
   // Passed to the default client built in [_createClient]; retained for future
   // non-loopback (`--ws-auth`) support.
@@ -133,6 +135,7 @@ class CodexPlugin implements CodexManagedApi {
       eventMapper:
           eventMapper ??
           CodexEventMapper(
+            pluginId: pluginId,
             projectCwd: resolvedProjectCwd,
             config: resolvedConfigReader.readDefaults(),
           ),
@@ -171,7 +174,7 @@ class CodexPlugin implements CodexManagedApi {
   String get serverUrl => _serverUrl;
 
   @override
-  String get id => "codex";
+  String get id => pluginId;
 
   @override
   Stream<BridgeSseEvent> get events => _eventBuffer.stream;

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -56,6 +56,7 @@ void main() {
       final created = events.single as BridgeSseSessionCreated;
       final session = shared.Session.fromJson(created.info);
       expect(session.id, "t-1");
+      expect(session.pluginId, isNull);
       expect(session.projectID, projectCwd);
       expect(session.directory, "/repo/app");
       expect(session.title, "Plan the theme");
@@ -89,6 +90,7 @@ void main() {
       expect(updated.titleChanged, isTrue);
       final session = shared.Session.fromJson(updated.info);
       expect(session.id, "t-1");
+      expect(session.pluginId, isNull);
       expect(session.title, "Welcome session");
       expect(session.projectID, projectCwd);
       expect(parseAsSesori(updated), isA<shared.SesoriSessionUpdated>());

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -11,7 +11,7 @@ import "package:test/test.dart";
 void main() {
   group("CodexEventMapper", () {
     const projectCwd = "/repo/app";
-    final mapper = CodexEventMapper(projectCwd: projectCwd);
+    final mapper = CodexEventMapper(pluginId: CodexPlugin.pluginId, projectCwd: projectCwd);
 
     /// Replicates `BridgeEventMapper`'s payload construction and runs the
     /// bridge's `SesoriSseEvent.fromJson`. Throwing here is exactly the bug
@@ -56,7 +56,7 @@ void main() {
       final created = events.single as BridgeSseSessionCreated;
       final session = shared.Session.fromJson(created.info);
       expect(session.id, "t-1");
-      expect(session.pluginId, isNull);
+      expect(session.pluginId, CodexPlugin.pluginId);
       expect(session.projectID, projectCwd);
       expect(session.directory, "/repo/app");
       expect(session.title, "Plan the theme");
@@ -90,7 +90,7 @@ void main() {
       expect(updated.titleChanged, isTrue);
       final session = shared.Session.fromJson(updated.info);
       expect(session.id, "t-1");
-      expect(session.pluginId, isNull);
+      expect(session.pluginId, CodexPlugin.pluginId);
       expect(session.title, "Welcome session");
       expect(session.projectID, projectCwd);
       expect(parseAsSesori(updated), isA<shared.SesoriSessionUpdated>());
@@ -118,7 +118,7 @@ void main() {
     test("thread/name/updated uses the plugin-fed directory for its project id", () {
       // A thread/name/updated notification carries no cwd, so the mapper relies
       // on the directory the plugin learned when the thread was started/resumed.
-      final scopedMapper = CodexEventMapper(projectCwd: projectCwd)
+      final scopedMapper = CodexEventMapper(pluginId: CodexPlugin.pluginId, projectCwd: projectCwd)
         ..setThreadDirectory("t-9", "/repo/app/packages/ui");
 
       final events = scopedMapper.map(
@@ -247,6 +247,7 @@ void main() {
 
     test("agentMessage falls back to config model when no per-thread model set", () {
       final richMapper = CodexEventMapper(
+        pluginId: CodexPlugin.pluginId,
         projectCwd: projectCwd,
         config: const CodexConfigDefaults(model: "gpt-5.5", modelProvider: "openai"),
       );
@@ -282,6 +283,7 @@ void main() {
 
     test("agentMessage uses the per-thread model the plugin recorded", () {
       final richMapper = CodexEventMapper(
+        pluginId: CodexPlugin.pluginId,
         projectCwd: projectCwd,
         config: const CodexConfigDefaults(model: "gpt-5.5", modelProvider: "openai"),
       );

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
@@ -4,7 +4,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 /// Cursor's event mapper: the standard ACP `session/update` handling from
 /// [AcpEventMapper] plus Cursor's `cursor/*` notification extensions.
 class CursorEventMapper extends AcpEventMapper {
-  CursorEventMapper({required super.launchDirectory, required super.pluginId}) : super(agentId: "cursor");
+  CursorEventMapper({required super.launchDirectory, required super.pluginId}) : super(agentId: pluginId);
 
   @override
   List<BridgeSseEvent> mapExtension(AcpNotification notification) {

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
@@ -4,7 +4,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 /// Cursor's event mapper: the standard ACP `session/update` handling from
 /// [AcpEventMapper] plus Cursor's `cursor/*` notification extensions.
 class CursorEventMapper extends AcpEventMapper {
-  CursorEventMapper({required super.launchDirectory}) : super(agentId: "cursor");
+  CursorEventMapper({required super.launchDirectory, required super.pluginId}) : super(agentId: "cursor");
 
   @override
   List<BridgeSseEvent> mapExtension(AcpNotification notification) {

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
@@ -27,6 +27,8 @@ import "cursor_model_probe.dart";
 /// from what was last pushed to the agent ([_appliedModelId]/[_appliedModeId]),
 /// which both avoids redundant calls and self-corrects interleaved sessions.
 class CursorPlugin extends AcpPlugin {
+  static const String pluginId = "cursor";
+
   factory CursorPlugin({
     String binaryPath = CursorBinary.defaultBinary,
     String? launchDirectory,
@@ -41,7 +43,7 @@ class CursorPlugin extends AcpPlugin {
         apiEndpoint: apiEndpoint,
       ),
       launchDirectory: cwd,
-      mapper: CursorEventMapper(launchDirectory: cwd),
+      mapper: CursorEventMapper(launchDirectory: cwd, pluginId: pluginId),
       processFactory: processFactory,
     );
   }
@@ -51,7 +53,7 @@ class CursorPlugin extends AcpPlugin {
     required super.launchDirectory,
     required CursorEventMapper mapper,
     super.processFactory,
-  }) : super(id: "cursor", agentDisplayName: "Cursor", eventMapper: mapper);
+  }) : super(id: pluginId, agentDisplayName: "Cursor", eventMapper: mapper);
 
   static const String _providerId = "cursor";
 

--- a/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
@@ -5,7 +5,7 @@ import "package:test/test.dart";
 
 void main() {
   group("CursorEventMapper", () {
-    final mapper = CursorEventMapper(launchDirectory: "/repo");
+    final mapper = CursorEventMapper(launchDirectory: "/repo", pluginId: CursorPlugin.pluginId);
 
     test("cursor/update_todos maps to a todo update", () {
       final events = mapper.map(

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_project.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_project.dart
@@ -6,12 +6,16 @@ part "plugin_project.g.dart";
 
 /// A project as exposed to the bridge.
 ///
+/// [id] is the plugin-defined project identity. [directory] is the plugin's
+/// declared live directory for the project and may differ from [id].
+///
 /// The [activity] field carries session-derived timestamps only; it is never
 /// populated from upstream project metadata.
 @freezed
 sealed class PluginProject with _$PluginProject {
   const factory PluginProject({
     required String id,
+    required String directory,
     String? name,
     PluginProjectActivity? activity,
   }) = _PluginProject;

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_project.freezed.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_project.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$PluginProject {
 
- String get id; String? get name; PluginProjectActivity? get activity;
+ String get id; String get directory; String? get name; PluginProjectActivity? get activity;
 /// Create a copy of PluginProject
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -27,16 +27,16 @@ $PluginProjectCopyWith<PluginProject> get copyWith => _$PluginProjectCopyWithImp
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginProject&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.activity, activity) || other.activity == activity));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginProject&&(identical(other.id, id) || other.id == id)&&(identical(other.directory, directory) || other.directory == directory)&&(identical(other.name, name) || other.name == name)&&(identical(other.activity, activity) || other.activity == activity));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,activity);
+int get hashCode => Object.hash(runtimeType,id,directory,name,activity);
 
 @override
 String toString() {
-  return 'PluginProject(id: $id, name: $name, activity: $activity)';
+  return 'PluginProject(id: $id, directory: $directory, name: $name, activity: $activity)';
 }
 
 
@@ -47,7 +47,7 @@ abstract mixin class $PluginProjectCopyWith<$Res>  {
   factory $PluginProjectCopyWith(PluginProject value, $Res Function(PluginProject) _then) = _$PluginProjectCopyWithImpl;
 @useResult
 $Res call({
- String id, String? name, PluginProjectActivity? activity
+ String id, String directory, String? name, PluginProjectActivity? activity
 });
 
 
@@ -64,9 +64,10 @@ class _$PluginProjectCopyWithImpl<$Res>
 
 /// Create a copy of PluginProject
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = freezed,Object? activity = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? directory = null,Object? name = freezed,Object? activity = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,directory: null == directory ? _self.directory : directory // ignore: cast_nullable_to_non_nullable
 as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String?,activity: freezed == activity ? _self.activity : activity // ignore: cast_nullable_to_non_nullable
 as PluginProjectActivity?,
@@ -93,10 +94,11 @@ $PluginProjectActivityCopyWith<$Res>? get activity {
 @JsonSerializable(createFactory: false)
 
 class _PluginProject implements PluginProject {
-  const _PluginProject({required this.id, this.name, this.activity});
+  const _PluginProject({required this.id, required this.directory, this.name, this.activity});
   
 
 @override final  String id;
+@override final  String directory;
 @override final  String? name;
 @override final  PluginProjectActivity? activity;
 
@@ -113,16 +115,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginProject&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.activity, activity) || other.activity == activity));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginProject&&(identical(other.id, id) || other.id == id)&&(identical(other.directory, directory) || other.directory == directory)&&(identical(other.name, name) || other.name == name)&&(identical(other.activity, activity) || other.activity == activity));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,activity);
+int get hashCode => Object.hash(runtimeType,id,directory,name,activity);
 
 @override
 String toString() {
-  return 'PluginProject(id: $id, name: $name, activity: $activity)';
+  return 'PluginProject(id: $id, directory: $directory, name: $name, activity: $activity)';
 }
 
 
@@ -133,7 +135,7 @@ abstract mixin class _$PluginProjectCopyWith<$Res> implements $PluginProjectCopy
   factory _$PluginProjectCopyWith(_PluginProject value, $Res Function(_PluginProject) _then) = __$PluginProjectCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String? name, PluginProjectActivity? activity
+ String id, String directory, String? name, PluginProjectActivity? activity
 });
 
 
@@ -150,9 +152,10 @@ class __$PluginProjectCopyWithImpl<$Res>
 
 /// Create a copy of PluginProject
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = freezed,Object? activity = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? directory = null,Object? name = freezed,Object? activity = freezed,}) {
   return _then(_PluginProject(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,directory: null == directory ? _self.directory : directory // ignore: cast_nullable_to_non_nullable
 as String,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String?,activity: freezed == activity ? _self.activity : activity // ignore: cast_nullable_to_non_nullable
 as PluginProjectActivity?,

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_project.g.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_project.g.dart
@@ -9,6 +9,7 @@ part of 'plugin_project.dart';
 Map<String, dynamic> _$PluginProjectToJson(_PluginProject instance) =>
     <String, dynamic>{
       'id': instance.id,
+      'directory': instance.directory,
       'name': ?instance.name,
       'activity': ?instance.activity?.toJson(),
     };

--- a/bridge/sesori_plugin_interface/test/plugin_project_test.dart
+++ b/bridge/sesori_plugin_interface/test/plugin_project_test.dart
@@ -2,15 +2,17 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
 void main() {
-  test("PluginProject serializes session-derived activity only", () {
+  test("PluginProject serializes directory independently from id", () {
     const project = PluginProject(
-      id: "/repo",
+      id: "project-123",
+      directory: "/repo",
       name: "Repo",
       activity: PluginProjectActivity(createdAt: 100, updatedAt: 200),
     );
 
     expect(project.toJson(), {
-      "id": "/repo",
+      "id": "project-123",
+      "directory": "/repo",
       "name": "Repo",
       "activity": {
         "createdAt": 100,

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -525,6 +525,7 @@ class OpenCodePlugin implements OpenCodeManagedApi {
     if (changed) _emitProjectsSummary();
     return _pluginModelMapper.mapProject(
       worktree: project.worktree,
+      directory: projectId,
       name: project.name,
       activity: null,
     );
@@ -559,7 +560,7 @@ class OpenCodePlugin implements OpenCodeManagedApi {
 
   @override
   Future<PluginProject> renameProject({required String projectId, required String name}) async {
-    // CRITICAL: projectId is the worktree path (PluginProject.id = worktree, see project.dart:33)
+    // projectId is the live directory used to resolve the OpenCode project UUID.
     // Must resolve the real OpenCode project UUID before calling PATCH
     final project = await _call(
       () => _service.repository.api.getProject(directory: projectId),
@@ -573,6 +574,7 @@ class OpenCodePlugin implements OpenCodeManagedApi {
     );
     return _pluginModelMapper.mapProject(
       worktree: updated.worktree,
+      directory: projectId,
       name: updated.name,
       activity: null,
     );

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
@@ -206,6 +206,7 @@ class OpenCodeRepository {
       return (
         project: _pluginModelMapper.mapProject(
           worktree: project.worktree,
+          directory: project.worktree,
           name: project.name,
           activity: _deriveActivityFromSessions(sessions),
         ),
@@ -467,6 +468,7 @@ class OpenCodeRepository {
       virtual.add((
         project: _pluginModelMapper.mapProject(
           worktree: directory,
+          directory: directory,
           name: null,
           activity: activity,
         ),

--- a/bridge/sesori_plugin_opencode/lib/src/plugin_model_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/plugin_model_mapper.dart
@@ -52,11 +52,13 @@ class PluginModelMapper {
 
   PluginProject mapProject({
     required String worktree,
+    required String directory,
     required String? name,
     required PluginProjectActivity? activity,
   }) {
     return PluginProject(
       id: worktree,
+      directory: directory,
       name: _effectiveProjectName(worktree: worktree, name: name),
       activity: activity,
     );

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -54,10 +54,12 @@ void main() {
 
       final real = projects.firstWhere((p) => p.id == "/repo");
       expect(real.id, equals("/repo"));
+      expect(real.directory, equals("/repo"));
       expect(real.name, equals("Main Repo"));
       expect(real.activity, const PluginProjectActivity(createdAt: 100, updatedAt: 200));
 
       final virtual = projects.firstWhere((p) => p.id == "/virtual");
+      expect(virtual.directory, equals("/virtual"));
       expect(virtual.name, equals("virtual"));
     });
 
@@ -123,6 +125,7 @@ void main() {
       await plugin.getProjects();
       final project = await plugin.getProject("/moved/repo");
       expect(project.id, equals("/repo"));
+      expect(project.directory, equals("/moved/repo"));
       expect(project.activity, isNull);
 
       final sessions = await plugin.getSessions("/moved/repo");
@@ -562,6 +565,7 @@ void main() {
 
         // PluginProject.id is always the worktree path, not the OpenCode UUID
         expect(project.id, equals("/repo"));
+        expect(project.directory, equals("/repo"));
         expect(project.name, equals("Renamed Repo"));
         expect(project.activity, isNull);
         expect(

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -1982,7 +1982,11 @@ class FakeOpenCodeRepository extends OpenCodeRepository {
     return _projects
         .map(
           (project) => (
-            project: PluginProject(id: project.worktree, name: project.name),
+            project: PluginProject(
+              id: project.worktree,
+              directory: project.worktree,
+              name: project.name,
+            ),
             sandboxes: project.sandboxes,
           ),
         )

--- a/bridge/sesori_plugin_opencode/test/sse_event_mapper_test.dart
+++ b/bridge/sesori_plugin_opencode/test/sse_event_mapper_test.dart
@@ -3,6 +3,7 @@ import "package:opencode_plugin/src/models/openapi/session.g.dart";
 import "package:opencode_plugin/src/models/sse_event_data.g.dart";
 import "package:opencode_plugin/src/sse_event_mapper.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" as shared;
 import "package:test/test.dart";
 
 AssistantMessage _assistantMessage({required Object? error}) {
@@ -96,6 +97,7 @@ void main() {
       final event = result! as BridgeSseSessionCreated;
       expect(event.info["projectID"], equals("/repo"));
       expect(event.info["directory"], equals("/repo/packages/foo"));
+      expect(shared.Session.fromJson(event.info).pluginId, isNull);
     });
 
     test("maps session.updated using provided canonical projectID", () {

--- a/bridge/sesori_plugin_opencode/test/sse_event_mapper_test.dart
+++ b/bridge/sesori_plugin_opencode/test/sse_event_mapper_test.dart
@@ -97,7 +97,7 @@ void main() {
       final event = result! as BridgeSseSessionCreated;
       expect(event.info["projectID"], equals("/repo"));
       expect(event.info["directory"], equals("/repo/packages/foo"));
-      expect(shared.Session.fromJson(event.info).pluginId, isNull);
+      expect(shared.Session.fromJson(event.info).pluginId, shared.legacyMissingPluginId);
     });
 
     test("maps session.updated using provided canonical projectID", () {

--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -49,10 +49,11 @@ shell-owned presentation. `module_app_ui` may depend on `module_core`,
 import product shells or `module_desktop_core`.
 
 Plugin identity is non-null inside client APIs, repositories, services, and
-cubits. Use `legacyMissingPluginId` only at flows that genuinely have no plugin
-identity context, and otherwise pass the selected or session-derived id through
-unchanged. Project-only request DTOs carry only `projectId`; composer operations
-use the dedicated plugin-scoped request DTO.
+cubits. `legacyMissingPluginId` is the concrete OpenCode identity because only
+OpenCode predates plugin attribution; use it only at flows that genuinely have
+no plugin identity context. Otherwise pass the selected or session-derived id
+through unchanged. Project-only request DTOs carry only `projectId`; composer
+operations use the dedicated plugin-scoped request DTO.
 
 ## Testing
 

--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -48,6 +48,12 @@ shell-owned presentation. `module_app_ui` may depend on `module_core`,
 `module_prego`, `sesori_shared`, and direct Flutter UI dependencies; it must not
 import product shells or `module_desktop_core`.
 
+Plugin identity is non-null inside client APIs, repositories, services, and
+cubits. Use `legacyMissingPluginId` only at flows that genuinely have no plugin
+identity context, and otherwise pass the selected or session-derived id through
+unchanged. Project-only request DTOs carry only `projectId`; composer operations
+use the dedicated plugin-scoped request DTO.
+
 ## Testing
 
 - `flutter test` from `app/`

--- a/client/app/test/capabilities/project/project_service_test.dart
+++ b/client/app/test/capabilities/project/project_service_test.dart
@@ -122,7 +122,7 @@ void main() {
           () => mockClient.post<Project>(
             "/project/current",
             fromJson: any(named: "fromJson"),
-            body: const ProjectIdRequest(projectId: "/home/user/current-project", pluginId: null),
+            body: const ProjectIdRequest(projectId: "/home/user/current-project"),
           ),
         ).called(1);
       });
@@ -150,7 +150,7 @@ void main() {
           () => mockClient.post<Project>(
             "/project/current",
             fromJson: any(named: "fromJson"),
-            body: const ProjectIdRequest(projectId: "/home/user/current-project", pluginId: null),
+            body: const ProjectIdRequest(projectId: "/home/user/current-project"),
           ),
         ).called(1);
       });
@@ -173,7 +173,7 @@ void main() {
           () => mockClient.post<Project>(
             "/project/current",
             fromJson: any(named: "fromJson"),
-            body: const ProjectIdRequest(projectId: "/home/user/current-project", pluginId: null),
+            body: const ProjectIdRequest(projectId: "/home/user/current-project"),
           ),
         ).called(1);
       });

--- a/client/app/test/capabilities/project/project_service_test.dart
+++ b/client/app/test/capabilities/project/project_service_test.dart
@@ -122,7 +122,7 @@ void main() {
           () => mockClient.post<Project>(
             "/project/current",
             fromJson: any(named: "fromJson"),
-            body: const ProjectIdRequest(projectId: "/home/user/current-project"),
+            body: const ProjectIdRequest(projectId: "/home/user/current-project", pluginId: null),
           ),
         ).called(1);
       });
@@ -150,7 +150,7 @@ void main() {
           () => mockClient.post<Project>(
             "/project/current",
             fromJson: any(named: "fromJson"),
-            body: const ProjectIdRequest(projectId: "/home/user/current-project"),
+            body: const ProjectIdRequest(projectId: "/home/user/current-project", pluginId: null),
           ),
         ).called(1);
       });
@@ -173,7 +173,7 @@ void main() {
           () => mockClient.post<Project>(
             "/project/current",
             fromJson: any(named: "fromJson"),
-            body: const ProjectIdRequest(projectId: "/home/user/current-project"),
+            body: const ProjectIdRequest(projectId: "/home/user/current-project", pluginId: null),
           ),
         ).called(1);
       });

--- a/client/app/test/core/routing/adaptive_session_router_test_harness.dart
+++ b/client/app/test/core/routing/adaptive_session_router_test_harness.dart
@@ -109,13 +109,22 @@ class AdaptiveSessionRouterTestHarness {
       return ApiResponse.success(SessionDiffsResponse(diffs: diffsBySession[sessionId] ?? const []));
     });
     when(
-      () => sessionRepository.listAgents(projectId: any(named: "projectId")),
+      () => sessionRepository.listAgents(
+        projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
+      ),
     ).thenAnswer((_) async => ApiResponse.success(Agents(agents: [testAgentInfo()])));
     when(
-      () => sessionRepository.listProviders(projectId: any(named: "projectId")),
+      () => sessionRepository.listProviders(
+        projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
+      ),
     ).thenAnswer((_) async => ApiResponse.success(testProviderListResponse()));
     when(
-      () => sessionRepository.listCommands(projectId: any(named: "projectId")),
+      () => sessionRepository.listCommands(
+        projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
+      ),
     ).thenAnswer((_) async => ApiResponse.success(const CommandListResponse(items: [])));
 
     Future<SessionDetailLoadResult> loadSnapshot(Invocation invocation) async {
@@ -239,6 +248,7 @@ Session adaptiveTestSession({
 }) {
   return Session(
     id: id,
+    pluginId: null,
     projectID: projectId,
     directory: "/tmp/$projectId",
     parentID: null,

--- a/client/app/test/core/routing/adaptive_session_router_test_harness.dart
+++ b/client/app/test/core/routing/adaptive_session_router_test_harness.dart
@@ -248,7 +248,7 @@ Session adaptiveTestSession({
 }) {
   return Session(
     id: id,
-    pluginId: null,
+    pluginId: "plugin-1",
     projectID: projectId,
     directory: "/tmp/$projectId",
     parentID: null,

--- a/client/app/test/core/widgets/session_split/session_split_shell_test.dart
+++ b/client/app/test/core/widgets/session_split/session_split_shell_test.dart
@@ -176,6 +176,7 @@ void main() {
       when(
         () => harness.sessionRepository.createSessionWithMessage(
           projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
           text: any(named: "text"),
           agent: any(named: "agent"),
           model: any(named: "model"),

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -82,7 +82,12 @@ void main() {
     sessionService = MockSessionService();
     voiceTranscriptionService = MockVoiceTranscriptionService();
 
-    when(() => sessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+    when(
+      () => sessionService.listAgents(
+        projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
+      ),
+    ).thenAnswer(
       (_) async => ApiResponse.success(
         Agents(
           agents: [
@@ -92,10 +97,20 @@ void main() {
         ),
       ),
     );
-    when(() => sessionService.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+    when(
+      () => sessionService.listProviders(
+        projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
+      ),
+    ).thenAnswer(
       (_) async => ApiResponse.success(testProviderListResponse()),
     );
-    when(() => sessionService.listCommands(projectId: any(named: "projectId"))).thenAnswer(
+    when(
+      () => sessionService.listCommands(
+        projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
+      ),
+    ).thenAnswer(
       (_) async => ApiResponse.success(const CommandListResponse(items: [])),
     );
 
@@ -133,7 +148,12 @@ void main() {
   });
 
   testWidgets("selecting a different variant updates the displayed variant", (tester) async {
-    when(() => sessionService.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+    when(
+      () => sessionService.listProviders(
+        projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
+      ),
+    ).thenAnswer(
       (_) async => ApiResponse.success(
         const ProviderListResponse(
           connectedOnly: false,
@@ -178,7 +198,12 @@ void main() {
   });
 
   testWidgets("selecting Default clears the displayed variant", (tester) async {
-    when(() => sessionService.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+    when(
+      () => sessionService.listProviders(
+        projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
+      ),
+    ).thenAnswer(
       (_) async => ApiResponse.success(
         const ProviderListResponse(
           connectedOnly: false,
@@ -251,6 +276,7 @@ void main() {
     when(
       () => sessionService.createSessionWithMessage(
         projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
         text: any(named: "text"),
         agent: any(named: "agent"),
         providerID: any(named: "providerID"),
@@ -281,6 +307,7 @@ void main() {
     when(
       () => sessionService.createSessionWithMessage(
         projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
         text: any(named: "text"),
         agent: any(named: "agent"),
         providerID: any(named: "providerID"),
@@ -310,6 +337,7 @@ void main() {
     verify(
       () => sessionService.createSessionWithMessage(
         projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
         text: any(named: "text"),
         agent: any(named: "agent"),
         providerID: any(named: "providerID"),
@@ -326,6 +354,7 @@ void main() {
     when(
       () => sessionService.createSessionWithMessage(
         projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
         text: any(named: "text"),
         agent: any(named: "agent"),
         providerID: any(named: "providerID"),
@@ -369,6 +398,7 @@ void main() {
     when(
       () => sessionService.createSessionWithMessage(
         projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
         text: any(named: "text"),
         agent: any(named: "agent"),
         providerID: any(named: "providerID"),
@@ -416,6 +446,7 @@ void main() {
     when(
       () => sessionService.createSessionWithMessage(
         projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
         text: any(named: "text"),
         agent: any(named: "agent"),
         providerID: any(named: "providerID"),
@@ -452,6 +483,7 @@ void main() {
     when(
       () => sessionService.createSessionWithMessage(
         projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
         text: any(named: "text"),
         agent: any(named: "agent"),
         providerID: any(named: "providerID"),
@@ -486,6 +518,7 @@ void main() {
     when(
       () => sessionService.createSessionWithMessage(
         projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
         text: any(named: "text"),
         agent: any(named: "agent"),
         providerID: any(named: "providerID"),

--- a/client/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/client/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -127,9 +127,9 @@ void main() {
         verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(1);
         verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
         verify(() => mockSessionService.getSessionStatuses()).called(1);
-        verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).called(1);
-        verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).called(1);
-        verify(() => mockSessionService.listCommands(projectId: "project-1")).called(1);
+        verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: null)).called(1);
+        verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: null)).called(1);
+        verify(() => mockSessionService.listCommands(projectId: "project-1", pluginId: null)).called(1);
         verify(() => mockSessionRepository.getSession(sessionId: sessionId)).called(1);
         verify(() => mockConnectionService.sessionEvents(sessionId)).called(1);
         verify(() => mockConnectionService.events).called(1);
@@ -189,9 +189,9 @@ void main() {
         verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(2);
         verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(2);
         verify(() => mockSessionService.getSessionStatuses()).called(2);
-        verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).called(2);
-        verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).called(2);
-        verify(() => mockSessionService.listCommands(projectId: "project-1")).called(2);
+        verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: null)).called(2);
+        verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: null)).called(2);
+        verify(() => mockSessionService.listCommands(projectId: "project-1", pluginId: null)).called(2);
         verify(() => mockSessionRepository.getSession(sessionId: sessionId)).called(2);
       },
     );
@@ -379,7 +379,10 @@ void main() {
       "selectVariant updates selectedAgentModel variant",
       build: () {
         when(
-          () => mockSessionService.listProviders(projectId: any(named: "projectId")),
+          () => mockSessionService.listProviders(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
         ).thenAnswer(
           (_) async => ApiResponse.success(
             const ProviderListResponse(
@@ -439,7 +442,10 @@ void main() {
       "selectVariant to null clears selectedAgentModel variant",
       build: () {
         when(
-          () => mockSessionService.listProviders(projectId: any(named: "projectId")),
+          () => mockSessionService.listProviders(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
         ).thenAnswer(
           (_) async => ApiResponse.success(
             const ProviderListResponse(
@@ -1959,21 +1965,30 @@ void _stubAllDefaults(
     ),
   );
   when(
-    () => service.listAgents(projectId: any(named: "projectId")),
+    () => service.listAgents(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+    ),
   ).thenAnswer(
     (_) => Future<ApiResponse<Agents>>.value(
       ApiResponse.success(Agents(agents: [testAgentInfo()])),
     ),
   );
   when(
-    () => service.listProviders(projectId: any(named: "projectId")),
+    () => service.listProviders(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+    ),
   ).thenAnswer(
     (_) => Future<ApiResponse<ProviderListResponse>>.value(
       ApiResponse.success(testProviderListResponse()),
     ),
   );
   when(
-    () => sessionService.listCommands(projectId: any(named: "projectId")),
+    () => sessionService.listCommands(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+    ),
   ).thenAnswer(
     (_) => Future<ApiResponse<CommandListResponse>>.value(
       ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),

--- a/client/app/test/features/session_detail/session_detail_cubit_test.dart
+++ b/client/app/test/features/session_detail/session_detail_cubit_test.dart
@@ -127,9 +127,9 @@ void main() {
         verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(1);
         verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
         verify(() => mockSessionService.getSessionStatuses()).called(1);
-        verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: null)).called(1);
-        verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: null)).called(1);
-        verify(() => mockSessionService.listCommands(projectId: "project-1", pluginId: null)).called(1);
+        verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: "plugin-1")).called(1);
+        verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: "plugin-1")).called(1);
+        verify(() => mockSessionService.listCommands(projectId: "project-1", pluginId: "plugin-1")).called(1);
         verify(() => mockSessionRepository.getSession(sessionId: sessionId)).called(1);
         verify(() => mockConnectionService.sessionEvents(sessionId)).called(1);
         verify(() => mockConnectionService.events).called(1);
@@ -189,9 +189,9 @@ void main() {
         verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(2);
         verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(2);
         verify(() => mockSessionService.getSessionStatuses()).called(2);
-        verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: null)).called(2);
-        verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: null)).called(2);
-        verify(() => mockSessionService.listCommands(projectId: "project-1", pluginId: null)).called(2);
+        verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: "plugin-1")).called(2);
+        verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: "plugin-1")).called(2);
+        verify(() => mockSessionService.listCommands(projectId: "project-1", pluginId: "plugin-1")).called(2);
         verify(() => mockSessionRepository.getSession(sessionId: sessionId)).called(2);
       },
     );

--- a/client/app/test/features/session_detail/widgets/adaptive_child_session_navigation_test.dart
+++ b/client/app/test/features/session_detail/widgets/adaptive_child_session_navigation_test.dart
@@ -54,7 +54,7 @@ Widget _buildApp({
 Session _childSession({required String id, String? title}) {
   return Session(
     id: id,
-    pluginId: null,
+    pluginId: "plugin-1",
     projectID: "project-1",
     directory: "/home/user/my-project",
     parentID: "session-parent",

--- a/client/app/test/features/session_detail/widgets/adaptive_child_session_navigation_test.dart
+++ b/client/app/test/features/session_detail/widgets/adaptive_child_session_navigation_test.dart
@@ -54,6 +54,7 @@ Widget _buildApp({
 Session _childSession({required String id, String? title}) {
   return Session(
     id: id,
+    pluginId: null,
     projectID: "project-1",
     directory: "/home/user/my-project",
     parentID: "session-parent",

--- a/client/app/test/features/session_list/session_lifecycle_ui_test.dart
+++ b/client/app/test/features/session_list/session_lifecycle_ui_test.dart
@@ -78,6 +78,7 @@ Widget _buildScreenApp({required Widget child}) {
 Session _testSessionWithPullRequest() {
   return const Session(
     id: "session-pr-1",
+    pluginId: null,
     projectID: "project-1",
     directory: "/home/user/my-project",
     parentID: null,

--- a/client/app/test/features/session_list/session_lifecycle_ui_test.dart
+++ b/client/app/test/features/session_list/session_lifecycle_ui_test.dart
@@ -78,7 +78,7 @@ Widget _buildScreenApp({required Widget child}) {
 Session _testSessionWithPullRequest() {
   return const Session(
     id: "session-pr-1",
-    pluginId: null,
+    pluginId: "plugin-1",
     projectID: "project-1",
     directory: "/home/user/my-project",
     parentID: null,

--- a/client/app/test/helpers/test_helpers.dart
+++ b/client/app/test/helpers/test_helpers.dart
@@ -325,7 +325,7 @@ void delegateSessionRepositoryToService({
   ).thenAnswer(
     (invocation) => service.listAgents(
       projectId: invocation.namedArguments[#projectId] as String,
-      pluginId: invocation.namedArguments[#pluginId] as String?,
+      pluginId: invocation.namedArguments[#pluginId] as String,
     ),
   );
   when(
@@ -336,7 +336,7 @@ void delegateSessionRepositoryToService({
   ).thenAnswer(
     (invocation) => service.listProviders(
       projectId: invocation.namedArguments[#projectId] as String,
-      pluginId: invocation.namedArguments[#pluginId] as String?,
+      pluginId: invocation.namedArguments[#pluginId] as String,
     ),
   );
   when(
@@ -347,7 +347,7 @@ void delegateSessionRepositoryToService({
   ).thenAnswer(
     (invocation) => service.listCommands(
       projectId: invocation.namedArguments[#projectId] as String?,
-      pluginId: invocation.namedArguments[#pluginId] as String?,
+      pluginId: invocation.namedArguments[#pluginId] as String,
     ),
   );
   when(
@@ -429,10 +429,11 @@ Session testSession({
   int? updatedAt,
   DateTime? archivedAt,
   SessionPromptDefaults? promptDefaults,
+  String pluginId = "plugin-1",
 }) {
   return Session(
     id: id ?? "session-1",
-    pluginId: null,
+    pluginId: pluginId,
     projectID: "project-1",
     directory: "/home/user/my-project",
     parentID: parentID,

--- a/client/app/test/helpers/test_helpers.dart
+++ b/client/app/test/helpers/test_helpers.dart
@@ -317,14 +317,38 @@ void delegateSessionRepositoryToService({
     (invocation) => service.getChildren(sessionId: invocation.namedArguments[#sessionId]! as String),
   );
   when(() => repository.getSessionStatuses()).thenAnswer((_) => service.getSessionStatuses());
-  when(() => repository.listAgents(projectId: any(named: "projectId"))).thenAnswer(
-    (invocation) => service.listAgents(projectId: invocation.namedArguments[#projectId] as String),
+  when(
+    () => repository.listAgents(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+    ),
+  ).thenAnswer(
+    (invocation) => service.listAgents(
+      projectId: invocation.namedArguments[#projectId] as String,
+      pluginId: invocation.namedArguments[#pluginId] as String?,
+    ),
   );
-  when(() => repository.listProviders(projectId: any(named: "projectId"))).thenAnswer(
-    (invocation) => service.listProviders(projectId: invocation.namedArguments[#projectId] as String),
+  when(
+    () => repository.listProviders(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+    ),
+  ).thenAnswer(
+    (invocation) => service.listProviders(
+      projectId: invocation.namedArguments[#projectId] as String,
+      pluginId: invocation.namedArguments[#pluginId] as String?,
+    ),
   );
-  when(() => repository.listCommands(projectId: any(named: "projectId"))).thenAnswer(
-    (invocation) => service.listCommands(projectId: invocation.namedArguments[#projectId] as String?),
+  when(
+    () => repository.listCommands(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+    ),
+  ).thenAnswer(
+    (invocation) => service.listCommands(
+      projectId: invocation.namedArguments[#projectId] as String?,
+      pluginId: invocation.namedArguments[#pluginId] as String?,
+    ),
   );
   when(
     () => repository.sendMessage(
@@ -408,6 +432,7 @@ Session testSession({
 }) {
   return Session(
     id: id ?? "session-1",
+    pluginId: null,
     projectID: "project-1",
     directory: "/home/user/my-project",
     parentID: parentID,

--- a/client/module_core/lib/src/api/session_api.dart
+++ b/client/module_core/lib/src/api/session_api.dart
@@ -17,33 +17,33 @@ class SessionApi {
 
   SessionApi({required RelayHttpApiClient client}) : _client = client;
 
-  Future<ApiResponse<Agents>> listAgents({required String projectId, required String? pluginId}) {
+  Future<ApiResponse<Agents>> listAgents({required String projectId, required String pluginId}) {
     return _client.post(
       "/agent",
       fromJson: Agents.fromJson,
-      body: ProjectIdRequest(projectId: projectId, pluginId: pluginId),
+      body: PluginProjectIdRequest(projectId: projectId, pluginId: pluginId),
     );
   }
 
-  Future<ApiResponse<ProviderListResponse>> listProviders({required String projectId, required String? pluginId}) {
+  Future<ApiResponse<ProviderListResponse>> listProviders({required String projectId, required String pluginId}) {
     return _client.post(
       "/provider",
       fromJson: ProviderListResponse.fromJson,
-      body: ProjectIdRequest(projectId: projectId, pluginId: pluginId),
+      body: PluginProjectIdRequest(projectId: projectId, pluginId: pluginId),
     );
   }
 
-  Future<ApiResponse<CommandListResponse>> listCommands({required String projectId, required String? pluginId}) {
+  Future<ApiResponse<CommandListResponse>> listCommands({required String projectId, required String pluginId}) {
     return _client.post(
       "/command",
       fromJson: CommandListResponse.fromJson,
-      body: ProjectIdRequest(projectId: projectId, pluginId: pluginId),
+      body: PluginProjectIdRequest(projectId: projectId, pluginId: pluginId),
     );
   }
 
   Future<ApiResponse<Session>> createSessionWithMessage({
     required String projectId,
-    required String? pluginId,
+    required String pluginId,
     required String text,
     required String? agent,
     required PromptModel? model,

--- a/client/module_core/lib/src/api/session_api.dart
+++ b/client/module_core/lib/src/api/session_api.dart
@@ -17,32 +17,33 @@ class SessionApi {
 
   SessionApi({required RelayHttpApiClient client}) : _client = client;
 
-  Future<ApiResponse<Agents>> listAgents({required String projectId}) {
+  Future<ApiResponse<Agents>> listAgents({required String projectId, required String? pluginId}) {
     return _client.post(
       "/agent",
       fromJson: Agents.fromJson,
-      body: ProjectIdRequest(projectId: projectId),
+      body: ProjectIdRequest(projectId: projectId, pluginId: pluginId),
     );
   }
 
-  Future<ApiResponse<ProviderListResponse>> listProviders({required String projectId}) {
+  Future<ApiResponse<ProviderListResponse>> listProviders({required String projectId, required String? pluginId}) {
     return _client.post(
       "/provider",
       fromJson: ProviderListResponse.fromJson,
-      body: ProjectIdRequest(projectId: projectId),
+      body: ProjectIdRequest(projectId: projectId, pluginId: pluginId),
     );
   }
 
-  Future<ApiResponse<CommandListResponse>> listCommands({required String projectId}) {
+  Future<ApiResponse<CommandListResponse>> listCommands({required String projectId, required String? pluginId}) {
     return _client.post(
       "/command",
       fromJson: CommandListResponse.fromJson,
-      body: ProjectIdRequest(projectId: projectId),
+      body: ProjectIdRequest(projectId: projectId, pluginId: pluginId),
     );
   }
 
   Future<ApiResponse<Session>> createSessionWithMessage({
     required String projectId,
+    required String? pluginId,
     required String text,
     required String? agent,
     required PromptModel? model,
@@ -55,6 +56,7 @@ class SessionApi {
       fromJson: Session.fromJson,
       body: CreateSessionRequest(
         projectId: projectId,
+        pluginId: pluginId,
         parts: [PromptPart.text(text: text)],
         agent: agent,
         model: model,

--- a/client/module_core/lib/src/capabilities/project/project_service.dart
+++ b/client/module_core/lib/src/capabilities/project/project_service.dart
@@ -22,7 +22,7 @@ class ProjectService {
     return _client.post(
       "/project/current",
       fromJson: Project.fromJson,
-      body: ProjectIdRequest(projectId: projectId, pluginId: null),
+      body: ProjectIdRequest(projectId: projectId),
     );
   }
 
@@ -48,7 +48,7 @@ class ProjectService {
   Future<ApiResponse<void>> hideProject({required String projectId}) {
     return _client.post(
       "/project/hide",
-      body: ProjectIdRequest(projectId: projectId, pluginId: null),
+      body: ProjectIdRequest(projectId: projectId),
       fromJson: SuccessEmptyResponse.fromJson,
     );
   }
@@ -72,7 +72,7 @@ class ProjectService {
   Future<ApiResponse<BaseBranchResponse>> getBaseBranch({required String projectId}) {
     return _client.post(
       "/project/base-branch",
-      body: ProjectIdRequest(projectId: projectId, pluginId: null),
+      body: ProjectIdRequest(projectId: projectId),
       fromJson: BaseBranchResponse.fromJson,
     );
   }

--- a/client/module_core/lib/src/capabilities/project/project_service.dart
+++ b/client/module_core/lib/src/capabilities/project/project_service.dart
@@ -22,7 +22,7 @@ class ProjectService {
     return _client.post(
       "/project/current",
       fromJson: Project.fromJson,
-      body: ProjectIdRequest(projectId: projectId),
+      body: ProjectIdRequest(projectId: projectId, pluginId: null),
     );
   }
 
@@ -48,7 +48,7 @@ class ProjectService {
   Future<ApiResponse<void>> hideProject({required String projectId}) {
     return _client.post(
       "/project/hide",
-      body: ProjectIdRequest(projectId: projectId),
+      body: ProjectIdRequest(projectId: projectId, pluginId: null),
       fromJson: SuccessEmptyResponse.fromJson,
     );
   }
@@ -72,7 +72,7 @@ class ProjectService {
   Future<ApiResponse<BaseBranchResponse>> getBaseBranch({required String projectId}) {
     return _client.post(
       "/project/base-branch",
-      body: ProjectIdRequest(projectId: projectId),
+      body: ProjectIdRequest(projectId: projectId, pluginId: null),
       fromJson: BaseBranchResponse.fromJson,
     );
   }

--- a/client/module_core/lib/src/capabilities/session/session_service.dart
+++ b/client/module_core/lib/src/capabilities/session/session_service.dart
@@ -86,15 +86,15 @@ class SessionService {
     return _repository.getSessionStatuses();
   }
 
-  Future<ApiResponse<Agents>> listAgents({required String projectId, required String? pluginId}) {
+  Future<ApiResponse<Agents>> listAgents({required String projectId, required String pluginId}) {
     return _repository.listAgents(projectId: projectId, pluginId: pluginId);
   }
 
-  Future<ApiResponse<ProviderListResponse>> listProviders({required String projectId, required String? pluginId}) {
+  Future<ApiResponse<ProviderListResponse>> listProviders({required String projectId, required String pluginId}) {
     return _repository.listProviders(projectId: projectId, pluginId: pluginId);
   }
 
-  Future<ApiResponse<CommandListResponse>> listCommands({required String? projectId, required String? pluginId}) {
+  Future<ApiResponse<CommandListResponse>> listCommands({required String? projectId, required String pluginId}) {
     final normalizedProjectId = projectId?.normalize();
     if (normalizedProjectId == null) {
       return Future.value(ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])));
@@ -105,7 +105,7 @@ class SessionService {
 
   Future<ApiResponse<Session>> createSessionWithMessage({
     required String projectId,
-    required String? pluginId,
+    required String pluginId,
     required String text,
     required String? agent,
     required String? providerID,

--- a/client/module_core/lib/src/capabilities/session/session_service.dart
+++ b/client/module_core/lib/src/capabilities/session/session_service.dart
@@ -86,25 +86,26 @@ class SessionService {
     return _repository.getSessionStatuses();
   }
 
-  Future<ApiResponse<Agents>> listAgents({required String projectId}) {
-    return _repository.listAgents(projectId: projectId);
+  Future<ApiResponse<Agents>> listAgents({required String projectId, required String? pluginId}) {
+    return _repository.listAgents(projectId: projectId, pluginId: pluginId);
   }
 
-  Future<ApiResponse<ProviderListResponse>> listProviders({required String projectId}) {
-    return _repository.listProviders(projectId: projectId);
+  Future<ApiResponse<ProviderListResponse>> listProviders({required String projectId, required String? pluginId}) {
+    return _repository.listProviders(projectId: projectId, pluginId: pluginId);
   }
 
-  Future<ApiResponse<CommandListResponse>> listCommands({required String? projectId}) {
+  Future<ApiResponse<CommandListResponse>> listCommands({required String? projectId, required String? pluginId}) {
     final normalizedProjectId = projectId?.normalize();
     if (normalizedProjectId == null) {
       return Future.value(ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])));
     }
 
-    return _repository.listCommands(projectId: normalizedProjectId);
+    return _repository.listCommands(projectId: normalizedProjectId, pluginId: pluginId);
   }
 
   Future<ApiResponse<Session>> createSessionWithMessage({
     required String projectId,
+    required String? pluginId,
     required String text,
     required String? agent,
     required String? providerID,
@@ -114,6 +115,7 @@ class SessionService {
     required bool dedicatedWorktree,
   }) => _repository.createSessionWithMessage(
     projectId: projectId,
+    pluginId: pluginId,
     text: text,
     agent: agent,
     model: _resolveModel(providerID: providerID, modelID: modelID),

--- a/client/module_core/lib/src/cubits/new_session/new_session_cubit.dart
+++ b/client/module_core/lib/src/cubits/new_session/new_session_cubit.dart
@@ -44,9 +44,9 @@ class NewSessionCubit extends Cubit<NewSessionState> {
         ApiResponse<ProviderListResponse> providersResponse,
         ApiResponse<CommandListResponse> commandsResponse,
       ) = await wait3(
-        _sessionService.listAgents(projectId: _projectId, pluginId: null),
-        _sessionService.listProviders(projectId: _projectId, pluginId: null),
-        _sessionService.listCommands(projectId: _projectId, pluginId: null),
+        _sessionService.listAgents(projectId: _projectId, pluginId: legacyMissingPluginId),
+        _sessionService.listProviders(projectId: _projectId, pluginId: legacyMissingPluginId),
+        _sessionService.listCommands(projectId: _projectId, pluginId: legacyMissingPluginId),
       );
 
       if (isClosed) return;
@@ -406,7 +406,7 @@ class NewSessionCubit extends Cubit<NewSessionState> {
 
     final response = await _sessionService.createSessionWithMessage(
       projectId: _projectId,
-      pluginId: null,
+      pluginId: legacyMissingPluginId,
       text: trimmed,
       agent: config?.agent,
       providerID: config?.agentModel?.providerID,

--- a/client/module_core/lib/src/cubits/new_session/new_session_cubit.dart
+++ b/client/module_core/lib/src/cubits/new_session/new_session_cubit.dart
@@ -44,9 +44,9 @@ class NewSessionCubit extends Cubit<NewSessionState> {
         ApiResponse<ProviderListResponse> providersResponse,
         ApiResponse<CommandListResponse> commandsResponse,
       ) = await wait3(
-        _sessionService.listAgents(projectId: _projectId),
-        _sessionService.listProviders(projectId: _projectId),
-        _sessionService.listCommands(projectId: _projectId),
+        _sessionService.listAgents(projectId: _projectId, pluginId: null),
+        _sessionService.listProviders(projectId: _projectId, pluginId: null),
+        _sessionService.listCommands(projectId: _projectId, pluginId: null),
       );
 
       if (isClosed) return;
@@ -406,6 +406,7 @@ class NewSessionCubit extends Cubit<NewSessionState> {
 
     final response = await _sessionService.createSessionWithMessage(
       projectId: _projectId,
+      pluginId: null,
       text: trimmed,
       agent: config?.agent,
       providerID: config?.agentModel?.providerID,

--- a/client/module_core/lib/src/repositories/session_repository.dart
+++ b/client/module_core/lib/src/repositories/session_repository.dart
@@ -7,7 +7,7 @@ import "../api/session_api.dart";
 @lazySingleton
 class SessionRepository {
   final SessionApi _api;
-  final _providerCache = <(String?, String), ProviderListResponse>{};
+  final _providerCache = <({String pluginId, String projectId}), ProviderListResponse>{};
 
   SessionRepository({
     required SessionApi api,
@@ -97,15 +97,15 @@ class SessionRepository {
     return _api.getSession(sessionId: sessionId);
   }
 
-  Future<ApiResponse<Agents>> listAgents({required String projectId, required String? pluginId}) {
+  Future<ApiResponse<Agents>> listAgents({required String projectId, required String pluginId}) {
     return _api.listAgents(projectId: projectId, pluginId: pluginId);
   }
 
   Future<ApiResponse<ProviderListResponse>> listProviders({
     required String projectId,
-    required String? pluginId,
+    required String pluginId,
   }) async {
-    final cacheKey = (pluginId, projectId);
+    final cacheKey = (pluginId: pluginId, projectId: projectId);
     if (_providerCache[cacheKey] case final providersCache?) {
       return ApiResponse.success(providersCache);
     }
@@ -132,13 +132,13 @@ class SessionRepository {
     return response;
   }
 
-  Future<ApiResponse<CommandListResponse>> listCommands({required String projectId, required String? pluginId}) {
+  Future<ApiResponse<CommandListResponse>> listCommands({required String projectId, required String pluginId}) {
     return _api.listCommands(projectId: projectId, pluginId: pluginId);
   }
 
   Future<ApiResponse<Session>> createSessionWithMessage({
     required String projectId,
-    required String? pluginId,
+    required String pluginId,
     required String text,
     required String? agent,
     required PromptModel? model,

--- a/client/module_core/lib/src/repositories/session_repository.dart
+++ b/client/module_core/lib/src/repositories/session_repository.dart
@@ -7,7 +7,7 @@ import "../api/session_api.dart";
 @lazySingleton
 class SessionRepository {
   final SessionApi _api;
-  final _providerCache = <String, ProviderListResponse>{};
+  final _providerCache = <(String?, String), ProviderListResponse>{};
 
   SessionRepository({
     required SessionApi api,
@@ -97,16 +97,20 @@ class SessionRepository {
     return _api.getSession(sessionId: sessionId);
   }
 
-  Future<ApiResponse<Agents>> listAgents({required String projectId}) {
-    return _api.listAgents(projectId: projectId);
+  Future<ApiResponse<Agents>> listAgents({required String projectId, required String? pluginId}) {
+    return _api.listAgents(projectId: projectId, pluginId: pluginId);
   }
 
-  Future<ApiResponse<ProviderListResponse>> listProviders({required String projectId}) async {
-    if (_providerCache[projectId] case final providersCache?) {
+  Future<ApiResponse<ProviderListResponse>> listProviders({
+    required String projectId,
+    required String? pluginId,
+  }) async {
+    final cacheKey = (pluginId, projectId);
+    if (_providerCache[cacheKey] case final providersCache?) {
       return ApiResponse.success(providersCache);
     }
 
-    final response = await _api.listProviders(projectId: projectId);
+    final response = await _api.listProviders(projectId: projectId, pluginId: pluginId);
 
     // Only cache once every provider in the response actually carries models.
     // Some backends build their model catalog asynchronously (e.g. the
@@ -122,18 +126,19 @@ class SessionRepository {
     if (response is SuccessResponse<ProviderListResponse> &&
         response.data.items.isNotEmpty &&
         response.data.items.every((provider) => provider.models.isNotEmpty)) {
-      _providerCache[projectId] = response.data;
+      _providerCache[cacheKey] = response.data;
     }
 
     return response;
   }
 
-  Future<ApiResponse<CommandListResponse>> listCommands({required String projectId}) {
-    return _api.listCommands(projectId: projectId);
+  Future<ApiResponse<CommandListResponse>> listCommands({required String projectId, required String? pluginId}) {
+    return _api.listCommands(projectId: projectId, pluginId: pluginId);
   }
 
   Future<ApiResponse<Session>> createSessionWithMessage({
     required String projectId,
+    required String? pluginId,
     required String text,
     required String? agent,
     required PromptModel? model,
@@ -143,6 +148,7 @@ class SessionRepository {
   }) {
     return _api.createSessionWithMessage(
       projectId: projectId,
+      pluginId: pluginId,
       text: text,
       agent: agent,
       model: model,

--- a/client/module_core/lib/src/services/session_detail_load_service.dart
+++ b/client/module_core/lib/src/services/session_detail_load_service.dart
@@ -41,31 +41,14 @@ class SessionDetailLoadService {
     try {
       final routeProjectId = projectId.normalize();
       final projectContextFuture = _loadProjectSessionContext(sessionId: sessionId);
-      final commandsFuture = routeProjectId == null ? null : _listCommands(projectId: routeProjectId);
-      final agentsFuture = routeProjectId == null ? null : _listAgents(projectId: routeProjectId);
-      final providersFuture = routeProjectId == null ? null : _listProviders(projectId: routeProjectId);
-      final (
-        messagesResponse,
-        questionsResponse,
-        permissionsResponse,
-        childrenResponse,
-        statusesResponse,
-        sessionResponse,
-      ) = await (
-        _repository.getMessages(sessionId: sessionId),
-        _repository.getPendingQuestions(sessionId: sessionId),
-        _repository.getPendingPermissions(sessionId: sessionId),
-        _repository.getChildren(sessionId: sessionId),
-        _repository.getSessionStatuses(),
-        _repository.getSession(sessionId: sessionId),
-      ).wait;
+      final messagesFuture = _repository.getMessages(sessionId: sessionId);
+      final questionsFuture = _repository.getPendingQuestions(sessionId: sessionId);
+      final permissionsFuture = _repository.getPendingPermissions(sessionId: sessionId);
+      final childrenFuture = _repository.getChildren(sessionId: sessionId);
+      final statusesFuture = _repository.getSessionStatuses();
+      final sessionResponse = await _repository.getSession(sessionId: sessionId);
       final projectContext = await projectContextFuture;
       final effectiveProjectId = routeProjectId ?? projectContext?.projectId;
-      // When the route carries no project id, resolve it from the session
-      // context so agents, commands, and providers are still project-scoped.
-      final commandsResponse = await (commandsFuture ?? _listCommands(projectId: effectiveProjectId));
-      final agentsResponse = await (agentsFuture ?? _listAgents(projectId: effectiveProjectId));
-      final providersResponse = await (providersFuture ?? _listProviders(projectId: effectiveProjectId));
       final session = switch (sessionResponse) {
         SuccessResponse(:final data) => data,
         ErrorResponse(:final error) => () {
@@ -73,6 +56,28 @@ class SessionDetailLoadService {
           return null;
         }(),
       };
+      final pluginId = session?.pluginId ?? legacyMissingPluginId;
+      final commandsFuture = _listCommands(projectId: effectiveProjectId, pluginId: pluginId);
+      final agentsFuture = _listAgents(projectId: effectiveProjectId, pluginId: pluginId);
+      final providersFuture = _listProviders(projectId: effectiveProjectId, pluginId: pluginId);
+      final (
+        messagesResponse,
+        questionsResponse,
+        permissionsResponse,
+        childrenResponse,
+        statusesResponse,
+      ) = await (
+        messagesFuture,
+        questionsFuture,
+        permissionsFuture,
+        childrenFuture,
+        statusesFuture,
+      ).wait;
+      final (commandsResponse, agentsResponse, providersResponse) = await (
+        commandsFuture,
+        agentsFuture,
+        providersFuture,
+      ).wait;
       final promptDefaults = session?.promptDefaults;
 
       final messages = switch (messagesResponse) {
@@ -140,7 +145,7 @@ class SessionDetailLoadService {
     }
   }
 
-  Future<ApiResponse<Agents>> _listAgents({required String? projectId}) {
+  Future<ApiResponse<Agents>> _listAgents({required String? projectId, required String pluginId}) {
     final normalizedProjectId = projectId?.normalize();
     if (normalizedProjectId == null) {
       // Without any project context there is no way to scope the agent list;
@@ -150,10 +155,10 @@ class SessionDetailLoadService {
       );
     }
 
-    return _repository.listAgents(projectId: normalizedProjectId, pluginId: null);
+    return _repository.listAgents(projectId: normalizedProjectId, pluginId: pluginId);
   }
 
-  Future<ApiResponse<CommandListResponse>> _listCommands({required String? projectId}) {
+  Future<ApiResponse<CommandListResponse>> _listCommands({required String? projectId, required String pluginId}) {
     final normalizedProjectId = projectId?.normalize();
     if (normalizedProjectId == null) {
       return Future<ApiResponse<CommandListResponse>>.value(
@@ -161,10 +166,10 @@ class SessionDetailLoadService {
       );
     }
 
-    return _repository.listCommands(projectId: normalizedProjectId, pluginId: null);
+    return _repository.listCommands(projectId: normalizedProjectId, pluginId: pluginId);
   }
 
-  Future<ApiResponse<ProviderListResponse>> _listProviders({required String? projectId}) {
+  Future<ApiResponse<ProviderListResponse>> _listProviders({required String? projectId, required String pluginId}) {
     final normalizedProjectId = projectId?.normalize();
     if (normalizedProjectId == null) {
       // Without any project context there is no project to scope providers to;
@@ -174,7 +179,7 @@ class SessionDetailLoadService {
       );
     }
 
-    return _repository.listProviders(projectId: normalizedProjectId, pluginId: null);
+    return _repository.listProviders(projectId: normalizedProjectId, pluginId: pluginId);
   }
 
   Future<ProjectSessionContext?> _loadProjectSessionContext({required String sessionId}) async {
@@ -199,6 +204,7 @@ class SessionDetailSnapshot {
   final List<CommandInfo> commands;
   final String? canonicalSessionTitle;
   final SessionPromptDefaults? promptDefaults;
+
   /// Whether this session is a root (main) session. `true` when the session
   /// metadata confirms `parentID == null`; `false` when `parentID != null`;
   /// `null` when the session metadata lookup failed, so we cannot tell.

--- a/client/module_core/lib/src/services/session_detail_load_service.dart
+++ b/client/module_core/lib/src/services/session_detail_load_service.dart
@@ -150,7 +150,7 @@ class SessionDetailLoadService {
       );
     }
 
-    return _repository.listAgents(projectId: normalizedProjectId);
+    return _repository.listAgents(projectId: normalizedProjectId, pluginId: null);
   }
 
   Future<ApiResponse<CommandListResponse>> _listCommands({required String? projectId}) {
@@ -161,7 +161,7 @@ class SessionDetailLoadService {
       );
     }
 
-    return _repository.listCommands(projectId: normalizedProjectId);
+    return _repository.listCommands(projectId: normalizedProjectId, pluginId: null);
   }
 
   Future<ApiResponse<ProviderListResponse>> _listProviders({required String? projectId}) {
@@ -174,7 +174,7 @@ class SessionDetailLoadService {
       );
     }
 
-    return _repository.listProviders(projectId: normalizedProjectId);
+    return _repository.listProviders(projectId: normalizedProjectId, pluginId: null);
   }
 
   Future<ProjectSessionContext?> _loadProjectSessionContext({required String sessionId}) async {

--- a/client/module_core/test/api/session_api_test.dart
+++ b/client/module_core/test/api/session_api_test.dart
@@ -20,6 +20,7 @@ void main() {
     test("createSessionWithMessage builds a request body with null variant when omitted", () async {
       const session = Session(
         id: "session-1",
+        pluginId: "plugin-1",
         projectID: "project-1",
         directory: "/tmp/project-1",
         parentID: null,
@@ -40,6 +41,7 @@ void main() {
 
       await api.createSessionWithMessage(
         projectId: "project-1",
+        pluginId: "plugin-1",
         text: "hello",
         agent: "build",
         model: const PromptModel(providerID: "openai", modelID: "gpt-5.4"),
@@ -57,6 +59,7 @@ void main() {
       )..called(1);
       final request = verification.captured.single as CreateSessionRequest;
       expect(request.variant, isNull);
+      expect(request.pluginId, "plugin-1");
     });
 
     test("sendMessage builds a request body with null variant when omitted", () async {
@@ -97,13 +100,13 @@ void main() {
         ),
       ).thenAnswer((_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])));
 
-      await api.listCommands(projectId: "project-1");
+      await api.listCommands(projectId: "project-1", pluginId: "plugin-1");
 
       verify(
         () => client.post<CommandListResponse>(
           "/command",
           fromJson: any(named: "fromJson"),
-          body: const ProjectIdRequest(projectId: "project-1"),
+          body: const ProjectIdRequest(projectId: "project-1", pluginId: "plugin-1"),
         ),
       ).called(1);
     });

--- a/client/module_core/test/api/session_api_test.dart
+++ b/client/module_core/test/api/session_api_test.dart
@@ -106,7 +106,7 @@ void main() {
         () => client.post<CommandListResponse>(
           "/command",
           fromJson: any(named: "fromJson"),
-          body: const ProjectIdRequest(projectId: "project-1", pluginId: "plugin-1"),
+          body: const PluginProjectIdRequest(projectId: "project-1", pluginId: "plugin-1"),
         ),
       ).called(1);
     });

--- a/client/module_core/test/capabilities/project/project_service_test.dart
+++ b/client/module_core/test/capabilities/project/project_service_test.dart
@@ -144,7 +144,7 @@ void main() {
         () => mockClient.post<void>(
           "/project/hide",
           fromJson: any(named: "fromJson"),
-          body: const ProjectIdRequest(projectId: "proj-1", pluginId: null),
+          body: const ProjectIdRequest(projectId: "proj-1"),
         ),
       ).called(1);
     });

--- a/client/module_core/test/capabilities/project/project_service_test.dart
+++ b/client/module_core/test/capabilities/project/project_service_test.dart
@@ -144,7 +144,7 @@ void main() {
         () => mockClient.post<void>(
           "/project/hide",
           fromJson: any(named: "fromJson"),
-          body: const ProjectIdRequest(projectId: "proj-1"),
+          body: const ProjectIdRequest(projectId: "proj-1", pluginId: null),
         ),
       ).called(1);
     });

--- a/client/module_core/test/capabilities/session/session_service_test.dart
+++ b/client/module_core/test/capabilities/session/session_service_test.dart
@@ -22,6 +22,7 @@ void main() {
     test("archiveSession sends cleanup options in request body", () async {
       const session = Session(
         id: "s1",
+        pluginId: null,
         projectID: "p1",
         directory: "/tmp/project",
         parentID: null,

--- a/client/module_core/test/capabilities/session/session_service_test.dart
+++ b/client/module_core/test/capabilities/session/session_service_test.dart
@@ -22,7 +22,7 @@ void main() {
     test("archiveSession sends cleanup options in request body", () async {
       const session = Session(
         id: "s1",
-        pluginId: null,
+        pluginId: legacyMissingPluginId,
         projectID: "p1",
         directory: "/tmp/project",
         parentID: null,

--- a/client/module_core/test/cubits/new_session/new_session_cubit_test.dart
+++ b/client/module_core/test/cubits/new_session/new_session_cubit_test.dart
@@ -21,14 +21,27 @@ void main() {
       selectionTracker = NewSessionSelectionTracker();
 
       when(
-        () => mockSessionService.listAgents(projectId: any(named: "projectId")),
+        () => mockSessionService.listAgents(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
       ).thenAnswer((_) async => ApiResponse<Agents>.success(const Agents(agents: <AgentInfo>[])));
-      when(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+      when(
+        () => mockSessionService.listProviders(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
+      ).thenAnswer(
         (_) async => ApiResponse<ProviderListResponse>.success(
           const ProviderListResponse(items: [], connectedOnly: false),
         ),
       );
-      when(() => mockSessionService.listCommands(projectId: any(named: "projectId"))).thenAnswer(
+      when(
+        () => mockSessionService.listCommands(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
+      ).thenAnswer(
         (_) async => ApiResponse<CommandListResponse>.success(const CommandListResponse(items: <CommandInfo>[])),
       );
     });
@@ -52,7 +65,12 @@ void main() {
     blocTest<NewSessionCubit, NewSessionState>(
       "loads available commands into idle state",
       build: () {
-        when(() => mockSessionService.listCommands(projectId: any(named: "projectId"))).thenAnswer(
+        when(
+          () => mockSessionService.listCommands(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
           (_) async => ApiResponse.success(
             const CommandListResponse(
               items: <CommandInfo>[
@@ -86,6 +104,7 @@ void main() {
         when(
           () => mockSessionService.createSessionWithMessage(
             projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
             text: any(named: "text"),
             agent: any(named: "agent"),
             providerID: any(named: "providerID"),
@@ -113,6 +132,7 @@ void main() {
         verify(
           () => mockSessionService.createSessionWithMessage(
             projectId: "project-1",
+            pluginId: null,
             text: "hello",
             agent: null,
             providerID: null,
@@ -131,6 +151,7 @@ void main() {
         when(
           () => mockSessionService.createSessionWithMessage(
             projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
             text: any(named: "text"),
             agent: any(named: "agent"),
             providerID: any(named: "providerID"),
@@ -162,6 +183,7 @@ void main() {
         verify(
           () => mockSessionService.createSessionWithMessage(
             projectId: "project-1",
+            pluginId: null,
             text: "",
             agent: null,
             providerID: null,
@@ -177,7 +199,12 @@ void main() {
     blocTest<NewSessionCubit, NewSessionState>(
       "selectVariant updates state and createSession forwards variant",
       build: () {
-        when(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+        when(
+          () => mockSessionService.listAgents(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
           (_) async => ApiResponse.success(
             const Agents(
               agents: [
@@ -194,6 +221,7 @@ void main() {
         when(
           () => mockSessionService.createSessionWithMessage(
             projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
             text: any(named: "text"),
             agent: any(named: "agent"),
             providerID: any(named: "providerID"),
@@ -236,6 +264,7 @@ void main() {
         verify(
           () => mockSessionService.createSessionWithMessage(
             projectId: "project-1",
+            pluginId: null,
             text: "hello",
             agent: "build",
             providerID: "openai",
@@ -251,7 +280,12 @@ void main() {
     blocTest<NewSessionCubit, NewSessionState>(
       "selectAgent changes agent without affecting selected model variant",
       build: () {
-        when(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+        when(
+          () => mockSessionService.listAgents(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
           (_) async => ApiResponse.success(
             const Agents(
               agents: [
@@ -298,7 +332,12 @@ void main() {
     blocTest<NewSessionCubit, NewSessionState>(
       "selectModel updates selectedAgentModel to the chosen model variant",
       build: () {
-        when(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+        when(
+          () => mockSessionService.listAgents(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
           (_) async => ApiResponse.success(
             const Agents(
               agents: [
@@ -341,7 +380,12 @@ void main() {
     blocTest<NewSessionCubit, NewSessionState>(
       "selectVariant updates selectedAgentModel variant",
       build: () {
-        when(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+        when(
+          () => mockSessionService.listAgents(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
           (_) async => ApiResponse.success(
             const Agents(
               agents: [
@@ -355,7 +399,12 @@ void main() {
             ),
           ),
         );
-        when(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+        when(
+          () => mockSessionService.listProviders(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
           (_) async => ApiResponse.success(
             const ProviderListResponse(
               connectedOnly: false,
@@ -402,7 +451,12 @@ void main() {
     blocTest<NewSessionCubit, NewSessionState>(
       "selectVariant to null clears selectedAgentModel variant",
       build: () {
-        when(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+        when(
+          () => mockSessionService.listAgents(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
           (_) async => ApiResponse.success(
             const Agents(
               agents: [
@@ -416,7 +470,12 @@ void main() {
             ),
           ),
         );
-        when(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+        when(
+          () => mockSessionService.listProviders(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
           (_) async => ApiResponse.success(
             const ProviderListResponse(
               connectedOnly: false,
@@ -465,7 +524,12 @@ void main() {
     blocTest<NewSessionCubit, NewSessionState>(
       "persists the chosen variant to the selection store",
       build: () {
-        when(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+        when(
+          () => mockSessionService.listAgents(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
           (_) async => ApiResponse.success(
             const Agents(
               agents: [
@@ -498,7 +562,12 @@ void main() {
     blocTest<NewSessionCubit, NewSessionState>(
       "persists the chosen model to the selection store",
       build: () {
-        when(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+        when(
+          () => mockSessionService.listAgents(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
           (_) async => ApiResponse.success(
             const Agents(
               agents: [
@@ -540,7 +609,12 @@ void main() {
           agent: null,
           agentModel: const AgentModel(providerID: "anthropic", modelID: "claude-3", variant: "deep"),
         );
-        when(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+        when(
+          () => mockSessionService.listProviders(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
           (_) async => ApiResponse.success(
             const ProviderListResponse(
               connectedOnly: false,
@@ -602,7 +676,12 @@ void main() {
           agent: null,
           agentModel: const AgentModel(providerID: "anthropic", modelID: "claude-3", variant: "legacy"),
         );
-        when(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+        when(
+          () => mockSessionService.listProviders(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
           (_) async => ApiResponse.success(
             const ProviderListResponse(
               connectedOnly: false,
@@ -657,7 +736,12 @@ void main() {
       "restores a persisted non-default agent on load",
       build: () {
         selectionTracker.write(projectId: "project-1", agent: "plan", agentModel: null);
-        when(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+        when(
+          () => mockSessionService.listAgents(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
           (_) async => ApiResponse.success(
             const Agents(
               agents: [
@@ -692,7 +776,12 @@ void main() {
       "falls back to the default agent when the persisted agent is gone",
       build: () {
         selectionTracker.write(projectId: "project-1", agent: "ghost", agentModel: null);
-        when(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+        when(
+          () => mockSessionService.listAgents(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
           (_) async => ApiResponse.success(
             const Agents(
               agents: [
@@ -725,7 +814,12 @@ void main() {
           agent: null,
           agentModel: const AgentModel(providerID: "ghost", modelID: "gone", variant: null),
         );
-        when(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+        when(
+          () => mockSessionService.listAgents(
+            projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
+          ),
+        ).thenAnswer(
           (_) async => ApiResponse.success(
             const Agents(
               agents: [
@@ -761,6 +855,7 @@ void main() {
         when(
           () => mockSessionService.createSessionWithMessage(
             projectId: any(named: "projectId"),
+            pluginId: any(named: "pluginId"),
             text: any(named: "text"),
             agent: any(named: "agent"),
             providerID: any(named: "providerID"),
@@ -790,6 +885,7 @@ void main() {
       when(
         () => mockSessionService.createSessionWithMessage(
           projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
           text: any(named: "text"),
           agent: any(named: "agent"),
           providerID: any(named: "providerID"),
@@ -817,6 +913,7 @@ void main() {
       when(
         () => mockSessionService.createSessionWithMessage(
           projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
           text: any(named: "text"),
           agent: any(named: "agent"),
           providerID: any(named: "providerID"),

--- a/client/module_core/test/cubits/new_session/new_session_cubit_test.dart
+++ b/client/module_core/test/cubits/new_session/new_session_cubit_test.dart
@@ -132,7 +132,7 @@ void main() {
         verify(
           () => mockSessionService.createSessionWithMessage(
             projectId: "project-1",
-            pluginId: null,
+            pluginId: legacyMissingPluginId,
             text: "hello",
             agent: null,
             providerID: null,
@@ -183,7 +183,7 @@ void main() {
         verify(
           () => mockSessionService.createSessionWithMessage(
             projectId: "project-1",
-            pluginId: null,
+            pluginId: legacyMissingPluginId,
             text: "",
             agent: null,
             providerID: null,
@@ -264,7 +264,7 @@ void main() {
         verify(
           () => mockSessionService.createSessionWithMessage(
             projectId: "project-1",
-            pluginId: null,
+            pluginId: legacyMissingPluginId,
             text: "hello",
             agent: "build",
             providerID: "openai",

--- a/client/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
@@ -97,7 +97,12 @@ void main() {
       when(() => mockProjectRepository.findSessionContext(sessionId: sessionId)).thenAnswer(
         (_) async => const ProjectSessionContext(projectId: "test-project", sessionTitle: null),
       );
-      when(() => mockSessionService.listCommands(projectId: any(named: "projectId"))).thenAnswer(
+      when(
+        () => mockSessionService.listCommands(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
+      ).thenAnswer(
         (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
       );
       stubSessionRepositoryGetSession(repository: mockSessionRepository, sessionId: sessionId);
@@ -278,8 +283,8 @@ void main() {
       verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getSessionStatuses()).called(1);
-      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).called(1);
-      verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).called(1);
+      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: null)).called(1);
+      verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: null)).called(1);
     });
 
     test("non-loaded state buffers permission events and replays after loaded", () async {
@@ -537,10 +542,20 @@ void _stubLoadApis(MockSessionService service, {required String sessionId}) {
       ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
     ),
   );
-  when(() => service.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+  when(
+    () => service.listAgents(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+    ),
+  ).thenAnswer(
     (_) => Future<ApiResponse<Agents>>.value(ApiResponse.success(Agents(agents: _agents()))),
   );
-  when(() => service.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+  when(
+    () => service.listProviders(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+    ),
+  ).thenAnswer(
     (_) => Future<ApiResponse<ProviderListResponse>>.value(ApiResponse.success(_providers())),
   );
 }

--- a/client/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
@@ -283,8 +283,8 @@ void main() {
       verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getSessionStatuses()).called(1);
-      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: null)).called(1);
-      verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: null)).called(1);
+      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: "plugin-1")).called(1);
+      verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: "plugin-1")).called(1);
     });
 
     test("non-loaded state buffers permission events and replays after loaded", () async {

--- a/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
@@ -173,6 +173,7 @@ void main() {
       // Emit a global child-session event while still loading
       const childSession = Session(
         id: "child-1",
+        pluginId: null,
         projectID: "project-1",
         directory: "/home/user/my-project",
         parentID: _sessionId,

--- a/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_event_buffer_test.dart
@@ -173,7 +173,7 @@ void main() {
       // Emit a global child-session event while still loading
       const childSession = Session(
         id: "child-1",
-        pluginId: null,
+        pluginId: "plugin-1",
         projectID: "project-1",
         directory: "/home/user/my-project",
         parentID: _sessionId,

--- a/client/module_core/test/cubits/session_detail/session_detail_reconnect_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_reconnect_test.dart
@@ -304,7 +304,12 @@ void _stubLoadApis(MockSessionService service) {
   when(() => service.getSessionStatuses()).thenAnswer(
     (_) async => ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
   );
-  when(() => service.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+  when(
+    () => service.listAgents(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+    ),
+  ).thenAnswer(
     (_) async => ApiResponse.success(
       const Agents(
         agents: [
@@ -313,12 +318,17 @@ void _stubLoadApis(MockSessionService service) {
       ),
     ),
   );
-  when(() => service.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+  when(
+    () => service.listProviders(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+    ),
+  ).thenAnswer(
     (_) async => ApiResponse.success(
       const ProviderListResponse(connectedOnly: false, items: <ProviderInfo>[]),
     ),
   );
-  when(() => service.listCommands(projectId: "project-1")).thenAnswer(
+  when(() => service.listCommands(projectId: "project-1", pluginId: null)).thenAnswer(
     (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
   );
 }

--- a/client/module_core/test/cubits/session_detail/session_detail_reconnect_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_reconnect_test.dart
@@ -328,7 +328,7 @@ void _stubLoadApis(MockSessionService service) {
       const ProviderListResponse(connectedOnly: false, items: <ProviderInfo>[]),
     ),
   );
-  when(() => service.listCommands(projectId: "project-1", pluginId: null)).thenAnswer(
+  when(() => service.listCommands(projectId: "project-1", pluginId: "plugin-1")).thenAnswer(
     (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
   );
 }

--- a/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
@@ -88,7 +88,12 @@ void main() {
       when(() => mockProjectRepository.findSessionContext(sessionId: sessionId)).thenAnswer(
         (_) async => const ProjectSessionContext(projectId: "test-project", sessionTitle: null),
       );
-      when(() => mockSessionService.listCommands(projectId: any(named: "projectId"))).thenAnswer(
+      when(
+        () => mockSessionService.listCommands(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
+      ).thenAnswer(
         (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
       );
       stubSessionRepositoryGetSession(repository: mockSessionRepository, sessionId: sessionId);
@@ -141,8 +146,8 @@ void main() {
         verifyNever(() => mockSessionService.getPendingQuestions(sessionId: sessionId));
         verifyNever(() => mockSessionService.getChildren(sessionId: sessionId));
         verifyNever(() => mockSessionService.getSessionStatuses());
-        verifyNever(() => mockSessionService.listAgents(projectId: any(named: "projectId")));
-        verifyNever(() => mockSessionService.listProviders(projectId: any(named: "projectId")));
+        verifyNever(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: null));
+        verifyNever(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: null));
 
         connectionStatus.add(connectedStatus);
         await Future<void>.delayed(const Duration(milliseconds: 20));
@@ -192,8 +197,8 @@ void main() {
       verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getSessionStatuses()).called(1);
-      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).called(1);
-      verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).called(1);
+      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: null)).called(1);
+      verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: null)).called(1);
 
       expect(emitted.first, isA<SessionDetailLoaded>().having((s) => s.isRefreshing, "isRefreshing", isTrue));
       expect(
@@ -224,7 +229,12 @@ void main() {
       cubit.selectModel(providerID: "openai", modelID: "gpt-4.1");
       cubit.selectVariant(const SessionVariant(id: "xhigh"));
 
-      when(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+      when(
+        () => mockSessionService.listAgents(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
+      ).thenAnswer(
         (_) async => ApiResponse.success(
           const Agents(
             agents: [
@@ -233,7 +243,12 @@ void main() {
           ),
         ),
       );
-      when(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+      when(
+        () => mockSessionService.listProviders(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
+      ).thenAnswer(
         (_) async => ApiResponse.success(
           const ProviderListResponse(
             connectedOnly: false,
@@ -345,10 +360,16 @@ void main() {
         (_) async => ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
       );
       when(
-        () => mockSessionService.listAgents(projectId: any(named: "projectId")),
+        () => mockSessionService.listAgents(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
       ).thenAnswer((_) async => ApiResponse.success(Agents(agents: _agents())));
       when(
-        () => mockSessionService.listProviders(projectId: any(named: "projectId")),
+        () => mockSessionService.listProviders(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
       ).thenAnswer((_) async => ApiResponse.success(_providers()));
 
       final emitted = <SessionDetailState>[];
@@ -403,7 +424,10 @@ void main() {
         ),
       );
       when(
-        () => mockSessionService.listProviders(projectId: any(named: "projectId")),
+        () => mockSessionService.listProviders(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
       ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
 
       mockConnectionService.emitDataMayBeStale();
@@ -440,8 +464,8 @@ void main() {
       verify(() => mockSessionService.getPendingPermissions(sessionId: any(named: "sessionId"))).called(1);
       verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getSessionStatuses()).called(1);
-      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).called(1);
-      verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).called(1);
+      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: null)).called(1);
+      verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: null)).called(1);
 
       messagesCompleter.complete(ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()])));
       await _awaitLoaded(cubit);
@@ -551,12 +575,23 @@ void main() {
         (_) async => ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
       );
       when(
-        () => mockSessionService.listAgents(projectId: any(named: "projectId")),
+        () => mockSessionService.listAgents(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
       ).thenAnswer((_) async => ApiResponse.success(Agents(agents: _agents())));
       when(
-        () => mockSessionService.listProviders(projectId: any(named: "projectId")),
+        () => mockSessionService.listProviders(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
       ).thenAnswer((_) async => ApiResponse.success(_providers()));
-      when(() => mockSessionService.listCommands(projectId: any(named: "projectId"))).thenAnswer(
+      when(
+        () => mockSessionService.listCommands(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
+      ).thenAnswer(
         (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
       );
 
@@ -574,8 +609,8 @@ void main() {
       verify(() => mockSessionService.getPendingPermissions(sessionId: any(named: "sessionId"))).called(1);
       verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getSessionStatuses()).called(1);
-      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"))).called(1);
-      verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"))).called(1);
+      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: null)).called(1);
+      verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: null)).called(1);
     });
   });
 }
@@ -616,10 +651,20 @@ void _stubLoadApis(MockSessionService service, {required String sessionId}) {
       ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
     ),
   );
-  when(() => service.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+  when(
+    () => service.listAgents(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+    ),
+  ).thenAnswer(
     (_) => Future<ApiResponse<Agents>>.value(ApiResponse.success(Agents(agents: _agents()))),
   );
-  when(() => service.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+  when(
+    () => service.listProviders(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+    ),
+  ).thenAnswer(
     (_) => Future<ApiResponse<ProviderListResponse>>.value(ApiResponse.success(_providers())),
   );
 }

--- a/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
@@ -146,8 +146,8 @@ void main() {
         verifyNever(() => mockSessionService.getPendingQuestions(sessionId: sessionId));
         verifyNever(() => mockSessionService.getChildren(sessionId: sessionId));
         verifyNever(() => mockSessionService.getSessionStatuses());
-        verifyNever(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: null));
-        verifyNever(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: null));
+        verifyNever(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: "plugin-1"));
+        verifyNever(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: "plugin-1"));
 
         connectionStatus.add(connectedStatus);
         await Future<void>.delayed(const Duration(milliseconds: 20));
@@ -197,8 +197,8 @@ void main() {
       verify(() => mockSessionService.getPendingQuestions(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getSessionStatuses()).called(1);
-      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: null)).called(1);
-      verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: null)).called(1);
+      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: "plugin-1")).called(1);
+      verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: "plugin-1")).called(1);
 
       expect(emitted.first, isA<SessionDetailLoaded>().having((s) => s.isRefreshing, "isRefreshing", isTrue));
       expect(
@@ -464,8 +464,8 @@ void main() {
       verify(() => mockSessionService.getPendingPermissions(sessionId: any(named: "sessionId"))).called(1);
       verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getSessionStatuses()).called(1);
-      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: null)).called(1);
-      verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: null)).called(1);
+      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: "plugin-1")).called(1);
+      verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: "plugin-1")).called(1);
 
       messagesCompleter.complete(ApiResponse.success(MessageWithPartsResponse(messages: [_messageWithParts()])));
       await _awaitLoaded(cubit);
@@ -609,8 +609,8 @@ void main() {
       verify(() => mockSessionService.getPendingPermissions(sessionId: any(named: "sessionId"))).called(1);
       verify(() => mockSessionService.getChildren(sessionId: sessionId)).called(1);
       verify(() => mockSessionService.getSessionStatuses()).called(1);
-      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: null)).called(1);
-      verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: null)).called(1);
+      verify(() => mockSessionService.listAgents(projectId: any(named: "projectId"), pluginId: "plugin-1")).called(1);
+      verify(() => mockSessionService.listProviders(projectId: any(named: "projectId"), pluginId: "plugin-1")).called(1);
     });
   });
 }

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -1021,7 +1021,7 @@ void main() {
       build: () {
         const existing = Session(
           id: "s1",
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           projectID: projectId,
           directory: "/home/user/my-project",
           parentID: null,
@@ -1048,7 +1048,7 @@ void main() {
             data: const SesoriSseEvent.sessionCreated(
               info: Session(
                 id: "s2",
-                pluginId: null,
+                pluginId: legacyMissingPluginId,
                 projectID: projectId,
                 directory: "/home/user/my-project",
                 parentID: null,
@@ -1174,7 +1174,7 @@ void main() {
             data: const SesoriSseEvent.sessionCreated(
               info: Session(
                 id: "child-1",
-                pluginId: null,
+                pluginId: legacyMissingPluginId,
                 projectID: projectId,
                 parentID: "s1",
                 directory: "/home/user/my-project",
@@ -1413,7 +1413,7 @@ void main() {
             data: const SesoriSseEvent.sessionCreated(
               info: Session(
                 id: "foreign-session",
-                pluginId: null,
+                pluginId: legacyMissingPluginId,
                 projectID: "project-other",
                 directory: "/other/project",
                 parentID: null,
@@ -1453,7 +1453,7 @@ void main() {
             data: const SesoriSseEvent.sessionUpdated(
               info: Session(
                 id: "foreign-session",
-                pluginId: null,
+                pluginId: legacyMissingPluginId,
                 projectID: "project-other",
                 directory: "/other/project",
                 parentID: null,
@@ -1491,7 +1491,7 @@ void main() {
             data: const SesoriSseEvent.sessionDeleted(
               info: Session(
                 id: "foreign-session",
-                pluginId: null,
+                pluginId: legacyMissingPluginId,
                 projectID: "project-other",
                 directory: "/other/project",
                 parentID: null,
@@ -1520,7 +1520,7 @@ void main() {
         const sessions = [
           Session(
             id: "s1",
-            pluginId: null,
+            pluginId: legacyMissingPluginId,
             projectID: "global",
             directory: "/tmp/foo",
             parentID: null,
@@ -1532,7 +1532,7 @@ void main() {
           ),
           Session(
             id: "s2",
-            pluginId: null,
+            pluginId: legacyMissingPluginId,
             projectID: "global",
             directory: "/home/bar",
             parentID: null,

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -1021,6 +1021,7 @@ void main() {
       build: () {
         const existing = Session(
           id: "s1",
+          pluginId: null,
           projectID: projectId,
           directory: "/home/user/my-project",
           parentID: null,
@@ -1047,6 +1048,7 @@ void main() {
             data: const SesoriSseEvent.sessionCreated(
               info: Session(
                 id: "s2",
+                pluginId: null,
                 projectID: projectId,
                 directory: "/home/user/my-project",
                 parentID: null,
@@ -1172,6 +1174,7 @@ void main() {
             data: const SesoriSseEvent.sessionCreated(
               info: Session(
                 id: "child-1",
+                pluginId: null,
                 projectID: projectId,
                 parentID: "s1",
                 directory: "/home/user/my-project",
@@ -1410,6 +1413,7 @@ void main() {
             data: const SesoriSseEvent.sessionCreated(
               info: Session(
                 id: "foreign-session",
+                pluginId: null,
                 projectID: "project-other",
                 directory: "/other/project",
                 parentID: null,
@@ -1449,6 +1453,7 @@ void main() {
             data: const SesoriSseEvent.sessionUpdated(
               info: Session(
                 id: "foreign-session",
+                pluginId: null,
                 projectID: "project-other",
                 directory: "/other/project",
                 parentID: null,
@@ -1486,6 +1491,7 @@ void main() {
             data: const SesoriSseEvent.sessionDeleted(
               info: Session(
                 id: "foreign-session",
+                pluginId: null,
                 projectID: "project-other",
                 directory: "/other/project",
                 parentID: null,
@@ -1514,6 +1520,7 @@ void main() {
         const sessions = [
           Session(
             id: "s1",
+            pluginId: null,
             projectID: "global",
             directory: "/tmp/foo",
             parentID: null,
@@ -1525,6 +1532,7 @@ void main() {
           ),
           Session(
             id: "s2",
+            pluginId: null,
             projectID: "global",
             directory: "/home/bar",
             parentID: null,

--- a/client/module_core/test/helpers/test_helpers.dart
+++ b/client/module_core/test/helpers/test_helpers.dart
@@ -234,14 +234,38 @@ void delegateSessionRepositoryToService({
     (invocation) => service.getChildren(sessionId: invocation.namedArguments[#sessionId]! as String),
   );
   when(() => repository.getSessionStatuses()).thenAnswer((_) => service.getSessionStatuses());
-  when(() => repository.listAgents(projectId: any(named: "projectId"))).thenAnswer(
-    (invocation) => service.listAgents(projectId: invocation.namedArguments[#projectId] as String),
+  when(
+    () => repository.listAgents(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+    ),
+  ).thenAnswer(
+    (invocation) => service.listAgents(
+      projectId: invocation.namedArguments[#projectId] as String,
+      pluginId: invocation.namedArguments[#pluginId] as String?,
+    ),
   );
-  when(() => repository.listProviders(projectId: any(named: "projectId"))).thenAnswer(
-    (invocation) => service.listProviders(projectId: invocation.namedArguments[#projectId] as String),
+  when(
+    () => repository.listProviders(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+    ),
+  ).thenAnswer(
+    (invocation) => service.listProviders(
+      projectId: invocation.namedArguments[#projectId] as String,
+      pluginId: invocation.namedArguments[#pluginId] as String?,
+    ),
   );
-  when(() => repository.listCommands(projectId: any(named: "projectId"))).thenAnswer(
-    (invocation) => service.listCommands(projectId: invocation.namedArguments[#projectId] as String?),
+  when(
+    () => repository.listCommands(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+    ),
+  ).thenAnswer(
+    (invocation) => service.listCommands(
+      projectId: invocation.namedArguments[#projectId] as String?,
+      pluginId: invocation.namedArguments[#pluginId] as String?,
+    ),
   );
   when(
     () => repository.sendMessage(
@@ -296,6 +320,7 @@ Project testProject({String? id, String? path, String? name}) {
 Session testSession({String? id, String? title, DateTime? archivedAt, bool unseen = false}) {
   return Session(
     id: id ?? "session-1",
+    pluginId: null,
     projectID: "project-1",
     directory: "/home/user/my-project",
     parentID: null,

--- a/client/module_core/test/helpers/test_helpers.dart
+++ b/client/module_core/test/helpers/test_helpers.dart
@@ -242,7 +242,7 @@ void delegateSessionRepositoryToService({
   ).thenAnswer(
     (invocation) => service.listAgents(
       projectId: invocation.namedArguments[#projectId] as String,
-      pluginId: invocation.namedArguments[#pluginId] as String?,
+      pluginId: invocation.namedArguments[#pluginId] as String,
     ),
   );
   when(
@@ -253,7 +253,7 @@ void delegateSessionRepositoryToService({
   ).thenAnswer(
     (invocation) => service.listProviders(
       projectId: invocation.namedArguments[#projectId] as String,
-      pluginId: invocation.namedArguments[#pluginId] as String?,
+      pluginId: invocation.namedArguments[#pluginId] as String,
     ),
   );
   when(
@@ -264,7 +264,7 @@ void delegateSessionRepositoryToService({
   ).thenAnswer(
     (invocation) => service.listCommands(
       projectId: invocation.namedArguments[#projectId] as String?,
-      pluginId: invocation.namedArguments[#pluginId] as String?,
+      pluginId: invocation.namedArguments[#pluginId] as String,
     ),
   );
   when(
@@ -317,10 +317,16 @@ Project testProject({String? id, String? path, String? name}) {
   });
 }
 
-Session testSession({String? id, String? title, DateTime? archivedAt, bool unseen = false}) {
+Session testSession({
+  String? id,
+  String? title,
+  DateTime? archivedAt,
+  bool unseen = false,
+  String pluginId = "plugin-1",
+}) {
   return Session(
     id: id ?? "session-1",
-    pluginId: null,
+    pluginId: pluginId,
     projectID: "project-1",
     directory: "/home/user/my-project",
     parentID: null,

--- a/client/module_core/test/repositories/session_repository_test.dart
+++ b/client/module_core/test/repositories/session_repository_test.dart
@@ -29,12 +29,20 @@ void main() {
       (_) async => ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
     );
     when(
-      () => api.listAgents(projectId: any(named: "projectId")),
+      () => api.listAgents(
+        projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
+      ),
     ).thenAnswer((_) async => ApiResponse.success(const Agents(agents: <AgentInfo>[])));
-    when(() => api.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+    when(
+      () => api.listProviders(
+        projectId: any(named: "projectId"),
+        pluginId: any(named: "pluginId"),
+      ),
+    ).thenAnswer(
       (_) async => ApiResponse.success(const ProviderListResponse(connectedOnly: false, items: <ProviderInfo>[])),
     );
-    when(() => api.listCommands(projectId: "project-1")).thenAnswer(
+    when(() => api.listCommands(projectId: "project-1", pluginId: "plugin-1")).thenAnswer(
       (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
     );
     when(
@@ -67,9 +75,9 @@ void main() {
     await repository.getPendingPermissions(sessionId: "session-1");
     await repository.getChildren(sessionId: "session-1");
     await repository.getSessionStatuses();
-    await repository.listAgents(projectId: "project-1");
-    await repository.listProviders(projectId: "project-1");
-    await repository.listCommands(projectId: "project-1");
+    await repository.listAgents(projectId: "project-1", pluginId: "plugin-1");
+    await repository.listProviders(projectId: "project-1", pluginId: "plugin-1");
+    await repository.listCommands(projectId: "project-1", pluginId: "plugin-1");
     await repository.sendMessage(
       sessionId: "session-1",
       text: "hello",
@@ -92,9 +100,9 @@ void main() {
     verify(() => api.getPendingPermissions(sessionId: "session-1")).called(1);
     verify(() => api.getChildren(sessionId: "session-1")).called(1);
     verify(api.getSessionStatuses).called(1);
-    verify(() => api.listAgents(projectId: "project-1")).called(1);
-    verify(() => api.listProviders(projectId: "project-1")).called(1);
-    verify(() => api.listCommands(projectId: "project-1")).called(1);
+    verify(() => api.listAgents(projectId: "project-1", pluginId: "plugin-1")).called(1);
+    verify(() => api.listProviders(projectId: "project-1", pluginId: "plugin-1")).called(1);
+    verify(() => api.listCommands(projectId: "project-1", pluginId: "plugin-1")).called(1);
     verify(
       () => api.sendMessage(
         sessionId: "session-1",
@@ -147,24 +155,24 @@ void main() {
     // First fetch returns an empty catalog (e.g. the ACP backend has not warmed
     // its model list yet); later fetches return the populated catalog.
     var calls = 0;
-    when(() => api.listProviders(projectId: "p1")).thenAnswer((_) async {
+    when(() => api.listProviders(projectId: "p1", pluginId: null)).thenAnswer((_) async {
       calls++;
       return ApiResponse.success(calls == 1 ? emptyProviders : populatedProviders);
     });
 
-    final first = await repository.listProviders(projectId: "p1");
+    final first = await repository.listProviders(projectId: "p1", pluginId: null);
     expect((first as SuccessResponse<ProviderListResponse>).data.items, isEmpty);
 
     // The empty result must NOT be cached: the second fetch hits the API again
     // and returns the now-populated catalog (the regression being guarded).
-    final second = await repository.listProviders(projectId: "p1");
+    final second = await repository.listProviders(projectId: "p1", pluginId: null);
     expect((second as SuccessResponse<ProviderListResponse>).data.items, isNotEmpty);
-    verify(() => api.listProviders(projectId: "p1")).called(2);
+    verify(() => api.listProviders(projectId: "p1", pluginId: null)).called(2);
 
     // The populated result IS cached: the third fetch is served without the API.
-    final third = await repository.listProviders(projectId: "p1");
+    final third = await repository.listProviders(projectId: "p1", pluginId: null);
     expect((third as SuccessResponse<ProviderListResponse>).data.items, isNotEmpty);
-    verifyNever(() => api.listProviders(projectId: "p1"));
+    verifyNever(() => api.listProviders(projectId: "p1", pluginId: null));
   });
 
   test("listProviders does not cache a partially populated multi-provider response", () async {
@@ -172,55 +180,61 @@ void main() {
     final repository = SessionRepository(api: api);
 
     ProviderInfo provider({required String id, required bool withModels}) => ProviderInfo(
-          id: id,
-          name: id,
-          defaultModelID: withModels ? "$id-default" : null,
-          models: withModels
-              ? {
-                  "$id-default": ProviderModel(
-                    id: "$id-default",
-                    providerID: id,
-                    name: "$id default",
-                    variants: <String>[],
-                    family: null,
-                    releaseDate: null,
-                  ),
-                }
-              : const <String, ProviderModel>{},
-        );
+      id: id,
+      name: id,
+      defaultModelID: withModels ? "$id-default" : null,
+      models: withModels
+          ? {
+              "$id-default": ProviderModel(
+                id: "$id-default",
+                providerID: id,
+                name: "$id default",
+                variants: <String>[],
+                family: null,
+                releaseDate: null,
+              ),
+            }
+          : const <String, ProviderModel>{},
+    );
 
     // A fast provider is already populated while a slow one (e.g. Cursor/ACP) is
     // still warming up with an empty models map; once warmed, both are populated.
     const connectedOnly = true;
     final partialProviders = ProviderListResponse(
       connectedOnly: connectedOnly,
-      items: [provider(id: "openai", withModels: true), provider(id: "cursor", withModels: false)],
+      items: [
+        provider(id: "openai", withModels: true),
+        provider(id: "cursor", withModels: false),
+      ],
     );
     final fullProviders = ProviderListResponse(
       connectedOnly: connectedOnly,
-      items: [provider(id: "openai", withModels: true), provider(id: "cursor", withModels: true)],
+      items: [
+        provider(id: "openai", withModels: true),
+        provider(id: "cursor", withModels: true),
+      ],
     );
 
     var calls = 0;
-    when(() => api.listProviders(projectId: "p1")).thenAnswer((_) async {
+    when(() => api.listProviders(projectId: "p1", pluginId: null)).thenAnswer((_) async {
       calls++;
       return ApiResponse.success(calls == 1 ? partialProviders : fullProviders);
     });
 
     // The partial response must NOT be cached, even though one provider has
     // models — otherwise the warming provider's picker would stay blank forever.
-    final first = await repository.listProviders(projectId: "p1");
+    final first = await repository.listProviders(projectId: "p1", pluginId: null);
     final firstItems = (first as SuccessResponse<ProviderListResponse>).data.items;
     expect(firstItems.firstWhere((p) => p.id == "cursor").models, isEmpty);
 
     // Next fetch hits the API again and returns the now-fully-populated catalog.
-    final second = await repository.listProviders(projectId: "p1");
+    final second = await repository.listProviders(projectId: "p1", pluginId: null);
     final secondItems = (second as SuccessResponse<ProviderListResponse>).data.items;
     expect(secondItems.firstWhere((p) => p.id == "cursor").models, isNotEmpty);
-    verify(() => api.listProviders(projectId: "p1")).called(2);
+    verify(() => api.listProviders(projectId: "p1", pluginId: null)).called(2);
 
     // The fully-populated result IS cached: the third fetch is served from cache.
-    await repository.listProviders(projectId: "p1");
-    verifyNever(() => api.listProviders(projectId: "p1"));
+    await repository.listProviders(projectId: "p1", pluginId: null);
+    verifyNever(() => api.listProviders(projectId: "p1", pluginId: null));
   });
 }

--- a/client/module_core/test/repositories/session_repository_test.dart
+++ b/client/module_core/test/repositories/session_repository_test.dart
@@ -155,24 +155,24 @@ void main() {
     // First fetch returns an empty catalog (e.g. the ACP backend has not warmed
     // its model list yet); later fetches return the populated catalog.
     var calls = 0;
-    when(() => api.listProviders(projectId: "p1", pluginId: null)).thenAnswer((_) async {
+    when(() => api.listProviders(projectId: "p1", pluginId: "plugin-1")).thenAnswer((_) async {
       calls++;
       return ApiResponse.success(calls == 1 ? emptyProviders : populatedProviders);
     });
 
-    final first = await repository.listProviders(projectId: "p1", pluginId: null);
+    final first = await repository.listProviders(projectId: "p1", pluginId: "plugin-1");
     expect((first as SuccessResponse<ProviderListResponse>).data.items, isEmpty);
 
     // The empty result must NOT be cached: the second fetch hits the API again
     // and returns the now-populated catalog (the regression being guarded).
-    final second = await repository.listProviders(projectId: "p1", pluginId: null);
+    final second = await repository.listProviders(projectId: "p1", pluginId: "plugin-1");
     expect((second as SuccessResponse<ProviderListResponse>).data.items, isNotEmpty);
-    verify(() => api.listProviders(projectId: "p1", pluginId: null)).called(2);
+    verify(() => api.listProviders(projectId: "p1", pluginId: "plugin-1")).called(2);
 
     // The populated result IS cached: the third fetch is served without the API.
-    final third = await repository.listProviders(projectId: "p1", pluginId: null);
+    final third = await repository.listProviders(projectId: "p1", pluginId: "plugin-1");
     expect((third as SuccessResponse<ProviderListResponse>).data.items, isNotEmpty);
-    verifyNever(() => api.listProviders(projectId: "p1", pluginId: null));
+    verifyNever(() => api.listProviders(projectId: "p1", pluginId: "plugin-1"));
   });
 
   test("listProviders does not cache a partially populated multi-provider response", () async {
@@ -216,25 +216,25 @@ void main() {
     );
 
     var calls = 0;
-    when(() => api.listProviders(projectId: "p1", pluginId: null)).thenAnswer((_) async {
+    when(() => api.listProviders(projectId: "p1", pluginId: "plugin-1")).thenAnswer((_) async {
       calls++;
       return ApiResponse.success(calls == 1 ? partialProviders : fullProviders);
     });
 
     // The partial response must NOT be cached, even though one provider has
     // models — otherwise the warming provider's picker would stay blank forever.
-    final first = await repository.listProviders(projectId: "p1", pluginId: null);
+    final first = await repository.listProviders(projectId: "p1", pluginId: "plugin-1");
     final firstItems = (first as SuccessResponse<ProviderListResponse>).data.items;
     expect(firstItems.firstWhere((p) => p.id == "cursor").models, isEmpty);
 
     // Next fetch hits the API again and returns the now-fully-populated catalog.
-    final second = await repository.listProviders(projectId: "p1", pluginId: null);
+    final second = await repository.listProviders(projectId: "p1", pluginId: "plugin-1");
     final secondItems = (second as SuccessResponse<ProviderListResponse>).data.items;
     expect(secondItems.firstWhere((p) => p.id == "cursor").models, isNotEmpty);
-    verify(() => api.listProviders(projectId: "p1", pluginId: null)).called(2);
+    verify(() => api.listProviders(projectId: "p1", pluginId: "plugin-1")).called(2);
 
     // The fully-populated result IS cached: the third fetch is served from cache.
-    await repository.listProviders(projectId: "p1", pluginId: null);
-    verifyNever(() => api.listProviders(projectId: "p1", pluginId: null));
+    await repository.listProviders(projectId: "p1", pluginId: "plugin-1");
+    verifyNever(() => api.listProviders(projectId: "p1", pluginId: "plugin-1"));
   });
 }

--- a/client/module_core/test/services/session_detail_load_service_test.dart
+++ b/client/module_core/test/services/session_detail_load_service_test.dart
@@ -56,6 +56,9 @@ void main() {
       expect(loaded.snapshot.messages, hasLength(1));
       expect(loaded.snapshot.commands, hasLength(1));
       expect(loaded.snapshot.canonicalSessionTitle, "Canonical title");
+      verify(() => repository.listAgents(projectId: "project-1", pluginId: "plugin-1")).called(1);
+      verify(() => repository.listProviders(projectId: "project-1", pluginId: "plugin-1")).called(1);
+      verify(() => repository.listCommands(projectId: "project-1", pluginId: "plugin-1")).called(1);
     });
 
     test("load uses route projectId to fetch commands when context lookup fails", () async {
@@ -68,7 +71,25 @@ void main() {
       expect(result, isA<SessionDetailLoadResultLoaded>());
       final loaded = result as SessionDetailLoadResultLoaded;
       expect(loaded.snapshot.commands, hasLength(1));
-      verify(() => repository.listCommands(projectId: "project-1", pluginId: null)).called(1);
+      verify(() => repository.listCommands(projectId: "project-1", pluginId: "plugin-1")).called(1);
+    });
+
+    test("load uses the legacy sentinel when session identity is unavailable", () async {
+      connectionStatus.add(connectedStatus);
+      _stubRepositorySnapshot(repository: repository, projectRepository: projectRepository);
+      when(
+        () => repository.getSession(sessionId: "session-1"),
+      ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
+      when(
+        () => repository.listCommands(projectId: "project-1", pluginId: legacyMissingPluginId),
+      ).thenAnswer((_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])));
+
+      final result = await service.load(sessionId: "session-1", projectId: "project-1");
+
+      expect(result, isA<SessionDetailLoadResultLoaded>());
+      verify(() => repository.listAgents(projectId: "project-1", pluginId: legacyMissingPluginId)).called(1);
+      verify(() => repository.listProviders(projectId: "project-1", pluginId: legacyMissingPluginId)).called(1);
+      verify(() => repository.listCommands(projectId: "project-1", pluginId: legacyMissingPluginId)).called(1);
     });
 
     test("initial load waits for connection readiness and then loads", () async {
@@ -116,7 +137,7 @@ void main() {
       when(() => projectRepository.findSessionContext(sessionId: "session-1")).thenAnswer(
         (_) async => const ProjectSessionContext(projectId: "project-1", sessionTitle: "Canonical title"),
       );
-      when(() => repository.listCommands(projectId: "project-1", pluginId: null)).thenAnswer(
+      when(() => repository.listCommands(projectId: "project-1", pluginId: legacyMissingPluginId)).thenAnswer(
         (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
       );
 
@@ -151,8 +172,8 @@ void main() {
       // Providers must be requested with the project resolved from the session
       // context — never the raw blank route id, which backends would normalize
       // to the bridge process CWD (the wrong project).
-      verify(() => repository.listProviders(projectId: "project-1", pluginId: null)).called(1);
-      verifyNever(() => repository.listProviders(projectId: "", pluginId: null));
+      verify(() => repository.listProviders(projectId: "project-1", pluginId: "plugin-1")).called(1);
+      verifyNever(() => repository.listProviders(projectId: "", pluginId: "plugin-1"));
     });
 
     test("no route project and no session context loads empty providers without a request", () async {
@@ -251,7 +272,7 @@ void _stubRepositorySnapshot({
       ),
     ),
   );
-  when(() => repository.listCommands(projectId: "project-1", pluginId: null)).thenAnswer(
+  when(() => repository.listCommands(projectId: "project-1", pluginId: "plugin-1")).thenAnswer(
     (_) async => ApiResponse.success(
       const CommandListResponse(
         items: <CommandInfo>[

--- a/client/module_core/test/services/session_detail_load_service_test.dart
+++ b/client/module_core/test/services/session_detail_load_service_test.dart
@@ -68,7 +68,7 @@ void main() {
       expect(result, isA<SessionDetailLoadResultLoaded>());
       final loaded = result as SessionDetailLoadResultLoaded;
       expect(loaded.snapshot.commands, hasLength(1));
-      verify(() => repository.listCommands(projectId: "project-1")).called(1);
+      verify(() => repository.listCommands(projectId: "project-1", pluginId: null)).called(1);
     });
 
     test("initial load waits for connection readiness and then loads", () async {
@@ -100,15 +100,23 @@ void main() {
         (_) async => ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
       );
       when(
-        () => repository.listAgents(projectId: any(named: "projectId")),
+        () => repository.listAgents(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
       ).thenAnswer((_) async => ApiResponse.success(const Agents(agents: <AgentInfo>[])));
-      when(() => repository.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+      when(
+        () => repository.listProviders(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
+      ).thenAnswer(
         (_) async => ApiResponse.success(const ProviderListResponse(connectedOnly: false, items: <ProviderInfo>[])),
       );
       when(() => projectRepository.findSessionContext(sessionId: "session-1")).thenAnswer(
         (_) async => const ProjectSessionContext(projectId: "project-1", sessionTitle: "Canonical title"),
       );
-      when(() => repository.listCommands(projectId: "project-1")).thenAnswer(
+      when(() => repository.listCommands(projectId: "project-1", pluginId: null)).thenAnswer(
         (_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])),
       );
 
@@ -143,8 +151,8 @@ void main() {
       // Providers must be requested with the project resolved from the session
       // context — never the raw blank route id, which backends would normalize
       // to the bridge process CWD (the wrong project).
-      verify(() => repository.listProviders(projectId: "project-1")).called(1);
-      verifyNever(() => repository.listProviders(projectId: ""));
+      verify(() => repository.listProviders(projectId: "project-1", pluginId: null)).called(1);
+      verifyNever(() => repository.listProviders(projectId: "", pluginId: null));
     });
 
     test("no route project and no session context loads empty providers without a request", () async {
@@ -157,7 +165,12 @@ void main() {
       expect(result, isA<SessionDetailLoadResultLoaded>());
       final loaded = result as SessionDetailLoadResultLoaded;
       expect(loaded.snapshot.providerData?.items, isEmpty);
-      verifyNever(() => repository.listProviders(projectId: any(named: "projectId")));
+      verifyNever(
+        () => repository.listProviders(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
+      );
     });
 
     test("project session context lookup failure is non-fatal when required reads succeed", () async {
@@ -195,7 +208,12 @@ void _stubRepositorySnapshot({
   when(() => repository.getSessionStatuses()).thenAnswer(
     (_) async => ApiResponse.success(const SessionStatusResponse(statuses: <String, SessionStatus>{})),
   );
-  when(() => repository.listAgents(projectId: any(named: "projectId"))).thenAnswer(
+  when(
+    () => repository.listAgents(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+    ),
+  ).thenAnswer(
     (_) async => ApiResponse.success(
       const Agents(
         agents: [
@@ -204,7 +222,12 @@ void _stubRepositorySnapshot({
       ),
     ),
   );
-  when(() => repository.listProviders(projectId: any(named: "projectId"))).thenAnswer(
+  when(
+    () => repository.listProviders(
+      projectId: any(named: "projectId"),
+      pluginId: any(named: "pluginId"),
+    ),
+  ).thenAnswer(
     (_) async => ApiResponse.success(
       const ProviderListResponse(
         connectedOnly: false,
@@ -228,7 +251,7 @@ void _stubRepositorySnapshot({
       ),
     ),
   );
-  when(() => repository.listCommands(projectId: "project-1")).thenAnswer(
+  when(() => repository.listCommands(projectId: "project-1", pluginId: null)).thenAnswer(
     (_) async => ApiResponse.success(
       const CommandListResponse(
         items: <CommandInfo>[

--- a/client/module_core/test/services/session_detail_load_service_test.dart
+++ b/client/module_core/test/services/session_detail_load_service_test.dart
@@ -74,7 +74,7 @@ void main() {
       verify(() => repository.listCommands(projectId: "project-1", pluginId: "plugin-1")).called(1);
     });
 
-    test("load uses the legacy sentinel when session identity is unavailable", () async {
+    test("load uses the legacy OpenCode default when session identity is unavailable", () async {
       connectionStatus.add(connectedStatus);
       _stubRepositorySnapshot(repository: repository, projectRepository: projectRepository);
       when(

--- a/client/module_core/test/services/slash_command_service_test.dart
+++ b/client/module_core/test/services/slash_command_service_test.dart
@@ -18,27 +18,36 @@ void main() {
     });
 
     test("listCommands returns empty response without transport when projectId is null", () async {
-      final result = await service.listCommands(projectId: null);
+      final result = await service.listCommands(projectId: null, pluginId: null);
 
       expect(result, isA<SuccessResponse<CommandListResponse>>());
       expect((result as SuccessResponse<CommandListResponse>).data.items, isEmpty);
-      verifyNever(() => mockRepository.listCommands(projectId: any(named: "projectId")));
+      verifyNever(
+        () => mockRepository.listCommands(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
+      );
     });
 
     test("listCommands trims projectId before repository call", () async {
       when(
-        () => mockRepository.listCommands(projectId: any(named: "projectId")),
+        () => mockRepository.listCommands(
+          projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
+        ),
       ).thenAnswer((_) async => ApiResponse.success(const CommandListResponse(items: <CommandInfo>[])));
 
-      await service.listCommands(projectId: "  project-1  ");
+      await service.listCommands(projectId: "  project-1  ", pluginId: "plugin-1");
 
-      verify(() => mockRepository.listCommands(projectId: "project-1")).called(1);
+      verify(() => mockRepository.listCommands(projectId: "project-1", pluginId: "plugin-1")).called(1);
     });
 
     test("createSessionWithMessage forwards raw variant", () async {
       when(
         () => mockRepository.createSessionWithMessage(
           projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
           text: any(named: "text"),
           agent: any(named: "agent"),
           model: any(named: "model"),
@@ -50,6 +59,7 @@ void main() {
 
       await service.createSessionWithMessage(
         projectId: "project-1",
+        pluginId: "plugin-1",
         text: "lib/main.dart",
         agent: "build",
         providerID: "openai",
@@ -62,6 +72,7 @@ void main() {
       verify(
         () => mockRepository.createSessionWithMessage(
           projectId: "project-1",
+          pluginId: "plugin-1",
           text: "lib/main.dart",
           agent: "build",
           model: const PromptModel(providerID: "openai", modelID: "gpt-4.1"),
@@ -212,6 +223,7 @@ void main() {
       when(
         () => mockRepository.createSessionWithMessage(
           projectId: any(named: "projectId"),
+          pluginId: any(named: "pluginId"),
           text: any(named: "text"),
           agent: any(named: "agent"),
           model: any(named: "model"),
@@ -223,6 +235,7 @@ void main() {
 
       await service.createSessionWithMessage(
         projectId: "project-1",
+        pluginId: "plugin-1",
         text: "hello",
         agent: "build",
         providerID: "openai",
@@ -235,6 +248,7 @@ void main() {
       verify(
         () => mockRepository.createSessionWithMessage(
           projectId: "project-1",
+          pluginId: "plugin-1",
           text: "hello",
           agent: "build",
           model: const PromptModel(providerID: "openai", modelID: "gpt-5.4"),
@@ -250,6 +264,7 @@ void main() {
 Session _session() {
   return const Session(
     id: "session-1",
+    pluginId: null,
     projectID: "project-1",
     directory: "/tmp/project-1",
     parentID: null,

--- a/client/module_core/test/services/slash_command_service_test.dart
+++ b/client/module_core/test/services/slash_command_service_test.dart
@@ -18,7 +18,7 @@ void main() {
     });
 
     test("listCommands returns empty response without transport when projectId is null", () async {
-      final result = await service.listCommands(projectId: null, pluginId: null);
+      final result = await service.listCommands(projectId: null, pluginId: legacyMissingPluginId);
 
       expect(result, isA<SuccessResponse<CommandListResponse>>());
       expect((result as SuccessResponse<CommandListResponse>).data.items, isEmpty);
@@ -264,7 +264,7 @@ void main() {
 Session _session() {
   return const Session(
     id: "session-1",
-    pluginId: null,
+    pluginId: legacyMissingPluginId,
     projectID: "project-1",
     directory: "/tmp/project-1",
     parentID: null,

--- a/client/module_core/test/services/sse_event_tracker_test.dart
+++ b/client/module_core/test/services/sse_event_tracker_test.dart
@@ -422,6 +422,7 @@ void main() {
         data: const SesoriSessionCreated(
           info: Session(
             id: "s1",
+            pluginId: null,
             projectID: "p1",
             directory: "/foo",
             parentID: null,

--- a/client/module_core/test/services/sse_event_tracker_test.dart
+++ b/client/module_core/test/services/sse_event_tracker_test.dart
@@ -422,7 +422,7 @@ void main() {
         data: const SesoriSessionCreated(
           info: Session(
             id: "s1",
-            pluginId: null,
+            pluginId: legacyMissingPluginId,
             projectID: "p1",
             directory: "/foo",
             parentID: null,

--- a/docs/COMPATIBILITY_DEBT.md
+++ b/docs/COMPATIBILITY_DEBT.md
@@ -44,16 +44,15 @@ it exists, and the exact cleanup to perform on the recorded date.
 
 - **Location:** `shared/sesori_shared/lib/src/models/sesori/session.dart`,
   `create_session_request.dart`, and `plugin_project_id_request.dart`.
-- **Debt:** Missing or null plugin identity decodes to
-  `legacyMissingPluginId` so plugin identity remains non-null internally.
+- **Debt:** Missing or null plugin identity decodes to the concrete OpenCode
+  identity through `legacyMissingPluginId` so identity remains non-null.
 - **Reason:** Peers released before parallel-plugin attribution may omit the
-  field from responses or requests. New peers always carry plugin identity,
-  while the compatibility window still includes older wire payloads.
+  field from responses or requests, and those peers could only target OpenCode.
+  New peers always carry plugin identity.
 - **Cleanup date:** 2027-01-12
 - **Exact cleanup:**
   1. Remove `legacyMissingPluginId` and its shared export.
   2. Remove the `@Default(legacyMissingPluginId)` compatibility defaults from
      `Session`, `CreateSessionRequest`, and `PluginProjectIdRequest`.
-  3. Require plugin identity in JSON from every supported peer and remove the
-     bridge's sentinel-to-active-plugin normalization.
+  3. Require plugin identity in JSON from every supported peer.
   4. Regenerate shared code and verify bridge, mobile, and desktop round-trips.

--- a/docs/COMPATIBILITY_DEBT.md
+++ b/docs/COMPATIBILITY_DEBT.md
@@ -38,4 +38,55 @@ it exists, and the exact cleanup to perform on the recorded date.
      always provide `projectID` and `updatedAt`.
   3. Update every handler that consumes `projectUpdated` to remove null-safe
      fallbacks and assume the fields are present.
-  4. Regenerate shared code and verify event round-trips.
+   4. Regenerate shared code and verify event round-trips.
+
+## `Session.pluginId` is nullable
+
+- **Location:** `shared/sesori_shared/lib/src/models/sesori/session.dart`
+- **Debt:** `Session.pluginId` is declared as `required String? pluginId`.
+- **Reason:** Bridges released before parallel-plugin attribution do not include
+  the field. New bridges always stamp their active plugin id, while clients must
+  continue accepting older responses during the compatibility window.
+- **Cleanup date:** 2027-01-12
+- **Exact cleanup:**
+  1. Change `Session.pluginId` to `required String pluginId`.
+  2. Remove client fallbacks that treat a null session plugin as the bridge
+     default.
+  3. Remove bridge/plugin fixtures that construct relay-facing sessions with a
+     null plugin id; plugin-internal payloads must be attributed before crossing
+     the bridge boundary.
+  4. Regenerate shared code and verify bridge, mobile, and desktop round-trips.
+
+## `CreateSessionRequest.pluginId` is nullable
+
+- **Location:** `shared/sesori_shared/lib/src/models/sesori/create_session_request.dart`
+- **Debt:** `CreateSessionRequest.pluginId` is declared as
+  `required String? pluginId`; null selects the bridge's only/default plugin.
+- **Reason:** Clients released before explicit plugin selection omit the field.
+  A non-null id is already validated and cannot silently route to another
+  plugin.
+- **Cleanup date:** 2027-01-12
+- **Exact cleanup:**
+  1. Change `CreateSessionRequest.pluginId` to `required String pluginId`.
+  2. Remove the bridge's null-to-default selection fallback.
+  3. Require every client create-session call to send its selected plugin id.
+  4. Regenerate shared code and verify bridge and client request round-trips.
+
+## Composer requests allow a missing plugin id
+
+- **Location:** `shared/sesori_shared/lib/src/models/sesori/project.dart` and
+  bridge handlers/repositories for `POST /agent`, `POST /provider`, and
+  `POST /command`.
+- **Debt:** These composer routes accept `ProjectIdRequest.pluginId == null` and
+  use the bridge's only/default plugin.
+- **Reason:** Older clients send only `projectId`. `ProjectIdRequest.pluginId`
+  remains structurally nullable because non-composer project routes also use
+  this generic DTO and do not require plugin selection.
+- **Cleanup date:** 2027-01-12
+- **Exact cleanup:**
+  1. Make the three composer routes reject a null plugin id while leaving the
+     shared DTO nullable for non-composer routes.
+  2. Remove null-to-default fallback from `AgentRepository`,
+     `ProviderRepository`, and `SessionRepository.getCommands`.
+  3. Require module-core composer calls to send the selected plugin id.
+  4. Verify older-client support has ended before removing the fallback.

--- a/docs/COMPATIBILITY_DEBT.md
+++ b/docs/COMPATIBILITY_DEBT.md
@@ -63,8 +63,8 @@ it exists, and the exact cleanup to perform on the recorded date.
 - **Debt:** `CreateSessionRequest.pluginId` is declared as
   `required String? pluginId`; null selects the bridge's only/default plugin.
 - **Reason:** Clients released before explicit plugin selection omit the field.
-  A non-null id is already validated and cannot silently route to another
-  plugin.
+  Until multi-plugin routing lands, the single-plugin bridge assumes a non-null
+  id identifies its active plugin.
 - **Cleanup date:** 2027-01-12
 - **Exact cleanup:**
   1. Change `CreateSessionRequest.pluginId` to `required String pluginId`.
@@ -86,7 +86,23 @@ it exists, and the exact cleanup to perform on the recorded date.
 - **Exact cleanup:**
   1. Make the three composer routes reject a null plugin id while leaving the
      shared DTO nullable for non-composer routes.
-  2. Remove null-to-default fallback from `AgentRepository`,
-     `ProviderRepository`, and `SessionRepository.getCommands`.
+   2. Remove null-to-default fallback from the composer route handlers.
   3. Require module-core composer calls to send the selected plugin id.
-  4. Verify older-client support has ended before removing the fallback.
+   4. Verify older-client support has ended before removing the fallback.
+
+## Native project rows may store the backend id as their path
+
+- **Location:** `bridge/app/lib/src/bridge/repositories/project_repository.dart`
+  and `bridge/app/lib/src/bridge/persistence/daos/projects_dao.dart`.
+- **Debt:** Native project listing replaces a persisted `path` only when it is
+  still exactly equal to the backend project id.
+- **Reason:** Bridges released before `PluginProject.directory` stored the id as
+  the default path. New bridges repair that legacy default from the plugin's
+  declared directory while preserving any separately recorded moved path.
+- **Cleanup date:** 2027-01-12
+- **Exact cleanup:**
+  1. Remove `ProjectsDao.replacePathIfMatches`.
+  2. Remove the native-list reconciliation loop from `ProjectRepository`.
+  3. Keep new-row seeding from `PluginProject.directory` unchanged.
+  4. Verify every supported bridge version has written explicit native project
+     directories before removing the repair.

--- a/docs/COMPATIBILITY_DEBT.md
+++ b/docs/COMPATIBILITY_DEBT.md
@@ -57,20 +57,3 @@ it exists, and the exact cleanup to perform on the recorded date.
   3. Require plugin identity in JSON from every supported peer and remove the
      bridge's sentinel-to-active-plugin normalization.
   4. Regenerate shared code and verify bridge, mobile, and desktop round-trips.
-
-## Native project rows may store the backend id as their path
-
-- **Location:** `bridge/app/lib/src/bridge/repositories/project_repository.dart`
-  and `bridge/app/lib/src/bridge/persistence/daos/projects_dao.dart`.
-- **Debt:** Native project listing replaces a persisted `path` only when it is
-  still exactly equal to the backend project id.
-- **Reason:** Bridges released before `PluginProject.directory` stored the id as
-  the default path. New bridges repair that legacy default from the plugin's
-  declared directory while preserving any separately recorded moved path.
-- **Cleanup date:** 2027-01-12
-- **Exact cleanup:**
-  1. Remove `ProjectsDao.replacePathIfMatches`.
-  2. Remove the native-list reconciliation loop from `ProjectRepository`.
-  3. Keep new-row seeding from `PluginProject.directory` unchanged.
-  4. Verify every supported bridge version has written explicit native project
-     directories before removing the repair.

--- a/docs/COMPATIBILITY_DEBT.md
+++ b/docs/COMPATIBILITY_DEBT.md
@@ -40,55 +40,23 @@ it exists, and the exact cleanup to perform on the recorded date.
      fallbacks and assume the fields are present.
    4. Regenerate shared code and verify event round-trips.
 
-## `Session.pluginId` is nullable
+## Legacy payloads may omit plugin identity
 
-- **Location:** `shared/sesori_shared/lib/src/models/sesori/session.dart`
-- **Debt:** `Session.pluginId` is declared as `required String? pluginId`.
-- **Reason:** Bridges released before parallel-plugin attribution do not include
-  the field. New bridges always stamp their active plugin id, while clients must
-  continue accepting older responses during the compatibility window.
+- **Location:** `shared/sesori_shared/lib/src/models/sesori/session.dart`,
+  `create_session_request.dart`, and `plugin_project_id_request.dart`.
+- **Debt:** Missing or null plugin identity decodes to
+  `legacyMissingPluginId` so plugin identity remains non-null internally.
+- **Reason:** Peers released before parallel-plugin attribution may omit the
+  field from responses or requests. New peers always carry plugin identity,
+  while the compatibility window still includes older wire payloads.
 - **Cleanup date:** 2027-01-12
 - **Exact cleanup:**
-  1. Change `Session.pluginId` to `required String pluginId`.
-  2. Remove client fallbacks that treat a null session plugin as the bridge
-     default.
-  3. Remove bridge/plugin fixtures that construct relay-facing sessions with a
-     null plugin id; plugin-internal payloads must be attributed before crossing
-     the bridge boundary.
+  1. Remove `legacyMissingPluginId` and its shared export.
+  2. Remove the `@Default(legacyMissingPluginId)` compatibility defaults from
+     `Session`, `CreateSessionRequest`, and `PluginProjectIdRequest`.
+  3. Require plugin identity in JSON from every supported peer and remove the
+     bridge's sentinel-to-active-plugin normalization.
   4. Regenerate shared code and verify bridge, mobile, and desktop round-trips.
-
-## `CreateSessionRequest.pluginId` is nullable
-
-- **Location:** `shared/sesori_shared/lib/src/models/sesori/create_session_request.dart`
-- **Debt:** `CreateSessionRequest.pluginId` is declared as
-  `required String? pluginId`; null selects the bridge's only/default plugin.
-- **Reason:** Clients released before explicit plugin selection omit the field.
-  Until multi-plugin routing lands, the single-plugin bridge assumes a non-null
-  id identifies its active plugin.
-- **Cleanup date:** 2027-01-12
-- **Exact cleanup:**
-  1. Change `CreateSessionRequest.pluginId` to `required String pluginId`.
-  2. Remove the bridge's null-to-default selection fallback.
-  3. Require every client create-session call to send its selected plugin id.
-  4. Regenerate shared code and verify bridge and client request round-trips.
-
-## Composer requests allow a missing plugin id
-
-- **Location:** `shared/sesori_shared/lib/src/models/sesori/project.dart` and
-  bridge handlers/repositories for `POST /agent`, `POST /provider`, and
-  `POST /command`.
-- **Debt:** These composer routes accept `ProjectIdRequest.pluginId == null` and
-  use the bridge's only/default plugin.
-- **Reason:** Older clients send only `projectId`. `ProjectIdRequest.pluginId`
-  remains structurally nullable because non-composer project routes also use
-  this generic DTO and do not require plugin selection.
-- **Cleanup date:** 2027-01-12
-- **Exact cleanup:**
-  1. Make the three composer routes reject a null plugin id while leaving the
-     shared DTO nullable for non-composer routes.
-   2. Remove null-to-default fallback from the composer route handlers.
-  3. Require module-core composer calls to send the selected plugin id.
-   4. Verify older-client support has ended before removing the fallback.
 
 ## Native project rows may store the backend id as their path
 

--- a/docs/parallel-plugins/PLAN.md
+++ b/docs/parallel-plugins/PLAN.md
@@ -8,8 +8,8 @@
 
 ## Current Pointer
 
-- **Last completed stage:** Stage 1A - pre-change baseline harness
-- **Next up:** Stage 1B - additive compatibility contracts
+- **Last completed stage:** Stage 1B - additive compatibility contracts
+- **Next up:** Stage 2 - catalog schema and indexed DAO queries
 - **Runtime default:** one selected plugin until Stage 7
 - **Catalog projection version:** not assigned until the schema migration lands
 
@@ -597,7 +597,7 @@ selection.
 |---|---|---|---|
 | ☑ | 0 | Execution plan approved | `aristotle-plan-review`; docs consistency |
 | ☑ | 1A | Pre-change baseline harness | AOT baseline JSON; app/Codex analysis |
-| ☐ | 1B | Additive compatibility contracts | Shared/plugin/client round trips |
+| ☑ | 1B | Additive compatibility contracts | Shared/plugin/client round trips |
 | ☐ | 2 | Catalog schema and indexed DAO queries | Drift structural/data migration tests; query plans |
 | ☐ | 3 | Catalog write-through and stable session binding | Mutation/routing tests; existing IDs preserved |
 | ☐ | 4 | Known-event projection and durable child hierarchy | Exhaustive event translation and ancestry tests |
@@ -830,6 +830,13 @@ release notes must identify that minimum rollback version.
 Record implementation discoveries here, newest first. A delta names the
 affected locked decision and updates the owning section in the same PR.
 
+- **Stage 1B:** `PluginProject.directory` now declares the native plugin's live
+  directory independently from its backend id. Shared session/create/composer
+  contracts carry nullable plugin identity for older-peer compatibility. The
+  single-plugin bridge stamps every outgoing session and rejects a mismatched
+  requested plugin before plugin I/O; no plugin map or selection UI was added.
+  Plugin metadata/import DTOs remain deferred to their first consumers in
+  Stages 5 and 7.
 - **Stage 1A:** The approved five-executable baseline scope included three paths
   that do not exist yet: event projection, import publication, and multi-plugin
   startup. Stage 1 was split into cohesive 1A benchmark and 1B contract PRs.

--- a/docs/parallel-plugins/PLAN.md
+++ b/docs/parallel-plugins/PLAN.md
@@ -198,10 +198,10 @@ default. Duplicates, unknown ids, and an explicitly empty set fail validation.
 
 Older clients omit `pluginId`. During the compatibility window the bridge uses
 the first enabled plugin for session creation and project-scoped composer data.
-New clients always send `pluginId`. `Session.pluginId` is nullable only while
-new clients may read sessions from an older bridge. This debt is recorded in
-`docs/COMPATIBILITY_DEBT.md` when the additive fields land, with exact removal
-steps and a dated target.
+New clients always send `pluginId`. Missing legacy identity normalizes to the
+shared `legacyMissingPluginId` wire sentinel; the bridge resolves that sentinel
+to its active plugin. Runtime identity remains non-null. This debt is recorded
+in `docs/COMPATIBILITY_DEBT.md` with exact removal steps and a dated target.
 
 ## 4. Catalog Schema
 
@@ -504,8 +504,10 @@ new-session selection.
 
 Shared request changes are additive:
 
-- nullable `pluginId` on create-session and project-scoped composer requests;
-- nullable `pluginId` on `Session` during the compatibility window; and
+- non-null `pluginId` with a legacy-missing sentinel on create-session,
+  plugin-scoped composer requests, and `Session`;
+- a dedicated plugin-scoped request DTO, while project-only requests carry no
+  plugin identity; and
 - typed plugin list, runtime state, health, import status, and import progress
   DTOs.
 
@@ -527,8 +529,8 @@ NewSessionCubit
 
 Saved agent/model/variant selection is keyed by project and plugin so backend-
 local ids never bleed between selections. Existing-session composer requests
-use `Session.pluginId`; the nullable old-bridge fallback uses the server default
-only during the compatibility window.
+use `Session.pluginId`; an old bridge's missing identity normalizes to the
+legacy sentinel and is resolved by the bridge during the compatibility window.
 
 Presentation remains in product UI. The chooser lives in
 `client/app/lib/features/new_session/`, alongside the current mobile new-session
@@ -625,8 +627,9 @@ the default fixed-host fixtures without changing production behavior.
 ### Stage 1B - Additive Compatibility Contracts
 
 - Add required `PluginProject.directory` and update all implementations/fakes.
-- Add nullable compatibility `pluginId` fields to `Session`,
-  `CreateSessionRequest`, and `ProjectIdRequest`.
+- Add non-null compatibility `pluginId` fields with a shared legacy-missing
+  sentinel to `Session`, `CreateSessionRequest`, and a dedicated plugin-scoped
+  project request DTO. Keep `ProjectIdRequest` project-only.
 - Stamp plugin identity at the existing single-plugin repository/service
   boundary. Carry request `pluginId` through the compatibility contract, but
   assume it identifies the active plugin until multi-plugin routing lands.

--- a/docs/parallel-plugins/PLAN.md
+++ b/docs/parallel-plugins/PLAN.md
@@ -196,12 +196,11 @@ Enabled plugin order is stable. Repeated `--plugin` flags override persisted
 `enabledPlugins`; otherwise settings win; otherwise OpenCode remains the sole
 default. Duplicates, unknown ids, and an explicitly empty set fail validation.
 
-Older clients omit `pluginId`. During the compatibility window the bridge uses
-the first enabled plugin for session creation and project-scoped composer data.
-New clients always send `pluginId`. Missing legacy identity normalizes to the
-shared `legacyMissingPluginId` wire sentinel; the bridge resolves that sentinel
-to its active plugin. Runtime identity remains non-null. This debt is recorded
-in `docs/COMPATIBILITY_DEBT.md` with exact removal steps and a dated target.
+Older clients omit `pluginId`. Missing legacy identity defaults to OpenCode,
+the only backend those clients could target; it is never substituted with the
+first enabled plugin. New clients always send `pluginId`. Runtime identity
+remains non-null. This debt is recorded in `docs/COMPATIBILITY_DEBT.md` with
+exact removal steps and a dated target.
 
 ## 4. Catalog Schema
 
@@ -504,7 +503,7 @@ new-session selection.
 
 Shared request changes are additive:
 
-- non-null `pluginId` with a legacy-missing sentinel on create-session,
+- non-null `pluginId` with an OpenCode legacy default on create-session,
   plugin-scoped composer requests, and `Session`;
 - a dedicated plugin-scoped request DTO, while project-only requests carry no
   plugin identity; and
@@ -529,8 +528,8 @@ NewSessionCubit
 
 Saved agent/model/variant selection is keyed by project and plugin so backend-
 local ids never bleed between selections. Existing-session composer requests
-use `Session.pluginId`; an old bridge's missing identity normalizes to the
-legacy sentinel and is resolved by the bridge during the compatibility window.
+use `Session.pluginId`; missing identity from an old bridge defaults to OpenCode
+during the compatibility window.
 
 Presentation remains in product UI. The chooser lives in
 `client/app/lib/features/new_session/`, alongside the current mobile new-session
@@ -627,9 +626,9 @@ the default fixed-host fixtures without changing production behavior.
 ### Stage 1B - Additive Compatibility Contracts
 
 - Add required `PluginProject.directory` and update all implementations/fakes.
-- Add non-null compatibility `pluginId` fields with a shared legacy-missing
-  sentinel to `Session`, `CreateSessionRequest`, and a dedicated plugin-scoped
-  project request DTO. Keep `ProjectIdRequest` project-only.
+- Add non-null compatibility `pluginId` fields with an OpenCode legacy default
+  to `Session`, `CreateSessionRequest`, and a dedicated plugin-scoped project
+  request DTO. Keep `ProjectIdRequest` project-only.
 - Stamp plugin identity at the existing single-plugin repository/service
   boundary. Carry request `pluginId` through the compatibility contract, but
   assume it identifies the active plugin until multi-plugin routing lands.

--- a/docs/parallel-plugins/PLAN.md
+++ b/docs/parallel-plugins/PLAN.md
@@ -627,8 +627,9 @@ the default fixed-host fixtures without changing production behavior.
 - Add required `PluginProject.directory` and update all implementations/fakes.
 - Add nullable compatibility `pluginId` fields to `Session`,
   `CreateSessionRequest`, and `ProjectIdRequest`.
-- Stamp and validate plugin identity at the existing single-plugin repository/
-  service boundary. A non-null id for another plugin is rejected, never ignored.
+- Stamp plugin identity at the existing single-plugin repository/service
+  boundary. Carry request `pluginId` through the compatibility contract, but
+  assume it identifies the active plugin until multi-plugin routing lands.
 - Add compatibility-debt entries and regenerate all affected Freezed code.
 - Defer plugin metadata/import DTOs and SSE variants until Stages 5 and 7, when
   their first production consumers land.
@@ -654,6 +655,9 @@ use the intended indexes.
 
 - Teach `SessionRepository` to resolve Sesori ids to backend bindings and route
   every targeted operation through the selected plugin API.
+- Start consuming request `pluginId` to select the owning plugin. Until this
+  stage, the single-plugin bridge deliberately carries but does not validate or
+  route on that field.
 - Allocate independent Sesori ids for newly created sessions while preserving
   migrated ids.
 - Write complete project/session projections on create/open/rename/archive/

--- a/shared/sesori_shared/AGENTS.md
+++ b/shared/sesori_shared/AGENTS.md
@@ -43,6 +43,10 @@ lib/
 - **Null keys omitted from wire payloads**: `build.yaml` sets `json_serializable` `include_if_null: false`, so nullable fields are dropped from `toJson()` output by default. Do **NOT** add `@JsonKey(includeIfNull: false)` explicitly — it is already the default here. (Decoding is unaffected: a missing key deserializes to `null`.)
 - **Strict analysis**: `strict-casts`, `strict-inference`, `strict-raw-types` all ON
 - **Barrel export**: All public API re-exported from `lib/sesori_shared.dart`
+- **Legacy plugin attribution**: Missing `pluginId` fields default to `opencode`
+  because released peers without attribution could only target OpenCode. This
+  is a narrow historical wire default, not a general licence for backend
+  behavior or capabilities in shared models.
 - **Platform-derived DTOs**: platform adapters gather facts through Flutter
   plugins or `dart:io`; shared builders accept plain values and own common wire
   schema normalization such as trimming, fallbacks, and length limits. Never

--- a/shared/sesori_shared/lib/sesori_shared.dart
+++ b/shared/sesori_shared/lib/sesori_shared.dart
@@ -46,6 +46,8 @@ export "src/models/sesori/notification_data.dart";
 export "src/models/sesori/pending_permission.dart";
 export "src/models/sesori/pending_question.dart";
 export "src/models/sesori/permission_reply.dart";
+export "src/models/sesori/plugin_identity.dart";
+export "src/models/sesori/plugin_project_id_request.dart";
 export "src/models/sesori/pr_enums.dart";
 export "src/models/sesori/project.dart";
 export "src/models/sesori/project_activity_summary.dart";

--- a/shared/sesori_shared/lib/src/models/sesori/create_session_request.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/create_session_request.dart
@@ -1,5 +1,6 @@
 import "package:freezed_annotation/freezed_annotation.dart";
 
+import "plugin_identity.dart";
 import "send_prompt_request.dart";
 import "session_variant.dart";
 
@@ -11,8 +12,7 @@ part "create_session_request.g.dart";
 sealed class CreateSessionRequest with _$CreateSessionRequest {
   const factory CreateSessionRequest({
     required String projectId,
-    // Nullable so requests remain compatible with older peers that do not identify plugins.
-    required String? pluginId,
+    @Default(legacyMissingPluginId) String pluginId,
     required List<PromptPart> parts,
     required String? agent,
     required PromptModel? model,

--- a/shared/sesori_shared/lib/src/models/sesori/create_session_request.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/create_session_request.dart
@@ -11,6 +11,8 @@ part "create_session_request.g.dart";
 sealed class CreateSessionRequest with _$CreateSessionRequest {
   const factory CreateSessionRequest({
     required String projectId,
+    // Nullable so requests remain compatible with older peers that do not identify plugins.
+    required String? pluginId,
     required List<PromptPart> parts,
     required String? agent,
     required PromptModel? model,

--- a/shared/sesori_shared/lib/src/models/sesori/create_session_request.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/create_session_request.freezed.dart
@@ -15,8 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$CreateSessionRequest {
 
- String get projectId;// Nullable so requests remain compatible with older peers that do not identify plugins.
- String? get pluginId; List<PromptPart> get parts; String? get agent; PromptModel? get model; String? get command; SessionVariant? get variant; bool get dedicatedWorktree;
+ String get projectId; String get pluginId; List<PromptPart> get parts; String? get agent; PromptModel? get model; String? get command; SessionVariant? get variant; bool get dedicatedWorktree;
 /// Create a copy of CreateSessionRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -49,7 +48,7 @@ abstract mixin class $CreateSessionRequestCopyWith<$Res>  {
   factory $CreateSessionRequestCopyWith(CreateSessionRequest value, $Res Function(CreateSessionRequest) _then) = _$CreateSessionRequestCopyWithImpl;
 @useResult
 $Res call({
- String projectId, String? pluginId, List<PromptPart> parts, String? agent, PromptModel? model, String? command, SessionVariant? variant, bool dedicatedWorktree
+ String projectId, String pluginId, List<PromptPart> parts, String? agent, PromptModel? model, String? command, SessionVariant? variant, bool dedicatedWorktree
 });
 
 
@@ -66,11 +65,11 @@ class _$CreateSessionRequestCopyWithImpl<$Res>
 
 /// Create a copy of CreateSessionRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? projectId = null,Object? pluginId = freezed,Object? parts = null,Object? agent = freezed,Object? model = freezed,Object? command = freezed,Object? variant = freezed,Object? dedicatedWorktree = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? projectId = null,Object? pluginId = null,Object? parts = null,Object? agent = freezed,Object? model = freezed,Object? command = freezed,Object? variant = freezed,Object? dedicatedWorktree = null,}) {
   return _then(_self.copyWith(
 projectId: null == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
-as String,pluginId: freezed == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
-as String?,parts: null == parts ? _self.parts : parts // ignore: cast_nullable_to_non_nullable
+as String,pluginId: null == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String,parts: null == parts ? _self.parts : parts // ignore: cast_nullable_to_non_nullable
 as List<PromptPart>,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullable_to_non_nullable
 as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as PromptModel?,command: freezed == command ? _self.command : command // ignore: cast_nullable_to_non_nullable
@@ -112,12 +111,11 @@ $SessionVariantCopyWith<$Res>? get variant {
 @JsonSerializable()
 
 class _CreateSessionRequest implements CreateSessionRequest {
-  const _CreateSessionRequest({required this.projectId, required this.pluginId, required final  List<PromptPart> parts, required this.agent, required this.model, required this.command, required this.variant, required this.dedicatedWorktree}): _parts = parts;
+  const _CreateSessionRequest({required this.projectId, this.pluginId = legacyMissingPluginId, required final  List<PromptPart> parts, required this.agent, required this.model, required this.command, required this.variant, required this.dedicatedWorktree}): _parts = parts;
   factory _CreateSessionRequest.fromJson(Map<String, dynamic> json) => _$CreateSessionRequestFromJson(json);
 
 @override final  String projectId;
-// Nullable so requests remain compatible with older peers that do not identify plugins.
-@override final  String? pluginId;
+@override@JsonKey() final  String pluginId;
  final  List<PromptPart> _parts;
 @override List<PromptPart> get parts {
   if (_parts is EqualUnmodifiableListView) return _parts;
@@ -164,7 +162,7 @@ abstract mixin class _$CreateSessionRequestCopyWith<$Res> implements $CreateSess
   factory _$CreateSessionRequestCopyWith(_CreateSessionRequest value, $Res Function(_CreateSessionRequest) _then) = __$CreateSessionRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String projectId, String? pluginId, List<PromptPart> parts, String? agent, PromptModel? model, String? command, SessionVariant? variant, bool dedicatedWorktree
+ String projectId, String pluginId, List<PromptPart> parts, String? agent, PromptModel? model, String? command, SessionVariant? variant, bool dedicatedWorktree
 });
 
 
@@ -181,11 +179,11 @@ class __$CreateSessionRequestCopyWithImpl<$Res>
 
 /// Create a copy of CreateSessionRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? projectId = null,Object? pluginId = freezed,Object? parts = null,Object? agent = freezed,Object? model = freezed,Object? command = freezed,Object? variant = freezed,Object? dedicatedWorktree = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? projectId = null,Object? pluginId = null,Object? parts = null,Object? agent = freezed,Object? model = freezed,Object? command = freezed,Object? variant = freezed,Object? dedicatedWorktree = null,}) {
   return _then(_CreateSessionRequest(
 projectId: null == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
-as String,pluginId: freezed == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
-as String?,parts: null == parts ? _self._parts : parts // ignore: cast_nullable_to_non_nullable
+as String,pluginId: null == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String,parts: null == parts ? _self._parts : parts // ignore: cast_nullable_to_non_nullable
 as List<PromptPart>,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullable_to_non_nullable
 as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as PromptModel?,command: freezed == command ? _self.command : command // ignore: cast_nullable_to_non_nullable

--- a/shared/sesori_shared/lib/src/models/sesori/create_session_request.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/create_session_request.freezed.dart
@@ -15,7 +15,8 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$CreateSessionRequest {
 
- String get projectId; List<PromptPart> get parts; String? get agent; PromptModel? get model; String? get command; SessionVariant? get variant; bool get dedicatedWorktree;
+ String get projectId;// Nullable so requests remain compatible with older peers that do not identify plugins.
+ String? get pluginId; List<PromptPart> get parts; String? get agent; PromptModel? get model; String? get command; SessionVariant? get variant; bool get dedicatedWorktree;
 /// Create a copy of CreateSessionRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +29,16 @@ $CreateSessionRequestCopyWith<CreateSessionRequest> get copyWith => _$CreateSess
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CreateSessionRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&const DeepCollectionEquality().equals(other.parts, parts)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.model, model) || other.model == model)&&(identical(other.command, command) || other.command == command)&&(identical(other.variant, variant) || other.variant == variant)&&(identical(other.dedicatedWorktree, dedicatedWorktree) || other.dedicatedWorktree == dedicatedWorktree));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CreateSessionRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId)&&const DeepCollectionEquality().equals(other.parts, parts)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.model, model) || other.model == model)&&(identical(other.command, command) || other.command == command)&&(identical(other.variant, variant) || other.variant == variant)&&(identical(other.dedicatedWorktree, dedicatedWorktree) || other.dedicatedWorktree == dedicatedWorktree));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,projectId,const DeepCollectionEquality().hash(parts),agent,model,command,variant,dedicatedWorktree);
+int get hashCode => Object.hash(runtimeType,projectId,pluginId,const DeepCollectionEquality().hash(parts),agent,model,command,variant,dedicatedWorktree);
 
 @override
 String toString() {
-  return 'CreateSessionRequest(projectId: $projectId, parts: $parts, agent: $agent, model: $model, command: $command, variant: $variant, dedicatedWorktree: $dedicatedWorktree)';
+  return 'CreateSessionRequest(projectId: $projectId, pluginId: $pluginId, parts: $parts, agent: $agent, model: $model, command: $command, variant: $variant, dedicatedWorktree: $dedicatedWorktree)';
 }
 
 
@@ -48,7 +49,7 @@ abstract mixin class $CreateSessionRequestCopyWith<$Res>  {
   factory $CreateSessionRequestCopyWith(CreateSessionRequest value, $Res Function(CreateSessionRequest) _then) = _$CreateSessionRequestCopyWithImpl;
 @useResult
 $Res call({
- String projectId, List<PromptPart> parts, String? agent, PromptModel? model, String? command, SessionVariant? variant, bool dedicatedWorktree
+ String projectId, String? pluginId, List<PromptPart> parts, String? agent, PromptModel? model, String? command, SessionVariant? variant, bool dedicatedWorktree
 });
 
 
@@ -65,10 +66,11 @@ class _$CreateSessionRequestCopyWithImpl<$Res>
 
 /// Create a copy of CreateSessionRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? projectId = null,Object? parts = null,Object? agent = freezed,Object? model = freezed,Object? command = freezed,Object? variant = freezed,Object? dedicatedWorktree = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? projectId = null,Object? pluginId = freezed,Object? parts = null,Object? agent = freezed,Object? model = freezed,Object? command = freezed,Object? variant = freezed,Object? dedicatedWorktree = null,}) {
   return _then(_self.copyWith(
 projectId: null == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
-as String,parts: null == parts ? _self.parts : parts // ignore: cast_nullable_to_non_nullable
+as String,pluginId: freezed == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String?,parts: null == parts ? _self.parts : parts // ignore: cast_nullable_to_non_nullable
 as List<PromptPart>,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullable_to_non_nullable
 as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as PromptModel?,command: freezed == command ? _self.command : command // ignore: cast_nullable_to_non_nullable
@@ -110,10 +112,12 @@ $SessionVariantCopyWith<$Res>? get variant {
 @JsonSerializable()
 
 class _CreateSessionRequest implements CreateSessionRequest {
-  const _CreateSessionRequest({required this.projectId, required final  List<PromptPart> parts, required this.agent, required this.model, required this.command, required this.variant, required this.dedicatedWorktree}): _parts = parts;
+  const _CreateSessionRequest({required this.projectId, required this.pluginId, required final  List<PromptPart> parts, required this.agent, required this.model, required this.command, required this.variant, required this.dedicatedWorktree}): _parts = parts;
   factory _CreateSessionRequest.fromJson(Map<String, dynamic> json) => _$CreateSessionRequestFromJson(json);
 
 @override final  String projectId;
+// Nullable so requests remain compatible with older peers that do not identify plugins.
+@override final  String? pluginId;
  final  List<PromptPart> _parts;
 @override List<PromptPart> get parts {
   if (_parts is EqualUnmodifiableListView) return _parts;
@@ -140,16 +144,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CreateSessionRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&const DeepCollectionEquality().equals(other._parts, _parts)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.model, model) || other.model == model)&&(identical(other.command, command) || other.command == command)&&(identical(other.variant, variant) || other.variant == variant)&&(identical(other.dedicatedWorktree, dedicatedWorktree) || other.dedicatedWorktree == dedicatedWorktree));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CreateSessionRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId)&&const DeepCollectionEquality().equals(other._parts, _parts)&&(identical(other.agent, agent) || other.agent == agent)&&(identical(other.model, model) || other.model == model)&&(identical(other.command, command) || other.command == command)&&(identical(other.variant, variant) || other.variant == variant)&&(identical(other.dedicatedWorktree, dedicatedWorktree) || other.dedicatedWorktree == dedicatedWorktree));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,projectId,const DeepCollectionEquality().hash(_parts),agent,model,command,variant,dedicatedWorktree);
+int get hashCode => Object.hash(runtimeType,projectId,pluginId,const DeepCollectionEquality().hash(_parts),agent,model,command,variant,dedicatedWorktree);
 
 @override
 String toString() {
-  return 'CreateSessionRequest(projectId: $projectId, parts: $parts, agent: $agent, model: $model, command: $command, variant: $variant, dedicatedWorktree: $dedicatedWorktree)';
+  return 'CreateSessionRequest(projectId: $projectId, pluginId: $pluginId, parts: $parts, agent: $agent, model: $model, command: $command, variant: $variant, dedicatedWorktree: $dedicatedWorktree)';
 }
 
 
@@ -160,7 +164,7 @@ abstract mixin class _$CreateSessionRequestCopyWith<$Res> implements $CreateSess
   factory _$CreateSessionRequestCopyWith(_CreateSessionRequest value, $Res Function(_CreateSessionRequest) _then) = __$CreateSessionRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String projectId, List<PromptPart> parts, String? agent, PromptModel? model, String? command, SessionVariant? variant, bool dedicatedWorktree
+ String projectId, String? pluginId, List<PromptPart> parts, String? agent, PromptModel? model, String? command, SessionVariant? variant, bool dedicatedWorktree
 });
 
 
@@ -177,10 +181,11 @@ class __$CreateSessionRequestCopyWithImpl<$Res>
 
 /// Create a copy of CreateSessionRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? projectId = null,Object? parts = null,Object? agent = freezed,Object? model = freezed,Object? command = freezed,Object? variant = freezed,Object? dedicatedWorktree = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? projectId = null,Object? pluginId = freezed,Object? parts = null,Object? agent = freezed,Object? model = freezed,Object? command = freezed,Object? variant = freezed,Object? dedicatedWorktree = null,}) {
   return _then(_CreateSessionRequest(
 projectId: null == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
-as String,parts: null == parts ? _self._parts : parts // ignore: cast_nullable_to_non_nullable
+as String,pluginId: freezed == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String?,parts: null == parts ? _self._parts : parts // ignore: cast_nullable_to_non_nullable
 as List<PromptPart>,agent: freezed == agent ? _self.agent : agent // ignore: cast_nullable_to_non_nullable
 as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as PromptModel?,command: freezed == command ? _self.command : command // ignore: cast_nullable_to_non_nullable

--- a/shared/sesori_shared/lib/src/models/sesori/create_session_request.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/create_session_request.g.dart
@@ -9,7 +9,7 @@ part of 'create_session_request.dart';
 _CreateSessionRequest _$CreateSessionRequestFromJson(Map json) =>
     _CreateSessionRequest(
       projectId: json['projectId'] as String,
-      pluginId: json['pluginId'] as String?,
+      pluginId: json['pluginId'] as String? ?? legacyMissingPluginId,
       parts: (json['parts'] as List<dynamic>)
           .map((e) => PromptPart.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),
@@ -32,7 +32,7 @@ Map<String, dynamic> _$CreateSessionRequestToJson(
   _CreateSessionRequest instance,
 ) => <String, dynamic>{
   'projectId': instance.projectId,
-  'pluginId': ?instance.pluginId,
+  'pluginId': instance.pluginId,
   'parts': instance.parts.map((e) => e.toJson()).toList(),
   'agent': ?instance.agent,
   'model': ?instance.model?.toJson(),

--- a/shared/sesori_shared/lib/src/models/sesori/create_session_request.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/create_session_request.g.dart
@@ -9,6 +9,7 @@ part of 'create_session_request.dart';
 _CreateSessionRequest _$CreateSessionRequestFromJson(Map json) =>
     _CreateSessionRequest(
       projectId: json['projectId'] as String,
+      pluginId: json['pluginId'] as String?,
       parts: (json['parts'] as List<dynamic>)
           .map((e) => PromptPart.fromJson(Map<String, dynamic>.from(e as Map)))
           .toList(),
@@ -31,6 +32,7 @@ Map<String, dynamic> _$CreateSessionRequestToJson(
   _CreateSessionRequest instance,
 ) => <String, dynamic>{
   'projectId': instance.projectId,
+  'pluginId': ?instance.pluginId,
   'parts': instance.parts.map((e) => e.toJson()).toList(),
   'agent': ?instance.agent,
   'model': ?instance.model?.toJson(),

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_identity.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_identity.dart
@@ -1,2 +1,5 @@
 /// Plugin identity used when decoding payloads from peers that predate plugin attribution.
-const String legacyMissingPluginId = "__legacy_missing_plugin_id__";
+///
+/// Those peers could only communicate with OpenCode, so their missing identity
+/// is attributed directly instead of introducing an unresolved wire value.
+const String legacyMissingPluginId = "opencode";

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_identity.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_identity.dart
@@ -1,0 +1,2 @@
+/// Plugin identity used when decoding payloads from peers that predate plugin attribution.
+const String legacyMissingPluginId = "__legacy_missing_plugin_id__";

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_project_id_request.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_project_id_request.dart
@@ -1,0 +1,17 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+import "plugin_identity.dart";
+
+part "plugin_project_id_request.freezed.dart";
+
+part "plugin_project_id_request.g.dart";
+
+@Freezed(fromJson: true, toJson: true)
+sealed class PluginProjectIdRequest with _$PluginProjectIdRequest {
+  const factory PluginProjectIdRequest({
+    required String projectId,
+    @Default(legacyMissingPluginId) String pluginId,
+  }) = _PluginProjectIdRequest;
+
+  factory PluginProjectIdRequest.fromJson(Map<String, dynamic> json) => _$PluginProjectIdRequestFromJson(json);
+}

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_project_id_request.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_project_id_request.freezed.dart
@@ -1,0 +1,151 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'plugin_project_id_request.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PluginProjectIdRequest {
+
+ String get projectId; String get pluginId;
+/// Create a copy of PluginProjectIdRequest
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$PluginProjectIdRequestCopyWith<PluginProjectIdRequest> get copyWith => _$PluginProjectIdRequestCopyWithImpl<PluginProjectIdRequest>(this as PluginProjectIdRequest, _$identity);
+
+  /// Serializes this PluginProjectIdRequest to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is PluginProjectIdRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,projectId,pluginId);
+
+@override
+String toString() {
+  return 'PluginProjectIdRequest(projectId: $projectId, pluginId: $pluginId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $PluginProjectIdRequestCopyWith<$Res>  {
+  factory $PluginProjectIdRequestCopyWith(PluginProjectIdRequest value, $Res Function(PluginProjectIdRequest) _then) = _$PluginProjectIdRequestCopyWithImpl;
+@useResult
+$Res call({
+ String projectId, String pluginId
+});
+
+
+
+
+}
+/// @nodoc
+class _$PluginProjectIdRequestCopyWithImpl<$Res>
+    implements $PluginProjectIdRequestCopyWith<$Res> {
+  _$PluginProjectIdRequestCopyWithImpl(this._self, this._then);
+
+  final PluginProjectIdRequest _self;
+  final $Res Function(PluginProjectIdRequest) _then;
+
+/// Create a copy of PluginProjectIdRequest
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? projectId = null,Object? pluginId = null,}) {
+  return _then(_self.copyWith(
+projectId: null == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
+as String,pluginId: null == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _PluginProjectIdRequest implements PluginProjectIdRequest {
+  const _PluginProjectIdRequest({required this.projectId, this.pluginId = legacyMissingPluginId});
+  factory _PluginProjectIdRequest.fromJson(Map<String, dynamic> json) => _$PluginProjectIdRequestFromJson(json);
+
+@override final  String projectId;
+@override@JsonKey() final  String pluginId;
+
+/// Create a copy of PluginProjectIdRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$PluginProjectIdRequestCopyWith<_PluginProjectIdRequest> get copyWith => __$PluginProjectIdRequestCopyWithImpl<_PluginProjectIdRequest>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$PluginProjectIdRequestToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _PluginProjectIdRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,projectId,pluginId);
+
+@override
+String toString() {
+  return 'PluginProjectIdRequest(projectId: $projectId, pluginId: $pluginId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$PluginProjectIdRequestCopyWith<$Res> implements $PluginProjectIdRequestCopyWith<$Res> {
+  factory _$PluginProjectIdRequestCopyWith(_PluginProjectIdRequest value, $Res Function(_PluginProjectIdRequest) _then) = __$PluginProjectIdRequestCopyWithImpl;
+@override @useResult
+$Res call({
+ String projectId, String pluginId
+});
+
+
+
+
+}
+/// @nodoc
+class __$PluginProjectIdRequestCopyWithImpl<$Res>
+    implements _$PluginProjectIdRequestCopyWith<$Res> {
+  __$PluginProjectIdRequestCopyWithImpl(this._self, this._then);
+
+  final _PluginProjectIdRequest _self;
+  final $Res Function(_PluginProjectIdRequest) _then;
+
+/// Create a copy of PluginProjectIdRequest
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? projectId = null,Object? pluginId = null,}) {
+  return _then(_PluginProjectIdRequest(
+projectId: null == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
+as String,pluginId: null == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/shared/sesori_shared/lib/src/models/sesori/plugin_project_id_request.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/plugin_project_id_request.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'plugin_project_id_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PluginProjectIdRequest _$PluginProjectIdRequestFromJson(Map json) =>
+    _PluginProjectIdRequest(
+      projectId: json['projectId'] as String,
+      pluginId: json['pluginId'] as String? ?? legacyMissingPluginId,
+    );
+
+Map<String, dynamic> _$PluginProjectIdRequestToJson(
+  _PluginProjectIdRequest instance,
+) => <String, dynamic>{
+  'projectId': instance.projectId,
+  'pluginId': instance.pluginId,
+};

--- a/shared/sesori_shared/lib/src/models/sesori/project.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project.dart
@@ -55,8 +55,6 @@ sealed class ProjectTime with _$ProjectTime {
 sealed class ProjectIdRequest with _$ProjectIdRequest {
   const factory ProjectIdRequest({
     required String projectId,
-    // Nullable so requests remain compatible with older peers that do not identify plugins.
-    required String? pluginId,
   }) = _ProjectIdRequest;
 
   factory ProjectIdRequest.fromJson(Map<String, dynamic> json) => _$ProjectIdRequestFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/project.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project.dart
@@ -55,6 +55,8 @@ sealed class ProjectTime with _$ProjectTime {
 sealed class ProjectIdRequest with _$ProjectIdRequest {
   const factory ProjectIdRequest({
     required String projectId,
+    // Nullable so requests remain compatible with older peers that do not identify plugins.
+    required String? pluginId,
   }) = _ProjectIdRequest;
 
   factory ProjectIdRequest.fromJson(Map<String, dynamic> json) => _$ProjectIdRequestFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/project.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project.freezed.dart
@@ -493,7 +493,8 @@ as int,
 /// @nodoc
 mixin _$ProjectIdRequest {
 
- String get projectId;
+ String get projectId;// Nullable so requests remain compatible with older peers that do not identify plugins.
+ String? get pluginId;
 /// Create a copy of ProjectIdRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -506,16 +507,16 @@ $ProjectIdRequestCopyWith<ProjectIdRequest> get copyWith => _$ProjectIdRequestCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectIdRequest&&(identical(other.projectId, projectId) || other.projectId == projectId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectIdRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,projectId);
+int get hashCode => Object.hash(runtimeType,projectId,pluginId);
 
 @override
 String toString() {
-  return 'ProjectIdRequest(projectId: $projectId)';
+  return 'ProjectIdRequest(projectId: $projectId, pluginId: $pluginId)';
 }
 
 
@@ -526,7 +527,7 @@ abstract mixin class $ProjectIdRequestCopyWith<$Res>  {
   factory $ProjectIdRequestCopyWith(ProjectIdRequest value, $Res Function(ProjectIdRequest) _then) = _$ProjectIdRequestCopyWithImpl;
 @useResult
 $Res call({
- String projectId
+ String projectId, String? pluginId
 });
 
 
@@ -543,10 +544,11 @@ class _$ProjectIdRequestCopyWithImpl<$Res>
 
 /// Create a copy of ProjectIdRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? projectId = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? projectId = null,Object? pluginId = freezed,}) {
   return _then(_self.copyWith(
 projectId: null == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
-as String,
+as String,pluginId: freezed == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 
@@ -558,10 +560,12 @@ as String,
 @JsonSerializable()
 
 class _ProjectIdRequest implements ProjectIdRequest {
-  const _ProjectIdRequest({required this.projectId});
+  const _ProjectIdRequest({required this.projectId, required this.pluginId});
   factory _ProjectIdRequest.fromJson(Map<String, dynamic> json) => _$ProjectIdRequestFromJson(json);
 
 @override final  String projectId;
+// Nullable so requests remain compatible with older peers that do not identify plugins.
+@override final  String? pluginId;
 
 /// Create a copy of ProjectIdRequest
 /// with the given fields replaced by the non-null parameter values.
@@ -576,16 +580,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ProjectIdRequest&&(identical(other.projectId, projectId) || other.projectId == projectId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ProjectIdRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,projectId);
+int get hashCode => Object.hash(runtimeType,projectId,pluginId);
 
 @override
 String toString() {
-  return 'ProjectIdRequest(projectId: $projectId)';
+  return 'ProjectIdRequest(projectId: $projectId, pluginId: $pluginId)';
 }
 
 
@@ -596,7 +600,7 @@ abstract mixin class _$ProjectIdRequestCopyWith<$Res> implements $ProjectIdReque
   factory _$ProjectIdRequestCopyWith(_ProjectIdRequest value, $Res Function(_ProjectIdRequest) _then) = __$ProjectIdRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String projectId
+ String projectId, String? pluginId
 });
 
 
@@ -613,10 +617,11 @@ class __$ProjectIdRequestCopyWithImpl<$Res>
 
 /// Create a copy of ProjectIdRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? projectId = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? projectId = null,Object? pluginId = freezed,}) {
   return _then(_ProjectIdRequest(
 projectId: null == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
-as String,
+as String,pluginId: freezed == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/project.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project.freezed.dart
@@ -493,8 +493,7 @@ as int,
 /// @nodoc
 mixin _$ProjectIdRequest {
 
- String get projectId;// Nullable so requests remain compatible with older peers that do not identify plugins.
- String? get pluginId;
+ String get projectId;
 /// Create a copy of ProjectIdRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -507,16 +506,16 @@ $ProjectIdRequestCopyWith<ProjectIdRequest> get copyWith => _$ProjectIdRequestCo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectIdRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ProjectIdRequest&&(identical(other.projectId, projectId) || other.projectId == projectId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,projectId,pluginId);
+int get hashCode => Object.hash(runtimeType,projectId);
 
 @override
 String toString() {
-  return 'ProjectIdRequest(projectId: $projectId, pluginId: $pluginId)';
+  return 'ProjectIdRequest(projectId: $projectId)';
 }
 
 
@@ -527,7 +526,7 @@ abstract mixin class $ProjectIdRequestCopyWith<$Res>  {
   factory $ProjectIdRequestCopyWith(ProjectIdRequest value, $Res Function(ProjectIdRequest) _then) = _$ProjectIdRequestCopyWithImpl;
 @useResult
 $Res call({
- String projectId, String? pluginId
+ String projectId
 });
 
 
@@ -544,11 +543,10 @@ class _$ProjectIdRequestCopyWithImpl<$Res>
 
 /// Create a copy of ProjectIdRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? projectId = null,Object? pluginId = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? projectId = null,}) {
   return _then(_self.copyWith(
 projectId: null == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
-as String,pluginId: freezed == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
-as String?,
+as String,
   ));
 }
 
@@ -560,12 +558,10 @@ as String?,
 @JsonSerializable()
 
 class _ProjectIdRequest implements ProjectIdRequest {
-  const _ProjectIdRequest({required this.projectId, required this.pluginId});
+  const _ProjectIdRequest({required this.projectId});
   factory _ProjectIdRequest.fromJson(Map<String, dynamic> json) => _$ProjectIdRequestFromJson(json);
 
 @override final  String projectId;
-// Nullable so requests remain compatible with older peers that do not identify plugins.
-@override final  String? pluginId;
 
 /// Create a copy of ProjectIdRequest
 /// with the given fields replaced by the non-null parameter values.
@@ -580,16 +576,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ProjectIdRequest&&(identical(other.projectId, projectId) || other.projectId == projectId)&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ProjectIdRequest&&(identical(other.projectId, projectId) || other.projectId == projectId));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,projectId,pluginId);
+int get hashCode => Object.hash(runtimeType,projectId);
 
 @override
 String toString() {
-  return 'ProjectIdRequest(projectId: $projectId, pluginId: $pluginId)';
+  return 'ProjectIdRequest(projectId: $projectId)';
 }
 
 
@@ -600,7 +596,7 @@ abstract mixin class _$ProjectIdRequestCopyWith<$Res> implements $ProjectIdReque
   factory _$ProjectIdRequestCopyWith(_ProjectIdRequest value, $Res Function(_ProjectIdRequest) _then) = __$ProjectIdRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String projectId, String? pluginId
+ String projectId
 });
 
 
@@ -617,11 +613,10 @@ class __$ProjectIdRequestCopyWithImpl<$Res>
 
 /// Create a copy of ProjectIdRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? projectId = null,Object? pluginId = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? projectId = null,}) {
   return _then(_ProjectIdRequest(
 projectId: null == projectId ? _self.projectId : projectId // ignore: cast_nullable_to_non_nullable
-as String,pluginId: freezed == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
-as String?,
+as String,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/project.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project.g.dart
@@ -44,11 +44,16 @@ _ProjectTime _$ProjectTimeFromJson(Map json) => _ProjectTime(
 Map<String, dynamic> _$ProjectTimeToJson(_ProjectTime instance) =>
     <String, dynamic>{'created': instance.created, 'updated': instance.updated};
 
-_ProjectIdRequest _$ProjectIdRequestFromJson(Map json) =>
-    _ProjectIdRequest(projectId: json['projectId'] as String);
+_ProjectIdRequest _$ProjectIdRequestFromJson(Map json) => _ProjectIdRequest(
+  projectId: json['projectId'] as String,
+  pluginId: json['pluginId'] as String?,
+);
 
 Map<String, dynamic> _$ProjectIdRequestToJson(_ProjectIdRequest instance) =>
-    <String, dynamic>{'projectId': instance.projectId};
+    <String, dynamic>{
+      'projectId': instance.projectId,
+      'pluginId': ?instance.pluginId,
+    };
 
 _ProjectPathRequest _$ProjectPathRequestFromJson(Map json) =>
     _ProjectPathRequest(path: json['path'] as String);

--- a/shared/sesori_shared/lib/src/models/sesori/project.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/project.g.dart
@@ -44,16 +44,11 @@ _ProjectTime _$ProjectTimeFromJson(Map json) => _ProjectTime(
 Map<String, dynamic> _$ProjectTimeToJson(_ProjectTime instance) =>
     <String, dynamic>{'created': instance.created, 'updated': instance.updated};
 
-_ProjectIdRequest _$ProjectIdRequestFromJson(Map json) => _ProjectIdRequest(
-  projectId: json['projectId'] as String,
-  pluginId: json['pluginId'] as String?,
-);
+_ProjectIdRequest _$ProjectIdRequestFromJson(Map json) =>
+    _ProjectIdRequest(projectId: json['projectId'] as String);
 
 Map<String, dynamic> _$ProjectIdRequestToJson(_ProjectIdRequest instance) =>
-    <String, dynamic>{
-      'projectId': instance.projectId,
-      'pluginId': ?instance.pluginId,
-    };
+    <String, dynamic>{'projectId': instance.projectId};
 
 _ProjectPathRequest _$ProjectPathRequestFromJson(Map json) =>
     _ProjectPathRequest(path: json['path'] as String);

--- a/shared/sesori_shared/lib/src/models/sesori/session.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.dart
@@ -1,6 +1,7 @@
 import "package:freezed_annotation/freezed_annotation.dart";
 
 import "agent_info.dart";
+import "plugin_identity.dart";
 import "pull_request_info.dart";
 
 part "session.freezed.dart";
@@ -32,11 +33,9 @@ sealed class SessionListRequest with _$SessionListRequest {
 
 @Freezed(fromJson: true, toJson: true)
 sealed class Session with _$Session {
-  // ignore: no_slop_linter/prefer_required_named_parameters, optional nullable field must remain omittable for backward-compatible JSON.
   const factory Session({
     required String id,
-    // Nullable so payloads from older peers without plugin routing metadata remain compatible.
-    required String? pluginId,
+    @Default(legacyMissingPluginId) String pluginId,
     required String projectID,
     required String directory,
     required String? parentID,

--- a/shared/sesori_shared/lib/src/models/sesori/session.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.dart
@@ -35,6 +35,8 @@ sealed class Session with _$Session {
   // ignore: no_slop_linter/prefer_required_named_parameters, optional nullable field must remain omittable for backward-compatible JSON.
   const factory Session({
     required String id,
+    // Nullable so payloads from older peers without plugin routing metadata remain compatible.
+    required String? pluginId,
     required String projectID,
     required String directory,
     required String? parentID,

--- a/shared/sesori_shared/lib/src/models/sesori/session.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.freezed.dart
@@ -298,8 +298,7 @@ as bool,
 /// @nodoc
 mixin _$Session {
 
- String get id;// Nullable so payloads from older peers without plugin routing metadata remain compatible.
- String? get pluginId; String get projectID; String get directory; String? get parentID; String? get title; SessionTime? get time; SessionSummary? get summary; PullRequestInfo? get pullRequest; SessionPromptDefaults? get promptDefaults; bool get hasWorktree;// Whether this session has unseen activity (new changes the user has not
+ String get id; String get pluginId; String get projectID; String get directory; String? get parentID; String? get title; SessionTime? get time; SessionSummary? get summary; PullRequestInfo? get pullRequest; SessionPromptDefaults? get promptDefaults; bool get hasWorktree;// Whether this session has unseen activity (new changes the user has not
 // viewed). Backend-computed; advances on activity and is cleared by viewing
 // the session or an explicit mark-as-read. Defaults to false so older
 // payloads (and the baseline) deserialize as "seen".
@@ -336,7 +335,7 @@ abstract mixin class $SessionCopyWith<$Res>  {
   factory $SessionCopyWith(Session value, $Res Function(Session) _then) = _$SessionCopyWithImpl;
 @useResult
 $Res call({
- String id, String? pluginId, String projectID, String directory, String? parentID, String? title, SessionTime? time, SessionSummary? summary, PullRequestInfo? pullRequest, SessionPromptDefaults? promptDefaults, bool hasWorktree, bool unseen
+ String id, String pluginId, String projectID, String directory, String? parentID, String? title, SessionTime? time, SessionSummary? summary, PullRequestInfo? pullRequest, SessionPromptDefaults? promptDefaults, bool hasWorktree, bool unseen
 });
 
 
@@ -353,11 +352,11 @@ class _$SessionCopyWithImpl<$Res>
 
 /// Create a copy of Session
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? pluginId = freezed,Object? projectID = null,Object? directory = null,Object? parentID = freezed,Object? title = freezed,Object? time = freezed,Object? summary = freezed,Object? pullRequest = freezed,Object? promptDefaults = freezed,Object? hasWorktree = null,Object? unseen = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? pluginId = null,Object? projectID = null,Object? directory = null,Object? parentID = freezed,Object? title = freezed,Object? time = freezed,Object? summary = freezed,Object? pullRequest = freezed,Object? promptDefaults = freezed,Object? hasWorktree = null,Object? unseen = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as String,pluginId: freezed == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
-as String?,projectID: null == projectID ? _self.projectID : projectID // ignore: cast_nullable_to_non_nullable
+as String,pluginId: null == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String,projectID: null == projectID ? _self.projectID : projectID // ignore: cast_nullable_to_non_nullable
 as String,directory: null == directory ? _self.directory : directory // ignore: cast_nullable_to_non_nullable
 as String,parentID: freezed == parentID ? _self.parentID : parentID // ignore: cast_nullable_to_non_nullable
 as String?,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
@@ -427,12 +426,11 @@ $SessionPromptDefaultsCopyWith<$Res>? get promptDefaults {
 @JsonSerializable()
 
 class _Session implements Session {
-  const _Session({required this.id, required this.pluginId, required this.projectID, required this.directory, required this.parentID, required this.title, required this.time, required this.summary, required this.pullRequest, required this.promptDefaults, this.hasWorktree = false, this.unseen = false});
+  const _Session({required this.id, this.pluginId = legacyMissingPluginId, required this.projectID, required this.directory, required this.parentID, required this.title, required this.time, required this.summary, required this.pullRequest, required this.promptDefaults, this.hasWorktree = false, this.unseen = false});
   factory _Session.fromJson(Map<String, dynamic> json) => _$SessionFromJson(json);
 
 @override final  String id;
-// Nullable so payloads from older peers without plugin routing metadata remain compatible.
-@override final  String? pluginId;
+@override@JsonKey() final  String pluginId;
 @override final  String projectID;
 @override final  String directory;
 @override final  String? parentID;
@@ -481,7 +479,7 @@ abstract mixin class _$SessionCopyWith<$Res> implements $SessionCopyWith<$Res> {
   factory _$SessionCopyWith(_Session value, $Res Function(_Session) _then) = __$SessionCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String? pluginId, String projectID, String directory, String? parentID, String? title, SessionTime? time, SessionSummary? summary, PullRequestInfo? pullRequest, SessionPromptDefaults? promptDefaults, bool hasWorktree, bool unseen
+ String id, String pluginId, String projectID, String directory, String? parentID, String? title, SessionTime? time, SessionSummary? summary, PullRequestInfo? pullRequest, SessionPromptDefaults? promptDefaults, bool hasWorktree, bool unseen
 });
 
 
@@ -498,11 +496,11 @@ class __$SessionCopyWithImpl<$Res>
 
 /// Create a copy of Session
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? pluginId = freezed,Object? projectID = null,Object? directory = null,Object? parentID = freezed,Object? title = freezed,Object? time = freezed,Object? summary = freezed,Object? pullRequest = freezed,Object? promptDefaults = freezed,Object? hasWorktree = null,Object? unseen = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? pluginId = null,Object? projectID = null,Object? directory = null,Object? parentID = freezed,Object? title = freezed,Object? time = freezed,Object? summary = freezed,Object? pullRequest = freezed,Object? promptDefaults = freezed,Object? hasWorktree = null,Object? unseen = null,}) {
   return _then(_Session(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as String,pluginId: freezed == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
-as String?,projectID: null == projectID ? _self.projectID : projectID // ignore: cast_nullable_to_non_nullable
+as String,pluginId: null == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String,projectID: null == projectID ? _self.projectID : projectID // ignore: cast_nullable_to_non_nullable
 as String,directory: null == directory ? _self.directory : directory // ignore: cast_nullable_to_non_nullable
 as String,parentID: freezed == parentID ? _self.parentID : parentID // ignore: cast_nullable_to_non_nullable
 as String?,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable

--- a/shared/sesori_shared/lib/src/models/sesori/session.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.freezed.dart
@@ -298,7 +298,8 @@ as bool,
 /// @nodoc
 mixin _$Session {
 
- String get id; String get projectID; String get directory; String? get parentID; String? get title; SessionTime? get time; SessionSummary? get summary; PullRequestInfo? get pullRequest; SessionPromptDefaults? get promptDefaults; bool get hasWorktree;// Whether this session has unseen activity (new changes the user has not
+ String get id;// Nullable so payloads from older peers without plugin routing metadata remain compatible.
+ String? get pluginId; String get projectID; String get directory; String? get parentID; String? get title; SessionTime? get time; SessionSummary? get summary; PullRequestInfo? get pullRequest; SessionPromptDefaults? get promptDefaults; bool get hasWorktree;// Whether this session has unseen activity (new changes the user has not
 // viewed). Backend-computed; advances on activity and is cleared by viewing
 // the session or an explicit mark-as-read. Defaults to false so older
 // payloads (and the baseline) deserialize as "seen".
@@ -315,16 +316,16 @@ $SessionCopyWith<Session> get copyWith => _$SessionCopyWithImpl<Session>(this as
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Session&&(identical(other.id, id) || other.id == id)&&(identical(other.projectID, projectID) || other.projectID == projectID)&&(identical(other.directory, directory) || other.directory == directory)&&(identical(other.parentID, parentID) || other.parentID == parentID)&&(identical(other.title, title) || other.title == title)&&(identical(other.time, time) || other.time == time)&&(identical(other.summary, summary) || other.summary == summary)&&(identical(other.pullRequest, pullRequest) || other.pullRequest == pullRequest)&&(identical(other.promptDefaults, promptDefaults) || other.promptDefaults == promptDefaults)&&(identical(other.hasWorktree, hasWorktree) || other.hasWorktree == hasWorktree)&&(identical(other.unseen, unseen) || other.unseen == unseen));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Session&&(identical(other.id, id) || other.id == id)&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId)&&(identical(other.projectID, projectID) || other.projectID == projectID)&&(identical(other.directory, directory) || other.directory == directory)&&(identical(other.parentID, parentID) || other.parentID == parentID)&&(identical(other.title, title) || other.title == title)&&(identical(other.time, time) || other.time == time)&&(identical(other.summary, summary) || other.summary == summary)&&(identical(other.pullRequest, pullRequest) || other.pullRequest == pullRequest)&&(identical(other.promptDefaults, promptDefaults) || other.promptDefaults == promptDefaults)&&(identical(other.hasWorktree, hasWorktree) || other.hasWorktree == hasWorktree)&&(identical(other.unseen, unseen) || other.unseen == unseen));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,projectID,directory,parentID,title,time,summary,pullRequest,promptDefaults,hasWorktree,unseen);
+int get hashCode => Object.hash(runtimeType,id,pluginId,projectID,directory,parentID,title,time,summary,pullRequest,promptDefaults,hasWorktree,unseen);
 
 @override
 String toString() {
-  return 'Session(id: $id, projectID: $projectID, directory: $directory, parentID: $parentID, title: $title, time: $time, summary: $summary, pullRequest: $pullRequest, promptDefaults: $promptDefaults, hasWorktree: $hasWorktree, unseen: $unseen)';
+  return 'Session(id: $id, pluginId: $pluginId, projectID: $projectID, directory: $directory, parentID: $parentID, title: $title, time: $time, summary: $summary, pullRequest: $pullRequest, promptDefaults: $promptDefaults, hasWorktree: $hasWorktree, unseen: $unseen)';
 }
 
 
@@ -335,7 +336,7 @@ abstract mixin class $SessionCopyWith<$Res>  {
   factory $SessionCopyWith(Session value, $Res Function(Session) _then) = _$SessionCopyWithImpl;
 @useResult
 $Res call({
- String id, String projectID, String directory, String? parentID, String? title, SessionTime? time, SessionSummary? summary, PullRequestInfo? pullRequest, SessionPromptDefaults? promptDefaults, bool hasWorktree, bool unseen
+ String id, String? pluginId, String projectID, String directory, String? parentID, String? title, SessionTime? time, SessionSummary? summary, PullRequestInfo? pullRequest, SessionPromptDefaults? promptDefaults, bool hasWorktree, bool unseen
 });
 
 
@@ -352,10 +353,11 @@ class _$SessionCopyWithImpl<$Res>
 
 /// Create a copy of Session
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? projectID = null,Object? directory = null,Object? parentID = freezed,Object? title = freezed,Object? time = freezed,Object? summary = freezed,Object? pullRequest = freezed,Object? promptDefaults = freezed,Object? hasWorktree = null,Object? unseen = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? pluginId = freezed,Object? projectID = null,Object? directory = null,Object? parentID = freezed,Object? title = freezed,Object? time = freezed,Object? summary = freezed,Object? pullRequest = freezed,Object? promptDefaults = freezed,Object? hasWorktree = null,Object? unseen = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as String,projectID: null == projectID ? _self.projectID : projectID // ignore: cast_nullable_to_non_nullable
+as String,pluginId: freezed == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String?,projectID: null == projectID ? _self.projectID : projectID // ignore: cast_nullable_to_non_nullable
 as String,directory: null == directory ? _self.directory : directory // ignore: cast_nullable_to_non_nullable
 as String,parentID: freezed == parentID ? _self.parentID : parentID // ignore: cast_nullable_to_non_nullable
 as String?,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
@@ -425,10 +427,12 @@ $SessionPromptDefaultsCopyWith<$Res>? get promptDefaults {
 @JsonSerializable()
 
 class _Session implements Session {
-  const _Session({required this.id, required this.projectID, required this.directory, required this.parentID, required this.title, required this.time, required this.summary, required this.pullRequest, required this.promptDefaults, this.hasWorktree = false, this.unseen = false});
+  const _Session({required this.id, required this.pluginId, required this.projectID, required this.directory, required this.parentID, required this.title, required this.time, required this.summary, required this.pullRequest, required this.promptDefaults, this.hasWorktree = false, this.unseen = false});
   factory _Session.fromJson(Map<String, dynamic> json) => _$SessionFromJson(json);
 
 @override final  String id;
+// Nullable so payloads from older peers without plugin routing metadata remain compatible.
+@override final  String? pluginId;
 @override final  String projectID;
 @override final  String directory;
 @override final  String? parentID;
@@ -457,16 +461,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Session&&(identical(other.id, id) || other.id == id)&&(identical(other.projectID, projectID) || other.projectID == projectID)&&(identical(other.directory, directory) || other.directory == directory)&&(identical(other.parentID, parentID) || other.parentID == parentID)&&(identical(other.title, title) || other.title == title)&&(identical(other.time, time) || other.time == time)&&(identical(other.summary, summary) || other.summary == summary)&&(identical(other.pullRequest, pullRequest) || other.pullRequest == pullRequest)&&(identical(other.promptDefaults, promptDefaults) || other.promptDefaults == promptDefaults)&&(identical(other.hasWorktree, hasWorktree) || other.hasWorktree == hasWorktree)&&(identical(other.unseen, unseen) || other.unseen == unseen));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Session&&(identical(other.id, id) || other.id == id)&&(identical(other.pluginId, pluginId) || other.pluginId == pluginId)&&(identical(other.projectID, projectID) || other.projectID == projectID)&&(identical(other.directory, directory) || other.directory == directory)&&(identical(other.parentID, parentID) || other.parentID == parentID)&&(identical(other.title, title) || other.title == title)&&(identical(other.time, time) || other.time == time)&&(identical(other.summary, summary) || other.summary == summary)&&(identical(other.pullRequest, pullRequest) || other.pullRequest == pullRequest)&&(identical(other.promptDefaults, promptDefaults) || other.promptDefaults == promptDefaults)&&(identical(other.hasWorktree, hasWorktree) || other.hasWorktree == hasWorktree)&&(identical(other.unseen, unseen) || other.unseen == unseen));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,projectID,directory,parentID,title,time,summary,pullRequest,promptDefaults,hasWorktree,unseen);
+int get hashCode => Object.hash(runtimeType,id,pluginId,projectID,directory,parentID,title,time,summary,pullRequest,promptDefaults,hasWorktree,unseen);
 
 @override
 String toString() {
-  return 'Session(id: $id, projectID: $projectID, directory: $directory, parentID: $parentID, title: $title, time: $time, summary: $summary, pullRequest: $pullRequest, promptDefaults: $promptDefaults, hasWorktree: $hasWorktree, unseen: $unseen)';
+  return 'Session(id: $id, pluginId: $pluginId, projectID: $projectID, directory: $directory, parentID: $parentID, title: $title, time: $time, summary: $summary, pullRequest: $pullRequest, promptDefaults: $promptDefaults, hasWorktree: $hasWorktree, unseen: $unseen)';
 }
 
 
@@ -477,7 +481,7 @@ abstract mixin class _$SessionCopyWith<$Res> implements $SessionCopyWith<$Res> {
   factory _$SessionCopyWith(_Session value, $Res Function(_Session) _then) = __$SessionCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String projectID, String directory, String? parentID, String? title, SessionTime? time, SessionSummary? summary, PullRequestInfo? pullRequest, SessionPromptDefaults? promptDefaults, bool hasWorktree, bool unseen
+ String id, String? pluginId, String projectID, String directory, String? parentID, String? title, SessionTime? time, SessionSummary? summary, PullRequestInfo? pullRequest, SessionPromptDefaults? promptDefaults, bool hasWorktree, bool unseen
 });
 
 
@@ -494,10 +498,11 @@ class __$SessionCopyWithImpl<$Res>
 
 /// Create a copy of Session
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? projectID = null,Object? directory = null,Object? parentID = freezed,Object? title = freezed,Object? time = freezed,Object? summary = freezed,Object? pullRequest = freezed,Object? promptDefaults = freezed,Object? hasWorktree = null,Object? unseen = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? pluginId = freezed,Object? projectID = null,Object? directory = null,Object? parentID = freezed,Object? title = freezed,Object? time = freezed,Object? summary = freezed,Object? pullRequest = freezed,Object? promptDefaults = freezed,Object? hasWorktree = null,Object? unseen = null,}) {
   return _then(_Session(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as String,projectID: null == projectID ? _self.projectID : projectID // ignore: cast_nullable_to_non_nullable
+as String,pluginId: freezed == pluginId ? _self.pluginId : pluginId // ignore: cast_nullable_to_non_nullable
+as String?,projectID: null == projectID ? _self.projectID : projectID // ignore: cast_nullable_to_non_nullable
 as String,directory: null == directory ? _self.directory : directory // ignore: cast_nullable_to_non_nullable
 as String,parentID: freezed == parentID ? _self.parentID : parentID // ignore: cast_nullable_to_non_nullable
 as String?,title: freezed == title ? _self.title : title // ignore: cast_nullable_to_non_nullable

--- a/shared/sesori_shared/lib/src/models/sesori/session.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.g.dart
@@ -35,6 +35,7 @@ Map<String, dynamic> _$SessionListRequestToJson(_SessionListRequest instance) =>
 
 _Session _$SessionFromJson(Map json) => _Session(
   id: json['id'] as String,
+  pluginId: json['pluginId'] as String?,
   projectID: json['projectID'] as String,
   directory: json['directory'] as String,
   parentID: json['parentID'] as String?,
@@ -63,6 +64,7 @@ _Session _$SessionFromJson(Map json) => _Session(
 
 Map<String, dynamic> _$SessionToJson(_Session instance) => <String, dynamic>{
   'id': instance.id,
+  'pluginId': ?instance.pluginId,
   'projectID': instance.projectID,
   'directory': instance.directory,
   'parentID': ?instance.parentID,

--- a/shared/sesori_shared/lib/src/models/sesori/session.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.g.dart
@@ -35,7 +35,7 @@ Map<String, dynamic> _$SessionListRequestToJson(_SessionListRequest instance) =>
 
 _Session _$SessionFromJson(Map json) => _Session(
   id: json['id'] as String,
-  pluginId: json['pluginId'] as String?,
+  pluginId: json['pluginId'] as String? ?? legacyMissingPluginId,
   projectID: json['projectID'] as String,
   directory: json['directory'] as String,
   parentID: json['parentID'] as String?,
@@ -64,7 +64,7 @@ _Session _$SessionFromJson(Map json) => _Session(
 
 Map<String, dynamic> _$SessionToJson(_Session instance) => <String, dynamic>{
   'id': instance.id,
-  'pluginId': ?instance.pluginId,
+  'pluginId': instance.pluginId,
   'projectID': instance.projectID,
   'directory': instance.directory,
   'parentID': ?instance.parentID,

--- a/shared/sesori_shared/test/models/plugin_id_compatibility_test.dart
+++ b/shared/sesori_shared/test/models/plugin_id_compatibility_test.dart
@@ -1,0 +1,114 @@
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("Session.pluginId", () {
+    test("round-trips a non-null value", () {
+      const session = Session(
+        id: "session-1",
+        pluginId: "opencode",
+        projectID: "project-1",
+        directory: "/tmp/project-1",
+        parentID: null,
+        title: null,
+        time: null,
+        summary: null,
+        pullRequest: null,
+        promptDefaults: null,
+      );
+
+      expect(Session.fromJson(session.toJson()).pluginId, "opencode");
+    });
+
+    test("decodes a missing key as null", () {
+      final session = Session.fromJson({
+        "id": "session-1",
+        "projectID": "project-1",
+        "directory": "/tmp/project-1",
+        "parentID": null,
+        "title": null,
+        "time": null,
+        "summary": null,
+        "pullRequest": null,
+      });
+
+      expect(session.pluginId, isNull);
+    });
+
+    test("omits a null value", () {
+      const session = Session(
+        id: "session-1",
+        pluginId: null,
+        projectID: "project-1",
+        directory: "/tmp/project-1",
+        parentID: null,
+        title: null,
+        time: null,
+        summary: null,
+        pullRequest: null,
+        promptDefaults: null,
+      );
+
+      expect(session.toJson(), isNot(contains("pluginId")));
+    });
+  });
+
+  group("CreateSessionRequest.pluginId", () {
+    CreateSessionRequest request({required String? pluginId}) => CreateSessionRequest(
+      projectId: "project-1",
+      pluginId: pluginId,
+      parts: const [PromptPart.text(text: "hello")],
+      agent: null,
+      model: null,
+      command: null,
+      variant: null,
+      dedicatedWorktree: false,
+    );
+
+    test("round-trips a non-null value", () {
+      final value = request(pluginId: "opencode");
+
+      expect(CreateSessionRequest.fromJson(value.toJson()).pluginId, "opencode");
+    });
+
+    test("decodes a missing key as null", () {
+      final value = CreateSessionRequest.fromJson({
+        "projectId": "project-1",
+        "parts": const [
+          {"type": "text", "text": "hello"},
+        ],
+        "agent": null,
+        "model": null,
+        "command": null,
+        "variant": null,
+        "dedicatedWorktree": false,
+      });
+
+      expect(value.pluginId, isNull);
+    });
+
+    test("omits a null value", () {
+      expect(request(pluginId: null).toJson(), isNot(contains("pluginId")));
+    });
+  });
+
+  group("ProjectIdRequest.pluginId", () {
+    test("round-trips a non-null value", () {
+      const request = ProjectIdRequest(projectId: "project-1", pluginId: "opencode");
+
+      expect(ProjectIdRequest.fromJson(request.toJson()).pluginId, "opencode");
+    });
+
+    test("decodes a missing key as null", () {
+      final request = ProjectIdRequest.fromJson({"projectId": "project-1"});
+
+      expect(request.pluginId, isNull);
+    });
+
+    test("omits a null value", () {
+      const request = ProjectIdRequest(projectId: "project-1", pluginId: null);
+
+      expect(request.toJson(), isNot(contains("pluginId")));
+    });
+  });
+}

--- a/shared/sesori_shared/test/models/plugin_id_compatibility_test.dart
+++ b/shared/sesori_shared/test/models/plugin_id_compatibility_test.dart
@@ -20,7 +20,7 @@ void main() {
       expect(Session.fromJson(session.toJson()).pluginId, "opencode");
     });
 
-    test("decodes a missing key as null", () {
+    test("normalizes missing and null keys to the legacy sentinel", () {
       final session = Session.fromJson({
         "id": "session-1",
         "projectID": "project-1",
@@ -32,29 +32,13 @@ void main() {
         "pullRequest": null,
       });
 
-      expect(session.pluginId, isNull);
-    });
-
-    test("omits a null value", () {
-      const session = Session(
-        id: "session-1",
-        pluginId: null,
-        projectID: "project-1",
-        directory: "/tmp/project-1",
-        parentID: null,
-        title: null,
-        time: null,
-        summary: null,
-        pullRequest: null,
-        promptDefaults: null,
-      );
-
-      expect(session.toJson(), isNot(contains("pluginId")));
+      expect(session.pluginId, legacyMissingPluginId);
+      expect(Session.fromJson({...session.toJson(), "pluginId": null}).pluginId, legacyMissingPluginId);
     });
   });
 
   group("CreateSessionRequest.pluginId", () {
-    CreateSessionRequest request({required String? pluginId}) => CreateSessionRequest(
+    CreateSessionRequest request({required String pluginId}) => CreateSessionRequest(
       projectId: "project-1",
       pluginId: pluginId,
       parts: const [PromptPart.text(text: "hello")],
@@ -71,7 +55,7 @@ void main() {
       expect(CreateSessionRequest.fromJson(value.toJson()).pluginId, "opencode");
     });
 
-    test("decodes a missing key as null", () {
+    test("normalizes missing and null keys to the legacy sentinel", () {
       final value = CreateSessionRequest.fromJson({
         "projectId": "project-1",
         "parts": const [
@@ -84,31 +68,41 @@ void main() {
         "dedicatedWorktree": false,
       });
 
-      expect(value.pluginId, isNull);
-    });
-
-    test("omits a null value", () {
-      expect(request(pluginId: null).toJson(), isNot(contains("pluginId")));
+      expect(value.pluginId, legacyMissingPluginId);
+      expect(CreateSessionRequest.fromJson({...value.toJson(), "pluginId": null}).pluginId, legacyMissingPluginId);
     });
   });
 
-  group("ProjectIdRequest.pluginId", () {
-    test("round-trips a non-null value", () {
-      const request = ProjectIdRequest(projectId: "project-1", pluginId: "opencode");
+  group("ProjectIdRequest", () {
+    test("contains only project identity", () {
+      const request = ProjectIdRequest(projectId: "project-1");
 
-      expect(ProjectIdRequest.fromJson(request.toJson()).pluginId, "opencode");
+      expect(ProjectIdRequest.fromJson(request.toJson()), request);
+      expect(request.toJson(), {"projectId": "project-1"});
+    });
+  });
+
+  group("PluginProjectIdRequest.pluginId", () {
+    test("round-trips a non-legacy value", () {
+      const request = PluginProjectIdRequest(projectId: "project-1", pluginId: "opencode");
+
+      expect(PluginProjectIdRequest.fromJson(request.toJson()), request);
     });
 
-    test("decodes a missing key as null", () {
-      final request = ProjectIdRequest.fromJson({"projectId": "project-1"});
+    test("normalizes missing and null keys to the legacy sentinel", () {
+      final request = PluginProjectIdRequest.fromJson({"projectId": "project-1"});
 
-      expect(request.pluginId, isNull);
+      expect(request.pluginId, legacyMissingPluginId);
+      expect(
+        PluginProjectIdRequest.fromJson({"projectId": "project-1", "pluginId": null}).pluginId,
+        legacyMissingPluginId,
+      );
     });
 
-    test("omits a null value", () {
-      const request = ProjectIdRequest(projectId: "project-1", pluginId: null);
+    test("serializes the sentinel explicitly", () {
+      const request = PluginProjectIdRequest(projectId: "project-1");
 
-      expect(request.toJson(), isNot(contains("pluginId")));
+      expect(request.toJson(), {"projectId": "project-1", "pluginId": legacyMissingPluginId});
     });
   });
 }

--- a/shared/sesori_shared/test/models/plugin_id_compatibility_test.dart
+++ b/shared/sesori_shared/test/models/plugin_id_compatibility_test.dart
@@ -20,7 +20,7 @@ void main() {
       expect(Session.fromJson(session.toJson()).pluginId, "opencode");
     });
 
-    test("normalizes missing and null keys to the legacy sentinel", () {
+    test("attributes missing and null keys to OpenCode", () {
       final session = Session.fromJson({
         "id": "session-1",
         "projectID": "project-1",
@@ -32,8 +32,9 @@ void main() {
         "pullRequest": null,
       });
 
-      expect(session.pluginId, legacyMissingPluginId);
-      expect(Session.fromJson({...session.toJson(), "pluginId": null}).pluginId, legacyMissingPluginId);
+      expect(legacyMissingPluginId, "opencode");
+      expect(session.pluginId, "opencode");
+      expect(Session.fromJson({...session.toJson(), "pluginId": null}).pluginId, "opencode");
     });
   });
 
@@ -55,7 +56,7 @@ void main() {
       expect(CreateSessionRequest.fromJson(value.toJson()).pluginId, "opencode");
     });
 
-    test("normalizes missing and null keys to the legacy sentinel", () {
+    test("attributes missing and null keys to OpenCode", () {
       final value = CreateSessionRequest.fromJson({
         "projectId": "project-1",
         "parts": const [
@@ -68,8 +69,8 @@ void main() {
         "dedicatedWorktree": false,
       });
 
-      expect(value.pluginId, legacyMissingPluginId);
-      expect(CreateSessionRequest.fromJson({...value.toJson(), "pluginId": null}).pluginId, legacyMissingPluginId);
+      expect(value.pluginId, "opencode");
+      expect(CreateSessionRequest.fromJson({...value.toJson(), "pluginId": null}).pluginId, "opencode");
     });
   });
 
@@ -89,20 +90,20 @@ void main() {
       expect(PluginProjectIdRequest.fromJson(request.toJson()), request);
     });
 
-    test("normalizes missing and null keys to the legacy sentinel", () {
+    test("attributes missing and null keys to OpenCode", () {
       final request = PluginProjectIdRequest.fromJson({"projectId": "project-1"});
 
-      expect(request.pluginId, legacyMissingPluginId);
+      expect(request.pluginId, "opencode");
       expect(
         PluginProjectIdRequest.fromJson({"projectId": "project-1", "pluginId": null}).pluginId,
-        legacyMissingPluginId,
+        "opencode",
       );
     });
 
-    test("serializes the sentinel explicitly", () {
+    test("serializes the legacy OpenCode default explicitly", () {
       const request = PluginProjectIdRequest(projectId: "project-1");
 
-      expect(request.toJson(), {"projectId": "project-1", "pluginId": legacyMissingPluginId});
+      expect(request.toJson(), {"projectId": "project-1", "pluginId": "opencode"});
     });
   });
 }

--- a/shared/sesori_shared/test/models/sesori_sse_event_test.dart
+++ b/shared/sesori_shared/test/models/sesori_sse_event_test.dart
@@ -75,6 +75,7 @@ void main() {
     test('serializes and deserializes Session info correctly', () {
       const session = Session(
         id: 'ses_001',
+        pluginId: null,
         projectID: 'proj_001',
         directory: '/home/user/project',
         parentID: null,
@@ -106,6 +107,7 @@ void main() {
     test('serializes and deserializes correctly', () {
       const session = Session(
         id: 'ses_002',
+        pluginId: null,
         projectID: 'proj_002',
         directory: '/home/user/other',
         parentID: null,
@@ -135,6 +137,7 @@ void main() {
     test('serializes and deserializes correctly', () {
       const session = Session(
         id: 'ses_003',
+        pluginId: null,
         projectID: 'proj_003',
         directory: '/deleted/path',
         parentID: null,
@@ -422,6 +425,7 @@ void main() {
       const created = SesoriSseEvent.sessionCreated(
         info: Session(
           id: 'x',
+          pluginId: null,
           projectID: 'p',
           directory: '/d',
           parentID: null,
@@ -439,6 +443,7 @@ void main() {
       const updated = SesoriSseEvent.sessionUpdated(
         info: Session(
           id: 'x',
+          pluginId: null,
           projectID: 'p',
           directory: '/d',
           parentID: null,
@@ -456,6 +461,7 @@ void main() {
       const deleted = SesoriSseEvent.sessionDeleted(
         info: Session(
           id: 'x',
+          pluginId: null,
           projectID: 'p',
           directory: '/d',
           parentID: null,
@@ -664,6 +670,7 @@ void main() {
       final json = const SesoriSseEvent.sessionCreated(
         info: Session(
           id: 'i',
+          pluginId: null,
           projectID: 'p',
           directory: '/d',
           parentID: null,
@@ -681,6 +688,7 @@ void main() {
       final json = const SesoriSseEvent.sessionUpdated(
         info: Session(
           id: 'i',
+          pluginId: null,
           projectID: 'p',
           directory: '/d',
           parentID: null,
@@ -698,6 +706,7 @@ void main() {
       final json = const SesoriSseEvent.sessionDeleted(
         info: Session(
           id: 'i',
+          pluginId: null,
           projectID: 'p',
           directory: '/d',
           parentID: null,

--- a/shared/sesori_shared/test/models/sesori_sse_event_test.dart
+++ b/shared/sesori_shared/test/models/sesori_sse_event_test.dart
@@ -75,7 +75,7 @@ void main() {
     test('serializes and deserializes Session info correctly', () {
       const session = Session(
         id: 'ses_001',
-        pluginId: null,
+        pluginId: legacyMissingPluginId,
         projectID: 'proj_001',
         directory: '/home/user/project',
         parentID: null,
@@ -107,7 +107,7 @@ void main() {
     test('serializes and deserializes correctly', () {
       const session = Session(
         id: 'ses_002',
-        pluginId: null,
+        pluginId: legacyMissingPluginId,
         projectID: 'proj_002',
         directory: '/home/user/other',
         parentID: null,
@@ -137,7 +137,7 @@ void main() {
     test('serializes and deserializes correctly', () {
       const session = Session(
         id: 'ses_003',
-        pluginId: null,
+        pluginId: legacyMissingPluginId,
         projectID: 'proj_003',
         directory: '/deleted/path',
         parentID: null,
@@ -425,7 +425,7 @@ void main() {
       const created = SesoriSseEvent.sessionCreated(
         info: Session(
           id: 'x',
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           projectID: 'p',
           directory: '/d',
           parentID: null,
@@ -443,7 +443,7 @@ void main() {
       const updated = SesoriSseEvent.sessionUpdated(
         info: Session(
           id: 'x',
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           projectID: 'p',
           directory: '/d',
           parentID: null,
@@ -461,7 +461,7 @@ void main() {
       const deleted = SesoriSseEvent.sessionDeleted(
         info: Session(
           id: 'x',
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           projectID: 'p',
           directory: '/d',
           parentID: null,
@@ -670,7 +670,7 @@ void main() {
       final json = const SesoriSseEvent.sessionCreated(
         info: Session(
           id: 'i',
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           projectID: 'p',
           directory: '/d',
           parentID: null,
@@ -688,7 +688,7 @@ void main() {
       final json = const SesoriSseEvent.sessionUpdated(
         info: Session(
           id: 'i',
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           projectID: 'p',
           directory: '/d',
           parentID: null,
@@ -706,7 +706,7 @@ void main() {
       final json = const SesoriSseEvent.sessionDeleted(
         info: Session(
           id: 'i',
-          pluginId: null,
+          pluginId: legacyMissingPluginId,
           projectID: 'p',
           directory: '/d',
           parentID: null,

--- a/shared/sesori_shared/test/models/session_has_worktree_test.dart
+++ b/shared/sesori_shared/test/models/session_has_worktree_test.dart
@@ -37,7 +37,7 @@ void main() {
     test("serializes hasWorktree to JSON", () {
       const session = Session(
         id: "ses_1",
-        pluginId: null,
+        pluginId: legacyMissingPluginId,
         projectID: "proj_1",
         directory: "/tmp",
         parentID: null,

--- a/shared/sesori_shared/test/models/session_has_worktree_test.dart
+++ b/shared/sesori_shared/test/models/session_has_worktree_test.dart
@@ -37,6 +37,7 @@ void main() {
     test("serializes hasWorktree to JSON", () {
       const session = Session(
         id: "ses_1",
+        pluginId: null,
         projectID: "proj_1",
         directory: "/tmp",
         parentID: null,

--- a/shared/sesori_shared/test/models/session_prompt_defaults_test.dart
+++ b/shared/sesori_shared/test/models/session_prompt_defaults_test.dart
@@ -43,6 +43,7 @@ void main() {
     test("round-trips non-null JSON", () {
       const session = Session(
         id: "ses_1",
+        pluginId: null,
         projectID: "proj_1",
         directory: "/tmp",
         parentID: null,

--- a/shared/sesori_shared/test/models/session_prompt_defaults_test.dart
+++ b/shared/sesori_shared/test/models/session_prompt_defaults_test.dart
@@ -43,7 +43,7 @@ void main() {
     test("round-trips non-null JSON", () {
       const session = Session(
         id: "ses_1",
-        pluginId: null,
+        pluginId: legacyMissingPluginId,
         projectID: "proj_1",
         directory: "/tmp",
         parentID: null,


### PR DESCRIPTION
## Summary
- add an explicit live directory to `PluginProject` while preserving backend-defined project ids
- add backward-compatible nullable plugin identity to sessions, session creation, and project-scoped requests
- stamp every bridge-produced session with the active plugin and reject mismatched selections before plugin I/O
- thread plugin identity through module-core APIs/repositories/services while current clients continue sending the single-plugin null fallback
- document dated compatibility cleanup and advance the parallel-plugin plan to Stage 2

## Behavior
- missing/null plugin ids preserve current one-plugin behavior
- the active plugin id is accepted explicitly
- a different plugin id returns a typed HTTP 400 before any plugin call
- no plugin map, lifecycle change, schema migration, capability matrix, or selection UI is introduced

## Architecture gates
- `aristotle-plan-review`: approved
- `aristotle-impl-review`: approved after rebasing onto latest `main`

## Verification
- bridge app: 1,853 tests
- plugin interface: 142 tests
- OpenCode: 363 tests
- Codex: 133 tests
- ACP: 125 tests
- Cursor: 37 tests
- shared: 300 tests
- module_core: 482 tests
- mobile Flutter: 585 tests
- desktop Flutter: 15 tests
- module_desktop_core: 29 tests
- fatal-info analysis passed all affected packages
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces plugin-scoped identity end-to-end and requires `PluginProject.directory` so live paths stay accurate. Legacy requests that omit plugin identity now concretely default to OpenCode.

- **New Features**
  - Normalized the legacy sentinel to `legacyMissingPluginId` and resolve it to OpenCode at the bridge boundary; `Session.pluginId` is stamped on all session payloads and SSEs (including deletes).
  - Switched `/agent`, `/provider`, and `/command` to `PluginProjectIdRequest`; bodies may omit `pluginId` for backward compatibility. `CreateSessionRequest` now carries `pluginId`.
  - Required `PluginProject.directory`; the bridge persists the plugin-declared live path and reconciles moves without mutating existing rows. Unseen stamps fall back to the session’s `directory` when project lookup or opaque ids block resolution.
  - Injected plugin ids through ACP/Cursor/Codex mappers using shared constants; provider cache is keyed by `(pluginId, projectId)`.

- **Migration**
  - Clients should send `pluginId` when listing agents/providers/commands and creating sessions; if omitted, the bridge treats it as OpenCode via `legacyMissingPluginId`.
  - Read `Session.pluginId` in consumers.
  - Plugins must populate `PluginProject(directory: <live path>)` and inject their plugin id into event mappers.

<sup>Written for commit ed8680590c94d7b20d51f5955784945b0bc153e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

