### PR TITLE
[Chore] updated liquid_glass_widgets to the latest version

### DIFF
--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.9
-  liquid_glass_widgets: ^0.21.3
+  liquid_glass_widgets: ^0.21.4
   http: ^1.6.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.12.0

--- a/client/module_prego/pubspec.yaml
+++ b/client/module_prego/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   meta: ^1.18.0
   flutter_svg: ^2.3.0
   universal_platform: ^1.1.0
-  liquid_glass_widgets: ^0.21.3
+  liquid_glass_widgets: ^0.21.4
   cue: ^0.3.1
 
 flutter:

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -921,10 +921,10 @@ packages:
     dependency: transitive
     description:
       name: liquid_glass_widgets
-      sha256: "0641f378af6e69455fe5c57717c8640792ae5ce1201a6e1fbb9733cb40901c22"
+      sha256: a6a0cd3ee751ee16a72d4bafc2748591f2e7660d3a91ab58f68edea2aa2bff88
       url: "https://pub.dev"
     source: hosted
-    version: "0.21.3"
+    version: "0.21.4"
   logging:
     dependency: transitive
     description:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates `liquid_glass_widgets` from 0.21.3 to 0.21.4 in the app and prego module, and syncs `pubspec.lock` to the new version. No app code changes; dependency-only update.

<sup>Written for commit b12ba175e560df07dc5fa35585d251ff615a66d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

