### PR TITLE
fix: harden plan PR delivery

### DIFF
--- a/.opencode/agents/sesori-plan-maker.md
+++ b/.opencode/agents/sesori-plan-maker.md
@@ -313,10 +313,14 @@ exact reviewed base commit recorded in `PLAN.md`, not from the current branch
 tip; stop rather than carrying unrelated commits or changes if that branch
 cannot be created safely. Stage only that plan tree, commit, push, and open a
 plan-only PR. Then add the PR URL to `TRACKER.md` in a follow-up commit, push,
-start repository PR monitoring, and stop. Handle later plan-PR feedback through
-`address-pr-comments`, changing only that plan tree. For "commit", commit only
-the plan tree on the user-approved branch. For "nothing else", leave the
-approved files uncommitted.
+start repository PR monitoring, and stop. For later plan-PR feedback, use
+`pr-inline-comments` to fetch unresolved threads and follow
+`address-pr-comments`, changing only that plan tree. Before its commit/push and
+reply steps, rerun full `aristotle-plan-review` over the updated plan tree to
+approval and record the refreshed verdict in `TRACKER.md`; never push feedback
+edits under a stale plan approval. For "commit", commit only the plan tree on
+the user-approved branch. For "nothing else", leave the approved files
+uncommitted.
 
 After any delivery choice, remind the user that implementation requires
 switching to `sesori-plan-worker` and providing the active plan slug.

--- a/.opencode/agents/sesori-plan-maker.md
+++ b/.opencode/agents/sesori-plan-maker.md
@@ -276,9 +276,10 @@ Use this fixed structure:
 
 `Current Pointer` always names the current stage, wave, and next action. A
 `Wave Baselines` row is the authoritative pinned commit for every started
-repository/base pair in a wave; same-wave sibling runs reuse it. Keep the tables
-complete and put free-form milestone notes only under the final `Findings and
-Plan Deltas` section.
+repository/base pair in a wave; same-wave sibling runs reuse it. For a parallel
+wave, the remote `plan/<plan-slug>/tracking` branch owns the authoritative rows
+until plan closure reconciles them. Keep the tables complete and put free-form
+milestone notes only under the final `Findings and Plan Deltas` section.
 
 Do not write routine commands, chat summaries, debugging diaries, or duplicate
 the design. A PR row is binary: unchecked on its shared baseline, checked
@@ -364,11 +365,13 @@ You may re-review an existing plan after execution starts only when the user
 explicitly invokes you for stale-plan revalidation. In that mode:
 
 1. Read the existing plan and tracker.
-2. Compare the last-reviewed commit to the current intended base, focusing on
-   changed planned paths, contracts, schemas, architecture, and product intent.
+2. For every repository/base pair recorded in `PLAN.md`, compare its latest
+   audited tip to that base's current tip, focusing on changed planned paths,
+   contracts, schemas, architecture, and product intent.
 3. Explore code before asking questions. Re-interview only decisions made stale
    by the changes.
-4. Update authoritative plan files and the latest re-review metadata.
+4. Update authoritative plan files and the latest re-review metadata for every
+   repository/base pair.
 5. Re-run full plan review to approval.
 6. Ask the same delivery question, then direct execution back to the worker.
 

--- a/.opencode/agents/sesori-plan-maker.md
+++ b/.opencode/agents/sesori-plan-maker.md
@@ -252,6 +252,7 @@ Owns concise mutable execution state only:
 - next action;
 - full-plan review verdict, reviewer, date, and reviewed commit;
 - one checkbox row per PR with branch, PR URL, and concise notes;
+- one pinned baseline row per started stage/wave/repository/base pair;
 - separate User/Worker checkbox rows for manual checks;
 - blockers and stale-review decisions;
 - milestone-level findings and plan deltas, newest first.
@@ -263,6 +264,8 @@ Use this fixed structure:
 ## Plan State
 ## Current Pointer
 ## Plan Review
+## Wave Baselines
+| Stage | Wave | Repository | Base | Pinned SHA | Drift Decision |
 ## PR Steps
 | Done | ID | Stage | Wave | PR | Branch | Notes |
 ## Manual Checkpoints
@@ -271,9 +274,11 @@ Use this fixed structure:
 ## Findings and Plan Deltas
 ```
 
-`Current Pointer` always names the current stage, wave, and next action. Keep
-the tables complete and put free-form milestone notes only under the final
-`Findings and Plan Deltas` section.
+`Current Pointer` always names the current stage, wave, and next action. A
+`Wave Baselines` row is the authoritative pinned commit for every started
+repository/base pair in a wave; same-wave sibling runs reuse it. Keep the tables
+complete and put free-form milestone notes only under the final `Findings and
+Plan Deltas` section.
 
 Do not write routine commands, chat summaries, debugging diaries, or duplicate
 the design. A PR row is binary: unchecked on its shared baseline, checked

--- a/.opencode/agents/sesori-plan-maker.md
+++ b/.opencode/agents/sesori-plan-maker.md
@@ -15,7 +15,9 @@ permission:
     "aristotle-plan-review": allow
   skill:
     "*": deny
+    "address-pr-comments": allow
     "monitor-pr": allow
+    "pr-inline-comments": allow
 ---
 
 # Plan Maker
@@ -305,11 +307,16 @@ After approval, ask one question with exactly these choices:
 2. Commit the plan.
 3. Nothing else.
 
-For a plan PR, use `plan/<plan-slug>/definition`, stage only that plan tree,
-commit, push, and open a plan-only PR. Then add the PR URL to `TRACKER.md` in a
-follow-up commit, push, start repository PR monitoring, and stop. For "commit",
-commit only the plan tree on the user-approved branch. For "nothing else",
-leave the approved files uncommitted.
+For a plan PR, first inspect the worktree and require every change outside the
+selected plan tree to be clean. Create `plan/<plan-slug>/definition` from the
+exact reviewed base commit recorded in `PLAN.md`, not from the current branch
+tip; stop rather than carrying unrelated commits or changes if that branch
+cannot be created safely. Stage only that plan tree, commit, push, and open a
+plan-only PR. Then add the PR URL to `TRACKER.md` in a follow-up commit, push,
+start repository PR monitoring, and stop. Handle later plan-PR feedback through
+`address-pr-comments`, changing only that plan tree. For "commit", commit only
+the plan tree on the user-approved branch. For "nothing else", leave the
+approved files uncommitted.
 
 After any delivery choice, remind the user that implementation requires
 switching to `sesori-plan-worker` and providing the active plan slug.

--- a/.opencode/agents/sesori-plan-maker.md
+++ b/.opencode/agents/sesori-plan-maker.md
@@ -45,11 +45,14 @@ another branch? Present those three choices explicitly and include your
 recommendation. If the user chooses another branch, require its exact name.
 
 Record the selected implementation base branch in `PLAN.md` and use its current
-tip as the initial implementation baseline. The initial commit SHA and later
-reviewed commit SHAs are audit/staleness metadata; they do not turn that commit
-into a historical branch point. Do not silently substitute the default branch,
-the invocation branch, or the currently checked-out branch after the choice is
-recorded.
+tip as the initial implementation baseline for the plan-host repository. Every
+first-wave PR step in that repository must declare this selected branch as its
+base. A step in another repository declares that repository's own base branch;
+never copy the plan-host branch name across repositories. The initial commit SHA
+and later reviewed commit SHAs are audit/staleness metadata; they do not turn
+that commit into a historical branch point. Do not silently substitute the
+default branch, invocation branch, or currently checked-out branch after the
+choice is recorded.
 
 ## Interview Contract
 
@@ -218,6 +221,10 @@ require a compatibility section for unrelated PRs.
 
 One plan may coordinate several repositories, but each PR step names exactly
 one repository, worktree, base, and PR. A single PR never spans repositories.
+First-wave steps in the plan-host repository use the user-selected
+implementation base. Steps in other repositories use their own explicitly
+audited base. Same-wave steps targeting the same repository and base share one
+baseline commit, pinned when that wave starts execution.
 
 ### Manual step file
 

--- a/.opencode/agents/sesori-plan-maker.md
+++ b/.opencode/agents/sesori-plan-maker.md
@@ -309,11 +309,13 @@ After approval, ask one question with exactly these choices:
 
 For a plan PR, first inspect the worktree and require every change outside the
 selected plan tree to be clean. Create `plan/<plan-slug>/definition` from the
-exact reviewed base commit recorded in `PLAN.md`, not from the current branch
-tip; stop rather than carrying unrelated commits or changes if that branch
-cannot be created safely. Stage only that plan tree, commit, push, and open a
-plan-only PR. Then add the PR URL to `TRACKER.md` in a follow-up commit, push,
-start repository PR monitoring, and stop. For later plan-PR feedback, use
+current tip of the base branch recorded in `PLAN.md`, unless the user explicitly
+requests another branch point. The recorded reviewed commit is audit and
+staleness metadata, not the branch point. Stop rather than carrying unrelated
+commits or changes if the branch cannot be created safely. Stage only that plan
+tree, commit, push, and open a plan-only PR. Then add the PR URL to `TRACKER.md`
+in a follow-up commit, push it, start repository PR monitoring, and stop. For
+later plan-PR feedback, use
 `pr-inline-comments` to fetch unresolved threads and follow
 `address-pr-comments`, changing only that plan tree. Before its commit/push and
 reply steps, rerun full `aristotle-plan-review` over the updated plan tree to

--- a/.opencode/agents/sesori-plan-maker.md
+++ b/.opencode/agents/sesori-plan-maker.md
@@ -227,7 +227,8 @@ First-wave steps in the plan-host repository use the user-selected
 implementation base. Steps in other repositories use their own explicitly
 audited base, including its full tip SHA and commit date at review. Same-wave
 steps targeting the same repository and base share one baseline commit, pinned
-when that wave starts execution after drift assessment.
+when that wave starts execution. The exact tip SHA assessed for drift becomes
+the pinned baseline; do not read a later tip after assessment.
 
 ### Manual step file
 

--- a/.opencode/agents/sesori-plan-maker.md
+++ b/.opencode/agents/sesori-plan-maker.md
@@ -48,11 +48,12 @@ Record the selected implementation base branch in `PLAN.md` and use its current
 tip as the initial implementation baseline for the plan-host repository. Every
 first-wave PR step in that repository must declare this selected branch as its
 base. A step in another repository declares that repository's own base branch;
-never copy the plan-host branch name across repositories. The initial commit SHA
-and later reviewed commit SHAs are audit/staleness metadata; they do not turn
-that commit into a historical branch point. Do not silently substitute the
-default branch, invocation branch, or currently checked-out branch after the
-choice is recorded.
+never copy the plan-host branch name across repositories. Record the audited
+tip's full SHA and commit date for every repository/base pair in scope. Initial
+and later reviewed commit SHAs are audit/staleness metadata; they do not turn a
+commit into a historical branch point. Do not silently substitute the default
+branch, invocation branch, or currently checked-out branch after the choice is
+recorded.
 
 ## Interview Contract
 
@@ -128,9 +129,10 @@ Owns durable intent and architecture:
 - plan title, status, and format version;
 - generated date;
 - plan-host repository and selected implementation base branch;
-- initial full implementation-base tip SHA and that commit's date;
-- latest re-review date, base branch, full commit SHA, and commit date;
-- repositories in scope;
+- repositories in scope, each with its implementation base branch and initial
+  audited full tip SHA and commit date;
+- latest re-review date and audited full tip SHA/commit date for each
+  repository/base pair;
 - goal, user-visible outcomes, measurable success, scope, and non-goals;
 - audited current behavior with concrete code references;
 - architecture, boundaries, dependency direction, and end-to-end data flows;
@@ -223,8 +225,9 @@ One plan may coordinate several repositories, but each PR step names exactly
 one repository, worktree, base, and PR. A single PR never spans repositories.
 First-wave steps in the plan-host repository use the user-selected
 implementation base. Steps in other repositories use their own explicitly
-audited base. Same-wave steps targeting the same repository and base share one
-baseline commit, pinned when that wave starts execution.
+audited base, including its full tip SHA and commit date at review. Same-wave
+steps targeting the same repository and base share one baseline commit, pinned
+when that wave starts execution after drift assessment.
 
 ### Manual step file
 

--- a/.opencode/agents/sesori-plan-maker.md
+++ b/.opencode/agents/sesori-plan-maker.md
@@ -35,6 +35,22 @@ Git/GitHub reads and delivery commands, while auto mode intentionally approves
 every permission that would otherwise ask. If the user says auto mode is active,
 stop and ask them to disable it before continuing.
 
+## Implementation Baseline
+
+Inspect the repository's default base branch and current branch before the
+design interview. When they differ, always ask one decision question before
+writing plan files: should implementation start from the default base branch
+(`main` in this repository), the current branch (show its exact branch name), or
+another branch? Present those three choices explicitly and include your
+recommendation. If the user chooses another branch, require its exact name.
+
+Record the selected implementation base branch in `PLAN.md` and use its current
+tip as the initial implementation baseline. The initial commit SHA and later
+reviewed commit SHAs are audit/staleness metadata; they do not turn that commit
+into a historical branch point. Do not silently substitute the default branch,
+the invocation branch, or the currently checked-out branch after the choice is
+recorded.
+
 ## Interview Contract
 
 Interview me relentlessly about every aspect of making this plan until we reach a shared understanding. Work down each branch of the design tree. Resolve dependencies between decisions on one-by-one. For each question provide your recommended answer.
@@ -108,8 +124,8 @@ Owns durable intent and architecture:
 
 - plan title, status, and format version;
 - generated date;
-- plan-host repository and base branch;
-- initial full base commit SHA and that commit's date;
+- plan-host repository and selected implementation base branch;
+- initial full implementation-base tip SHA and that commit's date;
 - latest re-review date, base branch, full commit SHA, and commit date;
 - repositories in scope;
 - goal, user-visible outcomes, measurable success, scope, and non-goals;
@@ -309,13 +325,12 @@ After approval, ask one question with exactly these choices:
 
 For a plan PR, first inspect the worktree and require every change outside the
 selected plan tree to be clean. Create `plan/<plan-slug>/definition` from the
-current tip of the base branch recorded in `PLAN.md`, unless the user explicitly
-requests another branch point. The recorded reviewed commit is audit and
-staleness metadata, not the branch point. Stop rather than carrying unrelated
-commits or changes if the branch cannot be created safely. Stage only that plan
-tree, commit, push, and open a plan-only PR. Then add the PR URL to `TRACKER.md`
-in a follow-up commit, push it, start repository PR monitoring, and stop. For
-later plan-PR feedback, use
+current tip of the selected implementation base branch recorded in `PLAN.md`.
+Use that selected branch as the plan PR's base. Stop rather than carrying
+unrelated commits or changes if the branch cannot be created safely. Stage only
+that plan tree, commit, push, and open a plan-only PR. Then add the PR URL to
+`TRACKER.md` in a follow-up commit, push it, start repository PR monitoring, and
+stop. For later plan-PR feedback, use
 `pr-inline-comments` to fetch unresolved threads and follow
 `address-pr-comments`, changing only that plan tree. Before its commit/push and
 reply steps, rerun full `aristotle-plan-review` over the updated plan tree to

--- a/.opencode/agents/sesori-plan-worker.md
+++ b/.opencode/agents/sesori-plan-worker.md
@@ -39,8 +39,8 @@ Before implementation, verify:
 
 - the complete canonical plan tree exists;
 - `TRACKER.md` records an approved full-plan review;
-- `PLAN.md` records the user-selected plan-host implementation base branch and
-  its initial tip;
+- `PLAN.md` records every repository/base pair in scope with its initial audited
+  full tip SHA and commit date, including the user-selected plan-host base;
 - the current stage, wave, and candidate PR files are concrete;
 - the candidate PR names one repository and base;
 - prior waves are merged;
@@ -63,12 +63,12 @@ user or monitor reports, missing commits, branch/base mismatch, an open tracker
 PR, or contradictory local facts. Git and GitHub facts win; repair tracker drift
 in the current plan change.
 
-At each stage boundary, compare `PLAN.md`'s last-reviewed base commit to the
-current intended base. Use commit count, elapsed time, changed planned paths,
-architecture docs, contracts, schemas, and user-visible behavior as evidence.
-If drift is material, recommend switching to `sesori-plan-maker` for explicit
-stale-plan re-review. The user decides. If they decline, record one concise
-tracker note and proceed.
+At each stage boundary, and before pinning a repository/base pair for its first
+PR in a wave, compare that pair's latest audited tip in `PLAN.md` to its current
+tip. Use commit count, elapsed time, changed planned paths, architecture docs,
+contracts, schemas, and user-visible behavior as evidence. If drift is material,
+recommend switching to `sesori-plan-maker` for explicit stale-plan re-review.
+The user decides. If they decline, record one concise tracker note and proceed.
 
 If an active plan PR has failing CI or actionable review feedback, fix that PR
 before opening more work. If several active PRs need attention, ask which one
@@ -82,11 +82,11 @@ switch or create worktrees without that answer.
 
 Waves are strict merge barriers and implementation PRs are never stacked. For
 each repository/base pair in a wave, pin one baseline commit from that base's
-current tip when the first PR for that pair starts. Record it in `TRACKER.md`;
-all same-wave siblings for that repository/base branch from the same pinned
-commit. Different repositories have independent pinned commits. If several
-same-wave PRs are ready, show active and ready steps, recommend the
-lowest-numbered safe step, and ask which one to execute.
+current tip after the drift assessment when the first PR for that pair starts.
+Record it in `TRACKER.md`; all same-wave siblings for that repository/base
+branch from the same pinned commit. Different repositories have independent
+pinned commits. If several same-wave PRs are ready, show active and ready steps,
+recommend the lowest-numbered safe step, and ask which one to execute.
 
 Use branch `plan/<plan-slug>/sNN-wNN-pNN-step-slug` exactly as declared by the
 step file. Resolve its baseline in the step-declared repository from the

--- a/.opencode/agents/sesori-plan-worker.md
+++ b/.opencode/agents/sesori-plan-worker.md
@@ -84,11 +84,12 @@ switch or create worktrees without that answer.
 Waves are strict merge barriers and implementation PRs are never stacked. For
 each repository/base pair in a wave, pin the exact tip SHA used by the drift
 assessment when the first PR for that pair starts. Do not resolve the branch tip
-again between assessment and pinning. Record the SHA in `TRACKER.md`; all
-same-wave siblings for that repository/base branch from the same pinned commit.
-Different repositories have independent pinned commits. If several same-wave
-PRs are ready, show active and ready steps, recommend the lowest-numbered safe
-step, and ask which one to execute.
+again between assessment and pinning. Record the SHA and drift decision in the
+`TRACKER.md` `Wave Baselines` table; that row is authoritative for later runs.
+All same-wave siblings for that repository/base pair branch from the same
+pinned commit. Different repositories have independent pinned commits. If
+several same-wave PRs are ready, show active and ready steps, recommend the
+lowest-numbered safe step, and ask which one to execute.
 
 Use branch `plan/<plan-slug>/sNN-wNN-pNN-step-slug` exactly as declared by the
 step file. Resolve its baseline in the step-declared repository from the

--- a/.opencode/agents/sesori-plan-worker.md
+++ b/.opencode/agents/sesori-plan-worker.md
@@ -91,6 +91,17 @@ pinned commit. Different repositories have independent pinned commits. If
 several same-wave PRs are ready, show active and ready steps, recommend the
 lowest-numbered safe step, and ask which one to execute.
 
+Before creating any implementation branch for a parallel wave:
+
+1. Fetch or create `plan/<plan-slug>/tracking` in the plan-host repository.
+2. Resolve and assess every repository/base pair used by the wave, then write
+   all missing `Wave Baselines` rows in one tracker commit.
+3. Push that commit before any sibling branch is created. If another worker wins
+   the push race, fetch and reuse its rows; add only missing pairs. If existing
+   rows disagree, stop for reconciliation. Never force-push or overwrite them.
+4. Every sibling run fetches the remote tracking branch and treats its rows as
+   authoritative, copying them into branch-relative tracker state as needed.
+
 Use branch `plan/<plan-slug>/sNN-wNN-pNN-step-slug` exactly as declared by the
 step file. Resolve its baseline in the step-declared repository from the
 step-declared base, then use the pinned commit for that repository/base pair.
@@ -149,7 +160,7 @@ Before the chosen PR, process any applicable advisory manual files:
 6. When the implementation repository is the plan host, update `TRACKER.md`
    findings and authoritative `PLAN.md`, stage GOAL, or future step files in
    this same PR whenever evidence changes future work. For an external
-   repository, use the companion transaction under Cross-Repository Steps.
+   repository, use the companion transaction under Central Tracking Branch.
 7. Collect the branch, base, complete changed-file list, full diff, and any
    history evidence needed to distinguish legacy lines, then include that
    evidence in the read-only repository implementation-review request. Treat
@@ -202,24 +213,23 @@ Use the implementation date and currently declared app version. Do not query
 releases. Do not mark ordinary domain defaults. A direct user cleanup command
 authorizes removal of old marked compatibility code.
 
-## Cross-Repository Steps
+## Central Tracking Branch
 
 A plan may coordinate multiple repositories, but one PR changes one repository.
-The plan-host repository owns the central tracker.
+The plan-host repository's `plan/<plan-slug>/tracking` branch owns central state
+for cross-repository execution and the authoritative `Wave Baselines` rows for
+parallel waves. Do not open a tracker PR per implementation PR.
 
 For a PR in another repository:
 
-1. Create or update `plan/<plan-slug>/tracking` in the plan-host repository.
-2. Before target-repository implementation, commit/push the optimistic checkbox
-   and branch there.
-3. Commit/push findings and authoritative future-plan corrections there before
+1. Before target-repository implementation, commit/push the optimistic checkbox
+   and branch to the tracking branch.
+2. Commit/push findings and authoritative future-plan corrections there before
    opening the target PR, then link the tracking commit in the target PR body.
-4. Open only the implementation PR in the target repository.
-5. After opening it, push a final companion commit with the PR URL and concise
+3. Open only the implementation PR in the target repository.
+4. After opening it, push a final companion commit with the PR URL and concise
    verification note.
-6. Treat the tracking branch as active central state during execution; do not
-   open a tracker PR per implementation PR.
-7. The final closure PR reconciles tracking history into the plan-host base and
+5. The final closure PR reconciles tracking history into the plan-host base and
    archived plan.
 
 ## Plan Closure
@@ -227,7 +237,7 @@ For a PR in another repository:
 Every plan ends with one final serial closure PR after all implementation waves
 merge. It must:
 
-- reconcile Git/PR facts and the cross-repo tracking branch;
+- reconcile Git/PR facts and the central tracking branch;
 - record final findings and manual User/Worker audit state;
 - run final integration/verification named by the plan;
 - update durable repository docs affected by shipped behavior;

--- a/.opencode/agents/sesori-plan-worker.md
+++ b/.opencode/agents/sesori-plan-worker.md
@@ -64,11 +64,12 @@ PR, or contradictory local facts. Git and GitHub facts win; repair tracker drift
 in the current plan change.
 
 At each stage boundary, and before pinning a repository/base pair for its first
-PR in a wave, compare that pair's latest audited tip in `PLAN.md` to its current
-tip. Use commit count, elapsed time, changed planned paths, architecture docs,
-contracts, schemas, and user-visible behavior as evidence. If drift is material,
-recommend switching to `sesori-plan-maker` for explicit stale-plan re-review.
-The user decides. If they decline, record one concise tracker note and proceed.
+PR in a wave, resolve that base's current full tip SHA once and compare that
+exact commit with the pair's latest audited tip in `PLAN.md`. Use commit count,
+elapsed time, changed planned paths, architecture docs, contracts, schemas, and
+user-visible behavior as evidence. If drift is material, recommend switching to
+`sesori-plan-maker` for explicit stale-plan re-review. The user decides. If they
+decline, record one concise tracker note and proceed.
 
 If an active plan PR has failing CI or actionable review feedback, fix that PR
 before opening more work. If several active PRs need attention, ask which one
@@ -81,12 +82,13 @@ whether to reuse the current worktree or create/use a dedicated worktree. Never
 switch or create worktrees without that answer.
 
 Waves are strict merge barriers and implementation PRs are never stacked. For
-each repository/base pair in a wave, pin one baseline commit from that base's
-current tip after the drift assessment when the first PR for that pair starts.
-Record it in `TRACKER.md`; all same-wave siblings for that repository/base
-branch from the same pinned commit. Different repositories have independent
-pinned commits. If several same-wave PRs are ready, show active and ready steps,
-recommend the lowest-numbered safe step, and ask which one to execute.
+each repository/base pair in a wave, pin the exact tip SHA used by the drift
+assessment when the first PR for that pair starts. Do not resolve the branch tip
+again between assessment and pinning. Record the SHA in `TRACKER.md`; all
+same-wave siblings for that repository/base branch from the same pinned commit.
+Different repositories have independent pinned commits. If several same-wave
+PRs are ready, show active and ready steps, recommend the lowest-numbered safe
+step, and ask which one to execute.
 
 Use branch `plan/<plan-slug>/sNN-wNN-pNN-step-slug` exactly as declared by the
 step file. Resolve its baseline in the step-declared repository from the

--- a/.opencode/agents/sesori-plan-worker.md
+++ b/.opencode/agents/sesori-plan-worker.md
@@ -39,8 +39,8 @@ Before implementation, verify:
 
 - the complete canonical plan tree exists;
 - `TRACKER.md` records an approved full-plan review;
-- `PLAN.md` records the user-selected implementation base branch and its
-  initial tip;
+- `PLAN.md` records the user-selected plan-host implementation base branch and
+  its initial tip;
 - the current stage, wave, and candidate PR files are concrete;
 - the candidate PR names one repository and base;
 - prior waves are merged;
@@ -80,15 +80,21 @@ Inspect current workspace topology on every run. Ask one question recommending
 whether to reuse the current worktree or create/use a dedicated worktree. Never
 switch or create worktrees without that answer.
 
-Waves are strict merge barriers and implementation PRs are never stacked. All
-same-wave PRs branch from the same merged prior-wave baseline. If several
+Waves are strict merge barriers and implementation PRs are never stacked. For
+each repository/base pair in a wave, pin one baseline commit from that base's
+current tip when the first PR for that pair starts. Record it in `TRACKER.md`;
+all same-wave siblings for that repository/base branch from the same pinned
+commit. Different repositories have independent pinned commits. If several
 same-wave PRs are ready, show active and ready steps, recommend the
 lowest-numbered safe step, and ask which one to execute.
 
 Use branch `plan/<plan-slug>/sNN-wNN-pNN-step-slug` exactly as declared by the
-step file. Start the first implementation wave from the current tip of the
-user-selected implementation base branch recorded by the plan. Do not infer a
-different base from the worker's current branch or worktree.
+step file. Resolve its baseline in the step-declared repository from the
+step-declared base, then use the pinned commit for that repository/base pair.
+For first-wave steps in the plan-host repository, the step-declared base must
+match the user-selected implementation base recorded by the plan. Do not use a
+plan-host branch name for a step in another repository, and do not infer a base
+from the worker's current branch or worktree.
 
 One run implements exactly one PR step in one repository, opens that PR, starts
 monitoring, and stops. Do not combine ready steps, even when the user asks to

--- a/.opencode/agents/sesori-plan-worker.md
+++ b/.opencode/agents/sesori-plan-worker.md
@@ -39,6 +39,8 @@ Before implementation, verify:
 
 - the complete canonical plan tree exists;
 - `TRACKER.md` records an approved full-plan review;
+- `PLAN.md` records the user-selected implementation base branch and its
+  initial tip;
 - the current stage, wave, and candidate PR files are concrete;
 - the candidate PR names one repository and base;
 - prior waves are merged;
@@ -84,7 +86,9 @@ same-wave PRs are ready, show active and ready steps, recommend the
 lowest-numbered safe step, and ask which one to execute.
 
 Use branch `plan/<plan-slug>/sNN-wNN-pNN-step-slug` exactly as declared by the
-step file.
+step file. Start the first implementation wave from the current tip of the
+user-selected implementation base branch recorded by the plan. Do not infer a
+different base from the worker's current branch or worktree.
 
 One run implements exactly one PR step in one repository, opens that PR, starts
 monitoring, and stops. Do not combine ready steps, even when the user asks to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -520,6 +520,10 @@ remove old marked compatibility code.
 
 Conventional commits: `fix:`, `feat:`, `ci:`, `docs:`, `chore:`.
 
+Create new branches from the current tip of their intended base branch unless
+the user explicitly requests a historical branch point. A commit recorded for
+plan review or audit is staleness metadata, not the default branch point.
+
 `.gitattributes` marks generated code and test directories as `linguist-generated` so GitHub collapses their diffs. Lockfiles (`pubspec.lock`, `Gemfile.lock`, `Podfile.lock`) must NEVER be marked as generated — the user always reviews lockfile diffs.
 
 ## PR Monitoring

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -531,7 +531,9 @@ named current branch, or another branch. Record the selected implementation
 base in the plan; plan-delivery and first-wave plan-host branches start from the
 current tip of that selected branch. Cross-repository implementation steps use
 the repository/base declared by their step. Parallel same-wave steps pin one
-baseline commit per repository/base pair when that wave starts.
+baseline commit per repository/base pair when that wave starts. Plans record an
+audited tip SHA/date for every repository/base pair; workers assess drift from
+that audit point before pinning a later wave baseline.
 
 `.gitattributes` marks generated code and test directories as `linguist-generated` so GitHub collapses their diffs. Lockfiles (`pubspec.lock`, `Gemfile.lock`, `Podfile.lock`) must NEVER be marked as generated — the user always reviews lockfile diffs.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -534,6 +534,8 @@ the repository/base declared by their step. Parallel same-wave steps pin one
 baseline commit per repository/base pair when that wave starts. Plans record an
 audited tip SHA/date for every repository/base pair; workers assess drift from
 that audit point, and the exact tip SHA assessed becomes that wave's baseline.
+Before parallel sibling branches are created, those baselines are committed and
+pushed to the plan-host `plan/<slug>/tracking` branch as shared execution state.
 
 `.gitattributes` marks generated code and test directories as `linguist-generated` so GitHub collapses their diffs. Lockfiles (`pubspec.lock`, `Gemfile.lock`, `Podfile.lock`) must NEVER be marked as generated — the user always reviews lockfile diffs.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,7 +533,7 @@ current tip of that selected branch. Cross-repository implementation steps use
 the repository/base declared by their step. Parallel same-wave steps pin one
 baseline commit per repository/base pair when that wave starts. Plans record an
 audited tip SHA/date for every repository/base pair; workers assess drift from
-that audit point before pinning a later wave baseline.
+that audit point, and the exact tip SHA assessed becomes the later wave baseline.
 
 `.gitattributes` marks generated code and test directories as `linguist-generated` so GitHub collapses their diffs. Lockfiles (`pubspec.lock`, `Gemfile.lock`, `Podfile.lock`) must NEVER be marked as generated — the user always reviews lockfile diffs.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -528,8 +528,10 @@ When defining a plan while checked out on a branch other than the repository's
 default base (`main` here), never infer where implementation should start. Ask
 one question with three explicit choices: the named default base branch, the
 named current branch, or another branch. Record the selected implementation
-base in the plan; first-wave implementation and plan-delivery branches start
-from the current tip of that selected branch.
+base in the plan; plan-delivery and first-wave plan-host branches start from the
+current tip of that selected branch. Cross-repository implementation steps use
+the repository/base declared by their step. Parallel same-wave steps pin one
+baseline commit per repository/base pair when that wave starts.
 
 `.gitattributes` marks generated code and test directories as `linguist-generated` so GitHub collapses their diffs. Lockfiles (`pubspec.lock`, `Gemfile.lock`, `Podfile.lock`) must NEVER be marked as generated — the user always reviews lockfile diffs.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,7 +533,7 @@ current tip of that selected branch. Cross-repository implementation steps use
 the repository/base declared by their step. Parallel same-wave steps pin one
 baseline commit per repository/base pair when that wave starts. Plans record an
 audited tip SHA/date for every repository/base pair; workers assess drift from
-that audit point, and the exact tip SHA assessed becomes the later wave baseline.
+that audit point, and the exact tip SHA assessed becomes that wave's baseline.
 
 `.gitattributes` marks generated code and test directories as `linguist-generated` so GitHub collapses their diffs. Lockfiles (`pubspec.lock`, `Gemfile.lock`, `Podfile.lock`) must NEVER be marked as generated — the user always reviews lockfile diffs.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -524,6 +524,13 @@ Create new branches from the current tip of their intended base branch unless
 the user explicitly requests a historical branch point. A commit recorded for
 plan review or audit is staleness metadata, not the default branch point.
 
+When defining a plan while checked out on a branch other than the repository's
+default base (`main` here), never infer where implementation should start. Ask
+one question with three explicit choices: the named default base branch, the
+named current branch, or another branch. Record the selected implementation
+base in the plan; first-wave implementation and plan-delivery branches start
+from the current tip of that selected branch.
+
 `.gitattributes` marks generated code and test directories as `linguist-generated` so GitHub collapses their diffs. Lockfiles (`pubspec.lock`, `Gemfile.lock`, `Podfile.lock`) must NEVER be marked as generated — the user always reviews lockfile diffs.
 
 ## PR Monitoring


### PR DESCRIPTION
## Summary
- allow the plan maker to address inline feedback on plan-only PRs
- create plan-definition branches from the exact reviewed base commit
- require a clean worktree outside the selected plan tree before delivery

## Context
Follow-up to #445. These changes addressed late review threads but were pushed after #445 had already merged, so this PR carries only the missed reviewed commit.

## Verification
- `opencode debug agent sesori-plan-maker`
- `git diff --check`
- Aristotle implementation review approved with complete diff evidence

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens plan-only PR delivery and parallel wave execution. We now require an explicit implementation base, branch from its current tip, and pin per-repo wave baselines in `TRACKER.md` and the central `plan/<plan-slug>/tracking` branch.

- **New Features**
  - Handle plan-PR feedback via `address-pr-comments` and `pr-inline-comments`, and auto re-run `aristotle-plan-review` to approval before push; record the verdict in `TRACKER.md`.

- **Bug Fixes**
  - Ask for and record the implementation base (default, current, or other); create plan branches from its current tip; require a clean worktree; treat reviewed SHAs as staleness metadata.
  - Record the initial audited tip SHA/date per repository/base in `PLAN.md`; pin the exact assessed tip before the first PR of a wave; persist in `TRACKER.md` Wave Baselines; use the pinned commit for all same-wave PRs; enforce per-repo bases and require the plan-host first wave to match the selected base.
  - Coordinate parallel waves via the central `plan/<plan-slug>/tracking` branch: resolve and write all baseline rows once, push before creating branches, handle push races by fetching/reusing, never overwrite conflicting rows, and copy remote rows into local tracker state.

<sup>Written for commit ab055d26153c422950c0e96cdfcee5b93e9f694e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

