### PR TITLE
chore: update Aristotle review model

### DIFF
--- a/.opencode/agents/aristotle-impl-review.md
+++ b/.opencode/agents/aristotle-impl-review.md
@@ -1,8 +1,8 @@
 ---
 description: Reviews implemented code (branches, PRs, changed files) against strict architectural rules for the Sesori monorepo. Validates layer boundaries, dependency direction, class cohesion, naming discipline, and simplicity in actual code. Rejects god classes, pass-through parameters, peer-as-child dependency patterns, asymmetric trigger handling, and misuse of class suffixes. Also flags new code that forecloses the documented product-direction invariants in docs/VISION.md, such as backend specifics leaking past the plugin boundary. Only flags new or changed code — preexisting legacy patterns are not flagged unless the change extends them. Always invoke before opening a PR.
 mode: subagent
-model: kimi-for-coding/k2p7
-variant: max
+model: openai/gpt-5.6-sol
+variant: high
 temperature: 0.1
 permission:
   "*": deny

--- a/.opencode/agents/aristotle-plan-review.md
+++ b/.opencode/agents/aristotle-plan-review.md
@@ -1,8 +1,8 @@
 ---
 description: Reviews development plans against strict architectural rules for the Sesori monorepo. Validates proposed layer boundaries, dependency direction, class cohesion, naming discipline, and simplicity before any code is written. Rejects god classes, pass-through parameters, peer-as-child dependency patterns, asymmetric trigger handling, and misuse of class suffixes. Also rejects designs that foreclose the documented product-direction invariants in docs/VISION.md, or that build speculatively ahead of need. Input is a plan containing a clear goal plus concrete implementation steps. Always invoke before implementation begins.
 mode: subagent
-model: kimi-for-coding/k2p7
-variant: max
+model: openai/gpt-5.6-sol
+variant: high
 temperature: 0.1
 permission:
   "*": deny


### PR DESCRIPTION
## Summary
- switch both Aristotle review agents to `openai/gpt-5.6-sol`
- configure the supported `high` reasoning-effort variant
- preserve existing prompts, temperature, and permissions

## Validation
- `opencode models openai` lists `openai/gpt-5.6-sol`
- `opencode debug agent` resolves both agents to OpenAI GPT-5.6 Sol with variant `high`
- fresh OpenCode implementation review: APPROVED
- `git diff --check main...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched both Aristotle review agents to `openai/gpt-5.6-sol` with the `high` reasoning-effort variant for more consistent reviews. No changes to prompts, temperature, or permissions.

- **Refactors**
  - Updated `.opencode/agents/aristotle-impl-review.md` and `.opencode/agents/aristotle-plan-review.md` from `kimi-for-coding/k2p7` to `openai/gpt-5.6-sol` (`high`).

<sup>Written for commit 474b3c6c6ccb401ab0b7796390fb5ea72d448617. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

