### PR TITLE
ci(ios): fix TestFlight build failure (showBuildSettings timeout + deprecated pilot option)

### DIFF
--- a/.github/workflows/_reusable-ios-testflight.yml
+++ b/.github/workflows/_reusable-ios-testflight.yml
@@ -53,6 +53,11 @@ jobs:
       ITC_TEAM_ID: ${{ secrets.ITC_TEAM_ID }}
       BUILD_NUMBER: ${{ inputs.build_number }}
       CI: true
+      # gym's pre-flight `xcodebuild -showBuildSettings` must load the full SPM
+      # package graph (Firebase + local Flutter packages), which takes far longer
+      # than fastlane's 3s default base timeout on a cold runner.
+      FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: '120'
+      FASTLANE_XCODEBUILD_SETTINGS_RETRIES: '5'
 
     steps:
       - name: Checkout repository

--- a/client/app/ios/fastlane/Fastfile
+++ b/client/app/ios/fastlane/Fastfile
@@ -366,7 +366,6 @@ platform :ios do
     upload_to_testflight(
       api_key: api_key,
       skip_waiting_for_build_processing: true,
-      wait_for_uploaded_build: false,
       changelog: build_commit_changelog(max_length: 4000)
     )
 


### PR DESCRIPTION
## Why

The iOS TestFlight workflow failed before it ever compiled. `build_app` (gym) runs a pre-flight `xcodebuild -showBuildSettings`, and fastlane gives that call a 3s base timeout with 4 doubling retries (3 → 6 → 12 → 24s):

```
$ xcodebuild -showBuildSettings -workspace Runner.xcworkspace -scheme Runner -configuration Release
Command timed out after 24 seconds on try 4 of 4
[!] xcodebuild -showBuildSettings timed out after 4 retries with a base timeout of 3
```

On this project that call has to load the full SPM package graph — the preceding `-resolvePackageDependencies` step in the same run took 63s (Firebase 12.15 + ~15 local Flutter packages, Xcode 26.6, cold runner). Everything before it (match, code-signing, build number) succeeded.

## What changed

- **`.github/workflows/_reusable-ios-testflight.yml`** — set `FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT=120` and `FASTLANE_XCODEBUILD_SETTINGS_RETRIES=5` on the deploy job, the exact knobs the fastlane error message names.
- **`client/app/ios/fastlane/Fastfile`** — remove `wait_for_uploaded_build: false` from `upload_to_testflight`. fastlane 2.237 marks it `deprecated: "No longer needed with the transition over to the App Store Connect API"`; `skip_waiting_for_build_processing: true` is not deprecated and stays.

CI-config only; no app code touched.

https://claude.ai/code/session_012A2HruHCxWqoBLaU9tPzG4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS TestFlight CI workflow by preventing `xcodebuild -showBuildSettings` timeouts that blocked builds. Also removes a deprecated `upload_to_testflight` option.

- **Bug Fixes**
  - Set `FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT=120` and `FASTLANE_XCODEBUILD_SETTINGS_RETRIES=5` in `.github/workflows/_reusable-ios-testflight.yml` so `gym`’s preflight `xcodebuild -showBuildSettings` can load the SPM graph on cold runners.
  - Removed deprecated `wait_for_uploaded_build` from `upload_to_testflight`; `skip_waiting_for_build_processing: true` stays. CI-only; no app code changes.

<sup>Written for commit e0270f701f001ea19e9ed9c57a01a92475fdfbd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

