### PR TITLE
fix(ui): extend menu highlights to panel edges

### DIFF
--- a/client/module_prego/lib/components/menus/prego_anchor_menu.dart
+++ b/client/module_prego/lib/components/menus/prego_anchor_menu.dart
@@ -305,21 +305,29 @@ class _PregoAnchorMenuState extends State<PregoAnchorMenu> {
   }
 
   Widget _flatPanel(BuildContext context, {required Rect triggerRect}) {
+    final entries = widget.entriesBuilder();
+    final edgePadding = EdgeInsets.only(
+      top: entries.isEmpty || entries.first is! PregoMenuItem ? 6 : 0,
+      bottom: entries.isEmpty || entries.last is! PregoMenuItem ? 6 : 0,
+    );
     return AnchoredFlatPanel(
       triggerRect: triggerRect,
       width: widget.menuWidth,
       height: widget.menuHeight,
       borderRadius: widget.menuBorderRadius,
       screenPadding: widget.menuScreenPadding,
-      // AnchoredFlatPanel owns the scroll and clips this column to the panel's
-      // rounded shape. Keeping the column flush with that clip lets the first
-      // and last item highlights reach the menu edges.
-      childBuilder: (context, close) => Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          for (final entry in widget.entriesBuilder()) _flatEntry(context, entry: entry, close: close),
-        ],
+      // Menu items meet the panel clip so their ink reaches its outer edges.
+      // Labels, dividers, and custom content keep the original edge breathing
+      // room when they bookend the menu.
+      childBuilder: (context, close) => Padding(
+        padding: edgePadding,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (final entry in entries) _flatEntry(context, entry: entry, close: close),
+          ],
+        ),
       ),
     );
   }
@@ -392,7 +400,9 @@ class _FlatMenuTile extends StatelessWidget {
     final leadingIcon = this.leadingIcon;
     return InkWell(
       onTap: onTap,
-      borderRadius: BorderRadius.circular(16),
+      // The enclosing Material clips the menu to its configured radius. A
+      // second radius here would round the shared edges between adjacent rows.
+      borderRadius: BorderRadius.zero,
       child: ConstrainedBox(
         // Matches GlassMenuItem's 44px iOS/Material touch target.
         constraints: const BoxConstraints(minHeight: 44),

--- a/client/module_prego/lib/components/menus/prego_anchor_menu.dart
+++ b/client/module_prego/lib/components/menus/prego_anchor_menu.dart
@@ -311,18 +311,15 @@ class _PregoAnchorMenuState extends State<PregoAnchorMenu> {
       height: widget.menuHeight,
       borderRadius: widget.menuBorderRadius,
       screenPadding: widget.menuScreenPadding,
-      // AnchoredFlatPanel owns the scroll, so this supplies just the padded
-      // column of entries; the panel scrolls it when the menu is taller than
-      // the room beside the trigger.
-      childBuilder: (context, close) => Padding(
-        padding: const EdgeInsets.symmetric(vertical: 6),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            for (final entry in widget.entriesBuilder()) _flatEntry(context, entry: entry, close: close),
-          ],
-        ),
+      // AnchoredFlatPanel owns the scroll and clips this column to the panel's
+      // rounded shape. Keeping the column flush with that clip lets the first
+      // and last item highlights reach the menu edges.
+      childBuilder: (context, close) => Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          for (final entry in widget.entriesBuilder()) _flatEntry(context, entry: entry, close: close),
+        ],
       ),
     );
   }

--- a/client/module_prego/test/components/prego_anchor_menu_test.dart
+++ b/client/module_prego/test/components/prego_anchor_menu_test.dart
@@ -65,6 +65,25 @@ void main() {
       expect(find.text("Alpha"), findsNothing);
     }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
+    testWidgets("first and last item highlights reach the panel edges", (tester) async {
+      await tester.pumpWidget(
+        _harness([
+          PregoMenuItem(title: "Alpha", subtitle: null, isSelected: false, onTap: () {}),
+          PregoMenuItem(title: "Beta", subtitle: null, isSelected: false, onTap: () {}),
+        ], flat: true),
+      );
+
+      await tester.tap(find.text("Open"));
+      await tester.pumpAndSettle();
+
+      final panelRect = tester.getRect(find.byType(SingleChildScrollView));
+      final firstItemRect = tester.getRect(find.widgetWithText(InkWell, "Alpha"));
+      final lastItemRect = tester.getRect(find.widgetWithText(InkWell, "Beta"));
+
+      expect(firstItemRect.top, panelRect.top);
+      expect(lastItemRect.bottom, panelRect.bottom);
+    });
+
     testWidgets("a custom entry can close the menu via its close callback", (tester) async {
       await tester.pumpWidget(
         _harness([

--- a/client/module_prego/test/components/prego_anchor_menu_test.dart
+++ b/client/module_prego/test/components/prego_anchor_menu_test.dart
@@ -77,11 +77,39 @@ void main() {
       await tester.pumpAndSettle();
 
       final panelRect = tester.getRect(find.byType(SingleChildScrollView));
-      final firstItemRect = tester.getRect(find.widgetWithText(InkWell, "Alpha"));
-      final lastItemRect = tester.getRect(find.widgetWithText(InkWell, "Beta"));
+      final firstItem = find.widgetWithText(InkWell, "Alpha");
+      final lastItem = find.widgetWithText(InkWell, "Beta");
+      final firstItemRect = tester.getRect(firstItem);
+      final lastItemRect = tester.getRect(lastItem);
 
       expect(firstItemRect.top, panelRect.top);
       expect(lastItemRect.bottom, panelRect.bottom);
+      expect(tester.widget<InkWell>(firstItem).borderRadius, BorderRadius.zero);
+      expect(tester.widget<InkWell>(lastItem).borderRadius, BorderRadius.zero);
+    });
+
+    testWidgets("custom entries keep the original inset at panel edges", (tester) async {
+      await tester.pumpWidget(
+        _harness([
+          PregoMenuCustom(
+            builder: (context, close) => const SizedBox(key: ValueKey("first-custom"), height: 12),
+          ),
+          PregoMenuItem(title: "Alpha", subtitle: null, isSelected: false, onTap: () {}),
+          PregoMenuCustom(
+            builder: (context, close) => const SizedBox(key: ValueKey("last-custom"), height: 12),
+          ),
+        ], flat: true),
+      );
+
+      await tester.tap(find.text("Open"));
+      await tester.pumpAndSettle();
+
+      final panelRect = tester.getRect(find.byType(SingleChildScrollView));
+      final firstCustomRect = tester.getRect(find.byKey(const ValueKey("first-custom")));
+      final lastCustomRect = tester.getRect(find.byKey(const ValueKey("last-custom")));
+
+      expect(firstCustomRect.top - panelRect.top, 6);
+      expect(panelRect.bottom - lastCustomRect.bottom, 6);
     });
 
     testWidgets("a custom entry can close the menu via its close callback", (tester) async {


### PR DESCRIPTION
## Summary
- remove the flat anchored menu's extra vertical content padding
- let the first and last option highlights meet the popup's clipped top and bottom edges
- add a widget regression test for both edge positions

## Test plan
- [x] `flutter test test/components/prego_anchor_menu_test.dart` (module_prego)
- [x] `flutter test test/features/project_list/project_tile_menu_test.dart test/features/session_list/session_tile_menu_test.dart` (app)
- [x] `flutter analyze` (module_prego)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend flat anchored menu item highlights to the panel’s top and bottom edges. Keep custom/structural entries inset while relying on the panel clip for smooth outer corners.

- **Bug Fixes**
  - Removed outer vertical padding in `PregoAnchorMenu` only when the first/last entries are items; custom or structural edge entries keep a 6px inset.
  - Set menu row `InkWell` borderRadius to zero so highlights meet the panel clip; added tests for edge item bounds and custom-entry insets.

<sup>Written for commit 19303915c187e7a5af8bccf9c288e5f6ebb9113f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

