### PR TITLE
fix(ui): polish permission request sheet

### DIFF
--- a/client/app/lib/features/session_detail/widgets/permission_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/permission_modal.dart
@@ -172,12 +172,19 @@ class PermissionModal extends StatelessWidget {
                                 data: permission.description,
                                 selectable: true,
                                 onTapLink: handleMarkdownLinkTap,
-                                styleSheet: buildSessionMarkdownStyleSheet(
-                                  prego: prego,
-                                  paragraphStyle: prego.textTheme.textSm.regular
-                                      .copyWith(color: prego.colors.textPrimary)
-                                      .monospace,
-                                ),
+                                styleSheet:
+                                    buildSessionMarkdownStyleSheet(
+                                      prego: prego,
+                                      paragraphStyle: prego.textTheme.textSm.regular
+                                          .copyWith(color: prego.colors.textPrimary)
+                                          .monospace,
+                                    ).copyWith(
+                                      codeblockDecoration: BoxDecoration(
+                                        color: prego.colors.bgSurface2,
+                                        borderRadius: BorderRadius.circular(prego.radius.md),
+                                        border: Border.all(color: prego.colors.borderSecondary),
+                                      ),
+                                    ),
                               ),
                             ),
                             SizedBox(width: prego.spacing.xs),

--- a/client/app/lib/features/session_detail/widgets/permission_modal.dart
+++ b/client/app/lib/features/session_detail/widgets/permission_modal.dart
@@ -8,6 +8,7 @@ import "package:theme_prego/module_prego.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 import "../../../core/extensions/text_style_x.dart";
+import "../../../core/widgets/copy_icon_button.dart";
 import "../../../core/widgets/markdown_styles.dart";
 
 /// Bottom sheet that presents a tool permission request from the AI assistant.
@@ -102,48 +103,92 @@ class PermissionModal extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            // Tool name
-            Container(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 12,
-                vertical: 8,
-              ),
-              decoration: BoxDecoration(
-                color: prego.colors.bgQuaternary,
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: Row(
-                children: [
-                  Icon(
-                    Icons.terminal,
-                    size: 16,
-                    color: prego.colors.textSecondary,
-                  ),
-                  const SizedBox(width: 8),
-                  Text(
-                    permission.tool,
-                    style: prego.textTheme.textSm.bold
-                        .copyWith(
-                          fontWeight: FontWeight.bold,
-                        )
-                        .monospace,
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 16),
-
-            // Description — scrolls on its own when tall so the actions below
-            // stay on screen.
+            // A long request scrolls as one card while the blocking actions
+            // remain pinned below it.
             Flexible(
               child: SingleChildScrollView(
-                child: MarkdownBody(
-                  data: permission.description,
-                  selectable: true,
-                  onTapLink: handleMarkdownLinkTap,
-                  styleSheet: buildSessionMarkdownStyleSheet(
-                    prego: prego,
-                    paragraphStyle: prego.textTheme.textSm.regular,
+                child: Container(
+                  key: const Key("permission-detail-card"),
+                  clipBehavior: Clip.antiAlias,
+                  decoration: BoxDecoration(
+                    color: prego.colors.bgSurface1,
+                    borderRadius: BorderRadius.circular(prego.radius.xl),
+                    border: Border.all(color: prego.colors.borderSecondary),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Padding(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: prego.spacing.lg,
+                          vertical: prego.spacing.md,
+                        ),
+                        child: Row(
+                          children: [
+                            Container(
+                              width: 28,
+                              height: 28,
+                              alignment: Alignment.center,
+                              decoration: BoxDecoration(
+                                color: prego.colors.bgBrandPrimary,
+                                borderRadius: BorderRadius.circular(prego.radius.md),
+                              ),
+                              child: Icon(
+                                TablerRegular.terminal,
+                                size: 16,
+                                color: prego.colors.textBrandPrimary,
+                              ),
+                            ),
+                            SizedBox(width: prego.spacing.md),
+                            Expanded(
+                              child: Text(
+                                permission.tool,
+                                style: prego.textTheme.textSm.bold.monospace,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      Container(
+                        key: const Key("permission-request-detail"),
+                        width: double.infinity,
+                        padding: EdgeInsetsDirectional.only(
+                          start: prego.spacing.lg,
+                          top: prego.spacing.lg,
+                          end: prego.spacing.xs,
+                          bottom: prego.spacing.lg,
+                        ),
+                        decoration: BoxDecoration(
+                          color: prego.colors.bgQuaternary,
+                          border: Border(top: BorderSide(color: prego.colors.borderSecondary)),
+                        ),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Expanded(
+                              child: MarkdownBody(
+                                data: permission.description,
+                                selectable: true,
+                                onTapLink: handleMarkdownLinkTap,
+                                styleSheet: buildSessionMarkdownStyleSheet(
+                                  prego: prego,
+                                  paragraphStyle: prego.textTheme.textSm.regular
+                                      .copyWith(color: prego.colors.textPrimary)
+                                      .monospace,
+                                ),
+                              ),
+                            ),
+                            SizedBox(width: prego.spacing.xs),
+                            CopyIconButton(
+                              text: permission.description,
+                              tooltip: context.loc.sessionDetailCopy,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
                   ),
                 ),
               ),

--- a/client/app/test/features/session_detail/widgets/permission_modal_test.dart
+++ b/client/app/test/features/session_detail/widgets/permission_modal_test.dart
@@ -1,0 +1,150 @@
+import "package:flutter/material.dart";
+import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:go_router/go_router.dart";
+import "package:sesori_mobile/core/widgets/copy_icon_button.dart";
+import "package:sesori_mobile/features/session_detail/widgets/permission_modal.dart";
+import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/module_prego.dart";
+
+const _command = "dart run build_runner build --delete-conflicting-outputs";
+
+const _permission = SesoriPermissionAsked(
+  requestID: "permission-1",
+  sessionID: "session-1",
+  displaySessionId: null,
+  tool: "bash",
+  description: _command,
+);
+
+class _ReplyCapture {
+  String? requestId;
+  String? sessionId;
+  PermissionReply? reply;
+
+  void onReply({
+    required String requestId,
+    required String sessionId,
+    required PermissionReply reply,
+  }) {
+    this.requestId = requestId;
+    this.sessionId = sessionId;
+    this.reply = reply;
+  }
+}
+
+GoRouter _createRouter({
+  required SesoriPermissionAsked permission,
+  required _ReplyCapture capture,
+}) {
+  return GoRouter(
+    routes: [
+      GoRoute(
+        path: "/",
+        builder: (context, state) {
+          return Scaffold(
+            body: Center(
+              child: FilledButton(
+                key: const Key("open-permission-modal"),
+                onPressed: () {
+                  PermissionModal.show(
+                    context,
+                    permission: permission,
+                    onReply: capture.onReply,
+                  );
+                },
+                child: const Text("Open permission modal"),
+              ),
+            ),
+          );
+        },
+      ),
+    ],
+  );
+}
+
+Widget _buildApp({required GoRouter router}) {
+  return MaterialApp.router(
+    routerConfig: router,
+    theme: ThemeData(extensions: [PregoDesignSystem.light]),
+    darkTheme: ThemeData(extensions: [PregoDesignSystem.dark]),
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+  );
+}
+
+Future<void> _openPermissionModal(WidgetTester tester) async {
+  await tester.tap(find.byKey(const Key("open-permission-modal")));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets("groups the tool and highlighted request detail in one card", (tester) async {
+    final capture = _ReplyCapture();
+    final router = _createRouter(permission: _permission, capture: capture);
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openPermissionModal(tester);
+
+    expect(find.text("bash"), findsOneWidget);
+    expect(find.text(_command), findsOneWidget);
+    expect(find.byIcon(TablerRegular.terminal), findsOneWidget);
+
+    final colors = PregoDesignSystem.light.colors;
+    final card = tester.widget<Container>(find.byKey(const Key("permission-detail-card")));
+    final cardDecoration = card.decoration! as BoxDecoration;
+    expect(cardDecoration.color, colors.bgSurface1);
+    expect((cardDecoration.border! as Border).top.color, colors.borderSecondary);
+
+    final detail = tester.widget<Container>(find.byKey(const Key("permission-request-detail")));
+    final detailDecoration = detail.decoration! as BoxDecoration;
+    expect(detailDecoration.color, colors.bgQuaternary);
+
+    final markdown = tester.widget<MarkdownBody>(find.byType(MarkdownBody));
+    expect(markdown.data, _command);
+    expect(markdown.selectable, isTrue);
+
+    final copyButton = tester.widget<CopyIconButton>(find.byType(CopyIconButton));
+    expect(copyButton.text, _command);
+  });
+
+  for (final replyCase in const [
+    (label: "Reject", reply: PermissionReply.reject),
+    (label: "Once", reply: PermissionReply.once),
+    (label: "Always Allow", reply: PermissionReply.always),
+  ]) {
+    testWidgets("forwards the ${replyCase.label.toLowerCase()} reply", (tester) async {
+      final capture = _ReplyCapture();
+      final router = _createRouter(permission: _permission, capture: capture);
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(_buildApp(router: router));
+      await _openPermissionModal(tester);
+      await tester.tap(find.text(replyCase.label));
+      await tester.pumpAndSettle();
+
+      expect(capture.requestId, _permission.requestID);
+      expect(capture.sessionId, _permission.sessionID);
+      expect(capture.reply, replyCase.reply);
+    });
+  }
+
+  testWidgets("keeps actions visible for a long request detail", (tester) async {
+    final capture = _ReplyCapture();
+    final permission = _permission.copyWith(
+      description: List.filled(80, "echo a long permission request").join("\n"),
+    );
+    final router = _createRouter(permission: permission, capture: capture);
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openPermissionModal(tester);
+
+    expect(find.text("Reject"), findsOneWidget);
+    expect(find.text("Once"), findsOneWidget);
+    expect(find.text("Always Allow"), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/client/app/test/features/session_detail/widgets/permission_modal_test.dart
+++ b/client/app/test/features/session_detail/widgets/permission_modal_test.dart
@@ -105,6 +105,9 @@ void main() {
     final markdown = tester.widget<MarkdownBody>(find.byType(MarkdownBody));
     expect(markdown.data, _command);
     expect(markdown.selectable, isTrue);
+    final codeBlockDecoration = markdown.styleSheet!.codeblockDecoration! as BoxDecoration;
+    expect(codeBlockDecoration.color, isNot(detailDecoration.color));
+    expect((codeBlockDecoration.border! as Border).top.color, colors.borderSecondary);
 
     final copyButton = tester.widget<CopyIconButton>(find.byType(CopyIconButton));
     expect(copyButton.text, _command);


### PR DESCRIPTION
## Summary
- group the permission tool and requested operation into one bordered detail card
- highlight the requested command/detail with selectable monospace styling and a copy action
- keep permission actions pinned for long requests and add focused reply/layout coverage

## Testing
- `dart analyze --fatal-infos` (`client/app`)
- `flutter test test/features/session_detail/widgets/permission_modal_test.dart`
- `flutter test test/features/session_detail/widgets/session_detail_body_test.dart`
- `flutter test` (`client/app`, 612 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the permission request sheet for clarity and usability. Groups the tool and requested operation into a single bordered card, highlights the command with selectable monospace and copy, preserves code block contrast, and keeps actions visible while long content scrolls.

- **New Features**
  - Grouped tool + request detail in a bordered card with terminal icon.
  - Selectable monospace rendering for the requested command with a `CopyIconButton`.
  - Pinned permission actions; long descriptions scroll independently.
  - New widget tests validate layout, copy, contrast, and reply forwarding.

<sup>Written for commit e81bdd6266a59fcf5fe9ea97c7b6c791503df843. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

