### PR TITLE
fix: allow multiple plugin event subscribers

### DIFF
--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -26,7 +26,8 @@ sealed class BridgePluginApi {
   /// Unique plugin identifier (e.g., "opencode", "codex")
   String get id;
 
-  /// Stream of bridge SSE events. Buffered until first listener subscribes.
+  /// Stream of bridge SSE events. Buffered until the first listener subscribes,
+  /// then broadcast to every attached listener.
   Stream<BridgeSseEvent> get events;
 
   /// Get sessions for a project directory.

--- a/bridge/sesori_plugin_interface/lib/src/buffered_stream.dart
+++ b/bridge/sesori_plugin_interface/lib/src/buffered_stream.dart
@@ -7,10 +7,10 @@ class BufferedUntilFirstListener<T> {
   bool _isClosed = false;
 
   BufferedUntilFirstListener() {
-    _controller = StreamController<T>(
+    _controller = StreamController<T>.broadcast(
       onListen: () {
         if (_hasListener) {
-          throw StateError("This stream supports only one listener.");
+          return;
         }
         _hasListener = true;
         for (final event in _buffer) {

--- a/bridge/sesori_plugin_interface/test/buffered_stream_test.dart
+++ b/bridge/sesori_plugin_interface/test/buffered_stream_test.dart
@@ -1,0 +1,45 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("BufferedUntilFirstListener", () {
+    test("delivers buffered events in order to the first listener", () async {
+      final buffered = BufferedUntilFirstListener<int>();
+      buffered.add(1);
+      buffered.add(2);
+      await buffered.close();
+
+      await expectLater(buffered.stream, emitsInOrder([1, 2, emitsDone]));
+    });
+
+    test("delivers live events to multiple listeners", () async {
+      final buffered = BufferedUntilFirstListener<int>();
+      final first = expectLater(buffered.stream, emitsInOrder([1, 2, emitsDone]));
+      final second = expectLater(buffered.stream, emitsInOrder([1, 2, emitsDone]));
+
+      buffered.add(1);
+      buffered.add(2);
+      await buffered.close();
+
+      await Future.wait<void>([first, second]);
+    });
+
+    test("allows another listener after an earlier listener cancels", () async {
+      final buffered = BufferedUntilFirstListener<int>();
+      final firstEvent = Completer<int>();
+      final firstSubscription = buffered.stream.listen(firstEvent.complete);
+
+      buffered.add(1);
+      expect(await firstEvent.future, 1);
+      await firstSubscription.cancel();
+
+      final later = expectLater(buffered.stream, emitsInOrder([2, emitsDone]));
+      buffered.add(2);
+      await buffered.close();
+
+      await later;
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- make buffered plugin event streams broadcast after their first listener attaches
- preserve ordered startup-event buffering for the first subscriber
- allow the orchestrator and debug SSE server to subscribe concurrently without terminating the bridge
- cover concurrent and replacement subscribers with regression tests

## Testing
- `dart test` in `bridge/sesori_plugin_interface` (145 tests)
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_interface`
- `dart test test/bridge/debug_server_test.dart` in `bridge/app` (13 tests)
- `make test` in `bridge` (1,876 tests)
- `make analyze` in `bridge`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow multiple subscribers to plugin event streams by switching to broadcast after the first listener, while preserving ordered buffering for the first subscriber. Prevents the bridge from terminating when the orchestrator and debug SSE server subscribe at the same time.

- **Bug Fixes**
  - Use `StreamController.broadcast` in `BufferedUntilFirstListener`, replay buffered events to the first listener, then broadcast live events to all listeners.
  - Remove single-listener restriction and allow re-subscription after cancellation.
  - Update `BridgePluginApi.events` docs to clarify broadcast behavior.
  - Add regression tests for ordered buffering, multi-listener delivery, and listener replacement.

<sup>Written for commit cc06fda93b22edc7996f6a7bb557464ab33d5fe4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

