### PR TITLE
fix(ui): size the glass menu from its rows, not a guess at them

### DIFF
--- a/client/app/lib/core/widgets/agent_model_buttons.dart
+++ b/client/app/lib/core/widgets/agent_model_buttons.dart
@@ -157,7 +157,7 @@ class _AgentMenu extends StatelessWidget {
     final loc = context.loc;
     return PregoAnchorMenu(
       menuWidth: 240,
-      menuHeight: agents.length > 6 ? 320 : null,
+      menuMaxHeight: _pickerMaxHeight,
       triggerBuilder: (context, toggle) => PregoButtonsGlass(
         leadingIcon: Icons.smart_toy_outlined,
         label: selectedAgent,
@@ -201,6 +201,7 @@ class _ModelMenu extends StatelessWidget {
     // custom entry so it can close the menu before the sheet rises.
     final entries = <PregoMenuEntry>[
       PregoMenuCustom(
+        height: _ModelSearchAffordance.height,
         builder: (context, close) => _ModelSearchAffordance(
           onTap: () {
             close();
@@ -209,15 +210,11 @@ class _ModelMenu extends StatelessWidget {
         ),
       ),
     ];
-    var modelRows = 0;
-    var headerRows = 0;
     for (final section in sections) {
       final models = section.models.where((model) => model.visibleByDefault).toList();
       if (models.isEmpty) continue;
-      headerRows++;
       entries.add(PregoMenuLabel(text: section.providerName));
       for (final model in models) {
-        modelRows++;
         entries.add(
           PregoMenuItem(
             title: model.displayName,
@@ -231,7 +228,7 @@ class _ModelMenu extends StatelessWidget {
 
     return PregoAnchorMenu(
       menuWidth: 320,
-      menuHeight: _modelMenuHeight(modelRows: modelRows, headerRows: headerRows),
+      menuMaxHeight: _pickerMaxHeight,
       triggerBuilder: (context, toggle) => PregoButtonsGlass(
         leadingIcon: Icons.memory_outlined,
         label: _resolveModelName(context, providers: providers, selected: selected),
@@ -259,7 +256,7 @@ class _VariantMenu extends StatelessWidget {
     final loc = context.loc;
     return PregoAnchorMenu(
       menuWidth: 220,
-      menuHeight: availableVariants.length > 6 ? 320 : null,
+      menuMaxHeight: _pickerMaxHeight,
       triggerBuilder: (context, toggle) => PregoButtonsGlass(
         leadingIcon: Icons.speed_outlined,
         label: selectedVariant ?? loc.sessionDetailVariantDefault,
@@ -294,17 +291,25 @@ class _ModelSearchAffordance extends StatelessWidget {
 
   const _ModelSearchAffordance({required this.onTap});
 
+  /// The row's rendered height — the [_barHeight] bar plus the [_bottomGap] that
+  /// separates it from the first provider heading. The glass popup budgets its
+  /// height from what each row declares, so this is what the menu is told; the
+  /// two constants below are the only things that decide it.
+  static const double height = _barHeight + _bottomGap;
+  static const double _barHeight = 40;
+  static const double _bottomGap = 8;
+
   @override
   Widget build(BuildContext context) {
     final prego = context.prego;
     final loc = context.loc;
     return Padding(
-      padding: const EdgeInsetsDirectional.fromSTEB(4, 0, 4, 8),
+      padding: const EdgeInsetsDirectional.fromSTEB(4, 0, 4, _bottomGap),
       child: GestureDetector(
         onTap: onTap,
         behavior: HitTestBehavior.opaque,
         child: Container(
-          height: 40,
+          height: _barHeight,
           padding: const EdgeInsets.symmetric(horizontal: 12),
           decoration: BoxDecoration(
             color: prego.colors.bgSurface1,
@@ -328,16 +333,10 @@ class _ModelSearchAffordance extends StatelessWidget {
 
 // ── Shared menu pieces ─────────────────────────────────────────────────────
 
-/// Fixed (always-scrollable) model-menu height that fits the quick-pick rows
-/// but caps so the popup never fills the screen; results scroll inside.
-double _modelMenuHeight({required int modelRows, required int headerRows}) {
-  const searchHeight = 52.0;
-  const itemHeight = 48.0;
-  const headerHeight = 30.0;
-  const verticalPadding = 36.0;
-  final natural = searchHeight + modelRows * itemHeight + headerRows * headerHeight + verticalPadding;
-  return natural.clamp(120.0, 380.0);
-}
+/// How tall a composer picker may grow before its rows start to scroll. The menu
+/// sizes itself to its rows below this; the cap only stops a long catalog (or a
+/// project with many agents) from swallowing the conversation behind it.
+const double _pickerMaxHeight = 380;
 
 String _resolveModelName(
   BuildContext context, {

--- a/client/app/test/core/widgets/agent_model_buttons_test.dart
+++ b/client/app/test/core/widgets/agent_model_buttons_test.dart
@@ -1,0 +1,95 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
+import "package:sesori_mobile/core/widgets/agent_model_buttons.dart";
+import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/module_prego.dart";
+
+/// The agents a real project reports — a handful, each with a description long
+/// enough to run past the row and ellipsize.
+final _agents = [
+  _agent(name: "build", description: "The default agent. Executes tools and edits files."),
+  _agent(name: "plan", description: "Plan mode. Disallows all edit tools."),
+  _agent(name: "sesori-plan-maker", description: "Creates implementation-ready, reviewed plans."),
+  _agent(name: "sesori-plan-worker", description: "Executes one reviewed plan step end to end."),
+];
+
+AgentInfo _agent({required String name, required String description}) =>
+    AgentInfo(name: name, description: description, model: null, mode: AgentMode.all);
+
+Widget _buildApp({required List<AgentInfo> agents, required void Function(String) onAgentSelected}) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [PregoDesignSystem.light]),
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      // Bottom-aligned, like the composer the pickers actually live in.
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          AgentModelButtons(
+            agents: agents,
+            selectedAgent: "sesori-plan-worker",
+            onAgentSelected: onAgentSelected,
+            providers: const [],
+            selectedAgentModel: null,
+            onModelSelected: ({required providerID, required modelID}) {},
+            availableVariants: const [],
+            onVariantSelected: (_) {},
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+void main() {
+  group("Agent picker", () {
+    testWidgets("shows every agent, with none clipped out of reach", (tester) async {
+      await tester.pumpWidget(_buildApp(agents: _agents, onAgentSelected: (_) {}));
+
+      await tester.tap(find.text("sesori-plan-worker"));
+      await tester.pumpAndSettle();
+
+      // Each agent is on screen, and the popup hides nothing below its fold —
+      // the picker used to under-size itself around its subtitled rows, clipping
+      // the last agent with no way to scroll to it.
+      for (final agent in _agents) {
+        expect(find.widgetWithText(GlassMenuItem, agent.name), findsOneWidget);
+      }
+      final popup = tester.state<ScrollableState>(find.byType(Scrollable)).position;
+      expect(popup.maxScrollExtent, equals(0.0));
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+
+    testWidgets("selects the agent the tap landed on", (tester) async {
+      final selected = <String>[];
+      await tester.pumpWidget(_buildApp(agents: _agents, onAgentSelected: selected.add));
+
+      await tester.tap(find.text("sesori-plan-worker"));
+      await tester.pumpAndSettle();
+
+      // Aimed at the lower edge of a row, where the popup's tap arithmetic used
+      // to have drifted far enough to select the agent below it.
+      final row = find.widgetWithText(GlassMenuItem, "plan");
+      await tester.tapAt(tester.getRect(row).bottomCenter - const Offset(0, 4));
+      await tester.pumpAndSettle();
+
+      expect(selected, equals(["plan"]));
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+
+    testWidgets("scrolls when a project brings more agents than fit", (tester) async {
+      final agents = [
+        for (var i = 0; i < 14; i++) _agent(name: "agent-$i", description: "Agent number $i."),
+      ];
+      await tester.pumpWidget(_buildApp(agents: agents, onAgentSelected: (_) {}));
+
+      await tester.tap(find.text("sesori-plan-worker"));
+      await tester.pumpAndSettle();
+
+      // Past the cap the rows scroll rather than being cut off.
+      final popup = tester.state<ScrollableState>(find.byType(Scrollable)).position;
+      expect(popup.maxScrollExtent, greaterThan(0.0));
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+  });
+}

--- a/client/module_prego/lib/components/menus/anchored_flat_panel.dart
+++ b/client/module_prego/lib/components/menus/anchored_flat_panel.dart
@@ -25,7 +25,7 @@ class AnchoredFlatPanel extends StatelessWidget {
     super.key,
     required this.triggerRect,
     required this.width,
-    required this.height,
+    required this.maxHeight,
     required this.borderRadius,
     required this.screenPadding,
     required this.childBuilder,
@@ -37,10 +37,10 @@ class AnchoredFlatPanel extends StatelessWidget {
   /// Fixed width of the bubble (clamped down to fit a narrow viewport).
   final double width;
 
-  /// Optional fixed maximum height. When set, the bubble caps at this height
-  /// and its content scrolls; when null it sizes to its content (still bounded
-  /// to stay on screen).
-  final double? height;
+  /// Caps how tall the bubble may grow; past it the content scrolls. Null lets
+  /// it grow with its content. Either way it is bounded by the room beside the
+  /// trigger — a cap only ever tightens that bound.
+  final double? maxHeight;
 
   /// Corner radius of the bubble.
   final double borderRadius;
@@ -71,9 +71,9 @@ class AnchoredFlatPanel extends StatelessWidget {
     final spaceBelow =
         screen.height - keyboard - safe.bottom - screenPadding.bottom - triggerRect.bottom - _gap;
     final expandUp = spaceAbove >= spaceBelow;
+    final cap = maxHeight;
     final available = math.max(0.0, expandUp ? spaceAbove : spaceBelow);
-    final height = this.height;
-    final maxHeight = height != null ? math.min(height, available) : available;
+    final effectiveMaxHeight = cap != null ? math.min(cap, available) : available;
 
     // module_prego is a GoRouter-agnostic design module (no go_router dep);
     // this pops the modal route CueModalTransition pushed for the popup.
@@ -104,7 +104,7 @@ class AnchoredFlatPanel extends StatelessWidget {
       delegate: _AnchoredPopupLayoutDelegate(
         triggerRect: triggerRect,
         width: width,
-        maxHeight: maxHeight,
+        maxHeight: effectiveMaxHeight,
         expandUp: expandUp,
         screenPadding: screenPadding,
         safe: safe,

--- a/client/module_prego/lib/components/menus/prego_anchor_menu.dart
+++ b/client/module_prego/lib/components/menus/prego_anchor_menu.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:math" as math;
 
 import "package:cue/cue.dart";
 import "package:flutter/material.dart";
@@ -65,9 +66,18 @@ class PregoMenuDivider extends PregoMenuEntry {
 /// [builder] receives a `close` callback that dismisses the menu — use it to
 /// collapse the popup before, say, raising a full-screen sheet.
 class PregoMenuCustom extends PregoMenuEntry {
-  const PregoMenuCustom({required this.builder});
+  const PregoMenuCustom({required this.builder, required this.height});
 
   final Widget Function(BuildContext context, VoidCallback close) builder;
+
+  /// The row's rendered height, which the caller must state.
+  ///
+  /// The glass popup lays itself out from declared row heights rather than by
+  /// measuring (see [_glassItemHeight]), and it cannot measure a widget it did
+  /// not build. Getting this wrong under-sizes the popup, so keep it in step
+  /// with what [builder] returns. The flat path measures for real and ignores
+  /// it.
+  final double height;
 }
 
 /// Builds the trigger that opens the menu. [toggle] opens (or, on the glass
@@ -134,7 +144,7 @@ class PregoAnchorMenu extends StatefulWidget {
     required this.triggerBuilder,
     required this.entriesBuilder,
     this.menuWidth = 240,
-    this.menuHeight,
+    this.menuMaxHeight,
     this.menuBorderRadius = 24,
     this.menuScreenPadding = const EdgeInsets.all(12),
     this.flat = false,
@@ -158,10 +168,15 @@ class PregoAnchorMenu extends StatefulWidget {
   /// Width of the open menu.
   final double menuWidth;
 
-  /// Optional fixed maximum height. When set, the menu caps at this height and
-  /// scrolls internally; when null it sizes to its content (still bounded to
-  /// stay on screen).
-  final double? menuHeight;
+  /// Caps how tall the open menu may grow; beyond it the rows scroll. Null (the
+  /// default) lets the menu grow with its content, which both paths still bound
+  /// to the room they have — the screen on the glass path, the space beside the
+  /// trigger on the flat one.
+  ///
+  /// The menu measures its own rows, so a cap is a product decision ("don't let
+  /// this swallow the screen"), never a guess at how tall the rows are. A menu
+  /// shorter than its cap is sized exactly to its content, not padded out to it.
+  final double? menuMaxHeight;
 
   /// Corner radius of the open menu.
   final double menuBorderRadius;
@@ -199,10 +214,11 @@ class _PregoAnchorMenuState extends State<PregoAnchorMenu> {
   // ── Glass path (Apple) ─────────────────────────────────────────────────────
 
   Widget _buildGlass(BuildContext context) {
+    final entries = widget.entriesBuilder();
     return GlassMenu(
       controller: _glassController,
       menuWidth: widget.menuWidth,
-      menuHeight: widget.menuHeight,
+      menuHeight: _glassHeight(context, entries: entries),
       menuBorderRadius: widget.menuBorderRadius,
       autoAdjustToScreen: true,
       menuPadding: widget.menuScreenPadding,
@@ -211,8 +227,28 @@ class _PregoAnchorMenuState extends State<PregoAnchorMenu> {
         toggle();
         _alignGlassMenuToTrigger(context);
       }),
-      items: [for (final entry in widget.entriesBuilder()) _glassEntry(context, entry: entry)],
+      items: [for (final entry in entries) _glassEntry(context, entry: entry)],
     );
+  }
+
+  /// The fixed height to pin the glass popup at, or null to let it grow with its
+  /// rows.
+  ///
+  /// [GlassMenu] has no notion of a maximum: a height either pins it (and it
+  /// scrolls inside) or is absent (and it wraps its rows, bounded by the
+  /// screen). [menuMaxHeight] is honoured by pinning it only once the rows
+  /// actually outgrow the cap — below that the popup wraps them exactly, with no
+  /// dead glass at the bottom.
+  double? _glassHeight(BuildContext context, {required List<PregoMenuEntry> entries}) {
+    final cap = widget.menuMaxHeight;
+    if (cap == null) return null;
+    // GlassMenu's own column chrome: 12px above the first row, 12px below the
+    // last, 2px between neighbours.
+    var natural = 24.0 + math.max(0, entries.length - 1) * 2.0;
+    for (final entry in entries) {
+      natural += _glassEntryHeight(context, entry: entry);
+    }
+    return natural > cap ? cap : null;
   }
 
   /// Re-anchors the just-opened glass popup under its trigger when the composer
@@ -239,7 +275,11 @@ class _PregoAnchorMenuState extends State<PregoAnchorMenu> {
     switch (entry) {
       case PregoMenuLabel(:final text):
         // GlassMenuLabel uppercases the title itself; we only supply the style.
-        return GlassMenuLabel(title: text, style: _labelStyle(prego));
+        return GlassMenuLabel(
+          title: text,
+          style: _labelStyle(prego),
+          height: _glassLabelHeight(context),
+        );
       case PregoMenuItem(
         :final title,
         :final subtitle,
@@ -252,6 +292,7 @@ class _PregoAnchorMenuState extends State<PregoAnchorMenu> {
           title: title,
           subtitle: subtitle,
           isSelected: isSelected,
+          height: _glassItemHeight(context, hasSubtitle: subtitle != null),
           // GlassMenuItem would paint a destructive row in Cupertino's system
           // red; the explicit style below keeps it on the design system's error
           // token instead. The flag still drives its press feedback.
@@ -265,9 +306,18 @@ class _PregoAnchorMenuState extends State<PregoAnchorMenu> {
           onTap: onTap,
         );
       case PregoMenuDivider():
-        return const GlassMenuDivider();
-      case PregoMenuCustom(:final builder):
-        return builder(context, _glassController.close);
+        return const GlassMenuDivider(height: _glassDividerHeight);
+      case PregoMenuCustom(:final builder, :final height):
+        // Hosted in a GlassMenuLabel — the one non-interactive row GlassMenu
+        // will take a height from. Handed back raw, the row would be budgeted at
+        // GlassMenu's 44px fallback for widgets it does not recognise, which
+        // under-sizes the popup. The label is pure chrome here (no title, no
+        // padding of its own), so the custom widget renders unchanged.
+        return GlassMenuLabel(
+          height: height,
+          horizontalPadding: 0,
+          child: builder(context, _glassController.close),
+        );
     }
   }
 
@@ -313,7 +363,9 @@ class _PregoAnchorMenuState extends State<PregoAnchorMenu> {
     return AnchoredFlatPanel(
       triggerRect: triggerRect,
       width: widget.menuWidth,
-      height: widget.menuHeight,
+      // The panel measures its rows for real, so the cap is all it needs: it
+      // shrink-wraps below it and scrolls above it.
+      maxHeight: widget.menuMaxHeight,
       borderRadius: widget.menuBorderRadius,
       screenPadding: widget.menuScreenPadding,
       // Menu items meet the panel clip so their ink reaches its outer edges.
@@ -443,6 +495,75 @@ class _FlatMenuTile extends StatelessWidget {
 }
 
 // ── Shared entry styling (keeps the glass and flat paths visually identical) ──
+
+// ── Glass row heights ────────────────────────────────────────────────────────
+//
+// [GlassMenu] never measures its rows: it lays the popup out from the heights
+// its items *declare* (`GlassMenuItem.height` and friends), falling back to a
+// guess at the text height — `fontSize × 1.2` per line, floored at a 44px touch
+// target — when a row leaves that height at its default. The design system's
+// rows are taller than that guess: `textSm` sits in a 20px line box and `textXs`
+// in an 18px one, so a title-plus-subtitle row really occupies 54px against a
+// guessed 47.
+//
+// Under-declaring is not just a cosmetic under-size. Those same heights are what
+// GlassMenu sums to size the popup, what it uses to place the selection pill,
+// and — for a popup short enough not to scroll — what it does index arithmetic
+// over to decide which row a tap landed on. Guess low and the last row is
+// clipped with no way to scroll to it, and taps near a row's lower edge fire the
+// row *below* the one under the finger.
+//
+// So every row we hand GlassMenu declares its true height, computed here from
+// the very styles the row is rendered with. `prego_anchor_menu_test` pins each
+// declaration against the height the row actually renders at, so a package
+// upgrade that changes a row's chrome fails there rather than in the field.
+
+/// Height of a [PregoMenuItem]'s glass row: [GlassMenuItem]'s 8px of padding
+/// above and below a title, plus a subtitle line when it carries one.
+double _glassItemHeight(BuildContext context, {required bool hasSubtitle}) {
+  const verticalPadding = 16.0;
+  final prego = context.prego;
+  var text = _lineHeight(context, style: _titleStyle(prego, isDestructive: false));
+  if (hasSubtitle) text += _lineHeight(context, style: _subtitleStyle(prego));
+  // Never below the 44px touch target GlassMenuItem floors its rows at.
+  return math.max(44, verticalPadding + text);
+}
+
+/// Height of a [PregoMenuLabel]'s glass row. [GlassMenuLabel] pins its box to
+/// the declared height, so it must clear the label's line box — at a large text
+/// scale that outgrows the 30px the package would otherwise assume.
+double _glassLabelHeight(BuildContext context) =>
+    math.max(30, _lineHeight(context, style: _labelStyle(context.prego)));
+
+/// Height of a [PregoMenuDivider]'s glass row — [GlassMenuDivider]'s own
+/// default, named so the height budget can account for it.
+const double _glassDividerHeight = 12;
+
+/// The height [GlassMenu] will budget for [entry] — which is exactly the height
+/// the row renders at, because every row above declares its own.
+///
+/// Exposed (via [debugGlassEntryHeight]) to the test that pins each declaration
+/// against the rendered row.
+double _glassEntryHeight(BuildContext context, {required PregoMenuEntry entry}) => switch (entry) {
+  PregoMenuLabel() => _glassLabelHeight(context),
+  PregoMenuItem(:final subtitle) => _glassItemHeight(context, hasSubtitle: subtitle != null),
+  PregoMenuDivider() => _glassDividerHeight,
+  PregoMenuCustom(:final height) => height,
+};
+
+@visibleForTesting
+double debugGlassEntryHeight(BuildContext context, {required PregoMenuEntry entry}) =>
+    _glassEntryHeight(context, entry: entry);
+
+/// The vertical space one line of [style] occupies, at the reader's text scale.
+/// Prego's styles set an explicit line height, so the line box is exactly the
+/// scaled font size times that factor — no font-metric guesswork.
+double _lineHeight(BuildContext context, {required TextStyle style}) {
+  final fontSize = MediaQuery.textScalerOf(context).scale(style.fontSize!);
+  return fontSize * style.height!;
+}
+
+// ── Shared entry styling, cont. ──────────────────────────────────────────────
 
 TextStyle _labelStyle(PregoDesignSystem prego) =>
     prego.textTheme.textXs.medium.copyWith(color: prego.colors.textSecondary, letterSpacing: 0.8);

--- a/client/module_prego/lib/components/menus/prego_popover.dart
+++ b/client/module_prego/lib/components/menus/prego_popover.dart
@@ -64,7 +64,7 @@ class PregoPopover extends StatelessWidget {
         triggerRect: triggerRect,
         width: popoverWidth,
         // Content-sized (still bounded to stay on screen).
-        height: null,
+        maxHeight: null,
         borderRadius: popoverBorderRadius,
         screenPadding: screenPadding,
         childBuilder: contentBuilder,

--- a/client/module_prego/test/components/prego_anchor_menu_test.dart
+++ b/client/module_prego/test/components/prego_anchor_menu_test.dart
@@ -4,13 +4,19 @@ import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
 import "package:theme_prego/components/menus/anchored_spotlight_backdrop.dart";
 import "package:theme_prego/module_prego.dart";
 
-Widget _harness(List<PregoMenuEntry> entries, {bool flat = false, PregoMenuSpotlight? spotlight}) {
+Widget _harness(
+  List<PregoMenuEntry> entries, {
+  bool flat = false,
+  PregoMenuSpotlight? spotlight,
+  double? maxHeight,
+}) {
   return MaterialApp(
     theme: ThemeData(extensions: [PregoDesignSystem.light]),
     home: Scaffold(
       body: Center(
         child: PregoAnchorMenu(
           menuWidth: 240,
+          menuMaxHeight: maxHeight,
           flat: flat,
           spotlight: spotlight,
           entriesBuilder: () => entries,
@@ -23,6 +29,23 @@ Widget _harness(List<PregoMenuEntry> entries, {bool flat = false, PregoMenuSpotl
     ),
   );
 }
+
+/// The rows of an agent picker — the shape that broke: a heading, then several
+/// rows carrying both a title and a subtitle.
+List<PregoMenuEntry> _agentEntries(List<String> names, {void Function(String name)? onTap}) => [
+  const PregoMenuLabel(text: "Agent"),
+  for (final name in names)
+    PregoMenuItem(
+      title: name,
+      subtitle: "The $name agent, described at some length",
+      isSelected: name == names.last,
+      onTap: () => onTap?.call(name),
+    ),
+];
+
+/// The scroll position of the open glass popup.
+ScrollPosition _popupScroll(WidgetTester tester) =>
+    tester.state<ScrollableState>(find.byType(Scrollable)).position;
 
 void main() {
   group("Android (flat) path", () {
@@ -116,6 +139,7 @@ void main() {
       await tester.pumpWidget(
         _harness([
           PregoMenuCustom(
+            height: 48,
             builder: (context, close) => TextButton(onPressed: close, child: const Text("Dismiss")),
           ),
           PregoMenuItem(title: "Alpha", subtitle: null, isSelected: false, onTap: () {}),
@@ -234,6 +258,137 @@ void main() {
 
       expect(taps, 1);
       expect(find.text("Alpha"), findsNothing);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+  });
+
+  // GlassMenu never measures its rows — it lays the popup out from the heights
+  // they declare, and for a popup short enough not to scroll it even resolves
+  // taps by doing index arithmetic over those same heights. Every row we hand it
+  // therefore declares its true height. These guard that: under-declare, and the
+  // last row is clipped with no way to scroll to it while taps land on the wrong
+  // agent.
+  group("Glass row heights", () {
+    testWidgets("declare the height each row actually renders at", (tester) async {
+      const custom = 64.0;
+      final entries = <PregoMenuEntry>[
+        const PregoMenuLabel(text: "Agent"),
+        PregoMenuItem(title: "Titled", subtitle: null, isSelected: false, onTap: () {}),
+        PregoMenuItem(title: "Subtitled", subtitle: "and described", isSelected: false, onTap: () {}),
+        const PregoMenuDivider(),
+        PregoMenuCustom(
+          height: custom,
+          builder: (context, close) => const SizedBox(height: custom, child: Text("Custom")),
+        ),
+      ];
+      await tester.pumpWidget(_harness(entries));
+
+      await tester.tap(find.text("Open"));
+      await tester.pumpAndSettle();
+
+      // Each declaration matches the rendered row to the pixel. A package
+      // upgrade that changes a row's chrome fails here, loudly, rather than
+      // silently clipping the menu in the field.
+      final context = tester.element(find.byType(GlassMenu));
+      final rows = <PregoMenuEntry, Finder>{
+        entries[1]: find.widgetWithText(GlassMenuItem, "Titled"),
+        entries[2]: find.widgetWithText(GlassMenuItem, "Subtitled"),
+        entries[3]: find.byType(GlassMenuDivider),
+        entries[4]: find.widgetWithText(GlassMenuLabel, "Custom"),
+      };
+      rows.forEach((entry, row) {
+        expect(
+          tester.getSize(row).height,
+          equals(debugGlassEntryHeight(context, entry: entry)),
+          reason: "$entry renders taller or shorter than the popup was told",
+        );
+      });
+      // The heading is the one row whose rendered box is the declared height
+      // itself; assert it clears its line box rather than round-tripping it.
+      expect(tester.getSize(find.widgetWithText(GlassMenuLabel, "AGENT")).height, equals(30.0));
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+
+    testWidgets("leave nothing hidden below the fold", (tester) async {
+      await tester.pumpWidget(_harness(_agentEntries(["Alpha", "Beta", "Gamma", "Delta"])));
+
+      await tester.tap(find.text("Open"));
+      await tester.pumpAndSettle();
+
+      // Uncapped and short enough to fit: the popup wraps its rows exactly, so
+      // there is nothing to scroll to and the last agent is on screen.
+      expect(_popupScroll(tester).maxScrollExtent, equals(0.0));
+      expect(find.widgetWithText(GlassMenuItem, "Delta"), findsOneWidget);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+
+    testWidgets("hold up when the reader scales their text", (tester) async {
+      // Set on the view, not via a local MediaQuery: the popup is painted in the
+      // app's Overlay, above any override we could wrap the trigger in.
+      tester.platformDispatcher.textScaleFactorTestValue = 1.8;
+      addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+
+      await tester.pumpWidget(_harness(_agentEntries(["Alpha", "Beta", "Gamma", "Delta"])));
+
+      await tester.tap(find.text("Open"));
+      await tester.pumpAndSettle();
+
+      // Rows grow with the text scale, and the popup's budget grows with them.
+      expect(_popupScroll(tester).maxScrollExtent, equals(0.0));
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+
+    testWidgets("route a tap to the row under the finger, edges included", (tester) async {
+      final tapped = <String>[];
+      const names = ["Alpha", "Beta", "Gamma", "Delta"];
+      await tester.pumpWidget(_harness(_agentEntries(names, onTap: tapped.add)));
+
+      for (final name in names) {
+        await tester.tap(find.text("Open"));
+        await tester.pumpAndSettle();
+
+        // The lower edge of the row, where a height under-declared by a few
+        // pixels per row has drifted far enough to hand the tap to the row below.
+        final row = find.widgetWithText(GlassMenuItem, name);
+        await tester.tapAt(tester.getRect(row).bottomCenter - const Offset(0, 4));
+        await tester.pumpAndSettle();
+      }
+
+      expect(tapped, equals(names));
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+
+    testWidgets("scroll, rather than clip, once the rows outgrow the cap", (tester) async {
+      final tapped = <String>[];
+      const names = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Eta", "Theta"];
+      await tester.pumpWidget(_harness(_agentEntries(names, onTap: tapped.add), maxHeight: 200));
+
+      await tester.tap(find.text("Open"));
+      await tester.pumpAndSettle();
+
+      // The cap holds, and what it hides is scrollable rather than lost.
+      expect(tester.getSize(find.byType(SingleChildScrollView)).height, equals(200.0));
+      expect(_popupScroll(tester).maxScrollExtent, greaterThan(0.0));
+
+      // Taps still land on the row they were aimed at once it has scrolled — the
+      // last agent, which was past the cap, is now reachable.
+      await tester.drag(find.byType(SingleChildScrollView), const Offset(0, -400));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(GlassMenuItem, "Theta"));
+      await tester.pumpAndSettle();
+
+      expect(tapped, equals(["Theta"]));
+    }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
+
+    testWidgets("size the popup to its rows when they stay under the cap", (tester) async {
+      await tester.pumpWidget(_harness(_agentEntries(["Alpha", "Beta"]), maxHeight: 380));
+
+      await tester.tap(find.text("Open"));
+      await tester.pumpAndSettle();
+
+      // A cap is a ceiling, not a fixed height: a two-agent menu is a two-agent
+      // menu, not 380px of glass with the bottom half empty.
+      final label = tester.getRect(find.widgetWithText(GlassMenuLabel, "AGENT"));
+      final lastRow = tester.getRect(find.widgetWithText(GlassMenuItem, "Beta"));
+      final popup = tester.getSize(find.byType(SingleChildScrollView)).height;
+      // The rows plus GlassMenu's 12px of padding at either end.
+      expect(popup, closeTo(lastRow.bottom - label.top + 24, 0.1));
+      expect(_popupScroll(tester).maxScrollExtent, equals(0.0));
     }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
   });
 

--- a/client/module_prego/test/components/prego_anchor_menu_test.dart
+++ b/client/module_prego/test/components/prego_anchor_menu_test.dart
@@ -115,10 +115,12 @@ void main() {
       await tester.pumpWidget(
         _harness([
           PregoMenuCustom(
+            height: 12,
             builder: (context, close) => const SizedBox(key: ValueKey("first-custom"), height: 12),
           ),
           PregoMenuItem(title: "Alpha", subtitle: null, isSelected: false, onTap: () {}),
           PregoMenuCustom(
+            height: 12,
             builder: (context, close) => const SizedBox(key: ValueKey("last-custom"), height: 12),
           ),
         ], flat: true),


### PR DESCRIPTION
## What

`GlassMenu` never measures its rows — it lays the popup out from the heights each row *declares*, falling back to a guess (`fontSize × 1.2`, floored at 44px) for any row that leaves its height at the default. Prego rows render taller than that guess (a title+subtitle row is 54px vs. a guessed 47), so the **agent picker** — the only glass menu with subtitles and no fixed height — under-sized itself: the last agent was clipped and the menu refused to scroll because it believed everything fit.

Those declared heights also drive the selection pill and, for short (non-scrolling) popups, the index arithmetic that maps a tap to a row. Under-declaring drifted the tap zones — a tap near the lower edge of one agent fired the agent below it.

## Fix

- Every row handed to `GlassMenu` now declares the height it really renders at, computed from its styles and the reader's text scale. `PregoMenuCustom` takes a height for the same reason — the component can't measure a widget it didn't build.
- With true heights known, the component owns the height budget: `menuHeight` (fixed on the glass path, a cap on the flat one) becomes `menuMaxHeight` — a cap on **both**. That retires the callers' guesswork: the "more than six agents" magic number in two pickers and the model menu's hand-rolled row math. Under the cap, a picker is sized exactly to its rows; past it, it scrolls.

## Tests

- Pin each row type's declared height against the height it renders at, so a package upgrade that changes a row's chrome fails there rather than clipping the menu in the field.
- Taps land on the row under the finger (edges included), nothing hides below the fold, rows survive text scaled to 1.8×, and past the cap they scroll and stay reachable.

https://claude.ai/code/session_01GbD9rbJheCGMmcWXfXEr4z

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes glass menus by sizing from the rows’ actual rendered heights. Prevents clipping in the agent/model pickers and fixes tap-target drift; menus now scroll only when they exceed a clear height cap.

- **Bug Fixes**
  - Rows now declare true heights computed from current text styles and text scale; glass layout, selection pill, and tap mapping use these values.
  - Introduced `menuMaxHeight` cap (replacing fixed heights/guesses): menus size exactly to content below the cap, scroll above it.
  - `PregoMenuCustom` requires a `height` so custom rows budget correctly on glass; flat-path tests now declare it.
  - Agent/variant/model pickers use a shared `_pickerMaxHeight = 380`; removed the “>6 items” rule and model menu’s manual row math.
  - Tests pin declared vs rendered heights, verify no clipping, correct edge taps, proper scrolling past the cap, and robustness up to 1.8× text scale.

- **Migration**
  - Replace `menuHeight` with `menuMaxHeight` on `PregoAnchorMenu` and `AnchoredFlatPanel`.
  - Pass an explicit `height` to `PregoMenuCustom` rows used in glass menus.
  - Remove any manual row-height or “magic number” sizing in callers; rely on the cap.

<sup>Written for commit 91c401500be632866c9da2025b23a149cacddde5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

