### PR TITLE
fix(cursor): refresh project activity during active turns

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "mobile-mcp": {
+      "command": "npx",
+      "args": ["-y", "@mobilenext/mobile-mcp@0.0.62"],
+      "env": {
+        "MOBILEMCP_DISABLE_TELEMETRY": "1"
+      }
+    }
+  }
+}

--- a/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_approval_registry.dart
@@ -73,8 +73,7 @@ class AcpApprovalRegistry {
     return AcpApprovalRegistry(
       emit: emit,
       respond: (id, result) => client.respondToServerRequest(id: id, result: result),
-      respondError: (id, code, message) =>
-          client.respondToServerRequestWithError(id: id, code: code, message: message),
+      respondError: (id, code, message) => client.respondToServerRequestWithError(id: id, code: code, message: message),
       idGenerator: idGenerator,
       activeSessionResolver: activeSessionResolver,
     );
@@ -104,8 +103,7 @@ class AcpApprovalRegistry {
   void respond(Object acpId, Object? result) => _respond(acpId, result);
 
   /// Respond to a server request with a JSON-RPC error.
-  void respondError(Object acpId, int code, String message) =>
-      _respondError(acpId, code, message);
+  void respondError(Object acpId, int code, String message) => _respondError(acpId, code, message);
 
   /// Generates the next stable bridge request id (`br-N`).
   String generateBridgeId() {
@@ -142,6 +140,7 @@ class AcpApprovalRegistry {
       questions: questions,
       replyBuilder: replyBuilder,
     );
+    _emitActivityChanged();
   }
 
   /// Override to handle harness-specific server requests (e.g. Cursor's
@@ -167,6 +166,7 @@ class AcpApprovalRegistry {
     _subscription = null;
     final remaining = List<_PendingApproval>.from(_pending.values);
     _pending.clear();
+    if (remaining.isNotEmpty) _emitActivityChanged();
     // Emit the resolution SSEs (not just answer the agent) so a phone showing a
     // prompt when the child exits mid-approval clears it, instead of displaying
     // a stale prompt until a reload — same as [cancelForSession].
@@ -199,14 +199,12 @@ class AcpApprovalRegistry {
         .toList(growable: false);
   }
 
-  String? sessionIdFor(String bridgeRequestId) =>
-      _pending[bridgeRequestId]?.sessionId;
+  String? sessionIdFor(String bridgeRequestId) => _pending[bridgeRequestId]?.sessionId;
 
   /// Whether [sessionId] is blocked awaiting user input — a pending permission
   /// ask or question. Both kinds count, mirroring the OpenCode tracker's
   /// "awaiting input" notion (see `_rootHasPendingInput`).
-  bool hasPendingInput(String sessionId) =>
-      _pending.values.any((e) => e.sessionId == sessionId);
+  bool hasPendingInput(String sessionId) => _pending.values.any((e) => e.sessionId == sessionId);
 
   /// Resolves every pending approval for [sessionId] as cancelled — used when
   /// a turn is aborted. ACP still requires the client to answer an in-flight
@@ -214,8 +212,12 @@ class AcpApprovalRegistry {
   /// it) and emits the replied/rejected event so the phone clears the prompt.
   void cancelForSession(String sessionId) {
     final entries = _pending.values.where((e) => e.sessionId == sessionId).toList(growable: false);
+    if (entries.isEmpty) return;
     for (final entry in entries) {
       _pending.remove(entry.bridgeRequestId);
+    }
+    _emitActivityChanged();
+    for (final entry in entries) {
       _resolveCancelled(entry, questionErrorMessage: "aborted");
     }
   }
@@ -258,8 +260,10 @@ class AcpApprovalRegistry {
   /// the server-supplied option whose `kind` matches and echoes its
   /// `optionId` (ACP requires the client to select a provided option).
   bool replyPermission(String bridgeRequestId, PluginPermissionReply reply) {
-    final entry = _pending.remove(bridgeRequestId);
+    final entry = _pending[bridgeRequestId];
     if (entry == null || entry.kind != _PendingKind.permission) return false;
+    _pending.remove(bridgeRequestId);
+    _emitActivityChanged();
     final optionId = _selectOptionId(_optionsFrom(entry.params), reply);
     if (optionId == null) {
       _respond(entry.acpId, const {
@@ -284,10 +288,11 @@ class AcpApprovalRegistry {
   }
 
   bool replyQuestion(String bridgeRequestId, List<List<String>> answers) {
-    final entry = _pending.remove(bridgeRequestId);
+    final entry = _pending[bridgeRequestId];
     if (entry == null || entry.kind != _PendingKind.question) return false;
-    final payload = entry.replyBuilder?.call(answers) ??
-        {"answers": answers.map((row) => row.toList()).toList()};
+    _pending.remove(bridgeRequestId);
+    _emitActivityChanged();
+    final payload = entry.replyBuilder?.call(answers) ?? {"answers": answers.map((row) => row.toList()).toList()};
     _respond(entry.acpId, payload);
     _emit(
       BridgeSseQuestionReplied(
@@ -300,8 +305,10 @@ class AcpApprovalRegistry {
   }
 
   bool rejectQuestion(String bridgeRequestId) {
-    final entry = _pending.remove(bridgeRequestId);
+    final entry = _pending[bridgeRequestId];
     if (entry == null || entry.kind != _PendingKind.question) return false;
+    _pending.remove(bridgeRequestId);
+    _emitActivityChanged();
     _respondError(entry.acpId, -32603, "user rejected");
     _emit(
       BridgeSseQuestionRejected(
@@ -349,6 +356,7 @@ class AcpApprovalRegistry {
       kind: _PendingKind.permission,
       params: request.params,
     );
+    _emitActivityChanged();
     final summary = _permissionSummary(request.params);
     _emit(
       BridgeSsePermissionAsked(
@@ -383,6 +391,12 @@ class AcpApprovalRegistry {
 
   static String? _str(Object? value) => value is String && value.isNotEmpty ? value : null;
 
+  /// Pending input contributes to `getActiveSessionsSummary()`. The project
+  /// and session-list screens consume that aggregate rather than individual
+  /// permission/question events, so every real registry mutation must request
+  /// a fresh summary.
+  void _emitActivityChanged() => _emit(const BridgeSseProjectUpdated());
+
   PluginPendingQuestion _toPluginPendingQuestion(_PendingApproval entry) {
     return PluginPendingQuestion(
       id: entry.bridgeRequestId,
@@ -406,10 +420,7 @@ class AcpApprovalRegistry {
   List<Map<String, dynamic>> _optionsFrom(Map<String, dynamic> params) {
     final raw = params["options"];
     if (raw is! List) return const [];
-    return raw
-        .whereType<Map<dynamic, dynamic>>()
-        .map((m) => m.cast<String, dynamic>())
-        .toList(growable: false);
+    return raw.whereType<Map<dynamic, dynamic>>().map((m) => m.cast<String, dynamic>()).toList(growable: false);
   }
 
   String? _selectOptionId(

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -245,8 +245,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
           if (notification.method == AcpMethods.sessionUpdate) {
             final sid = notification.params["sessionId"];
             final update = notification.params["update"];
-            final isCommandUpdate =
-                update is Map && update["sessionUpdate"] == "available_commands_update";
+            final isCommandUpdate = update is Map && update["sessionUpdate"] == "available_commands_update";
             if (sid is String && _suppressedSessions.contains(sid) && !isCommandUpdate) {
               // Replay from an in-flight resume-load — drop so old history does
               // not re-stream into the live conversation.
@@ -302,8 +301,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       );
     }
     if (init.requiresAuth) {
-      final methodId = authMethodId ??
-          (init.authMethods.isNotEmpty ? init.authMethods.first.id : null);
+      final methodId = authMethodId ?? (init.authMethods.isNotEmpty ? init.authMethods.first.id : null);
       if (methodId != null) {
         await client.request(
           method: AcpMethods.authenticate,
@@ -680,9 +678,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     // Acceptance gate: an unreachable agent fails the send itself; the turn
     // re-resolves the client at dispatch time (see [_runTurn]).
     await _connectedClient();
-    eventMapper
-        .mapSentPrompt(sessionId: sessionId, parts: parts)
-        .forEach(_eventBuffer.add);
+    eventMapper.mapSentPrompt(sessionId: sessionId, parts: parts).forEach(_eventBuffer.add);
     _enqueueTurn(
       sessionId: sessionId,
       parts: parts,
@@ -715,8 +711,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
 
   /// The directory a session should be loaded/operated in — its own canonical
   /// directory when known, else the launch directory.
-  String _directoryForSession(String sessionId) =>
-      _sessionDirectories[sessionId] ?? launchDirectory;
+  String _directoryForSession(String sessionId) => _sessionDirectories[sessionId] ?? launchDirectory;
 
   @override
   void primeSessionDirectory({required String sessionId, required String directory}) {
@@ -867,10 +862,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     required PluginSessionVariant? variant,
     required String? agent,
   }) {
-    final blocks = parts
-        .map(_promptPartToContentBlock)
-        .whereType<Map<String, dynamic>>()
-        .toList(growable: false);
+    final blocks = parts.map(_promptPartToContentBlock).whereType<Map<String, dynamic>>().toList(growable: false);
     if (blocks.isEmpty) return;
 
     final state = _turnStates.putIfAbsent(sessionId, _SessionTurnState.new);
@@ -883,6 +875,11 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
           status: const shared.SessionStatus.busy().toJson(),
         ),
       );
+      // Project/session-list activity is driven by the aggregate
+      // `projects.summary`, not by the per-session status event above. Tell
+      // the orchestrator to rebuild that aggregate when this session crosses
+      // from idle to active.
+      _eventBuffer.add(const BridgeSseProjectUpdated());
     }
     final expectedGeneration = state.generation;
     // Each link isolates its own failure (_runTurn never throws), so one
@@ -1019,6 +1016,10 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     if (state.pending == 0) {
       _sessionStatuses[sessionId] = const PluginSessionStatus.idle();
       _eventBuffer.add(BridgeSseSessionIdle(sessionID: sessionId));
+      // Mirror the 0 -> 1 invalidation in [_enqueueTurn]. Queued turns keep
+      // [pending] above zero, so one active period produces exactly one start
+      // and one completion summary refresh.
+      _eventBuffer.add(const BridgeSseProjectUpdated());
     }
     if (failed || refused) {
       _eventBuffer.add(BridgeSseSessionError(sessionID: sessionId));
@@ -1129,12 +1130,10 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   }
 
   @override
-  Future<List<PluginSession>> getChildSessions(String sessionId) async =>
-      const [];
+  Future<List<PluginSession>> getChildSessions(String sessionId) async => const [];
 
   @override
-  Future<Map<String, PluginSessionStatus>> getSessionStatuses() async =>
-      Map.unmodifiable(_sessionStatuses);
+  Future<Map<String, PluginSessionStatus>> getSessionStatuses() async => Map.unmodifiable(_sessionStatuses);
 
   @override
   Future<List<PluginMessageWithParts>> getSessionMessages(
@@ -1318,8 +1317,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   /// Recency key for picking the freshest session as the catalog source. A
   /// missing timestamp sorts oldest — any session is a valid catalog source, so
   /// falling back to 0 just means "no better candidate than first-seen".
-  static int _sessionRecency(PluginSession session) =>
-      session.time?.updated ?? session.time?.created ?? 0;
+  static int _sessionRecency(PluginSession session) => session.time?.updated ?? session.time?.created ?? 0;
 
   @override
   Future<List<PluginAgent>> getAgents({required String projectId}) async {
@@ -1371,14 +1369,12 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
   @override
   Future<List<PluginPendingQuestion>> getPendingQuestions({
     required String sessionId,
-  }) async =>
-      _approvalRegistry?.pendingForSession(sessionId) ?? const [];
+  }) async => _approvalRegistry?.pendingForSession(sessionId) ?? const [];
 
   @override
   Future<List<PluginPendingPermission>> getPendingPermissions({
     required String sessionId,
-  }) async =>
-      _approvalRegistry?.pendingPermissionsForSession(sessionId) ?? const [];
+  }) async => _approvalRegistry?.pendingPermissionsForSession(sessionId) ?? const [];
 
   @override
   Future<List<PluginPendingQuestion>> getProjectQuestions({
@@ -1458,8 +1454,7 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
     if (byProject.isEmpty) return const [];
 
     return [
-      for (final entry in byProject.entries)
-        PluginProjectActivitySummary(id: entry.key, activeSessions: entry.value),
+      for (final entry in byProject.entries) PluginProjectActivitySummary(id: entry.key, activeSessions: entry.value),
     ];
   }
 

--- a/bridge/sesori_plugin_acp/test/acp_approval_registry_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_approval_registry_test.dart
@@ -49,11 +49,12 @@ void main() {
     test("permission request surfaces as BridgeSsePermissionAsked", () async {
       requests.add(permission());
       await pump();
-      final asked = emitted.single as BridgeSsePermissionAsked;
+      final asked = emitted.whereType<BridgeSsePermissionAsked>().single;
       expect(asked.sessionID, "s1");
       expect(asked.tool, "execute");
       expect(asked.description, "Run rm");
       expect(asked.requestID, isNotEmpty);
+      expect(emitted.whereType<BridgeSseProjectUpdated>(), hasLength(1));
     });
 
     test("permission with no resolvable session is auto-cancelled, not enqueued", () async {
@@ -61,16 +62,18 @@ void main() {
       // request stamped with "" is dropped by the mobile client, so it must be
       // auto-cancelled here instead of enqueued (which would deadlock the turn
       // on a reply that can never arrive).
-      requests.add(const AcpServerRequest(
-        id: 9,
-        method: "session/request_permission",
-        params: {
-          "toolCall": {"toolCallId": "tc-9", "title": "Run rm", "kind": "execute"},
-          "options": [
-            {"optionId": "opt-allow-once", "name": "Allow", "kind": "allow_once"},
-          ],
-        },
-      ));
+      requests.add(
+        const AcpServerRequest(
+          id: 9,
+          method: "session/request_permission",
+          params: {
+            "toolCall": {"toolCallId": "tc-9", "title": "Run rm", "kind": "execute"},
+            "options": [
+              {"optionId": "opt-allow-once", "name": "Allow", "kind": "allow_once"},
+            ],
+          },
+        ),
+      );
       await pump();
       // Responded immediately with a cancelled outcome…
       final (id, result) = responds.single;
@@ -86,18 +89,19 @@ void main() {
     test("reply 'once' echoes the allow_once optionId", () async {
       requests.add(permission());
       await pump();
-      final id = (emitted.single as BridgeSsePermissionAsked).requestID;
+      final id = emitted.whereType<BridgeSsePermissionAsked>().single.requestID;
 
       expect(registry.replyPermission(id, PluginPermissionReply.once), isTrue);
       final (_, result) = responds.single;
       expect((result! as Map)["outcome"], {"outcome": "selected", "optionId": "opt-allow-once"});
       expect(emitted.whereType<BridgeSsePermissionReplied>(), hasLength(1));
+      expect(emitted.whereType<BridgeSseProjectUpdated>(), hasLength(2));
     });
 
     test("reply 'always' echoes the allow_always optionId", () async {
       requests.add(permission());
       await pump();
-      final id = (emitted.single as BridgeSsePermissionAsked).requestID;
+      final id = emitted.whereType<BridgeSsePermissionAsked>().single.requestID;
       registry.replyPermission(id, PluginPermissionReply.always);
       final (_, result) = responds.single;
       expect(((result! as Map)["outcome"] as Map)["optionId"], "opt-allow-always");
@@ -106,26 +110,28 @@ void main() {
     test("reply 'reject' echoes the reject optionId", () async {
       requests.add(permission());
       await pump();
-      final id = (emitted.single as BridgeSsePermissionAsked).requestID;
+      final id = emitted.whereType<BridgeSsePermissionAsked>().single.requestID;
       registry.replyPermission(id, PluginPermissionReply.reject);
       final (_, result) = responds.single;
       expect(((result! as Map)["outcome"] as Map)["optionId"], "opt-reject");
     });
 
     test("missing matching option falls back to cancelled", () async {
-      requests.add(const AcpServerRequest(
-        id: 9,
-        method: "session/request_permission",
-        params: {
-          "sessionId": "s1",
-          "toolCall": {"kind": "execute"},
-          "options": [
-            {"optionId": "opt-allow-once", "kind": "allow_once"},
-          ],
-        },
-      ));
+      requests.add(
+        const AcpServerRequest(
+          id: 9,
+          method: "session/request_permission",
+          params: {
+            "sessionId": "s1",
+            "toolCall": {"kind": "execute"},
+            "options": [
+              {"optionId": "opt-allow-once", "kind": "allow_once"},
+            ],
+          },
+        ),
+      );
       await pump();
-      final id = (emitted.single as BridgeSsePermissionAsked).requestID;
+      final id = emitted.whereType<BridgeSsePermissionAsked>().single.requestID;
       registry.replyPermission(id, PluginPermissionReply.reject);
       final (_, result) = responds.single;
       expect((result! as Map)["outcome"], {"outcome": "cancelled"});
@@ -134,20 +140,22 @@ void main() {
     test("reply 'once' does NOT escalate to allow_always when allow_once is absent", () async {
       // The agent only offers a session-persistent option. A user who chose a
       // one-time approval must not be silently upgraded to it — cancel instead.
-      requests.add(const AcpServerRequest(
-        id: 21,
-        method: "session/request_permission",
-        params: {
-          "sessionId": "s1",
-          "toolCall": {"kind": "execute"},
-          "options": [
-            {"optionId": "opt-allow-always", "kind": "allow_always"},
-            {"optionId": "opt-reject", "kind": "reject_once"},
-          ],
-        },
-      ));
+      requests.add(
+        const AcpServerRequest(
+          id: 21,
+          method: "session/request_permission",
+          params: {
+            "sessionId": "s1",
+            "toolCall": {"kind": "execute"},
+            "options": [
+              {"optionId": "opt-allow-always", "kind": "allow_always"},
+              {"optionId": "opt-reject", "kind": "reject_once"},
+            ],
+          },
+        ),
+      );
       await pump();
-      final id = (emitted.single as BridgeSsePermissionAsked).requestID;
+      final id = emitted.whereType<BridgeSsePermissionAsked>().single.requestID;
       registry.replyPermission(id, PluginPermissionReply.once);
       final (_, result) = responds.single;
       expect((result! as Map)["outcome"], {"outcome": "cancelled"});
@@ -180,6 +188,7 @@ void main() {
       expect(registry.hasPendingInput("s1"), isFalse);
       expect(emitted.whereType<BridgeSsePermissionReplied>(), hasLength(1));
       expect(emitted.whereType<BridgeSseQuestionRejected>(), hasLength(1));
+      expect(emitted.whereType<BridgeSseProjectUpdated>(), hasLength(1));
     });
 
     test("dispose emits resolution SSEs so the phone clears pending prompts", () async {
@@ -209,22 +218,29 @@ void main() {
       expect(errors.single.$2, -32603);
       expect(emitted.whereType<BridgeSsePermissionReplied>(), hasLength(1));
       expect(emitted.whereType<BridgeSseQuestionRejected>(), hasLength(1));
+      expect(emitted.whereType<BridgeSseProjectUpdated>(), hasLength(1));
     });
 
     test("a permission with non-string tool metadata still surfaces (no throw)", () async {
-      requests.add(const AcpServerRequest(
-        id: 31,
-        method: "session/request_permission",
-        params: {
-          "sessionId": "s1",
-          "toolCall": {"kind": 123, "title": {"x": 1}, "toolCallId": 7},
-          "options": [
-            {"optionId": "opt", "kind": "allow_once"},
-          ],
-        },
-      ));
+      requests.add(
+        const AcpServerRequest(
+          id: 31,
+          method: "session/request_permission",
+          params: {
+            "sessionId": "s1",
+            "toolCall": {
+              "kind": 123,
+              "title": {"x": 1},
+              "toolCallId": 7,
+            },
+            "options": [
+              {"optionId": "opt", "kind": "allow_once"},
+            ],
+          },
+        ),
+      );
       await pump();
-      final asked = emitted.single as BridgeSsePermissionAsked;
+      final asked = emitted.whereType<BridgeSsePermissionAsked>().single;
       expect(asked.tool, "tool");
       expect(asked.description, "permission requested");
     });
@@ -253,10 +269,16 @@ void main() {
       );
 
       expect(registry.pendingForSession("s1"), hasLength(1));
-      expect(registry.replyQuestion("q-1", [["yes"]]), isTrue);
+      expect(
+        registry.replyQuestion("q-1", [
+          ["yes"],
+        ]),
+        isTrue,
+      );
       final (_, result) = responds.single;
       expect((result! as Map)["selected"], "yes");
       expect(emitted.whereType<BridgeSseQuestionReplied>(), hasLength(1));
+      expect(emitted.whereType<BridgeSseProjectUpdated>(), hasLength(2));
     });
   });
 }

--- a/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_activity_test.dart
@@ -10,6 +10,7 @@ void main() {
   group("AcpPlugin.getActiveSessionsSummary", () {
     late FakeAcpProcess fake;
     late AcpPlugin plugin;
+    late List<BridgeSseEvent> emitted;
     const cwd = "/repo";
 
     setUp(() {
@@ -22,6 +23,8 @@ void main() {
         eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp", pluginId: "acp"),
         processFactory: (_) async => fake,
       );
+      emitted = [];
+      plugin.events.listen(emitted.add);
     });
 
     tearDown(() async {
@@ -73,6 +76,7 @@ void main() {
     test("idle session is not surfaced; a running turn is, then clears", () async {
       final sessionId = await connectAndCreateSession();
       expect(sessionId, "s1");
+      emitted.clear();
 
       // Created but idle -> no activity row.
       expect(plugin.getActiveSessionsSummary(), isEmpty);
@@ -97,15 +101,26 @@ void main() {
       expect(active.awaitingInput, isFalse);
       expect(active.isRetrying, isFalse);
       expect(active.childSessionIds, isEmpty, reason: "ACP sessions are flat");
+      expect(
+        emitted.whereType<BridgeSseProjectUpdated>(),
+        hasLength(1),
+        reason: "the project and session lists refresh when the turn starts",
+      );
 
       // Resolve the turn -> session goes idle -> summary clears.
       await respond("session/prompt", {"stopReason": "end_turn"});
       expect(plugin.getActiveSessionsSummary(), isEmpty);
+      expect(
+        emitted.whereType<BridgeSseProjectUpdated>(),
+        hasLength(2),
+        reason: "the activity row clears when the turn finishes",
+      );
     });
 
     test("a session awaiting a permission is surfaced with awaitingInput", () async {
       final sessionId = await connectAndCreateSession();
       expect(plugin.getActiveSessionsSummary(), isEmpty);
+      emitted.clear();
 
       // A permission ask arrives for the session (the agent is blocked on the
       // user). The base registry tracks it as pending input.
@@ -129,6 +144,11 @@ void main() {
       expect(active.id, sessionId);
       expect(active.awaitingInput, isTrue);
       expect(active.mainAgentRunning, isFalse, reason: "no prompt turn in flight");
+      expect(
+        emitted.whereType<BridgeSseProjectUpdated>(),
+        hasLength(1),
+        reason: "awaiting-input state refreshes project and session rows",
+      );
     });
   });
 }

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -87,8 +87,7 @@ void main() {
       throw StateError("agent never wrote $count '$method' frame(s)");
     }
 
-    Future<Map<String, dynamic>> waitForFrame(String method) =>
-        waitForFrameCount(method, 1);
+    Future<Map<String, dynamic>> waitForFrame(String method) => waitForFrameCount(method, 1);
 
     void respondTo(Map<String, dynamic> frame, Map<String, dynamic> result) {
       fake.emit({"jsonrpc": "2.0", "id": frame["id"], "result": result});
@@ -131,6 +130,7 @@ void main() {
 
     int busyCount() => emitted.whereType<BridgeSseSessionStatus>().length;
     int idleCount() => emitted.whereType<BridgeSseSessionIdle>().length;
+    int projectUpdateCount() => emitted.whereType<BridgeSseProjectUpdated>().length;
 
     test("an accepted prompt is emitted immediately as a user message", () async {
       await connect();
@@ -201,10 +201,12 @@ void main() {
     test("a second prompt on one session dispatches only after the first turn completes", () async {
       await connect();
       final sessionId = await createSession(cwd, "s1");
+      emitted.clear();
 
       await sendPrompt(sessionId, "first");
       final firstPrompt = await waitForFrame("session/prompt");
       expect(busyCount(), 1);
+      expect(projectUpdateCount(), 1);
 
       await sendPrompt(sessionId, "second");
       for (var i = 0; i < 10; i++) {
@@ -217,6 +219,11 @@ void main() {
       );
       expect(busyCount(), 1, reason: "queued turn keeps the one busy signal");
       expect(idleCount(), 0);
+      expect(
+        projectUpdateCount(),
+        1,
+        reason: "a queued turn does not create another active-period refresh",
+      );
 
       respondTo(firstPrompt, {"stopReason": "end_turn"});
       final secondPrompt = await waitForFrameCount("session/prompt", 2);
@@ -236,6 +243,7 @@ void main() {
       await pump();
       await pump();
       expect(idleCount(), 1, reason: "idle only after the last queued turn settles");
+      expect(projectUpdateCount(), 2, reason: "the aggregate refreshes once when the active period ends");
       expect(plugin.getActiveSessionsSummary(), isEmpty);
     });
 
@@ -604,8 +612,7 @@ void main() {
 
       Future<Map<String, dynamic>> promptFrameFor(String sessionId) async {
         for (var i = 0; i < 80; i++) {
-          final match = frames("session/prompt")
-              .where((f) => (f["params"] as Map)["sessionId"] == sessionId);
+          final match = frames("session/prompt").where((f) => (f["params"] as Map)["sessionId"] == sessionId);
           if (match.isNotEmpty) return match.last;
           await pump();
         }

--- a/bridge/sesori_plugin_cursor/test/cursor_approval_registry_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_approval_registry_test.dart
@@ -62,7 +62,7 @@ void main() {
       });
       await pump();
 
-      final asked = emitted.single as BridgeSseQuestionAsked;
+      final asked = emitted.whereType<BridgeSseQuestionAsked>().single;
       expect(asked.sessionID, "s1");
       expect(asked.displaySessionId, "s1");
       expect(asked.questions.single.question, "Pick one");
@@ -73,8 +73,11 @@ void main() {
       );
 
       expect(registry.pendingForSession("s1"), hasLength(1));
+      expect(emitted.whereType<BridgeSseProjectUpdated>(), hasLength(1));
 
-      registry.replyQuestion(asked.id, [["Yes"]]);
+      registry.replyQuestion(asked.id, [
+        ["Yes"],
+      ]);
       final reply = fake.written.last;
       expect(reply["id"], 1);
       final questions = (reply["result"] as Map)["questions"] as List;
@@ -90,10 +93,12 @@ void main() {
       });
       await pump();
 
-      final asked = emitted.single as BridgeSseQuestionAsked;
+      final asked = emitted.whereType<BridgeSseQuestionAsked>().single;
       expect(asked.questions.single.header, "Plan A");
 
-      registry.replyQuestion(asked.id, [["Accept"]]);
+      registry.replyQuestion(asked.id, [
+        ["Accept"],
+      ]);
       final reply = fake.written.last;
       expect((reply["result"] as Map)["accepted"], true);
     });
@@ -115,7 +120,7 @@ void main() {
       });
       await pump();
 
-      final asked = emitted.single as BridgeSseQuestionAsked;
+      final asked = emitted.whereType<BridgeSseQuestionAsked>().single;
       expect(asked.sessionID, "active-s", reason: "create_plan has no sessionId; falls back to the active turn");
       expect(asked.displaySessionId, "active-s");
       expect(asked.questions.single.header, "Plan Z");
@@ -142,7 +147,7 @@ void main() {
         },
       });
       await pump();
-      final asked = emitted.single as BridgeSseQuestionAsked;
+      final asked = emitted.whereType<BridgeSseQuestionAsked>().single;
       expect(asked.questions.single.multiple, false);
       expect(registry.pendingForSession("s1"), hasLength(1));
     });
@@ -233,8 +238,7 @@ void main() {
       await pump();
       final pending = registry.pendingForSession("s1").single;
       final labels = pending.questions.single.options.map((o) => o.label).toList();
-      expect(labels, ["Option", "Option (2)"],
-          reason: "duplicate labels are made unique so label->id stays 1:1");
+      expect(labels, ["Option", "Option (2)"], reason: "duplicate labels are made unique so label->id stays 1:1");
     });
 
     test("questions with no usable text are dropped", () async {
@@ -268,7 +272,8 @@ void main() {
         },
       });
       await pump();
-      expect(emitted.single, isA<BridgeSsePermissionAsked>());
+      expect(emitted.whereType<BridgeSsePermissionAsked>(), hasLength(1));
+      expect(emitted.whereType<BridgeSseProjectUpdated>(), hasLength(1));
     });
   });
 }

--- a/client/app/lib/capabilities/voice/voice_transcription_service.dart
+++ b/client/app/lib/capabilities/voice/voice_transcription_service.dart
@@ -142,8 +142,22 @@ class VoiceTranscriptionService {
         throw VoiceTranscriptionError.recordingFailed();
       }
 
+      if (generation != _transcriptionGeneration) {
+        throw VoiceTranscriptionError.cancelled();
+      }
+
       // Verify the file has actual content before uploading.
-      final fileSize = await File(path).length();
+      // cancelRecording may delete the file while this await is in flight.
+      final int fileSize;
+      try {
+        fileSize = await File(path).length();
+      } on FileSystemException catch (error, stackTrace) {
+        if (generation != _transcriptionGeneration) {
+          throw VoiceTranscriptionError.cancelled();
+        }
+        loge("Failed to read recording file", error, stackTrace);
+        throw VoiceTranscriptionError.recordingFailed();
+      }
       logt("[voice] recorded file: $fileSize bytes");
       if (fileSize == 0) {
         loge("Recording produced a 0-byte file");

--- a/client/app/test/capabilities/voice/voice_transcription_service_test.dart
+++ b/client/app/test/capabilities/voice/voice_transcription_service_test.dart
@@ -243,6 +243,20 @@ void main() {
         expect(service.isRecording, isFalse);
       });
 
+      test("cancels overlapping file length check: deleted file still throws TranscriptionCancelledError", () async {
+        await service.startRecording();
+        await File(recordingPath).writeAsBytes([1, 2, 3]);
+
+        // Cancel immediately so cleanup can delete the file while
+        // stopAndTranscribe is still awaiting File.length().
+        final stopFuture = service.stopAndTranscribe();
+        await service.cancelRecording();
+
+        await expectLater(stopFuture, throwsA(isA<TranscriptionCancelledError>()));
+        expect(service.isBusy, isFalse);
+        expect(service.isRecording, isFalse);
+      });
+
       test("cancel then restart: stale transcript from first call is discarded", () async {
         // Start recording #1 and begin transcription.
         await service.startRecording();

--- a/client/app/test/features/session_list/session_tile_menu_test.dart
+++ b/client/app/test/features/session_list/session_tile_menu_test.dart
@@ -30,9 +30,17 @@ void main() {
   });
 
   /// Renders the real panel with the real action dispatcher behind the rows.
-  Future<void> pumpPanel(WidgetTester tester, {required Session session}) async {
+  Future<void> pumpPanel(
+    WidgetTester tester, {
+    required Session session,
+    SessionActivityInfo? activityInfo,
+  }) async {
     when(() => cubit.state).thenReturn(
-      SessionListState.loaded(sessions: [session], baseBranch: null),
+      SessionListState.loaded(
+        sessions: [session],
+        activeSessionIds: activityInfo == null ? const {} : {session.id: activityInfo},
+        baseBranch: null,
+      ),
     );
 
     const dispatcher = SessionListActionDispatcher();
@@ -62,6 +70,23 @@ void main() {
     );
     await tester.pumpAndSettle();
   }
+
+  testWidgets("a running session is identified on its session-list row", (
+    tester,
+  ) async {
+    final session = testSession(title: "Running Session");
+
+    await pumpPanel(
+      tester,
+      session: session,
+      activityInfo: const SessionActivityInfo(mainAgentRunning: true),
+    );
+
+    final loc = AppLocalizations.of(
+      tester.element(find.widgetWithText(ListTile, "Running Session")),
+    )!;
+    expect(find.text(loc.sessionListRunning), findsOneWidget);
+  });
 
   Future<void> longPressTile(WidgetTester tester, {required String title}) async {
     await tester.longPress(find.widgetWithText(ListTile, title));
@@ -116,7 +141,12 @@ void main() {
 
   testWidgets("Mark as unread dismisses the menu and marks the session", (tester) async {
     final session = testSession(title: "My Session");
-    when(() => cubit.markSessionSeen(sessionId: any(named: "sessionId"), read: any(named: "read"))).thenAnswer(
+    when(
+      () => cubit.markSessionSeen(
+        sessionId: any(named: "sessionId"),
+        read: any(named: "read"),
+      ),
+    ).thenAnswer(
       (_) async {},
     );
 
@@ -224,7 +254,10 @@ void main() {
 
     expect(find.text("Delete"), findsNothing);
     verifyNever(
-      () => cubit.markSessionSeen(sessionId: any(named: "sessionId"), read: any(named: "read")),
+      () => cubit.markSessionSeen(
+        sessionId: any(named: "sessionId"),
+        read: any(named: "read"),
+      ),
     );
   });
 }


### PR DESCRIPTION
## Summary
- invalidate ACP project summaries when Cursor turns or approvals change
- restore live activity badges on project cards and individual session rows
- add regression coverage and project-scoped Mobile MCP simulator tooling

## Test plan
- [x] `dart test` in `bridge/sesori_plugin_acp`
- [x] `dart test` in `bridge/sesori_plugin_cursor`
- [x] `dart analyze sesori_plugin_acp sesori_plugin_cursor`
- [x] `flutter test test/features/session_list/session_tile_menu_test.dart`
- [x] verify Mobile MCP can discover and inspect the iPhone Air simulator

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes project activity during Cursor turns and approvals so project cards and session rows show live, accurate activity. Also fixes a voice transcription race so cancelling a recording reports “cancelled” even if the file is deleted during cleanup.

- **Bug Fixes**
  - Emit `BridgeSseProjectUpdated` when approvals are asked, replied, rejected, cancelled, or registry is disposed.
  - Emit `BridgeSseProjectUpdated` on session activity transitions (idle → busy and busy → idle) in ACP turns.
  - Ensure `getActiveSessionsSummary()` reflects both running turns and pending input, keeping project/session lists in sync.
  - Voice: Treat cancel-deleted recording as cancelled to prevent flaky failures; added tests.

- **Dependencies**
  - Added `.cursor/mcp.json` to run `@mobilenext/mobile-mcp@0.0.62` via `npx` with telemetry disabled for local simulator tooling.

<sup>Written for commit 351691ffbdf7108ee39abebfd1d91b0a4ae2780d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

