### PR TITLE
fix(acp): degrade rejected session/load to a usable thread

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1212,6 +1212,27 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       collector.modelId = eventMapper.modelForSession(sessionId);
       collector.providerId = eventMapper.providerForSession(sessionId);
       return collector.build();
+    } on AcpRpcException catch (error, stackTrace) {
+      if (error.code == -32601 || error.code == -32602) {
+        // cursor-agent rejects `session/load` for some stored sessions with
+        // method-not-found / invalid-params (e.g. a session created by a prior
+        // agent process, or whose worktree was moved/removed). This is not a
+        // transport failure and a retry cannot succeed, so degrade to whatever
+        // history replayed before the rejection — the same fail-soft empty
+        // thread the no-loadSession branch above returns — keeping the session
+        // openable and promptable instead of 502ing the whole detail view.
+        Log.w("[$id] session/load rejected for $sessionId (code ${error.code}); showing collected history", error, stackTrace);
+        return collector.build();
+      }
+      // Any other RPC error is a genuine load failure — surface it typed.
+      Error.throwWithStackTrace(
+        PluginOperationException(
+          "session/load history replay",
+          message: "history replay for $sessionId failed",
+          cause: error,
+        ),
+        stackTrace,
+      );
     } on Object catch (error, stackTrace) {
       // A broken replay (connect/init/auth/load failure) must stay
       // distinguishable from a genuinely empty thread: surface it as a typed

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1217,6 +1217,11 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
             error,
             stackTrace,
           );
+          // A command snapshot replayed before the rejection already mutated
+          // the process-global tracker, so consumers still need the refresh
+          // nudge — same flush as the success path below.
+          final commandRefresh = deferredCommandRefresh;
+          if (commandRefresh != null) _eventBuffer.add(commandRefresh);
           return collector.build();
         }
         // Any other RPC error is a genuine load failure — wrapped typed below.

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1186,15 +1186,42 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
           }
         }
       });
-      final raw = await replayClient.request(
-        method: AcpMethods.sessionLoad,
-        params: {
-          "sessionId": sessionId,
-          "cwd": _directoryForSession(sessionId),
-          "mcpServers": const <Object?>[],
-        },
-        timeout: const Duration(minutes: 2),
-      );
+      final Object? raw;
+      try {
+        raw = await replayClient.request(
+          method: AcpMethods.sessionLoad,
+          params: {
+            "sessionId": sessionId,
+            "cwd": _directoryForSession(sessionId),
+            "mcpServers": const <Object?>[],
+          },
+          timeout: const Duration(minutes: 2),
+        );
+      } on AcpRpcException catch (error, stackTrace) {
+        if (error.code == -32601 || error.code == -32602) {
+          // cursor-agent rejects `session/load` for some stored sessions with
+          // method-not-found / invalid-params (e.g. a session created by a
+          // prior agent process, or whose worktree was moved/removed). That is
+          // not a transport failure, so degrade to whatever history replayed
+          // before the rejection — fail-soft like the no-loadSession branch
+          // above — keeping the session openable and promptable instead of
+          // 502ing the whole detail view. Nothing is memoized: every open
+          // retries the load, so a rejection caused by a stale cwd recovers
+          // once a later enumeration repairs the session's directory. This
+          // catch is scoped to the load request alone — a rejected handshake
+          // (initialize/authenticate) must keep surfacing as the typed
+          // failure below, per the getSessionMessages contract.
+          Log.w(
+            "[$id] session/load rejected for $sessionId (code ${error.code}); "
+            "showing collected history",
+            error,
+            stackTrace,
+          );
+          return collector.build();
+        }
+        // Any other RPC error is a genuine load failure — wrapped typed below.
+        rethrow;
+      }
       // The load result also carries the model/mode catalog (and the loaded
       // session's current model) — capture it so the picker is populated and
       // replayed messages are stamped with the session's real model.
@@ -1212,27 +1239,6 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       collector.modelId = eventMapper.modelForSession(sessionId);
       collector.providerId = eventMapper.providerForSession(sessionId);
       return collector.build();
-    } on AcpRpcException catch (error, stackTrace) {
-      if (error.code == -32601 || error.code == -32602) {
-        // cursor-agent rejects `session/load` for some stored sessions with
-        // method-not-found / invalid-params (e.g. a session created by a prior
-        // agent process, or whose worktree was moved/removed). This is not a
-        // transport failure and a retry cannot succeed, so degrade to whatever
-        // history replayed before the rejection — the same fail-soft empty
-        // thread the no-loadSession branch above returns — keeping the session
-        // openable and promptable instead of 502ing the whole detail view.
-        Log.w("[$id] session/load rejected for $sessionId (code ${error.code}); showing collected history", error, stackTrace);
-        return collector.build();
-      }
-      // Any other RPC error is a genuine load failure — surface it typed.
-      Error.throwWithStackTrace(
-        PluginOperationException(
-          "session/load history replay",
-          message: "history replay for $sessionId failed",
-          cause: error,
-        ),
-        stackTrace,
-      );
     } on Object catch (error, stackTrace) {
       // A broken replay (connect/init/auth/load failure) must stay
       // distinguishable from a genuinely empty thread: surface it as a typed

--- a/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
@@ -1,0 +1,141 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+/// `getSessionMessages` replays a stored thread via a short-lived `session/load`
+/// client. cursor-agent rejects that load for some stored sessions with
+/// method-not-found / invalid-params (a session created by a prior agent
+/// process, or whose worktree was moved/removed). That is not a transport
+/// failure, so the read path must degrade to a usable (possibly empty) thread —
+/// mirroring the resume path — instead of 502ing the whole session-detail view.
+void main() {
+  group("AcpPlugin history replay", () {
+    late FakeAcpProcess fake;
+    late AcpPlugin plugin;
+    const cwd = "/repo";
+    const sessionId = "prior-run-session";
+
+    setUp(() {
+      fake = FakeAcpProcess();
+      plugin = AcpPlugin(
+        id: "acp",
+        agentDisplayName: "ACP",
+        launchSpec: const AcpLaunchSpec(command: "agent", args: ["acp"]),
+        launchDirectory: cwd,
+        eventMapper: AcpEventMapper(launchDirectory: cwd, agentId: "acp", pluginId: "acp"),
+        processFactory: (_) async => fake,
+      );
+      // Prime the session's directory so the replay skips the live warm-up
+      // enumeration and the only client it spins up is the replay client.
+      plugin.primeSessionDirectory(sessionId: sessionId, directory: cwd);
+    });
+
+    tearDown(() async {
+      await plugin.dispose();
+      await fake.close();
+    });
+
+    Future<void> pump() => Future<void>.delayed(Duration.zero);
+    Future<Map<String, dynamic>> waitForFrame(String method) async {
+      for (var i = 0; i < 400; i++) {
+        final matches = fake.written.where((f) => f["method"] == method);
+        if (matches.isNotEmpty) return matches.last;
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+      throw StateError("agent never wrote a '$method' frame");
+    }
+
+    Future<void> completeReplayHandshake() async {
+      final initFrame = await waitForFrame("initialize");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": initFrame["id"],
+        "result": {
+          "protocolVersion": 1,
+          "agentCapabilities": {"loadSession": true},
+          "authMethods": <Object?>[],
+        },
+      });
+      await pump();
+    }
+
+    test("session/load rejected with -32602 degrades to a usable thread, not a 502", () async {
+      final loading = plugin.getSessionMessages(sessionId);
+      await completeReplayHandshake();
+
+      final loadFrame = await waitForFrame("session/load");
+      expect((loadFrame["params"] as Map)["sessionId"], sessionId);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": loadFrame["id"],
+        "error": {"code": -32602, "message": "Invalid params"},
+      });
+
+      // The session stays openable: an empty (but usable) thread, not a throw.
+      expect(await loading, isEmpty);
+    });
+
+    test("session/load rejected with -32601 also degrades to a usable thread", () async {
+      final loading = plugin.getSessionMessages(sessionId);
+      await completeReplayHandshake();
+
+      final loadFrame = await waitForFrame("session/load");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": loadFrame["id"],
+        "error": {"code": -32601, "message": "Method not found"},
+      });
+
+      expect(await loading, isEmpty);
+    });
+
+    test("partial history replayed before a -32602 rejection is preserved", () async {
+      final loading = plugin.getSessionMessages(sessionId);
+      await completeReplayHandshake();
+
+      final loadFrame = await waitForFrame("session/load");
+      // Some history streamed in before the agent rejected the load.
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": sessionId,
+          "update": {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "partial reply"},
+          },
+        },
+      });
+      await pump();
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": loadFrame["id"],
+        "error": {"code": -32602, "message": "Invalid params"},
+      });
+
+      final messages = await loading;
+      expect(messages, isNotEmpty, reason: "history collected before the rejection must survive");
+      final text = messages
+          .expand((m) => m.parts)
+          .where((p) => p.type == PluginMessagePartType.text)
+          .map((p) => p.text)
+          .join();
+      expect(text, contains("partial reply"));
+    });
+
+    test("a genuine RPC error (not -32601/-32602) still surfaces as a typed failure", () async {
+      final loading = plugin.getSessionMessages(sessionId);
+      await completeReplayHandshake();
+
+      final loadFrame = await waitForFrame("session/load");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": loadFrame["id"],
+        "error": {"code": -32000, "message": "Server error"},
+      });
+
+      await expectLater(loading, throwsA(isA<PluginOperationException>()));
+    });
+  });
+}

--- a/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
@@ -137,5 +137,50 @@ void main() {
 
       await expectLater(loading, throwsA(isA<PluginOperationException>()));
     });
+
+    // The degrade is scoped to the `session/load` request alone: a rejected
+    // handshake means the replay client is broken (not "this stored session is
+    // unloadable"), and the getSessionMessages contract requires auth/transport
+    // failures to surface typed, never as an empty thread.
+
+    test("a -32602 rejection of `initialize` surfaces as a typed failure, not an empty thread", () async {
+      final loading = plugin.getSessionMessages(sessionId);
+
+      final initFrame = await waitForFrame("initialize");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": initFrame["id"],
+        "error": {"code": -32602, "message": "Invalid params"},
+      });
+
+      await expectLater(loading, throwsA(isA<PluginOperationException>()));
+    });
+
+    test("a -32601 rejection of `authenticate` surfaces as a typed failure, not an empty thread", () async {
+      final loading = plugin.getSessionMessages(sessionId);
+
+      final initFrame = await waitForFrame("initialize");
+      // The agent advertises an auth method, so the replay client must
+      // authenticate before loading — reject that instead of the load.
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": initFrame["id"],
+        "result": {
+          "protocolVersion": 1,
+          "agentCapabilities": {"loadSession": true},
+          "authMethods": [
+            {"id": "agent_login", "name": "Agent login"},
+          ],
+        },
+      });
+      final authFrame = await waitForFrame("authenticate");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": authFrame["id"],
+        "error": {"code": -32601, "message": "Method not found"},
+      });
+
+      await expectLater(loading, throwsA(isA<PluginOperationException>()));
+    });
   });
 }

--- a/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
@@ -124,6 +124,41 @@ void main() {
       expect(text, contains("partial reply"));
     });
 
+    test("a command snapshot replayed before a -32602 rejection still triggers a refresh", () async {
+      final emitted = <BridgeSseEvent>[];
+      plugin.events.listen(emitted.add);
+      final loading = plugin.getSessionMessages(sessionId);
+      await completeReplayHandshake();
+
+      final loadFrame = await waitForFrame("session/load");
+      // The agent replayed a command snapshot before rejecting the load. The
+      // process-global command tracker consumed it, so consumers must still be
+      // nudged to re-fetch commands on the degraded path.
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {
+          "sessionId": sessionId,
+          "update": {
+            "sessionUpdate": "available_commands_update",
+            "availableCommands": [
+              {"name": "from_replay"},
+            ],
+          },
+        },
+      });
+      await pump();
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": loadFrame["id"],
+        "error": {"code": -32602, "message": "Invalid params"},
+      });
+      await loading;
+      await pump();
+
+      expect(emitted.whereType<BridgeSseSessionsUpdated>(), isNotEmpty);
+    });
+
     test("a genuine RPC error (not -32601/-32602) still surfaces as a typed failure", () async {
       final loading = plugin.getSessionMessages(sessionId);
       await completeReplayHandshake();


### PR DESCRIPTION
## Problem

Opening a Cursor (ACP) session sometimes 502'd the whole session-detail view. `getSessionMessages` replays a stored thread via a short-lived `session/load` client, and cursor-agent rejects that load for some stored sessions with **method-not-found (`-32601`)** / **invalid-params (`-32602`)** — e.g. a session created by a prior agent process, or one whose worktree was moved/removed. That is not a transport failure — and nothing is memoized, so a rejection caused by a stale cwd recovers on a later open once enumeration repairs the session's directory.

## Fix

Add an `AcpRpcException` catch in the history-replay path:

- **`-32601` / `-32602` on `session/load`** → degrade to whatever history replayed before the rejection (fail-soft like the no-`loadSession` branch), keeping the session openable and promptable. Logged at `warning`.
- **Any other RPC code** → still a genuine load failure, surfaced as a typed `PluginOperationException`.
- The catch is **scoped to the `session/load` request alone**: a rejected handshake (`initialize`/`authenticate`) means the replay client is broken, not "this stored session is unloadable", so it keeps surfacing as the typed 502/retry state per the `getSessionMessages` contract (and matching the sibling degrade sites `_loadResident`/`_resumeResident`, which scope to the one RPC they name).

## Tests

New `acp_history_replay_test.dart` covers:
- `-32602` rejection → usable (empty) thread, not a throw
- `-32601` rejection → same
- partial history streamed before the rejection is preserved
- a non-`-32601/-32602` RPC error still surfaces as a typed `PluginOperationException`
- a `-32602` rejection of `initialize` and a `-32601` rejection of `authenticate` still surface as typed failures, not empty threads

https://claude.ai/code/session_01RSbyiAgic49kBscQaZFtTo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session-detail 502s by degrading `session/load` rejections to a usable thread. Also flushes the deferred command refresh so consumers re-fetch commands on degraded replays.

- **Bug Fixes**
  - Scope `AcpRpcException` handling to `session/load`; on `-32601`/`-32602` return collected history and log a warning.
  - Flush the deferred command refresh when degrading, so command lists stay in sync.
  - Preserve partial history streamed before the rejection.
  - Handshake rejections (`initialize`/`authenticate`) and other RPC codes still surface as `PluginOperationException`; tests cover degrade, partial-history, command-refresh, and handshake failures.

<sup>Written for commit 6d21142afe62e5d1a14547124a726706ac45ab96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

