### PR TITLE
fix(cursor): surface backend halt notices as explicit error messages

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -6,6 +6,28 @@ import "acp_content.dart";
 import "acp_protocol.dart";
 import "acp_stdio_client.dart";
 
+/// A backend "halt notice": the agent ended a turn without doing the requested
+/// work and instead streamed a terminal notice telling the user to change
+/// something (account, plan, model, or settings). Cursor's account/plan gate
+/// ("Check your settings to continue") is the canonical case.
+///
+/// On the wire such a notice is an ordinary `agent_message_chunk` ending with
+/// `stopReason: end_turn` — indistinguishable from real assistant prose — so a
+/// backend that knows its own gate wording recognizes it (see
+/// [AcpEventMapper.classifyHaltNotice]) and it is surfaced as a
+/// [shared.Message.error] instead of quiet assistant text, giving the user an
+/// explicit "the turn did not run" signal.
+class AcpHaltNotice {
+  const AcpHaltNotice({required this.errorName, required this.message});
+
+  /// Short stable label for the halt class (e.g. "cursor_gate"), carried in
+  /// the error message's `errorName`.
+  final String errorName;
+
+  /// The user-facing notice text to show (the agent's own wording).
+  final String message;
+}
+
 /// Translates ACP `session/update` notifications into bridge-neutral
 /// [BridgeSseEvent]s.
 ///
@@ -307,6 +329,17 @@ class AcpEventMapper {
   /// Cursor's `cursor/update_todos`). Base implementation drops them.
   List<BridgeSseEvent> mapExtension(AcpNotification notification) => const [];
 
+  /// Hook: classify a complete assistant message's [text] as a backend halt
+  /// notice (see [AcpHaltNotice]) — the agent ended the turn without doing the
+  /// requested work and told the user to change something. Returns the notice
+  /// to surface as an error message, or null for ordinary assistant prose.
+  ///
+  /// Base backends never halt this way; harness subclasses that emit
+  /// recognizable gate text (e.g. Cursor) override this. Also consulted by the
+  /// history-replay collector so a reloaded session renders the notice the same
+  /// way it did live.
+  AcpHaltNotice? classifyHaltNotice(String text) => null;
+
   List<BridgeSseEvent> _textChunk({
     required String sessionId,
     required Map<String, dynamic> update,
@@ -316,6 +349,19 @@ class AcpEventMapper {
   }) {
     final text = acpContentText(update["content"]);
     if (text == null || text.isEmpty) return const [];
+
+    // A backend may end a turn without doing the requested work and instead
+    // emit a terminal "halt" notice as an ordinary assistant message (Cursor's
+    // account/plan gates: "Check your settings to continue"). Only a message
+    // chunk can be such a notice, never a reasoning chunk. A recognized notice
+    // is surfaced as an explicit error message so the user sees the turn did not
+    // run, rather than a quiet line of assistant text. Cursor emits the notice
+    // as one atomic chunk; a hypothetically split notice falls through to plain
+    // text (no regression).
+    if (partType == PluginMessagePartType.text) {
+      final halt = classifyHaltNotice(text);
+      if (halt != null) return _haltNoticeEvents(sessionId: sessionId, notice: halt);
+    }
 
     // ACP v1: chunks of one message share a `messageId`; a change starts a new
     // message. Group by it when present, so an agent emitting several same-role
@@ -364,6 +410,38 @@ class AcpEventMapper {
       _openIdlessAssistant.add(sessionId);
     }
     return events;
+  }
+
+  /// Emits a backend halt [notice] (see [classifyHaltNotice]) as a single
+  /// error message so the client renders it with its explicit error card
+  /// instead of quiet assistant prose. The notice text rides in the error
+  /// message itself, so no separate part is needed. Deduped per turn: a
+  /// repeated identical chunk must not stack duplicate error cards.
+  List<BridgeSseEvent> _haltNoticeEvents({
+    required String sessionId,
+    required AcpHaltNotice notice,
+  }) {
+    final messageId = "$sessionId-t${_turn(sessionId)}-halt";
+    final started = _startedParts.putIfAbsent(sessionId, () => <String>{});
+    if (!started.add(messageId)) return const [];
+    // Any id-less assistant envelope opened earlier this turn is abandoned: the
+    // halt notice is the turn's outcome and stands alone, so a later reordered
+    // chunk opens a fresh envelope rather than appending to it.
+    _openIdlessAssistant.remove(sessionId);
+    return [
+      BridgeSseMessageUpdated(
+        info: shared.Message.error(
+          id: messageId,
+          sessionID: sessionId,
+          agent: agentId,
+          modelID: modelForSession(sessionId),
+          providerID: providerForSession(sessionId),
+          errorName: notice.errorName,
+          errorMessage: notice.message,
+          time: null,
+        ).toJson(),
+      ),
+    ];
   }
 
   List<BridgeSseEvent> _toolCall({

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -329,16 +329,23 @@ class AcpEventMapper {
   /// Cursor's `cursor/update_todos`). Base implementation drops them.
   List<BridgeSseEvent> mapExtension(AcpNotification notification) => const [];
 
-  /// Hook: classify a complete assistant message's [text] as a backend halt
-  /// notice (see [AcpHaltNotice]) — the agent ended the turn without doing the
+  /// Hook: classify an assistant message's [text] as a backend halt notice
+  /// (see [AcpHaltNotice]) — the agent ended the turn without doing the
   /// requested work and told the user to change something. Returns the notice
   /// to surface as an error message, or null for ordinary assistant prose.
+  ///
+  /// Invoked with two text shapes: live, [text] is a single `agent_message_chunk`
+  /// (which equals the whole message only because the notice is emitted as one
+  /// atomic chunk); on history replay, [text] is the fully-accumulated message
+  /// text. An override that must gate on the complete message (e.g. a backend
+  /// that splits its notice across chunks) has to account for the live per-chunk
+  /// shape.
   ///
   /// Base backends never halt this way; harness subclasses that emit
   /// recognizable gate text (e.g. Cursor) override this. Also consulted by the
   /// history-replay collector so a reloaded session renders the notice the same
   /// way it did live.
-  AcpHaltNotice? classifyHaltNotice(String text) => null;
+  AcpHaltNotice? classifyHaltNotice({required String text}) => null;
 
   List<BridgeSseEvent> _textChunk({
     required String sessionId,
@@ -359,7 +366,7 @@ class AcpEventMapper {
     // as one atomic chunk; a hypothetically split notice falls through to plain
     // text (no regression).
     if (partType == PluginMessagePartType.text) {
-      final halt = classifyHaltNotice(text);
+      final halt = classifyHaltNotice(text: text);
       if (halt != null) return _haltNoticeEvents(sessionId: sessionId, notice: halt);
     }
 
@@ -425,9 +432,12 @@ class AcpEventMapper {
     final started = _startedParts.putIfAbsent(sessionId, () => <String>{});
     if (!started.add(messageId)) return const [];
     // Any id-less assistant envelope opened earlier this turn is abandoned: the
-    // halt notice is the turn's outcome and stands alone, so a later reordered
-    // chunk opens a fresh envelope rather than appending to it.
-    _openIdlessAssistant.remove(sessionId);
+    // halt notice is the turn's outcome and stands alone. Closing it bumps the
+    // fallback sequence, so a later reordered id-less chunk recomputes a fresh
+    // message id and opens a new envelope rather than appending a delta to the
+    // abandoned one. (The dedupe return above runs first, so a repeated halt
+    // chunk can't double-bump the sequence.)
+    _closeIdlessAssistantEnvelope(sessionId);
     return [
       BridgeSseMessageUpdated(
         info: shared.Message.error(

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1157,6 +1157,9 @@ class AcpPlugin extends BridgeDerivedProjectsPluginApi {
       agentId: agentDisplayName,
       modelId: eventMapper.modelForSession(sessionId),
       providerId: eventMapper.providerForSession(sessionId),
+      // Reclassify a halt notice (e.g. Cursor's account/plan gate) the same way
+      // the live stream does, so reloaded history renders it identically.
+      haltClassifier: eventMapper.classifyHaltNotice,
     );
     StreamSubscription<AcpNotification>? sub;
     try {

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -25,7 +25,7 @@ class AcpReplayCollector {
   /// (see [AcpEventMapper.classifyHaltNotice]) so a reloaded session renders the
   /// notice as an error message exactly as it appeared live. Null on backends
   /// with no halt notices.
-  final AcpHaltNotice? Function(String text)? haltClassifier;
+  final AcpHaltNotice? Function({required String text})? haltClassifier;
 
   /// Model/provider stamped on replayed assistant messages. Mutable so the
   /// plugin can set the loaded session's real model after `session/load`
@@ -102,7 +102,7 @@ class AcpReplayCollector {
         draft.reasoning.isEmpty &&
         draft.tools.isEmpty &&
         draft.text.isNotEmpty) {
-      final halt = haltClassifier?.call(draft.text.toString());
+      final halt = haltClassifier?.call(text: draft.text.toString());
       if (halt != null) {
         return PluginMessageWithParts(
           info: PluginMessage.error(

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -15,7 +15,7 @@ class AcpReplayCollector {
     required this.agentId,
     this.modelId,
     this.providerId,
-    this.haltClassifier,
+    required this.haltClassifier,
   });
 
   final String sessionId;

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -1,6 +1,7 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "acp_content.dart";
+import "acp_event_mapper.dart" show AcpHaltNotice;
 
 /// Accumulates the `session/update` notifications replayed by `session/load`
 /// into ordered [PluginMessageWithParts] for `getSessionMessages`.
@@ -14,10 +15,17 @@ class AcpReplayCollector {
     required this.agentId,
     this.modelId,
     this.providerId,
+    this.haltClassifier,
   });
 
   final String sessionId;
   final String agentId;
+
+  /// Classifies a fully-accumulated assistant message as a backend halt notice
+  /// (see [AcpEventMapper.classifyHaltNotice]) so a reloaded session renders the
+  /// notice as an error message exactly as it appeared live. Null on backends
+  /// with no halt notices.
+  final AcpHaltNotice? Function(String text)? haltClassifier;
 
   /// Model/provider stamped on replayed assistant messages. Mutable so the
   /// plugin can set the loaded session's real model after `session/load`
@@ -86,6 +94,31 @@ class AcpReplayCollector {
   }
 
   PluginMessageWithParts _buildMessage(_Draft draft) {
+    // A recognized halt notice (e.g. Cursor's account/plan gate, streamed as a
+    // lone assistant message) is surfaced as an error message so a reloaded
+    // session matches the live rendering. Only a pure-text terminal notice
+    // qualifies — no reasoning, no tools — matching the shape the backend emits.
+    if (draft.role == "assistant" &&
+        draft.reasoning.isEmpty &&
+        draft.tools.isEmpty &&
+        draft.text.isNotEmpty) {
+      final halt = haltClassifier?.call(draft.text.toString());
+      if (halt != null) {
+        return PluginMessageWithParts(
+          info: PluginMessage.error(
+            id: draft.id,
+            sessionID: sessionId,
+            agent: agentId,
+            modelID: modelId,
+            providerID: providerId,
+            errorName: halt.errorName,
+            errorMessage: halt.message,
+            time: null,
+          ),
+          parts: const [],
+        );
+      }
+    }
     final parts = <PluginMessagePart>[];
     if (draft.reasoning.isNotEmpty) {
       parts.add(_textPart(draft, "reasoning", PluginMessagePartType.reasoning, draft.reasoning.toString()));

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -682,5 +682,94 @@ void main() {
     test("unknown variants are dropped", () {
       expect(mapper.map(update({"sessionUpdate": "current_mode_update"})), isEmpty);
     });
+
+    test("base mapper never classifies a chunk as a halt notice", () {
+      expect(mapper.classifyHaltNotice("Check your settings to continue"), isNull);
+    });
   });
+
+  group("AcpEventMapper halt notices", () {
+    late _HaltMapper mapper;
+
+    setUp(() {
+      mapper = _HaltMapper()
+        ..currentModelId = "claude-fable-5"
+        ..currentProviderId = "cursor";
+    });
+
+    AcpNotification update(Map<String, dynamic> body) => AcpNotification(
+      method: "session/update",
+      params: {"sessionId": "s1", "update": body},
+    );
+
+    test("a classified halt notice becomes a lone error message, not assistant text", () {
+      mapper.beginTurn("s1");
+      final events = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "\n\nHALT: fix it"},
+      }));
+
+      final message = shared.Message.fromJson(
+        events.whereType<BridgeSseMessageUpdated>().single.info,
+      );
+      expect(message, isA<shared.MessageError>());
+      expect((message as shared.MessageError).errorMessage, "HALT: fix it");
+      // No assistant text part or delta — the notice rides in the error message.
+      expect(events.whereType<BridgeSseMessagePartUpdated>(), isEmpty);
+      expect(events.whereType<BridgeSseMessagePartDelta>(), isEmpty);
+    });
+
+    test("a repeated identical halt chunk does not stack duplicate error cards", () {
+      mapper.beginTurn("s1");
+      mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "HALT: fix it"},
+      }));
+      final again = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "HALT: fix it"},
+      }));
+      expect(again, isEmpty);
+    });
+
+    test("a reasoning chunk is never classified as a halt notice", () {
+      mapper.beginTurn("s1");
+      final events = mapper.map(update({
+        "sessionUpdate": "agent_thought_chunk",
+        "content": {"type": "text", "text": "HALT: fix it"},
+      }));
+      expect(
+        events.whereType<BridgeSseMessagePartUpdated>().single.part.type,
+        PluginMessagePartType.reasoning,
+      );
+    });
+
+    test("ordinary assistant text still streams as an assistant message", () {
+      mapper.beginTurn("s1");
+      final events = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "real answer"},
+      }));
+      final message = shared.Message.fromJson(
+        events.whereType<BridgeSseMessageUpdated>().single.info,
+      );
+      expect(message, isA<shared.MessageAssistant>());
+      expect(events.whereType<BridgeSseMessagePartDelta>().single.delta, "real answer");
+    });
+  });
+}
+
+/// Test double: classifies any message whose trimmed text starts with "HALT:"
+/// as a halt notice, using the trimmed text as the shown message.
+class _HaltMapper extends AcpEventMapper {
+  _HaltMapper() : super(launchDirectory: "/repo", agentId: "cursor", pluginId: "cursor");
+
+  @override
+  AcpHaltNotice? classifyHaltNotice(String text) {
+    final trimmed = text.trim();
+    if (trimmed.startsWith("HALT:")) {
+      return AcpHaltNotice(errorName: "test_halt", message: trimmed);
+    }
+    return null;
+  }
 }

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -684,7 +684,7 @@ void main() {
     });
 
     test("base mapper never classifies a chunk as a halt notice", () {
-      expect(mapper.classifyHaltNotice("Check your settings to continue"), isNull);
+      expect(mapper.classifyHaltNotice(text: "Check your settings to continue"), isNull);
     });
   });
 
@@ -732,6 +732,34 @@ void main() {
       expect(again, isEmpty);
     });
 
+    test("id-less assistant text after a halt opens a fresh envelope", () {
+      mapper.beginTurn("s1");
+      final before = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "Before"},
+      }));
+      mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "HALT: fix it"},
+      }));
+      final after = mapper.map(update({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "After"},
+      }));
+
+      final beforeId = shared.Message.fromJson(
+        before.whereType<BridgeSseMessageUpdated>().single.info,
+      ).id;
+      // The halt abandons the pre-halt envelope, so the post-halt chunk must
+      // open a new one (its own envelope + a different message id), not append a
+      // delta to the abandoned envelope.
+      final afterId = shared.Message.fromJson(
+        after.whereType<BridgeSseMessageUpdated>().single.info,
+      ).id;
+      expect(afterId, isNot(beforeId));
+      expect(after.whereType<BridgeSseMessagePartDelta>().single.delta, "After");
+    });
+
     test("a reasoning chunk is never classified as a halt notice", () {
       mapper.beginTurn("s1");
       final events = mapper.map(update({
@@ -765,7 +793,7 @@ class _HaltMapper extends AcpEventMapper {
   _HaltMapper() : super(launchDirectory: "/repo", agentId: "cursor", pluginId: "cursor");
 
   @override
-  AcpHaltNotice? classifyHaltNotice(String text) {
+  AcpHaltNotice? classifyHaltNotice({required String text}) {
     final trimmed = text.trim();
     if (trimmed.startsWith("HALT:")) {
       return AcpHaltNotice(errorName: "test_halt", message: trimmed);

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -255,5 +255,36 @@ void main() {
         PluginMessagePartType.tool,
       ]));
     });
+
+    test("a halt notice replays as an error message with no text part", () {
+      final collector = AcpReplayCollector(
+        sessionId: "s1",
+        agentId: "Cursor",
+        modelId: "claude-fable-5",
+        providerId: "cursor",
+        haltClassifier: (text) => text.trim() == "Check your settings to continue"
+            ? const AcpHaltNotice(errorName: "cursor_gate", message: "Check your settings to continue")
+            : null,
+      )..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "\n\nCheck your settings to continue"},
+        }));
+
+      final message = collector.build().single;
+      expect(message.info, isA<PluginMessageError>());
+      expect((message.info as PluginMessageError).errorMessage, "Check your settings to continue");
+      expect(message.parts, isEmpty);
+    });
+
+    test("without a halt classifier the same chunk stays assistant text", () {
+      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
+        ..consume(upd({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "Check your settings to continue"},
+        }));
+      final message = collector.build().single;
+      expect(message.info, isA<PluginMessageAssistant>());
+      expect(message.parts, isNotEmpty);
+    });
   });
 }

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -14,6 +14,7 @@ void main() {
         agentId: "Cursor",
         modelId: "gpt-5.5",
         providerId: "cursor",
+        haltClassifier: null,
       )
         ..consume(upd({
           "sessionUpdate": "user_message_chunk",
@@ -53,7 +54,7 @@ void main() {
     });
 
     test("id-less text after a tool stays chronologically after the tool", () {
-      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
+      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor", haltClassifier: null)
         ..consume(upd({
           "sessionUpdate": "agent_message_chunk",
           "content": {"type": "text", "text": "Before"},
@@ -77,7 +78,7 @@ void main() {
     });
 
     test("a partial (output-only) update does not reset a completed tool to pending", () {
-      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
+      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor", haltClassifier: null)
         ..consume(upd({
           "sessionUpdate": "tool_call",
           "toolCallId": "t1",
@@ -103,7 +104,7 @@ void main() {
     });
 
     test("a title-only tool_call_update merges onto an existing draft (matches live)", () {
-      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
+      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor", haltClassifier: null)
         ..consume(upd({
           "sessionUpdate": "tool_call",
           "toolCallId": "t1",
@@ -124,7 +125,7 @@ void main() {
     });
 
     test("a non-string tool title does not throw mid-replay", () {
-      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
+      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor", haltClassifier: null)
         ..consume(upd({
           "sessionUpdate": "tool_call",
           "toolCallId": "t1",
@@ -144,6 +145,7 @@ void main() {
         agentId: "Cursor",
         modelId: "claude-opus-4-8",
         providerId: "cursor",
+        haltClassifier: null,
       )..consume(upd({
           "sessionUpdate": "agent_message_chunk",
           "content": {"type": "text", "text": "hi"},
@@ -156,7 +158,7 @@ void main() {
     test("a messageId change splits consecutive same-role chunks into two messages", () {
       // ACP v1: chunks of one message share a messageId; a change starts a new
       // message. Without honouring it, distinct same-role messages collapse.
-      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
+      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor", haltClassifier: null)
         ..consume(upd({
           "sessionUpdate": "agent_message_chunk",
           "messageId": "m1",
@@ -181,7 +183,7 @@ void main() {
     });
 
     test("chunks without a messageId keep the role-grouping behaviour", () {
-      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
+      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor", haltClassifier: null)
         ..consume(upd({
           "sessionUpdate": "agent_message_chunk",
           "content": {"type": "text", "text": "one"},
@@ -194,7 +196,7 @@ void main() {
     });
 
     test("an explicit messageId after id-less text starts a new message", () {
-      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
+      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor", haltClassifier: null)
         ..consume(upd({
           "sessionUpdate": "agent_message_chunk",
           "content": {"type": "text", "text": "id-less draft"},
@@ -212,7 +214,7 @@ void main() {
     });
 
     test("id-less text after an explicit messageId starts a new message", () {
-      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
+      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor", haltClassifier: null)
         ..consume(upd({
           "sessionUpdate": "agent_message_chunk",
           "messageId": "m1",
@@ -230,7 +232,7 @@ void main() {
     });
 
     test("a same-message thought and text share the message; tools attach without an id", () {
-      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
+      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor", haltClassifier: null)
         ..consume(upd({
           "sessionUpdate": "agent_thought_chunk",
           "messageId": "m1",
@@ -277,7 +279,7 @@ void main() {
     });
 
     test("without a halt classifier the same chunk stays assistant text", () {
-      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor")
+      final collector = AcpReplayCollector(sessionId: "s1", agentId: "Cursor", haltClassifier: null)
         ..consume(upd({
           "sessionUpdate": "agent_message_chunk",
           "content": {"type": "text", "text": "Check your settings to continue"},

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -262,7 +262,7 @@ void main() {
         agentId: "Cursor",
         modelId: "claude-fable-5",
         providerId: "cursor",
-        haltClassifier: (text) => text.trim() == "Check your settings to continue"
+        haltClassifier: ({required text}) => text.trim() == "Check your settings to continue"
             ? const AcpHaltNotice(errorName: "cursor_gate", message: "Check your settings to continue")
             : null,
       )..consume(upd({

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
@@ -47,9 +47,14 @@ class CursorEventMapper extends AcpEventMapper {
   /// whitespace, lowercases, and strips surrounding punctuation/emoji so the
   /// leading newlines, case, or decoration cursor-agent varies do not defeat
   /// the match — while still requiring the whole message to BE the phrase, so
-  /// ordinary prose that merely mentions it is never misclassified.
+  /// ordinary prose that merely mentions it is never misclassified. Letters and
+  /// digits of any script are content, never strippable decoration: a message
+  /// carrying words beyond the phrase must not collapse into a gate match.
   static String _normalize(String text) {
     final collapsed = text.replaceAll(RegExp(r"\s+"), " ").trim().toLowerCase();
-    return collapsed.replaceAll(RegExp(r"^[^a-z0-9]+|[^a-z0-9]+$"), "");
+    return collapsed.replaceAll(
+      RegExp(r"^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$", unicode: true),
+      "",
+    );
   }
 }

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
@@ -18,4 +18,38 @@ class CursorEventMapper extends AcpEventMapper {
     // have no sesori analog — dropped.
     return const [];
   }
+
+  @override
+  AcpHaltNotice? classifyHaltNotice(String text) {
+    if (_isGateNotice(text)) {
+      // Preserve cursor-agent's own wording (trimmed) as the shown message.
+      return AcpHaltNotice(errorName: "cursor_gate", message: text.trim());
+    }
+    return null;
+  }
+
+  /// cursor-agent account/plan/settings gate notices. When the selected model
+  /// or action isn't permitted on the Cursor account, cursor-agent ends the
+  /// turn normally (`stopReason: end_turn`) and streams one of these as an
+  /// ordinary `agent_message_chunk` — on the wire it is indistinguishable from
+  /// real output, so it is recognized here by exact (normalized) text.
+  ///
+  /// Add a phrase only with a captured wire trace of cursor-agent emitting it;
+  /// a reworded or localized gate simply falls through to plain assistant text
+  /// (the pre-existing behavior — no regression).
+  static const Set<String> _gateNoticePhrases = {
+    "check your settings to continue",
+  };
+
+  static bool _isGateNotice(String text) => _gateNoticePhrases.contains(_normalize(text));
+
+  /// Normalizes a notice for matching against [_gateNoticePhrases]: collapses
+  /// whitespace, lowercases, and strips surrounding punctuation/emoji so the
+  /// leading newlines, case, or decoration cursor-agent varies do not defeat
+  /// the match — while still requiring the whole message to BE the phrase, so
+  /// ordinary prose that merely mentions it is never misclassified.
+  static String _normalize(String text) {
+    final collapsed = text.replaceAll(RegExp(r"\s+"), " ").trim().toLowerCase();
+    return collapsed.replaceAll(RegExp(r"^[^a-z0-9]+|[^a-z0-9]+$"), "");
+  }
 }

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
@@ -20,7 +20,7 @@ class CursorEventMapper extends AcpEventMapper {
   }
 
   @override
-  AcpHaltNotice? classifyHaltNotice(String text) {
+  AcpHaltNotice? classifyHaltNotice({required String text}) {
     if (_isGateNotice(text)) {
       // Preserve cursor-agent's own wording (trimmed) as the shown message.
       return AcpHaltNotice(errorName: "cursor_gate", message: text.trim());

--- a/bridge/sesori_plugin_cursor/pubspec.yaml
+++ b/bridge/sesori_plugin_cursor/pubspec.yaml
@@ -18,6 +18,8 @@ dependencies:
   json_annotation: ^4.12.0
 
 dev_dependencies:
+  sesori_shared:
+    path: ../../shared/sesori_shared
   build_runner: any
   freezed: ^3.2.5
   json_serializable: ^6.14.0

--- a/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
@@ -70,14 +70,14 @@ void main() {
     });
 
     test("gate matching tolerates case and surrounding decoration", () {
-      expect(mapper.classifyHaltNotice("  CHECK YOUR SETTINGS TO CONTINUE.  "), isNotNull);
-      expect(mapper.classifyHaltNotice("⚠️ Check your settings to continue"), isNotNull);
+      expect(mapper.classifyHaltNotice(text: "  CHECK YOUR SETTINGS TO CONTINUE.  "), isNotNull);
+      expect(mapper.classifyHaltNotice(text: "⚠️ Check your settings to continue"), isNotNull);
     });
 
     test("ordinary prose that merely contains the phrase is not a gate", () {
       expect(
         mapper.classifyHaltNotice(
-          "Sure — check your settings to continue setting up the project, then rerun.",
+          text: "Sure — check your settings to continue setting up the project, then rerun.",
         ),
         isNull,
       );

--- a/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
@@ -74,6 +74,13 @@ void main() {
       expect(mapper.classifyHaltNotice(text: "⚠️ Check your settings to continue"), isNotNull);
     });
 
+    test("non-ASCII letters are content, not strippable decoration", () {
+      // Letters (any script) adjacent to the phrase mean the message is more
+      // than the gate notice; only punctuation/symbol/emoji decoration is
+      // stripped before the exact match.
+      expect(mapper.classifyHaltNotice(text: "É Check your settings to continue"), isNull);
+    });
+
     test("ordinary prose that merely contains the phrase is not a gate", () {
       expect(
         mapper.classifyHaltNotice(

--- a/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
@@ -1,6 +1,7 @@
 import "package:acp_plugin/acp_plugin.dart";
 import "package:cursor_plugin/cursor_plugin.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" as shared;
 import "package:test/test.dart";
 
 void main() {
@@ -40,6 +41,46 @@ void main() {
         ),
       );
       expect(events.whereType<BridgeSseMessagePartDelta>().single.delta, "hi");
+    });
+
+    test("an account/plan gate notice becomes an error message, not assistant text", () {
+      mapper.beginTurn("sg");
+      final events = mapper.map(
+        const AcpNotification(
+          method: "session/update",
+          params: {
+            "sessionId": "sg",
+            "update": {
+              "sessionUpdate": "agent_message_chunk",
+              // Exact wire capture from cursor-agent when a gated model is used.
+              "content": {"type": "text", "text": "\n\nCheck your settings to continue"},
+            },
+          },
+        ),
+      );
+      final message = shared.Message.fromJson(
+        events.whereType<BridgeSseMessageUpdated>().single.info,
+      );
+      expect(message, isA<shared.MessageError>());
+      expect(
+        (message as shared.MessageError).errorMessage,
+        "Check your settings to continue",
+      );
+      expect(events.whereType<BridgeSseMessagePartDelta>(), isEmpty);
+    });
+
+    test("gate matching tolerates case and surrounding decoration", () {
+      expect(mapper.classifyHaltNotice("  CHECK YOUR SETTINGS TO CONTINUE.  "), isNotNull);
+      expect(mapper.classifyHaltNotice("⚠️ Check your settings to continue"), isNotNull);
+    });
+
+    test("ordinary prose that merely contains the phrase is not a gate", () {
+      expect(
+        mapper.classifyHaltNotice(
+          "Sure — check your settings to continue setting up the project, then rerun.",
+        ),
+        isNull,
+      );
     });
   });
 }


### PR DESCRIPTION
## Problem

When a Cursor turn is gated by the account/plan (e.g. a model that isn't permitted on the current Cursor plan), `cursor-agent` doesn't refuse loudly — it ends the turn normally (`stopReason: end_turn`) and streams a terminal notice like **"Check your settings to continue"** as an ordinary `agent_message_chunk`. On the wire this is indistinguishable from real assistant prose, so the app rendered it as a quiet line of assistant text and the user had no signal that the turn never actually ran.

## Fix

Recognize these backend **halt notices** at the ACP event-mapping seam and surface them as explicit `Message.error` cards instead of assistant text.

- **`AcpEventMapper.classifyHaltNotice(text)`** — new hook on the base ACP mapper. Base backends never halt this way and return `null`; harness subclasses that know their own gate wording override it.
- **`CursorEventMapper`** overrides it to match `cursor-agent`'s gate wording by exact **normalized** text (whitespace-collapsed, lowercased, surrounding punctuation/emoji stripped). Matching requires the whole message to *be* the phrase, so ordinary prose that merely mentions it is never misclassified. New phrases require a captured wire trace; a reworded/localized gate just falls through to plain text (no regression).
- Only a pure-text message chunk can be a halt notice — never a reasoning chunk. The notice is emitted as a single deduped error message per turn (a repeated identical chunk doesn't stack duplicate cards), and any id-less assistant envelope opened earlier in the turn is abandoned since the notice is the turn's outcome.
- **History replay** (`AcpReplayCollector`) takes the same classifier via `haltClassifier`, so a reloaded session renders the notice identically to how it appeared live.

## Tests

- `acp_event_mapper_test` — halt notice becomes a lone error message (no text part/delta); repeated chunk doesn't stack; reasoning chunk is never classified; ordinary text still streams; base mapper never classifies.
- `acp_session_loader_test` — halt notice replays as an error message with no text part; without a classifier the same chunk stays assistant text.
- `cursor_event_mapper_test` — real wire-captured gate text becomes an error; matching tolerates case/decoration; prose merely containing the phrase is not a gate.

https://claude.ai/code/session_016csEwMUuGwnup6A7r2ZYne

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface `cursor-agent` halt notices (e.g., “Check your settings to continue”) as explicit error cards instead of assistant text so users see when a turn didn’t run. Hardened gate matching to treat non‑ASCII letters as content and avoid false positives.

- **Bug Fixes**
  - Added `AcpEventMapper.classifyHaltNotice({required String text})` to detect halt notices and emit a single `Message.error` per turn; only pure text qualifies (never reasoning), and any open id‑less assistant envelope is closed so post‑halt chunks open a fresh envelope.
  - Implemented classifier in `CursorEventMapper` with normalized exact‑phrase matching for “check your settings to continue”; normalization now strips only non‑letter/non‑digit decoration (Unicode‑aware) so letters from any script are treated as content; prose that merely contains the phrase is not matched.
  - History replay now requires an explicit `haltClassifier`; `AcpPlugin` passes `eventMapper.classifyHaltNotice` so reloaded sessions render the same error card; backends without notices pass `null` and the chunk stays assistant text.
  - Tests cover classification, dedupe, replay behavior, post‑halt fresh‑envelope/tool‑call sequences, and Unicode boundary handling.

- **Dependencies**
  - Added `sesori_shared` as a dev dependency in `bridge/sesori_plugin_cursor` for tests.

<sup>Written for commit c668dbc3dad40dee24b33efb643b36de4819678c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

