### PR TITLE
fix(ui): render native activity indicators reliably

### DIFF
--- a/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
+++ b/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
@@ -5,7 +5,6 @@ import Foundation
   import UIKit
 #elseif os(macOS)
   import AppKit
-  import CoreImage
   import FlutterMacOS
 #else
   #error("Unsupported Darwin platform")
@@ -164,16 +163,15 @@ private struct ColorComponents {
   }
 #elseif os(macOS)
   private final class NativeActivityIndicatorPlatformView: NSProgressIndicator {
+    private let indicatorColor: NSColor
+
     init(frame: NSRect, color: NSColor) {
+      indicatorColor = color
       super.init(frame: frame)
 
       isIndeterminate = true
       style = .spinning
       controlSize = .small
-      let colorFilter = CIFilter(name: "CIColorMonochrome")
-      colorFilter?.setValue(CIColor(color: color), forKey: kCIInputColorKey)
-      colorFilter?.setValue(1.0, forKey: kCIInputIntensityKey)
-      contentFilters = [colorFilter].compactMap { $0 }
       isDisplayedWhenStopped = true
       setAccessibilityElement(false)
 
@@ -184,6 +182,14 @@ private struct ColorComponents {
         object: nil
       )
       updateAnimationState()
+    }
+
+    // AppKit has no spinner tint API; draw-pass compositing avoids layer filters
+    // that distort Flutter platform-view geometry.
+    override func draw(_ dirtyRect: NSRect) {
+      super.draw(dirtyRect)
+      indicatorColor.setFill()
+      dirtyRect.fill(using: .sourceAtop)
     }
 
     required init?(coder: NSCoder) {

--- a/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
+++ b/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
@@ -1,4 +1,5 @@
 import "package:flutter/foundation.dart";
+import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
 import "package:flutter/rendering.dart";
 import "package:flutter/services.dart";
@@ -26,24 +27,19 @@ class PregoActivityIndicator extends StatelessWidget {
       role: SemanticsRole.loadingSpinner,
       child: ExcludeSemantics(
         child: RepaintBoundary(
-          child: animationsEnabled ? _animatedIndicator() : _indicator(value: _staticArcSweep),
+          child: animationsEnabled ? _animatedIndicator(context: context) : _indicator(value: _staticArcSweep),
         ),
       ),
     );
   }
 
-  Widget _animatedIndicator() {
+  Widget _animatedIndicator({required BuildContext context}) {
     if (kIsWeb) {
       return _indicator(value: null);
     }
 
     final nativeView = switch (defaultTargetPlatform) {
-      TargetPlatform.android => AndroidView(
-        viewType: _nativeViewType,
-        creationParams: color.toARGB32(),
-        creationParamsCodec: const StandardMessageCodec(),
-        hitTestBehavior: PlatformViewHitTestBehavior.transparent,
-      ),
+      TargetPlatform.android => _androidIndicator(context: context),
       TargetPlatform.iOS => UiKitView(
         viewType: _nativeViewType,
         creationParams: color.toARGB32(),
@@ -62,6 +58,36 @@ class PregoActivityIndicator extends StatelessWidget {
     return nativeView == null
         ? _indicator(value: null)
         : SizedBox.square(dimension: _defaultDimension, child: nativeView);
+  }
+
+  Widget _androidIndicator({required BuildContext context}) {
+    final layoutDirection = Directionality.of(context);
+
+    return PlatformViewLink(
+      viewType: _nativeViewType,
+      surfaceFactory: (context, controller) {
+        if (controller is! AndroidViewController) {
+          throw StateError("Expected an Android platform view controller");
+        }
+        return AndroidViewSurface(
+          controller: controller,
+          gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+          hitTestBehavior: PlatformViewHitTestBehavior.transparent,
+        );
+      },
+      onCreatePlatformView: (params) {
+        return PlatformViewsService.initExpensiveAndroidView(
+            id: params.id,
+            viewType: _nativeViewType,
+            layoutDirection: layoutDirection,
+            creationParams: color.toARGB32(),
+            creationParamsCodec: const StandardMessageCodec(),
+            onFocus: () => params.onFocusChanged(true),
+          )
+          ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
+          ..create();
+      },
+    );
   }
 
   CircularProgressIndicator _indicator({required double? value}) {

--- a/client/module_prego/test/components/prego_activity_indicator_test.dart
+++ b/client/module_prego/test/components/prego_activity_indicator_test.dart
@@ -36,10 +36,9 @@ void main() {
       ),
       findsOneWidget,
     );
-    final platformView = tester.widget<AndroidView>(find.byType(AndroidView));
+    final platformView = tester.widget<PlatformViewLink>(find.byType(PlatformViewLink));
     expect(platformView.viewType, "sesori/native-activity-indicator");
-    expect(platformView.creationParams, color.toARGB32());
-    expect(platformView.hitTestBehavior, PlatformViewHitTestBehavior.transparent);
+    expect(find.byType(AndroidView), findsNothing);
     expect(find.byType(CircularProgressIndicator), findsNothing);
     expect(tester.hasRunningAnimations, isFalse);
 
@@ -92,7 +91,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byType(AndroidView)), const Size.square(36));
+    expect(tester.getSize(find.byType(PlatformViewLink)), const Size.square(36));
 
     debugDefaultTargetPlatformOverride = null;
   });
@@ -111,6 +110,7 @@ void main() {
       isNotNull,
     );
     expect(find.byType(AndroidView), findsNothing);
+    expect(find.byType(PlatformViewLink), findsNothing);
     await tester.pump(const Duration(seconds: 1));
     expect(tester.hasRunningAnimations, isFalse);
 


### PR DESCRIPTION
## Summary

- use true Android hybrid composition so the native `ProgressBar` keeps animating while Flutter is idle
- tint the macOS `NSProgressIndicator` in its AppKit draw pass instead of relying on an ineffective Core Image filter
- preserve native animation ownership, requested color, semantics, reduced-motion behavior, sizing, and the working iOS path

## Root cause

The Android texture-composition path only recaptured RenderThread animation when Flutter submitted a frame, leaving the indicator frozen until scrolling. On macOS, the system indicator inherited a white dark-appearance style over the light Flutter surface, while the content filter did not tint the platform view.

## Verification

- Android 16 emulator: idle screenshots show the indicator advancing without scrolling
- macOS disposable Flutter host: 16px, 20px, and 36px indicators render blue; captures 400ms apart differ
- `flutter test` in `client/module_prego` (86 tests)
- `flutter test` in `client/app` (627 tests)
- focused native-indicator widget tests on the fresh branch
- `dart analyze` in `client/module_prego` (no changed-code findings)
- `swift format lint --strict`
- Android debug APK, iOS simulator, and macOS debug builds
- architecture plan and implementation reviews approved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix stalled Android spinners and incorrect macOS tint by switching to hybrid composition and tinting in AppKit, so indicators animate and render correctly even when Flutter is idle. Keeps iOS behavior, accessibility, sizing, and reduced-motion support unchanged.

- **Bug Fixes**
  - Android: Replace `AndroidView` with `PlatformViewLink`/`AndroidViewSurface` via `PlatformViewsService.initExpensiveAndroidView` to keep `ProgressBar` animating when Flutter is idle; transparent hit testing; respects layout direction.
  - macOS: Tint `NSProgressIndicator` in `draw(_:)` with source-atop compositing; remove ineffective Core Image filter; fixes color on light surfaces and avoids geometry distortion.
  - Tests: Update widget tests to expect `PlatformViewLink` and preserve non-animated path checks.

<sup>Written for commit e45a199946a16d78f97ba599f97f2ce4820ebaf4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

