### PR TITLE
feat(ui): redesign the empty sessions list and add the New task button

### DIFF
--- a/client/app/lib/features/session_list/session_empty_state.dart
+++ b/client/app/lib/features/session_list/session_empty_state.dart
@@ -63,7 +63,7 @@ class _EmptyTerminalGlyph extends StatelessWidget {
       clipBehavior: Clip.antiAlias,
       decoration: BoxDecoration(
         color: prego.colors.bgSurface4,
-        borderRadius: BorderRadius.circular(10),
+        borderRadius: BorderRadius.circular(prego.radius.lg),
         border: Border.all(width: 0.5, color: prego.colors.borderInsideReversedBottom),
       ),
       child: Padding(
@@ -89,6 +89,10 @@ class _EmptyTerminalGlyph extends StatelessWidget {
               children: [
                 Text(
                   r"$",
+                  // The glyph is a fixed-size illustration whose other elements
+                  // (dots, cursor bar) don't scale, so the prompt must not
+                  // partially scale with accessibility fonts either.
+                  textScaler: TextScaler.noScaling,
                   style: prego.textTheme.textMd.regular.copyWith(
                     color: prego.colors.textSuccessPrimary,
                     height: 1,
@@ -152,17 +156,17 @@ class _ProjectChip extends StatelessWidget {
     return ConstrainedBox(
       constraints: const BoxConstraints(maxWidth: 260),
       child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        padding: EdgeInsets.symmetric(horizontal: prego.spacing.lg, vertical: prego.spacing.md),
         decoration: BoxDecoration(
           color: prego.colors.bgSurface2,
-          borderRadius: BorderRadius.circular(999),
+          borderRadius: BorderRadius.circular(prego.radius.full),
           border: Border.all(color: prego.colors.borderSecondary),
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
             Icon(TablerSolid.brand_github, size: 14, color: prego.colors.textPrimary),
-            const SizedBox(width: 6),
+            SizedBox(width: prego.spacing.sm),
             Flexible(
               child: Text(
                 name,

--- a/client/app/lib/features/session_list/session_empty_state.dart
+++ b/client/app/lib/features/session_list/session_empty_state.dart
@@ -67,7 +67,7 @@ class _EmptyTerminalGlyph extends StatelessWidget {
         border: Border.all(width: 0.5, color: prego.colors.borderInsideReversedBottom),
       ),
       child: Padding(
-        padding: const EdgeInsets.fromLTRB(7, 6, 7, 7),
+        padding: const EdgeInsetsDirectional.fromSTEB(7, 6, 7, 7),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/client/app/lib/features/session_list/session_empty_state.dart
+++ b/client/app/lib/features/session_list/session_empty_state.dart
@@ -161,7 +161,7 @@ class _ProjectChip extends StatelessWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(TablerSolid.brand_github, size: 14, color: prego.colors.textSecondary),
+            Icon(TablerSolid.brand_github, size: 14, color: prego.colors.textPrimary),
             const SizedBox(width: 6),
             Flexible(
               child: Text(

--- a/client/app/lib/features/session_list/session_empty_state.dart
+++ b/client/app/lib/features/session_list/session_empty_state.dart
@@ -1,0 +1,179 @@
+import "package:flutter/material.dart";
+import "package:theme_prego/module_prego.dart";
+
+import "../../core/extensions/build_context_x.dart";
+
+/// Empty state for the sessions list when a project has no active sessions
+/// yet: a terminal-window glyph, an invitation to begin, and a chip naming the
+/// project the first task will run in.
+///
+/// Rendered inside a `SliverFillRemaining(hasScrollBody: false)`, so the glyph
+/// is a fixed size — an unbounded illustration would inflate the scroll extent.
+class SessionEmptyState extends StatelessWidget {
+  final String? projectName;
+
+  const SessionEmptyState({super.key, required this.projectName});
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+    final name = projectName;
+
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const ExcludeSemantics(
+            child: _EmptyTerminalGlyph(key: Key("session-empty-terminal")),
+          ),
+          const SizedBox(height: 18),
+          Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                context.loc.sessionListEmptyTitle,
+                textAlign: TextAlign.center,
+                style: prego.textTheme.textLg.regular.copyWith(color: prego.colors.textPrimary),
+              ),
+              if (name != null) ...[
+                SizedBox(height: prego.spacing.lg),
+                _ProjectChip(name: name),
+              ],
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A small mac-style terminal window: three window-control dots, a green shell
+/// prompt, and a blinking-style cursor bar — drawn in pure Flutter so it scales
+/// crisply and themes with the design system (no bundled asset).
+class _EmptyTerminalGlyph extends StatelessWidget {
+  const _EmptyTerminalGlyph({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+
+    return Container(
+      width: 154,
+      height: 113,
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: prego.colors.bgSurface4,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(width: 0.5, color: prego.colors.borderInsideReversedBottom),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(7, 6, 7, 7),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Fixed macOS window-control colours — brand-neutral window chrome,
+            // not theme tokens.
+            const Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _WindowDot(Color(0xFFFF5F57)),
+                SizedBox(width: 4),
+                _WindowDot(Color(0xFFFEBC2E)),
+                SizedBox(width: 4),
+                _WindowDot(Color(0xFF28C840)),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  r"$",
+                  style: prego.textTheme.textMd.regular.copyWith(
+                    color: prego.colors.textSuccessPrimary,
+                    height: 1,
+                  ),
+                ),
+                const SizedBox(width: 4),
+                _CursorBar(color: prego.colors.bgBrandSolid),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _WindowDot extends StatelessWidget {
+  final Color color;
+
+  const _WindowDot(this.color);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 6,
+      height: 6,
+      decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+    );
+  }
+}
+
+/// The shell cursor: a static brand-blue bar with a soft glow.
+class _CursorBar extends StatelessWidget {
+  final Color color;
+
+  const _CursorBar({required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 2,
+      height: 13,
+      decoration: BoxDecoration(
+        color: color,
+        boxShadow: [BoxShadow(color: color.withValues(alpha: 0.6), blurRadius: 9)],
+      ),
+    );
+  }
+}
+
+/// Non-interactive pill naming the project the first task will run in.
+class _ProjectChip extends StatelessWidget {
+  final String name;
+
+  const _ProjectChip({required this.name});
+
+  @override
+  Widget build(BuildContext context) {
+    final prego = context.prego;
+
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 260),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        decoration: BoxDecoration(
+          color: prego.colors.bgSurface2,
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(color: prego.colors.borderSecondary),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(TablerSolid.brand_github, size: 14, color: prego.colors.textSecondary),
+            const SizedBox(width: 6),
+            Flexible(
+              child: Text(
+                name,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: prego.textTheme.textMd.medium.copyWith(color: prego.colors.textSecondary),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/client/app/lib/features/session_list/session_list_content.dart
+++ b/client/app/lib/features/session_list/session_list_content.dart
@@ -8,6 +8,7 @@ import "../../core/constants.dart";
 import "../../core/extensions/build_context_x.dart";
 import "../../core/extensions/remote_failure_x.dart";
 import "../../core/routing/app_router.dart";
+import "session_empty_state.dart";
 import "session_tile.dart";
 
 /// Pull-to-refresh handler shared by [SessionListScaffold] and
@@ -28,6 +29,7 @@ Future<void> refreshSessionList(BuildContext context) async {
 }
 
 class SessionListContent extends StatelessWidget {
+  final String? projectName;
   final String? selectedSessionId;
   final ValueChanged<Session> onSessionTap;
   final SessionMenuEntriesBuilder sessionMenuEntries;
@@ -35,6 +37,7 @@ class SessionListContent extends StatelessWidget {
 
   const SessionListContent({
     super.key,
+    required this.projectName,
     this.selectedSessionId,
     required this.onSessionTap,
     required this.sessionMenuEntries,
@@ -58,9 +61,9 @@ class SessionListContent extends StatelessWidget {
         sessions.isEmpty
             ? SliverFillRemaining(
                 hasScrollBody: false,
-                child: Center(
-                  child: Text(showArchived ? loc.sessionListEmptyArchived : loc.sessionListEmpty),
-                ),
+                child: showArchived
+                    ? Center(child: Text(loc.sessionListEmptyArchived))
+                    : SessionEmptyState(projectName: projectName),
               )
             : SliverPadding(
                 padding: const EdgeInsets.symmetric(vertical: 8),

--- a/client/app/lib/features/session_list/session_list_panel.dart
+++ b/client/app/lib/features/session_list/session_list_panel.dart
@@ -139,6 +139,7 @@ class SessionListPanel extends StatelessWidget {
       slivers: [
         if (isRefreshing) const SliverToBoxAdapter(child: LinearProgressIndicator()),
         SessionListContent(
+          projectName: projectName,
           selectedSessionId: selectedSessionId,
           onSessionTap: onSessionTap,
           sessionMenuEntries: sessionMenuEntries,

--- a/client/app/lib/features/session_list/session_list_scaffold.dart
+++ b/client/app/lib/features/session_list/session_list_scaffold.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
 import "package:theme_prego/module_prego.dart";
 
 import "../../core/extensions/build_context_x.dart";
@@ -61,11 +62,11 @@ class SessionListScaffold extends StatelessWidget {
           },
         ),
       ],
-      floatingActionButton: PregoButtonsIconGlass(
-        icon: TablerRegular.plus,
-        size: PregoButtonsIconGlassSize.xl,
-        iconSize: 22,
-        semanticLabel: loc.sessionListNewSession,
+      floatingActionButton: PregoButtonsSolid(
+        label: loc.sessionListNewTask,
+        leadingIcon: TablerRegular.plus,
+        hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
+        size: PregoButtonsSolidSize.xl,
         onPressed: onNewSession,
       ),
       // Pull-to-refresh only makes sense once the list has loaded.
@@ -73,6 +74,7 @@ class SessionListScaffold extends StatelessWidget {
       slivers: [
         if (isRefreshing) const SliverToBoxAdapter(child: LinearProgressIndicator()),
         SessionListContent(
+          projectName: projectName,
           selectedSessionId: selectedSessionId,
           onSessionTap: onSessionTap,
           sessionMenuEntries: sessionMenuEntries,

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -168,7 +168,10 @@
     }
   },
   "sessionListLoadingSemantics": "Loading sessions",
-  "sessionListEmpty": "No sessions found",
+  "sessionListEmptyTitle": "Start your first task",
+  "@sessionListEmptyTitle": {
+    "description": "Headline on the sessions list when a project has no active sessions yet, inviting the user to begin."
+  },
   "sessionListUntitled": "Untitled session",
   "sessionListUpdated": "Updated {timestamp}",
   "@sessionListUpdated": {
@@ -183,6 +186,10 @@
   "sessionListErrorTitle": "Failed to load sessions",
   "sessionListRetry": "Retry",
   "sessionListNewSession": "New session",
+  "sessionListNewTask": "New task",
+  "@sessionListNewTask": {
+    "description": "Label of the primary button on the sessions list that starts a new task (session)."
+  },
   "sessionDetailTitle": "Session",
   "sessionDetailEmpty": "No messages yet",
   "sessionDetailErrorTitle": "Failed to load messages",

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -463,11 +463,11 @@ abstract class AppLocalizations {
   /// **'Loading sessions'**
   String get sessionListLoadingSemantics;
 
-  /// No description provided for @sessionListEmpty.
+  /// Headline on the sessions list when a project has no active sessions yet, inviting the user to begin.
   ///
   /// In en, this message translates to:
-  /// **'No sessions found'**
-  String get sessionListEmpty;
+  /// **'Start your first task'**
+  String get sessionListEmptyTitle;
 
   /// No description provided for @sessionListUntitled.
   ///
@@ -510,6 +510,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'New session'**
   String get sessionListNewSession;
+
+  /// Label of the primary button on the sessions list that starts a new task (session).
+  ///
+  /// In en, this message translates to:
+  /// **'New task'**
+  String get sessionListNewTask;
 
   /// No description provided for @sessionDetailTitle.
   ///

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -208,7 +208,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sessionListLoadingSemantics => 'Loading sessions';
 
   @override
-  String get sessionListEmpty => 'No sessions found';
+  String get sessionListEmptyTitle => 'Start your first task';
 
   @override
   String get sessionListUntitled => 'Untitled session';
@@ -232,6 +232,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get sessionListNewSession => 'New session';
+
+  @override
+  String get sessionListNewTask => 'New task';
 
   @override
   String get sessionDetailTitle => 'Session';

--- a/client/app/test/features/session_list/session_empty_state_test.dart
+++ b/client/app/test/features/session_list/session_empty_state_test.dart
@@ -11,6 +11,7 @@ void main() {
     WidgetTester tester, {
     required String? projectName,
     Brightness brightness = Brightness.light,
+    TextScaler textScaler = TextScaler.noScaling,
   }) async {
     final isDark = brightness == Brightness.dark;
     await tester.pumpWidget(
@@ -22,6 +23,10 @@ void main() {
         ),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
+        builder: (context, child) => MediaQuery(
+          data: MediaQuery.of(context).copyWith(textScaler: textScaler),
+          child: child!,
+        ),
         home: Scaffold(
           body: CustomScrollView(
             slivers: [
@@ -56,6 +61,20 @@ void main() {
     expect(find.text(emptyTitle(tester)), findsOneWidget);
     expect(find.byKey(const Key("session-empty-terminal")), findsOneWidget);
     expect(find.byIcon(TablerSolid.brand_github), findsNothing);
+  });
+
+  testWidgets("terminal glyph prompt ignores system text scaling", (tester) async {
+    await pumpEmptyState(tester, projectName: null);
+    final unscaled = tester.getSize(find.text(r"$"));
+
+    await pumpEmptyState(
+      tester,
+      projectName: null,
+      textScaler: const TextScaler.linear(3),
+    );
+
+    expect(tester.getSize(find.text(r"$")), unscaled);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets("renders without overflow in dark mode", (tester) async {

--- a/client/app/test/features/session_list/session_empty_state_test.dart
+++ b/client/app/test/features/session_list/session_empty_state_test.dart
@@ -1,0 +1,71 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:sesori_mobile/features/session_list/session_empty_state.dart";
+import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:theme_prego/module_prego.dart";
+
+void main() {
+  // Mirrors production hosting: the empty state renders inside a
+  // SliverFillRemaining(hasScrollBody: false) in the sessions scroll view.
+  Future<void> pumpEmptyState(
+    WidgetTester tester, {
+    required String? projectName,
+    Brightness brightness = Brightness.light,
+  }) async {
+    final isDark = brightness == Brightness.dark;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          colorScheme: (isDark ? PregoColors.dark : PregoColors.light).toFlutterColorScheme(),
+          textTheme: (isDark ? PregoTextTheme.dark : PregoTextTheme.light).asFlutterTextTheme(),
+          extensions: [isDark ? PregoDesignSystem.dark : PregoDesignSystem.light],
+        ),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: CustomScrollView(
+            slivers: [
+              SliverFillRemaining(
+                hasScrollBody: false,
+                child: SessionEmptyState(projectName: projectName),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  String emptyTitle(WidgetTester tester) =>
+      AppLocalizations.of(tester.element(find.byType(SessionEmptyState)))!.sessionListEmptyTitle;
+
+  testWidgets("renders the terminal glyph, headline, and project chip", (tester) async {
+    await pumpEmptyState(tester, projectName: "Sesori_app_monorepo");
+
+    expect(find.text(emptyTitle(tester)), findsOneWidget);
+    expect(find.byKey(const Key("session-empty-terminal")), findsOneWidget);
+    expect(find.byIcon(TablerSolid.brand_github), findsOneWidget);
+    expect(find.text("Sesori_app_monorepo"), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets("hides the project chip when there is no project name", (tester) async {
+    await pumpEmptyState(tester, projectName: null);
+
+    expect(find.text(emptyTitle(tester)), findsOneWidget);
+    expect(find.byKey(const Key("session-empty-terminal")), findsOneWidget);
+    expect(find.byIcon(TablerSolid.brand_github), findsNothing);
+  });
+
+  testWidgets("renders without overflow in dark mode", (tester) async {
+    await pumpEmptyState(
+      tester,
+      projectName: "Sesori_app_monorepo",
+      brightness: Brightness.dark,
+    );
+
+    expect(find.byKey(const Key("session-empty-terminal")), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## What

Redesigns the empty sessions-list screen (Figma `2258-18786`) and swaps in the new "New task" FAB.

- **Designed empty state** — replaces the bare "No sessions found" text with a pure-Flutter terminal-window glyph (mac window chrome + green `$` prompt + a static glowing cursor), a **"Start your first task"** headline, and a flat chip naming the project the first task will run in.
- **"New task" FAB** — the glass `+` on the phone scaffold becomes the solid black pill (`PregoButtonsSolid`, `primaryAlt`/`xl`) from the design. The split-pane panel keeps its own header button (outside the redesigned frame).
- **Archived-empty** keeps its existing simple message.

## Design notes

- The glyph is drawn from `context.prego` tokens (no bundled asset), so it themes light/dark automatically and sidesteps the known worktree `Image.asset` test flakiness. It's fixed-size so it doesn't inflate the `SliverFillRemaining` scroll extent, and is wrapped in `ExcludeSemantics`.
- The cursor is a **static** glow (no always-on animation), consistent with the repo's battery/animation stance.
- The chip shows the real `projectName` and **hides when it's null** — the shared `Project` model has no git-remote/slug field, so the Figma's `sesori-ai/…` slug has no backing data to invent.

## Copy note

The FAB reads **"New task"** per the design. Because that button also shows on the *populated* list, "task" now appears there while the rest of the app still says "session." Trivial revert to `sessionListNewSession` if we'd rather keep the vocabulary consistent.

## Testing

- `flutter analyze` clean across the app.
- All session-list tests pass, including 3 new ones in `session_empty_state_test.dart` (glyph/headline/chip render, chip hidden when no project, dark-mode no-overflow smoke).
- Not yet verified on a running device — the empty state needs a bridge + a zero-session project to drive.

https://claude.ai/code/session_01G1vRXkZpQeTaUq87pJsuiP

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the empty sessions list and replaced the FAB with a solid “New task” button to guide first-time users and match the latest `theme_prego` spec.

- **New Features**
  - Empty state with a Flutter-drawn terminal glyph and “Start your first task” headline; project chip shows when a name exists; archived-empty unchanged.
  - Phone: replaced the glass “+” FAB with a solid `PregoButtonsSolid` (`primaryAlt`/`xl`) labeled “New task”; split-pane keeps its header button.

- **Bug Fixes**
  - Corrected the GitHub icon color and aligned spacing/radius with `theme_prego` tokens.
  - Prevented text scaling from distorting the glyph by pinning the “$” prompt to `TextScaler.noScaling`; kept the glyph decorative (excluded from semantics) with a static cursor glow.
  - Switched glyph padding to `EdgeInsetsDirectional` to satisfy RTL lint.

<sup>Written for commit 64ef3379fe9d59080ff608e61a5ffe6e1b456c33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

