### PR TITLE
ci: analyze module_prego

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -64,6 +64,10 @@ jobs:
         run: dart analyze --fatal-infos
         working-directory: client/module_auth
 
+      - name: Analyze module_prego
+        run: dart analyze --fatal-infos
+        working-directory: client/module_prego
+
       - name: Run tests for module_core
         run: dart test
         working-directory: client/module_core

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -76,6 +76,10 @@ jobs:
         run: dart test
         working-directory: client/module_auth
 
+      - name: Run tests for module_prego
+        run: flutter test
+        working-directory: client/module_prego
+
       - name: Run tests for client/app
         run: flutter test
         working-directory: client/app

--- a/client/module_prego/lib/components/loaders/prego_ai_loader.dart
+++ b/client/module_prego/lib/components/loaders/prego_ai_loader.dart
@@ -213,19 +213,31 @@ class _AiLoaderPainter extends CustomPainter {
   (Color, double, double) _keyframe(double t) {
     if (t < _outlineAt) {
       final p = t / _outlineAt;
-      return (_lerpColor(solid, outline, p), 1 - p, _lerpDouble(1.0, 0.86, p));
+      return (
+        _lerpColor(a: solid, b: outline, t: p),
+        1 - p,
+        _lerpDouble(a: 1.0, b: 0.86, t: p),
+      );
     }
     if (t < _fadedAt) {
       final p = (t - _outlineAt) / (_fadedAt - _outlineAt);
-      return (_lerpColor(outline, faded, p), p, _lerpDouble(0.86, 0.92, p));
+      return (
+        _lerpColor(a: outline, b: faded, t: p),
+        p,
+        _lerpDouble(a: 0.86, b: 0.92, t: p),
+      );
     }
     final p = (t - _fadedAt) / (1 - _fadedAt);
-    return (_lerpColor(faded, solid, p), 1, _lerpDouble(0.92, 1.0, p));
+    return (
+      _lerpColor(a: faded, b: solid, t: p),
+      1,
+      _lerpDouble(a: 0.92, b: 1.0, t: p),
+    );
   }
 
-  static Color _lerpColor(Color a, Color b, double t) => Color.lerp(a, b, t) ?? b;
+  static Color _lerpColor({required Color a, required Color b, required double t}) => Color.lerp(a, b, t) ?? b;
 
-  static double _lerpDouble(double a, double b, double t) => a + (b - a) * t;
+  static double _lerpDouble({required double a, required double b, required double t}) => a + (b - a) * t;
 
   @override
   bool shouldRepaint(_AiLoaderPainter oldDelegate) {

--- a/client/module_prego/lib/components/loaders/prego_ai_loader.dart
+++ b/client/module_prego/lib/components/loaders/prego_ai_loader.dart
@@ -5,6 +5,7 @@ import "package:flutter/material.dart";
 
 import "../../motion/prego_reduced_motion.dart";
 import "../../theme/prego_theme.dart";
+import "../../utils/lerp_utils.dart";
 
 /// A sparkle marking AI activity, twinkling while [animate] is set.
 ///
@@ -214,30 +215,26 @@ class _AiLoaderPainter extends CustomPainter {
     if (t < _outlineAt) {
       final p = t / _outlineAt;
       return (
-        _lerpColor(a: solid, b: outline, t: p),
+        lerpColorNonNull(solid, outline, p),
         1 - p,
-        _lerpDouble(a: 1.0, b: 0.86, t: p),
+        lerpDoubleNonNull(1.0, 0.86, p),
       );
     }
     if (t < _fadedAt) {
       final p = (t - _outlineAt) / (_fadedAt - _outlineAt);
       return (
-        _lerpColor(a: outline, b: faded, t: p),
+        lerpColorNonNull(outline, faded, p),
         p,
-        _lerpDouble(a: 0.86, b: 0.92, t: p),
+        lerpDoubleNonNull(0.86, 0.92, p),
       );
     }
     final p = (t - _fadedAt) / (1 - _fadedAt);
     return (
-      _lerpColor(a: faded, b: solid, t: p),
+      lerpColorNonNull(faded, solid, p),
       1,
-      _lerpDouble(a: 0.92, b: 1.0, t: p),
+      lerpDoubleNonNull(0.92, 1.0, p),
     );
   }
-
-  static Color _lerpColor({required Color a, required Color b, required double t}) => Color.lerp(a, b, t) ?? b;
-
-  static double _lerpDouble({required double a, required double b, required double t}) => a + (b - a) * t;
 
   @override
   bool shouldRepaint(_AiLoaderPainter oldDelegate) {

--- a/client/module_prego/lib/components/menus/prego_anchor_menu.dart
+++ b/client/module_prego/lib/components/menus/prego_anchor_menu.dart
@@ -356,7 +356,7 @@ class _PregoAnchorMenuState extends State<PregoAnchorMenu> {
 
   Widget _flatPanel(BuildContext context, {required Rect triggerRect}) {
     final entries = widget.entriesBuilder();
-    final edgePadding = EdgeInsets.only(
+    final edgePadding = EdgeInsetsDirectional.only(
       top: entries.isEmpty || entries.first is! PregoMenuItem ? 6 : 0,
       bottom: entries.isEmpty || entries.last is! PregoMenuItem ? 6 : 0,
     );
@@ -559,8 +559,12 @@ double debugGlassEntryHeight(BuildContext context, {required PregoMenuEntry entr
 /// Prego's styles set an explicit line height, so the line box is exactly the
 /// scaled font size times that factor — no font-metric guesswork.
 double _lineHeight(BuildContext context, {required TextStyle style}) {
-  final fontSize = MediaQuery.textScalerOf(context).scale(style.fontSize!);
-  return fontSize * style.height!;
+  final fontSize = style.fontSize;
+  final height = style.height;
+  if (fontSize == null || height == null) {
+    throw StateError('Prego menu text styles must declare font size and height.');
+  }
+  return MediaQuery.textScalerOf(context).scale(fontSize) * height;
 }
 
 // ── Shared entry styling, cont. ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- run `dart analyze --fatal-infos` for `client/module_prego` in Mobile CI
- fix the five existing Prego lint findings exposed by the new gate
- preserve the existing loader interpolation and menu layout behavior

## Root cause
`client/module_prego/**` changes triggered Mobile CI, but the workflow never invoked the package-local analyzer. Desktop CI only validates Prego through its downstream desktop consumers, so Prego lint findings could merge without rejection.

## Testing
- `dart analyze --fatal-infos` (`client/module_prego`)
- `flutter test` (`client/module_prego`) - 86 tests passed
- `dart analyze --fatal-infos` (`client/app`)
- `dart analyze --fatal-infos` (`client/desktop`)
- required architecture plan and implementation reviews approved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Dart analyzer and adds tests for `client/module_prego` in Mobile CI to block regressions. Cleans up lints without changing the loader animation or menu layout.

- **Refactors**
  - CI: run `dart analyze --fatal-infos` and `flutter test` in `client/module_prego`.
  - Loader: replace local helpers with `lerpColorNonNull`/`lerpDoubleNonNull` from `utils/lerp_utils.dart`; behavior unchanged.
  - Menu: use `EdgeInsetsDirectional.only` for edge padding.
  - Text: add null checks in `_lineHeight`; throw if `fontSize` or `height` is missing.

<sup>Written for commit fd1232a19b0ab3a5869fe0e6393a8e0ac9a344c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

