### PR TITLE
fix(ui): restore Flutter indicators on Android and macOS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,6 +441,13 @@ Data flows downstream via streams and events — this is push-based. Polling is 
 
 Long-lived Flutter busy indicators preserve smooth visible motion unless the user explicitly approves another treatment. Isolate repaint damage and profile before reducing cadence; if continuous frames are unacceptable, deliberately use a static indicator. Animated indicators must stop under `TickerMode` and become static under reduced motion. Do not carry performance measurements across materially different animation implementations.
 
+Platform-view visual primitives require lifecycle and interaction profiling, not
+only static screenshots or idle measurements. Exercise insertion, removal,
+clipping, and scrolling into and out of view while checking the surrounding
+scene. Reject apparent power savings that come from visibly reduced animation
+cadence or destabilize adjacent rendering; prefer the Flutter renderer when a
+platform view cannot preserve smooth motion and scene composition.
+
 When a coalesced staleness queue drives snapshot refreshes, only a successfully applied snapshot consumes queued staleness. A failed or connection-blocked refresh must preserve and re-arm the prior signal, while signals arriving during the refresh remain queued independently.
 
 - **Polling** (flag): `Timer.periodic`, `Stream.periodic`, manual re-fetch loops, or repeatedly-triggered invalidation to re-fetch data you already had from a stream-capable source.

--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -53,6 +53,14 @@ plugin renderer they require. Keep registration automatic through the package's
 Flutter plugin metadata; mobile and desktop shells consume the exported widget
 and must not duplicate it or register its platform view manually.
 
+Before shipping a platform-view-backed visual primitive, profile its real
+lifecycle on every target it enables: repeated insertion/removal, clipping, and
+scrolling into and out of view. Verify surrounding blur, glass, and composited
+content as well as the native view itself. A static fixture, successful build,
+or idle power result is insufficient when the production UI changes the view
+hierarchy; use the Flutter renderer if platform-view lifecycle destabilizes the
+scene or lowers visible animation cadence.
+
 Plugin identity is non-null inside client APIs, repositories, services, and
 cubits. `legacyMissingPluginId` is the concrete OpenCode identity because only
 OpenCode predates plugin attribution; use it only at flows that genuinely have

--- a/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
+++ b/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
@@ -1,5 +1,4 @@
 import "package:flutter/foundation.dart";
-import "package:flutter/gestures.dart";
 import "package:flutter/material.dart";
 import "package:flutter/rendering.dart";
 import "package:flutter/services.dart";
@@ -27,67 +26,34 @@ class PregoActivityIndicator extends StatelessWidget {
       role: SemanticsRole.loadingSpinner,
       child: ExcludeSemantics(
         child: RepaintBoundary(
-          child: animationsEnabled ? _animatedIndicator(context: context) : _indicator(value: _staticArcSweep),
+          child: animationsEnabled ? _animatedIndicator() : _indicator(value: _staticArcSweep),
         ),
       ),
     );
   }
 
-  Widget _animatedIndicator({required BuildContext context}) {
+  Widget _animatedIndicator() {
     if (kIsWeb) {
       return _indicator(value: null);
     }
 
     final nativeView = switch (defaultTargetPlatform) {
-      TargetPlatform.android => _androidIndicator(context: context),
       TargetPlatform.iOS => UiKitView(
         viewType: _nativeViewType,
         creationParams: color.toARGB32(),
         creationParamsCodec: const StandardMessageCodec(),
         hitTestBehavior: PlatformViewHitTestBehavior.transparent,
       ),
-      TargetPlatform.macOS => AppKitView(
-        viewType: _nativeViewType,
-        creationParams: color.toARGB32(),
-        creationParamsCodec: const StandardMessageCodec(),
-        hitTestBehavior: PlatformViewHitTestBehavior.transparent,
-      ),
-      TargetPlatform.fuchsia || TargetPlatform.linux || TargetPlatform.windows => null,
+      TargetPlatform.android ||
+      TargetPlatform.fuchsia ||
+      TargetPlatform.linux ||
+      TargetPlatform.macOS ||
+      TargetPlatform.windows => null,
     };
 
     return nativeView == null
         ? _indicator(value: null)
         : SizedBox.square(dimension: _defaultDimension, child: nativeView);
-  }
-
-  Widget _androidIndicator({required BuildContext context}) {
-    final layoutDirection = Directionality.of(context);
-
-    return PlatformViewLink(
-      viewType: _nativeViewType,
-      surfaceFactory: (context, controller) {
-        if (controller is! AndroidViewController) {
-          throw StateError("Expected an Android platform view controller");
-        }
-        return AndroidViewSurface(
-          controller: controller,
-          gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
-          hitTestBehavior: PlatformViewHitTestBehavior.transparent,
-        );
-      },
-      onCreatePlatformView: (params) {
-        return PlatformViewsService.initExpensiveAndroidView(
-            id: params.id,
-            viewType: _nativeViewType,
-            layoutDirection: layoutDirection,
-            creationParams: color.toARGB32(),
-            creationParamsCodec: const StandardMessageCodec(),
-            onFocus: () => params.onFocusChanged(true),
-          )
-          ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
-          ..create();
-      },
-    );
   }
 
   CircularProgressIndicator _indicator({required double? value}) {

--- a/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
+++ b/client/module_prego/lib/components/loaders/prego_activity_indicator.dart
@@ -26,7 +26,10 @@ class PregoActivityIndicator extends StatelessWidget {
       role: SemanticsRole.loadingSpinner,
       child: ExcludeSemantics(
         child: RepaintBoundary(
-          child: animationsEnabled ? _animatedIndicator() : _indicator(value: _staticArcSweep),
+          child: SizedBox.square(
+            dimension: _defaultDimension,
+            child: animationsEnabled ? _animatedIndicator() : _indicator(value: _staticArcSweep),
+          ),
         ),
       ),
     );
@@ -51,9 +54,7 @@ class PregoActivityIndicator extends StatelessWidget {
       TargetPlatform.windows => null,
     };
 
-    return nativeView == null
-        ? _indicator(value: null)
-        : SizedBox.square(dimension: _defaultDimension, child: nativeView);
+    return nativeView ?? _indicator(value: null);
   }
 
   CircularProgressIndicator _indicator({required double? value}) {

--- a/client/module_prego/test/components/prego_activity_indicator_test.dart
+++ b/client/module_prego/test/components/prego_activity_indicator_test.dart
@@ -22,7 +22,7 @@ void main() {
     debugDefaultTargetPlatformOverride = platform;
   }
 
-  testWidgets("uses the native Android spinner without scheduling Flutter animation", (tester) async {
+  testWidgets("uses the Flutter Android spinner without a platform view", (tester) async {
     usePlatform(TargetPlatform.android);
     final handle = tester.ensureSemantics();
     await tester.pumpWidget(
@@ -36,11 +36,13 @@ void main() {
       ),
       findsOneWidget,
     );
-    final platformView = tester.widget<PlatformViewLink>(find.byType(PlatformViewLink));
-    expect(platformView.viewType, "sesori/native-activity-indicator");
+    expect(
+      tester.widget<CircularProgressIndicator>(find.byType(CircularProgressIndicator)).value,
+      isNull,
+    );
     expect(find.byType(AndroidView), findsNothing);
-    expect(find.byType(CircularProgressIndicator), findsNothing);
-    expect(tester.hasRunningAnimations, isFalse);
+    expect(find.byType(PlatformViewLink), findsNothing);
+    expect(tester.hasRunningAnimations, isTrue);
 
     final data = tester.getSemantics(find.byType(PregoActivityIndicator)).getSemanticsData();
     expect(data.role, SemanticsRole.loadingSpinner);
@@ -65,23 +67,23 @@ void main() {
     debugDefaultTargetPlatformOverride = null;
   });
 
-  testWidgets("uses the native macOS spinner without scheduling Flutter animation", (tester) async {
+  testWidgets("uses the Flutter macOS spinner without a platform view", (tester) async {
     usePlatform(TargetPlatform.macOS);
     await tester.pumpWidget(
       wrap(const PregoActivityIndicator(color: color)),
     );
 
-    final platformView = tester.widget<AppKitView>(find.byType(AppKitView));
-    expect(platformView.viewType, "sesori/native-activity-indicator");
-    expect(platformView.creationParams, color.toARGB32());
-    expect(platformView.hitTestBehavior, PlatformViewHitTestBehavior.transparent);
-    expect(find.byType(CircularProgressIndicator), findsNothing);
-    expect(tester.hasRunningAnimations, isFalse);
+    expect(
+      tester.widget<CircularProgressIndicator>(find.byType(CircularProgressIndicator)).value,
+      isNull,
+    );
+    expect(find.byType(AppKitView), findsNothing);
+    expect(tester.hasRunningAnimations, isTrue);
 
     debugDefaultTargetPlatformOverride = null;
   });
 
-  testWidgets("gives a loosely constrained native spinner a 36 pixel square", (tester) async {
+  testWidgets("gives a loosely constrained Flutter spinner a 36 pixel square", (tester) async {
     usePlatform(TargetPlatform.android);
     await tester.pumpWidget(
       const MaterialApp(
@@ -91,7 +93,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byType(PlatformViewLink)), const Size.square(36));
+    expect(tester.getSize(find.byType(CircularProgressIndicator)), const Size.square(36));
 
     debugDefaultTargetPlatformOverride = null;
   });

--- a/client/module_prego/test/components/prego_activity_indicator_test.dart
+++ b/client/module_prego/test/components/prego_activity_indicator_test.dart
@@ -86,8 +86,13 @@ void main() {
   testWidgets("gives a loosely constrained Flutter spinner a 36 pixel square", (tester) async {
     usePlatform(TargetPlatform.android);
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Center(
+      MaterialApp(
+        theme: ThemeData(
+          progressIndicatorTheme: const ProgressIndicatorThemeData(
+            constraints: BoxConstraints.tightFor(width: 72, height: 72),
+          ),
+        ),
+        home: const Center(
           child: PregoActivityIndicator(color: color),
         ),
       ),


### PR DESCRIPTION
## Summary

- stop instantiating activity-indicator platform views on Android and macOS
- restore the isolated Flutter `CircularProgressIndicator` on those targets while retaining UIKit on iOS
- add structural tests that prevent Android/macOS platform-view regressions
- document required insertion/removal and offscreen-scroll profiling for reusable platform-view UI

## Why

macOS platform-view lifecycle changes corrupted surrounding Flutter composition: content disappeared, blur stopped rendering, regions darkened, and scrolling an inline spinner out of view could darken the scene.

A controlled Pixel 10 Pro A/B also showed that the Android static saving came with roughly 10 fps presentation. Under a profile-mode scrolling workload that repeatedly attached and detached indicators, platform views used 21% more app CPU, 29% more monitored device power, 79% more CPU-rail power, and 114% more GPU-rail power than Flutter.

## Verification

- focused `PregoActivityIndicator` tests: 7 passed
- `flutter test` in `client/module_prego`: 86 passed
- `flutter test` in `client/app`: 624 passed
- `dart analyze` in `client/module_prego`: no changed-code findings
- Android profile APK build
- iOS simulator debug build
- macOS debug build
- architecture plan and implementation reviews approved

Per request, no Android or macOS app was launched after this rollback. Visual acceptance remains with the user.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Flutter-based spinners on Android and macOS and keeps the native UIKit spinner on iOS. Fixes rendering issues, reduces platform-view power/CPU/GPU overhead, and enforces a 36px default size.

- **Bug Fixes**
  - Android/macOS: replace platform views with Flutter `CircularProgressIndicator`; no `PlatformViewLink`/`AppKitView` created.
  - iOS: retain `UiKitView` native spinner.
  - Sizing: force a 36px square via `SizedBox.square`, independent of `ProgressIndicatorTheme` constraints.
  - Tests/Docs: assert no platform views on Android/macOS, verify enforced size, animation, and semantics; add lifecycle profiling guidance and prefer Flutter when platform views degrade motion or composition.

<sup>Written for commit 78e53713af8b30bba923d5abc20a38d59cc23851. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

