### PR TITLE
refactor(bridge): remove unused process listing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,8 @@ These rules catch the common structural failures that layer rules alone miss. Ap
 
 - **Ownership boundary test.** A split done only to reduce file length is a violation. An extracted class must still deserve to exist when line count pressure disappears. It must own lifecycle, state or invariants, a stable domain responsibility, or a multi-caller decision boundary. If it owns none of those, keep private methods in the original class. Reviewers must ask: **Would this class still deserve to exist if the original file were under the line limit?**
 
+- **Remove code made obsolete by a refactor in the same change.** Delete superseded production methods, contracts, fake overrides, state, imports, and tests alongside their replacement. Do not preserve an internal dead surface for hypothetical compatibility or a later cleanup; concrete shipped, wire, and persisted compatibility remains governed by the compatibility rules below.
+
 ### Bridge workspace (`bridge/`)
 
 **`bridge/app` — target directory structure:**

--- a/bridge/app/lib/src/server/api/system_process_api.dart
+++ b/bridge/app/lib/src/server/api/system_process_api.dart
@@ -21,10 +21,6 @@ class SystemProcessApi {
   final bool _isWindows;
   final String _platform;
 
-  Future<List<ProcessIdentity>> listProcesses() async {
-    return _isWindows ? _listWindowsProcesses() : _listPosixProcesses();
-  }
-
   /// Spawns [executable] detached (inheriting stdio), returning its pid without
   /// waiting. Used to launch a successor bridge during a restart.
   Future<int> startDetached({
@@ -74,25 +70,6 @@ class SystemProcessApi {
       wasRequested: wasRequested,
       attemptedAt: _clock.now(),
     );
-  }
-
-  Future<List<ProcessIdentity>> _listPosixProcesses() async {
-    final (command, args) = ("ps", <String>["-axwwo", "pid=,user=,lstart=,command="]);
-    final result = await _processRunner.run(
-      command,
-      args,
-      environment: {"LC_ALL": "C"},
-    );
-    if (result.exitCode != 0) {
-      throw ProcessException(
-        command,
-        args,
-        result.stderr.toString(),
-        result.exitCode,
-      );
-    }
-
-    return _parsePosixProcesses(stdout: result.stdout.toString());
   }
 
   /// Inspects a single POSIX process by querying `ps -p <pid>` so the OS
@@ -171,25 +148,6 @@ class SystemProcessApi {
       );
     }
     return processes;
-  }
-
-  Future<List<ProcessIdentity>> _listWindowsProcesses() async {
-    // The verbose form resolves extra metadata for every process and can hang
-    // long enough to abort bridge startup. Windows process listing only needs
-    // the image name and PID supplied by the basic tasklist output.
-    const command = "tasklist";
-    final args = <String>["/FO", "CSV", "/NH"];
-    final result = await _processRunner.run(command, args);
-    if (result.exitCode != 0) {
-      throw ProcessException(
-        command,
-        args,
-        result.stderr.toString(),
-        result.exitCode,
-      );
-    }
-
-    return _parseWindowsProcesses(stdout: result.stdout.toString());
   }
 
   /// Inspects a single Windows process by querying `tasklist` with its

--- a/bridge/app/lib/src/server/host/bridge_host_process_service.dart
+++ b/bridge/app/lib/src/server/host/bridge_host_process_service.dart
@@ -77,11 +77,6 @@ class BridgeHostProcessService implements HostProcessService {
   }
 
   @override
-  Future<List<ProcessIdentity>> list({required int? excludePid}) {
-    return _processRepository.listProcessIdentities(excludePid: excludePid);
-  }
-
-  @override
   Future<SignalResult> signalGraceful({required int pid}) {
     return _processRepository.sendGracefulSignal(pid: pid);
   }

--- a/bridge/app/lib/src/server/repositories/process_repository.dart
+++ b/bridge/app/lib/src/server/repositories/process_repository.dart
@@ -30,23 +30,6 @@ class ProcessRepository {
     return _toMatch(identity: identity);
   }
 
-  Future<List<ProcessIdentity>> listProcessIdentities({required int? excludePid}) async {
-    final processes = await _api.listProcesses();
-    final identities = <ProcessIdentity>[];
-    for (final identity in processes) {
-      if (excludePid != null && identity.pid == excludePid) {
-        continue;
-      }
-      identities.add(identity);
-    }
-    return identities;
-  }
-
-  Future<List<ProcessMatch>> listProcesses({required int? excludePid}) async {
-    final identities = await listProcessIdentities(excludePid: excludePid);
-    return identities.map((ProcessIdentity identity) => _toMatch(identity: identity)).toList();
-  }
-
   Future<int> startDetached({
     required String executable,
     required List<String> arguments,

--- a/bridge/app/test/server/api/system_process_api_test.dart
+++ b/bridge/app/test/server/api/system_process_api_test.dart
@@ -7,33 +7,6 @@ import "package:test/test.dart";
 
 void main() {
   group("SystemProcessApi (Windows)", () {
-    test("listProcesses avoids verbose tasklist and parses basic rows", () async {
-      final runner = _RecordingProcessRunner(
-        stdout:
-            '"sesori-bridge.exe","321","Console","1","12,345 K"\r\n'
-            '"opencode.exe","654","Console","1","98,765 K"\r\n',
-      );
-      final api = SystemProcessApi(
-        processRunner: runner,
-        clock: const ServerClock(),
-        isWindows: true,
-        platform: "windows",
-      );
-
-      final identities = await api.listProcesses();
-
-      expect(runner.calls, hasLength(1));
-      final call = runner.calls.single;
-      expect(call.executable, equals("tasklist"));
-      expect(call.arguments, equals(<String>["/FO", "CSV", "/NH"]));
-      expect(identities.map((identity) => identity.pid), equals(<int>[321, 654]));
-      expect(
-        identities.map((identity) => identity.executablePath),
-        equals(<String>["sesori-bridge.exe", "opencode.exe"]),
-      );
-      expect(identities.map((identity) => identity.ownerUser), everyElement(isNull));
-    });
-
     test("inspectProcess issues a PID-scoped tasklist filter", () async {
       final runner = _RecordingProcessRunner(
         stdout: '"sesori-bridge.exe","321","Console","1","12,345 K","Running","HOST\\alex","0:00:01","N/A"\r\n',

--- a/bridge/app/test/server/host/bridge_host_info_impl_test.dart
+++ b/bridge/app/test/server/host/bridge_host_info_impl_test.dart
@@ -159,16 +159,6 @@ class _FakeProcessRepository implements ProcessRepository {
   }
 
   @override
-  Future<List<ProcessIdentity>> listProcessIdentities({required int? excludePid}) {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<List<ProcessMatch>> listProcesses({required int? excludePid}) {
-    throw UnimplementedError();
-  }
-
-  @override
   Future<SignalResult> sendGracefulSignal({required int pid}) {
     throw UnimplementedError();
   }

--- a/bridge/app/test/server/host/bridge_host_process_service_test.dart
+++ b/bridge/app/test/server/host/bridge_host_process_service_test.dart
@@ -121,7 +121,7 @@ void main() {
 
     test('spawn falls back when inspection throws instead of failing the spawn', () async {
       starter.process = _FakeProcess(pidValue: 7001);
-      processRepository.inspectError = const ProcessException('ps', <String>['-axwwo']);
+      processRepository.inspectError = const ProcessException('ps', <String>['-p', '7001']);
 
       final spawned = await spawnAgent();
 
@@ -217,7 +217,7 @@ void main() {
       expect(await spawned.exitCode, 3);
     });
 
-    test('inspect and list delegate to the process repository', () async {
+    test('inspect delegates to the process repository', () async {
       final identity = _identity(
         pid: 211,
         startMarker: 'marker',
@@ -225,11 +225,8 @@ void main() {
         commandLine: '/usr/local/bin/opencode serve',
       );
       processRepository.inspectResults[211] = <ProcessIdentity?>[identity];
-      processRepository.identities = <ProcessIdentity>[identity];
 
       expect(await service().inspect(pid: 211), same(identity));
-      expect(await service().list(excludePid: 100), equals(<ProcessIdentity>[identity]));
-      expect(processRepository.lastExcludePid, 100);
     });
 
     test('signalGraceful and signalForce delegate to the process repository', () async {
@@ -409,8 +406,6 @@ class _FakeProcessRepository implements ProcessRepository {
 
   final Map<int, List<ProcessIdentity?>> inspectResults = <int, List<ProcessIdentity?>>{};
   Object? inspectError;
-  List<ProcessIdentity> identities = <ProcessIdentity>[];
-  int? lastExcludePid;
   SignalResult? gracefulResult;
   SignalResult? forceResult;
   final List<String> signalRequests = <String>[];
@@ -429,12 +424,6 @@ class _FakeProcessRepository implements ProcessRepository {
   }
 
   @override
-  Future<List<ProcessIdentity>> listProcessIdentities({required int? excludePid}) async {
-    lastExcludePid = excludePid;
-    return identities;
-  }
-
-  @override
   Future<SignalResult> sendGracefulSignal({required int pid}) async {
     signalRequests.add('graceful:$pid');
     return gracefulResult!;
@@ -448,11 +437,6 @@ class _FakeProcessRepository implements ProcessRepository {
 
   @override
   Future<ProcessMatch?> inspectProcessMatch({required int pid}) {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<List<ProcessMatch>> listProcesses({required int? excludePid}) {
     throw UnimplementedError();
   }
 }

--- a/bridge/app/test/server/host/bridge_plugin_host_impl_test.dart
+++ b/bridge/app/test/server/host/bridge_plugin_host_impl_test.dart
@@ -138,16 +138,6 @@ class _UnusedProcessRepository implements ProcessRepository {
   }
 
   @override
-  Future<List<ProcessIdentity>> listProcessIdentities({required int? excludePid}) {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<List<ProcessMatch>> listProcesses({required int? excludePid}) {
-    throw UnimplementedError();
-  }
-
-  @override
   Future<SignalResult> sendGracefulSignal({required int pid}) {
     throw UnimplementedError();
   }

--- a/bridge/app/test/server/repositories/bridge_instance_repository_test.dart
+++ b/bridge/app/test/server/repositories/bridge_instance_repository_test.dart
@@ -39,7 +39,6 @@ void main() {
       expect(candidates.first.startMarker, equals('Fri May 15 12:00:00 2026'));
       expect(processIdLookupRunner.executableNames, equals(<String>['sesori-bridge']));
       expect(processApi.inspectedPids, equals(<int>[10, 12]));
-      expect(processApi.listCallCount, equals(0));
     });
 
     test('filters other-user and pid-recycled non-bridge processes', () async {
@@ -171,18 +170,11 @@ class _LookupProcessRunner implements ProcessRunner {
 class _FakeSystemProcessApi implements SystemProcessApi {
   final Map<int, ProcessIdentity?> inspectionFacts = <int, ProcessIdentity?>{};
   final List<int> inspectedPids = <int>[];
-  int listCallCount = 0;
 
   @override
   Future<ProcessIdentity?> inspectProcess({required int pid}) async {
     inspectedPids.add(pid);
     return inspectionFacts[pid];
-  }
-
-  @override
-  Future<List<ProcessIdentity>> listProcesses() async {
-    listCallCount += 1;
-    return const <ProcessIdentity>[];
   }
 
   @override

--- a/bridge/app/test/server/repositories/process_repository_test.dart
+++ b/bridge/app/test/server/repositories/process_repository_test.dart
@@ -1,5 +1,3 @@
-import "dart:async";
-
 import "package:sesori_bridge/src/server/api/system_process_api.dart";
 import "package:sesori_bridge/src/server/foundation/process_match.dart";
 import "package:sesori_bridge/src/server/repositories/process_repository.dart";
@@ -44,46 +42,40 @@ void main() {
       expect(identity.capturedAt, equals(capturedAt));
     });
 
-    test("process inspection classifies bridge, OpenCode, and unknown matches", () async {
-      api.listFacts = <ProcessIdentity>[
-        ProcessIdentity(
-          pid: 10,
-          startMarker: null,
-          executablePath: "/Users/alex/.local/bin/sesori-bridge",
-          commandLine: "/Users/alex/.local/bin/sesori-bridge --relay wss://relay.sesori.com",
-          ownerUser: ProcessUser.fromRawUser("alex"),
-          platform: "macos",
-          capturedAt: DateTime.utc(2026, 5, 15, 12),
-        ),
-        ProcessIdentity(
-          pid: 11,
-          startMarker: null,
-          executablePath: "/usr/local/bin/opencode",
-          commandLine: "/usr/local/bin/opencode serve --port 45111",
-          ownerUser: ProcessUser.fromRawUser("alex"),
-          platform: "macos",
-          capturedAt: DateTime.utc(2026, 5, 15, 12, 1),
-        ),
-        ProcessIdentity(
-          pid: 12,
-          startMarker: null,
-          executablePath: "/usr/bin/python3",
-          commandLine: "python3 worker.py",
-          ownerUser: ProcessUser.fromRawUser("other"),
-          platform: "macos",
-          capturedAt: DateTime.utc(2026, 5, 15, 12, 2),
-        ),
-      ];
+    test("targeted process inspection classifies bridge and unknown matches", () async {
+      api.inspectFact = ProcessIdentity(
+        pid: 10,
+        startMarker: null,
+        executablePath: "/Users/alex/.local/bin/sesori-bridge",
+        commandLine: "/Users/alex/.local/bin/sesori-bridge --relay wss://relay.sesori.com",
+        ownerUser: ProcessUser.fromRawUser("alex"),
+        platform: "macos",
+        capturedAt: DateTime.utc(2026, 5, 15, 12),
+      );
 
-      final matches = await repository.listProcesses(excludePid: 11);
+      final bridgeMatch = await repository.inspectProcessMatch(pid: 10);
 
-      expect(matches, hasLength(2));
-      expect(matches.first.kind, equals(ProcessMatchKind.sesoriBridge));
-      expect(matches.first.isCurrentUserProcess, isTrue);
-      expect(matches.first.identity.pid, equals(10));
-      expect(matches.last.kind, equals(ProcessMatchKind.unknown));
-      expect(matches.last.isCurrentUserProcess, isFalse);
-      expect(matches.last.identity.startMarker, isNull);
+      expect(bridgeMatch, isNotNull);
+      expect(bridgeMatch!.kind, equals(ProcessMatchKind.sesoriBridge));
+      expect(bridgeMatch.isCurrentUserProcess, isTrue);
+      expect(bridgeMatch.identity.pid, equals(10));
+
+      api.inspectFact = ProcessIdentity(
+        pid: 12,
+        startMarker: null,
+        executablePath: "/usr/bin/python3",
+        commandLine: "python3 worker.py",
+        ownerUser: ProcessUser.fromRawUser("other"),
+        platform: "macos",
+        capturedAt: DateTime.utc(2026, 5, 15, 12, 2),
+      );
+
+      final unknownMatch = await repository.inspectProcessMatch(pid: 12);
+
+      expect(unknownMatch, isNotNull);
+      expect(unknownMatch!.kind, equals(ProcessMatchKind.unknown));
+      expect(unknownMatch.isCurrentUserProcess, isFalse);
+      expect(unknownMatch.identity.startMarker, isNull);
     });
 
     test("process repository exposes graceful and force signal primitives", () async {
@@ -109,7 +101,6 @@ void main() {
       expect(force.requestedSignal, equals(ShutdownSignal.force));
       expect(api.signalRequests, equals(<String>["graceful:44", "force:44"]));
       expect(api.inspectPid, isNull);
-      expect(api.listCallCount, equals(0));
     });
   });
 }
@@ -125,23 +116,15 @@ class _FakeSystemProcessApi implements SystemProcessApi {
   }
 
   ProcessIdentity? inspectFact;
-  List<ProcessIdentity> listFacts = <ProcessIdentity>[];
   SignalResult? gracefulResult;
   SignalResult? forceResult;
   int? inspectPid;
-  int listCallCount = 0;
   final List<String> signalRequests = <String>[];
 
   @override
   Future<ProcessIdentity?> inspectProcess({required int pid}) async {
     inspectPid = pid;
     return inspectFact;
-  }
-
-  @override
-  Future<List<ProcessIdentity>> listProcesses() async {
-    listCallCount += 1;
-    return listFacts;
   }
 
   @override

--- a/bridge/app/test/server/services/bridge_instance_service_test.dart
+++ b/bridge/app/test/server/services/bridge_instance_service_test.dart
@@ -573,16 +573,6 @@ class _FakeProcessRepository implements ProcessRepository {
   }
 
   @override
-  Future<List<ProcessIdentity>> listProcessIdentities({required int? excludePid}) async {
-    return const <ProcessIdentity>[];
-  }
-
-  @override
-  Future<List<ProcessMatch>> listProcesses({required int? excludePid}) async {
-    return const <ProcessMatch>[];
-  }
-
-  @override
   Future<SignalResult> sendGracefulSignal({required int pid}) async {
     signalRequests.add('graceful:$pid');
     if (throwGraceful) {

--- a/bridge/app/test/server/startup_mutex_repository_test.dart
+++ b/bridge/app/test/server/startup_mutex_repository_test.dart
@@ -335,16 +335,6 @@ class _FakeProcessRepository implements ProcessRepository {
   }
 
   @override
-  Future<List<ProcessIdentity>> listProcessIdentities({required int? excludePid}) async {
-    return const <ProcessIdentity>[];
-  }
-
-  @override
-  Future<List<ProcessMatch>> listProcesses({required int? excludePid}) async {
-    return const <ProcessMatch>[];
-  }
-
-  @override
   Future<SignalResult> sendGracefulSignal({required int pid}) {
     throw UnimplementedError();
   }

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
@@ -146,9 +146,6 @@ class _ProbeProcessService implements HostProcessService {
   Future<ProcessIdentity?> inspect({required int pid}) async => null;
 
   @override
-  Future<List<ProcessIdentity>> list({required int? excludePid}) async => const <ProcessIdentity>[];
-
-  @override
   Future<SignalResult> signalGraceful({required int pid}) async => _signal(pid);
 
   @override

--- a/bridge/sesori_plugin_interface/lib/src/host/host_process_service.dart
+++ b/bridge/sesori_plugin_interface/lib/src/host/host_process_service.dart
@@ -28,10 +28,6 @@ abstract class HostProcessService {
   /// process is running.
   Future<ProcessIdentity?> inspect({required int pid});
 
-  /// Lists the identities of all visible processes, optionally excluding
-  /// [excludePid] (typically the caller's own pid; pass `null` to list all).
-  Future<List<ProcessIdentity>> list({required int? excludePid});
-
   /// Sends the platform's graceful-stop signal to [pid] (SIGTERM on POSIX;
   /// Windows has no graceful signal and delivers a kill instead — the
   /// returned [SignalResult] records what was actually sent).

--- a/bridge/sesori_plugin_interface/test/lifecycle/bridge_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_interface/test/lifecycle/bridge_plugin_descriptor_test.dart
@@ -204,9 +204,6 @@ class _UnusedProcessService implements HostProcessService {
   Future<ProcessIdentity?> inspect({required int pid}) => throw UnimplementedError();
 
   @override
-  Future<List<ProcessIdentity>> list({required int? excludePid}) => throw UnimplementedError();
-
-  @override
   Future<SignalResult> signalGraceful({required int pid}) => throw UnimplementedError();
 
   @override

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_availability_test.dart
@@ -195,9 +195,6 @@ class _ProbeProcessService implements HostProcessService {
   Future<ProcessIdentity?> inspect({required int pid}) async => null;
 
   @override
-  Future<List<ProcessIdentity>> list({required int? excludePid}) async => const <ProcessIdentity>[];
-
-  @override
   Future<SignalResult> signalGraceful({required int pid}) async => _signal(pid);
 
   @override

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_test.dart
@@ -917,9 +917,6 @@ class _FakeHostProcessService implements HostProcessService {
   Future<ProcessIdentity?> inspect({required int pid}) async => inspectResults[pid];
 
   @override
-  Future<List<ProcessIdentity>> list({required int? excludePid}) async => const <ProcessIdentity>[];
-
-  @override
   Future<SignalResult> signalGraceful({required int pid}) async {
     signals.add("graceful:$pid");
     inspectResults.remove(pid);

--- a/bridge/sesori_plugin_runtime/test/managed_process_service_intent_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_process_service_intent_test.dart
@@ -381,9 +381,6 @@ class _FakeHostProcessService implements HostProcessService {
   }
 
   @override
-  Future<List<ProcessIdentity>> list({required int? excludePid}) async => const <ProcessIdentity>[];
-
-  @override
   Future<SignalResult> signalForce({required int pid}) async {
     signalRequests.add("force:$pid");
     return _signal(pid: pid, signal: ShutdownSignal.force);

--- a/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_process_service_start_test.dart
@@ -1036,9 +1036,6 @@ class _FakeHostProcessService implements HostProcessService {
   }
 
   @override
-  Future<List<ProcessIdentity>> list({required int? excludePid}) async => const <ProcessIdentity>[];
-
-  @override
   Future<SignalResult> signalForce({required int pid}) async {
     signalRequests.add("force:$pid");
     forceHooks[pid]?.call();

--- a/bridge/sesori_plugin_runtime/test/managed_process_service_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_process_service_test.dart
@@ -552,9 +552,6 @@ class _FakeHostProcessService implements HostProcessService {
   }
 
   @override
-  Future<List<ProcessIdentity>> list({required int? excludePid}) async => const <ProcessIdentity>[];
-
-  @override
   Future<SignalResult> signalForce({required int pid}) async {
     signalRequests.add("force:$pid");
     forceHooks[pid]?.call();

--- a/bridge/sesori_plugin_runtime/test/managed_runtime_monitor_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_runtime_monitor_test.dart
@@ -596,9 +596,6 @@ class _FakeHostProcessService implements HostProcessService {
   }
 
   @override
-  Future<List<ProcessIdentity>> list({required int? excludePid}) async => const <ProcessIdentity>[];
-
-  @override
   Future<SignalResult> signalForce({required int pid}) async {
     signalRequests.add("force:$pid");
     forceHooks[pid]?.call();


### PR DESCRIPTION
## Summary

Follow-up to #473. Targeted executable-name discovery and PID inspection replaced the previous full process-table path, leaving the old listing capability with no production callers.

- Remove `HostProcessService.list` and its bridge API/repository forwarding chain.
- Remove unfiltered POSIX `ps -ax...` and Windows `tasklist` listing implementations.
- Remove obsolete tests, fake overrides, state, and imports across bridge plugins.
- Preserve process classification coverage through targeted `inspectProcessMatch` calls.
- Record the repo-wide rule to remove code made obsolete by a refactor in the same change.

## Testing

- Focused tests across app, plugin interface, plugin runtime, OpenCode, and Cursor
- Strict `dart analyze --fatal-infos` in every changed module
- `make test` in `bridge` (1,889 tests)
- `make analyze` in `bridge`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused “list all processes” path across `bridge` and now rely solely on PID-scoped inspection. This simplifies the API and removes OS-wide `ps/tasklist` scans without changing behavior.

- **Refactors**
  - Deleted `SystemProcessApi.listProcesses`, `_listPosixProcesses`, and `_listWindowsProcesses`.
  - Removed `HostProcessService.list` and repository methods `listProcessIdentities`/`listProcesses`.
  - Updated tests, fakes, and plugins to use targeted `inspect({pid})`/`inspectProcessMatch(pid)`.
  - Added a repository rule in `AGENTS.md` to delete code made obsolete by a refactor.

<sup>Written for commit 74a6c29fb5ee655fa523995d7af6d1d8e3d030b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

