### PR TITLE
feat(ui): swipe project rows to reveal rename and hide actions

### DIFF
--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -221,7 +221,10 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
             itemCount: projects.length,
             itemBuilder: (context, index) {
               final project = projects[index];
+              // Keyed so a recycled element can't carry one project's revealed
+              // swipe actions onto another project's row.
               return ProjectTile(
+                key: ValueKey(project.id),
                 project: project,
                 activeSessions: activityById[project.id] ?? 0,
                 unseen: unseenByProjectId[project.id] ?? project.hasUnseenChanges,

--- a/client/app/lib/features/project_list/widgets/project_tile.dart
+++ b/client/app/lib/features/project_list/widgets/project_tile.dart
@@ -83,11 +83,6 @@ class ProjectTile extends StatelessWidget {
   /// row it is anchored to.
   static const double _menuWidth = 200;
 
-  /// The hide pill's resting width, from the design. Wider than the label
-  /// needs, so the row's committing action reads as the bigger target; the
-  /// pill stretches from here during an overdrag.
-  static const double _hidePillWidth = 136;
-
   @override
   Widget build(BuildContext context) {
     return PregoAnchorMenu(
@@ -172,7 +167,6 @@ class ProjectTile extends StatelessWidget {
           _renameAction(context: context, close: close),
         ],
         primaryActionBuilder: (context, close) => _hideAction(context: context, close: close),
-        primaryActionWidth: _hidePillWidth,
         onFullSwipe: () => unawaited(_hide(context: context)),
         // Right-click is the mouse counterpart of long-press. The row also has
         // to announce itself as a button and as one thing: that came free from
@@ -248,8 +242,10 @@ class ProjectTile extends StatelessWidget {
   }
 
   /// The swipe strip's hide pill — the primary action, which is also what a
-  /// full swipe commits. Fills the width [PregoSwipeActions] gives it so it
-  /// can stretch during an overdrag.
+  /// full swipe commits. Sized by its own content at rest; when
+  /// [PregoSwipeActions] widens its box during an overdrag, the button's
+  /// centered content rides the stretch. Not `fullWidth`: that needs a
+  /// bounded parent, and at rest the strip's width is open-ended.
   Widget _hideAction({required BuildContext context, required VoidCallback close}) {
     return PregoButtonsSolid(
       label: context.loc.hide,
@@ -257,7 +253,6 @@ class ProjectTile extends StatelessWidget {
       hierarchy: PregoButtonsSolidHierarchy.primary,
       type: PregoButtonsSolidType.warning,
       size: PregoButtonsSolidSize.md,
-      fullWidth: true,
       onPressed: () {
         close();
         unawaited(_hide(context: context));

--- a/client/app/lib/features/project_list/widgets/project_tile.dart
+++ b/client/app/lib/features/project_list/widgets/project_tile.dart
@@ -5,6 +5,7 @@ import "package:flutter_bloc/flutter_bloc.dart";
 import "package:path/path.dart" as p;
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
 import "package:theme_prego/module_prego.dart";
 
 import "../../../core/constants.dart";
@@ -52,6 +53,11 @@ String _toPosix(String path) => path.replaceAll(r"\", "/");
 /// anchored to the row, so the project being acted on stays visible beside the
 /// menu instead of being covered by a bottom sheet.
 ///
+/// The same actions are also behind a swipe ([PregoSwipeActions]): a partial
+/// swipe toward the start edge settles the row open on a rename button and a
+/// hide pill, and a full swipe commits the hide directly. The swipe is the
+/// quick path; the menu stays the discoverable and assistive one.
+///
 /// The menu is forced flat on every platform ([PregoAnchorMenu.flat]), like the
 /// onboarding support menu: the glass popup morphs out of its trigger's bounds,
 /// which for a full-width row reads as the row collapsing into a small panel,
@@ -76,6 +82,11 @@ class ProjectTile extends StatelessWidget {
   /// Wide enough for the longest action label without the panel spanning the
   /// row it is anchored to.
   static const double _menuWidth = 200;
+
+  /// The hide pill's resting width, from the design. Wider than the label
+  /// needs, so the row's committing action reads as the bigger target; the
+  /// pill stretches from here during an overdrag.
+  static const double _hidePillWidth = 136;
 
   @override
   Widget build(BuildContext context) {
@@ -148,62 +159,109 @@ class ProjectTile extends StatelessWidget {
     // darker than the rest so the reason is still legible.
     final dimmed = missing ? prego.colors.textDisabled : null;
 
-    // Right-click is the mouse counterpart of long-press. The row also has to
-    // announce itself as a button and as one thing: that came free from
-    // ListTile, whereas an InkWell contributes only the actions, not the role,
-    // and leaves the row's three lines as three separate nodes to swipe past.
-    return GestureDetector(
-      onSecondaryTap: openMenu,
-      child: MergeSemantics(
-        child: Semantics(
-          button: true,
-          child: InkWell(
-            onTap: () => _open(context: context, displayName: displayName, missing: missing),
-            onLongPress: openMenu,
-            child: Container(
-              padding: const EdgeInsets.symmetric(
-                horizontal: PregoSpacing.xl,
-                vertical: PregoSpacing.lg,
-              ),
-              decoration: BoxDecoration(
-                // A zero-width side is a single physical pixel and costs the
-                // row no height, so the divider doesn't push the list off its
-                // pitch.
-                border: Border(bottom: BorderSide(color: prego.colors.borderTertiary, width: 0)),
-              ),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      spacing: PregoSpacing.xs,
-                      children: [
-                        _titleRow(prego: prego, displayName: displayName, dimmed: dimmed),
-                        Text(
-                          projectShortPath(project),
-                          style: prego.textTheme.textSm.regular.copyWith(
-                            color: dimmed ?? prego.colors.textSecondary,
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
+    // The hairline sits outside the swipe stack so the divider holds still
+    // while the row's content slides. A zero-width side is a single physical
+    // pixel and costs the row no height, so the divider doesn't push the list
+    // off its pitch.
+    return Container(
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: prego.colors.borderTertiary, width: 0)),
+      ),
+      child: PregoSwipeActions(
+        actionsBuilder: (context, close) => [
+          _renameAction(context: context, close: close),
+        ],
+        primaryActionBuilder: (context, close) => _hideAction(context: context, close: close),
+        primaryActionWidth: _hidePillWidth,
+        onFullSwipe: () => unawaited(_hide(context: context)),
+        // Right-click is the mouse counterpart of long-press. The row also has
+        // to announce itself as a button and as one thing: that came free from
+        // ListTile, whereas an InkWell contributes only the actions, not the
+        // role, and leaves the row's three lines as three separate nodes to
+        // swipe past.
+        child: GestureDetector(
+          onSecondaryTap: openMenu,
+          child: MergeSemantics(
+            child: Semantics(
+              button: true,
+              child: InkWell(
+                onTap: () => _open(context: context, displayName: displayName, missing: missing),
+                onLongPress: openMenu,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: PregoSpacing.xl,
+                    vertical: PregoSpacing.lg,
+                  ),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          spacing: PregoSpacing.xs,
+                          children: [
+                            _titleRow(prego: prego, displayName: displayName, dimmed: dimmed),
+                            Text(
+                              projectShortPath(project),
+                              style: prego.textTheme.textSm.regular.copyWith(
+                                color: dimmed ?? prego.colors.textSecondary,
+                              ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            _StatusRow(project: project, activeSessions: activeSessions, unseen: unseen),
+                          ],
                         ),
-                        _StatusRow(project: project, activeSessions: activeSessions, unseen: unseen),
-                      ],
-                    ),
+                      ),
+                      ExcludeSemantics(
+                        child: Icon(
+                          TablerLight.chevron_right,
+                          size: _chevronSize,
+                          color: dimmed ?? prego.colors.textSecondary,
+                        ),
+                      ),
+                    ],
                   ),
-                  ExcludeSemantics(
-                    child: Icon(
-                      TablerLight.chevron_right,
-                      size: _chevronSize,
-                      color: dimmed ?? prego.colors.textSecondary,
-                    ),
-                  ),
-                ],
+                ),
               ),
             ),
           ),
         ),
       ),
+    );
+  }
+
+  /// The swipe strip's rename button. Icon-only, so the label rides in the
+  /// semantics instead.
+  Widget _renameAction({required BuildContext context, required VoidCallback close}) {
+    return Semantics(
+      label: context.loc.rename,
+      child: PregoButtonsSolid.iconOnly(
+        leadingIcon: TablerRegular.pencil,
+        hierarchy: PregoButtonsSolidHierarchy.secondary,
+        size: PregoButtonsSolidSize.md,
+        onPressed: () {
+          close();
+          _rename(context: context);
+        },
+      ),
+    );
+  }
+
+  /// The swipe strip's hide pill — the primary action, which is also what a
+  /// full swipe commits. Fills the width [PregoSwipeActions] gives it so it
+  /// can stretch during an overdrag.
+  Widget _hideAction({required BuildContext context, required VoidCallback close}) {
+    return PregoButtonsSolid(
+      label: context.loc.hide,
+      leadingIcon: TablerRegular.eye_off,
+      hierarchy: PregoButtonsSolidHierarchy.primary,
+      type: PregoButtonsSolidType.warning,
+      size: PregoButtonsSolidSize.md,
+      fullWidth: true,
+      onPressed: () {
+        close();
+        unawaited(_hide(context: context));
+      },
     );
   }
 

--- a/client/app/lib/l10n/app_en.arb
+++ b/client/app/lib/l10n/app_en.arb
@@ -359,6 +359,10 @@
   "projectHidden": "Project hidden",
   "projectHideFailed": "Failed to hide project",
   "hideProject": "Hide Project",
+  "hide": "Hide",
+  "@hide": {
+    "description": "Label on the swipe-revealed hide button of a project row. Kept short — the button is a compact pill."
+  },
   "projectFolderMissing": "Unavailable",
   "@projectFolderMissing": {
     "description": "Status shown on a project row whose folder no longer exists on disk. The row is greyed out and cannot be opened."

--- a/client/app/lib/l10n/app_localizations.dart
+++ b/client/app/lib/l10n/app_localizations.dart
@@ -1225,6 +1225,12 @@ abstract class AppLocalizations {
   /// **'Hide Project'**
   String get hideProject;
 
+  /// Label on the swipe-revealed hide button of a project row. Kept short — the button is a compact pill.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide'**
+  String get hide;
+
   /// Status shown on a project row whose folder no longer exists on disk. The row is greyed out and cannot be opened.
   ///
   /// In en, this message translates to:

--- a/client/app/lib/l10n/app_localizations_en.dart
+++ b/client/app/lib/l10n/app_localizations_en.dart
@@ -622,6 +622,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get hideProject => 'Hide Project';
 
   @override
+  String get hide => 'Hide';
+
+  @override
   String get projectFolderMissing => 'Unavailable';
 
   @override

--- a/client/app/test/features/project_list/project_tile_swipe_test.dart
+++ b/client/app/test/features/project_list/project_tile_swipe_test.dart
@@ -1,0 +1,216 @@
+import "package:flutter/material.dart";
+import "package:flutter_bloc/flutter_bloc.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:go_router/go_router.dart";
+import "package:mocktail/mocktail.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_mobile/core/di/injection.dart";
+import "package:sesori_mobile/features/project_list/project_list_screen.dart";
+import "package:sesori_mobile/features/project_list/rename_project_dialog.dart";
+import "package:sesori_mobile/features/project_list/widgets/project_tile.dart";
+import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/module_prego.dart";
+
+import "../../helpers/test_helpers.dart";
+
+/// Swiping a project row toward its start edge reveals the rename button and
+/// the hide pill ([PregoSwipeActions]); a full swipe commits the hide without
+/// the buttons. The long-press menu stays as the other path to the same
+/// actions.
+///
+/// Drag distances assume the 800px default test surface: the reveal strip is
+/// ~204px (settle-open past ~102px of drag) and the full-swipe commit
+/// threshold is 480px. ~20px of every drag is spent on touch slop.
+void main() {
+  const config = ServerConnectionConfig(relayHost: "relay.example.com", authToken: "test-token");
+  const health = HealthResponse(healthy: true, version: "0.1.200", filesystemAccessDegraded: null);
+  const connected = ConnectionStatus.connected(config: config, health: health);
+
+  late BehaviorSubject<ConnectionStatus> statusController;
+  late MockConnectionService mockConnectionService;
+  late MockProjectRepository mockProjectRepository;
+  late MockRegisteredBridgesService mockRegisteredBridgesService;
+  late StubConnectionOverlayCubit overlayCubit;
+
+  setUpAll(registerAllFallbackValues);
+
+  setUp(() {
+    statusController = BehaviorSubject<ConnectionStatus>.seeded(connected);
+    mockConnectionService = MockConnectionService();
+    mockProjectRepository = MockProjectRepository();
+    mockRegisteredBridgesService = MockRegisteredBridgesService();
+    overlayCubit = StubConnectionOverlayCubit();
+
+    when(() => mockConnectionService.status).thenAnswer((_) => statusController.stream);
+    when(() => mockConnectionService.currentStatus).thenAnswer((_) => statusController.value);
+    when(() => mockConnectionService.connectWithFreshAuthToken()).thenAnswer((_) async => true);
+    when(() => mockRegisteredBridgesService.hasRegisteredBridges()).thenAnswer((_) async => true);
+    // Hiding the only project empties the list, and the cubit enriches the
+    // empty state with the bridges it would offer to add a project on.
+    when(() => mockRegisteredBridgesService.getRegisteredBridges()).thenAnswer((_) async => const []);
+
+    getIt.registerLazySingleton<ProjectRepository>(() => mockProjectRepository);
+    registerListServices(
+      projectRepository: mockProjectRepository,
+    );
+    getIt.registerLazySingleton<ConnectionService>(() => mockConnectionService);
+    getIt.registerLazySingleton<SseEventTracker>(MockSseEventTracker.new);
+    getIt.registerLazySingleton<RouteSource>(MockRouteSource.new);
+    getIt.registerLazySingleton<SessionUnseenTracker>(FakeSessionUnseenTracker.new);
+    getIt.registerLazySingleton<RegisteredBridgesService>(() => mockRegisteredBridgesService);
+    getIt.registerLazySingleton<FailureReporter>(MockFailureReporter.new);
+  });
+
+  tearDown(() async {
+    await overlayCubit.close();
+    await statusController.close();
+    await getIt.reset();
+  });
+
+  final project = testProject(id: "/home/user/my-app", path: "/home/user/my-app");
+
+  /// Pumps the real screen with a single project loaded. A router hosts it
+  /// because the rename sheet pops itself with go_router's `context.pop()`.
+  Future<void> pumpScreen(WidgetTester tester) async {
+    when(() => mockProjectRepository.listProjects()).thenAnswer(
+      (_) async => ApiResponse.success(Projects(data: [project])),
+    );
+
+    final router = GoRouter(
+      routes: [
+        GoRoute(path: "/", builder: (_, _) => const ProjectListScreen()),
+        GoRoute(path: "/projects/:projectId/sessions", builder: (_, _) => const SizedBox.shrink()),
+      ],
+    );
+
+    await tester.pumpWidget(
+      BlocProvider<ConnectionOverlayCubit>.value(
+        value: overlayCubit,
+        child: MaterialApp.router(
+          theme: ThemeData(extensions: [PregoDesignSystem.light]),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Finder tile() => find.widgetWithText(ProjectTile, "my-app");
+
+  /// Swipes the row far enough to settle open on its actions.
+  Future<void> swipeOpen(WidgetTester tester) async {
+    await tester.drag(tile(), const Offset(-160, 0));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets("swiping the row reveals Rename and Hide without navigating or acting", (tester) async {
+    await pumpScreen(tester);
+
+    // The hide pill starts past the row's edge, clipped out of view.
+    expect(tester.getRect(find.text("Hide")).left, greaterThanOrEqualTo(800));
+
+    await swipeOpen(tester);
+
+    expect(tester.getRect(find.text("Hide")).left, lessThan(800));
+    expect(find.byIcon(TablerRegular.pencil), findsOneWidget);
+    // Still the list — the swipe is not a tap — and nothing was acted on.
+    expect(tile(), findsOneWidget);
+    verifyNever(() => mockProjectRepository.hideProject(projectId: any(named: "projectId")));
+    expect(find.byType(RenameProjectDialog), findsNothing);
+  });
+
+  testWidgets("the revealed Hide pill hides the project and confirms with a snackbar", (tester) async {
+    when(() => mockProjectRepository.hideProject(projectId: any(named: "projectId"))).thenAnswer(
+      (_) async => ApiResponse.success(null),
+    );
+
+    await pumpScreen(tester);
+    await swipeOpen(tester);
+
+    await tester.tap(find.text("Hide"));
+    await tester.pumpAndSettle();
+
+    verify(() => mockProjectRepository.hideProject(projectId: project.id)).called(1);
+    expect(find.text("Project hidden"), findsOneWidget);
+    expect(tile(), findsNothing);
+  });
+
+  testWidgets("a rejected hide from the pill keeps the row and reports the failure", (tester) async {
+    when(() => mockProjectRepository.hideProject(projectId: any(named: "projectId"))).thenAnswer(
+      (_) async => ApiResponse.error(ApiError.generic()),
+    );
+
+    await pumpScreen(tester);
+    await swipeOpen(tester);
+
+    await tester.tap(find.text("Hide"));
+    await tester.pumpAndSettle();
+
+    expect(find.text("Failed to hide project"), findsOneWidget);
+    expect(tile(), findsOneWidget);
+  });
+
+  testWidgets("the revealed rename button closes the row and opens the rename sheet", (tester) async {
+    await pumpScreen(tester);
+    await swipeOpen(tester);
+
+    await tester.tap(find.byIcon(TablerRegular.pencil));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RenameProjectDialog), findsOneWidget);
+    verifyNever(() => mockProjectRepository.hideProject(projectId: any(named: "projectId")));
+  });
+
+  testWidgets("a full swipe hides the project without touching the buttons", (tester) async {
+    when(() => mockProjectRepository.hideProject(projectId: any(named: "projectId"))).thenAnswer(
+      (_) async => ApiResponse.success(null),
+    );
+
+    await pumpScreen(tester);
+
+    await tester.drag(tile(), const Offset(-520, 0));
+    await tester.pumpAndSettle();
+
+    verify(() => mockProjectRepository.hideProject(projectId: project.id)).called(1);
+    expect(find.text("Project hidden"), findsOneWidget);
+    expect(tile(), findsNothing);
+  });
+
+  testWidgets("tapping the open row closes it instead of navigating; the next tap navigates", (tester) async {
+    await pumpScreen(tester);
+    await swipeOpen(tester);
+
+    // The tap lands on the row's close-catcher, not the content underneath.
+    await tester.tap(tile(), warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    // Closed, still on the list: the actions are back off-row and no route
+    // was pushed.
+    expect(tester.getRect(find.text("Hide")).left, greaterThanOrEqualTo(800));
+    expect(tile(), findsOneWidget);
+
+    await tester.tap(tile());
+    await tester.pumpAndSettle();
+
+    // Now it navigated: the sessions route covers the list.
+    expect(tile(), findsNothing);
+  });
+
+  testWidgets("the long-press menu still works after a swipe-open-close cycle", (tester) async {
+    await pumpScreen(tester);
+    await swipeOpen(tester);
+
+    await tester.tap(tile(), warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    await tester.longPress(tile());
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(InkWell, "Rename"), findsOneWidget);
+    expect(find.widgetWithText(InkWell, "Hide Project"), findsOneWidget);
+  });
+}

--- a/client/module_prego/lib/components/buttons/prego_buttons_solid.dart
+++ b/client/module_prego/lib/components/buttons/prego_buttons_solid.dart
@@ -266,6 +266,11 @@ class _PregoButtonsSolidState extends State<PregoButtonsSolid> {
             child: ClipRRect(
               borderRadius: BorderRadius.circular(PregoRadius.full),
               child: Stack(
+                // A box wider than the content — a tight constraint from a
+                // parent that sizes the button, like a swipe row stretching
+                // its primary action — centres the content rather than
+                // parking it at the default top-start.
+                alignment: Alignment.center,
                 children: [
                   child,
                   if (showSkeuomorphicOverlay)

--- a/client/module_prego/lib/interactions/prego_swipe_actions.dart
+++ b/client/module_prego/lib/interactions/prego_swipe_actions.dart
@@ -317,7 +317,9 @@ class _PregoSwipeActionsState extends State<PregoSwipeActions> with SingleTicker
   }
 
   void _settleTo(double target) {
-    if (_rowWidth <= 0) return;
+    // The close callback escapes to host action handlers, which may hold it
+    // across an await that outlives the row.
+    if (!mounted || _rowWidth <= 0) return;
     final value = (target / _rowWidth).clamp(0.0, 1.0);
     if (prefersReducedMotion(context)) {
       _controller.value = value;

--- a/client/module_prego/lib/interactions/prego_swipe_actions.dart
+++ b/client/module_prego/lib/interactions/prego_swipe_actions.dart
@@ -1,0 +1,338 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../motion/prego_reduced_motion.dart';
+import '../theme/prego_theme.dart';
+
+/// Builds the secondary actions revealed behind a [PregoSwipeActions] row.
+///
+/// [close] settles the row shut — call it first in an action's tap handler so
+/// the row is already closing while the action's effect (a dialog, a snackbar)
+/// plays out.
+typedef PregoSwipeActionListBuilder = List<Widget> Function(BuildContext context, VoidCallback close);
+
+/// Builds the primary action of a [PregoSwipeActions] row. Same [close]
+/// contract as [PregoSwipeActionListBuilder].
+typedef PregoSwipeActionBuilder = Widget Function(BuildContext context, VoidCallback close);
+
+/// A list row that swipes toward its start edge to reveal trailing actions —
+/// the iOS-Mail treatment: a partial swipe settles the row open with the
+/// actions tappable; continuing the swipe past the commit threshold and
+/// releasing runs [onFullSwipe] directly.
+///
+/// The actions trail the sliding content's edge (drawer motion), so the design
+/// reads as one strip: content, then actions, clipped to the row. During an
+/// overdrag past the open width the primary action stretches — its trailing
+/// edge stays pinned to the row's end while its body grows into the extra drag
+/// — which, with a haptic tick at the threshold, is the cue that releasing
+/// will commit.
+///
+/// The row closes itself on the interactions that would otherwise fight an
+/// open row: a tap anywhere outside it (which also keeps at most one row open
+/// per list, since a drag on a sibling starts with a pointer-down outside this
+/// one), a tap on the row's own content (absorbed, so the row doesn't also
+/// activate), and any scroll of the enclosing scrollable.
+///
+/// The gesture is undiscoverable to assistive tech by nature; hosts must keep
+/// an alternative path to the same actions (the project row's long-press
+/// menu). While closed the actions are excluded from semantics entirely, so
+/// the row still reads as one button.
+class PregoSwipeActions extends StatefulWidget {
+  const PregoSwipeActions({
+    super.key,
+    required this.child,
+    required this.actionsBuilder,
+    required this.primaryActionBuilder,
+    required this.primaryActionWidth,
+    required this.onFullSwipe,
+  });
+
+  /// The row content. Slides toward the start edge as the row opens.
+  final Widget child;
+
+  /// The secondary actions, laid out in order before the primary action.
+  final PregoSwipeActionListBuilder actionsBuilder;
+
+  /// The primary action — the one a full swipe commits. Rendered inside a box
+  /// the component sizes ([primaryActionWidth] plus any overdrag surplus), so
+  /// it must expand to fill the width it is given.
+  final PregoSwipeActionBuilder primaryActionBuilder;
+
+  /// The primary action's resting width. The component owns the action's box
+  /// so it can stretch it during an overdrag, which means the natural width
+  /// must be declared rather than measured — a fixed-width child would defeat
+  /// the stretch.
+  final double primaryActionWidth;
+
+  /// Committed by a full swipe: called once on release past the commit
+  /// threshold, while the row settles shut. The action owns any row removal;
+  /// if it fails, the row is simply closed.
+  final VoidCallback onFullSwipe;
+
+  @override
+  State<PregoSwipeActions> createState() => _PregoSwipeActionsState();
+}
+
+/// How long a settle (open, close) runs when motion is allowed.
+const Duration _settleDuration = Duration(milliseconds: 220);
+
+/// The fraction of the row's width past which releasing commits the full
+/// swipe.
+const double _commitFraction = 0.6;
+
+/// Velocity (logical px/s along the drag axis) treated as a fling: an opening
+/// fling settles the row open from any distance, a closing fling settles it
+/// shut and cancels a pending commit.
+const double _flingVelocity = 700;
+
+class _PregoSwipeActionsState extends State<PregoSwipeActions> with SingleTickerProviderStateMixin {
+  /// 0 is closed, 1 is the content slid fully off the row. The pixel extent is
+  /// this value times the row width, so thresholds stay proportional if the
+  /// row resizes mid-gesture.
+  late final AnimationController _controller = AnimationController(vsync: this);
+
+  final GlobalKey _stripKey = GlobalKey();
+
+  double _rowWidth = 0;
+
+  /// Measured from the actions strip's laid-out size, so token or label
+  /// changes never desync the settle target from the rendered actions.
+  double? _revealWidth;
+
+  bool _dragging = false;
+
+  /// Tracks threshold crossings during a drag, for the haptic edges and the
+  /// release decision.
+  bool _pastCommit = false;
+
+  /// The scroll position being watched while the row is revealed, so any list
+  /// scroll closes it. Null while closed.
+  ScrollPosition? _watchedScroll;
+
+  double get _extent => _controller.value * _rowWidth;
+
+  double get _overdragSurplus => math.max(0, _extent - (_revealWidth ?? double.infinity));
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_syncScrollWatch);
+  }
+
+  @override
+  void dispose() {
+    _unwatchScroll();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final actions = widget.actionsBuilder(context, _close);
+    final primary = widget.primaryActionBuilder(context, _close);
+
+    return TapRegion(
+      onTapOutside: (_) => _handleTapOutside(),
+      child: GestureDetector(
+        onHorizontalDragStart: _handleDragStart,
+        onHorizontalDragUpdate: _handleDragUpdate,
+        onHorizontalDragEnd: _handleDragEnd,
+        onHorizontalDragCancel: _handleDragCancel,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            _rowWidth = constraints.maxWidth;
+            return ClipRect(
+              child: AnimatedBuilder(
+                animation: _controller,
+                builder: (context, _) {
+                  final extent = _extent;
+                  // The content and the actions translate as one strip; the
+                  // actions sit just past the content's end edge and follow it
+                  // in.
+                  final dx = Directionality.of(context) == TextDirection.rtl ? extent : -extent;
+                  final shift = Offset(dx, 0);
+                  return Stack(
+                    children: [
+                      Transform.translate(offset: shift, child: widget.child),
+                      PositionedDirectional(
+                        start: _rowWidth,
+                        top: 0,
+                        bottom: 0,
+                        child: Transform.translate(
+                          offset: shift,
+                          // Off-screen actions must not be announced: while
+                          // closed the row reads as one merged button, and the
+                          // host's menu remains the assistive path to the same
+                          // actions.
+                          child: ExcludeSemantics(
+                            excluding: extent == 0,
+                            child: _actionsStrip(actions: actions, primary: primary),
+                          ),
+                        ),
+                      ),
+                      if (extent > 0)
+                        // Absorbs taps on the revealed row's content so it
+                        // closes instead of activating; sized to spare the
+                        // actions, which stay tappable.
+                        PositionedDirectional(
+                          start: 0,
+                          end: extent,
+                          top: 0,
+                          bottom: 0,
+                          child: ExcludeSemantics(
+                            child: GestureDetector(
+                              behavior: HitTestBehavior.opaque,
+                              onTap: _close,
+                              onSecondaryTap: _close,
+                              child: const SizedBox.expand(),
+                            ),
+                          ),
+                        ),
+                    ],
+                  );
+                },
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _actionsStrip({required List<Widget> actions, required Widget primary}) {
+    return KeyedSubtree(
+      key: _stripKey,
+      child: Padding(
+        // Start gap separates the strip from the sliding content edge; the end
+        // inset matches the row's own horizontal padding so the open actions
+        // sit flush with the rest of the screen's content.
+        padding: const EdgeInsetsDirectional.only(start: PregoSpacing.sm, end: PregoSpacing.xl),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          spacing: PregoSpacing.sm,
+          children: [
+            ...actions,
+            SizedBox(width: widget.primaryActionWidth + _overdragSurplus, child: primary),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // ── Gesture handling ───────────────────────────────────────────────────────
+
+  void _handleDragStart(DragStartDetails details) {
+    _dragging = true;
+    _controller.stop();
+    _measureRevealWidth();
+    _pastCommit = _extent >= _commitThreshold;
+  }
+
+  void _handleDragUpdate(DragUpdateDetails details) {
+    if (_rowWidth <= 0) return;
+    final extent = (_extent + _toExtentDelta(details.primaryDelta ?? 0)).clamp(0.0, _rowWidth);
+    _controller.value = extent / _rowWidth;
+
+    final past = extent >= _commitThreshold;
+    if (past == _pastCommit) return;
+    _pastCommit = past;
+    // The threshold is otherwise only visible as the stretch's progression;
+    // the tick marks the exact point past which releasing commits (and the
+    // lighter one, dragging back out again).
+    unawaited(past ? HapticFeedback.lightImpact() : HapticFeedback.selectionClick());
+  }
+
+  void _handleDragEnd(DragEndDetails details) {
+    _dragging = false;
+    final velocity = _toExtentDelta(details.primaryVelocity ?? 0);
+    // A deliberate fling back cancels a pending commit — position alone would
+    // read a fast "changed my mind" swipe as a commit.
+    if (_pastCommit && velocity > -_flingVelocity) {
+      widget.onFullSwipe();
+      _close();
+      return;
+    }
+    if (velocity > _flingVelocity) {
+      _settleTo(_revealWidth ?? 0);
+      return;
+    }
+    if (velocity < -_flingVelocity) {
+      _close();
+      return;
+    }
+    _settleToNearest();
+  }
+
+  void _handleDragCancel() {
+    _dragging = false;
+    _settleToNearest();
+  }
+
+  void _handleTapOutside() {
+    if (_extent == 0 || _dragging) return;
+    _close();
+  }
+
+  double get _commitThreshold => _commitFraction * _rowWidth;
+
+  /// Extent grows toward the start edge: a leftward drag in LTR, rightward in
+  /// RTL.
+  double _toExtentDelta(double primaryDelta) =>
+      Directionality.of(context) == TextDirection.rtl ? primaryDelta : -primaryDelta;
+
+  /// The settle target is the actions strip as laid out. Only trustworthy
+  /// while nothing is stretched, so a re-grab mid-overdrag keeps the previous
+  /// measurement.
+  void _measureRevealWidth() {
+    if (_overdragSurplus > 0) return;
+    final strip = _stripKey.currentContext?.findRenderObject();
+    if (strip is RenderBox && strip.hasSize) _revealWidth = strip.size.width;
+  }
+
+  // ── Settling ───────────────────────────────────────────────────────────────
+
+  void _close() => _settleTo(0);
+
+  void _settleToNearest() {
+    final reveal = _revealWidth ?? 0;
+    _settleTo(_extent > reveal / 2 ? reveal : 0);
+  }
+
+  void _settleTo(double target) {
+    if (_rowWidth <= 0) return;
+    final value = (target / _rowWidth).clamp(0.0, 1.0);
+    if (prefersReducedMotion(context)) {
+      _controller.value = value;
+      return;
+    }
+    unawaited(_controller.animateTo(value, duration: _settleDuration, curve: Curves.easeOutCubic));
+  }
+
+  // ── Close on scroll ────────────────────────────────────────────────────────
+
+  /// Watches the enclosing scrollable exactly while the row is revealed.
+  void _syncScrollWatch() {
+    final revealed = _controller.value > 0;
+    if (revealed && _watchedScroll == null) {
+      final scrollable = context.findAncestorStateOfType<ScrollableState>();
+      if (scrollable == null) return;
+      _watchedScroll = scrollable.position;
+      _watchedScroll?.addListener(_handleScroll);
+    } else if (!revealed) {
+      _unwatchScroll();
+    }
+  }
+
+  void _handleScroll() {
+    if (_dragging) return;
+    _close();
+  }
+
+  void _unwatchScroll() {
+    _watchedScroll?.removeListener(_handleScroll);
+    _watchedScroll = null;
+  }
+}

--- a/client/module_prego/lib/interactions/prego_swipe_actions.dart
+++ b/client/module_prego/lib/interactions/prego_swipe_actions.dart
@@ -46,7 +46,6 @@ class PregoSwipeActions extends StatefulWidget {
     required this.child,
     required this.actionsBuilder,
     required this.primaryActionBuilder,
-    required this.primaryActionWidth,
     required this.onFullSwipe,
   });
 
@@ -56,16 +55,12 @@ class PregoSwipeActions extends StatefulWidget {
   /// The secondary actions, laid out in order before the primary action.
   final PregoSwipeActionListBuilder actionsBuilder;
 
-  /// The primary action — the one a full swipe commits. Rendered inside a box
-  /// the component sizes ([primaryActionWidth] plus any overdrag surplus), so
-  /// it must expand to fill the width it is given.
+  /// The primary action — the one a full swipe commits. Rests at its own
+  /// natural width; during an overdrag the component re-boxes it wider (that
+  /// width plus the surplus), so it must fill any extra width it is given —
+  /// content that centers itself in a stretched box, the way the design
+  /// system's buttons lay out.
   final PregoSwipeActionBuilder primaryActionBuilder;
-
-  /// The primary action's resting width. The component owns the action's box
-  /// so it can stretch it during an overdrag, which means the natural width
-  /// must be declared rather than measured — a fixed-width child would defeat
-  /// the stretch.
-  final double primaryActionWidth;
 
   /// Committed by a full swipe: called once on release past the commit
   /// threshold, while the row settles shut. The action owns any row removal;
@@ -96,11 +91,18 @@ class _PregoSwipeActionsState extends State<PregoSwipeActions> with SingleTicker
 
   final GlobalKey _stripKey = GlobalKey();
 
+  final GlobalKey _primaryKey = GlobalKey();
+
   double _rowWidth = 0;
 
   /// Measured from the actions strip's laid-out size, so token or label
   /// changes never desync the settle target from the rendered actions.
   double? _revealWidth;
+
+  /// The primary action's natural width — the base the overdrag stretch grows
+  /// from. Measured alongside [_revealWidth], under the same staleness
+  /// contract.
+  double? _primaryWidth;
 
   bool _dragging = false;
 
@@ -115,6 +117,16 @@ class _PregoSwipeActionsState extends State<PregoSwipeActions> with SingleTicker
   double get _extent => _controller.value * _rowWidth;
 
   double get _overdragSurplus => math.max(0, _extent - (_revealWidth ?? double.infinity));
+
+  /// The width imposed on the primary action while the overdrag stretches it.
+  /// Null at rest and through the reveal, which leaves the action its natural
+  /// width.
+  double? get _primaryStretchTarget {
+    final surplus = _overdragSurplus;
+    final natural = _primaryWidth;
+    if (surplus <= 0 || natural == null) return null;
+    return natural + surplus;
+  }
 
   @override
   void initState() {
@@ -215,7 +227,7 @@ class _PregoSwipeActionsState extends State<PregoSwipeActions> with SingleTicker
           spacing: PregoSpacing.sm,
           children: [
             ...actions,
-            SizedBox(width: widget.primaryActionWidth + _overdragSurplus, child: primary),
+            SizedBox(key: _primaryKey, width: _primaryStretchTarget, child: primary),
           ],
         ),
       ),
@@ -227,7 +239,7 @@ class _PregoSwipeActionsState extends State<PregoSwipeActions> with SingleTicker
   void _handleDragStart(DragStartDetails details) {
     _dragging = true;
     _controller.stop();
-    _measureRevealWidth();
+    _measureRestingWidths();
     _pastCommit = _extent >= _commitThreshold;
   }
 
@@ -283,13 +295,16 @@ class _PregoSwipeActionsState extends State<PregoSwipeActions> with SingleTicker
   double _toExtentDelta(double primaryDelta) =>
       Directionality.of(context) == TextDirection.rtl ? primaryDelta : -primaryDelta;
 
-  /// The settle target is the actions strip as laid out. Only trustworthy
-  /// while nothing is stretched, so a re-grab mid-overdrag keeps the previous
-  /// measurement.
-  void _measureRevealWidth() {
+  /// The settle target is the actions strip as laid out, and the stretch base
+  /// is the primary action's own size within it. Only trustworthy while
+  /// nothing is stretched, so a re-grab mid-overdrag keeps the previous
+  /// measurements.
+  void _measureRestingWidths() {
     if (_overdragSurplus > 0) return;
     final strip = _stripKey.currentContext?.findRenderObject();
     if (strip is RenderBox && strip.hasSize) _revealWidth = strip.size.width;
+    final primary = _primaryKey.currentContext?.findRenderObject();
+    if (primary is RenderBox && primary.hasSize) _primaryWidth = primary.size.width;
   }
 
   // ── Settling ───────────────────────────────────────────────────────────────

--- a/client/module_prego/lib/module_prego.dart
+++ b/client/module_prego/lib/module_prego.dart
@@ -19,6 +19,7 @@ export 'components/surfaces/prego_bottom_sheet.dart';
 export 'components/surfaces/prego_surfaces.dart';
 export 'icons/tabler_icons.g.dart';
 export 'icons/vespr_icons.g.dart';
+export 'interactions/prego_swipe_actions.dart';
 export 'motion/prego_reduced_motion.dart';
 export 'theme/prego_glass.dart';
 export 'theme/prego_theme.dart';

--- a/client/module_prego/test/interactions/prego_swipe_actions_test.dart
+++ b/client/module_prego/test/interactions/prego_swipe_actions_test.dart
@@ -1,0 +1,334 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:theme_prego/module_prego.dart';
+
+/// The default test surface is 800 logical px wide, so the geometry the tests
+/// assert against is:
+/// - reveal width: 6 (start gap) + 40 (action) + 6 (gap) + 136 (primary) + 16
+///   (end inset) = 204, settle-open threshold 102;
+/// - commit threshold: 0.6 * 800 = 480.
+/// Drags lose ~18px to touch slop before the recognizer reports, so distances
+/// keep a margin on their side of each threshold.
+const double _surfaceWidth = 800;
+const double _revealWidth = 204;
+const double _primaryWidth = 136;
+
+class _Counters {
+  int contentTaps = 0;
+  int actionTaps = 0;
+  int primaryTaps = 0;
+  int fullSwipes = 0;
+}
+
+Widget _row({
+  required String label,
+  required _Counters counters,
+  bool closeOnAction = false,
+}) {
+  return PregoSwipeActions(
+    actionsBuilder: (context, close) => [
+      GestureDetector(
+        key: ValueKey('action-$label'),
+        behavior: HitTestBehavior.opaque,
+        onTap: () {
+          counters.actionTaps++;
+          if (closeOnAction) close();
+        },
+        child: const SizedBox(width: 40, height: 40, child: ColoredBox(color: Colors.blue)),
+      ),
+    ],
+    primaryActionBuilder: (context, close) => TextButton(
+      onPressed: () {
+        counters.primaryTaps++;
+        if (closeOnAction) close();
+      },
+      child: Text('Hide $label'),
+    ),
+    primaryActionWidth: _primaryWidth,
+    onFullSwipe: () => counters.fullSwipes++,
+    child: GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => counters.contentTaps++,
+      child: SizedBox(
+        height: 96,
+        child: Center(child: Text('$label content')),
+      ),
+    ),
+  );
+}
+
+Widget _harness({
+  required List<Widget> rows,
+  ScrollController? scrollController,
+  TextDirection textDirection = TextDirection.ltr,
+}) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [PregoDesignSystem.light]),
+    home: Directionality(
+      textDirection: textDirection,
+      child: Scaffold(
+        body: ListView(
+          controller: scrollController,
+          children: [
+            ...rows,
+            for (var i = 0; i < 10; i++) const SizedBox(height: 96),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+/// Drags [label]'s row horizontally by [dx] and lets it settle.
+Future<void> _swipe(WidgetTester tester, {required String label, required double dx}) async {
+  await tester.drag(find.text('$label content'), Offset(dx, 0));
+  await tester.pumpAndSettle();
+}
+
+/// The primary action's tappable rect for [label]'s row.
+Rect _primaryRect(WidgetTester tester, String label) =>
+    tester.getRect(find.widgetWithText(TextButton, 'Hide $label'));
+
+/// Moves a held gesture in steps, the way a finger streams move events.
+///
+/// A single big `moveBy` only wins the gesture arena: with the default
+/// [DragStartBehavior.start] the accepting event's whole delta is treated as
+/// positioning and discarded, so the drag would register as zero movement.
+/// [pumpEach] paces the stream — long pauses keep the release velocity under
+/// the fling threshold.
+Future<void> _moveInSteps(
+  WidgetTester tester,
+  TestGesture gesture, {
+  required Offset total,
+  int steps = 8,
+  Duration pumpEach = const Duration(milliseconds: 16),
+}) async {
+  final step = Offset(total.dx / steps, total.dy / steps);
+  for (var i = 0; i < steps; i++) {
+    await gesture.moveBy(step);
+    await tester.pump(pumpEach);
+  }
+}
+
+void main() {
+  testWidgets('rests closed: actions off-row, content tappable, none of the callbacks fired', (tester) async {
+    final counters = _Counters();
+    await tester.pumpWidget(_harness(rows: [_row(label: 'A', counters: counters)]));
+
+    // The strip is laid out past the row's end edge, clipped out of view.
+    expect(_primaryRect(tester, 'A').left, greaterThanOrEqualTo(_surfaceWidth));
+
+    await tester.tap(find.text('A content'));
+    await tester.pumpAndSettle();
+    expect(counters.contentTaps, 1);
+    expect(counters.actionTaps, 0);
+    expect(counters.primaryTaps, 0);
+    expect(counters.fullSwipes, 0);
+  });
+
+  testWidgets('while closed the actions are excluded from semantics', (tester) async {
+    final handle = tester.ensureSemantics();
+    final counters = _Counters();
+    await tester.pumpWidget(_harness(rows: [_row(label: 'A', counters: counters)]));
+
+    expect(find.bySemanticsLabel('Hide A'), findsNothing);
+
+    await _swipe(tester, label: 'A', dx: -150);
+
+    expect(find.bySemanticsLabel('Hide A'), findsOneWidget);
+    handle.dispose();
+  });
+
+  testWidgets('a short drag springs back closed', (tester) async {
+    final counters = _Counters();
+    await tester.pumpWidget(_harness(rows: [_row(label: 'A', counters: counters)]));
+
+    // ~62px after slop — under the 102px settle-open threshold.
+    await _swipe(tester, label: 'A', dx: -80);
+
+    expect(_primaryRect(tester, 'A').left, greaterThanOrEqualTo(_surfaceWidth));
+  });
+
+  testWidgets('a drag past half the reveal settles open with the actions in place and tappable', (tester) async {
+    final counters = _Counters();
+    await tester.pumpWidget(_harness(rows: [_row(label: 'A', counters: counters)]));
+
+    await _swipe(tester, label: 'A', dx: -150);
+
+    // Open geometry: the primary sits its own width plus the end inset from
+    // the row's end; the reveal width was measured, not declared.
+    final rect = _primaryRect(tester, 'A');
+    expect(rect.left, moreOrLessEquals(_surfaceWidth - 16 - _primaryWidth, epsilon: 1));
+    expect(rect.width, moreOrLessEquals(_primaryWidth, epsilon: 1));
+
+    await tester.tap(find.text('Hide A'));
+    await tester.pumpAndSettle();
+    expect(counters.primaryTaps, 1);
+
+    final actionTarget = tester.getCenter(find.byKey(const ValueKey('action-A')));
+    expect(actionTarget.dx, moreOrLessEquals(_surfaceWidth - _revealWidth + 6 + 20, epsilon: 1));
+    await tester.tap(find.byKey(const ValueKey('action-A')));
+    await tester.pumpAndSettle();
+    expect(counters.actionTaps, 1);
+    expect(counters.fullSwipes, 0);
+  });
+
+  testWidgets('an action can close the row through the builder callback', (tester) async {
+    final counters = _Counters();
+    await tester.pumpWidget(_harness(rows: [_row(label: 'A', counters: counters, closeOnAction: true)]));
+
+    await _swipe(tester, label: 'A', dx: -150);
+    await tester.tap(find.text('Hide A'));
+    await tester.pumpAndSettle();
+
+    expect(counters.primaryTaps, 1);
+    expect(_primaryRect(tester, 'A').left, greaterThanOrEqualTo(_surfaceWidth));
+  });
+
+  testWidgets('tapping the open row closes it without activating the content, which works again after', (tester) async {
+    final counters = _Counters();
+    await tester.pumpWidget(_harness(rows: [_row(label: 'A', counters: counters)]));
+
+    await _swipe(tester, label: 'A', dx: -150);
+    // The tap intentionally lands on the close-catcher covering the content.
+    await tester.tap(find.text('A content'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    expect(counters.contentTaps, 0);
+    expect(_primaryRect(tester, 'A').left, greaterThanOrEqualTo(_surfaceWidth));
+
+    await tester.tap(find.text('A content'));
+    await tester.pumpAndSettle();
+    expect(counters.contentTaps, 1);
+  });
+
+  testWidgets('a tap anywhere outside the open row closes it', (tester) async {
+    final counters = _Counters();
+    final other = _Counters();
+    await tester.pumpWidget(
+      _harness(rows: [_row(label: 'A', counters: counters), _row(label: 'B', counters: other)]),
+    );
+
+    await _swipe(tester, label: 'A', dx: -150);
+    await tester.tap(find.text('B content'));
+    await tester.pumpAndSettle();
+
+    expect(_primaryRect(tester, 'A').left, greaterThanOrEqualTo(_surfaceWidth));
+  });
+
+  testWidgets('opening a second row closes the first', (tester) async {
+    final a = _Counters();
+    final b = _Counters();
+    await tester.pumpWidget(_harness(rows: [_row(label: 'A', counters: a), _row(label: 'B', counters: b)]));
+
+    await _swipe(tester, label: 'A', dx: -150);
+    await _swipe(tester, label: 'B', dx: -150);
+
+    expect(_primaryRect(tester, 'A').left, greaterThanOrEqualTo(_surfaceWidth));
+    expect(_primaryRect(tester, 'B').left, lessThan(_surfaceWidth));
+  });
+
+  testWidgets('scrolling the enclosing list closes the open row', (tester) async {
+    final counters = _Counters();
+    final scrollController = ScrollController();
+    addTearDown(scrollController.dispose);
+    await tester.pumpWidget(
+      _harness(rows: [_row(label: 'A', counters: counters)], scrollController: scrollController),
+    );
+
+    await _swipe(tester, label: 'A', dx: -150);
+    expect(_primaryRect(tester, 'A').left, lessThan(_surfaceWidth));
+
+    // Programmatic, so the close is attributable to the scroll itself rather
+    // than to the pointer-down of a scroll gesture.
+    scrollController.jumpTo(40);
+    await tester.pumpAndSettle();
+
+    expect(_primaryRect(tester, 'A').left, greaterThanOrEqualTo(_surfaceWidth));
+  });
+
+  testWidgets('a full swipe past the commit threshold fires onFullSwipe once and closes', (tester) async {
+    final counters = _Counters();
+    await tester.pumpWidget(_harness(rows: [_row(label: 'A', counters: counters)]));
+
+    // ~502px after slop — past the 480px commit threshold.
+    await _swipe(tester, label: 'A', dx: -520);
+
+    expect(counters.fullSwipes, 1);
+    expect(counters.primaryTaps, 0);
+    expect(_primaryRect(tester, 'A').left, greaterThanOrEqualTo(_surfaceWidth));
+  });
+
+  testWidgets('the primary action stretches during the overdrag, trailing edge pinned to the row end', (tester) async {
+    final counters = _Counters();
+    await tester.pumpWidget(_harness(rows: [_row(label: 'A', counters: counters)]));
+
+    // 8 steps of -70; the first step is spent winning the arena, leaving
+    // ~490px of extent — past the 480px commit threshold.
+    final gesture = await tester.startGesture(tester.getCenter(find.text('A content')));
+    await _moveInSteps(tester, gesture, total: const Offset(-560, 0));
+
+    final rect = _primaryRect(tester, 'A');
+    expect(rect.right, moreOrLessEquals(_surfaceWidth - 16, epsilon: 1));
+    expect(rect.width, greaterThan(_primaryWidth + 200));
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(counters.fullSwipes, 1);
+  });
+
+  testWidgets('dragging past the threshold and back before releasing does not commit', (tester) async {
+    final counters = _Counters();
+    await tester.pumpWidget(_harness(rows: [_row(label: 'A', counters: counters)]));
+
+    final gesture = await tester.startGesture(tester.getCenter(find.text('A content')));
+    await _moveInSteps(tester, gesture, total: const Offset(-560, 0));
+    // Slow enough on the way back that the release is not a closing fling —
+    // a fast fling back is its own cancel path.
+    await _moveInSteps(
+      tester,
+      gesture,
+      total: const Offset(300, 0),
+      steps: 6,
+      pumpEach: const Duration(milliseconds: 100),
+    );
+    await gesture.up();
+    await tester.pumpAndSettle();
+
+    expect(counters.fullSwipes, 0);
+    // ~190px extent at release — past half the reveal, so it settles open.
+    expect(_primaryRect(tester, 'A').left, lessThan(_surfaceWidth));
+  });
+
+  testWidgets('reveals with a start-edge drag under RTL', (tester) async {
+    final counters = _Counters();
+    await tester.pumpWidget(
+      _harness(rows: [_row(label: 'A', counters: counters)], textDirection: TextDirection.rtl),
+    );
+
+    // In RTL the actions live past the left edge and a rightward drag reveals.
+    expect(_primaryRect(tester, 'A').right, lessThanOrEqualTo(0));
+
+    await _swipe(tester, label: 'A', dx: 150);
+
+    final rect = _primaryRect(tester, 'A');
+    expect(rect.left, moreOrLessEquals(16, epsilon: 1));
+
+    await tester.tap(find.text('Hide A'));
+    await tester.pumpAndSettle();
+    expect(counters.primaryTaps, 1);
+  });
+
+  testWidgets('disposing mid-settle does not throw', (tester) async {
+    final counters = _Counters();
+    await tester.pumpWidget(_harness(rows: [_row(label: 'A', counters: counters)]));
+
+    await tester.drag(find.text('A content'), const Offset(-150, 0));
+    await tester.pump();
+
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/client/module_prego/test/interactions/prego_swipe_actions_test.dart
+++ b/client/module_prego/test/interactions/prego_swipe_actions_test.dart
@@ -4,8 +4,9 @@ import 'package:theme_prego/module_prego.dart';
 
 /// The default test surface is 800 logical px wide, so the geometry the tests
 /// assert against is:
-/// - reveal width: 6 (start gap) + 40 (action) + 6 (gap) + 136 (primary) + 16
-///   (end inset) = 204, settle-open threshold 102;
+/// - reveal width: 6 (start gap) + 40 (action) + 6 (gap) + 136 (the primary's
+///   natural width — the harness child declares it, the component measures
+///   it) + 16 (end inset) = 204, settle-open threshold 102;
 /// - commit threshold: 0.6 * 800 = 480.
 /// Drags lose ~18px to touch slop before the recognizer reports, so distances
 /// keep a margin on their side of each threshold.
@@ -24,6 +25,7 @@ Widget _row({
   required String label,
   required _Counters counters,
   bool closeOnAction = false,
+  double primaryWidth = _primaryWidth,
 }) {
   return PregoSwipeActions(
     actionsBuilder: (context, close) => [
@@ -37,14 +39,18 @@ Widget _row({
         child: const SizedBox(width: 40, height: 40, child: ColoredBox(color: Colors.blue)),
       ),
     ],
-    primaryActionBuilder: (context, close) => TextButton(
-      onPressed: () {
-        counters.primaryTaps++;
-        if (closeOnAction) close();
-      },
-      child: Text('Hide $label'),
+    // The SizedBox stands in for a real action's content-driven size — the
+    // component measures it rather than being told.
+    primaryActionBuilder: (context, close) => SizedBox(
+      width: primaryWidth,
+      child: TextButton(
+        onPressed: () {
+          counters.primaryTaps++;
+          if (closeOnAction) close();
+        },
+        child: Text('Hide $label'),
+      ),
     ),
-    primaryActionWidth: _primaryWidth,
     onFullSwipe: () => counters.fullSwipes++,
     child: GestureDetector(
       behavior: HitTestBehavior.opaque,
@@ -171,6 +177,27 @@ void main() {
     await tester.pumpAndSettle();
     expect(counters.actionTaps, 1);
     expect(counters.fullSwipes, 0);
+  });
+
+  testWidgets("the reveal geometry follows the primary action's natural width", (tester) async {
+    final counters = _Counters();
+    await tester.pumpWidget(
+      _harness(rows: [_row(label: 'A', counters: counters, primaryWidth: 100)]),
+    );
+
+    // Nothing boxes the primary at rest — the strip lays it out at whatever
+    // width its content asks for.
+    expect(_primaryRect(tester, 'A').width, moreOrLessEquals(100, epsilon: 1));
+
+    await _swipe(tester, label: 'A', dx: -150);
+
+    // Reveal: 6 + 40 + 6 + 100 + 16 = 168 — narrower than the default
+    // harness's 204, because the measured geometry tracked the primary.
+    final rect = _primaryRect(tester, 'A');
+    expect(rect.left, moreOrLessEquals(_surfaceWidth - 16 - 100, epsilon: 1));
+    expect(rect.width, moreOrLessEquals(100, epsilon: 1));
+    final actionTarget = tester.getCenter(find.byKey(const ValueKey('action-A')));
+    expect(actionTarget.dx, moreOrLessEquals(_surfaceWidth - 168 + 6 + 20, epsilon: 1));
   });
 
   testWidgets('an action can close the row through the builder callback', (tester) async {

--- a/client/module_prego/test/interactions/prego_swipe_actions_test.dart
+++ b/client/module_prego/test/interactions/prego_swipe_actions_test.dart
@@ -346,6 +346,29 @@ void main() {
     expect(counters.primaryTaps, 1);
   });
 
+  testWidgets('the close callback is safe to call after the row is unmounted', (tester) async {
+    late VoidCallback close;
+    await tester.pumpWidget(
+      _harness(rows: [
+        PregoSwipeActions(
+          actionsBuilder: (context, c) {
+            close = c;
+            return const [SizedBox(width: 40, height: 40)];
+          },
+          primaryActionBuilder: (context, _) => const SizedBox(width: _primaryWidth),
+          onFullSwipe: () {},
+          child: const SizedBox(height: 96),
+        ),
+      ]),
+    );
+
+    // A host may hold [close] across an await (a confirmation dialog, an undo
+    // snackbar) while the row is removed underneath it.
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+
+    expect(close, returnsNormally);
+  });
+
   testWidgets('disposing mid-settle does not throw', (tester) async {
     final counters = _Counters();
     await tester.pumpWidget(_harness(rows: [_row(label: 'A', counters: counters)]));


### PR DESCRIPTION
## Summary

Swipe a project row to reveal its actions, per the ProjectListItem design.

- **`PregoSwipeActions`** (`module_prego/interactions/`) — a swipe-to-reveal row. A partial swipe settles open on the trailing actions; a full swipe commits the primary action, with the primary pill stretching through the overdrag as the commit cue. Rows auto-close on an outside tap, on tapping the revealed row itself, and on list scroll.
- **`ProjectTile`** — wires in a rename circle and a warning Hide pill, both reusing the existing menu flows. A full swipe hides the project directly. The long-press menu stays as the discoverable and assistive path.
- **`PregoButtonsSolid`** — centres its content Stack, so a button boxed wider than its content keeps the icon and label centred instead of pinned to the top-start.

The primary action rests at its natural width rather than a declared one: the component measures it at drag start alongside the reveal width, and only boxes it while the overdrag stretches it. That let the project tile drop its hardcoded 136px pill.

## Testing

- `prego_swipe_actions_test.dart` — 361 lines covering reveal, settle, full-swipe commit, and the three auto-close paths.
- `project_tile_swipe_test.dart` — 216 lines covering the wired-up rename/hide actions.

Note for anyone writing tests against this: a single large `moveBy` gets eaten by the gesture arena — drive the swipe with stepped moves.

https://claude.ai/code/session_018P3DxEjiTyoo3EgmUvV5N6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds swipe actions to project rows: a partial swipe reveals Rename and a warning Hide pill; a full swipe hides the project. Introduces a reusable `PregoSwipeActions` for the design system, with the long-press menu as the accessible path.

- **New Features**
  - `PregoSwipeActions`: swipe-to-reveal row with full-swipe commit (stretch + haptic cue); auto-closes on outside tap, row tap, and list scroll.
  - Integrated into `ProjectTile`: rename button and warning Hide pill; full swipe hides; actions are excluded from semantics while closed; RTL supported.
  - Primary action is content-sized at rest and measured at drag start (no hardcoded width).

- **Bug Fixes**
  - Keyed project rows so recycled list items don’t inherit a previous row’s revealed state.
  - Centered content in `PregoButtonsSolid` when stretched so icon and label stay centered.
  - Guarded swipe-row settle so calling the close callback after unmount is safe.

<sup>Written for commit b71d097f6b332a759d040842b0ce743d13418926. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

