### PR TITLE
feat: order running work alphabetically

### DIFF
--- a/client/app/test/helpers/test_helpers.dart
+++ b/client/app/test/helpers/test_helpers.dart
@@ -31,6 +31,7 @@ import "package:sesori_dart_core/src/repositories/session_repository.dart";
 import "package:sesori_dart_core/src/services/models/session_activity_info.dart";
 import "package:sesori_dart_core/src/services/project_list_service.dart";
 import "package:sesori_dart_core/src/services/registered_bridges_service.dart";
+import "package:sesori_dart_core/src/services/session_activity_calculator.dart";
 import "package:sesori_dart_core/src/services/session_list_service.dart";
 import "package:sesori_dart_core/src/services/session_unseen_tracker.dart";
 import "package:sesori_dart_core/src/services/session_viewing_service.dart";
@@ -144,10 +145,16 @@ void registerListServices({
     getIt.unregister<SessionListService>();
   }
   getIt.registerSingleton<ProjectListService>(
-    ProjectListService(repository: projectRepository),
+    ProjectListService(
+      repository: projectRepository,
+      activityCalculator: const SessionActivityCalculator(),
+    ),
   );
   getIt.registerSingleton<SessionListService>(
-    SessionListService(repository: projectRepository),
+    SessionListService(
+      repository: projectRepository,
+      activityCalculator: const SessionActivityCalculator(),
+    ),
   );
 }
 

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -13,6 +13,7 @@ import "../../logging/logging.dart";
 import "../../platform/route_source.dart";
 import "../../repositories/project_repository.dart";
 import "../../routing/app_routes.dart";
+import "../../services/models/session_activity_info.dart";
 import "../../services/project_list_service.dart";
 import "../../services/registered_bridges_service.dart";
 import "../../services/session_unseen_tracker.dart";
@@ -61,6 +62,9 @@ class ProjectListCubit extends Cubit<ProjectListState> {
     // 1. Immediate activity badge updates (no API call).
     _subscriptions.add(
       _sseEventTracker.projectActivity.listen(_onActivityUpdated),
+    );
+    _subscriptions.add(
+      _sseEventTracker.sessionActivity.listen(_onSessionActivityUpdated),
     );
 
     // 1a. Immediate project timestamp updates from SSE events (no API call).
@@ -164,6 +168,22 @@ class ProjectListCubit extends Cubit<ProjectListState> {
     }
   }
 
+  void _onSessionActivityUpdated(Map<String, Map<String, SessionActivityInfo>> activityByProjectId) {
+    if (isClosed) return;
+    if (state case final ProjectListLoaded loaded) {
+      final ordered = _projectListService.orderProjects(
+        projects: loaded.projects,
+        activityByProjectId: activityByProjectId,
+      );
+      emit(
+        loaded.copyWith(
+          projects: ordered,
+          unseenByProjectId: _unseenByProjectId(ordered),
+        ),
+      );
+    }
+  }
+
   void _onProjectTimestampUpdated(Map<String, int> timestampByProjectId) {
     try {
       if (isClosed) return;
@@ -174,10 +194,15 @@ class ProjectListCubit extends Cubit<ProjectListState> {
         );
         if (!merged.changed) return;
 
+        final ordered = _projectListService.orderProjects(
+          projects: merged.projects,
+          activityByProjectId: _sseEventTracker.currentSessionActivity,
+        );
+
         emit(
           loaded.copyWith(
-            projects: merged.projects,
-            unseenByProjectId: _unseenByProjectId(merged.projects),
+            projects: ordered,
+            unseenByProjectId: _unseenByProjectId(ordered),
           ),
         );
       }
@@ -465,9 +490,12 @@ class ProjectListCubit extends Cubit<ProjectListState> {
       return false;
     }
     if (state case final ProjectListLoaded loaded) {
-      final remaining = _projectListService.removeProject(
-        projects: loaded.projects,
-        projectId: projectId,
+      final remaining = _projectListService.orderProjects(
+        projects: _projectListService.removeProject(
+          projects: loaded.projects,
+          projectId: projectId,
+        ),
+        activityByProjectId: _sseEventTracker.currentSessionActivity,
       );
       emit(
         loaded.copyWith(
@@ -589,12 +617,16 @@ class ProjectListCubit extends Cubit<ProjectListState> {
 
     switch (projectResponse) {
       case SuccessResponse(data: Projects(data: final projects)):
-        final sortedProjects = _projectListService
+        final mergedProjects = _projectListService
             .mergeTimestampUpdates(
               projects: projects,
               timestampByProjectId: _sseEventTracker.currentProjectTimestampUpdates,
             )
             .projects;
+        final sortedProjects = _projectListService.orderProjects(
+          projects: mergedProjects,
+          activityByProjectId: _sseEventTracker.currentSessionActivity,
+        );
         // The REST aggregate is authoritative at fetch time — seed the tracker
         // so a stale live `true` can't keep a project bold after its last
         // unseen session was archived/deleted while an echo was missed.

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -181,9 +181,7 @@ class SessionListCubit extends Cubit<SessionListState> {
     if (isClosed) return;
     final current = state;
     if (current is! SessionListLoaded) return;
-    final loaded = current;
-    final projectActivity = activityByProjectId[_projectId] ?? <String, SessionActivityInfo>{};
-    emit(loaded.copyWith(activeSessionIds: projectActivity));
+    _emitFiltered();
   }
 
   void _onUnseenUpdated() {
@@ -572,6 +570,7 @@ class SessionListCubit extends Cubit<SessionListState> {
     final visible = _sessionListService.visibleSessions(
       sessions: _allSessions,
       showArchived: _showArchived,
+      activityBySessionId: _sseEventTracker.currentSessionActivity[_projectId] ?? const {},
     );
 
     if (isClosed) return;

--- a/client/module_core/lib/src/di/injection.config.dart
+++ b/client/module_core/lib/src/di/injection.config.dart
@@ -66,6 +66,8 @@ import 'package:sesori_dart_core/src/services/project_list_service.dart'
     as _i703;
 import 'package:sesori_dart_core/src/services/registered_bridges_service.dart'
     as _i699;
+import 'package:sesori_dart_core/src/services/session_activity_calculator.dart'
+    as _i84;
 import 'package:sesori_dart_core/src/services/session_detail_load_service.dart'
     as _i709;
 import 'package:sesori_dart_core/src/services/session_list_service.dart'
@@ -91,6 +93,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i1002.DraftStore>(() => _i1002.DraftStore());
     gh.lazySingleton<_i913.NewSessionSelectionTracker>(
       () => _i913.NewSessionSelectionTracker(),
+    );
+    gh.lazySingleton<_i84.SessionActivityCalculator>(
+      () => const _i84.SessionActivityCalculator(),
     );
     gh.lazySingleton<_i895.RoomKeyStorage>(
       () => _i895.RoomKeyStorage(gh<_i442.SecureStorage>()),
@@ -160,6 +165,18 @@ extension GetItInjectableX on _i174.GetIt {
         filesystemApi: gh<_i1068.FilesystemApi>(),
       ),
     );
+    gh.lazySingleton<_i703.ProjectListService>(
+      () => _i703.ProjectListService(
+        repository: gh<_i80.ProjectRepository>(),
+        activityCalculator: gh<_i84.SessionActivityCalculator>(),
+      ),
+    );
+    gh.lazySingleton<_i763.SessionListService>(
+      () => _i763.SessionListService(
+        repository: gh<_i80.ProjectRepository>(),
+        activityCalculator: gh<_i84.SessionActivityCalculator>(),
+      ),
+    );
     gh.lazySingleton<_i471.NotificationRepository>(
       () => _i471.NotificationRepository(api: gh<_i400.NotificationApi>()),
     );
@@ -176,12 +193,6 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i458.NotificationPreferencesRepository(
         api: gh<_i396.NotificationPreferencesApi>(),
       ),
-    );
-    gh.lazySingleton<_i703.ProjectListService>(
-      () => _i703.ProjectListService(repository: gh<_i80.ProjectRepository>()),
-    );
-    gh.lazySingleton<_i763.SessionListService>(
-      () => _i763.SessionListService(repository: gh<_i80.ProjectRepository>()),
     );
     gh.lazySingleton<_i157.SessionViewApi>(
       () => _i157.SessionViewApi(

--- a/client/module_core/lib/src/services/project_list_service.dart
+++ b/client/module_core/lib/src/services/project_list_service.dart
@@ -3,12 +3,19 @@ import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../repositories/project_repository.dart";
+import "models/session_activity_info.dart";
+import "session_activity_calculator.dart";
 
 @lazySingleton
 class ProjectListService {
   final ProjectRepository _repository;
+  final SessionActivityCalculator _activityCalculator;
 
-  ProjectListService({required ProjectRepository repository}) : _repository = repository;
+  ProjectListService({
+    required ProjectRepository repository,
+    required SessionActivityCalculator activityCalculator,
+  }) : _repository = repository,
+       _activityCalculator = activityCalculator;
 
   Future<ApiResponse<Projects>> listProjects() async {
     final response = await _repository.listProjects();
@@ -41,6 +48,24 @@ class ProjectListService {
     return _sortProjects(projects.where((project) => project.id != projectId));
   }
 
+  List<Project> orderProjects({
+    required Iterable<Project> projects,
+    required Map<String, Map<String, SessionActivityInfo>> activityByProjectId,
+  }) {
+    final running = <Project>[];
+    final remaining = <Project>[];
+    for (final project in projects) {
+      final activity = activityByProjectId[project.id];
+      if (activity != null && activity.values.any((session) => _activityCalculator.isRunning(activity: session))) {
+        running.add(project);
+      } else {
+        remaining.add(project);
+      }
+    }
+    running.sort((a, b) => _compareProjectsByNameAndId(a: a, b: b));
+    return [...running, ..._sortProjects(remaining)];
+  }
+
   List<Project> _sortProjects(Iterable<Project> projects) {
     return projects.toList()..sort((a, b) => _compareProjectsByTimestampAndName(a: a, b: b));
   }
@@ -57,6 +82,13 @@ class ProjectListService {
     };
     if (updatedCompare != 0) return updatedCompare;
 
+    final nameCompare = _effectiveName(a).toLowerCase().compareTo(_effectiveName(b).toLowerCase());
+    if (nameCompare != 0) return nameCompare;
+
+    return a.id.compareTo(b.id);
+  }
+
+  int _compareProjectsByNameAndId({required Project a, required Project b}) {
     final nameCompare = _effectiveName(a).toLowerCase().compareTo(_effectiveName(b).toLowerCase());
     if (nameCompare != 0) return nameCompare;
 

--- a/client/module_core/lib/src/services/project_list_service.dart
+++ b/client/module_core/lib/src/services/project_list_service.dart
@@ -89,10 +89,19 @@ class ProjectListService {
   }
 
   int _compareProjectsByNameAndId({required Project a, required Project b}) {
-    final nameCompare = _effectiveName(a).toLowerCase().compareTo(_effectiveName(b).toLowerCase());
+    final nameCompare = _displayName(a).toLowerCase().compareTo(_displayName(b).toLowerCase());
     if (nameCompare != 0) return nameCompare;
 
     return a.id.compareTo(b.id);
+  }
+
+  String _displayName(Project project) {
+    final name = project.name;
+    if (name != null) return name;
+
+    final path = project.path.isEmpty ? project.id : project.path;
+    final segments = path.replaceAll(r"\", "/").split("/").where((segment) => segment.isNotEmpty);
+    return segments.isEmpty ? path : segments.last;
   }
 
   String _effectiveName(Project project) => project.name ?? project.path;

--- a/client/module_core/lib/src/services/session_activity_calculator.dart
+++ b/client/module_core/lib/src/services/session_activity_calculator.dart
@@ -1,0 +1,12 @@
+import "package:injectable/injectable.dart";
+
+import "models/session_activity_info.dart";
+
+@lazySingleton
+class SessionActivityCalculator {
+  const SessionActivityCalculator();
+
+  bool isRunning({required SessionActivityInfo activity}) {
+    return activity.mainAgentRunning || activity.isRetrying || activity.backgroundTaskCount > 0;
+  }
+}

--- a/client/module_core/lib/src/services/session_list_service.dart
+++ b/client/module_core/lib/src/services/session_list_service.dart
@@ -3,12 +3,19 @@ import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../repositories/project_repository.dart";
+import "models/session_activity_info.dart";
+import "session_activity_calculator.dart";
 
 @lazySingleton
 class SessionListService {
   final ProjectRepository _repository;
+  final SessionActivityCalculator _activityCalculator;
 
-  SessionListService({required ProjectRepository repository}) : _repository = repository;
+  SessionListService({
+    required ProjectRepository repository,
+    required SessionActivityCalculator activityCalculator,
+  }) : _repository = repository,
+       _activityCalculator = activityCalculator;
 
   Future<ApiResponse<SessionListResponse>> listSessions({
     required String projectId,
@@ -29,9 +36,21 @@ class SessionListService {
   List<Session> visibleSessions({
     required Iterable<Session> sessions,
     required bool showArchived,
+    required Map<String, SessionActivityInfo> activityBySessionId,
   }) {
     final visible = showArchived ? sessions : sessions.where((session) => session.time?.archived == null);
-    return _sortSessions(visible);
+    final running = <Session>[];
+    final remaining = <Session>[];
+    for (final session in visible) {
+      final activity = activityBySessionId[session.id];
+      if (activity != null && _activityCalculator.isRunning(activity: activity)) {
+        running.add(session);
+      } else {
+        remaining.add(session);
+      }
+    }
+    running.sort((a, b) => _compareSessionsByTitleAndId(a: a, b: b));
+    return [...running, ..._sortSessions(remaining)];
   }
 
   List<Session> upsertSession({required Iterable<Session> sessions, required Session session}) {
@@ -47,5 +66,17 @@ class SessionListService {
 
   List<Session> _sortSessions(Iterable<Session> sessions) {
     return sessions.toList()..sort((a, b) => (b.time?.updated ?? 0).compareTo(a.time?.updated ?? 0));
+  }
+
+  int _compareSessionsByTitleAndId({required Session a, required Session b}) {
+    final titleCompare = switch ((a.title, b.title)) {
+      (null, null) => 0,
+      (null, _) => 1,
+      (_, null) => -1,
+      (final aTitle?, final bTitle?) => aTitle.toLowerCase().compareTo(bTitle.toLowerCase()),
+    };
+    if (titleCompare != 0) return titleCompare;
+
+    return a.id.compareTo(b.id);
   }
 }

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -11,7 +11,9 @@ import "package:sesori_dart_core/src/capabilities/server_connection/server_conne
 import "package:sesori_dart_core/src/cubits/project_list/add_project_outcome.dart";
 import "package:sesori_dart_core/src/cubits/project_list/project_list_cubit.dart";
 import "package:sesori_dart_core/src/cubits/project_list/project_list_state.dart";
+import "package:sesori_dart_core/src/services/models/session_activity_info.dart";
 import "package:sesori_dart_core/src/services/project_list_service.dart";
+import "package:sesori_dart_core/src/services/session_activity_calculator.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -59,7 +61,10 @@ void main() {
 
     setUp(() {
       mockProjectRepository = MockProjectRepository();
-      projectListService = ProjectListService(repository: mockProjectRepository);
+      projectListService = ProjectListService(
+        repository: mockProjectRepository,
+        activityCalculator: const SessionActivityCalculator(),
+      );
       mockConnectionService = MockConnectionService();
       mockSseEventTracker = MockSseEventTracker();
       mockRouteSource = MockRouteSource();
@@ -1255,6 +1260,53 @@ void main() {
       skip: 1,
       expect: () => [
         isA<ProjectListLoaded>().having((s) => s.activityById, "activityById", {_projectId: 3}),
+      ],
+    );
+
+    blocTest<ProjectListCubit, ProjectListState>(
+      "running activity received after REST creates an alphabetical prefix",
+      build: () {
+        when(() => mockProjectRepository.listProjects()).thenAnswer(
+          (_) async => ApiResponse.success(Projects(data: [projectA, projectB, projectC])),
+        );
+        return buildCubit();
+      },
+      act: (_) async {
+        await Future<void>.delayed(Duration.zero);
+        mockSseEventTracker.emitSessionActivity({
+          "A": {"a": const SessionActivityInfo(mainAgentRunning: true)},
+          "C": {"c": const SessionActivityInfo(backgroundTaskCount: 1)},
+        });
+        await Future<void>.delayed(Duration.zero);
+      },
+      skip: 1,
+      expect: () => [
+        isA<ProjectListLoaded>().having(
+          (state) => state.projects.map((project) => project.id).toList(),
+          "project order",
+          ["A", "C", "B"],
+        ),
+      ],
+    );
+
+    blocTest<ProjectListCubit, ProjectListState>(
+      "running activity received before REST is applied when projects arrive",
+      build: () {
+        mockSseEventTracker.emitSessionActivity({
+          "A": {"a": const SessionActivityInfo(mainAgentRunning: true)},
+          "C": {"c": const SessionActivityInfo(backgroundTaskCount: 1)},
+        });
+        when(() => mockProjectRepository.listProjects()).thenAnswer(
+          (_) async => ApiResponse.success(Projects(data: [projectA, projectB, projectC])),
+        );
+        return buildCubit();
+      },
+      expect: () => [
+        isA<ProjectListLoaded>().having(
+          (state) => state.projects.map((project) => project.id).toList(),
+          "project order",
+          ["A", "C", "B"],
+        ),
       ],
     );
 

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -12,6 +12,7 @@ import "package:sesori_dart_core/src/capabilities/server_connection/server_conne
 import "package:sesori_dart_core/src/cubits/session_list/session_list_cubit.dart";
 import "package:sesori_dart_core/src/cubits/session_list/session_list_state.dart";
 import "package:sesori_dart_core/src/services/models/session_activity_info.dart";
+import "package:sesori_dart_core/src/services/session_activity_calculator.dart";
 import "package:sesori_dart_core/src/services/session_list_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -38,7 +39,10 @@ void main() {
     setUp(() {
       mockSessionService = MockSessionService();
       mockProjectRepository = MockProjectRepository();
-      sessionListService = SessionListService(repository: mockProjectRepository);
+      sessionListService = SessionListService(
+        repository: mockProjectRepository,
+        activityCalculator: const SessionActivityCalculator(),
+      );
       mockConnectionService = MockConnectionService();
       mockSseEventTracker = MockSseEventTracker();
       fakeSessionUnseenTracker = FakeSessionUnseenTracker();
@@ -156,6 +160,85 @@ void main() {
           (state) => state.sessions.map((session) => session.id).toList(),
           "session order",
           ["untitled", "B", "A", "a"],
+        ),
+      ],
+    );
+
+    blocTest<SessionListCubit, SessionListState>(
+      "running activity received after REST creates an alphabetical prefix",
+      build: () {
+        mockRouteSource = MockRouteSource();
+        when(
+          () => mockProjectRepository.listSessions(
+            projectId: projectId,
+            waitForPrData: any(named: "waitForPrData"),
+          ),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(
+            SessionListResponse(
+              items: [
+                testSession(id: "C", title: "Charlie"),
+                testSession(id: "B", title: "Bravo"),
+                testSession(id: "A", title: "Alpha"),
+              ],
+            ),
+          ),
+        );
+        return buildCubit();
+      },
+      act: (_) async {
+        await Future<void>.delayed(Duration.zero);
+        mockSseEventTracker.emitSessionActivity({
+          projectId: {
+            "C": const SessionActivityInfo(mainAgentRunning: true),
+            "A": const SessionActivityInfo(isRetrying: true),
+          },
+        });
+        await Future<void>.delayed(Duration.zero);
+      },
+      skip: 1,
+      expect: () => [
+        isA<SessionListLoaded>().having(
+          (state) => state.sessions.map((session) => session.id).toList(),
+          "session order",
+          ["A", "C", "B"],
+        ),
+      ],
+    );
+
+    blocTest<SessionListCubit, SessionListState>(
+      "running activity received before REST is applied when sessions arrive",
+      build: () {
+        mockRouteSource = MockRouteSource();
+        mockSseEventTracker.emitSessionActivity({
+          projectId: {
+            "C": const SessionActivityInfo(mainAgentRunning: true),
+            "A": const SessionActivityInfo(isRetrying: true),
+          },
+        });
+        when(
+          () => mockProjectRepository.listSessions(
+            projectId: projectId,
+            waitForPrData: any(named: "waitForPrData"),
+          ),
+        ).thenAnswer(
+          (_) async => ApiResponse.success(
+            SessionListResponse(
+              items: [
+                testSession(id: "C", title: "Charlie"),
+                testSession(id: "B", title: "Bravo"),
+                testSession(id: "A", title: "Alpha"),
+              ],
+            ),
+          ),
+        );
+        return buildCubit();
+      },
+      expect: () => [
+        isA<SessionListLoaded>().having(
+          (state) => state.sessions.map((session) => session.id).toList(),
+          "session order",
+          ["A", "C", "B"],
         ),
       ],
     );

--- a/client/module_core/test/services/project_list_service_test.dart
+++ b/client/module_core/test/services/project_list_service_test.dart
@@ -1,0 +1,46 @@
+import "package:mocktail/mocktail.dart";
+import "package:sesori_dart_core/src/repositories/project_repository.dart";
+import "package:sesori_dart_core/src/services/models/session_activity_info.dart";
+import "package:sesori_dart_core/src/services/project_list_service.dart";
+import "package:sesori_dart_core/src/services/session_activity_calculator.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+class _MockProjectRepository extends Mock implements ProjectRepository {}
+
+void main() {
+  test("running projects form an alphabetical prefix while the tail stays timestamp ordered", () {
+    final service = ProjectListService(
+      repository: _MockProjectRepository(),
+      activityCalculator: const SessionActivityCalculator(),
+    );
+
+    final result = service.orderProjects(
+      projects: [
+        _project(id: "running-z", name: "Zulu", updatedAt: 400),
+        _project(id: "waiting-a", name: "Alpha", updatedAt: 300),
+        _project(id: "inactive-b", name: "Beta", updatedAt: 200),
+        _project(id: "running-a", name: "Alpha", updatedAt: 100),
+      ],
+      activityByProjectId: const {
+        "running-z": {"z": SessionActivityInfo(mainAgentRunning: true)},
+        "waiting-a": {"waiting": SessionActivityInfo(awaitingInput: true)},
+        "running-a": {"a": SessionActivityInfo(backgroundTaskCount: 1)},
+      },
+    );
+
+    expect(
+      result.map((project) => project.id),
+      ["running-a", "running-z", "waiting-a", "inactive-b"],
+    );
+  });
+}
+
+Project _project({required String id, required String name, required int updatedAt}) {
+  return Project(
+    id: id,
+    name: name,
+    path: "/projects/$id",
+    time: ProjectTime(created: 1, updated: updatedAt),
+  );
+}

--- a/client/module_core/test/services/project_list_service_test.dart
+++ b/client/module_core/test/services/project_list_service_test.dart
@@ -34,13 +34,33 @@ void main() {
       ["running-a", "running-z", "waiting-a", "inactive-b"],
     );
   });
+
+  test("nameless running projects sort by their displayed directory basename", () {
+    final service = ProjectListService(
+      repository: _MockProjectRepository(),
+      activityCalculator: const SessionActivityCalculator(),
+    );
+
+    final result = service.orderProjects(
+      projects: [
+        _project(id: "zulu", name: null, path: "/a/Zulu", updatedAt: 2),
+        _project(id: "alpha", name: null, path: r"C:\z\Alpha", updatedAt: 1),
+      ],
+      activityByProjectId: const {
+        "zulu": {"z": SessionActivityInfo(mainAgentRunning: true)},
+        "alpha": {"a": SessionActivityInfo(mainAgentRunning: true)},
+      },
+    );
+
+    expect(result.map((project) => project.id), ["alpha", "zulu"]);
+  });
 }
 
-Project _project({required String id, required String name, required int updatedAt}) {
+Project _project({required String id, required String? name, required int updatedAt, String? path}) {
   return Project(
     id: id,
     name: name,
-    path: "/projects/$id",
+    path: path ?? "/projects/$id",
     time: ProjectTime(created: 1, updated: updatedAt),
   );
 }

--- a/client/module_core/test/services/session_list_service_test.dart
+++ b/client/module_core/test/services/session_list_service_test.dart
@@ -1,0 +1,51 @@
+import "package:mocktail/mocktail.dart";
+import "package:sesori_dart_core/src/repositories/project_repository.dart";
+import "package:sesori_dart_core/src/services/models/session_activity_info.dart";
+import "package:sesori_dart_core/src/services/session_activity_calculator.dart";
+import "package:sesori_dart_core/src/services/session_list_service.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+class _MockProjectRepository extends Mock implements ProjectRepository {}
+
+void main() {
+  test("running sessions form an alphabetical prefix while the tail stays timestamp ordered", () {
+    final service = SessionListService(
+      repository: _MockProjectRepository(),
+      activityCalculator: const SessionActivityCalculator(),
+    );
+
+    final result = service.visibleSessions(
+      sessions: [
+        _session(id: "running-z", title: "Zulu", updatedAt: 400),
+        _session(id: "waiting-a", title: "Alpha", updatedAt: 300),
+        _session(id: "inactive-b", title: "Beta", updatedAt: 200),
+        _session(id: "running-a", title: "Alpha", updatedAt: 100),
+      ],
+      showArchived: true,
+      activityBySessionId: const {
+        "running-z": SessionActivityInfo(isRetrying: true),
+        "waiting-a": SessionActivityInfo(awaitingInput: true),
+        "running-a": SessionActivityInfo(mainAgentRunning: true),
+      },
+    );
+
+    expect(
+      result.map((session) => session.id),
+      ["running-a", "running-z", "waiting-a", "inactive-b"],
+    );
+  });
+}
+
+Session _session({required String id, required String title, required int updatedAt}) {
+  return Session(
+    id: id,
+    projectID: "project",
+    directory: "/project",
+    parentID: null,
+    title: title,
+    time: SessionTime(created: 1, updated: updatedAt, archived: null),
+    pullRequest: null,
+    promptDefaults: null,
+  );
+}


### PR DESCRIPTION
## Summary
- promote projects and sessions with actively running work into an alphabetical prefix
- keep awaiting-input-only and inactive work in updated-timestamp order
- apply the same ordering to initial REST loads and live activity updates

Running means the main agent is running, retrying, or has active background tasks.

## Verification
- `dart test` in `client/module_core` (513 tests)
- `dart analyze` in `client/module_core`
- `flutter analyze` in `client/app`
- `flutter analyze` in `client/desktop`
- Aristotle implementation architecture review approved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes projects and sessions with running work into an alphabetical prefix while keeping awaiting-input-only and inactive items sorted by last updated. Applies on initial REST loads and on live SSE activity updates.

- **New Features**
  - Added `SessionActivityCalculator` to define “running” (main agent running, retrying, or background tasks > 0).
  - Updated `ProjectListService` and `SessionListService` to prefix running items alphabetically—projects by display name (name or directory basename) and sessions by title—and keep the rest timestamp-ordered with stable tie-breaks.
  - Wired into `ProjectListCubit` and `SessionListCubit` so ordering updates on both REST fetch and SSE session activity; DI updated to provide the calculator.

<sup>Written for commit 10092b7b9d602281c032029be9ecdce373dec7e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

