### PR TITLE
fix(opencode): preserve compact commands and guidance

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/message_part_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/message_part_mapper.dart
@@ -22,6 +22,10 @@ import "models/openapi/tool_state_running.g.dart";
 class MessagePartMapper {
   const MessagePartMapper();
 
+  // OpenCode omits the original text from manual compaction parts, so restore
+  // the built-in command that produced the part for display in clients.
+  static const String _manualCompactionCommandText = "/compact";
+
   /// Maps a generated [Part] union to the plugin-facing [PluginMessagePart].
   ///
   /// Dispatches on the sealed [Part] variants — the generated discriminator
@@ -65,7 +69,7 @@ class MessagePartMapper {
       raw.sessionID,
       raw.messageID,
       auto ? PluginMessagePartType.compaction : PluginMessagePartType.text,
-      text: auto ? null : "/compact",
+      text: auto ? null : _manualCompactionCommandText,
     ),
     StepStartPart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.stepStart),
     StepFinishPart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.stepFinish),

--- a/bridge/sesori_plugin_opencode/lib/src/message_part_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/message_part_mapper.dart
@@ -60,7 +60,13 @@ class MessagePartMapper {
     FilePart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.file),
     SnapshotPart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.snapshot),
     PatchPart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.patch),
-    CompactionPart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.compaction),
+    CompactionPart(:final auto) => _part(
+      raw.id,
+      raw.sessionID,
+      raw.messageID,
+      auto ? PluginMessagePartType.compaction : PluginMessagePartType.text,
+      text: auto ? null : "/compact",
+    ),
     StepStartPart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.stepStart),
     StepFinishPart() => _part(raw.id, raw.sessionID, raw.messageID, PluginMessagePartType.stepFinish),
     // `Part` is an `abstract interface` (not `sealed`), so a default arm is

--- a/bridge/sesori_plugin_opencode/lib/src/models/send_prompt_body.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/models/send_prompt_body.dart
@@ -5,12 +5,14 @@ class SendPromptBody {
   final String? agent;
   final String? variant;
   final ({String providerID, String modelID})? model;
+  final bool noReply;
 
   const SendPromptBody({
     required this.parts,
     required this.agent,
     required this.variant,
     required this.model,
+    required this.noReply,
   });
 
   /// Converts our domain types to OpenCode's wire format.
@@ -55,6 +57,7 @@ class SendPromptBody {
           "providerID": selectedModel.providerID,
           "modelID": selectedModel.modelID,
         },
+      if (noReply) "noReply": true,
     };
   }
 }

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -247,7 +247,7 @@ class OpenCodeApi {
     await _client.post(
       // A no-reply prompt may be immediately followed by a dependent request,
       // so wait for OpenCode to persist it instead of forking prompt_async.
-      path: "/session/$sessionId/${body.noReply ? "prompt" : "prompt_async"}",
+      path: "/session/$sessionId/${body.noReply ? "message" : "prompt_async"}",
       headers: {
         "content-type": "application/json",
         _directoryOpenCodeHeader: ?directory,

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_api.dart
@@ -245,7 +245,9 @@ class OpenCodeApi {
     required String? directory,
   }) async {
     await _client.post(
-      path: "/session/$sessionId/prompt_async",
+      // A no-reply prompt may be immediately followed by a dependent request,
+      // so wait for OpenCode to persist it instead of forking prompt_async.
+      path: "/session/$sessionId/${body.noReply ? "prompt" : "prompt_async"}",
       headers: {
         "content-type": "application/json",
         _directoryOpenCodeHeader: ?directory,

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_repository.dart
@@ -103,6 +103,47 @@ class OpenCodeRepository {
     required PluginSessionVariant? variant,
     required ({String providerID, String modelID})? model,
   }) {
+    return _sendPrompt(
+      sessionId: sessionId,
+      directory: directory,
+      parts: parts,
+      agent: agent,
+      variant: variant,
+      model: model,
+      noReply: false,
+    );
+  }
+
+  /// Adds user-provided compaction guidance to the session without starting a
+  /// separate agent run. The following summarize call consumes it as context.
+  Future<void> addCompactionInstructions({
+    required String sessionId,
+    required String? directory,
+    required String instructions,
+    required String? agent,
+    required PluginSessionVariant? variant,
+    required ({String providerID, String modelID}) model,
+  }) {
+    return _sendPrompt(
+      sessionId: sessionId,
+      directory: directory,
+      parts: [PluginPromptPart.text(text: instructions)],
+      agent: agent,
+      variant: variant,
+      model: model,
+      noReply: true,
+    );
+  }
+
+  Future<void> _sendPrompt({
+    required String sessionId,
+    required String? directory,
+    required List<PluginPromptPart> parts,
+    required String? agent,
+    required PluginSessionVariant? variant,
+    required ({String providerID, String modelID})? model,
+    required bool noReply,
+  }) {
     return _api.sendPrompt(
       sessionId: sessionId,
       directory: directory?.normalize(),
@@ -111,6 +152,7 @@ class OpenCodeRepository {
         agent: agent,
         variant: variant?.id,
         model: model,
+        noReply: noReply,
       ),
     );
   }

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -307,9 +307,12 @@ class OpenCodeService {
     // OpenCode command counterpart — route it to the summarize endpoint, which
     // performs manual compaction. Everything else is a real slash command.
     final sendFuture = command == compactionCommandName
-        ? repository.summarize(
+        ? _compact(
             sessionId: sessionId,
             directory: directory,
+            arguments: arguments,
+            agent: agent,
+            variant: variant,
             model: _requireCompactionModel(model: model, sessionId: sessionId),
           )
         : repository.sendCommand(
@@ -348,6 +351,34 @@ class OpenCodeService {
           }),
         );
       },
+    );
+  }
+
+  Future<void> _compact({
+    required String sessionId,
+    required String? directory,
+    required String arguments,
+    required String? agent,
+    required PluginSessionVariant? variant,
+    required ({String providerID, String modelID}) model,
+  }) async {
+    final instructions = arguments.normalize();
+    if (instructions != null) {
+      // OpenCode's summarize payload has no instructions field. A no-reply
+      // prompt persists the guidance as context without running the agent.
+      await repository.addCompactionInstructions(
+        sessionId: sessionId,
+        directory: directory,
+        instructions: instructions,
+        agent: agent,
+        variant: variant,
+        model: model,
+      );
+    }
+    await repository.summarize(
+      sessionId: sessionId,
+      directory: directory,
+      model: model,
     );
   }
 

--- a/bridge/sesori_plugin_opencode/test/message_part_mapper_test.dart
+++ b/bridge/sesori_plugin_opencode/test/message_part_mapper_test.dart
@@ -1,0 +1,42 @@
+import "package:opencode_plugin/opencode_plugin.dart";
+import "package:opencode_plugin/src/models/openapi/compaction_part.g.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  const mapper = MessagePartMapper();
+
+  test("maps manual compaction to visible command text", () {
+    final part = mapper.mapPart(
+      const CompactionPart(
+        id: "part-1",
+        sessionID: "session-1",
+        messageID: "message-1",
+        auto: false,
+        overflow: null,
+        tailStartId: null,
+      ),
+    );
+
+    expect(part.type, equals(PluginMessagePartType.text));
+    expect(part.text, equals("/compact"));
+    expect(part.type.isVisible, isTrue);
+  });
+
+  test("keeps automatic compaction hidden", () {
+    final part = mapper.mapPart(
+      const CompactionPart(
+        id: "part-1",
+        sessionID: "session-1",
+        messageID: "message-1",
+        auto: true,
+        overflow: true,
+        tailStartId: null,
+      ),
+    );
+
+    expect(part.type, equals(PluginMessagePartType.compaction));
+    expect(part.text, isNull);
+    expect(part.type.isVisible, isFalse);
+  });
+}

--- a/bridge/sesori_plugin_opencode/test/opencode_api_http_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_api_http_test.dart
@@ -297,9 +297,23 @@ void main() {
         agent: null,
         variant: null,
         model: null,
+        noReply: false,
       );
 
       expect(body.toJson().containsKey("variant"), isFalse);
+      expect(body.toJson().containsKey("noReply"), isFalse);
+    });
+
+    test("SendPromptBody includes noReply when enabled", () {
+      const body = SendPromptBody(
+        parts: [PluginPromptPart.text(text: "Keep auth decisions")],
+        agent: "build",
+        variant: null,
+        model: (providerID: "openai", modelID: "gpt-4.1"),
+        noReply: true,
+      );
+
+      expect(body.toJson()["noReply"], isTrue);
     });
 
     test("SendCommandBody includes variant when provided", () {

--- a/bridge/sesori_plugin_opencode/test/opencode_api_http_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_api_http_test.dart
@@ -4,6 +4,7 @@ import "package:http/http.dart" as http;
 import "package:http/testing.dart";
 import "package:opencode_plugin/opencode_plugin.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
 void main() {
@@ -242,6 +243,45 @@ void main() {
           "model": "openai/gpt-4.1",
         }),
       );
+    });
+  });
+
+  group("OpenCodeApi.sendPrompt", () {
+    test("uses the synchronous endpoint for no-reply prompts", () async {
+      late http.BaseRequest capturedRequest;
+      late String capturedBody;
+      final mockClient = MockClient((request) async {
+        capturedRequest = request;
+        capturedBody = request.body;
+        return http.Response("{}", 200);
+      });
+      final api = OpenCodeApi(
+        client: OpenCodeRawHttpClient(
+          serverURL: "http://localhost:1234",
+          password: "test-pass",
+          client: mockClient,
+        ),
+      );
+
+      await api.sendPrompt(
+        sessionId: "ses-123",
+        body: const SendPromptBody(
+          parts: [PluginPromptPart.text(text: "Keep auth decisions")],
+          agent: "build",
+          variant: null,
+          model: (providerID: "openai", modelID: "gpt-4.1"),
+          noReply: true,
+        ),
+        directory: "/repo",
+      );
+
+      expect(capturedRequest.method, equals("POST"));
+      expect(
+        capturedRequest.url.toString(),
+        equals("http://localhost:1234/session/ses-123/prompt"),
+      );
+      expect(capturedRequest.headers["x-opencode-directory"], equals("/repo"));
+      expect(jsonDecodeMap(capturedBody)["noReply"], isTrue);
     });
   });
 

--- a/bridge/sesori_plugin_opencode/test/opencode_api_http_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_api_http_test.dart
@@ -278,7 +278,7 @@ void main() {
       expect(capturedRequest.method, equals("POST"));
       expect(
         capturedRequest.url.toString(),
-        equals("http://localhost:1234/session/ses-123/prompt"),
+        equals("http://localhost:1234/session/ses-123/message"),
       );
       expect(capturedRequest.headers["x-opencode-directory"], equals("/repo"));
       expect(jsonDecodeMap(capturedBody)["noReply"], isTrue);

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -254,7 +254,7 @@ void main() {
       );
     });
 
-    test("getSessionMessages filters patch and compaction parts", () async {
+    test("getSessionMessages filters patch and automatic compaction parts", () async {
       final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
 
       final messages = await plugin.getSessionMessages("ses-new-parts-filter");
@@ -1408,7 +1408,7 @@ class _FakeOpenCodeServer {
                 "sessionID": "ses-new-parts-filter",
                 "messageID": "m-npf",
                 "type": "compaction",
-                "auto": false,
+                "auto": true,
               },
               {
                 "id": "p-text",

--- a/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_repository_test.dart
@@ -1085,6 +1085,37 @@ void main() {
     });
   });
 
+  group("OpenCodeRepository.addCompactionInstructions", () {
+    test("persists instructions as a no-reply prompt", () async {
+      final api = _FakeApi();
+      final repository = OpenCodeRepository(api);
+
+      await repository.addCompactionInstructions(
+        sessionId: "ses-1",
+        directory: " /repo ",
+        instructions: "Keep auth decisions",
+        agent: "build",
+        variant: const PluginSessionVariant(id: "high"),
+        model: (providerID: "openai", modelID: "gpt-4.1"),
+      );
+
+      expect(api.lastPromptSessionId, equals("ses-1"));
+      expect(api.lastPromptDirectory, equals("/repo"));
+      expect(
+        api.lastPromptBody?.toJson(),
+        equals({
+          "parts": [
+            {"type": "text", "text": "Keep auth decisions"},
+          ],
+          "agent": "build",
+          "variant": "high",
+          "model": {"providerID": "openai", "modelID": "gpt-4.1"},
+          "noReply": true,
+        }),
+      );
+    });
+  });
+
   group("Send*Body toJson", () {
     test("SendPromptBody emits variant only when provided", () {
       final withVariant = const SendPromptBody(
@@ -1092,12 +1123,14 @@ void main() {
         agent: "build",
         variant: "low",
         model: null,
+        noReply: false,
       ).toJson();
       final withoutVariant = const SendPromptBody(
         parts: [PluginPromptPart.text(text: "Hello")],
         agent: "build",
         variant: null,
         model: null,
+        noReply: false,
       ).toJson();
 
       expect(withVariant["variant"], equals("low"));

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -701,7 +701,31 @@ void main() {
       expect(repository.lastSummarizeSessionId, equals("ses-1"));
       expect(repository.lastSummarizeDirectory, equals("/repo"));
       expect(repository.lastSummarizeModel, equals((providerID: "openai", modelID: "gpt-4.1")));
+      expect(repository.addCompactionInstructionsCalls, equals(0));
+      expect(repository.compactionOperations, equals(["summarize"]));
       // The real command endpoint must never be hit for compaction.
+      expect(repository.lastCommandName, isNull);
+    });
+
+    test("persists compact arguments before summarizing", () async {
+      final tracker = FakeActiveSessionTracker(sessionDirectories: const {"ses-1": "/repo"});
+      final repository = FakeOpenCodeRepository();
+      final service = OpenCodeService(repository, tracker);
+
+      await service.sendCommand(
+        sessionId: "ses-1",
+        command: OpenCodeService.compactionCommandName,
+        arguments: "  Keep auth decisions  ",
+        agent: "build",
+        variant: const PluginSessionVariant(id: "high"),
+        model: (providerID: "openai", modelID: "gpt-4.1"),
+      );
+
+      expect(repository.addCompactionInstructionsCalls, equals(1));
+      expect(repository.lastCompactionInstructions, equals("Keep auth decisions"));
+      expect(repository.lastCompactionInstructionsDirectory, equals("/repo"));
+      expect(repository.lastCompactionInstructionsModel, equals((providerID: "openai", modelID: "gpt-4.1")));
+      expect(repository.compactionOperations, equals(["instructions", "summarize"]));
       expect(repository.lastCommandName, isNull);
     });
 
@@ -1903,10 +1927,15 @@ class FakeOpenCodeRepository extends OpenCodeRepository {
   String? lastCommandVariant;
   ({String providerID, String modelID})? lastCommandModel;
   Completer<void>? sendCommandCompleter;
+  int addCompactionInstructionsCalls = 0;
+  String? lastCompactionInstructions;
+  String? lastCompactionInstructionsDirectory;
+  ({String providerID, String modelID})? lastCompactionInstructionsModel;
   int summarizeCalls = 0;
   String? lastSummarizeSessionId;
   String? lastSummarizeDirectory;
   ({String providerID, String modelID})? lastSummarizeModel;
+  final List<String> compactionOperations = [];
   String? lastDeletedSessionId;
   String? lastDeletedDirectory;
   String? lastReplyQuestionId;
@@ -2079,6 +2108,22 @@ class FakeOpenCodeRepository extends OpenCodeRepository {
   }
 
   @override
+  Future<void> addCompactionInstructions({
+    required String sessionId,
+    required String? directory,
+    required String instructions,
+    required String? agent,
+    required PluginSessionVariant? variant,
+    required ({String providerID, String modelID}) model,
+  }) async {
+    addCompactionInstructionsCalls += 1;
+    lastCompactionInstructions = instructions;
+    lastCompactionInstructionsDirectory = directory;
+    lastCompactionInstructionsModel = model;
+    compactionOperations.add("instructions");
+  }
+
+  @override
   Future<void> summarize({
     required String sessionId,
     required String? directory,
@@ -2088,6 +2133,7 @@ class FakeOpenCodeRepository extends OpenCodeRepository {
     lastSummarizeSessionId = sessionId;
     lastSummarizeDirectory = directory;
     lastSummarizeModel = model;
+    compactionOperations.add("summarize");
   }
 
   @override


### PR DESCRIPTION
## Summary
- preserve manual compaction as visible `/compact` history while keeping automatic compaction hidden
- send optional compaction guidance as a no-reply prompt before OpenCode summarization
- keep the fix isolated to the OpenCode plugin

This intentionally scoped PR supersedes #484 for the original bug.

## Verification
- `dart analyze --fatal-infos`
- `dart test` (368 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep manual /compact commands visible in history and persist optional compaction guidance for the next summarize, while keeping automatic compaction hidden. Scoped to the OpenCode plugin; no-reply prompts now use the synchronous /message endpoint.

- **Bug Fixes**
  - Map manual compaction to visible "/compact" (now a named constant); keep automatic compaction hidden.
  - Persist compact guidance via a no-reply prompt before summarize; API uses synchronous /message for no-reply to avoid races.
  - Tests cover part mapping, noReply payload inclusion and endpoint selection, and the compact flow.

<sup>Written for commit 67b9d421da59b1cfeb4b63dc5c514cbaec8a53a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

