### PR TITLE
chore(bridge): update coding backend runtimes

### DIFF
--- a/.opencode/skills/update-backend-runtimes/SKILL.md
+++ b/.opencode/skills/update-backend-runtimes/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: update-backend-runtimes
+description: Update the targeted OpenCode, Codex, and Cursor CLI runtime versions used by the Sesori bridge. Use when asked to update, bump, or refresh the coding backend runtimes, their minimum versions, or their release checksums.
+---
+
+# Update Backend Runtimes
+
+Update the bridge's OpenCode, Codex, and Cursor CLI targets to the latest stable releases. This is separate from the general Dart/Flutter dependency update workflow.
+
+## Scope
+
+- OpenCode managed runtime and PATH minimum:
+  `bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_manifest.dart`
+- OpenCode API surface metadata:
+  `bridge/sesori_plugin_opencode/tool/opencode_v1_surface.json`
+- OpenCode manifest tests:
+  `bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_manifest_test.dart`
+- Codex managed runtime and PATH minimum:
+  `bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart`
+- Codex manifest tests:
+  `bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart`
+- Cursor CLI minimum build:
+  `bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart`
+- Cursor availability tests:
+  `bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart`
+
+Read `bridge/AGENTS.md` before editing. Never hand-edit generated files.
+
+## Version Policy
+
+- Update OpenCode's `bundledVersion` to the latest stable `anomalyco/opencode` GitHub release.
+- Update Codex's `bundledVersion` to the latest stable `openai/codex` GitHub release.
+- Update Cursor's `minVersion` to the calendar date of the current build advertised by the official installer at `https://cursor.com/install`.
+- Do not raise OpenCode's `minPathVersion` unless the user gives a specific minimum or bridge code requires a newer API. If it changes, keep `opencode_v1_surface.json` metadata aligned.
+- Do not raise Codex's `minPathVersion` unless bridge code requires a newer app-server capability or the user explicitly requests it.
+- Ignore prereleases. Confirm GitHub's `latest` release and the corresponding npm package version agree for OpenCode and Codex when npm is available.
+
+## Discover Releases
+
+Fetch concise release data instead of printing complete release payloads.
+
+### OpenCode
+
+```bash
+gh api repos/anomalyco/opencode/releases/latest --jq '{tag: .tag_name, prerelease: .prerelease, assets: [.assets[] | select(.name == "opencode-darwin-arm64.zip" or .name == "opencode-darwin-x64.zip" or .name == "opencode-linux-arm64.tar.gz" or .name == "opencode-linux-x64.tar.gz" or .name == "opencode-windows-arm64.zip" or .name == "opencode-windows-x64.zip") | {name, digest}]}'
+npm view opencode-ai version
+```
+
+Require exactly these six assets and a non-null `sha256:` digest for each:
+
+- `opencode-darwin-arm64.zip`
+- `opencode-darwin-x64.zip`
+- `opencode-linux-arm64.tar.gz`
+- `opencode-linux-x64.tar.gz`
+- `opencode-windows-arm64.zip`
+- `opencode-windows-x64.zip`
+
+Strip the `sha256:` prefix when writing each digest into the manifest.
+
+### Codex
+
+```bash
+gh api repos/openai/codex/releases/latest --jq '{tag: .tag_name, prerelease: .prerelease, assets: [.assets[] | select(.name == "codex-aarch64-apple-darwin.tar.gz" or .name == "codex-x86_64-apple-darwin.tar.gz" or .name == "codex-aarch64-unknown-linux-musl.tar.gz" or .name == "codex-x86_64-unknown-linux-musl.tar.gz" or .name == "codex-aarch64-pc-windows-msvc.exe.zip" or .name == "codex-x86_64-pc-windows-msvc.exe.zip") | {name, digest}]}'
+npm view @openai/codex version
+```
+
+Codex release tags use `rust-vX.Y.Z`; store only `X.Y.Z` in the manifest. Require exactly these six assets and strip the `sha256:` prefix from their digests:
+
+- `codex-aarch64-apple-darwin.tar.gz`
+- `codex-x86_64-apple-darwin.tar.gz`
+- `codex-aarch64-unknown-linux-musl.tar.gz`
+- `codex-x86_64-unknown-linux-musl.tar.gz`
+- `codex-aarch64-pc-windows-msvc.exe.zip`
+- `codex-x86_64-pc-windows-msvc.exe.zip`
+
+Confirm asset filenames have not changed before editing. Do not guess mappings for renamed or missing assets.
+
+### Cursor
+
+Fetch the official installer without executing it:
+
+```bash
+curl -fsSL https://cursor.com/install
+```
+
+Extract the build identifier used in both the version directory and download URL, for example `2026.07.16-899851b`. Do not install or update Cursor locally just to discover the version. If the installer does not expose one unambiguous build identifier, stop and report the blocker rather than guessing.
+
+Cursor comparison parses only the leading `YYYY.MM.DD` calendar version. Store that date in `minVersion` so the displayed requirement exactly matches enforcement; retain the full installer build identifier only in the final report.
+
+## Edit
+
+1. Update OpenCode's bundled version and all six matching SHA-256 values.
+2. Apply an explicitly requested OpenCode minimum and synchronize the API surface metadata comment; otherwise preserve the existing minimum.
+3. Update Codex's bundled version, release-version documentation, and all six matching SHA-256 values.
+4. Preserve the Codex minimum unless a concrete requirement says otherwise.
+5. Update Cursor's minimum to the official current build's calendar date.
+6. Update hard-coded version URLs, version assertions, and recent-version fixtures in the three manifest/availability tests.
+7. Search the affected plugin packages for the replaced target versions. Update only references that describe the current pin; preserve historical comments and protocol-shape observations tied to older versions.
+8. Run `dart format` on changed Dart files.
+
+Use `apply_patch` for manual edits.
+
+## Verify
+
+Run the three plugin suites independently; they may run in parallel:
+
+```bash
+(cd bridge/sesori_plugin_opencode && dart test && dart analyze --fatal-infos)
+(cd bridge/sesori_plugin_codex && dart test && dart analyze --fatal-infos)
+(cd bridge/sesori_plugin_cursor && dart test && dart analyze --fatal-infos)
+git diff --check
+```
+
+If tests fail only because old versions are hard-coded in manifest assertions or availability fixtures, update those assertions to the new targets and rerun. Investigate all other failures normally.
+
+Before finishing, report:
+
+- old and new bundled/minimum versions for each backend
+- whether OpenCode or Codex compatibility floors changed and why
+- whether all twelve GitHub asset digests were refreshed
+- Cursor's installer-advertised build
+- test and analyzer results
+
+Do not commit, push, or create a PR unless the user asks.

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart
@@ -21,7 +21,7 @@ import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 /// the downloaded archive), confirm the [_assets] filenames still match the
 /// release, raise [minPathVersion] only if the bridge starts to require a newer
 /// codex API, and re-run the integration tests. The hashes below are the
-/// published asset digests for codex `rust-v0.142.0`.
+/// published asset digests for codex `rust-v0.144.5`.
 class CodexRuntimeManifest implements RuntimeManifest {
   const CodexRuntimeManifest();
 
@@ -29,7 +29,7 @@ class CodexRuntimeManifest implements RuntimeManifest {
   static final SemanticVersion _minPathVersion = SemanticVersion.parse(value: "0.139.0");
 
   /// The exact codex version the managed runtime installs.
-  static final SemanticVersion _bundledVersion = SemanticVersion.parse(value: "0.142.0");
+  static final SemanticVersion _bundledVersion = SemanticVersion.parse(value: "0.144.5");
 
   static const String _releaseBaseUrl = "https://github.com/openai/codex/releases/download";
 
@@ -43,13 +43,13 @@ class CodexRuntimeManifest implements RuntimeManifest {
       PlatformArch.arm64: RuntimeAsset(
         assetName: "codex-aarch64-apple-darwin.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "daa4443c455f48143d750912fa0f91d7b9456fa52972f725bc1254ae9b5a3648",
+        sha256: "a5b77d2fb393f201777809425ab28d9beb65ee0c0b2bf792f09eaf8ef1151592",
         archiveBinaryName: "codex-aarch64-apple-darwin",
       ),
       PlatformArch.x64: RuntimeAsset(
         assetName: "codex-x86_64-apple-darwin.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "20141a58b1e077b23f0387e99afc3d76280ecd6c92ef68334344a0a379d29336",
+        sha256: "ff5c894a9ffa6d97c225c8d3c869c7ef7573dcbd0cf9b762ecfb9fa96dbb7d88",
         archiveBinaryName: "codex-x86_64-apple-darwin",
       ),
     },
@@ -57,13 +57,13 @@ class CodexRuntimeManifest implements RuntimeManifest {
       PlatformArch.arm64: RuntimeAsset(
         assetName: "codex-aarch64-unknown-linux-musl.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "63fc9816f174ab4f713031e638201c49cfa7cc5f41a22b9db71010afa7e09892",
+        sha256: "5433789cd66e0db3b78cccd218d894471ed9e92fe93465120d1356508952084d",
         archiveBinaryName: "codex-aarch64-unknown-linux-musl",
       ),
       PlatformArch.x64: RuntimeAsset(
         assetName: "codex-x86_64-unknown-linux-musl.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "2e3acb39a277ff11c314d832cfdd246faebeea26bf01aff8e9e10641e6dea801",
+        sha256: "b6bea13bedf493232f6717714c45e783788c695cedcf37c344f73afc97b1ec9f",
         archiveBinaryName: "codex-x86_64-unknown-linux-musl",
       ),
     },
@@ -71,13 +71,13 @@ class CodexRuntimeManifest implements RuntimeManifest {
       PlatformArch.arm64: RuntimeAsset(
         assetName: "codex-aarch64-pc-windows-msvc.exe.zip",
         format: ArchiveFormat.zip,
-        sha256: "bfed1f82f822e4a749be336a5924d5a858949413498f6fc2ae9c1f806d3e02a9",
+        sha256: "e5f319f9f737605731aecf4208b7cda88df9ef0f98fa22c9935944bd7f267469",
         archiveBinaryName: "codex-aarch64-pc-windows-msvc.exe",
       ),
       PlatformArch.x64: RuntimeAsset(
         assetName: "codex-x86_64-pc-windows-msvc.exe.zip",
         format: ArchiveFormat.zip,
-        sha256: "b109ccef543d969128e22834857343af94fe446039ff51854926b585dd136e6f",
+        sha256: "c5fa9ad03f266640465da5677f2bcebd2db02a604940d1264b6a342d5136df91",
         archiveBinaryName: "codex-x86_64-pc-windows-msvc.exe",
       ),
     },

--- a/bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart
@@ -8,7 +8,7 @@ void main() {
 
   group("CodexRuntimeManifest", () {
     test("pinned versions", () {
-      expect(manifest.bundledVersion.toString(), "0.142.0");
+      expect(manifest.bundledVersion.toString(), "0.144.5");
       expect(manifest.minPathVersion.toString(), "0.139.0");
       expect(manifest.runtimeId, "codex");
       expect(manifest.pathExecutableName, "codex");
@@ -17,7 +17,9 @@ void main() {
     test("pins a sha256 asset for every platform target", () {
       for (final os in PlatformOs.values) {
         for (final arch in PlatformArch.values) {
-          final asset = manifest.assetFor(target: PlatformTarget(os: os, arch: arch));
+          final asset = manifest.assetFor(
+            target: PlatformTarget(os: os, arch: arch),
+          );
           expect(asset, isNotNull, reason: "missing asset for $os/$arch");
           expect(asset!.sha256, matches(RegExp(r"^[0-9a-f]{64}$")), reason: "$os/$arch sha256");
           expect(asset.assetName, isNotEmpty);
@@ -26,8 +28,9 @@ void main() {
     });
 
     test("darwin/linux ship .tar.gz, windows ships .exe.zip", () {
-      RuntimeAsset asset(PlatformOs os, PlatformArch arch) =>
-          manifest.assetFor(target: PlatformTarget(os: os, arch: arch))!;
+      RuntimeAsset asset(PlatformOs os, PlatformArch arch) => manifest.assetFor(
+        target: PlatformTarget(os: os, arch: arch),
+      )!;
 
       expect(asset(PlatformOs.macos, PlatformArch.arm64).format, ArchiveFormat.tarGz);
       expect(asset(PlatformOs.macos, PlatformArch.arm64).assetName, endsWith(".tar.gz"));
@@ -43,15 +46,27 @@ void main() {
 
     test("archive member is the target-triple name (asset name minus extension)", () {
       expect(
-        manifest.assetFor(target: const PlatformTarget(os: PlatformOs.macos, arch: PlatformArch.arm64))!.archiveBinaryName,
+        manifest
+            .assetFor(
+              target: const PlatformTarget(os: PlatformOs.macos, arch: PlatformArch.arm64),
+            )!
+            .archiveBinaryName,
         "codex-aarch64-apple-darwin",
       );
       expect(
-        manifest.assetFor(target: const PlatformTarget(os: PlatformOs.linux, arch: PlatformArch.x64))!.archiveBinaryName,
+        manifest
+            .assetFor(
+              target: const PlatformTarget(os: PlatformOs.linux, arch: PlatformArch.x64),
+            )!
+            .archiveBinaryName,
         "codex-x86_64-unknown-linux-musl",
       );
       expect(
-        manifest.assetFor(target: const PlatformTarget(os: PlatformOs.windows, arch: PlatformArch.x64))!.archiveBinaryName,
+        manifest
+            .assetFor(
+              target: const PlatformTarget(os: PlatformOs.windows, arch: PlatformArch.x64),
+            )!
+            .archiveBinaryName,
         "codex-x86_64-pc-windows-msvc.exe",
       );
     });
@@ -62,7 +77,7 @@ void main() {
       )!;
       expect(
         manifest.downloadUrlFor(asset: asset),
-        equals("https://github.com/openai/codex/releases/download/rust-v0.142.0/codex-aarch64-apple-darwin.tar.gz"),
+        equals("https://github.com/openai/codex/releases/download/rust-v0.144.5/codex-aarch64-apple-darwin.tar.gz"),
       );
     });
 

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
@@ -62,7 +62,7 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
   /// silently no-op model switching and history replay, so the experience is
   /// broken in ways the user can't see. Keep this target aligned with the
   /// latest verified Cursor CLI build.
-  static const String minVersion = "2026.07.16-899851b";
+  static const String minVersion = "2026.07.16";
 
   /// CLI option naming the Cursor CLI binary (path or PATH name). Declared
   /// as the bare local name — the bridge's [PluginCliOptionsMapper] namespaces

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
@@ -60,9 +60,9 @@ class CursorPluginDescriptor extends BridgePluginDescriptor {
   /// Minimum Cursor CLI build the bridge supports. Earlier builds (e.g.
   /// `2026.05.28`) advertise the `acp` model picker and `session/load` but
   /// silently no-op model switching and history replay, so the experience is
-  /// broken in ways the user can't see. `2026.06.15` is the verified-good
-  /// build where both work end-to-end.
-  static const String minVersion = "2026.06.15";
+  /// broken in ways the user can't see. Keep this target aligned with the
+  /// latest verified Cursor CLI build.
+  static const String minVersion = "2026.07.16-899851b";
 
   /// CLI option naming the Cursor CLI binary (path or PATH name). Declared
   /// as the bare local name — the bridge's [PluginCliOptionsMapper] namespaces

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
@@ -21,7 +21,7 @@ void main() {
       final processes = _ProbeProcessService(
         process: _ProbeProcess(
           pid: 4242,
-          stdoutBytes: utf8.encode("2026.06.15-18-00-12-6f5a2cf\n"),
+          stdoutBytes: utf8.encode("2026.07.16-899851b\n"),
           exitCode: Future<int>.value(0),
         ),
       );

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_manifest.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_runtime_manifest.dart
@@ -25,12 +25,12 @@ class OpenCodeRuntimeManifest implements RuntimeManifest {
   const OpenCodeRuntimeManifest();
 
   /// Minimum pre-installed OpenCode version the bridge will use as-is.
-  /// Conservative on purpose: prefer the user's own install whenever it is a
-  /// 1.x, and only download the managed runtime for genuinely old installs.
-  static final SemanticVersion _minPathVersion = SemanticVersion.parse(value: "1.0.0");
+  /// Conservative on purpose: prefer the user's own compatible install and
+  /// only download the managed runtime for genuinely old installs.
+  static final SemanticVersion _minPathVersion = SemanticVersion.parse(value: "1.14.0");
 
   /// The exact OpenCode version the managed runtime installs.
-  static final SemanticVersion _bundledVersion = SemanticVersion.parse(value: "1.17.18");
+  static final SemanticVersion _bundledVersion = SemanticVersion.parse(value: "1.18.3");
 
   static const String _releaseBaseUrl = "https://github.com/anomalyco/opencode/releases/download";
 
@@ -43,13 +43,13 @@ class OpenCodeRuntimeManifest implements RuntimeManifest {
       PlatformArch.arm64: RuntimeAsset(
         assetName: "opencode-darwin-arm64.zip",
         format: ArchiveFormat.zip,
-        sha256: "24327f89c103526c0518fc9b797767f318ab85ef3cee8636e722d6138f33aa3d",
+        sha256: "946f62b155638b911144b7bef520ee4a6442f696297907873463bca3524e40ef",
         archiveBinaryName: "opencode",
       ),
       PlatformArch.x64: RuntimeAsset(
         assetName: "opencode-darwin-x64.zip",
         format: ArchiveFormat.zip,
-        sha256: "cebf209aad2c0bd998fbac3f8dd1b45eef35da1af18cd698e78b111b73c5fbb0",
+        sha256: "4ea147867ba19e4ec03559df557811f1674f40788aea4d10326dc563b7667c6d",
         archiveBinaryName: "opencode",
       ),
     },
@@ -57,13 +57,13 @@ class OpenCodeRuntimeManifest implements RuntimeManifest {
       PlatformArch.arm64: RuntimeAsset(
         assetName: "opencode-linux-arm64.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "db9b53eae485da969a0a855bca465f9901dd84676384f724f320e3ccc5a9b107",
+        sha256: "da0a631174eba380b2a1d51f9d364fa3812da433e72743c72471d4b5da59c69d",
         archiveBinaryName: "opencode",
       ),
       PlatformArch.x64: RuntimeAsset(
         assetName: "opencode-linux-x64.tar.gz",
         format: ArchiveFormat.tarGz,
-        sha256: "e149d32ee5667c0cd5fb84d0bf8393b312e93782eeb4d74d29bbb0392de7133c",
+        sha256: "60f27b2679f00a511b6539f97e02448afaf58d9c66e2448285ea0c517ca84583",
         archiveBinaryName: "opencode",
       ),
     },
@@ -71,13 +71,13 @@ class OpenCodeRuntimeManifest implements RuntimeManifest {
       PlatformArch.arm64: RuntimeAsset(
         assetName: "opencode-windows-arm64.zip",
         format: ArchiveFormat.zip,
-        sha256: "fcfbd7f82242f47ec7e98bc8819eeebe716654e9bce1fb1bd7f364e887cb95ab",
+        sha256: "a549fb2e9041db9438bcd9b77bfa0a4b2476caf2d550f37479aabfec1b079bfb",
         archiveBinaryName: "opencode.exe",
       ),
       PlatformArch.x64: RuntimeAsset(
         assetName: "opencode-windows-x64.zip",
         format: ArchiveFormat.zip,
-        sha256: "7d489fd9b314e25bccf9c5dd2f17ef2774902c7b7db9aa34f46b0aab4715c70c",
+        sha256: "68bc62930f6cb5755e0409aa9de0bb270a66ed2b8c9cf0c029e9f2287ed5486e",
         archiveBinaryName: "opencode.exe",
       ),
     },

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_runtime_manifest_test.dart
@@ -10,7 +10,9 @@ void main() {
     test("pins a sha256 asset for every supported platform target", () {
       for (final os in PlatformOs.values) {
         for (final arch in PlatformArch.values) {
-          final asset = manifest.assetFor(target: PlatformTarget(os: os, arch: arch));
+          final asset = manifest.assetFor(
+            target: PlatformTarget(os: os, arch: arch),
+          );
           expect(asset, isNotNull, reason: "missing asset for $os/$arch");
           expect(asset!.sha256, matches(RegExp(r"^[0-9a-f]{64}$")), reason: "$os/$arch sha256");
           expect(asset.assetName, isNotEmpty);
@@ -19,8 +21,9 @@ void main() {
     });
 
     test("darwin/windows ship .zip, linux ships .tar.gz", () {
-      RuntimeAsset asset(PlatformOs os, PlatformArch arch) =>
-          manifest.assetFor(target: PlatformTarget(os: os, arch: arch))!;
+      RuntimeAsset asset(PlatformOs os, PlatformArch arch) => manifest.assetFor(
+        target: PlatformTarget(os: os, arch: arch),
+      )!;
 
       expect(asset(PlatformOs.macos, PlatformArch.arm64).format, ArchiveFormat.zip);
       expect(asset(PlatformOs.macos, PlatformArch.arm64).assetName, endsWith(".zip"));
@@ -36,11 +39,12 @@ void main() {
       )!;
       expect(
         manifest.downloadUrlFor(asset: asset),
-        equals("https://github.com/anomalyco/opencode/releases/download/v1.17.18/opencode-darwin-arm64.zip"),
+        equals("https://github.com/anomalyco/opencode/releases/download/v1.18.3/opencode-darwin-arm64.zip"),
       );
     });
 
     test("bundled version is at least the minimum supported version", () {
+      expect(manifest.minPathVersion.toString(), "1.14.0");
       expect(
         manifest.bundledVersion.compareTo(manifest.minPathVersion),
         greaterThanOrEqualTo(0),

--- a/bridge/sesori_plugin_opencode/tool/opencode_v1_surface.json
+++ b/bridge/sesori_plugin_opencode/tool/opencode_v1_surface.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Minimum supported OpenCode tag: v1.16.2. This allowlist is the v1 API surface used by the Sesori bridge; drift should surface through codegen, compile, or test failures.",
+  "_comment": "Minimum supported OpenCode tag: v1.14.0. This allowlist is the v1 API surface used by the Sesori bridge; drift should surface through codegen, compile, or test failures.",
   "operations": [
     "global.health",
     "project.list",


### PR DESCRIPTION
## Summary
- update the managed OpenCode runtime to 1.18.3 and require OpenCode 1.14.0 or newer on PATH
- update the managed Codex runtime to 0.144.5
- update the minimum Cursor CLI build date to 2026.07.16
- refresh OpenCode and Codex release asset SHA-256 digests and matching tests
- add an OpenCode skill for repeating backend runtime updates safely

## Verification
- `dart test` and `dart analyze --fatal-infos` in `bridge/sesori_plugin_opencode`
- `dart test` and `dart analyze --fatal-infos` in `bridge/sesori_plugin_codex`
- `dart test` and `dart analyze --fatal-infos` in `bridge/sesori_plugin_cursor`
- `git diff --check`