### PR TITLE
docs(plan): define bridge app onboarding

### DIFF
--- a/.opencode/agents/aristotle-impl-review.md
+++ b/.opencode/agents/aristotle-impl-review.md
@@ -40,6 +40,15 @@ Every violation you find is **BLOCKING**. There are no warnings or suggestions, 
 - No rule-sympathy. Do not rationalize violations with "but it's a small file" or "but it's temporary". Either it conforms or it does not.
 - No scope creep. Your scope is architectural integrity only. Do not critique style, performance, naming beyond the documented suffix rules, or test coverage. Other concerns belong to other reviewers.
 
+## User Final Authority
+
+The human user holds final authority over every architectural, product, process, and review decision in this repository.
+
+- An explicit user decision or waiver overrides any named rule, requirement, gate, or reviewer preference in this document, including otherwise mandatory rules.
+- Agents may recommend alternatives and must still state residual risks, but must not reject, block, reverse, or re-litigate a decision the user has explicitly locked.
+- Apply a waiver only to the exact behavior and scope the user named. Unwaived rules remain fully enforced.
+- Prefer a durable plan/tracker/PR record of the waiver when one exists. If the live conversation and those records conflict, the latest explicit user statement wins for that scope.
+
 ## Legacy Code
 
 Much of the existing codebase was written before this architectural guideline existed and does NOT follow it. This is expected — legacy code will be migrated over time.

--- a/.opencode/agents/aristotle-plan-review.md
+++ b/.opencode/agents/aristotle-plan-review.md
@@ -26,6 +26,15 @@ Every violation you find is **BLOCKING**. There are no warnings or suggestions, 
 - No rule-sympathy. Do not rationalize violations with "but it's a small class" or "but it's temporary". Either it conforms or it does not.
 - No scope creep. Your scope is architectural integrity only. Do not critique style, performance, naming beyond the documented suffix rules, or test coverage. Other concerns belong to other reviewers.
 
+## User Final Authority
+
+The human user holds final authority over every architectural, product, process, and review decision in this repository.
+
+- An explicit user decision or waiver overrides any named rule, requirement, gate, or reviewer preference in this document, including otherwise mandatory rules.
+- Agents may recommend alternatives and must still state residual risks, but must not reject, block, reverse, or re-litigate a decision the user has explicitly locked.
+- Apply a waiver only to the exact behavior and scope the user named. Unwaived rules remain fully enforced.
+- Prefer a durable plan/tracker record of the waiver when one exists. If the live conversation and the plan conflict, the latest explicit user statement wins for that scope.
+
 ## Legacy Code
 
 Much of the existing codebase was written before this architectural guideline existed and does NOT follow it. This is expected — legacy code will be migrated over time.

--- a/.opencode/agents/sesori-plan-maker.md
+++ b/.opencode/agents/sesori-plan-maker.md
@@ -80,7 +80,10 @@ Apply that text literally:
    decisions and include your recommended answer with a concrete rationale.
 4. Challenge contradictory, unsafe, over-broad, or speculative solutions.
    Recommend the smallest intent-preserving alternative, but never silently
-   replace the user's intent.
+   replace the user's intent. The user holds final authority: an explicit user
+   decision or waiver overrides any named architectural, product, process, or
+   review rule. Record the exact waived scope in the plan/tracker, keep all
+   unwaived rules enforced, and do not re-litigate a locked user decision.
 5. Follow each branch of the design tree: goal, users, success, non-goals,
    current behavior, architecture, data flow, compatibility, persistence,
    failure handling, security, rollout, observability, verification, manual

--- a/.opencode/agents/sesori-plan-worker.md
+++ b/.opencode/agents/sesori-plan-worker.md
@@ -271,6 +271,13 @@ multi-bridge addressing, thin product shells, headless bridge support, separate
 trust postures, one session-control surface, and autonomy at the bridge seam.
 Do not add speculative product abstractions.
 
+The user holds final authority. An explicit user decision or waiver recorded in
+the approved plan/tracker, or restated in the live conversation for the same
+scope, overrides any named architectural, product, process, or review rule for
+exactly that scope. Keep recommending safer alternatives when useful, but do not
+block, reverse, or re-litigate a locked user decision. Unwaived rules remain
+fully enforced.
+
 For Dart/Freezed transport compatibility, strongly prefer `@Default` when one
 honest legacy meaning exists. Normalize at the transport/repository boundary
 and keep values required and non-null through modern internal APIs whenever the

--- a/.plan/active/bridge-app-onboarding/PLAN.md
+++ b/.plan/active/bridge-app-onboarding/PLAN.md
@@ -2,7 +2,7 @@
 
 ## 0. Plan Metadata
 
-- **Status:** Approved — ready for delivery
+- **Status:** Finalized under user-authorized one-review/fix process — plan PR open
 - **Format version:** 1
 - **Generated:** 2026-07-17
 - **Plan slug:** `bridge-app-onboarding`
@@ -46,10 +46,11 @@ warnings.
 4. A token registration committed after the bridge begins waiting wakes all
    same-user long polls without a client-side polling interval; the bridge
    prints a brief success line and resumes startup.
-5. `s` or `skip`, case-insensitive after trimming and followed by Enter, cancels
-   any active token-refresh/status request or retry delay, waits for cancellation
-   settlement, and skips only the current run. A later bridge start prompts
-   again while no token exists.
+5. Once confirmed absence or a transient warning exposes onboarding/skip
+   guidance, `s` or `skip`, case-insensitive after trimming and followed by
+   Enter, cancels any active token-refresh/status request or retry delay, waits
+   for cancellation settlement, and skips only the current run. Input typed
+   during the initial silent check remains queued for the next real prompt.
 6. A normal 30-second server long-poll expiry returns `registered: false`, emits
    no warning, and is followed immediately by another long poll.
 7. Network failures, client-side request timeouts, HTTP 408/429, and HTTP 5xx
@@ -88,8 +89,9 @@ warnings.
 - One asynchronous bridge terminal-input owner reused by existing prompts.
 - A pure-Dart QR dependency and terminal formatter with capability/width
   fallbacks.
-- Additive generated Freezed/JSON output for a bridge-local typed response; no
-  generated file is hand-edited.
+- Additive shared Freezed email-login/refresh request DTOs plus a bridge-local
+  typed response, with all generated JSON output produced by tools rather than
+  hand-edited.
 - Focused unit, route, service, lifecycle, runner, formatting, and regression
   tests plus one advisory manual checkpoint.
 - Compatibility behavior and an exact cleanup marker for bridges talking to an
@@ -107,6 +109,8 @@ warnings.
 - Reusing lifetime `mobileSetupAt` activation history as current presence.
 - New database collections, indexes, migrations, Redis, change streams, leases,
   or horizontal-scaling abstractions.
+- A server-sent-event/WebSocket presence channel or importing/refactoring a
+  plugin SSE implementation into auth.
 - QR images/files, OSC hyperlinks, terminal probing commands, or unbounded
   support claims for every terminal/font/camera combination.
 - Auth, relay, plugin, shared wire, mobile, desktop, trust-posture, or
@@ -250,6 +254,7 @@ returned.
 bridge GET status?wait=true
   -> requireAuth identifies user
   -> AppClientPresenceService starts one absolute 30s deadline, then checks DeviceTokenRepository.hasAnyForUser
+  -> initial read misses deadline: service emits typed domain timeout; route maps it to existing 500
   -> absent before deadline: register per-user waiter for only the remaining budget + abort cleanup
   -> recheck repository after waiter registration
   -> return false on 30s timeout, or hijack/return nothing after disconnect
@@ -272,28 +277,41 @@ recheck paths remove listener/timer/map state.
 
 | Component | Layer / expected path | Ownership |
 |---|---|---|
+| `EmailLoginRequest` / `RefreshTokenRequest` | Shared API DTOs, `shared/sesori_shared/lib/src/models/auth/` | Freezed request bodies with exact existing `email`/`password` and `refreshToken` JSON keys. Export from `sesori_shared.dart`; bridge auth API serializes them instead of inline maps. No relay/mobile/desktop behavior changes. |
 | `AppClientPresenceResponse` | API DTO, `bridge/app/lib/src/auth/app_client_presence_response.dart` | Freezed/JSON transport shape with required non-null `registered`; generated output only through build_runner. |
 | `SesoriAuthApi` | Layer 1, `bridge/app/lib/src/auth/sesori_auth_api.dart` | Sole `Api` owner for the configurable Sesori auth server. Absorb existing email, OAuth, profile/me, refresh, bridge-registration and new app-status HTTP operations; own URI/header/body/typed decode plus abortable request/deadline mechanics. The PR deletes superseded use-case API classes and top-level HTTP functions rather than forwarding through them. |
 | `AuthRepository` | Layer 2, `bridge/app/lib/src/auth/auth_repository.dart` | Map profile/access-token validation and typed refresh results from `SesoriAuthApi`; distinguish transient, unavailable, and cancelled refresh failures without message parsing. |
-| `TokenStorage` | Layer 1 concrete auth storage boundary, `bridge/app/lib/src/auth/token_storage.dart` | Own token-file load/save/clear plus legacy bridge-id read over the existing path/permissions. Inject directly into `TokenService`, `BridgeRuntimeAuthService`, bridge-id migration, and logout; remove load/save/clear callback plumbing. |
+| `TokenStorage` | Layer 1 auth persistence API, `bridge/app/lib/src/auth/token_storage.dart` | Own raw token-file string read/write/clear over the existing path/permissions. It contains no JSON/provider/legacy mapping and only `TokenRepository` consumes it. |
+| `TokenRepository` | Layer 2 auth repository, `bridge/app/lib/src/auth/token_repository.dart` | Map `TokenStorage` missing/corrupt/persisted state into typed token-domain results and expose read/write/clear/legacy-id operations to services. `TokenService`, `BridgeRuntimeAuthService`, bridge-id migration, and logout depend on this repository rather than Layer 1 storage or callbacks. |
+| `BridgeIdStorage` / `BridgeIdRepository` | Layer 1/2 auth persistence seam, `bridge_id_storage.dart` and new `bridge_id_repository.dart` | Storage retains raw bridge-id file I/O. Repository owns typed read/write/clear mapping and is the only storage consumer; registration, migration, and logout services consume the repository. |
 | `LoginOAuthRepository` | Layer 2, `bridge/app/lib/src/auth/login_oauth_repository.dart` | Map OAuth init/status/ACK calls from the consolidated API for `LoginOAuthService`. |
 | Existing auth repositories | Layer 2, `login_email_repository.dart`, `bridge_registration_repository.dart` | Consume the same `SesoriAuthApi` directly and preserve their domain exception/result mapping; no forwarding API wrappers remain. |
 | `AppClientPresenceRepository` | Layer 2, `bridge/app/lib/src/auth/app_client_presence_repository.dart` | Accept an access token from its caller, delegate app status to `SesoriAuthApi`, normalize registered/absent/unauthorized/unavailable/transient/cancelled outcomes, and own the old-server compatibility seam. It has no token authority, retry, output, or delay policy. |
 | `TokenRefresher` / `TokenService` | Existing service contract and renamed `bridge/app/lib/src/auth/token_service.dart` implementation | Require both named `forceRefresh` and auth-local `AuthRequestCancellationSignal` on token acquisition, add typed access-failure kinds, and use abortable refresh via `AuthRepository`. Update both production implementors and every caller/fake. During onboarding the newly composed standalone service is the only token caller, so skip owns and terminates its refresh request. |
 | `AppOnboardingFormatter` | Foundation/pure formatter, `bridge/app/lib/src/foundation/app_onboarding_formatter.dart` | Convert URL + QR modules + width/ANSI/Unicode capabilities into bounded explicit black/white ANSI+Unicode text with a light quiet zone, or URL-only when polarity/capability/width safety is not proven. No I/O or lifecycle. |
-| `TerminalInteractionMode` | Foundation, `bridge/app/lib/src/foundation/terminal_interaction_mode.dart` | Typed `interactive` / `unavailable` / `legacyPostUpdate` result computed by composition roots from raw terminal facts and invocation environment. Existing terminal prompt decision/replace contracts move from `server/foundation` to root Foundation with it. |
-| `TerminalPromptApi` / `TerminalPromptRepository` | Root Layer 1/2, `bridge/app/lib/src/api/terminal_prompt_api.dart` and `lib/src/repositories/terminal_prompt_repository.dart` | Move the substantially changed terminal boundaries out of the minimal `server/` subsystem. API owns raw async terminal I/O/facts; repository receives interaction mode and maps provider/credentials/yes-no/onboarding outcomes. |
+| `TerminalInteractionMode` / `TerminalRenderingCapabilities` | Foundation typed models | `interactive` / `unavailable` / `legacyPostUpdate` and immutable ANSI/Unicode/width facts. Composition roots never derive these models from raw terminal/environment values. |
+| `TerminalPromptApi` / `TerminalPromptRepository` | Root Layer 1/2, `bridge/app/lib/src/api/terminal_prompt_api.dart` and `lib/src/repositories/terminal_prompt_repository.dart` | Move the substantially changed terminal boundaries out of the minimal `server/` subsystem. API owns raw async terminal I/O, attached-handle/environment facts, and capability reads. Repository is the sole mapper from those Layer-1 facts to typed mode/rendering capabilities and provider/credentials/yes-no/onboarding outcomes. |
 | `AppClientOnboardingService` | Layer 3, `bridge/app/lib/src/services/app_client_onboarding_service.dart` | Own access-token acquisition, exactly one forced refresh/retry after 401, checkpoint state, terminal subscription, cancellation, long-poll loop, internal retry timer, output, and exactly-once completion. It depends on root repositories/Foundation plus `TokenRefresher`, not on the `server/` subsystem. |
-| `BridgeRuntimeAuthService` | Root Layer 3, moved to `bridge/app/lib/src/services/bridge_runtime_auth_service.dart` | Delegate provider/credential input to root `TerminalPromptRepository`, use injected auth repositories/storage, preserve auth decisions/persistence, and import no runtime options/type. |
-| `BridgeStartupOrchestrator` | Root Layer 5, `bridge/app/lib/src/bridge_startup_orchestrator.dart` | Sole startup and session composition/lifecycle owner. Construct auth, terminal, token, onboarding and existing startup/session collaborators; authenticate, check availability, onboard, provision/start plugin, directly construct existing session `Orchestrator`, inject it into `BridgeRuntime`, invoke runner, and own disposal. |
-| `BridgeRuntime` change | Existing lifecycle holder | Delete static `BridgeRuntime.create`; retain the existing generative constructor over already-built session and lifecycle collaborators. |
-| `BridgeRuntimeRunner` | Injected consumer | Receive already-built `BridgeRuntime`, `PluginFailureLatch`, `BridgeRestartService`, and supervised flag as direct required constructor parameters; execute the ready runtime/session and map typed exit/failure outcomes. It constructs no lower layer. |
+| `BridgeRuntimeAuthService` | Root Layer 3, moved to `bridge/app/lib/src/services/bridge_runtime_auth_service.dart` | Delegate provider/credential input to root `TerminalPromptRepository`, use injected auth repositories, preserve auth decisions/persistence, and import no runtime options/type. |
+| `BridgeRuntimeRunner` | Existing process-startup composer | Retain the startup ownership locked by the active desktop and parallel-plugin plans: construct auth/terminal/token/onboarding and existing process-startup collaborators; authenticate, check availability, onboard, then continue mutex/provision/plugin startup and runtime handoff. |
+| Existing `Orchestrator` | Existing post-start session composer | Remain the room/session/event composer after plugin startup. `BridgeRuntime.create` stays the existing session-phase handoff factory and gains no onboarding, auth, terminal, or process-startup policy. |
 
-The startup orchestrator owns pre-plugin lifecycle; the existing session
-`Orchestrator` remains the sole relay/plugin/session-control owner after plugin
-start. Startup injects the completed runtime and typed outcome collaborators
-directly into runner, then retains teardown ownership around execution. The
-bridge remains headless and plugin-neutral.
+The user explicitly approves a narrow B-B5 exception for the established
+two-phase composition boundary required by the active desktop and parallel-
+plugin plans: `BridgeRuntimeRunner` is the process-startup composer and the
+existing `Orchestrator` is the post-start room/session/event composer.
+`BridgeRuntime.create` remains only the existing handoff inside the latter
+phase and gains no new startup ownership. No third startup orchestrator is
+introduced. This waiver does not authorize other cross-layer composers.
+
+The user explicitly approves a narrow exception to the repository's push-based
+default for the existing authentication request/response flow and this
+server-held app-presence long poll. `AppClientOnboardingService` may issue the
+next `wait=true` request immediately after a normal 30-second false response;
+the server still pushes registration through the currently held request after
+durable upsert, and there is no client timer between healthy rounds. This does
+not authorize pull loops elsewhere, an SSE abstraction, or moving retry/output
+policy below the service.
 
 Production constructor and lifecycle ownership is explicit:
 
@@ -306,6 +324,11 @@ SesoriAuthApi(
 AuthRepository(
   required SesoriAuthApi,
   required refreshRequestTimeout) # composition passes 15 seconds
+
+TokenStorage(required tokenFilePath)
+TokenRepository(required TokenStorage)
+BridgeIdStorage(required bridgeIdFilePath)
+BridgeIdRepository(required BridgeIdStorage)
 
 LoginEmailRepository(required SesoriAuthApi)
 LoginOAuthRepository(
@@ -320,7 +343,7 @@ AppClientPresenceRepository(
 TokenService(
   required initialToken,
   required AuthRepository,
-  required TokenStorage)
+  required TokenRepository)
 
 AppClientOnboardingService(
   required AppClientPresenceRepository,
@@ -331,28 +354,19 @@ AppClientOnboardingService(
   # owns AuthRequestCancellationController, terminal subscription, and cancellable Timer
 
 AppOnboardingFormatter(
-  required supportsAnsi,
-  required supportsUnicode,
-  required nullable terminalColumns)
-  # immutable rendering facts; no I/O or collaborator lifecycle
+  required TerminalRenderingCapabilities capabilities)
+  # repository-produced immutable model; no I/O or collaborator lifecycle
 
-TerminalPromptApi(required Stdin, required Stdout)
-  # owns/disposes its lazy input subscription plus FIFO pending-line buffer; no environment policy
+TerminalPromptApi(required Stdin, required Stdout, required environment)
+  # also receives invocation environment facts; owns/disposes lazy input + FIFO
 
-TerminalPromptRepository(
-  required TerminalPromptApi,
-  required TerminalInteractionMode)
-
-BridgeRuntimeRunner(
-  required BridgeRuntime,
-  required PluginFailureLatch,
-  required BridgeRestartService,
-  required isSupervised)
+TerminalPromptRepository(required TerminalPromptApi)
+  # maps raw API facts to typed interaction mode/rendering capabilities
 ```
 
 The duration comments describe production values, not optional constructor
-defaults: callers pass them explicitly. `BridgeStartupOrchestrator` owns the
-shared HTTP client's close lifecycle; `SesoriAuthApi` borrows it.
+defaults: callers pass them explicitly. `BridgeRuntimeRunner` retains ownership
+of the shared HTTP client's close lifecycle; `SesoriAuthApi` borrows it.
 `AppClientOnboardingService` creates/cancels its one-shot `Timer` internally and
 tests virtual time with `fake_async`; no delay callback or timer peer is added.
 
@@ -373,52 +387,50 @@ bootstrap preserves its existing auth-required exit for transient/unavailable.
 requiring message parsing. Every implementation, caller, and fake is updated.
 `AuthRequestCancellationSignal`/`AuthRequestCancellationController` live inside
 the self-contained `auth/` subsystem with `never`, `canCancel`, `isCancelled`,
-`whenCancelled`, and idempotent `cancel`; plugin-specific `StartAbortSignal`
+a broadcast cancellation stream, and idempotent `cancel`; plugin-specific `StartAbortSignal`
 remains untouched. When `canCancel` is true,
 `TokenService` awaits a near-expiry refresh instead of launching the legacy
 detached background-refresh branch, so onboarding completion can prove no
 refresh remains. Existing `never` callers retain background behavior.
 
-`TokenService` preserves the shipped distinction between initial token-file
-corruption and corruption observed only on the post-refresh re-read. Initial
-corruption is unavailable. A post-response `FormatException` retains only
-`lastProvider` from the valid pre-refresh snapshot and writes the newly issued
-tokens to repair the file; a missing/cleared post-refresh file still aborts
-persistence so logout cannot be resurrected.
+`TokenRepository` maps raw file/JSON state into typed available, missing,
+corrupt, and failure outcomes. `TokenService` preserves the shipped business
+distinction between initial corruption and corruption observed only on the
+post-refresh re-read. Initial corruption is unavailable. A post-response
+corrupt outcome retains only `lastProvider` from the valid pre-refresh snapshot
+and writes the newly issued tokens through the repository to repair the file; a
+missing/cleared post-refresh outcome still aborts persistence so logout cannot
+be resurrected.
 
-`runBridgeApp` moves from `bridge_runtime_runner.dart` into root
-`bridge_startup_orchestrator.dart`; `bin/bridge.dart` imports that root entrypoint.
-It creates `BridgeStartupOrchestrator` through its explicit composition factory
-from CLI/plugin inputs and invokes it. Runner never imports the startup
-orchestrator, eliminating a circular dependency. The startup
-orchestrator constructs every lower-layer collaborator, runs all pre-plugin
-phases, starts the plugin, directly constructs the existing session
-`Orchestrator`, injects that completed session plus lifecycle collaborators into
-plain `BridgeRuntime`, then directly injects `BridgeRuntime`, failure latch,
-restart service, and supervised flag into `BridgeRuntimeRunner`. It wraps runner
-execution in the existing shutdown coordinator/failure/exit lifecycle.
+`runBridgeApp` and `BridgeRuntimeRunner.run` remain in
+`bridge_runtime_runner.dart`, matching the active desktop and parallel-plugin
+plans. The runner replaces its touched inline/API/callback seams with the
+declared APIs, repositories, and services, runs onboarding at the locked point,
+then continues its existing mutex/provision/plugin-start flow and invokes
+`BridgeRuntime.create`. The existing session `Orchestrator` remains responsible
+for room/session/event composition after that handoff. The runner retains the
+existing shutdown coordinator/failure/exit lifecycle.
 
 ### Bridge state and cancellation flow
 
 ```text
-BridgeStartupOrchestrator composes graph
+BridgeRuntimeRunner composes startup graph
   -> standalone interactive + authenticated + plugin available
-  -> subscribe to typed terminal onboarding decisions
   -> AppClientOnboardingService gets current access token
   -> immediate AppClientPresenceRepository check(accessToken)
      -> unauthorized once: service forces token refresh and retries immediately
      -> unauthorized twice: unavailable/permanent
-     -> registered: cancel input subscription, continue silently
+      -> registered: continue silently; initial typed lines remain queued
      -> unavailable/permanent: warn once, cancel input, fail open
-     -> transient: warn once, race skip vs fixed 60s delay, retry immediate check
-     -> absent: render instructions + QR/fallback + exact URL
+      -> transient: show warning/skip guidance, arm input, race skip vs fixed 60s delay, retry immediate check
+      -> absent: render instructions + QR/fallback + exact URL, arm input
         -> long-poll status?wait=true
            -> registered: cancel input/request, print success, continue
            -> normal absent: immediately start next long poll, no warning
            -> transient: warn once, race skip vs fixed 60s delay
            -> unavailable/permanent: warn once and fail open
 
-terminal `s`/`skip` + Enter at any waiting point
+terminal `s`/`skip` + Enter at any guided waiting point
   -> typed skip event
   -> cancel owned AuthRequestCancellationController and retry timer
   -> cancel input subscription
@@ -427,9 +439,8 @@ terminal `s`/`skip` + Enter at any waiting point
 
 startup settles onboarding
   -> provision/start plugin
-  -> create existing session Orchestrator + BridgeRuntime
-  -> directly inject completed runtime + typed outcome collaborators
-  -> BridgeRuntimeRunner executes only the ready lifecycle
+  -> existing BridgeRuntime.create/session Orchestrator handoff
+  -> runner executes existing ready-runtime lifecycle
 ```
 
 If EOF or terminal loss makes the already-started prompt unanswerable, the
@@ -476,21 +487,36 @@ accepted aliases and continue waiting.
     transport and waits for settlement. Typed refresh failures are never
     classified by parsing messages.
 20. The substantially changed standalone token owner is `TokenService`, not a
-    manager, and receives concrete `TokenStorage`; touched token load/save/clear
-    callback plumbing is removed.
+    manager, and receives `TokenRepository`; only that repository consumes the
+    concrete `TokenStorage`. Touched token load/save/clear callback plumbing is
+    removed. Registration/migration/logout similarly consume
+    `BridgeIdRepository`, never `BridgeIdStorage` directly.
 21. The auth subsystem imports no `server/` or root core layer. Terminal API,
     repository, prompt contracts, and interaction mode move to root layer paths;
     the root onboarding service depends inward on auth repositories.
-22. `BridgeStartupOrchestrator` is the sole pre-plugin Layer-5 composer and
-    lifecycle owner. `BridgeRuntimeRunner` consumes direct already-built
-    collaborators and constructs no lower layer; the existing session
-    `Orchestrator` remains session-control owner after plugin start.
+22. To align with the active desktop and parallel-plugin plans, the user waives
+    strict B-B5 only for the established two-phase boundary:
+    `BridgeRuntimeRunner` remains the process-startup composer and the existing
+    `Orchestrator` remains the post-start session-control composer.
+    `BridgeRuntime.create` stays an unchanged handoff within the session phase;
+    no `BridgeStartupOrchestrator` or third composer is added. This exact waiver
+    also retains the existing `BridgeRuntimeRunner` name while it performs the
+    startup-composition role already locked by those active plans; it does not
+    authorize another misnamed composer.
 23. The bounded QR contract targets common interactive macOS/Linux/Windows
     terminals and renders only with explicit black/white ANSI plus Unicode when
     polarity, glyphs, and width are safe. URL-only is required for missing ANSI/
     Unicode, unknown polarity/width, or too-narrow rendering.
 24. No analytics, rollout telemetry, or post-release observation work is part
     of the plan.
+25. The user explicitly approves the existing authentication request/response
+    flow and this bounded server-held long poll as narrow exceptions to the
+    push-based default. Do not replace either with SSE or broaden the exception.
+26. For this PR-feedback round, the user explicitly directs one full plan review
+    followed by one finite correction pass, with no further Aristotle re-review.
+    The two findings from that review are corrected in the final plan; this is a
+    narrow process-gate waiver against an endless review/fix loop, not a waiver
+    of the findings or implementation review.
 
 ## 7. Backward Compatibility and Migration
 
@@ -532,18 +558,24 @@ moves in the same PR; old use-case API files/top-level HTTP functions are delete
 instead of retained as aliases. Existing auth wire requests/responses and
 user-visible failures remain regression contracts.
 
-The shipped `v1.3.0` legacy bridge-id reader/marker moves with its real file I/O
-into `TokenStorage`; it is not duplicated or removed. Its cleanup text is updated
-mechanically to remove `TokenStorage.readLegacyBridgeId` with
-`BridgeIdMigrationService` once pre-v1.3.0 installs are unsupported.
+The shipped `v1.3.0` legacy bridge-id reader/marker moves with its compatibility
+JSON mapping into `TokenRepository`; raw file access remains in `TokenStorage`.
+The repository exposes the typed legacy read to `BridgeIdMigrationService`. The
+marker is not duplicated or removed. Its cleanup text is updated mechanically to
+remove the repository method and migration service once pre-v1.3.0 installs are
+unsupported.
 
 ### Generated-code workflow
 
-S01-W02-P01 changes the source Freezed response model, adds `qr` to
-`bridge/app/pubspec.yaml`, runs `dart pub get` from `bridge/`, and runs the
-workspace `make codegen`. The worker reviews and commits generated
-`*.freezed.dart` / `*.g.dart` and `bridge/pubspec.lock` changes but never edits
-generated files by hand. There is no Drift work.
+S01-W02-P01 adds shared Freezed `EmailLoginRequest` and
+`RefreshTokenRequest` models under `shared/sesori_shared`, exports them from the
+barrel, and uses their `toJson()` output for the two migrated auth request
+bodies. It also changes the bridge-local Freezed response model and adds `qr` to
+`bridge/app/pubspec.yaml`. The worker runs the shared package's build_runner
+command and the bridge workspace `make codegen`, then reviews and commits only
+tool-produced `*.freezed.dart` / `*.g.dart`, relevant lockfiles, and declared
+source/export changes. Generated files are never hand-edited. There is no Drift
+work and no shared relay/protocol contract change.
 
 ## 8. Rollout and Verification
 
@@ -557,6 +589,26 @@ generated files by hand. There is no Drift work.
    required because old-server failure is explicitly compatible.
 5. Execute the advisory QR/platform checkpoint when representative terminals
    and a disposable same-account app registration are available.
+
+### Cross-repository tracker handoff
+
+S01-W01-P01's implementation branch lives only in the auth-server repository,
+so it cannot commit the plan-host `TRACKER.md`. After this plan PR merges and
+before creating the auth implementation branch, the worker creates/fetches the
+remote monorepo branch `plan/bridge-app-onboarding/tracking` from the selected
+`main` tip. It commits only the S01/W01 pinned auth baseline there, then updates
+that same branch with the auth implementation branch/PR URL and optimistic
+checked row after the auth PR opens. This administrative state branch adds no
+implementation PR and never mixes auth-server product files into the monorepo.
+
+After S01-W01-P01 merges, the W02 worker fetches the tracking branch, verifies
+its W01 state against the merged auth PR, records the assessed S01/W02 monorepo
+baseline there before branch creation, creates the W02 implementation branch
+from that exact assessed `main` tip, and copies only this plan's `TRACKER.md`
+from the tracking branch into the implementation branch. The W02 PR therefore
+carries both waves' tracker state back to `main`; after it merges, `main` is
+authoritative and the tracking branch is cleanup-only. No standalone tracker PR
+or third product PR is created.
 
 Rollback is stateless: the bridge PR can be reverted without server cleanup,
 and the auth PR can be reverted while new bridges fail open. No persisted skip,
@@ -575,7 +627,8 @@ waiter, or schema state survives a process.
 - Consolidated auth API tests prove every migrated existing operation plus
   configurable URL construction, bearer header, strict typed app-status parsing,
   30s/35s relationship, active app-status/refresh abort on skip/timeout, and
-  status exceptions.
+  status exceptions. Every settled request detaches its cancellation listener;
+  repeated long polls and successful `never` refreshes retain none.
 - Bridge repository tests prove unauthorized/status classification,
   permanent/old-server normalization, malformed response handling, caller-token
   forwarding, and no token-refresh/logging ownership.
@@ -584,7 +637,11 @@ waiter, or schema state survives a process.
   prompt ordering, exact URL equality, success, both skip
   aliases, invalid input, EOF, normal-timeout no-delay/no-warning behavior,
   fixed 60-second transient delay, indefinite retry, permanent fail-open, and
-  cancellation during request and delay.
+  cancellation during guided request/delay, plus preservation of lines typed
+  during the initial silent check.
+- Plan execution verifies the remote tracking branch records W01 before the
+  cross-repository barrier and that W02 imports only this plan's tracker file;
+  no product commit spans repositories.
 - Terminal tests prove one lazy async stdin subscription, FIFO type-ahead across
   gaps between sequential prompts, cancellation handoff without dropping queued
   lines, EOF, pre-echo password-line discard/re-entry, password echo restoration,
@@ -593,11 +650,15 @@ waiter, or schema state survives a process.
   white ANSI reset, width boundaries, required URL-only fallback without ANSI or
   Unicode and for unknown polarity/width, URL permanence, and deterministic
   output for the exact URL.
-- Startup-orchestrator tests prove sole lower-layer construction, mode gating,
-  checkpoint location before plugin startup, no held startup mutex,
+- Runner tests prove startup mode gating, checkpoint location before plugin
+  startup, no held startup mutex, typed terminal-repository mapping,
   early/shared `TokenService` reuse, existing session-Orchestrator creation only
-  after plugin start, direct runner injection/execution, and continuation for
-  success/skip/fail-open. Runner tests prove it constructs nothing.
+  after plugin start, and continuation for success/skip/fail-open. Session tests
+  prove the existing `Orchestrator` remains the post-start owner and
+  `BridgeRuntime.create` gains no onboarding/startup policy.
+- Shared-model tests prove `EmailLoginRequest` and `RefreshTokenRequest` emit the
+  exact legacy JSON keys and values; consolidated API fixtures prove byte-
+  compatible request bodies without inline JSON maps.
 - Token tests prove typed access classification, required non-null cancellation
   at every caller, both production implementors, post-refresh corruption repair
   without cleared-file resurrection, and no surviving refresh/control request
@@ -649,7 +710,7 @@ separate User/Worker evidence.
 | Warning spam during outage | One reporting owner and one warning per failed request, with no request for the following 60 seconds. |
 | Older/custom auth server lacks endpoint | Exact compatibility fallback for 404/405 warns once and fails open; auth deploys first. |
 | User signs in to a different account | Instructions say same account; only the authenticated bridge user's durable token wakes the waiter. |
-| Async stdin migration changes existing prompts | One terminal owner with a FIFO pending-line buffer, serialized/type-ahead prompt tests, pre-echo secret-line discard/re-entry, echo restoration, and startup-orchestrator/logout regressions; no raw-mode single-key handling. |
+| Async stdin migration changes existing prompts | One terminal owner with a FIFO pending-line buffer, serialized/type-ahead prompt tests, pre-echo secret-line discard/re-entry, echo restoration, and runner/logout regressions; no raw-mode single-key handling. |
 | Token file corrupts while refresh is in flight | Preserve the current post-response `FormatException` repair using only the valid pre-refresh provider plus new response tokens; missing/cleared state still blocks resurrection. |
 | App registration and skip complete together | One service completion gate cancels remaining request/subscription/delay and emits only one continuation/result message. |
 | QR scans poorly under a terminal theme/font | Render only with explicit black/white ANSI plus validated Unicode, a four-module light quiet zone, and known sufficient width; otherwise omit QR, retain the URL, and use advisory real scans. |
@@ -658,7 +719,7 @@ separate User/Worker evidence.
 | Plugin is unavailable | Preserve the quick availability probe before onboarding so users are not asked to install the app for a bridge that cannot start. |
 | Auth HTTP consolidation regresses existing flows | Migrate real methods into one `SesoriAuthApi`, delete wrappers only after callers move, and preserve email/OAuth/profile/refresh/bridge request fixtures plus user-visible mapping tests. |
 | Skip occurs during token refresh | Required `AuthRequestCancellationSignal` reaches both production token authorities and abortable auth transport; cancellable near-expiry refresh is awaited, and completion waits for settlement. |
-| Runner becomes a second composition root | `BridgeStartupOrchestrator` constructs/owns every startup layer and directly injects only the four required already-built runtime/outcome collaborators; runner has no constructors/factories for lower layers. Existing session `Orchestrator` is created only after plugin start. |
+| Startup ownership conflicts with desktop/parallel-plugin plans | User-approved narrow B-B5 waiver preserves `BridgeRuntimeRunner` as process-startup composer and existing `Orchestrator` as post-start session composer; `BridgeRuntime.create` gains no new policy and no third composer is introduced. |
 
 Deferred work includes live app liveness, distributed waiter signaling, richer
 deep links, browser opening, terminal QR files, persistent onboarding choices,
@@ -681,7 +742,8 @@ does not block merge or plan closure, and has separate User/Worker state.
 ```text
 created
   -> immediate registered true
-  -> waiting
+  -> initial read deadline: 500 transient failure, never false
+  -> confirmed absent: waiting
        -> registered true after durable upsert
        -> false after 30s timeout
        -> cancelled after client disconnect
@@ -699,6 +761,7 @@ waiter set before resolving it so mutation during iteration cannot skip peers.
 | 200 `registered: true` | Success; silent on initial check, confirmation after prompt. |
 | 200 `registered: false`, immediate | Render onboarding once, then long poll. |
 | 200 `registered: false`, long poll | Normal expiry; no warning/delay, immediately long poll again. |
+| 500 before server initial presence read completes | Unconfirmed/transient; no onboarding prompt, warn once, fixed cancellable 60-second delay, retry. |
 | Skip-triggered `RequestAbortedException` | Expected cancellation; no warning, continue current run. |
 | Repository returns unauthorized first occurrence | Service forces refresh once and retries immediately. |
 | Repository returns unauthorized after refresh | Service warns once and fails open. |

--- a/.plan/active/bridge-app-onboarding/PLAN.md
+++ b/.plan/active/bridge-app-onboarding/PLAN.md
@@ -379,6 +379,13 @@ remains untouched. When `canCancel` is true,
 detached background-refresh branch, so onboarding completion can prove no
 refresh remains. Existing `never` callers retain background behavior.
 
+`TokenService` preserves the shipped distinction between initial token-file
+corruption and corruption observed only on the post-refresh re-read. Initial
+corruption is unavailable. A post-response `FormatException` retains only
+`lastProvider` from the valid pre-refresh snapshot and writes the newly issued
+tokens to repair the file; a missing/cleared post-refresh file still aborts
+persistence so logout cannot be resurrected.
+
 `runBridgeApp` moves from `bridge_runtime_runner.dart` into root
 `bridge_startup_orchestrator.dart`; `bin/bridge.dart` imports that root entrypoint.
 It creates `BridgeStartupOrchestrator` through its explicit composition factory
@@ -457,8 +464,10 @@ accepted aliases and continue waiting.
 16. One 401 triggers one forced refresh and immediate retry; a second 401 fails
     open.
 17. Dart terminal input is unified under one asynchronous owner with a FIFO
-    pending-line buffer, preserving type-ahead across sequential prompts rather
-    than moving onboarding after plugin startup or relying on mixed reads.
+    pending-line buffer, preserving ordinary type-ahead across sequential
+    prompts rather than moving onboarding after plugin startup or relying on
+    mixed reads. Secret reads discard all lines queued before echo is disabled
+    and require fresh no-echo input.
 18. `SesoriAuthApi` becomes the sole API owner for the external auth provider;
     existing use-case APIs/top-level HTTP are migrated and removed in the bridge
     PR rather than wrapped.
@@ -578,8 +587,8 @@ waiter, or schema state survives a process.
   cancellation during request and delay.
 - Terminal tests prove one lazy async stdin subscription, FIFO type-ahead across
   gaps between sequential prompts, cancellation handoff without dropping queued
-  lines, EOF, password echo restoration, and unchanged yes/no/provider/
-  credential/logout behavior.
+  lines, EOF, pre-echo password-line discard/re-entry, password echo restoration,
+  and unchanged yes/no/provider/credential/logout behavior.
 - Formatter tests prove a light quiet zone, module orientation, explicit black/
   white ANSI reset, width boundaries, required URL-only fallback without ANSI or
   Unicode and for unknown polarity/width, URL permanence, and deterministic
@@ -590,8 +599,9 @@ waiter, or schema state survives a process.
   after plugin start, direct runner injection/execution, and continuation for
   success/skip/fail-open. Runner tests prove it constructs nothing.
 - Token tests prove typed access classification, required non-null cancellation
-  at every caller, both production implementors, and no surviving refresh/
-  control request after abort.
+  at every caller, both production implementors, post-refresh corruption repair
+  without cleared-file resurrection, and no surviving refresh/control request
+  after abort.
 
 ### Manual verification
 
@@ -620,6 +630,8 @@ separate User/Worker evidence.
   token/platform/device details.
 - Raw bearer tokens remain only in HTTP headers and existing token storage; QR
   and URL contain no identity or secret.
+- A password line is accepted only after terminal echo is disabled. Lines queued
+  earlier are discarded and re-requested rather than consumed as credentials.
 - Waiters are keyed by authenticated user id in process memory, removed on every
   completion path, and never persisted.
 - Local E2E, managed trust, relay encryption, plugin boundaries, multi-bridge
@@ -637,7 +649,8 @@ separate User/Worker evidence.
 | Warning spam during outage | One reporting owner and one warning per failed request, with no request for the following 60 seconds. |
 | Older/custom auth server lacks endpoint | Exact compatibility fallback for 404/405 warns once and fails open; auth deploys first. |
 | User signs in to a different account | Instructions say same account; only the authenticated bridge user's durable token wakes the waiter. |
-| Async stdin migration changes existing prompts | One terminal owner with a FIFO pending-line buffer, serialized/type-ahead prompt tests, echo restoration, and startup-orchestrator/logout regressions; no raw-mode single-key handling. |
+| Async stdin migration changes existing prompts | One terminal owner with a FIFO pending-line buffer, serialized/type-ahead prompt tests, pre-echo secret-line discard/re-entry, echo restoration, and startup-orchestrator/logout regressions; no raw-mode single-key handling. |
+| Token file corrupts while refresh is in flight | Preserve the current post-response `FormatException` repair using only the valid pre-refresh provider plus new response tokens; missing/cleared state still blocks resurrection. |
 | App registration and skip complete together | One service completion gate cancels remaining request/subscription/delay and emits only one continuation/result message. |
 | QR scans poorly under a terminal theme/font | Render only with explicit black/white ANSI plus validated Unicode, a four-module light quiet zone, and known sufficient width; otherwise omit QR, retain the URL, and use advisory real scans. |
 | QR dependency or generation broadens lock output | Add only pure-Dart `qr`, run normal workspace resolution/codegen, and reject unrelated lock/generated changes. |

--- a/.plan/active/bridge-app-onboarding/PLAN.md
+++ b/.plan/active/bridge-app-onboarding/PLAN.md
@@ -1,0 +1,712 @@
+# Bridge App Onboarding
+
+## 0. Plan Metadata
+
+- **Status:** Approved — ready for delivery
+- **Format version:** 1
+- **Generated:** 2026-07-17
+- **Plan slug:** `bridge-app-onboarding`
+- **Plan host:** `sesori-ai/sesori_apps_monorepo`
+- **Selected implementation base:** `main`
+
+| Repository | Implementation base | Initial audited tip | Commit date | Latest re-review | Latest audited tip | Commit date |
+|---|---|---|---|---|---|---|
+| `sesori-ai/sesori_apps_monorepo` | `main` | `5a76c0c420cd7db445f7fe2c8a2570265b4c84e0` | 2026-07-17T06:57:01Z | 2026-07-17 | `5a76c0c420cd7db445f7fe2c8a2570265b4c84e0` | 2026-07-17T06:57:01Z |
+| `sesori-ai/sesori_auth_server` | `master` | `b17a6e760b0c70c3dc3d1cd456ff93d814c75453` | 2026-07-16T14:14:09Z | 2026-07-17 | `b17a6e760b0c70c3dc3d1cd456ff93d814c75453` | 2026-07-16T14:14:09Z |
+
+These SHAs are audit and staleness metadata, not historical branch points. Each
+wave pins the then-current tip of its declared repository/base after assessing
+drift from the latest audited tip. The monorepo implementation branch is always
+based on the user-selected `main`; the auth-server branch is independently based
+on that repository's `master`.
+
+## 1. Goal
+
+Help a user who starts the standalone bridge without any registered Sesori app
+client install and sign in to the app before the bridge finishes starting. The
+bridge must present a scan-ready terminal QR plus the exact clickable app URL,
+then wake almost immediately when the same account durably registers an iOS,
+Android, macOS, Windows, or Linux app token.
+
+The checkpoint remains explicitly skippable for the current run and never
+weakens headless or desktop-supervised startup. Network outages remain
+observable and recoverable without tight request loops or continuously spammed
+warnings.
+
+## 2. Success Criteria
+
+1. An authenticated standalone interactive bridge performs a current app-token
+   check after the selected plugin passes its quick availability probe and
+   before runtime provisioning or plugin startup.
+2. If any current app token exists for the same account on iOS, Android, macOS,
+   Windows, or Linux, startup continues without new output.
+3. If no token exists, the terminal immediately prints same-account setup
+   instructions, a QR when terminal capabilities and width allow it, and the
+   byte-identical URL `https://sesori.com/app/?openStore=true` beneath the QR.
+4. A token registration committed after the bridge begins waiting wakes all
+   same-user long polls without a client-side polling interval; the bridge
+   prints a brief success line and resumes startup.
+5. `s` or `skip`, case-insensitive after trimming and followed by Enter, cancels
+   any active token-refresh/status request or retry delay, waits for cancellation
+   settlement, and skips only the current run. A later bridge start prompts
+   again while no token exists.
+6. A normal 30-second server long-poll expiry returns `registered: false`, emits
+   no warning, and is followed immediately by another long poll.
+7. Network failures, client-side request timeouts, HTTP 408/429, and HTTP 5xx
+   produce at most one warning for that failed attempt, wait a fixed 60 seconds,
+   and retry indefinitely until registration or explicit skip. The delay is
+   cancellable by skip.
+8. Permanent protocol failures, unsupported older/custom servers, and a second
+   401 after one forced token refresh warn once and fail open instead of
+   blocking startup.
+9. Desktop-supervised, noninteractive, legacy post-update, piped, and otherwise
+   unsupported terminal starts perform no onboarding wait or output.
+10. Existing provider, email/password, replacement, and logout prompts retain
+    their text, echo, EOF, default-answer, and noninteractive behavior after
+    terminal input moves under one asynchronous owner.
+11. QR output includes a four-module quiet zone, never exceeds known terminal
+    width, resets ANSI state, supports bounded ANSI/Unicode and ASCII fallbacks,
+    and degrades to the URL alone when safe rendering cannot be proven.
+12. Auth-server and bridge automated verification passes, and the advisory QR
+    scan matrix records representative dark/light and platform evidence without
+    adding product analytics or post-release observation targets.
+
+## 3. Scope
+
+### In Scope
+
+- An additive authenticated auth-server app-client status endpoint with an
+  immediate mode and a 30-second long-poll mode.
+- A repository existence query over current device-token records.
+- A race-safe, process-local app-client presence service that owns durable token
+  registration signaling, timeout cleanup, and disconnect cancellation.
+- Reuse/extraction of the auth server's proven request-close abort seam.
+- A consolidated per-provider `SesoriAuthApi` -> Repository -> Service ->
+  runtime-consumer flow for current registration checks, cancellable token
+  refresh, failure classification, retry, and skip.
+- One asynchronous bridge terminal-input owner reused by existing prompts.
+- A pure-Dart QR dependency and terminal formatter with capability/width
+  fallbacks.
+- Additive generated Freezed/JSON output for a bridge-local typed response; no
+  generated file is hand-edited.
+- Focused unit, route, service, lifecycle, runner, formatting, and regression
+  tests plus one advisory manual checkpoint.
+- Compatibility behavior and an exact cleanup marker for bridges talking to an
+  auth server that predates the new endpoint.
+
+### Non-Goals
+
+- A live app heartbeat, socket-presence signal, last-seen policy, or proof that
+  a registered FCM token still corresponds to an installed/running app.
+- Changing app token registration/logout behavior or adding mobile/desktop UI.
+- Opening a browser or app store from the bridge.
+- Persisting skip, suppressing future prompts, or adding a bridge CLI/config
+  option for this checkpoint.
+- Running the checkpoint in desktop-supervised or noninteractive bridge modes.
+- Reusing lifetime `mobileSetupAt` activation history as current presence.
+- New database collections, indexes, migrations, Redis, change streams, leases,
+  or horizontal-scaling abstractions.
+- QR images/files, OSC hyperlinks, terminal probing commands, or unbounded
+  support claims for every terminal/font/camera combination.
+- Auth, relay, plugin, shared wire, mobile, desktop, trust-posture, or
+  multi-bridge protocol changes unrelated to this onboarding flow.
+- Analytics, telemetry, rollout percentages, post-release targets, dashboards,
+  or observation work.
+
+## 4. Audited Baseline
+
+### Plan host and branch choice
+
+The plan was invoked on branch `bridge-onboarding-optimization`, while the
+repository default base is `main`. The user explicitly selected `main` as the
+implementation base. The current unrelated active plan
+`.plan/active/session-pull-request-monitoring/` may continue independently;
+workers assess drift at each wave rather than imposing speculative ordering.
+
+### Auth-server current behavior
+
+- `src/repositories/device-token-repo.ts:15-45` durably upserts app tokens and
+  can list every token for a user, but has no existence-only query.
+- `src/models/device.ts:3-9` defines every supported app platform: `ios`,
+  `android`, `macos`, `windows`, and `linux`.
+- `src/routes/notifications.ts:55-72` authenticates token registration, awaits
+  `DeviceTokenRepository.upsertToken`, then best-effort records the lifetime app
+  setup milestone. It publishes no post-commit signal.
+- `src/routes/notifications.ts:75-83` deletes a user's token on app logout.
+- `src/services/activation-service.ts` and activation state model lifetime
+  history. A historical `mobileSetupAt` remains present after token removal and
+  therefore cannot answer current registration.
+- `src/routes/auth/session-status.ts:42-101` implements an existing 30-second
+  OAuth long poll, checks connection liveness before reply delivery, and uses a
+  request-close `AbortSignal`.
+- `src/services/pending-auth-store.ts:419-508` demonstrates race-safe waiter
+  registration, timeout/abort cleanup, and a post-registration state recheck.
+  That OAuth store is session-token keyed and must not be reused for user app
+  presence.
+- `src/server.ts:68-72` has a global 100-request/minute limiter. One normal
+  status request per 30 seconds and one transient retry per 60 seconds remain
+  within that existing policy.
+- `AGENTS.md:67-72` records a single-instance production constraint for current
+  in-memory wait/debounce systems. This plan preserves that constraint rather
+  than inventing distributed signaling.
+- The auth application version declared in `package.json` is `0.1.0`; no schema
+  or package dependency change is required.
+
+### Bridge current behavior
+
+- `bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart:238-268`
+  constructs one `TerminalPromptApi`/`TerminalPromptRepository` and the
+  interactive auth flow.
+- `bridge_runtime_runner.dart:442-468` authenticates standalone or supervised
+  startup, then logs the authenticated user. No app-registration checkpoint
+  exists.
+- `bridge_runtime_runner.dart:479-501` resolves and checks the selected plugin
+  before runtime provisioning/startup. This quick failure boundary should stay
+  ahead of onboarding.
+- `bridge_runtime_runner.dart:503-559` provisions and starts the plugin, including
+  later single-live-bridge prompts. The onboarding wait must not hold the
+  startup mutex or begin provisioning.
+- `bridge_runtime_runner.dart:568-605` currently creates standalone
+  `TokenManager`/registration dependencies only after plugin startup. This PR
+  renames that substantially changed class to `TokenService`, composes it earlier,
+  and reuses one instance rather than duplicating token authority, so the
+  onboarding service can perform the one authorized 401 refresh while the
+  repository remains token-authority neutral.
+- `bridge/app/lib/src/server/api/terminal_prompt_api.dart:18-47` currently detects
+  interactivity but reads lines synchronously. `bridge_runtime_auth.dart:38-71`
+  also reads provider choice directly from global stdin.
+- `terminal_prompt_repository.dart:10-67` owns replacement and email/password
+  prompts, while `login_email_repository.dart:7-18` receives a synchronous
+  credential callback. These paths require a behavior-preserving asynchronous
+  migration before a cancellable skip listener can coexist with later prompts.
+- Dart's `Stdin` contract allows synchronous and asynchronous reads but declares
+  mixing them undefined. A temporary async skip listener followed by existing
+  `readLineSync` calls is therefore rejected.
+- `bridge/app/lib/src/auth/login_oauth_service.dart:13-17,208-253` already uses a
+  30-second-server/35-second-client long-poll relationship, but its polling
+  service does not classify or delay network failures for this new indefinite
+  checkpoint.
+- `bridge/app/lib/src/auth/bridge_registration_service.dart:152-162` provides
+  the established one-refresh-on-401 repository/service pattern.
+- `bridge/app/pubspec.yaml` declares `http: ^1.6.0`; that version exposes
+  `AbortableRequest` and `RequestAbortedException`. No QR dependency exists.
+- `TerminalGlyphValidator` and `TerminalColorValidator` already centralize
+  UTF-8/ANSI capability policy. `Stdout.terminalColumns` supplies width without
+  an external terminal-size package.
+- The bridge version is `1.5.1` in `bridge/app/pubspec.yaml` and
+  `bridge/app/lib/src/version.dart`. Workers re-read it immediately before
+  writing the compatibility marker.
+
+### Historical evidence
+
+The audited tips `b17a6e760b0c70c3dc3d1cd456ff93d814c75453` and
+`5a76c0c420cd7db445f7fe2c8a2570265b4c84e0` are the shipped-history points for
+the behavior above. Auth-server history and active instructions explicitly
+distinguish current device-token rows from lifetime activation milestones; the
+bridge history retains headless operation, configurable auth endpoints, one
+token-refresh authority, and terminal capability validators. This plan extends
+those seams instead of introducing a second source of truth.
+
+## 5. Architecture and Data Flow
+
+### Auth-server boundaries
+
+All new dependencies flow Foundation -> API/Repository -> Service -> route
+consumer. Same-layer classes remain independent.
+
+| Component | Layer / expected path | Ownership |
+|---|---|---|
+| `createRequestCloseSignal` extraction | Foundation, `src/lib/request-close-signal.ts` | Convert Fastify socket/reply close/finish events into one cleaned-up `AbortSignal`; no route or domain decisions. Reused by OAuth status and app-client status routes. |
+| `appClientStatusQuerySchema` / `appClientStatusReplySchema` | API contract, existing `src/models/api.ts` | Strict Zod query/reply schemas with inferred TypeScript types; route uses `safeParse` for both inbound query and outbound candidate reply. |
+| `DeviceTokenRepository.hasAnyForUser` | Repository, existing `src/repositories/device-token-repo.ts` | Perform one indexed existence query and return a boolean; no waiter or retry policy. |
+| `AppClientPresenceService` | Service, `src/services/app-client-presence-service.ts` | Own token registration used by notification routes, wake same-user waiters only after successful durable upsert, perform immediate/recheck reads, and clean up per-request timeout/abort state. Token deletion remains a direct existing route -> repository call because it has no waiter logic. |
+| App-client route | Consumer/API boundary, `src/routes/app-clients.ts` | Authenticate, `safeParse` the strict optional `wait=true` query, call the service with the request-close signal, check reply liveness, `safeParse` `{registered}` against the reply schema, and serialize the validated boolean response. |
+| `notificationRoutes` | Existing consumer | Delegate registration to `AppClientPresenceService`, keep deletion directly on `DeviceTokenRepository`, and retain activation failure isolation/notification sending behavior. |
+| `index.ts` / `server.ts` | Composition root | Construct one shared service instance and inject it into both routes. No route constructs a repository/service. |
+
+The endpoint contract is additive:
+
+```text
+GET /auth/app-clients/status
+Authorization: Bearer <user access token>
+
+200 { "registered": true }   # current token exists
+200 { "registered": false }  # immediate absence
+
+GET /auth/app-clients/status?wait=true
+200 { "registered": true }   # immediate current token or post-commit wake
+200 { "registered": false }  # no token when the 30-second wait expires
+401                           # missing/invalid user token
+400                           # invalid query shape
+```
+
+No token value, platform, user id, activation timestamp, or waiter identifier is
+returned.
+
+### Auth-server registration and waiter flow
+
+```text
+bridge GET status?wait=true
+  -> requireAuth identifies user
+  -> AppClientPresenceService checks DeviceTokenRepository.hasAnyForUser
+  -> absent: register per-user waiter + timeout/abort cleanup
+  -> recheck repository after waiter registration
+  -> return false on 30s timeout, or hijack/return nothing after disconnect
+
+app POST /notifications/register-token
+  -> requireAuth identifies same user
+  -> AppClientPresenceService.registerToken
+  -> DeviceTokenRepository.upsertToken commits
+  -> service resolves every same-user waiter true
+  -> route best-effort records lifetime activation
+  -> app receives existing { ok: true }
+```
+
+The register-then-recheck sequence closes the only meaningful lost-wakeup gap.
+An upsert failure never wakes a waiter. A user with multiple bridge polls wakes
+all of them; another user's waiters are untouched. Timeout, abort, and failed
+recheck paths remove listener/timer/map state.
+
+### Bridge boundaries
+
+| Component | Layer / expected path | Ownership |
+|---|---|---|
+| `AppClientPresenceResponse` | API DTO, `bridge/app/lib/src/auth/app_client_presence_response.dart` | Freezed/JSON transport shape with required non-null `registered`; generated output only through build_runner. |
+| `SesoriAuthApi` | Layer 1, `bridge/app/lib/src/auth/sesori_auth_api.dart` | Sole `Api` owner for the configurable Sesori auth server. Absorb existing email, OAuth, profile/me, refresh, bridge-registration and new app-status HTTP operations; own URI/header/body/typed decode plus abortable request/deadline mechanics. The PR deletes superseded use-case API classes and top-level HTTP functions rather than forwarding through them. |
+| `AuthRepository` | Layer 2, `bridge/app/lib/src/auth/auth_repository.dart` | Map profile/access-token validation and typed refresh results from `SesoriAuthApi`; distinguish transient, unavailable, and cancelled refresh failures without message parsing. |
+| `TokenStorage` | Layer 1 concrete auth storage boundary, `bridge/app/lib/src/auth/token_storage.dart` | Own token-file load/save/clear plus legacy bridge-id read over the existing path/permissions. Inject directly into `TokenService`, `BridgeRuntimeAuthService`, bridge-id migration, and logout; remove load/save/clear callback plumbing. |
+| `LoginOAuthRepository` | Layer 2, `bridge/app/lib/src/auth/login_oauth_repository.dart` | Map OAuth init/status/ACK calls from the consolidated API for `LoginOAuthService`. |
+| Existing auth repositories | Layer 2, `login_email_repository.dart`, `bridge_registration_repository.dart` | Consume the same `SesoriAuthApi` directly and preserve their domain exception/result mapping; no forwarding API wrappers remain. |
+| `AppClientPresenceRepository` | Layer 2, `bridge/app/lib/src/auth/app_client_presence_repository.dart` | Accept an access token from its caller, delegate app status to `SesoriAuthApi`, normalize registered/absent/unauthorized/unavailable/transient/cancelled outcomes, and own the old-server compatibility seam. It has no token authority, retry, output, or delay policy. |
+| `TokenRefresher` / `TokenService` | Existing service contract and renamed `bridge/app/lib/src/auth/token_service.dart` implementation | Add a required auth-local `AuthRequestCancellationSignal` to token acquisition, typed access-failure kinds, and abortable refresh via `AuthRepository`. Update both production implementors and every caller/fake. During onboarding the newly composed standalone service is the only token caller, so skip owns and terminates its refresh request. |
+| `AppOnboardingFormatter` | Foundation/pure formatter, `bridge/app/lib/src/foundation/app_onboarding_formatter.dart` | Convert URL + QR modules + width/ANSI/Unicode capabilities into bounded text with quiet zone and URL fallback. No I/O or lifecycle. |
+| `TerminalInteractionMode` | Foundation, `bridge/app/lib/src/foundation/terminal_interaction_mode.dart` | Typed `interactive` / `unavailable` / `legacyPostUpdate` result computed by composition roots from raw terminal facts and invocation environment. Existing terminal prompt decision/replace contracts move from `server/foundation` to root Foundation with it. |
+| `TerminalPromptApi` / `TerminalPromptRepository` | Root Layer 1/2, `bridge/app/lib/src/api/terminal_prompt_api.dart` and `lib/src/repositories/terminal_prompt_repository.dart` | Move the substantially changed terminal boundaries out of the minimal `server/` subsystem. API owns raw async terminal I/O/facts; repository receives interaction mode and maps provider/credentials/yes-no/onboarding outcomes. |
+| `AppClientOnboardingService` | Layer 3, `bridge/app/lib/src/services/app_client_onboarding_service.dart` | Own access-token acquisition, exactly one forced refresh/retry after 401, checkpoint state, terminal subscription, cancellation, long-poll loop, internal retry timer, output, and exactly-once completion. It depends on root repositories/Foundation plus `TokenRefresher`, not on the `server/` subsystem. |
+| `BridgeRuntimeAuthService` | Root Layer 3, moved to `bridge/app/lib/src/services/bridge_runtime_auth_service.dart` | Delegate provider/credential input to root `TerminalPromptRepository`, use injected auth repositories/storage, preserve auth decisions/persistence, and import no runtime options/type. |
+| `BridgeStartupOrchestrator` | Root Layer 5, `bridge/app/lib/src/bridge_startup_orchestrator.dart` | Sole startup and session composition/lifecycle owner. Construct auth, terminal, token, onboarding and existing startup/session collaborators; authenticate, check availability, onboard, provision/start plugin, directly construct existing session `Orchestrator`, inject it into `BridgeRuntime`, invoke runner, and own disposal. |
+| `BridgeRuntime` change | Existing lifecycle holder | Delete static `BridgeRuntime.create`; retain the existing generative constructor over already-built session and lifecycle collaborators. |
+| `BridgeRuntimeRunner` | Injected consumer | Receive already-built `BridgeRuntime`, `PluginFailureLatch`, `BridgeRestartService`, and supervised flag as direct required constructor parameters; execute the ready runtime/session and map typed exit/failure outcomes. It constructs no lower layer. |
+
+The startup orchestrator owns pre-plugin lifecycle; the existing session
+`Orchestrator` remains the sole relay/plugin/session-control owner after plugin
+start. Startup injects the completed runtime and typed outcome collaborators
+directly into runner, then retains teardown ownership around execution. The
+bridge remains headless and plugin-neutral.
+
+Production constructor and lifecycle ownership is explicit:
+
+```text
+SesoriAuthApi(
+  required authBackendUrl,
+  required shared http.Client)
+  # stores but never closes the shared client
+
+AuthRepository(
+  required SesoriAuthApi,
+  required refreshRequestTimeout) # composition passes 15 seconds
+
+LoginEmailRepository(required SesoriAuthApi)
+LoginOAuthRepository(
+  required SesoriAuthApi,
+  required AuthClientType,
+  required DeviceInfo)
+BridgeRegistrationRepository(required SesoriAuthApi)
+AppClientPresenceRepository(
+  required SesoriAuthApi,
+  required statusRequestTimeout) # composition passes 35 seconds
+
+TokenService(
+  required initialToken,
+  required AuthRepository,
+  required TokenStorage)
+
+AppClientOnboardingService(
+  required AppClientPresenceRepository,
+  required TokenRefresher,
+  required TerminalPromptRepository,
+  required AppOnboardingFormatter,
+  required retryDelay) # composition passes 60 seconds
+  # owns AuthRequestCancellationController, terminal subscription, and cancellable Timer
+
+AppOnboardingFormatter(
+  required supportsAnsi,
+  required supportsUnicode,
+  required nullable terminalColumns)
+  # immutable rendering facts; no I/O or collaborator lifecycle
+
+TerminalPromptApi(required Stdin, required Stdout)
+  # owns and disposes its lazy input subscription; no environment policy
+
+TerminalPromptRepository(
+  required TerminalPromptApi,
+  required TerminalInteractionMode)
+
+BridgeRuntimeRunner(
+  required BridgeRuntime,
+  required PluginFailureLatch,
+  required BridgeRestartService,
+  required isSupervised)
+```
+
+The duration comments describe production values, not optional constructor
+defaults: callers pass them explicitly. `BridgeStartupOrchestrator` owns the
+shared HTTP client's close lifecycle; `SesoriAuthApi` borrows it.
+`AppClientOnboardingService` creates/cancels its one-shot `Timer` internally and
+tests virtual time with `fake_async`; no delay callback or timer peer is added.
+
+`TokenRefresher.getAccessToken` adds required
+`AuthRequestCancellationSignal cancelled`. Existing callers pass
+`AuthRequestCancellationSignal.never`; onboarding passes its owned
+controller's signal. `TokenService` forwards the signal through `AuthRepository`
+to `SesoriAuthApi.refreshTokens`, whose `AbortableRequest` races cancellation
+and an active 15-second deadline.
+`ControlChannelTokenService`, the other production implementor, removes and
+completes its correlated pending request on abort; it never runs onboarding but
+keeps the shared contract symmetric. It maps caller cancellation to
+`cancelled`, control disconnection/request timeout to `transient`, and
+signed-out/null-token or disposed authority to `unavailable`; supervised
+bootstrap preserves its existing auth-required exit for transient/unavailable.
+`TokenAccessException` carries the kind plus safe cause/stack instead of
+requiring message parsing. Every implementation, caller, and fake is updated.
+`AuthRequestCancellationSignal`/`AuthRequestCancellationController` live inside
+the self-contained `auth/` subsystem with `never`, `canCancel`, `isCancelled`,
+`whenCancelled`, and idempotent `cancel`; plugin-specific `StartAbortSignal`
+remains untouched. When `canCancel` is true,
+`TokenService` awaits a near-expiry refresh instead of launching the legacy
+detached background-refresh branch, so onboarding completion can prove no
+refresh remains. Existing `never` callers retain background behavior.
+
+`runBridgeApp` moves from `bridge_runtime_runner.dart` into root
+`bridge_startup_orchestrator.dart`; `bin/bridge.dart` imports that root entrypoint.
+It creates `BridgeStartupOrchestrator` through its explicit composition factory
+from CLI/plugin inputs and invokes it. Runner never imports the startup
+orchestrator, eliminating a circular dependency. The startup
+orchestrator constructs every lower-layer collaborator, runs all pre-plugin
+phases, starts the plugin, directly constructs the existing session
+`Orchestrator`, injects that completed session plus lifecycle collaborators into
+plain `BridgeRuntime`, then directly injects `BridgeRuntime`, failure latch,
+restart service, and supervised flag into `BridgeRuntimeRunner`. It wraps runner
+execution in the existing shutdown coordinator/failure/exit lifecycle.
+
+### Bridge state and cancellation flow
+
+```text
+BridgeStartupOrchestrator composes graph
+  -> standalone interactive + authenticated + plugin available
+  -> subscribe to typed terminal onboarding decisions
+  -> AppClientOnboardingService gets current access token
+  -> immediate AppClientPresenceRepository check(accessToken)
+     -> unauthorized once: service forces token refresh and retries immediately
+     -> unauthorized twice: unavailable/permanent
+     -> registered: cancel input subscription, continue silently
+     -> unavailable/permanent: warn once, cancel input, fail open
+     -> transient: warn once, race skip vs fixed 60s delay, retry immediate check
+     -> absent: render instructions + QR/fallback + exact URL
+        -> long-poll status?wait=true
+           -> registered: cancel input/request, print success, continue
+           -> normal absent: immediately start next long poll, no warning
+           -> transient: warn once, race skip vs fixed 60s delay
+           -> unavailable/permanent: warn once and fail open
+
+terminal `s`/`skip` + Enter at any waiting point
+  -> typed skip event
+  -> cancel owned AuthRequestCancellationController and retry timer
+  -> cancel input subscription
+  -> print current-run skip confirmation
+  -> continue startup exactly once
+
+startup settles onboarding
+  -> provision/start plugin
+  -> create existing session Orchestrator + BridgeRuntime
+  -> directly inject completed runtime + typed outcome collaborators
+  -> BridgeRuntimeRunner executes only the ready lifecycle
+```
+
+If EOF or terminal loss makes the already-started prompt unanswerable, the
+service follows the noninteractive policy: cancel and fail open with one concise
+warning. Invalid lines do not cancel the network request; they reprint the
+accepted aliases and continue waiting.
+
+## 6. Locked Decisions
+
+1. The monorepo implementation base is `main`; the auth-server base is
+   `master`.
+2. This plan is independent of `session-pull-request-monitoring`; every wave
+   still performs normal drift assessment.
+3. The plan slug is `bridge-app-onboarding`.
+4. Current presence means at least one current device-token row on any supported
+   app platform, not lifetime setup history and not live connectivity.
+5. Only standalone interactive bridge starts run the checkpoint.
+6. Existing app registration continues silently.
+7. Missing registration shows terminal-only setup instructions, QR when safe,
+   and exact URL `https://sesori.com/app/?openStore=true`; no browser opens.
+8. The app must register under the same account as the authenticated bridge.
+9. Registration while waiting prints a brief success message.
+10. `s` and `skip`, case-insensitive with surrounding whitespace ignored and
+    followed by Enter, skip only the current run. Skip state is never persisted.
+11. Interactive startup waits indefinitely for registration or explicit skip
+    across transient outages.
+12. Normal 30-second long-poll expiry is silent and immediately repolled.
+13. Every transient non-normal failure waits a fixed 60 seconds before another
+    request. There is no exponential growth or shorter retry.
+14. Each failed attempt produces at most one warning; no layer double-logs it.
+15. Permanent/unsupported protocol outcomes fail open after one warning.
+16. One 401 triggers one forced refresh and immediate retry; a second 401 fails
+    open.
+17. Dart terminal input is unified under one asynchronous owner rather than
+    moving onboarding after plugin startup or relying on undefined mixed reads.
+18. `SesoriAuthApi` becomes the sole API owner for the external auth provider;
+    existing use-case APIs/top-level HTTP are migrated and removed in the bridge
+    PR rather than wrapped.
+19. Token acquisition requires an `AuthRequestCancellationSignal`; skip actively terminates
+    refresh/status transport and waits for settlement. Typed refresh failures
+    are never classified by parsing messages.
+20. The substantially changed standalone token owner is `TokenService`, not a
+    manager, and receives concrete `TokenStorage`; touched token load/save/clear
+    callback plumbing is removed.
+21. The auth subsystem imports no `server/` or root core layer. Terminal API,
+    repository, prompt contracts, and interaction mode move to root layer paths;
+    the root onboarding service depends inward on auth repositories.
+22. `BridgeStartupOrchestrator` is the sole pre-plugin Layer-5 composer and
+    lifecycle owner. `BridgeRuntimeRunner` consumes direct already-built
+    collaborators and constructs no lower layer; the existing session
+    `Orchestrator` remains session-control owner after plugin start.
+23. The bounded QR contract targets common interactive macOS/Linux/Windows
+    terminals, dark/light themes, ANSI/Unicode and ASCII fallbacks. URL-only is
+    valid for unsafe, unknown, or too-narrow rendering.
+24. No analytics, rollout telemetry, or post-release observation work is part
+    of the plan.
+
+## 7. Backward Compatibility and Migration
+
+### Auth-server compatibility
+
+The new endpoint and repository method are additive. Existing apps retain the
+same token registration/deletion request and `{ ok: true }` response. Existing
+bridges never call the endpoint. No database or environment migration occurs.
+
+If the auth endpoint is rolled back after the bridge ships, the bridge's
+old-server fallback treats 404/405 as unavailable and continues startup. The
+server should nevertheless deploy before bridge release so intended onboarding
+works on first use.
+
+### Bridge compatibility
+
+The bridge continues to accept configurable auth backends. In the repository
+branch that maps 404/405 endpoint absence, add this source marker immediately
+above the fallback using the actual implementation date and the version
+re-read from `bridge/app/pubspec.yaml` / `version.dart`:
+
+```dart
+// COMPATIBILITY <implementation-date> (v1.5.1): Auth servers predating app-client status return 404/405, so onboarding must fail open for older/custom deployments. Remove this fallback and its endpoint-omission tests after every supported auth server exposes GET /auth/app-clients/status.
+```
+
+Affected pairs are bridge `v1.5.1+` with auth deployments before S01-W01-P01,
+including custom backends that retain the otherwise-supported auth API. The
+normal permanent-failure policy for malformed/forbidden requests is not itself
+legacy compatibility code and is not marked.
+
+Existing prompt text/defaults remain stable. The synchronous-to-asynchronous
+terminal implementation is internal and adds no CLI/config contract. No
+persisted data or wire model is migrated.
+
+`SesoriAuthApi` consolidation and the required auth cancellation parameter
+are bridge-internal source changes delivered atomically. Every email, OAuth,
+profile/validation, refresh, bridge registration/deletion consumer and test fake
+moves in the same PR; old use-case API files/top-level HTTP functions are deleted
+instead of retained as aliases. Existing auth wire requests/responses and
+user-visible failures remain regression contracts.
+
+The shipped `v1.3.0` legacy bridge-id reader/marker moves with its real file I/O
+into `TokenStorage`; it is not duplicated or removed. Its cleanup text is updated
+mechanically to remove `TokenStorage.readLegacyBridgeId` with
+`BridgeIdMigrationService` once pre-v1.3.0 installs are unsupported.
+
+### Generated-code workflow
+
+S01-W02-P01 changes the source Freezed response model, adds `qr` to
+`bridge/app/pubspec.yaml`, runs `dart pub get` from `bridge/`, and runs the
+workspace `make codegen`. The worker reviews and commits generated
+`*.freezed.dart` / `*.g.dart` and `bridge/pubspec.lock` changes but never edits
+generated files by hand. There is no Drift work.
+
+## 8. Rollout and Verification
+
+### Release order
+
+1. Merge and deploy S01-W01-P01 to the auth server.
+2. Confirm the immediate and long-poll endpoint against the deployed auth
+   environment without exposing bearer tokens in retained evidence.
+3. Merge S01-W02-P01 to monorepo `main` only after the auth PR merge barrier.
+4. Release the bridge through its existing process. No flag or staged cohort is
+   required because old-server failure is explicitly compatible.
+5. Execute the advisory QR/platform checkpoint when representative terminals
+   and a disposable same-account app registration are available.
+
+Rollback is stateless: the bridge PR can be reverted without server cleanup,
+and the auth PR can be reverted while new bridges fail open. No persisted skip,
+waiter, or schema state survives a process.
+
+### Automated verification
+
+- Auth repository tests prove existence queries across all five platforms and
+  invalid/empty users without loading or exposing token values.
+- Auth service tests prove immediate truth, timeout false, all-same-user wake,
+  cross-user isolation, post-upsert ordering, failed-upsert non-wake,
+  register/recheck race closure, abort cleanup, and no timer/waiter leaks.
+- Auth route tests prove authentication, query validation, immediate and
+  long-poll responses, disconnect handling, and unchanged token/activation
+  behavior.
+- Consolidated auth API tests prove every migrated existing operation plus
+  configurable URL construction, bearer header, strict typed app-status parsing,
+  30s/35s relationship, active app-status/refresh abort on skip/timeout, and
+  status exceptions.
+- Bridge repository tests prove unauthorized/status classification,
+  permanent/old-server normalization, malformed response handling, caller-token
+  forwarding, and no token-refresh/logging ownership.
+- Bridge service tests use `fake_async`, fake repositories/token refreshers, and
+  captured output to prove exactly one 401 refresh, silent current registration,
+  prompt ordering, exact URL equality, success, both skip
+  aliases, invalid input, EOF, normal-timeout no-delay/no-warning behavior,
+  fixed 60-second transient delay, indefinite retry, permanent fail-open, and
+  cancellation during request and delay.
+- Terminal tests prove one lazy async stdin subscription, sequential prompts,
+  cancellation handoff to later prompts, EOF, password echo restoration, and
+  unchanged yes/no/provider/credential/logout behavior.
+- Formatter tests prove quiet zone, module orientation, ANSI reset, Unicode and
+  ASCII shapes, width boundaries, unknown-width fallback, URL permanence, and
+  deterministic output for the exact URL.
+- Startup-orchestrator tests prove sole lower-layer construction, mode gating,
+  checkpoint location before plugin startup, no held startup mutex,
+  early/shared `TokenService` reuse, existing session-Orchestrator creation only
+  after plugin start, direct runner injection/execution, and continuation for
+  success/skip/fail-open. Runner tests prove it constructs nothing.
+- Token tests prove typed access classification, required non-null cancellation
+  at every caller, both production implementors, and no surviving refresh/
+  control request after abort.
+
+### Manual verification
+
+S01-W02-M01 scans real terminal output and checks dark/light, width, skip,
+same-account wake, and silent-restart behavior. It is advisory and records
+separate User/Worker evidence.
+
+### Observability
+
+- Normal `registered: false` long-poll expiry is not an error and never logs.
+- A recovered transient attempt emits one concise warning identifying network,
+  timeout, or HTTP class and the exact 60-second retry; the service is the only
+  reporting owner.
+- Permanent/compatibility failure emits one warning that startup will continue.
+- Essential skip instructions are user-facing output, never hidden solely
+  behind log-level filtering.
+- No tokens, auth headers, local paths, device-token values, or raw response
+  bodies appear in output/evidence.
+- No new telemetry sink, counter, or analytics event is added.
+
+### Security
+
+- The endpoint requires the existing user bearer token and derives user id only
+  from auth middleware.
+- Responses reveal one boolean about the caller's own account and never return
+  token/platform/device details.
+- Raw bearer tokens remain only in HTTP headers and existing token storage; QR
+  and URL contain no identity or secret.
+- Waiters are keyed by authenticated user id in process memory, removed on every
+  completion path, and never persisted.
+- Local E2E, managed trust, relay encryption, plugin boundaries, multi-bridge
+  addressing, and session-control surfaces remain unchanged.
+
+## 9. Risks and Deferrals
+
+| Risk | Decision / mitigation |
+|---|---|
+| A stale FCM token makes a user look registered | Explicitly accepted: the locked source of truth is the current token row, not a heartbeat. Existing stale-token cleanup remains unchanged. |
+| Token registers between initial absence and long-poll waiter setup | Service registers the waiter then rechecks Mongo; post-commit signaling wakes all same-user waiters. |
+| Auth server runs multiple instances | Current deployment is documented single-instance. Distributed signaling is deferred until horizontal scaling is a real requirement. |
+| Client disconnect leaks a 30-second waiter | Shared request-close signal plus service timeout/abort cleanup; route and service tests inspect leak-free state. |
+| Network is unavailable indefinitely | Interactive startup retries every fixed 60 seconds as explicitly chosen; visible `s`/`skip` remains cancellable during request and delay. |
+| Warning spam during outage | One reporting owner and one warning per failed request, with no request for the following 60 seconds. |
+| Older/custom auth server lacks endpoint | Exact compatibility fallback for 404/405 warns once and fails open; auth deploys first. |
+| User signs in to a different account | Instructions say same account; only the authenticated bridge user's durable token wakes the waiter. |
+| Async stdin migration changes existing prompts | One terminal owner, serialized prompt tests, echo restoration, and startup-orchestrator/logout regressions; no raw-mode single-key handling. |
+| App registration and skip complete together | One service completion gate cancels remaining request/subscription/delay and emits only one continuation/result message. |
+| QR scans poorly under a terminal theme/font | Explicit black/white ANSI rendering where supported, quiet zone, bounded Unicode/ASCII fallbacks, width checks, URL always present, and advisory real scans. |
+| QR dependency or generation broadens lock output | Add only pure-Dart `qr`, run normal workspace resolution/codegen, and reject unrelated lock/generated changes. |
+| Holding startup mutex while user waits | Checkpoint runs before `startPluginUnderStartupMutex`; no mutex or runtime process exists during the wait. |
+| Plugin is unavailable | Preserve the quick availability probe before onboarding so users are not asked to install the app for a bridge that cannot start. |
+| Auth HTTP consolidation regresses existing flows | Migrate real methods into one `SesoriAuthApi`, delete wrappers only after callers move, and preserve email/OAuth/profile/refresh/bridge request fixtures plus user-visible mapping tests. |
+| Skip occurs during token refresh | Required `AuthRequestCancellationSignal` reaches both production token authorities and abortable auth transport; cancellable near-expiry refresh is awaited, and completion waits for settlement. |
+| Runner becomes a second composition root | `BridgeStartupOrchestrator` constructs/owns every startup layer and directly injects only the four required already-built runtime/outcome collaborators; runner has no constructors/factories for lower layers. Existing session `Orchestrator` is created only after plugin start. |
+
+Deferred work includes live app liveness, distributed waiter signaling, richer
+deep links, browser opening, terminal QR files, persistent onboarding choices,
+and any analytics.
+
+## 10. Stage Map
+
+| Stage | Outcome | Waves |
+|---|---|---|
+| S01 — App registration checkpoint | Auth server publishes race-safe current-registration long polling, then the standalone bridge consumes it with cancellable terminal onboarding and bounded QR output. | W01: S01-W01-P01; W02: S01-W02-P01 plus advisory S01-W02-M01 |
+
+Waves are strict merge barriers and no PR is stacked. The auth-server PR must
+merge before bridge implementation starts. The manual checkpoint is advisory,
+does not block merge or plan closure, and has separate User/Worker state.
+
+## 11. App-Registration State Machines
+
+### Server waiter states
+
+```text
+created
+  -> immediate registered true
+  -> waiting
+       -> registered true after durable upsert
+       -> false after 30s timeout
+       -> cancelled after client disconnect
+       -> failed if repository recheck throws
+```
+
+Every terminal edge removes the timeout, abort listener, waiter set entry, and
+empty user map entry before resolving. A registration snapshots the user's
+waiter set before resolving it so mutation during iteration cannot skip peers.
+
+### Bridge failure classification
+
+| Outcome | Handling |
+|---|---|
+| 200 `registered: true` | Success; silent on initial check, confirmation after prompt. |
+| 200 `registered: false`, immediate | Render onboarding once, then long poll. |
+| 200 `registered: false`, long poll | Normal expiry; no warning/delay, immediately long poll again. |
+| Skip-triggered `RequestAbortedException` | Expected cancellation; no warning, continue current run. |
+| Repository returns unauthorized first occurrence | Service forces refresh once and retries immediately. |
+| Repository returns unauthorized after refresh | Service warns once and fails open. |
+| 400/403/404/405/other non-retryable 4xx | Warn once and fail open; 404/405 branch carries compatibility marker. |
+| 408/429/5xx | Warn once, fixed cancellable 60-second delay, retry. |
+| Socket/client/network error | Warn once, fixed cancellable 60-second delay, retry. |
+| Client's active 35-second timeout | Abort socket, warn once, fixed cancellable 60-second delay, retry. |
+| Token refresh socket/408/429/5xx/15-second deadline | Typed transient; abort transport, warn once, fixed cancellable 60-second delay, retry. |
+| Token refresh local-token/4xx/malformed failure | Typed unavailable; warn once and fail open. |
+| Skip during token refresh | Typed cancellation; actively abort and await settlement, no failure warning. |
+| Malformed/missing required response field | Permanent protocol failure; warn once and fail open. |
+| Terminal EOF/loss while prompted | Warn once, abort request, fail open. |
+
+The retry delay begins after handling the failure and is always exactly 60
+seconds unless registration/skip/cancellation ends the one-shot service. A
+server-supplied retry hint does not create a second backoff policy in this scope.
+
+### QR rendering order
+
+1. Encode exactly `https://sesori.com/app/?openStore=true` with the audited
+   pure-Dart QR package and a fixed error-correction choice suitable for terminal
+   scanning.
+2. Add four light modules on every side.
+3. Prefer ANSI + Unicode compact half-block output with explicit black/white
+   foreground/background and a final reset.
+4. Fall back to non-ANSI Unicode blocks, then ASCII `##`/spaces according to
+   existing capability validators.
+5. Compute complete rendered width before output. If terminal width is unknown,
+   throws, or is smaller than the selected representation, omit the QR.
+6. Print the exact plain URL on its own line in every prompted case, regardless
+   of QR success.

--- a/.plan/active/bridge-app-onboarding/PLAN.md
+++ b/.plan/active/bridge-app-onboarding/PLAN.md
@@ -64,9 +64,10 @@ warnings.
 10. Existing provider, email/password, replacement, and logout prompts retain
     their text, echo, EOF, default-answer, and noninteractive behavior after
     terminal input moves under one asynchronous owner.
-11. QR output includes a four-module quiet zone, never exceeds known terminal
-    width, resets ANSI state, supports bounded ANSI/Unicode and ASCII fallbacks,
-    and degrades to the URL alone when safe rendering cannot be proven.
+11. QR output includes a four-module light quiet zone, never exceeds known
+    terminal width, and renders only through explicit black/white ANSI plus
+    Unicode when both capabilities are proven. Unknown polarity, missing ANSI/
+    Unicode, or unsafe width uses the plain-URL-only fallback.
 12. Auth-server and bridge automated verification passes, and the advisory QR
     scan matrix records representative dark/light and platform evidence without
     adding product analytics or post-release observation targets.
@@ -248,8 +249,8 @@ returned.
 ```text
 bridge GET status?wait=true
   -> requireAuth identifies user
-  -> AppClientPresenceService checks DeviceTokenRepository.hasAnyForUser
-  -> absent: register per-user waiter + timeout/abort cleanup
+  -> AppClientPresenceService starts one absolute 30s deadline, then checks DeviceTokenRepository.hasAnyForUser
+  -> absent before deadline: register per-user waiter for only the remaining budget + abort cleanup
   -> recheck repository after waiter registration
   -> return false on 30s timeout, or hijack/return nothing after disconnect
 
@@ -278,8 +279,8 @@ recheck paths remove listener/timer/map state.
 | `LoginOAuthRepository` | Layer 2, `bridge/app/lib/src/auth/login_oauth_repository.dart` | Map OAuth init/status/ACK calls from the consolidated API for `LoginOAuthService`. |
 | Existing auth repositories | Layer 2, `login_email_repository.dart`, `bridge_registration_repository.dart` | Consume the same `SesoriAuthApi` directly and preserve their domain exception/result mapping; no forwarding API wrappers remain. |
 | `AppClientPresenceRepository` | Layer 2, `bridge/app/lib/src/auth/app_client_presence_repository.dart` | Accept an access token from its caller, delegate app status to `SesoriAuthApi`, normalize registered/absent/unauthorized/unavailable/transient/cancelled outcomes, and own the old-server compatibility seam. It has no token authority, retry, output, or delay policy. |
-| `TokenRefresher` / `TokenService` | Existing service contract and renamed `bridge/app/lib/src/auth/token_service.dart` implementation | Add a required auth-local `AuthRequestCancellationSignal` to token acquisition, typed access-failure kinds, and abortable refresh via `AuthRepository`. Update both production implementors and every caller/fake. During onboarding the newly composed standalone service is the only token caller, so skip owns and terminates its refresh request. |
-| `AppOnboardingFormatter` | Foundation/pure formatter, `bridge/app/lib/src/foundation/app_onboarding_formatter.dart` | Convert URL + QR modules + width/ANSI/Unicode capabilities into bounded text with quiet zone and URL fallback. No I/O or lifecycle. |
+| `TokenRefresher` / `TokenService` | Existing service contract and renamed `bridge/app/lib/src/auth/token_service.dart` implementation | Require both named `forceRefresh` and auth-local `AuthRequestCancellationSignal` on token acquisition, add typed access-failure kinds, and use abortable refresh via `AuthRepository`. Update both production implementors and every caller/fake. During onboarding the newly composed standalone service is the only token caller, so skip owns and terminates its refresh request. |
+| `AppOnboardingFormatter` | Foundation/pure formatter, `bridge/app/lib/src/foundation/app_onboarding_formatter.dart` | Convert URL + QR modules + width/ANSI/Unicode capabilities into bounded explicit black/white ANSI+Unicode text with a light quiet zone, or URL-only when polarity/capability/width safety is not proven. No I/O or lifecycle. |
 | `TerminalInteractionMode` | Foundation, `bridge/app/lib/src/foundation/terminal_interaction_mode.dart` | Typed `interactive` / `unavailable` / `legacyPostUpdate` result computed by composition roots from raw terminal facts and invocation environment. Existing terminal prompt decision/replace contracts move from `server/foundation` to root Foundation with it. |
 | `TerminalPromptApi` / `TerminalPromptRepository` | Root Layer 1/2, `bridge/app/lib/src/api/terminal_prompt_api.dart` and `lib/src/repositories/terminal_prompt_repository.dart` | Move the substantially changed terminal boundaries out of the minimal `server/` subsystem. API owns raw async terminal I/O/facts; repository receives interaction mode and maps provider/credentials/yes-no/onboarding outcomes. |
 | `AppClientOnboardingService` | Layer 3, `bridge/app/lib/src/services/app_client_onboarding_service.dart` | Own access-token acquisition, exactly one forced refresh/retry after 401, checkpoint state, terminal subscription, cancellation, long-poll loop, internal retry timer, output, and exactly-once completion. It depends on root repositories/Foundation plus `TokenRefresher`, not on the `server/` subsystem. |
@@ -336,7 +337,7 @@ AppOnboardingFormatter(
   # immutable rendering facts; no I/O or collaborator lifecycle
 
 TerminalPromptApi(required Stdin, required Stdout)
-  # owns and disposes its lazy input subscription; no environment policy
+  # owns/disposes its lazy input subscription plus FIFO pending-line buffer; no environment policy
 
 TerminalPromptRepository(
   required TerminalPromptApi,
@@ -355,9 +356,10 @@ shared HTTP client's close lifecycle; `SesoriAuthApi` borrows it.
 `AppClientOnboardingService` creates/cancels its one-shot `Timer` internally and
 tests virtual time with `fake_async`; no delay callback or timer peer is added.
 
-`TokenRefresher.getAccessToken` adds required
-`AuthRequestCancellationSignal cancelled`. Existing callers pass
-`AuthRequestCancellationSignal.never`; onboarding passes its owned
+`TokenRefresher.getAccessToken` requires named `bool forceRefresh` and
+`AuthRequestCancellationSignal cancelled`. Existing callers explicitly pass
+`forceRefresh: false` and `AuthRequestCancellationSignal.never`; onboarding
+passes false for ordinary attempts, true for its one forced retry, and its owned
 controller's signal. `TokenService` forwards the signal through `AuthRepository`
 to `SesoriAuthApi.refreshTokens`, whose `AbortableRequest` races cancellation
 and an active 15-second deadline.
@@ -454,14 +456,16 @@ accepted aliases and continue waiting.
 15. Permanent/unsupported protocol outcomes fail open after one warning.
 16. One 401 triggers one forced refresh and immediate retry; a second 401 fails
     open.
-17. Dart terminal input is unified under one asynchronous owner rather than
-    moving onboarding after plugin startup or relying on undefined mixed reads.
+17. Dart terminal input is unified under one asynchronous owner with a FIFO
+    pending-line buffer, preserving type-ahead across sequential prompts rather
+    than moving onboarding after plugin startup or relying on mixed reads.
 18. `SesoriAuthApi` becomes the sole API owner for the external auth provider;
     existing use-case APIs/top-level HTTP are migrated and removed in the bridge
     PR rather than wrapped.
-19. Token acquisition requires an `AuthRequestCancellationSignal`; skip actively terminates
-    refresh/status transport and waits for settlement. Typed refresh failures
-    are never classified by parsing messages.
+19. Token acquisition requires explicit named `forceRefresh` and an
+    `AuthRequestCancellationSignal`; skip actively terminates refresh/status
+    transport and waits for settlement. Typed refresh failures are never
+    classified by parsing messages.
 20. The substantially changed standalone token owner is `TokenService`, not a
     manager, and receives concrete `TokenStorage`; touched token load/save/clear
     callback plumbing is removed.
@@ -473,8 +477,9 @@ accepted aliases and continue waiting.
     collaborators and constructs no lower layer; the existing session
     `Orchestrator` remains session-control owner after plugin start.
 23. The bounded QR contract targets common interactive macOS/Linux/Windows
-    terminals, dark/light themes, ANSI/Unicode and ASCII fallbacks. URL-only is
-    valid for unsafe, unknown, or too-narrow rendering.
+    terminals and renders only with explicit black/white ANSI plus Unicode when
+    polarity, glyphs, and width are safe. URL-only is required for missing ANSI/
+    Unicode, unknown polarity/width, or too-narrow rendering.
 24. No analytics, rollout telemetry, or post-release observation work is part
     of the plan.
 
@@ -571,12 +576,14 @@ waiter, or schema state survives a process.
   aliases, invalid input, EOF, normal-timeout no-delay/no-warning behavior,
   fixed 60-second transient delay, indefinite retry, permanent fail-open, and
   cancellation during request and delay.
-- Terminal tests prove one lazy async stdin subscription, sequential prompts,
-  cancellation handoff to later prompts, EOF, password echo restoration, and
-  unchanged yes/no/provider/credential/logout behavior.
-- Formatter tests prove quiet zone, module orientation, ANSI reset, Unicode and
-  ASCII shapes, width boundaries, unknown-width fallback, URL permanence, and
-  deterministic output for the exact URL.
+- Terminal tests prove one lazy async stdin subscription, FIFO type-ahead across
+  gaps between sequential prompts, cancellation handoff without dropping queued
+  lines, EOF, password echo restoration, and unchanged yes/no/provider/
+  credential/logout behavior.
+- Formatter tests prove a light quiet zone, module orientation, explicit black/
+  white ANSI reset, width boundaries, required URL-only fallback without ANSI or
+  Unicode and for unknown polarity/width, URL permanence, and deterministic
+  output for the exact URL.
 - Startup-orchestrator tests prove sole lower-layer construction, mode gating,
   checkpoint location before plugin startup, no held startup mutex,
   early/shared `TokenService` reuse, existing session-Orchestrator creation only
@@ -630,9 +637,9 @@ separate User/Worker evidence.
 | Warning spam during outage | One reporting owner and one warning per failed request, with no request for the following 60 seconds. |
 | Older/custom auth server lacks endpoint | Exact compatibility fallback for 404/405 warns once and fails open; auth deploys first. |
 | User signs in to a different account | Instructions say same account; only the authenticated bridge user's durable token wakes the waiter. |
-| Async stdin migration changes existing prompts | One terminal owner, serialized prompt tests, echo restoration, and startup-orchestrator/logout regressions; no raw-mode single-key handling. |
+| Async stdin migration changes existing prompts | One terminal owner with a FIFO pending-line buffer, serialized/type-ahead prompt tests, echo restoration, and startup-orchestrator/logout regressions; no raw-mode single-key handling. |
 | App registration and skip complete together | One service completion gate cancels remaining request/subscription/delay and emits only one continuation/result message. |
-| QR scans poorly under a terminal theme/font | Explicit black/white ANSI rendering where supported, quiet zone, bounded Unicode/ASCII fallbacks, width checks, URL always present, and advisory real scans. |
+| QR scans poorly under a terminal theme/font | Render only with explicit black/white ANSI plus validated Unicode, a four-module light quiet zone, and known sufficient width; otherwise omit QR, retain the URL, and use advisory real scans. |
 | QR dependency or generation broadens lock output | Add only pure-Dart `qr`, run normal workspace resolution/codegen, and reject unrelated lock/generated changes. |
 | Holding startup mutex while user waits | Checkpoint runs before `startPluginUnderStartupMutex`; no mutex or runtime process exists during the wait. |
 | Plugin is unavailable | Preserve the quick availability probe before onboarding so users are not asked to install the app for a bridge that cannot start. |
@@ -702,11 +709,13 @@ server-supplied retry hint does not create a second backoff policy in this scope
    pure-Dart QR package and a fixed error-correction choice suitable for terminal
    scanning.
 2. Add four light modules on every side.
-3. Prefer ANSI + Unicode compact half-block output with explicit black/white
-   foreground/background and a final reset.
-4. Fall back to non-ANSI Unicode blocks, then ASCII `##`/spaces according to
-   existing capability validators.
-5. Compute complete rendered width before output. If terminal width is unknown,
+3. Require validated ANSI and Unicode support, then use compact half-block output
+   with explicit black/white foreground/background and a final reset. This is
+   the only QR renderer because non-ANSI Unicode/ASCII cannot prove light/dark
+   polarity across terminal themes.
+4. Compute complete rendered width before output. If terminal width is unknown,
    throws, or is smaller than the selected representation, omit the QR.
+5. If ANSI or Unicode is unavailable, polarity is not provable, or rendering
+   fails, omit the QR rather than emitting an inverted/unsafe fallback.
 6. Print the exact plain URL on its own line in every prompted case, regardless
    of QR success.

--- a/.plan/active/bridge-app-onboarding/TRACKER.md
+++ b/.plan/active/bridge-app-onboarding/TRACKER.md
@@ -1,0 +1,81 @@
+# Bridge App Onboarding: Tracker
+
+## Plan State
+
+- **Status:** Approved — ready for delivery
+- **Implementation base:** `main`
+- **Plan slug:** `bridge-app-onboarding`
+- **Plan PR:** —
+- **Repositories:** `sesori-ai/sesori_apps_monorepo`, `sesori-ai/sesori_auth_server`
+
+## Current Pointer
+
+- **Stage:** S01 — App Registration Checkpoint
+- **Wave:** W01
+- **Next action:** Choose plan delivery. After delivery, use `sesori-plan-worker` with slug `bridge-app-onboarding` to pin the current auth-server `master` baseline for S01/W01 and implement S01-W01-P01.
+
+## Plan Review
+
+- **Verdict:** Approved — no architectural violations
+- **Reviewer:** `aristotle-plan-review`
+- **Date:** 2026-07-17
+- **Reviewed commit:** `5a76c0c420cd7db445f7fe2c8a2570265b4c84e0` plus the complete uncommitted `.plan/active/bridge-app-onboarding/` tree; external auth baseline `b17a6e760b0c70c3dc3d1cd456ff93d814c75453`
+
+## Wave Baselines
+
+| Stage | Wave | Repository | Base | Pinned SHA | Drift Decision |
+|---|---|---|---|---|---|
+
+No implementation wave has started. Workers add one authoritative row for each
+started stage/wave/repository/base pair after drift assessment and before branch
+creation.
+
+## PR Steps
+
+| Done | ID | Stage | Wave | PR | Branch | Notes |
+|---|---|---|---|---|---|---|
+| [ ] | S01-W01-P01 | S01 | W01 | — | `plan/bridge-app-onboarding/s01-w01-p01-app-client-presence-endpoint` | Add auth-server immediate/long-poll current app-registration endpoint and durable post-upsert wake. |
+| [ ] | S01-W02-P01 | S01 | W02 | — | `plan/bridge-app-onboarding/s01-w02-p01-interactive-app-onboarding` | Add standalone bridge checkpoint, async terminal ownership, retry/cancellation, and bounded QR output. |
+
+## Manual Checkpoints
+
+| User | Worker | ID | Check | Evidence |
+|---|---|---|---|---|
+| [ ] | [ ] | S01-W02-M01 | Scan and exercise terminal app onboarding across representative terminal capabilities | — |
+
+## Blockers and Staleness
+
+- No implementation blocker is known.
+- The auth-server endpoint must merge and deploy before bridge release. Wave W02
+  does not start until S01-W01-P01 merges.
+- Latest audited tips: monorepo `main`
+  `5a76c0c420cd7db445f7fe2c8a2570265b4c84e0`
+  (2026-07-17T06:57:01Z); auth-server `master`
+  `b17a6e760b0c70c3dc3d1cd456ff93d814c75453`
+  (2026-07-16T14:14:09Z). Each worker assesses and pins current drift.
+- The independent active `session-pull-request-monitoring` plan may proceed; a
+  worker stops and requests stale-plan re-review only if drift changes this
+  plan's touched paths, contracts, architecture, or product intent.
+
+## Findings and Plan Deltas
+
+- **2026-07-17 — Full-plan approval:** `aristotle-plan-review` approved the
+  complete two-repository plan after all architecture, lifecycle, compatibility,
+  command, wave, and tracker corrections; no violations remain.
+- **2026-07-17 — Review hardening:** Consolidated Sesori auth HTTP under one
+  provider API; added direct `TokenStorage`, renamed the standalone owner to
+  `TokenService`, defined typed cancellable token access across both authorities,
+  moved terminal/auth/onboarding classes to correct root layers, kept auth token
+  deletion out of the waiter service, injected logout registration directly,
+  and made root `BridgeStartupOrchestrator` the sole startup/session composer
+  while runner consumes only direct already-built collaborators.
+- **2026-07-17 — Approved design:** The user approved standalone-interactive-only
+  onboarding; current token existence across all app platforms; silent existing
+  registration; success feedback; `s`/`skip` + Enter; no persisted skip; exact
+  app URL; bounded terminal QR; server long polling; fixed 60-second transient
+  retry; indefinite interactive waiting; permanent fail-open compatibility;
+  unified asynchronous terminal input; and no analytics.
+- **2026-07-17 — Baseline audit:** Selected monorepo `main` rather than invocation
+  branch `bridge-onboarding-optimization`; independently audited auth-server
+  `master`. Current code has durable app tokens and OAuth waiter precedents but
+  no current-registration endpoint or bridge checkpoint.

--- a/.plan/active/bridge-app-onboarding/TRACKER.md
+++ b/.plan/active/bridge-app-onboarding/TRACKER.md
@@ -2,17 +2,17 @@
 
 ## Plan State
 
-- **Status:** Approved — ready for delivery
+- **Status:** Approved — plan PR merged (branch-relative optimistic state)
 - **Implementation base:** `main`
 - **Plan slug:** `bridge-app-onboarding`
-- **Plan PR:** —
+- **Plan PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/490
 - **Repositories:** `sesori-ai/sesori_apps_monorepo`, `sesori-ai/sesori_auth_server`
 
 ## Current Pointer
 
 - **Stage:** S01 — App Registration Checkpoint
 - **Wave:** W01
-- **Next action:** Choose plan delivery. After delivery, use `sesori-plan-worker` with slug `bridge-app-onboarding` to pin the current auth-server `master` baseline for S01/W01 and implement S01-W01-P01.
+- **Next action:** Use `sesori-plan-worker` with slug `bridge-app-onboarding` to pin the current auth-server `master` baseline for S01/W01 and implement S01-W01-P01.
 
 ## Plan Review
 
@@ -59,6 +59,10 @@ creation.
 
 ## Findings and Plan Deltas
 
+- **2026-07-17 — Plan delivery:** Opened plan-only PR
+  https://github.com/sesori-ai/sesori_apps_monorepo/pull/490 against selected
+  implementation base `main`; tracker state is optimistically post-merge on the
+  plan branch.
 - **2026-07-17 — Full-plan approval:** `aristotle-plan-review` approved the
   complete two-repository plan after all architecture, lifecycle, compatibility,
   command, wave, and tracker corrections; no violations remain.

--- a/.plan/active/bridge-app-onboarding/TRACKER.md
+++ b/.plan/active/bridge-app-onboarding/TRACKER.md
@@ -19,7 +19,7 @@
 - **Verdict:** Approved — no architectural violations
 - **Reviewer:** `aristotle-plan-review`
 - **Date:** 2026-07-17
-- **Reviewed commit:** `5a76c0c420cd7db445f7fe2c8a2570265b4c84e0` plus the complete uncommitted `.plan/active/bridge-app-onboarding/` tree; external auth baseline `b17a6e760b0c70c3dc3d1cd456ff93d814c75453`
+- **Reviewed commit:** `c75b597ddb965f02031b42a6f6d27feb11827aba` plus the complete uncommitted final architecture corrections in `.plan/active/bridge-app-onboarding/`; external auth baseline `b17a6e760b0c70c3dc3d1cd456ff93d814c75453`
 
 ## Wave Baselines
 

--- a/.plan/active/bridge-app-onboarding/TRACKER.md
+++ b/.plan/active/bridge-app-onboarding/TRACKER.md
@@ -2,7 +2,7 @@
 
 ## Plan State
 
-- **Status:** Approved — plan PR merged (branch-relative optimistic state)
+- **Status:** Finalized by user-authorized one-review/fix process — plan PR merged (branch-relative optimistic state)
 - **Implementation base:** `main`
 - **Plan slug:** `bridge-app-onboarding`
 - **Plan PR:** https://github.com/sesori-ai/sesori_apps_monorepo/pull/490
@@ -16,10 +16,10 @@
 
 ## Plan Review
 
-- **Verdict:** Approved — no architectural violations
+- **Verdict:** Final by explicit user waiver — one full review completed and its two findings corrected; no further plan re-review
 - **Reviewer:** `aristotle-plan-review`
 - **Date:** 2026-07-17
-- **Reviewed commit:** `cbcd9ba3a750b8281ae0f702be0da5f75de45096` plus the complete uncommitted second-round plan-PR feedback edits in `.plan/active/bridge-app-onboarding/`; external auth baseline `b17a6e760b0c70c3dc3d1cd456ff93d814c75453`
+- **Reviewed commit:** review covered the uncommitted draft after `2d2e07adcf2e4d03ee46404ec268e0d1d3e5ebfd`; its formatter-contract and logout-graph findings are corrected in the final working tree without re-review by explicit user direction; external auth baseline `b17a6e760b0c70c3dc3d1cd456ff93d814c75453`
 
 ## Wave Baselines
 
@@ -59,6 +59,31 @@ creation.
 
 ## Findings and Plan Deltas
 
+- **2026-07-17 — Review-loop waiver and final corrections:** The user directed
+  exactly one full plan review plus one finite fix pass, with no further plan
+  re-review. Corrected the formatter contract to accept only repository-produced
+  `TerminalRenderingCapabilities`, and made logout executable end to end:
+  composition performs one typed token-repository read, conditionally constructs
+  token/registration services, injects migration/repository/optional registration
+  into the runner, and owns exact disposal.
+- **2026-07-17 — Fourth plan-PR architecture correction:** Mapped the server's
+  initial-read deadline through a service-local failure to route-owned 500;
+  inserted `TokenRepository`/`BridgeIdRepository` so services no longer consume
+  persistence APIs; moved terminal mode/capability mapping wholly into
+  `TerminalPromptRepository`; and added shared Freezed email-login/refresh
+  request DTOs so consolidated auth contains no inline request maps. At the
+  user's direction, composition now aligns with the active desktop and parallel-
+  plugin plans: `BridgeRuntimeRunner` remains process-startup composer and the
+  existing `Orchestrator` remains post-start session composer under an exact
+  B-B5 waiver; the proposed `BridgeStartupOrchestrator` is removed.
+- **2026-07-17 — Locked architecture exception:** The user explicitly retained
+  long polling and approved both it and existing authentication request/response
+  as narrow exceptions to the push-based default; SSE and generic polling
+  abstractions remain out of scope.
+- **2026-07-17 — Third plan-PR review hardening:** Prevented unconfirmed absence
+  when the server's initial read misses its deadline, required detachable auth
+  cancellation listeners, preserved initial-silent-check input, and defined the
+  cross-repository tracker handoff through the remote tracking branch.
 - **2026-07-17 — Second plan-PR review hardening:** Preserved the shipped
   post-refresh token-file corruption repair while retaining cleared-file logout
   safety, and made secret reads discard/re-request any line queued before echo
@@ -75,13 +100,12 @@ creation.
 - **2026-07-17 — Full-plan approval:** `aristotle-plan-review` approved the
   complete two-repository plan after all architecture, lifecycle, compatibility,
   command, wave, and tracker corrections; no violations remain.
-- **2026-07-17 — Review hardening:** Consolidated Sesori auth HTTP under one
-  provider API; added direct `TokenStorage`, renamed the standalone owner to
-  `TokenService`, defined typed cancellable token access across both authorities,
-  moved terminal/auth/onboarding classes to correct root layers, kept auth token
-  deletion out of the waiter service, injected logout registration directly,
-  and made root `BridgeStartupOrchestrator` the sole startup/session composer
-  while runner consumes only direct already-built collaborators.
+- **2026-07-17 — Review hardening (later revised):** Consolidated Sesori auth
+  HTTP under one provider API, renamed the standalone owner to `TokenService`,
+  defined typed cancellable token access across both authorities, moved terminal/
+  auth/onboarding classes to root layers, kept auth token deletion out of the
+  waiter service, and injected logout registration directly. The later fourth-
+  round delta supersedes this draft's direct-storage and startup-composer shape.
 - **2026-07-17 — Approved design:** The user approved standalone-interactive-only
   onboarding; current token existence across all app platforms; silent existing
   registration; success feedback; `s`/`skip` + Enter; no persisted skip; exact

--- a/.plan/active/bridge-app-onboarding/TRACKER.md
+++ b/.plan/active/bridge-app-onboarding/TRACKER.md
@@ -19,7 +19,7 @@
 - **Verdict:** Approved — no architectural violations
 - **Reviewer:** `aristotle-plan-review`
 - **Date:** 2026-07-17
-- **Reviewed commit:** `c75b597ddb965f02031b42a6f6d27feb11827aba` plus the complete uncommitted final architecture corrections in `.plan/active/bridge-app-onboarding/`; external auth baseline `b17a6e760b0c70c3dc3d1cd456ff93d814c75453`
+- **Reviewed commit:** `49eca8c0b91204687f3c8949a4947f42eaeca269` plus the complete uncommitted plan-PR feedback edits in `.plan/active/bridge-app-onboarding/`; external auth baseline `b17a6e760b0c70c3dc3d1cd456ff93d814c75453`
 
 ## Wave Baselines
 
@@ -59,6 +59,11 @@ creation.
 
 ## Findings and Plan Deltas
 
+- **2026-07-17 — Plan-PR review hardening:** Made the auth wait deadline absolute
+  from before its initial read, required explicit `forceRefresh` at every token
+  caller, replaced lossy stdin broadcast handoff with FIFO pending-line
+  preservation, and restricted QR rendering to polarity-safe ANSI+Unicode with
+  URL-only fallback.
 - **2026-07-17 — Plan delivery:** Opened plan-only PR
   https://github.com/sesori-ai/sesori_apps_monorepo/pull/490 against selected
   implementation base `main`; tracker state is optimistically post-merge on the

--- a/.plan/active/bridge-app-onboarding/TRACKER.md
+++ b/.plan/active/bridge-app-onboarding/TRACKER.md
@@ -19,7 +19,7 @@
 - **Verdict:** Approved — no architectural violations
 - **Reviewer:** `aristotle-plan-review`
 - **Date:** 2026-07-17
-- **Reviewed commit:** `49eca8c0b91204687f3c8949a4947f42eaeca269` plus the complete uncommitted plan-PR feedback edits in `.plan/active/bridge-app-onboarding/`; external auth baseline `b17a6e760b0c70c3dc3d1cd456ff93d814c75453`
+- **Reviewed commit:** `cbcd9ba3a750b8281ae0f702be0da5f75de45096` plus the complete uncommitted second-round plan-PR feedback edits in `.plan/active/bridge-app-onboarding/`; external auth baseline `b17a6e760b0c70c3dc3d1cd456ff93d814c75453`
 
 ## Wave Baselines
 
@@ -59,6 +59,10 @@ creation.
 
 ## Findings and Plan Deltas
 
+- **2026-07-17 — Second plan-PR review hardening:** Preserved the shipped
+  post-refresh token-file corruption repair while retaining cleared-file logout
+  safety, and made secret reads discard/re-request any line queued before echo
+  is disabled.
 - **2026-07-17 — Plan-PR review hardening:** Made the auth wait deadline absolute
   from before its initial read, required explicit `forceRefresh` at every token
   caller, replaced lossy stdin broadcast handoff with FIFO pending-line

--- a/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/GOAL.md
+++ b/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/GOAL.md
@@ -27,10 +27,13 @@ open. Supervised and noninteractive bridge paths remain unchanged.
   delivery mode.
 - Before W01, the worker fetches auth-server `master`, assesses drift from
   `b17a6e760b0c70c3dc3d1cd456ff93d814c75453`, and records the exact assessed tip
-  as S01/W01's auth-server baseline in `TRACKER.md` before branch creation.
+  as S01/W01's auth-server baseline on remote plan-host branch
+  `plan/bridge-app-onboarding/tracking` before auth branch creation.
 - W02 starts only after S01-W01-P01 merges. Its worker fetches monorepo `main`,
   assesses drift from `5a76c0c420cd7db445f7fe2c8a2570265b4c84e0`
-  plus the now-merged auth contract, and records the exact monorepo baseline.
+  plus the now-merged auth contract, records the exact monorepo baseline on the
+  tracking branch, then creates W02 from that assessed `main` tip and imports
+  only this plan's `TRACKER.md` from the tracking branch.
 - The worker re-reads repository/workspace `AGENTS.md`, `docs/VISION.md`,
   `docs/ROADMAP.md`, the current bridge version, and touched tests after pinning
   each wave.
@@ -46,10 +49,15 @@ open. Supervised and noninteractive bridge paths remain unchanged.
   removes timers/listeners/map state.
 - The server's 30-second wait is one absolute deadline beginning before the
   initial repository read; reads and waiter time do not each receive a new cap.
+- If that deadline wins before the initial read establishes presence/absence,
+  the server returns a transient 500 rather than an unconfirmed false body.
 - The bridge uses its configurable auth backend and existing token authority.
 - No startup mutex, plugin runtime, relay, or backend process is held while the
   user waits.
 - Normal server long-poll expiry is not a failure and has no retry delay/log.
+- The user-approved push-default exception is limited to existing authentication
+  request/response and this server-held presence long poll; no SSE or reusable
+  polling abstraction is introduced.
 - Transient failures use exactly one cancellable 60-second delay and one warning
   per attempt; permanent failures warn once and fail open.
 - Terminal input has one asynchronous owner with FIFO pending-line preservation
@@ -57,10 +65,10 @@ open. Supervised and noninteractive bridge paths remain unchanged.
   mixed synchronous/asynchronous stdin are forbidden.
 - Secret input never consumes a line queued while echo was enabled; pre-switch
   lines are discarded and re-requested after echo is disabled.
-- `TerminalPromptApi` exposes raw terminal facts/I/O only.
-  `BridgeStartupOrchestrator` (and the independent logout composition) resolves
-  typed `TerminalInteractionMode` and injects it into
-  `TerminalPromptRepository`; runner owns no terminal policy.
+- `TerminalPromptApi` exposes raw terminal/environment facts and I/O only.
+  `TerminalPromptRepository` is the sole Layer-2 mapper to typed
+  `TerminalInteractionMode` and rendering capabilities; startup and logout
+  consumers never interpret raw terminal facts.
 - Access-token acquisition and one-refresh-on-401 coordination belong to
   `AppClientOnboardingService`; `AppClientPresenceRepository` only maps its API
   using the caller-supplied token.
@@ -72,15 +80,22 @@ open. Supervised and noninteractive bridge paths remain unchanged.
   `ControlChannelTokenService`, every production caller, and every fake implement
   it; typed refresh failures require no message parsing.
 - Onboarding skip actively aborts app-status and in-flight token-refresh
-  requests. No request or correlated control pull survives service completion.
-- Root Layer-5 `BridgeStartupOrchestrator` owns all auth/terminal/token/
-  onboarding construction and pre-plugin sequencing. `BridgeRuntimeRunner`
-  receives direct already-built runtime/failure/restart/supervised collaborators
-  and constructs no lower layer; existing session `Orchestrator` remains the
-  post-plugin control owner.
+  requests after guidance is shown. The initial silent check consumes no input,
+  and no request, listener, or correlated control pull survives settlement.
+- The user-approved B-B5 exception aligns this work with the active desktop and
+  parallel-plugin plans: `BridgeRuntimeRunner` remains the process-startup
+  composer, while the existing `Orchestrator` remains the post-plugin session/
+  event composer. `BridgeRuntime.create` gains no new policy and no third
+  composer is introduced.
+- Layer-1 `TokenStorage` and `BridgeIdStorage` are consumed only by their Layer-2
+  repositories; token, runtime-auth, registration, migration, and logout
+  services never access persistence APIs directly.
+- Shared Freezed email-login and refresh request DTOs preserve the existing JSON
+  bodies; migrated auth API code contains no inline request maps.
 - The URL is always present when onboarding is shown; QR requires proven ANSI+
   Unicode, explicit black/white polarity, and sufficient known width.
-- Generated files are regenerated from source and never hand-edited.
+- Shared and bridge generated files are regenerated from source and never
+  hand-edited.
 - No persistence migration, app/client UI, browser opening, live heartbeat,
   distributed waiter, analytics, or speculative abstraction is included.
 
@@ -117,8 +132,9 @@ open. Supervised and noninteractive bridge paths remain unchanged.
 - Compatibility marker date/version and cleanup text match the implementation
   and endpoint rollout.
 - No waiter/request/terminal subscription survives its owner lifecycle in tests.
-- `TRACKER.md` contains both pinned baselines, PR URLs, binary checked state on
-  implementation branches, and any advisory manual evidence.
+- `TRACKER.md` on merged monorepo `main` contains both pinned baselines, PR URLs,
+  binary checked state carried through the tracking/W02 branches, and any
+  advisory manual evidence. The remote tracking branch is cleanup-only.
 - The plan can close even if one or both manual checkboxes remain unexecuted for
   lack of representative terminals/devices.
 

--- a/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/GOAL.md
+++ b/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/GOAL.md
@@ -55,6 +55,8 @@ open. Supervised and noninteractive bridge paths remain unchanged.
 - Terminal input has one asynchronous owner with FIFO pending-line preservation
   across sequential prompts; raw single-key mode, lossy broadcast handoff, and
   mixed synchronous/asynchronous stdin are forbidden.
+- Secret input never consumes a line queued while echo was enabled; pre-switch
+  lines are discarded and re-requested after echo is disabled.
 - `TerminalPromptApi` exposes raw terminal facts/I/O only.
   `BridgeStartupOrchestrator` (and the independent logout composition) resolves
   typed `TerminalInteractionMode` and injects it into

--- a/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/GOAL.md
+++ b/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/GOAL.md
@@ -44,14 +44,17 @@ open. Supervised and noninteractive bridge paths remain unchanged.
 - Auth-server token upsert commits before presence wake; failed writes never wake.
 - Waiter registration and repository recheck are race-safe; every terminal path
   removes timers/listeners/map state.
+- The server's 30-second wait is one absolute deadline beginning before the
+  initial repository read; reads and waiter time do not each receive a new cap.
 - The bridge uses its configurable auth backend and existing token authority.
 - No startup mutex, plugin runtime, relay, or backend process is held while the
   user waits.
 - Normal server long-poll expiry is not a failure and has no retry delay/log.
 - Transient failures use exactly one cancellable 60-second delay and one warning
   per attempt; permanent failures warn once and fail open.
-- Terminal input has one asynchronous owner; raw single-key mode and mixed
-  synchronous/asynchronous stdin are forbidden.
+- Terminal input has one asynchronous owner with FIFO pending-line preservation
+  across sequential prompts; raw single-key mode, lossy broadcast handoff, and
+  mixed synchronous/asynchronous stdin are forbidden.
 - `TerminalPromptApi` exposes raw terminal facts/I/O only.
   `BridgeStartupOrchestrator` (and the independent logout composition) resolves
   typed `TerminalInteractionMode` and injects it into
@@ -62,10 +65,10 @@ open. Supervised and noninteractive bridge paths remain unchanged.
 - `SesoriAuthApi` is the sole per-provider API owner for Sesori auth HTTP. The
   bridge PR migrates existing auth use-case APIs/top-level HTTP operations into
   it and deletes those old boundaries rather than adding a presence wrapper.
-- `TokenRefresher` carries a required auth-local
-  `AuthRequestCancellationSignal`. Both
-  renamed `TokenService` and `ControlChannelTokenService`, every production caller, and
-  every fake implement it; typed refresh failures require no message parsing.
+- `TokenRefresher` carries required named `forceRefresh` and auth-local
+  `AuthRequestCancellationSignal`. Both the renamed `TokenService` and
+  `ControlChannelTokenService`, every production caller, and every fake implement
+  it; typed refresh failures require no message parsing.
 - Onboarding skip actively aborts app-status and in-flight token-refresh
   requests. No request or correlated control pull survives service completion.
 - Root Layer-5 `BridgeStartupOrchestrator` owns all auth/terminal/token/
@@ -73,8 +76,8 @@ open. Supervised and noninteractive bridge paths remain unchanged.
   receives direct already-built runtime/failure/restart/supervised collaborators
   and constructs no lower layer; existing session `Orchestrator` remains the
   post-plugin control owner.
-- The URL is always present when onboarding is shown; QR is optional by
-  capability/width.
+- The URL is always present when onboarding is shown; QR requires proven ANSI+
+  Unicode, explicit black/white polarity, and sufficient known width.
 - Generated files are regenerated from source and never hand-edited.
 - No persistence migration, app/client UI, browser opening, live heartbeat,
   distributed waiter, analytics, or speculative abstraction is included.

--- a/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/GOAL.md
+++ b/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/GOAL.md
@@ -1,0 +1,125 @@
+# Stage S01: App Registration Checkpoint
+
+## 0. Stage Metadata
+
+- **Stage ID:** S01
+- **Status:** Pending
+- **Repositories:** `sesori-ai/sesori_auth_server`, `sesori-ai/sesori_apps_monorepo`
+- **Implementation bases:** auth server `master`; monorepo `main`
+- **PR count:** 2
+- **Manual checkpoints:** 1 advisory
+
+## 1. Outcome
+
+The auth server exposes a race-safe authenticated current-app-registration
+status and wakes long polls only after durable token registration. The
+standalone interactive bridge consumes that endpoint before plugin startup,
+renders bounded terminal setup guidance only when needed, and waits until the
+same account registers or the user explicitly skips the current run.
+
+Transient failures retry at a fixed one-minute cadence without warning spam;
+unsupported/permanent protocol failures remain backward-compatible and fail
+open. Supervised and noninteractive bridge paths remain unchanged.
+
+## 2. Entry Criteria and Baseline
+
+- The complete plan tree is approved and delivered through the user's selected
+  delivery mode.
+- Before W01, the worker fetches auth-server `master`, assesses drift from
+  `b17a6e760b0c70c3dc3d1cd456ff93d814c75453`, and records the exact assessed tip
+  as S01/W01's auth-server baseline in `TRACKER.md` before branch creation.
+- W02 starts only after S01-W01-P01 merges. Its worker fetches monorepo `main`,
+  assesses drift from `5a76c0c420cd7db445f7fe2c8a2570265b4c84e0`
+  plus the now-merged auth contract, and records the exact monorepo baseline.
+- The worker re-reads repository/workspace `AGENTS.md`, `docs/VISION.md`,
+  `docs/ROADMAP.md`, the current bridge version, and touched tests after pinning
+  each wave.
+- The independent `session-pull-request-monitoring` plan has no semantic conflict
+  at audit. Any newly merged overlap is assessed rather than assumed safe.
+
+## 3. Invariants and Non-Goals
+
+- Dependencies flow Foundation -> API/Repository -> Service -> Consumer; no
+  repository depends on a repository peer and no route constructs dependencies.
+- Auth-server token upsert commits before presence wake; failed writes never wake.
+- Waiter registration and repository recheck are race-safe; every terminal path
+  removes timers/listeners/map state.
+- The bridge uses its configurable auth backend and existing token authority.
+- No startup mutex, plugin runtime, relay, or backend process is held while the
+  user waits.
+- Normal server long-poll expiry is not a failure and has no retry delay/log.
+- Transient failures use exactly one cancellable 60-second delay and one warning
+  per attempt; permanent failures warn once and fail open.
+- Terminal input has one asynchronous owner; raw single-key mode and mixed
+  synchronous/asynchronous stdin are forbidden.
+- `TerminalPromptApi` exposes raw terminal facts/I/O only.
+  `BridgeStartupOrchestrator` (and the independent logout composition) resolves
+  typed `TerminalInteractionMode` and injects it into
+  `TerminalPromptRepository`; runner owns no terminal policy.
+- Access-token acquisition and one-refresh-on-401 coordination belong to
+  `AppClientOnboardingService`; `AppClientPresenceRepository` only maps its API
+  using the caller-supplied token.
+- `SesoriAuthApi` is the sole per-provider API owner for Sesori auth HTTP. The
+  bridge PR migrates existing auth use-case APIs/top-level HTTP operations into
+  it and deletes those old boundaries rather than adding a presence wrapper.
+- `TokenRefresher` carries a required auth-local
+  `AuthRequestCancellationSignal`. Both
+  renamed `TokenService` and `ControlChannelTokenService`, every production caller, and
+  every fake implement it; typed refresh failures require no message parsing.
+- Onboarding skip actively aborts app-status and in-flight token-refresh
+  requests. No request or correlated control pull survives service completion.
+- Root Layer-5 `BridgeStartupOrchestrator` owns all auth/terminal/token/
+  onboarding construction and pre-plugin sequencing. `BridgeRuntimeRunner`
+  receives direct already-built runtime/failure/restart/supervised collaborators
+  and constructs no lower layer; existing session `Orchestrator` remains the
+  post-plugin control owner.
+- The URL is always present when onboarding is shown; QR is optional by
+  capability/width.
+- Generated files are regenerated from source and never hand-edited.
+- No persistence migration, app/client UI, browser opening, live heartbeat,
+  distributed waiter, analytics, or speculative abstraction is included.
+
+## 4. Execution Waves
+
+| Wave | ID | PR/check | Repository | Base | Can run in parallel | Merge barrier |
+|---|---|---|---|---|---|---|
+| W01 | S01-W01-P01 | Add app-client presence endpoint | `sesori-ai/sesori_auth_server` | `master` | N/A | Must merge before W02 starts |
+| W02 | S01-W02-P01 | Add interactive bridge app onboarding | `sesori-ai/sesori_apps_monorepo` | `main` | N/A | Must merge before stage exit |
+| W02 | S01-W02-M01 | Advisory terminal QR/app-registration check | Cross-repository deployed result | N/A | May run after artifacts/deploy are available | Advisory; never blocks |
+
+## 5. Integration and Manual Verification
+
+- Server route tests prove an absent waiter wakes from the existing app token
+  registration endpoint only after the Mongo upsert succeeds.
+- Bridge integration tests drive immediate present/absent, long-poll expiry,
+  post-start registration, old-server 404, 401 refresh, network failure, fixed
+  delay, skip during request/delay, and terminal EOF.
+- Runner tests prove the checkpoint is after authentication/plugin availability
+  but before mutex/provision/plugin start and is absent from supervised or
+  noninteractive paths.
+- Existing auth, token registration/deletion, provider/email login, replacement,
+  logout, plugin startup, and bridge registration tests remain green.
+- S01-W02-M01 scans the exact QR/URL and records platform/theme/width evidence
+  when available. Missing platform hardware leaves a checkbox unchecked and does
+  not block the stage.
+
+## 6. Exit Criteria
+
+- S01-W01-P01 is merged to auth-server `master`, deployed before bridge release,
+  and its server verification passes.
+- S01-W02-P01 is merged to monorepo `main` with generated output, lockfile,
+  analysis, tests, and host build passing.
+- Compatibility marker date/version and cleanup text match the implementation
+  and endpoint rollout.
+- No waiter/request/terminal subscription survives its owner lifecycle in tests.
+- `TRACKER.md` contains both pinned baselines, PR URLs, binary checked state on
+  implementation branches, and any advisory manual evidence.
+- The plan can close even if one or both manual checkboxes remain unexecuted for
+  lack of representative terminals/devices.
+
+## 7. Stage-Specific Detail
+
+The strict two-wave shape is also the rollout safety mechanism. Auth capability
+lands first as an additive endpoint. The bridge then consumes it with an exact
+old-server fallback, so an unexpected deployment rollback does not make a new
+bridge unusable. No stacked PR or cross-repository branch dependency is needed.

--- a/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w01-p01-app-client-presence-endpoint.md
+++ b/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w01-p01-app-client-presence-endpoint.md
@@ -7,7 +7,7 @@
 - **Worktree:** one dedicated auth-server worker worktree for this PR
 - **Base branch:** `master`
 - **Branch:** `plan/bridge-app-onboarding/s01-w01-p01-app-client-presence-endpoint`
-- **Wave baseline:** pin the assessed current `master` tip in `TRACKER.md` before branch creation
+- **Wave baseline:** pin the assessed current `master` tip in `TRACKER.md` on remote plan-host branch `plan/bridge-app-onboarding/tracking` before branch creation
 - **Audited reference:** `b17a6e760b0c70c3dc3d1cd456ff93d814c75453`
 - **Audited reference date:** 2026-07-16T14:14:09Z
 - **Contract-affecting:** Yes — additive authenticated HTTP endpoint
@@ -23,6 +23,9 @@ retain byte-compatible requests and responses.
 ## 2. Dependencies and Baseline
 
 - No implementation PR dependency beyond the approved plan.
+- The plan PR is merged to monorepo `main`. Create/fetch remote plan-host branch
+  `plan/bridge-app-onboarding/tracking` from that selected base; commit only the
+  S01/W01 pinned baseline before creating this auth implementation branch.
 - Fetch `master`, assess changed planned paths and auth middleware/device-token
   contracts from the audited reference, and pin the exact tip before branching.
 - Re-read root `AGENTS.md`, current package version, the activation-reminder
@@ -166,10 +169,16 @@ than hidden stateful collaborators.
 1. Capture one absolute deadline before starting the initial
    `hasAnyForUser` query. Race all reads/waiting through one completion gate so
    the advertised timeout includes initial-query time and late query completion
-   cannot send or mutate waiter state.
+   cannot send or mutate waiter state. If the deadline wins before that first
+   read establishes presence or absence, throw the service-local
+   `AppClientPresenceInitialReadTimeout` instead of returning false. The route
+   maps only that typed domain failure to the existing `InternalServerError` /
+   500 response; the service never imports or constructs an HTTP error, and the
+   bridge never presents unconfirmed absence.
 2. Return true when the initial query completes present before the deadline.
-3. If already aborted, the deadline has elapsed, or timeout is non-positive,
-   return false/cancel according to the route contract without storing state.
+3. After a completed false read, if already aborted, the deadline has elapsed,
+   or timeout is non-positive, return confirmed false/cancel according to the
+   route contract without storing state.
 4. Create waiter using only the remaining deadline budget plus a one-shot abort
    listener; store by user id.
 5. Requery `hasAnyForUser` after storage.
@@ -198,6 +207,10 @@ and error cannot resolve or clean one waiter twice.
 - After await, verify request/reply remains open. If closed, hijack/return as the
   OAuth route does rather than sending a late payload.
 - Return only `{ registered }` with status 200.
+- An absolute deadline reached before the initial read establishes true/false
+  surfaces from the service as `AppClientPresenceInitialReadTimeout`. The route
+  maps it to the existing 500 `internal_server_error` path; it is not serialized
+  as `{ registered: false }`.
 
 ### Error, lifecycle, concurrency
 
@@ -253,6 +266,9 @@ gains a field. There is no compatibility-only server fallback or source marker.
 - Timeout resolves false and clears timer/abort/map state; controlled slow
   initial-read and recheck tests prove their elapsed time consumes the same
   absolute 30-second budget and late completions emit no second result.
+- A stalled initial read that loses the deadline throws the service-local typed
+  failure; the route returns the existing 500 error form, never a false body,
+  and eventual read completion has no response/waiter effect.
 - Pre-aborted signal stores nothing.
 - Abort during wait resolves cancellation and clears everything.
 - Registration wakes all waiters for its user, not another user's waiters.
@@ -325,6 +341,8 @@ with mocks that cannot prove durable ordering.
 ## 10. Acceptance Criteria
 
 - Authenticated immediate and long-poll endpoint returns exact boolean contract.
+- Wait-mode initial-read deadline returns 500 so unconfirmed absence is never
+  represented as `registered: false`.
 - Any supported platform token counts.
 - Durable upsert precedes wake; failed upsert never wakes.
 - Waiter race, timeout, abort, error, and multi-user tests pass with no leaks.
@@ -341,7 +359,8 @@ with mocks that cannot prove durable ordering.
   review required by the worker before PR opening.
 - Only intended auth-server files are committed; branch is pushed and PR targets
   `master`.
-- `TRACKER.md` records S01/W01 baseline, branch, PR URL, and checked state on the
-  implementation branch.
+- The auth implementation branch remains auth-server-only. The remote plan-host
+  tracking branch records S01/W01 baseline before branch creation, then branch,
+  PR URL, and optimistic checked state after PR opening; it creates no tracker PR.
 - W02 does not start until this PR merges; deployment is confirmed before bridge
   release.

--- a/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w01-p01-app-client-presence-endpoint.md
+++ b/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w01-p01-app-client-presence-endpoint.md
@@ -163,14 +163,19 @@ than hidden stateful collaborators.
 
 `waitForRegistration({userId, timeoutMs, abortSignal})`:
 
-1. Query `hasAnyForUser`; return true immediately when present.
-2. If already aborted or timeout is non-positive, return false/cancel according
-   to the route contract without storing state.
-3. Create waiter, timeout, and one-shot abort listener; store by user id.
-4. Requery `hasAnyForUser` after storage.
-5. If present, remove and resolve true immediately. If the recheck throws,
+1. Capture one absolute deadline before starting the initial
+   `hasAnyForUser` query. Race all reads/waiting through one completion gate so
+   the advertised timeout includes initial-query time and late query completion
+   cannot send or mutate waiter state.
+2. Return true when the initial query completes present before the deadline.
+3. If already aborted, the deadline has elapsed, or timeout is non-positive,
+   return false/cancel according to the route contract without storing state.
+4. Create waiter using only the remaining deadline budget plus a one-shot abort
+   listener; store by user id.
+5. Requery `hasAnyForUser` after storage.
+6. If present, remove and resolve true immediately. If the recheck throws,
    remove all state before rethrowing.
-6. Timeout removes state and resolves false. Abort removes state and resolves a
+7. The absolute deadline removes state and resolves false. Abort removes state and resolves a
    cancellation result that the route does not serialize to a closed socket.
 
 Use one internal completion method so registration, recheck, timeout, abort,
@@ -187,8 +192,9 @@ and error cannot resolve or clean one waiter twice.
   `appClientStatusReplySchema.safeParse(candidateReply)` before sending, and map
   an impossible internal mismatch to the existing internal-server error path.
   The route never asserts or casts an unvalidated reply.
-- Use a 30,000 ms route constant; do not add environment config solely for this
-  endpoint.
+- Use a 30,000 ms route constant as one absolute service deadline beginning
+  before the initial repository read; do not add environment config solely for
+  this endpoint.
 - After await, verify request/reply remains open. If closed, hijack/return as the
   OAuth route does rather than sending a late payload.
 - Return only `{ registered }` with status 200.
@@ -244,7 +250,9 @@ gains a field. There is no compatibility-only server fallback or source marker.
   invalid user id follows the repository's explicit safe/throw convention chosen
   at the pinned baseline and never queries an inferred id.
 - Immediate service call returns true/false correctly and stores no waiter.
-- Timeout resolves false and clears timer/abort/map state.
+- Timeout resolves false and clears timer/abort/map state; controlled slow
+  initial-read and recheck tests prove their elapsed time consumes the same
+  absolute 30-second budget and late completions emit no second result.
 - Pre-aborted signal stores nothing.
 - Abort during wait resolves cancellation and clears everything.
 - Registration wakes all waiters for its user, not another user's waiters.
@@ -303,6 +311,9 @@ with mocks that cannot prove durable ordering.
 - Notifying before Mongo commit would create a false positive; service order and
   failed-upsert test make this impossible.
 - Query-then-wait can lose a transition; post-storage recheck closes the gap.
+- Starting the timeout after the initial read can exceed the bridge's 35-second
+  client deadline; one absolute deadline and slow-read tests enforce the route
+  contract.
 - Duplicating OAuth's close adapter could drift; extract and regression-test one
   Foundation seam.
 - A generic presence service could absorb deletion/notifications/activation;

--- a/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w01-p01-app-client-presence-endpoint.md
+++ b/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w01-p01-app-client-presence-endpoint.md
@@ -1,0 +1,336 @@
+# S01-W01-P01: Add App-Client Presence Endpoint
+
+## 0. Metadata
+
+- **ID:** S01-W01-P01
+- **Repository:** `sesori-ai/sesori_auth_server`
+- **Worktree:** one dedicated auth-server worker worktree for this PR
+- **Base branch:** `master`
+- **Branch:** `plan/bridge-app-onboarding/s01-w01-p01-app-client-presence-endpoint`
+- **Wave baseline:** pin the assessed current `master` tip in `TRACKER.md` before branch creation
+- **Audited reference:** `b17a6e760b0c70c3dc3d1cd456ff93d814c75453`
+- **Audited reference date:** 2026-07-16T14:14:09Z
+- **Contract-affecting:** Yes — additive authenticated HTTP endpoint
+
+## 1. Goal and Cohesion
+
+Expose whether the authenticated user has any current app token and support a
+30-second wait that wakes after durable token registration. The PR is
+independently cohesive: it adds and tests the complete server contract without
+requiring a bridge release, while existing app registration/deletion clients
+retain byte-compatible requests and responses.
+
+## 2. Dependencies and Baseline
+
+- No implementation PR dependency beyond the approved plan.
+- Fetch `master`, assess changed planned paths and auth middleware/device-token
+  contracts from the audited reference, and pin the exact tip before branching.
+- Re-read root `AGENTS.md`, current package version, the activation-reminder
+  instructions, and current OAuth long-poll tests after pinning.
+- Preserve the documented single-instance deployment constraint. Do not add
+  Redis, Mongo change streams, a lease, or cross-instance pub/sub.
+- Same-wave sibling baseline reuse is not applicable; this wave has one PR.
+
+## 3. Scope
+
+### In Scope
+
+- Add `DeviceTokenRepository.hasAnyForUser(userId)` using an existence query
+  that benefits from the existing user-leading index and does not load token
+  arrays or expose token values.
+- Add `AppClientPresenceService` with injected `DeviceTokenRepository`.
+- Move public notification-route token upsert behind that service so it owns
+  post-commit wake. Keep unchanged token deletion as a direct
+  `notificationRoutes -> DeviceTokenRepository.deleteByTokenForUser` call; do
+  not add a pass-through service method.
+- Add immediate current-registration reads.
+- Add race-safe per-user waiters with a 30-second route cap, request abort,
+  post-registration recheck, all-same-user wake, and complete cleanup.
+- Extract the proven Fastify request/reply close-to-`AbortSignal` adapter from
+  OAuth status into one Foundation utility reused by both routes.
+- Add authenticated `GET /auth/app-clients/status` and validated optional
+  `wait=true` query.
+- Add strict `appClientStatusQuerySchema` and `appClientStatusReplySchema` in
+  `src/models/api.ts`, with `AppClientStatusQuery` / `AppClientStatusReply`
+  inferred from those Zod schemas.
+- Wire one service instance through `src/index.ts`, `AppServices`, app-client
+  route, and notification route.
+- Add repository, service, route, disconnect, race, and regression tests.
+- Document the new process-local waiter constraint beside existing scaling
+  constraints if needed for repository truth.
+
+### Non-Goals
+
+- Returning token, platform, device, timestamp, count, or user details.
+- A liveness/heartbeat/last-seen API.
+- Waking on token deletion; waiters only wait for transition from zero current
+  tokens to at least one durable token.
+- Changing activation milestone semantics or failure isolation.
+- Changing notification send/stale-token cleanup behavior.
+- New collection/index/schema/config/package dependency.
+- Reusing or coupling to `PendingAuthStore`; its token-keyed OAuth state machine
+  remains independent.
+- Distributed signaling or multi-instance guarantees.
+- Bridge code or deployment in this repository.
+
+## 4. Audited Current Code and Assumptions
+
+- `src/repositories/device-token-repo.ts:15-45` owns upsert/list queries and uses
+  Mongo `ObjectId`; it has no current-existence method.
+- `tests/notifications/device-token-repo.test.ts:161-209` proves all-token reads
+  and the existing `{ userId: 1, createdAt: 1 }` index across desktop/mobile.
+- `src/routes/notifications.ts:55-72` currently awaits upsert before activation
+  recording; this ordering is the durable signal seam.
+- `src/routes/notifications.ts:75-83` owns authenticated single-token deletion.
+- `tests/notifications/routes.test.ts:82-232` proves all five platforms,
+  activation ordering/failure isolation, auth, validation, and deletion.
+- `src/routes/auth/session-status.ts:53-101,159-194` is the proven long-poll route
+  and request-close adapter.
+- `src/services/pending-auth-store.ts:419-508,593-635` proves the required
+  waiter/recheck/cleanup shape but is semantically OAuth-specific.
+- `src/server.ts:108-173` constructs auth middleware and registers routes from
+  injected `AppServices`.
+- `src/index.ts:59-101,152-171` constructs one device-token repository plus
+  notification/activation services.
+- Tests run sequentially with MongoDB through `tests/helpers/setup.ts`; new
+  service injection must preserve override/test cleanup behavior.
+- `DevicePlatform` already includes iOS, Android, macOS, Windows, and Linux; no
+  platform model change is needed.
+
+## 5. Design and Ownership
+
+### Expected files
+
+- `src/lib/request-close-signal.ts` (new extraction)
+- `src/repositories/device-token-repo.ts`
+- `src/services/app-client-presence-service.ts` (new)
+- `src/routes/app-clients.ts` (new)
+- `src/routes/auth/session-status.ts`
+- `src/routes/notifications.ts`
+- `src/models/api.ts`
+- `src/server.ts`
+- `src/index.ts`
+- `tests/notifications/device-token-repo.test.ts`
+- `tests/notifications/routes.test.ts`
+- `tests/services/app-client-presence-service.test.ts` (new)
+- `tests/auth/app-clients.test.ts` (new; use repository naming convention if
+  the pinned base centralizes auth route tests elsewhere)
+- `tests/auth/session-status.test.ts`
+- `tests/helpers/setup.ts`
+- `AGENTS.md` only if the new in-process waiter scaling fact is not otherwise
+  accurately documented; do not edit unrelated guidance.
+
+### Layers and collaborators
+
+- Foundation request-close adapter depends only on Fastify request/reply events.
+- `DeviceTokenRepository` remains the sole database owner.
+- `AppClientPresenceService` depends only on the repository and owns current
+  registration/waiter invariants. It does not depend on `ActivationService`,
+  `NotificationService`, `PendingAuthStore`, or another service.
+- `notificationRoutes` remains a consumer: registration through presence
+  service, deletion directly through the existing device-token repository,
+  activation through existing service, and sends through existing notification
+  service.
+- `appClientRoutes` remains a thin authenticated consumer over the presence
+  service.
+- `index.ts` is the sole constructor; `server.ts` performs injection/registration.
+
+No DAO/repository decision moves into a route, and no same-layer peer is made a
+child.
+
+Production construction is explicit:
+
+```ts
+new AppClientPresenceService({ deviceTokenRepo })
+```
+
+`index.ts` constructs that one instance. It owns only its in-memory waiter map
+and timers/listeners; it does not close the injected repository or database.
+`server.ts` injects the same instance into `appClientRoutes` and
+`notificationRoutes`, and retains direct `DeviceTokenRepository` injection into
+`notificationRoutes` for deletion only. The Foundation close-signal adapter is a stateless
+function, the route is a Fastify plugin, and the Zod contracts are schemas rather
+than hidden stateful collaborators.
+
+### Service algorithm
+
+`registerToken({userId, token, platform})`:
+
+1. Await `DeviceTokenRepository.upsertToken`.
+2. Snapshot current waiter set for `userId`.
+3. Remove/resolve each waiter as `true`; delete the empty map entry.
+4. Return. If step 1 throws, perform no notification.
+
+`waitForRegistration({userId, timeoutMs, abortSignal})`:
+
+1. Query `hasAnyForUser`; return true immediately when present.
+2. If already aborted or timeout is non-positive, return false/cancel according
+   to the route contract without storing state.
+3. Create waiter, timeout, and one-shot abort listener; store by user id.
+4. Requery `hasAnyForUser` after storage.
+5. If present, remove and resolve true immediately. If the recheck throws,
+   remove all state before rethrowing.
+6. Timeout removes state and resolves false. Abort removes state and resolves a
+   cancellation result that the route does not serialize to a closed socket.
+
+Use one internal completion method so registration, recheck, timeout, abort,
+and error cannot resolve or clean one waiter twice.
+
+### Route behavior
+
+- Require existing user auth for both immediate and wait modes.
+- Define the strict query schema as an object whose optional `wait` accepts only
+  the wire string `"true"`; omitted means immediate and unknown keys/values are
+  invalid. Run `appClientStatusQuerySchema.safeParse(request.query)` and map
+  failure to the existing 400 error form without truthy-string guessing.
+- Build `{ registered }`, run
+  `appClientStatusReplySchema.safeParse(candidateReply)` before sending, and map
+  an impossible internal mismatch to the existing internal-server error path.
+  The route never asserts or casts an unvalidated reply.
+- Use a 30,000 ms route constant; do not add environment config solely for this
+  endpoint.
+- After await, verify request/reply remains open. If closed, hijack/return as the
+  OAuth route does rather than sending a late payload.
+- Return only `{ registered }` with status 200.
+
+### Error, lifecycle, concurrency
+
+- Mongo errors propagate to Fastify's existing error handler; they are not
+  converted to false.
+- Client disconnect is expected cancellation, not a server error log.
+- A timeout is normal and returns false.
+- Multiple waiters for one user all resolve after one committed registration.
+- A token changing owner wakes only the new owner's waiters because the service
+  receives the authenticated registration user after upsert.
+- Service state is process-local and bounded by concurrent open requests/FDs;
+  no completed user history remains.
+- Existing app registration response does not wait for bridge clients beyond
+  synchronous in-memory waiter resolution.
+
+## 6. Backward Compatibility
+
+### Existing app clients
+
+`POST /notifications/register-token` keeps the same auth, body, all-platform
+acceptance, status, and `{ ok: true }` response. `DELETE
+/notifications/tokens/:token` remains unchanged. Activation recording stays
+best-effort after durable registration, so an activation failure still cannot
+fail token registration.
+
+### Existing bridge/custom clients
+
+The new route is additive. No current client sends it, and no existing response
+gains a field. There is no compatibility-only server fallback or source marker.
+
+### Rollback and deployment pairs
+
+- Old bridge + new server: no behavior change.
+- New bridge + new server: immediate/long-poll onboarding works.
+- New bridge + rolled-back/old server: bridge S01-W02-P01 handles endpoint
+  absence and fails open.
+
+## 7. Schema, Migration, and Generation
+
+- No Mongo document schema, collection, database config, or index changes.
+- No data migration or backfill.
+- No generated code.
+- No package dependency or lockfile change.
+
+## 8. Verification
+
+### Automated tests
+
+- `hasAnyForUser` returns false with no row and true for each supported platform;
+  invalid user id follows the repository's explicit safe/throw convention chosen
+  at the pinned baseline and never queries an inferred id.
+- Immediate service call returns true/false correctly and stores no waiter.
+- Timeout resolves false and clears timer/abort/map state.
+- Pre-aborted signal stores nothing.
+- Abort during wait resolves cancellation and clears everything.
+- Registration wakes all waiters for its user, not another user's waiters.
+- Upsert failure wakes nobody.
+- Registration in the initial-check/register-waiter gap is observed by the
+  post-registration recheck.
+- Recheck error cleans state before propagation.
+- Route immediate true/false, wait timeout, and registration wake return exact
+  response JSON after reply-schema `safeParse`.
+- Route without auth returns 401; invalid/unknown query values and keys return
+  400 through query-schema `safeParse`; reply-schema rejection takes the
+  internal-server error path in its focused test seam.
+- Closed request produces no late payload and leaves no waiter.
+- Existing token registration tests still prove all five platforms, activation
+  failure isolation, response compatibility, and deletion.
+- Deletion regression proves the route calls `DeviceTokenRepository` directly
+  and the presence service exposes no deletion forwarding method.
+- OAuth status tests prove the extracted request-close helper preserves ACK,
+  timeout, terminal response, disconnect, and listener cleanup behavior.
+
+### Manual verification
+
+Use local/deployed injection only if convenient: authenticate a disposable user,
+start one `wait=true` request, register a token through the existing route, and
+observe prompt completion after registration. Do not retain bearer/token values.
+The cross-repository user journey is owned by S01-W02-M01.
+
+### Exact commands
+
+```text
+# workdir: sesori_auth_server
+npm run format:check
+npm run lint
+npm run build
+npm test
+npm run circular-dependencies
+```
+
+`npm test` requires the repository's configured MongoDB test service. If it is
+unavailable, record the blocker rather than replacing route/repository tests
+with mocks that cannot prove durable ordering.
+
+### Regression guide
+
+- OAuth session status still wakes, expires, aborts, and ACKs as before.
+- App registration/deletion request/response and activation behavior are
+  unchanged.
+- Notification sending and stale-token deletion still use
+  `DeviceTokenRepository` through existing `NotificationService`.
+- Auth revocation/delete-all behavior remains repository-owned and does not need
+  to publish an appearance event.
+- Server shutdown/test cleanup leaves no open timer caused by presence waiters.
+
+## 9. Risks
+
+- Notifying before Mongo commit would create a false positive; service order and
+  failed-upsert test make this impossible.
+- Query-then-wait can lose a transition; post-storage recheck closes the gap.
+- Duplicating OAuth's close adapter could drift; extract and regression-test one
+  Foundation seam.
+- A generic presence service could absorb deletion/notifications/activation;
+  keep it limited to post-commit token registration signaling plus registration
+  wait. Deletion remains exclusively route -> device-token repository.
+- Multi-instance signaling is intentionally absent and must remain explicit in
+  docs/tests rather than implied.
+
+## 10. Acceptance Criteria
+
+- Authenticated immediate and long-poll endpoint returns exact boolean contract.
+- Any supported platform token counts.
+- Durable upsert precedes wake; failed upsert never wakes.
+- Waiter race, timeout, abort, error, and multi-user tests pass with no leaks.
+- Existing registration/deletion/activation and OAuth long-poll behavior passes.
+- No migration, new config, dependency, token exposure, or distributed machinery
+  is introduced.
+- All command groups pass.
+
+## 11. Definition of Done
+
+- Scope, tests, docs, and verification are complete on the pinned auth-server
+  baseline.
+- Architecture-bearing implementation receives the configured implementation
+  review required by the worker before PR opening.
+- Only intended auth-server files are committed; branch is pushed and PR targets
+  `master`.
+- `TRACKER.md` records S01/W01 baseline, branch, PR URL, and checked state on the
+  implementation branch.
+- W02 does not start until this PR merges; deployment is confirmed before bridge
+  release.

--- a/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w02-m01-terminal-onboarding-scan.md
+++ b/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w02-m01-terminal-onboarding-scan.md
@@ -1,0 +1,184 @@
+# S01-W02-M01: Verify Terminal App Onboarding and QR Scanning
+
+## 0. Metadata
+
+- **ID:** S01-W02-M01
+- **Type:** Advisory manual checkpoint
+- **Stage:** S01 — App Registration Checkpoint
+- **Wave:** W02
+- **Blocks later waves:** No
+- **Automation owner:** None; record separate User and Worker evidence in
+  `TRACKER.md`
+- **Worker capability:** Partial. A worker can build/run the bridge, use a local
+  or deployed auth server, resize the current macOS terminal, capture sanitized
+  output, and scan with an available simulator/physical device. The user is best
+  placed to provide independent physical-camera and representative Linux/Windows
+  terminal/theme evidence.
+
+## 1. Why Automation Is Insufficient
+
+Unit/integration tests prove QR modules, quiet zone, width math, exact URL,
+retry/cancellation, and server wake races. They cannot fully prove:
+
+- how real terminal fonts/colors render half blocks and ASCII cells;
+- camera focus/contrast against a physical display under dark/light themes;
+- common macOS/Linux/Windows terminal width and ANSI behavior;
+- the installed app/store handling of the exact public URL; or
+- perceived prompt clarity and wake responsiveness during a real same-account
+  app sign-in.
+
+This checkpoint supplements but never gates automated verification. Missing
+hardware/platform access leaves that party's checkbox unchecked.
+
+## 2. Setup
+
+Use a disposable/test account or safely controlled token state. Do not delete a
+primary user's device tokens merely to create the absent state, and never retain
+bearer tokens, FCM tokens, auth headers, local paths, or account identifiers in
+evidence.
+
+Prerequisites:
+
+1. S01-W01-P01 is deployed to the auth environment under test.
+2. S01-W02-P01 is merged or built from its reviewed implementation branch.
+3. A standalone bridge invocation with a real interactive stdin/stdout terminal.
+4. The selected plugin passes its availability probe.
+5. The bridge user currently has no app token, established through normal app
+   logout/token deletion on the disposable account.
+6. A phone camera or Sesori app capable of opening/scanning the displayed URL.
+7. At least one dark and one light terminal theme. Linux/Windows evidence may be
+   supplied independently when those hosts are available.
+
+Record only:
+
+- bridge full SHA and auth-server full SHA/deployment identifier;
+- bridge OS/architecture and terminal application/version;
+- terminal theme category, dimensions, and renderer path observed
+  (ANSI/Unicode, Unicode, ASCII, or URL-only);
+- app platform/version and approximate timestamps;
+- sanitized screenshots/video with account and local details redacted.
+
+## 3. Checklist
+
+### A. Missing-app prompt and exact destination
+
+- [ ] Start the standalone bridge while the disposable account has no token.
+- [ ] Confirm authentication/profile and plugin availability complete before the
+      onboarding output, while provisioning/plugin startup has not begun.
+- [ ] Confirm instructions explicitly say to use/sign in with the same account.
+- [ ] Confirm the QR is not visibly clipped and has blank quiet space around all
+      edges.
+- [ ] Confirm the plain line is exactly
+      `https://sesori.com/app/?openStore=true`, including slash/query/case.
+- [ ] Scan the QR and independently open/copy the plain URL. Confirm both resolve
+      to the same expected Sesori app/store destination.
+
+### B. Durable same-account wake
+
+- [ ] Install/open the app from that destination and sign in to the bridge's
+      same disposable account.
+- [ ] Confirm the bridge wakes promptly after the app's token registration
+      succeeds, without waiting for another client-side polling interval.
+- [ ] Confirm one brief success message appears and normal plugin provisioning/
+      startup then proceeds exactly once.
+- [ ] Restart the bridge while the token remains current. Confirm no onboarding
+      QR, URL, presence confirmation, or status warning appears.
+
+### C. Current-run skip and resurfacing
+
+- [ ] Return the disposable account to no-token state through normal app logout.
+- [ ] Start again and enter `s` followed by Enter during an active long poll.
+- [ ] Confirm the bridge promptly cancels the wait, prints one current-run skip
+      confirmation, and continues startup.
+- [ ] Restart while still no-token. Confirm onboarding resurfaces.
+- [ ] Repeat with ` skip ` and mixed case if practical; confirm trimming and
+      case-insensitive alias behavior.
+- [ ] Enter an unrelated line once. Confirm it does not skip and the accepted
+      aliases are restated without duplicating the full QR.
+
+### D. Terminal rendering matrix
+
+For every available row, scan the QR rather than judging appearance only:
+
+- [ ] macOS common terminal, dark theme, ordinary width.
+- [ ] macOS common terminal, light theme, ordinary width.
+- [ ] Linux common terminal, dark or light theme.
+- [ ] Windows Terminal/PowerShell host, dark or light theme.
+- [ ] ANSI+UTF-8 renderer path.
+- [ ] ANSI-disabled or `NO_COLOR` Unicode path.
+- [ ] ASCII fallback with UTF-8 disabled/`TERM=dumb`, where an interactive test
+      terminal can safely provide that environment.
+- [ ] Resize to exactly/comfortably wider than rendered QR and confirm scanning.
+- [ ] Resize too narrow and confirm the QR is omitted completely while the exact
+      URL and skip instructions remain usable.
+
+Do not claim support for untested terminals. Record skipped rows and available
+fallback evidence factually.
+
+### E. Failure cadence and cancellation
+
+Automated tests are authoritative for exact virtual time. If a safe network
+failure can be induced without disrupting other work:
+
+- [ ] During onboarding, make the auth endpoint unreachable or return a
+      controlled transient failure.
+- [ ] Confirm one warning identifies retry in 60 seconds and no repeated request
+      or warning occurs before that interval.
+- [ ] Enter `skip` during the delay and confirm immediate continuation rather
+      than waiting for the minute to end.
+- [ ] Restore connectivity/configuration after the check.
+
+Do not wait through repeated real minutes solely for extra confidence and do not
+point a production bridge at an untrusted server.
+
+## 4. Expected Evidence
+
+### Worker evidence
+
+- Sanitized command/build SHA summary and auth endpoint environment category.
+- Screenshot of rendered prompt + exact URL for each locally available renderer.
+- QR scan/open result and app platform used.
+- Approximate token-registration-to-success observation.
+- Silent existing-token restart and skip/resurface observations.
+- Narrow-terminal URL-only evidence.
+- Any controlled transient warning/skip observation, or explicit reason omitted.
+
+### User evidence
+
+- Independent physical-camera scan result.
+- Available macOS/Linux/Windows terminal/theme/rendering rows and screenshots.
+- Confirmation that QR and plain URL resolve identically.
+- Same-account sign-in wake and existing-token silent restart observation.
+- Prompt clarity/readability and any font/theme discrepancy.
+
+Evidence from one party never checks the other party's tracker box. Redact
+account identity, tokens, auth URLs if private, and filesystem paths.
+
+## 5. Pass Criteria
+
+A participating party passes when all safely available checks show:
+
+1. prompted output contains clear same-account guidance and exact URL;
+2. every renderer claimed as supported scans successfully with an intact quiet
+   zone under the tested theme/terminal;
+3. unsafe/too-narrow rendering degrades to URL-only without clipping;
+4. durable same-account registration wakes once and existing registration is
+   silent on restart;
+5. skip cancels current wait/delay, is not persisted, and unrelated input does
+   not skip; and
+6. any induced transient failure is bounded to one warning/request per fixed
+   interval.
+
+A functional mismatch is recorded under `Blockers and Staleness` and `Findings
+and Plan Deltas` with a scoped follow-up. Missing platform/device access is
+recorded as unexecuted and does not fail/block the plan.
+
+## 6. Cleanup
+
+- Restore the terminal theme, dimensions, color/locale environment, network, and
+  auth URL.
+- Log out/delete disposable app tokens and account data through normal supported
+  flows if no longer needed.
+- Remove local screenshots/video containing unredacted account, path, token, or
+  endpoint data.
+- Stop test bridge/auth processes and remove only disposable build artifacts.

--- a/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w02-m01-terminal-onboarding-scan.md
+++ b/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w02-m01-terminal-onboarding-scan.md
@@ -20,7 +20,7 @@
 Unit/integration tests prove QR modules, quiet zone, width math, exact URL,
 retry/cancellation, and server wake races. They cannot fully prove:
 
-- how real terminal fonts/colors render half blocks and ASCII cells;
+- how real terminal fonts/colors render explicit black/white ANSI half blocks;
 - camera focus/contrast against a physical display under dark/light themes;
 - common macOS/Linux/Windows terminal width and ANSI behavior;
 - the installed app/store handling of the exact public URL; or
@@ -54,7 +54,7 @@ Record only:
 - bridge full SHA and auth-server full SHA/deployment identifier;
 - bridge OS/architecture and terminal application/version;
 - terminal theme category, dimensions, and renderer path observed
-  (ANSI/Unicode, Unicode, ASCII, or URL-only);
+  (ANSI+Unicode QR or URL-only);
 - app platform/version and approximate timestamps;
 - sanitized screenshots/video with account and local details redacted.
 
@@ -104,10 +104,10 @@ For every available row, scan the QR rather than judging appearance only:
 - [ ] macOS common terminal, light theme, ordinary width.
 - [ ] Linux common terminal, dark or light theme.
 - [ ] Windows Terminal/PowerShell host, dark or light theme.
-- [ ] ANSI+UTF-8 renderer path.
-- [ ] ANSI-disabled or `NO_COLOR` Unicode path.
-- [ ] ASCII fallback with UTF-8 disabled/`TERM=dumb`, where an interactive test
-      terminal can safely provide that environment.
+- [ ] ANSI+UTF-8 renderer path in both dark and light themes.
+- [ ] ANSI-disabled or `NO_COLOR` path omits QR and retains the exact URL.
+- [ ] Unicode-disabled/`TERM=dumb` path omits QR and retains the exact URL where
+      an interactive test terminal can safely provide that environment.
 - [ ] Resize to exactly/comfortably wider than rendered QR and confirm scanning.
 - [ ] Resize too narrow and confirm the QR is omitted completely while the exact
       URL and skip instructions remain usable.

--- a/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w02-p01-interactive-app-onboarding.md
+++ b/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w02-p01-interactive-app-onboarding.md
@@ -71,8 +71,8 @@ or make onboarding depend on an unmerged internal stack.
 - Use the configured auth backend and bearer token; support immediate and
   `wait=true` requests.
 - Actively abort in-flight HTTP on skip and on the 35-second client deadline.
-- Extend `TokenRefresher.getAccessToken` with a required auth-local
-  `AuthRequestCancellationSignal`;
+- Make both named `forceRefresh` and auth-local
+  `AuthRequestCancellationSignal` required on `TokenRefresher.getAccessToken`;
   update `TokenService`, `ControlChannelTokenService`, every production caller,
   and every test fake.
 - Route standalone refresh through `AuthRepository` and an abortable
@@ -374,7 +374,7 @@ AppClientOnboardingService({
 })
 
 TokenRefresher.getAccessToken({
-  bool forceRefresh = false,
+  required bool forceRefresh,
   required AuthRequestCancellationSignal cancelled,
 })
 
@@ -441,8 +441,9 @@ a delay callback or constructing a timer collaborator.
 `AuthRepository` receives an explicit 15-second refresh request timeout and
 passes the caller's `AuthRequestCancellationSignal` to `SesoriAuthApi.refreshTokens`.
 `AppClientPresenceRepository` receives the 35-second status timeout and passes
-the same signal to the API. `AuthRequestCancellationSignal.never` is the explicit
-value for existing uncancellable callers; onboarding owns an
+the same signal to the API. `forceRefresh: false` and
+`AuthRequestCancellationSignal.never` are the explicit values for existing
+ordinary uncancellable callers; onboarding owns an
 `AuthRequestCancellationController` and
 passes its signal through token acquisition and app status. No nullable/default
 cancellation or message parsing is allowed.
@@ -618,13 +619,17 @@ stdout handle, or lifecycle.
 - `LogoutCommand` independently resolves `interactive`/`unavailable` from raw
   terminal handles, injects it, and disposes `TerminalPromptApi` in `finally`.
 - `TerminalPromptApi` does not subscribe to stdin in its constructor. The first
-  standalone prompt/read starts one lazy decoded-line subscription and fans
-  completed lines through a process-lifetime internal broadcast source.
-- Sequential prompt methods await the next line from that owner. The onboarding
-  decision method uses a cancellable stream subscription so detection can stop
-  consuming before later prompts.
-- Only one prompt is active by runner sequencing; add guards/tests against
-  overlapping consumers rather than a speculative queue of competing prompts.
+  standalone prompt/read starts one lazy process-lifetime decoded-line
+  subscription. Every completed line enters an internal FIFO pending-line
+  buffer even when no prompt is awaiting, preserving OS-stdin type-ahead and
+  pasted multi-line credentials across sequential prompts.
+- Sequential prompt methods consume one oldest pending line or await one queued
+  arrival from that owner. The onboarding decision read is cancellable; when
+  cancellation wins it removes only its own pending waiter and leaves every
+  already-queued or later line for the replacement/auth prompt.
+- Only one prompt is active by startup sequencing; add guards/tests against
+  overlapping consumers. The FIFO is input preservation, not a scheduler for
+  competing prompts.
 - Password reads set echo off immediately before awaiting and restore the prior
   value in `finally` on value, EOF, error, or disposal.
 - EOF closes the line source and maps to existing clear provider/credential
@@ -633,7 +638,7 @@ stdout handle, or lifecycle.
   registered with `BridgeShutdownCoordinator`.
 - Supervised mode reads its off-argv control secret before any terminal prompt
   subscribes; onboarding is gated out. Preserve `ControlSecretApi` and do not
-  route the bearer secret through a user-prompt broadcast.
+  route the bearer secret through the user-prompt line owner.
 
 ### Formatter contract
 
@@ -642,8 +647,10 @@ stdout handle, or lifecycle.
 - Use the pinned/audited `qr` API with a fixed error-correction level; never
   implement QR encoding manually.
 - Add four light modules on every edge.
-- Prefer ANSI+Unicode compact half blocks with explicit black/white foreground/
-  background and final reset; then non-ANSI Unicode; then ASCII `##`/spaces.
+- Render only when both ANSI and Unicode validators succeed, using compact half
+  blocks with explicit black/white foreground/background and final reset.
+  Non-ANSI Unicode and ASCII space/block renderers are prohibited because theme
+  polarity is unknown and a light quiet zone cannot be guaranteed.
 - Use existing glyph/color validators and a safely-read nullable terminal width.
 - Compute full width including quiet zone before rendering. Unknown/throwing/
   insufficient width returns no QR string, not a truncated code.
@@ -657,7 +664,7 @@ stdout handle, or lifecycle.
    `AuthRequestCancellationController`; pass its signal to every token/status operation.
 2. Immediate check:
    - service obtains
-     `TokenRefresher.getAccessToken(cancelled: controller.signal)` and passes the
+     `TokenRefresher.getAccessToken(forceRefresh: false, cancelled: controller.signal)` and passes the
      value/same signal to the repository;
    - `TokenAccessFailureKind.transient` follows the same one-warning/
      fixed-60-second policy; `unavailable` fails open because interactive auth
@@ -845,8 +852,9 @@ or leave a forwarding top-level reader.
   load/save/clear callback getters.
 - `AuthRequestCancellationSignal.never` never cancels; controller cancel is synchronous,
   idempotent, and completes `whenCancelled` once.
-- Every production `TokenRefresher` caller passes a required signal; existing
-  flows pass `never` and retain behavior. Every fake compiles with the signature.
+- Every production `TokenRefresher` caller passes required `forceRefresh` and
+  cancellation values; ordinary existing flows pass `false`/`never` and retain
+  behavior. Every fake compiles with the signature.
 - `TokenService` refresh success retains storage re-read, persistence,
   publication, and single-flight behavior over `AuthRepository` and direct
   `TokenStorage`.
@@ -894,8 +902,9 @@ or leave a forwarding top-level reader.
 
 #### Terminal and existing auth prompts
 
-- Lazy single subscription and deterministic dispose.
-- Sequential async reads hand off after onboarding subscription cancellation.
+- Lazy single subscription, FIFO pending-line buffering, and deterministic dispose.
+- Sequential async reads preserve lines typed/pasted before the next prompt;
+  onboarding cancellation removes its waiter without dropping queued/later lines.
 - Raw API terminal facts contain no product policy; startup orchestrator/repository
   `TerminalInteractionMode` preserves interactivity and legacy post-update
   behavior.
@@ -910,8 +919,9 @@ or leave a forwarding top-level reader.
 
 - QR module orientation/payload for exact URL and chosen correction level.
 - Four-module quiet zone on all edges.
-- ANSI+Unicode output and final reset; no ANSI when disallowed.
-- Unicode and ASCII fallback dimensions/content.
+- ANSI+Unicode output uses explicit black/white cells and final reset.
+- Missing ANSI, missing Unicode, unknown polarity/width, and insufficient width
+  omit QR and retain exact URL; no non-ANSI Unicode/ASCII QR is emitted.
 - Exact-fit width renders; one-column-too-narrow and unknown/throwing width omit.
 - URL-only output remains exact and scan instructions mention same account.
 - Deterministic snapshots contain no terminal-dependent global reads.
@@ -991,7 +1001,7 @@ the resolution conflict rather than committing broad generated/lock churn.
 
 - A `Future.any` without cancellation could leave stdin/HTTP alive; use owned
   subscriptions and active abort, then assert no late effects.
-- Starting the stdin broadcast in the constructor could steal supervised secret;
+- Starting the stdin subscription in the constructor could steal supervised secret;
   require lazy first-prompt subscription and mode tests.
 - Moving/renaming the legacy token owner could create duplicate refresh
   authorities; compose one `TokenService` instance early and reuse current later
@@ -1001,7 +1011,8 @@ the resolution conflict rather than committing broad generated/lock churn.
   after repositories/services and logout composition are migrated.
 - A cancellable refresh shared with another consumer could cancel unrelated
   work; startup sequencing gives onboarding exclusive `TokenService` use until it
-  settles, and existing later callers pass `AuthRequestCancellationSignal.never`.
+  settles, and existing later callers pass `forceRefresh: false` plus
+  `AuthRequestCancellationSignal.never`.
 - Treating initial network failure as absence could falsely prompt existing
   users; show only minimal retry/skip guidance until a real false response.
 - Treating 404 as absence would hang old servers; map to compatibility-unavailable.

--- a/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w02-p01-interactive-app-onboarding.md
+++ b/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w02-p01-interactive-app-onboarding.md
@@ -1,0 +1,1065 @@
+# S01-W02-P01: Add Interactive Bridge App Onboarding
+
+## 0. Metadata
+
+- **ID:** S01-W02-P01
+- **Repository:** `sesori-ai/sesori_apps_monorepo`
+- **Worktree:** one dedicated monorepo worker worktree for this PR
+- **Base branch:** `main`
+- **Branch:** `plan/bridge-app-onboarding/s01-w02-p01-interactive-app-onboarding`
+- **Wave baseline:** pin the assessed current `main` tip in `TRACKER.md` before branch creation
+- **Audited reference:** `5a76c0c420cd7db445f7fe2c8a2570265b4c84e0`
+- **Audited reference date:** 2026-07-17T06:57:01Z
+- **Contract-affecting:** Yes — auth HTTP consumption, CLI prompt behavior, and shipped old-server compatibility
+
+## 1. Goal and Cohesion
+
+Add the complete standalone interactive bridge checkpoint over the merged auth
+contract: safe asynchronous terminal ownership, initial current-registration
+check, bounded QR/URL guidance, instant server wake, explicit current-run skip,
+fixed one-minute transient retry, and permanent fail-open compatibility.
+
+The PR is independently cohesive because all bridge-side API, repository,
+service, terminal, composition, generated model, tests, and dependency work land
+together. No intermediate build can start an uncancellable prompt or consume a
+contract without typed fallback behavior.
+
+The existing auth HTTP consolidation is required, not opportunistic cleanup:
+the scoped architecture permits one API owner per external provider, so adding
+app status cannot create another use-case API. Moving the existing operations
+and cancellable refresh into `SesoriAuthApi` in this same PR is the smallest
+release-safe boundary; splitting it would either leave duplicate provider APIs
+or make onboarding depend on an unmerged internal stack.
+
+## 2. Dependencies and Baseline
+
+- S01-W01-P01 is merged to auth-server `master`; its exact endpoint contract is
+  re-read rather than inferred from this plan.
+- Auth deployment is available before bridge release. Local tests may use a fake
+  server and do not require production credentials.
+- Fetch monorepo `main`, assess drift from
+  `5a76c0c420cd7db445f7fe2c8a2570265b4c84e0` in every expected auth/runtime/
+  terminal/pubspec/test path, and pin the exact tip before branching.
+- Re-read existing root `AGENTS.md`, `bridge/AGENTS.md`, and
+  `bridge/app/AGENTS.md`, plus `docs/VISION.md`, `docs/ROADMAP.md`, and current
+  active plans. No scoped plugin-interface instruction file exists or is needed
+  because this PR does not modify that package.
+- Re-read `bridge/app/pubspec.yaml` and `lib/src/version.dart` immediately before
+  writing the compatibility marker; audited version is `1.5.1`.
+- Same-wave sibling baseline reuse is not applicable; this wave has one PR. The
+  manual checkpoint consumes the merged/deployed result rather than a branch.
+
+## 3. Scope
+
+### In Scope
+
+- Add pure-Dart `qr` as a direct `bridge/app` dependency and update workspace
+  resolution/lockfile through normal tooling.
+- Add bridge-local Freezed `AppClientPresenceResponse` and generated JSON code.
+- Add one per-provider `SesoriAuthApi`, `AuthRepository`,
+  `LoginOAuthRepository`, `AppClientPresenceRepository`, typed outcomes/
+  exceptions, `AppOnboardingFormatter`, and `AppClientOnboardingService`.
+- Move existing email login, OAuth init/status/ACK, profile `/auth/me`, token
+  validation/refresh, and bridge register/delete HTTP operations into
+  `SesoriAuthApi`; delete `LoginEmailApi`, `LoginOAuthApi`,
+  `BridgeRegistrationApi`, and top-level `profile.dart` / `validate.dart` HTTP
+  functions rather than retaining forwarding wrappers.
+- Rewire `LoginEmailRepository`, `LoginOAuthService` through new
+  `LoginOAuthRepository`, `BridgeRegistrationRepository`,
+  `BridgeRuntimeAuthService`, and renamed `TokenService` to the one API owner while
+  preserving their domain behavior.
+- Use the configured auth backend and bearer token; support immediate and
+  `wait=true` requests.
+- Actively abort in-flight HTTP on skip and on the 35-second client deadline.
+- Extend `TokenRefresher.getAccessToken` with a required auth-local
+  `AuthRequestCancellationSignal`;
+  update `TokenService`, `ControlChannelTokenService`, every production caller,
+  and every test fake.
+- Route standalone refresh through `AuthRepository` and an abortable
+  `SesoriAuthApi.refreshTokens` request with a 15-second active deadline. Define
+  typed transient/unavailable/cancelled token-refresh failure kinds without
+  parsing exception text.
+- Have `AppClientOnboardingService` refresh once on the first repository
+  unauthorized outcome; classify the second unauthorized/permanent
+  4xx/protocol outcomes as unavailable and network/timeout/408/429/5xx as
+  transient.
+- Add exact old-server compatibility marker and omission tests.
+- Convert `TerminalPromptApi` to one lazy process-lifetime asynchronous line
+  owner with deterministic disposal, output/capability access, EOF, and password
+  echo restoration; remove environment/startup-mode policy from this API.
+- Add typed `TerminalInteractionMode`, resolved by startup-orchestrator/logout composition
+  roots from raw terminal facts and the legacy relaunch marker, then injected
+  into `TerminalPromptRepository`.
+- Convert provider, credentials, replace/startup contention, and logout prompts
+  to the same async owner without visible contract changes.
+- Remove direct global stdin use from `BridgeRuntimeAuthService`; move email
+  credential prompting into the service/terminal repository boundary so
+  `LoginEmailRepository` remains focused on auth API mapping.
+- Move `BridgeRuntimeAuthService` from `bridge/runtime/` to root `lib/src/services/`
+  and remove its `BridgeCliOptions` dependency. Configured auth URL/client state
+  is already owned by injected `SesoriAuthApi`/repositories.
+- Add typed cancellable `s`/`skip` onboarding decisions to
+  `TerminalPromptRepository`.
+- Rename substantially changed `TokenManager`/`token_manager.dart` to
+  `TokenService`/`token_service.dart`, compose one instance immediately after
+  authentication, and
+  reuse it for onboarding and later bridge registration/runtime.
+- Run onboarding only when standalone + terminal interactive, after authenticated
+  username logging and successful plugin availability, before startup mutex,
+  provisioning, plugin start, relay, or bridge registration.
+- Add root Layer-5 `BridgeStartupOrchestrator` as sole constructor/owner of the
+  auth, terminal, token, onboarding and existing startup graph. It owns pre-plugin
+  sequencing/disposal, starts the plugin, creates the existing session
+  `Orchestrator` only afterward, injects that completed session into plain
+  `BridgeRuntime`, then directly injects the completed runtime and typed
+  failure/restart/supervised collaborators into `BridgeRuntimeRunner`.
+- Delete static `BridgeRuntime.create`; the existing generative `BridgeRuntime`
+  constructor receives already-built collaborators and session.
+- Reduce `BridgeRuntimeRunner` to a consumer of four direct already-built
+  runtime/outcome collaborators; it must
+  not construct an API, repository, service, token/terminal owner, plugin
+  collaborator, or session orchestrator.
+- Add focused API/repository/service/formatter/terminal/auth/runner tests and
+  compile the host native bridge.
+
+### Non-Goals
+
+- Changing shared models, plugins, relay, mobile, desktop, auth server, or app UI.
+- Migrating `PushNotificationClient`: it is an existing transport `Client`, not
+  another `Api` class, and its notification-send ownership remains unchanged.
+- Running onboarding in `--control-url` supervised mode or any noninteractive
+  path.
+- A new CLI option, config field, persisted skip, browser launch, store API, or
+  platform-specific deep link.
+- Raw one-key input, terminal raw mode, clearing partially typed terminal input,
+  shelling out to detect width/color, or adding a terminal-size dependency.
+- Retrying normal long-poll expiry with a timer.
+- Exponential/jittered backoff, automatic transient fail-open, or separate
+  `Retry-After` scheduling.
+- Logging in API/repository layers or double-reporting failures.
+- A live app heartbeat or validation of FCM token freshness.
+- Drift schema/migration work or generated-file hand edits.
+- Analytics or release observation work.
+
+## 4. Audited Current Code and Assumptions
+
+- `bridge_runtime_runner.dart:238-268` owns terminal/auth composition;
+  `:442-501` owns auth, profile output, and plugin availability.
+- `bridge_runtime_runner.dart:503-559` enters plugin start/provisioning, so the
+  checkpoint must run before that boundary and never inside the mutex callback.
+- `bridge_runtime_runner.dart:568-605` composes legacy `TokenManager` late; this
+  PR renames it to `TokenService` because its responsibility is a Layer-3 token
+  lifecycle, moves the single instance earlier, and preserves later consumers/
+  disposal.
+- `terminal_prompt_api.dart:18-47` uses sync input and password echo toggling.
+- `terminal_prompt_repository.dart:10-67` maps yes/no and credentials.
+- `bridge_runtime_auth.dart:38-71` has direct provider stdin and
+  `:74-169` owns login/persistence.
+- `login_email_repository.dart:7-18` currently receives a synchronous prompt
+  callback and then performs the auth request.
+- `bridge_logout_runner.dart:57-79` already awaits terminal decisions and can
+  consume the async repository without changing its public result.
+- `login_oauth_service.dart:208-253` establishes 35 seconds as the bridge-side
+  cap around a 30-second auth-server long poll.
+- `bridge_registration_service.dart:152-162` retries one 401 after force refresh.
+- Legacy `TokenManager` serializes active refreshes and publishes refreshed access
+  tokens. `AppClientOnboardingService` must use it for coordination; the
+  repository must not acquire/refresh tokens or invent refresh storage.
+- `token_refresher.dart:1-3` currently exposes no cancellation signal;
+  `token_manager.dart:98-110` performs refresh HTTP inline and collapses every
+  non-200 into legacy untyped `TokenRefreshException`. A skip cannot abort that request
+  at the audited baseline.
+- `ControlChannelTokenService` is the second production `TokenRefresher`; it
+  already owns correlated pending requests but has no caller-cancellation input.
+- `LoginEmailApi`, `LoginOAuthApi`, and `BridgeRegistrationApi`, plus top-level
+  `profile.dart` / `validate.dart` and inline legacy token-manager refresh HTTP, split
+  one external Sesori auth provider by use case. The new endpoint cannot add a
+  fourth use-case API; this PR consolidates the touched provider boundary.
+- `TerminalGlyphValidator` and `TerminalColorValidator` are existing Layer-0
+  policy; `Stdout.terminalColumns` may throw and must be treated as unknown.
+- `http ^1.6.0` supports active request abort. A plain `Future.timeout` that
+  leaves a request alive is insufficient.
+- No `qr` dependency or terminal QR implementation exists at the audited tip.
+- The exact app URL is a product constant, not the configurable auth/relay URL.
+
+## 5. Design and Ownership
+
+### Expected source/dependency files
+
+- `bridge/app/pubspec.yaml`
+- `bridge/pubspec.lock`
+- `bridge/app/lib/src/auth/app_client_presence_response.dart` (new)
+- generated response `*.freezed.dart` / `*.g.dart`
+- `bridge/app/lib/src/auth/sesori_auth_api.dart` (new sole provider API)
+- `bridge/app/lib/src/auth/auth_repository.dart` (new)
+- `bridge/app/lib/src/auth/login_oauth_repository.dart` (new)
+- `bridge/app/lib/src/auth/app_client_presence_repository.dart` (new)
+- `bridge/app/lib/src/services/app_client_onboarding_service.dart` (new)
+- `bridge/app/lib/src/foundation/app_onboarding_formatter.dart` (new)
+- `bridge/app/lib/src/auth/login_email_repository.dart`
+- `bridge/app/lib/src/auth/login_oauth_service.dart`
+- `bridge/app/lib/src/auth/bridge_registration_repository.dart`
+- `bridge/app/lib/src/auth/bridge_registration_service.dart`
+- `bridge/app/lib/src/auth/token_storage.dart` (new concrete token-file boundary)
+- `bridge/app/lib/src/auth/token.dart` retains `TokenData`/path values but moves
+  load/save/clear/legacy-read I/O into `TokenStorage`
+- `bridge/app/lib/src/auth/token_refresher.dart`
+- rename `bridge/app/lib/src/auth/token_manager.dart` to `token_service.dart` and
+  `TokenManager` to `TokenService`
+- rename `bridge/app/test/auth/token_manager_test.dart` to
+  `token_service_test.dart`; update every source/test reference and diagnostic
+  label so the forbidden `TokenManager` name does not survive
+- replace `bridge/app/lib/src/auth/token_refresh_exception.dart` with
+  `token_access_exception.dart` and typed `TokenAccessFailureKind`
+- remove `ControlTokenUnavailableException` from `token_refresher.dart`; both
+  production authorities use `TokenAccessException` kinds
+- delete superseded `login_email_api.dart`, `login_oauth_api.dart`,
+  `bridge_registration_api.dart`, `profile.dart`, and `validate.dart` after
+  migrating their real behavior/tests; do not leave forwarding wrappers
+- `bridge/app/lib/src/auth/auth_request_cancellation.dart` (new auth-local
+  read/write cancellation primitive; do not reuse plugin-specific
+  `StartAbortSignal` or import root core Foundation into `auth/`)
+- `bridge/app/lib/src/services/control_channel_token_service.dart`
+- production token call sites in `push_notification_client.dart`,
+  `bridge_registration_service.dart`, `metadata_service.dart`,
+  `orchestrator.dart`, and runtime composition pass
+  `AuthRequestCancellationSignal.never` when no caller cancellation exists
+- move `bridge/app/lib/src/server/api/terminal_prompt_api.dart` to
+  `bridge/app/lib/src/api/terminal_prompt_api.dart`
+- move `bridge/app/lib/src/server/repositories/terminal_prompt_repository.dart`
+  to `bridge/app/lib/src/repositories/terminal_prompt_repository.dart`
+- `bridge/app/lib/src/foundation/terminal_interaction_mode.dart` (new typed
+  composition policy)
+- move existing terminal-only `server/foundation/terminal_prompt_decision.dart`
+  and `bridge_replace_prompt.dart` to root `lib/src/foundation/`; place the small
+  typed onboarding outcome there as well, so the root repository has no outbound
+  dependency on the minimal `server/` subsystem
+- move `bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart` to
+  `bridge/app/lib/src/services/bridge_runtime_auth_service.dart`
+- `bridge/app/lib/src/bridge_startup_orchestrator.dart` (new root Layer-5 startup
+  and session composer/lifecycle owner)
+- `bridge/app/lib/src/bridge/runtime/bridge_runtime.dart` to delete the static
+  composition factory and retain only lifecycle over injected session/
+  collaborators
+- `bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart`
+  removes top-level `runBridgeApp` and every lower-layer constructor/helper;
+  retains only ready-runtime execution and typed exit mapping
+- `bridge/app/bin/bridge.dart` for logout-command interaction-mode composition
+  and terminal API disposal
+- `bridge/app/lib/src/bridge/runtime/bridge_logout_runner.dart` only if signature
+  propagation requires it; preserve behavior
+
+Expected tests mirror each owner under `bridge/app/test/auth/`,
+root `test/api/`, `test/repositories/`, `test/foundation/`, `test/services/`, and
+`test/bridge/runtime/`. Move existing terminal tests with their production files.
+Prefer focused new test files over growing an unrelated runner fixture, while
+reusing current helpers. Update every fake `TokenRefresher` found under
+`bridge/app/test/` to the required cancellation signature; migrate existing
+`profile_test.dart`, `validate_test.dart`, `bridge_registration_api_test.dart`,
+and login/OAuth HTTP fixtures into `sesori_auth_api_test.dart` and owning
+repository/service tests rather than deleting coverage. Move
+`test/bridge/runtime/bridge_runtime_auth_test.dart` to
+`test/services/bridge_runtime_auth_service_test.dart` with the production class;
+assert its methods accept no `BridgeCliOptions` or auth URL pass-through.
+
+### Dependency direction
+
+```text
+SesoriAuthApi
+  <- AuthRepository / LoginEmailRepository / LoginOAuthRepository /
+     BridgeRegistrationRepository / AppClientPresenceRepository
+  <- TokenService / BridgeRuntimeAuthService / LoginOAuthService /
+     BridgeRegistrationService / AppClientOnboardingService
+
+AppClientPresenceRepository
+     <- AppClientOnboardingService (+ TokenRefresher)
+
+TerminalPromptApi
+  <- TerminalPromptRepository
+     <- BridgeRuntimeAuthService / AppClientOnboardingService / existing consumers
+
+AppOnboardingFormatter
+  <- AppClientOnboardingService
+
+all startup APIs/repositories/services
+  <- BridgeStartupOrchestrator (Layer 5 constructor + phase owner)
+     -> existing session Orchestrator after plugin start
+     -> BridgeRuntimeRunner with direct already-built collaborators (consumer only)
+```
+
+- `SesoriAuthApi` is the single per-provider HTTP/JSON/abort boundary. No
+  use-case API forwards to it.
+- Repository accepts a caller-supplied access token and owns only
+  transport-to-domain normalization.
+- Service owns access-token acquisition, exactly-one forced refresh/retry,
+  timer/retry/output/race policy.
+- `BridgeStartupOrchestrator` composes and sequences; runner contains no inline
+  construction, HTTP, QR, input parser, or service factory.
+- Existing terminal repository remains the sole prompt normalization boundary;
+  no auth repository depends on it as a peer.
+- `LoginEmailRepository.performEmailLogin` receives already-normalized required
+  email/password from `BridgeRuntimeAuthService`; the repository no longer owns
+  prompt acquisition.
+- `LoginOAuthService` depends on `LoginOAuthRepository`, not the API.
+- `TokenService` depends on `AuthRepository` plus concrete `TokenStorage`, not
+  callbacks or the API, and implements the
+  cancellable token contract. `BridgeRuntimeAuthService` uses `AuthRepository`
+  for current `/auth/me`/refresh mapping and the same `TokenStorage` for local
+  reads/writes/clear instead of callbacks or top-level HTTP helpers.
+- `BridgeIdMigrationService` and touched logout paths also receive
+  `TokenStorage` directly; load/save/clear/legacy-read callbacks are removed.
+
+### Exact constructors and lifecycle owners
+
+```dart
+SesoriAuthApi({
+  required String authBackendUrl,
+  required http.Client client,
+})
+
+AuthRepository({
+  required SesoriAuthApi api,
+  required Duration refreshRequestTimeout,
+})
+
+LoginOAuthRepository({
+  required SesoriAuthApi api,
+  required AuthClientType clientType,
+  required DeviceInfo device,
+})
+
+AppClientPresenceRepository({
+  required SesoriAuthApi api,
+  required Duration statusRequestTimeout,
+})
+
+TokenStorage({required String tokenFilePath})
+
+TokenService({
+  required String initialToken,
+  required AuthRepository authRepository,
+  required TokenStorage tokenStorage,
+})
+
+BridgeRuntimeAuthService({
+  required LoginEmailRepository loginEmailRepository,
+  required LoginOAuthService loginOAuthService,
+  required AuthRepository authRepository,
+  required TokenStorage tokenStorage,
+  required TerminalPromptRepository terminalPromptRepository,
+})
+
+BridgeRuntimeAuthService.ensureAuthenticated()
+BridgeRuntimeAuthService.logAuthenticatedUser({required String accessToken})
+
+BridgeIdMigrationService({
+  required BridgeIdStorage bridgeIdStorage,
+  required TokenStorage tokenStorage,
+})
+
+BridgeLogoutRunner({
+  required BridgeInstanceRepository bridgeInstanceRepository,
+  required BridgeInstanceService bridgeInstanceService,
+  required TerminalPromptRepository terminalPromptRepository,
+  required TokenStorage tokenStorage,
+  required BridgeRegistrationService? bridgeRegistrationService,
+})
+
+AppClientOnboardingService({
+  required AppClientPresenceRepository repository,
+  required TokenRefresher tokenRefresher,
+  required TerminalPromptRepository terminalPromptRepository,
+  required AppOnboardingFormatter formatter,
+  required Duration retryDelay,
+})
+
+TokenRefresher.getAccessToken({
+  bool forceRefresh = false,
+  required AuthRequestCancellationSignal cancelled,
+})
+
+AuthRepository.refreshTokens({
+  required String refreshToken,
+  required AuthRequestCancellationSignal cancelled,
+})
+
+AppClientPresenceRepository.check({
+  required String accessToken,
+  required bool wait,
+  required AuthRequestCancellationSignal cancelled,
+})
+
+SesoriAuthApi.refreshTokens({
+  required String refreshToken,
+  required Duration requestTimeout,
+  required AuthRequestCancellationSignal cancelled,
+})
+
+SesoriAuthApi.getAppClientStatus({
+  required String accessToken,
+  required bool wait,
+  required Duration requestTimeout,
+  required AuthRequestCancellationSignal cancelled,
+})
+
+AppOnboardingFormatter({
+  required bool supportsAnsi,
+  required bool supportsUnicode,
+  required int? terminalColumns,
+})
+
+TerminalPromptApi({required Stdin stdin, required Stdout stdout})
+
+TerminalPromptRepository({
+  required TerminalPromptApi api,
+  required TerminalInteractionMode interactionMode,
+})
+
+BridgeStartupOrchestrator.compose({
+  required BridgeCliOptions options,
+  required PluginConfig pluginConfig,
+  required String pluginId,
+})
+
+BridgeRuntimeRunner({
+  required BridgeRuntime runtime,
+  required PluginFailureLatch failureLatch,
+  required BridgeRestartService restartService,
+  required bool isSupervised,
+})
+```
+
+Production composition passes 35 seconds and 60 seconds explicitly. The API
+stores the startup orchestrator's shared `http.Client` and never closes it; the
+startup orchestrator's shutdown coordinator remains its owner. `TerminalPromptApi` owns and
+disposes its lazy stdin subscription. `AppClientOnboardingService` owns one
+`AuthRequestCancellationController`, the onboarding input subscription, and one internal
+cancellable `Timer` for each retry wait. It cancels that timer on
+skip/success/fail-open/EOF; tests use existing `fake_async` rather than injecting
+a delay callback or constructing a timer collaborator.
+
+`AuthRepository` receives an explicit 15-second refresh request timeout and
+passes the caller's `AuthRequestCancellationSignal` to `SesoriAuthApi.refreshTokens`.
+`AppClientPresenceRepository` receives the 35-second status timeout and passes
+the same signal to the API. `AuthRequestCancellationSignal.never` is the explicit
+value for existing uncancellable callers; onboarding owns an
+`AuthRequestCancellationController` and
+passes its signal through token acquisition and app status. No nullable/default
+cancellation or message parsing is allowed.
+
+`AuthRequestCancellationSignal` is an auth-local read side with
+`AuthRequestCancellationSignal.never`, synchronous
+`canCancel`/`isCancelled`, and `Future<void> get whenCancelled`;
+`AuthRequestCancellationController` is the idempotent write side owned by
+onboarding. Keeping it in `auth/` preserves that subsystem's autonomy; the plan
+does not reuse/modify plugin `StartAbortSignal` or import root core Foundation
+into auth. API/token code checks `isCancelled` before allocating a request and
+races only `whenCancelled` after allocation.
+
+Failure vocabulary is also explicit:
+
+```dart
+enum TokenAccessFailureKind { transient, unavailable, cancelled }
+
+TokenAccessException({
+  required TokenAccessFailureKind kind,
+  required String reason,
+  required Object? cause,
+  required StackTrace? stackTrace,
+})
+
+SesoriAuthApiException({
+  required SesoriAuthOperation operation,
+  required int? statusCode,
+  required Object? cause,
+  required StackTrace? stackTrace,
+  required String? responseBody,
+})
+```
+
+`SesoriAuthOperation` is an enum, not a magic operation string. Only existing
+email/bridge repository mappings may inspect `responseBody`; app-presence and
+refresh output never log/retain it beyond exception lifetime.
+
+Immediately before composing onboarding, `BridgeStartupOrchestrator` resolves immutable
+formatter facts with existing `TerminalColorValidator`,
+`TerminalGlyphValidator`, and `TerminalPromptApi`'s safe nullable width read.
+The formatter stores only those scalar facts and owns no stream, environment,
+stdout handle, or lifecycle.
+
+### Layer-5 startup ownership
+
+- Move `runBridgeApp` from `bridge_runtime_runner.dart` into root
+  `bridge_startup_orchestrator.dart`. `bin/bridge.dart` imports the root
+  entrypoint; runner never imports startup orchestrator, so no cycle exists.
+  `runBridgeApp` only calls `BridgeStartupOrchestrator.compose` with parsed
+  CLI/plugin inputs and awaits `run`; it constructs no lower-layer graph.
+- The startup orchestrator absorbs current runner composition for every API,
+  repository, service, process/terminal/token owner touched by startup. It owns
+  the shared clients, shutdown coordinator, control channel, auth, plugin
+  availability, onboarding, startup mutex/provision/start sequencing,
+  registration/relay/runtime construction, debug/update/signal setup, and all
+  pre-run failure/exit cleanup.
+- It starts no plugin before onboarding settles and holds no startup mutex while
+  waiting. After plugin start, it directly constructs the existing session
+  `Orchestrator`, then injects that completed `OrchestratorSession` and already-
+  built lifecycle collaborators into plain `BridgeRuntime`.
+- The startup orchestrator constructs `BridgeRuntimeRunner` with the four direct
+  already-built constructor arguments, invokes it, and retains surrounding
+  shutdown/finally ownership. Runner executes the session and maps typed
+  plugin/restart/supervised outcomes only; no wrapper/context is introduced.
+- No Layer-5 peer is injected as a child of another. Startup orchestration ends
+  at handoff/teardown; the existing `Orchestrator` remains the single
+  relay/plugin/session-control surface during the live session.
+
+### Typed HTTP contract and classification
+
+`SesoriAuthApi`:
+
+- trims one trailing slash from the configured provider base and shares the
+  injected `http.Client` across `loginWithEmail`, `initOAuthSession`,
+  `getOAuthSessionStatus`, `ackOAuthSessionCompletion`,
+  `getAuthenticatedUser`, `refreshTokens`, `registerBridge`, `deleteBridge`, and
+  `getAppClientStatus`;
+- preserves each migrated method's current URI/header/body/DTO/status behavior;
+  repositories retain use-case/domain mapping;
+- adds `?wait=true` only to long-poll app status and sends bearer tokens only in
+  authorization headers;
+- accepts a required `AuthRequestCancellationSignal` and required timeout for app status
+  and refresh; uses `AbortableRequest` with one combined caller-cancel/deadline
+  trigger;
+- uses the repository-supplied 35 seconds for app status so the healthy
+  30-second server expiry wins, and 15 seconds for refresh;
+- checks an already-cancelled signal before send, actively aborts on later
+  cancellation/deadline, distinguishes caller cancellation from deadline, and
+  cancels deadline timers in every path;
+- accepts only 200 app status with strict Freezed `{registered: bool}` parsing;
+- throws one typed `SesoriAuthApiException` carrying operation/status and safe
+  cause/stack; raw bodies remain available only where existing email/
+  registration mapping requires them and are never logged by app presence.
+
+`AppClientPresenceRepository`:
+
+- receives required `accessToken` on every call and forwards it to the API;
+- returns typed `registered`, `absent`, `unauthorized`, or `unavailable`
+  outcomes;
+- maps 408/429/5xx, socket/client errors, and active client deadline to one typed
+  transient failure carrying safe cause/stack for the service;
+- preserves skip abort as typed expected cancellation;
+- maps API 401 to `unauthorized` without acquiring/refreshing a token or deciding
+  whether another attempt is allowed;
+- maps nonretryable 4xx and malformed/protocol responses to unavailable;
+- places the required compatibility marker immediately above 404/405 mapping.
+
+`AuthRepository` and token refresh:
+
+- maps `getAuthenticatedUser` into typed valid/unauthorized/non-auth-failure
+  results used by `BridgeRuntimeAuthService`; that service retains the shipped
+  validate-then-refresh/login coordination;
+- maps `refreshTokens` to required `TokenData` without owning token persistence;
+- classifies socket/client/active deadline/408/429/5xx as
+  `TokenAccessFailureKind.transient`, caller cancellation as `cancelled`, and
+  4xx rejection or malformed response as `unavailable`;
+- throws `TokenAccessException` with the enum kind and attached safe cause/stack
+  so `AppClientOnboardingService` never parses text;
+- `TokenService` keeps the legacy class's token file re-read/save/publish and
+  single-flight behavior, but sends actual refresh transport through this
+  repository with the caller signal. For `canCancel == true`, a token in the
+  existing background-refresh TTL band is refreshed synchronously instead of
+  spawning detached work; `AuthRequestCancellationSignal.never` preserves current
+  background behavior for existing callers;
+- `TokenService`, as token-state owner, maps missing/empty/cleared/corrupt local
+  token state and unsafe persistence failure to typed unavailable without moving
+  file decisions into `AuthRepository`;
+- onboarding's freshly constructed token service has no other consumers before the
+  checkpoint. Its cancellable refresh therefore exclusively owns the active
+  request; skip cancels it and service completion waits for the abort to settle
+  before plugin/registration consumers are composed;
+- `ControlChannelTokenService` checks pre-cancellation, races its correlated
+  response with `whenCancelled`, and removes the pending id. Caller cancellation
+  throws `TokenAccessFailureKind.cancelled`; control transport disconnection and
+  request timeout throw `transient`; signed-out/null-token responses and calls
+  after disposal throw `unavailable`. Late GUI replies remain ignored.
+  `ControlTokenUnavailableException` is removed, and supervised bootstrap maps
+  both typed transient/unavailable failures to its existing `authRequired` exit
+  behavior. Supervised onboarding remains gated out.
+
+`TokenStorage` ownership:
+
+- absorbs existing `loadTokens`, `saveTokens`, `clearTokens`, and
+  `readLegacyBridgeId` file/process logic from `token.dart` behind required
+  `read`, `write`, `clear`, and `readLegacyBridgeId` methods;
+- preserves token path, JSON, `lastProvider`, missing/corrupt behavior, Unix
+  directory/file permissions, Windows behavior, and the existing legacy
+  compatibility marker/cleanup;
+- is one concrete instance per command/run, injected directly into
+  `BridgeRuntimeAuthService`, `TokenService`, `BridgeIdMigrationService`, and
+  `BridgeLogoutRunner`/logout registration composition;
+- removes `loadTokens`/`saveTokens`/`clearTokens`/legacy-reader callbacks from
+  touched constructors and tests. Tests fake/implement the concrete Dart class
+  directly rather than introducing a one-to-one interface.
+- `LogoutCommand` performs local migration/token/id reads during composition,
+  creates a command-owned nullable `BridgeRegistrationService` only when usable
+  credentials/registration exist, and injects that collaborator directly into
+  `BridgeLogoutRunner`. The runner calls `unregister()` best-effort before
+  clearing storage; no `unregisterBridge` callback remains. Command-owned token/
+  registration services and HTTP client are disposed in `finally`.
+
+### Terminal ownership
+
+- `TerminalPromptApi` accepts only `Stdin`/`Stdout`, exposes their raw terminal
+  facts, capabilities, width, and I/O, and has no environment or legacy-relaunch
+  branch.
+- `BridgeStartupOrchestrator` resolves `TerminalInteractionMode.legacyPostUpdate` from
+  the existing environment marker; otherwise it resolves `interactive` only
+  when both raw terminal handles are attached, else `unavailable`. It injects
+  that mode into `TerminalPromptRepository` and uses the same local mode to gate
+  onboarding.
+- `LogoutCommand` independently resolves `interactive`/`unavailable` from raw
+  terminal handles, injects it, and disposes `TerminalPromptApi` in `finally`.
+- `TerminalPromptApi` does not subscribe to stdin in its constructor. The first
+  standalone prompt/read starts one lazy decoded-line subscription and fans
+  completed lines through a process-lifetime internal broadcast source.
+- Sequential prompt methods await the next line from that owner. The onboarding
+  decision method uses a cancellable stream subscription so detection can stop
+  consuming before later prompts.
+- Only one prompt is active by runner sequencing; add guards/tests against
+  overlapping consumers rather than a speculative queue of competing prompts.
+- Password reads set echo off immediately before awaiting and restore the prior
+  value in `finally` on value, EOF, error, or disposal.
+- EOF closes the line source and maps to existing clear provider/credential
+  failures or onboarding fail-open.
+- `dispose` cancels the underlying subscription/controller exactly once and is
+  registered with `BridgeShutdownCoordinator`.
+- Supervised mode reads its off-argv control secret before any terminal prompt
+  subscribes; onboarding is gated out. Preserve `ControlSecretApi` and do not
+  route the bearer secret through a user-prompt broadcast.
+
+### Formatter contract
+
+- One URL constant is passed to QR encoding and plain output; tests compare
+  exact bytes so they cannot drift.
+- Use the pinned/audited `qr` API with a fixed error-correction level; never
+  implement QR encoding manually.
+- Add four light modules on every edge.
+- Prefer ANSI+Unicode compact half blocks with explicit black/white foreground/
+  background and final reset; then non-ANSI Unicode; then ASCII `##`/spaces.
+- Use existing glyph/color validators and a safely-read nullable terminal width.
+- Compute full width including quiet zone before rendering. Unknown/throwing/
+  insufficient width returns no QR string, not a truncated code.
+- Formatting failure is isolated to URL-only output and one warning; it never
+  skips the registration wait or crashes startup.
+
+### Onboarding service state machine
+
+1. Subscribe to typed terminal outcomes before the immediate request so skip is
+   available during initial network failure. Create one
+   `AuthRequestCancellationController`; pass its signal to every token/status operation.
+2. Immediate check:
+   - service obtains
+     `TokenRefresher.getAccessToken(cancelled: controller.signal)` and passes the
+     value/same signal to the repository;
+   - `TokenAccessFailureKind.transient` follows the same one-warning/
+     fixed-60-second policy; `unavailable` fails open because interactive auth
+     already completed; `cancelled` is expected skip/EOF with no error warning;
+   - first unauthorized -> service calls
+     `getAccessToken(forceRefresh: true, cancelled: controller.signal)` and
+     retries once immediately;
+   - unauthorized after that retry -> warn once and fail open;
+   - registered -> finish silently;
+   - absent -> print full onboarding once and enter long poll;
+   - unavailable -> warn once and fail open;
+   - transient -> warn once, race skip with fixed 60-second delay, then repeat
+     immediate check without falsely showing QR;
+   - skip/EOF -> cancel and continue according to locked output policy.
+3. Long poll:
+   - acquire the current token for the attempt; retain the same one-refresh cap
+     within that attempt and reset the cap after any non-401 response;
+   - registered -> print success and finish;
+   - absent -> immediately repeat long poll with no warning/delay;
+   - unavailable -> warn once and fail open;
+   - transient -> warn once, fixed cancellable 60-second delay, then long poll;
+   - skip/EOF -> abort and continue.
+4. A single completion gate cancels the controller and retry timer/input
+   subscription, awaits any active token/status operation to settle its abort,
+   and prints at most one terminal outcome before startup orchestration proceeds.
+
+Warnings are emitted by this service only. API/repository throw or return typed
+outcomes without logging. Essential aliases remain visible when a failure first
+makes the checkpoint wait even before absence was confirmed.
+
+### Startup orchestration and runner handoff
+
+```text
+legacy bridge-id migration
+-> BridgeStartupOrchestrator composes shared SesoriAuthApi + repositories from its owned http.Client
+-> supervised control bootstrap OR standalone auth through migrated repositories
+-> compose one access-token provider/refresher (standalone TokenService or control service)
+-> authenticated-user output
+-> resolve descriptor + quick checkAvailability
+-> resolve TerminalInteractionMode at composition from raw handles + legacy marker
+-> if standalone and mode == interactive: onboarding service
+-> startup mutex / single-live-bridge decision / provision / plugin start
+-> reuse same token provider/refresher for registration, relay, runtime
+-> create existing session Orchestrator + BridgeRuntime
+-> directly inject BridgeRuntime + failure latch + restart service + supervised flag
+-> run BridgeRuntimeRunner (no construction)
+-> BridgeStartupOrchestrator owns final shutdown/disposal
+```
+
+No network onboarding runs when `options.isSupervised` or terminal is not
+interactive. A plugin-unavailable result exits before onboarding. The
+checkpoint does not construct/hold a plugin, backend runtime, startup lock,
+bridge registration, or relay connection.
+
+### Error, cancellation, concurrency, lifecycle
+
+- Skip aborts a live HTTP request and a retry timer; `RequestAbortedException`
+  caused by skip is expected and silent.
+- Skip during forced refresh propagates the same signal through `TokenService`,
+  `AuthRepository`, and `SesoriAuthApi`, actively closes the refresh request, and
+  is awaited before continuation.
+- The active client deadline aborts the request, then follows transient policy.
+- A normal server false response is not a timeout exception.
+- Refresh remains single-flight through `TokenService`; startup ordering gives
+  onboarding exclusive use before bridge registration/runtime consumers exist.
+- Invalid input leaves request and waiter active and reprints aliases.
+- Detection/skip/EOF/failure races resolve once; late futures cannot print,
+  retry, or consume later terminal lines.
+- Shutdown disposes terminal and shared clients through existing coordinator;
+  no timer/subscription/request survives.
+- The service retries indefinitely only while its one invocation remains active.
+
+## 6. Backward Compatibility
+
+### Old/custom auth server
+
+Place this marker immediately above the repository's 404/405 fallback, with the
+actual implementation date and currently declared version:
+
+```dart
+// COMPATIBILITY <implementation-date> (v1.5.1): Auth servers predating app-client status return 404/405, so onboarding must fail open for older/custom deployments. Remove this fallback and its endpoint-omission tests after every supported auth server exposes GET /auth/app-clients/status.
+```
+
+Fallback behavior: return typed unavailable, let the service warn once that app
+status could not be checked, then continue. Do not treat endpoint absence as
+`registered: false`, which would incorrectly display an indefinite prompt.
+
+Affected pairs:
+
+- new bridge `v1.5.1+` -> auth server before S01-W01-P01: fail open;
+- new bridge -> new server: full checkpoint;
+- old bridge -> new server: endpoint unused, no change.
+
+Cleanup is mechanical: delete the 404/405 special mapping and omission fixture,
+then let endpoint absence use the current unsupported-contract policy selected
+when all supported deployments expose it. Do not remove general permanent
+failure handling with the legacy branch.
+
+### Existing CLI behavior
+
+- Provider menu wording/choices and EOF guidance remain unchanged.
+- Email and password prompt text, password no-echo, and login errors remain
+  unchanged.
+- Replacement/startup-contention yes/no defaults remain unchanged.
+- Logout decisions/results remain unchanged.
+- Supervised control-secret input remains isolated and off argv.
+- New onboarding output exists only for confirmed absence or a transient status
+  failure requiring user-visible skip guidance.
+
+### Persistence/wire compatibility
+
+No bridge database, settings, token-file, shared relay model, CLI/config shape,
+or plugin contract changes. Skip and waiter state is memory-only.
+
+`SesoriAuthApi` consolidation is source-internal. Existing email, OAuth,
+profile/validation, refresh, bridge registration/deletion HTTP request shapes,
+status handling, DTOs, timeouts, and user-visible errors remain regression
+contracts. The PR deletes old APIs/helpers only after all callers and tests use
+the consolidated API through repositories; no deprecated forwarding alias is
+shipped. The required auth cancellation parameter is internal bridge source
+compatibility, and every production/test implementation and caller lands in the
+same PR.
+
+The existing `v1.3.0` legacy bridge-id compatibility marker moves immediately
+with `readLegacyBridgeId` from `token.dart` to `TokenStorage`; preserve its
+original date/version/rationale and update only the exact mechanical cleanup to
+name `TokenStorage` plus `BridgeIdMigrationService`. Do not duplicate the marker
+or leave a forwarding top-level reader.
+
+## 7. Generated-Code and Dependency Work
+
+1. Add the audited pure-Dart `qr` constraint to `bridge/app/pubspec.yaml`.
+2. Run `dart pub get` from `bridge/`; inspect `bridge/pubspec.lock` for only
+   expected dependency resolution.
+3. Define required non-null `AppClientPresenceResponse.registered` in source.
+4. Run `make codegen` from `bridge/`.
+5. Review generated response files; never hand-edit `*.freezed.dart` or
+   `*.g.dart`.
+6. No Drift table, schema version, migration, snapshot, or migration test.
+
+## 8. Verification
+
+### Automated tests
+
+#### API
+
+- One `SesoriAuthApi` owns base URL/client and every migrated method; no
+  `LoginEmailApi`, `LoginOAuthApi`, `BridgeRegistrationApi`, profile/validate
+  HTTP function, or token-manager inline HTTP remains.
+- Preserve email login, OAuth init/status/ACK, `/auth/me`, refresh, bridge
+  register/delete request/response/status fixtures byte-for-byte.
+- Base URL with/without trailing slash; immediate and `wait=true` app-status URI.
+- Bearer header and no token in URI/body/logs.
+- Strict true/false response parsing.
+- 4xx/5xx typed status failures without raw body exposure.
+- Malformed/missing/non-boolean `registered` fails as protocol error.
+- Pre-cancel prevents app-status/refresh allocation; later skip abort closes each
+  in-flight request promptly.
+- 35-second status and 15-second refresh deadlines actively abort, report typed
+  timeout, and clean timers.
+
+#### Repository
+
+- `AuthRepository` maps `/auth/me` and refresh DTO/status/network/cancel outcomes
+  without persistence or message parsing; `BridgeRuntimeAuthService` preserves
+  existing validate/refresh/login decisions.
+- `LoginOAuthRepository`, `LoginEmailRepository`, and
+  `BridgeRegistrationRepository` preserve existing mapping over the shared API
+  and remain independent peers.
+- Current token success/absence mapping.
+- Caller-supplied token is forwarded exactly; repository has no `TokenRefresher`
+  dependency and performs no refresh/retry.
+- 401 maps to typed unauthorized without becoming transient/permanent locally.
+- 404/405 compatibility fallback and exact cleanup-marker fixture.
+- 400/403/other permanent 4xx and malformed response become unavailable.
+- 408/429/5xx, socket/client exception, and active deadline become transient.
+- User skip remains cancellation, not transient warning/retry.
+- Repository emits no logs/output.
+
+#### Token contract and implementations
+
+- `TokenStorage` preserves read/write/clear, JSON/provider validation, missing
+  path, permissions, and legacy bridge-id compatibility behavior; auth service,
+  token service, migration, and logout tests inject it directly with no
+  load/save/clear callback getters.
+- `AuthRequestCancellationSignal.never` never cancels; controller cancel is synchronous,
+  idempotent, and completes `whenCancelled` once.
+- Every production `TokenRefresher` caller passes a required signal; existing
+  flows pass `never` and retain behavior. Every fake compiles with the signature.
+- `TokenService` refresh success retains storage re-read, persistence,
+  publication, and single-flight behavior over `AuthRepository` and direct
+  `TokenStorage`.
+- A cancellable near-expiry call awaits refresh and can abort it with no detached
+  work; an `AuthRequestCancellationSignal.never` near-expiry call preserves shipped
+  background-refresh/return-current behavior.
+- Token refresh HTTP 408/429/5xx, socket/client/deadline map to typed transient;
+  local missing/corrupt/revoked/4xx/malformed map unavailable; caller abort maps
+  cancelled, all without parsing messages.
+- Cancellation before/during refresh prevents or actively aborts transport,
+  leaves no active refresh future/request, does not persist/publish a token, and
+  allows a later uncancelled refresh.
+- `ControlChannelTokenService` pre/during cancellation removes its pending id,
+  throws typed cancelled failure, and ignores late replies; disconnected/timeout
+  assertions require transient, null-token/signed-out/disposed assertions require
+  unavailable, and existing push/newest-issued ordering remains unchanged.
+- Supervised bootstrap still returns `authRequired` for either transient or
+  unavailable token access, preserving current GUI behavior after removing
+  `ControlTokenUnavailableException`.
+
+#### Service
+
+- Access token is obtained per attempt; first unauthorized forces exactly one
+  refresh and immediate repository retry, second unauthorized warns/fails open,
+  and a later normal long-poll round starts with a fresh one-refresh allowance.
+- Token-refresher network/timeout errors use the fixed transient timer;
+  explicit missing/revoked/corrupt token-authority failures fail open once.
+- Initial registered: no onboarding, warning, or success output.
+- Initial absent: instructions/QR-or-fallback/URL output exactly once in order.
+- Exact URL is both QR payload and plain line.
+- Registration after prompt: one success and continuation.
+- `s`, `S`, `skip`, surrounding whitespace accepted; other lines reprint help.
+- Skip during immediate request, long poll, and 60-second delay aborts promptly.
+- Skip during forced token refresh aborts transport and the service waits for
+  cancellation settlement before continuing startup.
+- Skip is not persisted; a second service invocation prompts again.
+- Normal false long-poll repeats immediately with zero warnings and zero delay.
+- Each transient attempt emits one warning, arms exactly one internal 60-second
+  cancellable timer, and retries only after `fake_async` elapses it; repeated
+  failures prove indefinite policy without a delay callback.
+- Permanent/unavailable warns once and fails open.
+- EOF/terminal loss aborts and fails open once.
+- QR formatter exception falls back to URL and continues waiting.
+- Simultaneous registration/skip completes once with no late output/request.
+
+#### Terminal and existing auth prompts
+
+- Lazy single subscription and deterministic dispose.
+- Sequential async reads hand off after onboarding subscription cancellation.
+- Raw API terminal facts contain no product policy; startup orchestrator/repository
+  `TerminalInteractionMode` preserves interactivity and legacy post-update
+  behavior.
+- Provider choices 1-4, invalid retry, and EOF guidance unchanged.
+- Email/password values and password echo restoration on success/EOF/error.
+- Replacement yes/yes alias/default decline/noninteractive unchanged.
+- Logout prompt/result behavior unchanged.
+- Supervised `ControlSecretApi` still reads the first off-argv line without a
+  competing prompt subscriber.
+
+#### Formatter
+
+- QR module orientation/payload for exact URL and chosen correction level.
+- Four-module quiet zone on all edges.
+- ANSI+Unicode output and final reset; no ANSI when disallowed.
+- Unicode and ASCII fallback dimensions/content.
+- Exact-fit width renders; one-column-too-narrow and unknown/throwing width omit.
+- URL-only output remains exact and scan instructions mention same account.
+- Deterministic snapshots contain no terminal-dependent global reads.
+
+#### Startup orchestrator, direct runner injection, and regression
+
+- Standalone interactive runs after plugin availability and before plugin start.
+- Initial registered path is silent.
+- Supervised and noninteractive paths never call status API or formatter.
+- Plugin unavailable exits before status check.
+- Startup mutex/provision/plugin starter are not entered until onboarding settles.
+- One early standalone `TokenService` is reused for onboarding, registration,
+  relay/runtime and disposed once.
+- `BridgeStartupOrchestrator` constructs one `SesoriAuthApi` over its shared
+  client, injects all auth repositories/services, and leaves no superseded
+  use-case API constructor.
+- `_buildRegistrationService` receives the composed `SesoriAuthApi` instead of
+  auth URL/client pass-through parameters and is owned by startup orchestration.
+  Logout constructs one local
+  `http.Client` + `SesoriAuthApi` + `AuthRepository`, injects both registration
+  and token services, and closes only that command-owned client in `finally`.
+- `BridgeRuntimeAuthService` lives in root services, receives no
+  `BridgeCliOptions`, and imports no runtime/server higher-layer type.
+- Existing session `Orchestrator` is created only after plugin start.
+- Delete static `BridgeRuntime.create`; tests prove the existing generative
+  `BridgeRuntime` constructor receives the exact already-built session/
+  repositories used by debug/runtime consumers.
+- `BridgeRuntimeRunner` receives exactly the four direct declared constructor
+  arguments, constructs no lower-layer class, and preserves session/exit/failure
+  behavior.
+- `runBridgeApp` lives only in root startup-orchestrator source; import tests
+  prove runner has no startup-orchestrator import/cycle.
+- `BridgeStartupOrchestrator` retains shutdown/finally ownership around runner
+  execution and cleans partially prepared phases.
+- Success, skip, and fail-open continue normal plugin/registration startup.
+- Existing provider/email/OAuth, replacement, logout, plugin startup, bridge
+  registration, and shutdown tests pass.
+
+### Manual verification
+
+Execute S01-W02-M01 after an auth deployment and bridge build are available.
+Automated tests are authoritative for exact 60-second timing and rare races;
+manual work focuses on real terminal/camera behavior and user-visible flow.
+
+### Exact commands
+
+```text
+# workdir: bridge
+dart pub get
+make codegen
+make analyze
+make test
+
+# workdir: bridge/app
+dart analyze --fatal-infos
+make build-host
+```
+
+If `dart pub get` or code generation changes unrelated modules, stop and explain
+the resolution conflict rather than committing broad generated/lock churn.
+
+### Regression guide
+
+- Start with valid stored OAuth and email credentials; profile output and later
+  registration still use the same refreshed token.
+- Exercise replacement and logout after onboarding has completed to prove later
+  prompts receive lines and password/terminal modes are normal.
+- Start supervised bridge with control secret to prove no terminal subscription
+  steals the secret and no onboarding request occurs.
+- Start noninteractive/legacy post-update to prove no hang/output/request.
+- Run with old-server 404 fake to prove startup continues once, not an indefinite
+  missing-app prompt.
+- Verify no plugin process/provisioning/startup lock exists during a deliberately
+  held onboarding wait.
+
+## 9. Risks
+
+- A `Future.any` without cancellation could leave stdin/HTTP alive; use owned
+  subscriptions and active abort, then assert no late effects.
+- Starting the stdin broadcast in the constructor could steal supervised secret;
+  require lazy first-prompt subscription and mode tests.
+- Moving/renaming the legacy token owner could create duplicate refresh
+  authorities; compose one `TokenService` instance early and reuse current later
+  variables.
+- Consolidating existing auth HTTP could create a broad behavior regression;
+  preserve every old request fixture/status mapping and delete wrappers only
+  after repositories/services and logout composition are migrated.
+- A cancellable refresh shared with another consumer could cancel unrelated
+  work; startup sequencing gives onboarding exclusive `TokenService` use until it
+  settles, and existing later callers pass `AuthRequestCancellationSignal.never`.
+- Treating initial network failure as absence could falsely prompt existing
+  users; show only minimal retry/skip guidance until a real false response.
+- Treating 404 as absence would hang old servers; map to compatibility-unavailable.
+- Using terminal foreground colors alone can invert by theme; prefer explicit
+  black/white ANSI cells and retain URL/manual scans.
+- QR truncation destroys scans; precompute width and omit rather than clip.
+- A formatter/service god class could mix transport, token, terminal, and QR
+  policy; keep API/repository/formatter/service ownership explicit.
+- Broad terminal migration could alter auth behavior; signatures/tests preserve
+  visible contracts and remove only undefined mixed input.
+- Runner injection could grow into a service locator; keep exactly the four
+  direct declared arguments and reject wrapper contexts, maps, generic getters,
+  factories, URLs, clients, callbacks, or lower-layer construction parameters.
+- Moving startup composition could duplicate Layer-5 ownership; startup
+  orchestrator owns only pre-plugin composition/handoff/teardown, while the
+  existing `Orchestrator` remains the single live session-control surface.
+
+## 10. Acceptance Criteria
+
+- Mode, ordering, and silent-current behavior match the locked product flow.
+- Confirmed absence prints bounded QR when safe and always exact URL.
+- Same-user registration wakes and resumes with one success message.
+- Both skip aliases cancel request/delay and affect only current run.
+- Skip also actively aborts an in-flight token refresh; the service awaits it and
+  leaves no refresh/status/control request behind.
+- Normal expiry is silent/immediate; transient failure is one warning + exact
+  fixed 60 seconds; permanent failure is one warning + fail open.
+- One 401 refresh and old-server compatibility behavior are tested and marked.
+- `SesoriAuthApi` is the only Sesori-auth `Api`; all migrated existing operations
+  retain tests and no forwarding use-case API/top-level HTTP remains.
+- `TokenRefresher` cancellation and typed failure contracts cover both production
+  implementations, all callers, and all fakes without message parsing.
+- `TokenStorage` is injected directly into `TokenService`, runtime auth,
+  migration, and logout; touched constructors have no token load/save/clear
+  callbacks, and the forbidden `TokenManager` name/file is gone.
+- `BridgeLogoutRunner` receives nullable `BridgeRegistrationService` directly;
+  logout composition/tests contain no unregister callback forwarding boundary.
+- Terminal API/repository/Foundation files live at root layer paths, and the root
+  onboarding service has no dependency on `server/`.
+- Root `BridgeRuntimeAuthService` has no runtime-options dependency;
+  `BridgeStartupOrchestrator` is the sole startup composer and runner consumes
+  only the four direct already-built collaborators with no lower-layer
+  construction.
+- Existing prompts and supervised secret remain correct under one async stdin
+  owner.
+- No plugin/startup lock is held while waiting; no lifecycle resource leaks.
+- Generated/lock output is tool-produced and scoped; all commands pass.
+- No analytics, config, persistence, browser, shared, plugin, relay, mobile, or
+  desktop changes are included.
+
+## 11. Definition of Done
+
+- Scope, tests, generated output, dependency lock, manual guide, compatibility
+  marker, and regression evidence are complete on the pinned `main` baseline.
+- Architecture-bearing implementation receives the worker's configured
+  implementation review before PR opening.
+- Only intended monorepo files are committed; branch is pushed and PR targets
+  `main`.
+- `TRACKER.md` records S01/W02 baseline, branch, PR URL, checked state, and any
+  findings. The advisory manual row remains independently checkable.
+- Auth endpoint is deployed before the bridge release is initiated.

--- a/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w02-p01-interactive-app-onboarding.md
+++ b/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w02-p01-interactive-app-onboarding.md
@@ -7,10 +7,11 @@
 - **Worktree:** one dedicated monorepo worker worktree for this PR
 - **Base branch:** `main`
 - **Branch:** `plan/bridge-app-onboarding/s01-w02-p01-interactive-app-onboarding`
-- **Wave baseline:** pin the assessed current `main` tip in `TRACKER.md` before branch creation
+- **Wave baseline:** pin the assessed current `main` tip on remote `plan/bridge-app-onboarding/tracking`, then import this plan's `TRACKER.md` after branch creation
 - **Audited reference:** `5a76c0c420cd7db445f7fe2c8a2570265b4c84e0`
 - **Audited reference date:** 2026-07-17T06:57:01Z
-- **Contract-affecting:** Yes — auth HTTP consumption, CLI prompt behavior, and shipped old-server compatibility
+- **Touched workspaces:** `bridge/app`, `shared/sesori_shared`
+- **Contract-affecting:** Yes — auth HTTP consumption/request DTOs, CLI prompt behavior, and shipped old-server compatibility
 
 ## 1. Goal and Cohesion
 
@@ -19,10 +20,10 @@ contract: safe asynchronous terminal ownership, initial current-registration
 check, bounded QR/URL guidance, instant server wake, explicit current-run skip,
 fixed one-minute transient retry, and permanent fail-open compatibility.
 
-The PR is independently cohesive because all bridge-side API, repository,
-service, terminal, composition, generated model, tests, and dependency work land
-together. No intermediate build can start an uncancellable prompt or consume a
-contract without typed fallback behavior.
+The PR is independently cohesive because the shared auth request DTO sources,
+bridge API/repository/service/terminal/composition changes, generated output,
+tests, and dependency work land together. No intermediate build can start an
+uncancellable prompt or consume a contract without typed fallback behavior.
 
 The existing auth HTTP consolidation is required, not opportunistic cleanup:
 the scoped architecture permits one API owner per external provider, so adding
@@ -35,15 +36,22 @@ or make onboarding depend on an unmerged internal stack.
 
 - S01-W01-P01 is merged to auth-server `master`; its exact endpoint contract is
   re-read rather than inferred from this plan.
+- Fetch remote `plan/bridge-app-onboarding/tracking`, verify its S01/W01 baseline/
+  branch/PR/checked state against the merged auth PR, and stop on mismatch.
 - Auth deployment is available before bridge release. Local tests may use a fake
   server and do not require production credentials.
 - Fetch monorepo `main`, assess drift from
   `5a76c0c420cd7db445f7fe2c8a2570265b4c84e0` in every expected auth/runtime/
-  terminal/pubspec/test path, and pin the exact tip before branching.
-- Re-read existing root `AGENTS.md`, `bridge/AGENTS.md`, and
-  `bridge/app/AGENTS.md`, plus `docs/VISION.md`, `docs/ROADMAP.md`, and current
-  active plans. No scoped plugin-interface instruction file exists or is needed
-  because this PR does not modify that package.
+  terminal/shared-model/pubspec/test path, and pin the exact tip before branching.
+- Record that assessed S01/W02 tip on the tracking branch before creating the
+  implementation branch from the same `main` commit. Copy only
+  `.plan/active/bridge-app-onboarding/TRACKER.md` from tracking into the new
+  implementation branch; do not merge the tracking branch or add another PR.
+- Re-read existing root `AGENTS.md`, `bridge/AGENTS.md`,
+  `bridge/app/AGENTS.md`, and `shared/sesori_shared/AGENTS.md`, plus
+  `docs/VISION.md`, `docs/ROADMAP.md`, and current active plans. No scoped
+  plugin-interface instruction file exists or is needed because this PR does not
+  modify that package.
 - Re-read `bridge/app/pubspec.yaml` and `lib/src/version.dart` immediately before
   writing the compatibility marker; audited version is `1.5.1`.
 - Same-wave sibling baseline reuse is not applicable; this wave has one PR. The
@@ -56,6 +64,8 @@ or make onboarding depend on an unmerged internal stack.
 - Add pure-Dart `qr` as a direct `bridge/app` dependency and update workspace
   resolution/lockfile through normal tooling.
 - Add bridge-local Freezed `AppClientPresenceResponse` and generated JSON code.
+- Add shared Freezed `EmailLoginRequest` and `RefreshTokenRequest` sources,
+  exports, generated JSON code, and exact legacy-body tests.
 - Add one per-provider `SesoriAuthApi`, `AuthRepository`,
   `LoginOAuthRepository`, `AppClientPresenceRepository`, typed outcomes/
   exceptions, `AppOnboardingFormatter`, and `AppClientOnboardingService`.
@@ -85,11 +95,11 @@ or make onboarding depend on an unmerged internal stack.
   transient.
 - Add exact old-server compatibility marker and omission tests.
 - Convert `TerminalPromptApi` to one lazy process-lifetime asynchronous line
-  owner with deterministic disposal, output/capability access, EOF, and password
-  echo restoration; remove environment/startup-mode policy from this API.
-- Add typed `TerminalInteractionMode`, resolved by startup-orchestrator/logout composition
-  roots from raw terminal facts and the legacy relaunch marker, then injected
-  into `TerminalPromptRepository`.
+  owner with deterministic disposal, raw terminal/environment facts, capability
+  reads, EOF, and password echo restoration. It contains no product decision.
+- Add typed `TerminalInteractionMode` and `TerminalRenderingCapabilities`.
+  `TerminalPromptRepository` alone maps raw API facts plus the legacy relaunch
+  marker to those models; startup/logout consumers never interpret raw facts.
 - Convert provider, credentials, replace/startup contention, and logout prompts
   to the same async owner without visible contract changes.
 - Remove direct global stdin use from `BridgeRuntimeAuthService`; move email
@@ -107,24 +117,27 @@ or make onboarding depend on an unmerged internal stack.
 - Run onboarding only when standalone + terminal interactive, after authenticated
   username logging and successful plugin availability, before startup mutex,
   provisioning, plugin start, relay, or bridge registration.
-- Add root Layer-5 `BridgeStartupOrchestrator` as sole constructor/owner of the
-  auth, terminal, token, onboarding and existing startup graph. It owns pre-plugin
-  sequencing/disposal, starts the plugin, creates the existing session
-  `Orchestrator` only afterward, injects that completed session into plain
-  `BridgeRuntime`, then directly injects the completed runtime and typed
-  failure/restart/supervised collaborators into `BridgeRuntimeRunner`.
-- Delete static `BridgeRuntime.create`; the existing generative `BridgeRuntime`
-  constructor receives already-built collaborators and session.
-- Reduce `BridgeRuntimeRunner` to a consumer of four direct already-built
-  runtime/outcome collaborators; it must
-  not construct an API, repository, service, token/terminal owner, plugin
-  collaborator, or session orchestrator.
+- Preserve the process-startup ownership locked by the active desktop and
+  parallel-plugin plans: `BridgeRuntimeRunner` constructs the touched APIs,
+  repositories, services, and terminal/token owners, runs onboarding at the
+  declared pre-mutex point, then continues its existing provision/start/runtime
+  handoff. The existing `Orchestrator` remains the post-start session composer.
+- Keep `BridgeRuntime.create` as the existing session-phase handoff and add no
+  onboarding/auth/terminal/startup policy to it. Do not add
+  `BridgeStartupOrchestrator` or any third composition owner.
+- Add Layer-2 `TokenRepository` and `BridgeIdRepository`; only those repositories
+  consume `TokenStorage` and `BridgeIdStorage`. Remove persistence callback
+  plumbing and direct service/storage dependencies.
+- Add shared Freezed `EmailLoginRequest` and `RefreshTokenRequest` DTOs, barrel
+  exports, generated files, and exact-body tests; consolidated auth operations
+  must serialize these models instead of reproducing inline JSON maps.
 - Add focused API/repository/service/formatter/terminal/auth/runner tests and
   compile the host native bridge.
 
 ### Non-Goals
 
-- Changing shared models, plugins, relay, mobile, desktop, auth server, or app UI.
+- Changing plugins, relay, mobile, desktop, auth server, app UI, or shared relay/
+  session contracts. The two additive shared auth request DTOs are in scope.
 - Migrating `PushNotificationClient`: it is an existing transport `Client`, not
   another `Api` class, and its notification-send ownership remains unchanged.
 - Running onboarding in `--control-url` supervised mode or any noninteractive
@@ -134,6 +147,7 @@ or make onboarding depend on an unmerged internal stack.
 - Raw one-key input, terminal raw mode, clearing partially typed terminal input,
   shelling out to detect width/color, or adding a terminal-size dependency.
 - Retrying normal long-poll expiry with a timer.
+- Adding an auth SSE/WebSocket channel or importing/refactoring plugin SSE code.
 - Exponential/jittered backoff, automatic transient fail-open, or separate
   `Retry-After` scheduling.
 - Logging in API/repository layers or double-reporting failures.
@@ -175,6 +189,10 @@ or make onboarding depend on an unmerged internal stack.
   `profile.dart` / `validate.dart` and inline legacy token-manager refresh HTTP, split
   one external Sesori auth provider by use case. The new endpoint cannot add a
   fourth use-case API; this PR consolidates the touched provider boundary.
+- `login_email_api.dart` and both refresh implementations currently serialize
+  inline `{email, password}` / `{refreshToken}` maps. Moving those methods must
+  adopt shared Freezed request models required by `bridge/app/AGENTS.md`; exact
+  legacy key/value output remains the compatibility fixture.
 - `TerminalGlyphValidator` and `TerminalColorValidator` are existing Layer-0
   policy; `Stdout.terminalColumns` may throw and must be treated as unknown.
 - `http ^1.6.0` supports active request abort. A plain `Future.timeout` that
@@ -186,6 +204,12 @@ or make onboarding depend on an unmerged internal stack.
 
 ### Expected source/dependency files
 
+- `shared/sesori_shared/lib/src/models/auth/email_login_request.dart` and
+  generated `*.freezed.dart` / `*.g.dart` (new)
+- `shared/sesori_shared/lib/src/models/auth/refresh_token_request.dart` and
+  generated `*.freezed.dart` / `*.g.dart` (new)
+- `shared/sesori_shared/lib/sesori_shared.dart` barrel exports and focused model
+  tests; `shared/sesori_shared/pubspec.lock` only if normal resolution changes it
 - `bridge/app/pubspec.yaml`
 - `bridge/pubspec.lock`
 - `bridge/app/lib/src/auth/app_client_presence_response.dart` (new)
@@ -200,9 +224,13 @@ or make onboarding depend on an unmerged internal stack.
 - `bridge/app/lib/src/auth/login_oauth_service.dart`
 - `bridge/app/lib/src/auth/bridge_registration_repository.dart`
 - `bridge/app/lib/src/auth/bridge_registration_service.dart`
-- `bridge/app/lib/src/auth/token_storage.dart` (new concrete token-file boundary)
-- `bridge/app/lib/src/auth/token.dart` retains `TokenData`/path values but moves
-  load/save/clear/legacy-read I/O into `TokenStorage`
+- `bridge/app/lib/src/auth/token_storage.dart` (new Layer-1 token-file API)
+- `bridge/app/lib/src/auth/token_repository.dart` (new Layer-2 mapping boundary)
+- existing `bridge_id_storage.dart` remains Layer 1; add
+  `bridge_id_repository.dart` as its only Layer-2 consumer
+- `bridge/app/lib/src/auth/token.dart` retains `TokenData`/path values; raw file
+  I/O moves to `TokenStorage`, while current/legacy JSON mapping moves to
+  `TokenRepository`
 - `bridge/app/lib/src/auth/token_refresher.dart`
 - rename `bridge/app/lib/src/auth/token_manager.dart` to `token_service.dart` and
   `TokenManager` to `TokenService`
@@ -228,24 +256,24 @@ or make onboarding depend on an unmerged internal stack.
   `bridge/app/lib/src/api/terminal_prompt_api.dart`
 - move `bridge/app/lib/src/server/repositories/terminal_prompt_repository.dart`
   to `bridge/app/lib/src/repositories/terminal_prompt_repository.dart`
-- `bridge/app/lib/src/foundation/terminal_interaction_mode.dart` (new typed
-  composition policy)
+- `bridge/app/lib/src/foundation/terminal_interaction_mode.dart` and
+  `terminal_rendering_capabilities.dart` (new typed repository outputs)
 - move existing terminal-only `server/foundation/terminal_prompt_decision.dart`
   and `bridge_replace_prompt.dart` to root `lib/src/foundation/`; place the small
   typed onboarding outcome there as well, so the root repository has no outbound
   dependency on the minimal `server/` subsystem
 - move `bridge/app/lib/src/bridge/runtime/bridge_runtime_auth.dart` to
   `bridge/app/lib/src/services/bridge_runtime_auth_service.dart`
-- `bridge/app/lib/src/bridge_startup_orchestrator.dart` (new root Layer-5 startup
-  and session composer/lifecycle owner)
-- `bridge/app/lib/src/bridge/runtime/bridge_runtime.dart` to delete the static
-  composition factory and retain only lifecycle over injected session/
-  collaborators
-- `bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart`
-  removes top-level `runBridgeApp` and every lower-layer constructor/helper;
-  retains only ready-runtime execution and typed exit mapping
-- `bridge/app/bin/bridge.dart` for logout-command interaction-mode composition
-  and terminal API disposal
+- `bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart` retains
+  `runBridgeApp`, process-startup composition, shutdown, supervised-mode, and
+  plugin lifecycle ownership while replacing touched inline/callback seams and
+  inserting onboarding before the startup mutex
+- `bridge/app/lib/src/bridge/runtime/bridge_runtime.dart` and existing
+  `bridge/orchestrator.dart` only for dependency propagation required by the new
+  repositories/contracts; they gain no new composition responsibility
+- `bridge/app/bin/bridge.dart` for logout repository composition and terminal API
+  disposal; it constructs dependencies but performs no storage read/clear or raw
+  terminal mapping
 - `bridge/app/lib/src/bridge/runtime/bridge_logout_runner.dart` only if signature
   propagation requires it; preserve behavior
 
@@ -265,6 +293,9 @@ assert its methods accept no `BridgeCliOptions` or auth URL pass-through.
 ### Dependency direction
 
 ```text
+EmailLoginRequest / RefreshTokenRequest (shared Freezed DTOs)
+  -> SesoriAuthApi request serialization
+
 SesoriAuthApi
   <- AuthRepository / LoginEmailRepository / LoginOAuthRepository /
      BridgeRegistrationRepository / AppClientPresenceRepository
@@ -277,14 +308,29 @@ AppClientPresenceRepository
 TerminalPromptApi
   <- TerminalPromptRepository
      <- BridgeRuntimeAuthService / AppClientOnboardingService / existing consumers
+     -> typed TerminalInteractionMode / TerminalRenderingCapabilities
+
+TokenStorage <- TokenRepository
+  <- TokenService / BridgeRuntimeAuthService / BridgeIdMigrationService /
+     BridgeLogoutRunner
+
+BridgeIdStorage <- BridgeIdRepository
+  <- BridgeRegistrationService / BridgeIdMigrationService / logout flow
+
+logout composition:
+  TokenRepository.read typed outcome
+    -> available: command constructs TokenService -> BridgeRegistrationService
+    -> other: nullable registration dependency remains absent
+  TokenRepository + BridgeIdRepository -> BridgeIdMigrationService
+  all already-built dependencies -> BridgeLogoutRunner
 
 AppOnboardingFormatter
   <- AppClientOnboardingService
 
 all startup APIs/repositories/services
-  <- BridgeStartupOrchestrator (Layer 5 constructor + phase owner)
-     -> existing session Orchestrator after plugin start
-     -> BridgeRuntimeRunner with direct already-built collaborators (consumer only)
+  <- BridgeRuntimeRunner (user-approved process-startup composer)
+     -> existing BridgeRuntime.create handoff after plugin start
+     -> existing Orchestrator (post-start session composer)
 ```
 
 - `SesoriAuthApi` is the single per-provider HTTP/JSON/abort boundary. No
@@ -293,25 +339,31 @@ all startup APIs/repositories/services
   transport-to-domain normalization.
 - Service owns access-token acquisition, exactly-one forced refresh/retry,
   timer/retry/output/race policy.
-- `BridgeStartupOrchestrator` composes and sequences; runner contains no inline
-  construction, HTTP, QR, input parser, or service factory.
+- `BridgeRuntimeRunner` remains the process-startup composition root selected by
+  the active desktop and parallel-plugin plans. It constructs declared peers and
+  sequences phases; it does not inline HTTP, persistence, terminal mapping, QR,
+  or domain logic.
 - Existing terminal repository remains the sole prompt normalization boundary;
   no auth repository depends on it as a peer.
 - `LoginEmailRepository.performEmailLogin` receives already-normalized required
   email/password from `BridgeRuntimeAuthService`; the repository no longer owns
   prompt acquisition.
 - `LoginOAuthService` depends on `LoginOAuthRepository`, not the API.
-- `TokenService` depends on `AuthRepository` plus concrete `TokenStorage`, not
-  callbacks or the API, and implements the
-  cancellable token contract. `BridgeRuntimeAuthService` uses `AuthRepository`
-  for current `/auth/me`/refresh mapping and the same `TokenStorage` for local
-  reads/writes/clear instead of callbacks or top-level HTTP helpers.
-- `BridgeIdMigrationService` and touched logout paths also receive
-  `TokenStorage` directly; load/save/clear/legacy-read callbacks are removed.
+- `TokenService` depends on `AuthRepository` plus `TokenRepository`, not
+  callbacks, storage, or the API, and implements the cancellable token contract.
+  `BridgeRuntimeAuthService` uses `AuthRepository` for current `/auth/me`/refresh
+  mapping and `TokenRepository` for local token state.
+- `BridgeIdMigrationService` depends on `TokenRepository` and
+  `BridgeIdRepository`; registration/logout services use repositories as well.
+  Only repositories access the two storage APIs, and load/save/clear/legacy-read
+  callbacks are removed.
 
 ### Exact constructors and lifecycle owners
 
 ```dart
+EmailLoginRequest({required String email, required String password})
+RefreshTokenRequest({required String refreshToken})
+
 SesoriAuthApi({
   required String authBackendUrl,
   required http.Client client,
@@ -334,18 +386,39 @@ AppClientPresenceRepository({
 })
 
 TokenStorage({required String tokenFilePath})
+TokenStorage.readRaw()
+TokenStorage.writeRaw({required String json})
+TokenStorage.clear()
+TokenRepository({required TokenStorage storage})
+BridgeIdStorage({required String bridgeIdFilePath})
+BridgeIdRepository({required BridgeIdStorage storage})
+
+sealed class TokenReadOutcome
+TokenReadAvailable({required TokenData tokens})
+TokenReadMissing()
+TokenReadCorrupt({required Object cause, required StackTrace stackTrace})
+TokenReadFailure({required Object cause, required StackTrace stackTrace})
+
+TokenRepository.read()
+TokenRepository.write({required TokenData tokens})
+TokenRepository.clear()
+TokenRepository.readLegacyBridgeId()
+
+BridgeIdRepository.read()
+BridgeIdRepository.write({required String bridgeId})
+BridgeIdRepository.clear()
 
 TokenService({
   required String initialToken,
   required AuthRepository authRepository,
-  required TokenStorage tokenStorage,
+  required TokenRepository tokenRepository,
 })
 
 BridgeRuntimeAuthService({
   required LoginEmailRepository loginEmailRepository,
   required LoginOAuthService loginOAuthService,
   required AuthRepository authRepository,
-  required TokenStorage tokenStorage,
+  required TokenRepository tokenRepository,
   required TerminalPromptRepository terminalPromptRepository,
 })
 
@@ -353,15 +426,16 @@ BridgeRuntimeAuthService.ensureAuthenticated()
 BridgeRuntimeAuthService.logAuthenticatedUser({required String accessToken})
 
 BridgeIdMigrationService({
-  required BridgeIdStorage bridgeIdStorage,
-  required TokenStorage tokenStorage,
+  required BridgeIdRepository bridgeIdRepository,
+  required TokenRepository tokenRepository,
 })
 
 BridgeLogoutRunner({
   required BridgeInstanceRepository bridgeInstanceRepository,
   required BridgeInstanceService bridgeInstanceService,
   required TerminalPromptRepository terminalPromptRepository,
-  required TokenStorage tokenStorage,
+  required BridgeIdMigrationService bridgeIdMigrationService,
+  required TokenRepository tokenRepository,
   required BridgeRegistrationService? bridgeRegistrationService,
 })
 
@@ -403,35 +477,31 @@ SesoriAuthApi.getAppClientStatus({
 })
 
 AppOnboardingFormatter({
-  required bool supportsAnsi,
-  required bool supportsUnicode,
-  required int? terminalColumns,
+  required TerminalRenderingCapabilities capabilities,
 })
 
-TerminalPromptApi({required Stdin stdin, required Stdout stdout})
-
-TerminalPromptRepository({
-  required TerminalPromptApi api,
-  required TerminalInteractionMode interactionMode,
+TerminalPromptApi({
+  required Stdin stdin,
+  required Stdout stdout,
+  required Map<String, String> environment,
 })
 
-BridgeStartupOrchestrator.compose({
-  required BridgeCliOptions options,
-  required PluginConfig pluginConfig,
-  required String pluginId,
-})
-
-BridgeRuntimeRunner({
-  required BridgeRuntime runtime,
-  required PluginFailureLatch failureLatch,
-  required BridgeRestartService restartService,
-  required bool isSupervised,
-})
+TerminalPromptRepository({required TerminalPromptApi api})
+TerminalPromptRepository.interactionMode
+TerminalPromptRepository.renderingCapabilities
 ```
 
+`TokenRepository.read()` returns the sealed outcomes above rather than leaking
+`PathNotFoundException`, `FormatException`, or raw file exceptions. Write/clear
+and bridge-id repository operations throw typed repository exceptions with safe
+cause/stack when raw persistence fails. Services retain business policy:
+runtime auth chooses login/failure, token refresh prevents resurrection or
+performs the approved corrupt-post-read repair, registration handles revocation,
+and logout maps clear failure into its existing result.
+
 Production composition passes 35 seconds and 60 seconds explicitly. The API
-stores the startup orchestrator's shared `http.Client` and never closes it; the
-startup orchestrator's shutdown coordinator remains its owner. `TerminalPromptApi` owns and
+stores the runner's shared `http.Client` and never closes it; the runner's
+shutdown coordinator remains its owner. `TerminalPromptApi` owns and
 disposes its lazy stdin subscription. `AppClientOnboardingService` owns one
 `AuthRequestCancellationController`, the onboarding input subscription, and one internal
 cancellable `Timer` for each retry wait. It cancels that timer on
@@ -450,12 +520,14 @@ cancellation or message parsing is allowed.
 
 `AuthRequestCancellationSignal` is an auth-local read side with
 `AuthRequestCancellationSignal.never`, synchronous
-`canCancel`/`isCancelled`, and `Future<void> get whenCancelled`;
+`canCancel`/`isCancelled`, and a broadcast `Stream<void> get cancellations`;
 `AuthRequestCancellationController` is the idempotent write side owned by
 onboarding. Keeping it in `auth/` preserves that subsystem's autonomy; the plan
 does not reuse/modify plugin `StartAbortSignal` or import root core Foundation
-into auth. API/token code checks `isCancelled` before allocating a request and
-races only `whenCancelled` after allocation.
+into auth. Each API/token operation subscribes to `cancellations`, rechecks
+`isCancelled` after subscription to close the subscribe race, and cancels that
+request-scoped subscription in `finally` when the request/response settles.
+`never` emits nothing but its per-request subscription is still detached.
 
 Failure vocabulary is also explicit:
 
@@ -482,36 +554,36 @@ SesoriAuthApiException({
 email/bridge repository mappings may inspect `responseBody`; app-presence and
 refresh output never log/retain it beyond exception lifetime.
 
-Immediately before composing onboarding, `BridgeStartupOrchestrator` resolves immutable
-formatter facts with existing `TerminalColorValidator`,
-`TerminalGlyphValidator`, and `TerminalPromptApi`'s safe nullable width read.
-The formatter stores only those scalar facts and owns no stream, environment,
-stdout handle, or lifecycle.
+Immediately before composing onboarding, `BridgeRuntimeRunner` asks
+`TerminalPromptRepository` for typed `interactionMode` and
+`renderingCapabilities`. The repository maps raw API facts with existing
+`TerminalColorValidator`, `TerminalGlyphValidator`, the legacy environment
+marker, and safe nullable width handling. `AppOnboardingFormatter` receives only
+the immutable typed capability model and owns no stream, environment, stdout
+handle, or lifecycle.
 
 ### Layer-5 startup ownership
 
-- Move `runBridgeApp` from `bridge_runtime_runner.dart` into root
-  `bridge_startup_orchestrator.dart`. `bin/bridge.dart` imports the root
-  entrypoint; runner never imports startup orchestrator, so no cycle exists.
-  `runBridgeApp` only calls `BridgeStartupOrchestrator.compose` with parsed
-  CLI/plugin inputs and awaits `run`; it constructs no lower-layer graph.
-- The startup orchestrator absorbs current runner composition for every API,
-  repository, service, process/terminal/token owner touched by startup. It owns
-  the shared clients, shutdown coordinator, control channel, auth, plugin
-  availability, onboarding, startup mutex/provision/start sequencing,
-  registration/relay/runtime construction, debug/update/signal setup, and all
-  pre-run failure/exit cleanup.
-- It starts no plugin before onboarding settles and holds no startup mutex while
-  waiting. After plugin start, it directly constructs the existing session
-  `Orchestrator`, then injects that completed `OrchestratorSession` and already-
-  built lifecycle collaborators into plain `BridgeRuntime`.
-- The startup orchestrator constructs `BridgeRuntimeRunner` with the four direct
-  already-built constructor arguments, invokes it, and retains surrounding
-  shutdown/finally ownership. Runner executes the session and maps typed
-  plugin/restart/supervised outcomes only; no wrapper/context is introduced.
-- No Layer-5 peer is injected as a child of another. Startup orchestration ends
-  at handoff/teardown; the existing `Orchestrator` remains the single
-  relay/plugin/session-control surface during the live session.
+- `runBridgeApp` and `BridgeRuntimeRunner.run` stay in
+  `bridge_runtime_runner.dart`. This preserves the active parallel-plugin plan's
+  process lifecycle sequence and the desktop plan's one-time standalone/
+  supervised selection plus exit/shutdown semantics.
+- The user explicitly waives strict B-B5 only for this established two-phase
+  composition: `BridgeRuntimeRunner` wires process-startup layers and the
+  existing `Orchestrator` wires the post-start room/session/event graph.
+  `BridgeRuntime.create` remains the existing handoff within the session phase;
+  it gains no onboarding, auth, terminal, or process-startup policy. The waiver
+  includes retaining the existing `BridgeRuntimeRunner` name for the startup
+  role locked by those active plans, but authorizes no additional composer or
+  suffix exception.
+- The runner constructs each touched API/repository/service as peers, stores no
+  raw persistence or terminal mapping policy, and inserts onboarding after auth
+  plus availability but before startup mutex/provision/start. It retains shared
+  client, shutdown coordinator, partial-start cleanup, and typed exit ownership.
+- After onboarding settles, the runner continues the existing startup sequence
+  and invokes the existing runtime/session handoff. No
+  `BridgeStartupOrchestrator`, wrapper context, service locator, or third
+  composition owner is added.
 
 ### Typed HTTP contract and classification
 
@@ -533,7 +605,9 @@ stdout handle, or lifecycle.
   30-second server expiry wins, and 15 seconds for refresh;
 - checks an already-cancelled signal before send, actively aborts on later
   cancellation/deadline, distinguishes caller cancellation from deadline, and
-  cancels deadline timers in every path;
+  cancels deadline timers plus the request-scoped cancellation subscription in
+  every success/error/abort path. Normal completion settles the combined abort
+  trigger so healthy long-poll rounds and `never` refreshes retain no callbacks;
 - accepts only 200 app status with strict Freezed `{registered: bool}` parsing;
 - throws one typed `SesoriAuthApiException` carrying operation/status and safe
   cause/stack; raw bodies remain available only where existing email/
@@ -563,25 +637,28 @@ stdout handle, or lifecycle.
   4xx rejection or malformed response as `unavailable`;
 - throws `TokenAccessException` with the enum kind and attached safe cause/stack
   so `AppClientOnboardingService` never parses text;
-- `TokenService` keeps the legacy class's token file re-read/save/publish and
-  single-flight behavior, but sends actual refresh transport through this
-  repository with the caller signal. For `canCancel == true`, a token in the
+- `TokenService` keeps the legacy class's token-state re-read/persist/publish and
+  single-flight behavior through `TokenRepository`, while sending actual refresh
+  transport through `AuthRepository` with the caller signal. For
+  `canCancel == true`, a token in the
   existing background-refresh TTL band is refreshed synchronously instead of
   spawning detached work; `AuthRequestCancellationSignal.never` preserves current
   background behavior for existing callers;
-- `TokenService`, as token-state owner, maps initial missing/empty/corrupt state,
-  a file cleared during refresh, and unsafe persistence failure to typed
-  unavailable without moving file decisions into `AuthRepository`. Preserve the
-  shipped post-response recovery seam: if only the post-refresh re-read throws
-  `FormatException`, retain `lastProvider` from the valid pre-refresh snapshot
-  and persist the newly issued access/refresh tokens to repair the file. Missing/
-  cleared post-refresh state still prevents resurrection;
+- `TokenRepository` maps raw storage/JSON failures to sealed present, missing,
+  corrupt, and persistence-failure outcomes. `TokenService`, as token-state
+  owner, decides those initial or in-flight outcomes are unavailable. Preserve
+  the shipped post-response recovery seam: if only the repository's post-refresh
+  re-read outcome is corrupt, retain `lastProvider` from the valid pre-refresh
+  snapshot and persist the newly issued access/refresh tokens through the
+  repository to repair the file. Missing/cleared post-refresh state still
+  prevents resurrection;
 - onboarding's freshly constructed token service has no other consumers before the
   checkpoint. Its cancellable refresh therefore exclusively owns the active
   request; skip cancels it and service completion waits for the abort to settle
   before plugin/registration consumers are composed;
-- `ControlChannelTokenService` checks pre-cancellation, races its correlated
-  response with `whenCancelled`, and removes the pending id. Caller cancellation
+- `ControlChannelTokenService` installs a detachable cancellation subscription,
+  rechecks pre-cancellation, races its correlated response, and removes the
+  pending id/cancels the subscription in `finally`. Caller cancellation
   throws `TokenAccessFailureKind.cancelled`; control transport disconnection and
   request timeout throw `transient`; signed-out/null-token responses and calls
   after disposal throw `unavailable`. Late GUI replies remain ignored.
@@ -589,39 +666,57 @@ stdout handle, or lifecycle.
   both typed transient/unavailable failures to its existing `authRequired` exit
   behavior. Supervised onboarding remains gated out.
 
-`TokenStorage` ownership:
+`TokenStorage` / repository ownership:
 
-- absorbs existing `loadTokens`, `saveTokens`, `clearTokens`, and
-  `readLegacyBridgeId` file/process logic from `token.dart` behind required
-  `read`, `write`, `clear`, and `readLegacyBridgeId` methods;
-- preserves token path, JSON, `lastProvider`, missing/corrupt behavior, Unix
-  directory/file permissions, Windows behavior, and the existing legacy
+- `TokenStorage` absorbs only raw file/process behavior from `token.dart` behind
+  required `readRaw`, `writeRaw`, and `clear` methods; it preserves token path,
+  Unix directory/file permissions, and Windows behavior without parsing JSON;
+- `TokenRepository` owns current `TokenData` JSON/provider mapping,
+  missing/corrupt outcomes, serialization, and the legacy bridge-id read plus its
   compatibility marker/cleanup;
-- is one concrete instance per command/run, injected directly into
-  `BridgeRuntimeAuthService`, `TokenService`, `BridgeIdMigrationService`, and
-  `BridgeLogoutRunner`/logout registration composition;
+- is consumed only by one `TokenRepository` instance per command/run. That
+  repository maps missing/corrupt/persisted state into typed domain results and
+  is injected into `BridgeRuntimeAuthService`, `TokenService`,
+  `BridgeIdMigrationService`, and `BridgeLogoutRunner`;
+- existing `BridgeIdStorage` is likewise consumed only by
+  `BridgeIdRepository`, which is injected into bridge registration, migration,
+  and logout collaborators;
 - removes `loadTokens`/`saveTokens`/`clearTokens`/legacy-reader callbacks from
   touched constructors and tests. Tests fake/implement the concrete Dart class
-  directly rather than introducing a one-to-one interface.
-- `LogoutCommand` performs local migration/token/id reads during composition,
-  creates a command-owned nullable `BridgeRegistrationService` only when usable
-  credentials/registration exist, and injects that collaborator directly into
-  `BridgeLogoutRunner`. The runner calls `unregister()` best-effort before
-  clearing storage; no `unregisterBridge` callback remains. Command-owned token/
-  registration services and HTTP client are disposed in `finally`.
+  repository directly rather than introducing a one-to-one interface.
+- `LogoutCommand` constructs `TokenStorage -> TokenRepository` and
+  `BridgeIdStorage -> BridgeIdRepository`, then performs one typed
+  `TokenRepository.read()` solely to select the constructible dependency graph:
+  `TokenReadAvailable` supplies `TokenService.initialToken` and permits a
+  command-owned `BridgeRegistrationService`; missing/corrupt/failure leaves that
+  injected dependency null because no safe token authority exists. Missing is
+  silent; corrupt/failure emits the existing one best-effort unregister warning
+  without exposing token contents. The command does not read storage APIs,
+  interpret JSON, migrate ids, unregister, or clear tokens itself.
+- `LogoutCommand` always constructs `BridgeIdMigrationService` from
+  `TokenRepository` + `BridgeIdRepository` and injects it, the repository, and
+  nullable registration service into `BridgeLogoutRunner`. After any running-
+  bridge decision accepts logout, the runner invokes migration and then
+  `registrationService?.unregister()` inside one observable best-effort block;
+  it then clears tokens through `TokenRepository` and maps a typed clear failure
+  to the existing failed result. No unregister or persistence callback remains.
+- `LogoutCommand` owns lifecycle only: in `finally` it disposes nullable
+  `BridgeRegistrationService`, nullable `TokenService`, `TerminalPromptApi`, and
+  then the command-owned HTTP client. `BridgeLogoutRunner` owns none of those
+  collaborator lifecycles.
 
 ### Terminal ownership
 
-- `TerminalPromptApi` accepts only `Stdin`/`Stdout`, exposes their raw terminal
-  facts, capabilities, width, and I/O, and has no environment or legacy-relaunch
-  branch.
-- `BridgeStartupOrchestrator` resolves `TerminalInteractionMode.legacyPostUpdate` from
-  the existing environment marker; otherwise it resolves `interactive` only
-  when both raw terminal handles are attached, else `unavailable`. It injects
-  that mode into `TerminalPromptRepository` and uses the same local mode to gate
-  onboarding.
-- `LogoutCommand` independently resolves `interactive`/`unavailable` from raw
-  terminal handles, injects it, and disposes `TerminalPromptApi` in `finally`.
+- `TerminalPromptApi` accepts `Stdin`/`Stdout` plus invocation environment,
+  exposes only raw terminal attachment/capability/width/environment facts and
+  I/O, and contains no mode/rendering decision.
+- `TerminalPromptRepository` maps the legacy relaunch marker to
+  `legacyPostUpdate`, both attached handles to `interactive`, all other cases to
+  `unavailable`, and separately maps ANSI/Unicode/polarity/safe nullable width
+  into `TerminalRenderingCapabilities`.
+- `BridgeRuntimeRunner` and logout ask the repository for those typed values;
+  neither reads/maps raw API facts. Logout disposes `TerminalPromptApi` in
+  `finally`.
 - `TerminalPromptApi` does not subscribe to stdin in its constructor. The first
   standalone prompt/read starts one lazy process-lifetime decoded-line
   subscription. Every completed line enters an internal FIFO pending-line
@@ -668,9 +763,19 @@ stdout handle, or lifecycle.
 
 ### Onboarding service state machine
 
-1. Subscribe to typed terminal outcomes before the immediate request so skip is
-   available during initial network failure. Create one
-   `AuthRequestCancellationController`; pass its signal to every token/status operation.
+This repeated server-held long poll is an explicit user-approved exception to
+the push-based default, alongside the existing authentication request/response
+flow. Keep the exception local to `AppClientOnboardingService` and
+`AppClientPresenceRepository`: each request remains server-held and wakes from
+durable registration; normal false expiry immediately opens the next request
+without a client timer. Do not extract a generic polling service or move retry,
+terminal, or output policy into the repository.
+
+1. Create one `AuthRequestCancellationController`; pass its signal to every
+   token/status operation. Do not arm or consume onboarding input during the
+   initial silent request: no onboarding/retry guidance exists yet, and every
+   typed line must remain queued for a later real prompt if registration is
+   already current.
 2. Immediate check:
    - service obtains
      `TokenRefresher.getAccessToken(forceRefresh: false, cancelled: controller.signal)` and passes the
@@ -683,10 +788,12 @@ stdout handle, or lifecycle.
      retries once immediately;
    - unauthorized after that retry -> warn once and fail open;
    - registered -> finish silently;
-   - absent -> print full onboarding once and enter long poll;
+   - absent -> print full onboarding once, arm the onboarding decision reader,
+     and enter long poll;
    - unavailable -> warn once and fail open;
-   - transient -> warn once, race skip with fixed 60-second delay, then repeat
-     immediate check without falsely showing QR;
+   - transient -> print warning plus skip guidance, arm the onboarding decision
+     reader, race skip with fixed 60-second delay, then repeat immediate check
+     without falsely showing QR;
    - skip/EOF -> cancel and continue according to locked output policy.
 3. Long poll:
    - acquire the current token for the attempt; retain the same one-refresh cap
@@ -708,19 +815,17 @@ makes the checkpoint wait even before absence was confirmed.
 
 ```text
 legacy bridge-id migration
--> BridgeStartupOrchestrator composes shared SesoriAuthApi + repositories from its owned http.Client
+-> BridgeRuntimeRunner composes shared SesoriAuthApi + repositories from its owned http.Client
 -> supervised control bootstrap OR standalone auth through migrated repositories
 -> compose one access-token provider/refresher (standalone TokenService or control service)
 -> authenticated-user output
 -> resolve descriptor + quick checkAvailability
--> resolve TerminalInteractionMode at composition from raw handles + legacy marker
+-> read typed TerminalInteractionMode/rendering capabilities from TerminalPromptRepository
 -> if standalone and mode == interactive: onboarding service
 -> startup mutex / single-live-bridge decision / provision / plugin start
 -> reuse same token provider/refresher for registration, relay, runtime
--> create existing session Orchestrator + BridgeRuntime
--> directly inject BridgeRuntime + failure latch + restart service + supervised flag
--> run BridgeRuntimeRunner (no construction)
--> BridgeStartupOrchestrator owns final shutdown/disposal
+-> existing BridgeRuntime.create / session Orchestrator handoff
+-> runner executes runtime and owns final shutdown/disposal
 ```
 
 No network onboarding runs when `options.isSupervised` or terminal is not
@@ -786,7 +891,9 @@ failure handling with the legacy branch.
 ### Persistence/wire compatibility
 
 No bridge database, settings, token-file, shared relay model, CLI/config shape,
-or plugin contract changes. Skip and waiter state is memory-only.
+or plugin contract changes. The additive shared `EmailLoginRequest` and
+`RefreshTokenRequest` classes model already-shipped auth request bodies and do
+not change their wire bytes. Skip and waiter state is memory-only.
 
 `SesoriAuthApi` consolidation is source-internal. Existing email, OAuth,
 profile/validation, refresh, bridge registration/deletion HTTP request shapes,
@@ -798,21 +905,30 @@ compatibility, and every production/test implementation and caller lands in the
 same PR.
 
 The existing `v1.3.0` legacy bridge-id compatibility marker moves immediately
-with `readLegacyBridgeId` from `token.dart` to `TokenStorage`; preserve its
-original date/version/rationale and update only the exact mechanical cleanup to
-name `TokenStorage` plus `BridgeIdMigrationService`. Do not duplicate the marker
-or leave a forwarding top-level reader.
+with `readLegacyBridgeId` JSON mapping from `token.dart` to `TokenRepository`;
+preserve its original date/version/rationale and update only the exact mechanical
+cleanup to name `TokenRepository` and `BridgeIdMigrationService`. Raw access
+still delegates to `TokenStorage`. Do not duplicate the marker or leave a
+forwarding top-level reader.
 
 ## 7. Generated-Code and Dependency Work
 
-1. Add the audited pure-Dart `qr` constraint to `bridge/app/pubspec.yaml`.
-2. Run `dart pub get` from `bridge/`; inspect `bridge/pubspec.lock` for only
+1. Add sealed Freezed `EmailLoginRequest(email, password)` and
+   `RefreshTokenRequest(refreshToken)` under shared auth models with generated
+   `fromJson`/`toJson`, export both from `sesori_shared.dart`, and add exact-map
+   tests.
+2. Run `dart pub get` and
+   `dart run build_runner build --delete-conflicting-outputs` from
+   `shared/sesori_shared`; review only the two models' generated files and any
+   expected lock change.
+3. Add the audited pure-Dart `qr` constraint to `bridge/app/pubspec.yaml`.
+4. Run `dart pub get` from `bridge/`; inspect `bridge/pubspec.lock` for only
    expected dependency resolution.
-3. Define required non-null `AppClientPresenceResponse.registered` in source.
-4. Run `make codegen` from `bridge/`.
-5. Review generated response files; never hand-edit `*.freezed.dart` or
-   `*.g.dart`.
-6. No Drift table, schema version, migration, snapshot, or migration test.
+5. Define required non-null `AppClientPresenceResponse.registered` in source and
+   make `SesoriAuthApi` serialize the shared request DTOs rather than inline maps.
+6. Run `make codegen` from `bridge/`.
+7. Review all generated files; never hand-edit `*.freezed.dart` or `*.g.dart`.
+8. No Drift table, schema version, migration, snapshot, or migration test.
 
 ## 8. Verification
 
@@ -825,6 +941,13 @@ or leave a forwarding top-level reader.
   HTTP function, or token-manager inline HTTP remains.
 - Preserve email login, OAuth init/status/ACK, `/auth/me`, refresh, bridge
   register/delete request/response/status fixtures byte-for-byte.
+- Shared `EmailLoginRequest` and `RefreshTokenRequest` serialize exact legacy
+  key/value maps; consolidated email/refresh operations contain no inline JSON
+  request maps.
+- Because `sesori_shared` is consumed across products, unchanged bridge, mobile,
+  module-core/auth, desktop-core, and desktop-shell dependency graphs all resolve
+  and analyze; relevant package tests pass. No `module_app_ui` package exists at
+  the pinned baseline, so there is no shared-app-UI command to run.
 - Base URL with/without trailing slash; immediate and `wait=true` app-status URI.
 - Bearer header and no token in URI/body/logs.
 - Strict true/false response parsing.
@@ -855,18 +978,24 @@ or leave a forwarding top-level reader.
 
 #### Token contract and implementations
 
-- `TokenStorage` preserves read/write/clear, JSON/provider validation, missing
-  path, permissions, and legacy bridge-id compatibility behavior; auth service,
-  token service, migration, and logout tests inject it directly with no
-  load/save/clear callback getters.
+- `TokenStorage` preserves raw read/write/clear, path, and permissions while
+  `TokenRepository` maps JSON/provider validation, missing/corrupt state, and
+  legacy bridge-id compatibility behavior. Auth service, token service,
+  migration, and logout tests inject the repository with no storage dependency
+  or load/save/clear callback getters.
+- `BridgeIdRepository` is the only `BridgeIdStorage` consumer; registration,
+  migration, revocation, and logout tests prove services never import storage.
 - `AuthRequestCancellationSignal.never` never cancels; controller cancel is synchronous,
-  idempotent, and completes `whenCancelled` once.
+  idempotent, emits one cancellation, and closes once.
+- Successful/error/timeout app-status and refresh requests cancel their
+  request-scoped cancellation subscription and timer; repeated healthy long
+  polls and successful `never` refreshes leave zero retained abort callbacks.
 - Every production `TokenRefresher` caller passes required `forceRefresh` and
   cancellation values; ordinary existing flows pass `false`/`never` and retain
   behavior. Every fake compiles with the signature.
 - `TokenService` refresh success retains storage re-read, persistence,
-  publication, and single-flight behavior over `AuthRepository` and direct
-  `TokenStorage`.
+  publication, and single-flight behavior over `AuthRepository` and
+  `TokenRepository`.
 - A cancellable near-expiry call awaits refresh and can abort it with no detached
   work; an `AuthRequestCancellationSignal.never` near-expiry call preserves shipped
   background-refresh/return-current behavior.
@@ -895,11 +1024,17 @@ or leave a forwarding top-level reader.
   explicit missing/revoked/initially corrupt token-authority failures fail open
   once; post-response corruption repair remains a successful refresh.
 - Initial registered: no onboarding, warning, or success output.
+- Initial registered leaves every pre-typed non-onboarding line queued for the
+  next replacement/auth prompt.
 - Initial absent: instructions/QR-or-fallback/URL output exactly once in order.
 - Exact URL is both QR payload and plain line.
 - Registration after prompt: one success and continuation.
 - `s`, `S`, `skip`, surrounding whitespace accepted; other lines reprint help.
-- Skip during immediate request, long poll, and 60-second delay aborts promptly.
+- Skip during a guided immediate retry, long poll, and 60-second delay aborts
+  promptly; the first silent request consumes no terminal line.
+- Skip input is armed only after confirmed absence or the first transient warning
+  exposes skip guidance; before that point all lines remain queued. Once armed,
+  invalid lines retain the existing onboarding help/retry behavior.
 - Skip during forced token refresh aborts transport and the service waits for
   cancellation settlement before continuing startup.
 - Skip is not persisted; a second service invocation prompts again.
@@ -917,9 +1052,9 @@ or leave a forwarding top-level reader.
 - Lazy single subscription, FIFO pending-line buffering, and deterministic dispose.
 - Sequential async reads preserve ordinary lines typed before the next prompt;
   onboarding cancellation removes its waiter without dropping queued/later lines.
-- Raw API terminal facts contain no product policy; startup orchestrator/repository
-  `TerminalInteractionMode` preserves interactivity and legacy post-update
-  behavior.
+- Raw API terminal/environment facts contain no product policy;
+  `TerminalPromptRepository` maps typed interaction mode and rendering
+  capabilities, preserving interactivity and legacy post-update behavior.
 - Provider choices 1-4, invalid retry, and EOF guidance unchanged.
 - Email/password values and password echo restoration on success/EOF/error.
   A line queued before echo-off is never accepted as the password: it is
@@ -941,7 +1076,7 @@ or leave a forwarding top-level reader.
 - URL-only output remains exact and scan instructions mention same account.
 - Deterministic snapshots contain no terminal-dependent global reads.
 
-#### Startup orchestrator, direct runner injection, and regression
+#### Startup composition and regression
 
 - Standalone interactive runs after plugin availability and before plugin start.
 - Initial registered path is silent.
@@ -950,27 +1085,30 @@ or leave a forwarding top-level reader.
 - Startup mutex/provision/plugin starter are not entered until onboarding settles.
 - One early standalone `TokenService` is reused for onboarding, registration,
   relay/runtime and disposed once.
-- `BridgeStartupOrchestrator` constructs one `SesoriAuthApi` over its shared
-  client, injects all auth repositories/services, and leaves no superseded
-  use-case API constructor.
+- `BridgeRuntimeRunner` constructs one `SesoriAuthApi` over its shared client,
+  injects all auth repositories/services, and leaves no superseded use-case API
+  constructor.
 - `_buildRegistrationService` receives the composed `SesoriAuthApi` instead of
   auth URL/client pass-through parameters and is owned by startup orchestration.
-  Logout constructs one local
-  `http.Client` + `SesoriAuthApi` + `AuthRepository`, injects both registration
-  and token services, and closes only that command-owned client in `finally`.
+- Logout tests cover every typed token-read outcome. Available constructs
+  command-owned `TokenService` + `BridgeRegistrationService`; missing constructs
+  neither; corrupt/failure warns once and constructs neither. Every path injects
+  `BridgeIdMigrationService` and `TokenRepository` into the runner. Accepted
+  logout orders migration -> optional best-effort unregister -> repository clear;
+  cancelled logout performs none. `finally` disposes optional registration,
+  optional token service, terminal API, and command-owned HTTP client exactly
+  once in that order, including exceptions.
 - `BridgeRuntimeAuthService` lives in root services, receives no
   `BridgeCliOptions`, and imports no runtime/server higher-layer type.
-- Existing session `Orchestrator` is created only after plugin start.
-- Delete static `BridgeRuntime.create`; tests prove the existing generative
-  `BridgeRuntime` constructor receives the exact already-built session/
-  repositories used by debug/runtime consumers.
-- `BridgeRuntimeRunner` receives exactly the four direct declared constructor
-  arguments, constructs no lower-layer class, and preserves session/exit/failure
-  behavior.
-- `runBridgeApp` lives only in root startup-orchestrator source; import tests
-  prove runner has no startup-orchestrator import/cycle.
-- `BridgeStartupOrchestrator` retains shutdown/finally ownership around runner
-  execution and cleans partially prepared phases.
+- Existing session `Orchestrator` is created only after plugin start through the
+  existing `BridgeRuntime.create` handoff; that factory gains no onboarding,
+  auth, terminal, or startup policy.
+- `runBridgeApp` remains in runner source and runner preserves process startup,
+  session/exit/failure, desktop-supervised, and future parallel-plugin ownership.
+- No `BridgeStartupOrchestrator` or third composition owner exists. Tests assert
+  the user-approved two-phase boundary: runner before plugin/session handoff,
+  existing `Orchestrator` afterward.
+- Runner retains shutdown/finally ownership and cleans partially prepared phases.
 - Success, skip, and fail-open continue normal plugin/registration startup.
 - Existing provider/email/OAuth, replacement, logout, plugin startup, bridge
   registration, and shutdown tests pass.
@@ -984,6 +1122,12 @@ manual work focuses on real terminal/camera behavior and user-visible flow.
 ### Exact commands
 
 ```text
+# workdir: shared/sesori_shared
+dart pub get
+dart run build_runner build --delete-conflicting-outputs
+dart analyze
+dart test
+
 # workdir: bridge
 dart pub get
 make codegen
@@ -993,6 +1137,29 @@ make test
 # workdir: bridge/app
 dart analyze --fatal-infos
 make build-host
+
+# workdir: client
+dart pub get
+
+# workdir: client/module_auth
+dart analyze
+dart test
+
+# workdir: client/module_core
+dart analyze
+dart test
+
+# workdir: client/app
+dart analyze
+flutter test
+
+# workdir: client/module_desktop_core
+dart analyze
+dart test
+
+# workdir: client/desktop
+dart analyze
+flutter test
 ```
 
 If `dart pub get` or code generation changes unrelated modules, stop and explain
@@ -1044,12 +1211,12 @@ the resolution conflict rather than committing broad generated/lock churn.
   policy; keep API/repository/formatter/service ownership explicit.
 - Broad terminal migration could alter auth behavior; signatures/tests preserve
   visible contracts and remove only undefined mixed input.
-- Runner injection could grow into a service locator; keep exactly the four
-  direct declared arguments and reject wrapper contexts, maps, generic getters,
-  factories, URLs, clients, callbacks, or lower-layer construction parameters.
-- Moving startup composition could duplicate Layer-5 ownership; startup
-  orchestrator owns only pre-plugin composition/handoff/teardown, while the
-  existing `Orchestrator` remains the single live session-control surface.
+- Startup composition could drift away from desktop/parallel-plugin ownership;
+  retain runner as the process composer, existing `Orchestrator` as the live
+  session composer, and add no third composer or policy to `BridgeRuntime.create`.
+- Shared auth DTO generation could create unrelated churn; inspect generated and
+  lock diffs and stop rather than committing changes outside the two request
+  models, barrel, tests, and declared bridge response/dependency output.
 
 ## 10. Acceptance Criteria
 
@@ -1066,23 +1233,26 @@ the resolution conflict rather than committing broad generated/lock churn.
   retain tests and no forwarding use-case API/top-level HTTP remains.
 - `TokenRefresher` cancellation and typed failure contracts cover both production
   implementations, all callers, and all fakes without message parsing.
-- `TokenStorage` is injected directly into `TokenService`, runtime auth,
-  migration, and logout; touched constructors have no token load/save/clear
-  callbacks, and the forbidden `TokenManager` name/file is gone.
-- `BridgeLogoutRunner` receives nullable `BridgeRegistrationService` directly;
-  logout composition/tests contain no unregister callback forwarding boundary.
+- `TokenRepository` is injected into `TokenService`, runtime auth, migration,
+  and logout; only it accesses `TokenStorage`. `BridgeIdRepository` is the sole
+  `BridgeIdStorage` consumer. Touched constructors have no persistence callbacks,
+  and the forbidden `TokenManager` name/file is gone.
+- `BridgeLogoutRunner` receives `BridgeIdMigrationService`, `TokenRepository`,
+  and nullable `BridgeRegistrationService` directly; typed composition-time token
+  selection, migration -> optional unregister -> clear ordering, and command-
+  owned disposal are exhaustive in tests with no callback forwarding boundary.
 - Terminal API/repository/Foundation files live at root layer paths, and the root
   onboarding service has no dependency on `server/`.
 - Root `BridgeRuntimeAuthService` has no runtime-options dependency;
-  `BridgeStartupOrchestrator` is the sole startup composer and runner consumes
-  only the four direct already-built collaborators with no lower-layer
-  construction.
+  `BridgeRuntimeRunner` remains the user-approved process-startup composer and
+  existing `Orchestrator` the post-start composer, with no third owner.
 - Existing prompts and supervised secret remain correct under one async stdin
   owner.
 - No plugin/startup lock is held while waiting; no lifecycle resource leaks.
 - Generated/lock output is tool-produced and scoped; all commands pass.
-- No analytics, config, persistence, browser, shared, plugin, relay, mobile, or
-  desktop changes are included.
+- Shared email-login/refresh DTOs are additive and exact-body compatible; no
+  analytics, config, persisted schema, browser, plugin, relay, mobile, or desktop
+  behavior changes are included.
 
 ## 11. Definition of Done
 
@@ -1093,5 +1263,7 @@ the resolution conflict rather than committing broad generated/lock churn.
 - Only intended monorepo files are committed; branch is pushed and PR targets
   `main`.
 - `TRACKER.md` records S01/W02 baseline, branch, PR URL, checked state, and any
-  findings. The advisory manual row remains independently checkable.
+  findings while retaining imported W01 state. Its merge returns authoritative
+  tracker state to `main`; the tracking branch becomes cleanup-only. The
+  advisory manual row remains independently checkable.
 - Auth endpoint is deployed before the bridge release is initiated.

--- a/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w02-p01-interactive-app-onboarding.md
+++ b/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w02-p01-interactive-app-onboarding.md
@@ -569,9 +569,13 @@ stdout handle, or lifecycle.
   existing background-refresh TTL band is refreshed synchronously instead of
   spawning detached work; `AuthRequestCancellationSignal.never` preserves current
   background behavior for existing callers;
-- `TokenService`, as token-state owner, maps missing/empty/cleared/corrupt local
-  token state and unsafe persistence failure to typed unavailable without moving
-  file decisions into `AuthRepository`;
+- `TokenService`, as token-state owner, maps initial missing/empty/corrupt state,
+  a file cleared during refresh, and unsafe persistence failure to typed
+  unavailable without moving file decisions into `AuthRepository`. Preserve the
+  shipped post-response recovery seam: if only the post-refresh re-read throws
+  `FormatException`, retain `lastProvider` from the valid pre-refresh snapshot
+  and persist the newly issued access/refresh tokens to repair the file. Missing/
+  cleared post-refresh state still prevents resurrection;
 - onboarding's freshly constructed token service has no other consumers before the
   checkpoint. Its cancellable refresh therefore exclusively owns the active
   request; skip cancels it and service completion waits for the abort to settle
@@ -621,8 +625,8 @@ stdout handle, or lifecycle.
 - `TerminalPromptApi` does not subscribe to stdin in its constructor. The first
   standalone prompt/read starts one lazy process-lifetime decoded-line
   subscription. Every completed line enters an internal FIFO pending-line
-  buffer even when no prompt is awaiting, preserving OS-stdin type-ahead and
-  pasted multi-line credentials across sequential prompts.
+  buffer even when no prompt is awaiting, preserving ordinary OS-stdin
+  type-ahead across sequential non-secret prompts.
 - Sequential prompt methods consume one oldest pending line or await one queued
   arrival from that owner. The onboarding decision read is cancellable; when
   cancellation wins it removes only its own pending waiter and leaves every
@@ -630,8 +634,13 @@ stdout handle, or lifecycle.
 - Only one prompt is active by startup sequencing; add guards/tests against
   overlapping consumers. The FIFO is input preservation, not a scheduler for
   competing prompts.
-- Password reads set echo off immediately before awaiting and restore the prior
-  value in `finally` on value, EOF, error, or disposal.
+- Password input is the explicit security exception to FIFO type-ahead. Before a
+  line can be accepted as a password, the API atomically disables echo and
+  discards every line queued before that switch. The repository reports that
+  pre-prompt input was discarded and requests a fresh password while echo stays
+  off; only a line received after the switch is accepted. Restore the prior echo
+  value in `finally` on value, EOF, error, or disposal. Do not claim support for
+  pasted email+password batches without a future safe raw/bracketed-paste design.
 - EOF closes the line source and maps to existing clear provider/credential
   failures or onboarding fail-open.
 - `dispose` cancels the underlying subscription/controller exactly once and is
@@ -862,8 +871,10 @@ or leave a forwarding top-level reader.
   work; an `AuthRequestCancellationSignal.never` near-expiry call preserves shipped
   background-refresh/return-current behavior.
 - Token refresh HTTP 408/429/5xx, socket/client/deadline map to typed transient;
-  local missing/corrupt/revoked/4xx/malformed map unavailable; caller abort maps
-  cancelled, all without parsing messages.
+  initial local missing/corrupt/revoked/4xx/malformed and post-response cleared
+  state map unavailable; caller abort maps cancelled, all without parsing
+  messages. A post-response `FormatException` alone repairs from the valid
+  pre-refresh `lastProvider` plus new response tokens.
 - Cancellation before/during refresh prevents or actively aborts transport,
   leaves no active refresh future/request, does not persist/publish a token, and
   allows a later uncancelled refresh.
@@ -881,7 +892,8 @@ or leave a forwarding top-level reader.
   refresh and immediate repository retry, second unauthorized warns/fails open,
   and a later normal long-poll round starts with a fresh one-refresh allowance.
 - Token-refresher network/timeout errors use the fixed transient timer;
-  explicit missing/revoked/corrupt token-authority failures fail open once.
+  explicit missing/revoked/initially corrupt token-authority failures fail open
+  once; post-response corruption repair remains a successful refresh.
 - Initial registered: no onboarding, warning, or success output.
 - Initial absent: instructions/QR-or-fallback/URL output exactly once in order.
 - Exact URL is both QR payload and plain line.
@@ -903,13 +915,16 @@ or leave a forwarding top-level reader.
 #### Terminal and existing auth prompts
 
 - Lazy single subscription, FIFO pending-line buffering, and deterministic dispose.
-- Sequential async reads preserve lines typed/pasted before the next prompt;
+- Sequential async reads preserve ordinary lines typed before the next prompt;
   onboarding cancellation removes its waiter without dropping queued/later lines.
 - Raw API terminal facts contain no product policy; startup orchestrator/repository
   `TerminalInteractionMode` preserves interactivity and legacy post-update
   behavior.
 - Provider choices 1-4, invalid retry, and EOF guidance unchanged.
 - Email/password values and password echo restoration on success/EOF/error.
+  A line queued before echo-off is never accepted as the password: it is
+  discarded, a clear re-entry message is emitted while echo remains off, and a
+  fresh post-switch line is required.
 - Replacement yes/yes alias/default decline/noninteractive unchanged.
 - Logout prompt/result behavior unchanged.
 - Supervised `ControlSecretApi` still reads the first off-argv line without a
@@ -989,6 +1004,9 @@ the resolution conflict rather than committing broad generated/lock churn.
   registration still use the same refreshed token.
 - Exercise replacement and logout after onboarding has completed to prove later
   prompts receive lines and password/terminal modes are normal.
+- Type/paste a second credential line before the password no-echo phase and
+  confirm it is discarded rather than accepted; enter a fresh password after
+  the re-entry message and confirm echo is restored afterward.
 - Start supervised bridge with control secret to prove no terminal subscription
   steals the secret and no onboarding request occurs.
 - Start noninteractive/legacy post-update to prove no hang/output/request.
@@ -1003,6 +1021,9 @@ the resolution conflict rather than committing broad generated/lock churn.
   subscriptions and active abort, then assert no late effects.
 - Starting the stdin subscription in the constructor could steal supervised secret;
   require lazy first-prompt subscription and mode tests.
+- FIFO type-ahead could accept a password that arrived while echo was enabled;
+  atomically disable echo and discard all pre-switch queued lines before
+  accepting secret input, then regression-test re-entry and restoration.
 - Moving/renaming the legacy token owner could create duplicate refresh
   authorities; compose one `TokenService` instance early and reuse current later
   variables.


### PR DESCRIPTION
## Summary
- define the two-repository bridge app-onboarding implementation plan
- add the auth-server presence endpoint prerequisite and standalone bridge onboarding stage
- lock retry, cancellation, compatibility, terminal ownership, and verification behavior

## Plan review
- approved by `aristotle-plan-review` with no architectural violations

## Verification
- `git diff --check main...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines the bridge app onboarding plan across `sesori-ai/sesori_auth_server` and `sesori-ai/sesori_apps_monorepo`, adding a race‑safe presence endpoint (30‑s wait; wakes on durable token registration) and an interactive flow (QR/URL) with hardened token/secret input, 1‑min retry, skip, backward compatibility, safe terminal use, a manual QR check, and a tracker (S01/W01 pointer + next action). Also codifies user final authority across agent docs via scoped waivers that can override named rules while keeping unwaived rules enforced; review finalized by `aristotle-plan-review` under a user waiver.

<sup>Written for commit 9063dcc63d98aee0a3ef37040000dcaae0a6220a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

