### PR TITLE
fix(client): support bridges without plugin discovery

### DIFF
--- a/client/module_core/lib/src/repositories/plugin_repository.dart
+++ b/client/module_core/lib/src/repositories/plugin_repository.dart
@@ -10,5 +10,24 @@ class PluginRepository {
 
   PluginRepository({required PluginApi api}) : _api = api;
 
-  Future<ApiResponse<PluginListResponse>> listPlugins() => _api.listPlugins();
+  Future<ApiResponse<PluginListResponse>> listPlugins() async {
+    final response = await _api.listPlugins();
+    if (response case ErrorResponse(error: NonSuccessCodeError(errorCode: 404))) {
+      // COMPATIBILITY 2026-07-18 (v1.6.0): Bridges without plugin discovery return 404 and can only target OpenCode. Remove this fallback once those bridges are unsupported.
+      return ApiResponse.success(
+        const PluginListResponse(
+          plugins: [
+            PluginMetadata(
+              id: legacyMissingPluginId,
+              displayName: "OpenCode",
+              isDefault: true,
+              state: PluginLifecycleState.ready,
+              actionHint: null,
+            ),
+          ],
+        ),
+      );
+    }
+    return response;
+  }
 }

--- a/client/module_core/test/repositories/plugin_repository_test.dart
+++ b/client/module_core/test/repositories/plugin_repository_test.dart
@@ -40,8 +40,31 @@ void main() {
     expect(await repository.listPlugins(), ApiResponse<PluginListResponse>.success(response));
   });
 
-  test("surfaces API errors", () async {
-    final error = ApiError.generic();
+  test("maps an unsupported discovery route to the legacy OpenCode plugin", () async {
+    when(api.listPlugins).thenAnswer(
+      (_) async => ApiResponse.error(ApiError.nonSuccessCode(errorCode: 404, rawErrorString: null)),
+    );
+
+    expect(
+      await repository.listPlugins(),
+      ApiResponse<PluginListResponse>.success(
+        const PluginListResponse(
+          plugins: [
+            PluginMetadata(
+              id: legacyMissingPluginId,
+              displayName: "OpenCode",
+              isDefault: true,
+              state: PluginLifecycleState.ready,
+              actionHint: null,
+            ),
+          ],
+        ),
+      ),
+    );
+  });
+
+  test("surfaces errors other than an unsupported discovery route", () async {
+    final error = ApiError.nonSuccessCode(errorCode: 503, rawErrorString: null);
     when(api.listPlugins).thenAnswer((_) async => ApiResponse.error(error));
 
     expect(await repository.listPlugins(), ApiResponse<PluginListResponse>.error(error));


### PR DESCRIPTION
## Summary
- treat a `404` from `GET /plugin` as a pre-plugin bridge and expose its historical OpenCode target as the default routable plugin
- keep authentication, network, malformed-response, and other server failures explicit
- add regression coverage for both the legacy fallback and non-404 errors

## Compatibility
This restores newer client -> older bridge New Session support without changing the wire contract. Older clients paired with newer bridges are unaffected.

Follow-up to the valid backward-compatibility finding on #493. The stale command and variant findings are already guarded and tested on `main`; the live lifecycle finding would require a new reactive wire event, while failed plugins are terminal until bridge restart and degraded plugins remain routable.

## Verification
- `dart test test/repositories/plugin_repository_test.dart`
- `dart analyze --fatal-infos`
- `dart format --output=none --set-exit-if-changed lib/src/repositories/plugin_repository.dart test/repositories/plugin_repository_test.dart`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores compatibility with older bridges that lack plugin discovery by treating a 404 from GET /plugin as a legacy bridge and returning a default, ready `OpenCode` plugin. Other errors are unchanged and still surface to the caller.

- **Bug Fixes**
  - Map 404 from `GET /plugin` to a synthetic `PluginListResponse` with `OpenCode` as the default plugin.
  - Surface non-404 errors (auth, network, malformed responses) without alteration.
  - Add tests for the 404 fallback and for non-404 error pass-through.

<sup>Written for commit d088116e45c501fbb49f779a65e686dee611c557. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

