### PR TITLE
docs(readme): hyperlink and reorder assistant table; remove Windsurf

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,9 @@ Your laptop and phone perform an ephemeral X25519 key exchange, then encrypt eve
 | Assistant | Status | Notes |
 |---|---|---|
 | [OpenCode](https://opencode.ai) | Available | Deep native integration. |
-| Claude Code | Coming soon | Plugin architecture already supports multi-assistant backends. |
-| OpenAI Codex CLI | Beta | Enabled by default in an upcoming release. |
-| Cursor | Beta | ACP-based Cursor plugin; enabled by default in an upcoming release. |
-| Windsurf | Coming soon | Planned. |
+| [OpenAI Codex CLI](https://github.com/openai/codex) | Beta | Enabled by default in an upcoming release. |
+| [Cursor](https://cursor.com) | Beta | ACP-based Cursor plugin; enabled by default in an upcoming release. |
+| [Claude Code](https://claude.com) | Coming soon | Plugin architecture already supports multi-assistant backends. |
 
 ---
 


### PR DESCRIPTION
Small README follow-up after the README overhaul.

## What changed

- Removed Windsurf from the supported AI assistants table.
- Reordered the table so the beta assistants (OpenAI Codex CLI, Cursor) appear before the planned assistant (Claude Code).
- Added hyperlinks to every beta and planned assistant entry.

No production code or generated files were changed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the README assistant table to improve clarity: removed Windsurf, reordered entries to list beta assistants before planned, and added hyperlinks for each assistant. Docs-only change; no code affected.

<sup>Written for commit 3d67e71745d7e6ac1d22ca6a000fd55f6aac61dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

