### PR TITLE
feat(bridge): add bounded app onboarding

### DIFF
--- a/.plan/active/bridge-app-onboarding/PLAN.md
+++ b/.plan/active/bridge-app-onboarding/PLAN.md
@@ -9,7 +9,8 @@
   and its endpoint is deployed (user-confirmed 2026-07-18).
 - **Current state:** W01 merged and deployed; the reduced W02 implementation is
   complete and verified locally, and architecture implementation review approved
-  it. No implementation PR has been opened.
+  it. Implementation PR #504 is open and monitored; advisory checkpoint M01 is
+  still pending.
 
 ## Goal
 

--- a/.plan/active/bridge-app-onboarding/PLAN.md
+++ b/.plan/active/bridge-app-onboarding/PLAN.md
@@ -4,11 +4,12 @@
 
 - **Plan slug:** `bridge-app-onboarding`
 - **Implementation base:** monorepo `main`
-- **Pinned W02 base:** `4a156a78b3bf8572c280ce859b3b1370300a8105`
+- **Pinned W02 base:** `120a6f41329e64a4908907b6a318bb1f31bd805d`
 - **Auth dependency:** Satisfied — `sesori-ai/sesori_auth_server` PR #44 merged
   and its endpoint is deployed (user-confirmed 2026-07-18).
-- **Current state:** W01 merged and deployed; W02 redesigned after the user
-  rejected an over-broad first implementation.
+- **Current state:** W01 merged and deployed; the reduced W02 implementation is
+  complete and verified locally, and architecture implementation review approved
+  it. No implementation PR has been opened.
 
 ## Goal
 
@@ -31,8 +32,9 @@ checks again.
 ## Locked Behavior
 
 1. Run only for standalone interactive startup.
-2. Run after authentication and the selected plugin's quick availability check,
-   but before provisioning, startup mutex acquisition, or plugin startup.
+2. Run after authentication and the enabled plugins' concurrent availability
+   checks leave at least one plugin available, but before provisioning, startup
+   mutex acquisition, or plugin startup.
 3. Parse the account id with existing `parseJwtUserId` and normalize the
    configured auth base without changing profile, login, validation, refresh,
    `TokenManager`, or token persistence.

--- a/.plan/active/bridge-app-onboarding/TRACKER.md
+++ b/.plan/active/bridge-app-onboarding/TRACKER.md
@@ -2,7 +2,7 @@
 
 ## Plan State
 
-- **Status:** Reduced W02 implementation complete and verified locally; implementation PR not opened
+- **Status:** Reduced W02 implementation PR #504 open and monitored
 - **Implementation base:** `main`
 - **Plan slug:** `bridge-app-onboarding`
 - **Plan PRs:** original https://github.com/sesori-ai/sesori_apps_monorepo/pull/490; reduced-plan correction https://github.com/sesori-ai/sesori_apps_monorepo/pull/494
@@ -12,7 +12,7 @@
 
 - **Stage:** S01 — App Registration Checkpoint
 - **Wave:** W02
-- **Next action:** Open the S01-W02-P01 implementation PR when explicitly requested, then run the advisory M01 checkpoint.
+- **Next action:** Monitor PR #504 and address CI/review findings; then run the advisory M01 checkpoint.
 
 ## Plan Review
 
@@ -36,7 +36,7 @@ pair after drift assessment and before branch creation.
 | Done | ID | Stage | Wave | PR | Branch | Notes |
 |---|---|---|---|---|---|---|
 | [x] | S01-W01-P01 | S01 | W01 | https://github.com/sesori-ai/sesori_auth_server/pull/44 | `plan/bridge-app-onboarding/s01-w01-p01-app-client-presence-endpoint` | Merged and deployed. Delivers the auth-server immediate/long-poll current app-registration endpoint and durable post-upsert wake. Format, lint, build, 422 tests (1 skipped), circular-dependency check, and implementation review passed. |
-| [ ] | S01-W02-P01 | S01 | W02 | — | `bridge-onboarding-plan-c317b6` | Implementation, focused/full verification, host build, and architecture review complete locally. PR remains unchecked until opened/merged. |
+| [ ] | S01-W02-P01 | S01 | W02 | https://github.com/sesori-ai/sesori_apps_monorepo/pull/504 | `bridge-onboarding-plan-c317b6` | Implementation, focused/full verification, host build, and architecture review complete. PR is open and monitored; row remains unchecked until merge. |
 
 ## Manual Checkpoints
 
@@ -77,7 +77,8 @@ pair after drift assessment and before branch creation.
   workspace `make analyze`, workspace `make test`, and `make build-host` passed.
 - **2026-07-18 — W02 implementation review approved:**
   `aristotle-impl-review` approved the uncommitted implementation scope with no
-  architecture findings. No implementation PR was opened.
+  architecture findings. Implementation PR #504 was opened and monitoring
+  started immediately.
 
 - **2026-07-17 — W02 implementation discarded for excessive scope:** The first
   W02 implementation followed an over-broad plan that combined onboarding with

--- a/.plan/active/bridge-app-onboarding/TRACKER.md
+++ b/.plan/active/bridge-app-onboarding/TRACKER.md
@@ -2,7 +2,7 @@
 
 ## Plan State
 
-- **Status:** Reduced W02 plan PR open; production implementation not started
+- **Status:** Reduced W02 implementation complete and verified locally; implementation PR not opened
 - **Implementation base:** `main`
 - **Plan slug:** `bridge-app-onboarding`
 - **Plan PRs:** original https://github.com/sesori-ai/sesori_apps_monorepo/pull/490; reduced-plan correction https://github.com/sesori-ai/sesori_apps_monorepo/pull/494
@@ -12,7 +12,7 @@
 
 - **Stage:** S01 — App Registration Checkpoint
 - **Wave:** W02
-- **Next action:** Monitor reduced-plan PR #494; await user confirmation before production implementation.
+- **Next action:** Open the S01-W02-P01 implementation PR when explicitly requested, then run the advisory M01 checkpoint.
 
 ## Plan Review
 
@@ -26,7 +26,7 @@
 | Stage | Wave | Repository | Base | Pinned SHA | Drift Decision |
 |---|---|---|---|---|---|
 | S01 | W01 | `sesori-ai/sesori_auth_server` | `master` | `b17a6e760b0c70c3dc3d1cd456ff93d814c75453` | Historical W01 implementation baseline. PR #44 later merged to `master` at `8f7dd3b9d56d1797da4480c8806f0ac6033b9555` and was deployed. |
-| S01 | W02 | `sesori-ai/sesori_apps_monorepo` | `main` | `4a156a78b3bf8572c280ce859b3b1370300a8105` | Selected W02 implementation baseline; future implementation reassesses drift before coding. |
+| S01 | W02 | `sesori-ai/sesori_apps_monorepo` | `main` | `120a6f41329e64a4908907b6a318bb1f31bd805d` | Reassessed before implementation. Parallel-plugin work changed runner composition but not onboarding contracts or intent; W02 now gates after concurrent availability checks leave at least one plugin available. |
 
 Workers add one authoritative row for each started stage/wave/repository/base
 pair after drift assessment and before branch creation.
@@ -36,7 +36,7 @@ pair after drift assessment and before branch creation.
 | Done | ID | Stage | Wave | PR | Branch | Notes |
 |---|---|---|---|---|---|---|
 | [x] | S01-W01-P01 | S01 | W01 | https://github.com/sesori-ai/sesori_auth_server/pull/44 | `plan/bridge-app-onboarding/s01-w01-p01-app-client-presence-endpoint` | Merged and deployed. Delivers the auth-server immediate/long-poll current app-registration endpoint and durable post-upsert wake. Format, lint, build, 422 tests (1 skipped), circular-dependency check, and implementation review passed. |
-| [ ] | S01-W02-P01 | S01 | W02 | — | existing `bridge-onboarding-plan` worktree branch | Add a bounded one-time-per-backend/account checkpoint with no auth/token/terminal refactor. |
+| [ ] | S01-W02-P01 | S01 | W02 | — | `bridge-onboarding-plan-c317b6` | Implementation, focused/full verification, host build, and architecture review complete locally. PR remains unchecked until opened/merged. |
 
 ## Manual Checkpoints
 
@@ -49,9 +49,8 @@ pair after drift assessment and before branch creation.
 - No implementation blocker is known.
 - The auth-server prerequisite is complete: PR #44 merged and the endpoint was
   deployed (user-confirmed 2026-07-18).
-- The pinned monorepo W02 implementation baseline remains
-  `4a156a78b3bf8572c280ce859b3b1370300a8105`
-  (2026-07-17T18:02:33+03:00). The latest audited auth-server `master` tip is
+- The pinned monorepo W02 implementation baseline is
+  `120a6f41329e64a4908907b6a318bb1f31bd805d`. The latest audited auth-server `master` tip is
   PR #44's merge commit `8f7dd3b9d56d1797da4480c8806f0ac6033b9555`
   (2026-07-18T13:30:06Z), whose endpoint is deployed. Each future worker
   assesses and pins current drift.
@@ -60,6 +59,25 @@ pair after drift assessment and before branch creation.
   plan's touched paths, contracts, architecture, or product intent.
 
 ## Findings and Plan Deltas
+
+- **2026-07-18 — W02 baseline reassessed:** Current `main` at `120a6f413` includes
+  the parallel-plugin runtime merged after the original pinned baseline. The
+  touched runner and CLI composition changed, but the approved API, persistence,
+  logout, and bounded-checkpoint contracts remain valid. The singular
+  plugin-availability gate is now the current equivalent: run only after the
+  concurrent enabled-plugin checks leave at least one plugin available.
+- **2026-07-18 — Reduced W02 implemented:** Added the provider-level app-client
+  status operation with active per-request deadlines, opaque pair-marker storage,
+  status/state repositories, bounded ANSI+Unicode QR formatting, the standalone
+  interactive startup checkpoint, and accepted-logout marker clearing. Existing
+  auth, token, prompt, plugin, relay, client, and shared contracts were not
+  refactored.
+- **2026-07-18 — W02 verification complete:** `dart pub get`, bridge codegen,
+  41 focused onboarding/logout/runner tests, app `dart analyze --fatal-infos`,
+  workspace `make analyze`, workspace `make test`, and `make build-host` passed.
+- **2026-07-18 — W02 implementation review approved:**
+  `aristotle-impl-review` approved the uncommitted implementation scope with no
+  architecture findings. No implementation PR was opened.
 
 - **2026-07-17 — W02 implementation discarded for excessive scope:** The first
   W02 implementation followed an over-broad plan that combined onboarding with
@@ -71,9 +89,10 @@ pair after drift assessment and before branch creation.
 - **2026-07-17 — User-authorized wave overlap:** The user explicitly directed
   S01-W02-P01 to begin before S01-W01-P01 merges because the implementations are
   in separate repositories. This overrides only the implementation-start merge
-  barrier; auth-server merge/deploy still precedes bridge release. Current
-  monorepo `main` at `4a156a78b3bf8572c280ce859b3b1370300a8105`
-  remains the pinned W02 baseline.
+  barrier; auth-server merge/deploy still precedes bridge release. Monorepo
+  `main` at `4a156a78b3bf8572c280ce859b3b1370300a8105` was the preliminary
+  implementation baseline at that time; the reassessed implementation baseline
+  is recorded above.
 - **2026-07-17 — Reduced behavior selected:** The user selected one immediate
   check plus at most one 30-second server-held wait. The reduced design has no
   skip input, retry loop, token refresh, or asynchronous terminal ownership.

--- a/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/GOAL.md
+++ b/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/GOAL.md
@@ -32,8 +32,8 @@ until logout clears all markers.
 - Accepted CLI logout clears all markers before tokens; state-clear failure keeps
   tokens and reports failure. Cancelled logout preserves both.
 - All bridge-side failures warn once and fail open.
-- Supervised, noninteractive, and plugin-unavailable starts do not run the
-  checkpoint.
+- Supervised, noninteractive, and all-enabled-plugins-unavailable starts do not
+  run the checkpoint.
 
 ## Scope Boundary
 

--- a/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w02-p01-interactive-app-onboarding.md
+++ b/.plan/active/bridge-app-onboarding/stages/01-app-registration-checkpoint/w02-p01-interactive-app-onboarding.md
@@ -4,8 +4,8 @@
 
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Base:** `main`
-- **Pinned SHA:** `4a156a78b3bf8572c280ce859b3b1370300a8105`
-- **Branch:** existing `bridge-onboarding-plan` worktree branch
+- **Pinned SHA:** `120a6f41329e64a4908907b6a318bb1f31bd805d`
+- **Branch:** `bridge-onboarding-plan-c317b6`
 - **Dependency:** Satisfied — auth-server PR #44 merged and is deployed
 
 ## Goal
@@ -45,8 +45,9 @@ showing a bounded terminal QR and exact URL.
    immediate request, optionally prints guidance and runs one long poll, and
    fails open on every failure. It has no retry, skip, stdin, or token refresh.
 8. In `BridgeRuntimeRunner`, compose and invoke the service only when standalone
-   and `TerminalPromptApi.isInteractive`, after plugin availability and before
-   plugin startup/mutex/provisioning. Pass the already authenticated token.
+   and `TerminalPromptApi.isInteractive`, after concurrent availability checks
+   leave at least one enabled plugin available and before plugin startup/mutex/
+   provisioning. Pass the already authenticated token.
 9. Inject `AppOnboardingStateRepository` into `BridgeLogoutRunner`. After logout
    is accepted, clear all onboarding markers and then tokens. If state deletion
    fails, return the existing failed result and leave tokens intact. Cancelled
@@ -78,7 +79,8 @@ showing a bounded terminal QR and exact URL.
   response still attempts the marker write.
 - Remote or marker-write failure: one warning for that failed operation, no new
   marker from that operation, and startup continues.
-- Supervised/noninteractive/plugin-unavailable paths never call the endpoint.
+- Supervised/noninteractive/all-enabled-plugins-unavailable paths never call the
+  endpoint.
 - Accepted logout clears all markers before tokens; state-clear failure is
   observable and leaves tokens intact; cancelled logout preserves both.
 - Strict analyzer, focused tests, host build, and architecture implementation

--- a/bridge/app/bin/bridge.dart
+++ b/bridge/app/bin/bridge.dart
@@ -5,6 +5,7 @@ import 'package:args/args.dart' show ArgParserException;
 import 'package:args/command_runner.dart' as cli;
 import 'package:clock/clock.dart';
 import 'package:http/http.dart' as http;
+import 'package:sesori_bridge/src/api/app_onboarding_state_storage.dart';
 import 'package:sesori_bridge/src/api/bridge_settings_api.dart';
 import 'package:sesori_bridge/src/api/default_editor_api.dart';
 import 'package:sesori_bridge/src/api/wake_lock_client.dart';
@@ -24,6 +25,7 @@ import 'package:sesori_bridge/src/bridge/runtime/bridge_logout_runner.dart';
 import 'package:sesori_bridge/src/bridge/runtime/bridge_runtime_runner.dart';
 import 'package:sesori_bridge/src/bridge/runtime/plugin_cli_options_mapper.dart';
 import 'package:sesori_bridge/src/bridge/runtime/plugin_registry.dart';
+import 'package:sesori_bridge/src/repositories/app_onboarding_state_repository.dart';
 import 'package:sesori_bridge/src/repositories/bridge_settings_repository.dart';
 import 'package:sesori_bridge/src/repositories/default_editor_repository.dart';
 import 'package:sesori_bridge/src/repositories/wake_lock_repository.dart';
@@ -285,6 +287,9 @@ class LogoutCommand extends cli.Command<void> {
       ),
       terminalPromptRepository: terminalPromptRepository,
       unregisterBridge: () => _unregisterBridgeRegistration(authBackendUrl: authBackendUrl),
+      appOnboardingStateRepository: AppOnboardingStateRepository(
+        storage: AppOnboardingStateStorage(directoryPath: appOnboardingStateDirectoryPath()),
+      ),
     );
 
     final result = await logoutRunner.logout(currentPid: pid);
@@ -301,7 +306,7 @@ class LogoutCommand extends cli.Command<void> {
         Console.message('Logout cancelled; stored tokens were not cleared.');
         exitCode = 1;
       case BridgeLogoutStatus.failed:
-        Console.error('Error: Failed to clear authentication tokens: ${result.error}');
+        Console.error('Error: Failed to clear authentication state: ${result.error}');
         exitCode = 1;
     }
   }

--- a/bridge/app/lib/src/api/app_client_status_response.dart
+++ b/bridge/app/lib/src/api/app_client_status_response.dart
@@ -1,0 +1,11 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "app_client_status_response.freezed.dart";
+part "app_client_status_response.g.dart";
+
+@Freezed(fromJson: true, toJson: false)
+sealed class AppClientStatusResponse with _$AppClientStatusResponse {
+  const factory AppClientStatusResponse({required bool registered}) = _AppClientStatusResponse;
+
+  factory AppClientStatusResponse.fromJson(Map<String, dynamic> json) => _$AppClientStatusResponseFromJson(json);
+}

--- a/bridge/app/lib/src/api/app_client_status_response.freezed.dart
+++ b/bridge/app/lib/src/api/app_client_status_response.freezed.dart
@@ -1,0 +1,143 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'app_client_status_response.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$AppClientStatusResponse {
+
+ bool get registered;
+/// Create a copy of AppClientStatusResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$AppClientStatusResponseCopyWith<AppClientStatusResponse> get copyWith => _$AppClientStatusResponseCopyWithImpl<AppClientStatusResponse>(this as AppClientStatusResponse, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AppClientStatusResponse&&(identical(other.registered, registered) || other.registered == registered));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,registered);
+
+@override
+String toString() {
+  return 'AppClientStatusResponse(registered: $registered)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $AppClientStatusResponseCopyWith<$Res>  {
+  factory $AppClientStatusResponseCopyWith(AppClientStatusResponse value, $Res Function(AppClientStatusResponse) _then) = _$AppClientStatusResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool registered
+});
+
+
+
+
+}
+/// @nodoc
+class _$AppClientStatusResponseCopyWithImpl<$Res>
+    implements $AppClientStatusResponseCopyWith<$Res> {
+  _$AppClientStatusResponseCopyWithImpl(this._self, this._then);
+
+  final AppClientStatusResponse _self;
+  final $Res Function(AppClientStatusResponse) _then;
+
+/// Create a copy of AppClientStatusResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? registered = null,}) {
+  return _then(_self.copyWith(
+registered: null == registered ? _self.registered : registered // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _AppClientStatusResponse implements AppClientStatusResponse {
+  const _AppClientStatusResponse({required this.registered});
+  factory _AppClientStatusResponse.fromJson(Map<String, dynamic> json) => _$AppClientStatusResponseFromJson(json);
+
+@override final  bool registered;
+
+/// Create a copy of AppClientStatusResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$AppClientStatusResponseCopyWith<_AppClientStatusResponse> get copyWith => __$AppClientStatusResponseCopyWithImpl<_AppClientStatusResponse>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AppClientStatusResponse&&(identical(other.registered, registered) || other.registered == registered));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,registered);
+
+@override
+String toString() {
+  return 'AppClientStatusResponse(registered: $registered)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$AppClientStatusResponseCopyWith<$Res> implements $AppClientStatusResponseCopyWith<$Res> {
+  factory _$AppClientStatusResponseCopyWith(_AppClientStatusResponse value, $Res Function(_AppClientStatusResponse) _then) = __$AppClientStatusResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool registered
+});
+
+
+
+
+}
+/// @nodoc
+class __$AppClientStatusResponseCopyWithImpl<$Res>
+    implements _$AppClientStatusResponseCopyWith<$Res> {
+  __$AppClientStatusResponseCopyWithImpl(this._self, this._then);
+
+  final _AppClientStatusResponse _self;
+  final $Res Function(_AppClientStatusResponse) _then;
+
+/// Create a copy of AppClientStatusResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? registered = null,}) {
+  return _then(_AppClientStatusResponse(
+registered: null == registered ? _self.registered : registered // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/app/lib/src/api/app_client_status_response.g.dart
+++ b/bridge/app/lib/src/api/app_client_status_response.g.dart
@@ -1,0 +1,10 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'app_client_status_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_AppClientStatusResponse _$AppClientStatusResponseFromJson(Map json) =>
+    _AppClientStatusResponse(registered: json['registered'] as bool);

--- a/bridge/app/lib/src/api/app_onboarding_state_storage.dart
+++ b/bridge/app/lib/src/api/app_onboarding_state_storage.dart
@@ -1,0 +1,55 @@
+import "dart:io";
+
+import "package:path/path.dart" as path;
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show sesoriDataDirectory;
+
+String appOnboardingStateDirectoryPath() => path.join(sesoriDataDirectory(), "app_onboarding");
+
+/// Raw file boundary for opaque app-onboarding completion markers.
+class AppOnboardingStateStorage {
+  AppOnboardingStateStorage({required String directoryPath}) : _directoryPath = directoryPath;
+
+  final String _directoryPath;
+
+  Future<bool> markerExists({required String key}) => Future.value(File(path.join(_directoryPath, key)).existsSync());
+
+  Future<void> writeMarker({required String key}) async {
+    final directory = Directory(_directoryPath);
+    await directory.create(recursive: true);
+    if (!Platform.isWindows) {
+      await _setUnixMode(targetPath: directory.path, mode: "700");
+    }
+
+    final markerPath = path.join(_directoryPath, key);
+    if (Platform.isWindows) {
+      await File(markerPath).writeAsString("");
+      return;
+    }
+
+    final temporaryMarker = File("$markerPath.$pid.${DateTime.now().microsecondsSinceEpoch}.tmp");
+    try {
+      await temporaryMarker.writeAsString("");
+      await _setUnixMode(targetPath: temporaryMarker.path, mode: "600");
+      await temporaryMarker.rename(markerPath);
+    } finally {
+      if (temporaryMarker.existsSync()) {
+        temporaryMarker.deleteSync();
+      }
+    }
+  }
+
+  Future<void> clearAll() {
+    final directory = Directory(_directoryPath);
+    if (directory.existsSync()) {
+      directory.deleteSync(recursive: true);
+    }
+    return Future<void>.value();
+  }
+
+  Future<void> _setUnixMode({required String targetPath, required String mode}) async {
+    final result = await Process.run("chmod", [mode, targetPath]);
+    if (result.exitCode != 0) {
+      throw FileSystemException("Failed to set mode $mode", targetPath);
+    }
+  }
+}

--- a/bridge/app/lib/src/api/sesori_server_api.dart
+++ b/bridge/app/lib/src/api/sesori_server_api.dart
@@ -1,0 +1,57 @@
+import "dart:async";
+
+import "package:http/http.dart" as http;
+import "package:sesori_shared/sesori_shared.dart" show jsonDecodeMap;
+
+import "app_client_status_response.dart";
+
+class SesoriServerApiException implements Exception {
+  SesoriServerApiException({required this.statusCode, required this.uri});
+
+  final int statusCode;
+  final Uri uri;
+
+  @override
+  String toString() => "SesoriServerApiException: GET $uri returned status $statusCode";
+}
+
+/// Provider-level HTTP boundary for new Sesori auth-server operations.
+///
+/// Existing auth APIs remain in their current use-case-specific boundaries.
+class SesoriServerApi {
+  SesoriServerApi({
+    required String authBackendUrl,
+    required http.Client client,
+    required Duration requestDeadline,
+  }) : _authBackendUrl = authBackendUrl.replaceFirst(RegExp(r"/+$"), ""),
+       _client = client,
+       _requestDeadline = requestDeadline;
+
+  static const Duration defaultRequestDeadline = Duration(seconds: 35);
+
+  final String _authBackendUrl;
+  final http.Client _client;
+  final Duration _requestDeadline;
+
+  Future<AppClientStatusResponse> getAppClientStatus({
+    required String accessToken,
+    required bool wait,
+  }) async {
+    final endpoint = Uri.parse("$_authBackendUrl/auth/app-clients/status");
+    final uri = wait ? endpoint.replace(queryParameters: const {"wait": "true"}) : endpoint;
+    final abortCompleter = Completer<void>();
+    final deadlineTimer = Timer(_requestDeadline, abortCompleter.complete);
+    final request = http.AbortableRequest("GET", uri, abortTrigger: abortCompleter.future)
+      ..headers["Authorization"] = "Bearer $accessToken";
+
+    try {
+      final response = await http.Response.fromStream(await _client.send(request));
+      if (response.statusCode != 200) {
+        throw SesoriServerApiException(statusCode: response.statusCode, uri: uri);
+      }
+      return AppClientStatusResponse.fromJson(jsonDecodeMap(response.body));
+    } finally {
+      deadlineTimer.cancel();
+    }
+  }
+}

--- a/bridge/app/lib/src/bridge/runtime/bridge_logout_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_logout_runner.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Log;
 
 import '../../auth/token.dart' as token_store;
+import '../../repositories/app_onboarding_state_repository.dart';
 import '../../server/foundation/terminal_prompt_decision.dart';
 import '../../server/repositories/bridge_instance_repository.dart';
 import '../../server/repositories/terminal_prompt_repository.dart';
@@ -19,7 +20,7 @@ enum BridgeLogoutStatus {
   /// User declined to stop running bridges; tokens were not cleared.
   cancelled,
 
-  /// Deleting the token file failed; tokens may still be present.
+  /// Deleting onboarding state or the token file failed; tokens may still be present.
   failed,
 }
 
@@ -41,17 +42,20 @@ class BridgeLogoutRunner {
     required BridgeInstanceService bridgeInstanceService,
     required TerminalPromptRepository terminalPromptRepository,
     required Future<void> Function() unregisterBridge,
+    required AppOnboardingStateRepository appOnboardingStateRepository,
     Future<void> Function() clearTokens = token_store.clearTokens,
   }) : _bridgeInstanceRepository = bridgeInstanceRepository,
        _bridgeInstanceService = bridgeInstanceService,
        _terminalPromptRepository = terminalPromptRepository,
        _unregisterBridge = unregisterBridge,
+       _appOnboardingStateRepository = appOnboardingStateRepository,
        _clearTokens = clearTokens;
 
   final BridgeInstanceRepository _bridgeInstanceRepository;
   final BridgeInstanceService _bridgeInstanceService;
   final TerminalPromptRepository _terminalPromptRepository;
   final Future<void> Function() _unregisterBridge;
+  final AppOnboardingStateRepository _appOnboardingStateRepository;
   final Future<void> Function() _clearTokens;
 
   Future<BridgeLogoutResult> logout({required int currentPid}) async {
@@ -79,12 +83,22 @@ class BridgeLogoutRunner {
       }
     }
 
+    try {
+      await _appOnboardingStateRepository.clearAll();
+    } on Object catch (error) {
+      return BridgeLogoutResult(
+        status: BridgeLogoutStatus.failed,
+        runningBridgeCount: runningBridgeCount,
+        error: error,
+      );
+    }
+
     // Best-effort: remove this bridge's registration on the auth server while
     // we still have tokens. Logout must never block or fail because of this.
     try {
       await _unregisterBridge();
-    } on Object catch (error) {
-      Log.w('Failed to remove bridge registration on auth server (ignored): $error');
+    } on Object catch (error, stackTrace) {
+      Log.w('Failed to remove bridge registration on auth server (ignored)', error, stackTrace);
     }
 
     try {

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -27,9 +27,11 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
 import "package:sesori_shared/sesori_shared.dart"
     show AuthClientType, AuthDeviceInfoBuilder, DeviceInfo, legacyMissingPluginId;
 
+import "../../api/app_onboarding_state_storage.dart";
 import "../../api/bridge_settings_api.dart";
 import "../../api/control_secret_api.dart";
 import "../../api/database/database.dart";
+import "../../api/sesori_server_api.dart";
 import "../../auth/access_token_provider.dart";
 import "../../auth/bridge_id_migration_service.dart";
 import "../../auth/bridge_id_storage.dart";
@@ -47,8 +49,11 @@ import "../../control/bridge_control_message_dispatcher.dart";
 import "../../control/control_channel_loss_listener.dart";
 import "../../control/control_provision_notifier.dart";
 import "../../control/control_status_notifier.dart";
+import "../../foundation/app_onboarding_formatter.dart";
 import "../../foundation/control_channel_client.dart";
 import "../../listeners/catalog_import_console_listener.dart";
+import "../../repositories/app_client_status_repository.dart";
+import "../../repositories/app_onboarding_state_repository.dart";
 import "../../repositories/bridge_settings.dart";
 import "../../repositories/bridge_settings_repository.dart";
 import "../../server/api/loopback_port_api.dart";
@@ -71,6 +76,7 @@ import "../../server/repositories/startup_mutex_repository.dart";
 import "../../server/repositories/terminal_prompt_repository.dart";
 import "../../server/services/bridge_instance_service.dart";
 import "../../server/services/bridge_restart_service.dart";
+import "../../services/app_client_onboarding_service.dart";
 import "../../services/catalog_import_service.dart";
 import "../../services/control_channel_token_service.dart";
 import "../../services/control_prompt_service.dart";
@@ -589,8 +595,28 @@ class BridgeRuntimeRunner {
             availableDescriptors.add(result.descriptor);
         }
       }
+      final runAppOnboarding = shouldRunAppOnboarding(
+        isSupervised: options.isSupervised,
+        isInteractive: terminalPromptApi.isInteractive,
+        hasAvailablePlugins: availableDescriptors.isNotEmpty,
+      );
       if (availableDescriptors.isEmpty) {
         return 1;
+      }
+      if (runAppOnboarding) {
+        await AppClientOnboardingService(
+          statusRepository: AppClientStatusRepository(
+            api: SesoriServerApi(
+              authBackendUrl: options.authBackendUrl,
+              client: httpClient,
+              requestDeadline: SesoriServerApi.defaultRequestDeadline,
+            ),
+          ),
+          stateRepository: AppOnboardingStateRepository(
+            storage: AppOnboardingStateStorage(directoryPath: appOnboardingStateDirectoryPath()),
+          ),
+          formatter: AppOnboardingFormatter(out: io.stdout, environment: environment),
+        ).run(accessToken: authAccessToken, authBackendUrl: options.authBackendUrl);
       }
       // If this bridge was spawned by a restart, wait for the predecessor to
       // exit before single-live-bridge enforcement so the handoff is clean.
@@ -871,6 +897,13 @@ class BridgeRuntimeRunner {
       }
     }
   }
+
+  @visibleForTesting
+  static bool shouldRunAppOnboarding({
+    required bool isSupervised,
+    required bool isInteractive,
+    required bool hasAvailablePlugins,
+  }) => !isSupervised && isInteractive && hasAvailablePlugins;
 
   @visibleForTesting
   static void startCatalogImports({

--- a/bridge/app/lib/src/foundation/app_onboarding_formatter.dart
+++ b/bridge/app/lib/src/foundation/app_onboarding_formatter.dart
@@ -1,0 +1,78 @@
+import "dart:io";
+
+import "package:qr/qr.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
+    show TerminalColorValidator, TerminalGlyphValidator;
+
+class AppOnboardingFormatter {
+  AppOnboardingFormatter({required Stdout out, required Map<String, String> environment})
+    : _out = out,
+      _environment = environment;
+
+  static const String appUrl = "https://sesori.com/app/?openStore=true";
+  static const int _quietZoneModules = 4;
+  static const String _reset = "\x1b[0m";
+  static const String _blackForeground = "\x1b[30m";
+  static const String _whiteForeground = "\x1b[37m";
+  static const String _blackBackground = "\x1b[40m";
+  static const String _whiteBackground = "\x1b[47m";
+  static const String _upperHalfBlock = "▀";
+
+  final Stdout _out;
+  final Map<String, String> _environment;
+
+  String formatDestination() {
+    if (!TerminalColorValidator.isSupported(out: _out, environment: _environment) ||
+        !TerminalGlyphValidator.isSupported(environment: _environment)) {
+      return appUrl;
+    }
+
+    final int terminalColumns;
+    try {
+      terminalColumns = _out.terminalColumns;
+    } on Object {
+      return appUrl;
+    }
+
+    final image = QrImage(
+      QrCode(
+        payload: QrPayload.fromString(appUrl),
+        errorCorrectLevel: QrErrorCorrectLevel.medium,
+      ),
+    );
+    final renderedWidth = image.moduleCount + (_quietZoneModules * 2);
+    if (terminalColumns < renderedWidth) {
+      return appUrl;
+    }
+
+    return "${_renderQr(image: image)}$appUrl";
+  }
+
+  String _renderQr({required QrImage image}) {
+    final buffer = StringBuffer();
+    const start = -_quietZoneModules;
+    final end = image.moduleCount + _quietZoneModules;
+
+    for (var row = start; row < end; row += 2) {
+      for (var column = start; column < end; column++) {
+        final topDark = _isDark(image: image, row: row, column: column);
+        final bottomDark = _isDark(image: image, row: row + 1, column: column);
+        buffer
+          ..write(topDark ? _blackForeground : _whiteForeground)
+          ..write(bottomDark ? _blackBackground : _whiteBackground)
+          ..write(_upperHalfBlock);
+      }
+      buffer
+        ..write(_reset)
+        ..writeln();
+    }
+    return buffer.toString();
+  }
+
+  bool _isDark({required QrImage image, required int row, required int column}) {
+    if (row < 0 || column < 0 || row >= image.moduleCount || column >= image.moduleCount) {
+      return false;
+    }
+    return image.isDark(row, column);
+  }
+}

--- a/bridge/app/lib/src/repositories/app_client_status_repository.dart
+++ b/bridge/app/lib/src/repositories/app_client_status_repository.dart
@@ -1,0 +1,44 @@
+import "../api/sesori_server_api.dart";
+
+sealed class AppClientStatusResult {
+  const AppClientStatusResult();
+}
+
+final class AppClientRegistered extends AppClientStatusResult {
+  const AppClientRegistered();
+}
+
+final class AppClientAbsent extends AppClientStatusResult {
+  const AppClientAbsent();
+}
+
+final class AppClientStatusUnavailable extends AppClientStatusResult {
+  const AppClientStatusUnavailable({required this.error, required this.stackTrace});
+
+  final Object error;
+  final StackTrace stackTrace;
+}
+
+class AppClientStatusRepository {
+  AppClientStatusRepository({required SesoriServerApi api}) : _api = api;
+
+  final SesoriServerApi _api;
+
+  Future<AppClientStatusResult> getStatus({
+    required String accessToken,
+    required bool wait,
+  }) async {
+    try {
+      final response = await _api.getAppClientStatus(accessToken: accessToken, wait: wait);
+      return response.registered ? const AppClientRegistered() : const AppClientAbsent();
+    } on SesoriServerApiException catch (error, stackTrace) {
+      if (error.statusCode == 404 || error.statusCode == 405) {
+        // COMPATIBILITY 2026-07-18 (v1.5.1): Auth servers predating app-client status return 404/405, so onboarding must fail open for older/custom deployments. Remove this fallback and its endpoint-omission tests after every supported auth server exposes GET /auth/app-clients/status.
+        return AppClientStatusUnavailable(error: error, stackTrace: stackTrace);
+      }
+      return AppClientStatusUnavailable(error: error, stackTrace: stackTrace);
+    } on Object catch (error, stackTrace) {
+      return AppClientStatusUnavailable(error: error, stackTrace: stackTrace);
+    }
+  }
+}

--- a/bridge/app/lib/src/repositories/app_onboarding_state_repository.dart
+++ b/bridge/app/lib/src/repositories/app_onboarding_state_repository.dart
@@ -1,0 +1,60 @@
+import "dart:convert";
+
+import "package:crypto/crypto.dart" show sha256;
+
+import "../api/app_onboarding_state_storage.dart";
+
+sealed class AppOnboardingStateLookup {
+  const AppOnboardingStateLookup();
+}
+
+final class AppOnboardingStatePresent extends AppOnboardingStateLookup {
+  const AppOnboardingStatePresent();
+}
+
+final class AppOnboardingStateAbsent extends AppOnboardingStateLookup {
+  const AppOnboardingStateAbsent();
+}
+
+final class AppOnboardingStateReadFailed extends AppOnboardingStateLookup {
+  const AppOnboardingStateReadFailed({required this.error, required this.stackTrace});
+
+  final Object error;
+  final StackTrace stackTrace;
+}
+
+class AppOnboardingStateRepository {
+  AppOnboardingStateRepository({required AppOnboardingStateStorage storage}) : _storage = storage;
+
+  final AppOnboardingStateStorage _storage;
+
+  Future<AppOnboardingStateLookup> lookup({
+    required String authBackendUrl,
+    required String userId,
+  }) async {
+    try {
+      final exists = await _storage.markerExists(
+        key: _markerKey(authBackendUrl: authBackendUrl, userId: userId),
+      );
+      return exists ? const AppOnboardingStatePresent() : const AppOnboardingStateAbsent();
+    } on Object catch (error, stackTrace) {
+      return AppOnboardingStateReadFailed(error: error, stackTrace: stackTrace);
+    }
+  }
+
+  Future<void> markCompleted({
+    required String authBackendUrl,
+    required String userId,
+  }) {
+    return _storage.writeMarker(
+      key: _markerKey(authBackendUrl: authBackendUrl, userId: userId),
+    );
+  }
+
+  Future<void> clearAll() => _storage.clearAll();
+
+  String _markerKey({required String authBackendUrl, required String userId}) {
+    final normalizedAuthBackend = authBackendUrl.replaceFirst(RegExp(r"/+$"), "");
+    return sha256.convert(utf8.encode(jsonEncode([normalizedAuthBackend, userId]))).toString();
+  }
+}

--- a/bridge/app/lib/src/services/app_client_onboarding_service.dart
+++ b/bridge/app/lib/src/services/app_client_onboarding_service.dart
@@ -49,7 +49,7 @@ class AppClientOnboardingService {
 
     Console.message("Open the Sesori app and sign in with this same account:");
     Console.message(_formatter.formatDestination());
-    Console.message("Waiting up to 30 seconds for the app to connect...");
+    Console.message("Waiting up to 35 seconds for the app to connect...");
 
     final waited = await _statusRepository.getStatus(accessToken: accessToken, wait: true);
     switch (waited) {

--- a/bridge/app/lib/src/services/app_client_onboarding_service.dart
+++ b/bridge/app/lib/src/services/app_client_onboarding_service.dart
@@ -1,0 +1,73 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Console, Log;
+import "package:sesori_shared/sesori_shared.dart" show parseJwtUserId;
+
+import "../foundation/app_onboarding_formatter.dart";
+import "../repositories/app_client_status_repository.dart";
+import "../repositories/app_onboarding_state_repository.dart";
+
+class AppClientOnboardingService {
+  AppClientOnboardingService({
+    required AppClientStatusRepository statusRepository,
+    required AppOnboardingStateRepository stateRepository,
+    required AppOnboardingFormatter formatter,
+  }) : _statusRepository = statusRepository,
+       _stateRepository = stateRepository,
+       _formatter = formatter;
+
+  final AppClientStatusRepository _statusRepository;
+  final AppOnboardingStateRepository _stateRepository;
+  final AppOnboardingFormatter _formatter;
+
+  Future<void> run({required String accessToken, required String authBackendUrl}) async {
+    final userId = parseJwtUserId(accessToken);
+    if (userId == null) {
+      Log.w("Skipping app onboarding check: access token has no readable userId claim");
+      return;
+    }
+
+    final marker = await _stateRepository.lookup(authBackendUrl: authBackendUrl, userId: userId);
+    switch (marker) {
+      case AppOnboardingStatePresent():
+        return;
+      case AppOnboardingStateAbsent():
+        break;
+      case AppOnboardingStateReadFailed(:final error, :final stackTrace):
+        Log.w("Could not read app onboarding state; checking registration anyway", error, stackTrace);
+    }
+
+    final immediate = await _statusRepository.getStatus(accessToken: accessToken, wait: false);
+    switch (immediate) {
+      case AppClientRegistered():
+        await _markCompleted(authBackendUrl: authBackendUrl, userId: userId);
+        return;
+      case AppClientStatusUnavailable(:final error, :final stackTrace):
+        Log.w("Could not check Sesori app registration; continuing bridge startup", error, stackTrace);
+        return;
+      case AppClientAbsent():
+        break;
+    }
+
+    Console.message("Open the Sesori app and sign in with this same account:");
+    Console.message(_formatter.formatDestination());
+    Console.message("Waiting up to 30 seconds for the app to connect...");
+
+    final waited = await _statusRepository.getStatus(accessToken: accessToken, wait: true);
+    switch (waited) {
+      case AppClientRegistered():
+        await _markCompleted(authBackendUrl: authBackendUrl, userId: userId);
+        Console.message("Sesori app connected. Continuing bridge startup.");
+      case AppClientAbsent():
+        Console.message("No Sesori app connected yet; continuing bridge startup.");
+      case AppClientStatusUnavailable(:final error, :final stackTrace):
+        Log.w("Could not finish the Sesori app registration check; continuing bridge startup", error, stackTrace);
+    }
+  }
+
+  Future<void> _markCompleted({required String authBackendUrl, required String userId}) async {
+    try {
+      await _stateRepository.markCompleted(authBackendUrl: authBackendUrl, userId: userId);
+    } on Object catch (error, stackTrace) {
+      Log.w("Could not save app onboarding completion; the next start may check again", error, stackTrace);
+    }
+  }
+}

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   http: ^1.6.0
   crypto: ^3.0.7
   path: ^1.9.1
+  qr: ^4.0.0
   sesori_shared:
     path: ../../shared/sesori_shared
   clock: ^1.1.2

--- a/bridge/app/test/api/app_onboarding_state_storage_test.dart
+++ b/bridge/app/test/api/app_onboarding_state_storage_test.dart
@@ -1,0 +1,54 @@
+import "dart:io";
+
+import "package:path/path.dart" as path;
+import "package:sesori_bridge/src/api/app_onboarding_state_storage.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("AppOnboardingStateStorage", () {
+    late Directory temporaryDirectory;
+    late String markerDirectory;
+    late AppOnboardingStateStorage storage;
+
+    setUp(() async {
+      temporaryDirectory = await Directory.systemTemp.createTemp("sesori-onboarding-storage-");
+      markerDirectory = path.join(temporaryDirectory.path, "markers");
+      storage = AppOnboardingStateStorage(directoryPath: markerDirectory);
+    });
+
+    tearDown(() {
+      if (temporaryDirectory.existsSync()) {
+        temporaryDirectory.deleteSync(recursive: true);
+      }
+    });
+
+    test("writes an empty marker idempotently and clears the marker directory", () async {
+      const key = "aabbcc";
+
+      expect(await storage.markerExists(key: key), isFalse);
+      await storage.writeMarker(key: key);
+      await storage.writeMarker(key: key);
+
+      final marker = File(path.join(markerDirectory, key));
+      expect(await storage.markerExists(key: key), isTrue);
+      expect(marker.readAsStringSync(), isEmpty);
+
+      await storage.clearAll();
+
+      expect(Directory(markerDirectory).existsSync(), isFalse);
+      await storage.clearAll();
+    });
+
+    test("restricts the marker directory and files on Unix", () async {
+      if (Platform.isWindows) return;
+
+      const key = "ddeeff";
+      await storage.writeMarker(key: key);
+
+      final directoryMode = FileStat.statSync(markerDirectory).mode & 0x1ff;
+      final markerMode = FileStat.statSync(path.join(markerDirectory, key)).mode & 0x1ff;
+      expect(directoryMode, equals(0x1c0));
+      expect(markerMode, equals(0x180));
+    });
+  });
+}

--- a/bridge/app/test/api/sesori_server_api_test.dart
+++ b/bridge/app/test/api/sesori_server_api_test.dart
@@ -1,0 +1,124 @@
+import "dart:async";
+import "dart:convert";
+
+import "package:http/http.dart" as http;
+import "package:http/testing.dart";
+import "package:sesori_bridge/src/api/sesori_server_api.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("SesoriServerApi", () {
+    test("sends the immediate request to the exact endpoint with a bearer token", () async {
+      late http.Request request;
+      final api = SesoriServerApi(
+        authBackendUrl: "https://auth.example.test/",
+        client: MockClient((incoming) async {
+          request = incoming;
+          return http.Response('{"registered":true}', 200);
+        }),
+        requestDeadline: const Duration(seconds: 1),
+      );
+
+      final response = await api.getAppClientStatus(accessToken: "secret-token", wait: false);
+
+      expect(response.registered, isTrue);
+      expect(request.method, equals("GET"));
+      expect(request.url, equals(Uri.parse("https://auth.example.test/auth/app-clients/status")));
+      expect(request.headers["Authorization"], equals("Bearer secret-token"));
+    });
+
+    test("adds only wait=true for the long-poll request", () async {
+      late Uri requestUri;
+      final api = SesoriServerApi(
+        authBackendUrl: "https://auth.example.test",
+        client: MockClient((request) async {
+          requestUri = request.url;
+          return http.Response('{"registered":false}', 200);
+        }),
+        requestDeadline: const Duration(seconds: 1),
+      );
+
+      final response = await api.getAppClientStatus(accessToken: "token", wait: true);
+
+      expect(response.registered, isFalse);
+      expect(requestUri, equals(Uri.parse("https://auth.example.test/auth/app-clients/status?wait=true")));
+    });
+
+    test("rejects non-200 status and malformed response models", () async {
+      final statusApi = SesoriServerApi(
+        authBackendUrl: "https://auth.example.test",
+        client: MockClient((_) async => http.Response("missing", 503)),
+        requestDeadline: const Duration(seconds: 1),
+      );
+      final malformedApi = SesoriServerApi(
+        authBackendUrl: "https://auth.example.test",
+        client: MockClient((_) async => http.Response('{"registered":"yes"}', 200)),
+        requestDeadline: const Duration(seconds: 1),
+      );
+
+      await expectLater(
+        statusApi.getAppClientStatus(accessToken: "token", wait: false),
+        throwsA(isA<SesoriServerApiException>().having((error) => error.statusCode, "statusCode", 503)),
+      );
+      await expectLater(
+        malformedApi.getAppClientStatus(accessToken: "token", wait: false),
+        throwsA(isA<TypeError>()),
+      );
+    });
+
+    test("actively aborts a request when its deadline expires", () async {
+      final client = _AbortAwareClient();
+      final api = SesoriServerApi(
+        authBackendUrl: "https://auth.example.test",
+        client: client,
+        requestDeadline: Duration.zero,
+      );
+
+      await expectLater(
+        api.getAppClientStatus(accessToken: "token", wait: false),
+        throwsA(isA<http.RequestAbortedException>()),
+      );
+      expect(client.abortObserved, isTrue);
+    });
+
+    test("cancels the deadline after a completed response", () async {
+      final client = _ImmediateClient();
+      final api = SesoriServerApi(
+        authBackendUrl: "https://auth.example.test",
+        client: client,
+        requestDeadline: const Duration(milliseconds: 5),
+      );
+
+      await api.getAppClientStatus(accessToken: "token", wait: false);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(client.abortObserved, isFalse);
+    });
+  });
+}
+
+class _AbortAwareClient extends http.BaseClient {
+  bool abortObserved = false;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final abortable = request as http.Abortable;
+    await abortable.abortTrigger!;
+    abortObserved = true;
+    throw http.RequestAbortedException(request.url);
+  }
+}
+
+class _ImmediateClient extends http.BaseClient {
+  bool abortObserved = false;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final abortable = request as http.Abortable;
+    unawaited(abortable.abortTrigger?.then((_) => abortObserved = true));
+    return http.StreamedResponse(
+      Stream.value(utf8.encode('{"registered":true}')),
+      200,
+    );
+  }
+}

--- a/bridge/app/test/bridge/runtime/bridge_logout_runner_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_logout_runner_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:sesori_bridge/src/bridge/runtime/bridge_logout_runner.dart';
+import 'package:sesori_bridge/src/repositories/app_onboarding_state_repository.dart';
 import 'package:sesori_bridge/src/server/foundation/process_match.dart';
 import 'package:sesori_bridge/src/server/foundation/terminal_prompt_decision.dart';
 import 'package:sesori_bridge/src/server/models/bridge_startup_lock.dart';
@@ -17,6 +18,8 @@ void main() {
     late _FakeTerminalPromptRepository terminalPromptRepository;
     late int unregisterBridgeCalls;
     late Object? unregisterBridgeError;
+    late _FakeAppOnboardingStateRepository appOnboardingStateRepository;
+    late List<String> operations;
     late int clearTokensCalls;
     late int clearTokensCallsAtLastUnregister;
     late Object? clearTokensError;
@@ -28,6 +31,9 @@ void main() {
       terminalPromptRepository = _FakeTerminalPromptRepository();
       unregisterBridgeCalls = 0;
       unregisterBridgeError = null;
+      appOnboardingStateRepository = _FakeAppOnboardingStateRepository();
+      operations = [];
+      appOnboardingStateRepository.onClear = () => operations.add('onboarding-state');
       clearTokensCalls = 0;
       clearTokensCallsAtLastUnregister = -1;
       clearTokensError = null;
@@ -37,13 +43,16 @@ void main() {
         terminalPromptRepository: terminalPromptRepository,
         unregisterBridge: () async {
           unregisterBridgeCalls += 1;
+          operations.add('unregister');
           clearTokensCallsAtLastUnregister = clearTokensCalls;
           if (unregisterBridgeError != null) {
             throw unregisterBridgeError!;
           }
         },
+        appOnboardingStateRepository: appOnboardingStateRepository,
         clearTokens: () async {
           clearTokensCalls += 1;
+          operations.add('tokens');
           if (clearTokensError != null) {
             throw clearTokensError!;
           }
@@ -57,6 +66,7 @@ void main() {
       expect(result.status, equals(BridgeLogoutStatus.loggedOut));
       expect(result.runningBridgeCount, equals(0));
       expect(clearTokensCalls, equals(1));
+      expect(appOnboardingStateRepository.clearCalls, equals(1));
       expect(terminalPromptRepository.askCount, equals(0));
       expect(bridgeInstanceService.terminateRequests, isEmpty);
     });
@@ -70,6 +80,7 @@ void main() {
       expect(result.status, equals(BridgeLogoutStatus.cancelled));
       expect(result.runningBridgeCount, equals(1));
       expect(clearTokensCalls, equals(0));
+      expect(appOnboardingStateRepository.clearCalls, equals(0));
       expect(bridgeInstanceService.terminateRequests, isEmpty);
     });
 
@@ -85,6 +96,7 @@ void main() {
       expect(result.status, equals(BridgeLogoutStatus.loggedOutWithRunningBridges));
       expect(result.runningBridgeCount, equals(2));
       expect(clearTokensCalls, equals(1));
+      expect(appOnboardingStateRepository.clearCalls, equals(1));
       expect(bridgeInstanceService.terminateRequests, isEmpty);
     });
 
@@ -99,6 +111,7 @@ void main() {
       expect(result.status, equals(BridgeLogoutStatus.loggedOut));
       expect(result.runningBridgeCount, equals(0));
       expect(clearTokensCalls, equals(1));
+      expect(appOnboardingStateRepository.clearCalls, equals(1));
       expect(bridgeInstanceService.terminateRequests.single.map((b) => b.pid), equals(<int>[200]));
       expect(terminalPromptRepository.bridgeCounts, equals(<int>[1]));
     });
@@ -126,13 +139,28 @@ void main() {
       expect(result.error, equals(clearTokensError));
     });
 
+    test('reports failure and keeps tokens when clearing onboarding state throws', () async {
+      const error = FileSystemException('cannot delete onboarding state');
+      appOnboardingStateRepository.clearError = error;
+
+      final result = await service.logout(currentPid: 100);
+
+      expect(result.status, equals(BridgeLogoutStatus.failed));
+      expect(result.error, same(error));
+      expect(appOnboardingStateRepository.clearCalls, equals(1));
+      expect(unregisterBridgeCalls, equals(0));
+      expect(clearTokensCalls, equals(0));
+    });
+
     test('unregisters the bridge before clearing tokens', () async {
       final result = await service.logout(currentPid: 100);
 
       expect(result.status, equals(BridgeLogoutStatus.loggedOut));
       expect(unregisterBridgeCalls, equals(1));
+      expect(appOnboardingStateRepository.clearCalls, equals(1));
       expect(clearTokensCallsAtLastUnregister, equals(0));
       expect(clearTokensCalls, equals(1));
+      expect(operations, equals(['onboarding-state', 'unregister', 'tokens']));
     });
 
     test('still clears tokens when unregistering the bridge fails', () async {
@@ -153,9 +181,33 @@ void main() {
 
       expect(result.status, equals(BridgeLogoutStatus.cancelled));
       expect(unregisterBridgeCalls, equals(0));
+      expect(appOnboardingStateRepository.clearCalls, equals(0));
       expect(clearTokensCalls, equals(0));
     });
   });
+}
+
+class _FakeAppOnboardingStateRepository implements AppOnboardingStateRepository {
+  int clearCalls = 0;
+  Object? clearError;
+  void Function()? onClear;
+
+  @override
+  Future<void> clearAll() async {
+    clearCalls += 1;
+    onClear?.call();
+    if (clearError != null) throw clearError!;
+  }
+
+  @override
+  Future<AppOnboardingStateLookup> lookup({required String authBackendUrl, required String userId}) {
+    throw UnimplementedError('not used by logout');
+  }
+
+  @override
+  Future<void> markCompleted({required String authBackendUrl, required String userId}) {
+    throw UnimplementedError('not used by logout');
+  }
 }
 
 ProcessIdentity _candidate({required int pid}) {

--- a/bridge/app/test/bridge/runtime/bridge_runtime_runner_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_runner_test.dart
@@ -21,4 +21,44 @@ void main() {
       expect(BridgeRuntimeRunner.isLoopbackControlUrl(Uri.parse("https://localhost:9")), isFalse);
     });
   });
+
+  group("BridgeRuntimeRunner.shouldRunAppOnboarding", () {
+    test("runs only for an interactive standalone start with an available plugin", () {
+      expect(
+        BridgeRuntimeRunner.shouldRunAppOnboarding(
+          isSupervised: false,
+          isInteractive: true,
+          hasAvailablePlugins: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test("skips supervised, noninteractive, and all-plugin-unavailable starts", () {
+      expect(
+        BridgeRuntimeRunner.shouldRunAppOnboarding(
+          isSupervised: true,
+          isInteractive: true,
+          hasAvailablePlugins: true,
+        ),
+        isFalse,
+      );
+      expect(
+        BridgeRuntimeRunner.shouldRunAppOnboarding(
+          isSupervised: false,
+          isInteractive: false,
+          hasAvailablePlugins: true,
+        ),
+        isFalse,
+      );
+      expect(
+        BridgeRuntimeRunner.shouldRunAppOnboarding(
+          isSupervised: false,
+          isInteractive: true,
+          hasAvailablePlugins: false,
+        ),
+        isFalse,
+      );
+    });
+  });
 }

--- a/bridge/app/test/foundation/app_onboarding_formatter_test.dart
+++ b/bridge/app/test/foundation/app_onboarding_formatter_test.dart
@@ -1,0 +1,143 @@
+import "dart:io";
+
+import "package:qr/qr.dart";
+import "package:sesori_bridge/src/foundation/app_onboarding_formatter.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("AppOnboardingFormatter", () {
+    const unicodeEnvironment = {"LANG": "en_US.UTF-8"};
+
+    test("renders the exact medium-correction QR with a four-module quiet zone", () {
+      final formatter = AppOnboardingFormatter(
+        out: _FakeStdout(supportsAnsiEscapes: true, terminalColumns: 500),
+        environment: unicodeEnvironment,
+      );
+      final expectedImage = QrImage(
+        QrCode(
+          payload: QrPayload.fromString(AppOnboardingFormatter.appUrl),
+          errorCorrectLevel: QrErrorCorrectLevel.medium,
+        ),
+      );
+
+      final output = formatter.formatDestination();
+      final lines = output.split("\n");
+      final qrLines = lines.sublist(0, lines.length - 1);
+
+      expect(lines.last, equals(AppOnboardingFormatter.appUrl));
+      expect(qrLines, hasLength(((expectedImage.moduleCount + 8) / 2).ceil()));
+      for (var renderedRow = 0; renderedRow < qrLines.length; renderedRow++) {
+        final cells = _decodeCells(qrLines[renderedRow]);
+        expect(cells, hasLength(expectedImage.moduleCount + 8));
+        for (var renderedColumn = 0; renderedColumn < cells.length; renderedColumn++) {
+          final sourceRow = (renderedRow * 2) - 4;
+          final sourceColumn = renderedColumn - 4;
+          expect(
+            cells[renderedColumn].topDark,
+            equals(_expectedDark(expectedImage, row: sourceRow, column: sourceColumn)),
+          );
+          expect(
+            cells[renderedColumn].bottomDark,
+            equals(_expectedDark(expectedImage, row: sourceRow + 1, column: sourceColumn)),
+          );
+        }
+        expect(qrLines[renderedRow], endsWith("\x1b[0m"));
+      }
+      expect(output, contains("\x1b[30m"));
+      expect(output, contains("\x1b[37m"));
+      expect(output, contains("\x1b[40m"));
+      expect(output, contains("\x1b[47m"));
+    });
+
+    test("uses QR output only when the known terminal width is sufficient", () {
+      final wideOutput = AppOnboardingFormatter(
+        out: _FakeStdout(supportsAnsiEscapes: true, terminalColumns: 500),
+        environment: unicodeEnvironment,
+      ).formatDestination();
+      final requiredWidth = _decodeCells(wideOutput.split("\n").first).length;
+
+      expect(
+        AppOnboardingFormatter(
+          out: _FakeStdout(supportsAnsiEscapes: true, terminalColumns: requiredWidth),
+          environment: unicodeEnvironment,
+        ).formatDestination(),
+        contains("▀"),
+      );
+      expect(
+        AppOnboardingFormatter(
+          out: _FakeStdout(supportsAnsiEscapes: true, terminalColumns: requiredWidth - 1),
+          environment: unicodeEnvironment,
+        ).formatDestination(),
+        equals(AppOnboardingFormatter.appUrl),
+      );
+    });
+
+    test("falls back to the exact URL without ANSI and Unicode support", () {
+      expect(
+        AppOnboardingFormatter(
+          out: _FakeStdout(supportsAnsiEscapes: false, terminalColumns: 500),
+          environment: unicodeEnvironment,
+        ).formatDestination(),
+        equals(AppOnboardingFormatter.appUrl),
+      );
+      expect(
+        AppOnboardingFormatter(
+          out: _FakeStdout(supportsAnsiEscapes: true, terminalColumns: 500),
+          environment: const {"LANG": "C"},
+        ).formatDestination(),
+        equals(AppOnboardingFormatter.appUrl),
+      );
+    });
+
+    test("falls back to the exact URL when terminal width is unavailable", () {
+      expect(
+        AppOnboardingFormatter(
+          out: _FakeStdout(supportsAnsiEscapes: true, terminalColumnsError: StateError("no terminal")),
+          environment: unicodeEnvironment,
+        ).formatDestination(),
+        equals(AppOnboardingFormatter.appUrl),
+      );
+    });
+  });
+}
+
+List<({bool topDark, bool bottomDark})> _decodeCells(String line) {
+  final cellPattern = RegExp("\x1b\\[(30|37)m\x1b\\[(40|47)m▀");
+  return [
+    for (final match in cellPattern.allMatches(line))
+      (
+        topDark: match.group(1) == "30",
+        bottomDark: match.group(2) == "40",
+      ),
+  ];
+}
+
+bool _expectedDark(QrImage image, {required int row, required int column}) {
+  if (row < 0 || column < 0 || row >= image.moduleCount || column >= image.moduleCount) {
+    return false;
+  }
+  return image.isDark(row, column);
+}
+
+class _FakeStdout implements Stdout {
+  _FakeStdout({
+    required this.supportsAnsiEscapes,
+    int? terminalColumns,
+    this.terminalColumnsError,
+  }) : _terminalColumns = terminalColumns;
+
+  @override
+  final bool supportsAnsiEscapes;
+
+  final int? _terminalColumns;
+  final Object? terminalColumnsError;
+
+  @override
+  int get terminalColumns {
+    if (terminalColumnsError != null) throw terminalColumnsError!;
+    return _terminalColumns!;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/repositories/app_client_status_repository_test.dart
+++ b/bridge/app/test/repositories/app_client_status_repository_test.dart
@@ -1,0 +1,60 @@
+import "package:sesori_bridge/src/api/app_client_status_response.dart";
+import "package:sesori_bridge/src/api/sesori_server_api.dart";
+import "package:sesori_bridge/src/repositories/app_client_status_repository.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("AppClientStatusRepository", () {
+    test("maps strict true and false responses", () async {
+      final api = _FakeSesoriServerApi();
+      final repository = AppClientStatusRepository(api: api);
+
+      api.response = const AppClientStatusResponse(registered: true);
+      expect(await repository.getStatus(accessToken: "token", wait: false), isA<AppClientRegistered>());
+
+      api.response = const AppClientStatusResponse(registered: false);
+      expect(await repository.getStatus(accessToken: "token", wait: true), isA<AppClientAbsent>());
+      expect(api.waitValues, equals([false, true]));
+    });
+
+    test("maps legacy endpoint omission statuses to unavailable", () async {
+      for (final statusCode in [404, 405]) {
+        final api = _FakeSesoriServerApi()
+          ..error = SesoriServerApiException(
+            statusCode: statusCode,
+            uri: Uri.parse("https://auth.example.test/auth/app-clients/status"),
+          );
+        final result = await AppClientStatusRepository(
+          api: api,
+        ).getStatus(accessToken: "token", wait: false);
+
+        expect(result, isA<AppClientStatusUnavailable>());
+      }
+    });
+
+    test("maps transport and malformed-response failures to unavailable", () async {
+      const error = FormatException("bad body");
+      final api = _FakeSesoriServerApi()..error = error;
+
+      final result = await AppClientStatusRepository(
+        api: api,
+      ).getStatus(accessToken: "token", wait: false);
+
+      expect(result, isA<AppClientStatusUnavailable>());
+      expect((result as AppClientStatusUnavailable).error, same(error));
+    });
+  });
+}
+
+class _FakeSesoriServerApi implements SesoriServerApi {
+  AppClientStatusResponse response = const AppClientStatusResponse(registered: false);
+  Object? error;
+  final List<bool> waitValues = [];
+
+  @override
+  Future<AppClientStatusResponse> getAppClientStatus({required String accessToken, required bool wait}) async {
+    waitValues.add(wait);
+    if (error != null) throw error!;
+    return response;
+  }
+}

--- a/bridge/app/test/repositories/app_onboarding_state_repository_test.dart
+++ b/bridge/app/test/repositories/app_onboarding_state_repository_test.dart
@@ -1,0 +1,92 @@
+import "dart:io";
+
+import "package:sesori_bridge/src/api/app_onboarding_state_storage.dart";
+import "package:sesori_bridge/src/repositories/app_onboarding_state_repository.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("AppOnboardingStateRepository", () {
+    late _MemoryAppOnboardingStateStorage storage;
+    late AppOnboardingStateRepository repository;
+
+    setUp(() {
+      storage = _MemoryAppOnboardingStateStorage();
+      repository = AppOnboardingStateRepository(storage: storage);
+    });
+
+    test("maps missing and matching pair markers", () async {
+      expect(
+        await repository.lookup(authBackendUrl: "https://auth-a.test", userId: "user-a"),
+        isA<AppOnboardingStateAbsent>(),
+      );
+
+      await repository.markCompleted(authBackendUrl: "https://auth-a.test", userId: "user-a");
+
+      expect(
+        await repository.lookup(authBackendUrl: "https://auth-a.test/", userId: "user-a"),
+        isA<AppOnboardingStatePresent>(),
+      );
+    });
+
+    test("retains independent opaque markers for backend and account pairs", () async {
+      await repository.markCompleted(authBackendUrl: "https://auth-a.test", userId: "user-a");
+      await repository.markCompleted(authBackendUrl: "https://auth-b.test", userId: "user-a");
+      await repository.markCompleted(authBackendUrl: "https://auth-a.test", userId: "user-b");
+
+      expect(storage.keys, hasLength(3));
+      for (final key in storage.keys) {
+        expect(key, matches(RegExp(r"^[0-9a-f]{64}$")));
+        expect(key, isNot(contains("auth")));
+        expect(key, isNot(contains("user")));
+      }
+      expect(
+        await repository.lookup(authBackendUrl: "https://auth-a.test", userId: "user-a"),
+        isA<AppOnboardingStatePresent>(),
+      );
+      expect(
+        await repository.lookup(authBackendUrl: "https://auth-b.test", userId: "user-a"),
+        isA<AppOnboardingStatePresent>(),
+      );
+    });
+
+    test("maps marker read failures without treating them as present", () async {
+      const error = FileSystemException("unreadable marker directory");
+      storage.readError = error;
+
+      final result = await repository.lookup(authBackendUrl: "https://auth.test", userId: "user-a");
+
+      expect(result, isA<AppOnboardingStateReadFailed>());
+      expect((result as AppOnboardingStateReadFailed).error, same(error));
+    });
+
+    test("clears every retained pair marker", () async {
+      await repository.markCompleted(authBackendUrl: "https://auth-a.test", userId: "user-a");
+      await repository.markCompleted(authBackendUrl: "https://auth-b.test", userId: "user-b");
+
+      await repository.clearAll();
+
+      expect(storage.keys, isEmpty);
+    });
+  });
+}
+
+class _MemoryAppOnboardingStateStorage implements AppOnboardingStateStorage {
+  final Set<String> keys = {};
+  Object? readError;
+
+  @override
+  Future<bool> markerExists({required String key}) async {
+    if (readError != null) throw readError!;
+    return keys.contains(key);
+  }
+
+  @override
+  Future<void> writeMarker({required String key}) async {
+    keys.add(key);
+  }
+
+  @override
+  Future<void> clearAll() async {
+    keys.clear();
+  }
+}

--- a/bridge/app/test/services/app_client_onboarding_service_test.dart
+++ b/bridge/app/test/services/app_client_onboarding_service_test.dart
@@ -1,0 +1,259 @@
+import "dart:convert";
+import "dart:io";
+
+import "package:sesori_bridge/src/foundation/app_onboarding_formatter.dart";
+import "package:sesori_bridge/src/repositories/app_client_status_repository.dart";
+import "package:sesori_bridge/src/repositories/app_onboarding_state_repository.dart";
+import "package:sesori_bridge/src/services/app_client_onboarding_service.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, LogLevel;
+import "package:test/test.dart";
+
+void main() {
+  group("AppClientOnboardingService", () {
+    late _FakeAppClientStatusRepository statusRepository;
+    late _FakeAppOnboardingStateRepository stateRepository;
+    late AppClientOnboardingService service;
+    late _CapturingStdout stdoutCapture;
+    late _CapturingStdout stderrCapture;
+
+    setUp(() {
+      statusRepository = _FakeAppClientStatusRepository();
+      stateRepository = _FakeAppOnboardingStateRepository();
+      service = AppClientOnboardingService(
+        statusRepository: statusRepository,
+        stateRepository: stateRepository,
+        formatter: _StubAppOnboardingFormatter(),
+      );
+      stdoutCapture = _CapturingStdout();
+      stderrCapture = _CapturingStdout();
+      Log.level = LogLevel.warning;
+    });
+
+    tearDown(() {
+      Log.level = LogLevel.info;
+    });
+
+    test("matching marker performs no request and emits no output", () async {
+      stateRepository.lookupResult = const AppOnboardingStatePresent();
+
+      await _runCaptured(
+        () => service.run(
+          accessToken: _token(userId: "user-a"),
+          authBackendUrl: "https://auth.test",
+        ),
+        out: stdoutCapture,
+        err: stderrCapture,
+      );
+
+      expect(statusRepository.waitValues, isEmpty);
+      expect(stateRepository.markCalls, equals(0));
+      expect(stdoutCapture.lines, isEmpty);
+      expect(stderrCapture.lines, isEmpty);
+    });
+
+    test("missing JWT userId warns and performs no marker or status request", () async {
+      await _runCaptured(
+        () => service.run(accessToken: _token(userId: null), authBackendUrl: "https://auth.test"),
+        out: stdoutCapture,
+        err: stderrCapture,
+      );
+
+      expect(stateRepository.lookupCalls, equals(0));
+      expect(statusRepository.waitValues, isEmpty);
+      expect(stderrCapture.lines, hasLength(1));
+    });
+
+    test("immediate registration marks the pair and continues silently", () async {
+      statusRepository.results.add(const AppClientRegistered());
+
+      await _runCaptured(
+        () => service.run(
+          accessToken: _token(userId: "user-a"),
+          authBackendUrl: "https://auth.test/",
+        ),
+        out: stdoutCapture,
+        err: stderrCapture,
+      );
+
+      expect(statusRepository.waitValues, equals([false]));
+      expect(stateRepository.markCalls, equals(1));
+      expect(stateRepository.lastAuthBackendUrl, equals("https://auth.test/"));
+      expect(stateRepository.lastUserId, equals("user-a"));
+      expect(stdoutCapture.lines, isEmpty);
+      expect(stderrCapture.lines, isEmpty);
+    });
+
+    test("confirmed absence shows guidance and performs exactly one long poll", () async {
+      statusRepository.results
+        ..add(const AppClientAbsent())
+        ..add(const AppClientRegistered());
+
+      await _runCaptured(
+        () => service.run(
+          accessToken: _token(userId: "user-a"),
+          authBackendUrl: "https://auth.test",
+        ),
+        out: stdoutCapture,
+        err: stderrCapture,
+      );
+
+      expect(statusRepository.waitValues, equals([false, true]));
+      expect(stateRepository.markCalls, equals(1));
+      expect(stdoutCapture.lines, [
+        "Open the Sesori app and sign in with this same account:",
+        AppOnboardingFormatter.appUrl,
+        "Waiting up to 30 seconds for the app to connect...",
+        "Sesori app connected. Continuing bridge startup.",
+      ]);
+    });
+
+    test("false long poll prints one continuation line and does not mark", () async {
+      statusRepository.results
+        ..add(const AppClientAbsent())
+        ..add(const AppClientAbsent());
+
+      await _runCaptured(
+        () => service.run(
+          accessToken: _token(userId: "user-a"),
+          authBackendUrl: "https://auth.test",
+        ),
+        out: stdoutCapture,
+        err: stderrCapture,
+      );
+
+      expect(statusRepository.waitValues, equals([false, true]));
+      expect(stateRepository.markCalls, equals(0));
+      expect(stdoutCapture.lines.last, equals("No Sesori app connected yet; continuing bridge startup."));
+      expect(stderrCapture.lines, isEmpty);
+    });
+
+    test("marker read failure warns but a confirmed status still attempts the write", () async {
+      const readError = FileSystemException("cannot read marker");
+      stateRepository.lookupResult = const AppOnboardingStateReadFailed(
+        error: readError,
+        stackTrace: StackTrace.empty,
+      );
+      statusRepository.results.add(const AppClientRegistered());
+
+      await _runCaptured(
+        () => service.run(
+          accessToken: _token(userId: "user-a"),
+          authBackendUrl: "https://auth.test",
+        ),
+        out: stdoutCapture,
+        err: stderrCapture,
+      );
+
+      expect(stateRepository.markCalls, equals(1));
+      expect(stderrCapture.lines, hasLength(1));
+    });
+
+    test("remote failure warns once and does not retry or mark", () async {
+      statusRepository.results.add(
+        const AppClientStatusUnavailable(error: FormatException("offline"), stackTrace: StackTrace.empty),
+      );
+
+      await _runCaptured(
+        () => service.run(
+          accessToken: _token(userId: "user-a"),
+          authBackendUrl: "https://auth.test",
+        ),
+        out: stdoutCapture,
+        err: stderrCapture,
+      );
+
+      expect(statusRepository.waitValues, equals([false]));
+      expect(stateRepository.markCalls, equals(0));
+      expect(stderrCapture.lines, hasLength(1));
+    });
+
+    test("marker write failure warns and startup continues", () async {
+      stateRepository.markError = const FileSystemException("disk full");
+      statusRepository.results.add(const AppClientRegistered());
+
+      await _runCaptured(
+        () => service.run(
+          accessToken: _token(userId: "user-a"),
+          authBackendUrl: "https://auth.test",
+        ),
+        out: stdoutCapture,
+        err: stderrCapture,
+      );
+
+      expect(stateRepository.markCalls, equals(1));
+      expect(stderrCapture.lines, hasLength(1));
+    });
+  });
+}
+
+Future<void> _runCaptured(
+  Future<void> Function() operation, {
+  required _CapturingStdout out,
+  required _CapturingStdout err,
+}) {
+  return IOOverrides.runZoned(operation, stdout: () => out, stderr: () => err);
+}
+
+String _token({required String? userId}) {
+  final payload = base64Url.encode(utf8.encode(jsonEncode({"userId": userId}))).replaceAll("=", "");
+  return "header.$payload.signature";
+}
+
+class _FakeAppClientStatusRepository implements AppClientStatusRepository {
+  final List<AppClientStatusResult> results = [];
+  final List<bool> waitValues = [];
+
+  @override
+  Future<AppClientStatusResult> getStatus({required String accessToken, required bool wait}) async {
+    waitValues.add(wait);
+    return results.removeAt(0);
+  }
+}
+
+class _FakeAppOnboardingStateRepository implements AppOnboardingStateRepository {
+  AppOnboardingStateLookup lookupResult = const AppOnboardingStateAbsent();
+  int lookupCalls = 0;
+  int markCalls = 0;
+  Object? markError;
+  String? lastAuthBackendUrl;
+  String? lastUserId;
+
+  @override
+  Future<AppOnboardingStateLookup> lookup({required String authBackendUrl, required String userId}) async {
+    lookupCalls += 1;
+    return lookupResult;
+  }
+
+  @override
+  Future<void> markCompleted({required String authBackendUrl, required String userId}) async {
+    markCalls += 1;
+    lastAuthBackendUrl = authBackendUrl;
+    lastUserId = userId;
+    if (markError != null) throw markError!;
+  }
+
+  @override
+  Future<void> clearAll() {
+    throw UnimplementedError("not used by onboarding service");
+  }
+}
+
+class _StubAppOnboardingFormatter implements AppOnboardingFormatter {
+  @override
+  String formatDestination() => AppOnboardingFormatter.appUrl;
+}
+
+class _CapturingStdout implements Stdout {
+  final List<String> lines = [];
+
+  @override
+  bool get supportsAnsiEscapes => false;
+
+  @override
+  void writeln([Object? object = ""]) {
+    lines.add(object.toString());
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/app/test/services/app_client_onboarding_service_test.dart
+++ b/bridge/app/test/services/app_client_onboarding_service_test.dart
@@ -102,7 +102,7 @@ void main() {
       expect(stdoutCapture.lines, [
         "Open the Sesori app and sign in with this same account:",
         AppOnboardingFormatter.appUrl,
-        "Waiting up to 30 seconds for the app to connect...",
+        "Waiting up to 35 seconds for the app to connect...",
         "Sesori app connected. Continuing bridge startup.",
       ]);
     });

--- a/bridge/pubspec.lock
+++ b/bridge/pubspec.lock
@@ -433,6 +433,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5adccca7f0274326125fcdbf97328f5d6b1b2d7fb8a52a01cef9f40d96a759d9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   recase:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

- add a one-time standalone, interactive checkpoint for the current account's Sesori app registration
- show a bounded ANSI/Unicode QR plus the exact app URL, then perform at most one server-held registration wait
- persist opaque backend/account completion markers and clear them before tokens on accepted CLI logout

## Compatibility and scope

- supervised, noninteractive, and all-plugin-unavailable starts skip the checkpoint
- older or custom auth servers that return 404/405 fail open
- existing auth, token, prompt, plugin, relay, client, and shared contracts are unchanged
- adapts the approved plan to the merged parallel-plugin startup flow by gating after at least one enabled plugin remains available

## Verification

- `dart pub get` from `bridge/`
- `make codegen` from `bridge/`
- 41 focused onboarding, logout, and runner tests
- `dart analyze --fatal-infos` from `bridge/app/`
- `make analyze` from `bridge/`
- `make test` from `bridge/`
- `make build-host` from `bridge/app/`
- `aristotle-impl-review`: approved with no architecture findings

## Manual follow-up

- S01-W02-M01 remains pending for a real-terminal QR scan and disposable same-account registration exercise.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-time, bounded onboarding step that checks if the Sesori app is registered for the current account and shows a terminal QR plus exact URL to help connect. Improves first-run setup without blocking startup or changing existing auth/token flows.

- **New Features**
  - One-time interactive onboarding: immediate status check, then up to one long poll (≈35s), and fail-open on any error.
  - Terminal output: bounded ANSI/Unicode QR plus the exact app URL; falls back to URL if terminal lacks support or width.
  - Opaque completion markers per backend/account pair; cleared on accepted CLI logout before tokens.
  - Runs only for standalone interactive starts after concurrent plugin checks leave at least one enabled plugin available; supervised, noninteractive, or all-plugins-unavailable starts skip.
  - Compatible with older/custom auth servers (404/405): onboarding skips without blocking.

- **Bug Fixes**
  - Report client timeout/unavailability during the onboarding wait with a single warning, then continue startup.

<sup>Written for commit 215ef8dc42eaef739f4dac5e9a397e8d9771ce69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

