### PR TITLE
fix(bridge): wait for mobile app connection

### DIFF
--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime_runner.dart
@@ -503,7 +503,15 @@ class BridgeRuntimeRunner {
       // provider menu, no email/password prompt — the access token comes from
       // the GUI over the control channel. Standalone runs the unchanged
       // interactive flow. logAuthenticatedUser is identical on both paths.
+      // In supervised mode the GUI is the token authority: the control-channel
+      // token service is the access-token provider + refresher, pulling tokens
+      // from the GUI over the loopback channel. Standalone keeps the
+      // TokenManager, which refreshes against the auth server with the locally
+      // stored refresh token (no GUI exists to ask). Build it before interactive
+      // app onboarding so an unbounded wait can refresh its access token.
       final String authAccessToken;
+      final AccessTokenProvider accessTokenProvider;
+      final TokenRefresher tokenRefresher;
       final supervisedTokenService = controlChannelTokenService;
       if (supervisedTokenService != null) {
         try {
@@ -518,9 +526,20 @@ class BridgeRuntimeRunner {
           requestedSupervisedExit = SupervisedExitCode.authRequired;
           return SupervisedExitCode.authRequired.code;
         }
+        accessTokenProvider = supervisedTokenService;
+        tokenRefresher = supervisedTokenService;
       } else {
         final authTokens = await runtimeAuthService.ensureAuthenticated(options: options);
         authAccessToken = authTokens.accessToken;
+        final tokenManager = TokenManager(
+          initialToken: authAccessToken,
+          authBackendUrl: options.authBackendUrl,
+          loadTokens: loadTokens,
+          saveTokens: saveTokens,
+        );
+        shutdownCoordinator.add(disposable: tokenManager.dispose);
+        accessTokenProvider = tokenManager;
+        tokenRefresher = tokenManager;
       }
       await runtimeAuthService.logAuthenticatedUser(
         authBackendUrl: options.authBackendUrl,
@@ -616,6 +635,7 @@ class BridgeRuntimeRunner {
             storage: AppOnboardingStateStorage(directoryPath: appOnboardingStateDirectoryPath()),
           ),
           formatter: AppOnboardingFormatter(out: io.stdout, environment: environment),
+          tokenRefresher: tokenRefresher,
         ).run(accessToken: authAccessToken, authBackendUrl: options.authBackendUrl);
       }
       // If this bridge was spawned by a restart, wait for the predecessor to
@@ -668,29 +688,6 @@ class BridgeRuntimeRunner {
       for (final pluginId in options.enabledPluginIds) {
         final plugin = startedPlugins[pluginId];
         if (plugin != null) Console.message("Target [$pluginId]: ${plugin.describe().endpoint ?? pluginId}");
-      }
-
-      // In supervised mode the GUI is the token authority: the control-channel
-      // token service is the access-token provider + refresher, pulling tokens
-      // from the GUI over the loopback channel. Standalone keeps the
-      // TokenManager, which refreshes against the auth server with the locally
-      // stored refresh token (no GUI exists to ask). The control service's
-      // dispose is already registered with the shutdown coordinator above.
-      final AccessTokenProvider accessTokenProvider;
-      final TokenRefresher tokenRefresher;
-      if (supervisedTokenService != null) {
-        accessTokenProvider = supervisedTokenService;
-        tokenRefresher = supervisedTokenService;
-      } else {
-        final tokenManager = TokenManager(
-          initialToken: authAccessToken,
-          authBackendUrl: options.authBackendUrl,
-          loadTokens: loadTokens,
-          saveTokens: saveTokens,
-        );
-        shutdownCoordinator.add(disposable: tokenManager.dispose);
-        accessTokenProvider = tokenManager;
-        tokenRefresher = tokenManager;
       }
 
       // Supervised mode already built this early (so the dispatcher could route

--- a/bridge/app/lib/src/services/app_client_onboarding_service.dart
+++ b/bridge/app/lib/src/services/app_client_onboarding_service.dart
@@ -1,6 +1,7 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Console, Log;
 import "package:sesori_shared/sesori_shared.dart" show parseJwtUserId;
 
+import "../auth/token_refresher.dart";
 import "../foundation/app_onboarding_formatter.dart";
 import "../repositories/app_client_status_repository.dart";
 import "../repositories/app_onboarding_state_repository.dart";
@@ -10,13 +11,18 @@ class AppClientOnboardingService {
     required AppClientStatusRepository statusRepository,
     required AppOnboardingStateRepository stateRepository,
     required AppOnboardingFormatter formatter,
+    required TokenRefresher tokenRefresher,
   }) : _statusRepository = statusRepository,
        _stateRepository = stateRepository,
-       _formatter = formatter;
+       _formatter = formatter,
+       _tokenRefresher = tokenRefresher;
+
+  static const Duration _failureRetryDelay = Duration(seconds: 5);
 
   final AppClientStatusRepository _statusRepository;
   final AppOnboardingStateRepository _stateRepository;
   final AppOnboardingFormatter _formatter;
+  final TokenRefresher _tokenRefresher;
 
   Future<void> run({required String accessToken, required String authBackendUrl}) async {
     final userId = parseJwtUserId(accessToken);
@@ -47,19 +53,56 @@ class AppClientOnboardingService {
         break;
     }
 
-    Console.message("Open the Sesori app and sign in with this same account:");
+    Console.message("");
+    Console.message("Connect the Sesori mobile app to continue");
+    Console.message("");
+    Console.message(
+      "Use the QR code or link below to install or open Sesori, then sign in with this same account.",
+    );
+    Console.message("");
     Console.message(_formatter.formatDestination());
-    Console.message("Waiting up to 35 seconds for the app to connect...");
+    Console.message("");
+    Console.message("Waiting for the Sesori mobile app to connect...");
+    Console.message("Bridge startup is paused and will continue automatically once connected.");
 
-    final waited = await _statusRepository.getStatus(accessToken: accessToken, wait: true);
-    switch (waited) {
-      case AppClientRegistered():
-        await _markCompleted(authBackendUrl: authBackendUrl, userId: userId);
-        Console.message("Sesori app connected. Continuing bridge startup.");
-      case AppClientAbsent():
-        Console.message("No Sesori app connected yet; continuing bridge startup.");
-      case AppClientStatusUnavailable(:final error, :final stackTrace):
-        Log.w("Could not finish the Sesori app registration check; continuing bridge startup", error, stackTrace);
+    var waitFailureReported = false;
+    while (true) {
+      final String pollingAccessToken;
+      try {
+        pollingAccessToken = await _tokenRefresher.getAccessToken();
+      } on Object catch (error, stackTrace) {
+        if (!waitFailureReported) {
+          Log.w(
+            "Could not refresh authentication while waiting for the Sesori app; retrying",
+            error,
+            stackTrace,
+          );
+          waitFailureReported = true;
+        }
+        await Future<void>.delayed(_failureRetryDelay);
+        continue;
+      }
+
+      final waited = await _statusRepository.getStatus(accessToken: pollingAccessToken, wait: true);
+      switch (waited) {
+        case AppClientRegistered():
+          await _markCompleted(authBackendUrl: authBackendUrl, userId: userId);
+          Console.message("");
+          Console.message("Sesori mobile app connected. Continuing bridge startup.");
+          return;
+        case AppClientAbsent():
+          waitFailureReported = false;
+        case AppClientStatusUnavailable(:final error, :final stackTrace):
+          if (!waitFailureReported) {
+            Log.w(
+              "Could not check Sesori app registration; bridge startup remains paused and the check will retry",
+              error,
+              stackTrace,
+            );
+            waitFailureReported = true;
+          }
+          await Future<void>.delayed(_failureRetryDelay);
+      }
     }
   }
 

--- a/bridge/app/test/services/app_client_onboarding_service_test.dart
+++ b/bridge/app/test/services/app_client_onboarding_service_test.dart
@@ -1,6 +1,8 @@
 import "dart:convert";
 import "dart:io";
 
+import "package:fake_async/fake_async.dart";
+import "package:sesori_bridge/src/auth/token_refresher.dart";
 import "package:sesori_bridge/src/foundation/app_onboarding_formatter.dart";
 import "package:sesori_bridge/src/repositories/app_client_status_repository.dart";
 import "package:sesori_bridge/src/repositories/app_onboarding_state_repository.dart";
@@ -13,16 +15,19 @@ void main() {
     late _FakeAppClientStatusRepository statusRepository;
     late _FakeAppOnboardingStateRepository stateRepository;
     late AppClientOnboardingService service;
+    late _FakeTokenRefresher tokenRefresher;
     late _CapturingStdout stdoutCapture;
     late _CapturingStdout stderrCapture;
 
     setUp(() {
       statusRepository = _FakeAppClientStatusRepository();
       stateRepository = _FakeAppOnboardingStateRepository();
+      tokenRefresher = _FakeTokenRefresher(accessToken: _token(userId: "user-a"));
       service = AppClientOnboardingService(
         statusRepository: statusRepository,
         stateRepository: stateRepository,
         formatter: _StubAppOnboardingFormatter(),
+        tokenRefresher: tokenRefresher,
       );
       stdoutCapture = _CapturingStdout();
       stderrCapture = _CapturingStdout();
@@ -83,8 +88,11 @@ void main() {
       expect(stderrCapture.lines, isEmpty);
     });
 
-    test("confirmed absence shows guidance and performs exactly one long poll", () async {
+    test("confirmed absence shows guidance and polls until registration", () async {
+      tokenRefresher.accessToken = "refreshed-token";
       statusRepository.results
+        ..add(const AppClientAbsent())
+        ..add(const AppClientAbsent())
         ..add(const AppClientAbsent())
         ..add(const AppClientRegistered());
 
@@ -97,34 +105,63 @@ void main() {
         err: stderrCapture,
       );
 
-      expect(statusRepository.waitValues, equals([false, true]));
+      expect(statusRepository.waitValues, equals([false, true, true, true]));
+      expect(statusRepository.accessTokens, [
+        _token(userId: "user-a"),
+        "refreshed-token",
+        "refreshed-token",
+        "refreshed-token",
+      ]);
       expect(stateRepository.markCalls, equals(1));
       expect(stdoutCapture.lines, [
-        "Open the Sesori app and sign in with this same account:",
+        "",
+        "Connect the Sesori mobile app to continue",
+        "",
+        "Use the QR code or link below to install or open Sesori, then sign in with this same account.",
+        "",
         AppOnboardingFormatter.appUrl,
-        "Waiting up to 35 seconds for the app to connect...",
-        "Sesori app connected. Continuing bridge startup.",
+        "",
+        "Waiting for the Sesori mobile app to connect...",
+        "Bridge startup is paused and will continue automatically once connected.",
+        "",
+        "Sesori mobile app connected. Continuing bridge startup.",
       ]);
     });
 
-    test("false long poll prints one continuation line and does not mark", () async {
+    test("wait failure keeps startup paused and retries", () {
       statusRepository.results
         ..add(const AppClientAbsent())
-        ..add(const AppClientAbsent());
+        ..add(
+          const AppClientStatusUnavailable(
+            error: FormatException("offline"),
+            stackTrace: StackTrace.empty,
+          ),
+        )
+        ..add(const AppClientRegistered());
 
-      await _runCaptured(
-        () => service.run(
-          accessToken: _token(userId: "user-a"),
-          authBackendUrl: "https://auth.test",
-        ),
-        out: stdoutCapture,
-        err: stderrCapture,
-      );
+      fakeAsync((async) {
+        var completed = false;
+        _runCaptured(
+          () => service.run(
+            accessToken: _token(userId: "user-a"),
+            authBackendUrl: "https://auth.test",
+          ),
+          out: stdoutCapture,
+          err: stderrCapture,
+        ).then((_) => completed = true);
 
-      expect(statusRepository.waitValues, equals([false, true]));
-      expect(stateRepository.markCalls, equals(0));
-      expect(stdoutCapture.lines.last, equals("No Sesori app connected yet; continuing bridge startup."));
-      expect(stderrCapture.lines, isEmpty);
+        async.flushMicrotasks();
+        expect(statusRepository.waitValues, equals([false, true]));
+        expect(completed, isFalse);
+
+        async.elapse(const Duration(seconds: 5));
+        async.flushMicrotasks();
+        expect(statusRepository.waitValues, equals([false, true, true]));
+        expect(completed, isTrue);
+      });
+
+      expect(stateRepository.markCalls, equals(1));
+      expect(stderrCapture.lines, hasLength(1));
     });
 
     test("marker read failure warns but a confirmed status still attempts the write", () async {
@@ -202,12 +239,23 @@ String _token({required String? userId}) {
 class _FakeAppClientStatusRepository implements AppClientStatusRepository {
   final List<AppClientStatusResult> results = [];
   final List<bool> waitValues = [];
+  final List<String> accessTokens = [];
 
   @override
   Future<AppClientStatusResult> getStatus({required String accessToken, required bool wait}) async {
+    accessTokens.add(accessToken);
     waitValues.add(wait);
     return results.removeAt(0);
   }
+}
+
+class _FakeTokenRefresher implements TokenRefresher {
+  _FakeTokenRefresher({required this.accessToken});
+
+  String accessToken;
+
+  @override
+  Future<String> getAccessToken({bool forceRefresh = false}) async => accessToken;
 }
 
 class _FakeAppOnboardingStateRepository implements AppOnboardingStateRepository {


### PR DESCRIPTION
## Summary
- keep standalone bridge startup paused across repeated app-registration long polls until the Sesori mobile app connects
- refresh the access token between polls and retry transient wait failures without releasing startup
- replace the timeout-oriented QR copy with clearer install/open, sign-in, waiting, and connection guidance
- preserve the existing fail-open compatibility path when the initial status endpoint is unavailable on older or custom auth servers

## Testing
- `dart test test/services/app_client_onboarding_service_test.dart`
- `dart test test/bridge/runtime/bridge_runtime_runner_test.dart`
- `dart analyze --fatal-infos`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pause standalone bridge startup until the Sesori mobile app connects, with long‑poll retries and access‑token refresh. Improves QR/open/sign‑in guidance and keeps compatibility with older/custom auth servers.

- **New Features**
  - Pause startup and poll until the app registers; retry transient failures with 5s backoff.
  - Refresh the access token between polls and log failures once before retrying.
  - Clear console guidance: install/open the app, sign in, and “waiting until connected.”

- **Refactors**
  - Build `TokenManager` earlier and inject a `TokenRefresher` into the onboarding service.
  - Use the control‑channel token service in supervised runs; standalone uses local refresh. Both share the same wait loop.

<sup>Written for commit fc0cc23a7d70fbc56b63d45affa4129214b04bde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

