### PR TITLE
feat(ui): show login spinner only on the tapped provider button

### DIFF
--- a/client/app/lib/features/login/login_provider_buttons.dart
+++ b/client/app/lib/features/login/login_provider_buttons.dart
@@ -37,51 +37,57 @@ class LoginProviderButtons extends StatelessWidget {
   Widget build(BuildContext context) {
     final loc = context.loc;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        PregoButtonsSolid(
-          label: loc.loginWithGithub,
-          hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
-          size: PregoButtonsSolidSize.xl,
-          leadingIcon: VESPRSolid.github,
-          isLoading: isLoading && loadingOption == LoginOption.github,
-          fullWidth: true,
-          onPressed: isLoading ? null : onGithubSelected,
-        ),
-        if (showApple) ...[
-          const SizedBox(height: 12),
+    // Taps are blocked at the pointer level instead of via `onPressed: null`
+    // so the idle buttons keep their normal styling while a flow is in
+    // flight — the design has no grayed-out state for them.
+    return AbsorbPointer(
+      absorbing: isLoading,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
           PregoButtonsSolid(
-            label: loc.loginWithApple,
+            label: loc.loginWithGithub,
             hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
             size: PregoButtonsSolidSize.xl,
-            leadingIcon: VESPRSolid.apple,
-            isLoading: isLoading && loadingOption == LoginOption.apple,
+            leadingIcon: VESPRSolid.github,
+            isLoading: isLoading && loadingOption == LoginOption.github,
             fullWidth: true,
-            onPressed: isLoading ? null : onAppleSelected,
+            onPressed: onGithubSelected,
           ),
-        ],
-        const SizedBox(height: 12),
-        PregoButtonsSolid(
-          label: loc.loginWithGoogle,
-          hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
-          size: PregoButtonsSolidSize.xl,
-          leadingIcon: VESPRSolid.google,
-          isLoading: isLoading && loadingOption == LoginOption.google,
-          fullWidth: true,
-          onPressed: isLoading ? null : onGoogleSelected,
-        ),
-        if (!showEmailForm) ...[
+          if (showApple) ...[
+            const SizedBox(height: 12),
+            PregoButtonsSolid(
+              label: loc.loginWithApple,
+              hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
+              size: PregoButtonsSolidSize.xl,
+              leadingIcon: VESPRSolid.apple,
+              isLoading: isLoading && loadingOption == LoginOption.apple,
+              fullWidth: true,
+              onPressed: onAppleSelected,
+            ),
+          ],
           const SizedBox(height: 12),
           PregoButtonsSolid(
-            label: loc.signInWithEmail,
-            hierarchy: PregoButtonsSolidHierarchy.tertiary,
+            label: loc.loginWithGoogle,
+            hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
             size: PregoButtonsSolidSize.xl,
+            leadingIcon: VESPRSolid.google,
+            isLoading: isLoading && loadingOption == LoginOption.google,
             fullWidth: true,
-            onPressed: isLoading ? null : onShowEmailForm,
+            onPressed: onGoogleSelected,
           ),
+          if (!showEmailForm) ...[
+            const SizedBox(height: 12),
+            PregoButtonsSolid(
+              label: loc.signInWithEmail,
+              hierarchy: PregoButtonsSolidHierarchy.tertiary,
+              size: PregoButtonsSolidSize.xl,
+              fullWidth: true,
+              onPressed: onShowEmailForm,
+            ),
+          ],
         ],
-      ],
+      ),
     );
   }
 }

--- a/client/app/lib/features/login/login_provider_buttons.dart
+++ b/client/app/lib/features/login/login_provider_buttons.dart
@@ -39,54 +39,59 @@ class LoginProviderButtons extends StatelessWidget {
 
     // Taps are blocked at the pointer level instead of via `onPressed: null`
     // so the idle buttons keep their normal styling while a flow is in
-    // flight — the design has no grayed-out state for them.
-    return AbsorbPointer(
-      absorbing: isLoading,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          PregoButtonsSolid(
-            label: loc.loginWithGithub,
-            hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
-            size: PregoButtonsSolidSize.xl,
-            leadingIcon: VESPRSolid.github,
-            isLoading: isLoading && loadingOption == LoginOption.github,
-            fullWidth: true,
-            onPressed: onGithubSelected,
-          ),
-          if (showApple) ...[
-            const SizedBox(height: 12),
+    // flight — the design has no grayed-out state for them. AbsorbPointer
+    // does not cover keyboard activation of a focused button, so the buttons
+    // are also excluded from focus while loading.
+    return ExcludeFocus(
+      excluding: isLoading,
+      child: AbsorbPointer(
+        absorbing: isLoading,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
             PregoButtonsSolid(
-              label: loc.loginWithApple,
+              label: loc.loginWithGithub,
               hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
               size: PregoButtonsSolidSize.xl,
-              leadingIcon: VESPRSolid.apple,
-              isLoading: isLoading && loadingOption == LoginOption.apple,
+              leadingIcon: VESPRSolid.github,
+              isLoading: isLoading && loadingOption == LoginOption.github,
               fullWidth: true,
-              onPressed: onAppleSelected,
+              onPressed: onGithubSelected,
             ),
-          ],
-          const SizedBox(height: 12),
-          PregoButtonsSolid(
-            label: loc.loginWithGoogle,
-            hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
-            size: PregoButtonsSolidSize.xl,
-            leadingIcon: VESPRSolid.google,
-            isLoading: isLoading && loadingOption == LoginOption.google,
-            fullWidth: true,
-            onPressed: onGoogleSelected,
-          ),
-          if (!showEmailForm) ...[
+            if (showApple) ...[
+              const SizedBox(height: 12),
+              PregoButtonsSolid(
+                label: loc.loginWithApple,
+                hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
+                size: PregoButtonsSolidSize.xl,
+                leadingIcon: VESPRSolid.apple,
+                isLoading: isLoading && loadingOption == LoginOption.apple,
+                fullWidth: true,
+                onPressed: onAppleSelected,
+              ),
+            ],
             const SizedBox(height: 12),
             PregoButtonsSolid(
-              label: loc.signInWithEmail,
-              hierarchy: PregoButtonsSolidHierarchy.tertiary,
+              label: loc.loginWithGoogle,
+              hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
               size: PregoButtonsSolidSize.xl,
+              leadingIcon: VESPRSolid.google,
+              isLoading: isLoading && loadingOption == LoginOption.google,
               fullWidth: true,
-              onPressed: onShowEmailForm,
+              onPressed: onGoogleSelected,
             ),
+            if (!showEmailForm) ...[
+              const SizedBox(height: 12),
+              PregoButtonsSolid(
+                label: loc.signInWithEmail,
+                hierarchy: PregoButtonsSolidHierarchy.tertiary,
+                size: PregoButtonsSolidSize.xl,
+                fullWidth: true,
+                onPressed: onShowEmailForm,
+              ),
+            ],
           ],
-        ],
+        ),
       ),
     );
   }

--- a/client/app/lib/features/login/login_provider_buttons.dart
+++ b/client/app/lib/features/login/login_provider_buttons.dart
@@ -4,8 +4,16 @@ import "package:theme_prego/icons/vespr_icons.g.dart";
 
 import "../../../core/extensions/build_context_x.dart";
 
+/// The login options whose button can show an in-flight loading spinner.
+enum LoginOption { github, apple, google }
+
 class LoginProviderButtons extends StatelessWidget {
   final bool isLoading;
+
+  /// Which option's button swaps its provider logo for the loading spinner
+  /// while [isLoading] is true. Null when the active flow was not started by
+  /// one of these buttons (e.g. the email form).
+  final LoginOption? loadingOption;
   final bool showEmailForm;
   final bool showApple;
   final VoidCallback onGithubSelected;
@@ -16,6 +24,7 @@ class LoginProviderButtons extends StatelessWidget {
   const LoginProviderButtons({
     super.key,
     required this.isLoading,
+    required this.loadingOption,
     required this.showEmailForm,
     required this.showApple,
     required this.onGithubSelected,
@@ -36,7 +45,7 @@ class LoginProviderButtons extends StatelessWidget {
           hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
           size: PregoButtonsSolidSize.xl,
           leadingIcon: VESPRSolid.github,
-          isLoading: isLoading,
+          isLoading: isLoading && loadingOption == LoginOption.github,
           fullWidth: true,
           onPressed: isLoading ? null : onGithubSelected,
         ),
@@ -47,7 +56,7 @@ class LoginProviderButtons extends StatelessWidget {
             hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
             size: PregoButtonsSolidSize.xl,
             leadingIcon: VESPRSolid.apple,
-            isLoading: isLoading,
+            isLoading: isLoading && loadingOption == LoginOption.apple,
             fullWidth: true,
             onPressed: isLoading ? null : onAppleSelected,
           ),
@@ -58,7 +67,7 @@ class LoginProviderButtons extends StatelessWidget {
           hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
           size: PregoButtonsSolidSize.xl,
           leadingIcon: VESPRSolid.google,
-          isLoading: isLoading,
+          isLoading: isLoading && loadingOption == LoginOption.google,
           fullWidth: true,
           onPressed: isLoading ? null : onGoogleSelected,
         ),
@@ -68,7 +77,6 @@ class LoginProviderButtons extends StatelessWidget {
             label: loc.signInWithEmail,
             hierarchy: PregoButtonsSolidHierarchy.tertiary,
             size: PregoButtonsSolidSize.xl,
-            isLoading: isLoading,
             fullWidth: true,
             onPressed: isLoading ? null : onShowEmailForm,
           ),

--- a/client/app/lib/features/login/login_screen.dart
+++ b/client/app/lib/features/login/login_screen.dart
@@ -48,11 +48,26 @@ class _LoginScreenBody extends StatefulWidget {
 class _LoginScreenBodyState extends State<_LoginScreenBody> {
   bool _showEmailForm = false;
 
-  Future<void> _loginWithProvider(OAuthProvider provider) async {
+  /// The option whose button was tapped for the currently pending login flow.
+  /// Drives which button shows the loading spinner; cleared when the cubit
+  /// reaches a terminal state so a later email-form login cannot resurrect a
+  /// stale provider spinner.
+  LoginOption? _pendingOption;
+
+  Future<void> _loginWithProvider({
+    required LoginOption option,
+    required OAuthProvider provider,
+  }) async {
+    setState(() {
+      _pendingOption = option;
+    });
     await context.read<LoginCubit>().loginWithProvider(provider);
   }
 
   Future<void> _loginWithApple() async {
+    setState(() {
+      _pendingOption = LoginOption.apple;
+    });
     final rawNonce = _generateNonce();
     final hashedNonce = sha256.convert(utf8.encode(rawNonce)).toString();
 
@@ -82,6 +97,13 @@ class _LoginScreenBodyState extends State<_LoginScreenBody> {
     } on SignInWithAppleAuthorizationException catch (e) {
       if (e.code == AuthorizationErrorCode.canceled) {
         logd("Apple Sign-In cancelled by user");
+        // Cancelling the native sheet emits no cubit state, so the pending
+        // marker must be cleared here.
+        if (mounted) {
+          setState(() {
+            _pendingOption = null;
+          });
+        }
         return;
       }
       if (mounted) {
@@ -115,12 +137,21 @@ class _LoginScreenBodyState extends State<_LoginScreenBody> {
 
     return Scaffold(
       body: BlocListener<LoginCubit, LoginState>(
-        listenWhen: (previous, current) => current is LoginSuccess,
+        listenWhen: (previous, current) =>
+            current is LoginSuccess || current is LoginFailed || current is LoginTimeout || current is LoginIdle,
         listener: (context, state) {
-          // Relay connection is handled reactively: AuthManager emits
-          // AuthState.authenticated → ConnectionService connects. The
-          // connection overlay shows progress; navigation proceeds immediately.
-          context.goRoute(const AppRoute.projects());
+          if (state is LoginSuccess) {
+            // Relay connection is handled reactively: AuthManager emits
+            // AuthState.authenticated → ConnectionService connects. The
+            // connection overlay shows progress; navigation proceeds immediately.
+            context.goRoute(const AppRoute.projects());
+            return;
+          }
+          if (_pendingOption != null) {
+            setState(() {
+              _pendingOption = null;
+            });
+          }
         },
         child: Stack(
           children: [
@@ -162,11 +193,18 @@ class _LoginScreenBodyState extends State<_LoginScreenBody> {
                                 const SizedBox(height: 24),
                                 LoginProviderButtons(
                                   isLoading: isLoading,
+                                  loadingOption: _pendingOption,
                                   showEmailForm: _showEmailForm,
                                   showApple: !kIsWeb && defaultTargetPlatform == TargetPlatform.iOS,
-                                  onGithubSelected: () => _loginWithProvider(AuthProvider.github),
+                                  onGithubSelected: () => _loginWithProvider(
+                                    option: LoginOption.github,
+                                    provider: AuthProvider.github,
+                                  ),
                                   onAppleSelected: _loginWithApple,
-                                  onGoogleSelected: () => _loginWithProvider(AuthProvider.google),
+                                  onGoogleSelected: () => _loginWithProvider(
+                                    option: LoginOption.google,
+                                    provider: AuthProvider.google,
+                                  ),
                                   onShowEmailForm: _showEmailLogin,
                                 ),
                                 if (_showEmailForm) ...[

--- a/client/app/test/features/login/login_provider_buttons_test.dart
+++ b/client/app/test/features/login/login_provider_buttons_test.dart
@@ -55,6 +55,13 @@ void main() {
 
         expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
         expect(find.byIcon(VESPRSolid.github), findsNothing);
+
+        // The indicator must carry the button's foreground colour — the
+        // default gray ticks are invisible on the dark provider buttons.
+        final indicator = tester.widget<CupertinoActivityIndicator>(
+          find.byType(CupertinoActivityIndicator),
+        );
+        expect(indicator.color, isNotNull);
       },
       variant: TargetPlatformVariant.only(TargetPlatform.iOS),
     );

--- a/client/app/test/features/login/login_provider_buttons_test.dart
+++ b/client/app/test/features/login/login_provider_buttons_test.dart
@@ -1,0 +1,112 @@
+import "package:flutter/cupertino.dart";
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:sesori_mobile/features/login/login_provider_buttons.dart";
+import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:theme_prego/module_prego.dart";
+
+Widget _buildApp({
+  required bool isLoading,
+  required LoginOption? loadingOption,
+  VoidCallback? onGithubSelected,
+  VoidCallback? onAppleSelected,
+  VoidCallback? onGoogleSelected,
+  VoidCallback? onShowEmailForm,
+}) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [PregoDesignSystem.light]),
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: LoginProviderButtons(
+        isLoading: isLoading,
+        loadingOption: loadingOption,
+        showEmailForm: false,
+        showApple: true,
+        onGithubSelected: onGithubSelected ?? () {},
+        onAppleSelected: onAppleSelected ?? () {},
+        onGoogleSelected: onGoogleSelected ?? () {},
+        onShowEmailForm: onShowEmailForm ?? () {},
+      ),
+    ),
+  );
+}
+
+void main() {
+  group("LoginProviderButtons", () {
+    testWidgets("spinner replaces only the tapped provider's logo", (tester) async {
+      await tester.pumpWidget(
+        _buildApp(isLoading: true, loadingOption: LoginOption.google),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byIcon(VESPRSolid.google), findsNothing);
+      expect(find.byIcon(VESPRSolid.github), findsOneWidget);
+      expect(find.byIcon(VESPRSolid.apple), findsOneWidget);
+    });
+
+    testWidgets(
+      "spinner is the adaptive Cupertino variant on iOS",
+      (tester) async {
+        await tester.pumpWidget(
+          _buildApp(isLoading: true, loadingOption: LoginOption.github),
+        );
+
+        expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+        expect(find.byIcon(VESPRSolid.github), findsNothing);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.iOS),
+    );
+
+    testWidgets("all options are disabled while one is loading", (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(
+        _buildApp(
+          isLoading: true,
+          loadingOption: LoginOption.github,
+          onGithubSelected: () => calls.add("github"),
+          onAppleSelected: () => calls.add("apple"),
+          onGoogleSelected: () => calls.add("google"),
+          onShowEmailForm: () => calls.add("email"),
+        ),
+      );
+
+      await tester.tap(find.text("Sign in with GitHub"), warnIfMissed: false);
+      await tester.tap(find.text("Sign in with Apple"), warnIfMissed: false);
+      await tester.tap(find.text("Sign in with Google"), warnIfMissed: false);
+      await tester.tap(find.text("Sign in with Email"), warnIfMissed: false);
+      await tester.pump();
+
+      expect(calls, isEmpty);
+    });
+
+    testWidgets("no provider spinner during an email-form login", (tester) async {
+      await tester.pumpWidget(
+        _buildApp(isLoading: true, loadingOption: null),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.byIcon(VESPRSolid.github), findsOneWidget);
+      expect(find.byIcon(VESPRSolid.apple), findsOneWidget);
+      expect(find.byIcon(VESPRSolid.google), findsOneWidget);
+    });
+
+    testWidgets("taps reach their callbacks when idle", (tester) async {
+      final calls = <String>[];
+      await tester.pumpWidget(
+        _buildApp(
+          isLoading: false,
+          loadingOption: null,
+          onGithubSelected: () => calls.add("github"),
+          onGoogleSelected: () => calls.add("google"),
+        ),
+      );
+
+      await tester.tap(find.text("Sign in with GitHub"));
+      await tester.tap(find.text("Sign in with Google"));
+      await tester.pump();
+
+      expect(calls, equals(["github", "google"]));
+    });
+  });
+}

--- a/client/app/test/features/login/login_provider_buttons_test.dart
+++ b/client/app/test/features/login/login_provider_buttons_test.dart
@@ -96,6 +96,33 @@ void main() {
       }
     });
 
+    testWidgets("buttons cannot take keyboard focus while one is loading", (tester) async {
+      await tester.pumpWidget(
+        _buildApp(isLoading: true, loadingOption: LoginOption.github),
+      );
+
+      // Keyboard activation (e.g. Enter on a focused button) bypasses the
+      // pointer-level AbsorbPointer block, so the buttons must also be
+      // unfocusable while a flow is in flight.
+      final googleFocus = Focus.of(tester.element(find.text("Sign in with Google")));
+      googleFocus.requestFocus();
+      await tester.pump();
+
+      expect(googleFocus.hasFocus, isFalse);
+    });
+
+    testWidgets("buttons are focusable when idle", (tester) async {
+      await tester.pumpWidget(
+        _buildApp(isLoading: false, loadingOption: null),
+      );
+
+      final googleFocus = Focus.of(tester.element(find.text("Sign in with Google")));
+      googleFocus.requestFocus();
+      await tester.pump();
+
+      expect(googleFocus.hasFocus, isTrue);
+    });
+
     testWidgets("no provider spinner during an email-form login", (tester) async {
       await tester.pumpWidget(
         _buildApp(isLoading: true, loadingOption: null),

--- a/client/app/test/features/login/login_provider_buttons_test.dart
+++ b/client/app/test/features/login/login_provider_buttons_test.dart
@@ -3,6 +3,7 @@ import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:sesori_mobile/features/login/login_provider_buttons.dart";
 import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
 import "package:theme_prego/module_prego.dart";
 
 Widget _buildApp({
@@ -58,7 +59,7 @@ void main() {
       variant: TargetPlatformVariant.only(TargetPlatform.iOS),
     );
 
-    testWidgets("all options are disabled while one is loading", (tester) async {
+    testWidgets("options are untappable but keep enabled styling while one is loading", (tester) async {
       final calls = <String>[];
       await tester.pumpWidget(
         _buildApp(
@@ -78,6 +79,14 @@ void main() {
       await tester.pump();
 
       expect(calls, isEmpty);
+
+      // A null onPressed is what switches PregoButtonsSolid to its grayed
+      // disabled visuals; the design keeps idle options looking normal.
+      final buttons = tester.widgetList<PregoButtonsSolid>(find.byType(PregoButtonsSolid));
+      expect(buttons.length, equals(4));
+      for (final button in buttons) {
+        expect(button.onPressed, isNotNull);
+      }
     });
 
     testWidgets("no provider spinner during an email-form login", (tester) async {

--- a/client/module_prego/lib/components/buttons/prego_buttons_solid.dart
+++ b/client/module_prego/lib/components/buttons/prego_buttons_solid.dart
@@ -1,3 +1,4 @@
+import "package:flutter/cupertino.dart" show CupertinoActivityIndicator;
 import "package:flutter/material.dart";
 
 import "../../interactions/prego_tappable.dart";
@@ -871,10 +872,22 @@ class _LoadingSpinner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return CircularProgressIndicator.adaptive(
-      constraints: BoxConstraints.tight(Size(size, size)),
-      strokeWidth: 2,
-      valueColor: AlwaysStoppedAnimation<Color>(color),
-    );
+    // Not CircularProgressIndicator.adaptive: its Cupertino variant takes the
+    // tick colour from backgroundColor, not valueColor, so the themed colour
+    // is dropped and the default gray ticks are invisible on dark buttons.
+    switch (Theme.of(context).platform) {
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        return CupertinoActivityIndicator(color: color, radius: size / 2);
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        return CircularProgressIndicator(
+          constraints: BoxConstraints.tight(Size(size, size)),
+          strokeWidth: 2,
+          valueColor: AlwaysStoppedAnimation<Color>(color),
+        );
+    }
   }
 }


### PR DESCRIPTION
## Summary

Implements the login-screen loading design from Figma ([node 666-6093](https://www.figma.com/design/NILKXLD9cwuWHhLnGqPqeJ/Sesori?node-id=666-6093&m=dev)): tapping a login option shows the loading spinner **only on that button**, replacing its provider logo, while the other options stay in their normal visual state but become untappable.

## Changes

- **`LoginProviderButtons`** takes a new `LoginOption? loadingOption` (`github` / `apple` / `google`) alongside `isLoading`. Only the matching button sets `isLoading` on `PregoButtonsSolid`, whose loading state swaps the leading logo for `CircularProgressIndicator.adaptive` — the native Cupertino spinner on iOS.
- While a flow is in flight, taps are blocked with an `AbsorbPointer` around the button column instead of `onPressed: null`, because a null handler switches `PregoButtonsSolid` to its grayed disabled visuals. Idle buttons therefore look exactly like their normal state — just untappable.
- The **"Sign in with Email"** tertiary button no longer shows a spinner (it only reveals the form; the form's own submit button has its loading state).
- **`LoginScreen`** tracks the tapped option and passes it down. The marker is cleared on terminal cubit states (`failed` / `timeout` / `idle`) and on Apple-sheet cancel, so a later email-form login can't resurrect a stale provider spinner. It survives backgrounding, so the spinner is still on the right button after returning from the OAuth browser.

## Testing

- New `login_provider_buttons_test.dart` (5 widget tests): spinner only on the loading option with its logo removed, Cupertino variant on iOS, options untappable but keeping enabled styling while one loads, no provider spinner during an email-form login, callbacks firing when idle.
- Existing login cubit/screen tests pass (17 total in the folder); analyzer clean on touched files.
- Verified live on the iPhone Air simulator: tapped Google → spinner on Google only, GitHub/Apple/Email in normal styling; tapping GitHub during polling does nothing; polling status text shown.

https://claude.ai/code/session_011w6U97PDJfGn8LymKvg2La

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the spinner only on the tapped login provider button; other options look normal but can’t be tapped or focused while a login is in flight. The spinner clears on success/failure/timeout/idle or Apple cancel, and the email button never spins.

- **New Features**
  - Track the tapped provider in LoginScreen and pass a `loadingOption` to LoginProviderButtons.
  - Swap only that button’s icon for the adaptive spinner (Cupertino on iOS/macOS).
  - Keep idle buttons’ normal styling by blocking pointer taps with AbsorbPointer.

- **Bug Fixes**
  - Prevent keyboard-triggered logins while loading by excluding buttons from focus.
  - Honor the themed spinner color on iOS/macOS by using `CupertinoActivityIndicator` directly.

<sup>Written for commit 1aadae8ed5e938e7933745fa241db3f6c47912f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

