### PR TITLE
fix(client): commit email autofill before navigation

### DIFF
--- a/client/app/lib/features/login/login_screen.dart
+++ b/client/app/lib/features/login/login_screen.dart
@@ -135,6 +135,10 @@ class _LoginScreenBodyState extends State<_LoginScreenBody> {
     } finally {
       if (mounted) setState(() => _isEmailSheetOpen = false);
     }
+    if (!mounted) return;
+    if (context.read<LoginCubit>().state is LoginSuccess) {
+      context.goRoute(const AppRoute.projects());
+    }
   }
 
   @override
@@ -150,6 +154,9 @@ class _LoginScreenBodyState extends State<_LoginScreenBody> {
             current is LoginSuccess || current is LoginFailed || current is LoginTimeout || current is LoginIdle,
         listener: (context, state) {
           if (state is LoginSuccess) {
+            // The email sheet must commit its autofill context before this
+            // route is replaced. It navigates after the sheet has closed.
+            if (_isEmailSheetOpen) return;
             // Relay connection is handled reactively: AuthManager emits
             // AuthState.authenticated → ConnectionService connects. The
             // connection overlay shows progress; navigation proceeds immediately.

--- a/client/app/test/features/login/login_screen_test.dart
+++ b/client/app/test/features/login/login_screen_test.dart
@@ -1,13 +1,30 @@
+import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:get_it/get_it.dart";
+import "package:go_router/go_router.dart";
 import "package:mocktail/mocktail.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_mobile/features/login/login_screen.dart";
+import "package:sesori_mobile/l10n/app_localizations.dart";
+import "package:theme_prego/module_prego.dart";
 
 class MockOAuthFlowProvider extends Mock implements OAuthFlowProvider {}
 
 class MockUrlLauncher extends Mock implements UrlLauncher {}
+
+class MockLifecycleSource extends Mock implements LifecycleSource {}
+
+class RecordingNavigatorObserver extends NavigatorObserver {
+  bool poppedPopupRoute = false;
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    if (route is PopupRoute<void>) poppedPopupRoute = true;
+    super.didPop(route, previousRoute);
+  }
+}
 
 class MockAuthSession extends Mock implements AuthSession {
   final BehaviorSubject<AuthState> _authState = BehaviorSubject.seeded(const AuthState.unauthenticated());
@@ -19,14 +36,19 @@ class MockAuthSession extends Mock implements AuthSession {
   AuthState get currentState => _authState.value;
 
   @override
-  Future<AuthUser> loginWithEmail({required String email, required String password}) async =>
-      throw UnimplementedError();
+  Future<AuthUser> loginWithEmail({required String email, required String password}) async => const AuthUser(
+    id: "user-1",
+    provider: AuthProvider.email,
+    providerUserId: "alex@example.com",
+    providerUsername: null,
+  );
 }
 
 void main() {
   late MockOAuthFlowProvider mockOAuthFlowProvider;
   late MockUrlLauncher mockUrlLauncher;
   late MockAuthSession mockAuthSession;
+  late MockLifecycleSource mockLifecycleSource;
 
   setUpAll(() {
     registerFallbackValue(AuthProvider.github);
@@ -36,6 +58,7 @@ void main() {
     mockOAuthFlowProvider = MockOAuthFlowProvider();
     mockUrlLauncher = MockUrlLauncher();
     mockAuthSession = MockAuthSession();
+    mockLifecycleSource = MockLifecycleSource();
 
     final getIt = GetIt.instance;
     getIt.reset();
@@ -43,6 +66,11 @@ void main() {
     getIt.registerSingleton<OAuthFlowProvider>(mockOAuthFlowProvider);
     getIt.registerSingleton<UrlLauncher>(mockUrlLauncher);
     getIt.registerSingleton<AuthSession>(mockAuthSession);
+    getIt.registerSingleton<LifecycleSource>(mockLifecycleSource);
+
+    when(() => mockLifecycleSource.lifecycleStateStream).thenAnswer(
+      (_) => BehaviorSubject<LifecycleState>.seeded(LifecycleState.resumed).stream,
+    );
 
     when(() => mockAuthSession.getCurrentUser()).thenAnswer((_) async => null);
     when(() => mockAuthSession.restoreSession()).thenAnswer((_) async => false);
@@ -54,16 +82,36 @@ void main() {
     GetIt.instance.reset();
   });
 
-  group(
-    "LoginScreen",
-    () {
-      test(
-        "Widget tests for LoginScreen are skipped due to context.loc dependency. "
-        "Coverage provided by login_cubit_test.dart.",
-        () {
-          expect(true, isTrue);
-        },
-      );
-    },
-  );
+  testWidgets("email success commits autofill before navigating", (tester) async {
+    final observer = RecordingNavigatorObserver();
+    final router = GoRouter(
+      initialLocation: "/login",
+      observers: [observer],
+      routes: [
+        GoRoute(path: "/login", builder: (_, _) => const LoginScreen()),
+        GoRoute(
+          path: "/projects",
+          builder: (_, _) => const Scaffold(body: Text("Projects")),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MaterialApp.router(
+        theme: ThemeData(extensions: [PregoDesignSystem.light]),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        routerConfig: router,
+      ),
+    );
+    await tester.tap(find.text("Sign in with Email"));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextFormField).first, "alex@example.com");
+    await tester.enterText(find.byType(TextFormField).last, "hunter2");
+    await tester.tap(find.text("Sign in"));
+    await tester.pumpAndSettle();
+
+    expect(find.text("Projects"), findsOneWidget);
+    expect(observer.poppedPopupRoute, isTrue);
+  });
 }


### PR DESCRIPTION
## Summary

- defer Projects navigation while the email login sheet completes its success path
- let the sheet commit the accepted credentials to the autofill context before it pops
- replace the placeholder login screen test with a widget regression test that verifies the sheet pops before navigation

## Bug

`LoginCubit.loginWithEmail` emits `LoginSuccess` before returning `true`. The login screen listener immediately replaced the login route, disposing the email sheet with `AutofillContextAction.cancel`. The sheet therefore never reached its explicit `TextInput.finishAutofillContext()` call, so password managers were not offered the successfully authenticated credentials.

## Verification

- `flutter test test/features/login/login_screen_test.dart test/features/login/email_login_sheet_test.dart`
- `dart analyze lib/features/login/login_screen.dart test/features/login/login_screen_test.dart`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the email login sheet commits autofill before navigation so password managers can save credentials. Navigation to Projects now occurs after the sheet closes.

- **Bug Fixes**
  - Defer navigation to `/projects` until the email sheet closes and calls `TextInput.finishAutofillContext()`, gating the `LoginSuccess` listener while `_isEmailSheetOpen`.
  - Add a widget regression test that verifies the sheet pops before navigating to Projects.

<sup>Written for commit ef555b2970699a2c5e90d980439b37bd56a30793. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

