### PR TITLE
fix(ui): show pull-to-refresh below top bar

### DIFF
--- a/client/app/lib/features/session_list/session_list_content.dart
+++ b/client/app/lib/features/session_list/session_list_content.dart
@@ -16,8 +16,8 @@ const _actionDispatcher = SessionListActionDispatcher();
 
 /// Pull-to-refresh handler shared by [SessionListScaffold] and
 /// [SessionListPanel]: re-fetches the session list and reports the outcome via
-/// a snackbar. Both hosts own their own scroll view (and thus their own
-/// [RefreshIndicator]), so the refresh action lives here, next to the content.
+/// a snackbar. Both hosts own their own scroll view and refresh control, so the
+/// refresh action lives here, next to the content.
 Future<void> refreshSessionList(BuildContext context) async {
   final loc = context.loc;
   final success = await context.read<SessionListCubit>().refreshSessions(waitForPrData: true);

--- a/client/app/test/features/project_list/project_list_collapsing_title_test.dart
+++ b/client/app/test/features/project_list/project_list_collapsing_title_test.dart
@@ -151,8 +151,8 @@ void main() {
     await pumpScreen(tester, hasRegisteredBridges: false);
     verifyNever(() => mockConnectionService.reconnect());
 
-    // The scaffold's RefreshIndicator now drives the reconnect that the body's
-    // own pull-to-refresh used to.
+    // The scaffold's sliver refresh control drives the reconnect that the
+    // body's own pull-to-refresh used to.
     await tester.fling(find.byType(CustomScrollView), const Offset(0, 300), 1000);
     await tester.pumpAndSettle();
 

--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -1,3 +1,4 @@
+import "package:flutter/cupertino.dart" show CupertinoSliverRefreshControl;
 import "package:flutter/foundation.dart";
 import "package:flutter/material.dart";
 import "package:flutter/rendering.dart";
@@ -85,7 +86,7 @@ class PregoGlassScaffold extends StatefulWidget {
     this.scrollable = true,
   }) : assert(
          scrollable || onRefresh == null,
-         "onRefresh requires scrollable to be true (RefreshIndicator needs a draggable page)",
+         "onRefresh requires scrollable to be true (the refresh control needs a draggable page)",
        );
 
   /// Primary title — shown large below the bar and, once collapsed, inline.
@@ -152,7 +153,8 @@ class PregoGlassScaffold extends StatefulWidget {
   /// modal scrim such as a blocking loading indicator. Null shows nothing.
   final Widget? overlay;
 
-  /// When set, the scroll view is wrapped in a [RefreshIndicator].
+  /// When set, an in-scroll refresh control opens below the top bar and pushes
+  /// the page content down while it is pulled.
   final Future<void> Function()? onRefresh;
 
   /// Page background painted behind the glass. Defaults to `bgSurface1`.
@@ -212,6 +214,7 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
     final topPad = MediaQuery.paddingOf(context).top;
     final extendBehind = widget.extendBodyBehindBar;
     final collapsing = widget.titleMode == PregoTopNavigationTitleMode.collapsing;
+    final onRefresh = widget.onRefresh;
 
     // The bar. It shares this scaffold's [_scrollController] so its collapsing
     // title fades in as the large-title sliver below scrolls away.
@@ -258,10 +261,45 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
       ],
     );
 
-    Widget scrollView = CustomScrollView(
+    final scrollView = CustomScrollView(
       controller: _scrollController,
-      physics: widget.scrollable ? const AlwaysScrollableScrollPhysics() : const NeverScrollableScrollPhysics(),
+      // CupertinoSliverRefreshControl needs overscroll even on platforms whose
+      // default physics clamp at the edge. Its sliver extent is what moves the
+      // page content down during a pull instead of painting over it.
+      physics: !widget.scrollable
+          ? const NeverScrollableScrollPhysics()
+          : onRefresh != null
+          ? const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics())
+          : const AlwaysScrollableScrollPhysics(),
       slivers: [
+        // The refresh sliver must receive the scroll view's leading overscroll,
+        // so it precedes the bar spacer. Shift only its painted indicator below
+        // the live bar inset; the sliver itself opens at the scroll origin and
+        // pushes the spacer, large title, and caller-provided content down.
+        if (onRefresh != null)
+          CupertinoSliverRefreshControl(
+            onRefresh: onRefresh,
+            builder: (context, refreshState, pulledExtent, triggerDistance, indicatorExtent) {
+              final indicator = CupertinoSliverRefreshControl.buildRefreshIndicator(
+                context,
+                refreshState,
+                pulledExtent,
+                triggerDistance,
+                indicatorExtent,
+              );
+              // A non-extended body already begins below the bar.
+              if (!extendBehind) return indicator;
+
+              return ValueListenableBuilder<double>(
+                valueListenable: _bannerHeight,
+                child: indicator,
+                builder: (context, bannerHeight, indicator) => Transform.translate(
+                  offset: Offset(0, topPad + topNav.preferredSize.height + bannerHeight),
+                  child: indicator,
+                ),
+              );
+            },
+          ),
         // When the body scrolls behind the bar, reserve space so the title
         // clears it. When it doesn't, GlassScaffold already insets the body
         // below the bar, so a spacer would double the gap. Skipped entirely when
@@ -286,11 +324,6 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
         ...widget.slivers,
       ],
     );
-
-    final onRefresh = widget.onRefresh;
-    if (onRefresh != null) {
-      scrollView = RefreshIndicator(onRefresh: onRefresh, child: scrollView);
-    }
 
     final overlay = widget.overlay;
 

--- a/client/module_prego/test/components/prego_glass_scaffold_banner_test.dart
+++ b/client/module_prego/test/components/prego_glass_scaffold_banner_test.dart
@@ -1,3 +1,4 @@
+import "package:flutter/cupertino.dart";
 import "package:flutter/material.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:liquid_glass_widgets/liquid_glass_widgets.dart";
@@ -18,6 +19,7 @@ Widget _harness({
   required Widget? banner,
   bool extendBodyBehindBar = true,
   bool reserveBarSpace = true,
+  Future<void> Function()? onRefresh,
   List<Widget>? extraSlivers,
 }) {
   return MaterialApp(
@@ -29,8 +31,11 @@ Widget _harness({
       banner: banner,
       extendBodyBehindBar: extendBodyBehindBar,
       reserveBarSpace: reserveBarSpace,
+      onRefresh: onRefresh,
       slivers: [
-        const SliverToBoxAdapter(child: SizedBox(key: _contentKey, height: 10, width: double.infinity)),
+        const SliverToBoxAdapter(
+          child: SizedBox(key: _contentKey, height: 10, width: double.infinity),
+        ),
         ...?extraSlivers,
       ],
     ),
@@ -242,6 +247,27 @@ void main() {
     expect(tester.getSize(gradientFinder).height, PregoTopNavigation.barHeight);
   });
 
+  testWidgets("pull-to-refresh opens below the bar and moves content down", (tester) async {
+    await tester.pumpWidget(_harness(banner: _banner(), onRefresh: () async {}));
+    await tester.pumpAndSettle();
+
+    final barBottom = tester.getBottomRight(find.byType(GlassAppBar)).dy;
+    final initialContentTop = tester.getTopLeft(find.byKey(_contentKey)).dy;
+
+    final gesture = await tester.startGesture(tester.getCenter(find.byKey(_contentKey)));
+    await gesture.moveBy(const Offset(0, 80));
+    await tester.pump();
+
+    final indicator = find.byType(CupertinoActivityIndicator);
+    expect(indicator, findsOneWidget);
+    expect(tester.getTopLeft(indicator).dy, greaterThanOrEqualTo(barBottom));
+    expect(tester.getTopLeft(find.byKey(_contentKey)).dy, greaterThan(initialContentTop));
+    expect(tester.getBottomRight(find.byType(GlassAppBar)).dy, barBottom);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
   testWidgets("the banner slot clips through a ClipRect around its AnimatedSize", (tester) async {
     await tester.pumpWidget(_harness(banner: _banner()));
     await tester.pump();
@@ -280,7 +306,9 @@ void main() {
 
     // Mid-exit the retained copy still paints in the collapsing slot, but a
     // tap inside its visible slice must fall through.
-    final slotHeight = tester.getSize(find.ancestor(of: find.byKey(_bannerKey), matching: find.byType(ClipRect)).first).height;
+    final slotHeight = tester
+        .getSize(find.ancestor(of: find.byKey(_bannerKey), matching: find.byType(ClipRect)).first)
+        .height;
     expect(slotHeight, greaterThan(0));
     await tester.tapAt(Offset(tester.getSize(find.byType(GlassAppBar)).width / 2, slotHeight / 2));
     expect(taps, 1);


### PR DESCRIPTION
## Summary

- replace the glass scaffold's overlay refresh indicator with an in-scroll refresh sliver
- keep the spinner below the live top-bar and connection-banner inset while the bar remains fixed
- let the refresh sliver displace the large title and list content during the pull gesture

## Testing

- `dart analyze` in `client/module_prego`
- `dart analyze` in `client/app`
- `flutter test` in `client/module_prego`
- `flutter test test/features/project_list/project_list_collapsing_title_test.dart test/features/session_list/session_list_bar_test.dart` in `client/app`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows pull-to-refresh below the top bar by switching to an in-scroll refresh sliver that pushes content down, keeping the bar and connection banner fixed. Improves UX by removing the overlay spinner and aligning refresh behavior across screens.

- **Bug Fixes**
  - Replaced the `RefreshIndicator` overlay with a leading `CupertinoSliverRefreshControl` inside `CustomScrollView`.
  - Shifted the refresh indicator’s paint below the live bar and banner when the body extends behind the bar; content is displaced during pull.
  - Updated scroll physics to `BouncingScrollPhysics` (with `AlwaysScrollableScrollPhysics`) when refresh is enabled to allow overscroll.
  - Adjusted tests to validate reconnect via the scaffold refresh and the indicator’s position and content movement.

<sup>Written for commit c072dff18396dea6ec747969dfffd11ee5c3d144. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

