### PR TITLE
fix(ui): keep new-session composer visible

### DIFF
--- a/client/app/lib/features/new_session/new_session_screen.dart
+++ b/client/app/lib/features/new_session/new_session_screen.dart
@@ -164,6 +164,10 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
       },
       child: PregoGlassScaffold(
         title: loc.sessionListNewSession,
+        // The options own their scroll while the composer remains fixed, so
+        // use the full viewport behind a fixed title just like session chat.
+        titleMode: PregoTopNavigationTitleMode.inline,
+        reserveBarSpace: false,
         scrollable: false,
         banner: ConnectionBanner.maybeFor(context),
         // The loading scrim must dim the body while the glass back button
@@ -181,20 +185,23 @@ class _NewSessionBodyState extends State<_NewSessionBody> {
               )
             : null,
         slivers: [
-          // A single fill-remaining sliver pins the composer to the bottom while
-          // the variable-height plugin and worktree options scroll above it.
+          // Fill the viewport behind the bar so the variable-height options can
+          // shrink and scroll without pushing the pinned composer off-screen.
           // With the scaffold's keyboard resize (Scaffold default), the
           // composer rides above the keyboard when the field is focused.
           SliverFillRemaining(
-            hasScrollBody: false,
+            hasScrollBody: true,
             child: AbsorbPointer(
               absorbing: isSending,
               child: Column(
                 children: [
                   Expanded(
-                    child: SingleChildScrollView(
-                      key: const Key("new_session_options_scroll"),
-                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    child: PregoTopBarInsetBuilder(
+                      builder: (context, topInset, child) => SingleChildScrollView(
+                        key: const Key("new_session_options_scroll"),
+                        padding: EdgeInsetsDirectional.fromSTEB(16, topInset + 8, 16, 8),
+                        child: child,
+                      ),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -381,6 +381,29 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
+  testWidgets("keeps a multiline composer visible in a short viewport", (tester) async {
+    tester.view.physicalSize = const Size(700, 300);
+    tester.view.devicePixelRatio = 1;
+    tester.view.padding = const FakeViewPadding(top: 47, bottom: 34);
+    tester.view.viewPadding = const FakeViewPadding(top: 47, bottom: 34);
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_buildApp());
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(EditableText), "one\ntwo\nthree\nfour\nfive");
+    await tester.pumpAndSettle();
+
+    final screenBottom = tester.view.physicalSize.height / tester.view.devicePixelRatio;
+    final composerRect = tester.getRect(find.byType(PromptInput));
+    final inputRect = tester.getRect(find.byType(EditableText));
+
+    expect(composerRect.top, greaterThanOrEqualTo(0));
+    expect(composerRect.bottom, closeTo(screenBottom, 0.01));
+    expect(inputRect.top, greaterThanOrEqualTo(0));
+    expect(inputRect.bottom, lessThanOrEqualTo(screenBottom));
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets("hides the dedicated worktree toggle when the project does not support it", (tester) async {
     when(
       () => projectRepository.getProject(projectId: any(named: "projectId")),


### PR DESCRIPTION
## Summary

- keep the new-session composer anchored to the bottom of the resized viewport
- let plugin and worktree options shrink and scroll independently behind the glass header
- add short-viewport coverage for a multiline prompt and device safe-area insets

## Testing

- `dart analyze` (from `client/app`)
- `flutter test test/features/new_session/new_session_screen_test.dart`
- `flutter test test/features/new_session/new_session_screen_test.dart --plain-name "keeps a multiline composer visible in a short viewport"`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the New Session composer fixed at the bottom so it remains visible in short viewports and with multiline input. Options now scroll under the glass header, and safe-area insets are respected.

- **Bug Fixes**
  - Anchor the composer to the bottom; it stays above the keyboard and device insets, including for multiline input.
  - Let plugin/worktree options scroll under the glass header using the full viewport so they don’t push the composer off-screen.
  - Apply top-bar inset to options padding and add a widget test for short-viewport coverage.

<sup>Written for commit 9a6a3c7504b4858f41d89e2addb3190bbe82a0c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

