### PR TITLE
feat(ui): animate removed session and project rows

### DIFF
--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -204,6 +204,18 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
       ],
       ProjectListLoaded(:final projects, :final activityById, :final unseenByProjectId, :final bridges) => [
         if (isRefreshing) const SliverToBoxAdapter(child: LinearProgressIndicator()),
+        // Keep the list mounted at zero items so its final row can finish the
+        // closing transition before the connected-empty view takes over.
+        PregoAnimatedSliverList<Project>(
+          key: const ValueKey("project-list"),
+          items: projects,
+          itemKey: (project) => ValueKey(project.id),
+          itemBuilder: (context, _, project) => ProjectTile(
+            project: project,
+            activeSessions: activityById[project.id] ?? 0,
+            unseen: unseenByProjectId[project.id] ?? project.hasUnseenChanges,
+          ),
+        ),
         if (projects.isEmpty)
           // Same shape as the disconnected bodies above: the empty state joins
           // the page scroll rather than nesting one of its own.
@@ -215,22 +227,6 @@ class _ProjectListBodyState extends State<_ProjectListBody> {
             ),
           )
         else ...[
-          // The rows carry their own padding and hairline, and the design sets
-          // them flush against each other.
-          SliverList.builder(
-            itemCount: projects.length,
-            itemBuilder: (context, index) {
-              final project = projects[index];
-              // Keyed so a recycled element can't carry one project's revealed
-              // swipe actions onto another project's row.
-              return ProjectTile(
-                key: ValueKey(project.id),
-                project: project,
-                activeSessions: activityById[project.id] ?? 0,
-                unseen: unseenByProjectId[project.id] ?? project.hasUnseenChanges,
-              );
-            },
-          ),
           // Clear the floating folder FAB and the home indicator.
           SliverToBoxAdapter(child: SizedBox(height: MediaQuery.paddingOf(context).bottom + 96)),
         ],

--- a/client/app/lib/features/session_list/session_list_content.dart
+++ b/client/app/lib/features/session_list/session_list_content.dart
@@ -58,56 +58,53 @@ class SessionListContent extends StatelessWidget {
       SessionListLoading() => SliverToBoxAdapter(
         child: PregoSkeletonList(semanticLabel: loc.sessionListLoadingSemantics),
       ),
-      final SessionListLoaded loaded =>
-        loaded.sessions.isEmpty
-            ? SliverFillRemaining(
-                hasScrollBody: false,
-                child: loaded.showArchived
-                    ? Center(child: Text(loc.sessionListEmptyArchived))
-                    : SessionEmptyState(projectName: projectName),
-              )
-            : SliverPadding(
-                padding: const EdgeInsets.symmetric(vertical: 8),
-                sliver: SliverList.builder(
-                  itemCount: loaded.sessions.length,
-                  // Lets Flutter relocate a keyed row after the list reorders
-                  // (sessions live-sort by activity), so a swiped-open row
-                  // keeps its state with its session instead of at its old
-                  // index.
-                  findChildIndexCallback: (key) {
-                    if (key is! ValueKey<String>) return null;
-                    final index = loaded.sessions.indexWhere((session) => session.id == key.value);
-                    return index == -1 ? null : index;
-                  },
-                  itemBuilder: (_, index) {
-                    final session = loaded.sessions[index];
-                    final isArchived = session.time?.archived != null;
-                    final activityInfo = loaded.activeSessionIds[session.id];
+      final SessionListLoaded loaded => SliverMainAxisGroup(
+        slivers: [
+          // This sliver stays mounted when the list becomes empty, giving the
+          // final removed row time to close before the empty state settles in.
+          PregoAnimatedSliverList<Session>(
+            items: loaded.sessions,
+            itemKey: (session) => ValueKey(session.id),
+            itemBuilder: (_, index, session) {
+              final isArchived = session.time?.archived != null;
+              final activityInfo = loaded.activeSessionIds[session.id];
 
-                    return SessionTile(
-                      // Keyed so findChildIndexCallback above can remap this
-                      // row to its new index when the list reorders around it.
-                      key: ValueKey(session.id),
-                      session: session,
-                      isArchived: isArchived,
-                      isActive: activityInfo != null,
-                      unseen: loaded.isSessionUnseen(session: session),
-                      selected: selectedSessionId == session.id,
-                      awaitingInput: activityInfo?.awaitingInput ?? false,
-                      isRetrying: activityInfo?.isRetrying ?? false,
-                      backgroundTaskCount: activityInfo?.backgroundTaskCount ?? 0,
-                      onTap: () => onSessionTap(session),
-                      // The list's context, not the row's: archive/delete
-                      // unmount the row before their follow-ups run.
-                      menuEntries: () => sessionMenuEntries(context, session),
-                      onArchive: () => _actionDispatcher.handleSessionArchive(context: context, session: session),
-                      onDelete: () => _actionDispatcher.handleSessionDelete(context: context, session: session),
-                      onToggleUnread: () =>
-                          _actionDispatcher.handleSessionToggleUnread(context: context, session: session),
-                    );
-                  },
+              return Padding(
+                // Keep the list's outer breathing room attached to its first
+                // and last rows so that space collapses with the final item.
+                padding: EdgeInsetsDirectional.only(
+                  top: index == 0 ? 8 : 0,
+                  bottom: index == loaded.sessions.length - 1 ? 8 : 0,
                 ),
-              ),
+                child: SessionTile(
+                  session: session,
+                  isArchived: isArchived,
+                  isActive: activityInfo != null,
+                  unseen: loaded.isSessionUnseen(session: session),
+                  selected: selectedSessionId == session.id,
+                  awaitingInput: activityInfo?.awaitingInput ?? false,
+                  isRetrying: activityInfo?.isRetrying ?? false,
+                  backgroundTaskCount: activityInfo?.backgroundTaskCount ?? 0,
+                  onTap: () => onSessionTap(session),
+                  // The list's context, not the row's: archive/delete
+                  // unmount the row before their follow-ups run.
+                  menuEntries: () => sessionMenuEntries(context, session),
+                  onArchive: () => _actionDispatcher.handleSessionArchive(context: context, session: session),
+                  onDelete: () => _actionDispatcher.handleSessionDelete(context: context, session: session),
+                  onToggleUnread: () => _actionDispatcher.handleSessionToggleUnread(context: context, session: session),
+                ),
+              );
+            },
+          ),
+          if (loaded.sessions.isEmpty)
+            SliverFillRemaining(
+              hasScrollBody: false,
+              child: loaded.showArchived
+                  ? Center(child: Text(loc.sessionListEmptyArchived))
+                  : SessionEmptyState(projectName: projectName),
+            ),
+        ],
+      ),
       SessionListStaleProject() => SliverFillRemaining(
         hasScrollBody: false,
         child: _StaleProjectView(onBack: () => _exitSessionShell(context)),

--- a/client/app/test/features/project_list/project_tile_swipe_test.dart
+++ b/client/app/test/features/project_list/project_tile_swipe_test.dart
@@ -132,10 +132,16 @@ void main() {
     await swipeOpen(tester);
 
     await tester.tap(find.text("Hide"));
+    await tester.pump();
+
+    // The hide has completed and the empty state is already entering, but the
+    // removed row remains long enough to visibly close instead of snapping out.
+    expect(find.text("Project hidden"), findsOneWidget);
+    expect(tile(), findsOneWidget);
+
     await tester.pumpAndSettle();
 
     verify(() => mockProjectRepository.hideProject(projectId: project.id)).called(1);
-    expect(find.text("Project hidden"), findsOneWidget);
     expect(tile(), findsNothing);
   });
 

--- a/client/app/test/features/session_list/session_tile_menu_test.dart
+++ b/client/app/test/features/session_list/session_tile_menu_test.dart
@@ -146,7 +146,7 @@ void main() {
     expect(find.widgetWithText(InkWell, "Archive"), findsNothing);
   });
 
-  testWidgets("archiving still confirms with the undo snackbar after the row unmounts", (tester) async {
+  testWidgets("archiving closes the row before confirming with the undo snackbar", (tester) async {
     // testSession has no worktree, so Archive skips the confirm sheet and runs
     // directly. The cubit hides the row optimistically, so the row's own
     // context is unmounted long before the bridge call resolves — the entries
@@ -201,9 +201,17 @@ void main() {
     await longPressTile(tester, title: "My Session");
 
     await tester.tap(find.widgetWithText(InkWell, "Archive"));
+    await tester.pump();
+
+    // The optimistic archive has removed the session from cubit state, but the
+    // list retains its outgoing row for the closing transition.
+    expect(find.widgetWithText(SessionTile, "My Session"), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 130));
+    expect(find.widgetWithText(SessionTile, "My Session"), findsOneWidget);
+
     await tester.pumpAndSettle();
 
-    // The row is gone before the bridge call resolves…
+    // The row finishes closing before the bridge call resolves…
     expect(find.widgetWithText(SessionTile, "My Session"), findsNothing);
     expect(find.text("Session archived"), findsNothing);
 

--- a/client/module_prego/lib/components/lists/prego_animated_sliver_list.dart
+++ b/client/module_prego/lib/components/lists/prego_animated_sliver_list.dart
@@ -1,0 +1,151 @@
+import "package:flutter/material.dart";
+
+import "../../motion/prego_reduced_motion.dart";
+
+const Duration _itemTransitionDuration = Duration(milliseconds: 260);
+
+/// A sliver list that reconciles keyed [items] and animates rows as they enter
+/// or leave.
+///
+/// The caller owns the source list. This widget keeps only the presentation
+/// snapshot needed by [SliverAnimatedList] so a removed row can collapse and
+/// fade instead of disappearing between state emissions.
+class PregoAnimatedSliverList<T> extends StatefulWidget {
+  const PregoAnimatedSliverList({
+    super.key,
+    required this.items,
+    required this.itemKey,
+    required this.itemBuilder,
+  });
+
+  /// The items currently present in the source list.
+  final List<T> items;
+
+  /// Returns the stable, unique identity of an item across list updates.
+  final Key Function(T item) itemKey;
+
+  /// Builds an item at its current index.
+  final Widget Function(BuildContext context, int index, T item) itemBuilder;
+
+  @override
+  State<PregoAnimatedSliverList<T>> createState() => _PregoAnimatedSliverListState<T>();
+}
+
+class _PregoAnimatedSliverListState<T> extends State<PregoAnimatedSliverList<T>> {
+  final GlobalKey<SliverAnimatedListState> _listKey = GlobalKey<SliverAnimatedListState>();
+  late List<_ListEntry<T>> _entries;
+
+  @override
+  void initState() {
+    super.initState();
+    _entries = _entriesFor(widget);
+  }
+
+  @override
+  void didUpdateWidget(PregoAnimatedSliverList<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    final nextEntries = _entriesFor(widget);
+    final listState = _listKey.currentState;
+    if (listState == null) {
+      _entries = nextEntries;
+      return;
+    }
+
+    final duration = prefersReducedMotion(context) ? Duration.zero : _itemTransitionDuration;
+    final nextKeys = nextEntries.map((entry) => entry.key).toSet();
+
+    // Remove from the end so each index still addresses the old list while it
+    // is being shortened. The outgoing builder captures the old row snapshot.
+    for (var index = _entries.length - 1; index >= 0; index--) {
+      final entry = _entries[index];
+      if (nextKeys.contains(entry.key)) continue;
+
+      _entries.removeAt(index);
+      final outgoingKey = UniqueKey();
+      listState.removeItem(
+        index,
+        (context, animation) => _transition(
+          key: outgoingKey,
+          animation: animation,
+          child: oldWidget.itemBuilder(context, index, entry.item),
+        ),
+        duration: duration,
+      );
+    }
+
+    // Reorder retained entries before inserting new ones. The sliver's child
+    // index callback relocates their keyed elements without losing row state.
+    final retainedKeys = _entries.map((entry) => entry.key).toSet();
+    _entries = [
+      for (final entry in nextEntries)
+        if (retainedKeys.contains(entry.key)) entry,
+    ];
+
+    for (var index = 0; index < nextEntries.length; index++) {
+      final entry = nextEntries[index];
+      if (retainedKeys.contains(entry.key)) continue;
+
+      _entries.insert(index, entry);
+      listState.insertItem(index, duration: duration);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverAnimatedList(
+      key: _listKey,
+      initialItemCount: _entries.length,
+      findChildIndexCallback: (key) {
+        if (key is! _PregoAnimatedSliverItemKey) return null;
+        final index = _entries.indexWhere((entry) => entry.key == key.value);
+        return index == -1 ? null : index;
+      },
+      itemBuilder: (context, index, animation) {
+        final entry = _entries[index];
+        return _transition(
+          key: _PregoAnimatedSliverItemKey(entry.key),
+          animation: animation,
+          child: widget.itemBuilder(context, index, entry.item),
+        );
+      },
+    );
+  }
+
+  List<_ListEntry<T>> _entriesFor(PregoAnimatedSliverList<T> source) {
+    final entries = [for (final item in source.items) _ListEntry(key: source.itemKey(item), item: item)];
+    assert(() {
+      final keys = <Key>{};
+      for (final entry in entries) {
+        if (!keys.add(entry.key)) {
+          throw FlutterError(
+            "PregoAnimatedSliverList item keys must be unique. Duplicate key: ${entry.key.toString()}",
+          );
+        }
+      }
+      return true;
+    }());
+    return entries;
+  }
+
+  Widget _transition({required Key key, required Animation<double> animation, required Widget child}) {
+    final curvedAnimation = CurvedAnimation(parent: animation, curve: Curves.easeInOutCubic);
+    return SizeTransition(
+      key: key,
+      sizeFactor: curvedAnimation,
+      alignment: Alignment.topCenter,
+      child: FadeTransition(opacity: curvedAnimation, child: child),
+    );
+  }
+}
+
+class _ListEntry<T> {
+  const _ListEntry({required this.key, required this.item});
+
+  final Key key;
+  final T item;
+}
+
+class _PregoAnimatedSliverItemKey extends ValueKey<Key> {
+  const _PregoAnimatedSliverItemKey(super.value);
+}

--- a/client/module_prego/lib/components/lists/prego_animated_sliver_list.dart
+++ b/client/module_prego/lib/components/lists/prego_animated_sliver_list.dart
@@ -68,7 +68,11 @@ class _PregoAnimatedSliverListState<T> extends State<PregoAnimatedSliverList<T>>
         (context, animation) => _transition(
           key: outgoingKey,
           animation: animation,
-          child: oldWidget.itemBuilder(context, index, entry.item),
+          child: ExcludeSemantics(
+            child: IgnorePointer(
+              child: oldWidget.itemBuilder(context, index, entry.item),
+            ),
+          ),
         ),
         duration: duration,
       );

--- a/client/module_prego/lib/module_prego.dart
+++ b/client/module_prego/lib/module_prego.dart
@@ -9,6 +9,7 @@ export 'components/buttons/prego_buttons_icon_glass.dart';
 export 'components/buttons/prego_switch.dart';
 export 'components/icons/prego_avatar_user.dart';
 export 'components/inputs/prego_input_field.dart';
+export 'components/lists/prego_animated_sliver_list.dart';
 export 'components/loaders/prego_activity_indicator.dart';
 export 'components/loaders/prego_ai_loader.dart';
 export 'components/loaders/prego_skeleton.dart';

--- a/client/module_prego/test/components/prego_animated_sliver_list_test.dart
+++ b/client/module_prego/test/components/prego_animated_sliver_list_test.dart
@@ -4,7 +4,7 @@ import "package:theme_prego/module_prego.dart";
 
 const double _rowHeight = 80;
 
-Widget _harness(List<String> items, {bool disableAnimations = false}) {
+Widget _harness(List<String> items, {bool disableAnimations = false, VoidCallback? onTap}) {
   return MaterialApp(
     home: Builder(
       builder: (context) => MediaQuery(
@@ -14,10 +14,14 @@ Widget _harness(List<String> items, {bool disableAnimations = false}) {
             PregoAnimatedSliverList<String>(
               items: items,
               itemKey: ValueKey<String>.new,
-              itemBuilder: (context, index, item) => SizedBox(
+              itemBuilder: (context, index, item) => GestureDetector(
                 key: ValueKey("row-$item"),
-                height: _rowHeight,
-                child: Text(item),
+                behavior: HitTestBehavior.opaque,
+                onTap: onTap,
+                child: SizedBox(
+                  height: _rowHeight,
+                  child: Text(item),
+                ),
               ),
             ),
           ],
@@ -56,6 +60,23 @@ void main() {
 
     await tester.pumpAndSettle();
     expect(find.text("A"), findsNothing);
+  });
+
+  testWidgets("an outgoing row is no longer interactive or exposed to semantics", (tester) async {
+    final semantics = tester.ensureSemantics();
+    var taps = 0;
+    void onTap() => taps++;
+
+    await tester.pumpWidget(_harness(["A"], onTap: onTap));
+    expect(find.bySemanticsLabel("A"), findsOneWidget);
+
+    await tester.pumpWidget(_harness([], onTap: onTap));
+    expect(find.text("A"), findsOneWidget);
+    expect(find.bySemanticsLabel("A"), findsNothing);
+
+    await tester.tap(find.text("A"), warnIfMissed: false);
+    expect(taps, 0);
+    semantics.dispose();
   });
 
   testWidgets("reduced motion removes a row without a transition delay", (tester) async {

--- a/client/module_prego/test/components/prego_animated_sliver_list_test.dart
+++ b/client/module_prego/test/components/prego_animated_sliver_list_test.dart
@@ -1,0 +1,69 @@
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:theme_prego/module_prego.dart";
+
+const double _rowHeight = 80;
+
+Widget _harness(List<String> items, {bool disableAnimations = false}) {
+  return MaterialApp(
+    home: Builder(
+      builder: (context) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(disableAnimations: disableAnimations),
+        child: CustomScrollView(
+          slivers: [
+            PregoAnimatedSliverList<String>(
+              items: items,
+              itemKey: ValueKey<String>.new,
+              itemBuilder: (context, index, item) => SizedBox(
+                key: ValueKey("row-$item"),
+                height: _rowHeight,
+                child: Text(item),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets("removed row closes while the following row moves into place", (tester) async {
+    await tester.pumpWidget(_harness(["A", "B"]));
+    expect(tester.getTopLeft(find.byKey(const ValueKey("row-B"))).dy, _rowHeight);
+
+    await tester.pumpWidget(_harness(["B"]));
+    expect(find.text("A"), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 130));
+    final movingTop = tester.getTopLeft(find.byKey(const ValueKey("row-B"))).dy;
+    expect(movingTop, greaterThan(0));
+    expect(movingTop, lessThan(_rowHeight));
+
+    await tester.pumpAndSettle();
+    expect(find.text("A"), findsNothing);
+    expect(tester.getTopLeft(find.byKey(const ValueKey("row-B"))).dy, 0);
+  });
+
+  testWidgets("the last row remains mounted for its closing transition", (tester) async {
+    await tester.pumpWidget(_harness(["A"]));
+
+    await tester.pumpWidget(_harness([]));
+    expect(find.text("A"), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 130));
+    expect(tester.getSize(find.byType(SizeTransition)).height, inExclusiveRange(0, _rowHeight));
+
+    await tester.pumpAndSettle();
+    expect(find.text("A"), findsNothing);
+  });
+
+  testWidgets("reduced motion removes a row without a transition delay", (tester) async {
+    await tester.pumpWidget(_harness(["A"], disableAnimations: true));
+
+    await tester.pumpWidget(_harness([], disableAnimations: true));
+    await tester.pump();
+
+    expect(find.text("A"), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

- Add a reusable `PregoAnimatedSliverList` that reconciles stable row keys and animates insertions and removals.
- Collapse and fade removed session and project rows over 260 ms so surrounding rows move smoothly into place.
- Keep both lists mounted when their final item is removed, allowing the closing transition to finish before the empty state settles in.
- Respect reduced-motion preferences by removing transition delay.

## Verification

- `dart analyze` in `client/module_prego`
- `dart analyze` in `client/app`
- `flutter test test/components/prego_animated_sliver_list_test.dart` in `client/module_prego`
- `flutter test test/features/project_list/project_tile_swipe_test.dart` in `client/app`
- `flutter test test/features/session_list/session_tile_swipe_test.dart` in `client/app`
- `flutter test test/features/session_list/session_tile_menu_test.dart` in `client/app`

The focused screen tests verify that the hide/archive state update has completed while the outgoing row remains visible, then confirm it is removed after the transition settles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable `PregoAnimatedSliverList` and wires it into session and project lists to animate row removal and prevent snap-outs. Rows collapse and fade smoothly (260 ms), respect reduced-motion, and are non-interactive and hidden from semantics while closing.

- **New Features**
  - Introduced `PregoAnimatedSliverList` that reconciles keyed items, animates inserts/removals, keeps the sliver mounted at zero items so the last row can close, and blocks taps/semantics on outgoing rows.
  - Adopted in project and session lists; tests updated to verify the closing row remains briefly then unmounts. Exported via `module_prego.dart`.

<sup>Written for commit 8a388df45dafcd587af1cd5f11fd703df581d389. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

