### PR TITLE
fix(ui): keep project title fixed during refresh

### DIFF
--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -388,6 +388,7 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
             subtitle: widget.subtitleText,
             scrollController: _scrollController,
             onHeightChanged: _onLargeTitleHeightChanged,
+            pinDuringOverscroll: onRefresh != null,
           ),
         ...widget.slivers,
       ],
@@ -679,11 +680,13 @@ class _LargeTitleSliver extends StatelessWidget {
   final String? subtitle;
   final ScrollController scrollController;
   final ValueChanged<double> onHeightChanged;
+  final bool pinDuringOverscroll;
   const _LargeTitleSliver({
     required this.title,
     required this.subtitle,
     required this.scrollController,
     required this.onHeightChanged,
+    required this.pinDuringOverscroll,
   });
 
   @override
@@ -717,7 +720,7 @@ class _LargeTitleSliver extends StatelessWidget {
               // The refresh sliver displaces every later sliver. Counteract its
               // negative pull offset so the title stays fixed while the caller's
               // content opens below it; positive offsets still collapse normally.
-              final pullOffset = scrollOffset < 0 ? scrollOffset : 0.0;
+              final pullOffset = pinDuringOverscroll && scrollOffset < 0 ? scrollOffset : 0.0;
 
               return Transform.translate(
                 offset: Offset(0, pullOffset),

--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -351,8 +351,13 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
                 triggerDistance,
                 indicatorExtent,
               );
-              // A non-extended body already begins below the bar.
-              if (!extendBehind) return indicator;
+              // A non-extended body already begins below the bar, but its
+              // collapsing title still precedes the caller-provided content.
+              if (!extendBehind) {
+                return collapsing
+                    ? Transform.translate(offset: Offset(0, _largeTitleHeight), child: indicator)
+                    : indicator;
+              }
 
               return ValueListenableBuilder<double>(
                 valueListenable: _bannerHeight,

--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -176,7 +176,7 @@ class PregoGlassScaffold extends StatefulWidget {
   final Widget? overlay;
 
   /// When set, an in-scroll refresh control opens below the top bar and pushes
-  /// the page content down while it is pulled.
+  /// the caller-provided content down while it is pulled.
   final Future<void> Function()? onRefresh;
 
   /// Page background painted behind the glass. Defaults to `bgSurface1`.
@@ -215,6 +215,11 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
   /// body offset, and [PregoTopBarInsetBuilder] consumers — listens to it, so
   /// content tracks the moving bar and is exact at rest.
   final ValueNotifier<double> _bannerHeight = ValueNotifier<double>(0);
+
+  /// The collapsing title's rendered extent, including its bottom spacing.
+  /// Used to paint the refresh indicator below the title without assuming a
+  /// fixed text scale or whether a subtitle is present.
+  double _largeTitleHeight = 0;
 
   @override
   void dispose() {
@@ -259,6 +264,11 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
     // state on synchronous teardown — writing to the disposed notifier throws.
     if (!mounted) return;
     _bannerHeight.value = height;
+  }
+
+  void _onLargeTitleHeightChanged(double height) {
+    if (!mounted) return;
+    _largeTitleHeight = height;
   }
 
   @override
@@ -328,8 +338,8 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
       slivers: [
         // The refresh sliver must receive the scroll view's leading overscroll,
         // so it precedes the bar spacer. Shift only its painted indicator below
-        // the live bar inset; the sliver itself opens at the scroll origin and
-        // pushes the spacer, large title, and caller-provided content down.
+        // the live bar and large-title insets; the sliver itself opens at the
+        // scroll origin and pushes the caller-provided content down.
         if (onRefresh != null)
           CupertinoSliverRefreshControl(
             onRefresh: onRefresh,
@@ -348,7 +358,10 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
                 valueListenable: _bannerHeight,
                 child: indicator,
                 builder: (context, bannerHeight, indicator) => Transform.translate(
-                  offset: Offset(0, topPad + topNav.preferredSize.height + bannerHeight),
+                  offset: Offset(
+                    0,
+                    topPad + topNav.preferredSize.height + bannerHeight + (collapsing ? _largeTitleHeight : 0),
+                  ),
                   child: indicator,
                 ),
               );
@@ -374,6 +387,7 @@ class _PregoGlassScaffoldState extends State<PregoGlassScaffold> {
             title: widget.title,
             subtitle: widget.subtitleText,
             scrollController: _scrollController,
+            onHeightChanged: _onLargeTitleHeightChanged,
           ),
         ...widget.slivers,
       ],
@@ -540,7 +554,7 @@ class _AnimatedBannerSlotState extends State<_AnimatedBannerSlot> {
     //  - Align(heightFactor: 0) sizes the hidden slot to zero while keeping
     //    the retained content laid out, which is what AnimatedSize animates
     //    toward during the exit.
-    return _BannerSizeObserver(
+    return _HeightObserver(
       onHeightChanged: _onHeightChanged,
       child: ClipRect(
         child: AnimatedSize(
@@ -569,22 +583,22 @@ class _AnimatedBannerSlotState extends State<_AnimatedBannerSlot> {
 /// changes. The callback is invoked post-frame so listeners may safely call
 /// `setState`/notify — the same measure-and-report pattern as the session
 /// detail composer measurement.
-class _BannerSizeObserver extends SingleChildRenderObjectWidget {
-  const _BannerSizeObserver({required this.onHeightChanged, required super.child});
+class _HeightObserver extends SingleChildRenderObjectWidget {
+  const _HeightObserver({required this.onHeightChanged, required super.child});
 
   final ValueChanged<double> onHeightChanged;
 
   @override
-  RenderObject createRenderObject(BuildContext context) => _RenderBannerSizeObserver(onHeightChanged);
+  RenderObject createRenderObject(BuildContext context) => _RenderHeightObserver(onHeightChanged);
 
   @override
-  void updateRenderObject(BuildContext context, _RenderBannerSizeObserver renderObject) {
+  void updateRenderObject(BuildContext context, _RenderHeightObserver renderObject) {
     renderObject.onHeightChanged = onHeightChanged;
   }
 }
 
-class _RenderBannerSizeObserver extends RenderProxyBox {
-  _RenderBannerSizeObserver(this.onHeightChanged);
+class _RenderHeightObserver extends RenderProxyBox {
+  _RenderHeightObserver(this.onHeightChanged);
 
   ValueChanged<double> onHeightChanged;
   double? _lastReportedHeight;
@@ -664,10 +678,12 @@ class _LargeTitleSliver extends StatelessWidget {
   final String title;
   final String? subtitle;
   final ScrollController scrollController;
+  final ValueChanged<double> onHeightChanged;
   const _LargeTitleSliver({
     required this.title,
     required this.subtitle,
     required this.scrollController,
+    required this.onHeightChanged,
   });
 
   @override
@@ -676,48 +692,61 @@ class _LargeTitleSliver extends StatelessWidget {
     final subtitle = this.subtitle;
 
     return SliverToBoxAdapter(
-      child: Padding(
-        padding: const EdgeInsetsDirectional.fromSTEB(
-          PregoSpacing.x3l,
-          0,
-          PregoSpacing.x3l,
-          PregoSpacing.xl,
-        ),
-        child: ListenableBuilder(
-          listenable: scrollController,
-          builder: (context, _) {
-            /// 0 while the large title is fully shown, 1 once it has collapsed into the
-            /// bar. Delegates to [PregoTopNavigation.collapseProgressOf] — the single
-            /// source of truth for the collapse — so the large-title sliver fades out in
-            /// lockstep with the bar title fading in.
-            final collapseProgress = PregoTopNavigation.collapseProgressOf(scrollController);
-            // Fade via text alpha instead of an Opacity layer — no saveLayer per frame.
-            final opacity = (1 - collapseProgress).clamp(0.0, 1.0);
+      child: _HeightObserver(
+        onHeightChanged: onHeightChanged,
+        child: Padding(
+          padding: const EdgeInsetsDirectional.fromSTEB(
+            PregoSpacing.x3l,
+            0,
+            PregoSpacing.x3l,
+            PregoSpacing.xl,
+          ),
+          child: ListenableBuilder(
+            listenable: scrollController,
+            builder: (context, _) {
+              /// 0 while the large title is fully shown, 1 once it has collapsed into the
+              /// bar. Delegates to [PregoTopNavigation.collapseProgressOf] — the single
+              /// source of truth for the collapse — so the large-title sliver fades out in
+              /// lockstep with the bar title fading in.
+              final collapseProgress = PregoTopNavigation.collapseProgressOf(scrollController);
+              // Fade via text alpha instead of an Opacity layer — no saveLayer per frame.
+              final opacity = (1 - collapseProgress).clamp(0.0, 1.0);
+              final scrollOffset = scrollController.hasClients && scrollController.positions.length == 1
+                  ? scrollController.offset
+                  : 0.0;
+              // The refresh sliver displaces every later sliver. Counteract its
+              // negative pull offset so the title stays fixed while the caller's
+              // content opens below it; positive offsets still collapse normally.
+              final pullOffset = scrollOffset < 0 ? scrollOffset : 0.0;
 
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  title,
-                  style: prego.textTheme.displayMd.medium.copyWith(
-                    color: prego.colors.textPrimary.withMultipliedOpacity(opacity),
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                if (subtitle != null && subtitle.isNotEmpty)
-                  Text(
-                    subtitle,
-                    style: prego.textTheme.textMd.regular.copyWith(
-                      color: prego.colors.textSecondary.withMultipliedOpacity(opacity),
+              return Transform.translate(
+                offset: Offset(0, pullOffset),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      title,
+                      style: prego.textTheme.displayMd.medium.copyWith(
+                        color: prego.colors.textPrimary.withMultipliedOpacity(opacity),
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                     ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-              ],
-            );
-          },
+                    if (subtitle != null && subtitle.isNotEmpty)
+                      Text(
+                        subtitle,
+                        style: prego.textTheme.textMd.regular.copyWith(
+                          color: prego.colors.textSecondary.withMultipliedOpacity(opacity),
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                  ],
+                ),
+              );
+            },
+          ),
         ),
       ),
     );

--- a/client/module_prego/test/components/prego_glass_scaffold_banner_test.dart
+++ b/client/module_prego/test/components/prego_glass_scaffold_banner_test.dart
@@ -17,6 +17,7 @@ Widget _banner() => const SizedBox(
 
 Widget _harness({
   required Widget? banner,
+  PregoTopNavigationTitleMode titleMode = PregoTopNavigationTitleMode.inline,
   bool extendBodyBehindBar = true,
   bool reserveBarSpace = true,
   Future<void> Function()? onRefresh,
@@ -26,7 +27,7 @@ Widget _harness({
     theme: ThemeData(extensions: [PregoDesignSystem.light]),
     home: PregoGlassScaffold(
       title: "Title",
-      titleMode: PregoTopNavigationTitleMode.inline,
+      titleMode: titleMode,
       automaticallyImplyLeading: false,
       banner: banner,
       extendBodyBehindBar: extendBodyBehindBar,
@@ -263,6 +264,33 @@ void main() {
     expect(tester.getTopLeft(indicator).dy, greaterThanOrEqualTo(barBottom));
     expect(tester.getTopLeft(find.byKey(_contentKey)).dy, greaterThan(initialContentTop));
     expect(tester.getBottomRight(find.byType(GlassAppBar)).dy, barBottom);
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets("pull-to-refresh keeps a large title fixed and opens below it", (tester) async {
+    await tester.pumpWidget(
+      _harness(
+        banner: null,
+        titleMode: PregoTopNavigationTitleMode.collapsing,
+        onRefresh: () async {},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final largeTitle = find.descendant(of: find.byType(CustomScrollView), matching: find.text("Title"));
+    final initialTitleTop = tester.getTopLeft(largeTitle).dy;
+    final initialContentTop = tester.getTopLeft(find.byKey(_contentKey)).dy;
+
+    final gesture = await tester.startGesture(tester.getCenter(find.byKey(_contentKey)));
+    await gesture.moveBy(const Offset(0, 80));
+    await tester.pump();
+
+    final indicator = find.byType(CupertinoActivityIndicator);
+    expect(tester.getTopLeft(largeTitle).dy, moreOrLessEquals(initialTitleTop));
+    expect(tester.getTopLeft(indicator).dy, greaterThanOrEqualTo(tester.getBottomLeft(largeTitle).dy));
+    expect(tester.getTopLeft(find.byKey(_contentKey)).dy, greaterThan(initialContentTop));
 
     await gesture.up();
     await tester.pumpAndSettle();

--- a/client/module_prego/test/components/prego_glass_scaffold_banner_test.dart
+++ b/client/module_prego/test/components/prego_glass_scaffold_banner_test.dart
@@ -296,6 +296,29 @@ void main() {
     await tester.pumpAndSettle();
   });
 
+  testWidgets("non-extended pull-to-refresh also opens below the large title", (tester) async {
+    await tester.pumpWidget(
+      _harness(
+        banner: null,
+        titleMode: PregoTopNavigationTitleMode.collapsing,
+        extendBodyBehindBar: false,
+        onRefresh: () async {},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final largeTitle = find.descendant(of: find.byType(CustomScrollView), matching: find.text("Title"));
+    final gesture = await tester.startGesture(tester.getCenter(find.byKey(_contentKey)));
+    await gesture.moveBy(const Offset(0, 80));
+    await tester.pump();
+
+    final indicator = find.byType(CupertinoActivityIndicator);
+    expect(tester.getTopLeft(indicator).dy, greaterThanOrEqualTo(tester.getBottomLeft(largeTitle).dy));
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
   testWidgets("the banner slot clips through a ClipRect around its AnimatedSize", (tester) async {
     await tester.pumpWidget(_harness(banner: _banner()));
     await tester.pump();


### PR DESCRIPTION
## Summary

- keep the collapsing Projects title visually fixed during pull-to-refresh while project rows move down
- position the refresh indicator below the measured large-title extent, including text scaling and optional subtitles
- preserve normal upward title collapse and leave non-refreshable collapsing pages unchanged

## Testing

- `dart analyze` in `client/module_prego`
- `dart analyze` in `client/app`
- `flutter test` in `client/module_prego`
- `flutter test test/features/project_list/project_list_collapsing_title_test.dart` in `client/app`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pull-to-refresh so the collapsing Projects title stays fixed while content moves. The refresh indicator now appears just below the large title on both extended and non-extended pages; normal title collapse is unchanged.

- **Bug Fixes**
  - Pin the large title only during overscroll when `onRefresh` is set; only caller content shifts.
  - Offset the indicator below the measured large-title height (handles text scaling and optional subtitles), including on non-extended pages.
  - Leave non-refreshable pages unaffected.

<sup>Written for commit 85365e26afdd7f3408b1604717d43545e4769f36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

