### PR TITLE
fix(bridge): persist titles before backend sync

### DIFF
--- a/bridge/app/lib/src/bridge/debug_server.dart
+++ b/bridge/app/lib/src/bridge/debug_server.dart
@@ -15,6 +15,7 @@ class DebugServer {
   final FailureReporter _failureReporter;
   final BridgeRestartService _restartService;
   final Future<void> Function() _restartHandoff;
+  final Future<void> Function() _drainRoutedMutations;
   final int port;
   final List<HttpResponse> _sseClients = [];
   // ignore: cancel_subscriptions - cancelled by the failure-isolated drain.
@@ -37,11 +38,13 @@ class DebugServer {
     required FailureReporter failureReporter,
     required BridgeRestartService restartService,
     required Future<void> Function() restartHandoff,
+    required Future<void> Function() drainRoutedMutations,
   }) : _localWireEvents = localWireEvents,
        _router = router,
        _failureReporter = failureReporter,
        _restartService = restartService,
-       _restartHandoff = restartHandoff;
+       _restartHandoff = restartHandoff,
+       _drainRoutedMutations = drainRoutedMutations;
 
   int? get boundPort => _server?.port;
   RequestRouter get router => _router;
@@ -109,6 +112,7 @@ class DebugServer {
         await _serverClose;
       }),
     ]);
+    await attempt(_drainRoutedMutations);
     if (firstError != null) {
       Error.throwWithStackTrace(firstError!, firstStackTrace!);
     }

--- a/bridge/app/lib/src/bridge/orchestrator.dart
+++ b/bridge/app/lib/src/bridge/orchestrator.dart
@@ -670,6 +670,7 @@ class OrchestratorSession {
   Stream<int> get bytesSent => _bytesSentController.stream;
   Stream<SesoriSseEvent> get localWireEvents => _localWireEventsController.stream;
   RequestRouter get router => _router;
+  Future<void> drainRoutedMutations() => _sessionMutationDispatcher.drain();
 
   Future<void> run() async {
     final kxManager = KeyExchangeManager(_roomKey);

--- a/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
+++ b/bridge/app/lib/src/bridge/runtime/bridge_runtime.dart
@@ -45,6 +45,7 @@ class BridgeRuntime {
       failureReporter: _failureReporter,
       restartService: _restartService,
       restartHandoff: session.handleRestartHandoff,
+      drainRoutedMutations: session.drainRoutedMutations,
     );
   }
 

--- a/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
@@ -11,8 +11,10 @@ class SessionMutationDispatcher {
   final SessionRepository _sessionRepository;
   final StreamController<Session> _deletedSessionsController = StreamController<Session>.broadcast(sync: true);
   final Map<String, String?> _pendingTitles = {};
-  // Explicit DB-backed renames win over delayed backend title events.
-  final Map<String, String> _authoritativeTitles = {};
+  // Tracks local renames until their matching backend title event arrives.
+  final Map<String, String> _renameTitlesAwaitingEvents = {};
+  // Each superseded local title consumes at most one delayed backend event.
+  final Map<String, Set<String>> _supersededRenameTitles = {};
   Future<void> _tail = Future<void>.value();
   bool _disposed = false;
 
@@ -22,7 +24,12 @@ class SessionMutationDispatcher {
 
   Future<void> captureTitle({required String sessionId, required String? title}) {
     return _serialized(() async {
-      if (_authoritativeTitles.containsKey(sessionId) && _authoritativeTitles[sessionId] != title) return;
+      final superseded = _supersededRenameTitles[sessionId];
+      if (superseded?.remove(title) ?? false) {
+        if (superseded!.isEmpty) _supersededRenameTitles.remove(sessionId);
+        return;
+      }
+      _renameTitlesAwaitingEvents.remove(sessionId);
       await _captureTitle(sessionId: sessionId, title: title);
     });
   }
@@ -42,7 +49,14 @@ class SessionMutationDispatcher {
               message: "session $sessionId was not found",
             );
           }
-          _authoritativeTitles[sessionId] = title;
+          final previousTitle = _renameTitlesAwaitingEvents[sessionId];
+          if (previousTitle != null && previousTitle != title) {
+            (_supersededRenameTitles[sessionId] ??= {}).add(previousTitle);
+          }
+          _renameTitlesAwaitingEvents[sessionId] = title;
+          final superseded = _supersededRenameTitles[sessionId];
+          superseded?.remove(title);
+          if (superseded?.isEmpty ?? false) _supersededRenameTitles.remove(sessionId);
           persistedResult.complete(renamed);
         } catch (error, stackTrace) {
           persistedResult.completeError(error, stackTrace);
@@ -51,6 +65,9 @@ class SessionMutationDispatcher {
         try {
           await _sessionRepository.renameSession(sessionId: sessionId, title: title);
         } catch (error, stackTrace) {
+          if (_renameTitlesAwaitingEvents[sessionId] == title) {
+            _renameTitlesAwaitingEvents.remove(sessionId);
+          }
           Log.w("Could not propagate title for session $sessionId to its plugin", error, stackTrace);
         }
       }),
@@ -74,16 +91,20 @@ class SessionMutationDispatcher {
     return _serialized(() async {
       final deleted = await _sessionRepository.deleteSession(sessionId: sessionId);
       _pendingTitles.remove(sessionId);
-      _authoritativeTitles.remove(sessionId);
+      _renameTitlesAwaitingEvents.remove(sessionId);
+      _supersededRenameTitles.remove(sessionId);
       _deletedSessionsController.add(deleted);
     });
   }
+
+  Future<void> drain() => _serialized(() async {});
 
   Future<void> dispose() {
     if (_disposed) return Future.value();
     _disposed = true;
     return _serialized(() async {
-      _authoritativeTitles.clear();
+      _renameTitlesAwaitingEvents.clear();
+      _supersededRenameTitles.clear();
       await _deletedSessionsController.close();
     });
   }

--- a/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
@@ -8,14 +8,14 @@ import "../repositories/session_repository.dart";
 
 /// Serializes bridge-owned session mutations that share pending-title state.
 class SessionMutationDispatcher {
+  static const _backendTitleGuardDuration = Duration(seconds: 1);
+
   final SessionRepository _sessionRepository;
   final StreamController<Session> _deletedSessionsController = StreamController<Session>.broadcast(sync: true);
   final Map<String, String?> _pendingTitles = {};
-  // Tracks local renames until their matching backend title event arrives.
-  final Map<String, String> _renameTitlesAwaitingEvents = {};
-  // Each superseded local title consumes at most one delayed backend event.
-  final Map<String, Set<String>> _supersededRenameTitles = {};
+  final Map<String, ({String title, DateTime? expiresAt})> _backendTitleGuards = {};
   Future<void> _tail = Future<void>.value();
+  Future<void> _backendTail = Future<void>.value();
   bool _disposed = false;
 
   SessionMutationDispatcher({required SessionRepository sessionRepository}) : _sessionRepository = sessionRepository;
@@ -24,55 +24,35 @@ class SessionMutationDispatcher {
 
   Future<void> captureTitle({required String sessionId, required String? title}) {
     return _serialized(() async {
-      final superseded = _supersededRenameTitles[sessionId];
-      if (superseded?.remove(title) ?? false) {
-        if (superseded!.isEmpty) _supersededRenameTitles.remove(sessionId);
-        return;
+      final guard = _backendTitleGuards[sessionId];
+      if (guard != null) {
+        final active = guard.expiresAt == null || DateTime.now().isBefore(guard.expiresAt!);
+        if (active && guard.title != title) return;
+        _backendTitleGuards.remove(sessionId);
       }
-      _renameTitlesAwaitingEvents.remove(sessionId);
       await _captureTitle(sessionId: sessionId, title: title);
     });
   }
 
   /// Completes after the authoritative DB title is stored. Backend propagation
-  /// continues on the serialized tail so delete and dispose cannot overtake it.
+  /// continues on its own serialized tail so later DB writes stay immediate
+  /// while delete and dispose still cannot overtake backend synchronization.
   Future<Session> renameSession({required String sessionId, required String title}) {
-    final persistedResult = Completer<Session>();
-    unawaited(
-      _serialized(() async {
-        try {
-          final stored = await _sessionRepository.setSessionTitleIfStored(sessionId: sessionId, title: title);
-          final renamed = stored ? await _sessionRepository.getCatalogSession(sessionId: sessionId) : null;
-          if (renamed == null) {
-            throw PluginOperationException.notFound(
-              SessionOperation.renameSession.name,
-              message: "session $sessionId was not found",
-            );
-          }
-          final previousTitle = _renameTitlesAwaitingEvents[sessionId];
-          if (previousTitle != null && previousTitle != title) {
-            (_supersededRenameTitles[sessionId] ??= {}).add(previousTitle);
-          }
-          _renameTitlesAwaitingEvents[sessionId] = title;
-          final superseded = _supersededRenameTitles[sessionId];
-          superseded?.remove(title);
-          if (superseded?.isEmpty ?? false) _supersededRenameTitles.remove(sessionId);
-          persistedResult.complete(renamed);
-        } catch (error, stackTrace) {
-          persistedResult.completeError(error, stackTrace);
-          return;
-        }
-        try {
-          await _sessionRepository.renameSession(sessionId: sessionId, title: title);
-        } catch (error, stackTrace) {
-          if (_renameTitlesAwaitingEvents[sessionId] == title) {
-            _renameTitlesAwaitingEvents.remove(sessionId);
-          }
-          Log.w("Could not propagate title for session $sessionId to its plugin", error, stackTrace);
-        }
-      }),
-    );
-    return persistedResult.future;
+    return _serialized(() async {
+      final stored = await _sessionRepository.setSessionTitleIfStored(sessionId: sessionId, title: title);
+      final renamed = stored ? await _sessionRepository.getCatalogSession(sessionId: sessionId) : null;
+      if (renamed == null) {
+        throw PluginOperationException.notFound(
+          SessionOperation.renameSession.name,
+          message: "session $sessionId was not found",
+        );
+      }
+      _backendTitleGuards[sessionId] = (title: title, expiresAt: null);
+      unawaited(
+        _serializedBackend(() => _propagateTitle(sessionId: sessionId, title: title)),
+      );
+      return renamed;
+    });
   }
 
   Future<void> applyPendingTitle({required String sessionId}) {
@@ -89,24 +69,39 @@ class SessionMutationDispatcher {
   Future<void> deleteSession({required String sessionId}) {
     if (_disposed) return Future.error(StateError("SessionMutationDispatcher is disposed"));
     return _serialized(() async {
-      final deleted = await _sessionRepository.deleteSession(sessionId: sessionId);
+      final deleted = await _serializedBackend(() => _sessionRepository.deleteSession(sessionId: sessionId));
       _pendingTitles.remove(sessionId);
-      _renameTitlesAwaitingEvents.remove(sessionId);
-      _supersededRenameTitles.remove(sessionId);
+      _backendTitleGuards.remove(sessionId);
       _deletedSessionsController.add(deleted);
     });
   }
 
-  Future<void> drain() => _serialized(() async {});
+  Future<void> drain() => _serialized(() => _serializedBackend(() async {}));
 
   Future<void> dispose() {
     if (_disposed) return Future.value();
     _disposed = true;
     return _serialized(() async {
-      _renameTitlesAwaitingEvents.clear();
-      _supersededRenameTitles.clear();
+      await _serializedBackend(() async {});
+      _backendTitleGuards.clear();
       await _deletedSessionsController.close();
     });
+  }
+
+  Future<void> _propagateTitle({required String sessionId, required String title}) async {
+    try {
+      await _sessionRepository.renameSession(sessionId: sessionId, title: title);
+    } catch (error, stackTrace) {
+      Log.w("Could not propagate title for session $sessionId to its plugin", error, stackTrace);
+    } finally {
+      final guard = _backendTitleGuards[sessionId];
+      if (guard?.title == title && guard?.expiresAt == null) {
+        _backendTitleGuards[sessionId] = (
+          title: title,
+          expiresAt: DateTime.now().add(_backendTitleGuardDuration),
+        );
+      }
+    }
   }
 
   Future<void> _captureTitle({required String sessionId, required String? title}) async {
@@ -122,6 +117,20 @@ class SessionMutationDispatcher {
     final previous = _tail;
     final release = Completer<void>();
     _tail = release.future;
+    return () async {
+      await previous;
+      try {
+        return await operation();
+      } finally {
+        release.complete();
+      }
+    }();
+  }
+
+  Future<T> _serializedBackend<T>(Future<T> Function() operation) {
+    final previous = _backendTail;
+    final release = Completer<void>();
+    _backendTail = release.future;
     return () async {
       await previous;
       try {

--- a/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
@@ -1,7 +1,9 @@
 import "dart:async";
 
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, PluginOperationException;
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../repositories/models/session_operation.dart";
 import "../repositories/session_repository.dart";
 
 /// Serializes bridge-owned session mutations that share pending-title state.
@@ -9,6 +11,8 @@ class SessionMutationDispatcher {
   final SessionRepository _sessionRepository;
   final StreamController<Session> _deletedSessionsController = StreamController<Session>.broadcast(sync: true);
   final Map<String, String?> _pendingTitles = {};
+  // Explicit DB-backed renames win over delayed backend title events.
+  final Map<String, String> _authoritativeTitles = {};
   Future<void> _tail = Future<void>.value();
   bool _disposed = false;
 
@@ -18,16 +22,40 @@ class SessionMutationDispatcher {
 
   Future<void> captureTitle({required String sessionId, required String? title}) {
     return _serialized(() async {
+      if (_authoritativeTitles.containsKey(sessionId) && _authoritativeTitles[sessionId] != title) return;
       await _captureTitle(sessionId: sessionId, title: title);
     });
   }
 
+  /// Completes after the authoritative DB title is stored. Backend propagation
+  /// continues on the serialized tail so delete and dispose cannot overtake it.
   Future<Session> renameSession({required String sessionId, required String title}) {
-    return _serialized(() async {
-      final renamed = await _sessionRepository.renameSession(sessionId: sessionId, title: title);
-      await _captureTitle(sessionId: sessionId, title: title);
-      return _sessionRepository.enrichSession(session: renamed);
-    });
+    final persistedResult = Completer<Session>();
+    unawaited(
+      _serialized(() async {
+        try {
+          final stored = await _sessionRepository.setSessionTitleIfStored(sessionId: sessionId, title: title);
+          final renamed = stored ? await _sessionRepository.getCatalogSession(sessionId: sessionId) : null;
+          if (renamed == null) {
+            throw PluginOperationException.notFound(
+              SessionOperation.renameSession.name,
+              message: "session $sessionId was not found",
+            );
+          }
+          _authoritativeTitles[sessionId] = title;
+          persistedResult.complete(renamed);
+        } catch (error, stackTrace) {
+          persistedResult.completeError(error, stackTrace);
+          return;
+        }
+        try {
+          await _sessionRepository.renameSession(sessionId: sessionId, title: title);
+        } catch (error, stackTrace) {
+          Log.w("Could not propagate title for session $sessionId to its plugin", error, stackTrace);
+        }
+      }),
+    );
+    return persistedResult.future;
   }
 
   Future<void> applyPendingTitle({required String sessionId}) {
@@ -46,6 +74,7 @@ class SessionMutationDispatcher {
     return _serialized(() async {
       final deleted = await _sessionRepository.deleteSession(sessionId: sessionId);
       _pendingTitles.remove(sessionId);
+      _authoritativeTitles.remove(sessionId);
       _deletedSessionsController.add(deleted);
     });
   }
@@ -53,7 +82,10 @@ class SessionMutationDispatcher {
   Future<void> dispose() {
     if (_disposed) return Future.value();
     _disposed = true;
-    return _serialized(_deletedSessionsController.close);
+    return _serialized(() async {
+      _authoritativeTitles.clear();
+      await _deletedSessionsController.close();
+    });
   }
 
   Future<void> _captureTitle({required String sessionId, required String? title}) async {

--- a/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
+++ b/bridge/app/lib/src/bridge/services/session_mutation_dispatcher.dart
@@ -13,7 +13,7 @@ class SessionMutationDispatcher {
   final SessionRepository _sessionRepository;
   final StreamController<Session> _deletedSessionsController = StreamController<Session>.broadcast(sync: true);
   final Map<String, String?> _pendingTitles = {};
-  final Map<String, ({String title, DateTime? expiresAt})> _backendTitleGuards = {};
+  final Map<String, ({DateTime? expiresAt, Object token})> _backendTitleGuards = {};
   Future<void> _tail = Future<void>.value();
   Future<void> _backendTail = Future<void>.value();
   bool _disposed = false;
@@ -27,7 +27,7 @@ class SessionMutationDispatcher {
       final guard = _backendTitleGuards[sessionId];
       if (guard != null) {
         final active = guard.expiresAt == null || DateTime.now().isBefore(guard.expiresAt!);
-        if (active && guard.title != title) return;
+        if (active) return;
         _backendTitleGuards.remove(sessionId);
       }
       await _captureTitle(sessionId: sessionId, title: title);
@@ -47,9 +47,10 @@ class SessionMutationDispatcher {
           message: "session $sessionId was not found",
         );
       }
-      _backendTitleGuards[sessionId] = (title: title, expiresAt: null);
+      final guardToken = Object();
+      _backendTitleGuards[sessionId] = (expiresAt: null, token: guardToken);
       unawaited(
-        _serializedBackend(() => _propagateTitle(sessionId: sessionId, title: title)),
+        _serializedBackend(() => _propagateTitle(sessionId: sessionId, title: title, guardToken: guardToken)),
       );
       return renamed;
     });
@@ -88,18 +89,27 @@ class SessionMutationDispatcher {
     });
   }
 
-  Future<void> _propagateTitle({required String sessionId, required String title}) async {
+  Future<void> _propagateTitle({
+    required String sessionId,
+    required String title,
+    required Object guardToken,
+  }) async {
     try {
       await _sessionRepository.renameSession(sessionId: sessionId, title: title);
     } catch (error, stackTrace) {
       Log.w("Could not propagate title for session $sessionId to its plugin", error, stackTrace);
     } finally {
       final guard = _backendTitleGuards[sessionId];
-      if (guard?.title == title && guard?.expiresAt == null) {
+      if (identical(guard?.token, guardToken) && guard?.expiresAt == null) {
         _backendTitleGuards[sessionId] = (
-          title: title,
           expiresAt: DateTime.now().add(_backendTitleGuardDuration),
+          token: guardToken,
         );
+        Timer(_backendTitleGuardDuration, () {
+          if (identical(_backendTitleGuards[sessionId]?.token, guardToken)) {
+            _backendTitleGuards.remove(sessionId);
+          }
+        });
       }
     }
   }

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -1117,7 +1117,7 @@ void main() {
       expect(plugin.lastSendCommandSessionId, isNull);
     });
 
-    test("rename fails — session still returned successfully", () async {
+    test("plugin rename failure keeps the stored generated title", () async {
       final throwingPlugin = _ThrowingRenameSessionPlugin();
       metadataService.generateResult = const bridge_metadata.SessionMetadata(
         title: "Fix Login Bug",
@@ -1166,6 +1166,8 @@ void main() {
       );
 
       _expectRandomSesoriId(sessionId: result.id, backendSessionId: "s1");
+      expect(result.title, "Fix Login Bug");
+      expect((await db.sessionDao.getSession(sessionId: result.id))?.title, "Fix Login Bug");
       await throwingPlugin.close();
     });
   });

--- a/bridge/app/test/bridge/routing/create_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/create_session_handler_test.dart
@@ -63,6 +63,7 @@ void main() {
     late FakeMetadataService metadataService;
     late _FakeWorktreeService worktreeService;
     late SessionRepository sessionRepository;
+    late SessionMutationDispatcher sessionMutationDispatcher;
     late CreateSessionHandler handler;
     late AppDatabase db;
 
@@ -79,17 +80,19 @@ void main() {
         pullRequestDao: db.pullRequestDao,
         unseenCalculator: const SessionUnseenCalculator(),
       );
+      sessionMutationDispatcher = SessionMutationDispatcher(sessionRepository: sessionRepository);
       handler = CreateSessionHandler(
         sessionCreationService: SessionCreationService(
           metadataService: metadataService,
           worktreeService: worktreeService,
           sessionRepository: sessionRepository,
-          sessionMutationDispatcher: SessionMutationDispatcher(sessionRepository: sessionRepository),
+          sessionMutationDispatcher: sessionMutationDispatcher,
         ),
       );
     });
 
     tearDown(() async {
+      await sessionMutationDispatcher.dispose();
       await plugin.close();
       await db.close();
     });
@@ -744,6 +747,9 @@ void main() {
       _expectRandomSesoriId(sessionId: result.id, backendSessionId: "s1");
       expect(metadataService.lastGenerateMessage, equals("Fix the login bug"));
       expect(worktreeService.lastPreparePreferredBranchName, equals("fix-login-bug"));
+      expect(result.title, equals("Fix Login Bug"));
+      expect((await db.sessionDao.getSession(sessionId: result.id))?.title, equals("Fix Login Bug"));
+      await sessionMutationDispatcher.drain();
       expect(plugin.lastRenameSessionTitle, equals("Fix Login Bug"));
     });
 
@@ -1139,12 +1145,13 @@ void main() {
         pullRequestDao: db.pullRequestDao,
         unseenCalculator: const SessionUnseenCalculator(),
       );
+      final throwingDispatcher = SessionMutationDispatcher(sessionRepository: throwingRepository);
       final localHandler = CreateSessionHandler(
         sessionCreationService: SessionCreationService(
           metadataService: metadataService,
           worktreeService: worktreeService,
           sessionRepository: throwingRepository,
-          sessionMutationDispatcher: SessionMutationDispatcher(sessionRepository: throwingRepository),
+          sessionMutationDispatcher: throwingDispatcher,
         ),
       );
 
@@ -1168,6 +1175,7 @@ void main() {
       _expectRandomSesoriId(sessionId: result.id, backendSessionId: "s1");
       expect(result.title, "Fix Login Bug");
       expect((await db.sessionDao.getSession(sessionId: result.id))?.title, "Fix Login Bug");
+      await throwingDispatcher.dispose();
       await throwingPlugin.close();
     });
   });

--- a/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
+++ b/bridge/app/test/bridge/routing/get_sessions_handler_test.dart
@@ -1088,6 +1088,9 @@ class _TrackingSessionMutationDispatcher implements SessionMutationDispatcher {
   Future<void> deleteSession({required String sessionId}) async {}
 
   @override
+  Future<void> drain() async {}
+
+  @override
   Future<void> dispose() async {}
 
   @override

--- a/bridge/app/test/bridge/routing/rename_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/rename_session_handler_test.dart
@@ -18,6 +18,7 @@ void main() {
     late FakeBridgePlugin plugin;
     late AppDatabase db;
     late SessionRepository sessionRepository;
+    late SessionMutationDispatcher sessionMutationDispatcher;
     late RenameSessionHandler handler;
 
     setUp(() async {
@@ -30,9 +31,8 @@ void main() {
         pullRequestDao: db.pullRequestDao,
         unseenCalculator: const SessionUnseenCalculator(),
       );
-      handler = RenameSessionHandler(
-        sessionMutationDispatcher: SessionMutationDispatcher(sessionRepository: sessionRepository),
-      );
+      sessionMutationDispatcher = SessionMutationDispatcher(sessionRepository: sessionRepository);
+      handler = RenameSessionHandler(sessionMutationDispatcher: sessionMutationDispatcher);
       await sessionRepository.insertStoredSession(
         sessionId: "s1",
         backendSessionId: "backend-s1",
@@ -50,6 +50,7 @@ void main() {
     });
 
     tearDown(() async {
+      await sessionMutationDispatcher.dispose();
       await plugin.close();
       await db.close();
     });
@@ -87,12 +88,13 @@ void main() {
         queryParams: {},
         fragment: null,
       );
+      await sessionMutationDispatcher.dispose();
 
       expect(plugin.lastRenameSessionId, equals("backend-s1"));
       expect(plugin.lastRenameSessionTitle, equals("New Title"));
     });
 
-    test("returns mapped Session", () async {
+    test("returns the authoritative catalog Session", () async {
       await db.projectsDao.insertProjectsIfMissing(projectIds: ["p1"]);
       await db.sessionDao.insertSession(
         pluginId: "fake",
@@ -145,13 +147,14 @@ void main() {
       expect(result.id, equals("s1"));
       expect(result.projectID, equals("p1"));
       expect(result.directory, equals("/tmp"));
-      expect(result.parentID, equals("parent-1"));
+      expect(result.parentID, isNull);
       expect(result.title, equals("Renamed Session"));
-      expect(result.time?.created, equals(10));
-      expect(result.time?.updated, equals(20));
+      expect(result.time?.created, equals(1));
+      expect(result.time?.updated, greaterThan(1));
       expect(result.time?.archived, isNull);
       expect(result.pullRequest?.number, equals(13));
       expect(result.pullRequest?.title, equals("Rename PR"));
+      await sessionMutationDispatcher.dispose();
       expect(plugin.lastRenameSessionId, equals("backend-s1"));
     });
 
@@ -184,7 +187,7 @@ void main() {
       expect(plugin.lastRenameSessionId, isNull);
     });
 
-    test("stored plugin mismatch returns 503 before plugin I/O", () async {
+    test("stores a rename while the owning plugin is unavailable", () async {
       await sessionRepository.insertStoredSession(
         sessionId: "stale-plugin-session",
         backendSessionId: "backend-stale-plugin-session",
@@ -213,7 +216,8 @@ void main() {
         fragment: null,
       );
 
-      expect(response.status, 503);
+      expect(response.status, 200);
+      expect((await db.sessionDao.getSession(sessionId: "stale-plugin-session"))?.title, "New Title");
       expect(plugin.lastRenameSessionId, isNull);
     });
   });

--- a/bridge/app/test/bridge/services/session_mutation_dispatcher_test.dart
+++ b/bridge/app/test/bridge/services/session_mutation_dispatcher_test.dart
@@ -69,6 +69,65 @@ void main() {
       expect(plugin.renameCalls, isZero);
     });
 
+    test("returns the stored title while plugin propagation remains serialized", () async {
+      final renameStarted = Completer<void>();
+      final releaseRename = Completer<void>();
+      final deleteStarted = Completer<void>();
+      plugin
+        ..renameStarted = renameStarted
+        ..releaseRename = releaseRename.future
+        ..deleteStarted = deleteStarted;
+      await insertSession();
+
+      final rename = dispatcher.renameSession(sessionId: "s1", title: "Stored title");
+      await renameStarted.future;
+      Future<void>? deletion;
+      try {
+        final renamed = await rename.timeout(const Duration(milliseconds: 100));
+        deletion = dispatcher.deleteSession(sessionId: "s1");
+        await Future<void>.delayed(Duration.zero);
+
+        expect(renamed.title, "Stored title");
+        expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "Stored title");
+        expect(deleteStarted.isCompleted, isFalse);
+      } finally {
+        releaseRename.complete();
+      }
+      await deletion;
+      expect(deleteStarted.isCompleted, isTrue);
+    });
+
+    test("keeps the stored title when plugin propagation fails", () async {
+      plugin.renameError = StateError("rename failed");
+      await insertSession();
+
+      final renamed = await dispatcher.renameSession(sessionId: "s1", title: "Stored title");
+
+      expect(renamed.title, "Stored title");
+      expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "Stored title");
+      expect(plugin.renameCalls, 1);
+    });
+
+    test("does not let an older plugin title event overwrite a newer rename", () async {
+      final renameStarted = Completer<void>();
+      final releaseRename = Completer<void>();
+      plugin
+        ..renameStarted = renameStarted
+        ..releaseRename = releaseRename.future;
+      await insertSession();
+
+      await dispatcher.renameSession(sessionId: "s1", title: "First title");
+      await renameStarted.future;
+      final newerRename = dispatcher.renameSession(sessionId: "s1", title: "Newer title");
+      final staleEvent = dispatcher.captureTitle(sessionId: "s1", title: "First title");
+
+      releaseRename.complete();
+      await newerRename;
+      await staleEvent;
+
+      expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "Newer title");
+    });
+
     test("applies a pending null by removing the stored title copy", () async {
       await dispatcher.captureTitle(sessionId: "s1", title: null);
       await insertSession();
@@ -169,6 +228,9 @@ void main() {
 }
 
 class _FakeDerivedPlugin implements BridgeDerivedProjectsPluginApi {
+  Completer<void>? renameStarted;
+  Future<void>? releaseRename;
+  Object? renameError;
   Completer<void>? deleteStarted;
   Future<void>? releaseDelete;
   int renameCalls = 0;
@@ -189,6 +251,9 @@ class _FakeDerivedPlugin implements BridgeDerivedProjectsPluginApi {
   @override
   Future<PluginSession> renameSession({required String sessionId, required String title}) async {
     renameCalls++;
+    if (renameStarted case final started? when !started.isCompleted) started.complete();
+    if (releaseRename case final release?) await release;
+    if (renameError case final error?) throw error;
     return PluginSession(
       id: sessionId,
       projectID: "/repo",

--- a/bridge/app/test/bridge/services/session_mutation_dispatcher_test.dart
+++ b/bridge/app/test/bridge/services/session_mutation_dispatcher_test.dart
@@ -84,11 +84,15 @@ void main() {
       Future<void>? deletion;
       try {
         final renamed = await rename.timeout(const Duration(milliseconds: 100));
+        final newerRename = await dispatcher
+            .renameSession(sessionId: "s1", title: "Newer title")
+            .timeout(const Duration(milliseconds: 100));
         deletion = dispatcher.deleteSession(sessionId: "s1");
         await Future<void>.delayed(Duration.zero);
 
         expect(renamed.title, "Stored title");
-        expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "Stored title");
+        expect(newerRename.title, "Newer title");
+        expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "Newer title");
         expect(deleteStarted.isCompleted, isFalse);
       } finally {
         releaseRename.complete();
@@ -102,10 +106,25 @@ void main() {
       await insertSession();
 
       final renamed = await dispatcher.renameSession(sessionId: "s1", title: "Stored title");
+      await dispatcher.drain();
+      await dispatcher.captureTitle(sessionId: "s1", title: "Old backend title");
 
       expect(renamed.title, "Stored title");
       expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "Stored title");
       expect(plugin.renameCalls, 1);
+    });
+
+    test("accepts a later backend rename that reuses an older local title", () async {
+      await insertSession();
+
+      await dispatcher.renameSession(sessionId: "s1", title: "First title");
+      await dispatcher.renameSession(sessionId: "s1", title: "Second title");
+      await dispatcher.renameSession(sessionId: "s1", title: "Third title");
+      await dispatcher.drain();
+      await Future<void>.delayed(const Duration(milliseconds: 1100));
+      await dispatcher.captureTitle(sessionId: "s1", title: "First title");
+
+      expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "First title");
     });
 
     test("suppresses an older rename event without blocking later backend titles", () async {
@@ -127,6 +146,7 @@ void main() {
 
       expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "Newer title");
 
+      await dispatcher.captureTitle(sessionId: "s1", title: "Newer title");
       await dispatcher.captureTitle(sessionId: "s1", title: "External title");
       expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "External title");
     });

--- a/bridge/app/test/bridge/services/session_mutation_dispatcher_test.dart
+++ b/bridge/app/test/bridge/services/session_mutation_dispatcher_test.dart
@@ -108,7 +108,7 @@ void main() {
       expect(plugin.renameCalls, 1);
     });
 
-    test("does not let an older plugin title event overwrite a newer rename", () async {
+    test("suppresses an older rename event without blocking later backend titles", () async {
       final renameStarted = Completer<void>();
       final releaseRename = Completer<void>();
       plugin
@@ -126,6 +126,9 @@ void main() {
       await staleEvent;
 
       expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "Newer title");
+
+      await dispatcher.captureTitle(sessionId: "s1", title: "External title");
+      expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "External title");
     });
 
     test("applies a pending null by removing the stored title copy", () async {

--- a/bridge/app/test/bridge/services/session_mutation_dispatcher_test.dart
+++ b/bridge/app/test/bridge/services/session_mutation_dispatcher_test.dart
@@ -148,6 +148,10 @@ void main() {
 
       await dispatcher.captureTitle(sessionId: "s1", title: "Newer title");
       await dispatcher.captureTitle(sessionId: "s1", title: "External title");
+      expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "Newer title");
+
+      await Future<void>.delayed(const Duration(milliseconds: 1100));
+      await dispatcher.captureTitle(sessionId: "s1", title: "External title");
       expect((await db.sessionDao.getSession(sessionId: "s1"))?.title, "External title");
     });
 

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -625,17 +625,19 @@ class CodexPlugin implements CodexManagedApi {
     required String title,
   }) async {
     final client = await _connectedClient();
-    final retryStopwatch = Stopwatch();
+    Stopwatch? retryClock;
     for (var attempt = 1; ; attempt++) {
-      final remainingRetryTime = _renameRetryTimeout - retryStopwatch.elapsed;
-      if (retryStopwatch.isRunning && remainingRetryTime <= Duration.zero) {
+      final requestTimeout = retryClock == null
+          ? const Duration(seconds: 30)
+          : _renameRetryTimeout - retryClock.elapsed;
+      if (requestTimeout <= Duration.zero) {
         throw TimeoutException("Codex session rename retry deadline elapsed");
       }
       try {
         await client.request(
           method: "thread/name/set",
           params: {"threadId": sessionId, "name": title},
-          timeout: retryStopwatch.isRunning ? remainingRetryTime : const Duration(seconds: 30),
+          timeout: requestTimeout,
         );
         break;
       } on CodexRpcException catch (error) {
@@ -643,8 +645,8 @@ class CodexPlugin implements CodexManagedApi {
         // initial session metadata has been flushed. Retry only that transient
         // app-server failure; unrelated rename failures remain immediate.
         if (!_isEmptyRollout(error)) rethrow;
-        if (!retryStopwatch.isRunning) retryStopwatch.start();
-        if (retryStopwatch.elapsed + _renameRetryDelay > _renameRetryTimeout) rethrow;
+        retryClock ??= Stopwatch()..start();
+        if (retryClock.elapsed + _renameRetryDelay > _renameRetryTimeout) rethrow;
         Log.d(
           "Codex rollout metadata is not ready for session $sessionId; "
           "retrying rename after attempt $attempt",

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -38,8 +38,8 @@ import "services/codex_session_service.dart";
 /// Approval/permission flows still throw — those land in Phase 5.
 class CodexPlugin implements CodexManagedApi {
   static const String pluginId = "codex";
-  static const int _renameMaxAttempts = 5;
   static const Duration _renameRetryDelay = Duration(milliseconds: 100);
+  static const Duration _renameRetryTimeout = Duration(seconds: 2);
 
   final String _serverUrl;
   // Passed to the default client built in [_createClient]; retained for future
@@ -625,6 +625,7 @@ class CodexPlugin implements CodexManagedApi {
     required String title,
   }) async {
     final client = await _connectedClient();
+    final retryStopwatch = Stopwatch();
     for (var attempt = 1; ; attempt++) {
       try {
         await client.request(
@@ -636,10 +637,12 @@ class CodexPlugin implements CodexManagedApi {
         // thread/start can return after creating the rollout but before its
         // initial session metadata has been flushed. Retry only that transient
         // app-server failure; unrelated rename failures remain immediate.
-        if (attempt >= _renameMaxAttempts || !_isEmptyRollout(error)) rethrow;
+        if (!_isEmptyRollout(error)) rethrow;
+        if (!retryStopwatch.isRunning) retryStopwatch.start();
+        if (retryStopwatch.elapsed + _renameRetryDelay > _renameRetryTimeout) rethrow;
         Log.d(
           "Codex rollout metadata is not ready for session $sessionId; "
-          "retrying rename ($attempt/$_renameMaxAttempts)",
+          "retrying rename after attempt $attempt",
         );
         await Future<void>.delayed(_renameRetryDelay);
       }

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -38,6 +38,8 @@ import "services/codex_session_service.dart";
 /// Approval/permission flows still throw — those land in Phase 5.
 class CodexPlugin implements CodexManagedApi {
   static const String pluginId = "codex";
+  static const int _renameMaxAttempts = 5;
+  static const Duration _renameRetryDelay = Duration(milliseconds: 100);
 
   final String _serverUrl;
   // Passed to the default client built in [_createClient]; retained for future
@@ -585,6 +587,14 @@ class CodexPlugin implements CodexManagedApi {
         (error.code == -32600 && message.contains("not found"));
   }
 
+  bool _isEmptyRollout(CodexRpcException error) {
+    final message = error.message.toLowerCase();
+    return error.code == -32603 &&
+        message.contains("failed to read session metadata") &&
+        message.contains("rollout") &&
+        message.contains(" is empty");
+  }
+
   Map<String, dynamic>? _promptPartToUserInput(PluginPromptPart part) {
     return switch (part) {
       PluginPromptPartText(:final text) => {
@@ -615,10 +625,25 @@ class CodexPlugin implements CodexManagedApi {
     required String title,
   }) async {
     final client = await _connectedClient();
-    await client.request(
-      method: "thread/name/set",
-      params: {"threadId": sessionId, "name": title},
-    );
+    for (var attempt = 1; ; attempt++) {
+      try {
+        await client.request(
+          method: "thread/name/set",
+          params: {"threadId": sessionId, "name": title},
+        );
+        break;
+      } on CodexRpcException catch (error) {
+        // thread/start can return after creating the rollout but before its
+        // initial session metadata has been flushed. Retry only that transient
+        // app-server failure; unrelated rename failures remain immediate.
+        if (attempt >= _renameMaxAttempts || !_isEmptyRollout(error)) rethrow;
+        Log.d(
+          "Codex rollout metadata is not ready for session $sessionId; "
+          "retrying rename ($attempt/$_renameMaxAttempts)",
+        );
+        await Future<void>.delayed(_renameRetryDelay);
+      }
+    }
     final directory = _directoryForSession(sessionId);
     return PluginSession(
       id: sessionId,

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -627,10 +627,15 @@ class CodexPlugin implements CodexManagedApi {
     final client = await _connectedClient();
     final retryStopwatch = Stopwatch();
     for (var attempt = 1; ; attempt++) {
+      final remainingRetryTime = _renameRetryTimeout - retryStopwatch.elapsed;
+      if (retryStopwatch.isRunning && remainingRetryTime <= Duration.zero) {
+        throw TimeoutException("Codex session rename retry deadline elapsed");
+      }
       try {
         await client.request(
           method: "thread/name/set",
           params: {"threadId": sessionId, "name": title},
+          timeout: retryStopwatch.isRunning ? remainingRetryTime : const Duration(seconds: 30),
         );
         break;
       } on CodexRpcException catch (error) {

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -165,6 +165,71 @@ void main() {
       expect(renamed.directory, equals("/work/sample/packages/core"));
     });
 
+    test("renameSession retries while a fresh rollout is empty", () async {
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          result: {
+            "thread": {"id": "t-empty-rollout"},
+          },
+        ),
+        const _Response(result: {"turnId": "u-1"}),
+        const _Response(
+          error: {
+            "code": -32603,
+            "message":
+                "failed to set thread name: Fatal error: failed to update thread metadata "
+                "t-empty-rollout: thread-store internal error: failed to read session metadata "
+                "/tmp/rollout-t-empty-rollout.jsonl: rollout at "
+                "/tmp/rollout-t-empty-rollout.jsonl is empty",
+          },
+        ),
+        const _Response(result: {}),
+      ]);
+
+      await plugin.createSession(
+        directory: "/work/sample",
+        parentSessionId: null,
+        parts: const [PluginPromptPart.text(text: "start")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final renamed = await plugin.renameSession(
+        sessionId: "t-empty-rollout",
+        title: "Renamed",
+      );
+
+      expect(renamed.title, equals("Renamed"));
+      expect(fake.sentMethods.where((method) => method == "thread/name/set"), hasLength(2));
+    });
+
+    test("renameSession does not retry unrelated RPC failures", () async {
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          error: {
+            "code": -32603,
+            "message": "failed to set thread name: state database is unavailable",
+          },
+        ),
+        const _Response(result: {}),
+      ]);
+
+      await expectLater(
+        plugin.renameSession(sessionId: "t-failed", title: "Renamed"),
+        throwsA(
+          isA<CodexRpcException>().having(
+            (error) => error.message,
+            "message",
+            contains("state database is unavailable"),
+          ),
+        ),
+      );
+
+      expect(fake.sentMethods.where((method) => method == "thread/name/set"), hasLength(1));
+    });
+
     test("sendPrompt resumes a thread from a prior run before the turn", () async {
       // `t-existing` was never started in this plugin instance, so the
       // app-server has not loaded it — the plugin must resume it on demand

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -236,6 +236,31 @@ void main() {
       expect(fake.sentMethods.where((method) => method == "thread/name/set"), hasLength(1));
     });
 
+    test("renameSession bounds a stalled retry by the rollout deadline", () async {
+      fake.respondInOrder([
+        const _Response(result: _initOk),
+        const _Response(
+          error: {
+            "code": -32603,
+            "message":
+                "failed to read session metadata /tmp/rollout.jsonl: "
+                "rollout at /tmp/rollout.jsonl is empty",
+          },
+        ),
+        const _Response(respond: false),
+      ]);
+      final stopwatch = Stopwatch()..start();
+
+      await expectLater(
+        plugin
+            .renameSession(sessionId: "t-stalled", title: "Renamed")
+            .timeout(const Duration(seconds: 4)),
+        throwsA(isA<TimeoutException>()),
+      );
+
+      expect(stopwatch.elapsed, lessThan(const Duration(seconds: 3)));
+    });
+
     test("sendPrompt resumes a thread from a prior run before the turn", () async {
       // `t-existing` was never started in this plugin instance, so the
       // app-server has not loaded it — the plugin must resume it on demand
@@ -622,9 +647,10 @@ const Map<String, dynamic> _initOk = {
 
 class _Response {
   // ignore: unused_element_parameter
-  const _Response({this.result, this.error});
+  const _Response({this.result, this.error, this.respond = true});
   final Object? result;
   final Map<String, dynamic>? error;
+  final bool respond;
 }
 
 /// Fake app-server that records every method/params it received and
@@ -699,6 +725,7 @@ class _FakeAppServer {
       return;
     }
     final response = _pending.removeAt(0);
+    if (!response.respond) return;
     final envelope = <String, dynamic>{"jsonrpc": "2.0", "id": id};
     if (response.error != null) {
       envelope["error"] = response.error;

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -165,7 +165,17 @@ void main() {
       expect(renamed.directory, equals("/work/sample/packages/core"));
     });
 
-    test("renameSession retries while a fresh rollout is empty", () async {
+    test("renameSession retries beyond the initial rollout flush window", () async {
+      const emptyRolloutResponse = _Response(
+        error: {
+          "code": -32603,
+          "message":
+              "failed to set thread name: Fatal error: failed to update thread metadata "
+              "t-empty-rollout: thread-store internal error: failed to read session metadata "
+              "/tmp/rollout-t-empty-rollout.jsonl: rollout at "
+              "/tmp/rollout-t-empty-rollout.jsonl is empty",
+        },
+      );
       fake.respondInOrder([
         const _Response(result: _initOk),
         const _Response(
@@ -174,16 +184,12 @@ void main() {
           },
         ),
         const _Response(result: {"turnId": "u-1"}),
-        const _Response(
-          error: {
-            "code": -32603,
-            "message":
-                "failed to set thread name: Fatal error: failed to update thread metadata "
-                "t-empty-rollout: thread-store internal error: failed to read session metadata "
-                "/tmp/rollout-t-empty-rollout.jsonl: rollout at "
-                "/tmp/rollout-t-empty-rollout.jsonl is empty",
-          },
-        ),
+        emptyRolloutResponse,
+        emptyRolloutResponse,
+        emptyRolloutResponse,
+        emptyRolloutResponse,
+        emptyRolloutResponse,
+        emptyRolloutResponse,
         const _Response(result: {}),
       ]);
 
@@ -201,7 +207,7 @@ void main() {
       );
 
       expect(renamed.title, equals("Renamed"));
-      expect(fake.sentMethods.where((method) => method == "thread/name/set"), hasLength(2));
+      expect(fake.sentMethods.where((method) => method == "thread/name/set"), hasLength(7));
     });
 
     test("renameSession does not retry unrelated RPC failures", () async {


### PR DESCRIPTION
## Summary
- persist session titles in the bridge database and return the authoritative catalog session before waiting for backend propagation
- keep plugin renames on the serialized mutation tail so deletion and disposal cannot overtake them, while logging propagation failures without losing the stored title
- prevent delayed backend title events from overwriting a newer explicit database-backed rename
- retry Codex `thread/name/set` only for its transient empty-rollout metadata failure, with every retry bounded by the remaining two-second deadline

## Root cause
The rename workflow previously called the backend plugin before storing the bridge-owned title override. Codex can expose a newly created rollout before its initial `session_meta` line is flushed, causing `thread/name/set` to fail and the generated title never to reach the bridge database.

The bridge database is now the title source of truth. Backend rename is asynchronous synchronization and no longer blocks or invalidates the local rename.

## Testing
- `dart test test/bridge/services/session_mutation_dispatcher_test.dart` in `bridge/app`
- `dart test test/bridge/routing/rename_session_handler_test.dart` in `bridge/app`
- `dart test test/bridge/routing/create_session_handler_test.dart --name "plugin rename failure keeps the stored generated title"` in `bridge/app`
- `dart analyze --fatal-infos` in `bridge/app`
- `dart test` in `bridge/sesori_plugin_codex` (154 tests before the added stalled-retry regression)
- `dart test test/codex_plugin_write_path_test.dart` in `bridge/sesori_plugin_codex` (17 tests)
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_codex`
