### PR TITLE
chore(agents): use fast GPT variants

### DIFF
--- a/.opencode/agents/aristotle-impl-review.md
+++ b/.opencode/agents/aristotle-impl-review.md
@@ -1,7 +1,7 @@
 ---
 description: Reviews architecture-bearing production changes, not general implementation correctness. Prefers Git scopes such as a branch, commit range, recent commits, or PR, but also accepts file-based scopes. Avoids legacy-cleanup scope creep; callers seek user guidance after two rejected passes.
 mode: subagent
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.6-sol-fast
 variant: high
 temperature: 0.1
 permission:

--- a/.opencode/agents/aristotle-plan-review.md
+++ b/.opencode/agents/aristotle-plan-review.md
@@ -1,7 +1,7 @@
 ---
 description: Reviews an architecture-bearing development plan against strict Sesori architectural rules. The caller fixes findings directly without re-reviewing those fixes. A plan may be reviewed again after a too-vague rejection or considerable changes caused by new findings or user requests.
 mode: subagent
-model: openai/gpt-5.6-sol
+model: openai/gpt-5.6-sol-fast
 variant: high
 temperature: 0.1
 permission:


### PR DESCRIPTION
## Summary
- switch the Aristotle implementation reviewer to `openai/gpt-5.6-sol-fast`
- switch the Aristotle plan reviewer to `openai/gpt-5.6-sol-fast`

## Validation
- `git diff --check`
- confirmed all explicit GPT model references under `.opencode/agents` use fast variants


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the Aristotle implementation and plan review subagents to the fast model `openai/gpt-5.6-sol-fast` to speed up reviews. No other changes.

<sup>Written for commit b947c068f36e03efc4e1ae7c951ac4c4ffdc408a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

