### PR TITLE
fix(codex): restore custom tool call history

### DIFF
--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
@@ -1,4 +1,5 @@
 import "package:freezed_annotation/freezed_annotation.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 part "codex_rollout_dto.freezed.dart";
 part "codex_rollout_dto.g.dart";
@@ -80,8 +81,8 @@ sealed class CodexRolloutPayloadDto with _$CodexRolloutPayloadDto {
     required String? model,
     @JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) required CodexRolloutPayloadType? type,
     @JsonKey(unknownEnumValue: CodexRolloutRole.unknown) required CodexRolloutRole? role,
-    required List<CodexRolloutContentDto>? content,
-    required List<CodexRolloutContentDto>? summary,
+    @CodexRolloutContentListConverter() required List<CodexRolloutContentDto>? content,
+    @CodexRolloutContentListConverter() required List<CodexRolloutContentDto>? summary,
     @JsonKey(name: "call_id") required String? callId,
     required String? name,
     required String? arguments,
@@ -103,34 +104,31 @@ sealed class CodexRolloutContentDto with _$CodexRolloutContentDto {
   factory CodexRolloutContentDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutContentDtoFromJson(json);
 }
 
-/// Normalizes Codex tool output across persisted rollout versions.
-///
-/// Legacy function-call records store output as a string, while current custom
-/// tool-call records store a typed content array. The DTO exposes one typed
-/// representation to the rest of the plugin.
-class CodexRolloutOutputConverter implements JsonConverter<List<CodexRolloutContentDto>?, Object?> {
-  const CodexRolloutOutputConverter();
+/// Decodes typed rollout content without dropping an otherwise valid record
+/// when one nested item has drifted.
+class CodexRolloutContentListConverter implements JsonConverter<List<CodexRolloutContentDto>?, Object?> {
+  const CodexRolloutContentListConverter();
 
   @override
   List<CodexRolloutContentDto>? fromJson(Object? json) {
     if (json == null) return null;
-    if (json is String) {
-      return [
-        CodexRolloutContentDto(
-          type: CodexRolloutContentType.outputText,
-          text: json,
-        ),
-      ];
-    }
     if (json is! List) {
-      throw const FormatException("Codex rollout output must be a string or content array");
+      Log.w("[codex] skipping malformed rollout content list");
+      return const [];
     }
-    return [
-      for (final item in json)
-        CodexRolloutContentDto.fromJson(
-          (item as Map).cast<String, dynamic>(),
-        ),
-    ];
+    final content = <CodexRolloutContentDto>[];
+    for (final item in json) {
+      try {
+        content.add(
+          CodexRolloutContentDto.fromJson(
+            (item as Map).cast<String, dynamic>(),
+          ),
+        );
+      } on Object {
+        Log.w("[codex] skipping malformed rollout content item");
+      }
+    }
+    return content;
   }
 
   @override
@@ -149,6 +147,28 @@ class CodexRolloutOutputConverter implements JsonConverter<List<CodexRolloutCont
           "text": content.text,
         },
     ];
+  }
+}
+
+/// Normalizes Codex tool output across persisted rollout versions.
+///
+/// Legacy function-call records store output as a string, while current custom
+/// tool-call records store a typed content array. The DTO exposes one typed
+/// representation to the rest of the plugin.
+class CodexRolloutOutputConverter extends CodexRolloutContentListConverter {
+  const CodexRolloutOutputConverter();
+
+  @override
+  List<CodexRolloutContentDto>? fromJson(Object? json) {
+    if (json is String) {
+      return [
+        CodexRolloutContentDto(
+          type: CodexRolloutContentType.outputText,
+          text: json,
+        ),
+      ];
+    }
+    return super.fromJson(json);
   }
 }
 

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
@@ -14,10 +14,16 @@ enum CodexRolloutLineType {
 }
 
 enum CodexRolloutPayloadType {
+  message,
+  reasoning,
   @JsonValue("function_call")
   functionCall,
   @JsonValue("function_call_output")
   functionCallOutput,
+  @JsonValue("custom_tool_call")
+  customToolCall,
+  @JsonValue("custom_tool_call_output")
+  customToolCallOutput,
   @JsonValue("web_search_call")
   webSearchCall,
   unknown,
@@ -34,6 +40,8 @@ enum CodexRolloutContentType {
   inputText,
   @JsonValue("output_text")
   outputText,
+  @JsonValue("summary_text")
+  summaryText,
   unknown,
 }
 
@@ -70,11 +78,17 @@ sealed class CodexRolloutPayloadDto with _$CodexRolloutPayloadDto {
     required String? model,
     @JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) required CodexRolloutPayloadType? type,
     @JsonKey(unknownEnumValue: CodexRolloutRole.unknown) required CodexRolloutRole? role,
-    required List<CodexRolloutContentDto>? content,
+    // Payload variants reuse these fields with different shapes. In
+    // particular, codex 0.144.x custom tool outputs are typed content arrays,
+    // while legacy function outputs are strings. Preserve the wire value here
+    // and narrow it in the repository after inspecting the payload type.
+    required Object? content,
+    required Object? summary,
     @JsonKey(name: "call_id") required String? callId,
     required String? name,
     required String? arguments,
-    required String? output,
+    required String? input,
+    required Object? output,
     required CodexRolloutActionDto? action,
   }) = _CodexRolloutPayloadDto;
 

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
@@ -14,7 +14,9 @@ enum CodexRolloutLineType {
 }
 
 enum CodexRolloutPayloadType {
+  @JsonValue("message")
   message,
+  @JsonValue("reasoning")
   reasoning,
   @JsonValue("function_call")
   functionCall,
@@ -78,17 +80,13 @@ sealed class CodexRolloutPayloadDto with _$CodexRolloutPayloadDto {
     required String? model,
     @JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) required CodexRolloutPayloadType? type,
     @JsonKey(unknownEnumValue: CodexRolloutRole.unknown) required CodexRolloutRole? role,
-    // Payload variants reuse these fields with different shapes. In
-    // particular, codex 0.144.x custom tool outputs are typed content arrays,
-    // while legacy function outputs are strings. Preserve the wire value here
-    // and narrow it in the repository after inspecting the payload type.
-    required Object? content,
-    required Object? summary,
+    required List<CodexRolloutContentDto>? content,
+    required List<CodexRolloutContentDto>? summary,
     @JsonKey(name: "call_id") required String? callId,
     required String? name,
     required String? arguments,
     required String? input,
-    required Object? output,
+    @CodexRolloutOutputConverter() required List<CodexRolloutContentDto>? output,
     required CodexRolloutActionDto? action,
   }) = _CodexRolloutPayloadDto;
 
@@ -103,6 +101,55 @@ sealed class CodexRolloutContentDto with _$CodexRolloutContentDto {
   }) = _CodexRolloutContentDto;
 
   factory CodexRolloutContentDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutContentDtoFromJson(json);
+}
+
+/// Normalizes Codex tool output across persisted rollout versions.
+///
+/// Legacy function-call records store output as a string, while current custom
+/// tool-call records store a typed content array. The DTO exposes one typed
+/// representation to the rest of the plugin.
+class CodexRolloutOutputConverter implements JsonConverter<List<CodexRolloutContentDto>?, Object?> {
+  const CodexRolloutOutputConverter();
+
+  @override
+  List<CodexRolloutContentDto>? fromJson(Object? json) {
+    if (json == null) return null;
+    if (json is String) {
+      return [
+        CodexRolloutContentDto(
+          type: CodexRolloutContentType.outputText,
+          text: json,
+        ),
+      ];
+    }
+    if (json is! List) {
+      throw const FormatException("Codex rollout output must be a string or content array");
+    }
+    return [
+      for (final item in json)
+        CodexRolloutContentDto.fromJson(
+          (item as Map).cast<String, dynamic>(),
+        ),
+    ];
+  }
+
+  @override
+  Object? toJson(List<CodexRolloutContentDto>? object) {
+    if (object == null) return null;
+    return [
+      for (final content in object)
+        {
+          "type": switch (content.type) {
+            CodexRolloutContentType.inputText => "input_text",
+            CodexRolloutContentType.outputText => "output_text",
+            CodexRolloutContentType.summaryText => "summary_text",
+            CodexRolloutContentType.unknown => "unknown",
+            null => null,
+          },
+          "text": content.text,
+        },
+    ];
+  }
 }
 
 @Freezed(fromJson: true, toJson: false)

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
@@ -309,7 +309,11 @@ $CodexRolloutPayloadDtoCopyWith<$Res>? get payload {
 /// @nodoc
 mixin _$CodexRolloutPayloadDto {
 
- String? get id; String? get cwd; String? get timestamp;@JsonKey(name: "model_provider") String? get modelProvider;@JsonKey(name: "cli_version") String? get cliVersion; String? get model;@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? get type;@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? get role; List<CodexRolloutContentDto>? get content;@JsonKey(name: "call_id") String? get callId; String? get name; String? get arguments; String? get output; CodexRolloutActionDto? get action;
+ String? get id; String? get cwd; String? get timestamp;@JsonKey(name: "model_provider") String? get modelProvider;@JsonKey(name: "cli_version") String? get cliVersion; String? get model;@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? get type;@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? get role;// Payload variants reuse these fields with different shapes. In
+// particular, codex 0.144.x custom tool outputs are typed content arrays,
+// while legacy function outputs are strings. Preserve the wire value here
+// and narrow it in the repository after inspecting the payload type.
+ Object? get content; Object? get summary;@JsonKey(name: "call_id") String? get callId; String? get name; String? get arguments; String? get input; Object? get output; CodexRolloutActionDto? get action;
 /// Create a copy of CodexRolloutPayloadDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -320,16 +324,16 @@ $CodexRolloutPayloadDtoCopyWith<CodexRolloutPayloadDto> get copyWith => _$CodexR
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutPayloadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cliVersion, cliVersion) || other.cliVersion == cliVersion)&&(identical(other.model, model) || other.model == model)&&(identical(other.type, type) || other.type == type)&&(identical(other.role, role) || other.role == role)&&const DeepCollectionEquality().equals(other.content, content)&&(identical(other.callId, callId) || other.callId == callId)&&(identical(other.name, name) || other.name == name)&&(identical(other.arguments, arguments) || other.arguments == arguments)&&(identical(other.output, output) || other.output == output)&&(identical(other.action, action) || other.action == action));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutPayloadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cliVersion, cliVersion) || other.cliVersion == cliVersion)&&(identical(other.model, model) || other.model == model)&&(identical(other.type, type) || other.type == type)&&(identical(other.role, role) || other.role == role)&&const DeepCollectionEquality().equals(other.content, content)&&const DeepCollectionEquality().equals(other.summary, summary)&&(identical(other.callId, callId) || other.callId == callId)&&(identical(other.name, name) || other.name == name)&&(identical(other.arguments, arguments) || other.arguments == arguments)&&(identical(other.input, input) || other.input == input)&&const DeepCollectionEquality().equals(other.output, output)&&(identical(other.action, action) || other.action == action));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,cwd,timestamp,modelProvider,cliVersion,model,type,role,const DeepCollectionEquality().hash(content),callId,name,arguments,output,action);
+int get hashCode => Object.hash(runtimeType,id,cwd,timestamp,modelProvider,cliVersion,model,type,role,const DeepCollectionEquality().hash(content),const DeepCollectionEquality().hash(summary),callId,name,arguments,input,const DeepCollectionEquality().hash(output),action);
 
 @override
 String toString() {
-  return 'CodexRolloutPayloadDto(id: $id, cwd: $cwd, timestamp: $timestamp, modelProvider: $modelProvider, cliVersion: $cliVersion, model: $model, type: $type, role: $role, content: $content, callId: $callId, name: $name, arguments: $arguments, output: $output, action: $action)';
+  return 'CodexRolloutPayloadDto(id: $id, cwd: $cwd, timestamp: $timestamp, modelProvider: $modelProvider, cliVersion: $cliVersion, model: $model, type: $type, role: $role, content: $content, summary: $summary, callId: $callId, name: $name, arguments: $arguments, input: $input, output: $output, action: $action)';
 }
 
 
@@ -340,7 +344,7 @@ abstract mixin class $CodexRolloutPayloadDtoCopyWith<$Res>  {
   factory $CodexRolloutPayloadDtoCopyWith(CodexRolloutPayloadDto value, $Res Function(CodexRolloutPayloadDto) _then) = _$CodexRolloutPayloadDtoCopyWithImpl;
 @useResult
 $Res call({
- String? id, String? cwd, String? timestamp,@JsonKey(name: "model_provider") String? modelProvider,@JsonKey(name: "cli_version") String? cliVersion, String? model,@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? type,@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? role, List<CodexRolloutContentDto>? content,@JsonKey(name: "call_id") String? callId, String? name, String? arguments, String? output, CodexRolloutActionDto? action
+ String? id, String? cwd, String? timestamp,@JsonKey(name: "model_provider") String? modelProvider,@JsonKey(name: "cli_version") String? cliVersion, String? model,@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? type,@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? role, Object? content, Object? summary,@JsonKey(name: "call_id") String? callId, String? name, String? arguments, String? input, Object? output, CodexRolloutActionDto? action
 });
 
 
@@ -357,7 +361,7 @@ class _$CodexRolloutPayloadDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexRolloutPayloadDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? cwd = freezed,Object? timestamp = freezed,Object? modelProvider = freezed,Object? cliVersion = freezed,Object? model = freezed,Object? type = freezed,Object? role = freezed,Object? content = freezed,Object? callId = freezed,Object? name = freezed,Object? arguments = freezed,Object? output = freezed,Object? action = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? cwd = freezed,Object? timestamp = freezed,Object? modelProvider = freezed,Object? cliVersion = freezed,Object? model = freezed,Object? type = freezed,Object? role = freezed,Object? content = freezed,Object? summary = freezed,Object? callId = freezed,Object? name = freezed,Object? arguments = freezed,Object? input = freezed,Object? output = freezed,Object? action = freezed,}) {
   return _then(_self.copyWith(
 id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String?,cwd: freezed == cwd ? _self.cwd : cwd // ignore: cast_nullable_to_non_nullable
@@ -367,12 +371,11 @@ as String?,cliVersion: freezed == cliVersion ? _self.cliVersion : cliVersion // 
 as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as String?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
 as CodexRolloutPayloadType?,role: freezed == role ? _self.role : role // ignore: cast_nullable_to_non_nullable
-as CodexRolloutRole?,content: freezed == content ? _self.content : content // ignore: cast_nullable_to_non_nullable
-as List<CodexRolloutContentDto>?,callId: freezed == callId ? _self.callId : callId // ignore: cast_nullable_to_non_nullable
+as CodexRolloutRole?,content: freezed == content ? _self.content : content ,summary: freezed == summary ? _self.summary : summary ,callId: freezed == callId ? _self.callId : callId // ignore: cast_nullable_to_non_nullable
 as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String?,arguments: freezed == arguments ? _self.arguments : arguments // ignore: cast_nullable_to_non_nullable
-as String?,output: freezed == output ? _self.output : output // ignore: cast_nullable_to_non_nullable
-as String?,action: freezed == action ? _self.action : action // ignore: cast_nullable_to_non_nullable
+as String?,input: freezed == input ? _self.input : input // ignore: cast_nullable_to_non_nullable
+as String?,output: freezed == output ? _self.output : output ,action: freezed == action ? _self.action : action // ignore: cast_nullable_to_non_nullable
 as CodexRolloutActionDto?,
   ));
 }
@@ -397,7 +400,7 @@ $CodexRolloutActionDtoCopyWith<$Res>? get action {
 @JsonSerializable(createToJson: false)
 
 class _CodexRolloutPayloadDto implements CodexRolloutPayloadDto {
-  const _CodexRolloutPayloadDto({required this.id, required this.cwd, required this.timestamp, @JsonKey(name: "model_provider") required this.modelProvider, @JsonKey(name: "cli_version") required this.cliVersion, required this.model, @JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) required this.type, @JsonKey(unknownEnumValue: CodexRolloutRole.unknown) required this.role, required final  List<CodexRolloutContentDto>? content, @JsonKey(name: "call_id") required this.callId, required this.name, required this.arguments, required this.output, required this.action}): _content = content;
+  const _CodexRolloutPayloadDto({required this.id, required this.cwd, required this.timestamp, @JsonKey(name: "model_provider") required this.modelProvider, @JsonKey(name: "cli_version") required this.cliVersion, required this.model, @JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) required this.type, @JsonKey(unknownEnumValue: CodexRolloutRole.unknown) required this.role, required this.content, required this.summary, @JsonKey(name: "call_id") required this.callId, required this.name, required this.arguments, required this.input, required this.output, required this.action});
   factory _CodexRolloutPayloadDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutPayloadDtoFromJson(json);
 
 @override final  String? id;
@@ -408,19 +411,17 @@ class _CodexRolloutPayloadDto implements CodexRolloutPayloadDto {
 @override final  String? model;
 @override@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) final  CodexRolloutPayloadType? type;
 @override@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) final  CodexRolloutRole? role;
- final  List<CodexRolloutContentDto>? _content;
-@override List<CodexRolloutContentDto>? get content {
-  final value = _content;
-  if (value == null) return null;
-  if (_content is EqualUnmodifiableListView) return _content;
-  // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(value);
-}
-
+// Payload variants reuse these fields with different shapes. In
+// particular, codex 0.144.x custom tool outputs are typed content arrays,
+// while legacy function outputs are strings. Preserve the wire value here
+// and narrow it in the repository after inspecting the payload type.
+@override final  Object? content;
+@override final  Object? summary;
 @override@JsonKey(name: "call_id") final  String? callId;
 @override final  String? name;
 @override final  String? arguments;
-@override final  String? output;
+@override final  String? input;
+@override final  Object? output;
 @override final  CodexRolloutActionDto? action;
 
 /// Create a copy of CodexRolloutPayloadDto
@@ -433,16 +434,16 @@ _$CodexRolloutPayloadDtoCopyWith<_CodexRolloutPayloadDto> get copyWith => __$Cod
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexRolloutPayloadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cliVersion, cliVersion) || other.cliVersion == cliVersion)&&(identical(other.model, model) || other.model == model)&&(identical(other.type, type) || other.type == type)&&(identical(other.role, role) || other.role == role)&&const DeepCollectionEquality().equals(other._content, _content)&&(identical(other.callId, callId) || other.callId == callId)&&(identical(other.name, name) || other.name == name)&&(identical(other.arguments, arguments) || other.arguments == arguments)&&(identical(other.output, output) || other.output == output)&&(identical(other.action, action) || other.action == action));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexRolloutPayloadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cliVersion, cliVersion) || other.cliVersion == cliVersion)&&(identical(other.model, model) || other.model == model)&&(identical(other.type, type) || other.type == type)&&(identical(other.role, role) || other.role == role)&&const DeepCollectionEquality().equals(other.content, content)&&const DeepCollectionEquality().equals(other.summary, summary)&&(identical(other.callId, callId) || other.callId == callId)&&(identical(other.name, name) || other.name == name)&&(identical(other.arguments, arguments) || other.arguments == arguments)&&(identical(other.input, input) || other.input == input)&&const DeepCollectionEquality().equals(other.output, output)&&(identical(other.action, action) || other.action == action));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,cwd,timestamp,modelProvider,cliVersion,model,type,role,const DeepCollectionEquality().hash(_content),callId,name,arguments,output,action);
+int get hashCode => Object.hash(runtimeType,id,cwd,timestamp,modelProvider,cliVersion,model,type,role,const DeepCollectionEquality().hash(content),const DeepCollectionEquality().hash(summary),callId,name,arguments,input,const DeepCollectionEquality().hash(output),action);
 
 @override
 String toString() {
-  return 'CodexRolloutPayloadDto(id: $id, cwd: $cwd, timestamp: $timestamp, modelProvider: $modelProvider, cliVersion: $cliVersion, model: $model, type: $type, role: $role, content: $content, callId: $callId, name: $name, arguments: $arguments, output: $output, action: $action)';
+  return 'CodexRolloutPayloadDto(id: $id, cwd: $cwd, timestamp: $timestamp, modelProvider: $modelProvider, cliVersion: $cliVersion, model: $model, type: $type, role: $role, content: $content, summary: $summary, callId: $callId, name: $name, arguments: $arguments, input: $input, output: $output, action: $action)';
 }
 
 
@@ -453,7 +454,7 @@ abstract mixin class _$CodexRolloutPayloadDtoCopyWith<$Res> implements $CodexRol
   factory _$CodexRolloutPayloadDtoCopyWith(_CodexRolloutPayloadDto value, $Res Function(_CodexRolloutPayloadDto) _then) = __$CodexRolloutPayloadDtoCopyWithImpl;
 @override @useResult
 $Res call({
- String? id, String? cwd, String? timestamp,@JsonKey(name: "model_provider") String? modelProvider,@JsonKey(name: "cli_version") String? cliVersion, String? model,@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? type,@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? role, List<CodexRolloutContentDto>? content,@JsonKey(name: "call_id") String? callId, String? name, String? arguments, String? output, CodexRolloutActionDto? action
+ String? id, String? cwd, String? timestamp,@JsonKey(name: "model_provider") String? modelProvider,@JsonKey(name: "cli_version") String? cliVersion, String? model,@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? type,@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? role, Object? content, Object? summary,@JsonKey(name: "call_id") String? callId, String? name, String? arguments, String? input, Object? output, CodexRolloutActionDto? action
 });
 
 
@@ -470,7 +471,7 @@ class __$CodexRolloutPayloadDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexRolloutPayloadDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? cwd = freezed,Object? timestamp = freezed,Object? modelProvider = freezed,Object? cliVersion = freezed,Object? model = freezed,Object? type = freezed,Object? role = freezed,Object? content = freezed,Object? callId = freezed,Object? name = freezed,Object? arguments = freezed,Object? output = freezed,Object? action = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? cwd = freezed,Object? timestamp = freezed,Object? modelProvider = freezed,Object? cliVersion = freezed,Object? model = freezed,Object? type = freezed,Object? role = freezed,Object? content = freezed,Object? summary = freezed,Object? callId = freezed,Object? name = freezed,Object? arguments = freezed,Object? input = freezed,Object? output = freezed,Object? action = freezed,}) {
   return _then(_CodexRolloutPayloadDto(
 id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String?,cwd: freezed == cwd ? _self.cwd : cwd // ignore: cast_nullable_to_non_nullable
@@ -480,12 +481,11 @@ as String?,cliVersion: freezed == cliVersion ? _self.cliVersion : cliVersion // 
 as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as String?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
 as CodexRolloutPayloadType?,role: freezed == role ? _self.role : role // ignore: cast_nullable_to_non_nullable
-as CodexRolloutRole?,content: freezed == content ? _self._content : content // ignore: cast_nullable_to_non_nullable
-as List<CodexRolloutContentDto>?,callId: freezed == callId ? _self.callId : callId // ignore: cast_nullable_to_non_nullable
+as CodexRolloutRole?,content: freezed == content ? _self.content : content ,summary: freezed == summary ? _self.summary : summary ,callId: freezed == callId ? _self.callId : callId // ignore: cast_nullable_to_non_nullable
 as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String?,arguments: freezed == arguments ? _self.arguments : arguments // ignore: cast_nullable_to_non_nullable
-as String?,output: freezed == output ? _self.output : output // ignore: cast_nullable_to_non_nullable
-as String?,action: freezed == action ? _self.action : action // ignore: cast_nullable_to_non_nullable
+as String?,input: freezed == input ? _self.input : input // ignore: cast_nullable_to_non_nullable
+as String?,output: freezed == output ? _self.output : output ,action: freezed == action ? _self.action : action // ignore: cast_nullable_to_non_nullable
 as CodexRolloutActionDto?,
   ));
 }

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
@@ -309,11 +309,7 @@ $CodexRolloutPayloadDtoCopyWith<$Res>? get payload {
 /// @nodoc
 mixin _$CodexRolloutPayloadDto {
 
- String? get id; String? get cwd; String? get timestamp;@JsonKey(name: "model_provider") String? get modelProvider;@JsonKey(name: "cli_version") String? get cliVersion; String? get model;@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? get type;@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? get role;// Payload variants reuse these fields with different shapes. In
-// particular, codex 0.144.x custom tool outputs are typed content arrays,
-// while legacy function outputs are strings. Preserve the wire value here
-// and narrow it in the repository after inspecting the payload type.
- Object? get content; Object? get summary;@JsonKey(name: "call_id") String? get callId; String? get name; String? get arguments; String? get input; Object? get output; CodexRolloutActionDto? get action;
+ String? get id; String? get cwd; String? get timestamp;@JsonKey(name: "model_provider") String? get modelProvider;@JsonKey(name: "cli_version") String? get cliVersion; String? get model;@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? get type;@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? get role; List<CodexRolloutContentDto>? get content; List<CodexRolloutContentDto>? get summary;@JsonKey(name: "call_id") String? get callId; String? get name; String? get arguments; String? get input;@CodexRolloutOutputConverter() List<CodexRolloutContentDto>? get output; CodexRolloutActionDto? get action;
 /// Create a copy of CodexRolloutPayloadDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -344,7 +340,7 @@ abstract mixin class $CodexRolloutPayloadDtoCopyWith<$Res>  {
   factory $CodexRolloutPayloadDtoCopyWith(CodexRolloutPayloadDto value, $Res Function(CodexRolloutPayloadDto) _then) = _$CodexRolloutPayloadDtoCopyWithImpl;
 @useResult
 $Res call({
- String? id, String? cwd, String? timestamp,@JsonKey(name: "model_provider") String? modelProvider,@JsonKey(name: "cli_version") String? cliVersion, String? model,@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? type,@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? role, Object? content, Object? summary,@JsonKey(name: "call_id") String? callId, String? name, String? arguments, String? input, Object? output, CodexRolloutActionDto? action
+ String? id, String? cwd, String? timestamp,@JsonKey(name: "model_provider") String? modelProvider,@JsonKey(name: "cli_version") String? cliVersion, String? model,@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? type,@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? role, List<CodexRolloutContentDto>? content, List<CodexRolloutContentDto>? summary,@JsonKey(name: "call_id") String? callId, String? name, String? arguments, String? input,@CodexRolloutOutputConverter() List<CodexRolloutContentDto>? output, CodexRolloutActionDto? action
 });
 
 
@@ -371,11 +367,14 @@ as String?,cliVersion: freezed == cliVersion ? _self.cliVersion : cliVersion // 
 as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as String?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
 as CodexRolloutPayloadType?,role: freezed == role ? _self.role : role // ignore: cast_nullable_to_non_nullable
-as CodexRolloutRole?,content: freezed == content ? _self.content : content ,summary: freezed == summary ? _self.summary : summary ,callId: freezed == callId ? _self.callId : callId // ignore: cast_nullable_to_non_nullable
+as CodexRolloutRole?,content: freezed == content ? _self.content : content // ignore: cast_nullable_to_non_nullable
+as List<CodexRolloutContentDto>?,summary: freezed == summary ? _self.summary : summary // ignore: cast_nullable_to_non_nullable
+as List<CodexRolloutContentDto>?,callId: freezed == callId ? _self.callId : callId // ignore: cast_nullable_to_non_nullable
 as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String?,arguments: freezed == arguments ? _self.arguments : arguments // ignore: cast_nullable_to_non_nullable
 as String?,input: freezed == input ? _self.input : input // ignore: cast_nullable_to_non_nullable
-as String?,output: freezed == output ? _self.output : output ,action: freezed == action ? _self.action : action // ignore: cast_nullable_to_non_nullable
+as String?,output: freezed == output ? _self.output : output // ignore: cast_nullable_to_non_nullable
+as List<CodexRolloutContentDto>?,action: freezed == action ? _self.action : action // ignore: cast_nullable_to_non_nullable
 as CodexRolloutActionDto?,
   ));
 }
@@ -400,7 +399,7 @@ $CodexRolloutActionDtoCopyWith<$Res>? get action {
 @JsonSerializable(createToJson: false)
 
 class _CodexRolloutPayloadDto implements CodexRolloutPayloadDto {
-  const _CodexRolloutPayloadDto({required this.id, required this.cwd, required this.timestamp, @JsonKey(name: "model_provider") required this.modelProvider, @JsonKey(name: "cli_version") required this.cliVersion, required this.model, @JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) required this.type, @JsonKey(unknownEnumValue: CodexRolloutRole.unknown) required this.role, required this.content, required this.summary, @JsonKey(name: "call_id") required this.callId, required this.name, required this.arguments, required this.input, required this.output, required this.action});
+  const _CodexRolloutPayloadDto({required this.id, required this.cwd, required this.timestamp, @JsonKey(name: "model_provider") required this.modelProvider, @JsonKey(name: "cli_version") required this.cliVersion, required this.model, @JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) required this.type, @JsonKey(unknownEnumValue: CodexRolloutRole.unknown) required this.role, required final  List<CodexRolloutContentDto>? content, required final  List<CodexRolloutContentDto>? summary, @JsonKey(name: "call_id") required this.callId, required this.name, required this.arguments, required this.input, @CodexRolloutOutputConverter() required final  List<CodexRolloutContentDto>? output, required this.action}): _content = content,_summary = summary,_output = output;
   factory _CodexRolloutPayloadDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutPayloadDtoFromJson(json);
 
 @override final  String? id;
@@ -411,17 +410,37 @@ class _CodexRolloutPayloadDto implements CodexRolloutPayloadDto {
 @override final  String? model;
 @override@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) final  CodexRolloutPayloadType? type;
 @override@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) final  CodexRolloutRole? role;
-// Payload variants reuse these fields with different shapes. In
-// particular, codex 0.144.x custom tool outputs are typed content arrays,
-// while legacy function outputs are strings. Preserve the wire value here
-// and narrow it in the repository after inspecting the payload type.
-@override final  Object? content;
-@override final  Object? summary;
+ final  List<CodexRolloutContentDto>? _content;
+@override List<CodexRolloutContentDto>? get content {
+  final value = _content;
+  if (value == null) return null;
+  if (_content is EqualUnmodifiableListView) return _content;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+ final  List<CodexRolloutContentDto>? _summary;
+@override List<CodexRolloutContentDto>? get summary {
+  final value = _summary;
+  if (value == null) return null;
+  if (_summary is EqualUnmodifiableListView) return _summary;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
 @override@JsonKey(name: "call_id") final  String? callId;
 @override final  String? name;
 @override final  String? arguments;
 @override final  String? input;
-@override final  Object? output;
+ final  List<CodexRolloutContentDto>? _output;
+@override@CodexRolloutOutputConverter() List<CodexRolloutContentDto>? get output {
+  final value = _output;
+  if (value == null) return null;
+  if (_output is EqualUnmodifiableListView) return _output;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
 @override final  CodexRolloutActionDto? action;
 
 /// Create a copy of CodexRolloutPayloadDto
@@ -434,12 +453,12 @@ _$CodexRolloutPayloadDtoCopyWith<_CodexRolloutPayloadDto> get copyWith => __$Cod
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexRolloutPayloadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cliVersion, cliVersion) || other.cliVersion == cliVersion)&&(identical(other.model, model) || other.model == model)&&(identical(other.type, type) || other.type == type)&&(identical(other.role, role) || other.role == role)&&const DeepCollectionEquality().equals(other.content, content)&&const DeepCollectionEquality().equals(other.summary, summary)&&(identical(other.callId, callId) || other.callId == callId)&&(identical(other.name, name) || other.name == name)&&(identical(other.arguments, arguments) || other.arguments == arguments)&&(identical(other.input, input) || other.input == input)&&const DeepCollectionEquality().equals(other.output, output)&&(identical(other.action, action) || other.action == action));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexRolloutPayloadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.cliVersion, cliVersion) || other.cliVersion == cliVersion)&&(identical(other.model, model) || other.model == model)&&(identical(other.type, type) || other.type == type)&&(identical(other.role, role) || other.role == role)&&const DeepCollectionEquality().equals(other._content, _content)&&const DeepCollectionEquality().equals(other._summary, _summary)&&(identical(other.callId, callId) || other.callId == callId)&&(identical(other.name, name) || other.name == name)&&(identical(other.arguments, arguments) || other.arguments == arguments)&&(identical(other.input, input) || other.input == input)&&const DeepCollectionEquality().equals(other._output, _output)&&(identical(other.action, action) || other.action == action));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,cwd,timestamp,modelProvider,cliVersion,model,type,role,const DeepCollectionEquality().hash(content),const DeepCollectionEquality().hash(summary),callId,name,arguments,input,const DeepCollectionEquality().hash(output),action);
+int get hashCode => Object.hash(runtimeType,id,cwd,timestamp,modelProvider,cliVersion,model,type,role,const DeepCollectionEquality().hash(_content),const DeepCollectionEquality().hash(_summary),callId,name,arguments,input,const DeepCollectionEquality().hash(_output),action);
 
 @override
 String toString() {
@@ -454,7 +473,7 @@ abstract mixin class _$CodexRolloutPayloadDtoCopyWith<$Res> implements $CodexRol
   factory _$CodexRolloutPayloadDtoCopyWith(_CodexRolloutPayloadDto value, $Res Function(_CodexRolloutPayloadDto) _then) = __$CodexRolloutPayloadDtoCopyWithImpl;
 @override @useResult
 $Res call({
- String? id, String? cwd, String? timestamp,@JsonKey(name: "model_provider") String? modelProvider,@JsonKey(name: "cli_version") String? cliVersion, String? model,@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? type,@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? role, Object? content, Object? summary,@JsonKey(name: "call_id") String? callId, String? name, String? arguments, String? input, Object? output, CodexRolloutActionDto? action
+ String? id, String? cwd, String? timestamp,@JsonKey(name: "model_provider") String? modelProvider,@JsonKey(name: "cli_version") String? cliVersion, String? model,@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? type,@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? role, List<CodexRolloutContentDto>? content, List<CodexRolloutContentDto>? summary,@JsonKey(name: "call_id") String? callId, String? name, String? arguments, String? input,@CodexRolloutOutputConverter() List<CodexRolloutContentDto>? output, CodexRolloutActionDto? action
 });
 
 
@@ -481,11 +500,14 @@ as String?,cliVersion: freezed == cliVersion ? _self.cliVersion : cliVersion // 
 as String?,model: freezed == model ? _self.model : model // ignore: cast_nullable_to_non_nullable
 as String?,type: freezed == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
 as CodexRolloutPayloadType?,role: freezed == role ? _self.role : role // ignore: cast_nullable_to_non_nullable
-as CodexRolloutRole?,content: freezed == content ? _self.content : content ,summary: freezed == summary ? _self.summary : summary ,callId: freezed == callId ? _self.callId : callId // ignore: cast_nullable_to_non_nullable
+as CodexRolloutRole?,content: freezed == content ? _self._content : content // ignore: cast_nullable_to_non_nullable
+as List<CodexRolloutContentDto>?,summary: freezed == summary ? _self._summary : summary // ignore: cast_nullable_to_non_nullable
+as List<CodexRolloutContentDto>?,callId: freezed == callId ? _self.callId : callId // ignore: cast_nullable_to_non_nullable
 as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String?,arguments: freezed == arguments ? _self.arguments : arguments // ignore: cast_nullable_to_non_nullable
 as String?,input: freezed == input ? _self.input : input // ignore: cast_nullable_to_non_nullable
-as String?,output: freezed == output ? _self.output : output ,action: freezed == action ? _self.action : action // ignore: cast_nullable_to_non_nullable
+as String?,output: freezed == output ? _self._output : output // ignore: cast_nullable_to_non_nullable
+as List<CodexRolloutContentDto>?,action: freezed == action ? _self.action : action // ignore: cast_nullable_to_non_nullable
 as CodexRolloutActionDto?,
   ));
 }

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
@@ -309,7 +309,7 @@ $CodexRolloutPayloadDtoCopyWith<$Res>? get payload {
 /// @nodoc
 mixin _$CodexRolloutPayloadDto {
 
- String? get id; String? get cwd; String? get timestamp;@JsonKey(name: "model_provider") String? get modelProvider;@JsonKey(name: "cli_version") String? get cliVersion; String? get model;@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? get type;@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? get role; List<CodexRolloutContentDto>? get content; List<CodexRolloutContentDto>? get summary;@JsonKey(name: "call_id") String? get callId; String? get name; String? get arguments; String? get input;@CodexRolloutOutputConverter() List<CodexRolloutContentDto>? get output; CodexRolloutActionDto? get action;
+ String? get id; String? get cwd; String? get timestamp;@JsonKey(name: "model_provider") String? get modelProvider;@JsonKey(name: "cli_version") String? get cliVersion; String? get model;@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? get type;@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? get role;@CodexRolloutContentListConverter() List<CodexRolloutContentDto>? get content;@CodexRolloutContentListConverter() List<CodexRolloutContentDto>? get summary;@JsonKey(name: "call_id") String? get callId; String? get name; String? get arguments; String? get input;@CodexRolloutOutputConverter() List<CodexRolloutContentDto>? get output; CodexRolloutActionDto? get action;
 /// Create a copy of CodexRolloutPayloadDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -340,7 +340,7 @@ abstract mixin class $CodexRolloutPayloadDtoCopyWith<$Res>  {
   factory $CodexRolloutPayloadDtoCopyWith(CodexRolloutPayloadDto value, $Res Function(CodexRolloutPayloadDto) _then) = _$CodexRolloutPayloadDtoCopyWithImpl;
 @useResult
 $Res call({
- String? id, String? cwd, String? timestamp,@JsonKey(name: "model_provider") String? modelProvider,@JsonKey(name: "cli_version") String? cliVersion, String? model,@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? type,@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? role, List<CodexRolloutContentDto>? content, List<CodexRolloutContentDto>? summary,@JsonKey(name: "call_id") String? callId, String? name, String? arguments, String? input,@CodexRolloutOutputConverter() List<CodexRolloutContentDto>? output, CodexRolloutActionDto? action
+ String? id, String? cwd, String? timestamp,@JsonKey(name: "model_provider") String? modelProvider,@JsonKey(name: "cli_version") String? cliVersion, String? model,@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? type,@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? role,@CodexRolloutContentListConverter() List<CodexRolloutContentDto>? content,@CodexRolloutContentListConverter() List<CodexRolloutContentDto>? summary,@JsonKey(name: "call_id") String? callId, String? name, String? arguments, String? input,@CodexRolloutOutputConverter() List<CodexRolloutContentDto>? output, CodexRolloutActionDto? action
 });
 
 
@@ -399,7 +399,7 @@ $CodexRolloutActionDtoCopyWith<$Res>? get action {
 @JsonSerializable(createToJson: false)
 
 class _CodexRolloutPayloadDto implements CodexRolloutPayloadDto {
-  const _CodexRolloutPayloadDto({required this.id, required this.cwd, required this.timestamp, @JsonKey(name: "model_provider") required this.modelProvider, @JsonKey(name: "cli_version") required this.cliVersion, required this.model, @JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) required this.type, @JsonKey(unknownEnumValue: CodexRolloutRole.unknown) required this.role, required final  List<CodexRolloutContentDto>? content, required final  List<CodexRolloutContentDto>? summary, @JsonKey(name: "call_id") required this.callId, required this.name, required this.arguments, required this.input, @CodexRolloutOutputConverter() required final  List<CodexRolloutContentDto>? output, required this.action}): _content = content,_summary = summary,_output = output;
+  const _CodexRolloutPayloadDto({required this.id, required this.cwd, required this.timestamp, @JsonKey(name: "model_provider") required this.modelProvider, @JsonKey(name: "cli_version") required this.cliVersion, required this.model, @JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) required this.type, @JsonKey(unknownEnumValue: CodexRolloutRole.unknown) required this.role, @CodexRolloutContentListConverter() required final  List<CodexRolloutContentDto>? content, @CodexRolloutContentListConverter() required final  List<CodexRolloutContentDto>? summary, @JsonKey(name: "call_id") required this.callId, required this.name, required this.arguments, required this.input, @CodexRolloutOutputConverter() required final  List<CodexRolloutContentDto>? output, required this.action}): _content = content,_summary = summary,_output = output;
   factory _CodexRolloutPayloadDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutPayloadDtoFromJson(json);
 
 @override final  String? id;
@@ -411,7 +411,7 @@ class _CodexRolloutPayloadDto implements CodexRolloutPayloadDto {
 @override@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) final  CodexRolloutPayloadType? type;
 @override@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) final  CodexRolloutRole? role;
  final  List<CodexRolloutContentDto>? _content;
-@override List<CodexRolloutContentDto>? get content {
+@override@CodexRolloutContentListConverter() List<CodexRolloutContentDto>? get content {
   final value = _content;
   if (value == null) return null;
   if (_content is EqualUnmodifiableListView) return _content;
@@ -420,7 +420,7 @@ class _CodexRolloutPayloadDto implements CodexRolloutPayloadDto {
 }
 
  final  List<CodexRolloutContentDto>? _summary;
-@override List<CodexRolloutContentDto>? get summary {
+@override@CodexRolloutContentListConverter() List<CodexRolloutContentDto>? get summary {
   final value = _summary;
   if (value == null) return null;
   if (_summary is EqualUnmodifiableListView) return _summary;
@@ -473,7 +473,7 @@ abstract mixin class _$CodexRolloutPayloadDtoCopyWith<$Res> implements $CodexRol
   factory _$CodexRolloutPayloadDtoCopyWith(_CodexRolloutPayloadDto value, $Res Function(_CodexRolloutPayloadDto) _then) = __$CodexRolloutPayloadDtoCopyWithImpl;
 @override @useResult
 $Res call({
- String? id, String? cwd, String? timestamp,@JsonKey(name: "model_provider") String? modelProvider,@JsonKey(name: "cli_version") String? cliVersion, String? model,@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? type,@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? role, List<CodexRolloutContentDto>? content, List<CodexRolloutContentDto>? summary,@JsonKey(name: "call_id") String? callId, String? name, String? arguments, String? input,@CodexRolloutOutputConverter() List<CodexRolloutContentDto>? output, CodexRolloutActionDto? action
+ String? id, String? cwd, String? timestamp,@JsonKey(name: "model_provider") String? modelProvider,@JsonKey(name: "cli_version") String? cliVersion, String? model,@JsonKey(unknownEnumValue: CodexRolloutPayloadType.unknown) CodexRolloutPayloadType? type,@JsonKey(unknownEnumValue: CodexRolloutRole.unknown) CodexRolloutRole? role,@CodexRolloutContentListConverter() List<CodexRolloutContentDto>? content,@CodexRolloutContentListConverter() List<CodexRolloutContentDto>? summary,@JsonKey(name: "call_id") String? callId, String? name, String? arguments, String? input,@CodexRolloutOutputConverter() List<CodexRolloutContentDto>? output, CodexRolloutActionDto? action
 });
 
 

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
@@ -35,49 +35,38 @@ const _$CodexRolloutLineTypeEnumMap = {
   CodexRolloutLineType.unknown: 'unknown',
 };
 
-_CodexRolloutPayloadDto _$CodexRolloutPayloadDtoFromJson(Map json) =>
-    _CodexRolloutPayloadDto(
-      id: json['id'] as String?,
-      cwd: json['cwd'] as String?,
-      timestamp: json['timestamp'] as String?,
-      modelProvider: json['model_provider'] as String?,
-      cliVersion: json['cli_version'] as String?,
-      model: json['model'] as String?,
-      type: $enumDecodeNullable(
-        _$CodexRolloutPayloadTypeEnumMap,
-        json['type'],
-        unknownValue: CodexRolloutPayloadType.unknown,
-      ),
-      role: $enumDecodeNullable(
-        _$CodexRolloutRoleEnumMap,
-        json['role'],
-        unknownValue: CodexRolloutRole.unknown,
-      ),
-      content: (json['content'] as List<dynamic>?)
-          ?.map(
-            (e) => CodexRolloutContentDto.fromJson(
-              Map<String, dynamic>.from(e as Map),
-            ),
-          )
-          .toList(),
-      summary: (json['summary'] as List<dynamic>?)
-          ?.map(
-            (e) => CodexRolloutContentDto.fromJson(
-              Map<String, dynamic>.from(e as Map),
-            ),
-          )
-          .toList(),
-      callId: json['call_id'] as String?,
-      name: json['name'] as String?,
-      arguments: json['arguments'] as String?,
-      input: json['input'] as String?,
-      output: const CodexRolloutOutputConverter().fromJson(json['output']),
-      action: json['action'] == null
-          ? null
-          : CodexRolloutActionDto.fromJson(
-              Map<String, dynamic>.from(json['action'] as Map),
-            ),
-    );
+_CodexRolloutPayloadDto _$CodexRolloutPayloadDtoFromJson(
+  Map json,
+) => _CodexRolloutPayloadDto(
+  id: json['id'] as String?,
+  cwd: json['cwd'] as String?,
+  timestamp: json['timestamp'] as String?,
+  modelProvider: json['model_provider'] as String?,
+  cliVersion: json['cli_version'] as String?,
+  model: json['model'] as String?,
+  type: $enumDecodeNullable(
+    _$CodexRolloutPayloadTypeEnumMap,
+    json['type'],
+    unknownValue: CodexRolloutPayloadType.unknown,
+  ),
+  role: $enumDecodeNullable(
+    _$CodexRolloutRoleEnumMap,
+    json['role'],
+    unknownValue: CodexRolloutRole.unknown,
+  ),
+  content: const CodexRolloutContentListConverter().fromJson(json['content']),
+  summary: const CodexRolloutContentListConverter().fromJson(json['summary']),
+  callId: json['call_id'] as String?,
+  name: json['name'] as String?,
+  arguments: json['arguments'] as String?,
+  input: json['input'] as String?,
+  output: const CodexRolloutOutputConverter().fromJson(json['output']),
+  action: json['action'] == null
+      ? null
+      : CodexRolloutActionDto.fromJson(
+          Map<String, dynamic>.from(json['action'] as Map),
+        ),
+);
 
 const _$CodexRolloutPayloadTypeEnumMap = {
   CodexRolloutPayloadType.message: 'message',

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
@@ -53,17 +53,13 @@ _CodexRolloutPayloadDto _$CodexRolloutPayloadDtoFromJson(Map json) =>
         json['role'],
         unknownValue: CodexRolloutRole.unknown,
       ),
-      content: (json['content'] as List<dynamic>?)
-          ?.map(
-            (e) => CodexRolloutContentDto.fromJson(
-              Map<String, dynamic>.from(e as Map),
-            ),
-          )
-          .toList(),
+      content: json['content'],
+      summary: json['summary'],
       callId: json['call_id'] as String?,
       name: json['name'] as String?,
       arguments: json['arguments'] as String?,
-      output: json['output'] as String?,
+      input: json['input'] as String?,
+      output: json['output'],
       action: json['action'] == null
           ? null
           : CodexRolloutActionDto.fromJson(
@@ -72,8 +68,12 @@ _CodexRolloutPayloadDto _$CodexRolloutPayloadDtoFromJson(Map json) =>
     );
 
 const _$CodexRolloutPayloadTypeEnumMap = {
+  CodexRolloutPayloadType.message: 'message',
+  CodexRolloutPayloadType.reasoning: 'reasoning',
   CodexRolloutPayloadType.functionCall: 'function_call',
   CodexRolloutPayloadType.functionCallOutput: 'function_call_output',
+  CodexRolloutPayloadType.customToolCall: 'custom_tool_call',
+  CodexRolloutPayloadType.customToolCallOutput: 'custom_tool_call_output',
   CodexRolloutPayloadType.webSearchCall: 'web_search_call',
   CodexRolloutPayloadType.unknown: 'unknown',
 };
@@ -97,6 +97,7 @@ _CodexRolloutContentDto _$CodexRolloutContentDtoFromJson(Map json) =>
 const _$CodexRolloutContentTypeEnumMap = {
   CodexRolloutContentType.inputText: 'input_text',
   CodexRolloutContentType.outputText: 'output_text',
+  CodexRolloutContentType.summaryText: 'summary_text',
   CodexRolloutContentType.unknown: 'unknown',
 };
 

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
@@ -53,13 +53,25 @@ _CodexRolloutPayloadDto _$CodexRolloutPayloadDtoFromJson(Map json) =>
         json['role'],
         unknownValue: CodexRolloutRole.unknown,
       ),
-      content: json['content'],
-      summary: json['summary'],
+      content: (json['content'] as List<dynamic>?)
+          ?.map(
+            (e) => CodexRolloutContentDto.fromJson(
+              Map<String, dynamic>.from(e as Map),
+            ),
+          )
+          .toList(),
+      summary: (json['summary'] as List<dynamic>?)
+          ?.map(
+            (e) => CodexRolloutContentDto.fromJson(
+              Map<String, dynamic>.from(e as Map),
+            ),
+          )
+          .toList(),
       callId: json['call_id'] as String?,
       name: json['name'] as String?,
       arguments: json['arguments'] as String?,
       input: json['input'] as String?,
-      output: json['output'],
+      output: const CodexRolloutOutputConverter().fromJson(json['output']),
       action: json['action'] == null
           ? null
           : CodexRolloutActionDto.fromJson(

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
@@ -30,15 +30,17 @@ class CodexMessageRepository {
       );
     }
 
-    final toolOutputs = <String, String>{};
+    final toolOutputs = <String, String?>{};
     for (final line in lines) {
       final payload = line.payload;
-      if (payload?.type != CodexRolloutPayloadType.functionCallOutput) {
+      if (payload?.type != CodexRolloutPayloadType.functionCallOutput &&
+          payload?.type != CodexRolloutPayloadType.customToolCallOutput) {
         continue;
       }
       final callId = payload?.callId;
-      final output = payload?.output;
-      if (callId != null && output != null) toolOutputs[callId] = output;
+      if (callId != null && payload?.output != null) {
+        toolOutputs[callId] = _toolOutputText(payload?.output);
+      }
     }
 
     final messages = <PluginMessageWithParts>[];
@@ -74,10 +76,12 @@ class CodexMessageRepository {
       if (payload == null) continue;
       final messageTime = _messageTimeFrom(line.timestamp);
 
-      if (payload.type == CodexRolloutPayloadType.functionCall) {
+      if (payload.type == CodexRolloutPayloadType.functionCall ||
+          payload.type == CodexRolloutPayloadType.customToolCall) {
         final callId = payload.callId;
         final name = payload.name ?? "tool";
         final output = callId == null ? null : toolOutputs[callId];
+        final completed = callId != null && toolOutputs.containsKey(callId);
         messageCounter += 1;
         messages.add(
           _toolMessage(
@@ -85,14 +89,15 @@ class CodexMessageRepository {
             sessionId: sessionId,
             info: assistantInfo("m-$messageCounter", messageTime),
             tool: _normalizeToolName(name),
-            title: _toolCallTitle(payload.arguments),
-            status: output != null ? PluginToolStatus.completed : PluginToolStatus.running,
+            title: _toolCallTitle(payload.arguments ?? payload.input),
+            status: completed ? PluginToolStatus.completed : PluginToolStatus.running,
             output: output,
           ),
         );
         continue;
       }
-      if (payload.type == CodexRolloutPayloadType.functionCallOutput) {
+      if (payload.type == CodexRolloutPayloadType.functionCallOutput ||
+          payload.type == CodexRolloutPayloadType.customToolCallOutput) {
         continue;
       }
       if (payload.type == CodexRolloutPayloadType.webSearchCall) {
@@ -111,17 +116,50 @@ class CodexMessageRepository {
         continue;
       }
 
+      if (payload.type == CodexRolloutPayloadType.reasoning) {
+        final reasoning = _contentTexts(
+          payload.summary,
+          acceptedTypes: const {CodexRolloutContentType.summaryText},
+        ).join();
+        if (reasoning.isEmpty) continue;
+
+        messageCounter += 1;
+        final messageId = "m-$messageCounter";
+        messages.add(
+          PluginMessageWithParts(
+            info: assistantInfo(messageId, messageTime),
+            parts: [
+              PluginMessagePart(
+                id: "$messageId-reasoning",
+                sessionID: sessionId,
+                messageID: messageId,
+                type: PluginMessagePartType.reasoning,
+                text: reasoning,
+                tool: null,
+                state: null,
+                prompt: null,
+                description: null,
+                agent: null,
+                agentName: null,
+                attempt: null,
+                retryError: null,
+              ),
+            ],
+          ),
+        );
+        continue;
+      }
+
       if (payload.role != CodexRolloutRole.user && payload.role != CodexRolloutRole.assistant) {
         continue;
       }
-      final texts = [
-        for (final content in payload.content ?? const <CodexRolloutContentDto>[])
-          if ((content.type == CodexRolloutContentType.inputText ||
-                  content.type == CodexRolloutContentType.outputText) &&
-              content.text != null &&
-              content.text!.isNotEmpty)
-            content.text!,
-      ];
+      final texts = _contentTexts(
+        payload.content,
+        acceptedTypes: const {
+          CodexRolloutContentType.inputText,
+          CodexRolloutContentType.outputText,
+        },
+      );
       if (texts.isEmpty) continue;
 
       messageCounter += 1;
@@ -159,6 +197,49 @@ class CodexMessageRepository {
       );
     }
     return messages;
+  }
+
+  String? _toolOutputText(Object? output) {
+    if (output is String) return output;
+    final texts = _contentTexts(
+      output,
+      acceptedTypes: const {
+        CodexRolloutContentType.inputText,
+        CodexRolloutContentType.outputText,
+      },
+    );
+    return texts.isEmpty ? null : texts.join();
+  }
+
+  List<String> _contentTexts(
+    Object? raw, {
+    required Set<CodexRolloutContentType> acceptedTypes,
+  }) {
+    if (raw is! List) return const [];
+    final texts = <String>[];
+    for (final item in raw) {
+      if (item is String) {
+        if (item.isNotEmpty) texts.add(item);
+        continue;
+      }
+      if (item is! Map) continue;
+      try {
+        final content = CodexRolloutContentDto.fromJson(
+          item.cast<String, dynamic>(),
+        );
+        final text = content.text;
+        if (acceptedTypes.contains(content.type) && text != null && text.isNotEmpty) {
+          texts.add(text);
+        }
+      } on Object catch (error, stackTrace) {
+        Log.w(
+          "[codex] skipping malformed rollout content item",
+          error,
+          stackTrace,
+        );
+      }
+    }
+    return texts;
   }
 
   PluginMessageWithParts _toolMessage({

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
@@ -1,3 +1,5 @@
+import "dart:convert";
+
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" show jsonDecodeMap;
 
@@ -275,10 +277,8 @@ class CodexMessageRepository {
 
   String? _toolCallTitle(String? argumentsJson) {
     if (argumentsJson == null || argumentsJson.isEmpty) return null;
-    try {
-      final arguments = CodexToolArgumentsDto.fromJson(
-        jsonDecodeMap(argumentsJson),
-      );
+    final arguments = _tryDecodeToolArguments(raw: argumentsJson);
+    if (arguments != null) {
       for (final value in [
         arguments.cmd,
         arguments.command,
@@ -289,10 +289,54 @@ class CodexMessageRepository {
         if (value is String && value.isNotEmpty) return value;
         if (value is List && value.isNotEmpty) return value.join(" ");
       }
-    } on Object {
-      // Fall through to the raw arguments.
+    }
+    final embeddedCommand = _embeddedExecCommand(source: argumentsJson);
+    if (embeddedCommand != null && embeddedCommand.isNotEmpty) {
+      return embeddedCommand;
     }
     return argumentsJson.length > 120 ? argumentsJson.substring(0, 120) : argumentsJson;
+  }
+
+  CodexToolArgumentsDto? _tryDecodeToolArguments({required String raw}) {
+    try {
+      return CodexToolArgumentsDto.fromJson(jsonDecodeMap(raw));
+    } on Object {
+      return null;
+    }
+  }
+
+  String? _embeddedExecCommand({required String source}) {
+    const marker = "tools.exec_command(";
+    final markerIndex = source.indexOf(marker);
+    if (markerIndex < 0) return null;
+
+    final argumentsStart = markerIndex + marker.length;
+    final commandMatch = RegExp(
+      r'(?:^|[,{]\s*)(?:"cmd"|cmd)\s*:\s*',
+    ).firstMatch(source.substring(argumentsStart));
+    if (commandMatch == null) return null;
+    final valueStart = argumentsStart + commandMatch.end;
+    if (valueStart >= source.length || source.codeUnitAt(valueStart) != 0x22) {
+      return null;
+    }
+
+    var escaped = false;
+    for (var index = valueStart + 1; index < source.length; index++) {
+      final codeUnit = source.codeUnitAt(index);
+      if (escaped) {
+        escaped = false;
+      } else if (codeUnit == 0x5C) {
+        escaped = true;
+      } else if (codeUnit == 0x22) {
+        try {
+          final decoded = jsonDecode(source.substring(valueStart, index + 1));
+          return decoded is String ? decoded : null;
+        } on FormatException {
+          return null;
+        }
+      }
+    }
+    return null;
   }
 
   PluginMessageTime? _messageTimeFrom(String? raw) {

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
@@ -199,8 +199,7 @@ class CodexMessageRepository {
     return messages;
   }
 
-  String? _toolOutputText(Object? output) {
-    if (output is String) return output;
+  String? _toolOutputText(List<CodexRolloutContentDto>? output) {
     final texts = _contentTexts(
       output,
       acceptedTypes: const {
@@ -212,34 +211,13 @@ class CodexMessageRepository {
   }
 
   List<String> _contentTexts(
-    Object? raw, {
+    List<CodexRolloutContentDto>? content, {
     required Set<CodexRolloutContentType> acceptedTypes,
   }) {
-    if (raw is! List) return const [];
-    final texts = <String>[];
-    for (final item in raw) {
-      if (item is String) {
-        if (item.isNotEmpty) texts.add(item);
-        continue;
-      }
-      if (item is! Map) continue;
-      try {
-        final content = CodexRolloutContentDto.fromJson(
-          item.cast<String, dynamic>(),
-        );
-        final text = content.text;
-        if (acceptedTypes.contains(content.type) && text != null && text.isNotEmpty) {
-          texts.add(text);
-        }
-      } on Object catch (error, stackTrace) {
-        Log.w(
-          "[codex] skipping malformed rollout content item",
-          error,
-          stackTrace,
-        );
-      }
-    }
-    return texts;
+    return [
+      for (final item in content ?? const <CodexRolloutContentDto>[])
+        if (item.text case final text? when acceptedTypes.contains(item.type) && text.isNotEmpty) text,
+    ];
   }
 
   PluginMessageWithParts _toolMessage({

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -476,7 +476,7 @@ void main() {
               "status": "completed",
               "call_id": "call-1",
               "name": "exec",
-              "input": jsonEncode({"cmd": "ls -la"}),
+              "input": 'const r = await tools.exec_command({cmd:"ls -la"}); text(r.output);',
             },
           }),
           jsonEncode({

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -3,6 +3,7 @@ import "dart:convert";
 import "dart:io";
 
 import "package:codex_plugin/codex_plugin.dart";
+import "package:codex_plugin/src/api/models/codex_rollout_dto.dart";
 import "package:codex_plugin/src/repositories/codex_catalog_repository.dart";
 import "package:codex_plugin/src/repositories/codex_message_repository.dart";
 import "package:codex_plugin/src/repositories/models/codex_session_record.dart";
@@ -151,6 +152,57 @@ void main() {
       expect(output, contains("malformed rollout transcript record"));
       expect("malformed rollout transcript record".allMatches(output), hasLength(1));
       expect(output, isNot(contains("secret-source-content")));
+    });
+
+    test("current structured rollout records are not reported as malformed", () {
+      final path = _writeRollout(
+        codexHome,
+        path: "sessions/2026/07/22/rollout-current.jsonl",
+        sessionId: "019a0000-1111-2222-3333-aaaaaaaaaaaa",
+        cwd: "/repo/app",
+        cliVersion: "0.144.1",
+        extraLines: [
+          jsonEncode({
+            "type": "response_item",
+            "payload": {
+              "type": "custom_tool_call_output",
+              "call_id": "call-1",
+              "output": [
+                {"type": "input_text", "text": "command output"},
+              ],
+            },
+          }),
+          jsonEncode({
+            "type": "response_item",
+            "payload": {
+              "type": "reasoning",
+              "id": "reasoning-1",
+              "summary": [
+                {"type": "summary_text", "text": "Checking the result"},
+              ],
+            },
+          }),
+        ],
+      );
+
+      late List<CodexRolloutLineDto> header;
+      late List<CodexRolloutLineDto> transcript;
+      final output = _captureWarnings(() {
+        header = rolloutApi.readHeader(rolloutPath: path);
+        transcript = rolloutApi.readTranscript(rolloutPath: path);
+      }, level: LogLevel.verbose);
+
+      expect(output, isNot(contains("malformed rollout")));
+      expect(header, hasLength(3));
+      expect(transcript, hasLength(3));
+      expect(
+        transcript[1].payload?.type,
+        CodexRolloutPayloadType.customToolCallOutput,
+      );
+      expect(
+        transcript[2].payload?.type,
+        CodexRolloutPayloadType.reasoning,
+      );
     });
 
     test("listSessions joins index + rollout header and sorts by updatedAt", () {
@@ -390,6 +442,94 @@ void main() {
       final patch = messages[2].parts.single;
       expect(patch.tool, equals("edit"));
       expect(patch.state?.status, equals(PluginToolStatus.running));
+    });
+
+    test("readMessages restores current custom tool calls and reasoning", () {
+      final path = _writeRollout(
+        codexHome,
+        path: "sessions/2026/07/22/rollout-current-messages.jsonl",
+        sessionId: "019a0000-1111-2222-3333-bbbbbbbbbbbb",
+        cwd: "/repo/app",
+        cliVersion: "0.144.1",
+        extraLines: [
+          jsonEncode({
+            "type": "turn_context",
+            "payload": {"model": "gpt-5.4"},
+          }),
+          jsonEncode({
+            "timestamp": "2026-07-22T10:00:01Z",
+            "type": "response_item",
+            "payload": {
+              "type": "reasoning",
+              "id": "reasoning-1",
+              "summary": [
+                {"type": "summary_text", "text": "Inspecting the workspace"},
+              ],
+            },
+          }),
+          jsonEncode({
+            "timestamp": "2026-07-22T10:00:02Z",
+            "type": "response_item",
+            "payload": {
+              "type": "custom_tool_call",
+              "id": "tool-1",
+              "status": "completed",
+              "call_id": "call-1",
+              "name": "exec",
+              "input": jsonEncode({"cmd": "ls -la"}),
+            },
+          }),
+          jsonEncode({
+            "timestamp": "2026-07-22T10:00:03Z",
+            "type": "response_item",
+            "payload": {
+              "type": "custom_tool_call_output",
+              "call_id": "call-1",
+              "output": [
+                {"type": "input_text", "text": "total 0\nfoo.dart"},
+              ],
+            },
+          }),
+          jsonEncode({
+            "timestamp": "2026-07-22T10:00:04Z",
+            "type": "response_item",
+            "payload": {
+              "type": "message",
+              "id": "message-1",
+              "role": "assistant",
+              "content": [
+                {"type": "output_text", "text": "Done"},
+              ],
+            },
+          }),
+        ],
+      );
+
+      late List<PluginMessageWithParts> messages;
+      final output = _captureWarnings(() {
+        messages = messageRepository.readMessages(
+          rolloutPath: path,
+          sessionId: "019a0000-1111-2222-3333-bbbbbbbbbbbb",
+        );
+      }, level: LogLevel.verbose);
+
+      expect(output, isNot(contains("malformed rollout")));
+      expect(messages, hasLength(3));
+
+      final reasoning = messages[0].parts.single;
+      expect(reasoning.type, PluginMessagePartType.reasoning);
+      expect(reasoning.text, "Inspecting the workspace");
+
+      final tool = messages[1].parts.single;
+      expect(tool.type, PluginMessagePartType.tool);
+      expect(tool.tool, "shell");
+      expect(tool.state?.status, PluginToolStatus.completed);
+      expect(tool.state?.title, "ls -la");
+      expect(tool.state?.output, contains("foo.dart"));
+
+      final assistant = messages[2];
+      expect(assistant.parts.single.text, "Done");
+      expect((assistant.info as PluginMessageAssistant).modelID, "gpt-5.4");
     });
 
     test("readMessages clips tool output by complete Unicode code points", () {

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -444,7 +444,7 @@ void main() {
       expect(patch.state?.status, equals(PluginToolStatus.running));
     });
 
-    test("readMessages restores current custom tool calls and reasoning", () {
+    test("readMessages restores current calls around malformed content items", () {
       final path = _writeRollout(
         codexHome,
         path: "sessions/2026/07/22/rollout-current-messages.jsonl",
@@ -463,7 +463,9 @@ void main() {
               "type": "reasoning",
               "id": "reasoning-1",
               "summary": [
-                {"type": "summary_text", "text": "Inspecting the workspace"},
+                {"type": "summary_text", "text": "Inspecting "},
+                42,
+                {"type": "summary_text", "text": "the workspace"},
               ],
             },
           }),
@@ -486,7 +488,9 @@ void main() {
               "type": "custom_tool_call_output",
               "call_id": "call-1",
               "output": [
-                {"type": "input_text", "text": "total 0\nfoo.dart"},
+                {"type": "input_text", "text": "total 0\n"},
+                "schema-drifted item",
+                {"type": "input_text", "text": "foo.dart"},
               ],
             },
           }),
@@ -499,6 +503,7 @@ void main() {
               "role": "assistant",
               "content": [
                 {"type": "output_text", "text": "Done"},
+                false,
               ],
             },
           }),
@@ -513,7 +518,8 @@ void main() {
         );
       }, level: LogLevel.verbose);
 
-      expect(output, isNot(contains("malformed rollout")));
+      expect(output, contains("skipping malformed rollout content item"));
+      expect(output, isNot(contains("malformed rollout transcript record")));
       expect(messages, hasLength(3));
 
       final reasoning = messages[0].parts.single;


### PR DESCRIPTION
## Summary

- accept current Codex `custom_tool_call` and `custom_tool_call_output` rollout records without dropping them as malformed
- reconstruct persisted tool calls, typed tool output, and recoverable reasoning summaries while retaining legacy function-call compatibility
- add regression coverage for the Codex 0.144.x persisted record shapes that caused live messages to disappear after history refresh

## Root cause

Codex 0.144.x persists custom tool output as a typed content array, while the rollout DTO required a string. Deserialization therefore discarded each valid record, and the subsequent history refresh replaced the richer live stream with the incomplete reconstructed history.

## Verification

- `dart test` (154 tests)
- `dart analyze --fatal-infos`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores custom tool call history, reasoning, and assistant messages by accepting Codex 0.144.x rollout shapes and normalizing typed outputs. Keeps valid content when some items are malformed, fixing disappearing messages after refresh.

- **Bug Fixes**
  - Accept new payloads: `custom_tool_call`, `custom_tool_call_output`, `reasoning`, `message`, and content type `summary_text`.
  - Rebuild tool messages: status from `call_id`; title from `arguments` or `input`, including `tools.exec_command({cmd})`; restore reasoning parts.
  - Retain valid content: decode typed content arrays and skip only malformed items (avoid dropped records and false “malformed” logs).
  - Add regression tests for 0.144.x and current structured records.

- **Refactors**
  - Normalize tool output with `CodexRolloutOutputConverter`; decode content lists with `CodexRolloutContentListConverter`.
  - DTO updates: add `summary` and `input`; make `output` typed via converter; include enums for new payload and content types.

<sup>Written for commit 09f7dc8fb2dbeb8ccc0958d5f30ff7f7c3b1ec7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

